### PR TITLE
Avoid empty transaction from setting has_one association on new record.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Setting a has_one association on a new record no longer causes an empty
+    transaction.
+
+    *Dylan Thacker-Smith*
+
 *   Re-use `order` argument pre-processing for `reorder`.
 
     *Paul Nikitochkin*

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -27,6 +27,7 @@ module ActiveRecord
 
         return self.target if !(target || record)
         if (target != record) || record.changed?
+          save &&= owner.persisted?
           transaction_if(save) do
             remove_target!(options[:dependent]) if target && !target.destroyed?
 
@@ -34,7 +35,7 @@ module ActiveRecord
               set_owner_attributes(record)
               set_inverse_instance(record)
 
-              if owner.persisted? && save && !record.save
+              if save && !record.save
                 nullify_owner_attributes(record)
                 set_owner_attributes(target) if target
                 raise RecordNotSaved, "Failed to save the new associated #{reflection.name}."

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -505,6 +505,8 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_no_queries { company.account = nil }
     account = Account.find(2)
     assert_queries { company.account = account }
+
+    assert_no_queries { Firm.new.account = account }
   end
 
   def test_has_one_assignment_triggers_save_on_change


### PR DESCRIPTION
## Problem

When setting a has_one association on a new record as follows

``` ruby
Firm.new.account = account
```

it would open a transaction even though it wasn't saving the record.  So the the following database queries would get sent.

```
SAVEPOINT active_record_1
RELEASE SAVEPOINT active_record_1
```
## Solution

Update the `save` variable to reflect whether the record will be saved.  This way the check to determine if the transaction should be opened and the check to see if the record should be saved will be consistent.
