### PR TITLE
Fix sandbox #reload! exception with SQLite3

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -139,7 +139,7 @@ module ActiveRecord
 
       ActiveSupport.on_load(:active_record) do
         ActionDispatch::Reloader.send(hook) do
-          if ActiveRecord::Base.connected?
+          if ActiveRecord::Base.connected? && !app.sandbox
             ActiveRecord::Base.clear_reloadable_connections!
             ActiveRecord::Base.clear_cache!
           end

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -73,6 +73,13 @@ class ConsoleTest < ActiveSupport::TestCase
     assert User.new.respond_to?(:age)
   end
 
+  def test_reload_in_sandbox_does_not_rollback_sandbox_transaction
+    load_environment(true)
+    assert ActiveRecord::Base.connection.transaction_open?, 'Sandbox not active'
+    silence_stream(STDOUT) { irb_context.reload! }
+    assert ActiveRecord::Base.connection.transaction_open?
+  end
+
   def test_access_to_helpers
     load_environment
     helper = irb_context.helper


### PR DESCRIPTION
Fixes #11834

Stop connection_pool from disconnecting the connection holding the
sandbox transaction (which should remain open throughout the session).
This bug only occurs with SQLite sandboxes, because only a SQLite
connection requires_reloading.
