### PR TITLE
Raise an extended version of NoMethodError in AS::TimeWithZone.

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -2,6 +2,16 @@ require 'active_support/values/time_zone'
 require 'active_support/core_ext/object/acts_like'
 
 module ActiveSupport
+  class NoMethodOnObjectError < NoMethodError
+    attr_reader :object
+
+    def initialize(msg, name, args = nil, object = nil)
+      super(msg, name, args)
+
+      @object = object
+    end
+  end
+
   # A Time-like class that can represent a time in any time zone. Necessary
   # because standard Ruby Time instances are limited to UTC and the
   # system's <tt>ENV['TZ']</tt> zone.
@@ -363,7 +373,8 @@ module ActiveSupport
     def method_missing(sym, *args, &block)
       wrap_with_time_zone time.__send__(sym, *args, &block)
     rescue NoMethodError => e
-      raise e, e.message.sub(time.inspect, self.inspect), e.backtrace
+      msg = e.message.sub(time.inspect, self.inspect)
+      raise NoMethodOnObjectError.new(msg, sym, args, time), msg, e.backtrace
     end
 
     private

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -795,10 +795,11 @@ class TimeWithZoneTest < ActiveSupport::TestCase
   end
 
   def test_no_method_error_has_proper_context
-    e = assert_raises(NoMethodError) {
+    e = assert_raises(ActiveSupport::NoMethodOnObjectError) {
       @twz.this_method_does_not_exist
     }
-    assert_equal "undefined method `this_method_does_not_exist' for Fri, 31 Dec 1999 19:00:00 EST -05:00:Time", e.message
+    assert_equal @twz.time, e.object
+    assert_equal :this_method_does_not_exist, e.name
     assert_no_match "rescue", e.backtrace.first
   end
 


### PR DESCRIPTION
An error message can vary across Ruby implementations. This fix ensures an enhanced version of NoMethodError is raised, so that it can be inspected properly, instead of relying on the varying message.

Fixes issues with Rubinius and possibly JRuby.

/cc @dbussink @headius
