### PR TITLE
Changing deprecation_horizon to be Rails 4.2

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -828,7 +828,7 @@ module ActiveRecord
       end
 
       def proper_table_name(name, options = {})
-        ActiveSupport::Deprecation.warn "ActiveRecord::Migrator.proper_table_name is deprecated and will be removed in Rails 4.1. Use the proper_table_name instance method on ActiveRecord::Migration instead"
+        ActiveSupport::Deprecation.warn "ActiveRecord::Migrator.proper_table_name is deprecated and will be removed in Rails 4.2. Use the proper_table_name instance method on ActiveRecord::Migration instead"
         options = {
           table_name_prefix: ActiveRecord::Base.table_name_prefix,
           table_name_suffix: ActiveRecord::Base.table_name_suffix

--- a/activesupport/lib/active_support/deprecation.rb
+++ b/activesupport/lib/active_support/deprecation.rb
@@ -32,7 +32,7 @@ module ActiveSupport
     # and the second is a library name
     #
     #   ActiveSupport::Deprecation.new('2.0', 'MyLibrary')
-    def initialize(deprecation_horizon = '4.1', gem_name = 'Rails')
+    def initialize(deprecation_horizon = '4.2', gem_name = 'Rails')
       self.gem_name = gem_name
       self.deprecation_horizon = deprecation_horizon
       # By default, warnings are not silenced and debugging is off.


### PR DESCRIPTION
Also, `ActiveRecord::Migrator.proper_table_name` should actually have a deprecation horizon of Rails 4.2 (not 4.1).
