### PR TITLE
Creating ApplicationModel

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -31,6 +31,7 @@ require 'active_record/version'
 module ActiveRecord
   extend ActiveSupport::Autoload
 
+  autoload :ApplicationConfiguration
   autoload :Base
   autoload :Callbacks
   autoload :Core

--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -15,7 +15,7 @@ module ActiveRecord
     # existing object) and how it can be turned back into attributes (when the entity is saved to
     # the database).
     #
-    #   class Customer < ApplicationModel
+    #   class Customer < ApplicationRecord
     #     composed_of :balance, class_name: "Money", mapping: %w(balance amount)
     #     composed_of :address, mapping: [ %w(address_street street), %w(address_city city) ]
     #   end
@@ -136,7 +136,7 @@ module ActiveRecord
     # or an array. The <tt>:constructor</tt> and <tt>:converter</tt> options can be used to meet
     # these requirements:
     #
-    #   class NetworkResource < ApplicationModel
+    #   class NetworkResource < ApplicationRecord
     #     composed_of :cidr,
     #                 class_name: 'NetAddr::CIDR',
     #                 mapping: [ %w(network_address network), %w(cidr_range bits) ],

--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -15,7 +15,7 @@ module ActiveRecord
     # existing object) and how it can be turned back into attributes (when the entity is saved to
     # the database).
     #
-    #   class Customer < ActiveRecord::Base
+    #   class Customer < ApplicationModel
     #     composed_of :balance, class_name: "Money", mapping: %w(balance amount)
     #     composed_of :address, mapping: [ %w(address_street street), %w(address_city city) ]
     #   end
@@ -136,7 +136,7 @@ module ActiveRecord
     # or an array. The <tt>:constructor</tt> and <tt>:converter</tt> options can be used to meet
     # these requirements:
     #
-    #   class NetworkResource < ActiveRecord::Base
+    #   class NetworkResource < ApplicationModel
     #     composed_of :cidr,
     #                 class_name: 'NetAddr::CIDR',
     #                 mapping: [ %w(network_address network), %w(cidr_range bits) ],

--- a/activerecord/lib/active_record/application_configuration.rb
+++ b/activerecord/lib/active_record/application_configuration.rb
@@ -3,14 +3,28 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def configs_from(application)
+      def configs_from(mod)
         app_model = self
 
-        application.singleton_class.instance_eval do
+        mod.singleton_class.instance_eval do
           define_method(:application_model) { app_model }
         end
 
         define_singleton_method(:configs_from_application) { application }
+      end
+
+      def application_model(klass = nil)
+        return ActiveRecord::Base unless klass
+
+        klass = klass.class unless klass.respond_to?(:parents)
+
+        if klass.respond_to?(:application_model)
+          klass.application_model
+        elsif app_model = klass.parents.detect { |p| p.respond_to?(:application_model) }
+          app_model
+        else
+          ActiveRecord::Base
+        end
       end
     end
   end

--- a/activerecord/lib/active_record/application_configuration.rb
+++ b/activerecord/lib/active_record/application_configuration.rb
@@ -4,24 +4,24 @@ module ActiveRecord
 
     module ClassMethods
       def configs_from(mod)
-        app_model = self
+        app_record = self
 
         mod.singleton_class.instance_eval do
-          define_method(:application_model) { app_model }
+          define_method(:application_record) { app_record }
         end
 
         define_singleton_method(:configs_from_application) { application }
       end
 
-      def application_model(klass = nil)
+      def application_record(klass = nil)
         return ActiveRecord::Base unless klass
 
         klass = klass.class unless klass.respond_to?(:parents)
 
-        if klass.respond_to?(:application_model)
-          klass.application_model
-        elsif app_model = klass.parents.detect { |p| p.respond_to?(:application_model) }
-          app_model
+        if klass.respond_to?(:application_record)
+          klass.application_record
+        elsif app_record = klass.parents.detect { |p| p.respond_to?(:application_record) }
+          app_record
         else
           ActiveRecord::Base
         end

--- a/activerecord/lib/active_record/application_configuration.rb
+++ b/activerecord/lib/active_record/application_configuration.rb
@@ -1,0 +1,17 @@
+module ActiveRecord
+  module ApplicationConfiguration
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def configs_from(application)
+        app_model = self
+
+        application.singleton_class.instance_eval do
+          define_method(:application_model) { app_model }
+        end
+
+        define_singleton_method(:configs_from_application) { application }
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -179,7 +179,7 @@ module ActiveRecord
     # options hash. It works much the same way as Ruby's own <tt>attr*</tt>
     # methods.
     #
-    #   class Project < ApplicationModel
+    #   class Project < ApplicationRecord
     #     belongs_to              :portfolio
     #     has_one                 :project_manager
     #     has_many                :milestones
@@ -251,7 +251,7 @@ module ActiveRecord
     # which allows you to easily override with your own methods and call the original
     # generated method with +super+. For example:
     #
-    #   class Car < ApplicationModel
+    #   class Car < ApplicationRecord
     #     belongs_to :owner
     #     belongs_to :old_owner
     #     def owner=(new_owner)
@@ -276,10 +276,10 @@ module ActiveRecord
     #
     # Use +has_one+ in the base, and +belongs_to+ in the associated model.
     #
-    #   class Employee < ApplicationModel
+    #   class Employee < ApplicationRecord
     #     has_one :office
     #   end
-    #   class Office < ApplicationModel
+    #   class Office < ApplicationRecord
     #     belongs_to :employee    # foreign key - employee_id
     #   end
     #
@@ -287,10 +287,10 @@ module ActiveRecord
     #
     # Use +has_many+ in the base, and +belongs_to+ in the associated model.
     #
-    #   class Manager < ApplicationModel
+    #   class Manager < ApplicationRecord
     #     has_many :employees
     #   end
-    #   class Employee < ApplicationModel
+    #   class Employee < ApplicationRecord
     #     belongs_to :manager     # foreign key - manager_id
     #   end
     #
@@ -301,15 +301,15 @@ module ActiveRecord
     # The first way uses a +has_many+ association with the <tt>:through</tt> option and a join model, so
     # there are two stages of associations.
     #
-    #   class Assignment < ApplicationModel
+    #   class Assignment < ApplicationRecord
     #     belongs_to :programmer  # foreign key - programmer_id
     #     belongs_to :project     # foreign key - project_id
     #   end
-    #   class Programmer < ApplicationModel
+    #   class Programmer < ApplicationRecord
     #     has_many :assignments
     #     has_many :projects, through: :assignments
     #   end
-    #   class Project < ApplicationModel
+    #   class Project < ApplicationRecord
     #     has_many :assignments
     #     has_many :programmers, through: :assignments
     #   end
@@ -317,10 +317,10 @@ module ActiveRecord
     # For the second way, use +has_and_belongs_to_many+ in both models. This requires a join table
     # that has no corresponding model or primary key.
     #
-    #   class Programmer < ApplicationModel
+    #   class Programmer < ApplicationRecord
     #     has_and_belongs_to_many :projects       # foreign keys in the join table
     #   end
-    #   class Project < ApplicationModel
+    #   class Project < ApplicationRecord
     #     has_and_belongs_to_many :programmers    # foreign keys in the join table
     #   end
     #
@@ -334,12 +334,12 @@ module ActiveRecord
     # Both express a 1-1 relationship. The difference is mostly where to place the foreign
     # key, which goes on the table for the class declaring the +belongs_to+ relationship.
     #
-    #   class User < ApplicationModel
+    #   class User < ApplicationRecord
     #     # I reference an account.
     #     belongs_to :account
     #   end
     #
-    #   class Account < ApplicationModel
+    #   class Account < ApplicationRecord
     #     # One user references me.
     #     has_one :user
     #   end
@@ -405,7 +405,7 @@ module ActiveRecord
     # \Associations are built from <tt>Relation</tt>s, and you can use the <tt>Relation</tt> syntax
     # to customize them. For example, to add a condition:
     #
-    #   class Blog < ApplicationModel
+    #   class Blog < ApplicationRecord
     #     has_many :published_posts, -> { where published: true }, class_name: 'Post'
     #   end
     #
@@ -417,7 +417,7 @@ module ActiveRecord
     # is passed as a parameter to the block. For example, the following association would find all
     # events that occur on the user's birthday:
     #
-    #   class User < ApplicationModel
+    #   class User < ApplicationRecord
     #     has_many :birthday_events, ->(user) { where starts_on: user.birthday }, class_name: 'Event'
     #   end
     #
@@ -454,7 +454,7 @@ module ActiveRecord
     # modules. This is especially beneficial for adding new finders, creators, and other
     # factory-type methods that are only used as part of this association.
     #
-    #   class Account < ApplicationModel
+    #   class Account < ApplicationRecord
     #     has_many :people do
     #       def find_or_create_by_name(name)
     #         first_name, last_name = name.split(" ", 2)
@@ -477,11 +477,11 @@ module ActiveRecord
     #     end
     #   end
     #
-    #   class Account < ApplicationModel
+    #   class Account < ApplicationRecord
     #     has_many :people, -> { extending FindOrCreateByNameExtension }
     #   end
     #
-    #   class Company < ApplicationModel
+    #   class Company < ApplicationRecord
     #     has_many :people, -> { extending FindOrCreateByNameExtension }
     #   end
     #
@@ -507,12 +507,12 @@ module ActiveRecord
     # +has_and_belongs_to_many+ association. The advantage is that you're able to add validations,
     # callbacks, and extra attributes on the join model. Consider the following schema:
     #
-    #   class Author < ApplicationModel
+    #   class Author < ApplicationRecord
     #     has_many :authorships
     #     has_many :books, through: :authorships
     #   end
     #
-    #   class Authorship < ApplicationModel
+    #   class Authorship < ApplicationRecord
     #     belongs_to :author
     #     belongs_to :book
     #   end
@@ -523,17 +523,17 @@ module ActiveRecord
     #
     # You can also go through a +has_many+ association on the join model:
     #
-    #   class Firm < ApplicationModel
+    #   class Firm < ApplicationRecord
     #     has_many   :clients
     #     has_many   :invoices, through: :clients
     #   end
     #
-    #   class Client < ApplicationModel
+    #   class Client < ApplicationRecord
     #     belongs_to :firm
     #     has_many   :invoices
     #   end
     #
-    #   class Invoice < ApplicationModel
+    #   class Invoice < ApplicationRecord
     #     belongs_to :client
     #   end
     #
@@ -543,17 +543,17 @@ module ActiveRecord
     #
     # Similarly you can go through a +has_one+ association on the join model:
     #
-    #   class Group < ApplicationModel
+    #   class Group < ApplicationRecord
     #     has_many   :users
     #     has_many   :avatars, through: :users
     #   end
     #
-    #   class User < ApplicationModel
+    #   class User < ApplicationRecord
     #     belongs_to :group
     #     has_one    :avatar
     #   end
     #
-    #   class Avatar < ApplicationModel
+    #   class Avatar < ApplicationRecord
     #     belongs_to :user
     #   end
     #
@@ -581,7 +581,7 @@ module ActiveRecord
     # The last line ought to save the through record (a <tt>Taggable</tt>). This will only work if the
     # <tt>:inverse_of</tt> is set:
     #
-    #   class Taggable < ApplicationModel
+    #   class Taggable < ApplicationRecord
     #     belongs_to :post
     #     belongs_to :tag, inverse_of: :taggings
     #   end
@@ -602,7 +602,7 @@ module ActiveRecord
     # You can turn off the automatic detection of inverse associations by setting
     # the <tt>:inverse_of</tt> option to <tt>false</tt> like so:
     #
-    #   class Taggable < ApplicationModel
+    #   class Taggable < ApplicationRecord
     #     belongs_to :tag, inverse_of: false
     #   end
     #
@@ -611,17 +611,17 @@ module ActiveRecord
     # You can actually specify *any* association with the <tt>:through</tt> option, including an
     # association which has a <tt>:through</tt> option itself. For example:
     #
-    #   class Author < ApplicationModel
+    #   class Author < ApplicationRecord
     #     has_many :posts
     #     has_many :comments, through: :posts
     #     has_many :commenters, through: :comments
     #   end
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #     has_many :comments
     #   end
     #
-    #   class Comment < ApplicationModel
+    #   class Comment < ApplicationRecord
     #     belongs_to :commenter
     #   end
     #
@@ -630,17 +630,17 @@ module ActiveRecord
     #
     # An equivalent way of setting up this association this would be:
     #
-    #   class Author < ApplicationModel
+    #   class Author < ApplicationRecord
     #     has_many :posts
     #     has_many :commenters, through: :posts
     #   end
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #     has_many :comments
     #     has_many :commenters, through: :comments
     #   end
     #
-    #   class Comment < ApplicationModel
+    #   class Comment < ApplicationRecord
     #     belongs_to :commenter
     #   end
     #
@@ -655,11 +655,11 @@ module ActiveRecord
     # can be associated with. Rather, they specify an interface that a +has_many+ association
     # must adhere to.
     #
-    #   class Asset < ApplicationModel
+    #   class Asset < ApplicationRecord
     #     belongs_to :attachable, polymorphic: true
     #   end
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #     has_many :assets, as: :attachable         # The :as option specifies the polymorphic interface to use.
     #   end
     #
@@ -676,7 +676,7 @@ module ActiveRecord
     # and member posts that use the posts table for STI. In this case, there must be a +type+
     # column in the posts table.
     #
-    #   class Asset < ApplicationModel
+    #   class Asset < ApplicationRecord
     #     belongs_to :attachable, polymorphic: true
     #
     #     def attachable_type=(sType)
@@ -684,7 +684,7 @@ module ActiveRecord
     #     end
     #   end
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #     # because we store "Post" in attachable_type now dependent: :destroy will work
     #     has_many :assets, as: :attachable, dependent: :destroy
     #   end
@@ -715,7 +715,7 @@ module ActiveRecord
     # posts that each need to display their author triggers 101 database queries. Through the
     # use of eager loading, the 101 queries can be reduced to 2.
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #     belongs_to :author
     #     has_many   :comments
     #   end
@@ -778,7 +778,7 @@ module ActiveRecord
     # If you do want eager load only some members of an association it is usually more natural
     # to include an association which has conditions defined on it:
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #     has_many :approved_comments, -> { where approved: true }, class_name: 'Comment'
     #   end
     #
@@ -790,7 +790,7 @@ module ActiveRecord
     # If you eager load an association with a specified <tt>:limit</tt> option, it will be ignored,
     # returning all the associated objects:
     #
-    #   class Picture < ApplicationModel
+    #   class Picture < ApplicationRecord
     #     has_many :most_recent_comments, -> { order('id DESC').limit(10) }, class_name: 'Comment'
     #   end
     #
@@ -798,7 +798,7 @@ module ActiveRecord
     #
     # Eager loading is supported with polymorphic associations.
     #
-    #   class Address < ApplicationModel
+    #   class Address < ApplicationRecord
     #     belongs_to :addressable, polymorphic: true
     #   end
     #
@@ -872,11 +872,11 @@ module ActiveRecord
     #
     #   module MyApplication
     #     module Business
-    #       class Firm < ApplicationModel
+    #       class Firm < ApplicationRecord
     #         has_many :clients
     #       end
     #
-    #       class Client < ApplicationModel; end
+    #       class Client < ApplicationRecord; end
     #     end
     #   end
     #
@@ -887,11 +887,11 @@ module ActiveRecord
     #
     #   module MyApplication
     #     module Business
-    #       class Firm < ApplicationModel; end
+    #       class Firm < ApplicationRecord; end
     #     end
     #
     #     module Billing
-    #       class Account < ApplicationModel
+    #       class Account < ApplicationRecord
     #         belongs_to :firm, class_name: "MyApplication::Business::Firm"
     #       end
     #     end
@@ -902,16 +902,16 @@ module ActiveRecord
     # When you specify an association there is usually an association on the associated model
     # that specifies the same relationship in reverse. For example, with the following models:
     #
-    #    class Dungeon < ApplicationModel
+    #    class Dungeon < ApplicationRecord
     #      has_many :traps
     #      has_one :evil_wizard
     #    end
     #
-    #    class Trap < ApplicationModel
+    #    class Trap < ApplicationRecord
     #      belongs_to :dungeon
     #    end
     #
-    #    class EvilWizard < ApplicationModel
+    #    class EvilWizard < ApplicationRecord
     #      belongs_to :dungeon
     #    end
     #
@@ -933,16 +933,16 @@ module ActiveRecord
     # Active Record about inverse relationships and it will optimise object loading. For
     # example, if we changed our model definitions to:
     #
-    #    class Dungeon < ApplicationModel
+    #    class Dungeon < ApplicationRecord
     #      has_many :traps, inverse_of: :dungeon
     #      has_one :evil_wizard, inverse_of: :dungeon
     #    end
     #
-    #    class Trap < ApplicationModel
+    #    class Trap < ApplicationRecord
     #      belongs_to :dungeon, inverse_of: :traps
     #    end
     #
-    #    class EvilWizard < ApplicationModel
+    #    class EvilWizard < ApplicationRecord
     #      belongs_to :dungeon, inverse_of: :evil_wizard
     #    end
     #

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -179,7 +179,7 @@ module ActiveRecord
     # options hash. It works much the same way as Ruby's own <tt>attr*</tt>
     # methods.
     #
-    #   class Project < ActiveRecord::Base
+    #   class Project < ApplicationModel
     #     belongs_to              :portfolio
     #     has_one                 :project_manager
     #     has_many                :milestones
@@ -251,7 +251,7 @@ module ActiveRecord
     # which allows you to easily override with your own methods and call the original
     # generated method with +super+. For example:
     #
-    #   class Car < ActiveRecord::Base
+    #   class Car < ApplicationModel
     #     belongs_to :owner
     #     belongs_to :old_owner
     #     def owner=(new_owner)
@@ -276,10 +276,10 @@ module ActiveRecord
     #
     # Use +has_one+ in the base, and +belongs_to+ in the associated model.
     #
-    #   class Employee < ActiveRecord::Base
+    #   class Employee < ApplicationModel
     #     has_one :office
     #   end
-    #   class Office < ActiveRecord::Base
+    #   class Office < ApplicationModel
     #     belongs_to :employee    # foreign key - employee_id
     #   end
     #
@@ -287,10 +287,10 @@ module ActiveRecord
     #
     # Use +has_many+ in the base, and +belongs_to+ in the associated model.
     #
-    #   class Manager < ActiveRecord::Base
+    #   class Manager < ApplicationModel
     #     has_many :employees
     #   end
-    #   class Employee < ActiveRecord::Base
+    #   class Employee < ApplicationModel
     #     belongs_to :manager     # foreign key - manager_id
     #   end
     #
@@ -301,15 +301,15 @@ module ActiveRecord
     # The first way uses a +has_many+ association with the <tt>:through</tt> option and a join model, so
     # there are two stages of associations.
     #
-    #   class Assignment < ActiveRecord::Base
+    #   class Assignment < ApplicationModel
     #     belongs_to :programmer  # foreign key - programmer_id
     #     belongs_to :project     # foreign key - project_id
     #   end
-    #   class Programmer < ActiveRecord::Base
+    #   class Programmer < ApplicationModel
     #     has_many :assignments
     #     has_many :projects, through: :assignments
     #   end
-    #   class Project < ActiveRecord::Base
+    #   class Project < ApplicationModel
     #     has_many :assignments
     #     has_many :programmers, through: :assignments
     #   end
@@ -317,10 +317,10 @@ module ActiveRecord
     # For the second way, use +has_and_belongs_to_many+ in both models. This requires a join table
     # that has no corresponding model or primary key.
     #
-    #   class Programmer < ActiveRecord::Base
+    #   class Programmer < ApplicationModel
     #     has_and_belongs_to_many :projects       # foreign keys in the join table
     #   end
-    #   class Project < ActiveRecord::Base
+    #   class Project < ApplicationModel
     #     has_and_belongs_to_many :programmers    # foreign keys in the join table
     #   end
     #
@@ -334,12 +334,12 @@ module ActiveRecord
     # Both express a 1-1 relationship. The difference is mostly where to place the foreign
     # key, which goes on the table for the class declaring the +belongs_to+ relationship.
     #
-    #   class User < ActiveRecord::Base
+    #   class User < ApplicationModel
     #     # I reference an account.
     #     belongs_to :account
     #   end
     #
-    #   class Account < ActiveRecord::Base
+    #   class Account < ApplicationModel
     #     # One user references me.
     #     has_one :user
     #   end
@@ -405,7 +405,7 @@ module ActiveRecord
     # \Associations are built from <tt>Relation</tt>s, and you can use the <tt>Relation</tt> syntax
     # to customize them. For example, to add a condition:
     #
-    #   class Blog < ActiveRecord::Base
+    #   class Blog < ApplicationModel
     #     has_many :published_posts, -> { where published: true }, class_name: 'Post'
     #   end
     #
@@ -417,7 +417,7 @@ module ActiveRecord
     # is passed as a parameter to the block. For example, the following association would find all
     # events that occur on the user's birthday:
     #
-    #   class User < ActiveRecord::Base
+    #   class User < ApplicationModel
     #     has_many :birthday_events, ->(user) { where starts_on: user.birthday }, class_name: 'Event'
     #   end
     #
@@ -454,7 +454,7 @@ module ActiveRecord
     # modules. This is especially beneficial for adding new finders, creators, and other
     # factory-type methods that are only used as part of this association.
     #
-    #   class Account < ActiveRecord::Base
+    #   class Account < ApplicationModel
     #     has_many :people do
     #       def find_or_create_by_name(name)
     #         first_name, last_name = name.split(" ", 2)
@@ -477,11 +477,11 @@ module ActiveRecord
     #     end
     #   end
     #
-    #   class Account < ActiveRecord::Base
+    #   class Account < ApplicationModel
     #     has_many :people, -> { extending FindOrCreateByNameExtension }
     #   end
     #
-    #   class Company < ActiveRecord::Base
+    #   class Company < ApplicationModel
     #     has_many :people, -> { extending FindOrCreateByNameExtension }
     #   end
     #
@@ -507,12 +507,12 @@ module ActiveRecord
     # +has_and_belongs_to_many+ association. The advantage is that you're able to add validations,
     # callbacks, and extra attributes on the join model. Consider the following schema:
     #
-    #   class Author < ActiveRecord::Base
+    #   class Author < ApplicationModel
     #     has_many :authorships
     #     has_many :books, through: :authorships
     #   end
     #
-    #   class Authorship < ActiveRecord::Base
+    #   class Authorship < ApplicationModel
     #     belongs_to :author
     #     belongs_to :book
     #   end
@@ -523,17 +523,17 @@ module ActiveRecord
     #
     # You can also go through a +has_many+ association on the join model:
     #
-    #   class Firm < ActiveRecord::Base
+    #   class Firm < ApplicationModel
     #     has_many   :clients
     #     has_many   :invoices, through: :clients
     #   end
     #
-    #   class Client < ActiveRecord::Base
+    #   class Client < ApplicationModel
     #     belongs_to :firm
     #     has_many   :invoices
     #   end
     #
-    #   class Invoice < ActiveRecord::Base
+    #   class Invoice < ApplicationModel
     #     belongs_to :client
     #   end
     #
@@ -543,17 +543,17 @@ module ActiveRecord
     #
     # Similarly you can go through a +has_one+ association on the join model:
     #
-    #   class Group < ActiveRecord::Base
+    #   class Group < ApplicationModel
     #     has_many   :users
     #     has_many   :avatars, through: :users
     #   end
     #
-    #   class User < ActiveRecord::Base
+    #   class User < ApplicationModel
     #     belongs_to :group
     #     has_one    :avatar
     #   end
     #
-    #   class Avatar < ActiveRecord::Base
+    #   class Avatar < ApplicationModel
     #     belongs_to :user
     #   end
     #
@@ -581,7 +581,7 @@ module ActiveRecord
     # The last line ought to save the through record (a <tt>Taggable</tt>). This will only work if the
     # <tt>:inverse_of</tt> is set:
     #
-    #   class Taggable < ActiveRecord::Base
+    #   class Taggable < ApplicationModel
     #     belongs_to :post
     #     belongs_to :tag, inverse_of: :taggings
     #   end
@@ -602,7 +602,7 @@ module ActiveRecord
     # You can turn off the automatic detection of inverse associations by setting
     # the <tt>:inverse_of</tt> option to <tt>false</tt> like so:
     #
-    #   class Taggable < ActiveRecord::Base
+    #   class Taggable < ApplicationModel
     #     belongs_to :tag, inverse_of: false
     #   end
     #
@@ -611,17 +611,17 @@ module ActiveRecord
     # You can actually specify *any* association with the <tt>:through</tt> option, including an
     # association which has a <tt>:through</tt> option itself. For example:
     #
-    #   class Author < ActiveRecord::Base
+    #   class Author < ApplicationModel
     #     has_many :posts
     #     has_many :comments, through: :posts
     #     has_many :commenters, through: :comments
     #   end
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #     has_many :comments
     #   end
     #
-    #   class Comment < ActiveRecord::Base
+    #   class Comment < ApplicationModel
     #     belongs_to :commenter
     #   end
     #
@@ -630,17 +630,17 @@ module ActiveRecord
     #
     # An equivalent way of setting up this association this would be:
     #
-    #   class Author < ActiveRecord::Base
+    #   class Author < ApplicationModel
     #     has_many :posts
     #     has_many :commenters, through: :posts
     #   end
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #     has_many :comments
     #     has_many :commenters, through: :comments
     #   end
     #
-    #   class Comment < ActiveRecord::Base
+    #   class Comment < ApplicationModel
     #     belongs_to :commenter
     #   end
     #
@@ -655,11 +655,11 @@ module ActiveRecord
     # can be associated with. Rather, they specify an interface that a +has_many+ association
     # must adhere to.
     #
-    #   class Asset < ActiveRecord::Base
+    #   class Asset < ApplicationModel
     #     belongs_to :attachable, polymorphic: true
     #   end
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #     has_many :assets, as: :attachable         # The :as option specifies the polymorphic interface to use.
     #   end
     #
@@ -676,7 +676,7 @@ module ActiveRecord
     # and member posts that use the posts table for STI. In this case, there must be a +type+
     # column in the posts table.
     #
-    #   class Asset < ActiveRecord::Base
+    #   class Asset < ApplicationModel
     #     belongs_to :attachable, polymorphic: true
     #
     #     def attachable_type=(sType)
@@ -684,7 +684,7 @@ module ActiveRecord
     #     end
     #   end
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #     # because we store "Post" in attachable_type now dependent: :destroy will work
     #     has_many :assets, as: :attachable, dependent: :destroy
     #   end
@@ -715,7 +715,7 @@ module ActiveRecord
     # posts that each need to display their author triggers 101 database queries. Through the
     # use of eager loading, the 101 queries can be reduced to 2.
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #     belongs_to :author
     #     has_many   :comments
     #   end
@@ -778,7 +778,7 @@ module ActiveRecord
     # If you do want eager load only some members of an association it is usually more natural
     # to include an association which has conditions defined on it:
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #     has_many :approved_comments, -> { where approved: true }, class_name: 'Comment'
     #   end
     #
@@ -790,7 +790,7 @@ module ActiveRecord
     # If you eager load an association with a specified <tt>:limit</tt> option, it will be ignored,
     # returning all the associated objects:
     #
-    #   class Picture < ActiveRecord::Base
+    #   class Picture < ApplicationModel
     #     has_many :most_recent_comments, -> { order('id DESC').limit(10) }, class_name: 'Comment'
     #   end
     #
@@ -798,7 +798,7 @@ module ActiveRecord
     #
     # Eager loading is supported with polymorphic associations.
     #
-    #   class Address < ActiveRecord::Base
+    #   class Address < ApplicationModel
     #     belongs_to :addressable, polymorphic: true
     #   end
     #
@@ -872,11 +872,11 @@ module ActiveRecord
     #
     #   module MyApplication
     #     module Business
-    #       class Firm < ActiveRecord::Base
+    #       class Firm < ApplicationModel
     #         has_many :clients
     #       end
     #
-    #       class Client < ActiveRecord::Base; end
+    #       class Client < ApplicationModel; end
     #     end
     #   end
     #
@@ -887,11 +887,11 @@ module ActiveRecord
     #
     #   module MyApplication
     #     module Business
-    #       class Firm < ActiveRecord::Base; end
+    #       class Firm < ApplicationModel; end
     #     end
     #
     #     module Billing
-    #       class Account < ActiveRecord::Base
+    #       class Account < ApplicationModel
     #         belongs_to :firm, class_name: "MyApplication::Business::Firm"
     #       end
     #     end
@@ -902,16 +902,16 @@ module ActiveRecord
     # When you specify an association there is usually an association on the associated model
     # that specifies the same relationship in reverse. For example, with the following models:
     #
-    #    class Dungeon < ActiveRecord::Base
+    #    class Dungeon < ApplicationModel
     #      has_many :traps
     #      has_one :evil_wizard
     #    end
     #
-    #    class Trap < ActiveRecord::Base
+    #    class Trap < ApplicationModel
     #      belongs_to :dungeon
     #    end
     #
-    #    class EvilWizard < ActiveRecord::Base
+    #    class EvilWizard < ApplicationModel
     #      belongs_to :dungeon
     #    end
     #
@@ -933,16 +933,16 @@ module ActiveRecord
     # Active Record about inverse relationships and it will optimise object loading. For
     # example, if we changed our model definitions to:
     #
-    #    class Dungeon < ActiveRecord::Base
+    #    class Dungeon < ApplicationModel
     #      has_many :traps, inverse_of: :dungeon
     #      has_one :evil_wizard, inverse_of: :dungeon
     #    end
     #
-    #    class Trap < ActiveRecord::Base
+    #    class Trap < ApplicationModel
     #      belongs_to :dungeon, inverse_of: :traps
     #    end
     #
-    #    class EvilWizard < ActiveRecord::Base
+    #    class EvilWizard < ApplicationModel
     #      belongs_to :dungeon, inverse_of: :evil_wizard
     #    end
     #

--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -76,7 +76,7 @@ module ActiveRecord::Associations::Builder
     end
 
     # Defines the setter and getter methods for the association
-    # class Post < ActiveRecord::Base
+    # class Post < ApplicationModel
     #   has_many :comments
     # end
     #

--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -76,7 +76,7 @@ module ActiveRecord::Associations::Builder
     end
 
     # Defines the setter and getter methods for the association
-    # class Post < ApplicationModel
+    # class Post < ApplicationRecord
     #   has_many :comments
     # end
     #

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -138,7 +138,7 @@ module ActiveRecord
 
       # Starts a transaction in the association class's database connection.
       #
-      #   class Author < ApplicationModel
+      #   class Author < ApplicationRecord
       #     has_many :books
       #   end
       #

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -138,7 +138,7 @@ module ActiveRecord
 
       # Starts a transaction in the association class's database connection.
       #
-      #   class Author < ActiveRecord::Base
+      #   class Author < ApplicationModel
       #     has_many :books
       #   end
       #

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     #
     # For example, given
     #
-    #   class Blog < ApplicationModel
+    #   class Blog < ApplicationRecord
     #     has_many :posts
     #   end
     #
