### PR TITLE
check class hierarchy with is_a? in PredicateBuilder.expand

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix PredicateBuilder so polymorhic association keys in `where` clause can
+    also accept not only `ActiveRecord::Base` direct descendances (decorated
+    models, for example).
+
+    *Mikhail Dieterle*
+
 *   PostgreSQL adapter recognizes negative money values formatted with
     parentheses (eg. `($1.25) # => -1.25`)).
     Fixes #11899.

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -55,7 +55,7 @@ module ActiveRecord
       #
       # For polymorphic relationships, find the foreign key and type:
       # PriceEstimate.where(estimate_of: treasure)
-      if klass && value.class < Base && reflection = klass.reflect_on_association(column.to_sym)
+      if klass && value.is_a?(Base) && reflection = klass.reflect_on_association(column.to_sym)
         if reflection.polymorphic?
           queries << build(table[reflection.foreign_type], value.class.base_class)
         end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -81,6 +81,31 @@ module ActiveRecord
       assert_equal expected.to_sql, actual.to_sql
     end
 
+    def test_decorated_polymorphic_where
+      treasure_decorator = Struct.new(:model) do
+        def self.method_missing(method, *args, &block)
+          Treasure.send(method, *args, &block)
+        end
+
+        def is_a?(klass)
+          model.is_a?(klass)
+        end
+
+        def method_missing(method, *args, &block)
+          model.send(method, *args, &block)
+        end
+      end
+
+      treasure = Treasure.new
+      treasure.id = 1
+      decorated_treasure = treasure_decorator.new(treasure)
+
+      expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: 1)
+      actual   = PriceEstimate.where(estimate_of: decorated_treasure)
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
     def test_aliased_attribute
       expected = Topic.where(heading: 'The First Topic')
       actual   = Topic.where(title: 'The First Topic')


### PR DESCRIPTION
This patch replaces using condition `value.class < Base` in favor of `value.is_a?(Base)`

This is not break something in general using in Rails application (because ActiveRecord::Base is an abstract class and can not be instantiated), but makes convenient using decorator pattern.

For example [Draper gem](https://github.com/drapergem/draper) redefine [`#is_a?`](https://github.com/drapergem/draper/blob/master/lib/draper/decorator.rb#L179-L182) method to check against decorated class.

So this patch makes it possible to use

``` ruby
Comment.where(commentable: post.decorate)
# just like `Comment.where(commentable: post)`
```

instead of 

``` ruby
decorated_post = post.decorate
Comment.where(commentable_id: decorated_post.id, commentable_type: decorated_post.class.base_class.to_s)
```
