### PR TITLE
Restore response.stream in render_to_string with ActionController::Live

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Fix `render_to_string` in `ActionController::Live` to not break `response.stream`;
+    By wrapping `render_to_string` method to restore `response.stream` too.
+
+    This will work properly by this fix:
+
+        class FooController < ActionController::Base
+          include ActionController::Live
+
+          def streaming
+            response.stream.write "foo\n"
+
+            # This breaks existing response.stream before
+            render_to_string(text: 'zomg')
+
+            response.stream.write "bar\n"
+            response.stream.close
+          end
+        end
+
+    *Shota Fukumori (sora_h)*
+
 *   Allow REMOTE_ADDR, HTTP_HOST and HTTP_USER_AGENT to be overridden from
     the environment passed into `ActionDispatch::TestRequest.new`.
 

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -91,6 +91,8 @@ module ActionController
         end
       end
 
+      attr_writer :stream
+
       def commit!
         headers.freeze
         super
@@ -156,6 +158,13 @@ module ActionController
       message << exception.annoted_source_code.to_s if exception.respond_to?(:annoted_source_code)
       message << "  " << exception.backtrace.join("\n  ")
       logger.fatal("#{message}\n\n")
+    end
+
+    def render_to_string(*)
+      orig_stream = response.stream
+      super
+    ensure
+      response.stream = orig_stream if orig_stream
     end
 
     def response_body=(body)

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -16,6 +16,13 @@ module ActionController
         render :text => 'zomg'
       end
 
+      def render_string
+        response.stream.write 'foo'
+        rendered = render_to_string(:text => 'bar')
+        response.stream.write rendered
+        response.stream.close
+      end
+
       def default_header
         response.stream.write "<html><body>hi</body></html>"
         response.stream.close
@@ -157,6 +164,12 @@ module ActionController
     def test_render_text
       get :render_text
       assert_equal 'zomg', response.body
+      assert_stream_closed
+    end
+
+    def test_render_string
+      get :render_string
+      assert_equal 'foobar', response.body
       assert_stream_closed
     end
 


### PR DESCRIPTION
Fix `render_to_string` in `ActionController::Live` to not break `response.stream`;
By wrapping `render_to_string` method to restore `response.stream` too.

Because `render_to_string` modifies `response_body` temporally, but
it doesn't restore `response.stream`.

This will work properly by this fix:

``` ruby
class FooController < ActionController::Base
  include ActionController::Live

  def streaming
    response.stream.write "foo\n"

    # This breaks existing response.stream before
    render_to_string(text: 'foo')

    # This will raise IOError because render_to_string re-news `response.stream`,
    # and it has closed by `ActionController::Live#response_body=`
    response.stream.write "bar\n"
    response.stream.close
  end
end
```

Confirmed this can reproduce at Rails 4.0.0 too.
