### PR TITLE
Adding caching to OrderedOptions.

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -29,8 +29,10 @@ module ActiveSupport
     def method_missing(name, *args)
       name_string = name.to_s
       if name_string.chomp!('=')
+        define_writer_method(name, name_string)
         self[name_string] = args.first
       else
+        define_reader_method(name)
         self[name]
       end
     end
@@ -38,6 +40,24 @@ module ActiveSupport
     def respond_to_missing?(name, include_private)
       true
     end
+
+    private
+
+      def define_writer_method(name, name_string)
+        class_eval do
+          define_method(name) do |val|
+            self[name_string] = val
+          end
+        end
+      end
+
+      def define_reader_method(name)
+        class_eval do
+          define_method(name) do
+            self[name]
+          end
+        end
+      end
   end
 
   # +InheritableOptions+ provides a constructor to build an +OrderedOptions+

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -52,6 +52,31 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     assert_equal 56, a.else_where
   end
 
+  def test_caching_of_writer_method
+    a = ActiveSupport::OrderedOptions.new
+
+    original_owner = a.method(:allow_concurrency=).owner
+    assert_equal ActiveSupport::OrderedOptions, original_owner
+
+    a.allow_concurrency = true
+    current_owner = a.method(:allow_concurrency=).owner
+    assert_not_equal original_owner, current_owner
+    assert_not_equal ActiveSupport::OrderedOptions, current_owner
+  end
+
+  def test_caching_of_reader_method
+    a = ActiveSupport::OrderedOptions.new
+
+    original_owner = a.method(:allow_concurrency).owner
+    assert_equal ActiveSupport::OrderedOptions, original_owner
+
+    a.allow_concurrency = true
+    assert a.allow_concurrency
+    current_owner = a.method(:allow_concurrency).owner
+    assert_not_equal original_owner, current_owner
+    assert_not_equal ActiveSupport::OrderedOptions, current_owner
+  end
+
   def test_inheritable_options_continues_lookup_in_parent
     parent = ActiveSupport::OrderedOptions.new
     parent[:foo] = true


### PR DESCRIPTION
Instead of going through the method missing calls each time you make a call to an `OrderedOptions` hash, instead cache the method call for more performance.