@@ -57,7 +57,7 @@ module ActiveRecord
       #
       # *First:* Specify a subset of fields to be selected from the result set.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -114,7 +114,7 @@ module ActiveRecord
       # rules as <tt>ActiveRecord::Base.find</tt>. Returns <tt>ActiveRecord::RecordNotFound</tt>
       # error if the object can not be found.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -144,7 +144,7 @@ module ActiveRecord
       # If the collection is empty, the first form returns +nil+, and the second
       # form returns an empty array.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -174,7 +174,7 @@ module ActiveRecord
       # If the collection is empty, the first form returns +nil+, and the second
       # form returns an empty array.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -280,7 +280,7 @@ module ActiveRecord
       # inserts each record, +push+ and +concat+ behave identically. Returns +self+
       # so method calls may be chained.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     pets :has_many
       #   end
       #
@@ -306,7 +306,7 @@ module ActiveRecord
       # Replaces this collection with +other_array+. This will perform a diff
       # and delete/add only records that have changed.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -338,7 +338,7 @@ module ActiveRecord
       # sets the foreign keys to <tt>NULL</tt>. For, +has_many+ <tt>:through</tt>,
       # the default strategy is +delete_all+.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets # dependent: :nullify option by default
       #   end
       #
@@ -371,7 +371,7 @@ module ActiveRecord
       # are removed by calling their +destroy+ method. See +destroy+ for more
       # information.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets, dependent: :destroy
       #   end
       #
@@ -396,7 +396,7 @@ module ActiveRecord
       # If it is set to <tt>:delete_all</tt>, all the objects are deleted
       # *without* calling their +destroy+ method.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets, dependent: :delete_all
       #   end
       #
@@ -425,7 +425,7 @@ module ActiveRecord
       # ignoring the +:dependent+ option. It invokes +before_remove+,
       # +after_remove+ , +before_destroy+ and +after_destroy+ callbacks.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -457,7 +457,7 @@ module ActiveRecord
       # keys to <tt>NULL</tt>. For, +has_many+ <tt>:through</tt>, the default
       # strategy is +delete_all+.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets # dependent: :nullify option by default
       #   end
       #
@@ -485,7 +485,7 @@ module ActiveRecord
       # If it is set to <tt>:destroy</tt> all the +records+ are removed by calling
       # their +destroy+ method. See +destroy+ for more information.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets, dependent: :destroy
       #   end
       #
@@ -513,7 +513,7 @@ module ActiveRecord
       # If it is set to <tt>:delete_all</tt>, all the +records+ are deleted
       # *without* calling their +destroy+ method.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets, dependent: :delete_all
       #   end
       #
@@ -541,7 +541,7 @@ module ActiveRecord
       # You can pass +Fixnum+ or +String+ values, it finds the records
       # responding to the +id+ and executes delete on them.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -569,7 +569,7 @@ module ActiveRecord
       # This method will _always_ remove record from the database ignoring
       # the +:dependent+ option. Returns an array with the removed records.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -639,7 +639,7 @@ module ActiveRecord
 
       # Specifies whether the records should be unique or not.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -658,7 +658,7 @@ module ActiveRecord
 
       # Count all records using SQL.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -680,7 +680,7 @@ module ActiveRecord
       # equivalent. If not and you are going to need the records anyway
       # +length+ will take one less query. Otherwise +size+ is more efficient.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -706,7 +706,7 @@ module ActiveRecord
       # equivalent. If not and you are going to need the records anyway this
       # method will take one less query. Otherwise +size+ is more efficient.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -732,7 +732,7 @@ module ActiveRecord
       # not already been loaded and you are going to fetch the records anyway it
       # is better to check <tt>collection.length.zero?</tt>.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -749,7 +749,7 @@ module ActiveRecord
 
       # Returns +true+ if the collection is not empty.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -783,7 +783,7 @@ module ActiveRecord
       # Returns true if the collection has more than one record.
       # Equivalent to <tt>collection.size > 1</tt>.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -820,7 +820,7 @@ module ActiveRecord
 
       # Returns +true+ if the given object is present in the collection.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -855,7 +855,7 @@ module ActiveRecord
       # to the corresponding element in the other array, otherwise returns
       # +false+.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -881,7 +881,7 @@ module ActiveRecord
       # Returns a new array of objects from the collection. If the collection
       # hasn't been loaded, it fetches the records from the database.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -920,7 +920,7 @@ module ActiveRecord
       # to the association's primary key. Returns +self+, so several appends may be
       # chained together.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -957,7 +957,7 @@ module ActiveRecord
       # Reloads the collection from the database. Returns +self+.
       # Equivalent to <tt>collection(true)</tt>.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     #
     # For example, given
     #
-    #   class Blog < ActiveRecord::Base
+    #   class Blog < ApplicationModel
     #     has_many :posts
     #   end
     #
@@ -57,7 +57,7 @@ module ActiveRecord
       #
       # *First:* Specify a subset of fields to be selected from the result set.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -114,7 +114,7 @@ module ActiveRecord
       # rules as <tt>ActiveRecord::Base.find</tt>. Returns <tt>ActiveRecord::RecordNotFound</tt>
       # error if the object can not be found.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -144,7 +144,7 @@ module ActiveRecord
       # If the collection is empty, the first form returns +nil+, and the second
       # form returns an empty array.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -174,7 +174,7 @@ module ActiveRecord
       # If the collection is empty, the first form returns +nil+, and the second
       # form returns an empty array.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -280,7 +280,7 @@ module ActiveRecord
       # inserts each record, +push+ and +concat+ behave identically. Returns +self+
       # so method calls may be chained.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     pets :has_many
       #   end
       #
@@ -306,7 +306,7 @@ module ActiveRecord
       # Replaces this collection with +other_array+. This will perform a diff
       # and delete/add only records that have changed.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -338,7 +338,7 @@ module ActiveRecord
       # sets the foreign keys to <tt>NULL</tt>. For, +has_many+ <tt>:through</tt>,
       # the default strategy is +delete_all+.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets # dependent: :nullify option by default
       #   end
       #
@@ -371,7 +371,7 @@ module ActiveRecord
       # are removed by calling their +destroy+ method. See +destroy+ for more
       # information.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets, dependent: :destroy
       #   end
       #
@@ -396,7 +396,7 @@ module ActiveRecord
       # If it is set to <tt>:delete_all</tt>, all the objects are deleted
       # *without* calling their +destroy+ method.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets, dependent: :delete_all
       #   end
       #
@@ -425,7 +425,7 @@ module ActiveRecord
       # ignoring the +:dependent+ option. It invokes +before_remove+,
       # +after_remove+ , +before_destroy+ and +after_destroy+ callbacks.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -457,7 +457,7 @@ module ActiveRecord
       # keys to <tt>NULL</tt>. For, +has_many+ <tt>:through</tt>, the default
       # strategy is +delete_all+.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets # dependent: :nullify option by default
       #   end
       #
@@ -485,7 +485,7 @@ module ActiveRecord
       # If it is set to <tt>:destroy</tt> all the +records+ are removed by calling
       # their +destroy+ method. See +destroy+ for more information.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets, dependent: :destroy
       #   end
       #
@@ -513,7 +513,7 @@ module ActiveRecord
       # If it is set to <tt>:delete_all</tt>, all the +records+ are deleted
       # *without* calling their +destroy+ method.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets, dependent: :delete_all
       #   end
       #
@@ -541,7 +541,7 @@ module ActiveRecord
       # You can pass +Fixnum+ or +String+ values, it finds the records
       # responding to the +id+ and executes delete on them.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -569,7 +569,7 @@ module ActiveRecord
       # This method will _always_ remove record from the database ignoring
       # the +:dependent+ option. Returns an array with the removed records.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -639,7 +639,7 @@ module ActiveRecord
 
       # Specifies whether the records should be unique or not.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -658,7 +658,7 @@ module ActiveRecord
 
       # Count all records using SQL.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -680,7 +680,7 @@ module ActiveRecord
       # equivalent. If not and you are going to need the records anyway
       # +length+ will take one less query. Otherwise +size+ is more efficient.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -706,7 +706,7 @@ module ActiveRecord
       # equivalent. If not and you are going to need the records anyway this
       # method will take one less query. Otherwise +size+ is more efficient.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -732,7 +732,7 @@ module ActiveRecord
       # not already been loaded and you are going to fetch the records anyway it
       # is better to check <tt>collection.length.zero?</tt>.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -749,7 +749,7 @@ module ActiveRecord
 
       # Returns +true+ if the collection is not empty.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -783,7 +783,7 @@ module ActiveRecord
       # Returns true if the collection has more than one record.
       # Equivalent to <tt>collection.size > 1</tt>.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -820,7 +820,7 @@ module ActiveRecord
 
       # Returns +true+ if the given object is present in the collection.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -855,7 +855,7 @@ module ActiveRecord
       # to the corresponding element in the other array, otherwise returns
       # +false+.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -881,7 +881,7 @@ module ActiveRecord
       # Returns a new array of objects from the collection. If the collection
       # hasn't been loaded, it fetches the records from the database.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -920,7 +920,7 @@ module ActiveRecord
       # to the association's primary key. Returns +self+, so several appends may be
       # chained together.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -957,7 +957,7 @@ module ActiveRecord
       # Reloads the collection from the database. Returns +self+.
       # Equivalent to <tt>collection(true)</tt>.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       #
       #  Example :
       #
-      #  class Physician < ApplicationModel
+      #  class Physician < ApplicationRecord
       #    has_many :appointments
       #    has_many :patients, through: :appointments
       #  end

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       #
       #  Example :
       #
-      #  class Physician < ActiveRecord::Base
+      #  class Physician < ApplicationModel
       #    has_many :appointments
       #    has_many :patients, through: :appointments
       #  end

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -138,7 +138,7 @@ module ActiveRecord
         #
         #  Example:
         #
-        #  class Physician < ApplicationModel
+        #  class Physician < ApplicationRecord
         #    has_many :appointments
         #  end
         #

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -138,7 +138,7 @@ module ActiveRecord
         #
         #  Example:
         #
-        #  class Physician < ActiveRecord::Base
+        #  class Physician < ApplicationModel
         #    has_many :appointments
         #  end
         #

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -89,7 +89,7 @@ module ActiveRecord
       # Raises a <tt>ActiveRecord::DangerousAttributeError</tt> exception when an
       # \Active \Record method is defined in the model, otherwise +false+.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     def save
       #       'already defined by Active Record'
       #     end
@@ -135,7 +135,7 @@ module ActiveRecord
       # Returns +true+ if +attribute+ is an attribute method and table exists,
       # +false+ otherwise.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #   end
       #
       #   Person.attribute_method?('name')   # => true
@@ -148,7 +148,7 @@ module ActiveRecord
       # Returns an array of column names as strings if it's not an abstract class and
       # table exists. Otherwise it returns an empty array.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #   end
       #
       #   Person.attribute_names
@@ -181,7 +181,7 @@ module ActiveRecord
     # which will all return +true+. It also define the attribute methods if they have
     # not been generated.
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #   end
     #
     #   person = Person.new
@@ -213,7 +213,7 @@ module ActiveRecord
 
     # Returns +true+ if the given attribute is in the attributes hash, otherwise +false+.
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #   end
     #
     #   person = Person.new
@@ -226,7 +226,7 @@ module ActiveRecord
 
     # Returns an array of names for the attributes available on this object.
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #   end
     #
     #   person = Person.new
@@ -238,7 +238,7 @@ module ActiveRecord
 
     # Returns a hash of all the attributes with their names as keys and the values of the attributes as values.
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #   end
     #
     #   person = Person.create(name: 'Francesco', age: 22)
@@ -280,7 +280,7 @@ module ActiveRecord
     # to objects that respond to <tt>empty?</tt>, most notably Strings). Otherwise, +false+.
     # Note that it always returns +true+ with boolean attributes.
     #
-    #   class Task < ApplicationModel
+    #   class Task < ApplicationRecord
     #   end
     #
     #   person = Task.new(title: '', is_done: false)
@@ -298,7 +298,7 @@ module ActiveRecord
     # Returns the column object for the named attribute. Returns +nil+ if the
     # named attribute not exists.
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #   end
     #
     #   person = Person.new
@@ -318,7 +318,7 @@ module ActiveRecord
     #
     # Alias for the <tt>read_attribute</tt> method.
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #     belongs_to :organization
     #   end
     #
@@ -336,7 +336,7 @@ module ActiveRecord
     # Updates the attribute identified by <tt>attr_name</tt> with the specified +value+.
     # (Alias for the protected <tt>write_attribute</tt> method).
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #   end
     #
     #   person = Person.new

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -89,7 +89,7 @@ module ActiveRecord
       # Raises a <tt>ActiveRecord::DangerousAttributeError</tt> exception when an
       # \Active \Record method is defined in the model, otherwise +false+.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     def save
       #       'already defined by Active Record'
       #     end
@@ -135,7 +135,7 @@ module ActiveRecord
       # Returns +true+ if +attribute+ is an attribute method and table exists,
       # +false+ otherwise.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #   end
       #
       #   Person.attribute_method?('name')   # => true
@@ -148,7 +148,7 @@ module ActiveRecord
       # Returns an array of column names as strings if it's not an abstract class and
       # table exists. Otherwise it returns an empty array.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #   end
       #
       #   Person.attribute_names
@@ -181,7 +181,7 @@ module ActiveRecord
     # which will all return +true+. It also define the attribute methods if they have
     # not been generated.
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #   end
     #
     #   person = Person.new
@@ -213,7 +213,7 @@ module ActiveRecord
 
     # Returns +true+ if the given attribute is in the attributes hash, otherwise +false+.
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #   end
     #
     #   person = Person.new
@@ -226,7 +226,7 @@ module ActiveRecord
 
     # Returns an array of names for the attributes available on this object.
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #   end
     #
     #   person = Person.new
@@ -238,7 +238,7 @@ module ActiveRecord
 
     # Returns a hash of all the attributes with their names as keys and the values of the attributes as values.
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #   end
     #
     #   person = Person.create(name: 'Francesco', age: 22)
@@ -280,7 +280,7 @@ module ActiveRecord
     # to objects that respond to <tt>empty?</tt>, most notably Strings). Otherwise, +false+.
     # Note that it always returns +true+ with boolean attributes.
     #
-    #   class Task < ActiveRecord::Base
+    #   class Task < ApplicationModel
     #   end
     #
     #   person = Task.new(title: '', is_done: false)
@@ -298,7 +298,7 @@ module ActiveRecord
     # Returns the column object for the named attribute. Returns +nil+ if the
     # named attribute not exists.
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #   end
     #
     #   person = Person.new
@@ -318,7 +318,7 @@ module ActiveRecord
     #
     # Alias for the <tt>read_attribute</tt> method.
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #     belongs_to :organization
     #   end
     #
@@ -336,7 +336,7 @@ module ActiveRecord
     # Updates the attribute identified by <tt>attr_name</tt> with the specified +value+.
     # (Alias for the protected <tt>write_attribute</tt> method).
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #   end
     #
     #   person = Person.new

--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     # <tt>ActiveRecord::AttributeMethods::BeforeTypeCast</tt> provides a way to
     # read the value of the attributes before typecasting and deserialization.
     #
-    #   class Task < ActiveRecord::Base
+    #   class Task < ApplicationModel
     #   end
     #
     #   task = Task.new(id: '1', completed_on: '2012-10-21')
@@ -33,7 +33,7 @@ module ActiveRecord
       # Returns the value of the attribute identified by +attr_name+ before
       # typecasting and deserialization.
       #
-      #   class Task < ActiveRecord::Base
+      #   class Task < ApplicationModel
       #   end
       #
       #   task = Task.new(id: '1', completed_on: '2012-10-21')
@@ -48,7 +48,7 @@ module ActiveRecord
 
       # Returns a hash of attributes before typecasting and deserialization.
       #
-      #   class Task < ActiveRecord::Base
+      #   class Task < ApplicationModel
       #   end
       #
       #   task = Task.new(title: nil, is_done: true, completed_on: '2012-10-21')

--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     # <tt>ActiveRecord::AttributeMethods::BeforeTypeCast</tt> provides a way to
     # read the value of the attributes before typecasting and deserialization.
     #
-    #   class Task < ApplicationModel
+    #   class Task < ApplicationRecord
     #   end
     #
     #   task = Task.new(id: '1', completed_on: '2012-10-21')
@@ -33,7 +33,7 @@ module ActiveRecord
       # Returns the value of the attribute identified by +attr_name+ before
       # typecasting and deserialization.
       #
-      #   class Task < ApplicationModel
+      #   class Task < ApplicationRecord
       #   end
       #
       #   task = Task.new(id: '1', completed_on: '2012-10-21')
@@ -48,7 +48,7 @@ module ActiveRecord
 
       # Returns a hash of attributes before typecasting and deserialization.
       #
-      #   class Task < ApplicationModel
+      #   class Task < ApplicationRecord
       #   end
       #
       #   task = Task.new(title: nil, is_done: true, completed_on: '2012-10-21')

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -99,13 +99,13 @@ module ActiveRecord
 
         # Sets the name of the primary key column.
         #
-        #   class Project < ApplicationModel
+        #   class Project < ApplicationRecord
         #     self.primary_key = 'sysid'
         #   end
         #
         # You can also define the +primary_key+ method yourself:
         #
-        #   class Project < ApplicationModel
+        #   class Project < ApplicationRecord
         #     def self.primary_key
         #       'foo_' + super
         #     end

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -99,13 +99,13 @@ module ActiveRecord
 
         # Sets the name of the primary key column.
         #
-        #   class Project < ActiveRecord::Base
+        #   class Project < ApplicationModel
         #     self.primary_key = 'sysid'
         #   end
         #
         # You can also define the +primary_key+ method yourself:
         #
-        #   class Project < ActiveRecord::Base
+        #   class Project < ApplicationModel
         #     def self.primary_key
         #       'foo_' + super
         #     end

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -32,7 +32,7 @@ module ActiveRecord
         # ==== Example
         #
         #   # Serialize a preferences attribute.
-        #   class User < ActiveRecord::Base
+        #   class User < ApplicationModel
         #     serialize :preferences
         #   end
         def serialize(attr_name, class_name = Object)

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -32,7 +32,7 @@ module ActiveRecord
         # ==== Example
         #
         #   # Serialize a preferences attribute.
-        #   class User < ApplicationModel
+        #   class User < ApplicationRecord
         #     serialize :preferences
         #   end
         def serialize(attr_name, class_name = Object)

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -60,7 +60,7 @@ module ActiveRecord #:nodoc:
   # be used for statements that don't involve tainted data. The hash form works much like the array form, except
   # only equality and range is possible. Examples:
   #
-  #   class User < ApplicationModel
+  #   class User < ApplicationRecord
   #     def self.authenticate_unsafely(user_name, password)
   #       where("user_name = '#{user_name}' AND password = '#{password}'").first
   #     end
@@ -119,7 +119,7 @@ module ActiveRecord #:nodoc:
   # <tt>read_attribute(attr_name)</tt> and <tt>write_attribute(attr_name, value)</tt> to actually
   # change things.
   #
-  #   class Song < ApplicationModel
+  #   class Song < ApplicationRecord
   #     # Uses an integer of seconds to hold the length of the song
   #
   #     def length=(minutes)
@@ -187,7 +187,7 @@ module ActiveRecord #:nodoc:
   # This makes it possible to store arrays, hashes, and other non-mappable objects without doing
   # any additional work.
   #
-  #   class User < ApplicationModel
+  #   class User < ApplicationRecord
   #     serialize :preferences
   #   end
   #
@@ -197,7 +197,7 @@ module ActiveRecord #:nodoc:
   # You can also specify a class option as the second parameter that'll raise an exception
   # if a serialized object is retrieved as a descendant of a class not in the hierarchy.
   #
-  #   class User < ApplicationModel
+  #   class User < ApplicationRecord
   #     serialize :preferences, Hash
   #   end
   #
@@ -207,7 +207,7 @@ module ActiveRecord #:nodoc:
   # When you specify a class option, the default value for that attribute will be a new
   # instance of that class.
   #
-  #   class User < ApplicationModel
+  #   class User < ApplicationRecord
   #     serialize :preferences, OpenStruct
   #   end
   #
@@ -221,7 +221,7 @@ module ActiveRecord #:nodoc:
   # default is named "type" (can be changed by overwriting <tt>Base.inheritance_column</tt>).
   # This means that an inheritance looking like this:
   #
-  #   class Company < ApplicationModel; end
+  #   class Company < ApplicationRecord; end
   #   class Firm < Company; end
   #   class Client < Company; end
   #   class PriorityClient < Client; end

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -293,6 +293,7 @@ module ActiveRecord #:nodoc:
     extend Explain
     extend Delegation::DelegateCache
 
+    include ApplicationConfiguration
     include Persistence
     include ReadonlyAttributes
     include ModelSchema

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -60,7 +60,7 @@ module ActiveRecord #:nodoc:
   # be used for statements that don't involve tainted data. The hash form works much like the array form, except
   # only equality and range is possible. Examples:
   #
-  #   class User < ActiveRecord::Base
+  #   class User < ApplicationModel
   #     def self.authenticate_unsafely(user_name, password)
   #       where("user_name = '#{user_name}' AND password = '#{password}'").first
   #     end
@@ -119,7 +119,7 @@ module ActiveRecord #:nodoc:
   # <tt>read_attribute(attr_name)</tt> and <tt>write_attribute(attr_name, value)</tt> to actually
   # change things.
   #
-  #   class Song < ActiveRecord::Base
+  #   class Song < ApplicationModel
   #     # Uses an integer of seconds to hold the length of the song
   #
   #     def length=(minutes)
@@ -187,7 +187,7 @@ module ActiveRecord #:nodoc:
   # This makes it possible to store arrays, hashes, and other non-mappable objects without doing
   # any additional work.
   #
-  #   class User < ActiveRecord::Base
+  #   class User < ApplicationModel
   #     serialize :preferences
   #   end
   #
@@ -197,7 +197,7 @@ module ActiveRecord #:nodoc:
   # You can also specify a class option as the second parameter that'll raise an exception
   # if a serialized object is retrieved as a descendant of a class not in the hierarchy.
   #
-  #   class User < ActiveRecord::Base
+  #   class User < ApplicationModel
   #     serialize :preferences, Hash
   #   end
   #
@@ -207,7 +207,7 @@ module ActiveRecord #:nodoc:
   # When you specify a class option, the default value for that attribute will be a new
   # instance of that class.
   #
-  #   class User < ActiveRecord::Base
+  #   class User < ApplicationModel
   #     serialize :preferences, OpenStruct
   #   end
   #
@@ -221,7 +221,7 @@ module ActiveRecord #:nodoc:
   # default is named "type" (can be changed by overwriting <tt>Base.inheritance_column</tt>).
   # This means that an inheritance looking like this:
   #
-  #   class Company < ActiveRecord::Base; end
+  #   class Company < ApplicationModel; end
   #   class Firm < Company; end
   #   class Client < Company; end
   #   class PriorityClient < Client; end

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -32,7 +32,7 @@ module ActiveRecord
   # except that each <tt>_create</tt> callback is replaced by the corresponding <tt>_update</tt> callback.
   #
   # Examples:
-  #   class CreditCard < ApplicationModel
+  #   class CreditCard < ApplicationRecord
   #     # Strip everything but digits, so the user can specify "555 234 34" or
   #     # "5552-3434" and both will mean "55523434"
   #     before_validation(on: :create) do
@@ -40,7 +40,7 @@ module ActiveRecord
   #     end
   #   end
   #
-  #   class Subscription < ApplicationModel
+  #   class Subscription < ApplicationRecord
   #     before_create :record_signup
   #
   #     private
@@ -49,7 +49,7 @@ module ActiveRecord
   #       end
   #   end
   #
-  #   class Firm < ApplicationModel
+  #   class Firm < ApplicationRecord
   #     # Destroys the associated clients and people when the firm is destroyed
   #     before_destroy { |record| Person.destroy_all "firm_id = #{record.id}"   }
   #     before_destroy { |record| Client.destroy_all "client_of = #{record.id}" }
@@ -61,7 +61,7 @@ module ActiveRecord
   # use of the callback macros. Their main advantage is that the macros add behavior into a callback
   # queue that is kept intact down through an inheritance hierarchy.
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     before_destroy :destroy_author
   #   end
   #
@@ -73,7 +73,7 @@ module ActiveRecord
   # run, both +destroy_author+ and +destroy_readers+ are called. Contrast this to the following situation
   # where the +before_destroy+ method is overridden:
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     def before_destroy() destroy_author end
   #   end
   #
@@ -99,7 +99,7 @@ module ActiveRecord
   #
   # The method reference callbacks work by specifying a protected or private method available in the object, like this:
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     before_destroy :delete_parents
   #
   #     private
@@ -110,7 +110,7 @@ module ActiveRecord
   #
   # The callback objects have methods named after the callback called with the record as the only parameter, such as:
   #
-  #   class BankAccount < ApplicationModel
+  #   class BankAccount < ApplicationRecord
   #     before_save      EncryptionWrapper.new
   #     after_save       EncryptionWrapper.new
   #     after_initialize EncryptionWrapper.new
@@ -141,7 +141,7 @@ module ActiveRecord
   # a method by the name of the callback messaged. You can make these callbacks more flexible by passing in other
   # initialization data such as the name of the attribute to work with:
   #
-  #   class BankAccount < ApplicationModel
+  #   class BankAccount < ApplicationRecord
   #     before_save      EncryptionWrapper.new("credit_card_number")
   #     after_save       EncryptionWrapper.new("credit_card_number")
   #     after_initialize EncryptionWrapper.new("credit_card_number")
@@ -175,14 +175,14 @@ module ActiveRecord
   # The callback macros usually accept a symbol for the method they're supposed to run, but you can also
   # pass a "method string", which will then be evaluated within the binding of the callback. Example:
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     before_destroy 'self.class.delete_all "parent_id = #{id}"'
   #   end
   #
   # Notice that single quotes (') are used so the <tt>#{id}</tt> part isn't evaluated until the callback
   # is triggered. Also note that these inline callbacks can be stacked just like the regular ones:
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     before_destroy 'self.class.delete_all "parent_id = #{id}"',
   #                    'puts "Evaluated after parents are destroyed"'
   #   end
@@ -207,7 +207,7 @@ module ActiveRecord
   #
   # Let's look at the code below:
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     has_many :children, dependent: destroy
   #
   #     before_destroy :log_children
@@ -221,7 +221,7 @@ module ActiveRecord
   # In this case, the problem is that when the +before_destroy+ callback is executed, the children are not available
   # because the +destroy+ callback gets executed first. You can use the +prepend+ option on the +before_destroy+ callback to avoid this.
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     has_many :children, dependent: destroy
   #
   #     before_destroy :log_children, prepend: true

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -32,7 +32,7 @@ module ActiveRecord
   # except that each <tt>_create</tt> callback is replaced by the corresponding <tt>_update</tt> callback.
   #
   # Examples:
-  #   class CreditCard < ActiveRecord::Base
+  #   class CreditCard < ApplicationModel
   #     # Strip everything but digits, so the user can specify "555 234 34" or
   #     # "5552-3434" and both will mean "55523434"
   #     before_validation(on: :create) do
@@ -40,7 +40,7 @@ module ActiveRecord
   #     end
   #   end
   #
-  #   class Subscription < ActiveRecord::Base
+  #   class Subscription < ApplicationModel
   #     before_create :record_signup
   #
   #     private
@@ -49,7 +49,7 @@ module ActiveRecord
   #       end
   #   end
   #
-  #   class Firm < ActiveRecord::Base
+  #   class Firm < ApplicationModel
   #     # Destroys the associated clients and people when the firm is destroyed
   #     before_destroy { |record| Person.destroy_all "firm_id = #{record.id}"   }
   #     before_destroy { |record| Client.destroy_all "client_of = #{record.id}" }
@@ -61,7 +61,7 @@ module ActiveRecord
   # use of the callback macros. Their main advantage is that the macros add behavior into a callback
   # queue that is kept intact down through an inheritance hierarchy.
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     before_destroy :destroy_author
   #   end
   #
@@ -73,7 +73,7 @@ module ActiveRecord
   # run, both +destroy_author+ and +destroy_readers+ are called. Contrast this to the following situation
   # where the +before_destroy+ method is overridden:
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     def before_destroy() destroy_author end
   #   end
   #
@@ -99,7 +99,7 @@ module ActiveRecord
   #
   # The method reference callbacks work by specifying a protected or private method available in the object, like this:
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     before_destroy :delete_parents
   #
   #     private
@@ -110,7 +110,7 @@ module ActiveRecord
   #
   # The callback objects have methods named after the callback called with the record as the only parameter, such as:
   #
-  #   class BankAccount < ActiveRecord::Base
+  #   class BankAccount < ApplicationModel
   #     before_save      EncryptionWrapper.new
   #     after_save       EncryptionWrapper.new
   #     after_initialize EncryptionWrapper.new
@@ -141,7 +141,7 @@ module ActiveRecord
   # a method by the name of the callback messaged. You can make these callbacks more flexible by passing in other
   # initialization data such as the name of the attribute to work with:
   #
-  #   class BankAccount < ActiveRecord::Base
+  #   class BankAccount < ApplicationModel
   #     before_save      EncryptionWrapper.new("credit_card_number")
   #     after_save       EncryptionWrapper.new("credit_card_number")
   #     after_initialize EncryptionWrapper.new("credit_card_number")
@@ -175,14 +175,14 @@ module ActiveRecord
   # The callback macros usually accept a symbol for the method they're supposed to run, but you can also
   # pass a "method string", which will then be evaluated within the binding of the callback. Example:
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     before_destroy 'self.class.delete_all "parent_id = #{id}"'
   #   end
   #
   # Notice that single quotes (') are used so the <tt>#{id}</tt> part isn't evaluated until the callback
   # is triggered. Also note that these inline callbacks can be stacked just like the regular ones:
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     before_destroy 'self.class.delete_all "parent_id = #{id}"',
   #                    'puts "Evaluated after parents are destroyed"'
   #   end
@@ -207,7 +207,7 @@ module ActiveRecord
   #
   # Let's look at the code below:
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     has_many :children, dependent: destroy
   #
   #     before_destroy :log_children
@@ -221,7 +221,7 @@ module ActiveRecord
   # In this case, the problem is that when the +before_destroy+ callback is executed, the children are not available
   # because the +destroy+ callback gets executed first. You can use the +prepend+ option on the +before_destroy+ callback to avoid this.
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     has_many :children, dependent: destroy
   #
   #     before_destroy :log_children, prepend: true

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -125,7 +125,7 @@ module ActiveRecord
 
       # Returns an instance of <tt>Arel::Table</tt> loaded with the current table name.
       #
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationModel
       #     scope :published_and_commented, published.and(self.arel_table[:comments_count].gt(0))
       #   end
       def arel_table
@@ -185,7 +185,7 @@ module ActiveRecord
     # the attributes necessary for initializing an empty model object. For
     # example:
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #   end
     #
     #   post = Post.allocate
@@ -261,7 +261,7 @@ module ActiveRecord
     #
     # Example:
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #   end
     #   coder = {}
     #   Post.new.encode_with(coder)

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -125,7 +125,7 @@ module ActiveRecord
 
       # Returns an instance of <tt>Arel::Table</tt> loaded with the current table name.
       #
-      #   class Post < ApplicationModel
+      #   class Post < ApplicationRecord
       #     scope :published_and_commented, published.and(self.arel_table[:comments_count].gt(0))
       #   end
       def arel_table
