### PR TITLE
Indifferent access for model's error messages

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -70,7 +70,7 @@ module ActiveModel
     #   end
     def initialize(base)
       @base     = base
-      @messages = {}
+      @messages = ActiveSupport::HashWithIndifferentAccess.new
     end
 
     def initialize_dup(other) # :nodoc:

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -70,7 +70,7 @@ module ActiveModel
     #   end
     def initialize(base)
       @base     = base
-      @messages = ActiveSupport::HashWithIndifferentAccess.new
+      @messages = {}
     end
 
     def initialize_dup(other) # :nodoc:

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -77,6 +77,13 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal({ foo: "omg" }, errors.messages)
   end
 
+  test "sets the error with string key" do
+    errors = ActiveModel::Errors.new(self)
+    errors[:foo] = "omg"
+
+    assert_equal ["omg"], errors["foo"]
+  end
+
   test "values returns an array of messages" do
     errors = ActiveModel::Errors.new(self)
     errors.set(:foo, "omg")


### PR DESCRIPTION
I think `full_messages_for` should be consistent with `errors`. Before it was like this 

``` ruby
class Post
  include ActiveModel::Validatations
  attr_accessor :title
  validates_presence_of :title
end

post = Post.new
post.valid?

post.errors[:title] # => 'can't be blank'
post.errors['title'] # => 'can't be blank'

post.errors.full_messages_for :title # => ['Title can't be blank']
post.errors.full_messages_for 'title' # => []
```
