### PR TITLE
Make rake db tasks work properly with sqlite when run not from the Rails root path.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   SQLite db:structure_dump and db:structure_load tasks now support being run
+    not from the Rails.root path when a relative SQLite DB path is specified.
+    This is particularly useful when developing engines.
+
+    *Yury "Exoth" Trofimenko*
+
 *   Stop interpreting SQL 'string' columns as :string type because there is no
     common STRING datatype in SQL.
 

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -15,11 +15,7 @@ module ActiveRecord
       end
 
       def drop
-        require 'pathname'
-        path = Pathname.new configuration['database']
-        file = path.absolute? ? path.to_s : File.join(root, path)
-
-        FileUtils.rm(file) if File.exist?(file)
+        FileUtils.rm(dbfile_path) if File.exist?(dbfile_path)
       end
       alias :purge :drop
 
@@ -28,24 +24,31 @@ module ActiveRecord
       end
 
       def structure_dump(filename)
-        dbfile = configuration['database']
-        `sqlite3 #{dbfile} .schema > #{filename}`
+        `sqlite3 "#{dbfile_path}" .schema > "#{filename}"`
       end
 
       def structure_load(filename)
-        dbfile = configuration['database']
-        `sqlite3 #{dbfile} < "#{filename}"`
+        `sqlite3 "#{dbfile_path}" < "#{filename}"`
       end
 
       private
 
-      def configuration
-        @configuration
-      end
+        def dbfile_path
+          @dbfile_path ||= begin
+            require 'pathname'
+            path = Pathname.new configuration['database']
+            path.absolute? ? path.to_s : File.join(root, path)
+          end
+        end
 
-      def root
-        @root
-      end
+        def configuration
+          @configuration
+        end
+
+        def root
+          @root
+        end
+
     end
   end
 end

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -59,7 +59,7 @@ module ActiveRecord
   class SqliteDBDropTest < ActiveRecord::TestCase
     def setup
       @database      = "db_create.sqlite3"
-      @path          = stub(:to_s => '/absolute/path', :absolute? => true)
+      @path          = stub(to_s: '/absolute/path', absolute?: true)
       @configuration = {
         'adapter'  => 'sqlite3',
         'database' => @database
@@ -148,44 +148,110 @@ module ActiveRecord
   class SqliteStructureDumpTest < ActiveRecord::TestCase
     def setup
       @database      = "db_create.sqlite3"
+      @path          = stub(to_s: '/absolute/path', absolute?: true)
       @configuration = {
         'adapter'  => 'sqlite3',
         'database' => @database
       }
+      @filename = "awesome-file.sql"
+
+      Pathname.stubs(:new).returns(@path)
+      File.stubs(:join).returns('/former/relative/path')
+      FileUtils.stubs(:rm).returns(true)
     end
 
-    def test_structure_dump
-      dbfile   = @database
-      filename = "awesome-file.sql"
+    def test_creates_path_from_database
+      Pathname.expects(:new).with(@database).returns(@path)
 
-      ActiveRecord::Tasks::DatabaseTasks.structure_dump @configuration, filename, '/rails/root'
-      assert File.exists?(dbfile)
-      assert File.exists?(filename)
-    ensure
-      FileUtils.rm_f(filename)
-      FileUtils.rm_f(dbfile)
+      ActiveRecord::Tasks::SQLiteDatabaseTasks.any_instance.stubs(:`)
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_dump @configuration, @filename, '/rails/root'
+    end
+
+    def test_dumps_structure_with_absolute_path
+      File.stubs(:exist?).returns(true)
+      @path.stubs(:absolute?).returns(true)
+
+      ActiveRecord::Tasks::SQLiteDatabaseTasks.any_instance.expects(:`).
+        with(%Q(sqlite3 "/absolute/path" .schema > "#{@filename}"))
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_dump @configuration, @filename, '/rails/root'
+    end
+
+    def test_generates_absolute_path_with_given_root
+      @path.stubs(:absolute?).returns(false)
+
+      File.expects(:join).with('/rails/root', @path).
+        returns('/former/relative/path')
+
+      ActiveRecord::Tasks::SQLiteDatabaseTasks.any_instance.stubs(:`)
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_dump @configuration, @filename, '/rails/root'
+    end
+
+    def test_dumps_structure_with_relative_path
+      File.stubs(:exist?).returns(true)
+      @path.stubs(:absolute?).returns(false)
+
+      ActiveRecord::Tasks::SQLiteDatabaseTasks.any_instance.expects(:`).
+        with(%Q(sqlite3 "/former/relative/path" .schema > "#{@filename}"))
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_dump @configuration, @filename, '/rails/root'
     end
   end
 
   class SqliteStructureLoadTest < ActiveRecord::TestCase
     def setup
       @database      = "db_create.sqlite3"
+      @path          = stub(to_s: '/absolute/path', absolute?: true)
       @configuration = {
         'adapter'  => 'sqlite3',
         'database' => @database
       }
+      @filename = "awesome-file.sql"
+
+      Pathname.stubs(:new).returns(@path)
+      File.stubs(:join).returns('/former/relative/path')
+      FileUtils.stubs(:rm).returns(true)
     end
 
-    def test_structure_load
-      dbfile   = @database
-      filename = "awesome-file.sql"
+    def test_creates_path_from_database
+      Pathname.expects(:new).with(@database).returns(@path)
 
-      open(filename, 'w') { |f| f.puts("select datetime('now', 'localtime');") }
-      ActiveRecord::Tasks::DatabaseTasks.structure_load @configuration, filename, '/rails/root'
-      assert File.exists?(dbfile)
-    ensure
-      FileUtils.rm_f(filename)
-      FileUtils.rm_f(dbfile)
+      ActiveRecord::Tasks::SQLiteDatabaseTasks.any_instance.stubs(:`)
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_load @configuration, @filename, '/rails/root'
+    end
+
+    def test_loads_structure_with_absolute_path
+      File.stubs(:exist?).returns(true)
+      @path.stubs(:absolute?).returns(true)
+
+      ActiveRecord::Tasks::SQLiteDatabaseTasks.any_instance.expects(:`).
+        with(%Q(sqlite3 "/absolute/path" < "#{@filename}"))
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_load @configuration, @filename, '/rails/root'
+    end
+
+    def test_generates_absolute_path_with_given_root
+      @path.stubs(:absolute?).returns(false)
+
+      File.expects(:join).with('/rails/root', @path).
+        returns('/former/relative/path')
+
+      ActiveRecord::Tasks::SQLiteDatabaseTasks.any_instance.stubs(:`)
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_load @configuration, @filename, '/rails/root'
+    end
+
+    def test_loads_structure_with_relative_path
+      File.stubs(:exist?).returns(true)
+      @path.stubs(:absolute?).returns(false)
+
+      ActiveRecord::Tasks::SQLiteDatabaseTasks.any_instance.expects(:`).
+        with(%Q(sqlite3 "/former/relative/path" < "#{@filename}"))
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_load @configuration, @filename, '/rails/root'
     end
   end
 end


### PR DESCRIPTION
The easiest way to encounter the problem is to create a fresh new engine and then run:

```
rake db:create
rake db:structure:dump
Error: unable to open database "db/development.sqlite3": unable to open database file
```

So I fixed this for structure:dump and structure:load tasks in the same manner as it's already done for the drop task.
