### PR TITLE
Removed information about creating database

### DIFF
--- a/railties/lib/rails/templates/rails/welcome/index.html.erb
+++ b/railties/lib/rails/templates/rails/welcome/index.html.erb
@@ -232,8 +232,8 @@
             </li>
 
             <li>
-              <h2>Create your database</h2>
-              <p>Run <code>rake db:create</code> to create your database. If you're not using SQLite (the default), edit <span class="filename">config/database.yml</span> with your username and password.</p>
+              <h2>Configure your database</h2>
+              <p>If you're not using SQLite (the default), edit <span class="filename">config/database.yml</span> with your username and password.</p>
             </li>
           </ol>
         </div>


### PR DESCRIPTION
- As default index page is no longer in public folder, rails hits the
  welcome controller in railties for index action
- If the database is not created or username and password are
  incorrect in database.yml, those errors are first shown before index
  action succeeds
- welcome#index succeeds iff the database is created with correct
  details in database.yml
- So this information about creating database is not required in the
  index template
