### PR TITLE
use AR-JDBC (>=) 1.3.0 with AR 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,11 +58,11 @@ end
 
 platforms :jruby do
   gem 'json'
-  gem 'activerecord-jdbcsqlite3-adapter', '>= 1.2.7'
+  gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0'
 
   group :db do
-    gem 'activerecord-jdbcmysql-adapter', '>= 1.2.7'
-    gem 'activerecord-jdbcpostgresql-adapter', '>= 1.2.7'
+    gem 'activerecord-jdbcmysql-adapter', '>= 1.3.0'
+    gem 'activerecord-jdbcpostgresql-adapter', '>= 1.3.0'
   end
 end
 


### PR DESCRIPTION
version 1.2.x ain't really compatible with **4.0**
it's probably also a good idea to use 1.3.0 on the _"3-x-stable"_ branches ... 
since it should provide better compatibility with AR 3.x than 1.2.x did

p.s. some related discussion: https://github.com/rails/rails/issues/11595
