### PR TITLE
Fix #11679 - Can't manage cookies in custom errors

### DIFF
--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -33,8 +33,6 @@ module Rails
 
           # Must come after Rack::MethodOverride to properly log overridden methods
           middleware.use ::Rails::Rack::Logger, config.log_tags
-          middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
-          middleware.use ::ActionDispatch::DebugExceptions, app
           middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
 
           unless config.cache_classes
@@ -51,6 +49,9 @@ module Rails
             middleware.use config.session_store, config.session_options
             middleware.use ::ActionDispatch::Flash
           end
+
+          middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
+          middleware.use ::ActionDispatch::DebugExceptions, app
 
           middleware.use ::ActionDispatch::ParamsParser
           middleware.use ::Rack::Head


### PR DESCRIPTION
Changed the order of middleware stacks, moved the
show exceptions middleware under the cookies and flash middleware
so that custom exception application can change the cookie and flash

_yonbergman_
