### PR TITLE
Excluding action_view/vendor in API[ci skip]

### DIFF
--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -41,7 +41,8 @@ module Rails
           :include => %w(
             README.rdoc
             lib/action_view/**/*.rb
-          )
+          ),
+          :exclude => 'lib/action_view/vendor/*'
         },
 
         'actionmailer' => {

--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -16,8 +16,7 @@ module Rails
           :include => %w(
             README.rdoc
             lib/active_record/**/*.rb
-          ),
-          :exclude => 'lib/active_record/vendor/*'
+          )
         },
 
         'activemodel' => {
@@ -33,8 +32,7 @@ module Rails
             lib/abstract_controller/**/*.rb
             lib/action_controller/**/*.rb
             lib/action_dispatch/**/*.rb
-          ),
-          :exclude => 'lib/action_controller/vendor/*'
+          )
         },
 
         'actionview' => {
@@ -49,8 +47,7 @@ module Rails
           :include => %w(
             README.rdoc
             lib/action_mailer/**/*.rb
-          ),
-          :exclude => 'lib/action_mailer/vendor/*'
+          )
         },
 
         'railties' => {


### PR DESCRIPTION
We don't need to include vender in API generation
Same as we are not including in others
