### PR TITLE
Make `table_name.*` to act like `:all` in performing `count`

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -194,6 +194,7 @@ module ActiveRecord
           distinct = true
         end
 
+        column_name = :all if column_name =~ /\s*\.\*\s*/
         column_name = primary_key if column_name == :all && distinct
         distinct = nil if column_name =~ /\s*DISTINCT[\s(]+/i
       end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -129,6 +129,12 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 3, accounts.select(:firm_id).count
   end
 
+  def test_should_count_with_custom_select_all_and_limit
+    assert_nothing_raised do
+      assert_equal 2, Account.select("#{Account.table_name}.*").limit(2).count
+    end
+  end
+
   def test_count_should_shortcut_with_limit_zero
     accounts = Account.limit(0)
 


### PR DESCRIPTION
Make `table_name.*` to act like `:all` in performing `count`
Fixes https://github.com/rails/rails/issues/11824
