### PR TITLE
Fix eager loading a has_many association with a join and order clause

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Fix eager loading has_many association with ordering on a joined table
+
+    A has_many association ordering on a joined table would omit the join
+    when eager loaded:
+
+    class Character < ActiveRecord::Base
+      has_many :appearances, -> { joins(:books).order("books.published_on") }
+    end
+
+    Character.where(name: "Gandalf").includes(:appearances).first
+    => SQLite3::SQLException: no such column: books.published_on:
+      SELECT "appearances".* FROM "appearances"
+      WHERE "appearances"."character_id" IN (1)
+      ORDER BY "books"."published_on"
+
+    *Jonathon M. Abbott*
+
 *   Remove deprecated `ActiveRecord::Migrator.proper_table_name`. Use the
     `proper_table_name` instance method on `ActiveRecord::Migration` instead.
 

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -138,6 +138,7 @@ module ActiveRecord
 
           scope.where_values      = Array(values[:where])      + Array(preload_values[:where])
           scope.references_values = Array(values[:references]) + Array(preload_values[:references])
+          scope.joins_values      = Array(values[:joins])      + Array(preload_values[:joins])
           scope.bind_values       = (reflection_binds + preload_binds)
 
           scope._select!   preload_values[:select] || values[:select] || table[Arel.star]

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1904,4 +1904,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal [], authors(:david).posts_with_signature.map(&:title)
   end
+
+  test "eager loading an association with a join does not omit the join" do
+    authors = Author.where(name: "David")
+
+    assert authors.includes(:posts_with_comments_sorted_by_comment_id_via_join).first
+  end
 end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -5,6 +5,7 @@ class Author < ActiveRecord::Base
   has_many :posts_with_comments, -> { includes(:comments) }, :class_name => "Post"
   has_many :popular_grouped_posts, -> { includes(:comments).group("type").having("SUM(comments_count) > 1").select("type") }, :class_name => "Post"
   has_many :posts_with_comments_sorted_by_comment_id, -> { includes(:comments).order('comments.id') }, :class_name => "Post"
+  has_many :posts_with_comments_sorted_by_comment_id_via_join, -> { joins(:comments).order('comments.id') }, :class_name => "Post"
   has_many :posts_sorted_by_id_limited, -> { order('posts.id').limit(1) }, :class_name => "Post"
   has_many :posts_with_categories, -> { includes(:categories) }, :class_name => "Post"
   has_many :posts_with_comments_and_categories, -> { includes(:comments, :categories).order("posts.id") }, :class_name => "Post"


### PR DESCRIPTION
A has_many association ordering on a joined table would omit the join
when eager loaded.

```
class Character < ActiveRecord::Base
  has_many :appearances, -> { joins(:books).order("books.published_on") }
end

Character.where(name: "Gandalf").includes(:appearances).first
=> SQLite3::SQLException: no such column: books.published_on:
  SELECT "appearances".* FROM "appearances"
  WHERE "appearances"."character_id" IN (1)
  ORDER BY "books"."published_on"
```
