### PR TITLE
Implement a queue with namespacing support.

### DIFF
--- a/activesupport/lib/active_support/queueing.rb
+++ b/activesupport/lib/active_support/queueing.rb
@@ -2,6 +2,27 @@ require 'delegate'
 require 'thread'
 
 module ActiveSupport
+  # A queue wrapper that implements the ability to namespace
+  # multiple queues while adhering to the standard queue
+  # interface.
+  #
+  # The queue inherits from STDLIB's Hash. When
+  # initializing, the argument passed will be the default
+  # queue.
+  class MultiQueue < Hash
+    def self.default
+      self.new(ActiveSupport::Queue.new)
+    end
+
+    def method_missing(*args, &block)
+      default.send(*args, &block)
+    end
+
+    def respond_to? method
+      Hash.new.respond_to?(method) || default.respond_to?(method)
+    end
+  end
+
   # A Queue that simply inherits from STDLIB's Queue. When this
   # queue is used, Rails automatically starts a job runner in a
   # background thread.

--- a/activesupport/test/queueing/multi_queue_test.rb
+++ b/activesupport/test/queueing/multi_queue_test.rb
@@ -1,0 +1,156 @@
+require 'abstract_unit'
+require 'active_support/queueing'
+
+class MultiQueueTest < ActiveSupport::TestCase
+  include ActiveSupport
+
+  def test_initialization_argument_is_default
+    queue = new_queue
+    assert_nil queue.default
+
+    testQueue = TestQueue.new
+    queue = new_queue(testQueue)
+    assert_equal testQueue, queue.default
+
+    syncQueue = SynchronousQueue.new
+    queue = new_queue syncQueue
+    assert_equal syncQueue, queue.default
+
+    assert_equal queue.default, queue[:default]
+  end
+
+  def test_namespacing_queues
+    queue = new_queue
+
+    syncQueue = SynchronousQueue.new
+    queue[:mail] = syncQueue
+    assert_equal queue[:mail], syncQueue
+
+    testQueue = TestQueue.new
+    queue[:test] = testQueue
+    assert_equal queue[:test], testQueue
+
+    assert_nil queue.default
+  end
+
+  def test_passing_block_to_initialize_uses_custom_default
+    stdQueue = ActiveSupport::Queue.new
+    syncQueue = SynchronousQueue.new
+    queue = new_queue do |hash, key|
+      key.to_s.include?("mail") ? stdQueue : syncQueue
+    end
+
+    assert_equal stdQueue, queue[:mailer]
+    assert_equal stdQueue, queue[:mail]
+    assert_equal stdQueue, queue["mail-jobs"]
+
+    assert_equal syncQueue, queue[:test]
+    assert_equal syncQueue, queue[:mal]
+    assert_equal syncQueue, queue["awesome-jobs"]
+
+    assert_nil queue.default
+  end
+
+  def test_sending_methods_get_passed_to_default
+    mock = MockQueue.new
+    queue = new_queue mock
+
+    assert_throws :error do
+      queue.push
+    end
+
+    assert_throws :block do
+      queue.run_block { throw :block }
+    end
+
+    assert_throws :argument_given do
+      queue.run_block "arg" do
+        throw :block
+      end
+    end
+  end
+
+  def test_multi_queue_allows_hash_methods
+    queue = new_queue MockQueue.new
+    queue[:sync] = SynchronousQueue.new
+
+    assert_equal queue.default.member?, "answer"
+    assert_equal queue.member?(:sync), true
+  end
+
+  def test_setting_default_after_initialization
+    queue = new_queue
+    assert_nil queue.default
+
+    testQueue = TestQueue.new
+    queue.default = testQueue
+    assert_equal testQueue, queue.default
+    assert_equal testQueue, queue[:random]
+  end
+
+  def test_jobs_are_ran
+    ran = false
+    job = Job.new { ran = true }
+
+    queue = MultiQueue.default
+    queue.push job
+    queue.drain
+
+    assert_equal true, ran
+  end
+
+  def test_jobs_are_not_executed_syncronously_with_default_queue
+    run, ran = MultiQueue.default, MultiQueue.default
+    job = Job.new { ran.push run.pop }
+
+    queue = MultiQueue.default
+    queue.consumer.start
+    queue.push job
+    assert ran.empty?
+
+    run.push true
+    assert_equal true, ran.pop
+  end
+
+  def test_mulit_queue_static_default
+    queue = MultiQueue.default
+    assert MultiQueue === queue
+    assert ActiveSupport::Queue === queue.default
+  end
+
+  private
+    class Job
+      attr_reader :id
+      def initialize(id = 1, &block)
+        @id = id
+        @block = block
+      end
+
+      def run
+        @block.call if @block
+      end
+    end
+
+    def new_queue *args, &block
+      if block_given?
+        MultiQueue.new(*args, &block)
+      else
+        MultiQueue.new(*args, &block)
+      end
+    end
+
+    class MockQueue
+      def push
+        throw :error
+      end
+
+      def run_block *args, &block
+        throw :argument_given unless args.empty?
+        block.call()
+      end
+
+      def member?
+        "answer"
+      end
+    end
+end

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -56,6 +56,10 @@ module Rails
       application.queue
     end
 
