### PR TITLE
Update attributes with block

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -222,11 +222,12 @@ module ActiveRecord
     # Updates the attributes of the model from the passed-in hash and saves the
     # record, all wrapped in a transaction. If the object is invalid, the saving
     # will fail and false will be returned.
-    def update(attributes)
+    def update(attributes = nil)
       # The following transaction covers any possible database side-effects of the
       # attributes assignment. For example, setting the IDs of a child collection.
       with_transaction_returning_status do
-        assign_attributes(attributes)
+        assign_attributes(attributes) if attributes
+        yield self if block_given?
         save
       end
     end
@@ -235,11 +236,12 @@ module ActiveRecord
 
     # Updates its receiver just like +update+ but calls <tt>save!</tt> instead
     # of +save+, so an exception is raised if the record is invalid.
-    def update!(attributes)
+    def update!(attributes = nil)
       # The following transaction covers any possible database side-effects of the
       # attributes assignment. For example, setting the IDs of a child collection.
       with_transaction_returning_status do
-        assign_attributes(attributes)
+        assign_attributes(attributes) if attributes
+        yield self if block_given?
         save!
       end
     end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -701,6 +701,24 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal topic.title, Topic.find(1234).title
   end
 
+  def test_update_attributes_with_block
+    topic = Topic.find(1)
+    assert !topic.approved?
+    assert_equal "The First Topic", topic.title
+
+    topic.update_attributes do |topic|
+      topic.title = 'Topic with block updated'
+    end
+    topic.reload
+    assert_equal 'Topic with block updated', topic.title
+
+    topic.update_attributes("approved" => true, "title" => "Topic should be overriden by block") do |topic|
+      topic.title = 'Topic with block updated'
+    end
+    topic.reload
+    assert_equal 'Topic with block updated', topic.title
+  end
+
   def test_update!
     Reply.validates_presence_of(:title)
     reply = Reply.find(2)

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -706,14 +706,14 @@ class PersistenceTest < ActiveRecord::TestCase
     assert !topic.approved?
     assert_equal "The First Topic", topic.title
 
-    topic.update_attributes do |topic|
-      topic.title = 'Topic with block updated'
+    topic.update_attributes do |t|
+      t.title = 'Topic with block updated'
     end
     topic.reload
     assert_equal 'Topic with block updated', topic.title
 
-    topic.update_attributes("approved" => true, "title" => "Topic should be overriden by block") do |topic|
-      topic.title = 'Topic with block updated'
+    topic.update_attributes("approved" => true, "title" => "Topic should be overriden by block") do |t|
+      t.title = 'Topic with block updated'
     end
     topic.reload
     assert_equal 'Topic with block updated', topic.title


### PR DESCRIPTION
References issue #992

_Not sure why this was never integrated (or removed), but I think it has a valid use case_

ActiveRecord::Base#new and #create accepts both a Hash of attributes and a block:

``` ruby
  User.create(:first_name => 'Jamie') do |u|
    u.is_admin = false
  end
```

This patch adds that same functionality to update_attributes:

``` ruby
  user.update_attributes(:first_name => 'Jamie') do |u|
    u.is_admin = false
  end
  user.first_name #=> 'Jamie'
  user.is_admin   #=> false
```

A use case for this is in the administration area, where authenticated users might be allowed to update attributes that are otherwise protected.
