### PR TITLE
Make try with no arguments return a TryProxy

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/try.rb
+++ b/activesupport/lib/active_support/core_ext/object/try.rb
@@ -56,7 +56,7 @@ class Object
     if a.empty? && block_given?
       yield self
     elsif a.empty?
-      ActiveSupport::TryProxy::Raising.new(self)
+      self
     else
       public_send(*a, &b)
     end

--- a/activesupport/lib/active_support/try_proxy.rb
+++ b/activesupport/lib/active_support/try_proxy.rb
@@ -8,16 +8,6 @@ module ActiveSupport
       @object.public_send(mid, *args, &bk) if @object.respond_to?(mid)
     end
 
-    class Raising < BasicObject
-      def initialize(object)
-        @object = object
-      end
-
-      def method_missing(mid, *args, &bk)
-        @object.public_send(mid, *args, &bk)
-      end
-    end
-
     class Nil < BasicObject
       def method_missing(*)
         nil

--- a/activesupport/lib/active_support/try_proxy.rb
+++ b/activesupport/lib/active_support/try_proxy.rb
@@ -1,0 +1,27 @@
+module ActiveSupport
+  class TryProxy < BasicObject
+    def initialize(object)
+      @object = object
+    end
+
+    def method_missing(mid, *args, &bk)
+      @object.public_send(mid, *args, &bk) if @object.respond_to?(mid)
+    end
+
+    class Raising < BasicObject
+      def initialize(object)
+        @object = object
+      end
+
+      def method_missing(mid, *args, &bk)
+        @object.public_send(mid, *args, &bk)
+      end
+    end
+
+    class Nil < BasicObject
+      def method_missing(*)
+        nil
+      end
+    end
+  end
+end

--- a/activesupport/test/core_ext/object_and_class_ext_test.rb
+++ b/activesupport/test/core_ext/object_and_class_ext_test.rb
@@ -178,4 +178,16 @@ class ObjectTryTest < ActiveSupport::TestCase
 
     assert_nil klass.new.try(:private_method)
   end
+
+  def test_try_with_no_arguments
+    assert_equal "ell", "hello".try[1...-1]
+    assert_equal nil, nil.try[1...-1]
+    assert_equal nil, "hello".try.undefined_method
+  end
+
+  def test_try_bang_with_no_arguments
+    assert_equal "ell", "hello".try![1...-1]
+    assert_equal nil, nil.try![1...-1]
+    assert_raise(NoMethodError) { "hello".try!.undefined_method }
+  end
 end


### PR DESCRIPTION
I often see code along the lines of:

``` ruby
foo.try(:[], 0)
```

I find this harder to read than it should be.

This pull request changes the `try` method so that it returns an `ActiveSupport::TryProxy` when called without arguments. This proxy then forwards any methods sent to it to the original object.

For example, the above code can be rewritten as:

``` ruby
foo.try[0]
```

This does not break existing functionality. At the moment, calling `try` with no arguments raises an exception:

``` irb
>> 123.try
TypeError: nil is not a symbol
from /Users/charlie/.gem/ruby/2.0.0/gems/activesupport-4.0.0/lib/active_support/core_ext/object/try.rb:45:in `respond_to?'
>> 123.try!
ArgumentError: no method name given
from /Users/charlie/.gem/ruby/2.0.0/gems/activesupport-4.0.0/lib/active_support/core_ext/object/try.rb:55:in `public_send'
```
