### PR TITLE
Remove encoding check since adapater always returns `ASCII-8BIT` - encoded string

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -38,9 +38,6 @@ module ActiveRecord
     class SQLite3Column < Column #:nodoc:
       class <<  self
         def binary_to_string(value)
-          if value.encoding != Encoding::ASCII_8BIT
-            value = value.force_encoding(Encoding::ASCII_8BIT)
-          end
           value
         end
       end


### PR DESCRIPTION
Remove encoding check since adapater returns always `ASCII-8BIT` - encoded string
