### PR TITLE
Update Rails::Railtie::Configuration and ActionDispatch::Response#respond_to? to accept include_private argument

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -181,7 +181,7 @@ module ActionDispatch # :nodoc:
     end
     alias_method :status_message, :message
 
-    def respond_to?(method)
+    def respond_to?(method, include_private = false)
       if method.to_s == 'to_path'
         stream.respond_to?(:to_path)
       else

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -212,6 +212,11 @@ class ResponseTest < ActiveSupport::TestCase
       ActionDispatch::Response.default_headers = nil
     end
   end
+
+  test "respond_to? accepts include_private" do
+    assert_not @response.respond_to?(:method_missing)
+    assert @response.respond_to?(:method_missing, true)
+  end
 end
 
 class ResponseIntegrationTest < ActionDispatch::IntegrationTest

--- a/railties/lib/rails/railtie/configuration.rb
+++ b/railties/lib/rails/railtie/configuration.rb
@@ -80,7 +80,7 @@ module Rails
         to_prepare_blocks << blk if blk
       end
 
-      def respond_to?(name)
+      def respond_to?(name, include_private = false)
         super || @@options.key?(name.to_sym)
       end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -679,5 +679,12 @@ module ApplicationTests
       end
       assert_equal Logger::INFO, Rails.logger.level
     end
+
+    test "respond_to? accepts include_private" do
+      make_basic_app
+
+      assert_not Rails.configuration.respond_to?(:method_missing)
+      assert Rails.configuration.respond_to?(:method_missing, true)
+    end
   end
 end


### PR DESCRIPTION
Both Rails::Railtie::Configuration and ActionDispatch::Response define respond_to? with an incompatible signature and both call super in their implementations. This simply adds the second argument so that respond_to? can be called with the two-argument signature.
