### PR TITLE
:tables method in PostgreSQL respects the schema parameter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `tables` for PostgreSQL respects the "schema" parameter and fetches
+    tables only from that schema when it is supplied (the parameter used to
+    be called "name" and was not used anywhere in the method)
+
+    *Gilad Zohari*
+
 *   Don't allow `quote_value` to be called without a column.
 
     Some adapters require column information to do their job properly.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -88,12 +88,16 @@ module ActiveRecord
           execute "DROP DATABASE IF EXISTS #{quote_table_name(name)}"
         end
 
-        # Returns the list of all tables in the schema search path or a specified schema.
-        def tables(name = nil)
+        # Returns all table names
+        #
+        # If a specific schema is specified, it will list tables from
+        # that schema only, otherwise, it will list tables from
+        # the current schema search path
+        def tables(schema=nil)
           query(<<-SQL, 'SCHEMA').map { |row| row[0] }
             SELECT tablename
             FROM pg_tables
-            WHERE schemaname = ANY (current_schemas(false))
+            WHERE schemaname = #{schema ? "'#{schema}'" : 'ANY (current_schemas(false))'}
           SQL
         end
 


### PR DESCRIPTION
When the 'schema' param is supplied, the method should only fetch
tables from that schema (param was previously defined as 'name'
and was not used in the method). Otherwise, it should fetch all tables
from the current search path.
