### PR TITLE
Fix "show post" link in Getting Started guide

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -974,7 +974,7 @@ appear next to the "Show" link:
   <tr>
     <td><%= post.title %></td>
     <td><%= post.text %></td>
-    <td><%= link_to 'Show', post %></td>
+    <td><%= link_to 'Show', post(post) %></td>
     <td><%= link_to 'Edit', edit_post_path(post) %></td>
   </tr>
 <% end %>


### PR DESCRIPTION
Following the Getting Started guide, this line of code produces an error:

```
<td><%= link_to 'Show', post %></td>
```

The error is:

> ActionController::UrlGenerationError in Posts#index
> No route matches {:action=>"show", :controller=>"posts"} missing required keys: [:id]

It looks like the post method is just missing the necessary argument, which I've added in this pull request.
