### PR TITLE
Let the SQLite rake tasks run without rails

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -46,6 +46,7 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks.database_configuration = Rails.application.config.database_configuration
           ActiveRecord::Tasks::DatabaseTasks.migrations_paths = Rails.application.paths['db/migrate'].to_a
           ActiveRecord::Tasks::DatabaseTasks.fixtures_path = File.join Rails.root, 'test', 'fixtures'
+          ActiveRecord::Tasks::DatabaseTasks.root = Rails.root
 
           if defined?(ENGINE_PATH) && engine = Rails::Engine.find(ENGINE_PATH)
             if engine.paths['db/migrate'].existent

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -23,6 +23,7 @@ module ActiveRecord
     #   * +fixtures_path+: a path to fixtures directory.
     #   * +migrations_paths+: a list of paths to directories with migrations.
     #   * +seed_loader+: an object which will load seeds, it needs to respond to the +load_seed+ method.
+    #   * +root+: a path to the root of the application.
     #
     # Example usage of +DatabaseTasks+ outside Rails could look as such:
     #
@@ -37,7 +38,7 @@ module ActiveRecord
 
       attr_writer :current_config
       attr_accessor :database_configuration, :migrations_paths, :seed_loader, :db_dir,
-                    :fixtures_path, :env
+                    :fixtures_path, :env, :root
 
       LOCAL_HOSTS    = ['127.0.0.1', 'localhost']
 

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     class SQLiteDatabaseTasks # :nodoc:
       delegate :connection, :establish_connection, to: ActiveRecord::Base
 
-      def initialize(configuration, root = Rails.root)
+      def initialize(configuration, root = ActiveRecord::Tasks::DatabaseTasks.root)
         @configuration, @root = configuration, root
       end
 


### PR DESCRIPTION
This is a fix for #11697
When using the SQLite database tasks without the `Rails` module loaded, it failed, as the initializer relies on it.
