### PR TITLE
Fixing multi-word automatic inverse detection.

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -394,7 +394,7 @@ module ActiveRecord
         # returns either nil or the inverse association name that it finds.
         def automatic_inverse_of
           if can_find_inverse_of_automatically?(self)
-            inverse_name = active_record.name.downcase.to_sym
+            inverse_name = ActiveSupport::Inflector.underscore(active_record.name).to_sym
 
             begin
               reflection = klass.reflect_on_association(inverse_name)
@@ -413,7 +413,7 @@ module ActiveRecord
         end
 
         # Checks if the inverse reflection that is returned from the
-        # +set_automatic_inverse_of+ method is a valid reflection. We must
+        # +automatic_inverse_of+ method is a valid reflection. We must
         # make sure that the reflection's active_record name matches up
         # with the current reflection's klass name.
         #

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -9,9 +9,23 @@ require 'models/rating'
 require 'models/comment'
 require 'models/car'
 require 'models/bulb'
+require 'models/mixed_case_monkey'
 
 class AutomaticInverseFindingTests < ActiveRecord::TestCase
   fixtures :ratings, :comments, :cars
+
+  def test_has_one_and_belongs_to_should_find_inverse_automatically_on_multiple_word_name
+    monkey_reflection = MixedCaseMonkey.reflect_on_association(:man)
+    man_reflection = Man.reflect_on_association(:mixed_case_monkey)
+
+    assert_respond_to monkey_reflection, :has_inverse?
+    assert monkey_reflection.has_inverse?, "The monkey reflection should have an inverse"
+    assert_equal man_reflection, monkey_reflection.inverse_of, "The monkey reflection's inverse should be the man reflection"
+
+    assert_respond_to man_reflection, :has_inverse?
+    assert man_reflection.has_inverse?, "The man reflection should have an inverse"
+    assert_equal monkey_reflection, man_reflection.inverse_of, "The man reflection's inverse should be the monkey reflection"
+  end
 
   def test_has_one_and_belongs_to_should_find_inverse_automatically
     car_reflection = Car.reflect_on_association(:bulb)

--- a/activerecord/test/models/man.rb
+++ b/activerecord/test/models/man.rb
@@ -6,4 +6,5 @@ class Man < ActiveRecord::Base
   # These are "broken" inverse_of associations for the purposes of testing
   has_one :dirty_face, :class_name => 'Face', :inverse_of => :dirty_man
   has_many :secret_interests, :class_name => 'Interest', :inverse_of => :secret_man
+  has_one :mixed_case_monkey
 end

--- a/activerecord/test/models/mixed_case_monkey.rb
+++ b/activerecord/test/models/mixed_case_monkey.rb
@@ -1,3 +1,5 @@
 class MixedCaseMonkey < ActiveRecord::Base
   self.primary_key = 'monkeyID'
+
+  belongs_to :man
 end


### PR DESCRIPTION
Currently, ActiveRecord models with multiple words cannot have their inverse associations detected automatically. Thus, class names like "MixedCaseMonkey" on AR models will not get their inverses found correctly. The proposed patch should change that.

In the test that has been added, both the `MixedCaseMonkey` and the `Man` models should have inverses defined on their associations. However, only the inverse association on `Man` is found correctly.

\cc @spastorino 
