### PR TITLE
Add Kernel#{yes,on} and Kernel#{no,off}

### DIFF
--- a/activesupport/lib/active_support/core_ext/kernel.rb
+++ b/activesupport/lib/active_support/core_ext/kernel.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext/kernel/boolean'
 require 'active_support/core_ext/kernel/reporting'
 require 'active_support/core_ext/kernel/agnostics'
 require 'active_support/core_ext/kernel/debugger'

--- a/activesupport/lib/active_support/core_ext/kernel/boolean.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/boolean.rb
@@ -1,0 +1,13 @@
+module Kernel
+  # Alias for +true+.
+  def yes
+    true
+  end
+  alias :on :yes
+
+  # Alias for +false+.
+  def no
+    false
+  end
+  alias :off :no
+end

--- a/activesupport/test/core_ext/kernel_test.rb
+++ b/activesupport/test/core_ext/kernel_test.rb
@@ -66,6 +66,16 @@ class KernelTest < ActiveSupport::TestCase
     assert_equal "STDERR\n", capture(:stderr) { system('echo STDERR 1>&2') }
     assert_equal "STDOUT\n", capture(:stdout) { system('echo STDOUT') }
   end
+
+  def test_truth_aliases_yes_and_on
+    assert_equal true, yes
+    assert_equal true, on
+  end
+
+  def test_false_aliases_no_and_off
+    assert_equal false, no
+    assert_equal false, off
+  end
 end
 
 class KernelSuppressTest < ActiveSupport::TestCase


### PR DESCRIPTION
Introduce true and false aliases in the spirit of YAML and CoffeeScript.

While it may sounds silly at first, those are actually looking pretty neat, especially in configs. For example, here is the default development config with the aliases:

``` ruby
Rails.application.configure do
  # Settings specified here will take precedence over those in config/application.rb.

  # In the development environment your application's code is reloaded on
  # every request. This slows down response time but is perfect for development
  # since you don't have to restart the web server when you make code changes.
  config.cache_classes = no

  # Do not eager load code on boot.
  config.eager_load = no

  # Show full error reports and disable caching.
  config.consider_all_requests_local       = yes
  config.action_controller.perform_caching = yes

  # Don't care if the mailer can't send.
  config.action_mailer.raise_delivery_errors = no

  # Print deprecation notices to the Rails logger.
  config.active_support.deprecation = :log

  # Raise an error on page load if there are pending migrations.
  config.active_record.migration_error = :page_load

  # Debug mode disables concatenation and preprocessing of assets.
  # This option may cause significant delays in view rendering with a large
  # number of complex assets.
  config.assets.debug = on
end
```

It's just a little bit of sugar, but it makes me smile everytime I look at it.
