### PR TITLE
Add retry to `gem install bundler` for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 script: 'ci/travis.rb'
 before_install:
-  - gem install bundler
+  - travis_retry gem install bundler
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
This adds the retry behaviour used for other commands to the bundler installation. If the `gem install bundler` command fails, it will retry up to a total of three times before actually failing the build.
