### PR TITLE
Auto-generate stable fixture UUIDs on PostgreSQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Auto-generate stable fixture UUIDs on PostgreSQL.
+
+    Fixes: #11524
+
+    *Roderick van Domburg*
+
 *   `change_table` now uses the current adapter's `update_table_definition`
     method to retrieve a specific table definition.
     This ensures that `change_table` and `create_table` will use
@@ -751,6 +757,10 @@
 *   Fix `AR::Relation#merge` sometimes failing to preserve `readonly(false)` flag.
 
     *thedarkone*
+
+*   Test that PostgreSQL adapter includes `usec` when quoting `DateTime` objects
+
+    *Ben Cherry*
 
 *   Re-use `order` argument pre-processing for `reorder`.
 

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -2,6 +2,7 @@ require 'erb'
 require 'yaml'
 require 'zlib'
 require 'active_support/dependencies'
+require 'active_support/core_ext/securerandom'
 require 'active_record/fixture_set/file'
 require 'active_record/errors'
 
@@ -541,9 +542,13 @@ module ActiveRecord
     end
 
     # Returns a consistent, platform-independent identifier for +label+.
-    # Identifiers are positive integers less than 2^32.
-    def self.identify(label)
-      Zlib.crc32(label.to_s) % MAX_ID
+    # Integer identifiers are values less than 2^32. UUIDs are RFC 4122 version 5 SHA-1 hashes.
+    def self.identify(label, column_type = :integer)
+      if column_type == :uuid
+        SecureRandom.uuid_v5(SecureRandom::UUID_OID_NAMESPACE, label.to_s)
+      else
+        Zlib.crc32(label.to_s) % MAX_ID
+      end
     end
 
     # Superclass for the evaluation contexts used by ERB fixtures.
@@ -634,7 +639,7 @@ module ActiveRecord
 
           # generate a primary key if necessary
           if has_primary_key_column? && !row.include?(primary_key_name)
-            row[primary_key_name] = ActiveRecord::FixtureSet.identify(label)
+            row[primary_key_name] = ActiveRecord::FixtureSet.identify(label, primary_key_type)
           end
 
           # If STI is used, find the correct subclass for association reflection
@@ -657,7 +662,8 @@ module ActiveRecord
                   row[association.foreign_type] = $1
                 end
 
-                row[fk_name] = ActiveRecord::FixtureSet.identify(value)
+                fk_type = association.send(:active_record).columns_hash[association.foreign_key].type
+                row[fk_name] = ActiveRecord::FixtureSet.identify(value, fk_type)
               end
             when :has_many
               if association.options[:through]
@@ -684,6 +690,10 @@ module ActiveRecord
       def name
         @association.name
       end
+
+      def primary_key_type
+        @association.klass.column_types[@association.klass.primary_key].type
+      end
     end
 
     class HasManyThroughProxy < ReflectionProxy # :nodoc:
@@ -701,17 +711,22 @@ module ActiveRecord
         @primary_key_name ||= model_class && model_class.primary_key
       end
 
+      def primary_key_type
+        @primary_key_type ||= model_class && model_class.column_types[model_class.primary_key].type
+      end
+
       def add_join_records(rows, row, association)
         # This is the case when the join table has no fixtures file
         if (targets = row.delete(association.name.to_s))
-          table_name = association.join_table
-          lhs_key    = association.lhs_key
-          rhs_key    = association.rhs_key
+          table_name  = association.join_table
+          column_type = association.primary_key_type
+          lhs_key     = association.lhs_key
+          rhs_key     = association.rhs_key
 
           targets = targets.is_a?(Array) ? targets : targets.split(/\s*,\s*/)
           rows[table_name].concat targets.map { |target|
             { lhs_key => row[primary_key_name],
-              rhs_key => ActiveRecord::FixtureSet.identify(target) }
+              rhs_key => ActiveRecord::FixtureSet.identify(target, column_type) }
           }
         end
       end

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -11,13 +11,7 @@ class PostgresqlUUIDTest < ActiveRecord::TestCase
 
   def setup
     @connection = ActiveRecord::Base.connection
-
-    unless @connection.extension_enabled?('uuid-ossp')
-      @connection.enable_extension 'uuid-ossp'
-      @connection.commit_db_transaction
-    end
-
-    @connection.reconnect!
+    enable_uuid_ossp!(@connection)
 
     @connection.transaction do
       @connection.create_table('pg_uuids', id: :uuid, default: 'uuid_generate_v1()') do |t|

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -673,6 +673,12 @@ end
 class FoxyFixturesTest < ActiveRecord::TestCase
   fixtures :parrots, :parrots_pirates, :pirates, :treasures, :mateys, :ships, :computers, :developers, :"admin/accounts", :"admin/users"
 
