### PR TITLE
Generalize backtrace check on DelegationError.

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -192,8 +192,7 @@ class Module
             _ = #{to}                                                                           #   _ = client
             _.#{method}(#{definition})                                                          #   _.name(*args, &block)
           rescue NoMethodError => e                                                             # rescue NoMethodError => e
-            location = "%s:%d:in `%s'" % [__FILE__, __LINE__ - 2, '#{method_prefix}#{method}']  #   location = "%s:%d:in `%s'" % [__FILE__, __LINE__ - 2, 'customer_name']
-            if _.nil? && e.backtrace.first == location                                          #   if _.nil? && e.backtrace.first == location
+            if _.nil? && e.name == :#{method}                                                   #   if _.nil? && e.name == :name
               #{exception}                                                                      #     # add helpful message to the exception
             else                                                                                #   else
               raise                                                                             #     raise


### PR DESCRIPTION
Different Ruby implementations present backtraces differently, as it should be an information consumed by humans.
A better implementation should use data from the error, in this case returned by NoMethodError#name.

Fixes issues with Rubinius, which presents backtraces differently from MRI.

/cc @dbussink
