### PR TITLE
Refactor Date, Time, DateTime timezone methods

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/zones.rb
+++ b/activesupport/lib/active_support/core_ext/date/zones.rb
@@ -1,22 +1,6 @@
 require 'date'
-require 'active_support/core_ext/time/zones'
+require 'active_support/core_ext/date_and_time/zones'
 
 class Date
-  # Converts Date to a TimeWithZone in the current zone if Time.zone or Time.zone_default
-  # is set, otherwise converts Date to a Time via Date#to_time
-  #
-  #   Time.zone = 'Hawaii'         # => 'Hawaii'
-  #   Date.new(2000).in_time_zone  # => Sat, 01 Jan 2000 00:00:00 HST -10:00
-  #
-  # You can also pass in a TimeZone instance or string that identifies a TimeZone as an argument,
-  # and the conversion will be based on that zone instead of <tt>Time.zone</tt>.
-  #
-  #   Date.new(2000).in_time_zone('Alaska')  # => Sat, 01 Jan 2000 00:00:00 AKST -09:00
-  def in_time_zone(zone = ::Time.zone)
-    if zone
-      ::Time.find_zone!(zone).local(year, month, day)
-    else
-      to_time
-    end
-  end
+  include DateAndTime::Zones
 end

--- a/activesupport/lib/active_support/core_ext/date_and_time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/zones.rb
@@ -1,0 +1,41 @@
+module DateAndTime
+  module Zones
+    # Returns the simultaneous time in <tt>Time.zone</tt> if a zone is given or
+    # if Time.zone_default is set. Otherwise, it returns the current time.
+    #
+    #   Time.zone = 'Hawaii'        # => 'Hawaii'
+    #   DateTime.utc(2000).in_time_zone # => Fri, 31 Dec 1999 14:00:00 HST -10:00
+    #   Date.new(2000).in_time_zone  # => Sat, 01 Jan 2000 00:00:00 HST -10:00
+    #
+    # This method is similar to Time#localtime, except that it uses <tt>Time.zone</tt> as the local zone
+    # instead of the operating system's time zone.
+    #
+    # You can also pass in a TimeZone instance or string that identifies a TimeZone as an argument,
+    # and the conversion will be based on that zone instead of <tt>Time.zone</tt>.
+    #
+    #   Time.utc(2000).in_time_zone('Alaska') # => Fri, 31 Dec 1999 15:00:00 AKST -09:00
+    #   DateTime.utc(2000).in_time_zone('Alaska') # => Fri, 31 Dec 1999 15:00:00 AKST -09:00
+    #   Date.new(2000).in_time_zone('Alaska')  # => Sat, 01 Jan 2000 00:00:00 AKST -09:00
+    def in_time_zone(zone = ::Time.zone)
+      time_zone = ::Time.find_zone! zone
+      time = acts_like?(:time) ? self : nil
+
+      if time_zone
+        time_with_zone(time, time_zone)
+      else
+        time || self.to_time
+      end
+    end
+
+    private
+
+    def time_with_zone(time, zone)
+      if time
+        ActiveSupport::TimeWithZone.new(time.utc? ? time : time.getutc, zone)
+      else
+        ActiveSupport::TimeWithZone.new(nil, zone, to_time(:utc))
+      end
+    end
+  end
+end
+

--- a/activesupport/lib/active_support/core_ext/date_time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/zones.rb
@@ -1,25 +1,6 @@
 require 'date'
-require 'active_support/core_ext/time/zones'
+require 'active_support/core_ext/date_and_time/zones'
 
 class DateTime
-  # Returns the simultaneous time in <tt>Time.zone</tt>.
-  #
-  #   Time.zone = 'Hawaii'             # => 'Hawaii'
-  #   DateTime.new(2000).in_time_zone  # => Fri, 31 Dec 1999 14:00:00 HST -10:00
-  #
-  # This method is similar to Time#localtime, except that it uses <tt>Time.zone</tt>
-  # as the local zone instead of the operating system's time zone.
-  #
-  # You can also pass in a TimeZone instance or string that identifies a TimeZone
-  # as an argument, and the conversion will be based on that zone instead of
-  # <tt>Time.zone</tt>.
-  #
-  #   DateTime.new(2000).in_time_zone('Alaska') # => Fri, 31 Dec 1999 15:00:00 AKST -09:00
-  def in_time_zone(zone = ::Time.zone)
-    if zone
-      ActiveSupport::TimeWithZone.new(utc? ? self : getutc, ::Time.find_zone!(zone))
-    else
-      self
-    end
-  end
+  include DateAndTime::Zones
 end

--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -1,6 +1,8 @@
 require 'active_support/time_with_zone'
+require 'active_support/core_ext/date_and_time/zones'
 
 class Time
+  include DateAndTime::Zones
   class << self
     attr_accessor :zone_default
 
@@ -71,26 +73,6 @@ class Time
 
     def find_zone(time_zone)
       find_zone!(time_zone) rescue nil
-    end
-  end
-
-  # Returns the simultaneous time in <tt>Time.zone</tt>.
-  #
-  #   Time.zone = 'Hawaii'        # => 'Hawaii'
-  #   Time.utc(2000).in_time_zone # => Fri, 31 Dec 1999 14:00:00 HST -10:00
-  #
-  # This method is similar to Time#localtime, except that it uses <tt>Time.zone</tt> as the local zone
-  # instead of the operating system's time zone.
-  #
-  # You can also pass in a TimeZone instance or string that identifies a TimeZone as an argument,
-  # and the conversion will be based on that zone instead of <tt>Time.zone</tt>.
-  #
-  #   Time.utc(2000).in_time_zone('Alaska') # => Fri, 31 Dec 1999 15:00:00 AKST -09:00
-  def in_time_zone(zone = ::Time.zone)
-    if zone
-      ActiveSupport::TimeWithZone.new(utc? ? self : getutc, ::Time.find_zone!(zone))
-    else
-      self
     end
   end
 end

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -997,6 +997,14 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < ActiveSupport::TestCase
     Time.zone = nil
   end
 
+  def test_time_in_time_zone_doesnt_affect_receiver
+    with_env_tz 'Europe/London' do
+      time = Time.local(2000, 7, 1)
+      time_with_zone = time.in_time_zone('Eastern Time (US & Canada)')
+      assert_not time.utc?, 'time expected to be local, but is UTC'
+    end
+  end
+
   protected
     def with_env_tz(new_tz = 'US/Eastern')
       old_tz, ENV['TZ'] = ENV['TZ'], new_tz


### PR DESCRIPTION
Similar implementations of `#in_time_zone` exists for `Date`, `Time` and `DateTime` so
method is extracted into its own module. Also some logic is extracted into
private method.

/cc @pixeltrix 
