### PR TITLE
 add 'clear' and 'byteslice'  as an unsafe string methods

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -84,7 +84,7 @@ module ActiveSupport #:nodoc:
   class SafeBuffer < String
     UNSAFE_STRING_METHODS = %w(
       capitalize chomp chop delete downcase gsub lstrip next reverse rstrip
-      slice squeeze strip sub succ swapcase tr tr_s upcase prepend
+      slice squeeze strip sub succ swapcase tr tr_s upcase prepend clear byteslice
     )
 
     alias_method :original_concat, :concat


### PR DESCRIPTION
clear and byteslice are also unsafe string methods
