### PR TITLE
Avoid defining multibyte method names in JSON decoding test for JRuby Compatitibility

### DIFF
--- a/activesupport/test/json/decoding_test.rb
+++ b/activesupport/test/json/decoding_test.rb
@@ -55,12 +55,13 @@ class TestJSONDecoding < ActiveSupport::TestCase
     %q({"a":"Line1\u000aLine2"}) => {"a"=>"Line1\nLine2"}
   }
 
-  TESTS.each do |json, expected|
-    test "json decodes #{json}" do
+  TESTS.each_with_index do |(json, expected), index|
+    test "json decodes #{index}" do
       prev = ActiveSupport.parse_json_times
       ActiveSupport.parse_json_times = true
       silence_warnings do
-        assert_equal expected, ActiveSupport::JSON.decode(json)
+        assert_equal expected, ActiveSupport::JSON.decode(json), "JSON decoding \
+        failed for #{json}"
       end
       ActiveSupport.parse_json_times = prev
     end


### PR DESCRIPTION
This change is similar to #11736 & in same way switched with fixed string & the index of the hash for method name. the index was added because otherwise, ruby will raise Error.

**Before this change**:

> JRuby: raised an `NoMethodError` when running the decoding tests.
> MRI: all green.

**After this change**

> JRuby: All green :+1:  
> MRI: all green(no change)
#11700

cc: @steveklabnik @guilleiguaran @arunagw 