@@ -185,7 +185,7 @@ module ActiveRecord
     # the attributes necessary for initializing an empty model object. For
     # example:
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #   end
     #
     #   post = Post.allocate
@@ -261,7 +261,7 @@ module ActiveRecord
     #
     # Example:
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #   end
     #   coder = {}
     #   Post.new.encode_with(coder)

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -13,11 +13,11 @@ module ActiveRecord
 
   # Raised when an object assigned to an association has an incorrect type.
   #
-  #   class Ticket < ActiveRecord::Base
+  #   class Ticket < ApplicationModel
   #     has_many :patches
   #   end
   #
-  #   class Patch < ActiveRecord::Base
+  #   class Patch < ApplicationModel
   #     belongs_to :ticket
   #   end
   #
@@ -201,7 +201,7 @@ module ActiveRecord
 
   # Raised when a relation cannot be mutated because it's already loaded.
   #
-  #   class Task < ActiveRecord::Base
+  #   class Task < ApplicationModel
   #   end
   #
   #   relation = Task.all

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -13,11 +13,11 @@ module ActiveRecord
 
   # Raised when an object assigned to an association has an incorrect type.
   #
-  #   class Ticket < ApplicationModel
+  #   class Ticket < ApplicationRecord
   #     has_many :patches
   #   end
   #
-  #   class Patch < ApplicationModel
+  #   class Patch < ApplicationRecord
   #     belongs_to :ticket
   #   end
   #
@@ -201,7 +201,7 @@ module ActiveRecord
 
   # Raised when a relation cannot be mutated because it's already loaded.
   #
-  #   class Task < ApplicationModel
+  #   class Task < ApplicationRecord
   #   end
   #
   #   relation = Task.all

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -803,7 +803,7 @@ module ActiveRecord
       self.use_transactional_fixtures = true
       self.use_instantiated_fixtures = false
       self.pre_loaded_fixtures = false
-      self.config = ActiveRecord::Base
+      self.config = ActiveRecord::Base.application_model
 
       self.fixture_class_names = Hash.new do |h, fixture_set_name|
         h[fixture_set_name] = ActiveRecord::FixtureSet.default_fixture_model_name(fixture_set_name, self.config)
@@ -907,7 +907,7 @@ module ActiveRecord
         !self.class.uses_transaction?(method_name)
     end
 
-    def setup_fixtures(config = ActiveRecord::Base)
+    def setup_fixtures
       if pre_loaded_fixtures && !use_transactional_fixtures
         raise RuntimeError, 'pre_loaded_fixtures requires use_transactional_fixtures'
       end
@@ -916,6 +916,7 @@ module ActiveRecord
       @fixture_connections = []
       @@already_loaded_fixtures ||= {}
 
+      config = ActiveRecord::Base.application_model
       # Load fixtures once and begin transaction.
       if run_in_transaction?
         if @@already_loaded_fixtures[self.class]

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -803,7 +803,7 @@ module ActiveRecord
       self.use_transactional_fixtures = true
       self.use_instantiated_fixtures = false
       self.pre_loaded_fixtures = false
-      self.config = ActiveRecord::Base.application_model
+      self.config = ActiveRecord::Base.application_record
 
       self.fixture_class_names = Hash.new do |h, fixture_set_name|
         h[fixture_set_name] = ActiveRecord::FixtureSet.default_fixture_model_name(fixture_set_name, self.config)
@@ -916,7 +916,7 @@ module ActiveRecord
       @fixture_connections = []
       @@already_loaded_fixtures ||= {}
 
-      config = ActiveRecord::Base.application_model
+      config = ActiveRecord::Base.application_record
       # Load fixtures once and begin transaction.
       if run_in_transaction?
         if @@already_loaded_fixtures[self.class]

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -77,7 +77,7 @@ module ActiveRecord
       # to utilize the implied STI table name of the parent class, this will need to be true.
       # For example, given the following:
       #
-      #   class SuperClass < ApplicationModel
+      #   class SuperClass < ApplicationRecord
       #     self.abstract_class = true
       #   end
       #   class Child < SuperClass
@@ -189,7 +189,7 @@ module ActiveRecord
 
     # Sets the attribute used for single table inheritance to this class name if this is not the
     # ActiveRecord::Base descendant.
-    # Considering the hierarchy Reply < Message < ApplicationModel, this makes it possible to
+    # Considering the hierarchy Reply < Message < ApplicationRecord, this makes it possible to
     # do Reply.new without having to set <tt>Reply[Reply.inheritance_column] = "Reply"</tt> yourself.
     # No such attribute would be set for objects of the Message class in that example.
     def ensure_proper_type

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -77,7 +77,7 @@ module ActiveRecord
       # to utilize the implied STI table name of the parent class, this will need to be true.
       # For example, given the following:
       #
-      #   class SuperClass < ActiveRecord::Base
+      #   class SuperClass < ApplicationModel
       #     self.abstract_class = true
       #   end
       #   class Child < SuperClass
@@ -189,7 +189,7 @@ module ActiveRecord
 
     # Sets the attribute used for single table inheritance to this class name if this is not the
     # ActiveRecord::Base descendant.
-    # Considering the hierarchy Reply < Message < ActiveRecord::Base, this makes it possible to
+    # Considering the hierarchy Reply < Message < ApplicationModel, this makes it possible to
     # do Reply.new without having to set <tt>Reply[Reply.inheritance_column] = "Reply"</tt> yourself.
     # No such attribute would be set for objects of the Message class in that example.
     def ensure_proper_type

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -27,7 +27,7 @@ module ActiveRecord
     # You can override +to_param+ in your model to make +user_path+ construct
     # a path using the user's name instead of the user's id:
     #
-    #   class User < ActiveRecord::Base
+    #   class User < ApplicationModel
     #     def to_param  # overridden
     #       name
     #     end

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -27,7 +27,7 @@ module ActiveRecord
     # You can override +to_param+ in your model to make +user_path+ construct
     # a path using the user's name instead of the user's id:
     #
-    #   class User < ApplicationModel
+    #   class User < ApplicationRecord
     #     def to_param  # overridden
     #       name
     #     end

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -43,7 +43,7 @@ module ActiveRecord
     # This behavior can be turned off by setting <tt>ActiveRecord::Base.lock_optimistically = false</tt>.
     # To override the name of the +lock_version+ column, set the <tt>locking_column</tt> class attribute:
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #     self.locking_column = :lock_person
     #   end
     #

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -43,7 +43,7 @@ module ActiveRecord
     # This behavior can be turned off by setting <tt>ActiveRecord::Base.lock_optimistically = false</tt>.
     # To override the name of the +lock_version+ column, set the <tt>locking_column</tt> class attribute:
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #     self.locking_column = :lock_person
     #   end
     #

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -46,7 +46,7 @@ module ActiveRecord
     module ClassMethods
       # Guesses the table name (in forced lower-case) based on the name of the class in the
       # inheritance hierarchy descending directly from ActiveRecord::Base. So if the hierarchy
-      # looks like: Reply < Message < ActiveRecord::Base, then Message is used
+      # looks like: Reply < Message < ApplicationModel, then Message is used
       # to guess the table name even when called on Reply. The rules used to do the guess
       # are handled by the Inflector class in Active Support, which knows almost all common
       # English inflections. You can add new inflections in config/initializers/inflections.rb.
@@ -56,14 +56,14 @@ module ActiveRecord
       #
       # ==== Examples
       #
-      #   class Invoice < ActiveRecord::Base
+      #   class Invoice < ApplicationModel
       #   end
       #
       #   file                  class               table_name
       #   invoice.rb            Invoice             invoices
       #
-      #   class Invoice < ActiveRecord::Base
-      #     class Lineitem < ActiveRecord::Base
+      #   class Invoice < ApplicationModel
+      #     class Lineitem < ApplicationModel
       #     end
       #   end
       #
@@ -71,7 +71,7 @@ module ActiveRecord
       #   invoice.rb            Invoice::Lineitem   invoice_lineitems
       #
       #   module Invoice
-      #     class Lineitem < ActiveRecord::Base
+      #     class Lineitem < ApplicationModel
       #     end
       #   end
       #
@@ -85,7 +85,7 @@ module ActiveRecord
       #
       # You can also set your own table name explicitly:
       #
-      #   class Mouse < ActiveRecord::Base
+      #   class Mouse < ApplicationModel
       #     self.table_name = "mice"
       #   end
       #
@@ -93,7 +93,7 @@ module ActiveRecord
       # own computation. (Possibly using <tt>super</tt> to manipulate the default
       # table name.) Example:
       #
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationModel
       #     def self.table_name
       #       "special_" + super
       #     end
@@ -106,7 +106,7 @@ module ActiveRecord
 
       # Sets the table name explicitly. Example:
       #
-      #   class Project < ActiveRecord::Base
+      #   class Project < ApplicationModel
       #     self.table_name = "project"
       #   end
       #
@@ -190,7 +190,7 @@ module ActiveRecord
       # If a sequence name is not explicitly set when using PostgreSQL, it
       # will discover the sequence corresponding to your primary key for you.
       #
-      #   class Project < ActiveRecord::Base
+      #   class Project < ApplicationModel
       #     self.sequence_name = "projectseq"   # default would have been "project_seq"
       #   end
       def sequence_name=(value)

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -46,7 +46,7 @@ module ActiveRecord
     module ClassMethods
       # Guesses the table name (in forced lower-case) based on the name of the class in the
       # inheritance hierarchy descending directly from ActiveRecord::Base. So if the hierarchy
-      # looks like: Reply < Message < ApplicationModel, then Message is used
+      # looks like: Reply < Message < ApplicationRecord, then Message is used
       # to guess the table name even when called on Reply. The rules used to do the guess
       # are handled by the Inflector class in Active Support, which knows almost all common
       # English inflections. You can add new inflections in config/initializers/inflections.rb.
@@ -56,14 +56,14 @@ module ActiveRecord
       #
       # ==== Examples
       #
-      #   class Invoice < ApplicationModel
+      #   class Invoice < ApplicationRecord
       #   end
       #
       #   file                  class               table_name
       #   invoice.rb            Invoice             invoices
       #
-      #   class Invoice < ApplicationModel
-      #     class Lineitem < ApplicationModel
+      #   class Invoice < ApplicationRecord
+      #     class Lineitem < ApplicationRecord
       #     end
       #   end
       #
@@ -71,7 +71,7 @@ module ActiveRecord
       #   invoice.rb            Invoice::Lineitem   invoice_lineitems
       #
       #   module Invoice
-      #     class Lineitem < ApplicationModel
+      #     class Lineitem < ApplicationRecord
       #     end
       #   end
       #
@@ -85,7 +85,7 @@ module ActiveRecord
       #
       # You can also set your own table name explicitly:
       #
-      #   class Mouse < ApplicationModel
+      #   class Mouse < ApplicationRecord
       #     self.table_name = "mice"
       #   end
       #
@@ -93,7 +93,7 @@ module ActiveRecord
       # own computation. (Possibly using <tt>super</tt> to manipulate the default
       # table name.) Example:
       #
-      #   class Post < ApplicationModel
+      #   class Post < ApplicationRecord
       #     def self.table_name
       #       "special_" + super
       #     end
@@ -106,7 +106,7 @@ module ActiveRecord
 
       # Sets the table name explicitly. Example:
       #
-      #   class Project < ApplicationModel
+      #   class Project < ApplicationRecord
       #     self.table_name = "project"
       #   end
       #
@@ -190,7 +190,7 @@ module ActiveRecord
       # If a sequence name is not explicitly set when using PostgreSQL, it
       # will discover the sequence corresponding to your primary key for you.
       #
-      #   class Project < ApplicationModel
+      #   class Project < ApplicationRecord
       #     self.sequence_name = "projectseq"   # default would have been "project_seq"
       #   end
       def sequence_name=(value)

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -28,7 +28,7 @@ module ActiveRecord
     # <tt>author_attributes=(attributes)</tt> and
     # <tt>pages_attributes=(attributes)</tt>.
     #
-    #   class Book < ApplicationModel
+    #   class Book < ApplicationRecord
     #     has_one :author
     #     has_many :pages
     #
@@ -42,7 +42,7 @@ module ActiveRecord
     #
     # Consider a Member model that has one Avatar:
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar
     #   end
@@ -66,7 +66,7 @@ module ActiveRecord
     # attributes hash, you have to enable it first using the
     # <tt>:allow_destroy</tt> option.
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar, allow_destroy: true
     #   end
@@ -85,7 +85,7 @@ module ActiveRecord
     #
     # Consider a member that has a number of posts:
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts
     #   end
@@ -115,7 +115,7 @@ module ActiveRecord
     # hashes if they fail to pass your criteria. For example, the previous
     # example could be rewritten as:
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: proc { |attributes| attributes['title'].blank? }
     #   end
@@ -135,12 +135,12 @@ module ActiveRecord
     #
     # Alternatively, :reject_if also accepts a symbol for using methods:
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: :new_record?
     #   end
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: :reject_posts
     #
@@ -169,7 +169,7 @@ module ActiveRecord
     # option. This will allow you to also use the <tt>_destroy</tt> key to
     # destroy existing records:
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, allow_destroy: true
     #   end
@@ -220,12 +220,12 @@ module ActiveRecord
     # record, you can use <tt>validates_presence_of</tt> and
     # <tt>inverse_of</tt> as this example illustrates:
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_many :posts, inverse_of: :member
     #     accepts_nested_attributes_for :posts
     #   end
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #     belongs_to :member, inverse_of: :posts
     #     validates_presence_of :member
     #   end
@@ -238,7 +238,7 @@ module ActiveRecord
     # child object yourself before assignment, then this module will not
     # overwrite it, e.g.:
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar
     #

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -28,7 +28,7 @@ module ActiveRecord
     # <tt>author_attributes=(attributes)</tt> and
     # <tt>pages_attributes=(attributes)</tt>.
     #
-    #   class Book < ActiveRecord::Base
+    #   class Book < ApplicationModel
     #     has_one :author
     #     has_many :pages
     #
@@ -42,7 +42,7 @@ module ActiveRecord
     #
     # Consider a Member model that has one Avatar:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar
     #   end
@@ -66,7 +66,7 @@ module ActiveRecord
     # attributes hash, you have to enable it first using the
     # <tt>:allow_destroy</tt> option.
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar, allow_destroy: true
     #   end
@@ -85,7 +85,7 @@ module ActiveRecord
     #
     # Consider a member that has a number of posts:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_many :posts
     #     accepts_nested_attributes_for :posts
     #   end
@@ -115,7 +115,7 @@ module ActiveRecord
     # hashes if they fail to pass your criteria. For example, the previous
     # example could be rewritten as:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: proc { |attributes| attributes['title'].blank? }
     #   end
@@ -135,12 +135,12 @@ module ActiveRecord
     #
     # Alternatively, :reject_if also accepts a symbol for using methods:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: :new_record?
     #   end
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: :reject_posts
     #
@@ -169,7 +169,7 @@ module ActiveRecord
     # option. This will allow you to also use the <tt>_destroy</tt> key to
     # destroy existing records:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, allow_destroy: true
     #   end
@@ -220,12 +220,12 @@ module ActiveRecord
     # record, you can use <tt>validates_presence_of</tt> and
     # <tt>inverse_of</tt> as this example illustrates:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_many :posts, inverse_of: :member
     #     accepts_nested_attributes_for :posts
     #   end
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #     belongs_to :member, inverse_of: :posts
     #     validates_presence_of :member
     #   end
@@ -238,7 +238,7 @@ module ActiveRecord
     # child object yourself before assignment, then this module will not
     # overwrite it, e.g.:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar
     #

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -399,11 +399,11 @@ module ActiveRecord
     #
     # If used along with +belongs_to+ then +touch+ will invoke +touch+ method on associated object.
     #
-    #   class Brake < ActiveRecord::Base
+    #   class Brake < ApplicationModel
     #     belongs_to :car, touch: true
     #   end
     #
-    #   class Car < ActiveRecord::Base
+    #   class Car < ApplicationModel
     #     belongs_to :corporation, touch: true
     #   end
     #

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -399,11 +399,11 @@ module ActiveRecord
     #
     # If used along with +belongs_to+ then +touch+ will invoke +touch+ method on associated object.
     #
-    #   class Brake < ApplicationModel
+    #   class Brake < ApplicationRecord
     #     belongs_to :car, touch: true
     #   end
     #
-    #   class Car < ApplicationModel
+    #   class Car < ApplicationRecord
     #     belongs_to :corporation, touch: true
     #   end
     #

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -178,7 +178,7 @@ module ActiveRecord
     class AssociationReflection < MacroReflection #:nodoc:
       # Returns the target association's class.
       #
-      #   class Author < ActiveRecord::Base
+      #   class Author < ApplicationModel
       #     has_many :books
       #   end
       #
@@ -482,12 +482,12 @@ module ActiveRecord
       # Returns the source of the through reflection. It checks both a singularized
       # and pluralized form for <tt>:belongs_to</tt> or <tt>:has_many</tt>.
       #
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationModel
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
       #
-      #   class Tagging < ActiveRecord::Base
+      #   class Tagging < ApplicationModel
       #     belongs_to :post
       #     belongs_to :tag
       #   end
@@ -503,7 +503,7 @@ module ActiveRecord
       # Returns the AssociationReflection object specified in the <tt>:through</tt> option
       # of a HasManyThrough or HasOneThrough association.
       #
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationModel
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
@@ -523,7 +523,7 @@ module ActiveRecord
       # reflection. The base case for the recursion is a normal association, which just returns
       # [self] as its #chain.
       #
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationModel
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
@@ -602,7 +602,7 @@ module ActiveRecord
 
       # Gets an array of possible <tt>:through</tt> source reflection names in both singular and plural form.
       #
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationModel
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
@@ -630,7 +630,7 @@ module ActiveRecord
 Ambiguous source reflection for through association.  Please specify a :source
 directive on your declaration like:
 
-  class #{active_record.name} < ActiveRecord::Base
+  class #{active_record.name} < ApplicationModel
     #{macro} :#{name}, #{example_options}
   end
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -178,7 +178,7 @@ module ActiveRecord
     class AssociationReflection < MacroReflection #:nodoc:
       # Returns the target association's class.
       #
-      #   class Author < ApplicationModel
+      #   class Author < ApplicationRecord
       #     has_many :books
       #   end
       #
@@ -482,12 +482,12 @@ module ActiveRecord
       # Returns the source of the through reflection. It checks both a singularized
       # and pluralized form for <tt>:belongs_to</tt> or <tt>:has_many</tt>.
       #
-      #   class Post < ApplicationModel
+      #   class Post < ApplicationRecord
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
       #
-      #   class Tagging < ApplicationModel
+      #   class Tagging < ApplicationRecord
       #     belongs_to :post
       #     belongs_to :tag
       #   end
@@ -503,7 +503,7 @@ module ActiveRecord
       # Returns the AssociationReflection object specified in the <tt>:through</tt> option
       # of a HasManyThrough or HasOneThrough association.
       #
-      #   class Post < ApplicationModel
+      #   class Post < ApplicationRecord
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
@@ -523,7 +523,7 @@ module ActiveRecord
       # reflection. The base case for the recursion is a normal association, which just returns
       # [self] as its #chain.
       #
-      #   class Post < ApplicationModel
+      #   class Post < ApplicationRecord
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
@@ -602,7 +602,7 @@ module ActiveRecord
 
       # Gets an array of possible <tt>:through</tt> source reflection names in both singular and plural form.
       #
-      #   class Post < ApplicationModel
+      #   class Post < ApplicationRecord
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
@@ -630,7 +630,7 @@ module ActiveRecord
 Ambiguous source reflection for through association.  Please specify a :source
 directive on your declaration like:
 
-  class #{active_record.name} < ApplicationModel
+  class #{active_record.name} < ApplicationRecord
     #{macro} :#{name}, #{example_options}
   end
 

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -45,7 +45,7 @@ module ActiveRecord
       # that correspond to a +composed_of+ relationship with their expanded
       # aggregate attribute values.
       # Given:
-      #     class Person < ActiveRecord::Base
+      #     class Person < ApplicationModel
       #       composed_of :address, class_name: "Address",
       #         mapping: [%w(address_street street), %w(address_city city)]
       #     end

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -45,7 +45,7 @@ module ActiveRecord
       # that correspond to a +composed_of+ relationship with their expanded
       # aggregate attribute values.
       # Given:
-      #     class Person < ApplicationModel
+      #     class Person < ApplicationRecord
       #       composed_of :address, class_name: "Address",
       #         mapping: [%w(address_street street), %w(address_city city)]
       #     end

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -3,7 +3,7 @@ require 'active_record/scoping/named'
 require 'active_record/base'
 
 module ActiveRecord
-  class SchemaMigration < ActiveRecord::Base
+  class SchemaMigration < ApplicationModel
     class << self
 
       def table_name

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -3,7 +3,7 @@ require 'active_record/scoping/named'
 require 'active_record/base'
 
 module ActiveRecord
-  class SchemaMigration < ApplicationModel
+  class SchemaMigration < ApplicationRecord
     class << self
 
       def table_name

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       module ClassMethods
         # Returns a scope for the model without the +default_scope+.
         #
-        #   class Post < ActiveRecord::Base
+        #   class Post < ApplicationModel
         #     def self.default_scope
         #       where published: true
         #     end
@@ -41,7 +41,7 @@ module ActiveRecord
         # Use this macro in your model to set a default scope for all operations on
         # the model.
         #
-        #   class Article < ActiveRecord::Base
+        #   class Article < ApplicationModel
         #     default_scope { where(published: true) }
         #   end
         #
@@ -60,7 +60,7 @@ module ActiveRecord
         # If you use multiple +default_scope+ declarations in your model then
         # they will be merged together:
         #
-        #   class Article < ActiveRecord::Base
+        #   class Article < ApplicationModel
         #     default_scope { where(published: true) }
         #     default_scope { where(rating: 'G') }
         #   end
@@ -74,7 +74,7 @@ module ActiveRecord
         # If you need to do more complex things with a default scope, you can
         # alternatively define it as a class method:
         #
-        #   class Article < ActiveRecord::Base
+        #   class Article < ApplicationModel
         #     def self.default_scope
         #       # Should return a scope, you can call 'super' here etc.
         #     end

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       module ClassMethods
         # Returns a scope for the model without the +default_scope+.
         #
-        #   class Post < ApplicationModel
+        #   class Post < ApplicationRecord
         #     def self.default_scope
         #       where published: true
         #     end
@@ -41,7 +41,7 @@ module ActiveRecord
         # Use this macro in your model to set a default scope for all operations on
         # the model.
         #
-        #   class Article < ApplicationModel
+        #   class Article < ApplicationRecord
         #     default_scope { where(published: true) }
         #   end
         #
@@ -60,7 +60,7 @@ module ActiveRecord
         # If you use multiple +default_scope+ declarations in your model then
         # they will be merged together:
         #
-        #   class Article < ApplicationModel
+        #   class Article < ApplicationRecord
         #     default_scope { where(published: true) }
         #     default_scope { where(rating: 'G') }
         #   end
@@ -74,7 +74,7 @@ module ActiveRecord
         # If you need to do more complex things with a default scope, you can
         # alternatively define it as a class method:
         #
-        #   class Article < ApplicationModel
+        #   class Article < ApplicationRecord
         #     def self.default_scope
         #       # Should return a scope, you can call 'super' here etc.
         #     end

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -48,7 +48,7 @@ module ActiveRecord
         # represents a narrowing of a database query, such as
         # <tt>where(color: :red).select('shirts.*').includes(:washing_instructions)</tt>.
         #
-        #   class Shirt < ActiveRecord::Base
+        #   class Shirt < ApplicationModel
         #     scope :red, -> { where(color: 'red') }
         #     scope :dry_clean_only, -> { joins(:washing_instructions).where('washing_instructions.dry_clean_only = ?', true) }
         #   end
@@ -64,7 +64,7 @@ module ActiveRecord
         # Note that this is simply 'syntactic sugar' for defining an actual
         # class method:
         #
-        #   class Shirt < ActiveRecord::Base
+        #   class Shirt < ApplicationModel
         #     def self.red
         #       where(color: 'red')
         #     end
@@ -91,7 +91,7 @@ module ActiveRecord
         # descendant upon which the \scopes were defined. But they are also
         # available to +has_many+ associations. If,
         #
-        #   class Person < ActiveRecord::Base
+        #   class Person < ApplicationModel
         #     has_many :shirts
         #   end
         #
@@ -101,7 +101,7 @@ module ActiveRecord
         # \Named scopes can also have extensions, just as with +has_many+
         # declarations:
         #
-        #   class Shirt < ActiveRecord::Base
+        #   class Shirt < ApplicationModel
         #     scope :red, -> { where(color: 'red') } do
         #       def dom_id
         #         'red_shirts'
@@ -111,7 +111,7 @@ module ActiveRecord
         #
         # Scopes can also be used while creating/building a record.
         #
-        #   class Article < ActiveRecord::Base
+        #   class Article < ApplicationModel
         #     scope :published, -> { where(published: true) }
         #   end
         #
@@ -121,7 +121,7 @@ module ActiveRecord
         # \Class methods on your model are automatically available
         # on scopes. Assuming the following setup:
         #
-        #   class Article < ActiveRecord::Base
+        #   class Article < ApplicationModel
         #     scope :published, -> { where(published: true) }
         #     scope :featured, -> { where(featured: true) }
         #

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -48,7 +48,7 @@ module ActiveRecord
         # represents a narrowing of a database query, such as
         # <tt>where(color: :red).select('shirts.*').includes(:washing_instructions)</tt>.
         #
-        #   class Shirt < ApplicationModel
+        #   class Shirt < ApplicationRecord
         #     scope :red, -> { where(color: 'red') }
         #     scope :dry_clean_only, -> { joins(:washing_instructions).where('washing_instructions.dry_clean_only = ?', true) }
         #   end
@@ -64,7 +64,7 @@ module ActiveRecord
         # Note that this is simply 'syntactic sugar' for defining an actual
         # class method:
         #
-        #   class Shirt < ApplicationModel
+        #   class Shirt < ApplicationRecord
         #     def self.red
         #       where(color: 'red')
         #     end
@@ -91,7 +91,7 @@ module ActiveRecord
         # descendant upon which the \scopes were defined. But they are also
         # available to +has_many+ associations. If,
         #
-        #   class Person < ApplicationModel
+        #   class Person < ApplicationRecord
         #     has_many :shirts
         #   end
         #
@@ -101,7 +101,7 @@ module ActiveRecord
         # \Named scopes can also have extensions, just as with +has_many+
         # declarations:
         #
-        #   class Shirt < ApplicationModel
+        #   class Shirt < ApplicationRecord
         #     scope :red, -> { where(color: 'red') } do
         #       def dom_id
         #         'red_shirts'
@@ -111,7 +111,7 @@ module ActiveRecord
         #
         # Scopes can also be used while creating/building a record.
         #
-        #   class Article < ApplicationModel
+        #   class Article < ApplicationRecord
         #     scope :published, -> { where(published: true) }
         #   end
         #
@@ -121,7 +121,7 @@ module ActiveRecord
         # \Class methods on your model are automatically available
         # on scopes. Assuming the following setup:
         #
-        #   class Article < ApplicationModel
+        #   class Article < ApplicationRecord
         #     scope :published, -> { where(published: true) }
         #     scope :featured, -> { where(featured: true) }
         #

--- a/activerecord/lib/active_record/serializers/xml_serializer.rb
+++ b/activerecord/lib/active_record/serializers/xml_serializer.rb
@@ -160,7 +160,7 @@ module ActiveRecord #:nodoc:
     # subclasses to have complete control about what's generated. The general
     # form of doing this is:
     #
-    #   class IHaveMyOwnXML < ActiveRecord::Base
+    #   class IHaveMyOwnXML < ApplicationModel
     #     def to_xml(options = {})
     #       require 'builder'
     #       options[:indent] ||= 2

--- a/activerecord/lib/active_record/serializers/xml_serializer.rb
+++ b/activerecord/lib/active_record/serializers/xml_serializer.rb
@@ -160,7 +160,7 @@ module ActiveRecord #:nodoc:
     # subclasses to have complete control about what's generated. The general
     # form of doing this is:
     #
-    #   class IHaveMyOwnXML < ApplicationModel
+    #   class IHaveMyOwnXML < ApplicationRecord
     #     def to_xml(options = {})
     #       require 'builder'
     #       options[:indent] ||= 2

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -17,7 +17,7 @@ module ActiveRecord
   #
   # Examples:
   #
-  #   class User < ActiveRecord::Base
+  #   class User < ApplicationModel
   #     store :settings, accessors: [ :color, :homepage ], coder: JSON
   #   end
   #
@@ -45,7 +45,7 @@ module ActiveRecord
   # the default accessors (using the same name as the attribute) and calling <tt>super</tt>
   # to actually change things.
   #
-  #   class Song < ActiveRecord::Base
+  #   class Song < ApplicationModel
   #     # Uses a stored integer to hold the volume adjustment of the song
   #     store :settings, accessors: [:volume_adjustment]
   #

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -17,7 +17,7 @@ module ActiveRecord
   #
   # Examples:
   #
-  #   class User < ApplicationModel
+  #   class User < ApplicationRecord
   #     store :settings, accessors: [ :color, :homepage ], coder: JSON
   #   end
   #
@@ -45,7 +45,7 @@ module ActiveRecord
   # the default accessors (using the same name as the attribute) and calling <tt>super</tt>
   # to actually change things.
   #
-  #   class Song < ApplicationModel
+  #   class Song < ApplicationRecord
   #     # Uses a stored integer to hold the volume adjustment of the song
   #     store :settings, accessors: [:volume_adjustment]
   #

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -25,7 +25,7 @@ module ActiveRecord
   # If your attributes are time zone aware and you desire to skip time zone conversion to the current Time.zone
   # when reading certain attributes then you can do following:
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     self.skip_time_zone_conversion_for_attributes = [:written_on]
   #   end
   module Timestamp

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -25,7 +25,7 @@ module ActiveRecord
   # If your attributes are time zone aware and you desire to skip time zone conversion to the current Time.zone
   # when reading certain attributes then you can do following:
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     self.skip_time_zone_conversion_for_attributes = [:written_on]
   #   end
   module Timestamp

--- a/activerecord/lib/active_record/validations/associated.rb
+++ b/activerecord/lib/active_record/validations/associated.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       # Validates whether the associated object or objects are all valid.
       # Works with any kind of association.
       #
-      #   class Book < ApplicationModel
+      #   class Book < ApplicationRecord
       #     has_many :pages
       #     belongs_to :library
       #

--- a/activerecord/lib/active_record/validations/associated.rb
+++ b/activerecord/lib/active_record/validations/associated.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       # Validates whether the associated object or objects are all valid.
       # Works with any kind of association.
       #
-      #   class Book < ActiveRecord::Base
+      #   class Book < ApplicationModel
       #     has_many :pages
       #     belongs_to :library
       #

--- a/activerecord/lib/active_record/validations/presence.rb
+++ b/activerecord/lib/active_record/validations/presence.rb
@@ -21,7 +21,7 @@ module ActiveRecord
       # associated object is not marked for destruction. Happens by default
       # on save.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_one :face
       #     validates_presence_of :face
       #   end

