### PR TITLE
don't convert mailer default values to procs

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -56,4 +56,10 @@
     settings, headers, attachments, delivery settings or change delivery using
     `before_filter`, `after_filter`, etc. *Justin S. Leitgeb*
 
+*   invoke mailer defaults as procs only if they are procs, do not convert
+    with to_proc.  That an object is convertible to a proc does not mean it's
+    meant to be always used as a proc.  Fixes #11533
+
+    *Alex Tsukernik*
+
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/actionmailer/CHANGELOG.md) for previous changes.

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -670,7 +670,7 @@ module ActionMailer
       # Call all the procs (if any)
       class_default = self.class.default
       default_values = class_default.merge(class_default) do |k,v|
-        v.respond_to?(:to_proc) ? instance_eval(&v) : v
+        v.is_a?(Proc) ? instance_eval(&v) : v
       end
 
       # Handle defaults

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -578,6 +578,10 @@ class BaseTest < ActiveSupport::TestCase
     assert(mail1.to_s.to_i > mail2.to_s.to_i)
   end
 
+  test 'default values which have to_proc (e.g. symbols) should not be considered procs' do
+    assert(ProcMailer.welcome['x-has-to-proc'].to_s == 'symbol')
+  end
+
   test "we can call other defined methods on the class as needed" do
     mail = ProcMailer.welcome
     assert_equal("Thanks for signing up this afternoon", mail.subject)

--- a/actionmailer/test/mailers/proc_mailer.rb
+++ b/actionmailer/test/mailers/proc_mailer.rb
@@ -1,7 +1,8 @@
 class ProcMailer < ActionMailer::Base
   default to: 'system@test.lindsaar.net',
           'X-Proc-Method' => Proc.new { Time.now.to_i.to_s },
-          subject: Proc.new { give_a_greeting }
+          subject: Proc.new { give_a_greeting },
+          'x-has-to-proc' => :symbol
 
   def welcome
     mail


### PR DESCRIPTION
Invoke mailer defaults as procs only if they are procs, do not convert
with to_proc.  That an object is convertible to a proc does not mean it's
meant to be always used as a proc.  Fixes #11533

Conflicts:
    actionmailer/CHANGELOG.md
