### PR TITLE
[ci skip] Change link name of Rails i18n wiki.

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -28,7 +28,7 @@ After reading this guide, you will know:
 
 --------------------------------------------------------------------------------
 
-NOTE: The Ruby I18n framework provides you with all necessary means for internationalization/localization of your Rails application. You may, however, use any of various plugins and extensions available, which add additional functionality or features. See the Rails [I18n Wiki](http://rails-i18n.org/wiki) for more information.
+NOTE: The Ruby I18n framework provides you with all necessary means for internationalization/localization of your Rails application. You may, however, use any of various plugins and extensions available, which add additional functionality or features. See the Ruby [I18n Wiki](http://ruby-i18n.org/wiki) for more information.
 
 How I18n in Ruby on Rails Works
 -------------------------------


### PR DESCRIPTION
Actually it's Ruby i18n link.
