### PR TITLE
ensure freeze on Thread freezes locals (#11831)

### DIFF
--- a/activesupport/lib/active_support/core_ext/thread.rb
+++ b/activesupport/lib/active_support/core_ext/thread.rb
@@ -62,6 +62,11 @@ class Thread
     _locals.has_key?(key.to_sym)
   end
 
+  def freeze
+    _locals.freeze
+    super
+  end
+
   private
 
   def _locals

--- a/activesupport/test/core_ext/thread_test.rb
+++ b/activesupport/test/core_ext/thread_test.rb
@@ -63,6 +63,15 @@ class ThreadExt < ActiveSupport::TestCase
     end
   end
 
+  def test_thread_variable_frozen_after_set
+    t = Thread.new { }.join
+    t.thread_variable_set :foo, "bar"
+    t.freeze
+    assert_raises(RuntimeError) do
+      t.thread_variable_set(:baz, "qux")
+    end
+  end
+
   def test_thread_variable_security
     t = Thread.new { sleep }
 


### PR DESCRIPTION
The Thread thread variable backport didn't freeze the locals hash. This overrides freeze to freeze locals, and then call super.

https://github.com/rails/rails/issues/11831#issuecomment-22890710
