### PR TITLE
cleanup the file name from the generators usage file [ci skip]

### DIFF
--- a/railties/lib/rails/generators/rails/generator/USAGE
+++ b/railties/lib/rails/generators/rails/generator/USAGE
@@ -6,8 +6,7 @@ Example:
     `rails generate generator Awesome`
 
     creates a standard awesome generator:
-        lib/generators/awesome/
+        lib/generators/awesome
         lib/generators/awesome/awesome_generator.rb
         lib/generators/awesome/USAGE
-        lib/generators/awesome/templates/
-        test/lib/generators/awesome_generator_test.rb
+        lib/generators/awesome/templates


### PR DESCRIPTION
while I was executing the commands <b>rails generate generator Awesome</b>

It gave https://gist.github.com/rajcybage/8f7c43c1034845bd7c55

Not any file "test/lib/generators/awesome_generator_test.rb" 
