### PR TITLE
Guarantee mtime change for dynamic app files

### DIFF
--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -197,8 +197,6 @@ module ApplicationTests
           end
         RUBY
 
-        sleep 0.1
-
         get '/foo'
         assert_equal expected, last_response.body
       end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -241,10 +241,15 @@ module TestHelpers
     end
 
     def app_file(path, contents)
-      FileUtils.mkdir_p File.dirname("#{app_path}/#{path}")
-      File.open("#{app_path}/#{path}", 'w') do |f|
+      fpath = "#{app_path}/#{path}"
+      mtime = File.file?(fpath) ? File.mtime(fpath) : Time.now
+
+      FileUtils.mkdir_p File.dirname(fpath)
+      File.open(fpath, 'w') do |f|
         f.puts contents
       end
+
+      File.utime(File.atime(fpath), mtime + 1, fpath)
     end
 
     def remove_file(path)


### PR DESCRIPTION
Dynamically created files with time difference less than a second
are not detected as changed by reloader, sporadically breaking Travis tests
(updated on 3-2 only as it affects currently 1.8.7 suite only)
