### PR TITLE
Using URI.parser.unescape

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -528,13 +528,13 @@ module ActionView
 
         return false unless request.get? || request.head?
 
-        url_string = URI.unescape(url_for(options)).force_encoding(Encoding::BINARY)
+        url_string = URI.parser.unescape(url_for(options)).force_encoding(Encoding::BINARY)
 
         # We ignore any extra parameters in the request_uri if the
         # submitted url doesn't have any either. This lets the function
         # work with things like ?order=asc
         request_uri = url_string.index("?") ? request.fullpath : request.path
-        request_uri = URI.unescape(request_uri).force_encoding(Encoding::BINARY)
+        request_uri = URI.parser.unescape(request_uri).force_encoding(Encoding::BINARY)
 
         if url_string =~ /^\w+:\/\//
           url_string == "#{request.protocol}#{request.host_with_port}#{request_uri}"


### PR DESCRIPTION
Fixes warning

warning: URI.unescape is obsolete
