### PR TITLE
Set attributes from where clause on null relationship

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Objects intiantiated using a null relationship will now retain the
+    attributes of the where clause.
+
+    *Peter Brown*
+
 *   `add_to_target` now accepts a second optional `skip_callbacks` argument
 
     If truthy, it will skip the :before_add and :after_add callbacks.

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -42,10 +42,6 @@ module ActiveRecord
       ""
     end
 
-    def where_values_hash
-      {}
-    end
-
     def count(*)
       0
     end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1590,6 +1590,20 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal car.id, bulb.attributes_after_initialize['car_id']
   end
 
+  def test_attributes_are_set_when_initialized_from_has_many_null_relationship
+    car = Car.new name: "honda"
+    bulb = car.bulbs.where(name: 'headlight').first_or_initialize
+    assert_equal 'headlight', bulb.name
+  end
+
+  def test_attributes_are_set_when_initialized_from_polymorphic_has_many_null_relationship
+    post = Post.new title: "title", body: "bar"
+    tag = Tag.create!(name: "foo")
+    tagging = post.taggings.where(tag: tag).first_or_initialize
+    assert_equal tag.id, tagging.tag_id
+    assert_equal 'Post', tagging.taggable_type
+  end
+
   def test_replace
     car = Car.create(:name => 'honda')
     bulb1 = car.bulbs.create

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -289,6 +289,10 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal({}, Developer.none.where_values_hash)
   end
 
+  def test_null_relation_where_values_hash
+    assert_equal({'salary' => 100_000}, Developer.none.where(salary: 100_000).where_values_hash)
+  end
+
   def test_joins_with_nil_argument
     assert_nothing_raised { DependentFirm.joins(nil).first }
   end


### PR DESCRIPTION
When an association is created based on a null relationship, the
attributes from the where clause are lost. This fixes that behavior by
removing the overridden where_values_hash method and using the one on
the ActiveRecord::Relation class.

Fixes #11676 and #11675
