### PR TITLE
Defer stacktrace filtering in `load_missing_const`

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -199,7 +199,8 @@ module ActiveSupport #:nodoc:
         # Raise the first error for this set. If this const_missing came from an
         # earlier const_missing, this will result in the real error bubbling
         # all the way up
-        raise error
+        raise error.class, error.message,
+              caller.reject { |l| l.starts_with? __FILE__ }
       end
 
       def unloadable(const_desc = self)
@@ -518,8 +519,7 @@ module ActiveSupport #:nodoc:
       end
 
       raise NameError,
-            "uninitialized constant #{qualified_name}",
-            caller.reject {|l| l.starts_with? __FILE__ }
+            "uninitialized constant #{qualified_name}"
     end
 
     # Remove the constants that have been autoloaded, and those that have been


### PR DESCRIPTION
Rails loads missing constants in `const_missing` by looping through
the most specific to the least specific constant, calling
`load_missing_const`. When the more specific constant doesn't exist
`load_missing_const` raises a NameError, with a filtered stacktrace.
The NameError is usually discarded by `const_missing`.

The stacktrace filtering, i.e. `caller`, is expensive. We can avoid
the performance penalty by deferring the stacktrace filtering until we
actually want to raise the NameError in `const_missing`.

This appears to be fixed, or at least handled differently, in rails4.

Each call to `caller` takes approximately 60ms and can happen numerous
times throughout the request response cycle.