+  if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+    require 'models/uuid_parent'
+    require 'models/uuid_child'
+    fixtures :uuid_parents, :uuid_children 
+  end
+
   def test_identifies_strings
     assert_equal(ActiveRecord::FixtureSet.identify("foo"), ActiveRecord::FixtureSet.identify("foo"))
     assert_not_equal(ActiveRecord::FixtureSet.identify("foo"), ActiveRecord::FixtureSet.identify("FOO"))
@@ -685,6 +691,9 @@ class FoxyFixturesTest < ActiveRecord::TestCase
   def test_identifies_consistently
     assert_equal 207281424, ActiveRecord::FixtureSet.identify(:ruby)
     assert_equal 1066363776, ActiveRecord::FixtureSet.identify(:sapphire_2)
+
+    assert_equal 'f92b6bda-0d0d-5fe1-9124-502b18badded', ActiveRecord::FixtureSet.identify(:daddy, :uuid)
+    assert_equal 'b4b10018-ad47-595d-b42f-d8bdaa6d01bf', ActiveRecord::FixtureSet.identify(:sonny, :uuid)
   end
 
   TIMESTAMP_COLUMNS = %w(created_at created_on updated_at updated_on)

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -106,6 +106,15 @@ def verify_default_timezone_config
   end
 end
 
+def enable_uuid_ossp!(connection)
+  return false unless connection.supports_extensions?
+  return true if connection.extension_enabled?('uuid-ossp')
+
+  connection.enable_extension 'uuid-ossp'
+  connection.commit_db_transaction
+  connection.reconnect!
+end
+
 unless ENV['FIXTURE_DEBUG']
   module ActiveRecord::TestFixtures::ClassMethods
     def try_to_load_dependency_with_silence(*args)

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -63,7 +63,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
       next if column_set.empty?
 
       lengths = column_set.map do |column|
