### PR TITLE
fixing timezone typo

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -134,7 +134,7 @@ module ActiveSupport
       "Kathmandu"                    => "Asia/Kathmandu",
       "Astana"                       => "Asia/Dhaka",
       "Dhaka"                        => "Asia/Dhaka",
-      "Sri Jayawardenepura"          => "Asia/Colombo",
+      "Sri Jayawardenapura"          => "Asia/Colombo",
       "Almaty"                       => "Asia/Almaty",
       "Novosibirsk"                  => "Asia/Novosibirsk",
       "Rangoon"                      => "Asia/Rangoon",


### PR DESCRIPTION
This fixes a misspelling of the timezone city. See here for verification of correct spelling:
- http://en.wikipedia.org/wiki/Sri_Jayawardenapura_Kotte
- http://www.timeanddate.com/worldclock/city.html?n=1925
