### PR TITLE
Wrap Minitest's assert_raise so that it assert on the message.

### DIFF
--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -60,4 +60,9 @@ def restore_delivery_method
   ActionMailer::Base.delivery_method = @old_delivery_method
 end
 
+def assert_raise(*args)
+  e = super(*args)
+  assert_match(e.message, args.last, "The exception's message was incorrect") if args.last.is_a?(String)
+end
+
 ActiveSupport::Deprecation.silenced = true

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -380,3 +380,8 @@ module Backoffice
     class ImagesController < ResourcesController; end
   end
 end
+
+def assert_raise(*args)
+  e = super(*args)
+  assert_match(e.message, args.last, "The exception's message was incorrect") if args.last.is_a?(String)
+end

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -380,3 +380,8 @@ module Backoffice
     class ImagesController < ResourcesController; end
   end
 end
+
+def assert_raise(*args)
+  e = super(*args)
+  assert_match(e.message, args.last, "The exception's message was incorrect") if args.last.is_a?(String)
+end

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -8,3 +8,8 @@ require 'active_support/core_ext/string/access'
 ActiveSupport::Deprecation.debug = true
 
 require 'active_support/testing/autorun'
+
+def assert_raise(*args)
+  e = super(*args)
+  assert_match(e.message, args.last, "The exception's message was incorrect") if args.last.is_a?(String)
+end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -149,3 +149,8 @@ module InTimeZone
     ActiveRecord::Base.time_zone_aware_attributes = old_tz
   end
 end
+
+def assert_raise(*args)
+  e = super(*args)
+  assert_match(e.message, args.last, "The exception's message was incorrect") if args.last.is_a?(String)
+end

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -24,3 +24,8 @@ Thread.abort_on_exception = true
 
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveSupport::Deprecation.debug = true
+
+def assert_raise(*args)
+  e = super(*args)
+  assert_match(e.message, args.last, "The exception's message was incorrect") if args.last.is_a?(String)
+end

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -16,3 +16,8 @@ module TestApp
     config.secret_key_base = 'b3c631c314c0bbca50c1b2843150fe33'
   end
 end
+
+def assert_raise(*args)
+  e = super(*args)
+  assert_match(e.message, args.last, "The exception's message was incorrect") if args.last.is_a?(String)
+end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -285,3 +285,8 @@ Module.new do
     f.puts "require 'rails/all'"
   end
 end unless defined?(RAILS_ISOLATED_ENGINE)
+
+def assert_raise(*args)
+  e = super(*args)
+  assert_match(e.message, args.last, "The exception's message was incorrect") if args.last.is_a?(String)
+end


### PR DESCRIPTION
Wrap Minitest's assert_raise so that it assert on the message.

There are 14 assertions in the test suite that assert that a particular exception is raised and its message. 

Unfortunately Minitest don't test the message part. This is by design (https://github.com/seattlerb/minitest/issues/99). So all those tests are red herrings. This commit fixes it by wrapping the `assert_raise` method and adding the message assertion.

For example, currently, in `activesupport/test/core_ext/hash_ext_test.rb` if you change the `"Unknown key: failore"` to something else like `"This should fail"` it won't raise any error. I found this while I was working on https://github.com/rails/rails/pull/11624

``` ruby
  def test_assert_valid_keys
    assert_nothing_raised do
      { :failure => "stuff", :funny => "business" }.assert_valid_keys([ :failure, :funny ])
      { :failure => "stuff", :funny => "business" }.assert_valid_keys(:failure, :funny)
    end

    assert_raise(ArgumentError, "Unknown key: failore") do
      { :failore => "stuff", :funny => "business" }.assert_valid_keys([ :failure, :funny ])
      { :failore => "stuff", :funny => "business" }.assert_valid_keys(:failure, :funny)
    end
  end
```

With this commit, it will.

You can find all the red herring with this regular expression: `assert_raise\(\S*, "`

I added the method to the base helper of each project. Do we have a singular place where we could put this sort of thing?
