### PR TITLE
Update mapper documenation for match helper [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -362,8 +362,9 @@ module ActionDispatch
         #   # Yes, controller actions are just rack endpoints
         #   match 'photos/:id', to: PhotosController.action(:show)
         #
-        # Because request various HTTP verbs with a single action has security
-        # implications, is recommendable use HttpHelpers[rdoc-ref:HttpHelpers]
+        # Because requesting various HTTP verbs with a single action has security
+        # implications, you must either specify the actions in
+        # the via options or use one of the HtttpHelpers[rdoc-ref:HttpHelpers]
         # instead +match+
         #
         # === Options


### PR DESCRIPTION
This piece of documentation is out of date.
The use of match without any via option is prevented in rails 4,
the HTTP verbs have to be explicitly set. If they're not set then
the error message in normalize_conditions! (around line 186) is
shown.

(As a side note, this is my first pull request to rails. I think I'm following 
the format for PR's, but if there's something else I should be doing please 
let me know.)
