### PR TITLE
Cleanup of class_name

### DIFF
--- a/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 
 class Group < ActiveRecord::Base
   Group.table_name = 'group'
-  belongs_to :select, :class_name => 'Select'
+  belongs_to :select
   has_one :values
 end
 

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 
 class Group < ActiveRecord::Base
   Group.table_name = 'group'
-  belongs_to :select, :class_name => 'Select'
+  belongs_to :select
   has_one :values
 end
 


### PR DESCRIPTION
Don't think class name is needed as by default belongs_to :select will be linked to Select class.
