### PR TITLE
Readonly records can no longer be deleted.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Readonly records can no longer be deleted.
+
+    *David Peter*
+
 *   `add_to_target` now accepts a second optional `skip_callbacks` argument
 
     If truthy, it will skip the :before_add and :after_add callbacks.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -139,6 +139,7 @@ module ActiveRecord
     # callbacks or any <tt>:dependent</tt> association
     # options, use <tt>#destroy</tt>.
     def delete
+      raise ReadOnlyRecord if readonly?
       self.class.delete(id) if persisted?
       @destroyed = true
       freeze

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -25,6 +25,7 @@ class ReadOnlyTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::ReadOnlyRecord) { dev.save  }
     assert_raise(ActiveRecord::ReadOnlyRecord) { dev.save! }
     assert_raise(ActiveRecord::ReadOnlyRecord) { dev.destroy }
+    assert_raise(ActiveRecord::ReadOnlyRecord) { dev.delete }
   end
 
 


### PR DESCRIPTION
Pull request #6250 now prevents readonly models from being `destroy`ed, but the same behavior was not given to `delete`. This pull request adds that functionality.