-        if match = column.match(/t\.(?:integer|decimal|float|datetime|timestamp|time|date|text|binary|string|boolean)\s+"/)
+        if match = column.match(/t\.(?:integer|decimal|float|datetime|timestamp|time|date|text|binary|string|boolean|uuid)\s+"/)
           match[0].length
         end
       end

--- a/activerecord/test/fixtures/uuid_children.yml
+++ b/activerecord/test/fixtures/uuid_children.yml
@@ -1,0 +1,3 @@
+sonny:
+  uuid_parent: daddy
+  name: Sonny

--- a/activerecord/test/fixtures/uuid_parents.yml
+++ b/activerecord/test/fixtures/uuid_parents.yml
@@ -1,0 +1,2 @@
+daddy:
+  name: Daddy

--- a/activerecord/test/models/uuid_child.rb
+++ b/activerecord/test/models/uuid_child.rb
@@ -1,0 +1,3 @@
+class UuidChild < ActiveRecord::Base
+  belongs_to :uuid_parent
+end

--- a/activerecord/test/models/uuid_parent.rb
+++ b/activerecord/test/models/uuid_parent.rb
@@ -1,0 +1,3 @@
+class UuidParent < ActiveRecord::Base
+  has_many :uuid_children
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -17,6 +17,15 @@ ActiveRecord::Schema.define do
       ActiveRecord::Base.connection.create_table(*args, &block)
       ActiveRecord::Base.connection.execute "SET GENERATOR #{args.first}_seq TO 10000"
     end
+  when "PostgreSQL"
+    enable_uuid_ossp!(ActiveRecord::Base.connection)
+    create_table :uuid_parents, id: :uuid, force: true do |t|
+      t.string :name
+    end
+    create_table :uuid_children, id: :uuid, force: true do |t|
+      t.string :name
+      t.uuid :uuid_parent_id
+    end
   end
 
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `SecureRandom::uuid_v3` and `SecureRandom::uuid_v5` to support stable
+    UUID fixtures on PostgreSQL.
+
+    *Roderick van Domburg*
+
 *   Maintain proleptic gregorian in Time#advance
 
     `Time#advance` uses `Time#to_date` and `Date#advance` to calculate a new date.

--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -1,0 +1,47 @@
+module SecureRandom
+  UUID_DNS_NAMESPACE  = "k\xA7\xB8\x10\x9D\xAD\x11\xD1\x80\xB4\x00\xC0O\xD40\xC8" #:nodoc:
+  UUID_URL_NAMESPACE  = "k\xA7\xB8\x11\x9D\xAD\x11\xD1\x80\xB4\x00\xC0O\xD40\xC8" #:nodoc:
+  UUID_OID_NAMESPACE  = "k\xA7\xB8\x12\x9D\xAD\x11\xD1\x80\xB4\x00\xC0O\xD40\xC8" #:nodoc:
+  UUID_X500_NAMESPACE = "k\xA7\xB8\x14\x9D\xAD\x11\xD1\x80\xB4\x00\xC0O\xD40\xC8" #:nodoc:
+  
+  # Generates a v5 non-random UUID (Universally Unique IDentifier).
+  #
+  # Using Digest::MD5 generates version 3 UUIDs; Digest::SHA1 generates version 5 UUIDs.
+  # ::uuid_from_hash always generates the same UUID for a given name and namespace combination.
+  #
+  # See RFC 4122 for details of UUID at: http://www.ietf.org/rfc/rfc4122.txt
+  def self.uuid_from_hash(hash_class, uuid_namespace, name)
+    if hash_class == Digest::MD5
+      version = 3
+    elsif hash_class == Digest::SHA1
+      version = 5
+    else
+      raise ArgumentError, "Expected Digest::SHA1 or Digest::MD5, got #{hash_class.name}."
+    end
+
+    hash = hash_class.new
+    hash.update(uuid_namespace)
+    hash.update(name)
+
+    ary = hash.digest.unpack('NnnnnN')
+    ary[2] = (ary[2] & 0x0FFF) | (version << 12)
+    ary[3] = (ary[3] & 0x3FFF) | 0x8000
+
+    "%08x-%04x-%04x-%04x-%04x%08x" % ary
+  end
+
+  # Convenience method for ::uuid_from_hash using Digest::MD5.
+  def self.uuid_v3(uuid_namespace, name)
+    self.uuid_from_hash(Digest::MD5, uuid_namespace, name)
+  end
+
+  # Convenience method for ::uuid_from_hash using Digest::SHA1.
+  def self.uuid_v5(uuid_namespace, name)
+    self.uuid_from_hash(Digest::SHA1, uuid_namespace, name)
+  end
+
+  class << self
+    # Alias for ::uuid.
+    alias_method :uuid_v4, :uuid
+  end
+end

--- a/activesupport/test/core_ext/securerandom_test.rb
+++ b/activesupport/test/core_ext/securerandom_test.rb
@@ -1,0 +1,28 @@
+require 'abstract_unit'
+require 'active_support/core_ext/securerandom'
+
+class SecureRandomExt < ActiveSupport::TestCase
+  def test_v3_uuids
+    assert_equal "3d813cbb-47fb-32ba-91df-831e1593ac29", SecureRandom.uuid_v3(SecureRandom::UUID_DNS_NAMESPACE, "www.widgets.com")
+    assert_equal "86df55fb-428e-3843-8583-ba3c05f290bc", SecureRandom.uuid_v3(SecureRandom::UUID_URL_NAMESPACE, "http://www.widgets.com")
+    assert_equal "8c29ab0e-a2dc-3482-b5eb-20cb2e2387a1", SecureRandom.uuid_v3(SecureRandom::UUID_OID_NAMESPACE, "1.2.3")
+    assert_equal "ee49149d-53a4-304a-890b-468229f6afc3", SecureRandom.uuid_v3(SecureRandom::UUID_X500_NAMESPACE, "cn=John Doe, ou=People, o=Acme, Inc., c=US")
+  end
+
+  def test_v5_uuids
+    assert_equal "21f7f8de-8051-5b89-8680-0195ef798b6a", SecureRandom.uuid_v5(SecureRandom::UUID_DNS_NAMESPACE, "www.widgets.com")
+    assert_equal "4e570fd8-186d-5a74-90f0-4d28e34673a1", SecureRandom.uuid_v5(SecureRandom::UUID_URL_NAMESPACE, "http://www.widgets.com")
+    assert_equal "42d5e23b-3a02-5135-85c6-52d1102f1f00", SecureRandom.uuid_v5(SecureRandom::UUID_OID_NAMESPACE, "1.2.3")
+    assert_equal "fd5b2ddf-bcfe-58b6-90d6-db50f74db527", SecureRandom.uuid_v5(SecureRandom::UUID_X500_NAMESPACE, "cn=John Doe, ou=People, o=Acme, Inc., c=US")
+  end
+
+  def test_uuid_v4_alias
+    assert_equal SecureRandom.method(:uuid_v4), SecureRandom.method(:uuid)
+  end
+
+  def test_invalid_hash_class
+    assert_raise ArgumentError do
+      SecureRandom.uuid_from_hash(Digest::SHA2, SecureRandom::UUID_OID_NAMESPACE, '1.2.3')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #11524. This PR builds on that one by @ruckc:
- Added tests.
- Supports polymorphic associations by inspecting the polymorphic foreign key type.
