### PR TITLE
interceptor should mimick original method

### DIFF
--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -124,7 +124,7 @@ module LogIntercepter
   def self.extended(base)
     base.logged = []
   end
-  def log(sql, name, binds = [], &block)
+  def log(sql, name = 'SQL', binds = [], &block)
     if @intercepted
       @logged << [sql, name, binds]
       yield


### PR DESCRIPTION
This fix also makes the test order independent.

Here is the link to original log method https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L416-L429 .
