### PR TITLE
Performance regression in AR::Base.respond_to?

### DIFF
--- a/activerecord/lib/active_record/dynamic_matchers.rb
+++ b/activerecord/lib/active_record/dynamic_matchers.rb
@@ -35,7 +35,7 @@ module ActiveRecord
         end
 
         def pattern
-          /^#{prefix}_([_a-zA-Z]\w*)#{suffix}$/
+          @pattern ||= /\A#{prefix}_([_a-zA-Z]\w*)#{suffix}\Z/
         end
 
         def prefix

--- a/activerecord/test/cases/finder_respond_to_test.rb
+++ b/activerecord/test/cases/finder_respond_to_test.rb
@@ -21,6 +21,11 @@ class FinderRespondToTest < ActiveRecord::TestCase
     assert_respond_to Topic, :find_by_title
   end
 
+  def test_should_respond_to_find_by_with_bang
+    ensure_topic_method_is_not_cached(:find_by_title!)
+    assert_respond_to Topic, :find_by_title!
+  end
+
   def test_should_respond_to_find_by_two_attributes
     ensure_topic_method_is_not_cached(:find_by_title_and_author_name)
     assert_respond_to Topic, :find_by_title_and_author_name


### PR DESCRIPTION
There was a noticeable performance decrease from 3.2 to 4.0 in calling respond_to? on subclasses of `ActiveRecord::Base`. This is because of the way the dynamic matchers were split into `activerecord-deprecated_finders`. The regular expression for each matcher is compiled on each respond_to?.

```
Benchmark.ms { 100_000.times { ActiveRecord::Base.respond_to? :foobar } }
```

**before:** 1934.583252
**after:** 216.642399

Performance is even more significant when the finders from `activerecord-deprecated_finders` are included.

This commit caches the patterns of `ActiveRecord::DynamicMatcher`s in a class instance variable.

It would be great if this could be merged into master as well as 4-0-stable.
