### PR TITLE
Allow Relation#from to accept other relations with bind values.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow Relation#from to accept other relations with bind values.
+
+    *Ryan Wallace*
+
 *   Re-use `order` argument pre-processing for `reorder`.
 
     *Paul Nikitochkin*

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -915,6 +915,7 @@ module ActiveRecord
       case opts
       when Relation
         name ||= 'subquery'
+        self.bind_values = opts.bind_values + self.bind_values
         opts.arel.as(name.to_s)
       else
         opts

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -139,6 +139,13 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal relation.to_a, Topic.select('a.*').from(relation, :a).to_a
   end
 
+  def test_finding_with_subquery_with_binds
+    relation = Post.first.comments
+    assert_equal relation.to_a, Comment.select('*').from(relation).to_a
+    assert_equal relation.to_a, Comment.select('subquery.*').from(relation).to_a
+    assert_equal relation.to_a, Comment.select('a.*').from(relation, :a).to_a
+  end
+
   def test_finding_with_conditions
     assert_equal ["David"], Author.where(:name => 'David').map(&:name)
     assert_equal ['Mary'],  Author.where(["name = ?", 'Mary']).map(&:name)


### PR DESCRIPTION
Support for Relation#from to accept another relation was added in 64872d1e34d929ee30041b37900591aade2a5eaf but an invalid query is generated if the relation being passed to Relation#from has bind values. This pull request copies the bind variables to the parent relation, similar to the fix for Relation#where provided in 170fb5c80c990688f5f372a3ba0e6cb75fb6edf0.
