### PR TITLE
UUID are not sequenced, so pk comes back empty when the pk is a uuid.  S...

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -101,7 +101,8 @@ HEADER
           # first dump primary key column
           if @connection.respond_to?(:pk_and_sequence_for)
             pk, _ = @connection.pk_and_sequence_for(table)
-          elsif @connection.respond_to?(:primary_key)
+          end
+          if pk.empty? && @connection.respond_to?(:primary_key)
             pk = @connection.primary_key(table)
           end
 


### PR DESCRIPTION
...hould check both fields if pk wasn't found in the first one.
