### PR TITLE
AC::Base.looger => AV::Base.logger

### DIFF
--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -100,7 +100,7 @@ module ActionController
       begin
         yield output
       ensure
-        ActionController::Base.logger = old_logger
+        ActionView::Base.logger = old_logger
       end
     end
 


### PR DESCRIPTION
We can use ActionView::Base.logger instead of AC::Base.logger as https://github.com/rails/rails/commit/9b0ac0bc74569db460f87ea6888b3847be0ff5be
