### PR TITLE
Make AR::Base#touch fire the after_commit and after_rollback callbacks

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -264,6 +264,10 @@ module ActiveRecord
       with_transaction_returning_status { super }
     end
 
+    def touch(*)
+      with_transaction_returning_status { super }
+    end
+
     # Reset id and @new_record if the transaction rolls back.
     def rollback_active_record_state!
       remember_transaction_record_state

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -2211,7 +2211,9 @@ class BasicsTest < ActiveRecord::TestCase
     Bulb.create(:car => car)
 
     key = car.cache_key
-    car.bulb.touch
+    Bulb.transaction do
+      car.bulb.touch
+    end
     car.reload
     assert_not_equal key, car.cache_key
   ensure

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -8,6 +8,7 @@ require 'models/task'
 
 class TimestampTest < ActiveRecord::TestCase
   fixtures :developers, :owners, :pets, :toys, :cars, :tasks
+  self.use_transactional_fixtures = false
 
   def setup
     @developer = Developer.order(:id).first
@@ -160,6 +161,22 @@ class TimestampTest < ActiveRecord::TestCase
     assert_not_equal time, owner.updated_at
   ensure
     Toy.belongs_to :pet
+  end
+
+
+  def test_saving_a_record_with_a_belongs_to_that_specifies_touching_the_parent_should_call_callbacks_on_the_parent_object
+    pet   = Pet.first
+    owner = pet.owner
+    flag = false
+
+    owner.on_after_commit do
+      flag = true
+    end
+
+    pet.name = "Fluffy the Third"
+    pet.save
+
+    assert flag
   end
 
   def test_timestamp_attributes_for_create

--- a/activerecord/test/models/owner.rb
+++ b/activerecord/test/models/owner.rb
@@ -2,4 +2,20 @@ class Owner < ActiveRecord::Base
   self.primary_key = :owner_id
   has_many :pets
   has_many :toys, :through => :pets
+
+  after_commit :execute_blocks
+
+  def blocks
+    @blocks ||= []
+  end
+  def on_after_commit(&block)
+    blocks << block
+  end
+
+  def execute_blocks
+    blocks.each do |block|
+      block.call(self)
+    end
+    @blocks = []
+  end
 end


### PR DESCRIPTION
I expected

``` ruby
class Product < ActiveRecord::Base
  after_commit :expire_cache

  def expire_cache
    puts "cache expired"
  end

product.touch
```

to output "cache expired", but it doesn't, and it used to in Rails 3.0. This PR brings back that functionality by making touches call `after_commit` callbacks, woo!

We relied on `after_commit` callbacks being fired by touches to do things like expire caches, send documents to our search cluster, bump versions in Redis, etc. When we upgraded to 3.2, we found this problem and had to go and add `after_touch` callbacks to all those places to get touches to cause the same changes in the system. We make pretty heavy use of touches to bump timestamps up the association chain and whatnot, so they are a principle instigator of attribute change in the system. I think having to add both callbacks to _really_ get a callback fired when stuff changes is sucky because it means client code has to deal with de-duplication if both callbacks fire, client code has to be aware of the semantic differences of when they fire, and before this change there is no way to get called back to when a record's timestamp bump has definitely been committed to the database. 

Thanks for any feedback you can give me!