--- a/activerecord/lib/active_record/validations/presence.rb
+++ b/activerecord/lib/active_record/validations/presence.rb
@@ -21,7 +21,7 @@ module ActiveRecord
       # associated object is not marked for destruction. Happens by default
       # on save.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_one :face
       #     validates_presence_of :face
       #   end

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -90,14 +90,14 @@ module ActiveRecord
       # across the system. Useful for making sure that only one user
       # can be named "davidhh".
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     validates_uniqueness_of :user_name
       #   end
       #
       # It can also validate whether the value of the specified attributes are
       # unique based on a <tt>:scope</tt> parameter:
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     validates_uniqueness_of :user_name, scope: :account_id
       #   end
       #
@@ -105,7 +105,7 @@ module ActiveRecord
       # teacher can only be on the schedule once per semester for a particular
       # class.
       #
-      #   class TeacherSchedule < ActiveRecord::Base
+      #   class TeacherSchedule < ApplicationModel
       #     validates_uniqueness_of :teacher_id, scope: [:semester_id, :class_id]
       #   end
       #
@@ -114,7 +114,7 @@ module ActiveRecord
       # are not being taken into consideration when validating uniqueness
       # of the title attribute:
       #
-      #   class Article < ActiveRecord::Base
+      #   class Article < ApplicationModel
       #     validates_uniqueness_of :title, conditions: -> { where.not(status: 'archived') }
       #   end
       #

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -90,14 +90,14 @@ module ActiveRecord
       # across the system. Useful for making sure that only one user
       # can be named "davidhh".
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     validates_uniqueness_of :user_name
       #   end
       #
       # It can also validate whether the value of the specified attributes are
       # unique based on a <tt>:scope</tt> parameter:
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     validates_uniqueness_of :user_name, scope: :account_id
       #   end
       #
@@ -105,7 +105,7 @@ module ActiveRecord
       # teacher can only be on the schedule once per semester for a particular
       # class.
       #
-      #   class TeacherSchedule < ApplicationModel
+      #   class TeacherSchedule < ApplicationRecord
       #     validates_uniqueness_of :teacher_id, scope: [:semester_id, :class_id]
       #   end
       #
@@ -114,7 +114,7 @@ module ActiveRecord
       # are not being taken into consideration when validating uniqueness
       # of the title attribute:
       #
-      #   class Article < ApplicationModel
+      #   class Article < ApplicationRecord
       #     validates_uniqueness_of :title, conditions: -> { where.not(status: 'archived') }
       #   end
       #

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -44,7 +44,7 @@ module ActiveRecord
 
         # Used by the migration template to determine the parent name of the model
         def parent_class_name
-          options[:parent] || "ApplicationModel"
+          options[:parent] || "ApplicationRecord"
         end
 
     end

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -44,7 +44,7 @@ module ActiveRecord
 
         # Used by the migration template to determine the parent name of the model
         def parent_class_name
-          options[:parent] || "ActiveRecord::Base"
+          options[:parent] || "ApplicationModel"
         end
 
     end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -183,7 +183,7 @@ module ActiveRecord
   class AdapterTestWithoutTransaction < ActiveRecord::TestCase
     self.use_transactional_fixtures = false
 
-    class Klass < ApplicationModel
+    class Klass < ApplicationRecord
     end
 
     def setup

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -183,7 +183,7 @@ module ActiveRecord
   class AdapterTestWithoutTransaction < ActiveRecord::TestCase
     self.use_transactional_fixtures = false
 
-    class Klass < ActiveRecord::Base
+    class Klass < ApplicationModel
     end
 
     def setup

--- a/activerecord/test/cases/adapters/mysql/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql/case_sensitivity_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require 'models/person'
 
 class MysqlCaseSensitivityTest < ActiveRecord::TestCase
-  class CollationTest < ActiveRecord::Base
+  class CollationTest < ApplicationModel
     validates_uniqueness_of :string_cs_column, :case_sensitive => false
     validates_uniqueness_of :string_ci_column, :case_sensitive => false
   end

--- a/activerecord/test/cases/adapters/mysql/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql/case_sensitivity_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require 'models/person'
 
 class MysqlCaseSensitivityTest < ActiveRecord::TestCase
-  class CollationTest < ApplicationModel
+  class CollationTest < ApplicationRecord
     validates_uniqueness_of :string_cs_column, :case_sensitive => false
     validates_uniqueness_of :string_ci_column, :case_sensitive => false
   end

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class MysqlConnectionTest < ActiveRecord::TestCase
-  class Klass < ActiveRecord::Base
+  class Klass < ApplicationModel
   end
 
   def setup

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class MysqlConnectionTest < ActiveRecord::TestCase
-  class Klass < ApplicationModel
+  class Klass < ApplicationRecord
   end
 
   def setup

--- a/activerecord/test/cases/adapters/mysql/enum_test.rb
+++ b/activerecord/test/cases/adapters/mysql/enum_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class MysqlEnumTest < ActiveRecord::TestCase
-  class EnumTest < ActiveRecord::Base
+  class EnumTest < ApplicationModel
   end
 
   def test_enum_limit

--- a/activerecord/test/cases/adapters/mysql/enum_test.rb
+++ b/activerecord/test/cases/adapters/mysql/enum_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class MysqlEnumTest < ActiveRecord::TestCase
-  class EnumTest < ApplicationModel
+  class EnumTest < ApplicationRecord
   end
 
   def test_enum_limit

--- a/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
@@ -1,21 +1,21 @@
 require "cases/helper"
 
-class Group < ApplicationModel
+class Group < ApplicationRecord
   Group.table_name = 'group'
   belongs_to :select
   has_one :values
 end
 
-class Select < ApplicationModel
+class Select < ApplicationRecord
   Select.table_name = 'select'
   has_many :groups
 end
 
-class Values < ApplicationModel
+class Values < ApplicationRecord
   Values.table_name = 'values'
 end
 
-class Distinct < ApplicationModel
+class Distinct < ApplicationRecord
   Distinct.table_name = 'distinct'
   has_and_belongs_to_many :selects
   has_many :values, :through => :groups

--- a/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
@@ -1,21 +1,21 @@
 require "cases/helper"
 
-class Group < ActiveRecord::Base
+class Group < ApplicationModel
   Group.table_name = 'group'
   belongs_to :select
   has_one :values
 end
 
-class Select < ActiveRecord::Base
+class Select < ApplicationModel
   Select.table_name = 'select'
   has_many :groups
 end
 
-class Values < ActiveRecord::Base
+class Values < ApplicationModel
   Values.table_name = 'values'
 end
 
-class Distinct < ActiveRecord::Base
+class Distinct < ApplicationModel
   Distinct.table_name = 'distinct'
   has_and_belongs_to_many :selects
   has_many :values, :through => :groups

--- a/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require 'models/person'
 
 class Mysql2CaseSensitivityTest < ActiveRecord::TestCase
-  class CollationTest < ApplicationModel
+  class CollationTest < ApplicationRecord
     validates_uniqueness_of :string_cs_column, :case_sensitive => false
     validates_uniqueness_of :string_ci_column, :case_sensitive => false
   end

--- a/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require 'models/person'
 
 class Mysql2CaseSensitivityTest < ActiveRecord::TestCase
-  class CollationTest < ActiveRecord::Base
+  class CollationTest < ApplicationModel
     validates_uniqueness_of :string_cs_column, :case_sensitive => false
     validates_uniqueness_of :string_ci_column, :case_sensitive => false
   end

--- a/activerecord/test/cases/adapters/mysql2/enum_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/enum_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class Mysql2EnumTest < ActiveRecord::TestCase
-  class EnumTest < ApplicationModel
+  class EnumTest < ApplicationRecord
   end
 
   def test_enum_limit

--- a/activerecord/test/cases/adapters/mysql2/enum_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/enum_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class Mysql2EnumTest < ActiveRecord::TestCase
-  class EnumTest < ActiveRecord::Base
+  class EnumTest < ApplicationModel
   end
 
   def test_enum_limit

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -1,21 +1,21 @@
 require "cases/helper"
 
-class Group < ApplicationModel
+class Group < ApplicationRecord
   Group.table_name = 'group'
   belongs_to :select
   has_one :values
 end
 
-class Select < ApplicationModel
+class Select < ApplicationRecord
   Select.table_name = 'select'
   has_many :groups
 end
 
-class Values < ApplicationModel
+class Values < ApplicationRecord
   Values.table_name = 'values'
 end
 
-class Distinct < ApplicationModel
+class Distinct < ApplicationRecord
   Distinct.table_name = 'distinct'
   has_and_belongs_to_many :selects
   has_many :values, :through => :groups

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -1,21 +1,21 @@
 require "cases/helper"
 
-class Group < ActiveRecord::Base
+class Group < ApplicationModel
   Group.table_name = 'group'
   belongs_to :select
   has_one :values
 end
 
-class Select < ActiveRecord::Base
+class Select < ApplicationModel
   Select.table_name = 'select'
   has_many :groups
 end
 
-class Values < ActiveRecord::Base
+class Values < ApplicationModel
   Values.table_name = 'values'
 end
 
-class Distinct < ActiveRecord::Base
+class Distinct < ApplicationModel
   Distinct.table_name = 'distinct'
   has_and_belongs_to_many :selects
   has_many :values, :through => :groups

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -4,7 +4,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlArrayTest < ActiveRecord::TestCase
-  class PgArray < ActiveRecord::Base
+  class PgArray < ApplicationModel
     self.table_name = 'pg_arrays'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -4,7 +4,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlArrayTest < ActiveRecord::TestCase
-  class PgArray < ApplicationModel
+  class PgArray < ApplicationRecord
     self.table_name = 'pg_arrays'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlByteaTest < ActiveRecord::TestCase
-  class ByteaDataType < ActiveRecord::Base
+  class ByteaDataType < ApplicationModel
     self.table_name = 'bytea_data_type'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlByteaTest < ActiveRecord::TestCase
-  class ByteaDataType < ApplicationModel
+  class ByteaDataType < ApplicationRecord
     self.table_name = 'bytea_data_type'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 
 module ActiveRecord
   class PostgresqlConnectionTest < ActiveRecord::TestCase
-    class NonExistentTable < ApplicationModel
+    class NonExistentTable < ApplicationRecord
     end
 
     def setup

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 
 module ActiveRecord
   class PostgresqlConnectionTest < ActiveRecord::TestCase
-    class NonExistentTable < ActiveRecord::Base
+    class NonExistentTable < ApplicationModel
     end
 
     def setup

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -1,39 +1,39 @@
 require "cases/helper"
 
-class PostgresqlArray < ActiveRecord::Base
+class PostgresqlArray < ApplicationModel
 end
 
-class PostgresqlRange < ActiveRecord::Base
+class PostgresqlRange < ApplicationModel
 end
 
-class PostgresqlTsvector < ActiveRecord::Base
+class PostgresqlTsvector < ApplicationModel
 end
 
-class PostgresqlMoney < ActiveRecord::Base
+class PostgresqlMoney < ApplicationModel
 end
 
-class PostgresqlNumber < ActiveRecord::Base
+class PostgresqlNumber < ApplicationModel
 end
 
-class PostgresqlTime < ActiveRecord::Base
+class PostgresqlTime < ApplicationModel
 end
 
-class PostgresqlNetworkAddress < ActiveRecord::Base
+class PostgresqlNetworkAddress < ApplicationModel
 end
 
-class PostgresqlBitString < ActiveRecord::Base
+class PostgresqlBitString < ApplicationModel
 end
 
-class PostgresqlOid < ActiveRecord::Base
+class PostgresqlOid < ApplicationModel
 end
 
-class PostgresqlTimestampWithZone < ActiveRecord::Base
+class PostgresqlTimestampWithZone < ApplicationModel
 end
 
-class PostgresqlUUID < ActiveRecord::Base
+class PostgresqlUUID < ApplicationModel
 end
 
-class PostgresqlLtree < ActiveRecord::Base
+class PostgresqlLtree < ApplicationModel
 end
 
 class PostgresqlDataTypeTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -1,39 +1,39 @@
 require "cases/helper"
 
-class PostgresqlArray < ApplicationModel
+class PostgresqlArray < ApplicationRecord
 end
 
-class PostgresqlRange < ApplicationModel
+class PostgresqlRange < ApplicationRecord
 end
 
-class PostgresqlTsvector < ApplicationModel
+class PostgresqlTsvector < ApplicationRecord
 end
 
-class PostgresqlMoney < ApplicationModel
+class PostgresqlMoney < ApplicationRecord
 end
 
-class PostgresqlNumber < ApplicationModel
+class PostgresqlNumber < ApplicationRecord
 end
 
-class PostgresqlTime < ApplicationModel
+class PostgresqlTime < ApplicationRecord
 end
 
-class PostgresqlNetworkAddress < ApplicationModel
+class PostgresqlNetworkAddress < ApplicationRecord
 end
 
-class PostgresqlBitString < ApplicationModel
+class PostgresqlBitString < ApplicationRecord
 end
 
-class PostgresqlOid < ApplicationModel
+class PostgresqlOid < ApplicationRecord
 end
 
-class PostgresqlTimestampWithZone < ApplicationModel
+class PostgresqlTimestampWithZone < ApplicationRecord
 end
 
-class PostgresqlUUID < ApplicationModel
+class PostgresqlUUID < ApplicationRecord
 end
 
-class PostgresqlLtree < ApplicationModel
+class PostgresqlLtree < ApplicationRecord
 end
 
 class PostgresqlDataTypeTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlHstoreTest < ActiveRecord::TestCase
-  class Hstore < ActiveRecord::Base
+  class Hstore < ApplicationModel
     self.table_name = 'hstores'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlHstoreTest < ActiveRecord::TestCase
-  class Hstore < ApplicationModel
+  class Hstore < ApplicationRecord
     self.table_name = 'hstores'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlJSONTest < ActiveRecord::TestCase
-  class JsonDataType < ApplicationModel
+  class JsonDataType < ApplicationRecord
     self.table_name = 'json_data_type'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlJSONTest < ActiveRecord::TestCase
-  class JsonDataType < ActiveRecord::Base
+  class JsonDataType < ApplicationModel
     self.table_name = 'json_data_type'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/ltree_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/ltree_test.rb
@@ -4,7 +4,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlLtreeTest < ActiveRecord::TestCase
-  class Ltree < ActiveRecord::Base
+  class Ltree < ApplicationModel
     self.table_name = 'ltrees'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/ltree_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/ltree_test.rb
@@ -4,7 +4,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlLtreeTest < ActiveRecord::TestCase
-  class Ltree < ApplicationModel
+  class Ltree < ApplicationRecord
     self.table_name = 'ltrees'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class SchemaThing < ActiveRecord::Base
+class SchemaThing < ApplicationModel
 end
 
 class SchemaAuthorizationTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class SchemaThing < ApplicationModel
+class SchemaThing < ApplicationRecord
 end
 
 class SchemaAuthorizationTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -30,23 +30,23 @@ class SchemaTest < ActiveRecord::TestCase
   UNMATCHED_SEQUENCE_NAME = 'unmatched_primary_key_default_value_seq'
   UNMATCHED_PK_TABLE_NAME = 'table_with_unmatched_sequence_for_pk'
 
-  class Thing1 < ApplicationModel
+  class Thing1 < ApplicationRecord
     self.table_name = "test_schema.things"
   end
 
-  class Thing2 < ApplicationModel
+  class Thing2 < ApplicationRecord
     self.table_name = "test_schema2.things"
   end
 
-  class Thing3 < ApplicationModel
+  class Thing3 < ApplicationRecord
     self.table_name = 'test_schema."things.table"'
   end
 
-  class Thing4 < ApplicationModel
+  class Thing4 < ApplicationRecord
     self.table_name = 'test_schema."Things"'
   end
 
-  class Thing5 < ApplicationModel
+  class Thing5 < ApplicationRecord
     self.table_name = 'things'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -30,23 +30,23 @@ class SchemaTest < ActiveRecord::TestCase
   UNMATCHED_SEQUENCE_NAME = 'unmatched_primary_key_default_value_seq'
   UNMATCHED_PK_TABLE_NAME = 'table_with_unmatched_sequence_for_pk'
 
-  class Thing1 < ActiveRecord::Base
+  class Thing1 < ApplicationModel
     self.table_name = "test_schema.things"
   end
 
-  class Thing2 < ActiveRecord::Base
+  class Thing2 < ApplicationModel
     self.table_name = "test_schema2.things"
   end
 
-  class Thing3 < ActiveRecord::Base
+  class Thing3 < ApplicationModel
     self.table_name = 'test_schema."things.table"'
   end
 
-  class Thing4 < ActiveRecord::Base
+  class Thing4 < ApplicationModel
     self.table_name = 'test_schema."Things"'
   end
 
-  class Thing5 < ActiveRecord::Base
+  class Thing5 < ApplicationModel
     self.table_name = 'things'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlUUIDTest < ActiveRecord::TestCase
-  class UUID < ApplicationModel
+  class UUID < ApplicationRecord
     self.table_name = 'pg_uuids'
   end
 
@@ -65,7 +65,7 @@ class PostgresqlUUIDTest < ActiveRecord::TestCase
 end
 
 class PostgresqlUUIDTestNilDefault < ActiveRecord::TestCase
-  class UUID < ApplicationModel
+  class UUID < ApplicationRecord
     self.table_name = 'pg_uuids'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlUUIDTest < ActiveRecord::TestCase
-  class UUID < ActiveRecord::Base
+  class UUID < ApplicationModel
     self.table_name = 'pg_uuids'
   end
 
@@ -65,7 +65,7 @@ class PostgresqlUUIDTest < ActiveRecord::TestCase
 end
 
 class PostgresqlUUIDTestNilDefault < ActiveRecord::TestCase
-  class UUID < ActiveRecord::Base
+  class UUID < ApplicationModel
     self.table_name = 'pg_uuids'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/view_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/view_test.rb
@@ -13,7 +13,7 @@ class ViewTest < ActiveRecord::TestCase
     'moment timestamp without time zone'
   ]
 
-  class ThingView < ApplicationModel
+  class ThingView < ApplicationRecord
     self.table_name = 'test_schema.view_things'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/view_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/view_test.rb
@@ -13,7 +13,7 @@ class ViewTest < ActiveRecord::TestCase
     'moment timestamp without time zone'
   ]
 
-  class ThingView < ActiveRecord::Base
+  class ThingView < ApplicationModel
     self.table_name = 'test_schema.view_things'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/xml_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/xml_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlXMLTest < ActiveRecord::TestCase
-  class XmlDataType < ApplicationModel
+  class XmlDataType < ApplicationRecord
     self.table_name = 'xml_data_type'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/xml_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/xml_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlXMLTest < ActiveRecord::TestCase
-  class XmlDataType < ActiveRecord::Base
+  class XmlDataType < ApplicationModel
     self.table_name = 'xml_data_type'
   end
 

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     class SQLite3AdapterTest < ActiveRecord::TestCase
       self.use_transactional_fixtures = false
 
-      class DualEncoding < ActiveRecord::Base
+      class DualEncoding < ApplicationModel
       end
 
       def setup

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     class SQLite3AdapterTest < ActiveRecord::TestCase
       self.use_transactional_fixtures = false
 
-      class DualEncoding < ApplicationModel
+      class DualEncoding < ApplicationRecord
       end
 
       def setup

--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -143,7 +143,7 @@ end
 class OverridingAggregationsTest < ActiveRecord::TestCase
   class DifferentName; end
 
-  class Person < ActiveRecord::Base
+  class Person < ApplicationModel
     composed_of :composed_of, :mapping => %w(person_first_name first_name)
   end
 

--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -143,7 +143,7 @@ end
 class OverridingAggregationsTest < ActiveRecord::TestCase
   class DifferentName; end
 
-  class Person < ApplicationModel
+  class Person < ApplicationRecord
     composed_of :composed_of, :mapping => %w(person_first_name first_name)
   end
 

--- a/activerecord/test/cases/associations/eager_load_includes_full_sti_class_test.rb
+++ b/activerecord/test/cases/associations/eager_load_includes_full_sti_class_test.rb
@@ -3,7 +3,7 @@ require 'models/post'
 require 'models/tagging'
 
 module Namespaced
-  class Post < ApplicationModel
+  class Post < ApplicationRecord
     self.table_name = 'posts'
     has_one :tagging, :as => :taggable, :class_name => 'Tagging'
   end

--- a/activerecord/test/cases/associations/eager_load_includes_full_sti_class_test.rb
+++ b/activerecord/test/cases/associations/eager_load_includes_full_sti_class_test.rb
@@ -3,7 +3,7 @@ require 'models/post'
 require 'models/tagging'
 
 module Namespaced
-  class Post < ActiveRecord::Base
+  class Post < ApplicationModel
     self.table_name = 'posts'
     has_one :tagging, :as => :taggable, :class_name => 'Tagging'
   end

--- a/activerecord/test/cases/associations/eager_load_nested_include_test.rb
+++ b/activerecord/test/cases/associations/eager_load_nested_include_test.rb
@@ -22,38 +22,38 @@ module Remembered
   end
 end
 
-class ShapeExpression < ApplicationModel
+class ShapeExpression < ApplicationRecord
   belongs_to :shape, :polymorphic => true
   belongs_to :paint, :polymorphic => true
 end
 
-class Circle < ApplicationModel
+class Circle < ApplicationRecord
   has_many :shape_expressions, :as => :shape
   include Remembered
 end
-class Square < ApplicationModel
+class Square < ApplicationRecord
   has_many :shape_expressions, :as => :shape
   include Remembered
 end
-class Triangle < ApplicationModel
+class Triangle < ApplicationRecord
   has_many :shape_expressions, :as => :shape
   include Remembered
 end
-class PaintColor  < ApplicationModel
+class PaintColor  < ApplicationRecord
   has_many   :shape_expressions, :as => :paint
   belongs_to :non_poly, :foreign_key => "non_poly_one_id", :class_name => "NonPolyOne"
   include Remembered
 end
-class PaintTexture < ApplicationModel
+class PaintTexture < ApplicationRecord
   has_many   :shape_expressions, :as => :paint
   belongs_to :non_poly, :foreign_key => "non_poly_two_id", :class_name => "NonPolyTwo"
   include Remembered
 end
-class NonPolyOne < ApplicationModel
+class NonPolyOne < ApplicationRecord
   has_many :paint_colors
   include Remembered
 end
-class NonPolyTwo < ApplicationModel
+class NonPolyTwo < ApplicationRecord
   has_many :paint_textures
   include Remembered
 end

--- a/activerecord/test/cases/associations/eager_load_nested_include_test.rb
+++ b/activerecord/test/cases/associations/eager_load_nested_include_test.rb
@@ -22,38 +22,38 @@ module Remembered
   end
 end
 
-class ShapeExpression < ActiveRecord::Base
+class ShapeExpression < ApplicationModel
   belongs_to :shape, :polymorphic => true
   belongs_to :paint, :polymorphic => true
 end
 
-class Circle < ActiveRecord::Base
+class Circle < ApplicationModel
   has_many :shape_expressions, :as => :shape
   include Remembered
 end
-class Square < ActiveRecord::Base
+class Square < ApplicationModel
   has_many :shape_expressions, :as => :shape
   include Remembered
 end
-class Triangle < ActiveRecord::Base
+class Triangle < ApplicationModel
   has_many :shape_expressions, :as => :shape
   include Remembered
 end
-class PaintColor  < ActiveRecord::Base
+class PaintColor  < ApplicationModel
   has_many   :shape_expressions, :as => :paint
   belongs_to :non_poly, :foreign_key => "non_poly_one_id", :class_name => "NonPolyOne"
   include Remembered
 end
-class PaintTexture < ActiveRecord::Base
+class PaintTexture < ApplicationModel
   has_many   :shape_expressions, :as => :paint
   belongs_to :non_poly, :foreign_key => "non_poly_two_id", :class_name => "NonPolyTwo"
   include Remembered
 end
-class NonPolyOne < ActiveRecord::Base
+class NonPolyOne < ApplicationModel
   has_many :paint_colors
   include Remembered
 end
-class NonPolyTwo < ActiveRecord::Base
+class NonPolyTwo < ApplicationModel
   has_many :paint_textures
   include Remembered
 end

--- a/activerecord/test/cases/associations/eager_singularization_test.rb
+++ b/activerecord/test/cases/associations/eager_singularization_test.rb
@@ -1,40 +1,40 @@
 require "cases/helper"
 
-class Virus < ApplicationModel
+class Virus < ApplicationRecord
   belongs_to :octopus
 end
-class Octopus < ApplicationModel
+class Octopus < ApplicationRecord
   has_one :virus
 end
-class Pass < ApplicationModel
+class Pass < ApplicationRecord
   belongs_to :bus
 end
-class Bus < ApplicationModel
+class Bus < ApplicationRecord
   has_many :passes
 end
-class Mess < ApplicationModel
+class Mess < ApplicationRecord
   has_and_belongs_to_many :crises
 end
-class Crisis < ApplicationModel
+class Crisis < ApplicationRecord
   has_and_belongs_to_many :messes
   has_many :analyses, :dependent => :destroy
   has_many :successes, :through => :analyses
   has_many :dresses, :dependent => :destroy
   has_many :compresses, :through => :dresses
 end
-class Analysis < ApplicationModel
+class Analysis < ApplicationRecord
   belongs_to :crisis
   belongs_to :success
 end
-class Success < ApplicationModel
+class Success < ApplicationRecord
   has_many :analyses, :dependent => :destroy
   has_many :crises, :through => :analyses
 end
-class Dress < ApplicationModel
+class Dress < ApplicationRecord
   belongs_to :crisis
   has_many :compresses
 end
-class Compress < ApplicationModel
+class Compress < ApplicationRecord
   belongs_to :dress
 end
 

--- a/activerecord/test/cases/associations/eager_singularization_test.rb
+++ b/activerecord/test/cases/associations/eager_singularization_test.rb
@@ -1,40 +1,40 @@
 require "cases/helper"
 
-class Virus < ActiveRecord::Base
+class Virus < ApplicationModel
   belongs_to :octopus
 end
-class Octopus < ActiveRecord::Base
+class Octopus < ApplicationModel
   has_one :virus
 end
-class Pass < ActiveRecord::Base
+class Pass < ApplicationModel
   belongs_to :bus
 end
-class Bus < ActiveRecord::Base
+class Bus < ApplicationModel
   has_many :passes
 end
-class Mess < ActiveRecord::Base
+class Mess < ApplicationModel
   has_and_belongs_to_many :crises
 end
-class Crisis < ActiveRecord::Base
+class Crisis < ApplicationModel
   has_and_belongs_to_many :messes
   has_many :analyses, :dependent => :destroy
   has_many :successes, :through => :analyses
   has_many :dresses, :dependent => :destroy
   has_many :compresses, :through => :dresses
 end
-class Analysis < ActiveRecord::Base
+class Analysis < ApplicationModel
   belongs_to :crisis
   belongs_to :success
 end
-class Success < ActiveRecord::Base
+class Success < ApplicationModel
   has_many :analyses, :dependent => :destroy
   has_many :crises, :through => :analyses
 end
-class Dress < ActiveRecord::Base
+class Dress < ApplicationModel
   belongs_to :crisis
   has_many :compresses
 end
-class Compress < ActiveRecord::Base
+class Compress < ApplicationModel
   belongs_to :dress
 end
 

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -22,7 +22,7 @@ require 'models/country'
 require 'models/treaty'
 require 'active_support/core_ext/string/conversions'
 
-class ProjectWithAfterCreateHook < ApplicationModel
+class ProjectWithAfterCreateHook < ApplicationRecord
   self.table_name = 'projects'
   has_and_belongs_to_many :developers,
     :class_name => "DeveloperForProjectWithAfterCreateHook",
@@ -38,7 +38,7 @@ class ProjectWithAfterCreateHook < ApplicationModel
   end
 end
 
-class DeveloperForProjectWithAfterCreateHook < ApplicationModel
+class DeveloperForProjectWithAfterCreateHook < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects,
     :class_name => "ProjectWithAfterCreateHook",
@@ -47,7 +47,7 @@ class DeveloperForProjectWithAfterCreateHook < ApplicationModel
     :foreign_key => "developer_id"
 end
 
-class ProjectWithSymbolsForKeys < ApplicationModel
+class ProjectWithSymbolsForKeys < ApplicationRecord
   self.table_name = 'projects'
   has_and_belongs_to_many :developers,
     :class_name => "DeveloperWithSymbolsForKeys",
@@ -56,7 +56,7 @@ class ProjectWithSymbolsForKeys < ApplicationModel
     :association_foreign_key => "developer_id"
 end
 
-class DeveloperWithSymbolsForKeys < ApplicationModel
+class DeveloperWithSymbolsForKeys < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects,
     :class_name => "ProjectWithSymbolsForKeys",

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -22,7 +22,7 @@ require 'models/country'
 require 'models/treaty'
 require 'active_support/core_ext/string/conversions'
 
-class ProjectWithAfterCreateHook < ActiveRecord::Base
+class ProjectWithAfterCreateHook < ApplicationModel
   self.table_name = 'projects'
   has_and_belongs_to_many :developers,
     :class_name => "DeveloperForProjectWithAfterCreateHook",
@@ -38,7 +38,7 @@ class ProjectWithAfterCreateHook < ActiveRecord::Base
   end
 end
 
-class DeveloperForProjectWithAfterCreateHook < ActiveRecord::Base
+class DeveloperForProjectWithAfterCreateHook < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects,
     :class_name => "ProjectWithAfterCreateHook",
@@ -47,7 +47,7 @@ class DeveloperForProjectWithAfterCreateHook < ActiveRecord::Base
     :foreign_key => "developer_id"
 end
 
-class ProjectWithSymbolsForKeys < ActiveRecord::Base
+class ProjectWithSymbolsForKeys < ApplicationModel
   self.table_name = 'projects'
   has_and_belongs_to_many :developers,
     :class_name => "DeveloperWithSymbolsForKeys",
@@ -56,7 +56,7 @@ class ProjectWithSymbolsForKeys < ActiveRecord::Base
     :association_foreign_key => "developer_id"
 end
 
-class DeveloperWithSymbolsForKeys < ActiveRecord::Base
+class DeveloperWithSymbolsForKeys < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects,
     :class_name => "ProjectWithSymbolsForKeys",

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1508,7 +1508,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_defining_has_many_association_with_delete_all_dependency_lazily_evaluates_target_class
     ActiveRecord::Reflection::AssociationReflection.any_instance.expects(:class_name).never
     class_eval(<<-EOF, __FILE__, __LINE__ + 1)
-      class DeleteAllModel < ApplicationModel
+      class DeleteAllModel < ApplicationRecord
         has_many :nonentities, :dependent => :delete_all
       end
     EOF
@@ -1517,7 +1517,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_defining_has_many_association_with_nullify_dependency_lazily_evaluates_target_class
     ActiveRecord::Reflection::AssociationReflection.any_instance.expects(:class_name).never
     class_eval(<<-EOF, __FILE__, __LINE__ + 1)
-      class NullifyModel < ApplicationModel
+      class NullifyModel < ApplicationRecord
         has_many :nonentities, :dependent => :nullify
       end
     EOF

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1508,7 +1508,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_defining_has_many_association_with_delete_all_dependency_lazily_evaluates_target_class
     ActiveRecord::Reflection::AssociationReflection.any_instance.expects(:class_name).never
     class_eval(<<-EOF, __FILE__, __LINE__ + 1)
