### PR TITLE
test_registering_new_handlers and test_count_on_invalid_columns_raises can be case insensitive

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -172,7 +172,7 @@ class CalculationsTest < ActiveRecord::TestCase
       Account.select("credit_limit, firm_name").count
     }
 
-    assert_match "accounts", e.message
+    assert_match %r{accounts}i, e.message
     assert_match "credit_limit, firm_name", e.message
   end
 

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -8,7 +8,7 @@ module ActiveRecord
         Arel::Nodes::InfixOperation.new('~', column, value.source)
       end)
 
-      assert_match %r{["`]topics["`].["`]title["`] ~ 'rails'}, Topic.where(title: /rails/).to_sql
+      assert_match %r{["`]topics["`].["`]title["`] ~ 'rails'}i, Topic.where(title: /rails/).to_sql
     end
   end
 end


### PR DESCRIPTION
This pull requests addresses following failures with Oracle database adapters because
it handles table name in uppercase.
- test_registering_new_handlers

``` ruby
$ cd activerecord
$ ARCONN=oracle ruby -Itest test/cases/relation/predicate_builder_test.rb -n test_registering_new_handlers
Using oracle
Run options: -n test_registering_new_handlers --seed 32133

# Running:

F

Finished in 0.014449s, 69.2071 runs/s, 138.4142 assertions/s.

  1) Failure:
ActiveRecord::PredicateBuilderTest#test_registering_new_handlers [test/cases/relation/predicate_builder_test.rb:11]:
Expected /["`]topics["`].["`]title["`] ~ 'rails'/ to match "SELECT \"TOPICS\".* FROM \"TOPICS\"  WHERE (\"TOPICS\".\"TITLE\" ~ 'rails')".

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
$
```
- SQL statements generated by each adapters

``` sql
- sqlite3
SELECT "topics".* FROM "topics"  WHERE ("topics"."title" ~ 'rails')

- postgresql
SELECT "topics".* FROM "topics"  WHERE ("topics"."title" ~ 'rails')

- mysql
SELECT `topics`.* FROM `topics`  WHERE (`topics`.`title` ~ 'rails')

- mysql2
SELECT `topics`.* FROM `topics`  WHERE (`topics`.`title` ~ 'rails')

- oracle
SELECT "TOPICS".* FROM "TOPICS"  WHERE ("TOPICS"."TITLE" ~ 'rails')
```

test_count_on_invalid_columns_raises

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/calculations_test.rb -n test_count_on_invalid_columns_raises
Using oracle
Run options: -n test_count_on_invalid_columns_raises --seed 62751

# Running:

F

Finished in 0.257183s, 3.8883 runs/s, 11.6648 assertions/s.

  1) Failure:
CalculationsTest#test_count_on_invalid_columns_raises [test/cases/calculations_test.rb:175]:
Expected /accounts/ to match "OCIError: ORA-00909: invalid number of arguments: SELECT COUNT(credit_limit, firm_name) FROM \"ACCOUNTS\"".

1 runs, 3 assertions, 1 failures, 0 errors, 0 skips
$
```

Error messages of each adapters

``` sql
- sqlite3
SQLite3::SQLException: wrong number of arguments to function COUNT(): SELECT COUNT(credit_limit, firm_name) FROM "accounts"

- postgresql
PG::UndefinedFunction: ERROR:  function count(integer, character varying) does not exist
LINE 1: SELECT COUNT(credit_limit, firm_name) FROM "accounts"
               ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
: SELECT COUNT(credit_limit, firm_name) FROM "accounts"

- mysql
Mysql::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ' firm_name) FROM `accounts`' at line 1: SELECT COUNT(credit_limit, firm_name) FROM `accounts`

- mysql2
Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ' firm_name) FROM `accounts`' at line 1: SELECT COUNT(credit_limit, firm_name) FROM `accounts`

- oracle
OCIError: ORA-00909: invalid number of arguments: SELECT COUNT(credit_limit, firm_name) FROM "ACCOUNTS"
```
