### PR TITLE
Add installation instructions for FreeBSD [ci skip]

### DIFF
--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -63,6 +63,15 @@ If you are running Arch Linux, you're done with:
 $ sudo pacman -S libxml2 libxslt
 ```
 
+On FreeBSD, you just have to run:
+
+```bash
+# pkg_add -r libxml2 libxslt
+```
+
+Alternatively, you can install the `textproc/libxml2` and `textproc/libxslt`
+ports.
+
 If you have any problems with these libraries, you can install them manually by compiling the source code. Just follow the instructions at the [Red Hat/CentOS section of the Nokogiri tutorials](http://nokogiri.org/tutorials/installing_nokogiri.html#red_hat__centos) .
 
 Also, SQLite3 and its development files for the `sqlite3` gem — in Ubuntu you're done with just
@@ -82,6 +91,14 @@ If you are on Arch Linux, you will need to run:
 ```bash
 $ sudo pacman -S sqlite
 ```
+
+For FreeBSD users, you're done with:
+
+```bash
+# pkg_add -r sqlite3
+```
+
+Or compile the `databases/sqlite3` port.
 
 Get a recent version of [Bundler](http://gembundler.com/)
 
@@ -156,6 +173,17 @@ use MariaDB instead (see [this announcement](https://www.archlinux.org/news/mari
 $ sudo pacman -S mariadb libmariadbclient mariadb-clients
 $ sudo pacman -S postgresql postgresql-libs
 ```
+
+FreeBSD users will have to run the following:
+
+```bash
+# pkg_add -r mysql56-client mysql56-server
+# pkg_add -r postgresql92-client postgresql92-server
+```
+
+Or install them through ports (they are located under the `databases` folder).
+If you run into troubles during the installation of MySQL, please see
+[the MySQL documentation](http://dev.mysql.com/doc/refman/5.1/en/freebsd-installation.html).
 
 After that, run:
 


### PR DESCRIPTION
Hello,

As @fxn request [here](https://github.com/rails/docrails/commit/1565821c3432b5723909bf8b3b08d4230efa42f6#commitcomment-3732864), I took the liberty to add instructions for FreeBSD users. I have commit rights on docrails but open this pull request to make sure everything is right. Here are some notes:
- The examples are using the root prompt since the sudo command [should be installed](http://www.freshports.org/security/sudo/). If you want me to update the examples with `sudo`, let me know.
- I haven't put the commands for ports ; only for packages. However, there is the port's name in each case but I can update it if you want.
- Finally, the PostgreSQL version is 9.2 in the patch but the `postgresql93-{client,server}` packages are available but it's [still a beta](http://www.postgresql.org/about/news/1471/).

Have a nice day.
