### PR TITLE
Allow running db:structure:dump and db:structure:load when using Mysql2 and specifying a port in config/database.yml

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -136,7 +136,7 @@ IDENTIFIED BY '#{configuration['password']}' WITH GRANT OPTION;
         configuration.slice('host', 'port', 'socket').each do |k, v|
           args.concat([ "--#{k}", v ]) if v
         end
-        args
+        args.map(&:to_s)
       end
     end
   end

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -270,6 +270,13 @@ module ActiveRecord
       ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
     end
 
+    def test_structure_dump_accepts_numeric_configuration_options
+      filename = "awesome-file.sql"
+      Kernel.expects(:system).with("mysqldump", "--port", "3306", "--result-file", filename, "--no-data", "test-db").returns(true)
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration.merge("port" => 3306), filename)
+    end
+
     def test_warn_when_external_structure_dump_fails
       filename = "awesome-file.sql"
       Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "test-db").returns(false)
@@ -295,6 +302,13 @@ module ActiveRecord
       Kernel.expects(:system).with('mysql', '--execute', %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db")
 
       ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+    end
+
+    def test_structure_load_accepts_numeric_configuration_options
+      filename = "awesome-file.sql"
+      Kernel.expects(:system).with('mysql', "--port", "3306", '--execute', %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db")
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration.merge("port" => 3306), filename)
     end
   end
 


### PR DESCRIPTION
When using MySQL, the **ActiveRecord** rake tasks `db:structure:dump` and `db:structure:load` rely on calls to `Kernel.system` for shelling out to `mysqldump` and `mysql`. The `Kernel.system` method expects its arguments to be `String`s. However, the `Mysql2` client expects to be passed a numeric port number, which will be given in `database.yml` as a `Fixnum`.

The current code, with a `database.yml` like:

``` yaml
development:
  adapter: mysql2
  port: 3306
```

 raises an error like:

``` shell
$ my-app > rake db:structure:dump
rake aborted!
can't convert Fixnum into String
/Users/matt/code/my-app/vendor/gems/ruby/1.9.1/gems/activerecord-4.0.0/lib/active_record/tasks/mysql_database_tasks.rb:63:in `system'
/Users/matt/code/my-app/vendor/gems/ruby/1.9.1/gems/activerecord-4.0.0/lib/active_record/tasks/mysql_database_tasks.rb:63:in `structure_dump'
/Users/matt/code/my-app/vendor/gems/ruby/1.9.1/gems/activerecord-4.0.0/lib/active_record/tasks/database_tasks.rb:142:in `structure_dump'
/Users/matt/code/my-app/vendor/gems/ruby/1.9.1/gems/activerecord-4.0.0/lib/active_record/railties/databases.rake:288:in `block (3 levels) in <top (required)>'
Tasks: TOP => db:structure:dump
(See full trace by running task with --trace)
```

This PR casts all the arguments intended to be passed to `Kernel.system` to `String`s inside of `prepare_command_options`.
