### PR TITLE
Remove set_primary_key, replace with primary_key=

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -188,11 +188,11 @@ end
 ```
 
 It's also possible to override the column that should be used as the table's
-primary key using the `ActiveRecord::Base.set_primary_key` method:
+primary key using the `ActiveRecord::Base.primary_key=` method:
 
 ```ruby
 class Product < ActiveRecord::Base
-  set_primary_key "product_id"
+  self.primary_key = "product_id"
 end
 ```
 


### PR DESCRIPTION
First deprecated, now removed: https://github.com/rails/rails/commit/9add7608f1acaa68b025470e7a38901d7e6161ca#activerecord/lib/active_record/attribute_methods/primary_key.rb
