### PR TITLE
Conform to RFC2616-sec14 for */* media-range, #8987

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -118,11 +118,8 @@ module ActionDispatch
 
       protected
 
-      BROWSER_LIKE_ACCEPTS = /,\s*\*\/\*|\*\/\*\s*,/
-
       def valid_accept_header
-        (xhr? && (accept.present? || content_mime_type)) ||
-          (accept.present? && accept !~ BROWSER_LIKE_ACCEPTS)
+        (xhr? && content_mime_type) || accept.present?
       end
 
       def use_accept_header

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -220,16 +220,6 @@ class RespondToControllerTest < ActionController::TestCase
     end
   end
 
-  def test_json_or_yaml_with_leading_star_star
-    @request.accept = "*/*, application/json"
-    get :json_xml_or_html
-    assert_equal 'HTML', @response.body
-
-    @request.accept = "*/* , application/json"
-    get :json_xml_or_html
-    assert_equal 'HTML', @response.body
-  end
-
   def test_json_or_yaml
     xhr :get, :json_or_yaml
     assert_equal 'JSON', @response.body
@@ -392,13 +382,17 @@ class RespondToControllerTest < ActionController::TestCase
     assert_equal 'Whatever you ask for, I got it', @response.body
   end
 
-  def test_browser_check_with_any_any
-    @request.accept = "application/json, application/xml"
+  def test_with_any_any
+    @request.accept = "*/*, application/json"
     get :json_xml_or_html
     assert_equal 'JSON', @response.body
 
     @request.accept = "application/json, application/xml, */*"
     get :json_xml_or_html
+    assert_equal 'JSON', @response.body
+
+    @request.accept = "application/json, */*"
+    get :html_or_xml
     assert_equal 'HTML', @response.body
   end
 


### PR DESCRIPTION
When requesting:

```
Accept: application/json, text/javascript, */*; q=0.01
```

That q=0.01 marks _/_ with the least preference. We should not
short-circuit the Mime::Mimes sorting, which is handling the q-values
correctly.

This fixes the default request by jQuery.ajax(url, {dataType:'json'}),
which makes a request with the above Accept header, but Rails would
respond with HTML instead of JSON.
