### PR TITLE
Add timeout to test_async_stream

### DIFF
--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -135,7 +135,7 @@ module ActionController
 
       @controller.process :blocking_stream
 
-      assert t.join
+      assert t.join(3), 'timeout expired before the thread terminated'
     end
 
     def test_thread_locals_get_copied


### PR DESCRIPTION
Related to #11700 

Without timeout:

this test executed infinitely long on JRuby, as seen in the screenshot from Travis. see the 2nd row:
![](https://f.cloud.github.com/assets/235844/901707/592549e6-fb85-11e2-812a-1b9610125744.png)

With Timeout:
this test gracefully fails on JRuby, test on v1.7.4
Passes on MRI, tested on v2.0 & v1.9.3
