### PR TITLE
do not attempt to redefine AttrNames constant in AttributeMethods

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -26,7 +26,7 @@ module ActiveRecord
           const_set const_name, value.dup.freeze
         end
       end
-    }
+    } unless defined?(AttrNames)
 
     class AttributeMethodCache
       include Mutex_m


### PR DESCRIPTION
https://github.com/rails/rails/issues/10507

Trace showing issue is occurring in model definition, as example:

```
#0:/path/to/rails/project/app/models/a_test_model.rb:18::-: class ATestModel < ActiveRecord::Base
#0:/path/to/gems/kaminari-0.14.1/lib/kaminari/models/active_record_extension.rb:9:ActiveRecord::Base:>:         def inherited_with_kaminari(kls) #:nodoc:
#0:/path/to/gems/kaminari-0.14.1/lib/kaminari/models/active_record_extension.rb:10:ActiveRecord::Base:-:           inherited_without_kaminari kls
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:94:ActiveRecord::Core::ClassMethods:>:       def inherited(child_class) #:nodoc:
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:95:ActiveRecord::Core::ClassMethods:-:         child_class.initialize_generated_modules
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:99:ActiveRecord::Core::ClassMethods:>:       def initialize_generated_modules
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:100:ActiveRecord::Core::ClassMethods:-:         @attribute_methods_mutex = Mutex.new
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:103:ActiveRecord::Core::ClassMethods:-:         generated_attribute_methods.const_set(:AttrNames, Module.new {
#0:/path/to/gems/activemodel-4.0.0/lib/active_model/attribute_methods.rb:326:ActiveModel::AttributeMethods::ClassMethods:>:       def generated_attribute_methods #:nodoc:
#0:/path/to/gems/activemodel-4.0.0/lib/active_model/attribute_methods.rb:327:ActiveModel::AttributeMethods::ClassMethods:-:         @generated_attribute_methods ||= Module.new.tap { |mod| include mod }
#0:/path/to/gems/activemodel-4.0.0/lib/active_model/attribute_methods.rb:327:ActiveModel::AttributeMethods::ClassMethods:-:         @generated_attribute_methods ||= Module.new.tap { |mod| include mod }
#0:/path/to/gems/activemodel-4.0.0/lib/active_model/attribute_methods.rb:328:ActiveModel::AttributeMethods::ClassMethods:<:       end
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:104:ActiveRecord::Core::ClassMethods:-:           def self.const_missing(name)
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:109:ActiveRecord::Core::ClassMethods:-:         generated_feature_methods
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:112:ActiveRecord::Core::ClassMethods:>:       def generated_feature_methods
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:117:ActiveRecord::Core::ClassMethods:-:         end
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:114:ActiveRecord::Core::ClassMethods:-:           mod = const_set(:GeneratedFeatureMethods, Module.new)
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:115:ActiveRecord::Core::ClassMethods:-:           include mod
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:116:ActiveRecord::Core::ClassMethods:-:           mod
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:118:ActiveRecord::Core::ClassMethods:<:       end
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:110:ActiveRecord::Core::ClassMethods:<:       end
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:96:ActiveRecord::Core::ClassMethods:-:         super
#0:/path/to/bundler/gems/rails-observers-86bfe485dc39/lib/rails/observers/active_model/observing.rb:197:ActiveModel::Observing::ClassMethods:>:         def inherited(subclass) #:nodoc:
#0:/path/to/bundler/gems/rails-observers-86bfe485dc39/lib/rails/observers/active_model/observing.rb:198:ActiveModel::Observing::ClassMethods:-:           super
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:94:ActiveRecord::Core::ClassMethods:>:       def inherited(child_class) #:nodoc:
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:95:ActiveRecord::Core::ClassMethods:-:         child_class.initialize_generated_modules
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:99:ActiveRecord::Core::ClassMethods:>:       def initialize_generated_modules
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:100:ActiveRecord::Core::ClassMethods:-:         @attribute_methods_mutex = Mutex.new
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:103:ActiveRecord::Core::ClassMethods:-:         generated_attribute_methods.const_set(:AttrNames, Module.new {
#0:/path/to/gems/activemodel-4.0.0/lib/active_model/attribute_methods.rb:326:ActiveModel::AttributeMethods::ClassMethods:>:       def generated_attribute_methods #:nodoc:
#0:/path/to/gems/activemodel-4.0.0/lib/active_model/attribute_methods.rb:327:ActiveModel::AttributeMethods::ClassMethods:-:         @generated_attribute_methods ||= Module.new.tap { |mod| include mod }
#0:/path/to/gems/activemodel-4.0.0/lib/active_model/attribute_methods.rb:328:ActiveModel::AttributeMethods::ClassMethods:<:       end
#0:/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:104:ActiveRecord::Core::ClassMethods:-:           def self.const_missing(name)
/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:103: warning: already initialized constant #<Module:0x007fa772503f18>::AttrNames
/path/to/gems/activerecord-4.0.0/lib/active_record/core.rb:103: warning: previous definition of AttrNames was here
```

May not be best fix. Open to other suggestions. Seems like should be backported to 4.0.x if accepted.
