### PR TITLE
Escape the message of an exception in debug_exceptions to avoid bad rendering

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.erb
@@ -8,7 +8,7 @@
 </header>
 
 <div id="container">
-  <h2><%= @exception.message %></h2>
+  <h2><%= h @exception.message %></h2>
 
   <%= render template: "rescues/_source" %>
   <%= render template: "rescues/_trace" %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_template.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_template.erb
@@ -3,5 +3,5 @@
 </header>
 
 <div id="container">
-  <h2><%= @exception.message %></h2>
+  <h2><%= h @exception.message %></h2>
 </div>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.erb
@@ -2,7 +2,7 @@
   <h1>Routing Error</h1>
 </header>
 <div id="container">
-  <h2><%= @exception.message %></h2>
+  <h2><%= h @exception.message %></h2>
   <% unless @exception.failures.empty? %>
     <p>
       <h2>Failure reasons:</h2>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.erb
@@ -10,7 +10,7 @@
   <p>
     Showing <i><%= @exception.file_name %></i> where line <b>#<%= @exception.line_number %></b> raised:
   </p>
-  <pre><code><%= @exception.message %></code></pre>
+  <pre><code><%= h @exception.message %></code></pre>
 
   <div class="source">
     <div class="info">

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/unknown_action.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/unknown_action.erb
@@ -2,5 +2,5 @@
   <h1>Unknown action</h1>
 </header>
 <div id="container">
-  <h2><%= @exception.message %></h2>
+  <h2><%= h @exception.message %></h2>
 </div>


### PR DESCRIPTION
Sometimes, the exception message contains characters that may be interpreted as HTML, for instance :

`#<Hash:0x12345>` is shown as # on chrome : 

![screen shot 2013-08-21 at 3 23 53 pm](https://f.cloud.github.com/assets/803765/1001293/630c0626-0a66-11e3-9f03-7cd566e848e9.png)

After the fix : 

![screen shot 2013-08-21 at 3 23 20 pm](https://f.cloud.github.com/assets/803765/1001294/6b263c78-0a66-11e3-8d79-ce410f37f42f.png)
