### PR TITLE
excerpt() and highlight() now accept regular expressions.

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -155,9 +155,13 @@ module ActionView
       def excerpt(text, phrase, options = {})
         return unless text && phrase
 
-        separator = options[:separator] || ''
-        phrase    = Regexp.escape(phrase)
-        regex     = /#{phrase}/i
+        separator = options.fetch(:separator, nil) || ""
+        if Regexp === phrase
+          regex = phrase
+        else
+          phrase    = Regexp.escape(phrase)
+          regex     = /#{phrase}/i
+        end
 
         return unless matches = text.match(regex)
         phrase = matches[0]

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -123,7 +123,9 @@ module ActionView
           text
         else
           highlighter = options.fetch(:highlighter, '<mark>\1</mark>')
-          match = Array(phrases).map { |p| Regexp.escape(p) }.join('|')
+          match = Array(phrases).map do |p|
+            Regexp === p ? p.to_s : Regexp.escape(p)
+          end.join('|')
           text.gsub(/(#{match})(?![^<]*?>)/i, highlighter)
         end.html_safe
       end

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -264,6 +264,8 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("...is a beautiful morn...", excerpt("This is a beautiful morning", "beautiful", :radius => 5))
     assert_equal("This is a...", excerpt("This is a beautiful morning", "this", :radius => 5))
     assert_equal("...iful morning", excerpt("This is a beautiful morning", "morning", :radius => 5))
+    assert_equal("...udge Allen and...", excerpt("This day was challenging for judge Allen and his colleagues.", /\ballen\b/i, :radius => 5))
+    assert_equal("...judge Allen and...", excerpt("This day was challenging for judge Allen and his colleagues.", /\ballen\b/i, :radius => 1, :separator => ' '))
     assert_nil excerpt("This is a beautiful morning", "day")
   end
 

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -222,6 +222,11 @@ class TextHelperTest < ActionView::TestCase
     )
   end
 
+  def test_highlight_accepts_regexp
+    assert_equal("This day was challenging for judge <mark>Allen</mark> and his colleagues.",
+                 highlight("This day was challenging for judge Allen and his colleagues.", /\ballen\b/i))
+  end
+
   def test_highlight_with_multiple_phrases_in_one_pass
     assert_equal %(<em>wow</em> <em>em</em>), highlight('wow em', %w(wow em), :highlighter => '<em>\1</em>')
   end


### PR DESCRIPTION
The rationale behind this change is as follows: suppose you have a long text and you want to highlight an exact match as a whole word only. First, you need to have a way of extracting a piece of text that contains the whole word (`excerpt`) and then a way to `highlight` the same.
