### PR TITLE
allow to test AR master against AR-JDBC master (with `ENV['AR_JDBC']`)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 script: 'ci/travis.rb'
 before_install:
   - travis_retry gem install bundler
+  - "rvm current | grep 'jruby' && export AR_JDBC=true || echo"
 rvm:
   - 1.9.3
   - 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -62,11 +62,18 @@ end
 
 platforms :jruby do
   gem 'json'
-  gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0'
-
-  group :db do
-    gem 'activerecord-jdbcmysql-adapter', '>= 1.3.0'
-    gem 'activerecord-jdbcpostgresql-adapter', '>= 1.3.0'
+  if ENV['AR_JDBC']
+    gem 'activerecord-jdbcsqlite3-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: 'master'
+    group :db do
+      gem 'activerecord-jdbcmysql-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: 'master'
+      gem 'activerecord-jdbcpostgresql-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: 'master'
+    end
+  else
+    gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0'
+    group :db do
+      gem 'activerecord-jdbcmysql-adapter', '>= 1.3.0'
+      gem 'activerecord-jdbcpostgresql-adapter', '>= 1.3.0'
+    end
   end
 end
 


### PR DESCRIPTION
Allows for those few running tests under JRuby to run them against latest AR-JDBC (master).
While at the same time does not force MRI people to download a git repository with the bundle.
Some related discussion happened at PR #12095
