### PR TITLE
Update getting_started.md

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -514,11 +514,12 @@ module ActionDispatch
           @recall      = recall.dup
           @set         = set
 
+          normalize_recall!
           normalize_options!
           normalize_controller_action_id!
           use_relative_controller!
           normalize_controller!
-          handle_nil_action!
+          normalize_action!
         end
 
         def controller
@@ -537,6 +538,11 @@ module ActionDispatch
           end
         end
 
+        # Set 'index' as default action for recall
+        def normalize_recall!
+          @recall[:action] ||= 'index'
+        end
+
         def normalize_options!
           # If an explicit :controller was given, always make :action explicit
           # too, so that action expiry works as expected for things like
@@ -552,8 +558,8 @@ module ActionDispatch
             options[:controller]   = options[:controller].to_s
           end
 
-          if options[:action]
-            options[:action] = options[:action].to_s
+          if options.key?(:action)
+            options[:action] = (options[:action] || 'index').to_s
           end
         end
 
@@ -563,8 +569,6 @@ module ActionDispatch
         # :controller, :action or :id is not found, don't pull any
         # more keys from the recall.
         def normalize_controller_action_id!
-          @recall[:action] ||= 'index' if current_controller
-
           use_recall_for(:controller) or return
           use_recall_for(:action) or return
           use_recall_for(:id)
@@ -586,13 +590,11 @@ module ActionDispatch
           @options[:controller] = controller.sub(%r{^/}, '') if controller
         end
 
-        # This handles the case of action: nil being explicitly passed.
-        # It is identical to action: "index"
-        def handle_nil_action!
-          if options.has_key?(:action) && options[:action].nil?
-            options[:action] = 'index'
+        # Move 'index' action from options to recall
+        def normalize_action!
+          if @options[:action] == 'index'
+            @recall[:action] = @options.delete(:action)
           end
-          recall[:action] = options.delete(:action) if options[:action] == 'index'
         end
 
         # Generates a path from routes, returns [path, params].

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -644,7 +644,11 @@ Visit <http://localhost:3000/posts/new> and give it a try!
 
 ![Show action for posts](images/getting_started/show_action_for_posts.png)
 
-TIP: Note that `def post_params` is private. This new approach prevents an attacker from
+TIP: Note that def post_params is private, this also includes everything below the keyword 'private'. 
+This new approach prevents an attacker from setting the model's attributes by manipulating the hash 
+passed to the model. If you encounter an error about missing params try moving the whole function above
+the 'private' keyword.
+
 setting the model's attributes by manipulating the hash passed to the model.
 For more information, refer to
 [this blog post about Strong Parameters](http://weblog.rubyonrails.org/2012/3/21/strong-parameters/).


### PR DESCRIPTION
I changed a tip below some ruby code in "5.7 showing posts"
to make it apparent that anything below the keyword 'private' is also included as being private rather then just the definition immediately below it

it now reads as :

Note that `def post_params` is private, this also includes everything below the keyword 'private'. 
This new approach prevents an attacker from setting the model's attributes by manipulating the hash 
passed to the model. If you encounter an error about missing params try moving the whole function above
the 'private' keyword.
