### PR TITLE
Prefer single-quoted strings when you don't need string interpolation or...

### DIFF
--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -1,5 +1,5 @@
-require "action_controller/log_subscriber"
-require "action_controller/metal/params_wrapper"
+require 'action_controller/log_subscriber'
+require 'action_controller/metal/params_wrapper'
 
 module ActionController
   # Action Controllers are the core of a web request in \Rails. They are made up of one or more actions that are executed


### PR DESCRIPTION
... special symbols.

Maintaining Consistency of code with Single quotes
