### PR TITLE
Fix ImplicitRendering for BasicRendering

### DIFF
--- a/actionpack/lib/abstract_controller.rb
+++ b/actionpack/lib/abstract_controller.rb
@@ -11,6 +11,7 @@ module AbstractController
   autoload :Callbacks
   autoload :Collector
   autoload :DoubleRenderError, "abstract_controller/rendering"
+  autoload :Errors
   autoload :Helpers
   autoload :Logger
   autoload :Rendering

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -5,12 +5,6 @@ require 'active_support/descendants_tracker'
 require 'active_support/core_ext/module/anonymous'
 
 module AbstractController
-  class Error < StandardError #:nodoc:
-  end
-
-  class ActionNotFound < StandardError #:nodoc:
-  end
-
   # <tt>AbstractController::Base</tt> is a low-level API. Nobody should be
   # using it directly, and subclasses (like ActionController::Base) are
   # expected to provide their own +render+ method, since rendering means

--- a/actionpack/lib/abstract_controller/errors.rb
+++ b/actionpack/lib/abstract_controller/errors.rb
@@ -1,0 +1,27 @@
+module AbstractController
+  class AbstractControllerError < StandardError #:nodoc:
+  end
+
+  class ActionNotFound < AbstractControllerError #:nodoc:
+  end
+
+  class DoubleRenderError < AbstractControllerError #:nondoc:
+    DEFAULT_MESSAGE = "Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like \"redirect_to(...) and return\"."
+
+    def initialize(message = nil)
+      super(message || DEFAULT_MESSAGE)
+    end
+  end
+
+  class UnsupportedOperationError < AbstractControllerError #:nodoc:
+    def initialize
+      super "Unsupported render operation. BasicRendering supports only :text and :nothing options. If you would like to use templates and layouts, you need to include ActionView gem."
+    end
+  end
+
+  class NoRenderError < AbstractControllerError #:nodoc:
+    def initialize
+      super "BasicRendering requires controller action to invoke `render` method explicitly, with :text or :nothing option. If you would like to use templates and layouts, you need to include ActionView gem."
+    end
+  end
+end

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -64,6 +64,14 @@ module AbstractController
       hash
     end
 
+    # Flag if ImplicitRender should be called
+    # By default `BasicRendering` is used so we force user to
+    # render explicitly
+    # :api: private
+    def implicit_render?
+      false
+    end
+
     # Normalize args by converting render "foo" to render :action => "foo" and
     # render "foo/bar" to render :file => "foo/bar".
     # :api: plugin

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -2,14 +2,6 @@ require 'active_support/concern'
 require 'active_support/core_ext/class/attribute'
 
 module AbstractController
-  class DoubleRenderError < Error
-    DEFAULT_MESSAGE = "Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like \"redirect_to(...) and return\"."
-
-    def initialize(message = nil)
-      super(message || DEFAULT_MESSAGE)
-    end
-  end
-
   module Rendering
     extend ActiveSupport::Concern
 

--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -1,3 +1,5 @@
+require 'abstract_controller/errors'
+
 module ActionController
   module ImplicitRender
     def send_action(method, *args)
@@ -6,7 +8,7 @@ module ActionController
         if implicit_render?
           default_render
         elsif
-          raise ActionController::BasicRendering::NoRenderError
+          raise ::AbstractController::NoRenderError
         end
       end
       ret

--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -2,7 +2,13 @@ module ActionController
   module ImplicitRender
     def send_action(method, *args)
       ret = super
-      default_render unless performed?
+      unless performed?
+        if implicit_render?
+          default_render
+        elsif
+          raise ActionController::BasicRendering::NoRenderError
+        end
+      end
       ret
     end
 

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -1,5 +1,5 @@
 module ActionController
-  class RedirectBackError < AbstractController::Error #:nodoc:
+  class RedirectBackError < AbstractController::AbstractControllerError #:nodoc:
     DEFAULT_MESSAGE = 'No HTTP_REFERER was set in the request to this action, so redirect_to :back could not be called successfully. If this is a test, make sure to specify request.env["HTTP_REFERER"].'
 
     def initialize(message = nil)

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -29,6 +29,12 @@ module ActionController
         super "Unsupported render operation. BasicRendering supports only :text and :nothing options. For more, you need to include ActionView."
       end
     end
+
+    class NoRenderError < StandardError
+      def initialize
+        super "BasicRendering requires controller action to invoke `render` method explicitly, with :text or :nothing option. For more, you need to include ActionView."
+      end
+    end
   end
 
   module Rendering
@@ -43,7 +49,7 @@ module ActionController
     # Check for double render errors and set the content_type after rendering.
     def render(*args) #:nodoc:
       raise ::AbstractController::DoubleRenderError if self.response_body
-      super
+      super(*args)
       self.content_type ||= rendered_format.to_s
       self.response_body
     end

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -1,3 +1,5 @@
+require 'abstract_controller/errors'
+
 module ActionController
   # Basic rendering implements the most minimal rendering layer.
   # It only supports rendering :text and :nothing. Passing any other option will
@@ -16,24 +18,12 @@ module ActionController
       elsif opts.has_key?(:nothing) && opts[:nothing]
         self.response_body = " "
       else
-        raise UnsupportedOperationError
+        raise ::AbstractController::UnsupportedOperationError
       end
     end
 
     def rendered_format
       Mime::TEXT
-    end
-
-    class UnsupportedOperationError < StandardError
-      def initialize
-        super "Unsupported render operation. BasicRendering supports only :text and :nothing options. For more, you need to include ActionView."
-      end
-    end
-
-    class NoRenderError < StandardError
-      def initialize
-        super "BasicRendering requires controller action to invoke `render` method explicitly, with :text or :nothing option. For more, you need to include ActionView."
-      end
     end
   end
 

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -109,6 +109,10 @@ module ActionView
       Mime[lookup_context.rendered_format]
     end
 
+    def implicit_render?
+      true
+    end
+
     def default_protected_instance_vars
       super.concat([:@_view_context_class, :@_view_renderer, :@_lookup_context])
     end


### PR DESCRIPTION
When using `BasicRendering` you're obligated to invoke render explicitly in action method.

Before that fix, if you had controller like this:

```
class PagesController < ApplicationController
  def index
  end
end
```

following error was raised:

```
NoMethodError in PagesController#index

undefined method `has_key?' for nil:NilClass
```

After this change user will be instructed what to do with clear message:

```
ActionController::BasicRendering::NoRenderError in PagesController#index

BasicRendering requires controller action to invoke `render` method explicitly,
with :text or :nothing option. For more, you need to include ActionView.
```
