### PR TITLE
javascript_include_tag "extname" option for use by asset_path

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Added an `extname` hash option for `javascript_include_tag` method.
+
+    Before:
+
+        javascript_include_tag('templates.jst')
+        # => <script src="/javascripts/templates.jst.js"></script>
+
+    After:
+
+        javascript_include_tag('templates.jst', extname: false )
+        # => <script src="/javascripts/templates.jst"></script>
+
+    *Nathan Stitt*
+
 *   Fix `current_page?` when the URL contains escaped characters and the
     original URL is using the hexadecimal lowercased.
 

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -26,7 +26,8 @@ module ActionView
       # to <tt>assets/javascripts</tt>, full paths are assumed to be relative to the document
       # root. Relative paths are idiomatic, use absolute paths only when needed.
       #
-      # When passing paths, the ".js" extension is optional.
+      # When passing paths, the ".js" extension is optional.  If you do not want ".js"
+      # appended to the path <tt>extname: false</tt> can be set on the options.
       #
       # You can modify the HTML attributes of the script tag by passing a hash as the
       # last argument.
@@ -36,6 +37,9 @@ module ActionView
       #
       #   javascript_include_tag "xmlhr"
       #   # => <script src="/assets/xmlhr.js?1284139606"></script>
+      #
+      #   javascript_include_tag "template.jst", extname: false
+      #   # => <script src="/assets/template.jst?1284139606"></script>
       #
       #   javascript_include_tag "xmlhr.js"
       #   # => <script src="/assets/xmlhr.js?1284139606"></script>
@@ -51,8 +55,7 @@ module ActionView
       #   # => <script src="http://www.example.com/xmlhr.js"></script>
       def javascript_include_tag(*sources)
         options = sources.extract_options!.stringify_keys
-        path_options = options.extract!('protocol').symbolize_keys
-
+        path_options = options.extract!('protocol', 'extname').symbolize_keys
         sources.uniq.map { |source|
           tag_options = {
             "src" => path_to_javascript(source, path_options)

--- a/actionview/test/template/javascript_helper_test.rb
+++ b/actionview/test/template/javascript_helper_test.rb
@@ -51,6 +51,13 @@ class JavaScriptHelperTest < ActionView::TestCase
     assert_equal 'foo', output_buffer, 'javascript_tag without a block should not concat to output_buffer'
   end
 
+  # Setting the :extname option will control what extension (if any) is appended to the url for assets
+  def test_javascript_include_tag
+    assert_dom_equal "<script src='/foo.js'></script>",  javascript_include_tag('/foo')
+    assert_dom_equal "<script src='/foo'></script>",     javascript_include_tag('/foo', extname: false )
+    assert_dom_equal "<script src='/foo.bar'></script>", javascript_include_tag('/foo', extname: '.bar' )
+  end
+
   def test_javascript_tag_with_options
     assert_dom_equal "<script id=\"the_js_tag\">\n//<![CDATA[\nalert('hello')\n//]]>\n</script>",
       javascript_tag("alert('hello')", :id => "the_js_tag")


### PR DESCRIPTION
javascript_include_tag uses ActionView::Helpers.asset_path to compute the path for javascript files.  However asset_path automatically appends an extension onto the path which is controlled by the extname option. 

javascript_tag_helper only passed the 'protocol' option to asset_path, making it impossible to modify the extname behavior.  Without this, underscore JST template files are getting a '.js' extension appended to them.

This breaks the 'jammit' gem since it calls javascript_include_tag internally.   

For instance `javascript_include_tag('core.jst')` is returning `<script src="/javascripts/core.jst.js"></script>`
