### PR TITLE
Fixes #11619. The default STI scope of the target isn't applied to an original table.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   The default STI scope of the target isn't applied to an original table.
+    Fixes #11619.
+
+    *kennyj*
+
 *   Revert `ActiveRecord::Relation#order` change that make new order
     prepend the old one.
 

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -115,7 +115,7 @@ module ActiveRecord
                   .where(reflection.type => foreign_klass.base_class.name)
             end
 
-            scope_chain_items.concat [klass.send(:build_default_scope)].compact
+            scope_chain_items.concat [klass.send(:build_default_scope, false)].compact
 
             rel = scope_chain_items.inject(scope_chain_items.shift) do |left, right|
               left.merge right

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -112,4 +112,22 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
 
     assert_equal [author], Author.where(id: author).joins(:special_categorizations)
   end
+
+  test "the sti scope of the target isn't applied to an original table" do
+    begin
+      defaults = SpecialComment.default_scopes
+      SpecialComment.class_eval do
+        default_scopes = []
+        default_scope -> { order(:id) }
+      end
+  
+      assert_no_match(/"comments"\."type" IN/,
+           Post.where(:id => posts(:sti_comments).id)
+           .includes(:comments)
+           .includes(:special_comments)
+           .references(:special_comments).to_sql)
+    ensure
+      SpecialComment.default_scopes = defaults
+    end
+  end
 end


### PR DESCRIPTION
Closes #11619.
Before this change, the default STI scope is applied to an original table too.

Please also see b407839601c8dc7b007a6baddea3696b737c352b
