### PR TITLE
Raise exception on Cache.clear call with string argument

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -588,6 +588,10 @@ module ActiveSupport
           write(name, result, options)
           result
         end
+
+        def validate_for_hash(options) # :nodoc:
+          raise ArgumentError, 'Options must be a hash' unless options.is_a?(Hash)
+        end
     end
 
     # This class is used to represent cache entries. Cache entries have a value and an optional

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -22,10 +22,11 @@ module ActiveSupport
         extend Strategy::LocalCache
       end
 
-      # Deletes all items from the cache. In this case it deletes all the entries in the specified 
-      # file store directory except for .gitkeep. Be careful which directory is specified in your 
+      # Deletes all items from the cache. In this case it deletes all the entries in the specified
+      # file store directory except for .gitkeep. Be careful which directory is specified in your
       # config file when using +FileStore+ because everything in that directory will be deleted.
       def clear(options = nil)
+        validate_for_hash(options) if options
         root_dirs = Dir.entries(cache_path).reject {|f| (EXCLUDED_DIRS + [".gitkeep"]).include?(f)}
         FileUtils.rm_r(root_dirs.collect{|f| File.join(cache_path, f)})
       end

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -109,6 +109,7 @@ module ActiveSupport
       # Clear the entire cache on all memcached servers. This method should
       # be used with care when shared cache is being used.
       def clear(options = nil)
+        validate_for_hash(options) if options
         @data.flush_all
       rescue Dalli::DalliError => e
         logger.error("DalliError (#{e}): #{e.message}") if logger

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -29,6 +29,7 @@ module ActiveSupport
       end
 
       def clear(options = nil)
+        validate_for_hash(options) if options
         synchronize do
           @data.clear
           @key_access.clear

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -422,6 +422,10 @@ module CacheStoreBehavior
     assert_equal({key => "bar"}, @cache.read_multi(key))
     assert @cache.delete(key)
   end
+
+  def test_clear_exception_with_string_as_options_argument
+    assert_raises(ArgumentError) { @cache.clear('string') }
+  end
 end
 
 # https://rails.lighthouseapp.com/projects/8994/tickets/6225-memcachestore-cant-deal-with-umlauts-and-special-characters


### PR DESCRIPTION
Options argument from `clear(options)` in all bundled cache implementations
wasn't used at all, so calling `clear('some_string')` just flushes cache
without any warning. But this method can be easily confused with `delete`,
exactly what happened on my project. So I think it's better to check
if `options` is a hash, when it provided, and raise ArgumentError if not.
