### PR TITLE
Include web-console in new projects Gemfile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -10,6 +10,9 @@ source 'https://rubygems.org'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.2'
 
+# Run `rails console` in the browser. Read more: https://github.com/rails/web-console
+gem 'web-console', group: :development
+
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
   gem 'sdoc', require: false


### PR DESCRIPTION
As part of  the Google Summer of Code 2013, me and @guilleiguaran has been working on bringing `rails console` to the browser. Today we are proud to announce that we hit `0.1.0` and we have enough of it, to let you guys test it.

The project development lives in https://github.com/gsamokovarov/web-console and we'll be happy to get any feedback about how we can make it better. That this is more of a demo release and we will really appreciate all of the extra testing we can get. Feel free to open issues on https://github.com/gsamokovarov/web-console/issues with any bugs,  feature requests or general feedback.

/cc @guilleiguaran, @rafaelfranca, @pixeltrix, @spastorino, @drogus
