### PR TITLE
Free result_metadata directly instead of freeing 2nd, redundant call.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -507,12 +507,12 @@ module ActiveRecord
             cols = cache[:cols] ||= metadata.fetch_fields.map { |field|
               field.name
             }
+            metadata.free
           end
 
           result_set = ActiveRecord::Result.new(cols, stmt.to_a) if cols
           affected_rows = stmt.affected_rows
 
-          stmt.result_metadata.free if cols
           stmt.free_result
           stmt.close if binds.empty?
 


### PR DESCRIPTION
`result_metadata` returns a new object each time it is called, so calling `result_metadata.free` is essentially a noop.  Instead call `free` directly on the metadata when we're done with it.
