### PR TITLE
Refactor Url generation into ActionDispatch::Url

### DIFF
--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -65,6 +65,7 @@ module ActionDispatch
   autoload :Journey
   autoload :MiddlewareStack, 'action_dispatch/middleware/stack'
   autoload :Routing
+  autoload :Url
 
   module Http
     extend ActiveSupport::Autoload

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -5,17 +5,17 @@ module ActionDispatch
   module Http
     module URL
       IP_HOST_REGEXP  = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
-      HOST_REGEXP     = /(^.*:\/\/)?([^:]+)(?::(\d+$))?/
-      PROTOCOL_REGEXP = /^([^:]+)(:)?(\/\/)?$/
 
       mattr_accessor :tld_length
       self.tld_length = 1
 
       class << self
+        # TODO: Used by /actionpack/test/dispatch/request_test.rb:221
         def extract_domain(host, tld_length = @@tld_length)
           host.split('.').last(1 + tld_length).join('.') if named_host?(host)
         end
 
+        # TODO: Used by /actionpack/test/dispatch/routing_test.rb:3426
         def extract_subdomains(host, tld_length = @@tld_length)
           if named_host?(host)
             parts = host.split('.')
@@ -25,6 +25,7 @@ module ActionDispatch
           end
         end
 
+        # TODO: Used by /actionpack/test/dispatch/routing_test.rb:3426
         def extract_subdomain(host, tld_length = @@tld_length)
           extract_subdomains(host, tld_length).join('.')
         end
@@ -44,88 +45,9 @@ module ActionDispatch
 
         private
 
-        def build_host_url(options)
-          if options[:host].blank? && options[:only_path].blank?
-            raise ArgumentError, 'Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true'
-          end
-
-          result = ""
-
-          unless options[:only_path]
-            if match = options[:host].match(HOST_REGEXP)
-              options[:protocol] ||= match[1] unless options[:protocol] == false
-              options[:host]       = match[2]
-              options[:port]       = match[3] unless options.key?(:port)
-            end
-
-            options[:protocol] = normalize_protocol(options)
-            options[:host]     = normalize_host(options)
-            options[:port]     = normalize_port(options)
-
-            result << options[:protocol]
-            result << rewrite_authentication(options)
-            result << options[:host]
-            result << ":#{options[:port]}" if options[:port]
-          end
-          result
-        end
-
+        # TODO: Used by /actionpack/test/dispatch/routing_test.rb:3426
         def named_host?(host)
           host && IP_HOST_REGEXP !~ host
-        end
-
-        def same_host?(options)
-          (options[:subdomain] == true || !options.key?(:subdomain)) && options[:domain].nil?
-        end
-
-        def rewrite_authentication(options)
-          if options[:user] && options[:password]
-            "#{Rack::Utils.escape(options[:user])}:#{Rack::Utils.escape(options[:password])}@"
-          else
-            ""
-          end
-        end
-
-        def normalize_protocol(options)
-          case options[:protocol]
-          when nil
-            "http://"
-          when false, "//"
-            "//"
-          when PROTOCOL_REGEXP
-            "#{$1}://"
-          else
-            raise ArgumentError, "Invalid :protocol option: #{options[:protocol].inspect}"
-          end
-        end
-
-        def normalize_host(options)
-          return options[:host] if !named_host?(options[:host]) || same_host?(options)
-
-          tld_length = options[:tld_length] || @@tld_length
-
-          host = ""
-          if options[:subdomain] == true || !options.key?(:subdomain)
-            host << extract_subdomain(options[:host], tld_length).to_param
-          elsif options[:subdomain].present?
-            host << options[:subdomain].to_param
-          end
-          host << "." unless host.empty?
-          host << (options[:domain] || extract_domain(options[:host], tld_length))
-          host
-        end
-
-        def normalize_port(options)
-          return nil if options[:port].nil? || options[:port] == false
-
-          case options[:protocol]
-          when "//"
-            nil
-          when "https://"
-            options[:port].to_i == 443 ? nil : options[:port]
-          else
-            options[:port].to_i == 80 ? nil : options[:port]
-          end
         end
       end
 
