### PR TITLE
rescue from all exceptions in `ConnectionManagement#call`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   rescue from all exceptions in `ConnectionManagement#call`
+
+    Fixes #11497
+
+    As `ActiveRecord::ConnectionAdapters::ConnectionManagement` middleware does
+    not rescue from Exception (but only from StandardError), the Connection
+    Pool quickly runs out of connections when multiple erroneous Requests come
+    in right after each other.
+
+    Rescuing from all exceptions and not just StandardError, fixes this
+    behaviour.
+
+    *Vipul A M*
+
 *   `change_column` for PostgreSQL adapter respects the `:array` option.
 
     *Yves Senn*

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -624,7 +624,7 @@ module ActiveRecord
         end
 
         response
-      rescue
+      rescue Exception
         ActiveRecord::Base.clear_active_connections! unless testing
         raise
       end

--- a/activerecord/test/cases/connection_management_test.rb
+++ b/activerecord/test/cases/connection_management_test.rb
@@ -80,9 +80,9 @@ module ActiveRecord
       end
 
       def test_connections_closed_if_exception
-        app       = Class.new(App) { def call(env); raise; end }.new
+        app       = Class.new(App) { def call(env); raise NotImplementedError; end }.new
         explosive = ConnectionManagement.new(app)
-        assert_raises(RuntimeError) { explosive.call(@env) }
+        assert_raises(NotImplementedError) { explosive.call(@env) }
         assert !ActiveRecord::Base.connection_handler.active_connections?
       end
 


### PR DESCRIPTION
rescue from all exceptions in `ConnectionManagement#call`
Based on discussion from #11497 

Closes #11497
