### PR TITLE
[JRuby] Skip few of the ActiveSupport's inflector test cases

### DIFF
--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -24,3 +24,8 @@ Thread.abort_on_exception = true
 
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveSupport::Deprecation.debug = true
+
+# Skips the current run on JRuby using Minitest::Assertions#skip
+def jruby_skip(message = '')
+  skip message if RUBY_ENGINE == 'jruby'
+end

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -230,25 +230,35 @@ class InflectorTest < ActiveSupport::TestCase
     end
   end
 
+# FIXME: get following tests to pass on jruby, currently skipped
+#
+# Currently this fails because ActiveSupport::Multibyte::Unicode#tidy_bytes
+# required a specific Encoding::Converter(UTF-8 to UTF8-MAC) which unavailable on JRuby
+# causing our tests to error out.
+# related bug http://jira.codehaus.org/browse/JRUBY-7194
   def test_parameterize
+    jruby_skip "UTF-8 to UTF8-MAC Converter is unavailable"
     StringToParameterized.each do |some_string, parameterized_string|
       assert_equal(parameterized_string, ActiveSupport::Inflector.parameterize(some_string))
     end
   end
 
   def test_parameterize_and_normalize
+    jruby_skip "UTF-8 to UTF8-MAC Converter is unavailable"
     StringToParameterizedAndNormalized.each do |some_string, parameterized_string|
       assert_equal(parameterized_string, ActiveSupport::Inflector.parameterize(some_string))
     end
   end
 
   def test_parameterize_with_custom_separator
+    jruby_skip "UTF-8 to UTF8-MAC Converter is unavailable"
     StringToParameterizeWithUnderscore.each do |some_string, parameterized_string|
       assert_equal(parameterized_string, ActiveSupport::Inflector.parameterize(some_string, '_'))
     end
   end
 
   def test_parameterize_with_multi_character_separator
+    jruby_skip "UTF-8 to UTF8-MAC Converter is unavailable"
     StringToParameterized.each do |some_string, parameterized_string|
       assert_equal(parameterized_string.gsub('-', '__sep__'), ActiveSupport::Inflector.parameterize(some_string, '__sep__'))
     end


### PR DESCRIPTION
This doesn't affect MRI, JRuby only

[These tests](https://gist.github.com/gaurish/6264679) are failing on JRuby & will keep failing for quite some time as JRuby is missing some functionality(available in MRI) required for these tests to pass. here is the relevant bug report: [UTF-8 to UTF8-MAC Converter Missing ](http://jira.codehaus.org/browse/JRUBY-7194)

Since we know they are failing, why they are failing. it would be a good idea to skip them while we find a workaround or  wait for JRuby to implement the `UTF-8 to UTF8-MAC Converter`  which is not likely to happen soon.  

so is it a good idea to skip these for now?

cc: @arunagw, @guilleiguaran 
#11700