@@ -133,11 +55,6 @@ module ActionDispatch
         super
         @protocol = nil
         @port     = nil
-      end
-
-      # Returns the complete URL used for this request.
-      def url
-        protocol + host_with_port + fullpath
       end
 
       # Returns 'https://' if this is an SSL request and 'http://' otherwise.
@@ -195,16 +112,19 @@ module ActionDispatch
         standard_port? ? nil : port
       end
 
+      # TODO: Used by /actionpack/test/dispatch/rack_test.rb:107
       # Returns a string \port suffix, including colon, like ":8080" if the \port
       # number of this request is not the default HTTP \port 80 or HTTPS \port 443.
       def port_string
         standard_port? ? '' : ":#{port}"
       end
 
+      # TODO: Used by /actionpack/test/dispatch/rack_test.rb:148
       def server_port
         @env['SERVER_PORT'].to_i
       end
 
+      # TODO: Used by /actionpack/test/dispatch/request_test.rb:221
       # Returns the \domain part of a \host, such as "rubyonrails.org" in "www.rubyonrails.org". You can specify
       # a different <tt>tld_length</tt>, such as 2 to catch rubyonrails.co.uk in "www.rubyonrails.co.uk".
       def domain(tld_length = @@tld_length)

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -30,26 +30,16 @@ module ActionDispatch
         end
 
         def url_for(options = {})
-          options = options.dup
-          path  = options.delete(:script_name).to_s.chomp("/")
-          path << options.delete(:path).to_s
-
           params = options[:params].is_a?(Hash) ? options[:params] : options.slice(:params)
-          params.reject! { |_,v| v.to_param.nil? }
+          params = params.reject { |_,v| v.to_param.nil? }
+          options = options.merge(params: params)
 
-          result = build_host_url(options)
-          if options[:trailing_slash]
-            if path.include?('?')
-              result << path.sub(/\?/, '/\&')
-            else
-              result << path.sub(/[^\/]\z|\A\z/, '\&/')
-            end
+          url = ::ActionDispatch::Url.new(options)
+          if options[:only_path]
+            url.relative_path
           else
-            result << path
+            url.absolute_path
           end
-          result << "?#{params.to_query}" unless params.empty?
-          result << "##{Journey::Router::Utils.escape_fragment(options[:anchor].to_param.to_s)}" if options[:anchor]
-          result
         end
 
         private

