### PR TITLE
refactor existing test by using with_schema_search_path

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -257,9 +257,10 @@ class SchemaTest < ActiveRecord::TestCase
     assert_nothing_raised { ActiveRecord::Base.connection.remove_index! "things", "#{SCHEMA_NAME}.things_Index"}
 
     ActiveRecord::Base.connection.execute "CREATE INDEX \"things_Index\" ON #{SCHEMA_NAME}.things (name)"
-    ActiveRecord::Base.connection.schema_search_path = SCHEMA_NAME
-    assert_nothing_raised { ActiveRecord::Base.connection.remove_index! "things", "things_Index"}
-    ActiveRecord::Base.connection.schema_search_path = "public"
+
+    with_schema_search_path(SCHEMA_NAME) do
+      assert_nothing_raised { ActiveRecord::Base.connection.remove_index! "things", "things_Index"}
+    end
   end
 
   def test_primary_key_with_schema_specified


### PR DESCRIPTION
In the removed code line `ActiveRecord::Base.connection.schema_search_path = "public"` should have been within `ensure` block. With that new code that has been take care of.
