### PR TITLE
ActionMailer Guide: Should be "different formats".

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -378,7 +378,7 @@ Just like with controller views, use `yield` to render the view inside the
 layout.
 
 You can also pass in a `layout: 'layout_name'` option to the render call inside
-the format block to specify different layouts for different actions:
+the format block to specify different layouts for different formats:
 
 ```ruby
 class UserMailer < ActionMailer::Base


### PR DESCRIPTION
Just a typo.
