### PR TITLE
Remove $VERBOSE = nil from tasks.rb

### DIFF
--- a/railties/lib/rails/tasks.rb
+++ b/railties/lib/rails/tasks.rb
@@ -1,5 +1,3 @@
-$VERBOSE = nil
-
 # Load Rails Rakefile extensions
 %w(
   annotations


### PR DESCRIPTION
Permanently setting $VERBOSE to nil causes unwanted side effects (warnings
generated by app code are silenced when triggered by a rake task but visible
otherwise). silence_warnings {} would be safer to use here since it resets
$VERBOSE back to what it was when the block finishes.
