### PR TITLE
Use chop instead of singularize in Duration#inspect

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -73,7 +73,7 @@ module ActiveSupport
       consolidated = parts.inject(::Hash.new(0)) { |h,(l,r)| h[l] += r; h }
       parts = [:years, :months, :days, :minutes, :seconds].map do |length|
         n = consolidated[length]
-        "#{n} #{n == 1 ? length.to_s.singularize : length.to_s}" if n.nonzero?
+        "#{n} #{n == 1 ? length.to_s.chop : length.to_s}" if n.nonzero?
       end.compact
       parts = ["0 seconds"] if parts.empty?
       parts.to_sentence(:locale => :en)


### PR DESCRIPTION
Even though singularize tells a better story, chop is more than 50%
faster and is all that is necessary in the case of Duration#inspect, in
which all of the candidates for chopping appear in the same method and
are all singularized by removing the final 's'.

Benchmarks:

```
10000.times do
  1.second.inspect
end

original #inspect
   0.740000   0.000000   0.740000 (  0.739065)
   0.740000   0.000000   0.740000 (  0.741458)
   0.740000   0.010000   0.750000 (  0.744011)

refactored #inspect
   0.330000   0.000000   0.330000 (  0.333390)
   0.330000   0.000000   0.330000 (  0.331013)
   0.320000   0.000000   0.320000 (  0.330103)

10000.times do
  (1.day + 1.month + 2.minutes + 1.day).inspect
end

original #inspect
   0.790000   0.000000   0.790000 (  0.794624)
   0.770000   0.000000   0.770000 (  0.774577)
   0.770000   0.010000   0.780000 (  0.771295)

refactored #inspect
   0.390000   0.000000   0.390000 (  0.392921)
   0.400000   0.000000   0.400000 (  0.397412)
   0.370000   0.000000   0.370000 (  0.379660)
```
