### PR TITLE
request.local? should return true/false, not nil or the index of the matched string

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -296,7 +296,7 @@ module ActionDispatch
 
     # True if the request came from localhost, 127.0.0.1.
     def local?
-      LOCALHOST =~ remote_addr && LOCALHOST =~ remote_ip
+      (LOCALHOST =~ remote_addr).present? && (LOCALHOST =~ remote_ip).present?
     end
 
     # Remove nils from the params hash


### PR DESCRIPTION
According to the [ruby docs](http://www.ruby-doc.org/core-2.0.0/Regexp.html#label-%3D%7E+operator%29):

> If a match is found, the operator returns index of first match in string, otherwise it returns nil.

This commit changes the behavior of local? to return true or false, as the documentation states.
