### PR TITLE
ActiveRecord::Base#attributes return HashWithIndifferentAccess instance instead of Hash instance.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Return HashWithIndifferentAccess instance when calling `attributes` method.
+
+    *kennyj*
+
 *   Re-use `order` argument pre-processing for `reorder`.
 
     *Paul Nikitochkin*

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/enumerable'
 require 'mutex_m'
 
@@ -245,7 +246,7 @@ module ActiveRecord
     #   person.attributes
     #   # => {"id"=>3, "created_at"=>Sun, 21 Oct 2012 04:53:04, "updated_at"=>Sun, 21 Oct 2012 04:53:04, "name"=>"Francesco", "age"=>22}
     def attributes
-      attribute_names.each_with_object({}) { |name, attrs|
+      attribute_names.each_with_object(ActiveSupport::HashWithIndifferentAccess.new) { |name, attrs|
         attrs[name] = read_attribute(name)
       }
     end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -182,6 +182,11 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_attributes_return_hash_with_indifferent_access
+    category = Category.new(name: "Test category")
+    assert_equal category.attributes["name"], category.attributes[:name]
+  end
+
   def test_read_attributes_before_type_cast_on_datetime
     in_time_zone "Pacific Time (US & Canada)" do
       record = @target.new


### PR DESCRIPTION
In current behavior, ActiveRecord::Base#attributes return Hash instance.

But instance[] / instance[]= support not only string key but also symbol key.
And other many api support string / symbol key.

I think ActiveRecord::Base#attributes also return HWIA instance to support string / symbol keys.
