### PR TITLE
Backport: Allow errors on arbitrary keys to use message i18n

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -339,7 +339,11 @@ module ActiveModel
       defaults.flatten!
 
       key = defaults.shift
-      value = (attribute != :base ? @base.send(:read_attribute_for_validation, attribute) : nil)
+      value = if @base.respond_to?(attribute)
+                @base.send(:read_attribute_for_validation, attribute)
+              else
+                nil
+              end
 
       options = {
         :default => defaults,

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -191,5 +191,10 @@ class ErrorsTest < ActiveModel::TestCase
       person.errors.generate_message(:name, :blank)
     }
   end
+
+  test "can add errors to non-attributes with translations" do
+    person = Person.new
+    person.errors.add(:not_an_attribute, :invalid)
+  end
 end
 


### PR DESCRIPTION
Backport from https://github.com/rails/rails/pull/11873

ActiveModel::Errors reads attributes to allow them to be used in translations
for messages. It also allows errors to be added to arbitrary keys.

Rather than switching on the 'magic' `:base` key, check to see if the base
object responds to the attribute before trying to read it.

By doing this, we allow translations to be used to generate messages for 
errors on attributes to which the base model does not respond, generating more
meaningful errors while not relying on strings for the messages.
