### PR TITLE
Simplify select_one method.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -26,8 +26,7 @@ module ActiveRecord
       # Returns a record hash with the column names as keys and column values
       # as values.
       def select_one(arel, name = nil, binds = [])
-        result = select_all(arel, name, binds)
-        result.first if result
+        select_all(arel, name, binds).first
       end
 
       # Returns a single value from a record

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -374,14 +374,14 @@ module ActiveRecord
           update_sql(sql, name)
         end
 
-      def sql_for_insert(sql, pk, id_value, sequence_name, binds)
-        [sql, binds]
-      end
-
-      def last_inserted_id(result)
-        row = result.rows.first
-        row && row.first
-      end
+        def sql_for_insert(sql, pk, id_value, sequence_name, binds)
+          [sql, binds]
+        end
+  
+        def last_inserted_id(result)
+          row = result.rows.first
+          row && row.first
+        end
     end
   end
 end


### PR DESCRIPTION
tiny refactor :)

The select_all method always returns ActiveRecord::Result instance,
and the ActiveRecord::Result includes Enumerable mixin.
If an ActiveRecord::Result instance is empty, #first method returns nil. Thus we can simplify this method.

and I found an indentaion problem.
