### PR TITLE
Add plural form example for AR I18n section [ci skip]

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -731,6 +731,19 @@ en:
 
 Then `User.model_name.human` will return "Dude" and `User.human_attribute_name("login")` will return "Handle".
 
+You can also set a plural form for model names, adding as following:
+
+```ruby
+en:
+  activerecord:
+    models:
+      user:
+        one: Dude
+        other: Dudes
+```
+
+Then `User.model_name.human(:count => 2)` will return "Dudes". With `:count => 1` or without params will return "Dude".
+
 #### Error Message Scopes
 
 Active Record validation error messages can also be translated easily. Active Record gives you a couple of namespaces where you can place your message translations in order to provide different messages and translation for certain models, attributes, and/or validations. It also transparently takes single table inheritance into account.


### PR DESCRIPTION
Add a example of how to use plural form for model names.
