### PR TITLE
[JRuby] Avoid calling define_method with non-english chars in InflectorTest

### DIFF
--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -76,9 +76,10 @@ class InflectorTest < ActiveSupport::TestCase
     ActiveSupport::Inflector.inflections.uncountable "series" # Return to normal
   end
 
-  MixtureToTitleCase.each do |before, titleized|
-    define_method "test_titleize_#{before}" do
-      assert_equal(titleized, ActiveSupport::Inflector.titleize(before))
+  MixtureToTitleCase.each_with_index do |(before, titleized), index|
+    define_method "test_titleize_mixture_to_title_case_#{index}" do
+      assert_equal(titleized, ActiveSupport::Inflector.titleize(before), "mixture \
+        to TitleCase failed for #{before}")
     end
   end
 


### PR DESCRIPTION
When we call `define_method` with non-english chars like `¿por qué?` it
errors out on JRuby as of `1.7.4` & would leave out the following error

`invalid byte sequence in US-ASCII`

For more details, see the Bug reported:
[JRUBY-7189 - invalid byte sequence in US-ASCII](http://jira.codehaus.org/browse/JRUBY-7189)

To work around this issue, I have switched to define_method to define method name with US-ASCII & the index of the hash. the index was added because otherwise, ruby will raise method redefined warning.As far as I can see there are no side-effect of this change for other implementations. For readability I have added a message to `asssert_equal` informing for which word/phase the test has failed.

**Before this Change**:
JRuby: Tests terminated suddenly with an error about encoding . no report of Failues or errors
MRI: All Green.

**After this Change**:
JRuby:the `ActiveSupport` TestsSuite gracefully fails with report at the end which test failed & why.
MRI:All Green(no change)

With this, we are one More step closer to #11700!

Thanks to Thomas E Enebo from JRuby Core Team for [this comment](http://jira.codehaus.org/browse/JRUBY-7189?focusedCommentId=329939&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-329939)