-      class DeleteAllModel < ActiveRecord::Base
+      class DeleteAllModel < ApplicationModel
         has_many :nonentities, :dependent => :delete_all
       end
     EOF
@@ -1517,7 +1517,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_defining_has_many_association_with_nullify_dependency_lazily_evaluates_target_class
     ActiveRecord::Reflection::AssociationReflection.any_instance.expects(:class_name).never
     class_eval(<<-EOF, __FILE__, __LINE__ + 1)
-      class NullifyModel < ActiveRecord::Base
+      class NullifyModel < ApplicationModel
         has_many :nonentities, :dependent => :nullify
       end
     EOF

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -258,9 +258,9 @@ class AssociationProxyTest < ActiveRecord::TestCase
 end
 
 class OverridingAssociationsTest < ActiveRecord::TestCase
-  class DifferentPerson < ApplicationModel; end
+  class DifferentPerson < ApplicationRecord; end
 
-  class PeopleList < ApplicationModel
+  class PeopleList < ApplicationRecord
     has_and_belongs_to_many :has_and_belongs_to_many, :before_add => :enlist
     has_many :has_many, :before_add => :enlist
     belongs_to :belongs_to

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -258,9 +258,9 @@ class AssociationProxyTest < ActiveRecord::TestCase
 end
 
 class OverridingAssociationsTest < ActiveRecord::TestCase
-  class DifferentPerson < ActiveRecord::Base; end
+  class DifferentPerson < ApplicationModel; end
 
-  class PeopleList < ActiveRecord::Base
+  class PeopleList < ApplicationModel
     has_and_belongs_to_many :has_and_belongs_to_many, :before_add => :enlist
     has_many :has_many, :before_add => :enlist
     belongs_to :belongs_to

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -29,37 +29,37 @@ require 'models/car'
 require 'models/bulb'
 require 'rexml/document'
 
-class FirstAbstractClass < ActiveRecord::Base
+class FirstAbstractClass < ApplicationModel
   self.abstract_class = true
 end
 class SecondAbstractClass < FirstAbstractClass
   self.abstract_class = true
 end
 class Photo < SecondAbstractClass; end
-class Category < ActiveRecord::Base; end
-class Categorization < ActiveRecord::Base; end
-class Smarts < ActiveRecord::Base; end
-class CreditCard < ActiveRecord::Base
-  class PinNumber < ActiveRecord::Base
-    class CvvCode < ActiveRecord::Base; end
+class Category < ApplicationModel; end
+class Categorization < ApplicationModel; end
+class Smarts < ApplicationModel; end
+class CreditCard < ApplicationModel
+  class PinNumber < ApplicationModel
+    class CvvCode < ApplicationModel; end
     class SubCvvCode < CvvCode; end
   end
   class SubPinNumber < PinNumber; end
   class Brand < Category; end
 end
-class MasterCreditCard < ActiveRecord::Base; end
-class Post < ActiveRecord::Base; end
-class Computer < ActiveRecord::Base; end
-class NonExistentTable < ActiveRecord::Base; end
-class TestOracleDefault < ActiveRecord::Base; end
+class MasterCreditCard < ApplicationModel; end
+class Post < ApplicationModel; end
+class Computer < ApplicationModel; end
+class NonExistentTable < ApplicationModel; end
+class TestOracleDefault < ApplicationModel; end
 
 class ReadonlyTitlePost < Post
   attr_readonly :title
 end
 
-class Weird < ActiveRecord::Base; end
+class Weird < ApplicationModel; end
 
-class Boolean < ActiveRecord::Base
+class Boolean < ApplicationModel
   def has_fun
     super
   end
@@ -68,7 +68,7 @@ end
 class LintTest < ActiveRecord::TestCase
   include ActiveModel::Lint::Tests
 
-  class LintModel < ActiveRecord::Base; end
+  class LintModel < ApplicationModel; end
 
   def setup
     @model = LintModel.new
@@ -819,7 +819,7 @@ class BasicsTest < ActiveRecord::TestCase
       assert_equal 'a text field', default.char3
     end
 
-    class Geometric < ActiveRecord::Base; end
+    class Geometric < ApplicationModel; end
     def test_geometric_content
 
       # accepted format notes:
@@ -907,7 +907,7 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
-  class NumericData < ActiveRecord::Base
+  class NumericData < ApplicationModel
     self.table_name = 'numeric_data'
   end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -29,37 +29,37 @@ require 'models/car'
 require 'models/bulb'
 require 'rexml/document'
 
-class FirstAbstractClass < ApplicationModel
+class FirstAbstractClass < ApplicationRecord
   self.abstract_class = true
 end
 class SecondAbstractClass < FirstAbstractClass
   self.abstract_class = true
 end
 class Photo < SecondAbstractClass; end
-class Category < ApplicationModel; end
-class Categorization < ApplicationModel; end
-class Smarts < ApplicationModel; end
-class CreditCard < ApplicationModel
-  class PinNumber < ApplicationModel
-    class CvvCode < ApplicationModel; end
+class Category < ApplicationRecord; end
+class Categorization < ApplicationRecord; end
+class Smarts < ApplicationRecord; end
+class CreditCard < ApplicationRecord
+  class PinNumber < ApplicationRecord
+    class CvvCode < ApplicationRecord; end
     class SubCvvCode < CvvCode; end
   end
   class SubPinNumber < PinNumber; end
   class Brand < Category; end
 end
-class MasterCreditCard < ApplicationModel; end
-class Post < ApplicationModel; end
-class Computer < ApplicationModel; end
-class NonExistentTable < ApplicationModel; end
-class TestOracleDefault < ApplicationModel; end
+class MasterCreditCard < ApplicationRecord; end
+class Post < ApplicationRecord; end
+class Computer < ApplicationRecord; end
+class NonExistentTable < ApplicationRecord; end
+class TestOracleDefault < ApplicationRecord; end
 
 class ReadonlyTitlePost < Post
   attr_readonly :title
 end
 
-class Weird < ApplicationModel; end
+class Weird < ApplicationRecord; end
 
-class Boolean < ApplicationModel
+class Boolean < ApplicationRecord
   def has_fun
     super
   end
@@ -68,7 +68,7 @@ end
 class LintTest < ActiveRecord::TestCase
   include ActiveModel::Lint::Tests
 
-  class LintModel < ApplicationModel; end
+  class LintModel < ApplicationRecord; end
 
   def setup
     @model = LintModel.new
@@ -819,7 +819,7 @@ class BasicsTest < ActiveRecord::TestCase
       assert_equal 'a text field', default.char3
     end
 
-    class Geometric < ApplicationModel; end
+    class Geometric < ApplicationRecord; end
     def test_geometric_content
 
       # accepted format notes:
@@ -907,7 +907,7 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
-  class NumericData < ApplicationModel
+  class NumericData < ApplicationRecord
     self.table_name = 'numeric_data'
   end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -13,7 +13,7 @@ require 'models/ship_part'
 
 Company.has_many :accounts
 
-class NumericData < ApplicationModel
+class NumericData < ApplicationRecord
   self.table_name = 'numeric_data'
 end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -13,7 +13,7 @@ require 'models/ship_part'
 
 Company.has_many :accounts
 
-class NumericData < ActiveRecord::Base
+class NumericData < ApplicationModel
   self.table_name = 'numeric_data'
 end
 

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class CallbackDeveloper < ApplicationModel
+class CallbackDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   class << self
@@ -47,7 +47,7 @@ class CallbackDeveloperWithFalseValidation < CallbackDeveloper
   before_validation proc { |model| model.history << [:before_validation, :should_never_get_here] }
 end
 
-class ParentDeveloper < ApplicationModel
+class ParentDeveloper < ApplicationRecord
   self.table_name = 'developers'
   attr_accessor :after_save_called
   before_validation {|record| record.after_save_called = true}
@@ -57,7 +57,7 @@ class ChildDeveloper < ParentDeveloper
 
 end
 
-class RecursiveCallbackDeveloper < ApplicationModel
+class RecursiveCallbackDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   before_save :on_before_save
@@ -78,7 +78,7 @@ class RecursiveCallbackDeveloper < ApplicationModel
   end
 end
 
-class ImmutableDeveloper < ApplicationModel
+class ImmutableDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   validates_inclusion_of :salary, :in => 50000..200000
@@ -97,7 +97,7 @@ class ImmutableDeveloper < ApplicationModel
     end
 end
 
-class ImmutableMethodDeveloper < ApplicationModel
+class ImmutableMethodDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   validates_inclusion_of :salary, :in => 50000..200000
@@ -117,7 +117,7 @@ class ImmutableMethodDeveloper < ApplicationModel
   end
 end
 
-class OnCallbacksDeveloper < ApplicationModel
+class OnCallbacksDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   before_validation { history << :before_validation }
@@ -137,7 +137,7 @@ class OnCallbacksDeveloper < ApplicationModel
   end
 end
 
-class ContextualCallbacksDeveloper < ApplicationModel
+class ContextualCallbacksDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   before_validation { history << :before_validation }
@@ -163,7 +163,7 @@ class ContextualCallbacksDeveloper < ApplicationModel
   end
 end
 
-class CallbackCancellationDeveloper < ApplicationModel
+class CallbackCancellationDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   attr_reader   :after_save_called, :after_create_called, :after_update_called, :after_destroy_called

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class CallbackDeveloper < ActiveRecord::Base
+class CallbackDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   class << self
@@ -47,7 +47,7 @@ class CallbackDeveloperWithFalseValidation < CallbackDeveloper
   before_validation proc { |model| model.history << [:before_validation, :should_never_get_here] }
 end
 
-class ParentDeveloper < ActiveRecord::Base
+class ParentDeveloper < ApplicationModel
   self.table_name = 'developers'
   attr_accessor :after_save_called
   before_validation {|record| record.after_save_called = true}
@@ -57,7 +57,7 @@ class ChildDeveloper < ParentDeveloper
 
 end
 
-class RecursiveCallbackDeveloper < ActiveRecord::Base
+class RecursiveCallbackDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   before_save :on_before_save
@@ -78,7 +78,7 @@ class RecursiveCallbackDeveloper < ActiveRecord::Base
   end
 end
 
-class ImmutableDeveloper < ActiveRecord::Base
+class ImmutableDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   validates_inclusion_of :salary, :in => 50000..200000
@@ -97,7 +97,7 @@ class ImmutableDeveloper < ActiveRecord::Base
     end
 end
 
-class ImmutableMethodDeveloper < ActiveRecord::Base
+class ImmutableMethodDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   validates_inclusion_of :salary, :in => 50000..200000
@@ -117,7 +117,7 @@ class ImmutableMethodDeveloper < ActiveRecord::Base
   end
 end
 
-class OnCallbacksDeveloper < ActiveRecord::Base
+class OnCallbacksDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   before_validation { history << :before_validation }
@@ -137,7 +137,7 @@ class OnCallbacksDeveloper < ActiveRecord::Base
   end
 end
 
-class ContextualCallbacksDeveloper < ActiveRecord::Base
+class ContextualCallbacksDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   before_validation { history << :before_validation }
@@ -163,7 +163,7 @@ class ContextualCallbacksDeveloper < ActiveRecord::Base
   end
 end
 
-class CallbackCancellationDeveloper < ActiveRecord::Base
+class CallbackCancellationDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   attr_reader   :after_save_called, :after_create_called, :after_update_called, :after_destroy_called

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -2,7 +2,7 @@ require 'cases/helper'
 require 'models/person'
 require 'models/topic'
 
-class NonExistentTable < ActiveRecord::Base; end
+class NonExistentTable < ApplicationModel; end
 
 class CoreTest < ActiveRecord::TestCase
   fixtures :topics

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -2,7 +2,7 @@ require 'cases/helper'
 require 'models/person'
 require 'models/topic'
 
-class NonExistentTable < ApplicationModel; end
+class NonExistentTable < ApplicationRecord; end
 
 class CoreTest < ActiveRecord::TestCase
   fixtures :topics

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -40,7 +40,7 @@ class DefaultTest < ActiveRecord::TestCase
 end
 
 class DefaultStringsTest < ActiveRecord::TestCase
-  class DefaultString < ApplicationModel; end
+  class DefaultString < ApplicationRecord; end
 
   setup do
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -40,7 +40,7 @@ class DefaultTest < ActiveRecord::TestCase
 end
 
 class DefaultStringsTest < ActiveRecord::TestCase
-  class DefaultString < ActiveRecord::Base; end
+  class DefaultString < ApplicationModel; end
 
   setup do
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -22,7 +22,7 @@ private
   end
 end
 
-class NumericData < ApplicationModel
+class NumericData < ApplicationRecord
   self.table_name = 'numeric_data'
 end
 
@@ -557,7 +557,7 @@ class DirtyTest < ActiveRecord::TestCase
   end
 
   if ActiveRecord::Base.connection.supports_migrations?
-    class Testings < ApplicationModel; end
+    class Testings < ApplicationRecord; end
     def test_field_named_field
       ActiveRecord::Base.connection.create_table :testings do |t|
         t.string :field

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -22,7 +22,7 @@ private
   end
 end
 
-class NumericData < ActiveRecord::Base
+class NumericData < ApplicationModel
   self.table_name = 'numeric_data'
 end
 
@@ -557,7 +557,7 @@ class DirtyTest < ActiveRecord::TestCase
   end
 
   if ActiveRecord::Base.connection.supports_migrations?
-    class Testings < ActiveRecord::Base; end
+    class Testings < ApplicationModel; end
     def test_field_named_field
       ActiveRecord::Base.connection.create_table :testings do |t|
         t.string :field

--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class TestRecord < ActiveRecord::Base
+class TestRecord < ApplicationModel
 end
 
 class TestDisconnectedAdapter < ActiveRecord::TestCase

--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class TestRecord < ApplicationModel
+class TestRecord < ApplicationRecord
 end
 
 class TestDisconnectedAdapter < ActiveRecord::TestCase

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -9,6 +9,7 @@ require 'active_record'
 require 'cases/test_case'
 require 'active_support/dependencies'
 require 'active_support/logger'
+require 'models/application_model'
 
 require 'support/config'
 require 'support/connection'

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -9,7 +9,7 @@ require 'active_record'
 require 'cases/test_case'
 require 'active_support/dependencies'
 require 'active_support/logger'
-require 'models/application_model'
+require 'models/application_record'
 
 require 'support/config'
 require 'support/connection'

--- a/activerecord/test/cases/invalid_connection_test.rb
+++ b/activerecord/test/cases/invalid_connection_test.rb
@@ -3,7 +3,7 @@ require "cases/helper"
 class TestAdapterWithInvalidConnection < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class Bird < ApplicationModel
+  class Bird < ApplicationRecord
   end
 
   def setup

--- a/activerecord/test/cases/invalid_connection_test.rb
+++ b/activerecord/test/cases/invalid_connection_test.rb
@@ -3,7 +3,7 @@ require "cases/helper"
 class TestAdapterWithInvalidConnection < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class Bird < ActiveRecord::Base
+  class Bird < ApplicationModel
   end
 
   def setup

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -13,9 +13,9 @@ require 'models/engine'
 require 'models/wheel'
 require 'models/treasure'
 
-class LockWithoutDefault < ActiveRecord::Base; end
+class LockWithoutDefault < ApplicationModel; end
 
-class LockWithCustomColumnWithoutDefault < ActiveRecord::Base
+class LockWithCustomColumnWithoutDefault < ApplicationModel
   self.table_name = :lock_without_defaults_cust
   self.column_defaults # to test @column_defaults caching.
   self.locking_column = :custom_lock_version

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -13,9 +13,9 @@ require 'models/engine'
 require 'models/wheel'
 require 'models/treasure'
 
-class LockWithoutDefault < ApplicationModel; end
+class LockWithoutDefault < ApplicationRecord; end
 
-class LockWithCustomColumnWithoutDefault < ApplicationModel
+class LockWithCustomColumnWithoutDefault < ApplicationRecord
   self.table_name = :lock_without_defaults_cust
   self.column_defaults # to test @column_defaults caching.
   self.locking_column = :custom_lock_version

--- a/activerecord/test/cases/migration/helper.rb
+++ b/activerecord/test/cases/migration/helper.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
       CONNECTION_METHODS = %w[add_column remove_column rename_column add_index change_column rename_table column_exists? index_exists? add_reference add_belongs_to remove_reference remove_references remove_belongs_to]
 
-      class TestModel < ActiveRecord::Base
+      class TestModel < ApplicationModel
         self.table_name = :test_models
       end
 

--- a/activerecord/test/cases/migration/helper.rb
+++ b/activerecord/test/cases/migration/helper.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
       CONNECTION_METHODS = %w[add_column remove_column rename_column add_index change_column rename_table column_exists? index_exists? add_reference add_belongs_to remove_reference remove_references remove_belongs_to]
 
-      class TestModel < ApplicationModel
+      class TestModel < ApplicationRecord
         self.table_name = :test_models
       end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -11,11 +11,11 @@ require MIGRATIONS_ROOT + "/rename/1_we_need_things"
 require MIGRATIONS_ROOT + "/rename/2_rename_things"
 require MIGRATIONS_ROOT + "/decimal/1_give_me_big_numbers"
 
-class BigNumber < ApplicationModel; end
+class BigNumber < ApplicationRecord; end
 
-class Reminder < ApplicationModel; end
+class Reminder < ApplicationRecord; end
 
-class Thing < ApplicationModel; end
+class Thing < ApplicationRecord; end
 
 class MigrationTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -11,11 +11,11 @@ require MIGRATIONS_ROOT + "/rename/1_we_need_things"
 require MIGRATIONS_ROOT + "/rename/2_rename_things"
 require MIGRATIONS_ROOT + "/decimal/1_give_me_big_numbers"
 
-class BigNumber < ActiveRecord::Base; end
+class BigNumber < ApplicationModel; end
 
-class Reminder < ActiveRecord::Base; end
+class Reminder < ApplicationModel; end
 
-class Thing < ActiveRecord::Base; end
+class Thing < ApplicationModel; end
 
 class MigrationTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false

--- a/activerecord/test/cases/mixin_test.rb
+++ b/activerecord/test/cases/mixin_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class Mixin < ApplicationModel
+class Mixin < ApplicationRecord
 end
 
 # Let us control what Time.now returns for the TouchTest suite

--- a/activerecord/test/cases/mixin_test.rb
+++ b/activerecord/test/cases/mixin_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class Mixin < ActiveRecord::Base
+class Mixin < ApplicationModel
 end
 
 # Let us control what Time.now returns for the TouchTest suite

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1521,7 +1521,7 @@ class RelationTest < ActiveRecord::TestCase
     assert !Post.all.respond_to?(:by_lifo)
   end
 
-  class OMGTopic < ActiveRecord::Base
+  class OMGTopic < ApplicationModel
     self.table_name = 'topics'
 
     def self.__omg__

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1521,7 +1521,7 @@ class RelationTest < ActiveRecord::TestCase
     assert !Post.all.respond_to?(:by_lifo)
   end
 
-  class OMGTopic < ApplicationModel
+  class OMGTopic < ApplicationRecord
     self.table_name = 'topics'
 
     def self.__omg__

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -5,7 +5,7 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
   fixtures :topics
 
-  class ReplyWithCallbacks < ApplicationModel
+  class ReplyWithCallbacks < ApplicationRecord
     self.table_name = :topics
 
     belongs_to :topic, foreign_key: "parent_id"
@@ -23,7 +23,7 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
     end
   end
 
-  class TopicWithCallbacks < ApplicationModel
+  class TopicWithCallbacks < ApplicationRecord
     self.table_name = :topics
 
     has_many :replies, class_name: "ReplyWithCallbacks", foreign_key: "parent_id"
@@ -284,7 +284,7 @@ end
 class CallbacksOnMultipleActionsTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class TopicWithCallbacksOnMultipleActions < ApplicationModel
+  class TopicWithCallbacksOnMultipleActions < ApplicationRecord
     self.table_name = :topics
 
     after_commit(on: [:create, :destroy]) { |record| record.history << :create_and_destroy }

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -5,7 +5,7 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
   fixtures :topics
 
-  class ReplyWithCallbacks < ActiveRecord::Base
+  class ReplyWithCallbacks < ApplicationModel
     self.table_name = :topics
 
     belongs_to :topic, foreign_key: "parent_id"
@@ -23,7 +23,7 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
     end
   end
 
-  class TopicWithCallbacks < ActiveRecord::Base
+  class TopicWithCallbacks < ApplicationModel
     self.table_name = :topics
 
     has_many :replies, class_name: "ReplyWithCallbacks", foreign_key: "parent_id"
@@ -284,7 +284,7 @@ end
 class CallbacksOnMultipleActionsTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class TopicWithCallbacksOnMultipleActions < ActiveRecord::Base
+  class TopicWithCallbacksOnMultipleActions < ApplicationModel
     self.table_name = :topics
 
     after_commit(on: [:create, :destroy]) { |record| record.history << :create_and_destroy }

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -3,7 +3,7 @@ require 'cases/helper'
 class TransactionIsolationUnsupportedTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class Tag < ApplicationModel
+  class Tag < ApplicationRecord
   end
 
   setup do
@@ -22,11 +22,11 @@ end
 class TransactionIsolationTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class Tag < ApplicationModel
+  class Tag < ApplicationRecord
     self.table_name = 'tags'
   end
 
-  class Tag2 < ApplicationModel
+  class Tag2 < ApplicationRecord
     self.table_name = 'tags'
   end
 

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -3,7 +3,7 @@ require 'cases/helper'
 class TransactionIsolationUnsupportedTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class Tag < ActiveRecord::Base
+  class Tag < ApplicationModel
   end
 
   setup do
@@ -22,11 +22,11 @@ end
 class TransactionIsolationTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class Tag < ActiveRecord::Base
+  class Tag < ApplicationModel
     self.table_name = 'tags'
   end
 
-  class Tag2 < ActiveRecord::Base
+  class Tag2 < ApplicationModel
     self.table_name = 'tags'
   end
 

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class TestRecord < ActiveRecord::Base
+class TestRecord < ApplicationModel
 end
 
 class TestUnconnectedAdapter < ActiveRecord::TestCase

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class TestRecord < ApplicationModel
+class TestRecord < ApplicationRecord
 end
 
 class TestUnconnectedAdapter < ActiveRecord::TestCase

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -6,7 +6,7 @@ require 'models/warehouse_thing'
 require 'models/guid'
 require 'models/event'
 
-class Wizard < ApplicationModel
+class Wizard < ApplicationRecord
   self.abstract_class = true
 
   validates_uniqueness_of :name
@@ -30,7 +30,7 @@ class ReplyWithTitleObject < Reply
   def title; ReplyTitle.new; end
 end
 
-class Employee < ApplicationModel
+class Employee < ApplicationRecord
   self.table_name = 'postgresql_arrays'
   validates_uniqueness_of :nicknames
 end

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -6,7 +6,7 @@ require 'models/warehouse_thing'
 require 'models/guid'
 require 'models/event'
 
-class Wizard < ActiveRecord::Base
+class Wizard < ApplicationModel
   self.abstract_class = true
 
   validates_uniqueness_of :name
@@ -30,7 +30,7 @@ class ReplyWithTitleObject < Reply
   def title; ReplyTitle.new; end
 end
 
-class Employee < ActiveRecord::Base
+class Employee < ApplicationModel
   self.table_name = 'postgresql_arrays'
   validates_uniqueness_of :nicknames
 end

--- a/activerecord/test/models/admin/account.rb
+++ b/activerecord/test/models/admin/account.rb
@@ -1,3 +1,3 @@
-class Admin::Account < ActiveRecord::Base
+class Admin::Account < ApplicationModel
   has_many :users
 end

--- a/activerecord/test/models/admin/account.rb
+++ b/activerecord/test/models/admin/account.rb
@@ -1,3 +1,3 @@
-class Admin::Account < ApplicationModel
+class Admin::Account < ApplicationRecord
   has_many :users
 end

--- a/activerecord/test/models/admin/randomly_named_c1.rb
+++ b/activerecord/test/models/admin/randomly_named_c1.rb
@@ -1,3 +1,3 @@
-class Admin::ClassNameThatDoesNotFollowCONVENTIONS < ActiveRecord::Base
+class Admin::ClassNameThatDoesNotFollowCONVENTIONS < ApplicationModel
   self.table_name = :randomly_named_table
 end

--- a/activerecord/test/models/admin/randomly_named_c1.rb
+++ b/activerecord/test/models/admin/randomly_named_c1.rb
@@ -1,3 +1,3 @@
-class Admin::ClassNameThatDoesNotFollowCONVENTIONS < ApplicationModel
+class Admin::ClassNameThatDoesNotFollowCONVENTIONS < ApplicationRecord
   self.table_name = :randomly_named_table
 end

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -1,4 +1,4 @@
-class Admin::User < ApplicationModel
+class Admin::User < ApplicationRecord
   class Coder
     def initialize(default = {})
       @default = default

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -1,4 +1,4 @@
-class Admin::User < ActiveRecord::Base
+class Admin::User < ApplicationModel
   class Coder
     def initialize(default = {})
       @default = default

--- a/activerecord/test/models/aircraft.rb
+++ b/activerecord/test/models/aircraft.rb
@@ -1,4 +1,4 @@
-class Aircraft < ApplicationModel
+class Aircraft < ApplicationRecord
   self.pluralize_table_names = false
   has_many :engines, :foreign_key => "car_id"
 end

--- a/activerecord/test/models/aircraft.rb
+++ b/activerecord/test/models/aircraft.rb
@@ -1,4 +1,4 @@
-class Aircraft < ActiveRecord::Base
+class Aircraft < ApplicationModel
   self.pluralize_table_names = false
   has_many :engines, :foreign_key => "car_id"
 end

--- a/activerecord/test/models/application_model.rb
+++ b/activerecord/test/models/application_model.rb
@@ -1,0 +1,3 @@
+class ApplicationModel < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/activerecord/test/models/application_model.rb
+++ b/activerecord/test/models/application_model.rb
@@ -1,3 +1,0 @@
-class ApplicationModel < ActiveRecord::Base
-  self.abstract_class = true
-end

--- a/activerecord/test/models/application_record.rb
+++ b/activerecord/test/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/activerecord/test/models/arunit2_model.rb
+++ b/activerecord/test/models/arunit2_model.rb
@@ -1,3 +1,3 @@
-class ARUnit2Model < ActiveRecord::Base
+class ARUnit2Model < ApplicationModel
   self.abstract_class = true
 end

--- a/activerecord/test/models/arunit2_model.rb
+++ b/activerecord/test/models/arunit2_model.rb
@@ -1,3 +1,3 @@
-class ARUnit2Model < ApplicationModel
+class ARUnit2Model < ApplicationRecord
   self.abstract_class = true
 end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -1,4 +1,4 @@
-class Author < ApplicationModel
+class Author < ApplicationRecord
   has_many :posts
   has_one :post
   has_many :very_special_comments, :through => :posts
@@ -178,7 +178,7 @@ class Author < ApplicationModel
     end
 end
 
-class AuthorAddress < ApplicationModel
+class AuthorAddress < ApplicationRecord
   has_one :author
 
   def self.destroyed_author_address_ids
@@ -190,7 +190,7 @@ class AuthorAddress < ApplicationModel
   end
 end
 
-class AuthorFavorite < ApplicationModel
+class AuthorFavorite < ApplicationRecord
   belongs_to :author
   belongs_to :favorite_author, :class_name => "Author"
 end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -1,4 +1,4 @@
-class Author < ActiveRecord::Base
+class Author < ApplicationModel
   has_many :posts
   has_one :post
   has_many :very_special_comments, :through => :posts
@@ -178,7 +178,7 @@ class Author < ActiveRecord::Base
     end
 end
 
-class AuthorAddress < ActiveRecord::Base
+class AuthorAddress < ApplicationModel
   has_one :author
 
   def self.destroyed_author_address_ids
@@ -190,7 +190,7 @@ class AuthorAddress < ActiveRecord::Base
   end
 end
 
-class AuthorFavorite < ActiveRecord::Base
+class AuthorFavorite < ApplicationModel
   belongs_to :author
   belongs_to :favorite_author, :class_name => "Author"
 end

--- a/activerecord/test/models/auto_id.rb
+++ b/activerecord/test/models/auto_id.rb
@@ -1,4 +1,4 @@
-class AutoId < ActiveRecord::Base
+class AutoId < ApplicationModel
   def self.table_name () "auto_id_tests" end
   def self.primary_key () "auto_id" end
 end

--- a/activerecord/test/models/auto_id.rb
+++ b/activerecord/test/models/auto_id.rb
@@ -1,4 +1,4 @@
-class AutoId < ApplicationModel
+class AutoId < ApplicationRecord
   def self.table_name () "auto_id_tests" end
   def self.primary_key () "auto_id" end
 end

--- a/activerecord/test/models/binary.rb
+++ b/activerecord/test/models/binary.rb
@@ -1,2 +1,2 @@
-class Binary < ApplicationModel
+class Binary < ApplicationRecord
 end

--- a/activerecord/test/models/binary.rb
+++ b/activerecord/test/models/binary.rb
@@ -1,2 +1,2 @@
-class Binary < ActiveRecord::Base
+class Binary < ApplicationModel
 end

--- a/activerecord/test/models/bird.rb
+++ b/activerecord/test/models/bird.rb
@@ -1,4 +1,4 @@
-class Bird < ActiveRecord::Base
+class Bird < ApplicationModel
   belongs_to :pirate
   validates_presence_of :name
 

--- a/activerecord/test/models/bird.rb
+++ b/activerecord/test/models/bird.rb
@@ -1,4 +1,4 @@
-class Bird < ApplicationModel
+class Bird < ApplicationRecord
   belongs_to :pirate
   validates_presence_of :name
 

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -1,4 +1,4 @@
-class Book < ActiveRecord::Base
+class Book < ApplicationModel
   has_many :authors
 
   has_many :citations, :foreign_key => 'book1_id'

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -1,4 +1,4 @@
-class Book < ApplicationModel
+class Book < ApplicationRecord
   has_many :authors
 
   has_many :citations, :foreign_key => 'book1_id'

--- a/activerecord/test/models/boolean.rb
+++ b/activerecord/test/models/boolean.rb
@@ -1,2 +1,2 @@
-class Boolean < ActiveRecord::Base
+class Boolean < ApplicationModel
 end

--- a/activerecord/test/models/boolean.rb
+++ b/activerecord/test/models/boolean.rb
@@ -1,2 +1,2 @@
-class Boolean < ApplicationModel
+class Boolean < ApplicationRecord
 end

--- a/activerecord/test/models/bulb.rb
+++ b/activerecord/test/models/bulb.rb
@@ -1,4 +1,4 @@
-class Bulb < ActiveRecord::Base
+class Bulb < ApplicationModel
   default_scope { where(:name => 'defaulty') }
   belongs_to :car, :touch => true
 

--- a/activerecord/test/models/bulb.rb
+++ b/activerecord/test/models/bulb.rb
@@ -1,4 +1,4 @@
-class Bulb < ApplicationModel
+class Bulb < ApplicationRecord
   default_scope { where(:name => 'defaulty') }
   belongs_to :car, :touch => true
 

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -1,4 +1,4 @@
-class Car < ActiveRecord::Base
+class Car < ApplicationModel
 
   has_many :bulbs
   has_many :funky_bulbs, class_name: 'FunkyBulb', dependent: :destroy

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -1,4 +1,4 @@
-class Car < ApplicationModel
+class Car < ApplicationRecord
 
   has_many :bulbs
   has_many :funky_bulbs, class_name: 'FunkyBulb', dependent: :destroy

