### PR TITLE
Adding question methods to all the associations

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -86,6 +86,7 @@ module ActiveRecord::Associations::Builder
       mixin = model.generated_feature_methods
       define_readers(mixin)
       define_writers(mixin)
+      define_questions(mixin)
     end
 
     def define_readers(mixin)
@@ -100,6 +101,14 @@ module ActiveRecord::Associations::Builder
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}=(value)
           association(:#{name}).writer(value)
+        end
+      CODE
+    end
+
+    def define_questions(mixin)
+      mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
+        def #{name}?(*args)
+          association(:#{name}).reader(*args).present?
         end
       CODE
     end

--- a/activerecord/test/cases/associations/question_methods_test.rb
+++ b/activerecord/test/cases/associations/question_methods_test.rb
@@ -1,0 +1,45 @@
+require 'models/club'
+require 'models/membership'
+require 'models/category'
+require 'models/lesson'
+require 'models/student'
+
+class QuestionMethodsTest < ActiveRecord::TestCase
+  fixtures :clubs, :memberships, :categories
+
+  def test_question_method_to_belongs_to_association
+    club = Club.create
+    club.category = Category.create(name: "category")
+    assert club.category?
+
+    club = Club.create
+    assert_equal club.category?, false
+  end
+
+  def test_question_method_to_has_one_association
+    club = Club.create
+    club.sponsor = Sponsor.create
+    assert club.sponsor?
+
+    club = Club.create
+    assert_equal club.sponsor?, false
+  end
+
+  def test_question_method_to_has_many_association
+    club = Club.create
+    club.memberships.create!
+    assert club.memberships?
+
+    club = Club.create
+    assert_equal club.memberships?, false
+  end
+
+  def test_question_method_to_has_and_belongs_to_many_association
+    lesson = Lesson.create
+    lesson.students.create!
+    assert lesson.students?
+
+    lesson = Lesson.create
+    assert_equal lesson.students?, false
+  end
+end

--- a/activerecord/test/cases/associations/question_methods_test.rb
+++ b/activerecord/test/cases/associations/question_methods_test.rb
@@ -13,7 +13,7 @@ class QuestionMethodsTest < ActiveRecord::TestCase
     assert club.category?
 
     club = Club.create
-    assert_equal club.category?, false
+    assert_not club.category?
   end
 
   def test_question_method_to_has_one_association
@@ -22,7 +22,7 @@ class QuestionMethodsTest < ActiveRecord::TestCase
     assert club.sponsor?
 
     club = Club.create
-    assert_equal club.sponsor?, false
+    assert_not club.sponsor?
   end
 
   def test_question_method_to_has_many_association
@@ -31,7 +31,7 @@ class QuestionMethodsTest < ActiveRecord::TestCase
     assert club.memberships?
 
     club = Club.create
-    assert_equal club.memberships?, false
+    assert_not club.memberships?
   end
 
   def test_question_method_to_has_and_belongs_to_many_association
@@ -40,6 +40,6 @@ class QuestionMethodsTest < ActiveRecord::TestCase
     assert lesson.students?
 
     lesson = Lesson.create
-    assert_equal lesson.students?, false
+    assert_not lesson.students?
   end
 end

--- a/activerecord/test/cases/associations/question_methods_test.rb
+++ b/activerecord/test/cases/associations/question_methods_test.rb
@@ -1,3 +1,4 @@
+require "cases/helper"
 require 'models/club'
 require 'models/membership'
 require 'models/category'


### PR DESCRIPTION
This PR adds question methods to all the associations. The question mark methods allow us to know if there are records in a association. Example...

This makes it possible to use...

```
post = Post.create(title: "MyFirstPost")
post.comments?                                              # => false

post = Post.create(title: "MyFirstPost")
post.comments.create!
post.comments?                                              # => true
```

Instead of...

```
post = Post.create(title: "MyFirstPost")
post.comments.size > 0                                   # => false
```
