### PR TITLE
Remove using of suffix with term.

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -641,7 +641,7 @@ private
 ```
 
 See the `permit`? It allows us to accept both `title` and `text` in this
-action. With this change, you should finally be able to create new `Post`s.
+action. With this change, you should finally be able to create new posts.
 Visit <http://localhost:3000/posts/new> and give it a try!
 
 ![Show action for posts](images/getting_started/show_action_for_posts.png)


### PR DESCRIPTION
I do not think that using term with suffixes is good idea. In the guide uses `posts` instead of

``` markdown
`Post`s
```
