### PR TITLE
Convert Fixnum into String the port number like `db:structure:dump` task in MySQL.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `rake db:structure:dump` no longer crashes when the port was specified as `Fixnum`.
+
+    *Kenta Okamoto*
+
 *   `NullRelation#pluck` takes a list of columns
 
     The method signature in `NullRelation` was updated to mimic that in

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -134,8 +134,9 @@ IDENTIFIED BY '#{configuration['password']}' WITH GRANT OPTION;
         args << "--password=#{configuration['password']}"  if configuration['password']
         args.concat(['--default-character-set', configuration['encoding']]) if configuration['encoding']
         configuration.slice('host', 'port', 'socket').each do |k, v|
-          args.concat([ "--#{k}", v ]) if v
+          args.concat([ "--#{k}", v.to_s ]) if v
         end
+
         args
       end
     end

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -280,6 +280,15 @@ module ActiveRecord
 
       assert_match(/Could not dump the database structure/, warnings)
     end
+
+    def test_structure_dump_with_port_number
+      filename = "awesome-file.sql"
+      Kernel.expects(:system).with("mysqldump", "--port", "10000", "--result-file", filename, "--no-data", "test-db").returns(true)
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_dump(
+        @configuration.merge('port' => 10000),
+        filename)
+    end
   end
 
   class MySQLStructureLoadTest < ActiveRecord::TestCase


### PR DESCRIPTION
application.rb:

``` ruby
module MyApp
  class Application < Rails::Application
    # ...
    config.active_record.schema_format = :sql
  end
end
```

database.yml:

```
development:
  adapter: mysql2
  encoding: utf8
  database: my_app
  username: root
  password:
  port: 12345
```

Run `db:structure:dump` task in MySQL.

output:

```
rake aborted!
no implicit conversion of Fixnum into String
/path/to/myapp/.bundle/ruby/2.0.0/gems/activerecord-4.0.0/lib/active_record/tasks/mysql_database_tasks.rb:62:in `system'
/path/to/myapp/.bundle/ruby/2.0.0/gems/activerecord-4.0.0/lib/active_record/tasks/mysql_database_tasks.rb:62:in `structure_dump'
/path/to/myapp/.bundle/ruby/2.0.0/gems/activerecord-4.0.0/lib/active_record/tasks/database_tasks.rb:142:in `structure_dump'
/path/to/myapp/.bundle/ruby/2.0.0/gems/activerecord-4.0.0/lib/active_record/railties/databases.rake:288:in `block (3 levels) in <top (required)>'
Tasks: TOP => db:structure:dump
(See full trace by running task with --trace)
```

This solves the issue by convert Fixnum into String the port number.
