### PR TITLE
Use NameError#name to assert raised error.

### DIFF
--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -319,7 +319,7 @@ module RenderTestCases
     exception = assert_raises ActionView::Template::Error do
       @controller_view.render("partial_name_local_variable")
     end
-    assert_match "undefined local variable or method `partial_name_local_variable'", exception.message
+    assert_equal :partial_name_local_variable, exception.original_exception.name
   end
 
   # TODO: The reason for this test is unclear, improve documentation


### PR DESCRIPTION
This makes the test compatible with other Ruby implementations, which may implement error messages differently.
