### PR TITLE
Fix assign ip address with invalid values raise exception

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Assign inet/cidr attribute with `nil` value for invalid address.
+
+    Example:
+
+        record = User.new
+
+        record.logged_in_from_ip # is type of an inet or a cidr
+
+        # Before:
+        record.logged_in_from_ip = 'bad ip address' # raise exception
+
+        # After:
+        record.logged_in_from_ip = 'bad ip address' # do not raise exception
+        record.logged_in_from_ip # => nil
+        record.logged_in_from_ip_before_type_cast # => 'bad ip address'
+
+    *Paul Nikitochkin*
+
 *   `add_to_target` now accepts a second optional `skip_callbacks` argument
 
     If truthy, it will skip the :before_add and :after_add callbacks.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -100,7 +100,11 @@ module ActiveRecord
           if string.nil?
             nil
           elsif String === string
-            IPAddr.new(string)
+            begin
+              IPAddr.new(string)
+            rescue ArgumentError
+              nil
+            end
           else
             string
           end

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -558,6 +558,20 @@ _SQL
     assert_raise(ActiveRecord::StatementInvalid) { assert @first_bit_string.save }
   end
 
+  def test_invalid_network_address
+    @first_network_address.cidr_address = 'invalid addr'
+    assert_nil @first_network_address.cidr_address
+    assert_equal 'invalid addr', @first_network_address.cidr_address_before_type_cast
+    assert @first_network_address.save
+
+    @first_network_address.reload
+
+    @first_network_address.inet_address = 'invalid addr'
+    assert_nil @first_network_address.inet_address
+    assert_equal 'invalid addr', @first_network_address.inet_address_before_type_cast
+    assert @first_network_address.save
+  end
+
   def test_update_oid
     new_value = 567890
     assert @first_oid.obj_id = new_value


### PR DESCRIPTION
Closes #11552 

In order that set attribute should not be bang method, rescue invalid ip address exceptions.

There is two options to resolve #11552 issue:
- remain invalid value as attribute value and rescue all exceptions on type casting, like I have proposed in this PR
- return default `IPAddr.new` value like `BigDecimal` does: `IPAddr.new 'invalid' #=> #<IPAddr: IPv6:0000:0000:0000:0000:0000:0000:0000:0000/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff>`

What do you think about second solution?
