### PR TITLE
Remove duplication from time/date-time/date

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add Date#seconds_until_end_of_day, Date#beginning_of_hour and
+    Date#beginning_of_minute. All of which convert the Date to a TimeWithZone
+    at the same date at midnight, and then use the equivalent Time logic for
+    the methods.
+
+    *Gilad Zohari*
+
 *   Add String#remove(pattern) as a short-hand for the common pattern of String#gsub(pattern, '')
 
     *DHH*

--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -49,35 +49,11 @@ class Date
   end
 
   # Converts Date to a Time (or DateTime if necessary) with the time portion set to the beginning of the day (0:00)
-  # and then subtracts the specified number of seconds.
-  def ago(seconds)
-    in_time_zone.since(-seconds)
-  end
-
-  # Converts Date to a Time (or DateTime if necessary) with the time portion set to the beginning of the day (0:00)
   # and then adds the specified number of seconds
   def since(seconds)
     in_time_zone.since(seconds)
   end
   alias :in :since
-
-  # Converts Date to a Time (or DateTime if necessary) with the time portion set to the beginning of the day (0:00)
-  def beginning_of_day
-    in_time_zone
-  end
-  alias :midnight :beginning_of_day
-  alias :at_midnight :beginning_of_day
-  alias :at_beginning_of_day :beginning_of_day
-
-  # Converts Date to a Time (or DateTime if necessary) with the time portion set to the middle of the day (12:00)
-  def middle_of_day
-    in_time_zone.middle_of_day
-  end
-  alias :midday :middle_of_day
-  alias :noon :middle_of_day
-  alias :at_midday :middle_of_day
-  alias :at_noon :middle_of_day
-  alias :at_middle_of_day :middle_of_day
 
   # Converts Date to a Time (or DateTime if necessary) with the time portion set to the end of the day (23:59:59)
   def end_of_day
@@ -123,11 +99,15 @@ class Date
   #   Date.new(2007, 5, 12).change(day: 1)               # => Date.new(2007, 5, 1)
   #   Date.new(2007, 5, 12).change(year: 2005, month: 1) # => Date.new(2005, 1, 12)
   def change(options)
-    ::Date.new(
-      options.fetch(:year, year),
-      options.fetch(:month, month),
-      options.fetch(:day, day)
-    )
+    if (options.keys & [:hour, :min, :sec, :usec]).empty?
+      ::Date.new(
+        options.fetch(:year, year),
+        options.fetch(:month, month),
+        options.fetch(:day, day)
+      )
+    else
+      in_time_zone.change(options)
+    end
   end
   
   # Allow Date to be compared with Time by converting to DateTime and relying on the <=> from there.

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -213,6 +213,51 @@ module DateAndTime
     end
     alias :at_end_of_year :end_of_year
 
+    # Returns a new Time or Datetime representing the time a number of seconds ago,
+    # this is basically a wrapper around the Numeric extension
+    #
+    # If object is a Date, it is converted to a Time (or DateTime if necessary) with the time portion
+    # set to the beginning of the day (0:00), and then subtracts the specified number of seconds.
+    #
+    # Do not use this method in combination with x.months, use months_ago instead!
+    def ago(seconds)
+      since(-seconds)
+    end
+
+    # Returns a new Time or Datetime representing the start of the day (0:00)
+    # If object is a Date, it is converted into Time (or DateTime if necessary),
+    # with the time portion set to the beginning of the day (0:00).
+    def beginning_of_day
+      change(hour: 0)
+    end
+    alias :midnight :beginning_of_day
+    alias :at_midnight :beginning_of_day
+    alias :at_beginning_of_day :beginning_of_day
+
+    # Returns a new Time or DateTime representing the middle of the day (12:00)
+    # If object is a Date, it is converted to a Time (or DateTime if necessary)
+    # with the time portion set to the middle of the day (12:00).
+    def middle_of_day
+      change(hour: 12)
+    end
+    alias :midday :middle_of_day
+    alias :noon :middle_of_day
+    alias :at_midday :middle_of_day
+    alias :at_noon :middle_of_day
+    alias :at_middle_of_day :middle_of_day
+
+    # Returns a new Time or DateTime representing the start of the hour (hh:00:00)
+    def beginning_of_hour
+      change(:min => 0)
+    end
+    alias :at_beginning_of_hour :beginning_of_hour
+
+    # Returns a new Time or DateTime representing the start of the minute (hh:mm:00)
+    def beginning_of_minute
+      change(:sec => 0)
+    end
+    alias :at_beginning_of_minute :beginning_of_minute
+
     private
 
     def first_hour(date_or_time)

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -67,12 +67,6 @@ class DateTime
     end
   end
 
