### PR TITLE
add missing tests for xml_mini and fix wrong argument error in date.to_s...

### DIFF
--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -47,7 +47,7 @@ module ActiveSupport
 
     FORMATTING = {
       "symbol"   => Proc.new { |symbol| symbol.to_s },
-      "date"     => Proc.new { |date| date.to_s(:db) },
+      "date"     => Proc.new { |date| date.to_s },
       "dateTime" => Proc.new { |time| time.xmlschema },
       "binary"   => Proc.new { |binary| ::Base64.encode64(binary) },
       "yaml"     => Proc.new { |yaml| yaml.to_yaml }

--- a/activesupport/test/xml_mini_test.rb
+++ b/activesupport/test/xml_mini_test.rb
@@ -1,6 +1,7 @@
 require 'abstract_unit'
 require 'active_support/xml_mini'
 require 'active_support/builder'
+require 'bigdecimal'
 
 module XmlMiniTest
   class RenameKeyTest < ActiveSupport::TestCase
@@ -88,6 +89,61 @@ module XmlMiniTest
       assert_xml "<b>Howdy</b>"
     end
 
+    test "#to_tag should use the type value in the options hash" do
+      @xml.to_tag(:b, "blue", @options.merge(type: 'color'))
+      assert_xml( "<b type=\"color\">blue</b>" )
+    end
+
+    test "#to_tag accepts symbol types" do
+      @xml.to_tag(:b, :name, @options)
+      assert_xml( "<b type=\"symbol\">name</b>" )
+    end
+
+    test "#to_tag accepts boolean types" do
+      @xml.to_tag(:b, true, @options)
+      assert_xml( "<b type=\"boolean\">true</b>")
+    end
+
+    test "#to_tag accepts float types" do
+      @xml.to_tag(:b, 3.14, @options)
+      assert_xml( "<b type=\"float\">3.14</b>")
+    end
+
+    test "#to_tag accepts decimal types" do
+      @xml.to_tag(:b, ::BigDecimal.new("1.2"), @options)
+      assert_xml( "<b type=\"decimal\">0.12E1</b>")
+    end
+
+    test "#to_tag accepts date types" do
+      @xml.to_tag(:b, Date.new(2001,2,3), @options)
+      assert_xml( "<b type=\"date\">2001-02-03</b>")
+    end
+
+    test "#to_tag accepts datetime types" do
+      @xml.to_tag(:b, DateTime.new(2001,2,3,4,5,6,'+7'), @options)
+      assert_xml( "<b type=\"dateTime\">2001-02-03T04:05:06+07:00</b>")
+    end
+
+    test "#to_tag accepts time types" do
+      @xml.to_tag(:b, Time.new(1993, 02, 24, 12, 0, 0, "+09:00"), @options)
+      assert_xml( "<b type=\"dateTime\">1993-02-24T12:00:00+09:00</b>")
+    end
+
+    test "#to_tag accepts array types" do
+      @xml.to_tag(:b, ["first_name", "last_name"], @options)
+      assert_xml( "<b type=\"array\">[\"first_name\", \"last_name\"]</b>" )
+    end
+
+    test "#to_tag accepts hash types" do
+      @xml.to_tag(:b, { first_name: "Bob", last_name: "Marley" }, @options)
+      assert_xml( "<b first_name=\"Bob\" last_name=\"Marley\" type=\"hash\"/>" )
+    end
+
+    test "#to_tag should not add type when skip types option is set" do
+      @xml.to_tag(:b, "Bob", @options.merge(skip_types: 1))
+      assert_xml( "<b>Bob</b>" )
+    end
+
     test "#to_tag should dasherize the space when passed a string with spaces as a key" do
       @xml.to_tag("New   York", 33, @options)
       assert_xml "<New---York type=\"integer\">33</New---York>"
@@ -97,7 +153,7 @@ module XmlMiniTest
       @xml.to_tag(:"New   York", 33, @options)
       assert_xml "<New---York type=\"integer\">33</New---York>"
     end
-    # TODO: test the remaining functions hidden in #to_tag.
+
   end
 
   class WithBackendTest < ActiveSupport::TestCase


### PR DESCRIPTION
- added more tests for ActiveSupport ::XmlMini  to_tag method
- fix argument error in xml_mini.rb:50

XmlMiniTest::ToTagTest#test_#to_tag_accepts_date_types:
ArgumentError: wrong number of arguments (1 for 0)
    /Users/emre/code/rails/activesupport/lib/active_support/xml_mini.rb:50:in `to_s'