+    def queue= newQueue
+      application.queue = newQueue
+    end
+
     def backtrace_cleaner
       @backtrace_cleaner ||= begin
         # Relies on Active Support, so we have to lazy load to postpone definition until AS has been loaded

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -100,7 +100,6 @@ module Rails
     attr_accessor :assets, :sandbox, :queue_consumer
     alias_method :sandbox?, :sandbox
     attr_reader :reloaders
-    attr_writer :queue
 
     delegate :default_url_options, :default_url_options=, to: :routes
 
@@ -272,8 +271,12 @@ module Rails
       @config ||= Application::Configuration.new(find_root_with_flag("config.ru", Dir.pwd))
     end
 
+    def queue= newQueue
+      queue.default = newQueue
+    end
+
     def queue #:nodoc:
-      @queue ||= config.queue || ActiveSupport::Queue.new
+      @queue ||= config.queue || ActiveSupport::MultiQueue.default
     end
 
     def config=(configuration) #:nodoc:

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -13,10 +13,10 @@ module Rails
                     :railties_order, :relative_url_root, :secret_key_base, :secret_token,
                     :serve_static_assets, :ssl_options, :static_cache_control, :session_options,
                     :time_zone, :reload_classes_only_on_change,
-                    :queue, :queue_consumer, :beginning_of_week, :filter_redirect
+                    :queue_consumer, :beginning_of_week, :filter_redirect
 
       attr_writer :log_level
-      attr_reader :encoding
+      attr_reader :encoding, :queue
 
       def initialize(*)
         super
@@ -45,7 +45,7 @@ module Rails
         @exceptions_app                = nil
         @autoflush_log                 = true
         @log_formatter                 = ActiveSupport::Logger::SimpleFormatter.new
-        @queue                         = ActiveSupport::SynchronousQueue.new
+        @queue                         = ActiveSupport::MultiQueue.default
         @queue_consumer                = nil
         @eager_load                    = nil
         @secret_token                  = nil
@@ -143,6 +143,9 @@ module Rails
         end
       end
 
+      def queue= queue
+        @queue.default = queue
+      end
     end
   end
 end

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -110,7 +110,7 @@ module Rails
       end
 
       initializer :activate_queue_consumer do |app|
-        if config.queue.class == ActiveSupport::Queue
+        if config.queue.respond_to?(:default) && config.queue.default.instance_of?(ActiveSupport::Queue)
           app.queue_consumer = config.queue_consumer || config.queue.consumer
           app.queue_consumer.logger ||= Rails.logger if app.queue_consumer.respond_to?(:logger=)
           app.queue_consumer.start

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -30,4 +30,7 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
   <%- end -%>
+
+  # Use the synchronous queue to run jobs immediately.
+  # config.queue = ActiveSupport::SynchronousQueue.new
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -671,5 +671,27 @@ module ApplicationTests
         end
       end
     end
+
+    test "config.queue= sets the default queue to the argument given" do
+      add_to_config <<-RUBY
+        config.queue = ActiveSupport::SynchronousQueue.new
+      RUBY
+
+      require "#{app_path}/config/environment"
+
+      assert Rails.queue.instance_of?(ActiveSupport::MultiQueue)
+      assert Rails.queue.default.instance_of?(ActiveSupport::SynchronousQueue)
+    end
+
+    test "Rails.queue= sets the default queue to the argument given" do
+      add_to_config <<-RUBY
+        Rails.queue = ActiveSupport::SynchronousQueue.new
+      RUBY
+
+      require "#{app_path}/config/environment"
+
+      assert Rails.queue.instance_of?(ActiveSupport::MultiQueue)
+      assert Rails.queue.default.instance_of?(ActiveSupport::SynchronousQueue)
+    end
   end
 end


### PR DESCRIPTION
This pull request alters the Rails.queue interface to mimic the previously implemented queue with support for namespacing. This is done using `MultiQueue`, a subclass of `Hash`. `method_missing` is then defined to pass all missing method calls to the default queue. Essentially, you can then call `Rails.queue.push` and other queue-specific methods, which is the same as calling `Rails.queue.default.push`.

If you want to namespace your queues, you can set `Rails.queue[:mailer]=...` and access it through `Rails.queue[:mailer]`.

`Rails.queue=`, `Rails.application.queue=`, and `confiq.queue=` are all aliased to set the method argument as `Rails.queue.default`.

If you _really_ want to override the wrapper at `Rails.queue`, you'd have to call `Rails.instance_variable_set(:@queue, arg)`. 

Since `MultiQueue` inherits from `Hash`, you can also define [default_proc](http://www.ruby-doc.org/core-2.0/Hash.html#method-i-default_proc-3D) and implement dynamic namespacing.
