### PR TITLE
Remove sqlite specific`supports_autoincrement?` which defaults to true

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -180,11 +180,6 @@ module ActiveRecord
         true
       end
 
-      # Returns true
-      def supports_autoincrement? #:nodoc:
-        true
-      end
-
       def supports_index_sort_order?
         true
       end
@@ -606,11 +601,7 @@ module ActiveRecord
         end
 
         def default_primary_key_type
-          if supports_autoincrement?
-            'INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL'
-          else
-            'INTEGER PRIMARY KEY NOT NULL'
-          end
+          'INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL'
         end
 
         def translate_exception(exception, message)

--- a/activerecord/test/schema/sqlite_specific_schema.rb
+++ b/activerecord/test/schema/sqlite_specific_schema.rb
@@ -1,9 +1,6 @@
 ActiveRecord::Schema.define do
-  # For sqlite 3.1.0+, make a table with an autoincrement column
-  if supports_autoincrement?
-    create_table :table_with_autoincrement, :force => true do |t|
-      t.column :name, :string
-    end
+  create_table :table_with_autoincrement, :force => true do |t|
+    t.column :name, :string
   end
 
   execute "DROP TABLE fk_test_has_fk" rescue nil


### PR DESCRIPTION
Remove sqlite specific`supports_autoincrement?` which always defaults to true
