### PR TITLE
Hash#deep_merge does not yield block for false boolean value.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add proper check for value presence in Hash#deep_merge! when yielding a block.
+
+    Fixes #12072.
+
+    *Samuel Molnár*
+
 *   Ensure that autoloaded constants in all-caps nestings are marked as
     autoloaded.
 

--- a/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
@@ -19,7 +19,7 @@ class Hash
       if tv.is_a?(Hash) && v.is_a?(Hash)
         self[k] = tv.deep_merge(v, &block)
       else
-        self[k] = block && tv ? block.call(k, tv, v) : v
+        self[k] = block && !tv.nil? ? block.call(k, tv, v) : v
       end
     end
     self

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -656,6 +656,18 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal expected, hash_1
   end
 
+  def test_deep_merge_with_block_for_boolean_values
+    hash_1 = { :c => { :c1 => false, :c2 => false } }
+    hash_2 = { :c => { :c1 => true } }
+
+    expected = { :c => { :c1 => [:c1, false, true], :c2 => false } }
+
+    assert_equal(expected, hash_1.deep_merge(hash_2) { |k, o, n| [k, o, n] })
+
+    hash_1.deep_merge!(hash_2) { |k, o, n| [k, o, n] }
+    assert_equal expected, hash_1
+  end
+
   def test_deep_merge_on_indifferent_access
     hash_1 = HashWithIndifferentAccess.new({ :a => "a", :b => "b", :c => { :c1 => "c1", :c2 => "c2", :c3 => { :d1 => "d1" } } })
     hash_2 = HashWithIndifferentAccess.new({ :a => 1, :c => { :c1 => 2, :c3 => { :d2 => "d2" } } })


### PR DESCRIPTION
When applying deep_merge with block on Hash with _false_ keys, the block does not get yielded.

https://github.com/rails/rails/blob/ef5d85709d346e55827e88f53430a2cbe1e5fb9e/activesupport/lib/active_support/core_ext/hash/deep_merge.rb#L22

The value `tv` should be properly checked for nil, e.g. `!tv.nil?`.

Failing test:

``` ruby
  def test_deep_merge_with_block_for_boolean_values
    hash_1 = { c: { c1: false, c2: false } }
    hash_2 = { c: { c1: true } }

    expected = { c: { c1: [:c1, false, true], c2: false } } 

    assert_equal(expected, hash_1.deep_merge(hash_2) { |key, old, n| [key, old, n] })

    hash_1.deep_merge!(hash_2) { |key, old, n| [key, old, n] }
    assert_equal expected, hash_1
  end
```

Test output:

```
--- expected
+++ actual
@@ -1 +1 @@
-{:c=>{:c1=>[:c1, false, true], :c2=>false}}
+{:c=>{:c1=>true, :c2=>false}}
```
