### PR TITLE
Using indent method to refactor controller generator.

### DIFF
--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -32,18 +32,18 @@ module Rails
           # namespace :foo do
           #   namespace :bar do
           namespace_ladder = class_path.each_with_index.map do |ns, i|
-            %{#{" " * i * 2}namespace :#{ns} do\n  }
+            indent("namespace :#{ns} do\n", i * 2)
           end.join
 
           # Create route
           #     get "baz/index"
-          route = %{#{" " * depth * 2}get "#{file_name}/#{action}"\n}
+          route = indent(%{get "#{file_name}/#{action}"\n}, depth * 2)
 
           # Create `end` ladder
           #   end
           # end
           end_ladder = (1..depth).reverse_each.map do |i|
-            "#{" " * i * 2}end\n"
+            indent("end\n", i * 2)
           end.join
 
           # Combine the 3 parts to generate complete route entry


### PR DESCRIPTION
Small refactor that uses the previously defined `indent` method for making indentations in the controller generator. 

\cc @spastorino
