### PR TITLE
Added method `#eql?` to `ActiveSupport::Duration`, in addition to `#==`.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Added method `#eql?` to `ActiveSupport::Duration`, in addition to `#==`.
+
+    Currently, the following returns `false`, contrary to expectation:
+
+        1.minute.eql?(1.minute)
+
+    Adding method `#eql?` will make this behave like expected. Method `#eql?` is
+    just a bit stricter than `#==`, as it checks whether the argument is also a duration. Their
+    parts may be different though.
+
+        1.minute.eql?(60.seconds)  # => true
+        1.minute.eql?(60)          # => false
+
+    *Joost Lubach*
+
 *   Remove 'cow' => 'kine' irregular inflection from default inflections.
 
     *Andrew White*

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -49,6 +49,12 @@ module ActiveSupport
       end
     end
 
+    # Returns +true+ if +other+ is also a Duration instance, which has the
+    # same parts as this one.
+    def eql?(other)
+      Duration === other && other.value.eql?(value)
+    end
+
     def self.===(other) #:nodoc:
       other.is_a?(Duration)
     rescue ::NoMethodError

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -30,6 +30,14 @@ class DurationTest < ActiveSupport::TestCase
     assert !(1.day == 'foo')
   end
 
+  def test_eql
+    assert 1.minute.eql?(1.minute)
+    assert 1.minute.eql?(60.seconds)
+    assert 1.minute.eql?(180.seconds - 2.minutes)
+    assert !1.minute.eql?(60)
+    assert !1.minute.eql?('foo')
+  end
+
   def test_inspect
     assert_equal '0 seconds',                       0.seconds.inspect
     assert_equal '1 month',                         1.month.inspect


### PR DESCRIPTION
Currently, the following returns `false`, contrary to expectation:

```
1.minute.eql?(1.minute)
```

Adding method `#eql?` will make this behave like expected. Method `#eql?` is
just a bit stricter than `#==`, as it checks whether the argument is also a
uration. Their parts may be different though.

```
1.minute.eql?(60.seconds)  # => true
1.minute.eql?(60)          # => false
```
