### PR TITLE
Remove duplication in include test

### DIFF
--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -56,10 +56,6 @@ class ConcernTest < ActiveSupport::TestCase
     @klass.send(:include, Baz)
     assert_equal "baz", @klass.new.baz
     assert @klass.included_modules.include?(ConcernTest::Baz)
-
-    @klass.send(:include, Baz)
-    assert_equal "baz", @klass.new.baz
-    assert @klass.included_modules.include?(ConcernTest::Baz)
   end
 
   def test_class_methods_are_extended


### PR DESCRIPTION
This is following #11492

This code duplication goes back to 4 years ago, in 783deae99a4850f597135146b19e7ee4622da94e.
Back then, `ActiveSupport::Concern` had a `#use` method, which was removed later on in the profit of the currently used native `#include`.

[This use method](https://github.com/maratvmk/rails/blob/783deae99a4850f597135146b19e7ee4622da94e/activesupport/lib/active_support/core_ext/module/setup.rb#L9) was a bit intrusive.
Therefore, it quite made sense to test that reincluding a module when it has already been didn't just remove it.

Since we now rely on the native include method now, though, there is no use for this anymore.

cc @senny
