### PR TITLE
Use binary mode to write uploaded files

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -605,7 +605,7 @@ The object in the `params` hash is an instance of a subclass of IO. Depending on
 ```ruby
 def upload
   uploaded_io = params[:person][:picture]
-  File.open(Rails.root.join('public', 'uploads', uploaded_io.original_filename), 'w') do |file|
+  File.open(Rails.root.join('public', 'uploads', uploaded_io.original_filename), 'wb') do |file|
     file.write(uploaded_io.read)
   end
 end


### PR DESCRIPTION
See: http://stackoverflow.com/a/4988984/129798 for an explanation for why this is required for Ruby 1.9.
