### PR TITLE
Credit Ruby with Test::Unit

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -471,7 +471,7 @@ spec/models/user_spec.rb:
 
 INFO: A good description of unit testing in Rails is given in [A Guide to Testing Rails Applications](testing.html)
 
-Rails comes with a test suite called `Test::Unit`. Rails owes its stability to the use of tests. The tasks available in the `test:` namespace helps in running the different tests you will hopefully write.
+Rails comes with a test suite called Minitest. Rails owes its stability to the use of tests. The tasks available in the `test:` namespace helps in running the different tests you will hopefully write.
 
 ### `tmp`
 


### PR DESCRIPTION
Previous slightly misleading; Test::Unit is native to Ruby, not Rails. Wouldn't mind citing rspec here too, but I won't make that call.
