### PR TITLE
 Reverse routing (hash access methods for named route )

### DIFF
--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -27,11 +27,15 @@ module ActionDispatch
           assert_equal '/bar', url_helpers.bar_path
         end
 
+        assert_equal 'foo', url_helpers.hash_for_foo_path[:action]
+        assert_raises NoMethodError do
+          assert_equal 'foo', url_helpers.hash_for_bar_path[:action]
+        end
+
         draw do
           get 'foo', to: SimpleApp.new('foo#index')
           get 'bar', to: SimpleApp.new('bar#index')
         end
-
         assert_equal '/foo', url_helpers.foo_path
         assert_equal '/bar', url_helpers.bar_path
       end
@@ -59,10 +63,16 @@ module ActionDispatch
         assert_equal '/foo', url_helpers.foo_path
         assert_equal '/bar', url_helpers.bar_path
 
+        assert_equal 'foo', url_helpers.hash_for_foo_path[:action]
+        assert_equal 'bar', url_helpers.hash_for_bar_path[:action]
+
         draw do
           get 'foo', to: SimpleApp.new('foo#index')
         end
 
+        assert_raises NoMethodError do
+          assert_equal 'bar', url_helpers.hash_for_bar_path[:action]
+        end
         assert_equal '/foo', url_helpers.foo_path
         assert_raises NoMethodError do
           assert_equal '/bar', url_helpers.bar_path
@@ -76,6 +86,7 @@ module ActionDispatch
           end
         end
 
+        assert_equal 'show', url_helpers.hash_for_foo_bar_path[:action]
         assert_equal '/foo/1/bar/2', url_helpers.foo_bar_path(1, 2)
         assert_equal '/foo/1/bar/2', url_helpers.foo_bar_path(2, foo_id: 1)
       end


### PR DESCRIPTION
In our company we have a lot of projects where we depend of controller and action (in our acl for example).
In basic case we can get it from params.
But sometimes we have situations where we need to know action/controller by name of the path/url.
Before this https://github.com/rails/rails/commit/02f2e3d538f79d61ab5abdcdb3bea30843d3ee4a commit i used method hash_for_[any]_path that return options i need.
Now, i decide to upgrade some of projects to rails4 and of course i get 
`undefined method hash_for_{any}_path`
I find two way how i can fix it

---

``` ruby
Rails.application.routes.recognize_path(any_path)
```

Sometimes its working. Thats good! But for actions that needed :id this method not working for me (i dont know about id in my acl)

---

2) Very ugly code like this

``` ruby
Rails.application.routes.routes.routes.find { |x| x.name == any_path }
```

I dont want to see this code. That's why this request here.

If this request is useless and no will be merged - can anyone to say me why hash access methods were removed?
