### PR TITLE
Enable number_to_percentage to keep the number's precision by allowing :precision option value to be nil

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -184,4 +184,9 @@
 
     *Daniel Schierbeck*
 
+*   Enable number_to_percentage to keep the number's precision by allowing :precision to be nil
+    
+
+    *Jack Xu*
+
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -79,6 +79,10 @@ module ActiveSupport
           assert_equal("123.4%", number_helper.number_to_percentage(123.400, :precision => 3, :strip_insignificant_zeros => true))
           assert_equal("1.000,000%", number_helper.number_to_percentage(1000, :delimiter => '.', :separator => ','))
           assert_equal("1000.000  %", number_helper.number_to_percentage(1000, :format => "%n  %"))
+          assert_equal("1000%", number_helper.number_to_percentage(1000, precision: nil))
+          assert_equal("1000%", number_helper.number_to_percentage(1000, precision: nil))
+          assert_equal("1000.1%", number_helper.number_to_percentage(1000.1, precision: nil))
+          assert_equal("-0.13 %", number_helper.number_to_percentage("-0.13", precision: nil, :format => "%n %"))
         end
       end
 


### PR DESCRIPTION
When converting numbers to percentage using number_to_percentage helper method, it is sometimes necessary to keep the numbers’ precision as is, without having to set an arbitrary precision value.

for example, we have an array of numbers, and I would like to keep their precision so that

``` ruby
numbers = [1000, 0.12, 43.1]
numbers.map {|x| number_to_percentage(x, precision: nil)}  # =>  ['1000%', '0.12%', '43.1%']
```
