### PR TITLE
Why are String#downcase/upcase etc considered making a string unsafe?

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -83,8 +83,8 @@ end
 module ActiveSupport #:nodoc:
   class SafeBuffer < String
     UNSAFE_STRING_METHODS = %w(
-      capitalize chomp chop delete downcase gsub lstrip next reverse rstrip
-      slice squeeze strip sub succ swapcase tr tr_s upcase prepend
+      chomp chop delete gsub lstrip next reverse rstrip
+      slice squeeze strip sub succ swapcase tr tr_s prepend
     )
 
     alias_method :original_concat, :concat

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -84,7 +84,7 @@ module ActiveSupport #:nodoc:
   class SafeBuffer < String
     UNSAFE_STRING_METHODS = %w(
       chomp chop delete gsub lstrip next reverse rstrip
-      slice squeeze strip sub succ swapcase tr tr_s prepend
+      slice squeeze strip sub succ tr tr_s prepend
     )
 
     alias_method :original_concat, :concat


### PR DESCRIPTION
Per: https://github.com/rails/rails/commit/1300c034775a5d52ad9141fdf5bbdbb9159df96a#commitcomment-3887460
