### PR TITLE
Fix status codes in document

### DIFF
--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -375,9 +375,9 @@ Rails understands both numeric status codes and the corresponding symbols shown 
 |                     | 423              | :locked                          |
 |                     | 424              | :failed_dependency               |
 |                     | 426              | :upgrade_required                |
-|                     | 423              | :precondition_required           |
-|                     | 424              | :too_many_requests               |
-|                     | 426              | :request_header_fields_too_large |
+|                     | 428              | :precondition_required           |
+|                     | 429              | :too_many_requests               |
+|                     | 431              | :request_header_fields_too_large |
 | **Server Error**    | 500              | :internal_server_error           |
 |                     | 501              | :not_implemented                 |
 |                     | 502              | :bad_gateway                     |


### PR DESCRIPTION
Fixed typos in "Layouts and Rendering in Rails".

[RFC 6585 Additional HTTP Status Codes](http://www.ietf.org/rfc/rfc6585.txt)

> 428 Precondition Required
> 429 Too Many Requests
> 431 Request Header Fields Too Large
