### PR TITLE
Removes order by primary key from ActiveRecord::FinderMethods#find_first

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -366,11 +366,7 @@ module ActiveRecord
     end
 
     def find_first_with_limit(limit)
-      if order_values.empty? && primary_key
-        order(arel_table[primary_key].asc).limit(limit).to_a
-      else
-        limit(limit).to_a
-      end
+      limit(limit).to_a
     end
 
     def find_last


### PR DESCRIPTION
The fact that ActiveRecord::FinderMethods#find_first implicitly applies a sort order by the primary key of the table will work against the query intended by the developer. An example of where the order by primary key works against the
developer happens when using the `rank()` window function in PostgreSQL. Take the following query

``` sql
SELECT scores.*, rank() OVER (ORDER BY points DESC)
FROM scores
```

These records will come back sorted by their rank (determined by the `ORDER BY` in the `OVER` clause. If you wanted to get the top score back from within ActiveRecord, you could use the following query to get the top score with it's rank:

``` ruby
Score.select(:score, 'rank() OVER (ORDER BY points DESC)').first
```

The problem with this query is the fact that since there is no explicit order called on it via `order()`, when `find_first` gets called, the sorting by primary key will alter the order of the results, returning the incorrect "first" result.
