### PR TITLE
Newly instantiated STI records with no changes are marked as dirty, PR for test and fix

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Newly instantiated STI records are not marked as dirty
+    
+    Example:
+    
+        class Parrot < ActiveRecord::Base
+        end
+        
+        class LiveParrot < Parrot
+        end
+        
+        # Before: 
+        Parrot.new.changed? # => false
+        LiveParrot.new.changed? # => true
+        
+        # After:
+        Parrot.new.changed? # => false
+        LiveParrot.new.changed? # => false
+        
+    *James Prior*
+
 *   Assign inet/cidr attribute with `nil` value for invalid address.
 
     Example:

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -305,6 +305,14 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal [], pirate.changed
     assert_equal Hash.new, pirate.changes
   end
+  
+  def test_inherited_object_should_not_be_changed_when_instantiated
+    # Using an STI class here
+    live_parrot = LiveParrot.new
+    assert !live_parrot.changed?
+    assert_equal [], live_parrot.changed
+    assert_equal Hash.new, live_parrot.changes    
+  end
 
   def test_attribute_will_change!
     pirate = Pirate.create!(:catchphrase => 'arr')


### PR DESCRIPTION
Example:

```
class Parrot < ActiveRecord::Base
end

class LiveParrot < Parrot
end

# Before:
Parrot.new.changed? # => false
LiveParrot.new.changed? # => true

# After:
Parrot.new.changed? # => false
LiveParrot.new.changed? # => false
```
