### PR TITLE
Refactor string_to_cidr method. Relates to #11552

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -97,12 +97,10 @@ module ActiveRecord
         end
 
         def string_to_cidr(string)
-          if string.nil?
-            nil
-          elsif String === string
+          if String === string
             begin
               IPAddr.new(string)
-            rescue ArgumentError
+            rescue IPAddr::InvalidAddressError
               nil
             end
           else


### PR DESCRIPTION
Removes unnecessary check for string.nil? and is rescues from [IPAddr::InvalidAddressError](http://www.ruby-doc.org/stdlib-2.0/libdoc/ipaddr/rdoc/IPAddr/InvalidAddressError.html) instead of ArgumentError
