### PR TITLE
Collapse where constraints to the Arel::Nodes::And node

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix: joins association, with defined in the scope block constraints by using several
+    where constraints and at least of them is not `Arel::Nodes::Equality`,
+    generates invalid SQL expression.
+
+    Fixes: #11963
+
+    *Paul Nikitochkin*
+
 *   Re-use `order` argument pre-processing for `reorder`.
 
     *Paul Nikitochkin*

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -882,14 +882,13 @@ module ActiveRecord
     end
 
     def collapse_wheres(arel, wheres)
-      equalities = wheres.grep(Arel::Nodes::Equality)
-
-      arel.where(Arel::Nodes::And.new(equalities)) unless equalities.empty?
-
-      (wheres - equalities).each do |where|
+      predicates = wheres.map do |where|
+        next where if ::Arel::Nodes::Equality === where
         where = Arel.sql(where) if String === where
-        arel.where(Arel::Nodes::Grouping.new(where))
+        Arel::Nodes::Grouping.new(where)
       end
+
+      arel.where(Arel::Nodes::And.new(predicates)) if predicates.present?
     end
 
     def build_where(opts, other = [])

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -41,6 +41,11 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     assert_no_match(/WHERE/i, sql)
   end
 
+  def test_join_association_conditions_support_string_and_arel_expressions
+    assert_equal 0, Author.joins(:welcome_posts_with_comment).count
+    assert_equal 1, Author.joins(:welcome_posts_with_comments).count
+  end
+
   def test_join_conditions_allow_nil_associations
     authors = Author.includes(:essays).where(:essays => {:id => nil})
     assert_equal 2, authors.count

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -31,6 +31,13 @@ class Author < ActiveRecord::Base
   has_many :thinking_posts, -> { where(:title => 'So I was thinking') }, :dependent => :delete_all, :class_name => 'Post'
   has_many :welcome_posts, -> { where(:title => 'Welcome to the weblog') }, :class_name => 'Post'
 
+  has_many :welcome_posts_with_comment,
+           -> { where(title: 'Welcome to the weblog').where('comments_count = ?', 1) },
+           class_name: 'Post'
+  has_many :welcome_posts_with_comments,
+           -> { where(title: 'Welcome to the weblog').where(Post.arel_table[:comments_count].gt(0)) },
+           class_name: 'Post'
+
   has_many :comments_desc, -> { order('comments.id DESC') }, :through => :posts, :source => :comments
   has_many :limited_comments, -> { limit(1) }, :through => :posts, :source => :comments
   has_many :funky_comments, :through => :posts, :source => :comments


### PR DESCRIPTION
In order to remove duplication with joining where constraints by `AND` on traverse `arel.constraints`,
refactored `collapse_wheres` to add to `arel.wheres` on `build_arel` only one node `Arel::Nodes::And`.

This refactoring remove duplication to which fixed #11963:

``` diff
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -122,7 +122,7 @@ module ActiveRecord
             end

             if rel && !rel.arel.constraints.empty?
-              constraint = constraint.and rel.arel.constraints
+              constraint = rel.arel.constraints.inject(constraint) {|constraint, c| constraint.and c}
             end

             joins << join(table, constraint)
```

because `Arel::Nodes::Node#and` expected that argument (in our case `rel.arel.constraints`) is not `Array`, in that way `Arel::Visitors::ToSql` on visiting `Array` returns `,` instead of `AND`.
