### PR TITLE
Correctly singularize "criteria"

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -58,6 +58,7 @@ module ActiveSupport
     inflect.irregular('sex', 'sexes')
     inflect.irregular('move', 'moves')
     inflect.irregular('zombie', 'zombies')
+    inflect.irregular('criterion', 'criteria')
 
     inflect.uncountable(%w(equipment information rice money species series fish sheep jeans police))
   end


### PR DESCRIPTION
"criteria".singularize # => "criterium"
"criterion".pluralize # => "criterions"

A criterium is a bike race, the singular of criteria is criterion. I'm fairly sure this is an irregular, and not a standard inflection rule that needs to be added.
