### PR TITLE
fix the changelog typo[ci skip]

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,5 +1,5 @@
 *   Fix `current_page?` when the URL contains escaped characters and the
-    original URL is using the hexdecimal lowercased.
+    original URL is using the hexadecimal lowercased.
 
     *Rafael Mendonça França*
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -34,7 +34,7 @@
 
 *   When using optimistic locking, `update` was not passing the column to `quote_value`
     to allow the connection adapter to properly determine how to quote the value. This was
-    affecting certain databases that use specific colmn types.
+    affecting certain databases that use specific column types.
 
     Fixes: #6763
 


### PR DESCRIPTION
Some of the spelling was wrong on CHANGELOG(s), is fixed.

Thanks
