### PR TITLE
JSON serializer options now accept optional names.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Added more options to JSON serialization. `only` and `methods` options now accept hashes
+    with a new name in which to store the results. `include` option now accepts a `root` key
+    that specifies the name under which the association will be stored.
+
+    *Sergio Campamá*
+
 *   Fix has_secure_password. `password_confirmation` validations are triggered
     even if no `password_confirmation` is set.
 

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -213,4 +213,22 @@ class JsonSerializationTest < ActiveModel::TestCase
     assert_no_match %r{"awesome":}, json
     assert_no_match %r{"preferences":}, json
   end
+
+  test "only option with hashes should return json with new name" do
+    json = @contact.to_json(only: {name: :new_name, age: :oldness})
+
+    assert_match %r{"new_name":"Konata Izumi"}, json
+    assert_match %r{"oldness":16}, json
+    assert_no_match %r{"name"}, json
+    assert_no_match %r{"age"}, json
+
+  end
+
+  test "methods options with hashes should return json with new method names" do
+    def @contact.last_name_and_age; @name.split(" ").last + " " + @age.to_s; end
+    json = @contact.to_json(methods: {last_name_and_age: :classification})
+
+    assert_match %r{"classification":"Izumi 16"}, json
+    assert_no_match %r{"last_name_and_age"}, json
+  end
 end

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -286,8 +286,12 @@ class Hash
   def as_json(options = nil) #:nodoc:
     # create a subset of the hash by applying :only or :except
     subset = if options
-      if attrs = options[:only]
-        slice(*Array(attrs))
+      if only = options[:only]
+        if only.is_a?(Hash)
+          Hash[slice(*Array(only.keys)).map { |k,v| [only[k], v]}]
+        else
+          slice(*Array(only))
+        end
       elsif attrs = options[:except]
         except(*Array(attrs))
       else

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -328,6 +328,20 @@ class TestJSONEncoding < ActiveSupport::TestCase
     assert_equal false, false.as_json
   end
 
+  def test_only_option_with_new_names
+    people = [
+      { :name => 'John', :address => { :city => 'London', :country => 'UK' }},
+      { :name => 'Jean', :address => { :city => 'Paris' , :country => 'France' }}
+    ]
+    json = people.as_json :only => {address: :location, city: :province}
+    expected = [
+      { 'location' => { 'province' => 'London' }},
+      { 'location' => { 'province' => 'Paris' }}
+    ]
+
+    assert_equal(expected, json)
+  end
+
   protected
 
     def object_keys(json_object)


### PR DESCRIPTION
'only' and 'methods' options for the JSON serializer now accept hashes
in which the key is the attribute to store and the value is the name in
which the result will be stored. 'include' now accepts a root option
that will be the name the association will be stored under.

```
person = Person.create(name: "Bob")
person.to_json(only: {name: :real_name})
  => "{\"real_name\":\"Bob\"}"

person.to_json(methods: {full_name: :new_name})
  => "{\"new_name\":\"Bob McKenzie\"}"

person.to_json(only :name, include: {children: {root: :kids, only:
  :name}})
  => "{\"name\":\"Bob\",\"kids\":[{\"name\":\"Jimmy\"}]"
```
