### PR TITLE
When testing cache issues, it is useful to log the actual key, including namespace

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -533,7 +533,7 @@ module ActiveSupport
         end
 
         def instrument(operation, key, options = nil)
-          log { "Cache #{operation}: #{key}#{options.blank? ? "" : " (#{options.inspect})"}" }
+          log { "Cache #{operation}: #{namespaced_key(key, options)}#{options.blank? ? "" : " (#{options.inspect})"}" }
 
           payload = { :key => key }
           payload.merge!(options) if options.is_a?(Hash)

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -1045,6 +1045,19 @@ class CacheStoreLoggerTest < ActiveSupport::TestCase
     assert @buffer.string.present?
   end
 
+  def test_log_with_string_namespace
+    @cache.fetch('foo', {namespace: 'string_namespace'}) { 'bar' }
+    assert_match %r{string_namespace:foo}, @buffer.string
+  end
+
+  def test_log_with_proc_namespace
+    proc = Proc.new do
+      "proc_namespace"
+    end    
+    @cache.fetch('foo', {:namespace => proc}) { 'bar' }
+    assert_match %r{proc_namespace:foo}, @buffer.string
+  end
+  
   def test_mute_logging
     @cache.mute { @cache.fetch('foo') { 'bar' } }
     assert @buffer.string.blank?


### PR DESCRIPTION
When using fetch or read in the ActiveSupport::Cache, **_namespaced_key(key,options)**_ is used.
For these cases where you need to debug the actual cache behavior, in debug level, I think it's worth logging the actual key being used in the code, rather than the stripped down version, without the namespace.

I've added test for both Proc and string based namespaces.
