### PR TITLE
Make 'enable_extension' revertible

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow enable_extension migration method to be revertible.
+ 
+    *Eric Tipton*
+
 *   Type cast hstore values on write, so that the value is consistent
     with reading from the database.
 

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -73,7 +73,7 @@ module ActiveRecord
       [:create_table, :create_join_table, :rename_table, :add_column, :remove_column,
         :rename_index, :rename_column, :add_index, :remove_index, :add_timestamps, :remove_timestamps,
         :change_column_default, :add_reference, :remove_reference, :transaction,
-        :drop_join_table, :drop_table, :execute_block,
+        :drop_join_table, :drop_table, :execute_block, :enable_extension,
         :change_column, :execute, :remove_columns, # irreversible methods need to be here too
       ].each do |method|
         class_eval <<-EOV, __FILE__, __LINE__ + 1
@@ -100,6 +100,7 @@ module ActiveRecord
           add_column:        :remove_column,
           add_timestamps:    :remove_timestamps,
           add_reference:     :remove_reference,
+          enable_extension:  :disable_extension
         }.each do |cmd, inv|
           [[inv, cmd], [cmd, inv]].uniq.each do |method, inverse|
             class_eval <<-EOV, __FILE__, __LINE__ + 1

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -242,6 +242,16 @@ module ActiveRecord
         add = @recorder.inverse_of :remove_belongs_to, [:table, :user]
         assert_equal [:add_reference, [:table, :user], nil], add
       end
+
+      def test_invert_enable_extension
+        disable = @recorder.inverse_of :enable_extension, ['uuid-ossp']
+        assert_equal [:disable_extension, ['uuid-ossp'], nil], disable
+      end
+
+      def test_invert_disable_extension
+        enable = @recorder.inverse_of :disable_extension, ['uuid-ossp']
+        assert_equal [:enable_extension, ['uuid-ossp'], nil], enable
+      end
     end
   end
 end


### PR DESCRIPTION
If 'enable_extension' is used in a migration's 'change' method, use
'disable_extension' on down migration (and vice-versa).
