### PR TITLE
Upgrade ActiveRecord-JDBC-Adapter to v1.3 for better compatibility with ActiveRecord 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,12 +61,13 @@ platforms :ruby do
 end
 
 platforms :jruby do
-  gem 'activerecord-jdbcsqlite3-adapter', '>= 1.2.7'
-
-  group :db do
-    gem 'activerecord-jdbcmysql-adapter', '>= 1.2.7'
-    gem 'activerecord-jdbcpostgresql-adapter', '>= 1.2.7'
-  end
+    git 'git://github.com/jruby/activerecord-jdbc-adapter.git' do
+      gem 'activerecord-jdbcsqlite3-adapter'
+      group :db do
+        gem 'activerecord-jdbcmysql-adapter'
+        gem 'activerecord-jdbcpostgresql-adapter'
+      end
+    end
 end
 
 # gems that are necessary for ActiveRecord tests with Oracle database


### PR DESCRIPTION
While trying to run rails tests on JRuby, I noticed [LOT(more than 50) of failing tests](https://gist.github.com/gaurish/6206687) in ActionView'PolymorphicRoutesTest. noticed that nearly all of them failed because of errors related to AR:JDBC adapter, errors due AR 4's `exec_insert` not being well support, circular require warnings etc.

I did some research & it turns out the the current version of AR:JDBC v1.2.7 is not well supported & has many bugs. Fortunately, thanks to a [recent fundraiser](https://www.bountysource.com/fundraisers/311-activerecord-jdbc-adapter-1-3-x/) there is a new version which fixes most of the known issues & provides better compatibility with AR 4 & things like `exec_insert`.  from their [README](https://github.com/jruby/activerecord-jdbc-adapter/blob/master/README.md):

> Version 1.3.x of AR-JDBC adapter strives to provide ActiveRecord 4.x compatibility (as well as still supporting 2.3 and 3.x) from a single code base. It's a recommended update for all AR-JDBC 1.2.x users.

the full change is available [here](https://github.com/jruby/activerecord-jdbc-adapter/blob/master/History.md#130rc1-080313).

after this upgrade all tests in ActionView's `PolymorphicRoutesTest` are now green :green_heart: 

cc: @arunagw @steveklabnik @tenderlove 
#11700
