### PR TITLE
Removed redundant xml override from pg adapter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Removed redundant override of `xml` column definition for PG,
+    in order to use `xml` column type instead of `text`
+
+    *Paul Nikitochkin*, *Michael Nikitochkin*
+
 *   Revert `ActiveRecord::Relation#order` change that make new order
     prepend the old one.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -373,15 +373,11 @@ module ActiveRecord
           self
         end
 
-        def xml(options = {})
-          column(args[0], :text, options)
-        end
-
         private
 
-        def create_column_definition(name, type)
-          ColumnDefinition.new name, type
-        end
+          def create_column_definition(name, type)
+            ColumnDefinition.new name, type
+          end
       end
 
       class Table < ActiveRecord::ConnectionAdapters::Table

--- a/activerecord/test/cases/adapters/postgresql/xml_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/xml_test.rb
@@ -1,0 +1,39 @@
+# encoding: utf-8
+
+require 'cases/helper'
+require 'active_record/base'
+require 'active_record/connection_adapters/postgresql_adapter'
+
+class PostgresqlXMLTest < ActiveRecord::TestCase
+  class XmlDataType < ActiveRecord::Base
+    self.table_name = 'xml_data_type'
+  end
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+    begin
+      @connection.transaction do
+        @connection.create_table('xml_data_type') do |t|
+          t.xml 'payload', default: {}
+        end
+      end
+    rescue ActiveRecord::StatementInvalid
+      return skip "do not test on PG without xml"
+    end
+    @column = XmlDataType.columns.find { |c| c.name == 'payload' }
+  end
+
+  def teardown
+    @connection.execute 'drop table if exists xml_data_type'
+  end
+
+  def test_column
+    assert_equal :xml, @column.type
+  end
+
+  def test_null_xml
+    @connection.execute %q|insert into xml_data_type (payload) VALUES(null)|
+    x = XmlDataType.first
+    assert_equal(nil, x.payload)
+  end
+end


### PR DESCRIPTION
In order that `xml` column defined in https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L267, overrides of `xml` to have text column is redundant.

Closes: #11706
