### PR TITLE
Add Object#is_any_of?(option1, option2, ...)

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,8 +1,22 @@
+*   Add Object#in?(option1, option2, ...)
+
+    Returns true if the object is equal to any of the possibilities specified as parameters.
+
+    This simplifies:
+
+        if params[:subject] == :english || params[:subject] == :math || params[:subject] == :biology
+
+    to:
+
+        if params[:subject].in?(:english, :math, :biology)
+
+    *Gonzalo Rodríguez-Baltanás Díaz
+
 *   Improve `ActiveSupport::Cache::MemoryStore` cache size calculation.
     The memory used by a key/entry pair is calculated via `#cached_size`:
 
         def cached_size(key, entry)
-          key.to_s.bytesize + entry.size + PER_ENTRY_OVERHEAD
+            key.to_s.bytesize + entry.size + PER_ENTRY_OVERHEAD
         end
 
     The value of `PER_ENTRY_OVERHEAD` is 240 bytes based on an [empirical

--- a/activesupport/lib/active_support/core_ext/object.rb
+++ b/activesupport/lib/active_support/core_ext/object.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/object/duplicable'
 require 'active_support/core_ext/object/deep_dup'
 require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/object/inclusion'
+require 'active_support/core_ext/object/in'
 
 require 'active_support/core_ext/object/conversions'
 require 'active_support/core_ext/object/instance_variables'

--- a/activesupport/lib/active_support/core_ext/object/in.rb
+++ b/activesupport/lib/active_support/core_ext/object/in.rb
@@ -1,0 +1,16 @@
+class Object
+  # Returns true if the object is equal to any of the
+  # possibilities specified as parameters.
+  #
+  # This simplifies:
+  #
+  #   if params[:subject] == :english || params[:subject] == :math || params[:subject] == :biology
+  #
+  # ...to:
+  #
+  #   if params[:subject].in?(:english, :math, :biology)
+  #
+  def in?(*possibilities)
+    possibilities.include?(self)
+  end
+end

--- a/activesupport/test/core_ext/object_and_class_ext_test.rb
+++ b/activesupport/test/core_ext/object_and_class_ext_test.rb
@@ -166,7 +166,7 @@ class ObjectTryTest < ActiveSupport::TestCase
 
     assert_raise(NoMethodError) { klass.new.try!(:private_method) }
   end
-  
+
   def test_try_with_private_method
     klass = Class.new do
       private
@@ -177,5 +177,17 @@ class ObjectTryTest < ActiveSupport::TestCase
     end
 
     assert_nil klass.new.try(:private_method)
+  end
+end
+
+class ObjectIsAnyOf < ActiveSupport::TestCase
+  def test_in_is_true
+    assert('option1'.in?('option1', 'option2', 'option3'))
+    assert('option2'.in?('option1', 'option2', 'option3'))
+    assert('option3'.in?('option1', 'option2', 'option3'))
+  end
+
+  def test_in_is_false
+    assert_equal(false, 'this is not a valid option'.in?('option1', 'option2', 'option3'))
   end
 end


### PR DESCRIPTION
Returns true if the object is equal to any of the possibilities specified as parameters.

This simplifies:

``` ruby
if params[:subject] == :english || params[:subject] == :math || params[:subject] == :biology
```

to:

``` ruby
if params[:subject].is_any_of?(:english, :math, :biology)
```
