### PR TITLE
text_area should handle nil value option like text_field

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Fix `text_area` to behave like `text_field` when `nil` is given as
+    value.
+
+    Before:
+
+        f.text_field :field, value: nil #=> <input value="">
+        f.text_area :field, value: nil  #=> <textarea>value of field</textarea>
+
+    After:
+
+        f.text_area :field, value: nil  #=> <textarea></textarea>
+
+    *Joel Cogen*
+
 *   Element of the `grouped_options_for_select` can
     optionally contain html attributes as the last element of the array.
 

--- a/actionview/lib/action_view/helpers/tags/text_area.rb
+++ b/actionview/lib/action_view/helpers/tags/text_area.rb
@@ -10,7 +10,7 @@ module ActionView
             options["cols"], options["rows"] = size.split("x") if size.respond_to?(:split)
           end
 
-          content_tag("textarea", options.delete('value') || value_before_type_cast(object), options)
+          content_tag("textarea", options.delete("value") { value_before_type_cast(object) }, options)
         end
       end
     end

--- a/actionview/lib/action_view/helpers/tags/text_field.rb
+++ b/actionview/lib/action_view/helpers/tags/text_field.rb
@@ -5,8 +5,8 @@ module ActionView
         def render
           options = @options.stringify_keys
           options["size"] = options["maxlength"] unless options.key?("size")
-          options["type"]  ||= field_type
-          options["value"] = options.fetch("value"){ value_before_type_cast(object) } unless field_type == "file"
+          options["type"] ||= field_type
+          options["value"] = options.fetch("value") { value_before_type_cast(object) } unless field_type == "file"
           options["value"] &&= ERB::Util.html_escape(options["value"])
           add_default_name_and_id(options)
           tag("input", options)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -676,6 +676,13 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_text_area_with_nil_alternate_value
+    assert_dom_equal(
+      %{<textarea id="post_body" name="post[body]">\n</textarea>},
+      text_area("post", "body", value: nil)
+    )
+  end
+
   def test_text_area_with_html_entities
     @post.body = "The HTML Entity for & is &amp;"
     assert_dom_equal(


### PR DESCRIPTION
Before:

```
f.text_field :field, value: nil #=> <input value="">
f.text_area :field, value: nil  #=> <textarea>value of field</textarea>
```

`text_field` uses `options.fetch` with a block to specify the default value, whereas `text_area` uses `||`. When given a value of `nil`, this makes `text_field` use the `nil` value because the key exists, whereas `text_area` will go for the default.

After:

```
f.text_area :field, value: nil  #=> <textarea></textarea>
```

I modified `text_area` to also use a block. This makes both helpers behave the same way, which is IMO the expected behaviour when you explicitly pass `nil` as value.
