### PR TITLE
use sdoc gem for rails 3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,11 +25,7 @@ gem 'rake', '>= 0.8.7'
 gem 'mocha', '>= 0.13.0', :require => false
 
 group :doc do
-  # The current sdoc cannot generate GitHub links due
-  # to a bug, but the PR that fixes it has been there
-  # for some weeks unapplied. As a temporary solution
-  # this is our own fork with the fix.
-  gem 'sdoc',  :git => 'git://github.com/fxn/sdoc.git'
+  gem 'sdoc', '~> 0.3'
   gem 'RedCloth', '~> 4.2'
   gem 'w3c_validators'
 end


### PR DESCRIPTION
I've tested this using rdoc 3.12.2 from Ruby 1.9.3 and sdoc gem version 0.3.20, and everything seems ok including the github links.

/cc @fxn and 4936fc3
