### PR TITLE
Ensure /db is included in git repo of plugin

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -102,7 +102,6 @@ task default: :test
     def test_dummy_clean
       inside dummy_path do
         remove_file ".gitignore"
-        remove_file "db/seeds.rb"
         remove_file "doc"
         remove_file "Gemfile"
         remove_file "lib/tasks"


### PR DESCRIPTION
While generating a plugin that does not use the database, an empty `db/` folder will be created if the `seeds.rb` file is removed from the folder. Git does not recognise empty directories, so it will not add the `/db` folder to source. See the output here: https://github.com/schneems/default-rails-plugin

Then any tests run on a remote machine will fail:

http://stackoverflow.com/questions/17955787/sqlite3cantopenexception-unable-to-open-database-file-while-testing-ruby-gem

Either we can include the `seeds.rb` file in the generate output of `rails plugin new` or we could add a blank `.gitignore` file to ensure that the `/db` folder is included in the git repo. 

I don't see a good reason for removing the file (it only has comments anyway) and all tests pass even when we keep the file in the repo. 

You won't run into this problem is you run a migration in your plugin's tests since that creates a `db/migrate` folder.

All tests pass Railties.
