### PR TITLE
Add a note about edge guides in the feedback section[ci skip]

### DIFF
--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -106,8 +106,10 @@
         </p>
         <p>
           You may also find incomplete content, or stuff that is not up to date.
-          Please do add any missing documentation for master. Check the
-          <%= link_to 'Ruby on Rails Guides Guidelines', 'ruby_on_rails_guides_guidelines.html' %>
+          Please do add any missing documentation for master. Make sure to check
+          <%= link_to 'Edge Guides','http://edgeguides.rubyonrails.org' %> first to verify
+          if the issues are already fixed or not on the master branch.
+          Check the <%= link_to 'Ruby on Rails Guides Guidelines', 'ruby_on_rails_guides_guidelines.html' %>
           for style and conventions.
         </p>
         <p>


### PR DESCRIPTION
Most of the times issues related to docs reported on github are already fixed on edge guides. This PR adds a note about edge guides in the feedback section so people can check edge guides before reporting issues on github.
