### PR TITLE
AS::TimeZone's cache thread safety

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -379,7 +379,7 @@ module ActiveSupport
         case arg
           when String
           begin
-            lazy_zones_map[arg] ||= lookup(arg).tap { |tz| tz.utc_offset }
+            lazy_zones_map[arg] ||= create(arg).tap { |tz| tz.utc_offset }
           rescue TZInfo::InvalidTimezoneIdentifier
             nil
           end
@@ -407,10 +407,6 @@ module ActiveSupport
         end
 
       private
-
-        def lookup(name)
-          (tzinfo = find_tzinfo(name)) && create(tzinfo.name.freeze)
-        end
 
         def lazy_zones_map
           require_tzinfo


### PR DESCRIPTION
- use `TS::Cache` instead of concurrently accessible global `Hash`,
- unify 2 redundant (`@lazy_zones_map` and `@zones_map`) lazy populated maps.
