### PR TITLE
Fix jruby warning when capture calls unlink on an open tempfile

### DIFF
--- a/activesupport/lib/active_support/core_ext/kernel/reporting.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/reporting.rb
@@ -91,6 +91,7 @@ module Kernel
     stream_io.rewind
     return captured_stream.read
   ensure
+    captured_stream.close
     captured_stream.unlink
     stream_io.reopen(origin_stream)
   end


### PR DESCRIPTION
jruby cannot unlink a tempfile unless it is closed first.

See http://jira.codehaus.org/browse/JRUBY-6688 for jruby details.
#11700

cc: @arunagw, @rafaelfranca
