### PR TITLE
make test not depend on order

### DIFF
--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -191,6 +191,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_preloading_has_one_through_on_belongs_to
+    MemberDetail.delete_all
     assert_not_nil @member.member_type
     @organization = organizations(:nsa)
     @member_detail = MemberDetail.new


### PR DESCRIPTION
`NestedThroughAssociationsTest` adds records to `member_details` table.
When test performs `@member_details[0]` then the order of record
is not guaranteed. Hence it is best to start with a clean slate by
deleting unwanted records.

/cc @tenderlove
