### PR TITLE
Add missing method for Rails destroy command. Fixes #12141.

### DIFF
--- a/railties/lib/rails/commands/commands_tasks.rb
+++ b/railties/lib/rails/commands/commands_tasks.rb
@@ -51,6 +51,10 @@ EOT
       generate_or_destroy(:generate)
     end
 
+    def destroy
+      generate_or_destroy(:destroy)
+    end
+
     def console
       require_command!("console")
       options = Rails::Console.parse_arguments(argv)


### PR DESCRIPTION
Earlier commit f1f249d83615faab1a030c2303c0026a5b0b2ff8 moved Rails commands into
class but missed to add 'destroy' method. This commit adds missing 'destroy'
method.
