### PR TITLE
Stop interpreting SQL 'string' columns as :string type.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -272,7 +272,7 @@ module ActiveRecord
             :text
           when /blob/i, /binary/i
             :binary
-          when /char/i, /string/i
+          when /char/i
             :string
           when /boolean/i
             :boolean

--- a/activerecord/test/cases/adapters/postgresql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/quoting_test.rb
@@ -47,7 +47,7 @@ module ActiveRecord
 
         def test_quote_cast_numeric
           fixnum = 666
-          c = Column.new(nil, nil, 'string')
+          c = Column.new(nil, nil, 'varchar')
           assert_equal "'666'", @conn.quote(fixnum, c)
           c = Column.new(nil, nil, 'text')
           assert_equal "'666'", @conn.quote(fixnum, c)


### PR DESCRIPTION
SQL doesn't have a string type, and interpreting 'string' as text is
contrary to at least SQLite3's behavior:

"Note that a declared type of 'STRING' has an affinity of NUMERIC, not TEXT."
http://www.sqlite.org/datatype3.html

Is there a supported database that uses this column type? I may have missed something.
