### PR TITLE
Handle aliased attributes in AR::Relation#select, #order, etc.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Handle aliased attributes `select()`, `order()` and `reorder()`.
+
+    *Tsutomu Kuroda*
+
 *   Reset the collection association when calling `reset` on it.
 
     Before:

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -234,7 +234,9 @@ module ActiveRecord
 
     def select!(*fields) # :nodoc:
       fields.flatten!
-
+      fields.map! do |field|
+        klass.attribute_alias?(field) ? klass.attribute_alias(field).to_sym : field
+      end
       self.select_values += fields
       self
     end
@@ -1048,9 +1050,11 @@ module ActiveRecord
       order_args.map! do |arg|
         case arg
         when Symbol
+          arg = klass.attribute_alias(arg).to_sym if klass.attribute_alias?(arg)
           table[arg].asc
         when Hash
           arg.map { |field, dir|
+            field = klass.attribute_alias(field).to_sym if klass.attribute_alias?(field)
             table[field].send(dir)
           }
         else

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -14,6 +14,10 @@ module ActiveRecord
       def relation_delegate_class(klass)
         self.class.relation_delegate_class(klass)
       end
+
+      def attribute_alias?(name)
+        false
+      end
     end
 
     def relation

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -206,10 +206,34 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal topics(:fourth).title, topics.first.title
   end
 
+  def test_finding_with_order_by_aliased_attributes
+    topics = Topic.order(:heading)
+    assert_equal 5, topics.to_a.size
+    assert_equal topics(:fifth).title, topics.first.title
+  end
+
+  def test_finding_with_assoc_order_by_aliased_attributes
+    topics = Topic.order(heading: :desc)
+    assert_equal 5, topics.to_a.size
+    assert_equal topics(:third).title, topics.first.title
+  end
+
   def test_finding_with_reorder
     topics = Topic.order('author_name').order('title').reorder('id').to_a
     topics_titles = topics.map{ |t| t.title }
     assert_equal ['The First Topic', 'The Second Topic of the day', 'The Third Topic of the day', 'The Fourth Topic of the day', 'The Fifth Topic of the day'], topics_titles
+  end
+
+  def test_finding_with_reorder_by_aliased_attributes
+    topics = Topic.order('author_name').reorder(:heading)
+    assert_equal 5, topics.to_a.size
+    assert_equal topics(:fifth).title, topics.first.title
+  end
+
+  def test_finding_with_assoc_reorder_by_aliased_attributes
+    topics = Topic.order('author_name').reorder(heading: :desc)
+    assert_equal 5, topics.to_a.size
+    assert_equal topics(:third).title, topics.first.title
   end
 
   def test_finding_with_order_and_take
@@ -773,6 +797,13 @@ class RelationTest < ActiveRecord::TestCase
     developer = Developer.where(id: david.id).select(:name, :salary).first
     assert_equal david.name, developer.name
     assert_equal david.salary, developer.salary
+  end
+
+  def test_select_takes_an_aliased_attribute
+    first = topics(:first)
+
+    topic = Topic.where(id: first.id).select(:heading).first
+    assert_equal first.heading, topic.heading
   end
 
   def test_select_argument_error


### PR DESCRIPTION
With this we can write `Model#select(:aliased)`, `Model#order(:aliased)`, `Model#reoder(aliased: :desc)`, etc.

Supplementary work to 54122067acaad39b277a5363c6d11d6804c7bf6b.
