### PR TITLE
Make rake db tasks work properly with sqlite when run not from the Rails root path.

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -429,7 +429,8 @@ db_namespace = namespace :db do
         raise 'Error dumping database' if $?.exitstatus == 1
         File.open(filename, "a") { |f| f << "SET search_path TO #{ActiveRecord::Base.connection.schema_search_path};\n\n" }
       when /sqlite/
-        dbfile = config['database']
+        path = Pathname.new(config['database'])
+        dbfile = path.absolute? ? path.to_s : File.join(Rails.root, path)
         `sqlite3 #{dbfile} .schema > #{filename}`
       when 'sqlserver'
         `smoscript -s #{config['host']} -d #{config['database']} -u #{config['username']} -p #{config['password']} -f #{filename} -A -U`
@@ -462,7 +463,8 @@ db_namespace = namespace :db do
         set_psql_env(config)
         `psql -f "#{filename}" #{config['database']}`
       when /sqlite/
-        dbfile = config['database']
+        path = Pathname.new(config['database'])
+        dbfile = path.absolute? ? path.to_s : File.join(Rails.root, path)
         `sqlite3 #{dbfile} < "#{filename}"`
       when 'sqlserver'
         `sqlcmd -S #{config['host']} -d #{config['database']} -U #{config['username']} -P #{config['password']} -i #{filename}`
@@ -532,7 +534,8 @@ db_namespace = namespace :db do
         drop_database(abcs['test'])
         create_database(abcs['test'])
       when /sqlite/
-        dbfile = abcs['test']['database']
+        path = Pathname.new(abcs['test']['database'])
+        dbfile = path.absolute? ? path.to_s : File.join(Rails.root, path)
         File.delete(dbfile) if File.exist?(dbfile)
       when 'sqlserver'
         test = abcs.deep_dup['test']


### PR DESCRIPTION
The easiest way to encounter the problem is to create a fresh new engine and then run:

```
rake db:create
rake db:structure:dump
Error: unable to open database "db/development.sqlite3": unable to open database file
```

So I fixed this for structure:dump, structure:load, and test:purge tasks in the same manner as it's already done in the drop_database method. The bug is the same in the rails 4. So I can make another pull request to fix it there.
