### PR TITLE
Pass assert_dom_equal message arg to underlying assertion

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix an issue where `assert_dom_equal` and `assert_dom_not_equal` were
+    ignoring the passed failure message argument.
+
+    Fixes #11751
+
+    *Ryan McGeary*
+
 *   Allow REMOTE_ADDR, HTTP_HOST and HTTP_USER_AGENT to be overridden from
     the environment passed into `ActionDispatch::TestRequest.new`.
 

--- a/actionpack/lib/action_dispatch/testing/assertions/dom.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/dom.rb
@@ -7,20 +7,20 @@ module ActionDispatch
       #
       #   # assert that the referenced method generates the appropriate HTML string
       #   assert_dom_equal '<a href="http://www.example.com">Apples</a>', link_to("Apples", "http://www.example.com")
-      def assert_dom_equal(expected, actual, message = "")
+      def assert_dom_equal(expected, actual, message = nil)
         expected_dom = HTML::Document.new(expected).root
         actual_dom   = HTML::Document.new(actual).root
-        assert_equal expected_dom, actual_dom
+        assert_equal expected_dom, actual_dom, message
       end
 
       # The negated form of +assert_dom_equivalent+.
       #
       #   # assert that the referenced method does not generate the specified HTML string
       #   assert_dom_not_equal '<a href="http://www.example.com">Apples</a>', link_to("Oranges", "http://www.example.com")
-      def assert_dom_not_equal(expected, actual, message = "")
+      def assert_dom_not_equal(expected, actual, message = nil)
         expected_dom = HTML::Document.new(expected).root
         actual_dom   = HTML::Document.new(actual).root
-        assert_not_equal expected_dom, actual_dom
+        assert_not_equal expected_dom, actual_dom, message
       end
     end
   end


### PR DESCRIPTION
`#assert_dom_equal` and `#assert_dom_not_equal` both take a "failure" `message` argument, but this argument was not utilized.