-  # Returns a new DateTime representing the time a number of seconds ago.
-  # Do not use this method in combination with x.months, use months_ago instead!
-  def ago(seconds)
-    since(-seconds)
-  end
-
   # Returns a new DateTime representing the time a number of seconds since the
   # instance time. Do not use this method in combination with x.months, use
   # months_since instead!
@@ -81,47 +75,17 @@ class DateTime
   end
   alias :in :since
 
-  # Returns a new DateTime representing the start of the day (0:00).
-  def beginning_of_day
-    change(:hour => 0)
-  end
-  alias :midnight :beginning_of_day
-  alias :at_midnight :beginning_of_day
-  alias :at_beginning_of_day :beginning_of_day
-
-  # Returns a new DateTime representing the middle of the day (12:00)
-  def middle_of_day
-    change(:hour => 12)
-  end
-  alias :midday :middle_of_day
-  alias :noon :middle_of_day
-  alias :at_midday :middle_of_day
-  alias :at_noon :middle_of_day
-  alias :at_middle_of_day :middle_of_day
-
   # Returns a new DateTime representing the end of the day (23:59:59).
   def end_of_day
     change(:hour => 23, :min => 59, :sec => 59)
   end
   alias :at_end_of_day :end_of_day
 
-  # Returns a new DateTime representing the start of the hour (hh:00:00).
-  def beginning_of_hour
-    change(:min => 0)
-  end
-  alias :at_beginning_of_hour :beginning_of_hour
-
   # Returns a new DateTime representing the end of the hour (hh:59:59).
   def end_of_hour
     change(:min => 59, :sec => 59)
   end
   alias :at_end_of_hour :end_of_hour
-
-  # Returns a new DateTime representing the start of the minute (hh:mm:00).
-  def beginning_of_minute
-    change(:sec => 0)
-  end
-  alias :at_beginning_of_minute :beginning_of_minute
 
   # Returns a new DateTime representing the end of the minute (hh:mm:59).
   def end_of_minute
@@ -153,5 +117,4 @@ class DateTime
   def <=>(other)
     super other.to_datetime
   end
-
 end

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -120,11 +120,6 @@ class Time
     end
   end
 
-  # Returns a new Time representing the time a number of seconds ago, this is basically a wrapper around the Numeric extension
-  def ago(seconds)
-    since(-seconds)
-  end
-
   # Returns a new Time representing the time a number of seconds since the instance time
   def since(seconds)
     self + seconds
@@ -133,24 +128,6 @@ class Time
   end
   alias :in :since
 
-  # Returns a new Time representing the start of the day (0:00)
-  def beginning_of_day
-    #(self - seconds_since_midnight).change(usec: 0)
-    change(:hour => 0)
-  end
-  alias :midnight :beginning_of_day
-  alias :at_midnight :beginning_of_day
-  alias :at_beginning_of_day :beginning_of_day
-
-  # Returns a new Time representing the middle of the day (12:00)
-  def middle_of_day
-    change(:hour => 12)
-  end
-  alias :midday :middle_of_day
-  alias :noon :middle_of_day
-  alias :at_midday :middle_of_day
-  alias :at_noon :middle_of_day
-  alias :at_middle_of_day :middle_of_day
 
   # Returns a new Time representing the end of the day, 23:59:59.999999 (.999999999 in ruby1.9)
   def end_of_day
@@ -163,12 +140,6 @@ class Time
   end
   alias :at_end_of_day :end_of_day
 
