### PR TITLE
Make AR::Base#touch fire the after_commit and after_rollback callbacks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## unreleased ##
 
+*   Make ActiveRecord::Base#touch fire the `after_commit` and `after_rollback` callbacks.
+
+    * Harry Brundage *
+
 *   PostgreSQL adapter recognizes negative money values formatted with
     parentheses (eg. `($1.25) # => -1.25`)).
     Fixes #11899.

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -275,6 +275,10 @@ module ActiveRecord
       with_transaction_returning_status { super }
     end
 
+    def touch(*)
+      with_transaction_returning_status { super }
+    end
+
     # Reset id and @new_record if the transaction rolls back.
     def rollback_active_record_state!
       remember_transaction_record_state

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1465,7 +1465,9 @@ class BasicsTest < ActiveRecord::TestCase
     Bulb.create(car: car)
 
     key = car.cache_key
-    car.bulb.touch
+    Bulb.transaction do
+      car.bulb.touch
+    end
     car.reload
     assert_not_equal key, car.cache_key
   end

--- a/activerecord/test/models/owner.rb
+++ b/activerecord/test/models/owner.rb
@@ -2,4 +2,21 @@ class Owner < ActiveRecord::Base
   self.primary_key = :owner_id
   has_many :pets, -> { order 'pets.name desc' }
   has_many :toys, :through => :pets
+
+  after_commit :execute_blocks
+
+  def blocks
+    @blocks ||= []
+  end
+
+  def on_after_commit(&block)
+    blocks << block
+  end
+
+  def execute_blocks
+    blocks.each do |block|
+      block.call(self)
+    end
+    @blocks = []
+  end
 end


### PR DESCRIPTION
I expected

``` ruby
class Product < ActiveRecord::Base
  after_commit :expire_cache

  def expire_cache
    puts "cache expired"
  end

product.touch
```

to output "cache expired", but it doesn't, and it used to in Rails 3.0. This PR brings back that functionality by making touches call `after_commit` callbacks, woo!

We relied on `after_commit` callbacks being fired by touches to do things like expire caches, send documents to our search cluster, bump versions in Redis, etc. When we upgraded to 3.2, we found this problem and had to go and add `after_touch` callbacks to all those places to get touches to cause the same changes in the system. We make pretty heavy use of touches to bump timestamps up the association chain and whatnot, so they are a principle instigator of attribute change in the system. I think having to add both callbacks to _really_ get a callback fired when stuff changes is sucky because it means client code has to deal with de-duplication if both callbacks fire, client code has to be aware of the semantic differences of when they fire, and before this change there is no way to get called back to when a record's timestamp bump has definitely been committed to the database. 

Thanks for any feedback you can give me!

@carlosantoniodasilva this is a follow up to #12026 on top of `4-0-stable`, is this what you need?
