### PR TITLE
Fix use of store with hstore

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -67,8 +67,10 @@ module ActiveRecord
 
     module ClassMethods
       def store(store_attribute, options = {})
-        serialize store_attribute, IndifferentCoder.new(options[:coder])
-        store_accessor(store_attribute, options[:accessors]) if options.has_key? :accessors
+        if self.columns_hash[store_attribute.to_s].type != :hstore
+          serialize store_attribute, IndifferentCoder.new(options[:coder])
+        end
+        store_accessor(store_attribute, options[:accessors]) 
       end
 
       def store_accessor(store_attribute, *keys)

--- a/activerecord/test/cases/adapters/postgresql/hstore_store_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_store_test.rb
@@ -1,0 +1,36 @@
+require "cases/helper"
+
+class HstoreStoreTest < ActiveRecord::TestCase
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+
+    unless @connection.supports_extensions?
+      return skip "do not test on PG without hstore"
+    end
+  end
+
+  class Pinky < ActiveRecord::Base
+    self.table_name = 'postgresql_hstores'
+    store :hash_store, accessors: [:intelligence, :charisma]
+  end
+
+  test "can save to a hstore column using 'store'" do
+    pinky = Pinky.new
+    pinky.intelligence = 'notsomuch'
+    pinky.charisma = 'plenty'
+    pinky.save!
+  end
+
+  class Brain < ActiveRecord::Base
+    self.table_name = 'postgresql_hstores'
+    store_accessor :hash_store, [:intelligence, :charisma]
+  end
+
+  test "can save to a hstore column using 'store_accessor'" do
+    brain = Brain.new
+    brain.intelligence = 'overwhelming'
+    brain.charisma = 'insufficient'
+    brain.save!
+  end
+end


### PR DESCRIPTION
The docs for store say that you can use it like this:

```
class User < ActiveRecord::Base
  store :settings, accessors: [ :color, :homepage ]
end
```

This fails when the :settings column is a PostgreSQL Hstore:

```
HstoreStoreTest#test_can_save_to_a_hstore_column_using_'store':
ActiveRecord::StatementInvalid: PG::Error: ERROR:  Syntax error near '!' at position 4
: INSERT INTO "postgresql_hstores" ("hash_store") VALUES ($1) RETURNING "id"
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:779:in `get_last_result'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:779:in `exec_cache'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:139:in `block in exec_query'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:422:in `block in log'
    /vagrant/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:417:in `log'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:137:in `exec_query'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:183:in `exec_insert'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:95:in `insert'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
    /vagrant/rails/activerecord/lib/active_record/relation.rb:63:in `insert'
    /vagrant/rails/activerecord/lib/active_record/persistence.rb:486:in `create_record'
    /vagrant/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:67:in `create_record'
    /vagrant/rails/activerecord/lib/active_record/callbacks.rb:303:in `block in create_record'
    /vagrant/rails/activesupport/lib/active_support/callbacks.rb:82:in `run_callbacks'
    /vagrant/rails/activerecord/lib/active_record/callbacks.rb:303:in `create_record'
    /vagrant/rails/activerecord/lib/active_record/timestamp.rb:57:in `create_record'
    /vagrant/rails/activerecord/lib/active_record/persistence.rb:466:in `create_or_update'
    /vagrant/rails/activerecord/lib/active_record/callbacks.rb:299:in `block in create_or_update'
    /vagrant/rails/activesupport/lib/active_support/callbacks.rb:82:in `run_callbacks'
    /vagrant/rails/activerecord/lib/active_record/callbacks.rb:299:in `create_or_update'
    /vagrant/rails/activerecord/lib/active_record/persistence.rb:128:in `save!'
    /vagrant/rails/activerecord/lib/active_record/validations.rb:57:in `save!'
    /vagrant/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
    /vagrant/rails/activerecord/lib/active_record/transactions.rb:277:in `block in save!'
    /vagrant/rails/activerecord/lib/active_record/transactions.rb:329:in `block in with_transaction_returning_status'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `block in transaction'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:209:in `within_new_transaction'
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:201:in `transaction'
    /vagrant/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
    /vagrant/rails/activerecord/lib/active_record/transactions.rb:326:in `with_transaction_returning_status'
    /vagrant/rails/activerecord/lib/active_record/transactions.rb:277:in `save!'
    test/cases/adapters/postgresql/hstore_store_test.rb:22:in `block in <class:HstoreStoreTest>'
```

Using only store_accessor works fine like this example:

```
class Brain < ActiveRecord::Base
  store_accessor :hstore, [:intelligence, :charisma]
end
```

This commit fixes store's functionality when used for Hstore columns. 

I see two options though:
- store.rb's docs are updated to say you can't use 'store' with hstore columns and you must only use store_accessor
- we keep store functional by doing something like this PR does

Pinging @carlosantoniodasilva since he worked on this bit of code the most.
