### PR TITLE
[Perf] Don't use Enumerable#next in pluck since it is very slow

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -161,8 +161,7 @@ module ActiveRecord
         result = result.map do |attributes|
           values = klass.initialize_attributes(attributes).values
 
-          iter = columns.each
-          values.map { |value| iter.next.type_cast value }
+          columns.zip(values).map { |column, value| column.type_cast value }
         end
         columns.one? ? result.map!(&:first) : result
       end


### PR DESCRIPTION
Similar to #12090, using Enumerable#next in the pluck method creates many extra Fibers which drastically affects performance.

Here are some benchmarks

```
Rails master
3.times { Item.pluck(:id) } #=> 2.080483

Rails master with optimization (pull request)
3.times { Item.pluck(:id) } #=> 0.025729
```

Here is a gist to replicate my results.
https://gist.github.com/rywall/6395171
