### PR TITLE
Fix Has many through with order source preload

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -56,7 +56,15 @@ module ActiveRecord
               through_options[:include]    = options[:include] || options[:source]
               through_options[:conditions] = options[:conditions]
             end
-            through_options[:order] = options[:order] if options.has_key?(:order)
+
+            if options.has_key?(:order)
+              through_options[:order] = options[:order]
+
+              if options.has_key?(:through) && options.has_key?(:source)
+                through_options[:include] = options[:source]
+              end
+            end
+
           end
 
           through_options

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -75,6 +75,11 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_has_many_through_with_order_and_source
+    authors = Author.includes(:comments_desc).to_a
+    assert_no_queries { authors.map(&:comments_desc) }
+  end
+
   def test_with_two_tables_in_from_without_getting_double_quoted
     posts = Post.select("posts.*").from("authors, posts").eager_load(:comments).where("posts.author_id = authors.id").order("posts.id").to_a
     assert_equal 2, posts.first.comments.size


### PR DESCRIPTION
This fixes a ActiveRecord 3 preloader regression (behavior worked correctly for ActiveRecord 2) 
@senny already patched ActiveRecord 4:

https://github.com/rails/rails/issues/8663
