### PR TITLE
Use class_attribute or accessor instead of method

### DIFF
--- a/actionpack/test/controller/layout_test.rb
+++ b/actionpack/test/controller/layout_test.rb
@@ -12,7 +12,7 @@ ActionView::Template::register_template_handler :mab,
 ActionController::Base.view_paths = [ File.dirname(__FILE__) + '/../fixtures/layout_tests/' ]
 
 class LayoutTest < ActionController::Base
-  def self.controller_path; 'views' end
+  self.controller_path = 'views'
   def self._implied_layout_name; to_s.underscore.gsub(/_controller$/, '') ; end
   self.view_paths = ActionController::Base.view_paths.dup
 end

--- a/actionpack/test/controller/new_base/base_test.rb
+++ b/actionpack/test/controller/new_base/base_test.rb
@@ -33,14 +33,14 @@ module Dispatching
   class EmptyController < ActionController::Base ; end
   class SubEmptyController < EmptyController ; end
   class NonDefaultPathController < ActionController::Base
-    def self.controller_path; "i_am_not_default"; end
+    self.controller_path = "i_am_not_default"
   end
 
   module Submodule
     class ContainedEmptyController < ActionController::Base ; end
     class ContainedSubEmptyController < ContainedEmptyController ; end
     class ContainedNonDefaultPathController < ActionController::Base
-      def self.controller_path; "i_am_extremely_not_default"; end
+      self.controller_path = "i_am_extremely_not_default"
     end
   end
 

--- a/actionpack/test/controller/view_paths_test.rb
+++ b/actionpack/test/controller/view_paths_test.rb
@@ -2,7 +2,7 @@ require 'abstract_unit'
 
 class ViewLoadPathsTest < ActionController::TestCase
   class TestController < ActionController::Base
-    def self.controller_path() "test" end
+    self.controller_path = "test"
 
     before_action :add_view_path, only: :hello_world_at_request_time
 

--- a/activerecord/test/models/column_name.rb
+++ b/activerecord/test/models/column_name.rb
@@ -1,3 +1,3 @@
 class ColumnName < ActiveRecord::Base
-  def self.table_name () "colnametests" end
+  self.table_name = "colnametests"
 end


### PR DESCRIPTION
Use: self.foo = 'bar' when accessor or class_attribute exist
Instead of: def self.foo; 'bar'; end
