### PR TITLE
FalseClass#blank? now returns false

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   FalseClass#blank? now returns false, making it complient with TrueClass
+
+    *Elad Meidar*
+
 *   Remove 'cow' => 'kine' irregular inflection from default inflections.
 
     *Andrew White*

--- a/activesupport/lib/active_support/core_ext/false_class.rb
+++ b/activesupport/lib/active_support/core_ext/false_class.rb
@@ -1,0 +1,1 @@
+require 'active_support/core_ext/false_class/blank'

--- a/activesupport/lib/active_support/core_ext/false_class/blank.rb
+++ b/activesupport/lib/active_support/core_ext/false_class/blank.rb
@@ -1,0 +1,17 @@
+class FalseClass
+  # A FalseClass object is not blank.
+  #
+  # Object#blank? causes false values to return as blank.
+  # For example, '', '   ', +nil+, [], and {} are all blank.
+  #
+  # This causes presence validators that use Object#blank? to return the
+  # right result for boolean values containing a false value.
+  def blank?
+    false
+  end
+
+  # A FalseClass object is always present
+  def present?
+    true
+  end
+end

--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -53,7 +53,7 @@ class FalseClass
   #
   #   false.blank? # => true
   def blank?
-    true
+    false
   end
 end
 

--- a/activesupport/test/core_ext/blank_test.rb
+++ b/activesupport/test/core_ext/blank_test.rb
@@ -4,8 +4,8 @@ require 'abstract_unit'
 require 'active_support/core_ext/object/blank'
 
 class BlankTest < ActiveSupport::TestCase
-  BLANK = [ EmptyTrue.new, nil, false, '', '   ', "  \n\t  \r ", '　', [], {} ]
-  NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, 'a', [nil], { nil => 0 } ]
+  BLANK = [ EmptyTrue.new, nil, '', '   ', "  \n\t  \r ", '　', [], {} ]
+  NOT   = [ EmptyFalse.new, Object.new, false, true, 0, 1, 'a', [nil], { nil => 0 } ]
 
   def test_blank
     BLANK.each { |v| assert v.blank?,  "#{v.inspect} should be blank" }

--- a/activesupport/test/core_ext/false_class_blank_test.rb
+++ b/activesupport/test/core_ext/false_class_blank_test.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+require 'abstract_unit'
+require 'active_support/core_ext/false_class/blank'
+
+class FalsClassBlankTest < ActiveSupport::TestCase
+
+  def test_blank_on_true_value
+    v = true
+    assert !v.blank?, "#{v.inspect} should not be blank"
+  end
+
+  def test_blank_on_false_value
+    v = false
+    assert !v.blank?, "#{v.inspect} should not be blank"
+  end
+end


### PR DESCRIPTION
false.blank? used to return true, it caused presence validations to raise a validation error on boolean fields, containing the legit value of false.
Also, although made by design, false values aren't blank.