--- a/actionpack/lib/action_dispatch/url.rb
+++ b/actionpack/lib/action_dispatch/url.rb
@@ -1,0 +1,164 @@
+module ActionDispatch
+  class Url
+    IP_HOST_REGEXP  = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
+    HOST_REGEXP     = /(^.*:\/\/)?([^:]+)(?::(\d+$))?/
+    PROTOCOL_REGEXP = /^([^:]+)(:)?(\/\/)?$/
+
+    class << self
+      def tld_length
+        @tld_length ||= 1
+      end
+      attr_writer :tld_length
+    end
+
+    def initialize(options={})
+      options = options.dup
+
+      if match = options[:host] && options[:host].to_s.match(HOST_REGEXP)
+        options[:host_protocol] = match[1]
+        options[:host]          = match[2]
+        options[:host_port]     = match[3]
+      end
+
+      if options[:path].to_s.include?('?')
+        path, query = options[:path].split('?')
+        params = options[:params] || {}
+        options[:path] = path
+        options[:params] = Rack::Utils.parse_nested_query(query).merge(params)
+      end
+
+      if options[:path].to_s.include?('#')
+        path, anchor = options[:path].split('#')
+        options[:path] = path
+        options[:anchor] = anchor if options[:anchor].blank?
+      end
+
+      @options = options
+    end
+
+    attr_reader :options
+
+    def absolute_path
+      [ protocol_string, auth_string, host_string, port_string, relative_path ].join('')
+    end
+
+    def relative_path
+      path = [ script_name_string, path_string ].join('')
+      path << trailing_slash_string unless path.end_with?('/')
+      path << [ params_string, anchor_string ].join('')
+    end
+
+    def protocol_string
+      protocol = options[:protocol].nil? ? options[:host_protocol] : options[:protocol]
+
+      case protocol
+      when nil
+        'http://'
+      when false, '//'
+        '//'
+      when PROTOCOL_REGEXP
+        "#{$1}://"
+      else
+        raise ArgumentError, "Invalid :protocol option: #{protocol.inspect}"
+      end
+    end
+
+    def auth_string
+      user, password = options[:user], options[:password]
+      if user && password
+        "#{Rack::Utils.escape(user)}:#{Rack::Utils.escape(password)}@"
+      else
+        ''
+      end
+    end
+
+    def host_string
+      if options[:host].blank?
+        raise ArgumentError, 'Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true'
+      end
+
+      if options[:host] =~ IP_HOST_REGEXP
+        if options[:domain].blank?
+          subdomain, domain = nil, options[:host]
+        else
+          subdomain, domain = options[:subdomain], options[:domain]
+        end
+      else
+        subdomain, domain = split_host(options[:host])
+        subdomain = options[:subdomain] if options.key?(:subdomain) && options[:subdomain] != true
+      end
+
+      subdomain = subdomain.to_param if subdomain.present?
+      domain = options[:domain] if options[:domain].present?
+      domain = domain.chomp('/')
+
+      subdomain.blank? ? domain : "#{subdomain}.#{domain}"
+    end
+
+    def tld_length
+      (options[:tld_length] || self.class.tld_length).to_i
+    end
+
+    def port_string
+      return '' unless options.fetch(:port, true)
+      port = options[:port].presence || options[:host_port]
+      return '' unless port
+
+      if standard_port?(protocol_string, port.to_i)
+        ''
+      else
+        ":#{port}"
+      end
+    end
+
+    def script_name_string
+      return '' unless options[:script_name]
+      options[:script_name].chomp('/')
+    end
+
+    def path_string
+      return '' unless options[:path]
+      if options[:path] == '/'
+        '/'
+      else
+        options[:path].chomp('/')
+      end
+    end
+
+    def trailing_slash_string
+      options[:trailing_slash] ? '/' : ''
+    end
+
+    def params_string
+      return '' if options[:params].blank?
+      params = options[:params].to_query
+      params.blank? ? '' : "?#{params}"
+    end
+
+    def anchor_string
+      return '' if options[:anchor].blank?
+      anchor = ActionDispatch::Journey::Router::Utils.escape_fragment(options[:anchor].to_param)
+      anchor.blank? ? '' : "##{anchor}"
+    end
+
+    private
+
+    def split_host(host)
+      parts = host.split('.')
+      [ parts[0..-(tld_length + 2)].join('.'), parts.last(tld_length + 1).join('.') ]
+    end
+
+    def standard_port?(protocol, port)
+      case protocol
+      when 'http://'
+        port == 80
+      when 'https://'
+        port == 443
+      when '//'
+        port == 80 || port == 443
+      else
+        false
+      end
+    end
+  end
+end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -14,7 +14,7 @@ class RequestTest < ActiveSupport::TestCase
     assert_equal '/books', url_for(:only_path => true, :path => '/books')
 
     assert_equal 'http://www.example.com/books/?q=code', url_for(trailing_slash: true, path: '/books?q=code')
-    assert_equal 'http://www.example.com/books/?spareslashes=////', url_for(trailing_slash: true, path: '/books?spareslashes=////')
+    assert_equal 'http://www.example.com/books/?spareslashes=%2F%2F%2F%2F', url_for(trailing_slash: true, path: '/books?spareslashes=////')
 
     assert_equal 'http://www.example.com',  url_for
     assert_equal 'http://api.example.com',  url_for(:subdomain => 'api')

