### PR TITLE
Raise TypeError for PostgreSQL ranges with alphabet

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -81,12 +81,19 @@ module ActiveRecord
           end
         end
 
+        # PostgreSQL doesn't support Alphabetic ranges
+        def valid_range?(value)
+          value.to_s !~ /[[:alpha:]]/
+        end
+
         def type_cast(value, column, array_member = false)
           return super(value, column) unless column
 
           case value
           when Range
-            return super(value, column) unless /range$/ =~ column.sql_type
+            if column.sql_type !~ /range$/ || !valid_range?(value)
+              return super(value, column)
+            end
             PostgreSQLColumn.range_to_string(value)
           when NilClass
             if column.array && array_member

--- a/activerecord/test/cases/adapters/postgresql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/quoting_test.rb
@@ -33,6 +33,18 @@ module ActiveRecord
           assert_equal ip, @conn.type_cast(ip, c)
         end
 
+        def test_type_cast_raise_on_alphabetic_range
+          range = ("a".."z")
+          c = PostgreSQLColumn.new(nil, nil, nil, 'int4range')
+          assert_raises(TypeError) { @conn.type_cast(range, c) }
+        end
+
+        def test_type_cast_raise_on_alphabetic_and_numeric_range
+          range = ("a1".."b1")
+          c = PostgreSQLColumn.new(nil, nil, nil, 'int4range')
+          assert_raises(TypeError) { @conn.type_cast(range, c) }
+        end
+
         def test_quote_float_nan
           nan = 0.0/0
           c = Column.new(nil, 1, 'float')


### PR DESCRIPTION
Passing valid Ruby Alphabetic ranges such as
"a..z" into pg range columns currently fails with
a syntax error coming from the db:
So when saving `"a".."z"` in a `int4range` PostgreSQL column it raises:

```
<ActiveRecord::StatementInvalid>
"PG::Error: ERROR:  invalid input syntax for integer ...
```

 it should probably throw a `TypeError: can't cast Range to int4range`.

test case : https://gist.github.com/gzohari/6096239
