### PR TITLE
Backport #4224 to 3-2-stable.

### DIFF
--- a/activerecord/test/fixtures/admin/randomly_named_a9.yml
+++ b/activerecord/test/fixtures/admin/randomly_named_a9.yml
@@ -1,0 +1,7 @@
+first_instance:
+  some_attribute: AAA
+  another_attribute: 000
+
+second_instance:
+  some_attribute: BBB
+  another_attribute: 999

--- a/activerecord/test/fixtures/admin/randomly_named_b0.yml
+++ b/activerecord/test/fixtures/admin/randomly_named_b0.yml
@@ -1,0 +1,7 @@
+first_instance:
+  some_attribute: AAA
+  another_attribute: 000
+
+second_instance:
+  some_attribute: BBB
+  another_attribute: 999

--- a/activerecord/test/fixtures/other_topics.yml
+++ b/activerecord/test/fixtures/other_topics.yml
@@ -1,0 +1,41 @@
+first:
+  id: 1
+  title: The First Topic
+  author_name: David
+  author_email_address: david@loudthinking.com
+  written_on: 2003-07-16t15:28:11.2233+01:00
+  last_read: 2004-04-15
+  bonus_time: 2005-01-30t15:28:00.00+01:00
+  content: Have a nice day
+  approved: false
+  replies_count: 1
+
+second:
+  id: 2
+  title: The Second Topic of the day
+  author_name: Mary
+  written_on: 2004-07-15t15:28:00.0099+01:00
+  content: Have a nice day
+  approved: true
+  replies_count: 0
+  parent_id: 1
+  type: Reply
+
+third:
+  id: 3
+  title: The Third Topic of the day
+  author_name: Carl
+  written_on: 2005-07-15t15:28:00.0099+01:00
+  content: I'm a troll
+  approved: true
+  replies_count: 1
+
+fourth:
+  id: 4
+  title: The Fourth Topic of the day
+  author_name: Carl
+  written_on: 2006-07-15t15:28:00.0099+01:00
+  content: Why not?
+  approved: true
+  type: Reply
+  parent_id: 3

--- a/activerecord/test/fixtures/randomly_named_a9.yml
+++ b/activerecord/test/fixtures/randomly_named_a9.yml
@@ -1,0 +1,7 @@
+first_instance:
+  some_attribute: AAA
+  another_attribute: 000
+
+second_instance:
+  some_attribute: BBB
+  another_attribute: 999

--- a/activerecord/test/models/admin/randomly_named_c1.rb
+++ b/activerecord/test/models/admin/randomly_named_c1.rb
@@ -1,0 +1,3 @@
+class Admin::ClassNameThatDoesNotFollowCONVENTIONS < ActiveRecord::Base
+  self.table_name = :randomly_named_table
+end

--- a/activerecord/test/models/randomly_named_c1.rb
+++ b/activerecord/test/models/randomly_named_c1.rb
@@ -1,0 +1,3 @@
+class ClassNameThatDoesNotFollowCONVENTIONS < ActiveRecord::Base
+  self.table_name = :randomly_named_table
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -543,6 +543,11 @@ ActiveRecord::Schema.define do
     t.string :type
   end
 
+  create_table :randomly_named_table, :force => true do |t|
+    t.string  :some_attribute
+    t.integer :another_attribute
+  end
+
   create_table :ratings, :force => true do |t|
     t.integer :comment_id
     t.integer :value


### PR DESCRIPTION
This is a version of #4481 that backports the functional changes of #4224 while attempting to be minimally invasive.
