### PR TITLE
ActiveRecord: Include usecs when quoting DateTime in PostgreSQL adapter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Test that PostgreSQL adapter includes `usec` when quoting `DateTime` objects
+
+    *Ben Cherry*
+
 *   Fix PredicateBuilder so polymorhic association keys in `where` clause can
     also accept not only `ActiveRecord::Base` direct descendances (decorated
     models, for example).

--- a/activerecord/test/cases/adapters/postgresql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/quoting_test.rb
@@ -52,6 +52,11 @@ module ActiveRecord
           c = Column.new(nil, nil, 'text')
           assert_equal "'666'", @conn.quote(fixnum, c)
         end
+
+        def test_quote_time_usec
+          assert_equal "'1970-01-01 00:00:00.000000'", @conn.quote(Time.at(0))
+          assert_equal "'1970-01-01 00:00:00.000000'", @conn.quote(Time.at(0).to_datetime)
+        end
       end
     end
   end


### PR DESCRIPTION
The PostgreSQL adapter has a bug where it fails to include the fractional seconds when quoting DateTime values for queries or storage.  This causes loss of precision during storage, and also failure during future query operations, like so:

```
f = Foo.first
Foo.where(:created_at => f.created_at.to_datetime).first.id == f.id # false
```

This patch ensures the usec are sent when quoting DateTime objects (as they are for Time objects)
