### PR TITLE
objectify_html_options

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -767,7 +767,7 @@ module ActionView
       #
       # Please refer to the documentation of the base helper for details.
       def select(method, choices, options = {}, html_options = {})
-        @template.select(@object_name, method, choices, objectify_options(options), @default_options.merge(html_options))
+        @template.select(@object_name, method, choices, objectify_options(options), objectify_html_options(html_options))
       end
 
       # Wraps ActionView::Helpers::FormOptionsHelper#collection_select for form builders:
@@ -779,7 +779,7 @@ module ActionView
       #
       # Please refer to the documentation of the base helper for details.
       def collection_select(method, collection, value_method, text_method, options = {}, html_options = {})
-        @template.collection_select(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_options.merge(html_options))
+        @template.collection_select(@object_name, method, collection, value_method, text_method, objectify_options(options), objectify_html_options(html_options))
       end
 
       # Wraps ActionView::Helpers::FormOptionsHelper#grouped_collection_select for form builders:
@@ -791,7 +791,7 @@ module ActionView
       #
       # Please refer to the documentation of the base helper for details.
       def grouped_collection_select(method, collection, group_method, group_label_method, option_key_method, option_value_method, options = {}, html_options = {})
-        @template.grouped_collection_select(@object_name, method, collection, group_method, group_label_method, option_key_method, option_value_method, objectify_options(options), @default_options.merge(html_options))
+        @template.grouped_collection_select(@object_name, method, collection, group_method, group_label_method, option_key_method, option_value_method, objectify_options(options), objectify_html_options(html_options))
       end
 
       # Wraps ActionView::Helpers::FormOptionsHelper#time_zone_select for form builders:
@@ -803,7 +803,7 @@ module ActionView
       #
       # Please refer to the documentation of the base helper for details.
       def time_zone_select(method, priority_zones = nil, options = {}, html_options = {})
-        @template.time_zone_select(@object_name, method, priority_zones, objectify_options(options), @default_options.merge(html_options))
+        @template.time_zone_select(@object_name, method, priority_zones, objectify_options(options), objectify_html_options(html_options))
       end
 
       # Wraps ActionView::Helpers::FormOptionsHelper#collection_check_boxes for form builders:
@@ -815,7 +815,7 @@ module ActionView
       #
       # Please refer to the documentation of the base helper for details.
       def collection_check_boxes(method, collection, value_method, text_method, options = {}, html_options = {}, &block)
-        @template.collection_check_boxes(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_options.merge(html_options), &block)
+        @template.collection_check_boxes(@object_name, method, collection, value_method, text_method, objectify_options(options), objectify_html_options(html_options), &block)
       end
 
       # Wraps ActionView::Helpers::FormOptionsHelper#collection_radio_buttons for form builders:
@@ -827,8 +827,14 @@ module ActionView
       #
       # Please refer to the documentation of the base helper for details.
       def collection_radio_buttons(method, collection, value_method, text_method, options = {}, html_options = {}, &block)
-        @template.collection_radio_buttons(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_options.merge(html_options), &block)
+        @template.collection_radio_buttons(@object_name, method, collection, value_method, text_method, objectify_options(options), objectify_html_options(html_options), &block)
       end
+
+      private
+      
+        def objectify_html_options(html_options)
+          @default_options.merge(html_options)
+        end
     end
   end
 end


### PR DESCRIPTION
Use `objectify_html_options` for `html_option` of the collection FormBuilder inputs.
Makes it easier to tap into FormBuilder
