### PR TITLE
Encourage practice of storing secret_key_base in env variable for security

### DIFF
--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Expect secret_key_base via ENV['SECRET_TOKEN'].
+
+    *Gary S. Weaver*
+
 *   Removed repetitive th tags. Instead of them added one th tag with a colspan attribute.
 
     *Sıtkı Bağdat*

--- a/guides/code/getting_started/config/initializers/secret_token.rb
+++ b/guides/code/getting_started/config/initializers/secret_token.rb
@@ -1,12 +1,19 @@
-# Be sure to restart your server when you modify this file.
+# Be sure to restart your server if you modify the value of secret_key_base.
 
-# Your secret key for verifying the integrity of signed cookies.
+# Your secret key is used for verifying the integrity of signed cookies.
 # If you change this key, all old signed cookies will become invalid!
 
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-# You can use `rake secret` to generate a secure secret key.
+# Make sure the secret is at least 30 characters and all random, no regular
+# words or you'll be exposed to dictionary attacks.
 
-# Make sure your secret_key_base is kept private
-# if you're sharing your code publicly.
-Blog::Application.config.secret_key_base = 'e8aab50cec8a06a75694111a4cbaf6e22fc288ccbc6b268683aae7273043c69b15ca07d10c92a788dd6077a54762cbfcc55f19c3459f7531221b3169f8171a53'
+# You may use `rake secret` to generate a secure secret key, then set that
+# value in the 'SECRET_TOKEN' environment variable, or set the value of
+# Rails.application.config.secret_key_base below below to the secret string.
+
+# Make sure your secret_key_base is kept private!
+
+raise "You must set a secret token in the 'SECRET_TOKEN' environment "\
+  "variable or "\
+  "in config/initializers/secret_token.rb" if ENV['SECRET_TOKEN'].blank?
+
+Rails.application.config.secret_key_base = ENV['SECRET_TOKEN']

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   New applications expect secret_key_base via ENV['SECRET_TOKEN'].
+
+    *Gary S. Weaver*
+
 *   rake notes now searches *.less files
 
     *Josh Crowder*

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -278,10 +278,6 @@ module Rails
         end
       end
 
-      def app_secret
-        SecureRandom.hex(64)
-      end
-
       def mysql_socket
         @mysql_socket ||= [
           "/tmp/mysql.sock",                        # default

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/secret_token.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/secret_token.rb.tt
@@ -1,12 +1,19 @@
-# Be sure to restart your server when you modify this file.
+# Be sure to restart your server if you modify the value of secret_key_base.
 
 # Your secret key is used for verifying the integrity of signed cookies.
 # If you change this key, all old signed cookies will become invalid!
 
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-# You can use `rake secret` to generate a secure secret key.
+# Make sure the secret is at least 30 characters and all random, no regular
+# words or you'll be exposed to dictionary attacks.
 
-# Make sure your secret_key_base is kept private
-# if you're sharing your code publicly.
-Rails.application.config.secret_key_base = '<%= app_secret %>'
+# You may use `rake secret` to generate a secure secret key, then set that
+# value in the 'SECRET_TOKEN' environment variable, or set the value of
+# Rails.application.config.secret_key_base below below to the secret string.
+
+# Make sure your secret_key_base is kept private!
+
+raise "You must set a secret token in the 'SECRET_TOKEN' environment "\
+  "variable or "\
+  "in config/initializers/secret_token.rb" if ENV['SECRET_TOKEN'].blank?
+
+Rails.application.config.secret_key_base = ENV['SECRET_TOKEN']


### PR DESCRIPTION
It's time to start encouraging people store the app secret in an environment variable. It's in the guide, and the guide app even had a hardcoded value. Let's fix that.
