### PR TITLE
Fix collection labels not including form namespace.

### DIFF
--- a/actionview/lib/action_view/helpers/tags/collection_helpers.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_helpers.rb
@@ -18,7 +18,8 @@ module ActionView
           end
 
           def label(label_html_options={}, &block)
-            @template_object.label(@object_name, @sanitized_attribute_name, @text, label_html_options, &block)
+            html_options = label_html_options.merge(@input_html_options.slice(:namespace))
+            @template_object.label(@object_name, @sanitized_attribute_name, @text, html_options, &block)
           end
         end
 


### PR DESCRIPTION
Present in Rails 4-0-stable and in master.

This bug would prevent clicks on labels for collection form elements (radio buttons and check boxes) from selecting the associated input because the label's "for" attribute doesn't include the form namespace.

The bug can be replicated with the following code.

``` erb
<%= form_for Struct.new(:terms).new, :as => 'fakemodel', :url => '', :namespace => 'NAMESPACE' do |f| %>
  <%= f.label :terms %> <em>Non-collection label has correct ID that includes namespace</em></br>
  <%= f.collection_radio_buttons :terms, ["Test option"], :to_s, :to_s %> <em>Collection label has incorrect FOR attribute value that doesn't include the namespace</em>
<% end %>
```

I'm unsure of how to test this as the form_collections_helper_test.rb doesn't seem to have any way to set up the form options. Any suggestions are welcome.