-  # Returns a new Time representing the start of the hour (x:00)
-  def beginning_of_hour
-    change(:min => 0)
-  end
-  alias :at_beginning_of_hour :beginning_of_hour
-
   # Returns a new Time representing the end of the hour, x:59:59.999999 (.999999999 in ruby1.9)
   def end_of_hour
     change(
@@ -179,11 +150,6 @@ class Time
   end
   alias :at_end_of_hour :end_of_hour
 
-  # Returns a new Time representing the start of the minute (x:xx:00)
-  def beginning_of_minute
-    change(:sec => 0)
-  end
-  alias :at_beginning_of_minute :beginning_of_minute
 
   # Returns a new Time representing the end of the minute, x:xx:59.999999 (.999999999 in ruby1.9)
   def end_of_minute

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -238,4 +238,19 @@ module DateAndTimeBehavior
   ensure
     Date.beginning_of_week = old_bw
   end
+
+  def test_ago
+    assert_equal date_time_init(2005,2,22,10,10,9),  date_time_init(2005,2,22,10,10,10).ago(1)
+    assert_equal date_time_init(2005,2,22,9,10,10),  date_time_init(2005,2,22,10,10,10).ago(3600)
+    assert_equal date_time_init(2005,2,20,10,10,10), date_time_init(2005,2,22,10,10,10).ago(86400*2)
+    assert_equal date_time_init(2005,2,20,9,9,45),   date_time_init(2005,2,22,10,10,10).ago(86400*2 + 3600 + 25)
+  end
+
+  def test_beginning_of_hour
+    assert_equal date_time_init(2005,2,4,19,0,0), date_time_init(2005,2,4,19,30,10).beginning_of_hour
+  end
+
+  def test_beginning_of_minute
+    assert_equal date_time_init(2005,2,4,19,30,0), date_time_init(2005,2,4,19,30,10).beginning_of_minute
+  end
 end

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -248,6 +248,14 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.local(2005,2,21,0,0,0), Date.new(2005,2,21).beginning_of_day
   end
 
+  def test_beginning_of_hour
+    assert_equal Time.local(2005,2,21,0,0,0), Date.new(2005,2,21).beginning_of_hour
+  end
+
+  def test_beginning_of_minute
+    assert_equal Time.local(2005,2,21,0,0,0), Date.new(2005,2,21).beginning_of_minute
+  end
+
   def test_middle_of_day
     assert_equal Time.local(2005,2,21,12,0,0), Date.new(2005,2,21).middle_of_day
   end
@@ -348,11 +356,16 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     ensure
       Time.zone = old_tz
     end
+
 end
 
 class DateExtBehaviorTest < ActiveSupport::TestCase
   def test_date_acts_like_date
     assert Date.new.acts_like_date?
+  end
+
+  def test_date_does_not_act_like_time
+    assert !Date.new.acts_like?(:time)
   end
 
   def test_freeze_doesnt_clobber_memoized_instance_methods

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -90,16 +90,8 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal DateTime.civil(2005,2,4,23,59,59), DateTime.civil(2005,2,4,10,10,10).end_of_day
   end
 
-  def test_beginning_of_hour
-    assert_equal DateTime.civil(2005,2,4,19,0,0), DateTime.civil(2005,2,4,19,30,10).beginning_of_hour
-  end
-
   def test_end_of_hour
     assert_equal DateTime.civil(2005,2,4,19,59,59), DateTime.civil(2005,2,4,19,30,10).end_of_hour
-  end
-
-  def test_beginning_of_minute
-    assert_equal DateTime.civil(2005,2,4,19,30,0), DateTime.civil(2005,2,4,19,30,10).beginning_of_minute
   end
 
   def test_end_of_minute
@@ -114,13 +106,6 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_last_year
     assert_equal DateTime.civil(2004,6,5,10),  DateTime.civil(2005,6,5,10,0,0).last_year
-  end
-
-  def test_ago
-    assert_equal DateTime.civil(2005,2,22,10,10,9),  DateTime.civil(2005,2,22,10,10,10).ago(1)
-    assert_equal DateTime.civil(2005,2,22,9,10,10),  DateTime.civil(2005,2,22,10,10,10).ago(3600)
-    assert_equal DateTime.civil(2005,2,20,10,10,10), DateTime.civil(2005,2,22,10,10,10).ago(86400*2)
-    assert_equal DateTime.civil(2005,2,20,9,9,45),   DateTime.civil(2005,2,22,10,10,10).ago(86400*2 + 3600 + 25)
   end
 
   def test_since

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -129,14 +129,6 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
-  def test_beginning_of_hour
-    assert_equal Time.local(2005,2,4,19,0,0), Time.local(2005,2,4,19,30,10).beginning_of_hour
-  end
-
-  def test_beginning_of_minute
-    assert_equal Time.local(2005,2,4,19,30,0), Time.local(2005,2,4,19,30,10).beginning_of_minute
-  end
-
   def test_end_of_day
     assert_equal Time.local(2007,8,12,23,59,59,Rational(999999999, 1000)), Time.local(2007,8,12,10,10,10).end_of_day
     with_env_tz 'US/Eastern' do
@@ -159,13 +151,6 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_last_year
     assert_equal Time.local(2004,6,5,10),  Time.local(2005,6,5,10,0,0).last_year
-  end
-
-  def test_ago
-    assert_equal Time.local(2005,2,22,10,10,9),  Time.local(2005,2,22,10,10,10).ago(1)
-    assert_equal Time.local(2005,2,22,9,10,10),  Time.local(2005,2,22,10,10,10).ago(3600)
-    assert_equal Time.local(2005,2,20,10,10,10), Time.local(2005,2,22,10,10,10).ago(86400*2)
-    assert_equal Time.local(2005,2,20,9,9,45),   Time.local(2005,2,22,10,10,10).ago(86400*2 + 3600 + 25)
   end
 
   def test_daylight_savings_time_crossings_backward_start


### PR DESCRIPTION
Methods moved:
:ago, :beginning_of_day, :middle_of_day, :beginning_of_hour,
:beginning_of_minute.

Date#change is now aware of hours/minutes/seconds, and when they are
passed to it, a TimeWithZone will created for that date at midnight.

The following new methods are a results of this change: Date#beginning_of_hour and, Date#beginning_of_minute
