### PR TITLE
Rebase and make fixes to #6763 "Specified column type for quote_value" 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,7 +1,8 @@
-*   When using optimisitc locking, `update` whas not passing the column type to `quote_value`
+*   When using optimistic locking, `update` was not passing the column to `quote_value`
     to allow the connection adapter to properly determine how to quote the value. This was
     affecting certain databases that use specific colmn types.
-    Fix #6763
+
+    Fixes: #6763
 
     *Alfred Wong*
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Don't allow `quote_value` to be called without a column.
+
+    Some adapters require column information to do their job properly.
+    By enforcing the provision of the column for this internal method
+    we ensure that those using adapters that require column information
+    will always get the proper behavior.
+
+    *Ben Woosley*
+
 *   When using optimistic locking, `update` was not passing the column to `quote_value`
     to allow the connection adapter to properly determine how to quote the value. This was
     affecting certain databases that use specific colmn types.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   When using optimisitc locking, `update` whas not passing the column type to `quote_value`
+    to allow the connection adapter to properly determine how to quote the value. This was
+    affecting certain databases that use specific colmn types.
+    Fix #6763
+
+    *Alfred Wong*
+
 *   rescue from all exceptions in `ConnectionManagement#call`
 
     Fixes #11497

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -82,7 +82,7 @@ module ActiveRecord
 
             stmt = relation.where(
               relation.table[self.class.primary_key].eq(id).and(
-                relation.table[lock_col].eq(self.class.quote_value(previous_lock_value, self.class.columns_hash[lock_col]))
+                relation.table[lock_col].eq(self.class.quote_value(previous_lock_value, column_for_attribute(lock_col)))
               )
             ).arel.compile_update(arel_attributes_with_values_for_update(attribute_names))
 

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -82,7 +82,7 @@ module ActiveRecord
 
             stmt = relation.where(
               relation.table[self.class.primary_key].eq(id).and(
-                relation.table[lock_col].eq(self.class.quote_value(previous_lock_value))
+                relation.table[lock_col].eq(self.class.quote_value(previous_lock_value, self.class.columns_hash[lock_col]))
               )
             ).arel.compile_update(arel_attributes_with_values_for_update(attribute_names))
 

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -3,8 +3,8 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def quote_value(value, column = nil) #:nodoc:
-        connection.quote(value,column)
+      def quote_value(value, column) #:nodoc:
+        connection.quote(value, column)
       end
 
       # Used to sanitize objects before they're used in an SQL SELECT statement. Delegates to <tt>connection.quote</tt>.

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -613,7 +613,7 @@ class FinderTest < ActiveRecord::TestCase
   def test_named_bind_with_postgresql_type_casts
     l = Proc.new { bind(":a::integer '2009-01-01'::date", :a => '10') }
     assert_nothing_raised(&l)
-    assert_equal "#{ActiveRecord::Base.quote_value('10')}::integer '2009-01-01'::date", l.call
+    assert_equal "#{ActiveRecord::Base.connection.quote('10')}::integer '2009-01-01'::date", l.call
   end
 
   def test_string_sanitation

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -1,4 +1,5 @@
 require 'thread'
+require 'mocha/setup'
 require "cases/helper"
 require 'models/person'
 require 'models/job'
@@ -27,6 +28,18 @@ end
 
 class OptimisticLockingTest < ActiveRecord::TestCase
   fixtures :people, :legacy_things, :references, :string_key_objects, :peoples_treasures
+
+  def test_quote_value_passed_lock_col
+    p1 = Person.find(1)
+    assert_equal 0, p1.lock_version
+
+    Person.expects(:quote_value).with(0, Person.columns_hash[Person.locking_column]).returns('0').once
+
+    p1.first_name = 'anika2'
+    p1.save!
+
+    assert_equal 1, p1.lock_version
+  end
 
   def test_non_integer_lock_existing
     s1 = StringKeyObject.find("record1")

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -1,5 +1,4 @@
 require 'thread'
-require 'mocha/setup'
 require "cases/helper"
 require 'models/person'
 require 'models/job'


### PR DESCRIPTION
This obsoletes #6763 and #10972

Additional fixes over #6763 are:
1) Fix typos in changelog
2) Remove mocha/setup test require, which was causing deprecation warnings and failures.
3) Prefer the `column_for_attribute` accessor over direct access to the columns_hash.
4) Don't allow `quote_value` to be called without a column. As in #6763, some adapters require column information to do their job properly, so we'd better always supply it.
