### PR TITLE
Need gem sdoc > '0.3.20' to run rake doc:rails

### DIFF
--- a/railties/lib/rails/tasks/documentation.rake
+++ b/railties/lib/rails/tasks/documentation.rake
@@ -5,6 +5,8 @@ rescue LoadError
   # available only if the application bundle includes "rdoc" (normally as a
   # dependency of the "sdoc" gem.)
   #
+  # Need to have gem 'sdoc', '0.3.20' installed in order to run
+  #
   # If RDoc is not available it is fine that we do not generate the tasks that
   # depend on it. Just be robust to this gotcha and go on.
 else


### PR DESCRIPTION
Need to specify the version of sdoc since older versions fail to generate the docs.
