### PR TITLE
fix the broken link in rails doc api[ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ database rows as objects and embellish these data objects with business logic
 methods. Although most Rails models are backed by a database, models can also
 be ordinary Ruby classes, or Ruby classes that implement a set of interfaces
 as provided by the Active Model module. You can read more about Active Record
-in its [README](activerecord/README.rdoc).
+in its [README](https://github.com/rails/rails/blob/master/activerecord/README.rdoc).
 
 The _Controller layer_ is responsible for handling incoming HTTP requests and
 providing a suitable response. Usually this means returning HTML, but Rails
@@ -33,7 +33,7 @@ In Rails, the Controller and View layers are handled together by Action Pack.
 These two layers are bundled in a single package due to their heavy interdependence.
 This is unlike the relationship between Active Record and Action Pack, which are
 independent. Each of these packages can be used independently outside of Rails. You
-can read more about Action Pack in its [README](actionpack/README.rdoc).
+can read more about Action Pack in its [README](https://github.com/rails/rails/blob/master/actionpack/README.rdoc).
 
 ## Getting Started
 


### PR DESCRIPTION
It was pointing to http://api.rubyonrails.org/activerecord/README.rdoc and http://api.rubyonrails.org/actionpack/README.rdoc and which throw 404
