### PR TITLE
Make test order independent

### DIFF
--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -186,7 +186,9 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
     members = assert_queries(4) { Member.includes(:organization_member_details_2).to_a.sort_by(&:id) }
     groucho_details, other_details = member_details(:groucho), member_details(:some_other_guy)
 
-    assert_no_queries do
+    # postgresql test if randomly executed then executes "SHOW max_identifier_length". Hence
+    # the need to ignore certain predefined sqls that deal with system calls.
+    assert_no_queries(ignore_none: false) do
       assert_equal [groucho_details, other_details], members.first.organization_member_details_2.sort_by(&:id)
     end
   end

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -45,8 +45,9 @@ module ActiveRecord
       x
     end
 
-    def assert_no_queries(&block)
-      assert_queries(0, :ignore_none => true, &block)
+    def assert_no_queries(options = {}, &block)
+      options.reverse_merge! ignore_none: true
+      assert_queries(0, options, &block)
     end
 
     def assert_column(model, column_name, msg=nil)


### PR DESCRIPTION
postgresql test if randomly executed then executes "SHOW max_identifier_length". Hence
the need to ignore certain predefined sqls that deal with system calls.

Here is the exact failure I get in master if tests are executed in reverse order for postgresql.

```

NestedThroughAssociationsTest#test_has_many_through_has_one_through_with_has_many_source_reflection_preload [/Users/nsingh/dev/rails_edge/rails/activerecord/test/cases/associations/nested_through_associations_test.rb:189]:
1 instead of 0 queries were executed.
Queries:
SHOW max_identifier_length.
Expected: 0
  Actual: 1
```
