### PR TITLE
Use MiniTest::Unit::TestCase instead of Minitest::Test  [ci skip]

### DIFF
--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -25,7 +25,7 @@ class Comment < ActiveRecord::Base
   belongs_to :post
 end
 
-class BugTest < Minitest::Test
+class BugTest < MiniTest::Unit::TestCase
   def test_association_stuff
     post = Post.create!
     post.comments << Comment.create!


### PR DESCRIPTION
Hello,

Since Rails 4.0.x is depending on Minitest 4.x, the constant won't be available so the gist won't run.

Have a nice day.
