### PR TITLE
Rename error messages for restrict_dependent_destroy errors

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Rename messages for association `restrict_dependent_destroy` errors
+
+    Previously `has_one` and `has_many` associations were using the
+    `one` and `many` messages respectively. Both of these keys have special
+    meaning in I18n (they are considered to be pluralizations) so by
+    renaming them to `has_one` and `has_many` we make the messages more explicit
+    and most importantly they don't clash with linguistical systems that need to
+    validate translation keys (and their pluralizations).
+
+    *Christopher Dell*
+
 *   Log bind variables after they are type casted. This makes it more
     transparent what values are actually sent to the database.
 

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -15,7 +15,7 @@ module ActiveRecord
         when :restrict_with_error
           unless empty?
             record = klass.human_attribute_name(reflection.name).downcase
-            owner.errors.add(:base, :"restrict_dependent_destroy.many", record: record)
+            owner.errors.add(:base, :"restrict_dependent_destroy.has_many", record: record)
             false
           end
 

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -12,7 +12,7 @@ module ActiveRecord
         when :restrict_with_error
           if load_target
             record = klass.human_attribute_name(reflection.name).downcase
-            owner.errors.add(:base, :"restrict_dependent_destroy.one", record: record)
+            owner.errors.add(:base, :"restrict_dependent_destroy.has_one", record: record)
             false
           end
 

--- a/activerecord/lib/active_record/locale/en.yml
+++ b/activerecord/lib/active_record/locale/en.yml
@@ -15,8 +15,8 @@ en:
       messages:
         record_invalid: "Validation failed: %{errors}"
         restrict_dependent_destroy:
-          one: "Cannot delete record because a dependent %{record} exists"
-          many: "Cannot delete record because dependent %{record} exist"
+          has_one: "Cannot delete record because a dependent %{record} exists"
+          has_many: "Cannot delete record because dependent %{record} exist"
         # Append your own errors here or at the model/attributes scope.
 
       # You can define own errors for models or model attributes.


### PR DESCRIPTION
The problem here is that I18n uses the `many` and `one` keys to indicate forms of pluralization.

Systems that rely on this convention are unable to understand that this key is merely describing a type of association, and should not expect there to be other forms of pluralization (eg. `zero`, `few`, `other` etc...).

Previously submitted as PR #11416
