### PR TITLE
[PG adapter] Use infinity const

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -17,8 +17,8 @@ module ActiveRecord
           return string unless String === string
 
           case string
-          when 'infinity'; 1.0 / 0.0
-          when '-infinity'; -1.0 / 0.0
+          when 'infinity'; Float::INFINITY
+          when '-infinity'; -Float::INFINITY
           when / BC$/
             super("-" + string.sub(/ BC$/, ""))
           else


### PR DESCRIPTION
Kinda microoptimization, but why not?

``` ruby
require 'benchmark'

n = 10_000_000

Benchmark.bm do |x|
  x.report('/') { n.times { 1.0 / 0.0 } }
  x.report('const') { n.times { Float::INFINITY } }
end
```

```
       user     system      total        real
/  0.920000   0.010000   0.930000 (  0.913245)
const  0.500000   0.000000   0.500000 (  0.506287)
```
