### PR TITLE
Closes #12115. Fix `simple_format` with sanitizing option when the text contains single line feed.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `simple_format` with sanitizing option when the text contains
+    single line feed. Fix #12115.
+
+    *kennyj*
+
 *   Only cache template digests if `config.cache_template_loading` id true.
 
     *Josh Lauer*, *Justin Ridgewell*

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -75,6 +75,11 @@ class TextHelperTest < ActionView::TestCase
     assert_equal options, passed_options
   end
 
+  def test_simple_format_with_sanitizing
+    assert_equal "<p>foo \n<br /> bar </p>\n\n<p> baz &lt;hr&gt; bab</p>",
+                 simple_format("foo \n bar \n\n baz <hr> bab", {}, sanitize: true)
+  end
+
   def test_truncate
     assert_equal "Hello World!", truncate("Hello World!", :length => 12)
     assert_equal "Hello Wor...", truncate("Hello World!!", :length => 12)


### PR DESCRIPTION
If we call `simple_format` method with sanitizing option, a single line feed (\n) is replaced with unexpected characters .

```
&lt;br /&gt;
```

I think we should backport  to 4-0-stable.
