### PR TITLE
Rack::Logger naked rescue fix

### DIFF
--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -38,7 +38,7 @@ module Rails
         resp = @app.call(env)
         resp[2] = ::Rack::BodyProxy.new(resp[2]) { finish(request) }
         resp
-      rescue
+      rescue Exception
         finish(request)
         raise
       ensure

--- a/railties/test/rack_logger_test.rb
+++ b/railties/test/rack_logger_test.rb
@@ -57,11 +57,14 @@ module Rails
       end
 
       def test_notification_on_raise
-        logger = TestLogger.new { raise }
+        logger = TestLogger.new do
+          # using an exception class that is not a StandardError subclass on purpose
+          raise NotImplementedError
+        end
 
         assert_difference('subscriber.starts.length') do
           assert_difference('subscriber.finishes.length') do
-            assert_raises(RuntimeError) do
+            assert_raises(NotImplementedError) do
               logger.call 'REQUEST_METHOD' => 'GET'
             end
           end

--- a/railties/test/rack_logger_test.rb
+++ b/railties/test/rack_logger_test.rb
@@ -1,3 +1,4 @@
+require 'abstract_unit'
 require 'active_support/testing/autorun'
 require 'active_support/test_case'
 require 'rails/rack/logger'


### PR DESCRIPTION
This is similar to #11497.

PS: there are no other dangerous "naked" `rescue`s in the rest of the Rails codebase.
