### PR TITLE
Preserve DST boolean to fix marshalling Time in JRuby

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -184,4 +184,10 @@
 
     *Daniel Schierbeck*
 
+*   Preserve DST boolean to fix marshalling Time in JRuby (credit to @andrewtabit)
+
+    Fixes #10900 
+
+    *Mike Admire*
+
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Preserve DST boolean to fix marshalling Time in JRuby (credit to @andrewtabit)
+
+    Fixes #10900 
+
+    *Mike Admire*
+
 *   Add String#remove(pattern) as a short-hand for the common pattern of String#gsub(pattern, '')
 
     *DHH*
@@ -183,11 +189,5 @@
         end
 
     *Daniel Schierbeck*
-
-*   Preserve DST boolean to fix marshalling Time in JRuby (credit to @andrewtabit)
-
-    Fixes #10900 
-
-    *Mike Admire*
 
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activesupport/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
Store isdst as an instance variable to eliminate the one hour time
difference when doing Marshal.load(Marshal.dump(Time.now)) between
active_support/core_ext/time/marshal and JRuby Marshal.
