### PR TITLE
Improve Active Record instrumentation

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -75,8 +75,15 @@ module ActiveRecord
       def cache_sql(sql, binds)
         result =
           if @query_cache[sql].key?(binds)
-            ActiveSupport::Notifications.instrument("sql.active_record",
-              :sql => sql, :binds => binds, :name => "CACHE", :connection_id => object_id)
+            payload = {
+              :sql           => sql,
+              :binds         => binds,
+              :name          => "CACHE",
+              :connection_id => object_id
+            }
+
+            ActiveSupport::Notifications.instrument("sql.active_record", payload)
+
             @query_cache[sql][binds]
           else
             @query_cache[sql][binds] = yield

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -79,6 +79,7 @@ module ActiveRecord
               :sql           => sql,
               :binds         => binds,
               :name          => "CACHE",
+              :operation     => nil,
               :connection_id => object_id
             }
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -426,6 +426,7 @@ module ActiveRecord
           :sql           => sql,
           :name          => name,
           :connection_id => object_id,
+          :operation     => parse_operation(sql),
           :binds         => binds
         }
 
@@ -436,6 +437,18 @@ module ActiveRecord
         exception = translate_exception(e, message)
         exception.set_backtrace e.backtrace
         raise exception
+      end
+
+      OPERATIONS = %w[select update delete insert].freeze
+
+      def parse_operation(sql)
+        operation = sql.split(" ").first.downcase
+
+        if OPERATIONS.include?(operation)
+          operation.to_sym
+        else
+          nil
+        end
       end
 
       def translate_exception(exception, message)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -422,12 +422,14 @@ module ActiveRecord
       protected
 
       def log(sql, name = "SQL", binds = [])
-        @instrumenter.instrument(
-          "sql.active_record",
+        payload = {
           :sql           => sql,
           :name          => name,
           :connection_id => object_id,
-          :binds         => binds) { yield }
+          :binds         => binds
+        }
+
+        @instrumenter.instrument("sql.active_record", payload) { yield }
       rescue => e
         message = "#{e.class.name}: #{e.message}: #{sql}"
         @logger.error message if @logger

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -439,13 +439,11 @@ module ActiveRecord
         raise exception
       end
 
-      OPERATIONS = %w[select update delete insert].freeze
+      OPERATIONS = /\A\s*(select|update|delete|insert)\b/i
 
       def parse_operation(sql)
-        operation = sql.split(" ").first.downcase
-
-        if OPERATIONS.include?(operation)
-          operation.to_sym
+        if OPERATIONS =~ sql
+          $1.downcase.to_sym
         else
           nil
         end

--- a/activerecord/lib/active_record/explain_subscriber.rb
+++ b/activerecord/lib/active_record/explain_subscriber.rb
@@ -19,9 +19,11 @@ module ActiveRecord
     # On the other hand, we want to monitor the performance of our real database
     # queries, not the performance of the access to the query cache.
     IGNORED_PAYLOADS = %w(SCHEMA EXPLAIN CACHE)
-    EXPLAINED_SQLS = /\A\s*(select|update|delete|insert)\b/i
+
     def ignore_payload?(payload)
-      payload[:exception] || IGNORED_PAYLOADS.include?(payload[:name]) || payload[:sql] !~ EXPLAINED_SQLS
+      payload[:exception] ||
+        IGNORED_PAYLOADS.include?(payload[:name]) ||
+        payload[:operation].nil?
     end
 
     ActiveSupport::Notifications.subscribe("sql.active_record", new)

--- a/activerecord/test/cases/connection_adapters/abstract_adapter_test.rb
+++ b/activerecord/test/cases/connection_adapters/abstract_adapter_test.rb
@@ -11,15 +11,15 @@ module ActiveRecord
       end
     end
 
-    class FakeAdapter < AbstractAdapter
-      def make_that_query(sql)
-        log(sql) do
-          # Do that thing.
+    class AbstractAdapterTest < ActiveRecord::TestCase
+      class FakeAdapter < AbstractAdapter
+        def make_that_query(sql)
+          log(sql) do
+            # Do that thing.
+          end
         end
       end
-    end
 
-    class AbstractAdapterTest < ActiveRecord::TestCase
       attr_reader :adapter
 
       def setup

--- a/activerecord/test/cases/explain_subscriber_test.rb
+++ b/activerecord/test/cases/explain_subscriber_test.rb
@@ -25,26 +25,21 @@ if ActiveRecord::Base.connection.supports_explain?
 
     def test_collects_nothing_if_collect_is_false
       ActiveRecord::ExplainRegistry.collect = false
-      SUBSCRIBER.finish(nil, nil, name: 'SQL', sql: 'select 1 from users', binds: [1, 2])
+      SUBSCRIBER.finish(nil, nil, name: 'SQL', sql: 'select 1 from users', binds: [1, 2], :operation => :select)
       assert queries.empty?
     end
 
     def test_collects_pairs_of_queries_and_binds
       sql   = 'select 1 from users'
       binds = [1, 2]
-      SUBSCRIBER.finish(nil, nil, name: 'SQL', sql: sql, binds: binds)
+      SUBSCRIBER.finish(nil, nil, name: 'SQL', sql: sql, binds: binds, :operation => :select)
       assert_equal 1, queries.size
       assert_equal sql, queries[0][0]
       assert_equal binds, queries[0][1]
     end
 
-    def test_collects_nothing_if_the_statement_is_not_whitelisted
-      SUBSCRIBER.finish(nil, nil, name: 'SQL', sql: 'SHOW max_identifier_length')
-      assert queries.empty?
-    end
-
-    def test_collects_nothing_if_the_statement_is_only_partially_matched
-      SUBSCRIBER.finish(nil, nil, name: 'SQL', sql: 'select_db yo_mama')
+    def test_collects_nothing_if_the_operation_is_not_known
+      SUBSCRIBER.finish(nil, nil, name: 'SQL', sql: 'SHOW max_identifier_length', :operation => nil)
       assert queries.empty?
     end
 


### PR DESCRIPTION
I've implemented some monitoring of an app using AS::Notifications, but the instrumentation of Active Record is somewhat rudimentary.

This pull request adds the SQL "operation" to the event payloads (I'm not 100% sure that's the best name.) For instance, a `SELECT` query will emit an event with a payload including `:operation => :select`. Only `SELECT`, `INSERT`, `UPDATE`, and `DELETE` are supported.

Furthermore, the ExplainSubscriber has been updated to take advantage of this new payload so it doesn't have to parse the query itself.
