### PR TITLE
Stray nodoc causes rest of file not parsed [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -848,8 +848,6 @@ module ActiveRecord
       def scope
         @association.scope
       end
-
-      # :nodoc:
       alias spawn scope
 
       # Equivalent to <tt>Array#==</tt>. Returns +true+ if the two arrays


### PR DESCRIPTION
I doubt it's intentional because there are some nice documentations written but got skipped because of this directive.
