### PR TITLE
[Fixes #11512] improves cache size calculation in MemoryStore

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -143,4 +143,17 @@
 
     *Daniel Schierbeck*
 
+*   Improve `ActiveSupport::Cache::MemoryStore` cache size calculation.
+    The memory used by a key/entry pair is calculated via `#cached_size`:
+
+        def cached_size(key, entry)
+          key.to_s.bytesize + entry.size + PER_ENTRY_OVERHEAD
+        end
+
+    The value of `PER_ENTRY_OVERHEAD` is 240 bytes based on an [empirical
+    estimation](https://gist.github.com/ssimeonov/6047200) for 64-bit MRI on 
+    1.9.3 and 2.0. GH#11512
+
+    *Simeon Simeonov*
+
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activesupport/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
- Takes the size of cache keys into account
- Takes per-entry overhead into account
- See https://github.com/rails/rails/issues/11512
