### PR TITLE
Fix default values of arguments to follow Rails convention

### DIFF
--- a/actionmailer/lib/action_mailer/delivery_methods.rb
+++ b/actionmailer/lib/action_mailer/delivery_methods.rb
@@ -49,13 +49,13 @@ module ActionMailer
       #   add_delivery_method :sendmail, Mail::Sendmail,
       #     location:  '/usr/sbin/sendmail',
       #     arguments: '-i -t'
-      def add_delivery_method(symbol, klass, default_options={})
+      def add_delivery_method(symbol, klass, default_options = {})
         class_attribute(:"#{symbol}_settings") unless respond_to?(:"#{symbol}_settings")
         send(:"#{symbol}_settings=", default_options)
         self.delivery_methods = delivery_methods.merge(symbol.to_sym => klass).freeze
       end
 
-      def wrap_delivery_behavior(mail, method=nil, options=nil) # :nodoc:
+      def wrap_delivery_behavior(mail, method = nil, options = nil) # :nodoc:
         method ||= self.delivery_method
         mail.delivery_handler = self
 


### PR DESCRIPTION
Fix default spacing in actionmailer delivery methods

``` ruby
def add_delivery_method(symbol, klass, default_options = {})
        class_attribute(:"#{symbol}_settings") unless respond_to?(:"#{symbol}_settings")
        send(:"#{symbol}_settings=", default_options)
        self.delivery_methods = delivery_methods.merge(symbol.to_sym => klass).freeze
end

def wrap_delivery_behavior(mail, method = nil, options = nil) # :nodoc:
  method ||= self.delivery_method
  mail.delivery_handler = self

  case method
  when NilClass
    raise "Delivery method cannot be nil"
  when Symbol
    if klass = delivery_methods[method]
      mail.delivery_method(klass,(send(:"#{method}_settings") || {}).merge!(options || {}))
    else
      raise "Invalid delivery method #{method.inspect}"
    end
  else
    mail.delivery_method(method)
  end

  mail.perform_deliveries    = perform_deliveries
  mail.raise_delivery_errors = raise_delivery_errors
end
```