--- a/activerecord/test/models/categorization.rb
+++ b/activerecord/test/models/categorization.rb
@@ -1,4 +1,4 @@
-class Categorization < ApplicationModel
+class Categorization < ApplicationRecord
   belongs_to :post
   belongs_to :category
   belongs_to :named_category, :class_name => 'Category', :foreign_key => :named_category_name, :primary_key => :name
@@ -10,7 +10,7 @@ class Categorization < ApplicationModel
   has_many   :authors_using_custom_pk, :class_name => 'Author', :foreign_key => :id,        :primary_key => :category_id
 end
 
-class SpecialCategorization < ApplicationModel
+class SpecialCategorization < ApplicationRecord
   self.table_name = 'categorizations'
   default_scope { where(:special => true) }
 

--- a/activerecord/test/models/categorization.rb
+++ b/activerecord/test/models/categorization.rb
@@ -1,4 +1,4 @@
-class Categorization < ActiveRecord::Base
+class Categorization < ApplicationModel
   belongs_to :post
   belongs_to :category
   belongs_to :named_category, :class_name => 'Category', :foreign_key => :named_category_name, :primary_key => :name
@@ -10,7 +10,7 @@ class Categorization < ActiveRecord::Base
   has_many   :authors_using_custom_pk, :class_name => 'Author', :foreign_key => :id,        :primary_key => :category_id
 end
 
-class SpecialCategorization < ActiveRecord::Base
+class SpecialCategorization < ApplicationModel
   self.table_name = 'categorizations'
   default_scope { where(:special => true) }
 

--- a/activerecord/test/models/category.rb
+++ b/activerecord/test/models/category.rb
@@ -1,4 +1,4 @@
-class Category < ActiveRecord::Base
+class Category < ApplicationModel
   has_and_belongs_to_many :posts
   has_and_belongs_to_many :special_posts, :class_name => "Post"
   has_and_belongs_to_many :other_posts, :class_name => "Post"

--- a/activerecord/test/models/category.rb
+++ b/activerecord/test/models/category.rb
@@ -1,4 +1,4 @@
-class Category < ApplicationModel
+class Category < ApplicationRecord
   has_and_belongs_to_many :posts
   has_and_belongs_to_many :special_posts, :class_name => "Post"
   has_and_belongs_to_many :other_posts, :class_name => "Post"

--- a/activerecord/test/models/citation.rb
+++ b/activerecord/test/models/citation.rb
@@ -1,4 +1,4 @@
-class Citation < ApplicationModel
+class Citation < ApplicationRecord
   belongs_to :reference_of, :class_name => "Book", :foreign_key => :book2_id
 
   belongs_to :book1, :class_name => "Book", :foreign_key => :book1_id

--- a/activerecord/test/models/citation.rb
+++ b/activerecord/test/models/citation.rb
@@ -1,4 +1,4 @@
-class Citation < ActiveRecord::Base
+class Citation < ApplicationModel
   belongs_to :reference_of, :class_name => "Book", :foreign_key => :book2_id
 
   belongs_to :book1, :class_name => "Book", :foreign_key => :book1_id

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -1,4 +1,4 @@
-class Club < ActiveRecord::Base
+class Club < ApplicationModel
   has_one :membership
   has_many :memberships, :inverse_of => false
   has_many :members, :through => :memberships

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -1,4 +1,4 @@
-class Club < ApplicationModel
+class Club < ApplicationRecord
   has_one :membership
   has_many :memberships, :inverse_of => false
   has_many :members, :through => :memberships

--- a/activerecord/test/models/column_name.rb
+++ b/activerecord/test/models/column_name.rb
@@ -1,3 +1,3 @@
-class ColumnName < ApplicationModel
+class ColumnName < ApplicationRecord
   self.table_name = "colnametests"
 end

--- a/activerecord/test/models/column_name.rb
+++ b/activerecord/test/models/column_name.rb
@@ -1,3 +1,3 @@
-class ColumnName < ActiveRecord::Base
+class ColumnName < ApplicationModel
   self.table_name = "colnametests"
 end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -1,4 +1,4 @@
-class Comment < ApplicationModel
+class Comment < ApplicationRecord
   scope :limit_by, lambda {|l| limit(l) }
   scope :containing_the_letter_e, -> { where("comments.body LIKE '%e%'") }
   scope :not_again, -> { where("comments.body NOT LIKE '%again%'") }

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -1,4 +1,4 @@
-class Comment < ActiveRecord::Base
+class Comment < ApplicationModel
   scope :limit_by, lambda {|l| limit(l) }
   scope :containing_the_letter_e, -> { where("comments.body LIKE '%e%'") }
   scope :not_again, -> { where("comments.body NOT LIKE '%again%'") }

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -1,4 +1,4 @@
-class AbstractCompany < ApplicationModel
+class AbstractCompany < ApplicationRecord
   self.abstract_class = true
 end
 
@@ -176,7 +176,7 @@ end
 class VerySpecialClient < SpecialClient
 end
 
-class Account < ApplicationModel
+class Account < ApplicationRecord
   belongs_to :firm, :class_name => 'Company'
   belongs_to :unautosaved_firm, :foreign_key => "firm_id", :class_name => "Firm", :autosave => false
 

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -1,4 +1,4 @@
-class AbstractCompany < ActiveRecord::Base
+class AbstractCompany < ApplicationModel
   self.abstract_class = true
 end
 
@@ -176,7 +176,7 @@ end
 class VerySpecialClient < SpecialClient
 end
 
-class Account < ActiveRecord::Base
+class Account < ApplicationModel
   belongs_to :firm, :class_name => 'Company'
   belongs_to :unautosaved_firm, :foreign_key => "firm_id", :class_name => "Firm", :autosave => false
 

--- a/activerecord/test/models/company_in_module.rb
+++ b/activerecord/test/models/company_in_module.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/object/with_options'
 
 module MyApplication
   module Business
-    class Company < ApplicationModel
+    class Company < ApplicationRecord
     end
 
     class Firm < Company
@@ -17,15 +17,15 @@ module MyApplication
       belongs_to :firm, :foreign_key => "client_of"
       belongs_to :firm_with_other_name, :class_name => "Firm", :foreign_key => "client_of"
 
-      class Contact < ApplicationModel; end
+      class Contact < ApplicationRecord; end
     end
 
-    class Developer < ApplicationModel
+    class Developer < ApplicationRecord
       has_and_belongs_to_many :projects
       validates_length_of :name, :within => (3..20)
     end
 
-    class Project < ApplicationModel
+    class Project < ApplicationRecord
       has_and_belongs_to_many :developers
     end
 
@@ -34,7 +34,7 @@ module MyApplication
         'prefixed_'
       end
 
-      class Company < ApplicationModel
+      class Company < ApplicationRecord
       end
 
       class Firm < Company
@@ -42,24 +42,24 @@ module MyApplication
       end
 
       module Nested
-        class Company < ApplicationModel
+        class Company < ApplicationRecord
         end
       end
     end
   end
 
   module Billing
-    class Firm < ApplicationModel
+    class Firm < ApplicationRecord
       self.table_name = 'companies'
     end
 
     module Nested
-      class Firm < ApplicationModel
+      class Firm < ApplicationRecord
         self.table_name = 'companies'
       end
     end
 
-    class Account < ApplicationModel
+    class Account < ApplicationRecord
       with_options(:foreign_key => :firm_id) do |i|
         i.belongs_to :firm, :class_name => 'MyApplication::Business::Firm'
         i.belongs_to :qualified_billing_firm, :class_name => 'MyApplication::Billing::Firm'

--- a/activerecord/test/models/company_in_module.rb
+++ b/activerecord/test/models/company_in_module.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/object/with_options'
 
 module MyApplication
   module Business
-    class Company < ActiveRecord::Base
+    class Company < ApplicationModel
     end
 
     class Firm < Company
@@ -17,15 +17,15 @@ module MyApplication
       belongs_to :firm, :foreign_key => "client_of"
       belongs_to :firm_with_other_name, :class_name => "Firm", :foreign_key => "client_of"
 
-      class Contact < ActiveRecord::Base; end
+      class Contact < ApplicationModel; end
     end
 
-    class Developer < ActiveRecord::Base
+    class Developer < ApplicationModel
       has_and_belongs_to_many :projects
       validates_length_of :name, :within => (3..20)
     end
 
-    class Project < ActiveRecord::Base
+    class Project < ApplicationModel
       has_and_belongs_to_many :developers
     end
 
@@ -34,7 +34,7 @@ module MyApplication
         'prefixed_'
       end
 
-      class Company < ActiveRecord::Base
+      class Company < ApplicationModel
       end
 
       class Firm < Company
@@ -42,24 +42,24 @@ module MyApplication
       end
 
       module Nested
-        class Company < ActiveRecord::Base
+        class Company < ApplicationModel
         end
       end
     end
   end
 
   module Billing
-    class Firm < ActiveRecord::Base
+    class Firm < ApplicationModel
       self.table_name = 'companies'
     end
 
     module Nested
-      class Firm < ActiveRecord::Base
+      class Firm < ApplicationModel
         self.table_name = 'companies'
       end
     end
 
-    class Account < ActiveRecord::Base
+    class Account < ApplicationModel
       with_options(:foreign_key => :firm_id) do |i|
         i.belongs_to :firm, :class_name => 'MyApplication::Business::Firm'
         i.belongs_to :qualified_billing_firm, :class_name => 'MyApplication::Billing::Firm'

--- a/activerecord/test/models/computer.rb
+++ b/activerecord/test/models/computer.rb
@@ -1,3 +1,3 @@
-class Computer < ApplicationModel
+class Computer < ApplicationRecord
   belongs_to :developer, :foreign_key=>'developer'
 end

--- a/activerecord/test/models/computer.rb
+++ b/activerecord/test/models/computer.rb
@@ -1,3 +1,3 @@
-class Computer < ActiveRecord::Base
+class Computer < ApplicationModel
   belongs_to :developer, :foreign_key=>'developer'
 end

--- a/activerecord/test/models/contact.rb
+++ b/activerecord/test/models/contact.rb
@@ -28,11 +28,11 @@ module ContactFakeColumns
   end
 end
 
-class Contact < ActiveRecord::Base
+class Contact < ApplicationModel
   extend ContactFakeColumns
 end
 
-class ContactSti < ActiveRecord::Base
+class ContactSti < ApplicationModel
   extend ContactFakeColumns
   column :type, :string
 

--- a/activerecord/test/models/contact.rb
+++ b/activerecord/test/models/contact.rb
@@ -28,11 +28,11 @@ module ContactFakeColumns
   end
 end
 
-class Contact < ApplicationModel
+class Contact < ApplicationRecord
   extend ContactFakeColumns
 end
 
-class ContactSti < ApplicationModel
+class ContactSti < ApplicationRecord
   extend ContactFakeColumns
   column :type, :string
 

--- a/activerecord/test/models/contract.rb
+++ b/activerecord/test/models/contract.rb
@@ -1,4 +1,4 @@
-class Contract < ActiveRecord::Base
+class Contract < ApplicationModel
   belongs_to :company
   belongs_to :developer
 

--- a/activerecord/test/models/contract.rb
+++ b/activerecord/test/models/contract.rb
@@ -1,4 +1,4 @@
-class Contract < ApplicationModel
+class Contract < ApplicationRecord
   belongs_to :company
   belongs_to :developer
 

--- a/activerecord/test/models/country.rb
+++ b/activerecord/test/models/country.rb
@@ -1,4 +1,4 @@
-class Country < ApplicationModel
+class Country < ApplicationRecord
 
   self.primary_key = :country_id
 

--- a/activerecord/test/models/country.rb
+++ b/activerecord/test/models/country.rb
@@ -1,4 +1,4 @@
-class Country < ActiveRecord::Base
+class Country < ApplicationModel
 
   self.primary_key = :country_id
 

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -1,4 +1,4 @@
-class Customer < ApplicationModel
+class Customer < ApplicationRecord
   cattr_accessor :gps_conversion_was_run
 
   composed_of :address, :mapping => [ %w(address_street street), %w(address_city city), %w(address_country country) ], :allow_nil => true

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -1,4 +1,4 @@
-class Customer < ActiveRecord::Base
+class Customer < ApplicationModel
   cattr_accessor :gps_conversion_was_run
 
   composed_of :address, :mapping => [ %w(address_street street), %w(address_city city), %w(address_country country) ], :allow_nil => true

--- a/activerecord/test/models/dashboard.rb
+++ b/activerecord/test/models/dashboard.rb
@@ -1,3 +1,3 @@
-class Dashboard < ActiveRecord::Base
+class Dashboard < ApplicationModel
   self.primary_key = :dashboard_id
 end

--- a/activerecord/test/models/dashboard.rb
+++ b/activerecord/test/models/dashboard.rb
@@ -1,3 +1,3 @@
-class Dashboard < ApplicationModel
+class Dashboard < ApplicationRecord
   self.primary_key = :dashboard_id
 end

--- a/activerecord/test/models/default.rb
+++ b/activerecord/test/models/default.rb
@@ -1,2 +1,2 @@
-class Default < ApplicationModel
+class Default < ApplicationRecord
 end

--- a/activerecord/test/models/default.rb
+++ b/activerecord/test/models/default.rb
@@ -1,2 +1,2 @@
-class Default < ActiveRecord::Base
+class Default < ApplicationModel
 end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -6,7 +6,7 @@ module DeveloperProjectsAssociationExtension2
   end
 end
 
-class Developer < ApplicationModel
+class Developer < ApplicationRecord
   has_and_belongs_to_many :projects do
     def find_most_recent
       order("id DESC").first
@@ -63,18 +63,18 @@ class Developer < ApplicationModel
 
 end
 
-class AuditLog < ApplicationModel
+class AuditLog < ApplicationRecord
   belongs_to :developer, :validate => true
   belongs_to :unvalidated_developer, :class_name => 'Developer'
 end
 
 DeveloperSalary = Struct.new(:amount)
-class DeveloperWithAggregate < ApplicationModel
+class DeveloperWithAggregate < ApplicationRecord
   self.table_name = 'developers'
   composed_of :salary, :class_name => 'DeveloperSalary', :mapping => [%w(salary amount)]
 end
 
-class DeveloperWithBeforeDestroyRaise < ApplicationModel
+class DeveloperWithBeforeDestroyRaise < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, :join_table => 'developers_projects', :foreign_key => 'developer_id'
   before_destroy :raise_if_projects_empty!
@@ -84,18 +84,18 @@ class DeveloperWithBeforeDestroyRaise < ApplicationModel
   end
 end
 
-class DeveloperWithSelect < ApplicationModel
+class DeveloperWithSelect < ApplicationRecord
   self.table_name = 'developers'
   default_scope { select('name') }
 end
 
-class DeveloperWithIncludes < ApplicationModel
+class DeveloperWithIncludes < ApplicationRecord
   self.table_name = 'developers'
   has_many :audit_logs, :foreign_key => :developer_id
   default_scope { includes(:audit_logs) }
 end
 
-class DeveloperFilteredOnJoins < ApplicationModel
+class DeveloperFilteredOnJoins < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
@@ -104,34 +104,34 @@ class DeveloperFilteredOnJoins < ApplicationModel
   end
 end
 
-class DeveloperOrderedBySalary < ApplicationModel
+class DeveloperOrderedBySalary < ApplicationRecord
   self.table_name = 'developers'
   default_scope { order('salary DESC') }
 
   scope :by_name, -> { order('name DESC') }
 end
 
-class DeveloperCalledDavid < ApplicationModel
+class DeveloperCalledDavid < ApplicationRecord
   self.table_name = 'developers'
   default_scope { where("name = 'David'") }
 end
 
-class LazyLambdaDeveloperCalledDavid < ApplicationModel
+class LazyLambdaDeveloperCalledDavid < ApplicationRecord
   self.table_name = 'developers'
   default_scope lambda { where(:name => 'David') }
 end
 
-class LazyBlockDeveloperCalledDavid < ApplicationModel
+class LazyBlockDeveloperCalledDavid < ApplicationRecord
   self.table_name = 'developers'
   default_scope { where(:name => 'David') }
 end
 
-class CallableDeveloperCalledDavid < ApplicationModel
+class CallableDeveloperCalledDavid < ApplicationRecord
   self.table_name = 'developers'
   default_scope OpenStruct.new(:call => where(:name => 'David'))
 end
 
-class ClassMethodDeveloperCalledDavid < ApplicationModel
+class ClassMethodDeveloperCalledDavid < ApplicationRecord
   self.table_name = 'developers'
 
   def self.default_scope
@@ -139,7 +139,7 @@ class ClassMethodDeveloperCalledDavid < ApplicationModel
   end
 end
 
-class ClassMethodReferencingScopeDeveloperCalledDavid < ApplicationModel
+class ClassMethodReferencingScopeDeveloperCalledDavid < ApplicationRecord
   self.table_name = 'developers'
   scope :david, -> { where(:name => 'David') }
 
@@ -148,20 +148,20 @@ class ClassMethodReferencingScopeDeveloperCalledDavid < ApplicationModel
   end
 end
 
-class LazyBlockReferencingScopeDeveloperCalledDavid < ApplicationModel
+class LazyBlockReferencingScopeDeveloperCalledDavid < ApplicationRecord
   self.table_name = 'developers'
   scope :david, -> { where(:name => 'David') }
   default_scope { david }
 end
 
-class DeveloperCalledJamis < ApplicationModel
+class DeveloperCalledJamis < ApplicationRecord
   self.table_name = 'developers'
 
   default_scope { where(:name => 'Jamis') }
   scope :poor, -> { where('salary < 150000') }
 end
 
-class PoorDeveloperCalledJamis < ApplicationModel
+class PoorDeveloperCalledJamis < ApplicationRecord
   self.table_name = 'developers'
 
   default_scope -> { where(:name => 'Jamis', :salary => 50000) }
@@ -173,7 +173,7 @@ class InheritedPoorDeveloperCalledJamis < DeveloperCalledJamis
   default_scope -> { where(:salary => 50000) }
 end
 
-class MultiplePoorDeveloperCalledJamis < ApplicationModel
+class MultiplePoorDeveloperCalledJamis < ApplicationRecord
   self.table_name = 'developers'
 
   default_scope -> { where(:name => 'Jamis') }
@@ -192,14 +192,14 @@ class ModuleIncludedPoorDeveloperCalledJamis < DeveloperCalledJamis
   include SalaryDefaultScope
 end
 
-class EagerDeveloperWithDefaultScope < ApplicationModel
+class EagerDeveloperWithDefaultScope < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope { includes(:projects) }
 end
 
-class EagerDeveloperWithClassMethodDefaultScope < ApplicationModel
+class EagerDeveloperWithClassMethodDefaultScope < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
@@ -208,28 +208,28 @@ class EagerDeveloperWithClassMethodDefaultScope < ApplicationModel
   end
 end
 
-class EagerDeveloperWithLambdaDefaultScope < ApplicationModel
+class EagerDeveloperWithLambdaDefaultScope < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope lambda { includes(:projects) }
 end
 
-class EagerDeveloperWithBlockDefaultScope < ApplicationModel
+class EagerDeveloperWithBlockDefaultScope < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope { includes(:projects) }
 end
 
-class EagerDeveloperWithCallableDefaultScope < ApplicationModel
+class EagerDeveloperWithCallableDefaultScope < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope OpenStruct.new(:call => includes(:projects))
 end
 
-class ThreadsafeDeveloper < ApplicationModel
+class ThreadsafeDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   def self.default_scope
@@ -238,7 +238,7 @@ class ThreadsafeDeveloper < ApplicationModel
   end
 end
 
-class CachedDeveloper < ApplicationModel
+class CachedDeveloper < ApplicationRecord
   self.table_name = "developers"
   self.cache_timestamp_format = :number
 end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -6,7 +6,7 @@ module DeveloperProjectsAssociationExtension2
   end
 end
 
-class Developer < ActiveRecord::Base
+class Developer < ApplicationModel
   has_and_belongs_to_many :projects do
     def find_most_recent
       order("id DESC").first
@@ -63,18 +63,18 @@ class Developer < ActiveRecord::Base
 
 end
 
-class AuditLog < ActiveRecord::Base
+class AuditLog < ApplicationModel
   belongs_to :developer, :validate => true
   belongs_to :unvalidated_developer, :class_name => 'Developer'
 end
 
 DeveloperSalary = Struct.new(:amount)
-class DeveloperWithAggregate < ActiveRecord::Base
+class DeveloperWithAggregate < ApplicationModel
   self.table_name = 'developers'
   composed_of :salary, :class_name => 'DeveloperSalary', :mapping => [%w(salary amount)]
 end
 
-class DeveloperWithBeforeDestroyRaise < ActiveRecord::Base
+class DeveloperWithBeforeDestroyRaise < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, :join_table => 'developers_projects', :foreign_key => 'developer_id'
   before_destroy :raise_if_projects_empty!
@@ -84,18 +84,18 @@ class DeveloperWithBeforeDestroyRaise < ActiveRecord::Base
   end
 end
 
-class DeveloperWithSelect < ActiveRecord::Base
+class DeveloperWithSelect < ApplicationModel
   self.table_name = 'developers'
   default_scope { select('name') }
 end
 
-class DeveloperWithIncludes < ActiveRecord::Base
+class DeveloperWithIncludes < ApplicationModel
   self.table_name = 'developers'
   has_many :audit_logs, :foreign_key => :developer_id
   default_scope { includes(:audit_logs) }
 end
 
-class DeveloperFilteredOnJoins < ActiveRecord::Base
+class DeveloperFilteredOnJoins < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
@@ -104,34 +104,34 @@ class DeveloperFilteredOnJoins < ActiveRecord::Base
   end
 end
 
-class DeveloperOrderedBySalary < ActiveRecord::Base
+class DeveloperOrderedBySalary < ApplicationModel
   self.table_name = 'developers'
   default_scope { order('salary DESC') }
 
   scope :by_name, -> { order('name DESC') }
 end
 
-class DeveloperCalledDavid < ActiveRecord::Base
+class DeveloperCalledDavid < ApplicationModel
   self.table_name = 'developers'
   default_scope { where("name = 'David'") }
 end
 
-class LazyLambdaDeveloperCalledDavid < ActiveRecord::Base
+class LazyLambdaDeveloperCalledDavid < ApplicationModel
   self.table_name = 'developers'
   default_scope lambda { where(:name => 'David') }
 end
 
-class LazyBlockDeveloperCalledDavid < ActiveRecord::Base
+class LazyBlockDeveloperCalledDavid < ApplicationModel
   self.table_name = 'developers'
   default_scope { where(:name => 'David') }
 end
 
-class CallableDeveloperCalledDavid < ActiveRecord::Base
+class CallableDeveloperCalledDavid < ApplicationModel
   self.table_name = 'developers'
   default_scope OpenStruct.new(:call => where(:name => 'David'))
 end
 
-class ClassMethodDeveloperCalledDavid < ActiveRecord::Base
+class ClassMethodDeveloperCalledDavid < ApplicationModel
   self.table_name = 'developers'
 
   def self.default_scope
@@ -139,7 +139,7 @@ class ClassMethodDeveloperCalledDavid < ActiveRecord::Base
   end
 end
 
-class ClassMethodReferencingScopeDeveloperCalledDavid < ActiveRecord::Base
+class ClassMethodReferencingScopeDeveloperCalledDavid < ApplicationModel
   self.table_name = 'developers'
   scope :david, -> { where(:name => 'David') }
 
@@ -148,20 +148,20 @@ class ClassMethodReferencingScopeDeveloperCalledDavid < ActiveRecord::Base
   end
 end
 
-class LazyBlockReferencingScopeDeveloperCalledDavid < ActiveRecord::Base
+class LazyBlockReferencingScopeDeveloperCalledDavid < ApplicationModel
   self.table_name = 'developers'
   scope :david, -> { where(:name => 'David') }
   default_scope { david }
 end
 
-class DeveloperCalledJamis < ActiveRecord::Base
+class DeveloperCalledJamis < ApplicationModel
   self.table_name = 'developers'
 
   default_scope { where(:name => 'Jamis') }
   scope :poor, -> { where('salary < 150000') }
 end
 
-class PoorDeveloperCalledJamis < ActiveRecord::Base
+class PoorDeveloperCalledJamis < ApplicationModel
   self.table_name = 'developers'
 
   default_scope -> { where(:name => 'Jamis', :salary => 50000) }
@@ -173,7 +173,7 @@ class InheritedPoorDeveloperCalledJamis < DeveloperCalledJamis
   default_scope -> { where(:salary => 50000) }
 end
 
-class MultiplePoorDeveloperCalledJamis < ActiveRecord::Base
+class MultiplePoorDeveloperCalledJamis < ApplicationModel
   self.table_name = 'developers'
 
   default_scope -> { where(:name => 'Jamis') }
@@ -192,14 +192,14 @@ class ModuleIncludedPoorDeveloperCalledJamis < DeveloperCalledJamis
   include SalaryDefaultScope
 end
 
-class EagerDeveloperWithDefaultScope < ActiveRecord::Base
+class EagerDeveloperWithDefaultScope < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope { includes(:projects) }
 end
 
-class EagerDeveloperWithClassMethodDefaultScope < ActiveRecord::Base
+class EagerDeveloperWithClassMethodDefaultScope < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
@@ -208,28 +208,28 @@ class EagerDeveloperWithClassMethodDefaultScope < ActiveRecord::Base
   end
 end
 
-class EagerDeveloperWithLambdaDefaultScope < ActiveRecord::Base
+class EagerDeveloperWithLambdaDefaultScope < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope lambda { includes(:projects) }
 end
 
-class EagerDeveloperWithBlockDefaultScope < ActiveRecord::Base
+class EagerDeveloperWithBlockDefaultScope < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope { includes(:projects) }
 end
 
-class EagerDeveloperWithCallableDefaultScope < ActiveRecord::Base
+class EagerDeveloperWithCallableDefaultScope < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope OpenStruct.new(:call => includes(:projects))
 end
 
-class ThreadsafeDeveloper < ActiveRecord::Base
+class ThreadsafeDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   def self.default_scope
@@ -238,7 +238,7 @@ class ThreadsafeDeveloper < ActiveRecord::Base
   end
 end
 
-class CachedDeveloper < ActiveRecord::Base
+class CachedDeveloper < ApplicationModel
   self.table_name = "developers"
   self.cache_timestamp_format = :number
 end

--- a/activerecord/test/models/dog.rb
+++ b/activerecord/test/models/dog.rb
@@ -1,4 +1,4 @@
-class Dog < ActiveRecord::Base
+class Dog < ApplicationModel
   belongs_to :breeder, class_name: "DogLover", counter_cache: :bred_dogs_count
   belongs_to :trainer, class_name: "DogLover", counter_cache: :trained_dogs_count
   belongs_to :doglover, foreign_key: :dog_lover_id, class_name: "DogLover", counter_cache: true

--- a/activerecord/test/models/dog.rb
+++ b/activerecord/test/models/dog.rb
@@ -1,4 +1,4 @@
-class Dog < ApplicationModel
+class Dog < ApplicationRecord
   belongs_to :breeder, class_name: "DogLover", counter_cache: :bred_dogs_count
   belongs_to :trainer, class_name: "DogLover", counter_cache: :trained_dogs_count
   belongs_to :doglover, foreign_key: :dog_lover_id, class_name: "DogLover", counter_cache: true

--- a/activerecord/test/models/dog_lover.rb
+++ b/activerecord/test/models/dog_lover.rb
@@ -1,4 +1,4 @@
-class DogLover < ApplicationModel
+class DogLover < ApplicationRecord
   has_many :trained_dogs, class_name: "Dog", foreign_key: :trainer_id, dependent: :destroy
   has_many :bred_dogs, class_name: "Dog", foreign_key: :breeder_id
   has_many :dogs

--- a/activerecord/test/models/dog_lover.rb
+++ b/activerecord/test/models/dog_lover.rb
@@ -1,4 +1,4 @@
-class DogLover < ActiveRecord::Base
+class DogLover < ApplicationModel
   has_many :trained_dogs, class_name: "Dog", foreign_key: :trainer_id, dependent: :destroy
   has_many :bred_dogs, class_name: "Dog", foreign_key: :breeder_id
   has_many :dogs

--- a/activerecord/test/models/edge.rb
+++ b/activerecord/test/models/edge.rb
@@ -1,5 +1,5 @@
 # This class models an edge in a directed graph.
-class Edge < ActiveRecord::Base
+class Edge < ApplicationModel
   belongs_to :source, :class_name => 'Vertex', :foreign_key => 'source_id'
   belongs_to :sink,   :class_name => 'Vertex', :foreign_key => 'sink_id'
 end

--- a/activerecord/test/models/edge.rb
+++ b/activerecord/test/models/edge.rb
@@ -1,5 +1,5 @@
 # This class models an edge in a directed graph.
-class Edge < ApplicationModel
+class Edge < ApplicationRecord
   belongs_to :source, :class_name => 'Vertex', :foreign_key => 'source_id'
   belongs_to :sink,   :class_name => 'Vertex', :foreign_key => 'sink_id'
 end

--- a/activerecord/test/models/electron.rb
+++ b/activerecord/test/models/electron.rb
@@ -1,3 +1,3 @@
-class Electron < ApplicationModel
+class Electron < ApplicationRecord
   belongs_to :molecule
 end

--- a/activerecord/test/models/electron.rb
+++ b/activerecord/test/models/electron.rb
@@ -1,3 +1,3 @@
-class Electron < ActiveRecord::Base
+class Electron < ApplicationModel
   belongs_to :molecule
 end

--- a/activerecord/test/models/engine.rb
+++ b/activerecord/test/models/engine.rb
@@ -1,4 +1,4 @@
-class Engine < ApplicationModel
+class Engine < ApplicationRecord
   belongs_to :my_car, :class_name => 'Car', :foreign_key => 'car_id',  :counter_cache => :engines_count
 end
 

--- a/activerecord/test/models/engine.rb
+++ b/activerecord/test/models/engine.rb
@@ -1,4 +1,4 @@
-class Engine < ActiveRecord::Base
+class Engine < ApplicationModel
   belongs_to :my_car, :class_name => 'Car', :foreign_key => 'car_id',  :counter_cache => :engines_count
 end
 

--- a/activerecord/test/models/entrant.rb
+++ b/activerecord/test/models/entrant.rb
@@ -1,3 +1,3 @@
-class Entrant < ActiveRecord::Base
+class Entrant < ApplicationModel
   belongs_to :course
 end

--- a/activerecord/test/models/entrant.rb
+++ b/activerecord/test/models/entrant.rb
@@ -1,3 +1,3 @@
-class Entrant < ApplicationModel
+class Entrant < ApplicationRecord
   belongs_to :course
 end

--- a/activerecord/test/models/essay.rb
+++ b/activerecord/test/models/essay.rb
@@ -1,4 +1,4 @@
-class Essay < ActiveRecord::Base
+class Essay < ApplicationModel
   belongs_to :writer, :primary_key => :name, :polymorphic => true
   belongs_to :category, :primary_key => :name
   has_one :owner, :primary_key => :name

