### PR TITLE
Don't require using application_name before options

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -18,6 +18,10 @@ module Rails
 
       argument :app_path, type: :string
 
+      def self.strict_args_position
+        false
+      end
+
       def self.add_shared_options_for(name)
         class_option :template,           type: :string, aliases: '-m',
                                           desc: "Path to some #{name} template (can be a filesystem path or URL)"

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -151,17 +151,11 @@ module Rails
                              desc: "Show Rails version number and quit"
 
       def initialize(*args)
-        if args[0].blank?
-          if args[1].blank?
-            # rails new
-            raise Error, "Application name should be provided in arguments. For details run: rails --help"
-          else
-            # rails new --skip-bundle my_new_application
-            raise Error, "Options should be given after the application name. For details run: rails --help"
-          end
-        end
-
         super
+
+        unless app_path
+          raise Error, "Application name should be provided in arguments. For details run: rails --help"
+        end
 
         if !options[:skip_active_record] && !DATABASES.include?(options[:database])
           raise Error, "Invalid value for --database option. Supported for preconfiguration are: #{DATABASES.join(", ")}."

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -176,10 +176,12 @@ task default: :test
                                                  "skip adding entry to Gemfile"
 
       def initialize(*args)
-        raise Error, "Options should be given after the plugin name. For details run: rails plugin new --help" if args[0].blank?
-
         @dummy_path = nil
         super
+
+        unless plugin_path
+          raise Error, "Plugin name should be provided in arguments. For details run: rails plugin new --help"
+        end
       end
 
       public_task :create_root

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -46,11 +46,6 @@ module SharedGeneratorTests
     assert_no_file "test"
   end
 
-  def test_options_before_application_name_raises_an_error
-    content = capture(:stderr){ run_generator(["--pretend", destination_root]) }
-    assert_match(/Options should be given after the \w+ name. For details run: rails( plugin new)? --help\n/, content)
-  end
-
   def test_name_collision_raises_an_error
     reserved_words = %w[application destroy plugin runner test]
     reserved_words.each do |reserved|


### PR DESCRIPTION
When I create new rails app it usually goes like this:

```
$ rails new --skip-something teh-app
Options should be given after the application name. For details run: rails --help
# fffffffuuuuu
$ rails new teh-app --skip-something
```

This pull requests fixes the situation to make it work more like this

```
$ rails new --skip-something teh-app
      create
      create  README.rdoc
      create  Rakefile
```

I'm not really sure if we support anything which can break after this change, if not I will gladly commit this to master.

It also has a nice side effect, I think that the new code is much cleaner.
