### PR TITLE
Add Range#limit(value) to core_ext

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add Range#limit(value) as a method of ensuring a value is included within a given range
+
+    *Dermot Haughey*
+
 *   Ensure that autoloaded constants in all-caps nestings are marked as
     autoloaded.
 

--- a/activesupport/lib/active_support/core_ext/range.rb
+++ b/activesupport/lib/active_support/core_ext/range.rb
@@ -1,3 +1,4 @@
 require 'active_support/core_ext/range/conversions'
 require 'active_support/core_ext/range/include_range'
 require 'active_support/core_ext/range/overlaps'
+require 'active_support/core_ext/range/limit'

--- a/activesupport/lib/active_support/core_ext/range/limit.rb
+++ b/activesupport/lib/active_support/core_ext/range/limit.rb
@@ -1,0 +1,14 @@
+class Range
+  # Limit a value to be within the range if it is outside of it, otherwise return the endpoint it is closest to
+  #  (1..5).limit(9) # => 5
+  #  (1..5).limit(-1) # => 1
+  #  (1..5).limit(3) # => 3
+  def limit(value)
+    return value if cover?(value)
+    if (value < self.min)
+      self.min
+    elsif (value > self.max)
+      self.max
+    end
+  end
+end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -12,7 +12,7 @@ class RangeTest < ActiveSupport::TestCase
     date_range = Time.utc(2005, 12, 10, 15, 30)..Time.utc(2005, 12, 10, 17, 30)
     assert_equal "BETWEEN '2005-12-10 15:30:00' AND '2005-12-10 17:30:00'", date_range.to_s(:db)
   end
-  
+
   def test_date_range
     assert_instance_of Range, DateTime.new..DateTime.new
     assert_instance_of Range, DateTime::Infinity.new..DateTime::Infinity.new
@@ -20,6 +20,18 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_overlaps_last_inclusive
     assert((1..5).overlaps?(5..10))
+  end
+
+  def test_limit_greater_than
+    assert_equal 5, (1..5).limit(9)
+  end
+
+  def test_limit_less_than
+    assert_equal 1, (1..5).limit(-1)
+  end
+
+  def test_limit_inclusive
+    assert_equal 3, (1..5).limit(3)
   end
 
   def test_overlaps_last_exclusive


### PR DESCRIPTION
Add method to simplify ensuring a value is within a given range. When it
is greater than the maximum, return the maximum. When it is greater than
the minimum, return the minimum. Otherwise, return the original value.

Also included are tests for the functionality, and an updated changelog
to reflect the functionality.
Add tests

Add core extension for Range.limit

Add to changelog
