### PR TITLE
form_for - fix :namespace and :as options clash

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix `form_for` when both `namespace` and `as` options are present
+
+    `as` option no longer overwrites `namespace` option when generating
+    html id attribute of the form element
+
+    *Adam Niedzielski*
+
 *   Only cache template digests if `config.cache_template_loading` id true.
 
     *Josh Lauer*, *Justin Ridgewell*

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -442,10 +442,11 @@ module ActionView
         object = convert_to_model(object)
 
         as = options[:as]
+        namespace = options[:namespace]
         action, method = object.respond_to?(:persisted?) && object.persisted? ? [:edit, :patch] : [:new, :post]
         options[:html].reverse_merge!(
           class:  as ? "#{action}_#{as}" : dom_class(object, action),
-          id:     as ? "#{action}_#{as}" : [options[:namespace], dom_id(object, action)].compact.join("_").presence,
+          id:     (as ? [namespace, action, as] : [namespace, dom_id(object, action)]).compact.join("_").presence,
           method: method
         )
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1681,6 +1681,18 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_for_with_namespace_and_as_option
+    form_for(@post, namespace: 'namespace', as: 'custom_name') do |f|
+      concat f.text_field(:title)
+    end
+
+    expected = whole_form('/posts/123', 'namespace_edit_custom_name', 'edit_custom_name', method: 'patch') do
+      "<input id='namespace_custom_name_title' name='custom_name[title]' type='text' value='Hello World' />"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_two_form_for_with_namespace
     form_for(@post, namespace: 'namespace_1') do |f|
       concat f.label(:title)


### PR DESCRIPTION
:as option should not overwrite :namespace option when
generating html id attribute of the form element. id should be prefixed
by specified namespace even if :as option is present

Add test case showing the issue and code fixing it
