### PR TITLE
Fix for #4971 - "can't use fixtures with a created engine"

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
@@ -10,6 +10,7 @@ Rails.backtrace_cleaner.remove_silencers!
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 # Load fixtures from the engine
-if ActiveSupport::TestCase.method_defined?(:fixture_path=)
-  ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
+class ActiveSupport::TestCase
+  self.fixture_path = File.expand_path("../fixtures", __FILE__)
+  fixtures :all
 end


### PR DESCRIPTION
A fix for loading the fixtures in the test_helper.rb generated for engines.

Changes the method of setting the fixture path; works around an issue checking if the fixture_path= method exists. As it is currently, `ActiveSupport::TestCase.method_defined?(:fixture_path=)` always returns false and the path will never be set.

In addition the fixtures were not being loaded.

References issue #4971
