### PR TITLE
Have the doc:app rake task process all .rdoc files from both top-level and doc/ directories

### DIFF
--- a/railties/lib/rails/tasks/documentation.rake
+++ b/railties/lib/rails/tasks/documentation.rake
@@ -50,7 +50,8 @@ else
       rdoc.title    = ENV['title'] || "Rails Application Documentation"
       rdoc.options << '--line-numbers'
       rdoc.options << '--charset' << 'utf-8'
-      rdoc.rdoc_files.include('README.rdoc')
+      rdoc.rdoc_files.include('*.rdoc')
+      rdoc.rdoc_files.include('doc/*.rdoc')
       rdoc.rdoc_files.include('app/**/*.rb')
       rdoc.rdoc_files.include('lib/**/*.rb')
     }


### PR DESCRIPTION
Have the doc:app rake task process all .rdoc files from both the top-level directory and and the doc/ sub-directory of a Rails application and include them as pages in the generated HTML output, and not just the top-level README.rdoc.
