### PR TITLE
Add error message for including nokogiri in Gemfile for rake doc:guides

### DIFF
--- a/guides/rails_guides.rb
+++ b/guides/rails_guides.rb
@@ -39,6 +39,25 @@ ERROR
   exit 1
 end
 
+begin
+  require 'nokogiri'
+rescue LoadError
+  # This can happen if doc:guides is executed in an application.
+  $stderr.puts('Generating guides requires Nokogiri.')
+  $stderr.puts(<<ERROR) if bundler?
+Please add
+
+  gem 'nokogiri'
+
+to the Gemfile, run
+
+  bundle install
+
+and try again.
+ERROR
+  exit 1
+end
+
 require 'rails_guides/markdown'
 require "rails_guides/generator"
 RailsGuides::Generator.new.generate


### PR DESCRIPTION
- When `rake doc:guides` is run from applications, it complains for
  presence of redcarpet if it not present in Gemfile
- Similarly it should complain about nokogiri
