### PR TITLE
Remove redundant `string_to_binary` from type-casting

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -15,7 +15,6 @@ module ActiveRecord
           return "'#{quote_string(value)}'" unless column
 
           case column.type
-          when :binary then "'#{quote_string(column.string_to_binary(value))}'"
           when :integer then value.to_i.to_s
           when :float then value.to_f.to_s
           else

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -16,9 +16,6 @@ module ActiveRecord
     # +columns+ attribute of said TableDefinition object, in order to be used
     # for generating a number of table creation or table changing SQL statements.
     class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :primary_key) #:nodoc:
-      def string_to_binary(value)
-        value
-      end
 
       def primary_key?
         primary_key || type.to_sym == :primary_key

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -246,8 +246,8 @@ module ActiveRecord
       # QUOTING ==================================================
 
       def quote(value, column = nil)
-        if value.kind_of?(String) && column && column.type == :binary && column.class.respond_to?(:string_to_binary)
-          s = column.class.string_to_binary(value).unpack("H*")[0]
+        if value.kind_of?(String) && column && column.type == :binary
+          s = value.unpack("H*")[0]
           "x'#{s}'"
         elsif value.kind_of?(BigDecimal)
           value.to_s("F")

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -119,17 +119,7 @@ module ActiveRecord
         type_cast(default)
       end
 
-      # Used to convert from Strings to BLOBs
-      def string_to_binary(value)
-        self.class.string_to_binary(value)
-      end
-
       class << self
-        # Used to convert from Strings to BLOBs
-        def string_to_binary(value)
-          value
-        end
-
         # Used to convert from BLOBs to Strings
         def binary_to_string(value)
           value

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -226,8 +226,8 @@ module ActiveRecord
       # QUOTING ==================================================
 
       def quote(value, column = nil)
-        if value.kind_of?(String) && column && column.type == :binary && column.class.respond_to?(:string_to_binary)
-          s = column.class.string_to_binary(value).unpack("H*")[0]
+        if value.kind_of?(String) && column && column.type == :binary
+          s = value.unpack("H*")[0]
           "x'#{s}'"
         else
           super

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -184,25 +184,6 @@ module ActiveRecord
         assert_equal "'lo\\\\l'", @quoter.quote('lo\l', FakeColumn.new(:binary))
       end
 
-      def test_quote_binary_with_string_to_binary
-        col = Class.new(FakeColumn) {
-          def string_to_binary(value)
-            'foo'
-          end
-        }.new(:binary)
-        assert_equal "'foo'", @quoter.quote('lo\l', col)
-      end
-
-      def test_quote_as_mb_chars_binary_column_with_string_to_binary
-        col = Class.new(FakeColumn) {
-          def string_to_binary(value)
-            'foo'
-          end
-        }.new(:binary)
-        string = ActiveSupport::Multibyte::Chars.new('lo\l')
-        assert_equal "'foo'", @quoter.quote(string, col)
-      end
-
       def test_string_with_crazy_column
         assert_equal "'lo\\\\l'", @quoter.quote('lo\l', FakeColumn.new(:foo))
       end


### PR DESCRIPTION
Remove redundant `string_to_binary` from type-casting
