### PR TITLE
Remove duplication from date_time calculations

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -10,16 +10,6 @@ class DateTime
     end
   end
 
-  # Tells whether the DateTime object's datetime lies in the past.
-  def past?
-    self < ::DateTime.current
-  end
-
-  # Tells whether the DateTime object's datetime lies in the future.
-  def future?
-    self > ::DateTime.current
-  end
-
   # Seconds since midnight: DateTime.now.seconds_since_midnight.
   def seconds_since_midnight
     sec + (min * 60) + (hour * 3600)


### PR DESCRIPTION
Methods: `past?` and `future?` are already defined identically
in date_and_time/calculations.rb which is included in Date.
Because DateTime is a subclass of Date, it can call them.

/cc @pixeltrix
