### PR TITLE
Deprecated CircularReferenceError in AS::JSON::Encoding

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Removed circular reference protection in JSON encoder, deprecated 
+    ActiveSupport::JSON::Encoding::CircularReferenceError.
+
+    *Godfrey Chan*, *Sergio Campamá*
+
 *   Add String#remove(pattern) as a short-hand for the common pattern of String#gsub(pattern, '')
 
     *DHH*

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -138,19 +138,28 @@ class TestJSONEncoding < ActiveSupport::TestCase
   def test_exception_raised_when_encoding_circular_reference_in_array
     a = [1]
     a << a
-    assert_raise(ActiveSupport::JSON::Encoding::CircularReferenceError) { ActiveSupport::JSON.encode(a) }
+
+    assert_deprecated do
+      assert_raise(ActiveSupport::JSON::Encoding::CircularReferenceError) { ActiveSupport::JSON.encode(a) }
+    end
   end
 
   def test_exception_raised_when_encoding_circular_reference_in_hash
     a = { :name => 'foo' }
     a[:next] = a
-    assert_raise(ActiveSupport::JSON::Encoding::CircularReferenceError) { ActiveSupport::JSON.encode(a) }
+
+    assert_deprecated do
+      assert_raise(ActiveSupport::JSON::Encoding::CircularReferenceError) { ActiveSupport::JSON.encode(a) }
+    end
   end
 
   def test_exception_raised_when_encoding_circular_reference_in_hash_inside_array
     a = { :name => 'foo', :sub => [] }
     a[:sub] << a
-    assert_raise(ActiveSupport::JSON::Encoding::CircularReferenceError) { ActiveSupport::JSON.encode(a) }
+
+    assert_deprecated do
+      assert_raise(ActiveSupport::JSON::Encoding::CircularReferenceError) { ActiveSupport::JSON.encode(a) }
+    end
   end
 
   def test_hash_key_identifiers_are_always_quoted

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -52,7 +52,7 @@ class TestJSONEncoding < ActiveSupport::TestCase
                    [ 'a "string" with quotes & an ampersand', %("a \\"string\\" with quotes \\u0026 an ampersand") ],
                    [ 'http://test.host/posts/1', %("http://test.host/posts/1")],
                    [ "Control characters: \x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\342\200\250\342\200\251",
-                     %("Control characters: \\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\b\\t\\n\\u000B\\f\\r\\u000E\\u000F\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017\\u0018\\u0019\\u001A\\u001B\\u001C\\u001D\\u001E\\u001F\\u2028\\u2029") ]]
+                     %("Control characters: \\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\b\\t\\n\\u000b\\f\\r\\u000e\\u000f\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017\\u0018\\u0019\\u001a\\u001b\\u001c\\u001d\\u001e\\u001f\\u2028\\u2029") ]]
 
   ArrayTests    = [[ ['a', 'b', 'c'],          %([\"a\",\"b\",\"c\"])          ],
                    [ [1, 'a', :b, nil, false], %([1,\"a\",\"b\",null,false]) ]]

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -22,6 +22,12 @@ class TestJSONEncoding < ActiveSupport::TestCase
     end
   end
 
+  class CustomArray
+    def as_json(options)
+      [:foo, 'bar']
+    end
+  end
+
   class CustomWithOptions
     attr_accessor :foo, :bar
 
@@ -61,7 +67,7 @@ class TestJSONEncoding < ActiveSupport::TestCase
 
   ObjectTests   = [[ Foo.new(1, 2), %({\"a\":1,\"b\":2}) ]]
   HashlikeTests = [[ Hashlike.new, %({\"a\":1}) ]]
-  CustomTests   = [[ Custom.new, '"custom"' ]]
+  CustomTests   = [[ Custom.new, '"custom"' ], [ CustomArray.new, %([\"foo\",\"bar\"]) ]]
 
   RegexpTests   = [[ /^a/, '"(?-mix:^a)"' ], [/^\w{1,2}[a-z]+/ix, '"(?ix-m:^\\\\w{1,2}[a-z]+)"']]
 
@@ -279,7 +285,7 @@ class TestJSONEncoding < ActiveSupport::TestCase
     assert_equal(%([{"address":{"city":"London"}},{"address":{"city":"Paris"}}]), json)
   end
 
-  def test_to_json_should_not_keep_options_around
+  def test_hash_to_json_should_not_keep_options_around
     f = CustomWithOptions.new
     f.foo = "hello"
     f.bar = "world"
@@ -287,6 +293,15 @@ class TestJSONEncoding < ActiveSupport::TestCase
     hash = {"foo" => f, "other_hash" => {"foo" => "other_foo", "test" => "other_test"}}
     assert_equal({"foo"=>{"foo"=>"hello","bar"=>"world"},
                   "other_hash" => {"foo"=>"other_foo","test"=>"other_test"}}, JSON.parse(hash.to_json))
+  end
+
+  def test_array_to_json_should_not_keep_options_around
+    f = CustomWithOptions.new
+    f.foo = "hello"
+    f.bar = "world"
+
+    array = [f, {"foo" => "other_foo", "test" => "other_test"}]
+    assert_equal([{"foo"=>"hello","bar"=>"world"},{"foo"=>"other_foo","test"=>"other_test"}], JSON.parse(array.to_json))
   end
 
   def test_struct_encoding


### PR DESCRIPTION
This is drop one of my JSON encoder refactor. This commit removed the circular reference protection as discussed with @jeremy, and as part of the refactor it also happened to fixed an encoder bugs, which I added coverage for in my second commit. I can squash them if that's preferred.

Special thanks to @sergiocampama! The refactor reused/integrated a lot of code and idea from his previous pull request.
