### PR TITLE
Allow errors on arbitrary keys to use message i18n

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `ActiveModel::Errors` raising NoMethodError when adding errors to
+    arbitrary keys on models and using I18n translations.
+
+    *Caleb Thompson*
+
 *   Fix `has_secure_password` to honor bcrypt-ruby's cost attribute.
 
     *T.J. Schuck*

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -423,7 +423,11 @@ module ActiveModel
       defaults.flatten!
 
       key = defaults.shift
-      value = (attribute != :base ? @base.send(:read_attribute_for_validation, attribute) : nil)
+      value = if @base.respond_to?(attribute)
+                @base.send(:read_attribute_for_validation, attribute)
+              else
+                nil
+              end
 
       options = {
         default: defaults,

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -300,4 +300,16 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors.expects(:generate_message).with(:name, :blank, { message: 'custom' })
     person.errors.add_on_blank :name, message: 'custom'
   end
+
+  test "can add error to non-attribute and use translation key as message" do
+    person = Person.new
+    person.errors.add(:not_an_attribute, :invalid)
+    assert_equal ['is invalid'], person.errors[:not_an_attribute]
+  end
+
+  test "non-attribute translations get correct options" do
+    person = Person.new
+    I18n.expects(:translate).with(:"errors.attributes.not_an_attribute.invalid", has_entries(attribute: :not_an_attribute, value: nil))
+    person.errors.add(:not_an_attribute, :invalid)
+  end
 end


### PR DESCRIPTION
ActiveModel::Errors reads attributes to allow them to be used in translations
for messages. It also allows errors to be added to arbitrary keys.

Rather than switching on the 'magic' `:base` key, check to see if the base
object responds to the attribute before trying to read it.

By doing this, we allow translations to be used to generate messages for 
errors on attributes to which the base model does not respond, generating more
meaningful errors while not relying on strings for the messages.
