### PR TITLE
Update #6791 "AR::Migrator.bulk_migration option"

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `ActiveRecord::Migrator.bulk_migration` option
+    to support running migration under same DDL transaction
+
+    *Bogdan Gusiev*
+
 *   Queries such as `Computer.joins(:monitor).group(:status).count` will now be
     interpreted as  `Computer.joins(:monitor).group('computers.status').count`
     so that when `Computer` and `Monitor` have both `status` columns we don't


### PR DESCRIPTION
This update #6791 and integrates it with the `disable_ddl_transaction!` option that was added since the PR was first opened.

Could probably use some additional testing to handle the interplay between these two features.
