### PR TITLE
Document min_cost in ActiveModel::SecurePassword

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -2,7 +2,9 @@ module ActiveModel
   module SecurePassword
     extend ActiveSupport::Concern
 
-    class << self; attr_accessor :min_cost; end
+    class << self
+      attr_accessor :min_cost # :nodoc:
+    end
     self.min_cost = false
 
     module ClassMethods


### PR DESCRIPTION
Adding missing documentation for `ActiveModel::SecurePassword::min_cost`
