### PR TITLE
Respond to PUT/PATCH API request with :ok

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Change `respond_to` behavior for PUT/PATCH API requests: rather than a
+    simple `head :no_content` (204), return :ok (200) and the entire updated
+    object in the response body.
+
+    *claudiob*
+
 *   Allows ActionDispatch::Request::LOCALHOST to match any IPv4 127.0.0.0/8
     loopback address.
 

--- a/actionpack/lib/action_controller/metal/responder.rb
+++ b/actionpack/lib/action_controller/metal/responder.rb
@@ -208,6 +208,8 @@ module ActionController #:nodoc:
         display resource
       elsif post?
         display resource, :status => :created, :location => api_location
+      elsif patch? || put?
+        display resource, status: :ok, location: api_location
       else
         head :no_content
       end

--- a/actionpack/test/controller/mime/respond_with_test.rb
+++ b/actionpack/test/controller/mime/respond_with_test.rb
@@ -379,20 +379,25 @@ class RespondWithControllerTest < ActionController::TestCase
     end
   end
 
-  def test_using_resource_for_put_with_xml_yields_no_content_on_success
-    @request.accept = "application/xml"
-    put :using_resource
-    assert_equal "application/xml", @response.content_type
-    assert_equal 204, @response.status
-    assert_equal "", @response.body
+  def test_using_resource_for_put_with_xml_yields_ok_on_success
+    with_test_route_set do
+      @request.accept = "application/xml"
+      put :using_resource
+      assert_equal "application/xml", @response.content_type
+      assert_equal 200, @response.status
+      assert_equal "<name>david</name>", @response.body
+    end
   end
 
-  def test_using_resource_for_put_with_json_yields_no_content_on_success
-    @request.accept = "application/json"
-    put :using_resource_with_json
-    assert_equal "application/json", @response.content_type
-    assert_equal 204, @response.status
-    assert_equal "", @response.body
+  def test_using_resource_for_put_with_json_yields_ok_on_success
+    with_test_route_set do
+      Customer.any_instance.stubs(:to_json).returns('{"name": "David"}')
+      @request.accept = "application/json"
+      put :using_resource
+      assert_equal "application/json", @response.content_type
+      assert_equal 200, @response.status
+      assert_equal '{"name": "David"}', @response.body
+    end
   end
 
   def test_using_resource_for_put_with_xml_yields_unprocessable_entity_on_failure


### PR DESCRIPTION
This commits changes the behavior of `respond_to` for successful PUT/PATCH
requests on format associated with APIs, such as :xml and :json.

Previously, `respond_to` would just return :no_content (204) and no body.
After this commit, it returns :ok (200) and the entire updated object as
the response body.

The rationale behind this commit is that a PUT, POST or PATCH call may make
modifications to fields of the underlying resource that weren't part of the
provided parameters (for example: created_at or updated_at timestamps).

This commit prevents an API consumer from having to hit the API again for an
updated representation. Rails already provides the created representation after
a POST, so it is coherent to have the same behavior on PUT and PATCH.

See discussion at https://github.com/rails/rails/issues/12096
