### PR TITLE
Port all remaining self.protected_instance_variables to class methods

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -373,8 +373,6 @@ module ActionMailer
     include AbstractController::AssetPaths
     include AbstractController::Callbacks
 
-    self.protected_instance_variables = [:@_action_has_layout]
-
     helper ActionMailer::MailHelper
 
     private_class_method :new #:nodoc:
@@ -386,6 +384,10 @@ module ActionMailer
       content_type: "text/plain",
       parts_order:  [ "text/plain", "text/enriched", "text/html" ]
     }.freeze
+
+    def self.default_protected_instance_vars
+      super.concat [:@_action_has_layout]
+    end
 
     class << self
       # Register one or more Observers which will be notified when mail is delivered.

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -114,6 +114,11 @@ module AbstractController
       end
     end
 
+    # Define some internal variables that should not be propagated to the view.
+    def self.default_protected_instance_vars
+      []
+    end
+
     abstract!
 
     # Calls the action going through the entire action dispatch stack.

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -13,13 +13,8 @@ module AbstractController
   module Rendering
     extend ActiveSupport::Concern
 
-    included do
-      class_attribute :protected_instance_variables
-      self.protected_instance_variables = []
-    end
-
-    def default_protected_instance_vars
-      [:@_action_name, :@_response_body, :@_formats, :@_prefixes, :@_config]
+    def self.default_protected_instance_vars
+      super.concat [:@_action_name, :@_response_body, :@_formats, :@_prefixes, :@_config]
     end
 
     # Raw rendering of a template to a string.
@@ -57,10 +52,9 @@ module AbstractController
     # :api: public
     def view_assigns
       hash = {}
-      variables  = instance_variables
-      variables -= protected_instance_variables
-      variables -= default_protected_instance_vars
-      variables.each { |name| hash[name[1..-1]] = instance_variable_get(name) }
+      (instance_variables - self.class.default_protected_instance_vars).each do |name|
+        hash[name[1..-1]] = instance_variable_get(name)
+      end
       hash
     end
 

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -261,11 +261,12 @@ module ActionController
       include mod
     end
 
-    # Define some internal variables that should not be propagated to the view.
-    self.protected_instance_variables = [
-      :@_status, :@_headers, :@_params, :@_env, :@_response, :@_request,
-      :@_view_runtime, :@_stream, :@_url_options, :@_action_has_layout
-    ]
+    def self.default_protected_instance_vars
+      super.concat [
+        :@_status, :@_headers, :@_params, :@_env, :@_response, :@_request,
+        :@_view_runtime, :@_stream, :@_url_options, :@_action_has_layout
+      ]
+    end
 
     ActiveSupport.run_load_hooks(:action_controller, self)
   end

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -17,7 +17,7 @@ class ActionController::Base
   def assigns(key = nil)
     assigns = {}
     instance_variables.each do |ivar|
-      next if ActionController::Base.protected_instance_variables.include?(ivar)
+      next if ActionController::Base.default_protected_instance_vars.include?(ivar)
       assigns[ivar[1..-1]] = instance_variable_get(ivar)
     end
 


### PR DESCRIPTION
One of few small, unfinished things. Only `ActionView` stuff was using method approach, with this PR all stuff got ported to it.
