### PR TITLE
Execute conditional procs on controller filters only for current action

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix an issue where :if and :unless controller action procs were being run
+    before checking for the correct action in the :only and :unless options.
+
+    Fixes #11799
+
+    *Nicholas Jakobsen*
+
 *   Fix an issue where `assert_dom_equal` and `assert_dom_not_equal` were
     ignoring the passed failure message argument.
 

--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -38,7 +38,7 @@ module AbstractController
       def _normalize_callback_option(options, from, to) # :nodoc:
         if from = options[from]
           from = Array(from).map {|o| "action_name == '#{o}'"}.join(" || ")
-          options[to] = Array(options[to]) << from
+          options[to] = Array(options[to]).unshift(from)
         end
       end
 

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -208,6 +208,10 @@ class FilterTest < ActionController::TestCase
     before_filter(ConditionalClassFilter, :ensure_login, Proc.new {|c| c.instance_variable_set(:"@ran_proc_filter1", true)}, :except => :show_without_filter) { |c| c.instance_variable_set(:"@ran_proc_filter2", true)}
   end
 
+  class OnlyConditionalOptionsFilter < ConditionalFilterController
+    before_filter :ensure_login, :only => :index, :if => Proc.new {|c| c.instance_variable_set(:"@ran_conditional_index_proc", true) }
+  end
+
   class ConditionalOptionsFilter < ConditionalFilterController
     before_filter :ensure_login, :if => Proc.new { |c| true }
     before_filter :clean_up_tmp, :if => Proc.new { |c| false }
@@ -647,6 +651,11 @@ class FilterTest < ActionController::TestCase
     assert assigns["ran_class_filter"]
     test_process(ExceptConditionClassController, "show_without_filter")
     assert !assigns["ran_class_filter"]
+  end
+
+  def test_running_only_condition_and_conditional_options
+    test_process(OnlyConditionalOptionsFilter, "show")
+    assert_not assigns["ran_conditional_index_proc"]
   end
 
   def test_running_before_and_after_condition_filters


### PR DESCRIPTION
Starting with Rails 4, and present in 4-0-stable and master, action callbacks like before_filter always execute the method/proc passed to :if. This was not the case in Rails 3.x.

Aside from the obvious performance issue, this regression is problematic because apps may expect certain url params be present in one action, that will be used in the :if proc. If another action is also executing the proc, those url params may not be present, causing the app to explode.

I've created a new rails 4 app to demonstrate the issue. https://github.com/njakobsen/filter_bug

I've fixed the problem by adding :only and :except options for controller filters before :if and :unless, instead of after. This prevents running :if and :unless procs when not on the specified action.
