### PR TITLE
Updating Rails README.md to reflect current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,6 @@ pattern.
 Understanding the MVC pattern is key to understanding Rails. MVC divides your
 application into three layers, each with a specific responsibility.
 
-The _View layer_ is composed of "templates" that are responsible for providing
-appropriate representations of your application's resources. Templates can
-come in a variety of formats, but most view templates are HTML with embedded
-Ruby code (ERB files).
-
 The _Model layer_ represents your domain model (such as Account, Product,
 Person, Post, etc.) and encapsulates the business logic that is specific to
 your application. In Rails, database-backed model classes are derived from
@@ -24,16 +19,26 @@ as provided by the Active Model module. You can read more about Active Record
 in its [README](activerecord/README.rdoc).
 
 The _Controller layer_ is responsible for handling incoming HTTP requests and
-providing a suitable response. Usually this means returning HTML, but Rails
-controllers can also generate XML, JSON, PDFs, mobile-specific views, and
-more. Controllers manipulate models and render view templates in order to
-generate the appropriate HTTP response.
+providing a suitable response. Usually this means returning HTML, but Rails controllers
+can also generate XML, JSON, PDFs, mobile-specific views, and more. Controllers load and
+manipulate models, and render view templates in order to generate the appropriate HTTP response.
+In Rails, incoming requests are routed by Action Dispatch to an appropriate controller, and
+controller classes are derived from `ActionController::Base`. Action Dispatch and Action Controller
+are bundled together in Action Pack. You can read more about Action Pack in its
+[README](actionpack/README.rdoc).
 
-In Rails, the Controller and View layers are handled together by Action Pack.
-These two layers are bundled in a single package due to their heavy interdependence.
-This is unlike the relationship between Active Record and Action Pack, which are
-independent. Each of these packages can be used independently outside of Rails. You
-can read more about Action Pack in its [README](actionpack/README.rdoc).
+The _View layer_ is composed of "templates" that are responsible for providing
+appropriate representations of your application's resources. Templates can
+come in a variety of formats, but most view templates are HTML with embedded
+Ruby code (ERB files). Views are typically rendered to generate a controller response,
+or to generate the body of an email. In Rails, View generation is handled by Action View.
+You can read more about Action View in its [README](actionview/README.rdoc).
+
+Active Record, Action Pack, and Action View can each be used independently outside Rails.
+In addition to them, Rails also comes with Action Mailer ([README](actionmailer/README.rdoc)), a library
+to generate and send emails; and Active Support ([README](activesupport/README.rdoc)), a collection of
+utility classes and standard library extensions that are useful for Rails, and may also be used
+independently outisde Rails.
 
 ## Getting Started
 


### PR DESCRIPTION
Updating the global Rails README following work by @strzalek et al, which extracted Action View to a separate gem. Also, some other improvements to the README to reflect the current state of the framework.

Summary of changes:
- Reordered the paragraphs discussing MVC from View-Model-Controller to Model-Controller-View, based on how (IMHO) most people think about the structure and hierarchy of the framework and their code in it.
- Added references to ActionView and its README in the _View_ paragraph.
- Reworded the _Controller_ paragraph to briefly mentioned routing as handled by Action Dispatch, and that both Action Dispatch and Action Controller work together to form the request-handling Action Pack.
- Changed wording in _Controller_ from "manipulate models" to "load and manipulate models", as many actions only read from models.
- Removed paragraph saying Action Pack is coupled with Action View, as this is no longer the case.
- Added brief references to Action Mailer and Active Support (and their respective READMEs), since they are both major Rails components. Briefly mentioned in the _View_ paragraph that Action View is often used to generate the body of the email, in addition to the other typical of using to build a response body.
