### PR TITLE
Fix DateTime.civil_from_format to work with Ruby 2.0

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -62,7 +62,7 @@ class DateTime
   #   # => Mon, 17 Dec 2012 00:00:00 +0000
   def self.civil_from_format(utc_or_local, year, month=1, day=1, hour=0, min=0, sec=0)
     if utc_or_local.to_sym == :local
-      offset = ::Time.local(year, month, day).utc_offset.to_r / 86400
+      offset = Rational(::Time.local(year, month, day).utc_offset, 86400)
     else
       offset = 0
     end


### PR DESCRIPTION
TimeExtCalculationsTest had 2 failing tests on ruby-2.0.0-p247:
test_local_time and test_time_with_datetime_fallback

For some reason Fixnum#to_r method is returning Fixnum instead of
Rational which results in zero offset after division.

This patch works around the problem by using explicit call to
Rational constructor.
