### PR TITLE
fix order dependent test related to migration

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -846,6 +846,10 @@ class CopyMigrationsTest < ActiveRecord::TestCase
   end
 
   def test_check_pending_with_stdlib_logger
+    migrations_path = MIGRATIONS_ROOT + "/valid"
+    ActiveRecord::Migrator.migrations_paths = migrations_path
+    ActiveRecord::Migrator.up migrations_path
+
     old, ActiveRecord::Base.logger = ActiveRecord::Base.logger, ::Logger.new($stdout)
     quietly do
       assert_nothing_raised { ActiveRecord::Migration::CheckPending.new(Proc.new {}).call({}) }


### PR DESCRIPTION
If the order in which tests are executed is changed then test fails.
This commit ensures that all migrations are run before ensuring that
there are no pending migration.
