### PR TITLE
Move glue methods & BasicRendering to AbstractController

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -50,6 +50,7 @@ module AbstractController
     # Return Content-Type of rendered content
     # :api: public
     def rendered_format
+      Mime::TEXT
     end
 
     DEFAULT_PROTECTED_INSTANCE_VARIABLES = %w(

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -18,6 +18,12 @@ module AbstractController
       self.protected_instance_variables = []
     end
 
+    # Normalize arguments, options and then delegates render_to_body and
+    # sticks the result in self.response_body.
+    # :api: public
+    def render(*args, &block)
+    end
+
     # Raw rendering of a template to a string.
     #
     # It is similar to render, except that it does not
@@ -30,17 +36,15 @@ module AbstractController
     # overridden in order to still return a string.
     # :api: plugin
     def render_to_string(*args, &block)
+      options = _normalize_render(*args, &block)
+      render_to_body(options)
     end
 
     # Raw rendering of a template.
-    # :api: plugin
-    def render_to_body(options = {})
-    end
-
-    # Normalize arguments, options and then delegates render_to_body and
-    # sticks the result in self.response_body.
     # :api: public
-    def render(*args, &block)
+    def render_to_body(options = {})
+      _process_options(options)
+      _render_template(options)
     end
 
     # Return Content-Type of rendered content
@@ -81,6 +85,14 @@ module AbstractController
     # Process extra options.
     # :api: plugin
     def _process_options(options)
+      options
+    end
+
+    # Normalize args and options.
+    # :api: private
+    def _normalize_render(*args, &block)
+      options = _normalize_args(*args, &block)
+      _normalize_options(options)
       options
     end
   end

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -97,4 +97,32 @@ module AbstractController
       options
     end
   end
+
+  # Basic rendering implements the most minimal rendering layer.
+  # It only supports rendering :text and :nothing. Passing any other option will
+  # result in `UnsupportedOperationError` exception. For more functionality like
+  # different formats, layouts etc. you should use `ActionView` gem.
+  module BasicRendering
+    extend ActiveSupport::Concern
+
+    # Render text or nothing (empty string) to response_body
+    # :api: public
+    def render(*args, &block)
+      super(*args, &block)
+      opts = args.first
+      if opts.has_key?(:text) && opts[:text].present?
+        self.response_body = opts[:text]
+      elsif opts.has_key?(:nothing) && opts[:nothing]
+        self.response_body = " "
+      else
+        raise UnsupportedOperationError
+      end
+    end
+
+    class UnsupportedOperationError < StandardError
+      def initialize
+        super "Unsupported render operation. BasicRendering supports only :text and :nothing options. For more, you need to include ActionView."
+      end
+    end
+  end
 end

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -14,7 +14,7 @@ module ActionController
   #
   metal = Class.new(Metal) do
     include AbstractController::Rendering
-    include ActionController::BasicRendering
+    include AbstractController::BasicRendering
   end
 
   # Action Controllers are the core of a web request in \Rails. They are made up of one or more actions that are executed

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -1,32 +1,4 @@
 module ActionController
-  # Basic rendering implements the most minimal rendering layer.
-  # It only supports rendering :text and :nothing. Passing any other option will
-  # result in `UnsupportedOperationError` exception. For more functionality like
-  # different formats, layouts etc. you should use `ActionView` gem.
-  module BasicRendering
-    extend ActiveSupport::Concern
-
-    # Render text or nothing (empty string) to response_body
-    # :api: public
-    def render(*args, &block)
-      super(*args, &block)
-      opts = args.first
-      if opts.has_key?(:text) && opts[:text].present?
-        self.response_body = opts[:text]
-      elsif opts.has_key?(:nothing) && opts[:nothing]
-        self.response_body = " "
-      else
-        raise UnsupportedOperationError
-      end
-    end
-
-    class UnsupportedOperationError < StandardError
-      def initialize
-        super "Unsupported render operation. BasicRendering supports only :text and :nothing options. For more, you need to include ActionView."
-      end
-    end
-  end
-
   module Rendering
     extend ActiveSupport::Concern
 

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -20,10 +20,6 @@ module ActionController
       end
     end
 
-    def rendered_format
-      Mime::TEXT
-    end
-
     class UnsupportedOperationError < StandardError
       def initialize
         super "Unsupported render operation. BasicRendering supports only :text and :nothing options. For more, you need to include ActionView."

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -84,20 +84,6 @@ module ActionView
       self.response_body = render_to_body(options)
     end
 
-    # Raw rendering of a template to a string.
-    # :api: public
-    def render_to_string(*args, &block)
-      options = _normalize_render(*args, &block)
-      render_to_body(options)
-    end
-
-    # Raw rendering of a template.
-    # :api: public
-    def render_to_body(options = {})
-      _process_options(options)
-      _render_template(options)
-    end
-
     # Find and renders a template based on the options given.
     # :api: private
     def _render_template(options) #:nodoc:
@@ -110,14 +96,6 @@ module ActionView
     end
 
     private
-
-      # Normalize args and options.
-      # :api: private
-      def _normalize_render(*args, &block)
-        options = _normalize_args(*args, &block)
-        _normalize_options(options)
-        options
-      end
 
       # Normalize args by converting render "foo" to render :action => "foo" and
       # render "foo/bar" to render :file => "foo/bar".


### PR DESCRIPTION
Next things that we were discussing with @josevalim on skype.

I've moved the `render_to_string`, `render_to_body` and `_normalize_render` method implementations to `AbstractController` as they were anything more as just a glue method invoking other methods.

Besides that I've moved `BasicRendering` from ActionPack to AbstractController and set `rendered_format` to text by default in AbstractController.