--- a/actionpack/test/url_test.rb
+++ b/actionpack/test/url_test.rb
@@ -1,0 +1,346 @@
+require 'abstract_unit'
+
+class UrlTest < ActiveSupport::TestCase
+
+  def url(options={})
+    ::ActionDispatch::Url.new(options)
+  end
+
+  def test_url(options={})
+    url({ host: 'example.com' }.merge(options))
+  end
+
+  def assert_relative(path, options={})
+    assert_equal(path, url(options).relative_path)
+  end
+
+  def assert_absolute(path, options={})
+    assert_equal(path, url(options).absolute_path)
+  end
+
+  test 'relative_path returns blank string when path is false' do
+    assert_relative('', host: 'example.com')
+    assert_relative('', host: 'example.com', path: '')
+    assert_relative('', host: 'example.com', path: nil)
+    assert_relative('', host: 'example.com', path: false)
+    assert_relative('?sort=asc', host: 'example.com', path: nil, params: {sort: 'asc'})
+    assert_relative('#anchor', host: 'example.com', path: nil, anchor: 'anchor')
+    assert_relative('?sort=asc#anchor', host: 'example.com', path: nil, params: {sort: 'asc'}, anchor: 'anchor')
+  end
+
+  test 'relative_path joins path, params, and anchor' do
+    assert_relative('/c/a/1', host: 'example.com', path: '/c/a/1')
+    assert_relative('/c/a/1?sort=asc', host: 'example.com', path: '/c/a/1', params: {sort: 'asc'})
+    assert_relative('/c/a/1#anchor', host: 'example.com', path: '/c/a/1', anchor: 'anchor')
+    assert_relative('/c/a/1?sort=asc#anchor', host: 'example.com', path: '/c/a/1', params: {sort: 'asc'}, anchor: 'anchor')
+  end
+
+  test 'relative_path adds optional trailing_slash' do
+    options = { host: 'example.com', path: '/c/a/1', trailing_slash: true }
+    assert_relative('/c/a/1/', options)
+    assert_relative('/c/a/1/', options.merge(path: '/c/a/1/'))
+    assert_relative('/c/a/1/?sort=asc', options.merge(params: {sort: 'asc'}))
+    assert_relative('/c/a/1/#anchor', options.merge(anchor: 'anchor'))
+    assert_relative('/c/a/1/?sort=asc#anchor', options.merge(params: {sort: 'asc'}, anchor: 'anchor'))
+  end
+
+  test 'relative_path does not add double trailing slash' do
+    assert_relative '/', host: 'example.com',  path: '',  trailing_slash: true
+    assert_relative '/', host: 'example.com/', path: '',  trailing_slash: true
+    assert_relative '/', host: 'example.com',  path: '/', trailing_slash: true
+    assert_relative '/', host: 'example.com/', path: '/', trailing_slash: true
+  end
+
+  test 'relative_path does not require host' do
+    assert_equal('/c/a/1', url(path: '/c/a/1').relative_path)
+  end
+
+  test 'absolute_path returns full url' do
+    options = { host: 'example.com' }
+    assert_absolute('http://example.com', options)
+    assert_absolute('http://example.com/path', options.merge(path: '/path'))
+    assert_absolute('http://bob:secret@example.com/path', options.merge(path: '/path', user: 'bob', password: 'secret'))
+    assert_absolute('http://example.com#anchor', options.merge(anchor: 'anchor'))
+    assert_absolute('http://example.com?sort=asc', options.merge(params: {sort: 'asc'}))
+    assert_absolute('http://example.com/c/a/1?sort=asc', options.merge(path: '/c/a/1', params: {sort: 'asc'}))
+    assert_absolute('http://api.example.com/c/a/1?sort=asc#anchor', options.merge(path: '/c/a/1', params: {sort: 'asc'}, anchor: 'anchor', subdomain: 'api'))
+  end
+
+  test 'absolute_path adds optional trailing slash' do
+    options = { host: 'example.com', trailing_slash: true }
+    assert_absolute('http://example.com/', options)
+    assert_absolute('http://example.com/path/', options.merge(path: '/path'))
+    assert_absolute('http://example.com/#anchor', options.merge(anchor: 'anchor'))
+    assert_absolute('http://example.com/?sort=asc', options.merge(params: {sort: 'asc'}))
+    assert_absolute('http://example.com/c/a/1/?sort=asc', options.merge(path: '/c/a/1', params: {sort: 'asc'}))
+    assert_absolute('http://api.example.com/c/a/1/?sort=asc#anchor', options.merge(path: '/c/a/1', params: {sort: 'asc'}, anchor: 'anchor', subdomain: 'api'))
+  end
+
+  test 'absolute_path raises ArgumentError without host' do
+    assert_raises(ArgumentError) { url(path: '/c/a/1').absolute_path }
+  end
+
+
+  test 'initialize parses options[:host] uri into parts' do
+    assert_equal({ host: 'example.com', host_protocol: nil, host_port: nil },
+                 url(host: 'example.com').options)
+    assert_equal({ host: 'example.com', host_protocol: 'http://', host_port: nil },
+                 url(host: 'http://example.com').options)
+    assert_equal({ host: 'example.com', host_protocol: 'https://', host_port: nil },
+                 url(host: 'https://example.com').options)
+    assert_equal({ host: 'example.com', host_protocol: 'http://', host_port: '3000' },
+                 url(host: 'http://example.com:3000').options)
+    assert_equal({ host: 'example.com', host_protocol: 'https://', host_port: '3000' },
+                 url(host: 'https://example.com:3000').options)
+  end
+
+  test 'initialize does not parse protocol relative options[:host]' do
+    # TODO: what is the correct behavior?
+    assert_equal({ host: '//example.com', host_protocol: nil, host_port: nil },
+                 url(host: '//example.com').options)
+  end
+
+  test 'protocol_string returns http when nil' do
+    assert_equal('http://', test_url(protocol: nil).protocol_string)
+  end
+
+  test 'protocol_string returns relative protocol when false' do
+    assert_equal('//', test_url(protocol: false).protocol_string)
+    assert_equal('//', test_url(protocol: '//').protocol_string)
+  end
+
+  test 'protocol_string returns protocol when valid' do
+    assert_equal('https://', test_url(protocol: 'https://').protocol_string)
+    assert_equal('ftp://', test_url(protocol: 'ftp://').protocol_string)
+  end
+
+  test 'protocol_string accepts protocol without separator' do
+    assert_equal('https://', test_url(protocol: 'https').protocol_string)
+    assert_equal('https://', test_url(protocol: 'https:').protocol_string)
+    assert_equal('https://', test_url(protocol: 'https://').protocol_string)
+  end
+
+  test 'protocol_string defaults to protocol parsed from options[:host]' do
+    assert_equal('ftp://', url(host: 'ftp://example.com').protocol_string)
+    assert_equal('ftp://', url(host: 'ftp://example.com', protocol: nil).protocol_string)
+    assert_equal('https://', url(host: 'ftp://example.com', protocol: 'https').protocol_string)
+    assert_equal('https://', url(host: 'example.com', protocol: 'https').protocol_string)
+    assert_equal('ftp://', url(host: 'example.com', protocol: 'ftp').protocol_string)
+  end
+
+  test 'protocol_string raises ArgumentError when protocol is invalid' do
+    assert_raises(ArgumentError) { test_url(protocol: ':invalid').protocol_string }
+  end
+
+  test 'auth_string returns blank string without authentication' do
+    assert_equal('', url(host: 'example.com').auth_string)
+  end
+
+  test 'auth_string returns blank string unless both user and password are given' do
+    assert_equal('', url(host: 'example.com', user: 'bob').auth_string)
+    assert_equal('', url(host: 'example.com', password: 'secret').auth_string)
+  end
+
+  test 'auth_string returns username and password with authentication' do
+    assert_equal('bob:secret@', url(host: 'example.com', user: 'bob', password: 'secret').auth_string)
+  end
+
+  test 'auth_string escapes username and password' do
+    assert_equal('b%26b:s%3Fcr%26t@', url(host: 'example.com', user: 'b&b', password: 's?cr&t').auth_string)
+  end
+
+  test 'host_string raises ArgumentError if options[:host] is missing' do
+    assert_raises(ArgumentError) { url.host_string }
+  end
+
+  test 'host_string defaults to options[:host]' do
+    assert_equal('example.com', url(host: 'example.com').host_string)
+    assert_equal('api.example.com', url(host: 'api.example.com').host_string)
+    assert_equal('www.example.com', url(host: 'http://www.example.com:3000').host_string)
+  end
+
+  test 'host_string returns IP if host is IP address' do
+    assert_equal('127.0.0.1', url(host: '127.0.0.1').host_string)
+  end
+
+  test 'host_string does not prepend subdomain if host is IP address' do
+    assert_equal('127.0.0.1', url(host: '127.0.0.1', subdomain: 'api').host_string)
+  end
+
+  test 'host_string replaces domain when given' do
+    assert_equal('37signals.com', url(host: 'example.com', domain: '37signals.com').host_string)
+    assert_equal('37signals.com', url(host: '127.0.0.1', domain: '37signals.com').host_string)
+    assert_equal('api.37signals.com', url(host: 'api.example.com', domain: '37signals.com').host_string)
+  end
+
+  test 'host_string does not replace domain if falsey' do
+    assert_equal('www.example.com', url(host: 'www.example.com', domain: '').host_string)
+    assert_equal('www.example.com', url(host: 'www.example.com', domain: nil).host_string)
+    assert_equal('www.example.com', url(host: 'www.example.com', domain: false).host_string)
+  end
+
+  test 'host_string replaces subdomain when given' do
+    assert_equal('api.example.com', url(host: 'example.com', subdomain: 'api').host_string)
+    assert_equal('api.example.com', url(host: 'www.example.com', subdomain: 'api').host_string)
+    assert_equal('api.example.com', url(host: 'ns1.www.example.com', subdomain: 'api').host_string)
+    assert_equal('api.37signals.com', url(host: 'example.com', subdomain: 'api', domain: '37signals.com').host_string)
+  end
+
+  test 'host_string removes all subdomains if falsey' do
+    assert_equal('example.com', url(host: 'api.example.com', subdomain: '').host_string)
+    assert_equal('example.com', url(host: 'www.example.com', subdomain: nil).host_string)
+    assert_equal('example.com', url(host: 'ns1.www.example.com', subdomain: false).host_string)
+    assert_equal('37signals.com', url(host: 'api.example.com', subdomain: nil, domain: '37signals.com').host_string)
+  end
+
+  test 'host_string keeps subdomain if true' do
+    assert_equal('api.example.com', url(host: 'api.example.com', subdomain: true).host_string)
+  end
+
+  test 'host_string calls #to_param on subdomain object' do
+    assert_equal('www.example.com', url(host: 'example.com', subdomain: mock(to_param: 'www')).host_string)
+    assert_equal('www.example.com', url(host: 'api.example.com', subdomain: mock(to_param: 'www')).host_string)
+    assert_equal('example.com', url(host: 'api.example.com', subdomain: mock(to_param: '')).host_string)
+  end
+
+  test 'host_string defaults to TLD length 1' do
+    assert_equal('api.co.uk', url(host: 'www.example.co.uk', subdomain: 'api').host_string)
+    assert_equal('api.example.co.uk', url(host: 'www.example.co.uk', subdomain: 'api', tld_length: 2).host_string)
+    assert_equal('api.example.example.com', url(host: 'api.example.co.uk', domain: 'example.com').host_string)
+    assert_equal('api.example.com', url(host: 'api.example.co.uk', domain: 'example.com', tld_length: 2).host_string)
+  end
+
+  test 'host_string replaces domain and subdomain for host IP address' do
+    assert_equal('api.example.com', url(host: '127.0.0.1', subdomain: 'api', domain: 'example.com').host_string)
+  end
+
+  test 'host_string chomps trailing slash' do
+    assert_equal('test.host', url(host: 'test.host/').host_string)
+    assert_equal('127.0.0.1', url(host: '127.0.0.1/').host_string)
+    assert_equal('example.com', url(host: 'test.host', domain: 'example.com/').host_string)
+  end
+
+  test 'port_string returns empty string for default ports' do
+    assert_equal('', test_url(protocol: 'http://', port: 80).port_string)
+    assert_equal('', test_url(protocol: 'https://', port: 443).port_string)
+  end
+
+  test 'port_string returns empty string when disabled' do
+    assert_equal(':8443', url(host: 'http://example.com:8443').port_string)
+    assert_equal('', url(host: 'http://example.com:8443', port: nil).port_string)
+    assert_equal('', url(host: 'http://example.com:8443', port: false).port_string)
+  end
+
+  test 'port_string returns :port for custom port' do
+    assert_equal(':3000', test_url(protocol: 'http://', port: 3000).port_string)
+    assert_equal(':80', test_url(protocol: 'https://', port: 80).port_string)
+    assert_equal(':443', test_url(protocol: 'http://', port: 443).port_string)
+  end
+
+  test 'port_string accounts for parsed host protocol' do
+    assert_equal(':3000', url(host: 'http://www.example.com:3000').port_string)
+    assert_equal('', url(host: 'https://www.example.com:443').port_string)
+    assert_equal('', url(host: 'https://www.example.com', port: 443).port_string)
+  end
+
+  test 'port_string returns empty string for relative protocols and known ports' do
+    # TODO: Should this only be blank for :80 and :443?
+    assert_equal('', test_url(protocol: false).port_string)
+    assert_equal('', test_url(protocol: false, port: 80).port_string)
+    assert_equal('', test_url(protocol: false, port: 443).port_string)
+    assert_equal(':3000', test_url(protocol: '//', port: 3000).port_string)
+  end
+
+  test 'script_name_string returns empty string when false' do
+    assert_equal('', url(host: 'example.com').script_name_string)
+    assert_equal('', url(host: 'example.com', script_name: nil).script_name_string)
+    assert_equal('', url(host: 'example.com', script_name: false).script_name_string)
+  end
+
+  test 'script_name_string returns string if given' do
+    assert_equal('/app', url(host: 'example.com', script_name: '/app').script_name_string)
+  end
+
+  test 'script_name_string removes trailing slash' do
+    assert_equal('/app', url(host: 'example.com', script_name: '/app/').script_name_string)
+  end
+
+  test 'path_string returns normalized path' do
+    assert_equal('/c/a/1', url(host: 'example.com', path: '/c/a/1').path_string)
+  end
+
+  test 'path_string removes trailing slash' do
+    assert_equal('/c/a/1', url(host: 'example.com', path: '/c/a/1/').path_string)
+    assert_equal('/', url(host: 'example.com', path: '/').path_string)
+    assert_equal('', url(host: 'example.com', path: '').path_string)
+  end
+
+  test 'path_string parses existing params' do
+    assert_equal('/c/a/1', url(host: 'example.com', path: '/c/a/1?q=code').path_string)
+    assert_equal('?q=code', url(host: 'example.com', path: '/c/a/1?q=code').params_string)
+    assert_equal('?q=code&sort=asc', url(host: 'example.com', path: '/c/a/1?q=code', params: {sort: 'asc'}).params_string)
+  end
+
+  test 'path_string parses and deep_merges existing params' do
+    params = { a: { b: 1, c: 2 } }
+    assert_equal("?#{params.to_query}", url(host: 'example.com', path: '/path?a[b]=1', params: {a: {c: 2}}).params_string)
+  end
+
+  test 'path_string parses existing anchor' do
+    assert_equal('/c/a/1', url(host: 'example.com', path: '/c/a/1#anchor').path_string)
+    assert_equal('#anchor', url(host: 'example.com', path: '/c/a/1#anchor').anchor_string)
+    assert_equal('#heading2', url(host: 'example.com', path: '/c/a/1#anchor', anchor: 'heading2').anchor_string)
+  end
+
+  test 'path_string parses existing params and anchor' do
+    assert_equal('/c/a/1', url(host: 'example.com', path: '/c/a/1?q=code#anchor').path_string)
+  end
+
+  test 'params_string returns empty string when blank' do
+    assert_equal('', url(host: 'example.com', params: nil).params_string)
+    assert_equal('', url(host: 'example.com', params: '').params_string)
+    assert_equal('', url(host: 'example.com', params: false).params_string)
+    assert_equal('', url(host: 'example.com', params: {}).params_string)
+    assert_equal('', url(host: 'example.com', params: mock(to_query: '')).params_string)
+  end
+
+  test 'params_string converts hash to string' do
+    assert_equal('?sort=asc', url(host: 'example.com', params: {sort: 'asc'}).params_string)
+  end
+
+  test 'params_string calls #to_query on object' do
+    params = mock(:to_query => 'sort=asc')
+    assert_equal('?sort=asc', url(host: 'example.com', params: params).params_string)
+  end
+
+  test 'params_string escapes characters' do
+    assert_equal('?spareslashes=%2F%2F%2F%2F', url(host: 'www.example.com', path: '/books?spareslashes=////').params_string)
+    assert_equal('?spareslashes=%2F%2F%2F%2F', url(host: 'www.example.com', params: { spareslashes: '////' }).params_string)
+  end
+
+  test 'anchor_string returns empty string when blank' do
+    assert_equal('', url(host: 'example.com', anchor: '').anchor_string)
+    assert_equal('', url(host: 'example.com', anchor: nil).anchor_string)
+    assert_equal('', url(host: 'example.com', anchor: false).anchor_string)
+    assert_equal('', url(host: 'example.com', anchor: mock(to_param: '')).anchor_string)
+  end
+
+  test 'anchor_string returns anchored string' do
+    assert_equal('#anchor', url(host: 'example.com', anchor: 'anchor').anchor_string)
+  end
+
+  test 'anchor_string calls #to_param on object' do
+    assert_equal('#anchor', url(host: 'example.com', anchor: mock(to_param: 'anchor')).anchor_string)
+  end
+
+  test 'anchor_string escapes unsafe characters' do
+    assert_equal('#%23anchor', url(host: 'example.com', anchor: '#anchor').anchor_string)
+    assert_equal('#%23anchor', url(host: 'example.com', anchor: mock(to_param: '#anchor')).anchor_string)
+  end
+
+  test 'anchor_string does not escape safe characters' do
+    assert_equal('#name=user&email=user@domain.com', url(host: 'example.com', anchor: 'name=user&email=user@domain.com').anchor_string)
+    assert_equal('#name=user&email=user@domain.com', url(host: 'example.com', anchor: mock(to_param: 'name=user&email=user@domain.com')).anchor_string)
+  end
+
+end


