### PR TITLE
Revert default protected instance vars

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -373,6 +373,8 @@ module ActionMailer
     include AbstractController::AssetPaths
     include AbstractController::Callbacks
 
+    self.protected_instance_variables = [:@_action_has_layout]
+
     helper ActionMailer::MailHelper
 
     private_class_method :new #:nodoc:
@@ -384,10 +386,6 @@ module ActionMailer
       content_type: "text/plain",
       parts_order:  [ "text/plain", "text/enriched", "text/html" ]
     }.freeze
-
-    def self.default_protected_instance_vars
-      super.concat [:@_action_has_layout]
-    end
 
     class << self
       # Register one or more Observers which will be notified when mail is delivered.

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -114,11 +114,6 @@ module AbstractController
       end
     end
 
-    # Define some internal variables that should not be propagated to the view.
-    def self.default_protected_instance_vars
-      []
-    end
-
     abstract!
 
     # Calls the action going through the entire action dispatch stack.

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -18,10 +18,6 @@ module AbstractController
       self.protected_instance_variables = []
     end
 
-    def default_protected_instance_vars
-      [:@_action_name, :@_response_body, :@_formats, :@_prefixes, :@_config]
-    end
-
     # Raw rendering of a template to a string.
     #
     # It is similar to render, except that it does not
@@ -52,6 +48,11 @@ module AbstractController
     def rendered_format
     end
 
+    DEFAULT_PROTECTED_INSTANCE_VARIABLES = %w(
+      @_action_name @_response_body @_formats @_prefixes @_config
+      @_view_context_class @_view_renderer @_lookup_context
+    )
+
     # This method should return a hash with assigns.
     # You can overwrite this configuration per controller.
     # :api: public
@@ -59,7 +60,7 @@ module AbstractController
       hash = {}
       variables  = instance_variables
       variables -= protected_instance_variables
-      variables -= default_protected_instance_vars
+      variables -= DEFAULT_PROTECTED_INSTANCE_VARIABLES
       variables.each { |name| hash[name[1..-1]] = instance_variable_get(name) }
       hash
     end

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -13,8 +13,13 @@ module AbstractController
   module Rendering
     extend ActiveSupport::Concern
 
-    def self.default_protected_instance_vars
-      super.concat [:@_action_name, :@_response_body, :@_formats, :@_prefixes, :@_config]
+    included do
+      class_attribute :protected_instance_variables
+      self.protected_instance_variables = []
+    end
+
+    def default_protected_instance_vars
+      [:@_action_name, :@_response_body, :@_formats, :@_prefixes, :@_config]
     end
 
     # Raw rendering of a template to a string.
@@ -52,9 +57,10 @@ module AbstractController
     # :api: public
     def view_assigns
       hash = {}
-      (instance_variables - self.class.default_protected_instance_vars).each do |name|
-        hash[name[1..-1]] = instance_variable_get(name)
-      end
+      variables  = instance_variables
+      variables -= protected_instance_variables
+      variables -= default_protected_instance_vars
+      variables.each { |name| hash[name[1..-1]] = instance_variable_get(name) }
       hash
     end
 

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -261,12 +261,11 @@ module ActionController
       include mod
     end
 
-    def self.default_protected_instance_vars
-      super.concat [
-        :@_status, :@_headers, :@_params, :@_env, :@_response, :@_request,
-        :@_view_runtime, :@_stream, :@_url_options, :@_action_has_layout
-      ]
-    end
+    # Define some internal variables that should not be propagated to the view.
+    self.protected_instance_variables = [
+      :@_status, :@_headers, :@_params, :@_env, :@_response, :@_request,
+      :@_view_runtime, :@_stream, :@_url_options, :@_action_has_layout
+    ]
 
     ActiveSupport.run_load_hooks(:action_controller, self)
   end

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -17,7 +17,7 @@ class ActionController::Base
   def assigns(key = nil)
     assigns = {}
     instance_variables.each do |ivar|
-      next if ActionController::Base.default_protected_instance_vars.include?(ivar)
+      next if ActionController::Base.protected_instance_variables.include?(ivar)
       assigns[ivar[1..-1]] = instance_variable_get(ivar)
     end
 

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -109,10 +109,6 @@ module ActionView
       Mime[lookup_context.rendered_format]
     end
 
-    def default_protected_instance_vars
-      super.concat([:@_view_context_class, :@_view_renderer, :@_lookup_context])
-    end
-
     private
 
       # Normalize args and options.


### PR DESCRIPTION
It wasn't good idea and after discussing it with @josevalim we've decided that it would be better to revert this back to previous solution with instance variable instead of calling methods. It was more expensive (calling super & array concatenation) without much value added.
