### PR TITLE
[Fixes #11734]Correct Association Basics Guide on has_and_belongs_to_many

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1944,8 +1944,8 @@ While Rails uses intelligent defaults that will work well in most situations, th
 
 ```ruby
 class Parts < ActiveRecord::Base
-  has_and_belongs_to_many :assemblies, uniq: true,
-                                       read_only: true
+  has_and_belongs_to_many :assemblies, autosave: true,
+                                       readonly: true
 end
 ```
 
@@ -1957,6 +1957,7 @@ The `has_and_belongs_to_many` association supports these options:
 * `:foreign_key`
 * `:join_table`
 * `:validate`
+* `:readonly`
 
 ##### `:association_foreign_key`
 


### PR DESCRIPTION
Done the following changes:
1. Replace `uniq`  in example with `autosave` as `uniq` is not supported
   on `has_and_belongs_to_many`
2. Add `:readonly` option to list of supported call as per [EdgeApi](http://edgeapi.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-has_and_belongs_to_many)
