### PR TITLE
Warning on doc for assets under lib|vendor not precompiling

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -235,6 +235,11 @@ scope of the application or those libraries which are shared across applications
 * `vendor/assets` is for assets that are owned by outside entities, such as
 code for JavaScript plugins and CSS frameworks.
 
+WARNING: If you are upgrading from Rails 3, please take into account that assets
+under `lib/assets` or `vendor/assets` are available for inclusion via the
+application manifests but no longer part of the precompile array. See
+[Precompiling Assets](#precompiling-assets) for guidance.
+
 #### Search Paths
 
 When a file is referenced from a manifest or a helper, Sprockets searches the


### PR DESCRIPTION
There is no reference to having assets under `lib/assets` or `vendor/assets` that they will not be precompiled.
Took me a while to figure this out since it's only documented on the upgrade notes.