### PR DESCRIPTION
Inspired by @gilesbowkett, I took a shot at DRYing up `#url_for` in Rails core a little.

As a first step, I've pulled out the logic related to generating a URL string into a separate class and documented all the edge cases handled in code with tests.

In a separate commit I've shown how `ActionDispatch::Http::URL#url_for` can be refactored to use this new helper class. No integration tests were removed in this PR (to demonstrate that this not break current functionality), but eventually some of the URL generating integration tests could be removed by ensuring the unit tests cover all the edge cases.

The idea behind this PR is not to change the `url_for` API in any way, but only to simplify the internal implementation and document all the edge cases. With a first-class citizen Url object, I think we could move on to reducing the number of things that have to know how to generate URLs.

Outstanding issues:
1. Will this kind of refactoring even be considered for rails-core? :)
2. Is `ActionDispatch::Url` a good name for this class? I did not want to conflict with the existing `ActionDispatch::Http::URL`.
3. There is one test that is currently not passing in master:

``` ruby
# actionpack/test/dispatch/request_test.rb:17
assert_equal 'http://www.example.com/books/?spareslashes=////',
  url_for(trailing_slash: true, path: '/books?spareslashes=////')
```

Currently, my patch changes this to:

``` ruby
assert_equal 'http://www.example.com/books/?spareslashes=%2F%2F%2F%2F',
  url_for(trailing_slash: true, path: '/books?spareslashes=////')
```

I believe this is more correct behavior, because if the same param was passed into options[:params], the slashes would indeed be escaped via #to_query:

``` ruby
# actionpack/test/url_test.rb
assert_equal '?spareslashes=%2F%2F%2F%2F', url(host: 'www.example.com',
  path: '/books?spareslashes=////').params_string
assert_equal '?spareslashes=%2F%2F%2F%2F', url(host: 'www.example.com',
  params: { spareslashes: '////' }).params_string
```

If there is a strong push to not escape params that are passed in via options[:path], I can change it. After all, the main purpose of this PR is only to fully document the edge cases and encapsulate it in a reusable class.
