### PR TITLE
Improved conditional for iterator

### DIFF
--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -78,7 +78,7 @@ module ActiveModel
     def initialize(params={})
       params.each do |attr, value|
         self.public_send("#{attr}=", value)
-      end if params
+      end if params.present?
 
       super()
     end


### PR DESCRIPTION
Default value for params is {} which isn't falsy. 
So this should save :each from firing up every time with an empty hash.
