### PR TITLE
Add option 'class_namespace' to association macros

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -17,7 +17,7 @@ module ActiveRecord::Associations::Builder
     end
     self.extensions = []
 
-    VALID_OPTIONS = [:class_name, :foreign_key, :validate]
+    VALID_OPTIONS = [:class_name, :class_namespace, :foreign_key, :validate]
 
     attr_reader :name, :scope, :options
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -143,7 +143,7 @@ module ActiveRecord
       # <tt>composed_of :balance, class_name: 'Money'</tt> returns <tt>'Money'</tt>
       # <tt>has_many :clients</tt> returns <tt>'Client'</tt>
       def class_name
-        @class_name ||= (options[:class_name] || derive_class_name).to_s
+        @class_name ||= (options[:class_name] || class_name_with_namespace || derive_class_name).to_s
       end
 
       # Returns +true+ if +self+ and +other_aggregation+ have the same +name+ attribute, +active_record+ attribute,
@@ -159,6 +159,10 @@ module ActiveRecord
       private
         def derive_class_name
           name.to_s.camelize
+        end
+
+        def class_name_with_namespace
+          "#{options[:class_namespace]}::#{derive_class_name}" if options[:class_namespace]
         end
     end
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -76,7 +76,14 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_reflection_klass_for_nested_class_name
-    reflection = MacroReflection.new(:company, nil, nil, { :class_name => 'MyApplication::Business::Company' }, ActiveRecord::Base)
+    reflection = MacroReflection.new(:has_one, :company, nil, { :class_name => 'MyApplication::Business::Company' }, ActiveRecord::Base)
+    assert_nothing_raised do
+      assert_equal MyApplication::Business::Company, reflection.klass
+    end
+  end
+
+  def test_reflection_klass_for_class_namespace
+    reflection = MacroReflection.new(:has_one, :company, nil, { :class_namespace => 'MyApplication::Business' }, ActiveRecord::Base)
     assert_nothing_raised do
       assert_equal MyApplication::Business::Company, reflection.klass
     end


### PR DESCRIPTION
Can be used as `has_many :languages, class_namespace: 'ProfileData'` to get ProfileData::Languages class, but this option mainly added to support this variant:

``` ruby
class Profile < ActiveRecord::Base
  with_options class_namespace: 'ProfileData' do |m|
    m.has_many :languages
    m.has_many :education
    m.has_many :interests, dependent: :destroy
  end
end

class ProfileData::Language
  # ...
end

class ProfileData::Education
  # ...
end

class ProfileData::Interest
  # ...
end
```

Class structure like this is common for big projects, so I think it can be used to make code a little cleaner.

I will handle changelog and doc changes if you support this changes.
