### PR TITLE
`ActiveSupport::Dependencies`: consts in uppercase nestings not marked as autoloaded

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Ensure that autoloaded constants in all-caps nestings are marked as
+    autoloaded.
+
+    *Simon Coffey*
+
 *   Add String#remove(pattern) as a short-hand for the common pattern of String#gsub(pattern, '')
 
     *DHH*

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -459,7 +459,7 @@ module ActiveSupport #:nodoc:
         if loaded.include?(expanded)
           raise "Circular dependency detected while autoloading constant #{qualified_name}"
         else
-          require_or_load(expanded)
+          require_or_load(expanded, qualified_name)
           raise LoadError, "Unable to autoload constant #{qualified_name}, expected #{file_path} to define it" unless from_mod.const_defined?(const_name, false)
           return from_mod.const_get(const_name)
         end

--- a/activesupport/test/autoloading_fixtures/html/some_class.rb
+++ b/activesupport/test/autoloading_fixtures/html/some_class.rb
@@ -1,0 +1,4 @@
+module HTML
+  class SomeClass
+  end
+end

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -647,6 +647,14 @@ class DependenciesTest < ActiveSupport::TestCase
     Object.class_eval { remove_const :E }
   end
 
+  def test_constants_in_capitalized_nesting_marked_as_autoloaded
+    with_autoloading_fixtures do
+      ActiveSupport::Dependencies.load_missing_constant(HTML, "SomeClass")
+
+      assert ActiveSupport::Dependencies.autoloaded?("HTML::SomeClass")
+    end
+  end
+
   def test_unloadable
     with_autoloading_fixtures do
       Object.const_set :M, Module.new


### PR DESCRIPTION
Constants autoloaded in all-caps nestings are not getting marked as such by `ActiveSupport::Dependencies`. As a result they're not reloaded after modification when `cache_classes` is disabled. A failing test case is included.

This was because the originally requested constant name was not being passed to `#load_or_require`, so the expected location of the new constant had to be inferred from the path name using `String#camelize`. So if you autoloaded `HTML::SomeClass`, the watcher was told to look for new constants in `Html`, and none were found.

I've fixed this by passing the qualified constant name to `#load_or_require`. This seemed to be the original intention behind the optional `const_path` argument to that method, which was previously unused.

The full build passes on the rails-dev-box - any feedback would be greatly appreciated. I've left the commits separate for review but will squash them if it's okay to merge.

Edit: this bug affects 3.2, 4.0 and master - assuming it's okay to merge, please can it be considered for backporting to the older branches?
