### PR TITLE
Update Rails 3.2.x guide link [ci skip]

### DIFF
--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -15,7 +15,7 @@
 </p>
 <% end %>
 <p>
-  The guides for Rails 3.2.x are available at <a href="http://guides.rubyonrails.org/v3.2.13/">http://guides.rubyonrails.org/v3.2.13/</a>.
+  The guides for Rails 3.2.x are available at <a href="http://guides.rubyonrails.org/v3.2.14/">http://guides.rubyonrails.org/v3.2.14/</a>.
 </p>
 <p>
   The guides for Rails 2.3.x are available at <a href="http://guides.rubyonrails.org/v2.3.11/">http://guides.rubyonrails.org/v2.3.11/</a>.


### PR DESCRIPTION
Rails 3.2.14 was released, yet 3.2.x link in the guide still points to 3.2.13.
