### PR TITLE
Add dafault PK order to FinderMethods#first and fix #last(N)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## unreleased ##
+*   Add default ordering by primary_key to #first.
+    Fixes #11774
+    
+    *Eugene Kalenkovich*
 
 *   Load fixtures from linked folders.
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## unreleased ##
+*   Fix FinderMethods#last unscoped primary key.
+    Addresses #11917
+
+    *Eugene Kalenkovich*
+
 *   Add default ordering by primary_key to #first.
     Fixes #11774
     

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -114,7 +114,7 @@ module ActiveRecord
     def first(*args)
       if args.any?
         if args.first.kind_of?(Integer) || (loaded? && !args.first.kind_of?(Hash))
-          limit(*args).to_a
+          find_first_with_limit(*args)
         else
           apply_finder_options(args.first).first
         end
@@ -378,7 +378,15 @@ module ActiveRecord
       if loaded?
         @records.first
       else
-        @first ||= limit(1).to_a[0]
+        @first ||= find_first_with_limit(1)[0]
+      end
+    end
+
+    def find_first_with_limit(limit)
+      if order_values.empty? && primary_key
+        order("#{quoted_table_name}.#{quoted_primary_key}").limit(limit).to_a
+      else
+        limit(limit).to_a
       end
     end
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -134,8 +134,8 @@ module ActiveRecord
     def last(*args)
       if args.any?
         if args.first.kind_of?(Integer) || (loaded? && !args.first.kind_of?(Hash))
-          if order_values.empty?
-            order("#{primary_key} DESC").limit(*args).reverse
+          if order_values.empty? && primary_key
+            order("#{quoted_table_name}.#{quoted_primary_key} DESC").limit(*args).reverse
           else
             to_a.last(*args)
           end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -305,6 +305,16 @@ class FinderTest < ActiveRecord::TestCase
     assert_sql(/LIMIT 5|ROWNUM <= 5/) { Topic.last(5).entries }
   end
 
+  def test_first_and_last_should_use_default_order
+    assert_sql(/ORDER BY .topics.\..id./) { Topic.first }
+    assert_sql(/ORDER BY .topics.\..id. DESC/) { Topic.last }
+  end
+
+  def test_first_and_last_with_integer_should_use_default_order
+    assert_sql(/ORDER BY .topics.\..id./) { Topic.first(2).entries }
+    assert_sql(/ORDER BY id DESC/) { Topic.last(5).entries }
+  end
+
   def test_last_with_integer_and_order_should_keep_the_order
     assert_equal Topic.order("title").to_a.last(2), Topic.order("title").last(2)
   end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -312,11 +312,17 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_first_and_last_with_integer_should_use_default_order
     assert_sql(/ORDER BY .topics.\..id./) { Topic.first(2).entries }
-    assert_sql(/ORDER BY id DESC/) { Topic.last(5).entries }
+    assert_sql(/ORDER BY .topics.\..id. DESC/) { Topic.last(5).entries }
   end
 
   def test_last_with_integer_and_order_should_keep_the_order
     assert_equal Topic.order("title").to_a.last(2), Topic.order("title").last(2)
+  end
+
+  def test_last_with_integer_should_work_with_joins
+    assert_nothing_raised do
+      Post.joins(:comments).last(2)
+    end
   end
 
   def test_last_with_integer_and_order_should_not_use_sql_limit

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -190,7 +190,7 @@ class NamedScopeTest < ActiveRecord::TestCase
   end
 
   def test_first_and_last_should_allow_integers_for_limit
-    assert_equal Topic.base.first(2), Topic.base.to_a.first(2)
+    assert_equal Topic.base.first(2), Topic.base.order("id").to_a.first(2)
     assert_equal Topic.base.last(2), Topic.base.order("id").to_a.last(2)
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1062,7 +1062,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal Post.where(:author_id => 1).all, author_posts.all
 
     all_posts = relation.only(:limit)
-    assert_equal Post.limit(1).all.first, all_posts.first
+    assert_equal Post.limit(1).order("id").all.first, all_posts.first
   end
 
   def test_extensions_with_only


### PR DESCRIPTION
Addresses #11774 ( unordered #first makes has_one association fragile / dependent on order of records returned by database ) and #11917 ( table.joins(:relation).limit(N) breaking on sqlite )
