### PR TITLE
Add config to method calls in fixtures.

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -379,16 +379,16 @@ module ActiveRecord
 
     @@all_cached_fixtures = Hash.new { |h,k| h[k] = {} }
 
-    def self.default_fixture_model_name(fixture_set_name) # :nodoc:
-      ActiveRecord::Base.pluralize_table_names ?
+    def self.default_fixture_model_name(fixture_set_name, config = ActiveRecord::Base) # :nodoc:
+      config.pluralize_table_names ?
         fixture_set_name.singularize.camelize :
         fixture_set_name.camelize
     end
 
-    def self.default_fixture_table_name(fixture_set_name) # :nodoc:
-       "#{ ActiveRecord::Base.table_name_prefix }"\
+    def self.default_fixture_table_name(fixture_set_name, config = ActiveRecord::Base) # :nodoc:
+       "#{ config.table_name_prefix }"\
        "#{ fixture_set_name.tr('/', '_') }"\
-       "#{ ActiveRecord::Base.table_name_suffix }".to_sym
+       "#{ config.table_name_suffix }".to_sym
     end
 
     def self.reset_cache
@@ -436,7 +436,7 @@ module ActiveRecord
     cattr_accessor :all_loaded_fixtures
     self.all_loaded_fixtures = {}
 
-    def self.create_fixtures(fixtures_directory, fixture_set_names, class_names = {})
+    def self.create_fixtures(fixtures_directory, fixture_set_names, class_names = {}, config = ActiveRecord::Base)
       fixture_set_names = Array(fixture_set_names).map(&:to_s)
       class_names = class_names.stringify_keys
 
@@ -455,7 +455,7 @@ module ActiveRecord
             fixtures_map[fs_name] = new( # ActiveRecord::FixtureSet.new
               connection,
               fs_name,
-              class_names[fs_name] || (default_fixture_model_name(fs_name).safe_constantize),
+              class_names[fs_name] || (default_fixture_model_name(fs_name, config).safe_constantize),
               ::File.join(fixtures_directory, fs_name))
           end
 
@@ -497,12 +497,13 @@ module ActiveRecord
       Zlib.crc32(label.to_s) % MAX_ID
     end
 
-    attr_reader :table_name, :name, :fixtures, :model_class
+    attr_reader :table_name, :name, :fixtures, :model_class, :config
 
-    def initialize(connection, name, class_name, path)
+    def initialize(connection, name, class_name, path, config = ActiveRecord::Base)
       @fixtures = {} # Ordered hash
       @name     = name
       @path     = path
+      @config   = config
 
       if class_name.is_a?(String)
         ActiveSupport::Deprecation.warn("The ability to pass in strings as a class name will be removed in Rails 4.2, consider using the class itself instead.")
@@ -519,7 +520,7 @@ module ActiveRecord
 
       @table_name = ( model_class.respond_to?(:table_name) ?
                       model_class.table_name :
-                      self.class.default_fixture_table_name(name) )
+                      self.class.default_fixture_table_name(name, config) )
 
       read_fixture_files
     end
@@ -543,7 +544,7 @@ module ActiveRecord
     # Return a hash of rows to be inserted. The key is the table, the value is
     # a list of rows to insert to that table.
     def table_rows
-      now = ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.now
+      now = config.default_timezone == :utc ? Time.now.utc : Time.now
       now = now.to_s(:db)
 
       # allow a standard key to be used for doing defaults in YAML
@@ -727,14 +728,16 @@ module ActiveRecord
       class_attribute :use_transactional_fixtures
       class_attribute :use_instantiated_fixtures # true, false, or :no_instances
       class_attribute :pre_loaded_fixtures
+      class_attribute :config
 
       self.fixture_table_names = []
       self.use_transactional_fixtures = true
       self.use_instantiated_fixtures = false
       self.pre_loaded_fixtures = false
+      self.config = ActiveRecord::Base
 
       self.fixture_class_names = Hash.new do |h, fixture_set_name|
-        h[fixture_set_name] = ActiveRecord::FixtureSet.default_fixture_model_name(fixture_set_name)
+        h[fixture_set_name] = ActiveRecord::FixtureSet.default_fixture_model_name(fixture_set_name, self.config)
       end
     end
 
