### PR TITLE
Only cache template digests if !config.cache_template_loading

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Only cache template digests if config.cache_template_loading, since
+    ActionView::Resolver.caching is set to the same value as
+    config.cache_template_loading
+
+    *Josh Lauer* *Justin Ridgewell*
+
 *   Added an `extname` hash option for `javascript_include_tag` method.
 
     Before:

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -184,6 +184,15 @@ class TemplateDigestorTest < ActionView::TestCase
     assert_not_equal digest_phone, digest_fridge_phone
   end
 
+  def test_cache_template_loading
+    resolver_before = ActionView::Resolver.caching
+    ActionView::Resolver.caching = false
+    assert_digest_difference("messages/edit", true) do
+      change_template("comments/_comment")
+    end
+    ActionView::Resolver.caching = resolver_before
+  end
+
   private
     def assert_logged(message)
       old_logger = ActionView::Base.logger
@@ -200,9 +209,9 @@ class TemplateDigestorTest < ActionView::TestCase
       end
     end
 
-    def assert_digest_difference(template_name)
+    def assert_digest_difference(template_name, persistent = false)
       previous_digest = digest(template_name)
-      ActionView::Digestor.cache.clear
+      ActionView::Digestor.cache.clear unless persistent
 
       yield
 


### PR DESCRIPTION
Since ActionView::Resolver.caching is set to the same value as config.cache_template_loading
only cache template digests if config.cache_template_loading is not falsy.

Fixes issues #10752 and #10791
