### PR TITLE
Rails.logger should have level specified by config.log_level. 

### DIFF
--- a/activemodel/test/cases/railtie_test.rb
+++ b/activemodel/test/cases/railtie_test.rb
@@ -8,7 +8,7 @@ class RailtieTest < ActiveModel::TestCase
     require 'active_model/railtie'
 
     # Set a fake logger to avoid creating the log directory automatically
-    fake_logger = mock()
+    fake_logger = Logger.new(nil)
 
     @app ||= Class.new(::Rails::Application) do
       config.eager_load = false

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -42,7 +42,6 @@ INFO
           logger = ActiveSupport::Logger.new f
           logger.formatter = config.log_formatter
           logger = ActiveSupport::TaggedLogging.new(logger)
-          logger.level = ActiveSupport::Logger.const_get(config.log_level.to_s.upcase)
           logger
         rescue StandardError
           logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDERR))
@@ -53,6 +52,8 @@ INFO
           )
           logger
         end
+
+        Rails.logger.level = ActiveSupport::Logger.const_get(config.log_level.to_s.upcase)
       end
 
       # Initialize cache early in the stack so railties can make use of it.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -671,5 +671,13 @@ module ApplicationTests
         end
       end
     end
+
+    test "config.log_level with custom logger" do
+      make_basic_app do |app|
+        app.config.logger = Logger.new(STDOUT)
+        app.config.log_level = :info
+      end
+      assert_equal Logger::INFO, Rails.logger.level
+    end
   end
 end


### PR DESCRIPTION
Fix bug when log level of Rails.logger (which was set via config.logger) does not match the config.log_level.

Example:

```
# in config/application.rb
 config.logger = Logger.new(STDOUT)

# in config/environments/development.rb
 config.log_level = :info
```

Start rails console for example

```
$ rails c
> Rails.logger.level
=> 0
> ActiveSupport::Logger::INFO == Rails.logger.level
=> false 
```
