### PR TITLE
Yakko guides gemfile should exist

### DIFF
--- a/guides/Gemfile
+++ b/guides/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+
+gem 'redcarpet'
+gem 'nokogiri'
+gem 'rack-test'

--- a/guides/Gemfile.lock
+++ b/guides/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    mini_portile (0.5.1)
+    nokogiri (1.6.0)
+      mini_portile (~> 0.5.0)
+    rack (1.5.2)
+    rack-test (0.6.2)
+      rack (>= 1.0)
+    redcarpet (3.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri
+  rack-test
+  redcarpet


### PR DESCRIPTION
I believe a Gemfile is suitable here because 'rake guides:generate' requires 3 gems to be installed
