### PR TITLE
Adding LESS to rake notes

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   rake notes now searches *.less files
+
+    *Josh Crowder*
+
 *   Generate nested route for namespaced controller generated using
     `rails g controller`.
     Fixes #11532.

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -82,7 +82,7 @@ class SourceAnnotationExtractor
             case item
             when /\.(builder|rb|coffee|rake)$/
               /#\s*(#{tag}):?\s*(.*)$/
-            when /\.(css|scss|sass|js)$/
+            when /\.(css|scss|sass|less|js)$/
               /\/\/\s*(#{tag}):?\s*(.*)$/
             when /\.erb$/
               /<%\s*#\s*(#{tag}):?\s*(.*?)\s*%>/

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -25,6 +25,7 @@ module ApplicationTests
         app_file "app/assets/stylesheets/application.css", "// TODO: note in css"
         app_file "app/assets/stylesheets/application.css.scss", "// TODO: note in scss"
         app_file "app/assets/stylesheets/application.css.sass", "// TODO: note in sass"
+        app_file "app/assets/stylesheets/application.css.less", "// TODO: note in less"
         app_file "app/controllers/application_controller.rb", 1000.times.map { "" }.join("\n") << "# TODO: note in ruby"
         app_file "lib/tasks/task.rake", "# TODO: note in rake"
 
@@ -48,6 +49,7 @@ module ApplicationTests
           assert_match(/note in css/, output)
           assert_match(/note in scss/, output)
           assert_match(/note in sass/, output)
+          assert_match(/note in less/, output)
           assert_match(/note in rake/, output)
 
           assert_equal 10, lines.size


### PR DESCRIPTION
Hi guys! This is my first contribution, hope its ok.

I have made a small change to source_annotation extractor so it supports LESS. I wasn't sure where the tests lived for this, if it needs a test I'd happily do it if someone can point me in the right direction :)

rake notes now supports the LESS file format
- Added LESS file extension to to list
