### PR TITLE
Renamed private methods _create_record and _update_record

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -138,11 +138,11 @@ module ActiveRecord
       end
 
       def create(attributes = {}, &block)
-        create_record(attributes, &block)
+        _create_record(attributes, &block)
       end
 
       def create!(attributes = {}, &block)
-        create_record(attributes, true, &block)
+        _create_record(attributes, true, &block)
       end
 
       # Add +records+ to this association. Returns +self+ so method calls may
@@ -452,13 +452,13 @@ module ActiveRecord
           persisted + memory
         end
 
-        def create_record(attributes, raise = false, &block)
+        def _create_record(attributes, raise = false, &block)
           unless owner.persisted?
             raise ActiveRecord::RecordNotSaved, "You cannot call create unless the parent is saved"
           end
 
           if attributes.is_a?(Array)
-            attributes.collect { |attr| create_record(attr, raise, &block) }
+            attributes.collect { |attr| _create_record(attr, raise, &block) }
           else
             transaction do
               add_to_target(build_record(attributes)) do |record|

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -18,11 +18,11 @@ module ActiveRecord
       end
 
       def create(attributes = {}, &block)
-        create_record(attributes, &block)
+        _create_record(attributes, &block)
       end
 
       def create!(attributes = {}, &block)
-        create_record(attributes, true, &block)
+        _create_record(attributes, true, &block)
       end
 
       def build(attributes = {})
@@ -52,7 +52,7 @@ module ActiveRecord
           replace(record)
         end
 
-        def create_record(attributes, raise_error = false)
+        def _create_record(attributes, raise_error = false)
           record = build_record(attributes)
           yield(record) if block_given?
           saved = record.save

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -79,11 +79,11 @@ module ActiveRecord
         end
       end
 
-      def update_record(*)
+      def _update_record(*)
         partial_writes? ? super(keys_for_partial_write) : super
       end
 
-      def create_record(*)
+      def _create_record(*)
         partial_writes? ? super(keys_for_partial_write) : super
       end
 

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -302,11 +302,11 @@ module ActiveRecord
       run_callbacks(:save) { super }
     end
 
-    def create_record #:nodoc:
+    def _create_record #:nodoc:
       run_callbacks(:create) { super }
     end
 
-    def update_record(*) #:nodoc:
+    def _update_record(*) #:nodoc:
       run_callbacks(:update) { super }
     end
   end

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -66,7 +66,7 @@ module ActiveRecord
           send(lock_col + '=', previous_lock_value + 1)
         end
 
-        def update_record(attribute_names = @attributes.keys) #:nodoc:
+        def _update_record(attribute_names = @attributes.keys) #:nodoc:
           return super unless locking_enabled?
           return 0 if attribute_names.empty?
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -477,24 +477,24 @@ module ActiveRecord
 
     def create_or_update
       raise ReadOnlyRecord if readonly?
-      result = new_record? ? create_record : update_record
+      result = new_record? ? _create_record : _update_record
       result != false
     end
 
     # Updates the associated record with values matching those of the instance attributes.
     # Returns the number of affected rows.
-    def update_record(attribute_names = @attributes.keys)
+    def _update_record(attribute_names = @attributes.keys)
       attributes_values = arel_attributes_with_values_for_update(attribute_names)
       if attributes_values.empty?
         0
       else
-        self.class.unscoped.update_record attributes_values, id, id_was
+        self.class.unscoped._update_record attributes_values, id, id_was
       end
     end
 
     # Creates a record with values matching those of the instance attributes
     # and returns its id.
-    def create_record(attribute_names = @attributes.keys)
+    def _create_record(attribute_names = @attributes.keys)
       attributes_values = arel_attributes_with_values_for_create(attribute_names)
 
       new_id = self.class.unscoped.insert attributes_values

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -70,7 +70,7 @@ module ActiveRecord
         binds)
     end
 
-    def update_record(values, id, id_was) # :nodoc:
+    def _update_record(values, id, id_was) # :nodoc:
       substitutes, binds = substitute_values values
       um = @klass.unscoped.where(@klass.arel_table[@klass.primary_key].eq(id_was || id)).arel.compile_update(substitutes, @klass.primary_key)
 

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -43,7 +43,7 @@ module ActiveRecord
 
   private
 
-    def create_record
+    def _create_record
       if self.record_timestamps
         current_time = current_time_from_proper_timezone
 
@@ -57,7 +57,7 @@ module ActiveRecord
       super
     end
 
-    def update_record(*args)
+    def _update_record(*args)
       if should_record_timestamps?
         current_time = current_time_from_proper_timezone
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -863,4 +863,22 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
       end
     end
   end
+
+  test 'belongs_to works with model name Record' do
+    Record = Class.new(ActiveRecord::Base) do
+      connection.create_table :records
+    end
+
+    Foo = Class.new(ActiveRecord::Base) do
+      connection.create_table :foos do |t|
+        t.belongs_to :record
+      end
+
+      belongs_to :record
+    end
+
+    record = Record.create!
+    Foo.create! record: record
+    assert_equal 1, Foo.count
+  end
 end


### PR DESCRIPTION
This is to ensure that they are not accidentally called by the app code.
They are renamed to `_create_record` and `_update_record` respectively.
Closes #11645
