### PR TITLE
Remove privatizing of Fixnum#/ from assert_distance_of_time_in_words

### DIFF
--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -19,8 +19,6 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def assert_distance_of_time_in_words(from, to=nil)
-    Fixnum.send :private, :/  # test we avoid Integer#/ (redefined by mathn)
-
     to ||= from
 
     # 0..1 minute with :include_seconds => true
@@ -123,12 +121,16 @@ class DateHelperTest < ActionView::TestCase
     assert_equal "about 4 hours", distance_of_time_in_words(from + 4.hours, to)
     assert_equal "less than 20 seconds", distance_of_time_in_words(from + 19.seconds, to, :include_seconds => true)
     assert_equal "less than a minute", distance_of_time_in_words(from + 19.seconds, to, :include_seconds => false)
-
-  ensure
-    Fixnum.send :public, :/
   end
 
   def test_distance_in_words
+    from = Time.utc(2004, 6, 6, 21, 45, 0)
+    assert_distance_of_time_in_words(from)
+  end
+
+  def test_distance_in_words_with_mathn_required
+    # test we avoid Integer#/ (redefined by mathn)
+    require 'mathn'
     from = Time.utc(2004, 6, 6, 21, 45, 0)
     assert_distance_of_time_in_words(from)
   end


### PR DESCRIPTION
MRI reimplemented Date in C so it doesn't hit this division anymore
while JRuby still uses the old stdlib implementation of Date so
it will always hit this.

With this change the actionview date_helper_test.rb tests should pass on JRuby.

The privatizing of Fixnum#/ was introduced in https://github.com/rails/rails/commit/dc3ac357dc21c8ba05de95760da2b2c9f963012e.
#11700

cc: @arunagw, @rafaelfranca
