### PR TITLE
on SchemaCache use the connection getter instead of the obj given

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -9,7 +9,7 @@ module ActiveRecord
         @tables     = {}
 
         @columns = Hash.new do |h, table_name|
-          h[table_name] = conn.columns(table_name, "#{table_name} Columns")
+          h[table_name] = connection.columns(table_name, "#{table_name} Columns")
         end
 
         @columns_hash = Hash.new do |h, table_name|
@@ -19,7 +19,7 @@ module ActiveRecord
         end
 
         @primary_keys = Hash.new do |h, table_name|
-          h[table_name] = table_exists?(table_name) ? conn.primary_key(table_name) : nil
+          h[table_name] = table_exists?(table_name) ? connection.primary_key(table_name) : nil
         end
       end
 


### PR DESCRIPTION
Hash `default_proc` needs to use the connection getter to avoid inconsistent results if the connection ivar is changed.

Ideally `@connection` cannot be changed on schema_cache as it doesnt have a setter, but we still can `instance_variable_set(:@connection, conn)`. Therefore we need to use the getter on the proc so it will always use the ivar.

As this is super small, and trivial, IMO, it doesn't justify adding tests for it. (also this behaviour is fixed on rails4)

feedback ? @carlosantoniodasilva @rafaelfranca