--- a/activerecord/test/models/essay.rb
+++ b/activerecord/test/models/essay.rb
@@ -1,4 +1,4 @@
-class Essay < ApplicationModel
+class Essay < ApplicationRecord
   belongs_to :writer, :primary_key => :name, :polymorphic => true
   belongs_to :category, :primary_key => :name
   has_one :owner, :primary_key => :name

--- a/activerecord/test/models/event.rb
+++ b/activerecord/test/models/event.rb
@@ -1,3 +1,3 @@
-class Event < ApplicationModel
+class Event < ApplicationRecord
   validates_uniqueness_of :title
 end

--- a/activerecord/test/models/event.rb
+++ b/activerecord/test/models/event.rb
@@ -1,3 +1,3 @@
-class Event < ActiveRecord::Base
+class Event < ApplicationModel
   validates_uniqueness_of :title
 end

--- a/activerecord/test/models/eye.rb
+++ b/activerecord/test/models/eye.rb
@@ -1,4 +1,4 @@
-class Eye < ActiveRecord::Base
+class Eye < ApplicationModel
   attr_reader :after_create_callbacks_stack
   attr_reader :after_update_callbacks_stack
   attr_reader :after_save_callbacks_stack
@@ -32,6 +32,6 @@ class Eye < ActiveRecord::Base
   alias trace_after_save2 trace_after_save
 end
 
-class Iris < ActiveRecord::Base
+class Iris < ApplicationModel
   belongs_to :eye
 end

--- a/activerecord/test/models/eye.rb
+++ b/activerecord/test/models/eye.rb
@@ -1,4 +1,4 @@
-class Eye < ApplicationModel
+class Eye < ApplicationRecord
   attr_reader :after_create_callbacks_stack
   attr_reader :after_update_callbacks_stack
   attr_reader :after_save_callbacks_stack
@@ -32,6 +32,6 @@ class Eye < ApplicationModel
   alias trace_after_save2 trace_after_save
 end
 
-class Iris < ApplicationModel
+class Iris < ApplicationRecord
   belongs_to :eye
 end

--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -1,4 +1,4 @@
-class Face < ActiveRecord::Base
+class Face < ApplicationModel
   belongs_to :man, :inverse_of => :face
   belongs_to :polymorphic_man, :polymorphic => true, :inverse_of => :polymorphic_face
   # These is a "broken" inverse_of for the purposes of testing

--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -1,4 +1,4 @@
-class Face < ApplicationModel
+class Face < ApplicationRecord
   belongs_to :man, :inverse_of => :face
   belongs_to :polymorphic_man, :polymorphic => true, :inverse_of => :polymorphic_face
   # These is a "broken" inverse_of for the purposes of testing

--- a/activerecord/test/models/friendship.rb
+++ b/activerecord/test/models/friendship.rb
@@ -1,4 +1,4 @@
-class Friendship < ActiveRecord::Base
+class Friendship < ApplicationModel
   belongs_to :friend, class_name: 'Person'
   # friend_too exists to test a bug, and probably shouldn't be used elsewhere
   belongs_to :friend_too, foreign_key: 'friend_id', class_name: 'Person', counter_cache: :friends_too_count

--- a/activerecord/test/models/friendship.rb
+++ b/activerecord/test/models/friendship.rb
@@ -1,4 +1,4 @@
-class Friendship < ApplicationModel
+class Friendship < ApplicationRecord
   belongs_to :friend, class_name: 'Person'
   # friend_too exists to test a bug, and probably shouldn't be used elsewhere
   belongs_to :friend_too, foreign_key: 'friend_id', class_name: 'Person', counter_cache: :friends_too_count

--- a/activerecord/test/models/guid.rb
+++ b/activerecord/test/models/guid.rb
@@ -1,2 +1,2 @@
-class Guid < ApplicationModel
+class Guid < ApplicationRecord
 end

--- a/activerecord/test/models/guid.rb
+++ b/activerecord/test/models/guid.rb
@@ -1,2 +1,2 @@
-class Guid < ActiveRecord::Base
+class Guid < ApplicationModel
 end

--- a/activerecord/test/models/interest.rb
+++ b/activerecord/test/models/interest.rb
@@ -1,4 +1,4 @@
-class Interest < ApplicationModel
+class Interest < ApplicationRecord
   belongs_to :man, :inverse_of => :interests
   belongs_to :polymorphic_man, :polymorphic => true, :inverse_of => :polymorphic_interests
   belongs_to :zine, :inverse_of => :interests

--- a/activerecord/test/models/interest.rb
+++ b/activerecord/test/models/interest.rb
@@ -1,4 +1,4 @@
-class Interest < ActiveRecord::Base
+class Interest < ApplicationModel
   belongs_to :man, :inverse_of => :interests
   belongs_to :polymorphic_man, :polymorphic => true, :inverse_of => :polymorphic_interests
   belongs_to :zine, :inverse_of => :interests

--- a/activerecord/test/models/invoice.rb
+++ b/activerecord/test/models/invoice.rb
@@ -1,4 +1,4 @@
-class Invoice < ApplicationModel
+class Invoice < ApplicationRecord
   has_many :line_items, :autosave => true
   before_save {|record| record.balance = record.line_items.map(&:amount).sum }
 end

--- a/activerecord/test/models/invoice.rb
+++ b/activerecord/test/models/invoice.rb
@@ -1,4 +1,4 @@
-class Invoice < ActiveRecord::Base
+class Invoice < ApplicationModel
   has_many :line_items, :autosave => true
   before_save {|record| record.balance = record.line_items.map(&:amount).sum }
 end

--- a/activerecord/test/models/item.rb
+++ b/activerecord/test/models/item.rb
@@ -1,4 +1,4 @@
-class AbstractItem < ApplicationModel
+class AbstractItem < ApplicationRecord
   self.abstract_class = true
   has_one :tagging, :as => :taggable
 end

--- a/activerecord/test/models/item.rb
+++ b/activerecord/test/models/item.rb
@@ -1,4 +1,4 @@
-class AbstractItem < ActiveRecord::Base
+class AbstractItem < ApplicationModel
   self.abstract_class = true
   has_one :tagging, :as => :taggable
 end

--- a/activerecord/test/models/job.rb
+++ b/activerecord/test/models/job.rb
@@ -1,4 +1,4 @@
-class Job < ApplicationModel
+class Job < ApplicationRecord
   has_many :references
   has_many :people, :through => :references
   belongs_to :ideal_reference, :class_name => 'Reference'

--- a/activerecord/test/models/job.rb
+++ b/activerecord/test/models/job.rb
@@ -1,4 +1,4 @@
-class Job < ActiveRecord::Base
+class Job < ApplicationModel
   has_many :references
   has_many :people, :through => :references
   belongs_to :ideal_reference, :class_name => 'Reference'

--- a/activerecord/test/models/joke.rb
+++ b/activerecord/test/models/joke.rb
@@ -1,7 +1,7 @@
-class Joke < ApplicationModel
+class Joke < ApplicationRecord
   self.table_name = 'funny_jokes'
 end
 
-class GoodJoke < ApplicationModel
+class GoodJoke < ApplicationRecord
   self.table_name = 'funny_jokes'
 end

--- a/activerecord/test/models/joke.rb
+++ b/activerecord/test/models/joke.rb
@@ -1,7 +1,7 @@
-class Joke < ActiveRecord::Base
+class Joke < ApplicationModel
   self.table_name = 'funny_jokes'
 end
 
-class GoodJoke < ActiveRecord::Base
+class GoodJoke < ApplicationModel
   self.table_name = 'funny_jokes'
 end

--- a/activerecord/test/models/keyboard.rb
+++ b/activerecord/test/models/keyboard.rb
@@ -1,3 +1,3 @@
-class Keyboard < ApplicationModel
+class Keyboard < ApplicationRecord
   self.primary_key = 'key_number'
 end

--- a/activerecord/test/models/keyboard.rb
+++ b/activerecord/test/models/keyboard.rb
@@ -1,3 +1,3 @@
-class Keyboard < ActiveRecord::Base
+class Keyboard < ApplicationModel
   self.primary_key = 'key_number'
 end

--- a/activerecord/test/models/legacy_thing.rb
+++ b/activerecord/test/models/legacy_thing.rb
@@ -1,3 +1,3 @@
-class LegacyThing < ActiveRecord::Base
+class LegacyThing < ApplicationModel
   self.locking_column = :version
 end

--- a/activerecord/test/models/legacy_thing.rb
+++ b/activerecord/test/models/legacy_thing.rb
@@ -1,3 +1,3 @@
-class LegacyThing < ApplicationModel
+class LegacyThing < ApplicationRecord
   self.locking_column = :version
 end

--- a/activerecord/test/models/lesson.rb
+++ b/activerecord/test/models/lesson.rb
@@ -1,7 +1,7 @@
 class LessonError < Exception
 end
 
-class Lesson < ApplicationModel
+class Lesson < ApplicationRecord
   has_and_belongs_to_many :students
   before_destroy :ensure_no_students
 

--- a/activerecord/test/models/lesson.rb
+++ b/activerecord/test/models/lesson.rb
@@ -1,7 +1,7 @@
 class LessonError < Exception
 end
 
-class Lesson < ActiveRecord::Base
+class Lesson < ApplicationModel
   has_and_belongs_to_many :students
   before_destroy :ensure_no_students
 

--- a/activerecord/test/models/line_item.rb
+++ b/activerecord/test/models/line_item.rb
@@ -1,3 +1,3 @@
-class LineItem < ActiveRecord::Base
+class LineItem < ApplicationModel
   belongs_to :invoice, :touch => true
 end

--- a/activerecord/test/models/line_item.rb
+++ b/activerecord/test/models/line_item.rb
@@ -1,3 +1,3 @@
-class LineItem < ApplicationModel
+class LineItem < ApplicationRecord
   belongs_to :invoice, :touch => true
 end

--- a/activerecord/test/models/liquid.rb
+++ b/activerecord/test/models/liquid.rb
@@ -1,4 +1,4 @@
-class Liquid < ActiveRecord::Base
+class Liquid < ApplicationModel
   self.table_name = :liquid
   has_many :molecules, -> { distinct }
 end

--- a/activerecord/test/models/liquid.rb
+++ b/activerecord/test/models/liquid.rb
@@ -1,4 +1,4 @@
-class Liquid < ApplicationModel
+class Liquid < ApplicationRecord
   self.table_name = :liquid
   has_many :molecules, -> { distinct }
 end

--- a/activerecord/test/models/man.rb
+++ b/activerecord/test/models/man.rb
@@ -1,4 +1,4 @@
-class Man < ActiveRecord::Base
+class Man < ApplicationModel
   has_one :face, :inverse_of => :man
   has_one :polymorphic_face, :class_name => 'Face', :as => :polymorphic_man, :inverse_of => :polymorphic_man
   has_many :interests, :inverse_of => :man

--- a/activerecord/test/models/man.rb
+++ b/activerecord/test/models/man.rb
@@ -1,4 +1,4 @@
-class Man < ApplicationModel
+class Man < ApplicationRecord
   has_one :face, :inverse_of => :man
   has_one :polymorphic_face, :class_name => 'Face', :as => :polymorphic_man, :inverse_of => :polymorphic_man
   has_many :interests, :inverse_of => :man

--- a/activerecord/test/models/matey.rb
+++ b/activerecord/test/models/matey.rb
@@ -1,4 +1,4 @@
-class Matey < ApplicationModel
+class Matey < ApplicationRecord
   belongs_to :pirate
   belongs_to :target, :class_name => 'Pirate'
 end

--- a/activerecord/test/models/matey.rb
+++ b/activerecord/test/models/matey.rb
@@ -1,4 +1,4 @@
-class Matey < ActiveRecord::Base
+class Matey < ApplicationModel
   belongs_to :pirate
   belongs_to :target, :class_name => 'Pirate'
 end

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -1,4 +1,4 @@
-class Member < ActiveRecord::Base
+class Member < ApplicationModel
   has_one :current_membership
   has_one :selected_membership
   has_one :membership
@@ -30,7 +30,7 @@ class Member < ActiveRecord::Base
   has_one :club_through_many, :through => :current_memberships, :source => :club
 end
 
-class SelfMember < ActiveRecord::Base
+class SelfMember < ApplicationModel
   self.table_name = "members"
   has_and_belongs_to_many :friends, :class_name => "SelfMember", :join_table => "member_friends"
 end

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -1,4 +1,4 @@
-class Member < ApplicationModel
+class Member < ApplicationRecord
   has_one :current_membership
   has_one :selected_membership
   has_one :membership
@@ -30,7 +30,7 @@ class Member < ApplicationModel
   has_one :club_through_many, :through => :current_memberships, :source => :club
 end
 
-class SelfMember < ApplicationModel
+class SelfMember < ApplicationRecord
   self.table_name = "members"
   has_and_belongs_to_many :friends, :class_name => "SelfMember", :join_table => "member_friends"
 end

--- a/activerecord/test/models/member_detail.rb
+++ b/activerecord/test/models/member_detail.rb
@@ -1,4 +1,4 @@
-class MemberDetail < ApplicationModel
+class MemberDetail < ApplicationRecord
   belongs_to :member, :inverse_of => false
   belongs_to :organization
   has_one :member_type, :through => :member

--- a/activerecord/test/models/member_detail.rb
+++ b/activerecord/test/models/member_detail.rb
@@ -1,4 +1,4 @@
-class MemberDetail < ActiveRecord::Base
+class MemberDetail < ApplicationModel
   belongs_to :member, :inverse_of => false
   belongs_to :organization
   has_one :member_type, :through => :member

--- a/activerecord/test/models/member_type.rb
+++ b/activerecord/test/models/member_type.rb
@@ -1,3 +1,3 @@
-class MemberType < ActiveRecord::Base
+class MemberType < ApplicationModel
   has_many :members
 end

--- a/activerecord/test/models/member_type.rb
+++ b/activerecord/test/models/member_type.rb
@@ -1,3 +1,3 @@
-class MemberType < ApplicationModel
+class MemberType < ApplicationRecord
   has_many :members
 end

--- a/activerecord/test/models/membership.rb
+++ b/activerecord/test/models/membership.rb
@@ -1,4 +1,4 @@
-class Membership < ActiveRecord::Base
+class Membership < ApplicationModel
   belongs_to :member
   belongs_to :club
 end

--- a/activerecord/test/models/membership.rb
+++ b/activerecord/test/models/membership.rb
@@ -1,4 +1,4 @@
-class Membership < ApplicationModel
+class Membership < ApplicationRecord
   belongs_to :member
   belongs_to :club
 end

--- a/activerecord/test/models/minimalistic.rb
+++ b/activerecord/test/models/minimalistic.rb
@@ -1,2 +1,2 @@
-class Minimalistic < ActiveRecord::Base
+class Minimalistic < ApplicationModel
 end

--- a/activerecord/test/models/minimalistic.rb
+++ b/activerecord/test/models/minimalistic.rb
@@ -1,2 +1,2 @@
-class Minimalistic < ApplicationModel
+class Minimalistic < ApplicationRecord
 end

--- a/activerecord/test/models/minivan.rb
+++ b/activerecord/test/models/minivan.rb
@@ -1,4 +1,4 @@
-class Minivan < ApplicationModel
+class Minivan < ApplicationRecord
   self.primary_key = :minivan_id
 
   belongs_to :speedometer

--- a/activerecord/test/models/minivan.rb
+++ b/activerecord/test/models/minivan.rb
@@ -1,4 +1,4 @@
-class Minivan < ActiveRecord::Base
+class Minivan < ApplicationModel
   self.primary_key = :minivan_id
 
   belongs_to :speedometer

--- a/activerecord/test/models/mixed_case_monkey.rb
+++ b/activerecord/test/models/mixed_case_monkey.rb
@@ -1,4 +1,4 @@
-class MixedCaseMonkey < ActiveRecord::Base
+class MixedCaseMonkey < ApplicationModel
   self.primary_key = 'monkeyID'
 
   belongs_to :man

--- a/activerecord/test/models/mixed_case_monkey.rb
+++ b/activerecord/test/models/mixed_case_monkey.rb
@@ -1,4 +1,4 @@
-class MixedCaseMonkey < ApplicationModel
+class MixedCaseMonkey < ApplicationRecord
   self.primary_key = 'monkeyID'
 
   belongs_to :man

--- a/activerecord/test/models/molecule.rb
+++ b/activerecord/test/models/molecule.rb
@@ -1,4 +1,4 @@
-class Molecule < ApplicationModel
+class Molecule < ApplicationRecord
   belongs_to :liquid
   has_many :electrons
 end

--- a/activerecord/test/models/molecule.rb
+++ b/activerecord/test/models/molecule.rb
@@ -1,4 +1,4 @@
-class Molecule < ActiveRecord::Base
+class Molecule < ApplicationModel
   belongs_to :liquid
   has_many :electrons
 end

--- a/activerecord/test/models/movie.rb
+++ b/activerecord/test/models/movie.rb
@@ -1,4 +1,4 @@
-class Movie < ApplicationModel
+class Movie < ApplicationRecord
   def self.primary_key
     "movieid"
   end

--- a/activerecord/test/models/movie.rb
+++ b/activerecord/test/models/movie.rb
@@ -1,4 +1,4 @@
-class Movie < ActiveRecord::Base
+class Movie < ApplicationModel
   def self.primary_key
     "movieid"
   end

--- a/activerecord/test/models/order.rb
+++ b/activerecord/test/models/order.rb
@@ -1,4 +1,4 @@
-class Order < ActiveRecord::Base
+class Order < ApplicationModel
   belongs_to :billing, :class_name => 'Customer', :foreign_key => 'billing_customer_id'
   belongs_to :shipping, :class_name => 'Customer', :foreign_key => 'shipping_customer_id'
 end

--- a/activerecord/test/models/order.rb
+++ b/activerecord/test/models/order.rb
@@ -1,4 +1,4 @@
-class Order < ApplicationModel
+class Order < ApplicationRecord
   belongs_to :billing, :class_name => 'Customer', :foreign_key => 'billing_customer_id'
   belongs_to :shipping, :class_name => 'Customer', :foreign_key => 'shipping_customer_id'
 end

--- a/activerecord/test/models/organization.rb
+++ b/activerecord/test/models/organization.rb
@@ -1,4 +1,4 @@
-class Organization < ActiveRecord::Base
+class Organization < ApplicationModel
   has_many :member_details
   has_many :members, :through => :member_details
 

--- a/activerecord/test/models/organization.rb
+++ b/activerecord/test/models/organization.rb
@@ -1,4 +1,4 @@
-class Organization < ApplicationModel
+class Organization < ApplicationRecord
   has_many :member_details
   has_many :members, :through => :member_details
 

--- a/activerecord/test/models/owner.rb
+++ b/activerecord/test/models/owner.rb
@@ -1,4 +1,4 @@
-class Owner < ActiveRecord::Base
+class Owner < ApplicationModel
   self.primary_key = :owner_id
   has_many :pets, -> { order 'pets.name desc' }
   has_many :toys, :through => :pets

--- a/activerecord/test/models/owner.rb
+++ b/activerecord/test/models/owner.rb
@@ -1,4 +1,4 @@
-class Owner < ApplicationModel
+class Owner < ApplicationRecord
   self.primary_key = :owner_id
   has_many :pets, -> { order 'pets.name desc' }
   has_many :toys, :through => :pets

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -1,4 +1,4 @@
-class Parrot < ApplicationModel
+class Parrot < ApplicationRecord
   self.inheritance_column = :parrot_sti_class
 
   has_and_belongs_to_many :pirates

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -1,4 +1,4 @@
-class Parrot < ActiveRecord::Base
+class Parrot < ApplicationModel
   self.inheritance_column = :parrot_sti_class
 
   has_and_belongs_to_many :pirates

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -1,4 +1,4 @@
-class Person < ApplicationModel
+class Person < ApplicationRecord
   has_many :readers
   has_many :secure_readers
   has_one  :reader
@@ -38,21 +38,21 @@ class Person < ApplicationModel
   scope :females, -> { where(:gender => 'F') }
 end
 
-class PersonWithDependentDestroyJobs < ApplicationModel
+class PersonWithDependentDestroyJobs < ApplicationRecord
   self.table_name = 'people'
 
   has_many :references, :foreign_key => :person_id
   has_many :jobs, :source => :job, :through => :references, :dependent => :destroy
 end
 
-class PersonWithDependentDeleteAllJobs < ApplicationModel
+class PersonWithDependentDeleteAllJobs < ApplicationRecord
   self.table_name = 'people'
 
   has_many :references, :foreign_key => :person_id
   has_many :jobs, :source => :job, :through => :references, :dependent => :delete_all
 end
 
-class PersonWithDependentNullifyJobs < ApplicationModel
+class PersonWithDependentNullifyJobs < ApplicationRecord
   self.table_name = 'people'
 
   has_many :references, :foreign_key => :person_id
@@ -60,7 +60,7 @@ class PersonWithDependentNullifyJobs < ApplicationModel
 end
 
 
-class LoosePerson < ApplicationModel
+class LoosePerson < ApplicationRecord
   self.table_name = 'people'
   self.abstract_class = true
 
@@ -73,7 +73,7 @@ end
 
 class LooseDescendant < LoosePerson; end
 
-class TightPerson < ApplicationModel
+class TightPerson < ApplicationRecord
   self.table_name = 'people'
 
   has_one    :best_friend,    :class_name => 'TightPerson', :foreign_key => :best_friend_id
@@ -85,13 +85,13 @@ end
 
 class TightDescendant < TightPerson; end
 
-class RichPerson < ApplicationModel
+class RichPerson < ApplicationRecord
   self.table_name = 'people'
 
   has_and_belongs_to_many :treasures, :join_table => 'peoples_treasures'
 end
 
-class NestedPerson < ApplicationModel
+class NestedPerson < ApplicationRecord
   self.table_name = 'people'
 
   has_one :best_friend, :class_name => 'NestedPerson', :foreign_key => :best_friend_id
@@ -121,7 +121,7 @@ class Insure
   end
 end
 
-class SerializedPerson < ApplicationModel
+class SerializedPerson < ApplicationRecord
   self.table_name = 'people'
 
   serialize :insures, Insure

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -1,4 +1,4 @@
-class Person < ActiveRecord::Base
+class Person < ApplicationModel
   has_many :readers
   has_many :secure_readers
   has_one  :reader
@@ -38,21 +38,21 @@ class Person < ActiveRecord::Base
   scope :females, -> { where(:gender => 'F') }
 end
 
-class PersonWithDependentDestroyJobs < ActiveRecord::Base
+class PersonWithDependentDestroyJobs < ApplicationModel
   self.table_name = 'people'
 
   has_many :references, :foreign_key => :person_id
   has_many :jobs, :source => :job, :through => :references, :dependent => :destroy
 end
 
-class PersonWithDependentDeleteAllJobs < ActiveRecord::Base
+class PersonWithDependentDeleteAllJobs < ApplicationModel
   self.table_name = 'people'
 
   has_many :references, :foreign_key => :person_id
   has_many :jobs, :source => :job, :through => :references, :dependent => :delete_all
 end
 
-class PersonWithDependentNullifyJobs < ActiveRecord::Base
+class PersonWithDependentNullifyJobs < ApplicationModel
   self.table_name = 'people'
 
   has_many :references, :foreign_key => :person_id
@@ -60,7 +60,7 @@ class PersonWithDependentNullifyJobs < ActiveRecord::Base
 end
 
 
-class LoosePerson < ActiveRecord::Base
+class LoosePerson < ApplicationModel
   self.table_name = 'people'
   self.abstract_class = true
 
@@ -73,7 +73,7 @@ end
 
 class LooseDescendant < LoosePerson; end
 
-class TightPerson < ActiveRecord::Base
+class TightPerson < ApplicationModel
   self.table_name = 'people'
 
   has_one    :best_friend,    :class_name => 'TightPerson', :foreign_key => :best_friend_id
@@ -85,13 +85,13 @@ end
 
 class TightDescendant < TightPerson; end
 
-class RichPerson < ActiveRecord::Base
+class RichPerson < ApplicationModel
   self.table_name = 'people'
 
   has_and_belongs_to_many :treasures, :join_table => 'peoples_treasures'
 end
 
-class NestedPerson < ActiveRecord::Base
+class NestedPerson < ApplicationModel
   self.table_name = 'people'
 
   has_one :best_friend, :class_name => 'NestedPerson', :foreign_key => :best_friend_id
@@ -121,7 +121,7 @@ class Insure
   end
 end
 
-class SerializedPerson < ActiveRecord::Base
+class SerializedPerson < ApplicationModel
   self.table_name = 'people'
 
   serialize :insures, Insure

--- a/activerecord/test/models/pet.rb
+++ b/activerecord/test/models/pet.rb
@@ -1,4 +1,4 @@
-class Pet < ActiveRecord::Base
+class Pet < ApplicationModel
   attr_accessor :current_user
 
   self.primary_key = :pet_id

--- a/activerecord/test/models/pet.rb
+++ b/activerecord/test/models/pet.rb
@@ -1,4 +1,4 @@
-class Pet < ApplicationModel
+class Pet < ApplicationRecord
   attr_accessor :current_user
 
   self.primary_key = :pet_id

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -1,4 +1,4 @@
-class Pirate < ActiveRecord::Base
+class Pirate < ApplicationModel
   belongs_to :parrot, :validate => true
   belongs_to :non_validated_parrot, :class_name => 'Parrot'
   has_and_belongs_to_many :parrots, -> { order('parrots.id ASC') }, :validate => true

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -1,4 +1,4 @@
-class Pirate < ApplicationModel
+class Pirate < ApplicationRecord
   belongs_to :parrot, :validate => true
   belongs_to :non_validated_parrot, :class_name => 'Parrot'
   has_and_belongs_to_many :parrots, -> { order('parrots.id ASC') }, :validate => true

--- a/activerecord/test/models/possession.rb
+++ b/activerecord/test/models/possession.rb
@@ -1,3 +1,3 @@
-class Possession < ActiveRecord::Base
+class Possession < ApplicationModel
   self.table_name = 'having'
 end

--- a/activerecord/test/models/possession.rb
+++ b/activerecord/test/models/possession.rb
@@ -1,3 +1,3 @@
-class Possession < ApplicationModel
+class Possession < ApplicationRecord
   self.table_name = 'having'
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -1,5 +1,5 @@
-class Post < ApplicationModel
-  class CategoryPost < ApplicationModel
+class Post < ApplicationRecord
+  class CategoryPost < ApplicationRecord
     self.table_name = "categories_posts"
     belongs_to :category
     belongs_to :post
@@ -172,7 +172,7 @@ class SubStiPost < StiPost
   self.table_name = Post.table_name
 end
 
-class FirstPost < ApplicationModel
+class FirstPost < ApplicationRecord
   self.table_name = 'posts'
   default_scope { where(:id => 1) }
 
@@ -180,7 +180,7 @@ class FirstPost < ApplicationModel
   has_one  :comment,  :foreign_key => :post_id
 end
 
-class PostWithDefaultInclude < ApplicationModel
+class PostWithDefaultInclude < ApplicationRecord
   self.table_name = 'posts'
   default_scope { includes(:comments) }
   has_many :comments, :foreign_key => :post_id
@@ -191,12 +191,12 @@ class PostWithSpecialCategorization < Post
   default_scope { where(:type => 'PostWithSpecialCategorization').joins(:categorizations).where(:categorizations => { :special => true }) }
 end
 
-class PostWithDefaultScope < ApplicationModel
+class PostWithDefaultScope < ApplicationRecord
   self.table_name = 'posts'
   default_scope { order(:title) }
 end
 
-class SpecialPostWithDefaultScope < ApplicationModel
+class SpecialPostWithDefaultScope < ApplicationRecord
   self.table_name = 'posts'
   default_scope { where(:id => [1, 5,6]) }
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -1,5 +1,5 @@
-class Post < ActiveRecord::Base
-  class CategoryPost < ActiveRecord::Base
+class Post < ApplicationModel
+  class CategoryPost < ApplicationModel
     self.table_name = "categories_posts"
     belongs_to :category
     belongs_to :post
@@ -172,7 +172,7 @@ class SubStiPost < StiPost
   self.table_name = Post.table_name
 end
 
-class FirstPost < ActiveRecord::Base
+class FirstPost < ApplicationModel
   self.table_name = 'posts'
   default_scope { where(:id => 1) }
 
@@ -180,7 +180,7 @@ class FirstPost < ActiveRecord::Base
   has_one  :comment,  :foreign_key => :post_id
 end
 
-class PostWithDefaultInclude < ActiveRecord::Base
+class PostWithDefaultInclude < ApplicationModel
   self.table_name = 'posts'
   default_scope { includes(:comments) }
   has_many :comments, :foreign_key => :post_id
@@ -191,12 +191,12 @@ class PostWithSpecialCategorization < Post
   default_scope { where(:type => 'PostWithSpecialCategorization').joins(:categorizations).where(:categorizations => { :special => true }) }
 end
 
-class PostWithDefaultScope < ActiveRecord::Base
+class PostWithDefaultScope < ApplicationModel
   self.table_name = 'posts'
   default_scope { order(:title) }
 end
 
-class SpecialPostWithDefaultScope < ActiveRecord::Base
+class SpecialPostWithDefaultScope < ApplicationModel
   self.table_name = 'posts'
   default_scope { where(:id => [1, 5,6]) }
 end

--- a/activerecord/test/models/price_estimate.rb
+++ b/activerecord/test/models/price_estimate.rb
@@ -1,4 +1,4 @@
-class PriceEstimate < ActiveRecord::Base
+class PriceEstimate < ApplicationModel
   belongs_to :estimate_of, :polymorphic => true
   belongs_to :thing, polymorphic: true
 end

--- a/activerecord/test/models/price_estimate.rb
+++ b/activerecord/test/models/price_estimate.rb
@@ -1,4 +1,4 @@
-class PriceEstimate < ApplicationModel
+class PriceEstimate < ApplicationRecord
   belongs_to :estimate_of, :polymorphic => true
   belongs_to :thing, polymorphic: true
 end

--- a/activerecord/test/models/project.rb
+++ b/activerecord/test/models/project.rb
@@ -1,4 +1,4 @@
-class Project < ApplicationModel
+class Project < ApplicationRecord
   has_and_belongs_to_many :developers, -> { distinct.order 'developers.name desc, developers.id desc' }
   has_and_belongs_to_many :readonly_developers, -> { readonly }, :class_name => "Developer"
   has_and_belongs_to_many :selected_developers, -> { distinct.select "developers.*" }, :class_name => "Developer"

--- a/activerecord/test/models/project.rb
+++ b/activerecord/test/models/project.rb
@@ -1,4 +1,4 @@
-class Project < ActiveRecord::Base
+class Project < ApplicationModel
   has_and_belongs_to_many :developers, -> { distinct.order 'developers.name desc, developers.id desc' }
   has_and_belongs_to_many :readonly_developers, -> { readonly }, :class_name => "Developer"
   has_and_belongs_to_many :selected_developers, -> { distinct.select "developers.*" }, :class_name => "Developer"

