### PR TITLE
Rails 4 Custom Flash Type Undefined After Error

### DIFF
--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -30,7 +30,7 @@ module ActionController #:nodoc:
       # names, and it will be available in your views.
       def add_flash_types(*types)
         types.each do |type|        
-          unless respond_to?(type)
+          unless instance_methods(false).include?(type)
             define_method(type) do
               request.flash[type]
             end

--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -29,15 +29,15 @@ module ActionController #:nodoc:
       # This method will automatically define a new method for each of the given
       # names, and it will be available in your views.
       def add_flash_types(*types)
-        types.each do |type|
-          next if _flash_types.include?(type)
-
-          define_method(type) do
-            request.flash[type]
+        types.each do |type|        
+          unless respond_to?(type)
+            define_method(type) do
+              request.flash[type]
+            end
+            helper_method type
           end
-          helper_method type
 
-          _flash_types << type
+          _flash_types << type unless _flash_types.include?(type)
         end
       end
     end

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -237,6 +237,18 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
       render :inline => "flash: #{flash["that"]}"
     end
 
+    def show_bar
+      render :inline => "bar is: #{bar}"
+    end
+
+    def raise_error
+      raise 'Error'
+    end
+
+    def set_another_bar
+      redirect_to action: 'raise_error', bar: 'foo'
+    end
+
     def set_bar
       flash[:bar] = "for great justice"
       head :ok
@@ -286,6 +298,25 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_equal 'for great justice', @controller.bar
     end
+  end
+
+  class MyController < ActionController::Base
+    
+  end
+
+  def test_added_flash_types_exists_after_error
+    MyController.add_flash_types :bar
+    ctrl1 = MyController.new
+
+    flash_h = {:bar => 'foo'}
+    req = mock
+    req.stubs(:flash).returns(flash_h)
+    ctrl1.stubs(:request).returns(req)
+    ctrl1.flash[:bar] = 'foo'
+    assert_equal 'foo', ctrl1.bar 
+    ctrl2 = MyController.new
+    ctrl2.stubs(:request).returns(req)    
+    ctrl2.bar
   end
 
   private

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -300,23 +300,20 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  class MyController < ActionController::Base
-    
-  end
-
   def test_added_flash_types_exists_after_error
-    MyController.add_flash_types :bar
-    ctrl1 = MyController.new
 
-    flash_h = {:bar => 'foo'}
+    TestController.add_flash_types :bar
+    controller = TestController.new
     req = mock
-    req.stubs(:flash).returns(flash_h)
-    ctrl1.stubs(:request).returns(req)
-    ctrl1.flash[:bar] = 'foo'
-    assert_equal 'foo', ctrl1.bar 
-    ctrl2 = MyController.new
-    ctrl2.stubs(:request).returns(req)    
-    ctrl2.bar
+    req.stubs(:flash).returns({:bar => 'foo'})
+
+    controller.stubs(:request).returns(req)
+    assert_equal 'foo', controller.bar 
+
+    controller = TestController.new
+    controller.stubs(:request).returns(req)
+
+    assert_equal 'foo', controller.bar
   end
 
   private

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -237,18 +237,6 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
       render :inline => "flash: #{flash["that"]}"
     end
 
-    def show_bar
-      render :inline => "bar is: #{bar}"
-    end
-
-    def raise_error
-      raise 'Error'
-    end
-
-    def set_another_bar
-      redirect_to action: 'raise_error', bar: 'foo'
-    end
-
     def set_bar
       flash[:bar] = "for great justice"
       head :ok


### PR DESCRIPTION
A suggested fix to https://github.com/rails/rails/issues/12057

After an error is raised the custom flash methods are unavailable, it seems that they disappear from the scope of from where they were defined.

The class instance variable which holds the name of the custom flash types persists but it does not redefine the method upon a new request (perhaps exceptions clear out the scope of the dynamically inserted methods of a controller?).

The suggested fix checks whether the controller has the new method and if it doesn't it define_method it.

I was not able to reproduce the error in the integration test while imitating a route that raises an exception so I added a unit test.
