### PR TITLE
type_cast_config_to_boolean should return true for 'true'

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -81,6 +81,8 @@ module ActiveRecord
       def self.type_cast_config_to_boolean(config)
         if config == "false"
           false
+        elsif config == "true"
+          true
         else
           config
         end


### PR DESCRIPTION
currently `'false'` is returned as `false`
while `'true'` is not type-casted to `true`
which is still truth-y but a bit confusing
