### PR TITLE
[Performance] Don't create fibers while merging bind variables

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -107,11 +107,11 @@ module ActiveRecord
         bind_values  = filter_binds(lhs_binds, removed) + rhs_binds
 
         conn = relation.klass.connection
-        bviter = bind_values.each.with_index
+        bv_index = 0
         where_values.map! do |node|
           if Arel::Nodes::Equality === node && Arel::Nodes::BindParam === node.right
-            (column, _), i = bviter.next
-            substitute = conn.substitute_at column, i
+            substitute = conn.substitute_at(bind_values[bv_index].first, bv_index)
+            bv_index += 1
             Arel::Nodes::Equality.new(node.left, substitute)
           else
             node


### PR DESCRIPTION
Master branch has a serious performance regression when including objects for a relation. e.g. `Item.includes(:people)`.

The regression is caused by the use of an enumerator in the relation merger.rb, see https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation/merger.rb#L110

This causes ruby to create many fibers (6309 according to ruby-prof call graph) while iterating, when the same effect could be achieved by changing how the bind_values enumerable is accessed. See pull request.

Here are my test results for my own project

```
Rails 3.2.13
Item.include(:people).limit(1000) #=> 1.049828

Rails 4 4-0-stable
Item.include(:people).limit(1000) #=> 3.609199

Rails 4 master
Item.include(:people).limit(1000) #=> 31.08081

Rails 4 master with optimization (pull request)
Item.include(:people).limit(1000) #=> 2.134169
```

Obviously there is still a performance regression between 3.2.13 and Rails 4.x, but at least this fix brings it back to a reasonable level. I'll look into the remaining performance hit soon.

Use the following gist to test performance on various versions of rails.
https://gist.github.com/njakobsen/6393783
