### PR TITLE
Modify the Hash#assert_valid_keys error message to provide better information.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Show valid keys when assert_valid_keys raises an exception.
+    And show the wrong value as it was entered.
+
+    *Gonzalo Rodríguez-Baltanás Díaz*
+
 *   Don't allow `quote_value` to be called without a column.
 
     Some adapters require column information to do their job properly.

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -61,13 +61,13 @@ class Hash
   # on a mismatch. Note that keys are NOT treated indifferently, meaning if you
   # use strings for keys but assert symbols as keys, this will fail.
   #
-  #   { name: 'Rob', years: '28' }.assert_valid_keys(:name, :age) # => raises "ArgumentError: Unknown key: years"
-  #   { name: 'Rob', age: '28' }.assert_valid_keys('name', 'age') # => raises "ArgumentError: Unknown key: name"
+  #   { name: 'Rob', years: '28' }.assert_valid_keys(:name, :age) # => raises "ArgumentError: Unknown key: :years. Valid keys are: :name, :age"
+  #   { name: 'Rob', age: '28' }.assert_valid_keys('name', 'age') # => raises "ArgumentError: Unknown key: :name. Valid keys are: 'name', 'age'"
   #   { name: 'Rob', age: '28' }.assert_valid_keys(:name, :age)   # => passes, raises nothing
   def assert_valid_keys(*valid_keys)
     valid_keys.flatten!
     each_key do |k|
-      raise ArgumentError.new("Unknown key: #{k}") unless valid_keys.include?(k)
+      raise ArgumentError.new("Unknown key: #{k.inspect}. Valid keys are: #{valid_keys.map(&:inspect).join(', ')}") unless valid_keys.include?(k)
     end
   end
 

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -624,7 +624,7 @@ class HashExtTest < ActiveSupport::TestCase
       { :failure => "stuff", :funny => "business" }.assert_valid_keys(:failure, :funny)
     end
 
-    assert_raise(ArgumentError, "Unknown key: failore") do
+    assert_raise(ArgumentError, "Unknown key: :failore. Valid keys are: :failure, :funny") do
       { :failore => "stuff", :funny => "business" }.assert_valid_keys([ :failure, :funny ])
       { :failore => "stuff", :funny => "business" }.assert_valid_keys(:failure, :funny)
     end


### PR DESCRIPTION
Modify the Hash#assert_valid_keys error message so that:
- It shows the valid keys. 
- Show the wrong value as it was entered.
# Previously

``` ruby
{ :failore => "stuff", :funny => "business" }.assert_valid_keys([ :failure, :funny ])
# => ArgumentError: Unknown key: failore
{ 'failore' => "stuff", :funny => "business" }.assert_valid_keys([ :failure, :funny ])
# => ArgumentError: Unknown key: failore
```
# Now

``` ruby
{ 'failore' => "stuff", :funny => "business" }.assert_valid_keys([ :failure, :funny ])
# => ArgumentError: Unknown key: "failore". Valid keys are: :failure, :funny

{ :failore => "stuff", :funny => "business" }.assert_valid_keys([ :failure, :funny ])
# => ArgumentError: Unknown key: :failore. Valid keys are: :failure, :funny
```
