### PR TITLE
fix order dependent test

### DIFF
--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -453,6 +453,11 @@ class TransactionTest < ActiveRecord::TestCase
         raise ActiveRecord::Rollback
       end
     end
+
+   ensure
+    Topic.reset_column_information # reset the column information to get correct reading
+    Topic.connection.remove_column('topics', 'stuff') if Topic.column_names.include?('stuff')
+    Topic.reset_column_information # reset the column information again for other tests
   end
 
   def test_transactions_state_from_rollback


### PR DESCRIPTION
`ReflectionTest` uses column information in tests and those tests break
if tests are run in random order.
