### PR TITLE
Add option `sorted: true` to ActiveModel::Serializators#as_json

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -63,12 +63,13 @@ module ActiveModel
   #   person.to_json             # => "{\"name\":\"Bob\"}"
   #   person.to_xml              # => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<serial-person...
   #
-  # Valid options are <tt>:only</tt>, <tt>:except</tt>, <tt>:methods</tt> and
-  # <tt>:include</tt>. The following are all valid examples:
+  # Valid options are <tt>:only</tt>, <tt>:except</tt>, <tt>:methods</tt>,
+  # <tt>:include</tt> and <tt>:sorted</tt>. The following are all valid examples:
   #
   #   person.serializable_hash(only: 'name')
   #   person.serializable_hash(include: :address)
   #   person.serializable_hash(include: { address: { only: 'city' }})
+  #   person.serializable_hash(sorted: true) # returned alphabetically sorted
   module Serialization
     # Returns a serialized hash of your object.
     #
@@ -94,10 +95,11 @@ module ActiveModel
     #   person.serializable_hash(except: :name) # => {"age"=>22}
     #   person.serializable_hash(methods: :capitalized_name)
     #   # => {"name"=>"bob", "age"=>22, "capitalized_name"=>"Bob"}
+    #   person.serializable_hash(sorted: true) # => {"age"=>22, "name"=>"bob"}
     def serializable_hash(options = nil)
       options ||= {}
 
-      attribute_names = attributes.keys
+      attribute_names = options[:sorted] ? attributes.keys.sort : attributes.keys
       if only = options[:only]
         attribute_names &= Array(only).map(&:to_s)
       elsif except = options[:except]

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -155,6 +155,12 @@ class JsonSerializationTest < ActiveModel::TestCase
     end
   end
 
+  test "as_json should return a ordered hash given sorted option" do
+    json = @contact.as_json(sorted: true)
+    warn "we are using following #{json}"
+    assert_equal %w(age awesome created_at name preferences), json.keys
+  end
+
   test "from_json should work without a root (class attribute)" do
     json = @contact.to_json
     result = Contact.new.from_json(json)


### PR DESCRIPTION
After much back(#11812) & fourth(90c450f), I think this is a good solution for people who would like to have a consistent order across various implementations .

By default `as_json` keeps the order by ruby engine which may be different on jruby vs mri. If you need to be fully sure that you always need a sorted hash whose order is consistent across all ruby implementations, use `sorted: true`.

Example:

``` ruby
class Person
    include ActiveModel::Serialization
    attr_accessor :name, :age
    def attributes
      {'name' => nil, 'age' => nil}
    end
    def capitalized_name
       name.capitalize
    end
end
```

``` ruby
person.serializable_hash                # => {"name"=>"bob", "age"=>22}
person.serializable_hash(sorted: true) # => {"age"=>22, "name"=>"bob"}
```

so basically, with `sorted` option we will get a alphabetically sorted hash which lot of people will find useful. 

cc: @guilleiguaran @spastorino
