### PR TITLE
Add :within option for numericality validator

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add support to numericality validator for `within: 1..10` for a more succinct syntax then
+    `greater_than_or_equal_to: 1, less_than_or_equal_to: 10`
+
+    *Matthew Savage*
+
 *   Fix has_secure_password. `password_confirmation` validations are triggered
     even if no `password_confirmation` is set.
 

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add support to numericality validator for `within: 1..10` for a more succinct syntax then
+    `greater_than_and_equal_to: 1, less_than_and_equal_to: 10`
+
+    *Matthew Savage*
+
 *   Fix has_secure_password. `password_confirmation` validations are triggered
     even if no `password_confirmation` is set.
 

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -8,6 +8,15 @@ module ActiveModel
 
       RESERVED_OPTIONS = CHECKS.keys + [:only_integer]
 
+      def initialize(options)
+        if range = (options.delete(:in) || options.delete(:within))
+          raise ArgumentError, ":in and :within must be a Range" unless range.is_a?(Range)
+          options[:greater_than_or_equal_to], options[:less_than_or_equal_to] = range.min, range.max
+        end
+        
+        super
+      end
+
       def check_validity!
         keys = CHECKS.keys - [:odd, :even]
         options.slice(*keys).each do |option, value|
@@ -94,6 +103,10 @@ module ActiveModel
       # * <tt>:allow_nil</tt> - Skip validation if attribute is +nil+ (default is
       #   +false+). Notice that for fixnum and float columns empty strings are
       #   converted to +nil+.
+      # * <tt>:within</tt> - A range specifying the minimum and maximum value of
+      #   the attribute. It is possible to use a large number as the range end if
+      #   you wish for it to be 'unbounded', however it would better to use <tt>:greater_than</tt>
+      # * <tt>:in</tt> - A synonym (or alias) for <tt>:within</tt>.
       # * <tt>:greater_than</tt> - Specifies the value must be greater than the
       #   supplied value.
       # * <tt>:greater_than_or_equal_to</tt> - Specifies the value must be

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -106,6 +106,18 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!([2])
   end
 
+  def test_validates_numericality_with_range
+    Topic.validates_numericality_of :approved, in: 1..4
+    invalid!([20])
+    valid!([1, 2, 3, 4])
+  end
+
+  def test_validates_numericality_with_range_excluding_end_value
+    Topic.validates_numericality_of :approved, in: 1...4
+    invalid!([20, 4])
+    valid!([1, 2, 3])
+  end
+
   def test_validates_numericality_with_other_than
     Topic.validates_numericality_of :approved, other_than: 0
 


### PR DESCRIPTION
The following patch adds the :within option to validates_numericality_of in ActiveModel.

This allows the developer to use:

``` ruby
validates_numericality_of :age, within: 18..25
```

instead of 

``` ruby
validates_numericality_of :age, greater_than_or_equal_to: 18, less_than_or_equal_to: 25
```
