### PR TITLE
Minor refactor - Uses Enumerable#to_a instead of iterate and add to an array

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/grouping.rb
+++ b/activesupport/lib/active_support/core_ext/array/grouping.rb
@@ -31,9 +31,7 @@ class Array
     if block_given?
       collection.each_slice(number) { |slice| yield(slice) }
     else
-      groups = []
-      collection.each_slice(number) { |group| groups << group }
-      groups
+      collection.each_slice(number).to_a
     end
   end
 

--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -119,7 +119,7 @@ class Date
       options.fetch(:day, day)
     )
   end
-  
+
   # Allow Date to be compared with Time by converting to DateTime and relying on the <=> from there.
   def compare_with_coercion(other)
     if other.is_a?(Time)

--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -235,7 +235,6 @@ module ActiveSupport
         value.map! { |i| deep_to_h(i) }
         value.length > 1 ? value : value.first
       end
-
   end
 end
 


### PR DESCRIPTION
The [Enumerable#to_a](http://ruby-doc.org/core-2.0/Enumerable.html#method-i-to_a) do the same job as the iteration + array addition.

I also take to the opportunity to remove an unnecessary [white space](https://github.com/rails/rails/pull/11625/files#L2L122) and [empty line](https://github.com/rails/rails/pull/11625/files#L3L238).
