### PR TITLE
Prefer single-quoted strings when you don't need string interpolation or...

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -1,9 +1,9 @@
-require "rails"
-require "action_controller"
-require "action_dispatch/railtie"
-require "action_view/railtie"
-require "abstract_controller/railties/routes_helpers"
-require "action_controller/railties/helpers"
+require 'rails'
+require 'action_controller'
+require 'action_dispatch/railtie'
+require 'action_view/railtie'
+require 'abstract_controller/railties/routes_helpers'
+require 'action_controller/railties/helpers'
 
 module ActionController
   class Railtie < Rails::Railtie #:nodoc:


### PR DESCRIPTION
... special symbols.

Consistent across file using single quotes
