### PR TITLE
Don't raise when writing an attribute with and out of range time

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -34,7 +34,11 @@ module ActiveRecord
           if create_time_zone_conversion_attribute?(attr_name, columns_hash[attr_name])
             method_body, line = <<-EOV, __LINE__ + 1
               def #{attr_name}=(time)
-                time_with_zone = time.respond_to?(:in_time_zone) ? time.in_time_zone : nil
+                time_with_zone = begin
+                  time.respond_to?(:in_time_zone) ? time.in_time_zone : nil
+                rescue ArgumentError
+                  nil
+                end
                 previous_time = attribute_changed?("#{attr_name}") ? changed_attributes["#{attr_name}"] : read_attribute(:#{attr_name})
                 write_attribute(:#{attr_name}, time)
                 #{attr_name}_will_change! if previous_time != time_with_zone

--- a/activerecord/test/cases/attribute_methods/time_zone_conversion_test.rb
+++ b/activerecord/test/cases/attribute_methods/time_zone_conversion_test.rb
@@ -1,0 +1,15 @@
+require "cases/helper"
+require 'models/developer'
+
+module ActiveRecord
+  module AttributeMethods
+    class TimeZoneConversionTest < ActiveSupport::TestCase
+
+      def test_invalid_date_doesnt_raise
+        developer = Developer.new(updated_on: 'invalid')
+        assert_equal nil, developer.updated_on
+        assert_equal 'invalid', developer.updated_on_before_type_cast
+      end
+    end
+  end
+end


### PR DESCRIPTION
The following code will raise an `ArgumentError` because of an out of range time:

``` ruby
Model.new(:created_at => '2010-33-22T09:30:25Z')
```

However, this won't raise, this will set `created_at` to nil instead :

``` ruby
Model.new(:created_at => 'Foobar')
```

I think the first example should act as the second one, hence this PR.

What do you think ?
