### PR TITLE
Remove the unused, undocumented SQLite3Adapter#supports_count_distinct?

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -631,7 +631,6 @@ module ActiveRecord
         true
       end
 
-      # Returns true.
       def supports_explain?
         true
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -189,11 +189,6 @@ module ActiveRecord
         @statements.clear
       end
 
-      # Returns true
-      def supports_count_distinct? #:nodoc:
-        true
-      end
-
       def supports_index_sort_order?
         true
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -141,14 +141,12 @@ module ActiveRecord
         'SQLite'
       end
 
-      # Returns true
       def supports_ddl_transactions?
         true
       end
 
-      # Returns true if SQLite version is '3.6.8' or greater, false otherwise.
       def supports_savepoints?
-        sqlite_version >= '3.6.8'
+        true
       end
 
       # Returns true, since this connection adapter supports prepared statement
@@ -162,7 +160,6 @@ module ActiveRecord
         true
       end
 
-      # Returns true.
       def supports_primary_key? #:nodoc:
         true
       end
@@ -171,7 +168,6 @@ module ActiveRecord
         true
       end
 
-      # Returns true
       def supports_add_column?
         true
       end
@@ -218,7 +214,6 @@ module ActiveRecord
         @connection.encoding.to_s
       end
 
-      # Returns true.
       def supports_explain?
         true
       end


### PR DESCRIPTION
These have returned true since 3cc9b5f1, are only used internally and in tests.

Also drop a sqlite_version check because we only support 3.6.16+ now.

A few things this prompts:
- `#default_primary_key_type` is defunct but documented
- `#supports_primary_key?` is not used internally, but is documented in `AbstractAdapter` and `AbstractMysqlAdapter`
- `#sqlite_version` is also unused internally, but that seems like it may be useful.

Should we deprecate and remove these?
