### PR TITLE
Fixing repond_with working directly on the options hash #fixes 12029

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fixing repond_with working directly on the options hash
+    This fixes an issue where the respond_with worked directly with the given
+    options hash, so that if a user relied on it after calling respond_with,
+    the hash wouldn't be the same.
+
+    Fixes #12029
+
+    *bluehotdog*
+
 *   Fix `ActionDispatch::RemoteIp::GetIp#calculate_ip` to only check for spoofing
     attacks if both `HTTP_CLIENT_IP` and `HTTP_X_FORWARDED_FOR` are set.
 

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -326,6 +326,7 @@ module ActionController #:nodoc:
 
       if collector = retrieve_collector_from_mimes(&block)
         options = resources.size == 1 ? {} : resources.extract_options!
+        options = options.clone
         options[:default_response] = collector.response
         (options.delete(:responder) || self.class.responder).call(self, resources, options)
       end

--- a/actionpack/test/controller/mime/respond_with_test.rb
+++ b/actionpack/test/controller/mime/respond_with_test.rb
@@ -65,7 +65,17 @@ class RespondWithController < ActionController::Base
     respond_with(resource, :responder => responder)
   end
 
+  def respond_with_additional_params
+    @params = RespondWithController.params
+    respond_with({:result => resource}, @params)
+  end
+
 protected
+  def self.params
+    {
+        :foo => 'bar'
+    }
+  end
 
   def resource
     Customer.new("david", request.delete? ? nil : 13)
@@ -143,6 +153,11 @@ class RespondWithControllerTest < ActionController::TestCase
     Mime::Type.unregister(:iphone)
     Mime::Type.unregister(:touch)
     Mime::Type.unregister(:mobile)
+  end
+
+  def test_respond_with_shouldnt_modify_original_hash
+    get :respond_with_additional_params
+    assert_equal RespondWithController.params, assigns(:params)
   end
 
   def test_using_resource


### PR DESCRIPTION
This fixes an issue where the respond_with worked directly with the given
options hash, so that if a user relied on it after calling respond_with,
the hash wouldn't be the same.

Fixes #12029
