### PR TITLE
Currently, we clear query_cache in cache block finish, even if we may al...

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `QueryCache` to work with nested blocks, so that it will only clear the existing cache
+    after leaving the outer block instead of clearing it right after the inner block is finished.
+
+    *Vipul A M*
+
 *   The ERB in fixture files is no longer evaluated in the context of the main
     object. Helper methods used by multiple fixtures should be defined on the
     class object returned by `ActiveRecord::FixtureSet.context_class`.

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -31,8 +31,8 @@ module ActiveRecord
         old, @query_cache_enabled = @query_cache_enabled, true
         yield
       ensure
-        clear_query_cache
         @query_cache_enabled = old
+        clear_query_cache unless @query_cache_enabled
       end
 
       def enable_query_cache!

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -134,6 +134,15 @@ class QueryCacheTest < ActiveRecord::TestCase
     end
   end
 
+  def test_find_queries_with_multi_cache_blocks
+    Task.cache do
+      Task.cache do
+        assert_queries(2) { Task.find(1); Task.find(2) }
+      end
+      assert_queries(0) { Task.find(1); Task.find(1); Task.find(2) }
+    end
+  end
+
   def test_count_queries_with_cache
     Task.cache do
       assert_queries(1) { Task.count; Task.count }


### PR DESCRIPTION
Currently, we clear query_cache in cache block finish, even if we may already have cache true.

This commit takes into account the last cache_enabled value, before clearing query_cache.
