### PR TITLE
Reverse order with order direction in the middle

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,12 @@
-*   Allow enable_extension migration method to be revertible.
+*   Generate valid SQL for `ActiveRecord::Relation#reverse_order` if directions of the order
+    in the middle of the expression like: `id DESC nulls first` for `PostgreSQL`
+
+    Fixes: #11571
  
+    *Paul Nikitochkin*
+
+*   Allow enable_extension migration method to be revertible.
+
     *Eric Tipton*
 
 *   Type cast hstore values on write, so that the value is consistent

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -991,7 +991,10 @@ module ActiveRecord
         when String
           o.to_s.split(',').map! do |s|
             s.strip!
-            s.gsub!(/\sasc\Z/i, ' DESC') || s.gsub!(/\sdesc\Z/i, ' ASC') || s.concat(' DESC')
+
+            s.gsub!(/\sasc(\s|\Z)/i, " DESC\\1") ||
+              s.gsub!(/\sdesc(\s|\Z)/i, " ASC\\1") ||
+              s.concat(' DESC')
           end
         when Symbol
           { o => :desc }

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -170,6 +170,18 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal topics(:fourth).title, topics.first.title
   end
 
+  def test_finding_with_order_direction_in_the_middle
+    unless current_adapter?(:PostgreSQLAdapter)
+      return skip("only tested on postgresql")
+    end
+
+    topics = Topic.order('id ASC nulls last')
+    assert_equal topics(:first).title, topics.first.title
+
+    topics = Topic.order('id DESC nulls last').reverse_order
+    assert_equal topics(:first).title, topics.first.title
+  end
+
   def test_raising_exception_on_invalid_hash_params
     assert_raise(ArgumentError) { Topic.order(:name, "id DESC", :id => :DeSc) }
   end


### PR DESCRIPTION
Order part of query with custom statements like `nulls first` or
`nulls last` at the end which arrange `null` values to top or bottom,
is broken for reverse order sql generation by adding `DESC` at the end,
because of skipping `asc|desc` before `nulls first|last` expression.

Refactored `reverse_sql_order` to take this in account:
that there is `nulls` statement after order direction
which are added by SQL:2003 extension T611, "Elementary OLAP operations" (https://en.wikipedia.org/wiki/Order_by).

Closes #11571