@@ -760,7 +763,7 @@ module ActiveRecord
         end
 
         self.fixture_table_names |= fixture_set_names
-        require_fixture_classes(fixture_set_names)
+        require_fixture_classes(fixture_set_names, self.config)
         setup_fixture_accessors(fixture_set_names)
       end
 
@@ -775,7 +778,7 @@ module ActiveRecord
         end
       end
 
-      def require_fixture_classes(fixture_set_names = nil)
+      def require_fixture_classes(fixture_set_names = nil, config = ActiveRecord::Base)
         if fixture_set_names
           fixture_set_names = fixture_set_names.map { |n| n.to_s }
         else
@@ -783,7 +786,7 @@ module ActiveRecord
         end
 
         fixture_set_names.each do |file_name|
-          file_name = file_name.singularize if ActiveRecord::Base.pluralize_table_names
+          file_name = file_name.singularize if config.pluralize_table_names
           try_to_load_dependency(file_name)
         end
       end
@@ -835,7 +838,7 @@ module ActiveRecord
         !self.class.uses_transaction?(method_name)
     end
 
-    def setup_fixtures
+    def setup_fixtures(config = ActiveRecord::Base)
       if pre_loaded_fixtures && !use_transactional_fixtures
         raise RuntimeError, 'pre_loaded_fixtures requires use_transactional_fixtures'
       end
@@ -849,7 +852,7 @@ module ActiveRecord
         if @@already_loaded_fixtures[self.class]
           @loaded_fixtures = @@already_loaded_fixtures[self.class]
         else
-          @loaded_fixtures = load_fixtures
+          @loaded_fixtures = load_fixtures(config)
           @@already_loaded_fixtures[self.class] = @loaded_fixtures
         end
         @fixture_connections = enlist_fixture_connections
@@ -860,11 +863,11 @@ module ActiveRecord
       else
         ActiveRecord::FixtureSet.reset_cache
         @@already_loaded_fixtures[self.class] = nil
-        @loaded_fixtures = load_fixtures
+        @loaded_fixtures = load_fixtures(config)
       end
 
       # Instantiate fixtures for every test if requested.
-      instantiate_fixtures if use_instantiated_fixtures
+      instantiate_fixtures(config) if use_instantiated_fixtures
     end
 
     def teardown_fixtures
@@ -886,19 +889,19 @@ module ActiveRecord
     end
 
     private
-      def load_fixtures
-        fixtures = ActiveRecord::FixtureSet.create_fixtures(fixture_path, fixture_table_names, fixture_class_names)
+      def load_fixtures(config)
+        fixtures = ActiveRecord::FixtureSet.create_fixtures(fixture_path, fixture_table_names, fixture_class_names, config)
         Hash[fixtures.map { |f| [f.name, f] }]
       end
 
       # for pre_loaded_fixtures, only require the classes once. huge speed improvement
       @@required_fixture_classes = false
 
-      def instantiate_fixtures
+      def instantiate_fixtures(config)
         if pre_loaded_fixtures
           raise RuntimeError, 'Load fixtures before instantiating them.' if ActiveRecord::FixtureSet.all_loaded_fixtures.empty?
           unless @@required_fixture_classes
-            self.class.require_fixture_classes ActiveRecord::FixtureSet.all_loaded_fixtures.keys
+            self.class.require_fixture_classes ActiveRecord::FixtureSet.all_loaded_fixtures.keys, config
             @@required_fixture_classes = true
           end
           ActiveRecord::FixtureSet.instantiate_all_loaded_fixtures(self, load_instances?)

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -574,7 +574,7 @@ class FixturesBrokenRollbackTest < ActiveRecord::TestCase
   end
 
   private
-    def load_fixtures
+    def load_fixtures(config)
       raise 'argh'
     end
 end


### PR DESCRIPTION
Allows you to change your configuration for calls to `table_name_prefix`, `table_name_suffix`, and `pluralize_table_names`.

The default configuration is still ActiveRecord::Base, but you are now
able to change the configuration easily.

\cc @spastorino