--- a/activerecord/test/models/randomly_named_c1.rb
+++ b/activerecord/test/models/randomly_named_c1.rb
@@ -1,3 +1,3 @@
-class ClassNameThatDoesNotFollowCONVENTIONS < ApplicationModel
+class ClassNameThatDoesNotFollowCONVENTIONS < ApplicationRecord
   self.table_name = :randomly_named_table
 end

--- a/activerecord/test/models/randomly_named_c1.rb
+++ b/activerecord/test/models/randomly_named_c1.rb
@@ -1,3 +1,3 @@
-class ClassNameThatDoesNotFollowCONVENTIONS < ActiveRecord::Base
+class ClassNameThatDoesNotFollowCONVENTIONS < ApplicationModel
   self.table_name = :randomly_named_table
 end

--- a/activerecord/test/models/rating.rb
+++ b/activerecord/test/models/rating.rb
@@ -1,4 +1,4 @@
-class Rating < ApplicationModel
+class Rating < ApplicationRecord
   belongs_to :comment
   has_many :taggings, :as => :taggable
 end

--- a/activerecord/test/models/rating.rb
+++ b/activerecord/test/models/rating.rb
@@ -1,4 +1,4 @@
-class Rating < ActiveRecord::Base
+class Rating < ApplicationModel
   belongs_to :comment
   has_many :taggings, :as => :taggable
 end

--- a/activerecord/test/models/reader.rb
+++ b/activerecord/test/models/reader.rb
@@ -1,18 +1,18 @@
-class Reader < ActiveRecord::Base
+class Reader < ApplicationModel
   belongs_to :post
   belongs_to :person, :inverse_of => :readers
   belongs_to :single_person, :class_name => 'Person', :foreign_key => :person_id, :inverse_of => :reader
   belongs_to :first_post, -> { where(id: [2, 3]) }
 end
 
-class SecureReader < ActiveRecord::Base
+class SecureReader < ApplicationModel
   self.table_name = "readers"
 
   belongs_to :secure_post, :class_name => "Post", :foreign_key => "post_id"
   belongs_to :secure_person, :inverse_of => :secure_readers, :class_name => "Person", :foreign_key => "person_id"
 end
 
-class LazyReader < ActiveRecord::Base
+class LazyReader < ApplicationModel
   self.table_name = "readers"
   default_scope -> { where(skimmer: true) }
 

--- a/activerecord/test/models/reader.rb
+++ b/activerecord/test/models/reader.rb
@@ -1,18 +1,18 @@
-class Reader < ApplicationModel
+class Reader < ApplicationRecord
   belongs_to :post
   belongs_to :person, :inverse_of => :readers
   belongs_to :single_person, :class_name => 'Person', :foreign_key => :person_id, :inverse_of => :reader
   belongs_to :first_post, -> { where(id: [2, 3]) }
 end
 
-class SecureReader < ApplicationModel
+class SecureReader < ApplicationRecord
   self.table_name = "readers"
 
   belongs_to :secure_post, :class_name => "Post", :foreign_key => "post_id"
   belongs_to :secure_person, :inverse_of => :secure_readers, :class_name => "Person", :foreign_key => "person_id"
 end
 
-class LazyReader < ApplicationModel
+class LazyReader < ApplicationRecord
   self.table_name = "readers"
   default_scope -> { where(skimmer: true) }
 

--- a/activerecord/test/models/reference.rb
+++ b/activerecord/test/models/reference.rb
@@ -1,4 +1,4 @@
-class Reference < ApplicationModel
+class Reference < ApplicationRecord
   belongs_to :person
   belongs_to :job
 
@@ -16,7 +16,7 @@ class Reference < ApplicationModel
   end
 end
 
-class BadReference < ApplicationModel
+class BadReference < ApplicationRecord
   self.table_name = 'references'
   default_scope { where(:favourite => false) }
 end

--- a/activerecord/test/models/reference.rb
+++ b/activerecord/test/models/reference.rb
@@ -1,4 +1,4 @@
-class Reference < ActiveRecord::Base
+class Reference < ApplicationModel
   belongs_to :person
   belongs_to :job
 
@@ -16,7 +16,7 @@ class Reference < ActiveRecord::Base
   end
 end
 
-class BadReference < ActiveRecord::Base
+class BadReference < ApplicationModel
   self.table_name = 'references'
   default_scope { where(:favourite => false) }
 end

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -1,4 +1,4 @@
-class Ship < ApplicationModel
+class Ship < ApplicationRecord
   self.record_timestamps = false
 
   belongs_to :pirate

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -1,4 +1,4 @@
-class Ship < ActiveRecord::Base
+class Ship < ApplicationModel
   self.record_timestamps = false
 
   belongs_to :pirate

--- a/activerecord/test/models/ship_part.rb
+++ b/activerecord/test/models/ship_part.rb
@@ -1,4 +1,4 @@
-class ShipPart < ApplicationModel
+class ShipPart < ApplicationRecord
   belongs_to :ship
   has_many :trinkets, :class_name => "Treasure", :as => :looter
   accepts_nested_attributes_for :trinkets, :allow_destroy => true

--- a/activerecord/test/models/ship_part.rb
+++ b/activerecord/test/models/ship_part.rb
@@ -1,4 +1,4 @@
-class ShipPart < ActiveRecord::Base
+class ShipPart < ApplicationModel
   belongs_to :ship
   has_many :trinkets, :class_name => "Treasure", :as => :looter
   accepts_nested_attributes_for :trinkets, :allow_destroy => true

--- a/activerecord/test/models/shop.rb
+++ b/activerecord/test/models/shop.rb
@@ -1,12 +1,12 @@
 module Shop
-  class Collection < ActiveRecord::Base
+  class Collection < ApplicationModel
     has_many :products, :dependent => :nullify
   end
 
-  class Product < ActiveRecord::Base
+  class Product < ApplicationModel
     has_many :variants, :dependent => :delete_all
   end
 
-  class Variant < ActiveRecord::Base
+  class Variant < ApplicationModel
   end
 end

--- a/activerecord/test/models/shop.rb
+++ b/activerecord/test/models/shop.rb
@@ -1,12 +1,12 @@
 module Shop
-  class Collection < ApplicationModel
+  class Collection < ApplicationRecord
     has_many :products, :dependent => :nullify
   end
 
-  class Product < ApplicationModel
+  class Product < ApplicationRecord
     has_many :variants, :dependent => :delete_all
   end
 
-  class Variant < ApplicationModel
+  class Variant < ApplicationRecord
   end
 end

--- a/activerecord/test/models/speedometer.rb
+++ b/activerecord/test/models/speedometer.rb
@@ -1,4 +1,4 @@
-class Speedometer < ActiveRecord::Base
+class Speedometer < ApplicationModel
   self.primary_key = :speedometer_id
   belongs_to :dashboard
 

--- a/activerecord/test/models/speedometer.rb
+++ b/activerecord/test/models/speedometer.rb
@@ -1,4 +1,4 @@
-class Speedometer < ApplicationModel
+class Speedometer < ApplicationRecord
   self.primary_key = :speedometer_id
   belongs_to :dashboard
 

--- a/activerecord/test/models/sponsor.rb
+++ b/activerecord/test/models/sponsor.rb
@@ -1,4 +1,4 @@
-class Sponsor < ActiveRecord::Base
+class Sponsor < ApplicationModel
   belongs_to :sponsor_club, :class_name => "Club", :foreign_key => "club_id"
   belongs_to :sponsorable, :polymorphic => true
   belongs_to :thing, :polymorphic => true, :foreign_type => :sponsorable_type, :foreign_key => :sponsorable_id

--- a/activerecord/test/models/sponsor.rb
+++ b/activerecord/test/models/sponsor.rb
@@ -1,4 +1,4 @@
-class Sponsor < ApplicationModel
+class Sponsor < ApplicationRecord
   belongs_to :sponsor_club, :class_name => "Club", :foreign_key => "club_id"
   belongs_to :sponsorable, :polymorphic => true
   belongs_to :thing, :polymorphic => true, :foreign_type => :sponsorable_type, :foreign_key => :sponsorable_id

--- a/activerecord/test/models/string_key_object.rb
+++ b/activerecord/test/models/string_key_object.rb
@@ -1,3 +1,3 @@
-class StringKeyObject < ActiveRecord::Base
+class StringKeyObject < ApplicationModel
   self.primary_key = :id
 end

--- a/activerecord/test/models/string_key_object.rb
+++ b/activerecord/test/models/string_key_object.rb
@@ -1,3 +1,3 @@
-class StringKeyObject < ApplicationModel
+class StringKeyObject < ApplicationRecord
   self.primary_key = :id
 end

--- a/activerecord/test/models/student.rb
+++ b/activerecord/test/models/student.rb
@@ -1,3 +1,3 @@
-class Student < ActiveRecord::Base
+class Student < ApplicationModel
   has_and_belongs_to_many :lessons
 end

--- a/activerecord/test/models/student.rb
+++ b/activerecord/test/models/student.rb
@@ -1,3 +1,3 @@
-class Student < ApplicationModel
+class Student < ApplicationRecord
   has_and_belongs_to_many :lessons
 end

--- a/activerecord/test/models/subject.rb
+++ b/activerecord/test/models/subject.rb
@@ -1,6 +1,6 @@
 # used for OracleSynonymTest, see test/synonym_test_oracle.rb
 #
-class Subject < ApplicationModel
+class Subject < ApplicationRecord
 
   # added initialization of author_email_address in the same way as in Topic class
   # as otherwise synonym test was failing

--- a/activerecord/test/models/subject.rb
+++ b/activerecord/test/models/subject.rb
@@ -1,6 +1,6 @@
 # used for OracleSynonymTest, see test/synonym_test_oracle.rb
 #
-class Subject < ActiveRecord::Base
+class Subject < ApplicationModel
 
   # added initialization of author_email_address in the same way as in Topic class
   # as otherwise synonym test was failing

--- a/activerecord/test/models/subscriber.rb
+++ b/activerecord/test/models/subscriber.rb
@@ -1,4 +1,4 @@
-class Subscriber < ApplicationModel
+class Subscriber < ApplicationRecord
   self.primary_key = 'nick'
   has_many :subscriptions
   has_many :books, :through => :subscriptions

--- a/activerecord/test/models/subscriber.rb
+++ b/activerecord/test/models/subscriber.rb
@@ -1,4 +1,4 @@
-class Subscriber < ActiveRecord::Base
+class Subscriber < ApplicationModel
   self.primary_key = 'nick'
   has_many :subscriptions
   has_many :books, :through => :subscriptions

--- a/activerecord/test/models/subscription.rb
+++ b/activerecord/test/models/subscription.rb
@@ -1,4 +1,4 @@
-class Subscription < ActiveRecord::Base
+class Subscription < ApplicationModel
   belongs_to :subscriber, :counter_cache => :books_count
   belongs_to :book
 end

--- a/activerecord/test/models/subscription.rb
+++ b/activerecord/test/models/subscription.rb
@@ -1,4 +1,4 @@
-class Subscription < ApplicationModel
+class Subscription < ApplicationRecord
   belongs_to :subscriber, :counter_cache => :books_count
   belongs_to :book
 end

--- a/activerecord/test/models/tag.rb
+++ b/activerecord/test/models/tag.rb
@@ -1,4 +1,4 @@
-class Tag < ActiveRecord::Base
+class Tag < ApplicationModel
   has_many :taggings
   has_many :taggables, :through => :taggings
   has_one  :tagging

--- a/activerecord/test/models/tag.rb
+++ b/activerecord/test/models/tag.rb
@@ -1,4 +1,4 @@
-class Tag < ApplicationModel
+class Tag < ApplicationRecord
   has_many :taggings
   has_many :taggables, :through => :taggings
   has_one  :tagging

--- a/activerecord/test/models/tagging.rb
+++ b/activerecord/test/models/tagging.rb
@@ -2,7 +2,7 @@
 module Taggable
 end
 
-class Tagging < ActiveRecord::Base
+class Tagging < ApplicationModel
   belongs_to :tag, -> { includes(:tagging) }
   belongs_to :super_tag,   :class_name => 'Tag', :foreign_key => 'super_tag_id'
   belongs_to :invalid_tag, :class_name => 'Tag', :foreign_key => 'tag_id'

--- a/activerecord/test/models/tagging.rb
+++ b/activerecord/test/models/tagging.rb
@@ -2,7 +2,7 @@
 module Taggable
 end
 
-class Tagging < ApplicationModel
+class Tagging < ApplicationRecord
   belongs_to :tag, -> { includes(:tagging) }
   belongs_to :super_tag,   :class_name => 'Tag', :foreign_key => 'super_tag_id'
   belongs_to :invalid_tag, :class_name => 'Tag', :foreign_key => 'tag_id'

--- a/activerecord/test/models/task.rb
+++ b/activerecord/test/models/task.rb
@@ -1,4 +1,4 @@
-class Task < ActiveRecord::Base
+class Task < ApplicationModel
   def updated_at
     ending
   end

--- a/activerecord/test/models/task.rb
+++ b/activerecord/test/models/task.rb
@@ -1,4 +1,4 @@
-class Task < ApplicationModel
+class Task < ApplicationRecord
   def updated_at
     ending
   end

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -1,4 +1,4 @@
-class Topic < ActiveRecord::Base
+class Topic < ApplicationModel
   scope :base, -> { all }
   scope :written_before, lambda { |time|
     if time
@@ -115,7 +115,7 @@ class BlankTopic < Topic
 end
 
 module Web
-  class Topic < ActiveRecord::Base
+  class Topic < ApplicationModel
     has_many :replies, :dependent => :destroy, :foreign_key => "parent_id", :class_name => 'Web::Reply'
   end
 end

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -1,4 +1,4 @@
-class Topic < ApplicationModel
+class Topic < ApplicationRecord
   scope :base, -> { all }
   scope :written_before, lambda { |time|
     if time
@@ -115,7 +115,7 @@ class BlankTopic < Topic
 end
 
 module Web
-  class Topic < ApplicationModel
+  class Topic < ApplicationRecord
     has_many :replies, :dependent => :destroy, :foreign_key => "parent_id", :class_name => 'Web::Reply'
   end
 end

--- a/activerecord/test/models/toy.rb
+++ b/activerecord/test/models/toy.rb
@@ -1,4 +1,4 @@
-class Toy < ApplicationModel
+class Toy < ApplicationRecord
   self.primary_key = :toy_id
   belongs_to :pet
 

--- a/activerecord/test/models/toy.rb
+++ b/activerecord/test/models/toy.rb
@@ -1,4 +1,4 @@
-class Toy < ActiveRecord::Base
+class Toy < ApplicationModel
   self.primary_key = :toy_id
   belongs_to :pet
 

--- a/activerecord/test/models/traffic_light.rb
+++ b/activerecord/test/models/traffic_light.rb
@@ -1,4 +1,4 @@
-class TrafficLight < ActiveRecord::Base
+class TrafficLight < ApplicationModel
   serialize :state, Array
   serialize :long_state, Array
 end

--- a/activerecord/test/models/traffic_light.rb
+++ b/activerecord/test/models/traffic_light.rb
@@ -1,4 +1,4 @@
-class TrafficLight < ApplicationModel
+class TrafficLight < ApplicationRecord
   serialize :state, Array
   serialize :long_state, Array
 end

--- a/activerecord/test/models/treasure.rb
+++ b/activerecord/test/models/treasure.rb
@@ -1,4 +1,4 @@
-class Treasure < ActiveRecord::Base
+class Treasure < ApplicationModel
   has_and_belongs_to_many :parrots
   belongs_to :looter, :polymorphic => true
 

--- a/activerecord/test/models/treasure.rb
+++ b/activerecord/test/models/treasure.rb
@@ -1,4 +1,4 @@
-class Treasure < ApplicationModel
+class Treasure < ApplicationRecord
   has_and_belongs_to_many :parrots
   belongs_to :looter, :polymorphic => true
 

--- a/activerecord/test/models/treaty.rb
+++ b/activerecord/test/models/treaty.rb
@@ -1,4 +1,4 @@
-class Treaty < ActiveRecord::Base
+class Treaty < ApplicationModel
 
   self.primary_key = :treaty_id
 

--- a/activerecord/test/models/treaty.rb
+++ b/activerecord/test/models/treaty.rb
@@ -1,4 +1,4 @@
-class Treaty < ApplicationModel
+class Treaty < ApplicationRecord
 
   self.primary_key = :treaty_id
 

--- a/activerecord/test/models/tyre.rb
+++ b/activerecord/test/models/tyre.rb
@@ -1,3 +1,3 @@
-class Tyre < ActiveRecord::Base
+class Tyre < ApplicationModel
   belongs_to :car
 end

--- a/activerecord/test/models/tyre.rb
+++ b/activerecord/test/models/tyre.rb
@@ -1,3 +1,3 @@
-class Tyre < ApplicationModel
+class Tyre < ApplicationRecord
   belongs_to :car
 end

--- a/activerecord/test/models/vegetables.rb
+++ b/activerecord/test/models/vegetables.rb
@@ -1,4 +1,4 @@
-class Vegetable < ActiveRecord::Base
+class Vegetable < ApplicationModel
 
   validates_presence_of :name
 

--- a/activerecord/test/models/vegetables.rb
+++ b/activerecord/test/models/vegetables.rb
@@ -1,4 +1,4 @@
-class Vegetable < ApplicationModel
+class Vegetable < ApplicationRecord
 
   validates_presence_of :name
 

--- a/activerecord/test/models/vertex.rb
+++ b/activerecord/test/models/vertex.rb
@@ -1,5 +1,5 @@
 # This class models a vertex in a directed graph.
-class Vertex < ApplicationModel
+class Vertex < ApplicationRecord
   has_many :sink_edges, :class_name => 'Edge', :foreign_key => 'source_id'
   has_many :sinks, :through => :sink_edges
 

--- a/activerecord/test/models/vertex.rb
+++ b/activerecord/test/models/vertex.rb
@@ -1,5 +1,5 @@
 # This class models a vertex in a directed graph.
-class Vertex < ActiveRecord::Base
+class Vertex < ApplicationModel
   has_many :sink_edges, :class_name => 'Edge', :foreign_key => 'source_id'
   has_many :sinks, :through => :sink_edges
 

--- a/activerecord/test/models/warehouse_thing.rb
+++ b/activerecord/test/models/warehouse_thing.rb
@@ -1,4 +1,4 @@
-class WarehouseThing < ApplicationModel
+class WarehouseThing < ApplicationRecord
   self.table_name = "warehouse-things"
 
   validates_uniqueness_of :value

--- a/activerecord/test/models/warehouse_thing.rb
+++ b/activerecord/test/models/warehouse_thing.rb
@@ -1,4 +1,4 @@
-class WarehouseThing < ActiveRecord::Base
+class WarehouseThing < ApplicationModel
   self.table_name = "warehouse-things"
 
   validates_uniqueness_of :value

--- a/activerecord/test/models/wheel.rb
+++ b/activerecord/test/models/wheel.rb
@@ -1,3 +1,3 @@
-class Wheel < ActiveRecord::Base
+class Wheel < ApplicationModel
   belongs_to :wheelable, :polymorphic => true, :counter_cache => true
 end

--- a/activerecord/test/models/wheel.rb
+++ b/activerecord/test/models/wheel.rb
@@ -1,3 +1,3 @@
-class Wheel < ApplicationModel
+class Wheel < ApplicationRecord
   belongs_to :wheelable, :polymorphic => true, :counter_cache => true
 end

--- a/activerecord/test/models/without_table.rb
+++ b/activerecord/test/models/without_table.rb
@@ -1,3 +1,3 @@
-class WithoutTable < ApplicationModel
+class WithoutTable < ApplicationRecord
   default_scope -> { where(:published => true) }
 end

--- a/activerecord/test/models/without_table.rb
+++ b/activerecord/test/models/without_table.rb
@@ -1,3 +1,3 @@
-class WithoutTable < ActiveRecord::Base
+class WithoutTable < ApplicationModel
   default_scope -> { where(:published => true) }
 end

--- a/activerecord/test/models/zine.rb
+++ b/activerecord/test/models/zine.rb
@@ -1,3 +1,3 @@
-class Zine < ApplicationModel
+class Zine < ApplicationRecord
   has_many :interests, :inverse_of => :zine
 end

--- a/activerecord/test/models/zine.rb
+++ b/activerecord/test/models/zine.rb
@@ -1,3 +1,3 @@
-class Zine < ActiveRecord::Base
+class Zine < ApplicationModel
   has_many :interests, :inverse_of => :zine
 end

--- a/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
@@ -1,0 +1,3 @@
+class ApplicationModel < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
@@ -1,4 +1,3 @@
 class ApplicationModel < ActiveRecord::Base
   self.abstract_class = true
-  configs_from Rails.application
 end

--- a/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
@@ -1,3 +1,4 @@
 class ApplicationModel < ActiveRecord::Base
   self.abstract_class = true
+  configs_from Rails.application
 end

--- a/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
@@ -1,3 +1,0 @@
-class ApplicationModel < ActiveRecord::Base
-  self.abstract_class = true
-end

--- a/railties/lib/rails/generators/rails/app/templates/app/models/application_record.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/models/application_record.rb.tt
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -99,7 +99,7 @@ module ApplicationTests
     end
 
     def test_code_statistics_sanity
-      assert_match "Code LOC: 5     Test LOC: 0     Code to Test Ratio: 1:0.0",
+      assert_match "Code LOC: 8     Test LOC: 0     Code to Test Ratio: 1:0.0",
         Dir.chdir(app_path){ `rake stats` }
     end
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -99,7 +99,7 @@ module ApplicationTests
     end
 
     def test_code_statistics_sanity
-      assert_match "Code LOC: 8     Test LOC: 0     Code to Test Ratio: 1:0.0",
+      assert_match "Code LOC: 9     Test LOC: 0     Code to Test Ratio: 1:0.0",
         Dir.chdir(app_path){ `rake stats` }
     end
 

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -25,7 +25,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
   def test_invokes_default_orm
     run_generator
-    assert_file "app/models/account.rb", /class Account < ActiveRecord::Base/
+    assert_file "app/models/account.rb", /class Account < ApplicationModel/
   end
 
   def test_model_with_parent_option
@@ -44,7 +44,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_file "app/models/admin.rb", /module Admin/
     assert_file "app/models/admin.rb", /def self\.table_name_prefix/
     assert_file "app/models/admin.rb", /'admin_'/
-    assert_file "app/models/admin/account.rb", /class Admin::Account < ActiveRecord::Base/
+    assert_file "app/models/admin/account.rb", /class Admin::Account < ApplicationModel/
   end
 
   def test_migration

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -25,7 +25,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
   def test_invokes_default_orm
     run_generator
-    assert_file "app/models/account.rb", /class Account < ApplicationModel/
+    assert_file "app/models/account.rb", /class Account < ApplicationRecord/
   end
 
   def test_model_with_parent_option
@@ -44,7 +44,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_file "app/models/admin.rb", /module Admin/
     assert_file "app/models/admin.rb", /def self\.table_name_prefix/
     assert_file "app/models/admin.rb", /'admin_'/
-    assert_file "app/models/admin/account.rb", /class Admin::Account < ApplicationModel/
+    assert_file "app/models/admin/account.rb", /class Admin::Account < ApplicationRecord/
   end
 
   def test_migration

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -92,7 +92,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
 
   def test_adds_namespace_to_model
     run_generator
-    assert_file "app/models/test_app/account.rb", /module TestApp/, /  class Account < ActiveRecord::Base/
+    assert_file "app/models/test_app/account.rb", /module TestApp/, /  class Account < ApplicationModel/
   end
 
   def test_model_with_namespace
@@ -100,7 +100,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
     assert_file "app/models/test_app/admin.rb", /module TestApp/, /module Admin/
     assert_file "app/models/test_app/admin.rb", /def self\.table_name_prefix/
     assert_file "app/models/test_app/admin.rb", /'test_app_admin_'/
-    assert_file "app/models/test_app/admin/account.rb", /module TestApp/, /class Admin::Account < ActiveRecord::Base/
+    assert_file "app/models/test_app/admin/account.rb", /module TestApp/, /class Admin::Account < ApplicationModel/
   end
 
   def test_migration
@@ -202,7 +202,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
     run_generator
 
     # Model
-    assert_file "app/models/test_app/product_line.rb", /module TestApp\n  class ProductLine < ActiveRecord::Base/
+    assert_file "app/models/test_app/product_line.rb", /module TestApp\n  class ProductLine < ApplicationModel/
     assert_file "test/models/test_app/product_line_test.rb", /module TestApp\n  class ProductLineTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/product_lines.yml"
     assert_migration "db/migrate/create_test_app_product_lines.rb"
@@ -271,7 +271,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ActiveRecord::Base/
+    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ApplicationModel/
     assert_file "test/models/test_app/admin/role_test.rb", /module TestApp\n  class Admin::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_roles.rb"
@@ -340,7 +340,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin/user/special.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  class Admin::User::Special::Role < ActiveRecord::Base/
+    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  class Admin::User::Special::Role < ApplicationModel/
     assert_file "test/models/test_app/admin/user/special/role_test.rb", /module TestApp\n  class Admin::User::Special::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/user/special/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_user_special_roles.rb"

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -92,7 +92,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
 
   def test_adds_namespace_to_model
     run_generator
-    assert_file "app/models/test_app/account.rb", /module TestApp/, /  class Account < ApplicationModel/
+    assert_file "app/models/test_app/account.rb", /module TestApp/, /  class Account < ApplicationRecord/
   end
 
   def test_model_with_namespace
@@ -100,7 +100,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
     assert_file "app/models/test_app/admin.rb", /module TestApp/, /module Admin/
     assert_file "app/models/test_app/admin.rb", /def self\.table_name_prefix/
     assert_file "app/models/test_app/admin.rb", /'test_app_admin_'/
-    assert_file "app/models/test_app/admin/account.rb", /module TestApp/, /class Admin::Account < ApplicationModel/
+    assert_file "app/models/test_app/admin/account.rb", /module TestApp/, /class Admin::Account < ApplicationRecord/
   end
 
   def test_migration
@@ -202,7 +202,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
     run_generator
 
     # Model
-    assert_file "app/models/test_app/product_line.rb", /module TestApp\n  class ProductLine < ApplicationModel/
+    assert_file "app/models/test_app/product_line.rb", /module TestApp\n  class ProductLine < ApplicationRecord/
     assert_file "test/models/test_app/product_line_test.rb", /module TestApp\n  class ProductLineTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/product_lines.yml"
     assert_migration "db/migrate/create_test_app_product_lines.rb"
@@ -271,7 +271,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ApplicationModel/
+    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ApplicationRecord/
     assert_file "test/models/test_app/admin/role_test.rb", /module TestApp\n  class Admin::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_roles.rb"
@@ -340,7 +340,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin/user/special.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  class Admin::User::Special::Role < ApplicationModel/
+    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  class Admin::User::Special::Role < ApplicationRecord/
     assert_file "test/models/test_app/admin/user/special/role_test.rb", /module TestApp\n  class Admin::User::Special::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/user/special/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_user_special_roles.rb"

--- a/railties/test/generators/resource_generator_test.rb
+++ b/railties/test/generators/resource_generator_test.rb
@@ -61,14 +61,14 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
 
   def test_plural_names_are_singularized
     content = run_generator ["accounts".freeze]
-    assert_file "app/models/account.rb", /class Account < ActiveRecord::Base/
+    assert_file "app/models/account.rb", /class Account < ApplicationModel/
     assert_file "test/models/account_test.rb", /class AccountTest/
     assert_match(/Plural version of the model detected, using singularized version. Override with --force-plural./, content)
   end
 
   def test_plural_names_can_be_forced
     content = run_generator ["accounts", "--force-plural"]
-    assert_file "app/models/accounts.rb", /class Accounts < ActiveRecord::Base/
+    assert_file "app/models/accounts.rb", /class Accounts < ApplicationModel/
     assert_file "test/models/accounts_test.rb", /class AccountsTest/
     assert_no_match(/Plural version of the model detected/, content)
   end

--- a/railties/test/generators/resource_generator_test.rb
+++ b/railties/test/generators/resource_generator_test.rb
@@ -61,14 +61,14 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
 
   def test_plural_names_are_singularized
     content = run_generator ["accounts".freeze]
-    assert_file "app/models/account.rb", /class Account < ApplicationModel/
+    assert_file "app/models/account.rb", /class Account < ApplicationRecord/
     assert_file "test/models/account_test.rb", /class AccountTest/
     assert_match(/Plural version of the model detected, using singularized version. Override with --force-plural./, content)
   end
 
   def test_plural_names_can_be_forced
     content = run_generator ["accounts", "--force-plural"]
-    assert_file "app/models/accounts.rb", /class Accounts < ApplicationModel/
+    assert_file "app/models/accounts.rb", /class Accounts < ApplicationRecord/
     assert_file "test/models/accounts_test.rb", /class AccountsTest/
     assert_no_match(/Plural version of the model detected/, content)
   end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -11,7 +11,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     # Model
-    assert_file "app/models/product_line.rb", /class ProductLine < ApplicationModel/
+    assert_file "app/models/product_line.rb", /class ProductLine < ApplicationRecord/
     assert_file "test/models/product_line_test.rb", /class ProductLineTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/product_lines.yml"
     assert_migration "db/migrate/create_product_lines.rb", /belongs_to :product, index: true/
@@ -127,7 +127,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Model
     assert_file "app/models/admin.rb", /module Admin/
-    assert_file "app/models/admin/role.rb", /class Admin::Role < ApplicationModel/
+    assert_file "app/models/admin/role.rb", /class Admin::Role < ApplicationRecord/
     assert_file "test/models/admin/role_test.rb", /class Admin::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/admin/roles.yml"
     assert_migration "db/migrate/create_admin_roles.rb"

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -11,7 +11,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     # Model
-    assert_file "app/models/product_line.rb", /class ProductLine < ActiveRecord::Base/
+    assert_file "app/models/product_line.rb", /class ProductLine < ApplicationModel/
     assert_file "test/models/product_line_test.rb", /class ProductLineTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/product_lines.yml"
     assert_migration "db/migrate/create_product_lines.rb", /belongs_to :product, index: true/
@@ -127,7 +127,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Model
     assert_file "app/models/admin.rb", /module Admin/
-    assert_file "app/models/admin/role.rb", /class Admin::Role < ActiveRecord::Base/
+    assert_file "app/models/admin/role.rb", /class Admin::Role < ApplicationModel/
     assert_file "test/models/admin/role_test.rb", /class Admin::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/admin/roles.yml"
     assert_migration "db/migrate/create_admin_roles.rb"


### PR DESCRIPTION
This PR creates the `ApplicationModel` class. This class will serve as an intermediate between a model and `ActiveRecord::Base`. Currently, to create a model, one follows the following procedure:

``` ruby
class MyModelName < ActiveRecord::Base
end
```

This inherits directly from `ActiveRecord::Base` and means that all configurations on `ActiveRecord::Base` are global to all of its subclasses (unless the subclass redefines the configuration on its own).

I'm introducing `ApplicationModel` so that models have an intermediary layer for inheritance like so:

``` ruby
class MyModelName < ApplicationModel
end
```

What the `ApplicationModel` class does is allow different sets of configurations to be defined on multiple applications. Each Rails application will have its own `ApplicationModel`. The `ApplicationModel` figures out which application it belongs when it is pulled in through the railtie and `configs_from` is specified.

\cc @spastorino, @josevalim Can you guys take a look? I'm sure there's something I forgot so please let me know.
