### PR TITLE
fixed `as_json` correctly returning JSON Ready values

### DIFF
--- a/actionpack/test/controller/render_json_test.rb
+++ b/actionpack/test/controller/render_json_test.rb
@@ -8,7 +8,7 @@ class RenderJsonTest < ActionController::TestCase
     def as_json(options={})
       hash = { :a => :b, :c => :d, :e => :f }
       hash.except!(*options[:except]) if options[:except]
-      hash
+      hash.as_json(options)
     end
 
     def to_json(options = {})

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -241,7 +241,7 @@ module ActiveModel
     #   person.errors.as_json                      # => {:name=>["can not be nil"]}
     #   person.errors.as_json(full_messages: true) # => {:name=>["name can not be nil"]}
     def as_json(options=nil)
-      to_hash(options && options[:full_messages])
+      to_hash(options && options[:full_messages]).as_json(options)
     end
 
     # Returns a Hash of attributes with their error messages. If +full_messages+

--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -97,7 +97,7 @@ module ActiveModel
           { root => serializable_hash(options) }
         else
           serializable_hash(options)
-        end
+        end.as_json
       end
 
       # Sets the model +attributes+ from a JSON string. Returns +self+.

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -238,14 +238,14 @@ class ErrorsTest < ActiveModel::TestCase
     person = Person.new
     person.validate!
 
-    assert_equal({ name: ["can not be nil"] }, person.errors.as_json)
+    assert_equal({ "name" => ["can not be nil"] }, person.errors.as_json)
   end
 
   test "as_json with :full_messages option creates a json formatted representation of the errors containing complete messages" do
     person = Person.new
     person.validate!
 
-    assert_equal({ name: ["name can not be nil"] }, person.errors.as_json(full_messages: true))
+    assert_equal({ "name" => ["name can not be nil"] }, person.errors.as_json(full_messages: true))
   end
 
   test "generate_message works without i18n_scope" do

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -151,7 +151,7 @@ class JsonSerializationTest < ActiveModel::TestCase
     assert_kind_of Hash, json
     assert_kind_of Hash, json['contact']
     %w(name age created_at awesome preferences).each do |field|
-      assert_equal @contact.send(field), json['contact'][field]
+      assert_equal @contact.send(field).as_json, json['contact'][field]
     end
   end
 
@@ -195,7 +195,7 @@ class JsonSerializationTest < ActiveModel::TestCase
   end
 
   test "custom as_json should be honored when generating json" do
-    def @contact.as_json(options); { name: name, created_at: created_at }; end
+    def @contact.as_json(options); { name: name, created_at: created_at }.as_json(options); end
     json = @contact.to_json
 
     assert_match %r{"name":"Konata Izumi"}, json

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   fixed `as_json` correctly returning JSON Ready values
+    
+    Standarized the output of `as_json` methods to JSON Ready values.
+
+    Fixes #11460
+
+    *Sergio Campamá*, *Godfrey Chan*
+
 *   Remove 'cow' => 'kine' irregular inflection from default inflections.
 
     *Andrew White*


### PR DESCRIPTION
The `as_json` methods introduced in `ActiveSupport::JSON::Encoding::Encoder` weren't standarized in the output format, besides having incorrect arguments for certain methods (rails/rails#11460). The way the encoder works has been rewritten to standarize the output to JSON Ready values. Part of that refactoring included the simplification of the circular detection logic and fixing a few cases in which the detection didn't work.

To fix the issues described in rails/rails#11460, `as_json` had to be standarized across Rails to return a JSON Ready value, which only contains primitives that can be directly mapped to JSON primitives (`Array`, `Hash`, `Numeric`, `String`, `TrueClass`,`FalseClass`, `NilClass`). This meant rewriting some tests that failed to comply with this requirement, among other minor changes in `ActiveModel` and `ActionPack`.

Fixes rails/rails#11460
