### PR TITLE
Uses mysql2 0.3.13 or later.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -1,6 +1,6 @@
 require 'active_record/connection_adapters/abstract_mysql_adapter'
 
-gem 'mysql2', '~> 0.3.10'
+gem 'mysql2', '~> 0.3.13'
 require 'mysql2'
 
 module ActiveRecord


### PR DESCRIPTION
We merged d97269dac70155be19b0a1ee4e1d988988aaebdb.
But in the `mysql2_adapter.rb`, we still use `mysql2 gem 0.3.10 or later`.
So I think we bump gem version in the file.
