### PR TITLE
Specify mysql engine on creation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Allow to pass an ``:engine`` option to the ``create_table`` method to be able to choose any MySQL Engine
+
+    Example :
+        create_table :users, engine: 'InnoDB', do |t|
+
+    *Ken Mazaika*, *Adrien Siami*
+
 *   Floats with limit >= 25 that get turned into doubles in MySQL no longer have
     their limit dropped from the schema.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -12,6 +12,10 @@ module ActiveRecord
         {}
       end
 
+      def table_options(table)
+        nil
+      end
+
       # Truncates a table alias according to the limits of the current adapter.
       def table_alias_for(table_name)
         table_name[0...table_alias_length].tr('.', '_')

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -268,6 +268,16 @@ module ActiveRecord
         @connection.last_id
       end
 
+      def table_options(table)
+        res = self.execute "SHOW TABLE STATUS LIKE '#{table}'"
+        engine = res.first[res.fields.index("Engine")]
+
+        options = ''
+        options = "ENGINE=#{engine}".inspect if engine
+      
+        options
+      end
+
       private
 
       def connect

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -294,6 +294,16 @@ module ActiveRecord
         @connection.insert_id
       end
 
+      def table_options(table)
+        res = self.exec_without_stmt "SHOW TABLE STATUS LIKE '#{table}'"
+        engine = res.first.to_hash.first['Engine']
+
+        options = ''
+        options = "ENGINE=#{engine}".inspect if engine
+      
+        options
+      end
+
       module Fields
         class Type
           def type; end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -129,6 +129,10 @@ HEADER
             tbl.print ", id: false"
           end
           tbl.print ", force: true"
+
+          options = @connection.table_options(table)
+          tbl.print ", options: #{options}" unless options.blank?
+
           tbl.puts " do |t|"
 
           # then dump all non-primary key columns

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -238,6 +238,12 @@ class SchemaDumperTest < ActiveRecord::TestCase
       assert_match %r{add_index "key_tests", \["awesome"\], name: "index_key_tests_on_awesome", type: :fulltext}, output
       assert_match %r{add_index "key_tests", \["pizza"\], name: "index_key_tests_on_pizza", using: :btree}, output
     end
+
+    def test_schema_dumps_engine
+      output = standard_dump
+      assert_match %r{create_table "wheels", force: true, options: "ENGINE=InnoDB" do \|t\|$}, output
+    end
+
   end
 
   def test_schema_dump_includes_decimal_options


### PR DESCRIPTION
I merged #8242 so it can be applied cleanly

I didn't squash because I don't want @kenmazaika 's contribution to be lost, and he does not seem to want to merge this himself.

Thanks
