### PR TITLE
Fix that a collection proxy could be cached before the save of the owner, resulting in an invalid proxy lacking the owner’s id

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Cache CollectionAssociation#reader proxies separately before and after
+    the owner has been saved so that the proxy is not cached without the
+    owner's id.
+
+    *Ben Woosley*
+
 *   Honor overridden `rack.test` in Rack environment for the connection
     management middleware.
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -33,7 +33,13 @@ module ActiveRecord
           reload
         end
 
-        @proxy ||= CollectionProxy.create(klass, self)
+        if owner.new_record?
+          # Cache the proxy separately before the owner has an id
+          # or else a post-save proxy will still lack the id
+          @new_record_proxy ||= CollectionProxy.create(klass, self)
+        else
+          @proxy ||= CollectionProxy.create(klass, self)
+        end
       end
 
       # Implements the writer method, e.g. foo.items= for Foo.has_many :items

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -387,6 +387,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal "Summit", Firm.all.merge!(:order => "id").first.clients_using_primary_key.first.name
   end
 
+  def test_update_all_on_association_accessed_before_save
+    firm = Firm.new(name: 'Firm')
+    firm.clients << Client.first
+    firm.save!
+    assert_equal firm.clients.count, firm.clients.update_all(description: 'Great!')
+  end
+
   def test_belongs_to_sanity
     c = Client.new
     assert_nil c.firm, "belongs_to failed sanity check on new object"


### PR DESCRIPTION
Absent this fix calls like: owner.association.update_all to behave unexpectedly because they try to act on association objects where
owner_id is null.

more evidence here: https://gist.github.com/Empact/5865555

```
Active Record 3.2.13
-- create_table(:firms, {:force=>true})
   -> 0.1371s
-- create_table(:clients, {:force=>true})
   -> 0.0005s
1 clients. 1 expected.
1 clients updated. 1 expected.
```

```
Active Record 4.0.0
-- create_table(:firms, {:force=>true})
   -> 0.1606s
-- create_table(:clients, {:force=>true})
   -> 0.0004s
1 clients. 1 expected.
0 clients updated. 1 expected.
```
