### PR TITLE
Fixes raise in strong params super overwritten

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixes `ActionController::Parameters#fetch` overwriting `KeyError` returned by
+    default block.
+
+    *Jonas Schuber Erlandsson*
+
 *   Fix `ActionDispatch::RemoteIp::GetIp#calculate_ip` to only check for spoofing
     attacks if both `HTTP_CLIENT_IP` and `HTTP_X_FORWARDED_FOR` are set.
 

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -152,6 +152,11 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert_equal "monkey", @params.fetch(:foo) { "monkey" }
   end
 
+  test "fetch doesnt raise ParameterMissing exception if there is a default that is nil" do
+    assert_equal nil, @params.fetch(:foo, nil)
+    assert_equal nil, @params.fetch(:foo) { nil }
+  end
+
   test "not permitted is sticky on accessors" do
     assert !@params.slice(:person).permitted?
     assert !@params[:person][:name].permitted?

--- a/actionpack/test/controller/parameters/raise_in_super_block_test.rb
+++ b/actionpack/test/controller/parameters/raise_in_super_block_test.rb
@@ -1,0 +1,52 @@
+require 'abstract_unit'
+require 'action_controller/metal/strong_parameters'
+
+class BasicParametersTest < ActiveSupport::TestCase
+  test 'KeyError in fetch block should not be coverd up when key is symbol' do
+    params = ActionController::Parameters.new()
+    err = assert_raises(KeyError){
+      params.fetch(:missing_key){ {}.fetch(:also_missing) }
+    }
+    assert_match(/:also_missing$/, err.message)
+  end
+
+  test 'inner key super set of outer key should be handled correctly when keys are symbols' do
+    params = ActionController::Parameters.new()
+    err = assert_raises(KeyError){
+      params.fetch(:missing_key){ {}.fetch(:another_missing_key) }
+    }
+    assert_match(/:another_missing_key$/, err.message)
+  end
+
+  test 'inner key sub set of outer key should be handled correctly when keys are symbols' do
+    params = ActionController::Parameters.new()
+    err = assert_raises(KeyError){
+      params.fetch(:another_missing_key){ {}.fetch(:missing_key) }
+    }
+    assert_match(/:missing_key$/, err.message)
+  end
+
+  test 'KeyError in fetch block should not be coverd up when key is string' do
+    params = ActionController::Parameters.new()
+    err = assert_raises(KeyError){
+      params.fetch('missing_key'){ {}.fetch('also_missing') }
+    }
+    assert_match(/"also_missing"$/, err.message)
+  end
+
+  test 'inner key super set of outer key should be handled correctly when keys are strings' do
+    params = ActionController::Parameters.new()
+    err = assert_raises(KeyError){
+      params.fetch('missing_key'){ {}.fetch('another_missing_key') }
+    }
+    assert_match(/"another_missing_key"$/, err.message)
+  end
+
+  test 'inner key sub set of outer key should be handled correctly when keys are strings' do
+    params = ActionController::Parameters.new()
+    err = assert_raises(KeyError){
+      params.fetch('another_missing_key'){ {}.fetch('missing_key') }
+    }
+    assert_match(/"missing_key"$/, err.message)
+  end
+end


### PR DESCRIPTION
**The original issue for this was raised over at [rails/strong_parameters](https://github.com/rails/strong_parameters/pull/156)**

When executing an `ActionController::Parameters#fetch` with a block
that raises a `KeyError` the raised `KeyError` will be rescued and
converted to an `ActionController::ParameterMissing` exception,
covering up the original exception.

This commit fixes the problem by checking if the `KeyError` message
is actually about the key requested in the call to
`ActionController::Parameters#fetch`. If it is we raise a new
`ActionController::ParameterMissing` exception and if it is not we
re-raise the original `KeyError` instead.

I could not come up with a more clever way of doing this than using
string comparison :/ Any suggestion to clean that up?

The tests might be excessive? But I wanted to have coverage of all
the possible cases. Should I have?

Any comments on the code, especially in the tests, are welcome. I
normally play with rspec, so minitest is a bit unfamiliar to me ...  
