### PR TITLE
Fix SchemaDumper to emit unknown column types properly for SQLite

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix SchemaDumper to emit unknown column types properly for SQLite
+    Fixes #2708
+
+    *Vipul A M*
+
 *   Fix PredicateBuilder so polymorhic association keys in `where` clause can
     also accept not only `ActiveRecord::Base` direct descendances (decorated
     models, for example).

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -436,7 +436,7 @@ module ActiveRecord
 
       # Adds `:array` option to the default set provided by the
       # AbstractAdapter
-      def prepare_column_options(column, types)
+      def prepare_column_options(column)
         spec = super
         spec[:array] = 'true' if column.respond_to?(:array) && column.array
         spec

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -34,7 +34,6 @@ module ActiveRecord
 
       def initialize(connection)
         @connection = connection
-        @types = @connection.native_database_types
         @version = Migrator::current_version rescue nil
       end
 
@@ -93,72 +92,37 @@ HEADER
         end
       end
 
+    def dump_primary_key(tbl, table, columns)
+      if @connection.respond_to?(:pk_and_sequence_for)
+        pk, _ = @connection.pk_and_sequence_for(table)
+      elsif @connection.respond_to?(:primary_key)
+        pk = @connection.primary_key(table)
+      end
+      tbl.print "  create_table #{remove_prefix_and_suffix(table).inspect}"
+      pkcol = columns.detect { |c| c.name == pk }
+      if pkcol
+        if pk != 'id'
+          tbl.print %Q(, primary_key: "#{pk}")
+        elsif pkcol.sql_type == 'uuid'
+          tbl.print ", id: :uuid"
+        end
+      else
+        tbl.print ", id: false"
+      end
+      tbl.print ", force: true"
+      tbl.puts " do |t|"
+      pk
+    end
+
+
+
       def table(table, stream)
         columns = @connection.columns(table)
         begin
           tbl = StringIO.new
-
-          # first dump primary key column
-          if @connection.respond_to?(:pk_and_sequence_for)
-            pk, _ = @connection.pk_and_sequence_for(table)
-          elsif @connection.respond_to?(:primary_key)
-            pk = @connection.primary_key(table)
-          end
-
-          tbl.print "  create_table #{remove_prefix_and_suffix(table).inspect}"
-          pkcol = columns.detect { |c| c.name == pk }
-          if pkcol
-            if pk != 'id'
-              tbl.print %Q(, primary_key: "#{pk}")
-            elsif pkcol.sql_type == 'uuid'
-              tbl.print ", id: :uuid"
-            end
-          else
-            tbl.print ", id: false"
-          end
-          tbl.print ", force: true"
-          tbl.puts " do |t|"
-
-          # then dump all non-primary key columns
-          column_specs = columns.map do |column|
-            raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
-            next if column.name == pk
-            @connection.column_spec(column, @types)
-          end.compact
-
-          # find all migration keys used in this table
-          keys = @connection.migration_keys
-
-          # figure out the lengths for each column based on above keys
-          lengths = keys.map { |key|
-            column_specs.map { |spec|
-              spec[key] ? spec[key].length + 2 : 0
-            }.max
-          }
-
-          # the string we're going to sprintf our values against, with standardized column widths
-          format_string = lengths.map{ |len| "%-#{len}s" }
-
-          # find the max length for the 'type' column, which is special
-          type_length = column_specs.map{ |column| column[:type].length }.max
-
-          # add column type definition to our format string
-          format_string.unshift "    t.%-#{type_length}s "
-
-          format_string *= ''
-
-          column_specs.each do |colspec|
-            values = keys.zip(lengths).map{ |key, len| colspec.key?(key) ? colspec[key] + ", " : " " * len }
-            values.unshift colspec[:type]
-            tbl.print((format_string % values).gsub(/,\s*$/, ''))
-            tbl.puts
-          end
-
-          tbl.puts "  end"
-          tbl.puts
-
+          pk = dump_primary_key(tbl, table, columns)
+          @connection.dump_columns(tbl, columns, pk)
           indexes(table, tbl)
-
           tbl.rewind
           stream.print tbl.read
         rescue => e

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -388,4 +388,12 @@ class SchemaDumperTest < ActiveRecord::TestCase
     $stdout = original
   end
 
+  if current_adapter?(:SQLite3Adapter)
+    def test_random_type_dump
+      output = standard_dump
+      assert_match %r{create_table "unknown_columns_table"}, output
+      assert_match %r{t\.random_type "random_column"}, output
+    end
+  end
+
 end

--- a/activerecord/test/schema/sqlite_specific_schema.rb
+++ b/activerecord/test/schema/sqlite_specific_schema.rb
@@ -22,4 +22,13 @@ _SQL
     FOREIGN KEY ('fk_id') REFERENCES 'fk_test_has_pk'('id')
   );
 _SQL
+
+  execute "DROP TABLE unknown_columns_table" rescue nil
+  execute <<_SQL
+  CREATE TABLE 'unknown_columns_table' (
+    'bool_column' bool,
+    'random_column' random_type
+  );
+_SQL
+
 end


### PR DESCRIPTION
Fix SchemaDumper to emit unknown column types properly for SQLite

Move Connection specific Dumping logic to ConnectionAdapters

Refactor to stop passing connection values unnecessarily to SchemaDumper methods

Fixes https://github.com/rails/rails/issues/2708
