### PR TITLE
Creating application model template

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ application into three layers, each with a specific responsibility.
 The _Model layer_ represents your domain model (such as Account, Product,
 Person, Post, etc.) and encapsulates the business logic that is specific to
 your application. In Rails, database-backed model classes are derived from
-`ActiveRecord::Base`. Active Record allows you to present the data from
+`ActiveRecord::Base` through an application specific subclass called
+`ApplicationRecord`. Active Record allows you to present the data from
 database rows as objects and embellish these data objects with business logic
 methods. Although most Rails models are backed by a database, models can also
 be ordinary Ruby classes, or Ruby classes that implement a set of interfaces
@@ -23,7 +24,8 @@ providing a suitable response. Usually this means returning HTML, but Rails cont
 can also generate XML, JSON, PDFs, mobile-specific views, and more. Controllers load and
 manipulate models, and render view templates in order to generate the appropriate HTTP response.
 In Rails, incoming requests are routed by Action Dispatch to an appropriate controller, and
-controller classes are derived from `ActionController::Base`. Action Dispatch and Action Controller
+controller classes are derived from `ActionController::Base` through an application specific 
+subclass called `ApplicationController`. Action Dispatch and Action Controller
 are bundled together in Action Pack. You can read more about Action Pack in its
 [README](actionpack/README.rdoc).
 

--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -2,10 +2,11 @@
 
 Active Record connects classes to relational database tables to establish an
 almost zero-configuration persistence layer for applications. The library
-provides a base class that, when subclassed, sets up a mapping between the new
-class and an existing table in the database. In the context of an application,
-these classes are commonly referred to as *models*. Models can also be
-connected to other models; this is done by defining *associations*.
+provides a base class, and subclassing an application specific version of
+this base class sets up a mapping between the new class and an existing
+table in the database. In the context of an application, these classes are
+commonly referred to as *models*. Models can also be connected to other
+models; this is done by defining *associations*.
 
 Active Record relies heavily on naming in that it uses class and association
 names to establish mappings between respective database tables and foreign key
@@ -17,7 +18,7 @@ A short rundown of some of the major features:
 
 * Automated mapping between classes and tables, attributes and columns.
 
-   class Product < ActiveRecord::Base
+   class Product < ApplicationRecord
    end
 
    The Product class is automatically mapped to the table named "products",
@@ -37,7 +38,7 @@ A short rundown of some of the major features:
 
 * Associations between objects defined by simple class methods.
 
-   class Firm < ActiveRecord::Base
+   class Firm < ApplicationRecord
      has_many   :clients
      has_one    :account
      belongs_to :conglomerate
@@ -48,7 +49,7 @@ A short rundown of some of the major features:
 
 * Aggregations of value objects.
 
-   class Account < ActiveRecord::Base
+   class Account < ApplicationRecord
      composed_of :balance, class_name: 'Money',
                  mapping: %w(balance amount)
      composed_of :address,
@@ -60,7 +61,7 @@ A short rundown of some of the major features:
 
 * Validation rules that can differ for new or existing objects.
 
-    class Account < ActiveRecord::Base
+    class Account < ApplicationRecord
       validates :subdomain, :name, :email_address, :password, presence: true
       validates :subdomain, uniqueness: true
       validates :terms_of_service, acceptance: true, on: :create
@@ -72,7 +73,7 @@ A short rundown of some of the major features:
 
 * Callbacks available for the entire life cycle (instantiation, saving, destroying, validating, etc.).
 
-   class Person < ActiveRecord::Base
+   class Person < ApplicationRecord
      before_destroy :invalidate_payment_plan
      # the `invalidate_payment_plan` method gets called just before Person#destroy
    end
@@ -82,7 +83,7 @@ A short rundown of some of the major features:
 
 * Inheritance hierarchies.
 
-   class Company < ActiveRecord::Base; end
+   class Company < ApplicationRecord; end
    class Firm < Company; end
    class Client < Company; end
    class PriorityClient < Client; end

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -31,6 +31,7 @@ require 'active_record/version'
 module ActiveRecord
   extend ActiveSupport::Autoload
 
+  autoload :ApplicationConfiguration
   autoload :Base
   autoload :Callbacks
   autoload :Core

--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -15,7 +15,7 @@ module ActiveRecord
     # existing object) and how it can be turned back into attributes (when the entity is saved to
     # the database).
     #
-    #   class Customer < ApplicationModel
+    #   class Customer < ApplicationRecord
     #     composed_of :balance, class_name: "Money", mapping: %w(balance amount)
     #     composed_of :address, mapping: [ %w(address_street street), %w(address_city city) ]
     #   end
@@ -136,7 +136,7 @@ module ActiveRecord
     # or an array. The <tt>:constructor</tt> and <tt>:converter</tt> options can be used to meet
     # these requirements:
     #
-    #   class NetworkResource < ApplicationModel
+    #   class NetworkResource < ApplicationRecord
     #     composed_of :cidr,
     #                 class_name: 'NetAddr::CIDR',
     #                 mapping: [ %w(network_address network), %w(cidr_range bits) ],

--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -15,7 +15,7 @@ module ActiveRecord
     # existing object) and how it can be turned back into attributes (when the entity is saved to
     # the database).
     #
-    #   class Customer < ActiveRecord::Base
+    #   class Customer < ApplicationModel
     #     composed_of :balance, class_name: "Money", mapping: %w(balance amount)
     #     composed_of :address, mapping: [ %w(address_street street), %w(address_city city) ]
     #   end
@@ -136,7 +136,7 @@ module ActiveRecord
     # or an array. The <tt>:constructor</tt> and <tt>:converter</tt> options can be used to meet
     # these requirements:
     #
-    #   class NetworkResource < ActiveRecord::Base
+    #   class NetworkResource < ApplicationModel
     #     composed_of :cidr,
     #                 class_name: 'NetAddr::CIDR',
     #                 mapping: [ %w(network_address network), %w(cidr_range bits) ],

--- a/activerecord/lib/active_record/application_configuration.rb
+++ b/activerecord/lib/active_record/application_configuration.rb
@@ -4,7 +4,7 @@ module ActiveRecord
 
     module ClassMethods
       def application_record(klass = nil)
-        return ActiveRecord::Base unless klass
+        return base_app_record unless klass
 
         klass = klass.class unless klass.respond_to?(:parents)
 
@@ -13,9 +13,15 @@ module ActiveRecord
         elsif app_record = klass.parents.detect { |p| p.respond_to?(:application_record) }
           app_record
         else
-          ActiveRecord::Base
+          base_app_record
         end
       end
+
+      private
+
+        def base_app_record
+          @base_app_record ||= defined?(ApplicationRecord) ? ApplicationRecord : ActiveRecord::Base
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/application_configuration.rb
+++ b/activerecord/lib/active_record/application_configuration.rb
@@ -2,6 +2,47 @@ module ActiveRecord
   module ApplicationConfiguration
     extend ActiveSupport::Concern
 
+    # The <tt>ApplicationConfiguration</tt> module allows you to control different
+    # configurations that have been set on a particular namespace or model. The
+    # <tt>ApplicationRecord</tt> class for a particular model can be accessed and used
+    # for finding configurations.
+    #
+    # To access this class, you can use the <tt>application_record</tt> method on
+    # any subclass of <tt>ActiveRecord::Base</tt>. For example:
+    #
+    #   class MyModel < ApplicationRecord
+    #   end
+    #
+    #   ActiveRecord::Base.application_record  # => ApplicationRecord
+    #   MyModel.application_record             # => ApplicationRecord
+    #
+    # Moreover, you can use namespacing of modules with the <tt>application_record</tt>
+    # method.
+    #
+    #   module MyNamespace
+    #     class ApplicationRecord < ::ApplicationRecord
+    #     end
+    #
+    #     class MyModel < ApplicationRecord
+    #     end
+    #   end
+    #
+    #   ActiveRecord::Base.application_record    # => ApplicationRecord
+    #   MyNamespace::MyModel.application_record  # => MyNamespace::ApplicationRecord
+    #
+    # You may additionally pass in a class to <tt>application_record</tt>, and
+    # it will look for the configuration of that class. For example:
+    #
+    #   ActiveRecord::Base.application_record(MyNamespace::MyModel) 
+    #       # => MyNamespace::ApplicationRecord
+    #
+    # If the class that is passed into <tt>application_record</tt> does not have
+    # a configuration associated with it, then the method will return the value
+    # that would have been returned without any argument. 
+    #
+    #   ActiveRecord::Base.application_reocrd('something_with_no_config')
+    #       # => ApplicationRecord
+    #
     module ClassMethods
       def configs_from(mod)
         app_record = self

--- a/activerecord/lib/active_record/application_configuration.rb
+++ b/activerecord/lib/active_record/application_configuration.rb
@@ -3,16 +3,6 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def configs_from(mod)
-        app_record = self
-
-        mod.singleton_class.instance_eval do
-          define_method(:application_record) { app_record }
-        end
-
-        define_singleton_method(:configs_from_application) { application }
-      end
-
       def application_record(klass = nil)
         return ActiveRecord::Base unless klass
 

--- a/activerecord/lib/active_record/application_configuration.rb
+++ b/activerecord/lib/active_record/application_configuration.rb
@@ -3,14 +3,28 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def configs_from(application)
+      def configs_from(mod)
         app_model = self
 
-        application.singleton_class.instance_eval do
+        mod.singleton_class.instance_eval do
           define_method(:application_model) { app_model }
         end
 
         define_singleton_method(:configs_from_application) { application }
+      end
+
+      def application_model(klass = nil)
+        return ActiveRecord::Base unless klass
+
+        klass = klass.class unless klass.respond_to?(:parents)
+
+        if klass.respond_to?(:application_model)
+          klass.application_model
+        elsif app_model = klass.parents.detect { |p| p.respond_to?(:application_model) }
+          app_model
+        else
+          ActiveRecord::Base
+        end
       end
     end
   end

--- a/activerecord/lib/active_record/application_configuration.rb
+++ b/activerecord/lib/active_record/application_configuration.rb
@@ -4,24 +4,24 @@ module ActiveRecord
 
     module ClassMethods
       def configs_from(mod)
-        app_model = self
+        app_record = self
 
         mod.singleton_class.instance_eval do
-          define_method(:application_model) { app_model }
+          define_method(:application_record) { app_record }
         end
 
         define_singleton_method(:configs_from_application) { application }
       end
 
-      def application_model(klass = nil)
+      def application_record(klass = nil)
         return ActiveRecord::Base unless klass
 
         klass = klass.class unless klass.respond_to?(:parents)
 
-        if klass.respond_to?(:application_model)
-          klass.application_model
-        elsif app_model = klass.parents.detect { |p| p.respond_to?(:application_model) }
-          app_model
+        if klass.respond_to?(:application_record)
+          klass.application_record
+        elsif app_record = klass.parents.detect { |p| p.respond_to?(:application_record) }
+          app_record
         else
           ActiveRecord::Base
         end

--- a/activerecord/lib/active_record/application_configuration.rb
+++ b/activerecord/lib/active_record/application_configuration.rb
@@ -3,6 +3,13 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
+      def configs_from(mod)
+        app_record = self
+        define_singleton_method(:application_record) { |klass = nil| app_record }
+
+        mod.define_singleton_method(:application_record) { |klass = nil| app_record }
+      end
+
       def application_record(klass = nil)
         return base_app_record unless klass
 

--- a/activerecord/lib/active_record/application_configuration.rb
+++ b/activerecord/lib/active_record/application_configuration.rb
@@ -1,0 +1,17 @@
+module ActiveRecord
+  module ApplicationConfiguration
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def configs_from(application)
+        app_model = self
+
+        application.singleton_class.instance_eval do
+          define_method(:application_model) { app_model }
+        end
+
+        define_singleton_method(:configs_from_application) { application }
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -179,7 +179,7 @@ module ActiveRecord
     # options hash. It works much the same way as Ruby's own <tt>attr*</tt>
     # methods.
     #
-    #   class Project < ApplicationModel
+    #   class Project < ApplicationRecord
     #     belongs_to              :portfolio
     #     has_one                 :project_manager
     #     has_many                :milestones
@@ -251,7 +251,7 @@ module ActiveRecord
     # which allows you to easily override with your own methods and call the original
     # generated method with +super+. For example:
     #
-    #   class Car < ApplicationModel
+    #   class Car < ApplicationRecord
     #     belongs_to :owner
     #     belongs_to :old_owner
     #     def owner=(new_owner)
@@ -276,10 +276,10 @@ module ActiveRecord
     #
     # Use +has_one+ in the base, and +belongs_to+ in the associated model.
     #
-    #   class Employee < ApplicationModel
+    #   class Employee < ApplicationRecord
     #     has_one :office
     #   end
-    #   class Office < ApplicationModel
+    #   class Office < ApplicationRecord
     #     belongs_to :employee    # foreign key - employee_id
     #   end
     #
@@ -287,10 +287,10 @@ module ActiveRecord
     #
     # Use +has_many+ in the base, and +belongs_to+ in the associated model.
     #
-    #   class Manager < ApplicationModel
+    #   class Manager < ApplicationRecord
     #     has_many :employees
     #   end
-    #   class Employee < ApplicationModel
+    #   class Employee < ApplicationRecord
     #     belongs_to :manager     # foreign key - manager_id
     #   end
     #
@@ -301,15 +301,15 @@ module ActiveRecord
     # The first way uses a +has_many+ association with the <tt>:through</tt> option and a join model, so
     # there are two stages of associations.
     #
-    #   class Assignment < ApplicationModel
+    #   class Assignment < ApplicationRecord
     #     belongs_to :programmer  # foreign key - programmer_id
     #     belongs_to :project     # foreign key - project_id
     #   end
-    #   class Programmer < ApplicationModel
+    #   class Programmer < ApplicationRecord
     #     has_many :assignments
     #     has_many :projects, through: :assignments
     #   end
-    #   class Project < ApplicationModel
+    #   class Project < ApplicationRecord
     #     has_many :assignments
     #     has_many :programmers, through: :assignments
     #   end
@@ -317,10 +317,10 @@ module ActiveRecord
     # For the second way, use +has_and_belongs_to_many+ in both models. This requires a join table
     # that has no corresponding model or primary key.
     #
-    #   class Programmer < ApplicationModel
+    #   class Programmer < ApplicationRecord
     #     has_and_belongs_to_many :projects       # foreign keys in the join table
     #   end
-    #   class Project < ApplicationModel
+    #   class Project < ApplicationRecord
     #     has_and_belongs_to_many :programmers    # foreign keys in the join table
     #   end
     #
@@ -334,12 +334,12 @@ module ActiveRecord
     # Both express a 1-1 relationship. The difference is mostly where to place the foreign
     # key, which goes on the table for the class declaring the +belongs_to+ relationship.
     #
-    #   class User < ApplicationModel
+    #   class User < ApplicationRecord
     #     # I reference an account.
     #     belongs_to :account
     #   end
     #
-    #   class Account < ApplicationModel
+    #   class Account < ApplicationRecord
     #     # One user references me.
     #     has_one :user
     #   end
@@ -405,7 +405,7 @@ module ActiveRecord
     # \Associations are built from <tt>Relation</tt>s, and you can use the <tt>Relation</tt> syntax
     # to customize them. For example, to add a condition:
     #
-    #   class Blog < ApplicationModel
+    #   class Blog < ApplicationRecord
     #     has_many :published_posts, -> { where published: true }, class_name: 'Post'
     #   end
     #
@@ -417,7 +417,7 @@ module ActiveRecord
     # is passed as a parameter to the block. For example, the following association would find all
     # events that occur on the user's birthday:
     #
-    #   class User < ApplicationModel
+    #   class User < ApplicationRecord
     #     has_many :birthday_events, ->(user) { where starts_on: user.birthday }, class_name: 'Event'
     #   end
     #
@@ -454,7 +454,7 @@ module ActiveRecord
     # modules. This is especially beneficial for adding new finders, creators, and other
     # factory-type methods that are only used as part of this association.
     #
-    #   class Account < ApplicationModel
+    #   class Account < ApplicationRecord
     #     has_many :people do
     #       def find_or_create_by_name(name)
     #         first_name, last_name = name.split(" ", 2)
@@ -477,11 +477,11 @@ module ActiveRecord
     #     end
     #   end
     #
-    #   class Account < ApplicationModel
+    #   class Account < ApplicationRecord
     #     has_many :people, -> { extending FindOrCreateByNameExtension }
     #   end
     #
-    #   class Company < ApplicationModel
+    #   class Company < ApplicationRecord
     #     has_many :people, -> { extending FindOrCreateByNameExtension }
     #   end
     #
@@ -507,12 +507,12 @@ module ActiveRecord
     # +has_and_belongs_to_many+ association. The advantage is that you're able to add validations,
     # callbacks, and extra attributes on the join model. Consider the following schema:
     #
-    #   class Author < ApplicationModel
+    #   class Author < ApplicationRecord
     #     has_many :authorships
     #     has_many :books, through: :authorships
     #   end
     #
-    #   class Authorship < ApplicationModel
+    #   class Authorship < ApplicationRecord
     #     belongs_to :author
     #     belongs_to :book
     #   end
@@ -523,17 +523,17 @@ module ActiveRecord
     #
     # You can also go through a +has_many+ association on the join model:
     #
-    #   class Firm < ApplicationModel
+    #   class Firm < ApplicationRecord
     #     has_many   :clients
     #     has_many   :invoices, through: :clients
     #   end
     #
-    #   class Client < ApplicationModel
+    #   class Client < ApplicationRecord
     #     belongs_to :firm
     #     has_many   :invoices
     #   end
     #
-    #   class Invoice < ApplicationModel
+    #   class Invoice < ApplicationRecord
     #     belongs_to :client
     #   end
     #
@@ -543,17 +543,17 @@ module ActiveRecord
     #
     # Similarly you can go through a +has_one+ association on the join model:
     #
-    #   class Group < ApplicationModel
+    #   class Group < ApplicationRecord
     #     has_many   :users
     #     has_many   :avatars, through: :users
     #   end
     #
-    #   class User < ApplicationModel
+    #   class User < ApplicationRecord
     #     belongs_to :group
     #     has_one    :avatar
     #   end
     #
-    #   class Avatar < ApplicationModel
+    #   class Avatar < ApplicationRecord
     #     belongs_to :user
     #   end
     #
@@ -581,7 +581,7 @@ module ActiveRecord
     # The last line ought to save the through record (a <tt>Taggable</tt>). This will only work if the
     # <tt>:inverse_of</tt> is set:
     #
-    #   class Taggable < ApplicationModel
+    #   class Taggable < ApplicationRecord
     #     belongs_to :post
     #     belongs_to :tag, inverse_of: :taggings
     #   end
@@ -602,7 +602,7 @@ module ActiveRecord
     # You can turn off the automatic detection of inverse associations by setting
     # the <tt>:inverse_of</tt> option to <tt>false</tt> like so:
     #
-    #   class Taggable < ApplicationModel
+    #   class Taggable < ApplicationRecord
     #     belongs_to :tag, inverse_of: false
     #   end
     #
@@ -611,17 +611,17 @@ module ActiveRecord
     # You can actually specify *any* association with the <tt>:through</tt> option, including an
     # association which has a <tt>:through</tt> option itself. For example:
     #
-    #   class Author < ApplicationModel
+    #   class Author < ApplicationRecord
     #     has_many :posts
     #     has_many :comments, through: :posts
     #     has_many :commenters, through: :comments
     #   end
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #     has_many :comments
     #   end
     #
-    #   class Comment < ApplicationModel
+    #   class Comment < ApplicationRecord
     #     belongs_to :commenter
     #   end
     #
@@ -630,17 +630,17 @@ module ActiveRecord
     #
     # An equivalent way of setting up this association this would be:
     #
-    #   class Author < ApplicationModel
+    #   class Author < ApplicationRecord
     #     has_many :posts
     #     has_many :commenters, through: :posts
     #   end
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #     has_many :comments
     #     has_many :commenters, through: :comments
     #   end
     #
-    #   class Comment < ApplicationModel
+    #   class Comment < ApplicationRecord
     #     belongs_to :commenter
     #   end
     #
@@ -655,11 +655,11 @@ module ActiveRecord
     # can be associated with. Rather, they specify an interface that a +has_many+ association
     # must adhere to.
     #
-    #   class Asset < ApplicationModel
+    #   class Asset < ApplicationRecord
     #     belongs_to :attachable, polymorphic: true
     #   end
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #     has_many :assets, as: :attachable         # The :as option specifies the polymorphic interface to use.
     #   end
     #
@@ -676,7 +676,7 @@ module ActiveRecord
     # and member posts that use the posts table for STI. In this case, there must be a +type+
     # column in the posts table.
     #
-    #   class Asset < ApplicationModel
+    #   class Asset < ApplicationRecord
     #     belongs_to :attachable, polymorphic: true
     #
     #     def attachable_type=(sType)
@@ -684,7 +684,7 @@ module ActiveRecord
     #     end
     #   end
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #     # because we store "Post" in attachable_type now dependent: :destroy will work
     #     has_many :assets, as: :attachable, dependent: :destroy
     #   end
@@ -715,7 +715,7 @@ module ActiveRecord
     # posts that each need to display their author triggers 101 database queries. Through the
     # use of eager loading, the 101 queries can be reduced to 2.
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #     belongs_to :author
     #     has_many   :comments
     #   end
@@ -778,7 +778,7 @@ module ActiveRecord
     # If you do want eager load only some members of an association it is usually more natural
     # to include an association which has conditions defined on it:
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #     has_many :approved_comments, -> { where approved: true }, class_name: 'Comment'
     #   end
     #
@@ -790,7 +790,7 @@ module ActiveRecord
     # If you eager load an association with a specified <tt>:limit</tt> option, it will be ignored,
     # returning all the associated objects:
     #
-    #   class Picture < ApplicationModel
+    #   class Picture < ApplicationRecord
     #     has_many :most_recent_comments, -> { order('id DESC').limit(10) }, class_name: 'Comment'
     #   end
     #
@@ -798,7 +798,7 @@ module ActiveRecord
     #
     # Eager loading is supported with polymorphic associations.
     #
-    #   class Address < ApplicationModel
+    #   class Address < ApplicationRecord
     #     belongs_to :addressable, polymorphic: true
     #   end
     #
@@ -872,11 +872,11 @@ module ActiveRecord
     #
     #   module MyApplication
     #     module Business
-    #       class Firm < ApplicationModel
+    #       class Firm < ApplicationRecord
     #         has_many :clients
     #       end
     #
-    #       class Client < ApplicationModel; end
+    #       class Client < ApplicationRecord; end
     #     end
     #   end
     #
@@ -887,11 +887,11 @@ module ActiveRecord
     #
     #   module MyApplication
     #     module Business
-    #       class Firm < ApplicationModel; end
+    #       class Firm < ApplicationRecord; end
     #     end
     #
     #     module Billing
-    #       class Account < ApplicationModel
+    #       class Account < ApplicationRecord
     #         belongs_to :firm, class_name: "MyApplication::Business::Firm"
     #       end
     #     end
@@ -902,16 +902,16 @@ module ActiveRecord
     # When you specify an association there is usually an association on the associated model
     # that specifies the same relationship in reverse. For example, with the following models:
     #
-    #    class Dungeon < ApplicationModel
+    #    class Dungeon < ApplicationRecord
     #      has_many :traps
     #      has_one :evil_wizard
     #    end
     #
-    #    class Trap < ApplicationModel
+    #    class Trap < ApplicationRecord
     #      belongs_to :dungeon
     #    end
     #
-    #    class EvilWizard < ApplicationModel
+    #    class EvilWizard < ApplicationRecord
     #      belongs_to :dungeon
     #    end
     #
@@ -933,16 +933,16 @@ module ActiveRecord
     # Active Record about inverse relationships and it will optimise object loading. For
     # example, if we changed our model definitions to:
     #
-    #    class Dungeon < ApplicationModel
+    #    class Dungeon < ApplicationRecord
     #      has_many :traps, inverse_of: :dungeon
     #      has_one :evil_wizard, inverse_of: :dungeon
     #    end
     #
-    #    class Trap < ApplicationModel
+    #    class Trap < ApplicationRecord
     #      belongs_to :dungeon, inverse_of: :traps
     #    end
     #
-    #    class EvilWizard < ApplicationModel
+    #    class EvilWizard < ApplicationRecord
     #      belongs_to :dungeon, inverse_of: :evil_wizard
     #    end
     #

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -179,7 +179,7 @@ module ActiveRecord
     # options hash. It works much the same way as Ruby's own <tt>attr*</tt>
     # methods.
     #
-    #   class Project < ActiveRecord::Base
+    #   class Project < ApplicationModel
     #     belongs_to              :portfolio
     #     has_one                 :project_manager
     #     has_many                :milestones
@@ -251,7 +251,7 @@ module ActiveRecord
     # which allows you to easily override with your own methods and call the original
     # generated method with +super+. For example:
     #
-    #   class Car < ActiveRecord::Base
+    #   class Car < ApplicationModel
     #     belongs_to :owner
     #     belongs_to :old_owner
     #     def owner=(new_owner)
@@ -276,10 +276,10 @@ module ActiveRecord
     #
     # Use +has_one+ in the base, and +belongs_to+ in the associated model.
     #
-    #   class Employee < ActiveRecord::Base
+    #   class Employee < ApplicationModel
     #     has_one :office
     #   end
-    #   class Office < ActiveRecord::Base
+    #   class Office < ApplicationModel
     #     belongs_to :employee    # foreign key - employee_id
     #   end
     #
@@ -287,10 +287,10 @@ module ActiveRecord
     #
     # Use +has_many+ in the base, and +belongs_to+ in the associated model.
     #
-    #   class Manager < ActiveRecord::Base
+    #   class Manager < ApplicationModel
     #     has_many :employees
     #   end
-    #   class Employee < ActiveRecord::Base
+    #   class Employee < ApplicationModel
     #     belongs_to :manager     # foreign key - manager_id
     #   end
     #
@@ -301,15 +301,15 @@ module ActiveRecord
     # The first way uses a +has_many+ association with the <tt>:through</tt> option and a join model, so
     # there are two stages of associations.
     #
-    #   class Assignment < ActiveRecord::Base
+    #   class Assignment < ApplicationModel
     #     belongs_to :programmer  # foreign key - programmer_id
     #     belongs_to :project     # foreign key - project_id
     #   end
-    #   class Programmer < ActiveRecord::Base
+    #   class Programmer < ApplicationModel
     #     has_many :assignments
     #     has_many :projects, through: :assignments
     #   end
-    #   class Project < ActiveRecord::Base
+    #   class Project < ApplicationModel
     #     has_many :assignments
     #     has_many :programmers, through: :assignments
     #   end
@@ -317,10 +317,10 @@ module ActiveRecord
     # For the second way, use +has_and_belongs_to_many+ in both models. This requires a join table
     # that has no corresponding model or primary key.
     #
-    #   class Programmer < ActiveRecord::Base
+    #   class Programmer < ApplicationModel
     #     has_and_belongs_to_many :projects       # foreign keys in the join table
     #   end
-    #   class Project < ActiveRecord::Base
+    #   class Project < ApplicationModel
     #     has_and_belongs_to_many :programmers    # foreign keys in the join table
     #   end
     #
@@ -334,12 +334,12 @@ module ActiveRecord
     # Both express a 1-1 relationship. The difference is mostly where to place the foreign
     # key, which goes on the table for the class declaring the +belongs_to+ relationship.
     #
-    #   class User < ActiveRecord::Base
+    #   class User < ApplicationModel
     #     # I reference an account.
     #     belongs_to :account
     #   end
     #
-    #   class Account < ActiveRecord::Base
+    #   class Account < ApplicationModel
     #     # One user references me.
     #     has_one :user
     #   end
@@ -405,7 +405,7 @@ module ActiveRecord
     # \Associations are built from <tt>Relation</tt>s, and you can use the <tt>Relation</tt> syntax
     # to customize them. For example, to add a condition:
     #
-    #   class Blog < ActiveRecord::Base
+    #   class Blog < ApplicationModel
     #     has_many :published_posts, -> { where published: true }, class_name: 'Post'
     #   end
     #
@@ -417,7 +417,7 @@ module ActiveRecord
     # is passed as a parameter to the block. For example, the following association would find all
     # events that occur on the user's birthday:
     #
-    #   class User < ActiveRecord::Base
+    #   class User < ApplicationModel
     #     has_many :birthday_events, ->(user) { where starts_on: user.birthday }, class_name: 'Event'
     #   end
     #
@@ -454,7 +454,7 @@ module ActiveRecord
     # modules. This is especially beneficial for adding new finders, creators, and other
     # factory-type methods that are only used as part of this association.
     #
-    #   class Account < ActiveRecord::Base
+    #   class Account < ApplicationModel
     #     has_many :people do
     #       def find_or_create_by_name(name)
     #         first_name, last_name = name.split(" ", 2)
@@ -477,11 +477,11 @@ module ActiveRecord
     #     end
     #   end
     #
-    #   class Account < ActiveRecord::Base
+    #   class Account < ApplicationModel
     #     has_many :people, -> { extending FindOrCreateByNameExtension }
     #   end
     #
-    #   class Company < ActiveRecord::Base
+    #   class Company < ApplicationModel
     #     has_many :people, -> { extending FindOrCreateByNameExtension }
     #   end
     #
@@ -507,12 +507,12 @@ module ActiveRecord
     # +has_and_belongs_to_many+ association. The advantage is that you're able to add validations,
     # callbacks, and extra attributes on the join model. Consider the following schema:
     #
-    #   class Author < ActiveRecord::Base
+    #   class Author < ApplicationModel
     #     has_many :authorships
     #     has_many :books, through: :authorships
     #   end
     #
-    #   class Authorship < ActiveRecord::Base
+    #   class Authorship < ApplicationModel
     #     belongs_to :author
     #     belongs_to :book
     #   end
@@ -523,17 +523,17 @@ module ActiveRecord
     #
     # You can also go through a +has_many+ association on the join model:
     #
-    #   class Firm < ActiveRecord::Base
+    #   class Firm < ApplicationModel
     #     has_many   :clients
     #     has_many   :invoices, through: :clients
     #   end
     #
-    #   class Client < ActiveRecord::Base
+    #   class Client < ApplicationModel
     #     belongs_to :firm
     #     has_many   :invoices
     #   end
     #
-    #   class Invoice < ActiveRecord::Base
+    #   class Invoice < ApplicationModel
     #     belongs_to :client
     #   end
     #
@@ -543,17 +543,17 @@ module ActiveRecord
     #
     # Similarly you can go through a +has_one+ association on the join model:
     #
-    #   class Group < ActiveRecord::Base
+    #   class Group < ApplicationModel
     #     has_many   :users
     #     has_many   :avatars, through: :users
     #   end
     #
-    #   class User < ActiveRecord::Base
+    #   class User < ApplicationModel
     #     belongs_to :group
     #     has_one    :avatar
     #   end
     #
-    #   class Avatar < ActiveRecord::Base
+    #   class Avatar < ApplicationModel
     #     belongs_to :user
     #   end
     #
@@ -581,7 +581,7 @@ module ActiveRecord
     # The last line ought to save the through record (a <tt>Taggable</tt>). This will only work if the
     # <tt>:inverse_of</tt> is set:
     #
-    #   class Taggable < ActiveRecord::Base
+    #   class Taggable < ApplicationModel
     #     belongs_to :post
     #     belongs_to :tag, inverse_of: :taggings
     #   end
@@ -602,7 +602,7 @@ module ActiveRecord
     # You can turn off the automatic detection of inverse associations by setting
     # the <tt>:inverse_of</tt> option to <tt>false</tt> like so:
     #
-    #   class Taggable < ActiveRecord::Base
+    #   class Taggable < ApplicationModel
     #     belongs_to :tag, inverse_of: false
     #   end
     #
@@ -611,17 +611,17 @@ module ActiveRecord
     # You can actually specify *any* association with the <tt>:through</tt> option, including an
     # association which has a <tt>:through</tt> option itself. For example:
     #
-    #   class Author < ActiveRecord::Base
+    #   class Author < ApplicationModel
     #     has_many :posts
     #     has_many :comments, through: :posts
     #     has_many :commenters, through: :comments
     #   end
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #     has_many :comments
     #   end
     #
-    #   class Comment < ActiveRecord::Base
+    #   class Comment < ApplicationModel
     #     belongs_to :commenter
     #   end
     #
@@ -630,17 +630,17 @@ module ActiveRecord
     #
     # An equivalent way of setting up this association this would be:
     #
-    #   class Author < ActiveRecord::Base
+    #   class Author < ApplicationModel
     #     has_many :posts
     #     has_many :commenters, through: :posts
     #   end
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #     has_many :comments
     #     has_many :commenters, through: :comments
     #   end
     #
-    #   class Comment < ActiveRecord::Base
+    #   class Comment < ApplicationModel
     #     belongs_to :commenter
     #   end
     #
@@ -655,11 +655,11 @@ module ActiveRecord
     # can be associated with. Rather, they specify an interface that a +has_many+ association
     # must adhere to.
     #
-    #   class Asset < ActiveRecord::Base
+    #   class Asset < ApplicationModel
     #     belongs_to :attachable, polymorphic: true
     #   end
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #     has_many :assets, as: :attachable         # The :as option specifies the polymorphic interface to use.
     #   end
     #
@@ -676,7 +676,7 @@ module ActiveRecord
     # and member posts that use the posts table for STI. In this case, there must be a +type+
     # column in the posts table.
     #
-    #   class Asset < ActiveRecord::Base
+    #   class Asset < ApplicationModel
     #     belongs_to :attachable, polymorphic: true
     #
     #     def attachable_type=(sType)
@@ -684,7 +684,7 @@ module ActiveRecord
     #     end
     #   end
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #     # because we store "Post" in attachable_type now dependent: :destroy will work
     #     has_many :assets, as: :attachable, dependent: :destroy
     #   end
@@ -715,7 +715,7 @@ module ActiveRecord
     # posts that each need to display their author triggers 101 database queries. Through the
     # use of eager loading, the 101 queries can be reduced to 2.
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #     belongs_to :author
     #     has_many   :comments
     #   end
@@ -778,7 +778,7 @@ module ActiveRecord
     # If you do want eager load only some members of an association it is usually more natural
     # to include an association which has conditions defined on it:
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #     has_many :approved_comments, -> { where approved: true }, class_name: 'Comment'
     #   end
     #
@@ -790,7 +790,7 @@ module ActiveRecord
     # If you eager load an association with a specified <tt>:limit</tt> option, it will be ignored,
     # returning all the associated objects:
     #
-    #   class Picture < ActiveRecord::Base
+    #   class Picture < ApplicationModel
     #     has_many :most_recent_comments, -> { order('id DESC').limit(10) }, class_name: 'Comment'
     #   end
     #
@@ -798,7 +798,7 @@ module ActiveRecord
     #
     # Eager loading is supported with polymorphic associations.
     #
-    #   class Address < ActiveRecord::Base
+    #   class Address < ApplicationModel
     #     belongs_to :addressable, polymorphic: true
     #   end
     #
@@ -872,11 +872,11 @@ module ActiveRecord
     #
     #   module MyApplication
     #     module Business
-    #       class Firm < ActiveRecord::Base
+    #       class Firm < ApplicationModel
     #         has_many :clients
     #       end
     #
-    #       class Client < ActiveRecord::Base; end
+    #       class Client < ApplicationModel; end
     #     end
     #   end
     #
@@ -887,11 +887,11 @@ module ActiveRecord
     #
     #   module MyApplication
     #     module Business
-    #       class Firm < ActiveRecord::Base; end
+    #       class Firm < ApplicationModel; end
     #     end
     #
     #     module Billing
-    #       class Account < ActiveRecord::Base
+    #       class Account < ApplicationModel
     #         belongs_to :firm, class_name: "MyApplication::Business::Firm"
     #       end
     #     end
@@ -902,16 +902,16 @@ module ActiveRecord
     # When you specify an association there is usually an association on the associated model
     # that specifies the same relationship in reverse. For example, with the following models:
     #
-    #    class Dungeon < ActiveRecord::Base
+    #    class Dungeon < ApplicationModel
     #      has_many :traps
     #      has_one :evil_wizard
     #    end
     #
-    #    class Trap < ActiveRecord::Base
+    #    class Trap < ApplicationModel
     #      belongs_to :dungeon
     #    end
     #
-    #    class EvilWizard < ActiveRecord::Base
+    #    class EvilWizard < ApplicationModel
     #      belongs_to :dungeon
     #    end
     #
@@ -933,16 +933,16 @@ module ActiveRecord
     # Active Record about inverse relationships and it will optimise object loading. For
     # example, if we changed our model definitions to:
     #
-    #    class Dungeon < ActiveRecord::Base
+    #    class Dungeon < ApplicationModel
     #      has_many :traps, inverse_of: :dungeon
     #      has_one :evil_wizard, inverse_of: :dungeon
     #    end
     #
-    #    class Trap < ActiveRecord::Base
+    #    class Trap < ApplicationModel
     #      belongs_to :dungeon, inverse_of: :traps
     #    end
     #
-    #    class EvilWizard < ActiveRecord::Base
+    #    class EvilWizard < ApplicationModel
     #      belongs_to :dungeon, inverse_of: :evil_wizard
     #    end
     #

--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -76,7 +76,7 @@ module ActiveRecord::Associations::Builder
     end
 
     # Defines the setter and getter methods for the association
-    # class Post < ActiveRecord::Base
+    # class Post < ApplicationModel
     #   has_many :comments
     # end
     #

--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -76,7 +76,7 @@ module ActiveRecord::Associations::Builder
     end
 
     # Defines the setter and getter methods for the association
-    # class Post < ApplicationModel
+    # class Post < ApplicationRecord
     #   has_many :comments
     # end
     #

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -138,7 +138,7 @@ module ActiveRecord
 
       # Starts a transaction in the association class's database connection.
       #
-      #   class Author < ApplicationModel
+      #   class Author < ApplicationRecord
       #     has_many :books
       #   end
       #

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -138,7 +138,7 @@ module ActiveRecord
 
       # Starts a transaction in the association class's database connection.
       #
-      #   class Author < ActiveRecord::Base
+      #   class Author < ApplicationModel
       #     has_many :books
       #   end
       #

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     #
     # For example, given
     #
-    #   class Blog < ApplicationModel
+    #   class Blog < ApplicationRecord
     #     has_many :posts
     #   end
     #
@@ -57,7 +57,7 @@ module ActiveRecord
       #
       # *First:* Specify a subset of fields to be selected from the result set.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -114,7 +114,7 @@ module ActiveRecord
       # rules as <tt>ActiveRecord::Base.find</tt>. Returns <tt>ActiveRecord::RecordNotFound</tt>
       # error if the object can not be found.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -144,7 +144,7 @@ module ActiveRecord
       # If the collection is empty, the first form returns +nil+, and the second
       # form returns an empty array.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -174,7 +174,7 @@ module ActiveRecord
       # If the collection is empty, the first form returns +nil+, and the second
       # form returns an empty array.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -280,7 +280,7 @@ module ActiveRecord
       # inserts each record, +push+ and +concat+ behave identically. Returns +self+
       # so method calls may be chained.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     pets :has_many
       #   end
       #
@@ -306,7 +306,7 @@ module ActiveRecord
       # Replaces this collection with +other_array+. This will perform a diff
       # and delete/add only records that have changed.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -338,7 +338,7 @@ module ActiveRecord
       # sets the foreign keys to <tt>NULL</tt>. For, +has_many+ <tt>:through</tt>,
       # the default strategy is +delete_all+.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets # dependent: :nullify option by default
       #   end
       #
@@ -371,7 +371,7 @@ module ActiveRecord
       # are removed by calling their +destroy+ method. See +destroy+ for more
       # information.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets, dependent: :destroy
       #   end
       #
@@ -396,7 +396,7 @@ module ActiveRecord
       # If it is set to <tt>:delete_all</tt>, all the objects are deleted
       # *without* calling their +destroy+ method.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets, dependent: :delete_all
       #   end
       #
@@ -425,7 +425,7 @@ module ActiveRecord
       # ignoring the +:dependent+ option. It invokes +before_remove+,
       # +after_remove+ , +before_destroy+ and +after_destroy+ callbacks.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -457,7 +457,7 @@ module ActiveRecord
       # keys to <tt>NULL</tt>. For, +has_many+ <tt>:through</tt>, the default
       # strategy is +delete_all+.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets # dependent: :nullify option by default
       #   end
       #
@@ -485,7 +485,7 @@ module ActiveRecord
       # If it is set to <tt>:destroy</tt> all the +records+ are removed by calling
       # their +destroy+ method. See +destroy+ for more information.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets, dependent: :destroy
       #   end
       #
@@ -513,7 +513,7 @@ module ActiveRecord
       # If it is set to <tt>:delete_all</tt>, all the +records+ are deleted
       # *without* calling their +destroy+ method.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets, dependent: :delete_all
       #   end
       #
@@ -541,7 +541,7 @@ module ActiveRecord
       # You can pass +Fixnum+ or +String+ values, it finds the records
       # responding to the +id+ and executes delete on them.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -569,7 +569,7 @@ module ActiveRecord
       # This method will _always_ remove record from the database ignoring
       # the +:dependent+ option. Returns an array with the removed records.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -639,7 +639,7 @@ module ActiveRecord
 
       # Specifies whether the records should be unique or not.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -658,7 +658,7 @@ module ActiveRecord
 
       # Count all records using SQL.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -680,7 +680,7 @@ module ActiveRecord
       # equivalent. If not and you are going to need the records anyway
       # +length+ will take one less query. Otherwise +size+ is more efficient.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -706,7 +706,7 @@ module ActiveRecord
       # equivalent. If not and you are going to need the records anyway this
       # method will take one less query. Otherwise +size+ is more efficient.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -732,7 +732,7 @@ module ActiveRecord
       # not already been loaded and you are going to fetch the records anyway it
       # is better to check <tt>collection.length.zero?</tt>.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -749,7 +749,7 @@ module ActiveRecord
 
       # Returns +true+ if the collection is not empty.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -783,7 +783,7 @@ module ActiveRecord
       # Returns true if the collection has more than one record.
       # Equivalent to <tt>collection.size > 1</tt>.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -820,7 +820,7 @@ module ActiveRecord
 
       # Returns +true+ if the given object is present in the collection.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -855,7 +855,7 @@ module ActiveRecord
       # to the corresponding element in the other array, otherwise returns
       # +false+.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -881,7 +881,7 @@ module ActiveRecord
       # Returns a new array of objects from the collection. If the collection
       # hasn't been loaded, it fetches the records from the database.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -920,7 +920,7 @@ module ActiveRecord
       # to the association's primary key. Returns +self+, so several appends may be
       # chained together.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #
@@ -957,7 +957,7 @@ module ActiveRecord
       # Reloads the collection from the database. Returns +self+.
       # Equivalent to <tt>collection(true)</tt>.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_many :pets
       #   end
       #

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     #
     # For example, given
     #
-    #   class Blog < ActiveRecord::Base
+    #   class Blog < ApplicationModel
     #     has_many :posts
     #   end
     #
@@ -57,7 +57,7 @@ module ActiveRecord
       #
       # *First:* Specify a subset of fields to be selected from the result set.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -114,7 +114,7 @@ module ActiveRecord
       # rules as <tt>ActiveRecord::Base.find</tt>. Returns <tt>ActiveRecord::RecordNotFound</tt>
       # error if the object can not be found.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -144,7 +144,7 @@ module ActiveRecord
       # If the collection is empty, the first form returns +nil+, and the second
       # form returns an empty array.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -174,7 +174,7 @@ module ActiveRecord
       # If the collection is empty, the first form returns +nil+, and the second
       # form returns an empty array.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -280,7 +280,7 @@ module ActiveRecord
       # inserts each record, +push+ and +concat+ behave identically. Returns +self+
       # so method calls may be chained.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     pets :has_many
       #   end
       #
@@ -306,7 +306,7 @@ module ActiveRecord
       # Replaces this collection with +other_array+. This will perform a diff
       # and delete/add only records that have changed.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -338,7 +338,7 @@ module ActiveRecord
       # sets the foreign keys to <tt>NULL</tt>. For, +has_many+ <tt>:through</tt>,
       # the default strategy is +delete_all+.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets # dependent: :nullify option by default
       #   end
       #
@@ -371,7 +371,7 @@ module ActiveRecord
       # are removed by calling their +destroy+ method. See +destroy+ for more
       # information.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets, dependent: :destroy
       #   end
       #
@@ -396,7 +396,7 @@ module ActiveRecord
       # If it is set to <tt>:delete_all</tt>, all the objects are deleted
       # *without* calling their +destroy+ method.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets, dependent: :delete_all
       #   end
       #
@@ -425,7 +425,7 @@ module ActiveRecord
       # ignoring the +:dependent+ option. It invokes +before_remove+,
       # +after_remove+ , +before_destroy+ and +after_destroy+ callbacks.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -457,7 +457,7 @@ module ActiveRecord
       # keys to <tt>NULL</tt>. For, +has_many+ <tt>:through</tt>, the default
       # strategy is +delete_all+.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets # dependent: :nullify option by default
       #   end
       #
@@ -485,7 +485,7 @@ module ActiveRecord
       # If it is set to <tt>:destroy</tt> all the +records+ are removed by calling
       # their +destroy+ method. See +destroy+ for more information.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets, dependent: :destroy
       #   end
       #
@@ -513,7 +513,7 @@ module ActiveRecord
       # If it is set to <tt>:delete_all</tt>, all the +records+ are deleted
       # *without* calling their +destroy+ method.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets, dependent: :delete_all
       #   end
       #
@@ -541,7 +541,7 @@ module ActiveRecord
       # You can pass +Fixnum+ or +String+ values, it finds the records
       # responding to the +id+ and executes delete on them.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -569,7 +569,7 @@ module ActiveRecord
       # This method will _always_ remove record from the database ignoring
       # the +:dependent+ option. Returns an array with the removed records.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -639,7 +639,7 @@ module ActiveRecord
 
       # Specifies whether the records should be unique or not.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -658,7 +658,7 @@ module ActiveRecord
 
       # Count all records using SQL.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -680,7 +680,7 @@ module ActiveRecord
       # equivalent. If not and you are going to need the records anyway
       # +length+ will take one less query. Otherwise +size+ is more efficient.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -706,7 +706,7 @@ module ActiveRecord
       # equivalent. If not and you are going to need the records anyway this
       # method will take one less query. Otherwise +size+ is more efficient.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -732,7 +732,7 @@ module ActiveRecord
       # not already been loaded and you are going to fetch the records anyway it
       # is better to check <tt>collection.length.zero?</tt>.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -749,7 +749,7 @@ module ActiveRecord
 
       # Returns +true+ if the collection is not empty.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -783,7 +783,7 @@ module ActiveRecord
       # Returns true if the collection has more than one record.
       # Equivalent to <tt>collection.size > 1</tt>.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -820,7 +820,7 @@ module ActiveRecord
 
       # Returns +true+ if the given object is present in the collection.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -855,7 +855,7 @@ module ActiveRecord
       # to the corresponding element in the other array, otherwise returns
       # +false+.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -881,7 +881,7 @@ module ActiveRecord
       # Returns a new array of objects from the collection. If the collection
       # hasn't been loaded, it fetches the records from the database.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -920,7 +920,7 @@ module ActiveRecord
       # to the association's primary key. Returns +self+, so several appends may be
       # chained together.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #
@@ -957,7 +957,7 @@ module ActiveRecord
       # Reloads the collection from the database. Returns +self+.
       # Equivalent to <tt>collection(true)</tt>.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_many :pets
       #   end
       #

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       #
       #  Example :
       #
-      #  class Physician < ApplicationModel
+      #  class Physician < ApplicationRecord
       #    has_many :appointments
       #    has_many :patients, through: :appointments
       #  end

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       #
       #  Example :
       #
-      #  class Physician < ActiveRecord::Base
+      #  class Physician < ApplicationModel
       #    has_many :appointments
       #    has_many :patients, through: :appointments
       #  end

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -138,7 +138,7 @@ module ActiveRecord
         #
         #  Example:
         #
-        #  class Physician < ApplicationModel
+        #  class Physician < ApplicationRecord
         #    has_many :appointments
         #  end
         #

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -138,7 +138,7 @@ module ActiveRecord
         #
         #  Example:
         #
-        #  class Physician < ActiveRecord::Base
+        #  class Physician < ApplicationModel
         #    has_many :appointments
         #  end
         #

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -89,7 +89,7 @@ module ActiveRecord
       # Raises a <tt>ActiveRecord::DangerousAttributeError</tt> exception when an
       # \Active \Record method is defined in the model, otherwise +false+.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     def save
       #       'already defined by Active Record'
       #     end
@@ -135,7 +135,7 @@ module ActiveRecord
       # Returns +true+ if +attribute+ is an attribute method and table exists,
       # +false+ otherwise.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #   end
       #
       #   Person.attribute_method?('name')   # => true
@@ -148,7 +148,7 @@ module ActiveRecord
       # Returns an array of column names as strings if it's not an abstract class and
       # table exists. Otherwise it returns an empty array.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #   end
       #
       #   Person.attribute_names
@@ -181,7 +181,7 @@ module ActiveRecord
     # which will all return +true+. It also define the attribute methods if they have
     # not been generated.
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #   end
     #
     #   person = Person.new
@@ -213,7 +213,7 @@ module ActiveRecord
 
     # Returns +true+ if the given attribute is in the attributes hash, otherwise +false+.
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #   end
     #
     #   person = Person.new
@@ -226,7 +226,7 @@ module ActiveRecord
 
     # Returns an array of names for the attributes available on this object.
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #   end
     #
     #   person = Person.new
@@ -238,7 +238,7 @@ module ActiveRecord
 
     # Returns a hash of all the attributes with their names as keys and the values of the attributes as values.
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #   end
     #
     #   person = Person.create(name: 'Francesco', age: 22)
@@ -280,7 +280,7 @@ module ActiveRecord
     # to objects that respond to <tt>empty?</tt>, most notably Strings). Otherwise, +false+.
     # Note that it always returns +true+ with boolean attributes.
     #
-    #   class Task < ApplicationModel
+    #   class Task < ApplicationRecord
     #   end
     #
     #   person = Task.new(title: '', is_done: false)
@@ -298,7 +298,7 @@ module ActiveRecord
     # Returns the column object for the named attribute. Returns +nil+ if the
     # named attribute not exists.
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #   end
     #
     #   person = Person.new
@@ -318,7 +318,7 @@ module ActiveRecord
     #
     # Alias for the <tt>read_attribute</tt> method.
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #     belongs_to :organization
     #   end
     #
@@ -336,7 +336,7 @@ module ActiveRecord
     # Updates the attribute identified by <tt>attr_name</tt> with the specified +value+.
     # (Alias for the protected <tt>write_attribute</tt> method).
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #   end
     #
     #   person = Person.new

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -105,7 +105,7 @@ module ActiveRecord
           raise DangerousAttributeError, "#{method_name} is defined by Active Record"
         end
 
-        if superclass == Base || superclass == ApplicationRecord
+        if superclass == ActiveRecord::Base.application_record || superclass == Base
           super
         else
           # If B < A and A defines its own attribute method, then we don't want to overwrite that.

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -105,7 +105,7 @@ module ActiveRecord
           raise DangerousAttributeError, "#{method_name} is defined by Active Record"
         end
 
-        if superclass == Base
+        if superclass == Base || superclass == ApplicationRecord
           super
         else
           # If B < A and A defines its own attribute method, then we don't want to overwrite that.

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -89,7 +89,7 @@ module ActiveRecord
       # Raises a <tt>ActiveRecord::DangerousAttributeError</tt> exception when an
       # \Active \Record method is defined in the model, otherwise +false+.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     def save
       #       'already defined by Active Record'
       #     end
@@ -135,7 +135,7 @@ module ActiveRecord
       # Returns +true+ if +attribute+ is an attribute method and table exists,
       # +false+ otherwise.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #   end
       #
       #   Person.attribute_method?('name')   # => true
@@ -148,7 +148,7 @@ module ActiveRecord
       # Returns an array of column names as strings if it's not an abstract class and
       # table exists. Otherwise it returns an empty array.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #   end
       #
       #   Person.attribute_names
@@ -181,7 +181,7 @@ module ActiveRecord
     # which will all return +true+. It also define the attribute methods if they have
     # not been generated.
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #   end
     #
     #   person = Person.new
@@ -213,7 +213,7 @@ module ActiveRecord
 
     # Returns +true+ if the given attribute is in the attributes hash, otherwise +false+.
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #   end
     #
     #   person = Person.new
@@ -226,7 +226,7 @@ module ActiveRecord
 
     # Returns an array of names for the attributes available on this object.
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #   end
     #
     #   person = Person.new
@@ -238,7 +238,7 @@ module ActiveRecord
 
     # Returns a hash of all the attributes with their names as keys and the values of the attributes as values.
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #   end
     #
     #   person = Person.create(name: 'Francesco', age: 22)
@@ -280,7 +280,7 @@ module ActiveRecord
     # to objects that respond to <tt>empty?</tt>, most notably Strings). Otherwise, +false+.
     # Note that it always returns +true+ with boolean attributes.
     #
-    #   class Task < ActiveRecord::Base
+    #   class Task < ApplicationModel
     #   end
     #
     #   person = Task.new(title: '', is_done: false)
@@ -298,7 +298,7 @@ module ActiveRecord
     # Returns the column object for the named attribute. Returns +nil+ if the
     # named attribute not exists.
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #   end
     #
     #   person = Person.new
@@ -318,7 +318,7 @@ module ActiveRecord
     #
     # Alias for the <tt>read_attribute</tt> method.
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #     belongs_to :organization
     #   end
     #
@@ -336,7 +336,7 @@ module ActiveRecord
     # Updates the attribute identified by <tt>attr_name</tt> with the specified +value+.
     # (Alias for the protected <tt>write_attribute</tt> method).
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #   end
     #
     #   person = Person.new

--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     # <tt>ActiveRecord::AttributeMethods::BeforeTypeCast</tt> provides a way to
     # read the value of the attributes before typecasting and deserialization.
     #
-    #   class Task < ActiveRecord::Base
+    #   class Task < ApplicationModel
     #   end
     #
     #   task = Task.new(id: '1', completed_on: '2012-10-21')
@@ -33,7 +33,7 @@ module ActiveRecord
       # Returns the value of the attribute identified by +attr_name+ before
       # typecasting and deserialization.
       #
-      #   class Task < ActiveRecord::Base
+      #   class Task < ApplicationModel
       #   end
       #
       #   task = Task.new(id: '1', completed_on: '2012-10-21')
@@ -48,7 +48,7 @@ module ActiveRecord
 
       # Returns a hash of attributes before typecasting and deserialization.
       #
-      #   class Task < ActiveRecord::Base
+      #   class Task < ApplicationModel
       #   end
       #
       #   task = Task.new(title: nil, is_done: true, completed_on: '2012-10-21')

--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     # <tt>ActiveRecord::AttributeMethods::BeforeTypeCast</tt> provides a way to
     # read the value of the attributes before typecasting and deserialization.
     #
-    #   class Task < ApplicationModel
+    #   class Task < ApplicationRecord
     #   end
     #
     #   task = Task.new(id: '1', completed_on: '2012-10-21')
@@ -33,7 +33,7 @@ module ActiveRecord
       # Returns the value of the attribute identified by +attr_name+ before
       # typecasting and deserialization.
       #
-      #   class Task < ApplicationModel
+      #   class Task < ApplicationRecord
       #   end
       #
       #   task = Task.new(id: '1', completed_on: '2012-10-21')
@@ -48,7 +48,7 @@ module ActiveRecord
 
       # Returns a hash of attributes before typecasting and deserialization.
       #
-      #   class Task < ApplicationModel
+      #   class Task < ApplicationRecord
       #   end
       #
       #   task = Task.new(title: nil, is_done: true, completed_on: '2012-10-21')

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -99,13 +99,13 @@ module ActiveRecord
 
         # Sets the name of the primary key column.
         #
-        #   class Project < ApplicationModel
+        #   class Project < ApplicationRecord
         #     self.primary_key = 'sysid'
         #   end
         #
         # You can also define the +primary_key+ method yourself:
         #
-        #   class Project < ApplicationModel
+        #   class Project < ApplicationRecord
         #     def self.primary_key
         #       'foo_' + super
         #     end

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -99,13 +99,13 @@ module ActiveRecord
 
         # Sets the name of the primary key column.
         #
-        #   class Project < ActiveRecord::Base
+        #   class Project < ApplicationModel
         #     self.primary_key = 'sysid'
         #   end
         #
         # You can also define the +primary_key+ method yourself:
         #
-        #   class Project < ActiveRecord::Base
+        #   class Project < ApplicationModel
         #     def self.primary_key
         #       'foo_' + super
         #     end

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -32,7 +32,7 @@ module ActiveRecord
         # ==== Example
         #
         #   # Serialize a preferences attribute.
-        #   class User < ActiveRecord::Base
+        #   class User < ApplicationModel
         #     serialize :preferences
         #   end
         def serialize(attr_name, class_name = Object)

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -32,7 +32,7 @@ module ActiveRecord
         # ==== Example
         #
         #   # Serialize a preferences attribute.
-        #   class User < ApplicationModel
+        #   class User < ApplicationRecord
         #     serialize :preferences
         #   end
         def serialize(attr_name, class_name = Object)

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -60,7 +60,7 @@ module ActiveRecord #:nodoc:
   # be used for statements that don't involve tainted data. The hash form works much like the array form, except
   # only equality and range is possible. Examples:
   #
-  #   class User < ApplicationModel
+  #   class User < ApplicationRecord
   #     def self.authenticate_unsafely(user_name, password)
   #       where("user_name = '#{user_name}' AND password = '#{password}'").first
   #     end
@@ -119,7 +119,7 @@ module ActiveRecord #:nodoc:
   # <tt>read_attribute(attr_name)</tt> and <tt>write_attribute(attr_name, value)</tt> to actually
   # change things.
   #
-  #   class Song < ApplicationModel
+  #   class Song < ApplicationRecord
   #     # Uses an integer of seconds to hold the length of the song
   #
   #     def length=(minutes)
@@ -187,7 +187,7 @@ module ActiveRecord #:nodoc:
   # This makes it possible to store arrays, hashes, and other non-mappable objects without doing
   # any additional work.
   #
-  #   class User < ApplicationModel
+  #   class User < ApplicationRecord
   #     serialize :preferences
   #   end
   #
@@ -197,7 +197,7 @@ module ActiveRecord #:nodoc:
   # You can also specify a class option as the second parameter that'll raise an exception
   # if a serialized object is retrieved as a descendant of a class not in the hierarchy.
   #
-  #   class User < ApplicationModel
+  #   class User < ApplicationRecord
   #     serialize :preferences, Hash
   #   end
   #
@@ -207,7 +207,7 @@ module ActiveRecord #:nodoc:
   # When you specify a class option, the default value for that attribute will be a new
   # instance of that class.
   #
-  #   class User < ApplicationModel
+  #   class User < ApplicationRecord
   #     serialize :preferences, OpenStruct
   #   end
   #
@@ -221,7 +221,7 @@ module ActiveRecord #:nodoc:
   # default is named "type" (can be changed by overwriting <tt>Base.inheritance_column</tt>).
   # This means that an inheritance looking like this:
   #
-  #   class Company < ApplicationModel; end
+  #   class Company < ApplicationRecord; end
   #   class Firm < Company; end
   #   class Client < Company; end
   #   class PriorityClient < Client; end

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -293,6 +293,7 @@ module ActiveRecord #:nodoc:
     extend Explain
     extend Delegation::DelegateCache
 
+    include ApplicationConfiguration
     include Persistence
     include ReadonlyAttributes
     include ModelSchema

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -60,7 +60,7 @@ module ActiveRecord #:nodoc:
   # be used for statements that don't involve tainted data. The hash form works much like the array form, except
   # only equality and range is possible. Examples:
   #
-  #   class User < ActiveRecord::Base
+  #   class User < ApplicationModel
   #     def self.authenticate_unsafely(user_name, password)
   #       where("user_name = '#{user_name}' AND password = '#{password}'").first
   #     end
@@ -119,7 +119,7 @@ module ActiveRecord #:nodoc:
   # <tt>read_attribute(attr_name)</tt> and <tt>write_attribute(attr_name, value)</tt> to actually
   # change things.
   #
-  #   class Song < ActiveRecord::Base
+  #   class Song < ApplicationModel
   #     # Uses an integer of seconds to hold the length of the song
   #
   #     def length=(minutes)
@@ -187,7 +187,7 @@ module ActiveRecord #:nodoc:
   # This makes it possible to store arrays, hashes, and other non-mappable objects without doing
   # any additional work.
   #
-  #   class User < ActiveRecord::Base
+  #   class User < ApplicationModel
   #     serialize :preferences
   #   end
   #
@@ -197,7 +197,7 @@ module ActiveRecord #:nodoc:
   # You can also specify a class option as the second parameter that'll raise an exception
   # if a serialized object is retrieved as a descendant of a class not in the hierarchy.
   #
-  #   class User < ActiveRecord::Base
+  #   class User < ApplicationModel
   #     serialize :preferences, Hash
   #   end
   #
@@ -207,7 +207,7 @@ module ActiveRecord #:nodoc:
   # When you specify a class option, the default value for that attribute will be a new
   # instance of that class.
   #
-  #   class User < ActiveRecord::Base
+  #   class User < ApplicationModel
   #     serialize :preferences, OpenStruct
   #   end
   #
@@ -221,7 +221,7 @@ module ActiveRecord #:nodoc:
   # default is named "type" (can be changed by overwriting <tt>Base.inheritance_column</tt>).
   # This means that an inheritance looking like this:
   #
-  #   class Company < ActiveRecord::Base; end
+  #   class Company < ApplicationModel; end
   #   class Firm < Company; end
   #   class Client < Company; end
   #   class PriorityClient < Client; end

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -32,7 +32,7 @@ module ActiveRecord
   # except that each <tt>_create</tt> callback is replaced by the corresponding <tt>_update</tt> callback.
   #
   # Examples:
-  #   class CreditCard < ApplicationModel
+  #   class CreditCard < ApplicationRecord
   #     # Strip everything but digits, so the user can specify "555 234 34" or
   #     # "5552-3434" and both will mean "55523434"
   #     before_validation(on: :create) do
@@ -40,7 +40,7 @@ module ActiveRecord
   #     end
   #   end
   #
-  #   class Subscription < ApplicationModel
+  #   class Subscription < ApplicationRecord
   #     before_create :record_signup
   #
   #     private
@@ -49,7 +49,7 @@ module ActiveRecord
   #       end
   #   end
   #
-  #   class Firm < ApplicationModel
+  #   class Firm < ApplicationRecord
   #     # Destroys the associated clients and people when the firm is destroyed
   #     before_destroy { |record| Person.destroy_all "firm_id = #{record.id}"   }
   #     before_destroy { |record| Client.destroy_all "client_of = #{record.id}" }
@@ -61,7 +61,7 @@ module ActiveRecord
   # use of the callback macros. Their main advantage is that the macros add behavior into a callback
   # queue that is kept intact down through an inheritance hierarchy.
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     before_destroy :destroy_author
   #   end
   #
@@ -73,7 +73,7 @@ module ActiveRecord
   # run, both +destroy_author+ and +destroy_readers+ are called. Contrast this to the following situation
   # where the +before_destroy+ method is overridden:
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     def before_destroy() destroy_author end
   #   end
   #
@@ -99,7 +99,7 @@ module ActiveRecord
   #
   # The method reference callbacks work by specifying a protected or private method available in the object, like this:
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     before_destroy :delete_parents
   #
   #     private
@@ -110,7 +110,7 @@ module ActiveRecord
   #
   # The callback objects have methods named after the callback called with the record as the only parameter, such as:
   #
-  #   class BankAccount < ApplicationModel
+  #   class BankAccount < ApplicationRecord
   #     before_save      EncryptionWrapper.new
   #     after_save       EncryptionWrapper.new
   #     after_initialize EncryptionWrapper.new
@@ -141,7 +141,7 @@ module ActiveRecord
   # a method by the name of the callback messaged. You can make these callbacks more flexible by passing in other
   # initialization data such as the name of the attribute to work with:
   #
-  #   class BankAccount < ApplicationModel
+  #   class BankAccount < ApplicationRecord
   #     before_save      EncryptionWrapper.new("credit_card_number")
   #     after_save       EncryptionWrapper.new("credit_card_number")
   #     after_initialize EncryptionWrapper.new("credit_card_number")
@@ -175,14 +175,14 @@ module ActiveRecord
   # The callback macros usually accept a symbol for the method they're supposed to run, but you can also
   # pass a "method string", which will then be evaluated within the binding of the callback. Example:
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     before_destroy 'self.class.delete_all "parent_id = #{id}"'
   #   end
   #
   # Notice that single quotes (') are used so the <tt>#{id}</tt> part isn't evaluated until the callback
   # is triggered. Also note that these inline callbacks can be stacked just like the regular ones:
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     before_destroy 'self.class.delete_all "parent_id = #{id}"',
   #                    'puts "Evaluated after parents are destroyed"'
   #   end
@@ -207,7 +207,7 @@ module ActiveRecord
   #
   # Let's look at the code below:
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     has_many :children, dependent: destroy
   #
   #     before_destroy :log_children
@@ -221,7 +221,7 @@ module ActiveRecord
   # In this case, the problem is that when the +before_destroy+ callback is executed, the children are not available
   # because the +destroy+ callback gets executed first. You can use the +prepend+ option on the +before_destroy+ callback to avoid this.
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     has_many :children, dependent: destroy
   #
   #     before_destroy :log_children, prepend: true

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -32,7 +32,7 @@ module ActiveRecord
   # except that each <tt>_create</tt> callback is replaced by the corresponding <tt>_update</tt> callback.
   #
   # Examples:
-  #   class CreditCard < ActiveRecord::Base
+  #   class CreditCard < ApplicationModel
   #     # Strip everything but digits, so the user can specify "555 234 34" or
   #     # "5552-3434" and both will mean "55523434"
   #     before_validation(on: :create) do
@@ -40,7 +40,7 @@ module ActiveRecord
   #     end
   #   end
   #
-  #   class Subscription < ActiveRecord::Base
+  #   class Subscription < ApplicationModel
   #     before_create :record_signup
   #
   #     private
@@ -49,7 +49,7 @@ module ActiveRecord
   #       end
   #   end
   #
-  #   class Firm < ActiveRecord::Base
+  #   class Firm < ApplicationModel
   #     # Destroys the associated clients and people when the firm is destroyed
   #     before_destroy { |record| Person.destroy_all "firm_id = #{record.id}"   }
   #     before_destroy { |record| Client.destroy_all "client_of = #{record.id}" }
@@ -61,7 +61,7 @@ module ActiveRecord
   # use of the callback macros. Their main advantage is that the macros add behavior into a callback
   # queue that is kept intact down through an inheritance hierarchy.
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     before_destroy :destroy_author
   #   end
   #
@@ -73,7 +73,7 @@ module ActiveRecord
   # run, both +destroy_author+ and +destroy_readers+ are called. Contrast this to the following situation
   # where the +before_destroy+ method is overridden:
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     def before_destroy() destroy_author end
   #   end
   #
@@ -99,7 +99,7 @@ module ActiveRecord
   #
   # The method reference callbacks work by specifying a protected or private method available in the object, like this:
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     before_destroy :delete_parents
   #
   #     private
@@ -110,7 +110,7 @@ module ActiveRecord
   #
   # The callback objects have methods named after the callback called with the record as the only parameter, such as:
   #
-  #   class BankAccount < ActiveRecord::Base
+  #   class BankAccount < ApplicationModel
   #     before_save      EncryptionWrapper.new
   #     after_save       EncryptionWrapper.new
   #     after_initialize EncryptionWrapper.new
@@ -141,7 +141,7 @@ module ActiveRecord
   # a method by the name of the callback messaged. You can make these callbacks more flexible by passing in other
   # initialization data such as the name of the attribute to work with:
   #
-  #   class BankAccount < ActiveRecord::Base
+  #   class BankAccount < ApplicationModel
   #     before_save      EncryptionWrapper.new("credit_card_number")
   #     after_save       EncryptionWrapper.new("credit_card_number")
   #     after_initialize EncryptionWrapper.new("credit_card_number")
@@ -175,14 +175,14 @@ module ActiveRecord
   # The callback macros usually accept a symbol for the method they're supposed to run, but you can also
   # pass a "method string", which will then be evaluated within the binding of the callback. Example:
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     before_destroy 'self.class.delete_all "parent_id = #{id}"'
   #   end
   #
   # Notice that single quotes (') are used so the <tt>#{id}</tt> part isn't evaluated until the callback
   # is triggered. Also note that these inline callbacks can be stacked just like the regular ones:
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     before_destroy 'self.class.delete_all "parent_id = #{id}"',
   #                    'puts "Evaluated after parents are destroyed"'
   #   end
@@ -207,7 +207,7 @@ module ActiveRecord
   #
   # Let's look at the code below:
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     has_many :children, dependent: destroy
   #
   #     before_destroy :log_children
@@ -221,7 +221,7 @@ module ActiveRecord
   # In this case, the problem is that when the +before_destroy+ callback is executed, the children are not available
   # because the +destroy+ callback gets executed first. You can use the +prepend+ option on the +before_destroy+ callback to avoid this.
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     has_many :children, dependent: destroy
   #
   #     before_destroy :log_children, prepend: true

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -113,7 +113,7 @@ module ActiveRecord
 
       def quoted_date(value)
         if value.acts_like?(:time)
-          zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
+          zone_conversion_method = ActiveRecord::Base.application_record.default_timezone == :utc ? :getutc : :getlocal
 
           if value.respond_to?(zone_conversion_method)
             value = value.send(zone_conversion_method)

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -216,7 +216,7 @@ module ActiveRecord
         if @connection
           # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been
           # made since we established the connection
-          @connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
+          @connection.query_options[:database_timezone] = ActiveRecord::Base.application_record.default_timezone
         end
 
         super

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -850,7 +850,7 @@ module ActiveRecord
           # If using Active Record's time zone support configure the connection to return
           # TIMESTAMP WITH ZONE types in UTC.
           # (SET TIME ZONE does not use an equals sign like other SET variables)
-          if ActiveRecord::Base.default_timezone == :utc
+          if ActiveRecord::Base.application_record.default_timezone == :utc
             execute("SET time zone 'UTC'", 'SCHEMA')
           elsif @local_tz
             execute("SET time zone '#{@local_tz}'", 'SCHEMA')

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -125,7 +125,7 @@ module ActiveRecord
 
       # Returns an instance of <tt>Arel::Table</tt> loaded with the current table name.
       #
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationModel
       #     scope :published_and_commented, published.and(self.arel_table[:comments_count].gt(0))
       #   end
       def arel_table
@@ -185,7 +185,7 @@ module ActiveRecord
     # the attributes necessary for initializing an empty model object. For
     # example:
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #   end
     #
     #   post = Post.allocate
@@ -261,7 +261,7 @@ module ActiveRecord
     #
     # Example:
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #   end
     #   coder = {}
     #   Post.new.encode_with(coder)

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -125,7 +125,7 @@ module ActiveRecord
 
       # Returns an instance of <tt>Arel::Table</tt> loaded with the current table name.
       #
-      #   class Post < ApplicationModel
+      #   class Post < ApplicationRecord
       #     scope :published_and_commented, published.and(self.arel_table[:comments_count].gt(0))
       #   end
       def arel_table
@@ -185,7 +185,7 @@ module ActiveRecord
     # the attributes necessary for initializing an empty model object. For
     # example:
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #   end
     #
     #   post = Post.allocate
@@ -261,7 +261,7 @@ module ActiveRecord
     #
     # Example:
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #   end
     #   coder = {}
     #   Post.new.encode_with(coder)

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -13,11 +13,11 @@ module ActiveRecord
 
   # Raised when an object assigned to an association has an incorrect type.
   #
-  #   class Ticket < ActiveRecord::Base
+  #   class Ticket < ApplicationModel
   #     has_many :patches
   #   end
   #
-  #   class Patch < ActiveRecord::Base
+  #   class Patch < ApplicationModel
   #     belongs_to :ticket
   #   end
   #
@@ -201,7 +201,7 @@ module ActiveRecord
 
   # Raised when a relation cannot be mutated because it's already loaded.
   #
-  #   class Task < ActiveRecord::Base
+  #   class Task < ApplicationModel
   #   end
   #
   #   relation = Task.all

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -13,11 +13,11 @@ module ActiveRecord
 
   # Raised when an object assigned to an association has an incorrect type.
   #
-  #   class Ticket < ApplicationModel
+  #   class Ticket < ApplicationRecord
   #     has_many :patches
   #   end
   #
-  #   class Patch < ApplicationModel
+  #   class Patch < ApplicationRecord
   #     belongs_to :ticket
   #   end
   #
@@ -201,7 +201,7 @@ module ActiveRecord
 
   # Raised when a relation cannot be mutated because it's already loaded.
   #
-  #   class Task < ApplicationModel
+  #   class Task < ApplicationRecord
   #   end
   #
   #   relation = Task.all

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -815,7 +815,7 @@ module ActiveRecord
       self.use_transactional_fixtures = true
       self.use_instantiated_fixtures = false
       self.pre_loaded_fixtures = false
-      self.config = ActiveRecord::Base.application_model
+      self.config = ActiveRecord::Base.application_record
 
       self.fixture_class_names = Hash.new do |h, fixture_set_name|
         h[fixture_set_name] = ActiveRecord::FixtureSet.default_fixture_model_name(fixture_set_name, self.config)
@@ -928,7 +928,7 @@ module ActiveRecord
       @fixture_connections = []
       @@already_loaded_fixtures ||= {}
 
-      config = ActiveRecord::Base.application_model
+      config = ActiveRecord::Base.application_record
       # Load fixtures once and begin transaction.
       if run_in_transaction?
         if @@already_loaded_fixtures[self.class]

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -815,7 +815,7 @@ module ActiveRecord
       self.use_transactional_fixtures = true
       self.use_instantiated_fixtures = false
       self.pre_loaded_fixtures = false
-      self.config = ActiveRecord::Base
+      self.config = ActiveRecord::Base.application_model
 
       self.fixture_class_names = Hash.new do |h, fixture_set_name|
         h[fixture_set_name] = ActiveRecord::FixtureSet.default_fixture_model_name(fixture_set_name, self.config)
@@ -919,7 +919,7 @@ module ActiveRecord
         !self.class.uses_transaction?(method_name)
     end
 
-    def setup_fixtures(config = ActiveRecord::Base)
+    def setup_fixtures
       if pre_loaded_fixtures && !use_transactional_fixtures
         raise RuntimeError, 'pre_loaded_fixtures requires use_transactional_fixtures'
       end
@@ -928,6 +928,7 @@ module ActiveRecord
       @fixture_connections = []
       @@already_loaded_fixtures ||= {}
 
+      config = ActiveRecord::Base.application_model
       # Load fixtures once and begin transaction.
       if run_in_transaction?
         if @@already_loaded_fixtures[self.class]

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -77,7 +77,7 @@ module ActiveRecord
       # to utilize the implied STI table name of the parent class, this will need to be true.
       # For example, given the following:
       #
-      #   class SuperClass < ApplicationModel
+      #   class SuperClass < ApplicationRecord
       #     self.abstract_class = true
       #   end
       #   class Child < SuperClass
@@ -189,7 +189,7 @@ module ActiveRecord
 
     # Sets the attribute used for single table inheritance to this class name if this is not the
     # ActiveRecord::Base descendant.
-    # Considering the hierarchy Reply < Message < ApplicationModel, this makes it possible to
+    # Considering the hierarchy Reply < Message < ApplicationRecord, this makes it possible to
     # do Reply.new without having to set <tt>Reply[Reply.inheritance_column] = "Reply"</tt> yourself.
     # No such attribute would be set for objects of the Message class in that example.
     def ensure_proper_type

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -77,7 +77,7 @@ module ActiveRecord
       # to utilize the implied STI table name of the parent class, this will need to be true.
       # For example, given the following:
       #
-      #   class SuperClass < ActiveRecord::Base
+      #   class SuperClass < ApplicationModel
       #     self.abstract_class = true
       #   end
       #   class Child < SuperClass
@@ -189,7 +189,7 @@ module ActiveRecord
 
     # Sets the attribute used for single table inheritance to this class name if this is not the
     # ActiveRecord::Base descendant.
-    # Considering the hierarchy Reply < Message < ActiveRecord::Base, this makes it possible to
+    # Considering the hierarchy Reply < Message < ApplicationModel, this makes it possible to
     # do Reply.new without having to set <tt>Reply[Reply.inheritance_column] = "Reply"</tt> yourself.
     # No such attribute would be set for objects of the Message class in that example.
     def ensure_proper_type

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -27,7 +27,7 @@ module ActiveRecord
     # You can override +to_param+ in your model to make +user_path+ construct
     # a path using the user's name instead of the user's id:
     #
-    #   class User < ActiveRecord::Base
+    #   class User < ApplicationModel
     #     def to_param  # overridden
     #       name
     #     end

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -27,7 +27,7 @@ module ActiveRecord
     # You can override +to_param+ in your model to make +user_path+ construct
     # a path using the user's name instead of the user's id:
     #
-    #   class User < ApplicationModel
+    #   class User < ApplicationRecord
     #     def to_param  # overridden
     #       name
     #     end

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -43,7 +43,7 @@ module ActiveRecord
     # This behavior can be turned off by setting <tt>ActiveRecord::Base.lock_optimistically = false</tt>.
     # To override the name of the +lock_version+ column, set the <tt>locking_column</tt> class attribute:
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationModel
     #     self.locking_column = :lock_person
     #   end
     #

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -43,7 +43,7 @@ module ActiveRecord
     # This behavior can be turned off by setting <tt>ActiveRecord::Base.lock_optimistically = false</tt>.
     # To override the name of the +lock_version+ column, set the <tt>locking_column</tt> class attribute:
     #
-    #   class Person < ApplicationModel
+    #   class Person < ApplicationRecord
     #     self.locking_column = :lock_person
     #   end
     #

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -684,17 +684,17 @@ module ActiveRecord
 
     # Determines the version number of the next migration.
     def next_migration_number(number)
-      if ActiveRecord::Base.timestamped_migrations
+      if ActiveRecord::Base.application_record.timestamped_migrations
         [Time.now.utc.strftime("%Y%m%d%H%M%S"), "%.14d" % number].max
       else
         "%.3d" % number
       end
     end
 
-    def table_name_options(config = ActiveRecord::Base)
+    def table_name_options
       {
-        table_name_prefix: config.table_name_prefix,
-        table_name_suffix: config.table_name_suffix
+        table_name_prefix: ActiveRecord::Base.application_record.table_name_prefix,
+        table_name_suffix: ActiveRecord::Base.application_record.table_name_suffix
       }
     end
 
@@ -830,8 +830,8 @@ module ActiveRecord
       def proper_table_name(name, options = {})
         ActiveSupport::Deprecation.warn "ActiveRecord::Migrator.proper_table_name is deprecated and will be removed in Rails 4.2. Use the proper_table_name instance method on ActiveRecord::Migration instead"
         options = {
-          table_name_prefix: ActiveRecord::Base.table_name_prefix,
-          table_name_suffix: ActiveRecord::Base.table_name_suffix
+          table_name_prefix: ActiveRecord::Base.application_record.table_name_prefix,
+          table_name_suffix: ActiveRecord::Base.application_record.table_name_suffix
         }.merge(options)
         if name.respond_to? :table_name
           name.table_name

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -46,7 +46,7 @@ module ActiveRecord
     module ClassMethods
       # Guesses the table name (in forced lower-case) based on the name of the class in the
       # inheritance hierarchy descending directly from ActiveRecord::Base. So if the hierarchy
-      # looks like: Reply < Message < ActiveRecord::Base, then Message is used
+      # looks like: Reply < Message < ApplicationModel, then Message is used
       # to guess the table name even when called on Reply. The rules used to do the guess
       # are handled by the Inflector class in Active Support, which knows almost all common
       # English inflections. You can add new inflections in config/initializers/inflections.rb.
@@ -56,14 +56,14 @@ module ActiveRecord
       #
       # ==== Examples
       #
-      #   class Invoice < ActiveRecord::Base
+      #   class Invoice < ApplicationModel
       #   end
       #
       #   file                  class               table_name
       #   invoice.rb            Invoice             invoices
       #
-      #   class Invoice < ActiveRecord::Base
-      #     class Lineitem < ActiveRecord::Base
+      #   class Invoice < ApplicationModel
+      #     class Lineitem < ApplicationModel
       #     end
       #   end
       #
@@ -71,7 +71,7 @@ module ActiveRecord
       #   invoice.rb            Invoice::Lineitem   invoice_lineitems
       #
       #   module Invoice
-      #     class Lineitem < ActiveRecord::Base
+      #     class Lineitem < ApplicationModel
       #     end
       #   end
       #
@@ -85,7 +85,7 @@ module ActiveRecord
       #
       # You can also set your own table name explicitly:
       #
-      #   class Mouse < ActiveRecord::Base
+      #   class Mouse < ApplicationModel
       #     self.table_name = "mice"
       #   end
       #
@@ -93,7 +93,7 @@ module ActiveRecord
       # own computation. (Possibly using <tt>super</tt> to manipulate the default
       # table name.) Example:
       #
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationModel
       #     def self.table_name
       #       "special_" + super
       #     end
@@ -106,7 +106,7 @@ module ActiveRecord
 
       # Sets the table name explicitly. Example:
       #
-      #   class Project < ActiveRecord::Base
+      #   class Project < ApplicationModel
       #     self.table_name = "project"
       #   end
       #
@@ -190,7 +190,7 @@ module ActiveRecord
       # If a sequence name is not explicitly set when using PostgreSQL, it
       # will discover the sequence corresponding to your primary key for you.
       #
-      #   class Project < ActiveRecord::Base
+      #   class Project < ApplicationModel
       #     self.sequence_name = "projectseq"   # default would have been "project_seq"
       #   end
       def sequence_name=(value)

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -46,7 +46,7 @@ module ActiveRecord
     module ClassMethods
       # Guesses the table name (in forced lower-case) based on the name of the class in the
       # inheritance hierarchy descending directly from ActiveRecord::Base. So if the hierarchy
-      # looks like: Reply < Message < ApplicationModel, then Message is used
+      # looks like: Reply < Message < ApplicationRecord, then Message is used
       # to guess the table name even when called on Reply. The rules used to do the guess
       # are handled by the Inflector class in Active Support, which knows almost all common
       # English inflections. You can add new inflections in config/initializers/inflections.rb.
@@ -56,14 +56,14 @@ module ActiveRecord
       #
       # ==== Examples
       #
-      #   class Invoice < ApplicationModel
+      #   class Invoice < ApplicationRecord
       #   end
       #
       #   file                  class               table_name
       #   invoice.rb            Invoice             invoices
       #
-      #   class Invoice < ApplicationModel
-      #     class Lineitem < ApplicationModel
+      #   class Invoice < ApplicationRecord
+      #     class Lineitem < ApplicationRecord
       #     end
       #   end
       #
@@ -71,7 +71,7 @@ module ActiveRecord
       #   invoice.rb            Invoice::Lineitem   invoice_lineitems
       #
       #   module Invoice
-      #     class Lineitem < ApplicationModel
+      #     class Lineitem < ApplicationRecord
       #     end
       #   end
       #
@@ -85,7 +85,7 @@ module ActiveRecord
       #
       # You can also set your own table name explicitly:
       #
-      #   class Mouse < ApplicationModel
+      #   class Mouse < ApplicationRecord
       #     self.table_name = "mice"
       #   end
       #
@@ -93,7 +93,7 @@ module ActiveRecord
       # own computation. (Possibly using <tt>super</tt> to manipulate the default
       # table name.) Example:
       #
-      #   class Post < ApplicationModel
+      #   class Post < ApplicationRecord
       #     def self.table_name
       #       "special_" + super
       #     end
@@ -106,7 +106,7 @@ module ActiveRecord
 
       # Sets the table name explicitly. Example:
       #
-      #   class Project < ApplicationModel
+      #   class Project < ApplicationRecord
       #     self.table_name = "project"
       #   end
       #
@@ -190,7 +190,7 @@ module ActiveRecord
       # If a sequence name is not explicitly set when using PostgreSQL, it
       # will discover the sequence corresponding to your primary key for you.
       #
-      #   class Project < ApplicationModel
+      #   class Project < ApplicationRecord
       #     self.sequence_name = "projectseq"   # default would have been "project_seq"
       #   end
       def sequence_name=(value)

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -28,7 +28,7 @@ module ActiveRecord
     # <tt>author_attributes=(attributes)</tt> and
     # <tt>pages_attributes=(attributes)</tt>.
     #
-    #   class Book < ApplicationModel
+    #   class Book < ApplicationRecord
     #     has_one :author
     #     has_many :pages
     #
@@ -42,7 +42,7 @@ module ActiveRecord
     #
     # Consider a Member model that has one Avatar:
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar
     #   end
@@ -66,7 +66,7 @@ module ActiveRecord
     # attributes hash, you have to enable it first using the
     # <tt>:allow_destroy</tt> option.
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar, allow_destroy: true
     #   end
@@ -85,7 +85,7 @@ module ActiveRecord
     #
     # Consider a member that has a number of posts:
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts
     #   end
@@ -115,7 +115,7 @@ module ActiveRecord
     # hashes if they fail to pass your criteria. For example, the previous
     # example could be rewritten as:
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: proc { |attributes| attributes['title'].blank? }
     #   end
@@ -135,12 +135,12 @@ module ActiveRecord
     #
     # Alternatively, :reject_if also accepts a symbol for using methods:
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: :new_record?
     #   end
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: :reject_posts
     #
@@ -169,7 +169,7 @@ module ActiveRecord
     # option. This will allow you to also use the <tt>_destroy</tt> key to
     # destroy existing records:
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, allow_destroy: true
     #   end
@@ -220,12 +220,12 @@ module ActiveRecord
     # record, you can use <tt>validates_presence_of</tt> and
     # <tt>inverse_of</tt> as this example illustrates:
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_many :posts, inverse_of: :member
     #     accepts_nested_attributes_for :posts
     #   end
     #
-    #   class Post < ApplicationModel
+    #   class Post < ApplicationRecord
     #     belongs_to :member, inverse_of: :posts
     #     validates_presence_of :member
     #   end
@@ -238,7 +238,7 @@ module ActiveRecord
     # child object yourself before assignment, then this module will not
     # overwrite it, e.g.:
     #
-    #   class Member < ApplicationModel
+    #   class Member < ApplicationRecord
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar
     #

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -28,7 +28,7 @@ module ActiveRecord
     # <tt>author_attributes=(attributes)</tt> and
     # <tt>pages_attributes=(attributes)</tt>.
     #
-    #   class Book < ActiveRecord::Base
+    #   class Book < ApplicationModel
     #     has_one :author
     #     has_many :pages
     #
@@ -42,7 +42,7 @@ module ActiveRecord
     #
     # Consider a Member model that has one Avatar:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar
     #   end
@@ -66,7 +66,7 @@ module ActiveRecord
     # attributes hash, you have to enable it first using the
     # <tt>:allow_destroy</tt> option.
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar, allow_destroy: true
     #   end
@@ -85,7 +85,7 @@ module ActiveRecord
     #
     # Consider a member that has a number of posts:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_many :posts
     #     accepts_nested_attributes_for :posts
     #   end
@@ -115,7 +115,7 @@ module ActiveRecord
     # hashes if they fail to pass your criteria. For example, the previous
     # example could be rewritten as:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: proc { |attributes| attributes['title'].blank? }
     #   end
@@ -135,12 +135,12 @@ module ActiveRecord
     #
     # Alternatively, :reject_if also accepts a symbol for using methods:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: :new_record?
     #   end
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: :reject_posts
     #
@@ -169,7 +169,7 @@ module ActiveRecord
     # option. This will allow you to also use the <tt>_destroy</tt> key to
     # destroy existing records:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, allow_destroy: true
     #   end
@@ -220,12 +220,12 @@ module ActiveRecord
     # record, you can use <tt>validates_presence_of</tt> and
     # <tt>inverse_of</tt> as this example illustrates:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_many :posts, inverse_of: :member
     #     accepts_nested_attributes_for :posts
     #   end
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationModel
     #     belongs_to :member, inverse_of: :posts
     #     validates_presence_of :member
     #   end
@@ -238,7 +238,7 @@ module ActiveRecord
     # child object yourself before assignment, then this module will not
     # overwrite it, e.g.:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationModel
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar
     #

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -399,11 +399,11 @@ module ActiveRecord
     #
     # If used along with +belongs_to+ then +touch+ will invoke +touch+ method on associated object.
     #
-    #   class Brake < ActiveRecord::Base
+    #   class Brake < ApplicationModel
     #     belongs_to :car, touch: true
     #   end
     #
-    #   class Car < ActiveRecord::Base
+    #   class Car < ApplicationModel
     #     belongs_to :corporation, touch: true
     #   end
     #

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -399,11 +399,11 @@ module ActiveRecord
     #
     # If used along with +belongs_to+ then +touch+ will invoke +touch+ method on associated object.
     #
-    #   class Brake < ApplicationModel
+    #   class Brake < ApplicationRecord
     #     belongs_to :car, touch: true
     #   end
     #
-    #   class Car < ApplicationModel
+    #   class Car < ApplicationRecord
     #     belongs_to :corporation, touch: true
     #   end
     #

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -178,7 +178,7 @@ module ActiveRecord
     class AssociationReflection < MacroReflection #:nodoc:
       # Returns the target association's class.
       #
-      #   class Author < ActiveRecord::Base
+      #   class Author < ApplicationModel
       #     has_many :books
       #   end
       #
@@ -482,12 +482,12 @@ module ActiveRecord
       # Returns the source of the through reflection. It checks both a singularized
       # and pluralized form for <tt>:belongs_to</tt> or <tt>:has_many</tt>.
       #
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationModel
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
       #
-      #   class Tagging < ActiveRecord::Base
+      #   class Tagging < ApplicationModel
       #     belongs_to :post
       #     belongs_to :tag
       #   end
@@ -503,7 +503,7 @@ module ActiveRecord
       # Returns the AssociationReflection object specified in the <tt>:through</tt> option
       # of a HasManyThrough or HasOneThrough association.
       #
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationModel
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
@@ -523,7 +523,7 @@ module ActiveRecord
       # reflection. The base case for the recursion is a normal association, which just returns
       # [self] as its #chain.
       #
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationModel
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
@@ -602,7 +602,7 @@ module ActiveRecord
 
       # Gets an array of possible <tt>:through</tt> source reflection names in both singular and plural form.
       #
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationModel
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
@@ -630,7 +630,7 @@ module ActiveRecord
 Ambiguous source reflection for through association.  Please specify a :source
 directive on your declaration like:
 
-  class #{active_record.name} < ActiveRecord::Base
+  class #{active_record.name} < ApplicationModel
     #{macro} :#{name}, #{example_options}
   end
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -178,7 +178,7 @@ module ActiveRecord
     class AssociationReflection < MacroReflection #:nodoc:
       # Returns the target association's class.
       #
-      #   class Author < ApplicationModel
+      #   class Author < ApplicationRecord
       #     has_many :books
       #   end
       #
@@ -482,12 +482,12 @@ module ActiveRecord
       # Returns the source of the through reflection. It checks both a singularized
       # and pluralized form for <tt>:belongs_to</tt> or <tt>:has_many</tt>.
       #
-      #   class Post < ApplicationModel
+      #   class Post < ApplicationRecord
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
       #
-      #   class Tagging < ApplicationModel
+      #   class Tagging < ApplicationRecord
       #     belongs_to :post
       #     belongs_to :tag
       #   end
@@ -503,7 +503,7 @@ module ActiveRecord
       # Returns the AssociationReflection object specified in the <tt>:through</tt> option
       # of a HasManyThrough or HasOneThrough association.
       #
-      #   class Post < ApplicationModel
+      #   class Post < ApplicationRecord
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
@@ -523,7 +523,7 @@ module ActiveRecord
       # reflection. The base case for the recursion is a normal association, which just returns
       # [self] as its #chain.
       #
-      #   class Post < ApplicationModel
+      #   class Post < ApplicationRecord
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
@@ -602,7 +602,7 @@ module ActiveRecord
 
       # Gets an array of possible <tt>:through</tt> source reflection names in both singular and plural form.
       #
-      #   class Post < ApplicationModel
+      #   class Post < ApplicationRecord
       #     has_many :taggings
       #     has_many :tags, through: :taggings
       #   end
@@ -630,7 +630,7 @@ module ActiveRecord
 Ambiguous source reflection for through association.  Please specify a :source
 directive on your declaration like:
 
-  class #{active_record.name} < ApplicationModel
+  class #{active_record.name} < ApplicationRecord
     #{macro} :#{name}, #{example_options}
   end
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -630,7 +630,7 @@ module ActiveRecord
 Ambiguous source reflection for through association.  Please specify a :source
 directive on your declaration like:
 
-  class #{active_record.name} < ApplicationRecord
+  class #{active_record.name} < ActiveRecord::Base.application_record
     #{macro} :#{name}, #{example_options}
   end
 

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -45,7 +45,7 @@ module ActiveRecord
       # that correspond to a +composed_of+ relationship with their expanded
       # aggregate attribute values.
       # Given:
-      #     class Person < ActiveRecord::Base
+      #     class Person < ApplicationModel
       #       composed_of :address, class_name: "Address",
       #         mapping: [%w(address_street street), %w(address_city city)]
       #     end

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -45,7 +45,7 @@ module ActiveRecord
       # that correspond to a +composed_of+ relationship with their expanded
       # aggregate attribute values.
       # Given:
-      #     class Person < ApplicationModel
+      #     class Person < ApplicationRecord
       #       composed_of :address, class_name: "Address",
       #         mapping: [%w(address_street street), %w(address_city city)]
       #     end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -201,7 +201,7 @@ HEADER
       end
 
       def remove_prefix_and_suffix(table)
-        table.gsub(/^(#{ActiveRecord::Base.table_name_prefix})(.+)(#{ActiveRecord::Base.table_name_suffix})$/,  "\\2")
+        table.gsub(/^(#{ActiveRecord::Base.application_record.table_name_prefix})(.+)(#{ActiveRecord::Base.application_record.table_name_suffix})$/,  "\\2")
       end
   end
 end

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -3,7 +3,7 @@ require 'active_record/scoping/named'
 require 'active_record/base'
 
 module ActiveRecord
-  class SchemaMigration < ActiveRecord::Base
+  class SchemaMigration < ApplicationModel
     class << self
 
       def table_name

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -3,7 +3,7 @@ require 'active_record/scoping/named'
 require 'active_record/base'
 
 module ActiveRecord
-  class SchemaMigration < ApplicationRecord
+  class SchemaMigration < ActiveRecord::Base.application_record
     class << self
 
       def table_name

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -3,7 +3,7 @@ require 'active_record/scoping/named'
 require 'active_record/base'
 
 module ActiveRecord
-  class SchemaMigration < ApplicationModel
+  class SchemaMigration < ApplicationRecord
     class << self
 
       def table_name

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       module ClassMethods
         # Returns a scope for the model without the +default_scope+.
         #
-        #   class Post < ActiveRecord::Base
+        #   class Post < ApplicationModel
         #     def self.default_scope
         #       where published: true
         #     end
@@ -41,7 +41,7 @@ module ActiveRecord
         # Use this macro in your model to set a default scope for all operations on
         # the model.
         #
-        #   class Article < ActiveRecord::Base
+        #   class Article < ApplicationModel
         #     default_scope { where(published: true) }
         #   end
         #
@@ -60,7 +60,7 @@ module ActiveRecord
         # If you use multiple +default_scope+ declarations in your model then
         # they will be merged together:
         #
-        #   class Article < ActiveRecord::Base
+        #   class Article < ApplicationModel
         #     default_scope { where(published: true) }
         #     default_scope { where(rating: 'G') }
         #   end
@@ -74,7 +74,7 @@ module ActiveRecord
         # If you need to do more complex things with a default scope, you can
         # alternatively define it as a class method:
         #
-        #   class Article < ActiveRecord::Base
+        #   class Article < ApplicationModel
         #     def self.default_scope
         #       # Should return a scope, you can call 'super' here etc.
         #     end

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       module ClassMethods
         # Returns a scope for the model without the +default_scope+.
         #
-        #   class Post < ApplicationModel
+        #   class Post < ApplicationRecord
         #     def self.default_scope
         #       where published: true
         #     end
@@ -41,7 +41,7 @@ module ActiveRecord
         # Use this macro in your model to set a default scope for all operations on
         # the model.
         #
-        #   class Article < ApplicationModel
+        #   class Article < ApplicationRecord
         #     default_scope { where(published: true) }
         #   end
         #
@@ -60,7 +60,7 @@ module ActiveRecord
         # If you use multiple +default_scope+ declarations in your model then
         # they will be merged together:
         #
-        #   class Article < ApplicationModel
+        #   class Article < ApplicationRecord
         #     default_scope { where(published: true) }
         #     default_scope { where(rating: 'G') }
         #   end
@@ -74,7 +74,7 @@ module ActiveRecord
         # If you need to do more complex things with a default scope, you can
         # alternatively define it as a class method:
         #
-        #   class Article < ApplicationModel
+        #   class Article < ApplicationRecord
         #     def self.default_scope
         #       # Should return a scope, you can call 'super' here etc.
         #     end

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -48,7 +48,7 @@ module ActiveRecord
         # represents a narrowing of a database query, such as
         # <tt>where(color: :red).select('shirts.*').includes(:washing_instructions)</tt>.
         #
-        #   class Shirt < ActiveRecord::Base
+        #   class Shirt < ApplicationModel
         #     scope :red, -> { where(color: 'red') }
         #     scope :dry_clean_only, -> { joins(:washing_instructions).where('washing_instructions.dry_clean_only = ?', true) }
         #   end
@@ -64,7 +64,7 @@ module ActiveRecord
         # Note that this is simply 'syntactic sugar' for defining an actual
         # class method:
         #
-        #   class Shirt < ActiveRecord::Base
+        #   class Shirt < ApplicationModel
         #     def self.red
         #       where(color: 'red')
         #     end
@@ -91,7 +91,7 @@ module ActiveRecord
         # descendant upon which the \scopes were defined. But they are also
         # available to +has_many+ associations. If,
         #
-        #   class Person < ActiveRecord::Base
+        #   class Person < ApplicationModel
         #     has_many :shirts
         #   end
         #
@@ -101,7 +101,7 @@ module ActiveRecord
         # \Named scopes can also have extensions, just as with +has_many+
         # declarations:
         #
-        #   class Shirt < ActiveRecord::Base
+        #   class Shirt < ApplicationModel
         #     scope :red, -> { where(color: 'red') } do
         #       def dom_id
         #         'red_shirts'
@@ -111,7 +111,7 @@ module ActiveRecord
         #
         # Scopes can also be used while creating/building a record.
         #
-        #   class Article < ActiveRecord::Base
+        #   class Article < ApplicationModel
         #     scope :published, -> { where(published: true) }
         #   end
         #
@@ -121,7 +121,7 @@ module ActiveRecord
         # \Class methods on your model are automatically available
         # on scopes. Assuming the following setup:
         #
-        #   class Article < ActiveRecord::Base
+        #   class Article < ApplicationModel
         #     scope :published, -> { where(published: true) }
         #     scope :featured, -> { where(featured: true) }
         #

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -48,7 +48,7 @@ module ActiveRecord
         # represents a narrowing of a database query, such as
         # <tt>where(color: :red).select('shirts.*').includes(:washing_instructions)</tt>.
         #
-        #   class Shirt < ApplicationModel
+        #   class Shirt < ApplicationRecord
         #     scope :red, -> { where(color: 'red') }
         #     scope :dry_clean_only, -> { joins(:washing_instructions).where('washing_instructions.dry_clean_only = ?', true) }
         #   end
@@ -64,7 +64,7 @@ module ActiveRecord
         # Note that this is simply 'syntactic sugar' for defining an actual
         # class method:
         #
-        #   class Shirt < ApplicationModel
+        #   class Shirt < ApplicationRecord
         #     def self.red
         #       where(color: 'red')
         #     end
@@ -91,7 +91,7 @@ module ActiveRecord
         # descendant upon which the \scopes were defined. But they are also
         # available to +has_many+ associations. If,
         #
-        #   class Person < ApplicationModel
+        #   class Person < ApplicationRecord
         #     has_many :shirts
         #   end
         #
@@ -101,7 +101,7 @@ module ActiveRecord
         # \Named scopes can also have extensions, just as with +has_many+
         # declarations:
         #
-        #   class Shirt < ApplicationModel
+        #   class Shirt < ApplicationRecord
         #     scope :red, -> { where(color: 'red') } do
         #       def dom_id
         #         'red_shirts'
@@ -111,7 +111,7 @@ module ActiveRecord
         #
         # Scopes can also be used while creating/building a record.
         #
-        #   class Article < ApplicationModel
+        #   class Article < ApplicationRecord
         #     scope :published, -> { where(published: true) }
         #   end
         #
@@ -121,7 +121,7 @@ module ActiveRecord
         # \Class methods on your model are automatically available
         # on scopes. Assuming the following setup:
         #
-        #   class Article < ApplicationModel
+        #   class Article < ApplicationRecord
         #     scope :published, -> { where(published: true) }
         #     scope :featured, -> { where(featured: true) }
         #

--- a/activerecord/lib/active_record/serializers/xml_serializer.rb
+++ b/activerecord/lib/active_record/serializers/xml_serializer.rb
@@ -160,7 +160,7 @@ module ActiveRecord #:nodoc:
     # subclasses to have complete control about what's generated. The general
     # form of doing this is:
     #
-    #   class IHaveMyOwnXML < ActiveRecord::Base
+    #   class IHaveMyOwnXML < ApplicationModel
     #     def to_xml(options = {})
     #       require 'builder'
     #       options[:indent] ||= 2

--- a/activerecord/lib/active_record/serializers/xml_serializer.rb
+++ b/activerecord/lib/active_record/serializers/xml_serializer.rb
@@ -160,7 +160,7 @@ module ActiveRecord #:nodoc:
     # subclasses to have complete control about what's generated. The general
     # form of doing this is:
     #
-    #   class IHaveMyOwnXML < ApplicationModel
+    #   class IHaveMyOwnXML < ApplicationRecord
     #     def to_xml(options = {})
     #       require 'builder'
     #       options[:indent] ||= 2

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -17,7 +17,7 @@ module ActiveRecord
   #
   # Examples:
   #
-  #   class User < ActiveRecord::Base
+  #   class User < ApplicationModel
   #     store :settings, accessors: [ :color, :homepage ], coder: JSON
   #   end
   #
@@ -45,7 +45,7 @@ module ActiveRecord
   # the default accessors (using the same name as the attribute) and calling <tt>super</tt>
   # to actually change things.
   #
-  #   class Song < ActiveRecord::Base
+  #   class Song < ApplicationModel
   #     # Uses a stored integer to hold the volume adjustment of the song
   #     store :settings, accessors: [:volume_adjustment]
   #

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -17,7 +17,7 @@ module ActiveRecord
   #
   # Examples:
   #
-  #   class User < ApplicationModel
+  #   class User < ApplicationRecord
   #     store :settings, accessors: [ :color, :homepage ], coder: JSON
   #   end
   #
@@ -45,7 +45,7 @@ module ActiveRecord
   # the default accessors (using the same name as the attribute) and calling <tt>super</tt>
   # to actually change things.
   #
-  #   class Song < ApplicationModel
+  #   class Song < ApplicationRecord
   #     # Uses a stored integer to hold the volume adjustment of the song
   #     store :settings, accessors: [:volume_adjustment]
   #

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -25,7 +25,7 @@ module ActiveRecord
   # If your attributes are time zone aware and you desire to skip time zone conversion to the current Time.zone
   # when reading certain attributes then you can do following:
   #
-  #   class Topic < ActiveRecord::Base
+  #   class Topic < ApplicationModel
   #     self.skip_time_zone_conversion_for_attributes = [:written_on]
   #   end
   module Timestamp

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -25,7 +25,7 @@ module ActiveRecord
   # If your attributes are time zone aware and you desire to skip time zone conversion to the current Time.zone
   # when reading certain attributes then you can do following:
   #
-  #   class Topic < ApplicationModel
+  #   class Topic < ApplicationRecord
   #     self.skip_time_zone_conversion_for_attributes = [:written_on]
   #   end
   module Timestamp

--- a/activerecord/lib/active_record/translation.rb
+++ b/activerecord/lib/active_record/translation.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     def lookup_ancestors #:nodoc:
       klass = self
       classes = [klass]
-      return classes if klass == ActiveRecord::Base
+      return classes if klass == ActiveRecord::Base || klass == ApplicationRecord
 
       while klass != klass.base_class
         classes << klass = klass.superclass

--- a/activerecord/lib/active_record/translation.rb
+++ b/activerecord/lib/active_record/translation.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     def lookup_ancestors #:nodoc:
       klass = self
       classes = [klass]
-      return classes if klass == ActiveRecord::Base || klass == ApplicationRecord
+      return classes if klass == ActiveRecord::Base.application_record || klass == ActiveRecord::Base
 
       while klass != klass.base_class
         classes << klass = klass.superclass

--- a/activerecord/lib/active_record/validations/associated.rb
+++ b/activerecord/lib/active_record/validations/associated.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       # Validates whether the associated object or objects are all valid.
       # Works with any kind of association.
       #
-      #   class Book < ApplicationModel
+      #   class Book < ApplicationRecord
       #     has_many :pages
       #     belongs_to :library
       #

--- a/activerecord/lib/active_record/validations/associated.rb
+++ b/activerecord/lib/active_record/validations/associated.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       # Validates whether the associated object or objects are all valid.
       # Works with any kind of association.
       #
-      #   class Book < ActiveRecord::Base
+      #   class Book < ApplicationModel
       #     has_many :pages
       #     belongs_to :library
       #

--- a/activerecord/lib/active_record/validations/presence.rb
+++ b/activerecord/lib/active_record/validations/presence.rb
@@ -21,7 +21,7 @@ module ActiveRecord
       # associated object is not marked for destruction. Happens by default
       # on save.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     has_one :face
       #     validates_presence_of :face
       #   end

--- a/activerecord/lib/active_record/validations/presence.rb
+++ b/activerecord/lib/active_record/validations/presence.rb
@@ -21,7 +21,7 @@ module ActiveRecord
       # associated object is not marked for destruction. Happens by default
       # on save.
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     has_one :face
       #     validates_presence_of :face
       #   end

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -90,14 +90,14 @@ module ActiveRecord
       # across the system. Useful for making sure that only one user
       # can be named "davidhh".
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     validates_uniqueness_of :user_name
       #   end
       #
       # It can also validate whether the value of the specified attributes are
       # unique based on a <tt>:scope</tt> parameter:
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationModel
       #     validates_uniqueness_of :user_name, scope: :account_id
       #   end
       #
@@ -105,7 +105,7 @@ module ActiveRecord
       # teacher can only be on the schedule once per semester for a particular
       # class.
       #
-      #   class TeacherSchedule < ActiveRecord::Base
+      #   class TeacherSchedule < ApplicationModel
       #     validates_uniqueness_of :teacher_id, scope: [:semester_id, :class_id]
       #   end
       #
@@ -114,7 +114,7 @@ module ActiveRecord
       # are not being taken into consideration when validating uniqueness
       # of the title attribute:
       #
-      #   class Article < ActiveRecord::Base
+      #   class Article < ApplicationModel
       #     validates_uniqueness_of :title, conditions: -> { where.not(status: 'archived') }
       #   end
       #

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -90,14 +90,14 @@ module ActiveRecord
       # across the system. Useful for making sure that only one user
       # can be named "davidhh".
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     validates_uniqueness_of :user_name
       #   end
       #
       # It can also validate whether the value of the specified attributes are
       # unique based on a <tt>:scope</tt> parameter:
       #
-      #   class Person < ApplicationModel
+      #   class Person < ApplicationRecord
       #     validates_uniqueness_of :user_name, scope: :account_id
       #   end
       #
@@ -105,7 +105,7 @@ module ActiveRecord
       # teacher can only be on the schedule once per semester for a particular
       # class.
       #
-      #   class TeacherSchedule < ApplicationModel
+      #   class TeacherSchedule < ApplicationRecord
       #     validates_uniqueness_of :teacher_id, scope: [:semester_id, :class_id]
       #   end
       #
@@ -114,7 +114,7 @@ module ActiveRecord
       # are not being taken into consideration when validating uniqueness
       # of the title attribute:
       #
-      #   class Article < ApplicationModel
+      #   class Article < ApplicationRecord
       #     validates_uniqueness_of :title, conditions: -> { where.not(status: 'archived') }
       #   end
       #

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -44,7 +44,7 @@ module ActiveRecord
 
         # Used by the migration template to determine the parent name of the model
         def parent_class_name
-          options[:parent] || "ApplicationModel"
+          options[:parent] || "ApplicationRecord"
         end
 
     end

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -44,7 +44,7 @@ module ActiveRecord
 
         # Used by the migration template to determine the parent name of the model
         def parent_class_name
-          options[:parent] || "ActiveRecord::Base"
+          options[:parent] || "ApplicationModel"
         end
 
     end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -183,7 +183,7 @@ module ActiveRecord
   class AdapterTestWithoutTransaction < ActiveRecord::TestCase
     self.use_transactional_fixtures = false
 
-    class Klass < ApplicationModel
+    class Klass < ApplicationRecord
     end
 
     def setup

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -183,7 +183,7 @@ module ActiveRecord
   class AdapterTestWithoutTransaction < ActiveRecord::TestCase
     self.use_transactional_fixtures = false
 
-    class Klass < ActiveRecord::Base
+    class Klass < ApplicationModel
     end
 
     def setup

--- a/activerecord/test/cases/adapters/mysql/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql/case_sensitivity_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require 'models/person'
 
 class MysqlCaseSensitivityTest < ActiveRecord::TestCase
-  class CollationTest < ActiveRecord::Base
+  class CollationTest < ApplicationModel
     validates_uniqueness_of :string_cs_column, :case_sensitive => false
     validates_uniqueness_of :string_ci_column, :case_sensitive => false
   end

--- a/activerecord/test/cases/adapters/mysql/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql/case_sensitivity_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require 'models/person'
 
 class MysqlCaseSensitivityTest < ActiveRecord::TestCase
-  class CollationTest < ApplicationModel
+  class CollationTest < ApplicationRecord
     validates_uniqueness_of :string_cs_column, :case_sensitive => false
     validates_uniqueness_of :string_ci_column, :case_sensitive => false
   end

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class MysqlConnectionTest < ActiveRecord::TestCase
-  class Klass < ActiveRecord::Base
+  class Klass < ApplicationModel
   end
 
   def setup

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class MysqlConnectionTest < ActiveRecord::TestCase
-  class Klass < ApplicationModel
+  class Klass < ApplicationRecord
   end
 
   def setup

--- a/activerecord/test/cases/adapters/mysql/enum_test.rb
+++ b/activerecord/test/cases/adapters/mysql/enum_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class MysqlEnumTest < ActiveRecord::TestCase
-  class EnumTest < ActiveRecord::Base
+  class EnumTest < ApplicationModel
   end
 
   def test_enum_limit

--- a/activerecord/test/cases/adapters/mysql/enum_test.rb
+++ b/activerecord/test/cases/adapters/mysql/enum_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class MysqlEnumTest < ActiveRecord::TestCase
-  class EnumTest < ApplicationModel
+  class EnumTest < ApplicationRecord
   end
 
   def test_enum_limit

--- a/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
@@ -1,21 +1,21 @@
 require "cases/helper"
 
-class Group < ApplicationModel
+class Group < ApplicationRecord
   Group.table_name = 'group'
   belongs_to :select
   has_one :values
 end
 
-class Select < ApplicationModel
+class Select < ApplicationRecord
   Select.table_name = 'select'
   has_many :groups
 end
 
-class Values < ApplicationModel
+class Values < ApplicationRecord
   Values.table_name = 'values'
 end
 
-class Distinct < ApplicationModel
+class Distinct < ApplicationRecord
   Distinct.table_name = 'distinct'
   has_and_belongs_to_many :selects
   has_many :values, :through => :groups

--- a/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
@@ -1,21 +1,21 @@
 require "cases/helper"
 
-class Group < ActiveRecord::Base
+class Group < ApplicationModel
   Group.table_name = 'group'
   belongs_to :select
   has_one :values
 end
 
-class Select < ActiveRecord::Base
+class Select < ApplicationModel
   Select.table_name = 'select'
   has_many :groups
 end
 
-class Values < ActiveRecord::Base
+class Values < ApplicationModel
   Values.table_name = 'values'
 end
 
-class Distinct < ActiveRecord::Base
+class Distinct < ApplicationModel
   Distinct.table_name = 'distinct'
   has_and_belongs_to_many :selects
   has_many :values, :through => :groups

--- a/activerecord/test/cases/adapters/mysql/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/schema_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         table       = Post.table_name
         @db_name    = db
 
-        @omgpost = Class.new(ActiveRecord::Base) do
+        @omgpost = Class.new(ApplicationRecord) do
           self.table_name = "#{db}.#{table}"
           def self.name; 'Post'; end
         end

--- a/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require 'models/person'
 
 class Mysql2CaseSensitivityTest < ActiveRecord::TestCase
-  class CollationTest < ApplicationModel
+  class CollationTest < ApplicationRecord
     validates_uniqueness_of :string_cs_column, :case_sensitive => false
     validates_uniqueness_of :string_ci_column, :case_sensitive => false
   end

--- a/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require 'models/person'
 
 class Mysql2CaseSensitivityTest < ActiveRecord::TestCase
-  class CollationTest < ActiveRecord::Base
+  class CollationTest < ApplicationModel
     validates_uniqueness_of :string_cs_column, :case_sensitive => false
     validates_uniqueness_of :string_ci_column, :case_sensitive => false
   end

--- a/activerecord/test/cases/adapters/mysql2/enum_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/enum_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class Mysql2EnumTest < ActiveRecord::TestCase
-  class EnumTest < ApplicationModel
+  class EnumTest < ApplicationRecord
   end
 
   def test_enum_limit

--- a/activerecord/test/cases/adapters/mysql2/enum_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/enum_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class Mysql2EnumTest < ActiveRecord::TestCase
-  class EnumTest < ActiveRecord::Base
+  class EnumTest < ApplicationModel
   end
 
   def test_enum_limit

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -1,21 +1,21 @@
 require "cases/helper"
 
-class Group < ApplicationModel
+class Group < ApplicationRecord
   Group.table_name = 'group'
   belongs_to :select
   has_one :values
 end
 
-class Select < ApplicationModel
+class Select < ApplicationRecord
   Select.table_name = 'select'
   has_many :groups
 end
 
-class Values < ApplicationModel
+class Values < ApplicationRecord
   Values.table_name = 'values'
 end
 
-class Distinct < ApplicationModel
+class Distinct < ApplicationRecord
   Distinct.table_name = 'distinct'
   has_and_belongs_to_many :selects
   has_many :values, :through => :groups

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -1,21 +1,21 @@
 require "cases/helper"
 
-class Group < ActiveRecord::Base
+class Group < ApplicationModel
   Group.table_name = 'group'
   belongs_to :select
   has_one :values
 end
 
-class Select < ActiveRecord::Base
+class Select < ApplicationModel
   Select.table_name = 'select'
   has_many :groups
 end
 
-class Values < ActiveRecord::Base
+class Values < ApplicationModel
   Values.table_name = 'values'
 end
 
-class Distinct < ActiveRecord::Base
+class Distinct < ApplicationModel
   Distinct.table_name = 'distinct'
   has_and_belongs_to_many :selects
   has_many :values, :through => :groups

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         table       = Post.table_name
         @db_name    = db
 
-        @omgpost = Class.new(ActiveRecord::Base) do
+        @omgpost = Class.new(ApplicationRecord) do
           self.table_name = "#{db}.#{table}"
           def self.name; 'Post'; end
         end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -4,7 +4,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlArrayTest < ActiveRecord::TestCase
-  class PgArray < ActiveRecord::Base
+  class PgArray < ApplicationModel
     self.table_name = 'pg_arrays'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -4,7 +4,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlArrayTest < ActiveRecord::TestCase
-  class PgArray < ApplicationModel
+  class PgArray < ApplicationRecord
     self.table_name = 'pg_arrays'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlByteaTest < ActiveRecord::TestCase
-  class ByteaDataType < ActiveRecord::Base
+  class ByteaDataType < ApplicationModel
     self.table_name = 'bytea_data_type'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlByteaTest < ActiveRecord::TestCase
-  class ByteaDataType < ApplicationModel
+  class ByteaDataType < ApplicationRecord
     self.table_name = 'bytea_data_type'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 
 module ActiveRecord
   class PostgresqlConnectionTest < ActiveRecord::TestCase
-    class NonExistentTable < ApplicationModel
+    class NonExistentTable < ApplicationRecord
     end
 
     def setup

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 
 module ActiveRecord
   class PostgresqlConnectionTest < ActiveRecord::TestCase
-    class NonExistentTable < ActiveRecord::Base
+    class NonExistentTable < ApplicationModel
     end
 
     def setup

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -1,39 +1,39 @@
 require "cases/helper"
 
-class PostgresqlArray < ActiveRecord::Base
+class PostgresqlArray < ApplicationModel
 end
 
-class PostgresqlRange < ActiveRecord::Base
+class PostgresqlRange < ApplicationModel
 end
 
-class PostgresqlTsvector < ActiveRecord::Base
+class PostgresqlTsvector < ApplicationModel
 end
 
-class PostgresqlMoney < ActiveRecord::Base
+class PostgresqlMoney < ApplicationModel
 end
 
-class PostgresqlNumber < ActiveRecord::Base
+class PostgresqlNumber < ApplicationModel
 end
 
-class PostgresqlTime < ActiveRecord::Base
+class PostgresqlTime < ApplicationModel
 end
 
-class PostgresqlNetworkAddress < ActiveRecord::Base
+class PostgresqlNetworkAddress < ApplicationModel
 end
 
-class PostgresqlBitString < ActiveRecord::Base
+class PostgresqlBitString < ApplicationModel
 end
 
-class PostgresqlOid < ActiveRecord::Base
+class PostgresqlOid < ApplicationModel
 end
 
-class PostgresqlTimestampWithZone < ActiveRecord::Base
+class PostgresqlTimestampWithZone < ApplicationModel
 end
 
-class PostgresqlUUID < ActiveRecord::Base
+class PostgresqlUUID < ApplicationModel
 end
 
-class PostgresqlLtree < ActiveRecord::Base
+class PostgresqlLtree < ApplicationModel
 end
 
 class PostgresqlDataTypeTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -1,39 +1,39 @@
 require "cases/helper"
 
-class PostgresqlArray < ApplicationModel
+class PostgresqlArray < ApplicationRecord
 end
 
-class PostgresqlRange < ApplicationModel
+class PostgresqlRange < ApplicationRecord
 end
 
-class PostgresqlTsvector < ApplicationModel
+class PostgresqlTsvector < ApplicationRecord
 end
 
-class PostgresqlMoney < ApplicationModel
+class PostgresqlMoney < ApplicationRecord
 end
 
-class PostgresqlNumber < ApplicationModel
+class PostgresqlNumber < ApplicationRecord
 end
 
-class PostgresqlTime < ApplicationModel
+class PostgresqlTime < ApplicationRecord
 end
 
-class PostgresqlNetworkAddress < ApplicationModel
+class PostgresqlNetworkAddress < ApplicationRecord
 end
 
-class PostgresqlBitString < ApplicationModel
+class PostgresqlBitString < ApplicationRecord
 end
 
-class PostgresqlOid < ApplicationModel
+class PostgresqlOid < ApplicationRecord
 end
 
-class PostgresqlTimestampWithZone < ApplicationModel
+class PostgresqlTimestampWithZone < ApplicationRecord
 end
 
-class PostgresqlUUID < ApplicationModel
+class PostgresqlUUID < ApplicationRecord
 end
 
-class PostgresqlLtree < ApplicationModel
+class PostgresqlLtree < ApplicationRecord
 end
 
 class PostgresqlDataTypeTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlHstoreTest < ActiveRecord::TestCase
-  class Hstore < ActiveRecord::Base
+  class Hstore < ApplicationModel
     self.table_name = 'hstores'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlHstoreTest < ActiveRecord::TestCase
-  class Hstore < ApplicationModel
+  class Hstore < ApplicationRecord
     self.table_name = 'hstores'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlJSONTest < ActiveRecord::TestCase
-  class JsonDataType < ApplicationModel
+  class JsonDataType < ApplicationRecord
     self.table_name = 'json_data_type'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlJSONTest < ActiveRecord::TestCase
-  class JsonDataType < ActiveRecord::Base
+  class JsonDataType < ApplicationModel
     self.table_name = 'json_data_type'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/ltree_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/ltree_test.rb
@@ -4,7 +4,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlLtreeTest < ActiveRecord::TestCase
-  class Ltree < ActiveRecord::Base
+  class Ltree < ApplicationModel
     self.table_name = 'ltrees'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/ltree_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/ltree_test.rb
@@ -4,7 +4,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlLtreeTest < ActiveRecord::TestCase
-  class Ltree < ApplicationModel
+  class Ltree < ApplicationRecord
     self.table_name = 'ltrees'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class SchemaThing < ActiveRecord::Base
+class SchemaThing < ApplicationModel
 end
 
 class SchemaAuthorizationTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class SchemaThing < ApplicationModel
+class SchemaThing < ApplicationRecord
 end
 
 class SchemaAuthorizationTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -30,23 +30,23 @@ class SchemaTest < ActiveRecord::TestCase
   UNMATCHED_SEQUENCE_NAME = 'unmatched_primary_key_default_value_seq'
   UNMATCHED_PK_TABLE_NAME = 'table_with_unmatched_sequence_for_pk'
 
-  class Thing1 < ApplicationModel
+  class Thing1 < ApplicationRecord
     self.table_name = "test_schema.things"
   end
 
-  class Thing2 < ApplicationModel
+  class Thing2 < ApplicationRecord
     self.table_name = "test_schema2.things"
   end
 
-  class Thing3 < ApplicationModel
+  class Thing3 < ApplicationRecord
     self.table_name = 'test_schema."things.table"'
   end
 
-  class Thing4 < ApplicationModel
+  class Thing4 < ApplicationRecord
     self.table_name = 'test_schema."Things"'
   end
 
-  class Thing5 < ApplicationModel
+  class Thing5 < ApplicationRecord
     self.table_name = 'things'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -30,23 +30,23 @@ class SchemaTest < ActiveRecord::TestCase
   UNMATCHED_SEQUENCE_NAME = 'unmatched_primary_key_default_value_seq'
   UNMATCHED_PK_TABLE_NAME = 'table_with_unmatched_sequence_for_pk'
 
-  class Thing1 < ActiveRecord::Base
+  class Thing1 < ApplicationModel
     self.table_name = "test_schema.things"
   end
 
-  class Thing2 < ActiveRecord::Base
+  class Thing2 < ApplicationModel
     self.table_name = "test_schema2.things"
   end
 
-  class Thing3 < ActiveRecord::Base
+  class Thing3 < ApplicationModel
     self.table_name = 'test_schema."things.table"'
   end
 
-  class Thing4 < ActiveRecord::Base
+  class Thing4 < ApplicationModel
     self.table_name = 'test_schema."Things"'
   end
 
-  class Thing5 < ActiveRecord::Base
+  class Thing5 < ApplicationModel
     self.table_name = 'things'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlUUIDTest < ActiveRecord::TestCase
-  class UUID < ApplicationModel
+  class UUID < ApplicationRecord
     self.table_name = 'pg_uuids'
   end
 
@@ -65,7 +65,7 @@ class PostgresqlUUIDTest < ActiveRecord::TestCase
 end
 
 class PostgresqlUUIDTestNilDefault < ActiveRecord::TestCase
-  class UUID < ApplicationModel
+  class UUID < ApplicationRecord
     self.table_name = 'pg_uuids'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlUUIDTest < ActiveRecord::TestCase
-  class UUID < ActiveRecord::Base
+  class UUID < ApplicationModel
     self.table_name = 'pg_uuids'
   end
 
@@ -65,7 +65,7 @@ class PostgresqlUUIDTest < ActiveRecord::TestCase
 end
 
 class PostgresqlUUIDTestNilDefault < ActiveRecord::TestCase
-  class UUID < ActiveRecord::Base
+  class UUID < ApplicationModel
     self.table_name = 'pg_uuids'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/view_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/view_test.rb
@@ -13,7 +13,7 @@ class ViewTest < ActiveRecord::TestCase
     'moment timestamp without time zone'
   ]
 
-  class ThingView < ApplicationModel
+  class ThingView < ApplicationRecord
     self.table_name = 'test_schema.view_things'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/view_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/view_test.rb
@@ -13,7 +13,7 @@ class ViewTest < ActiveRecord::TestCase
     'moment timestamp without time zone'
   ]
 
-  class ThingView < ActiveRecord::Base
+  class ThingView < ApplicationModel
     self.table_name = 'test_schema.view_things'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/xml_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/xml_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlXMLTest < ActiveRecord::TestCase
-  class XmlDataType < ApplicationModel
+  class XmlDataType < ApplicationRecord
     self.table_name = 'xml_data_type'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/xml_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/xml_test.rb
@@ -5,7 +5,7 @@ require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlXMLTest < ActiveRecord::TestCase
-  class XmlDataType < ActiveRecord::Base
+  class XmlDataType < ApplicationModel
     self.table_name = 'xml_data_type'
   end
 

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     class SQLite3AdapterTest < ActiveRecord::TestCase
       self.use_transactional_fixtures = false
 
-      class DualEncoding < ActiveRecord::Base
+      class DualEncoding < ApplicationModel
       end
 
       def setup

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     class SQLite3AdapterTest < ActiveRecord::TestCase
       self.use_transactional_fixtures = false
 
-      class DualEncoding < ApplicationModel
+      class DualEncoding < ApplicationRecord
       end
 
       def setup

--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -143,7 +143,7 @@ end
 class OverridingAggregationsTest < ActiveRecord::TestCase
   class DifferentName; end
 
-  class Person < ActiveRecord::Base
+  class Person < ApplicationModel
     composed_of :composed_of, :mapping => %w(person_first_name first_name)
   end
 

--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -143,7 +143,7 @@ end
 class OverridingAggregationsTest < ActiveRecord::TestCase
   class DifferentName; end
 
-  class Person < ApplicationModel
+  class Person < ApplicationRecord
     composed_of :composed_of, :mapping => %w(person_first_name first_name)
   end
 

--- a/activerecord/test/cases/application_configuration_test.rb
+++ b/activerecord/test/cases/application_configuration_test.rb
@@ -1,0 +1,54 @@
+require 'cases/helper'
+
+module SomeNamespace
+  class ApplicationRecord < ::ApplicationRecord
+    configs_from(SomeNamespace)
+  end
+
+  class SomeModel < ApplicationRecord
+  end
+end
+
+class AnotherModel < ApplicationRecord
+end
+
+class ApplicationConfigurationTest < ActiveRecord::TestCase
+  def test_base_application_record
+    assert_equal ApplicationRecord, ActiveRecord::Base.application_record
+  end
+
+  def test_application_record_method_on_namespace
+    assert_equal SomeNamespace::ApplicationRecord, SomeNamespace::ApplicationRecord.application_record
+    assert_equal ApplicationRecord, ApplicationRecord.application_record
+    assert_nothing_raised do
+      assert_equal SomeNamespace::ApplicationRecord, SomeNamespace::ApplicationRecord.application_record('some_object')
+      assert_equal ApplicationRecord, ApplicationRecord.application_record('some_object')
+    end
+  end
+
+  def test_application_record_method_on_model
+    assert_equal SomeNamespace::ApplicationRecord, SomeNamespace::SomeModel.application_record
+    assert_equal ApplicationRecord, AnotherModel.application_record
+
+    assert_nothing_raised do
+      assert_equal SomeNamespace::ApplicationRecord, SomeNamespace::SomeModel.application_record('another_object')
+      assert_equal ApplicationRecord, AnotherModel.application_record('another_object')
+    end
+  end
+
+  def test_application_record_method_on_module
+    assert_equal SomeNamespace::ApplicationRecord, SomeNamespace.application_record
+    assert_nothing_raised do
+      assert_equal SomeNamespace::ApplicationRecord, SomeNamespace.application_record('one_more_object')
+    end
+  end
+
+  def test_arguments_passed_into_application_record_on_ar_base
+    assert_equal SomeNamespace::ApplicationRecord, ActiveRecord::Base.application_record(SomeNamespace)
+    assert_equal SomeNamespace::ApplicationRecord, ActiveRecord::Base.application_record(SomeNamespace::SomeModel)
+    assert_equal SomeNamespace::ApplicationRecord, ActiveRecord::Base.application_record(SomeNamespace::ApplicationRecord)
+
+    assert_equal ApplicationRecord, ActiveRecord::Base.application_record(AnotherModel)
+    assert_equal ApplicationRecord, ActiveRecord::Base.application_record(ApplicationRecord)
+  end
+end

--- a/activerecord/test/cases/application_record_test.rb
+++ b/activerecord/test/cases/application_record_test.rb
@@ -1,0 +1,159 @@
+require 'cases/helper'
+require 'models/topic'
+
+class ModelBaseInherited < ActiveRecord::Base
+  class << self
+    # Use the Man table
+    def table_name
+      "men"
+    end
+
+    def reset_configs
+      self.table_name_prefix = ""
+      self.table_name_suffix = ""
+    end
+  end
+end
+
+class ModelAppRecordInherited < ApplicationRecord
+end
+
+class ModelDoubleInherited < ModelAppRecordInherited
+end
+
+class ApplicationRecordTest < ActiveRecord::TestCase
+  fixtures :topics
+
+  def test_changing_prefix_on_ar_base
+    prefix = 'my_prefix'
+    ActiveRecord::Base.table_name_prefix = prefix
+    assert_equal prefix, ModelBaseInherited.table_name_prefix
+    assert_equal prefix, ModelAppRecordInherited.table_name_prefix
+  end
+
+  def test_changing_prefix_on_ar_base_inherited_model
+    prefix = 'my_prefix'
+    new_prefix = 'new_prefix'
+    ActiveRecord::Base.table_name_prefix = prefix
+    ModelBaseInherited.table_name_prefix = new_prefix
+
+    assert_equal new_prefix, ModelBaseInherited.table_name_prefix
+    assert_equal prefix, ActiveRecord::Base.table_name_prefix
+  end
+
+  def test_changing_prefix_on_application_record_inherited_model
+    prefix = 'my_prefix'
+    new_prefix = 'new_prefix'
+    ActiveRecord::Base.table_name_prefix = prefix
+    Topic.table_name_prefix = new_prefix
+
+    assert_equal new_prefix, Topic.table_name_prefix
+    assert_equal prefix, ActiveRecord::Base.table_name_prefix
+  end
+
+  def test_double_inheritence_rules
+    top_suffix = ActiveRecord::Base.table_name_suffix
+    new_suffix = 'some_new_suffix'
+    newest_suffix = 'an_even_newer_suffix'
+
+    ModelAppRecordInherited.table_name_suffix = new_suffix
+    assert_equal top_suffix, ActiveRecord::Base.table_name_suffix
+    assert_equal new_suffix, ModelAppRecordInherited.table_name_suffix
+    assert_equal new_suffix, ModelDoubleInherited.table_name_suffix
+
+    ModelDoubleInherited.table_name_suffix = newest_suffix
+    assert_equal top_suffix, ActiveRecord::Base.table_name_suffix
+    assert_equal new_suffix, ModelAppRecordInherited.table_name_suffix
+    assert_equal newest_suffix, ModelDoubleInherited.table_name_suffix
+  end
+
+  def test_creating_new_record_from_base_inherited
+    ModelBaseInherited.reset_configs
+
+    assert_nothing_raised do
+      ModelBaseInherited.new
+    end
+  end
+
+  def test_persisting_new_record_from_base_inherited
+    ModelBaseInherited.reset_configs
+
+    man = ModelBaseInherited.new
+    man.name = 'John Wang'
+    assert_nothing_raised { man.save }
+
+    assert_equal man.id, ModelBaseInherited.find_by_name('John Wang').id
+  end
+end
+
+class MultipleApplicationRecordTest < ActiveRecord::TestCase
+  module FirstNamespace
+    class ApplicationRecord < ::ApplicationRecord
+    end
+
+    class SomeModel < ApplicationRecord
+    end
+  end
+
+  module SecondNamespace
+    class ApplicationRecord < ::ApplicationRecord
+    end
+
+    class SomeModel < ApplicationRecord
+    end
+  end
+
+  def test_changing_config_in_namespaces_are_isolated
+    FirstNamespace::SomeModel.pluralize_table_names = false
+    SecondNamespace::SomeModel.pluralize_table_names = true
+
+    assert !FirstNamespace::SomeModel.pluralize_table_names
+    assert SecondNamespace::SomeModel.pluralize_table_names
+
+    FirstNamespace::SomeModel.pluralize_table_names = true
+  end
+
+  def test_changing_config_on_models_isolated_across_namespaces
+    format = :number
+    ApplicationRecord.cache_timestamp_format = format
+    assert_equal format, FirstNamespace::SomeModel.cache_timestamp_format
+    assert_equal format, SecondNamespace::SomeModel.cache_timestamp_format
+
+    new_format = :long
+    FirstNamespace::SomeModel.cache_timestamp_format = new_format
+    assert_equal format, ApplicationRecord.cache_timestamp_format
+    assert_equal new_format, FirstNamespace::SomeModel.cache_timestamp_format
+    assert_equal format, SecondNamespace::SomeModel.cache_timestamp_format
+  end
+
+  def test_changing_module_application_record_does_not_propogate
+    original_prefix = ApplicationRecord.table_name_prefix
+    first_prefix = 'first_prefix'
+    second_prefix = 'second_prefix'
+
+    FirstNamespace::ApplicationRecord.table_name_prefix = first_prefix
+    SecondNamespace::ApplicationRecord.table_name_prefix = second_prefix
+
+    assert_equal first_prefix, FirstNamespace::ApplicationRecord.table_name_prefix
+    assert_equal second_prefix, SecondNamespace::ApplicationRecord.table_name_prefix
+    assert_equal first_prefix, FirstNamespace::SomeModel.table_name_prefix
+    assert_equal second_prefix, SecondNamespace::SomeModel.table_name_prefix
+    assert_equal original_prefix, ApplicationRecord.table_name_prefix
+  end
+
+  def test_changing_config_on_model_does_not_move_up_ancestor_chain
+    base_scopes = ActiveRecord::Base.default_scopes
+    app_record_scopes = ApplicationRecord.default_scopes
+    first_namespace_scopes = FirstNamespace::ApplicationRecord.default_scopes
+    second_namespace_scopes = SecondNamespace::ApplicationRecord.default_scopes
+    new_scopes = [ proc {} ]
+
+    FirstNamespace::SomeModel.default_scopes = new_scopes
+
+    assert_equal new_scopes, FirstNamespace::SomeModel.default_scopes
+    assert_equal base_scopes, ActiveRecord::Base.default_scopes
+    assert_equal app_record_scopes, ApplicationRecord.default_scopes
+    assert_equal first_namespace_scopes, FirstNamespace::ApplicationRecord.default_scopes
+    assert_equal second_namespace_scopes, SecondNamespace::ApplicationRecord.default_scopes
+  end
+end

--- a/activerecord/test/cases/application_record_test.rb
+++ b/activerecord/test/cases/application_record_test.rb
@@ -29,6 +29,7 @@ class ApplicationRecordTest < ActiveRecord::TestCase
     ActiveRecord::Base.table_name_prefix = prefix
     assert_equal prefix, ModelBaseInherited.table_name_prefix
     assert_equal prefix, ModelAppRecordInherited.table_name_prefix
+    ActiveRecord::Base.table_name_prefix = ""
   end
 
   def test_changing_prefix_on_ar_base_inherited_model
@@ -39,6 +40,7 @@ class ApplicationRecordTest < ActiveRecord::TestCase
 
     assert_equal new_prefix, ModelBaseInherited.table_name_prefix
     assert_equal prefix, ActiveRecord::Base.table_name_prefix
+    ActiveRecord::Base.table_name_prefix = ""
   end
 
   def test_changing_prefix_on_application_record_inherited_model
@@ -49,6 +51,8 @@ class ApplicationRecordTest < ActiveRecord::TestCase
 
     assert_equal new_prefix, Topic.table_name_prefix
     assert_equal prefix, ActiveRecord::Base.table_name_prefix
+    ActiveRecord::Base.table_name_prefix = ""
+    Topic.table_name_prefix = ""
   end
 
   def test_double_inheritence_rules
@@ -124,6 +128,7 @@ class MultipleApplicationRecordTest < ActiveRecord::TestCase
     assert_equal format, ApplicationRecord.cache_timestamp_format
     assert_equal new_format, FirstNamespace::SomeModel.cache_timestamp_format
     assert_equal format, SecondNamespace::SomeModel.cache_timestamp_format
+    ApplicationRecord.cache_timestamp_format = :nsec
   end
 
   def test_changing_module_application_record_does_not_propogate

--- a/activerecord/test/cases/associations/eager_load_includes_full_sti_class_test.rb
+++ b/activerecord/test/cases/associations/eager_load_includes_full_sti_class_test.rb
@@ -3,7 +3,7 @@ require 'models/post'
 require 'models/tagging'
 
 module Namespaced
-  class Post < ApplicationModel
+  class Post < ApplicationRecord
     self.table_name = 'posts'
     has_one :tagging, :as => :taggable, :class_name => 'Tagging'
   end

--- a/activerecord/test/cases/associations/eager_load_includes_full_sti_class_test.rb
+++ b/activerecord/test/cases/associations/eager_load_includes_full_sti_class_test.rb
@@ -3,7 +3,7 @@ require 'models/post'
 require 'models/tagging'
 
 module Namespaced
-  class Post < ActiveRecord::Base
+  class Post < ApplicationModel
     self.table_name = 'posts'
     has_one :tagging, :as => :taggable, :class_name => 'Tagging'
   end

--- a/activerecord/test/cases/associations/eager_load_nested_include_test.rb
+++ b/activerecord/test/cases/associations/eager_load_nested_include_test.rb
@@ -22,38 +22,38 @@ module Remembered
   end
 end
 
-class ShapeExpression < ApplicationModel
+class ShapeExpression < ApplicationRecord
   belongs_to :shape, :polymorphic => true
   belongs_to :paint, :polymorphic => true
 end
 
-class Circle < ApplicationModel
+class Circle < ApplicationRecord
   has_many :shape_expressions, :as => :shape
   include Remembered
 end
-class Square < ApplicationModel
+class Square < ApplicationRecord
   has_many :shape_expressions, :as => :shape
   include Remembered
 end
-class Triangle < ApplicationModel
+class Triangle < ApplicationRecord
   has_many :shape_expressions, :as => :shape
   include Remembered
 end
-class PaintColor  < ApplicationModel
+class PaintColor  < ApplicationRecord
   has_many   :shape_expressions, :as => :paint
   belongs_to :non_poly, :foreign_key => "non_poly_one_id", :class_name => "NonPolyOne"
   include Remembered
 end
-class PaintTexture < ApplicationModel
+class PaintTexture < ApplicationRecord
   has_many   :shape_expressions, :as => :paint
   belongs_to :non_poly, :foreign_key => "non_poly_two_id", :class_name => "NonPolyTwo"
   include Remembered
 end
-class NonPolyOne < ApplicationModel
+class NonPolyOne < ApplicationRecord
   has_many :paint_colors
   include Remembered
 end
-class NonPolyTwo < ApplicationModel
+class NonPolyTwo < ApplicationRecord
   has_many :paint_textures
   include Remembered
 end

--- a/activerecord/test/cases/associations/eager_load_nested_include_test.rb
+++ b/activerecord/test/cases/associations/eager_load_nested_include_test.rb
@@ -22,38 +22,38 @@ module Remembered
   end
 end
 
-class ShapeExpression < ActiveRecord::Base
+class ShapeExpression < ApplicationModel
   belongs_to :shape, :polymorphic => true
   belongs_to :paint, :polymorphic => true
 end
 
-class Circle < ActiveRecord::Base
+class Circle < ApplicationModel
   has_many :shape_expressions, :as => :shape
   include Remembered
 end
-class Square < ActiveRecord::Base
+class Square < ApplicationModel
   has_many :shape_expressions, :as => :shape
   include Remembered
 end
-class Triangle < ActiveRecord::Base
+class Triangle < ApplicationModel
   has_many :shape_expressions, :as => :shape
   include Remembered
 end
-class PaintColor  < ActiveRecord::Base
+class PaintColor  < ApplicationModel
   has_many   :shape_expressions, :as => :paint
   belongs_to :non_poly, :foreign_key => "non_poly_one_id", :class_name => "NonPolyOne"
   include Remembered
 end
-class PaintTexture < ActiveRecord::Base
+class PaintTexture < ApplicationModel
   has_many   :shape_expressions, :as => :paint
   belongs_to :non_poly, :foreign_key => "non_poly_two_id", :class_name => "NonPolyTwo"
   include Remembered
 end
-class NonPolyOne < ActiveRecord::Base
+class NonPolyOne < ApplicationModel
   has_many :paint_colors
   include Remembered
 end
-class NonPolyTwo < ActiveRecord::Base
+class NonPolyTwo < ApplicationModel
   has_many :paint_textures
   include Remembered
 end

--- a/activerecord/test/cases/associations/eager_singularization_test.rb
+++ b/activerecord/test/cases/associations/eager_singularization_test.rb
@@ -1,40 +1,40 @@
 require "cases/helper"
 
-class Virus < ApplicationModel
+class Virus < ApplicationRecord
   belongs_to :octopus
 end
-class Octopus < ApplicationModel
+class Octopus < ApplicationRecord
   has_one :virus
 end
-class Pass < ApplicationModel
+class Pass < ApplicationRecord
   belongs_to :bus
 end
-class Bus < ApplicationModel
+class Bus < ApplicationRecord
   has_many :passes
 end
-class Mess < ApplicationModel
+class Mess < ApplicationRecord
   has_and_belongs_to_many :crises
 end
-class Crisis < ApplicationModel
+class Crisis < ApplicationRecord
   has_and_belongs_to_many :messes
   has_many :analyses, :dependent => :destroy
   has_many :successes, :through => :analyses
   has_many :dresses, :dependent => :destroy
   has_many :compresses, :through => :dresses
 end
-class Analysis < ApplicationModel
+class Analysis < ApplicationRecord
   belongs_to :crisis
   belongs_to :success
 end
-class Success < ApplicationModel
+class Success < ApplicationRecord
   has_many :analyses, :dependent => :destroy
   has_many :crises, :through => :analyses
 end
-class Dress < ApplicationModel
+class Dress < ApplicationRecord
   belongs_to :crisis
   has_many :compresses
 end
-class Compress < ApplicationModel
+class Compress < ApplicationRecord
   belongs_to :dress
 end
 

--- a/activerecord/test/cases/associations/eager_singularization_test.rb
+++ b/activerecord/test/cases/associations/eager_singularization_test.rb
@@ -1,40 +1,40 @@
 require "cases/helper"
 
-class Virus < ActiveRecord::Base
+class Virus < ApplicationModel
   belongs_to :octopus
 end
-class Octopus < ActiveRecord::Base
+class Octopus < ApplicationModel
   has_one :virus
 end
-class Pass < ActiveRecord::Base
+class Pass < ApplicationModel
   belongs_to :bus
 end
-class Bus < ActiveRecord::Base
+class Bus < ApplicationModel
   has_many :passes
 end
-class Mess < ActiveRecord::Base
+class Mess < ApplicationModel
   has_and_belongs_to_many :crises
 end
-class Crisis < ActiveRecord::Base
+class Crisis < ApplicationModel
   has_and_belongs_to_many :messes
   has_many :analyses, :dependent => :destroy
   has_many :successes, :through => :analyses
   has_many :dresses, :dependent => :destroy
   has_many :compresses, :through => :dresses
 end
-class Analysis < ActiveRecord::Base
+class Analysis < ApplicationModel
   belongs_to :crisis
   belongs_to :success
 end
-class Success < ActiveRecord::Base
+class Success < ApplicationModel
   has_many :analyses, :dependent => :destroy
   has_many :crises, :through => :analyses
 end
-class Dress < ActiveRecord::Base
+class Dress < ApplicationModel
   belongs_to :crisis
   has_many :compresses
 end
-class Compress < ActiveRecord::Base
+class Compress < ApplicationModel
   belongs_to :dress
 end
 

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -22,7 +22,7 @@ require 'models/country'
 require 'models/treaty'
 require 'active_support/core_ext/string/conversions'
 
-class ProjectWithAfterCreateHook < ApplicationModel
+class ProjectWithAfterCreateHook < ApplicationRecord
   self.table_name = 'projects'
   has_and_belongs_to_many :developers,
     :class_name => "DeveloperForProjectWithAfterCreateHook",
@@ -38,7 +38,7 @@ class ProjectWithAfterCreateHook < ApplicationModel
   end
 end
 
-class DeveloperForProjectWithAfterCreateHook < ApplicationModel
+class DeveloperForProjectWithAfterCreateHook < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects,
     :class_name => "ProjectWithAfterCreateHook",
@@ -47,7 +47,7 @@ class DeveloperForProjectWithAfterCreateHook < ApplicationModel
     :foreign_key => "developer_id"
 end
 
-class ProjectWithSymbolsForKeys < ApplicationModel
+class ProjectWithSymbolsForKeys < ApplicationRecord
   self.table_name = 'projects'
   has_and_belongs_to_many :developers,
     :class_name => "DeveloperWithSymbolsForKeys",
@@ -56,7 +56,7 @@ class ProjectWithSymbolsForKeys < ApplicationModel
     :association_foreign_key => "developer_id"
 end
 
-class DeveloperWithSymbolsForKeys < ApplicationModel
+class DeveloperWithSymbolsForKeys < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects,
     :class_name => "ProjectWithSymbolsForKeys",

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -22,7 +22,7 @@ require 'models/country'
 require 'models/treaty'
 require 'active_support/core_ext/string/conversions'
 
-class ProjectWithAfterCreateHook < ActiveRecord::Base
+class ProjectWithAfterCreateHook < ApplicationModel
   self.table_name = 'projects'
   has_and_belongs_to_many :developers,
     :class_name => "DeveloperForProjectWithAfterCreateHook",
@@ -38,7 +38,7 @@ class ProjectWithAfterCreateHook < ActiveRecord::Base
   end
 end
 
-class DeveloperForProjectWithAfterCreateHook < ActiveRecord::Base
+class DeveloperForProjectWithAfterCreateHook < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects,
     :class_name => "ProjectWithAfterCreateHook",
@@ -47,7 +47,7 @@ class DeveloperForProjectWithAfterCreateHook < ActiveRecord::Base
     :foreign_key => "developer_id"
 end
 
-class ProjectWithSymbolsForKeys < ActiveRecord::Base
+class ProjectWithSymbolsForKeys < ApplicationModel
   self.table_name = 'projects'
   has_and_belongs_to_many :developers,
     :class_name => "DeveloperWithSymbolsForKeys",
@@ -56,7 +56,7 @@ class ProjectWithSymbolsForKeys < ActiveRecord::Base
     :association_foreign_key => "developer_id"
 end
 
-class DeveloperWithSymbolsForKeys < ActiveRecord::Base
+class DeveloperWithSymbolsForKeys < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects,
     :class_name => "ProjectWithSymbolsForKeys",

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1508,7 +1508,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_defining_has_many_association_with_delete_all_dependency_lazily_evaluates_target_class
     ActiveRecord::Reflection::AssociationReflection.any_instance.expects(:class_name).never
     class_eval(<<-EOF, __FILE__, __LINE__ + 1)
-      class DeleteAllModel < ApplicationModel
+      class DeleteAllModel < ApplicationRecord
         has_many :nonentities, :dependent => :delete_all
       end
     EOF
@@ -1517,7 +1517,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_defining_has_many_association_with_nullify_dependency_lazily_evaluates_target_class
     ActiveRecord::Reflection::AssociationReflection.any_instance.expects(:class_name).never
     class_eval(<<-EOF, __FILE__, __LINE__ + 1)
-      class NullifyModel < ApplicationModel
+      class NullifyModel < ApplicationRecord
         has_many :nonentities, :dependent => :nullify
       end
     EOF

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -46,11 +46,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_anonymous_has_many
-    developer = Class.new(ActiveRecord::Base) {
+    developer = Class.new(ApplicationRecord) {
       self.table_name = 'developers'
       dev = self
 
-      developer_project = Class.new(ActiveRecord::Base) {
+      developer_project = Class.new(ApplicationRecord) {
         self.table_name = 'developers_projects'
         belongs_to :developer, :class => dev
       }

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1508,7 +1508,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_defining_has_many_association_with_delete_all_dependency_lazily_evaluates_target_class
     ActiveRecord::Reflection::AssociationReflection.any_instance.expects(:class_name).never
     class_eval(<<-EOF, __FILE__, __LINE__ + 1)
-      class DeleteAllModel < ActiveRecord::Base
+      class DeleteAllModel < ApplicationModel
         has_many :nonentities, :dependent => :delete_all
       end
     EOF
@@ -1517,7 +1517,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_defining_has_many_association_with_nullify_dependency_lazily_evaluates_target_class
     ActiveRecord::Reflection::AssociationReflection.any_instance.expects(:class_name).never
     class_eval(<<-EOF, __FILE__, __LINE__ + 1)
-      class NullifyModel < ActiveRecord::Base
+      class NullifyModel < ApplicationModel
         has_many :nonentities, :dependent => :nullify
       end
     EOF

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -38,7 +38,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def make_model(name)
-    Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }
+    Class.new(ApplicationRecord) { define_singleton_method(:name) { name } }
   end
 
   def test_singleton_has_many_through

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -105,15 +105,15 @@ end
 class InverseAssociationTests < ActiveRecord::TestCase
   def test_should_allow_for_inverse_of_options_in_associations
     assert_nothing_raised(ArgumentError, 'ActiveRecord should allow the inverse_of options on has_many') do
-      Class.new(ActiveRecord::Base).has_many(:wheels, :inverse_of => :car)
+      Class.new(ApplicationRecord).has_many(:wheels, :inverse_of => :car)
     end
 
     assert_nothing_raised(ArgumentError, 'ActiveRecord should allow the inverse_of options on has_one') do
-      Class.new(ActiveRecord::Base).has_one(:engine, :inverse_of => :car)
+      Class.new(ApplicationRecord).has_one(:engine, :inverse_of => :car)
     end
 
     assert_nothing_raised(ArgumentError, 'ActiveRecord should allow the inverse_of options on belongs_to') do
-      Class.new(ActiveRecord::Base).belongs_to(:car, :inverse_of => :driver)
+      Class.new(ApplicationRecord).belongs_to(:car, :inverse_of => :driver)
     end
   end
 

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -742,7 +742,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     def find_post_with_dependency(post_id, association, association_name, dependency)
       class_name = "PostWith#{association.to_s.classify}#{dependency.to_s.classify}"
       Post.find(post_id).update_columns type: class_name
-      klass = Object.const_set(class_name, Class.new(ActiveRecord::Base))
+      klass = Object.const_set(class_name, Class.new(ApplicationRecord))
       klass.table_name = 'posts'
       klass.send(association, association_name, :as => :taggable, :dependent => dependency)
       klass.find(post_id)

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -82,7 +82,7 @@ class AssociationsTest < ActiveRecord::TestCase
 
   def test_bad_collection_keys
     assert_raise(ArgumentError, 'ActiveRecord should have barked on bad collection keys') do
-      Class.new(ActiveRecord::Base).has_many(:wheels, :name => 'wheels')
+      Class.new(ApplicationRecord).has_many(:wheels, :name => 'wheels')
     end
   end
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -258,9 +258,9 @@ class AssociationProxyTest < ActiveRecord::TestCase
 end
 
 class OverridingAssociationsTest < ActiveRecord::TestCase
-  class DifferentPerson < ApplicationModel; end
+  class DifferentPerson < ApplicationRecord; end
 
-  class PeopleList < ApplicationModel
+  class PeopleList < ApplicationRecord
     has_and_belongs_to_many :has_and_belongs_to_many, :before_add => :enlist
     has_many :has_many, :before_add => :enlist
     belongs_to :belongs_to

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -258,9 +258,9 @@ class AssociationProxyTest < ActiveRecord::TestCase
 end
 
 class OverridingAssociationsTest < ActiveRecord::TestCase
-  class DifferentPerson < ActiveRecord::Base; end
+  class DifferentPerson < ApplicationModel; end
 
-  class PeopleList < ActiveRecord::Base
+  class PeopleList < ApplicationModel
     has_and_belongs_to_many :has_and_belongs_to_many, :before_add => :enlist
     has_many :has_many, :before_add => :enlist
     belongs_to :belongs_to

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -18,7 +18,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   def setup
     @old_matchers = ActiveRecord::Base.send(:attribute_method_matchers).dup
-    @target = Class.new(ActiveRecord::Base)
+    @target = Class.new(ApplicationRecord)
     @target.table_name = 'topics'
   end
 
@@ -507,7 +507,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   def test_raises_dangerous_attribute_error_when_defining_activerecord_method_in_model
     %w(save create_or_update).each do |method|
-      klass = Class.new ActiveRecord::Base
+      klass = Class.new ApplicationRecord
       klass.class_eval "def #{method}() 'defined #{method}' end"
       assert_raise ActiveRecord::DangerousAttributeError do
         klass.instance_method_already_implemented?(method)
@@ -767,7 +767,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   # that by defining a 'foo' method in the generated methods module for B.
   # (That module will be inserted between the two, e.g. [B, <GeneratedAttributes>, A].)
   def test_inherited_custom_accessors
-    klass = Class.new(ActiveRecord::Base) do
+    klass = Class.new(ApplicationRecord) do
       self.table_name = "topics"
       self.abstract_class = true
       def title; "omg"; end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -29,37 +29,37 @@ require 'models/car'
 require 'models/bulb'
 require 'rexml/document'
 
-class FirstAbstractClass < ActiveRecord::Base
+class FirstAbstractClass < ApplicationModel
   self.abstract_class = true
 end
 class SecondAbstractClass < FirstAbstractClass
   self.abstract_class = true
 end
 class Photo < SecondAbstractClass; end
-class Category < ActiveRecord::Base; end
-class Categorization < ActiveRecord::Base; end
-class Smarts < ActiveRecord::Base; end
-class CreditCard < ActiveRecord::Base
-  class PinNumber < ActiveRecord::Base
-    class CvvCode < ActiveRecord::Base; end
+class Category < ApplicationModel; end
+class Categorization < ApplicationModel; end
+class Smarts < ApplicationModel; end
+class CreditCard < ApplicationModel
+  class PinNumber < ApplicationModel
+    class CvvCode < ApplicationModel; end
     class SubCvvCode < CvvCode; end
   end
   class SubPinNumber < PinNumber; end
   class Brand < Category; end
 end
-class MasterCreditCard < ActiveRecord::Base; end
-class Post < ActiveRecord::Base; end
-class Computer < ActiveRecord::Base; end
-class NonExistentTable < ActiveRecord::Base; end
-class TestOracleDefault < ActiveRecord::Base; end
+class MasterCreditCard < ApplicationModel; end
+class Post < ApplicationModel; end
+class Computer < ApplicationModel; end
+class NonExistentTable < ApplicationModel; end
+class TestOracleDefault < ApplicationModel; end
 
 class ReadonlyTitlePost < Post
   attr_readonly :title
 end
 
-class Weird < ActiveRecord::Base; end
+class Weird < ApplicationModel; end
 
-class Boolean < ActiveRecord::Base
+class Boolean < ApplicationModel
   def has_fun
     super
   end
@@ -68,7 +68,7 @@ end
 class LintTest < ActiveRecord::TestCase
   include ActiveModel::Lint::Tests
 
-  class LintModel < ActiveRecord::Base; end
+  class LintModel < ApplicationModel; end
 
   def setup
     @model = LintModel.new
@@ -819,7 +819,7 @@ class BasicsTest < ActiveRecord::TestCase
       assert_equal 'a text field', default.char3
     end
 
-    class Geometric < ActiveRecord::Base; end
+    class Geometric < ApplicationModel; end
     def test_geometric_content
 
       # accepted format notes:
@@ -907,7 +907,7 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
-  class NumericData < ActiveRecord::Base
+  class NumericData < ApplicationModel
     self.table_name = 'numeric_data'
   end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -29,37 +29,37 @@ require 'models/car'
 require 'models/bulb'
 require 'rexml/document'
 
-class FirstAbstractClass < ApplicationModel
+class FirstAbstractClass < ApplicationRecord
   self.abstract_class = true
 end
 class SecondAbstractClass < FirstAbstractClass
   self.abstract_class = true
 end
 class Photo < SecondAbstractClass; end
-class Category < ApplicationModel; end
-class Categorization < ApplicationModel; end
-class Smarts < ApplicationModel; end
-class CreditCard < ApplicationModel
-  class PinNumber < ApplicationModel
-    class CvvCode < ApplicationModel; end
+class Category < ApplicationRecord; end
+class Categorization < ApplicationRecord; end
+class Smarts < ApplicationRecord; end
+class CreditCard < ApplicationRecord
+  class PinNumber < ApplicationRecord
+    class CvvCode < ApplicationRecord; end
     class SubCvvCode < CvvCode; end
   end
   class SubPinNumber < PinNumber; end
   class Brand < Category; end
 end
-class MasterCreditCard < ApplicationModel; end
-class Post < ApplicationModel; end
-class Computer < ApplicationModel; end
-class NonExistentTable < ApplicationModel; end
-class TestOracleDefault < ApplicationModel; end
+class MasterCreditCard < ApplicationRecord; end
+class Post < ApplicationRecord; end
+class Computer < ApplicationRecord; end
+class NonExistentTable < ApplicationRecord; end
+class TestOracleDefault < ApplicationRecord; end
 
 class ReadonlyTitlePost < Post
   attr_readonly :title
 end
 
-class Weird < ApplicationModel; end
+class Weird < ApplicationRecord; end
 
-class Boolean < ApplicationModel
+class Boolean < ApplicationRecord
   def has_fun
     super
   end
@@ -68,7 +68,7 @@ end
 class LintTest < ActiveRecord::TestCase
   include ActiveModel::Lint::Tests
 
-  class LintModel < ApplicationModel; end
+  class LintModel < ApplicationRecord; end
 
   def setup
     @model = LintModel.new
@@ -819,7 +819,7 @@ class BasicsTest < ActiveRecord::TestCase
       assert_equal 'a text field', default.char3
     end
 
-    class Geometric < ApplicationModel; end
+    class Geometric < ApplicationRecord; end
     def test_geometric_content
 
       # accepted format notes:
@@ -907,7 +907,7 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
-  class NumericData < ApplicationModel
+  class NumericData < ApplicationRecord
     self.table_name = 'numeric_data'
   end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1064,7 +1064,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_quoted_table_name_after_set_table_name
-    klass = Class.new(ActiveRecord::Base)
+    klass = Class.new(ApplicationRecord)
 
     klass.table_name = "foo"
     assert_equal "foo", klass.table_name
@@ -1076,14 +1076,14 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_set_table_name_with_inheritance
-    k = Class.new( ActiveRecord::Base )
+    k = Class.new(ApplicationRecord)
     def k.name; "Foo"; end
     def k.table_name; super + "ks"; end
     assert_equal "foosks", k.table_name
   end
 
   def test_sequence_name_with_abstract_class
-    ak = Class.new(ActiveRecord::Base)
+    ak = Class.new(ApplicationRecord)
     ak.abstract_class = true
     k = Class.new(ak)
     k.table_name = "projects"
@@ -1288,7 +1288,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_current_scope_is_reset
-    Object.const_set :UnloadablePost, Class.new(ActiveRecord::Base)
+    Object.const_set :UnloadablePost, Class.new(ApplicationRecord)
     UnloadablePost.send(:current_scope=, UnloadablePost.all)
 
     UnloadablePost.unloadable
@@ -1332,7 +1332,7 @@ class BasicsTest < ActiveRecord::TestCase
       flunk "there should be no post constant"
     end
 
-    self.class.const_set("Post", Class.new(ActiveRecord::Base) {
+    self.class.const_set("Post", Class.new(ApplicationRecord) {
       has_many :comments
     })
 
@@ -1447,7 +1447,7 @@ class BasicsTest < ActiveRecord::TestCase
       scope = mock
       scope.expects(meth).with(:foo, :bar).returns(record)
 
-      klass = Class.new(ActiveRecord::Base)
+      klass = Class.new(ApplicationRecord)
       klass.stubs(:all => scope)
 
       assert_equal record, klass.public_send(meth, :foo, :bar)
@@ -1455,12 +1455,12 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   test "scoped can take a values hash" do
-    klass = Class.new(ActiveRecord::Base)
+    klass = Class.new(ApplicationRecord)
     assert_equal ['foo'], klass.all.merge!(select: 'foo').select_values
   end
 
   test "connection_handler can be overridden" do
-    klass = Class.new(ActiveRecord::Base)
+    klass = Class.new(ApplicationRecord)
     orig_handler = klass.connection_handler
     new_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
     thread_connection_handler = nil
@@ -1476,7 +1476,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   test "new threads get default the default connection handler" do
-    klass = Class.new(ActiveRecord::Base)
+    klass = Class.new(ApplicationRecord)
     orig_handler = klass.connection_handler
     handler = nil
 
@@ -1491,7 +1491,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   test "changing a connection handler in a main thread does not poison the other threads" do
-    klass = Class.new(ActiveRecord::Base)
+    klass = Class.new(ApplicationRecord)
     orig_handler = klass.connection_handler
     new_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
     after_handler = nil

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -13,7 +13,7 @@ require 'models/ship_part'
 
 Company.has_many :accounts
 
-class NumericData < ApplicationModel
+class NumericData < ApplicationRecord
   self.table_name = 'numeric_data'
 end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -13,7 +13,7 @@ require 'models/ship_part'
 
 Company.has_many :accounts
 
-class NumericData < ActiveRecord::Base
+class NumericData < ApplicationModel
   self.table_name = 'numeric_data'
 end
 

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class CallbackDeveloper < ApplicationModel
+class CallbackDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   class << self
@@ -47,7 +47,7 @@ class CallbackDeveloperWithFalseValidation < CallbackDeveloper
   before_validation proc { |model| model.history << [:before_validation, :should_never_get_here] }
 end
 
-class ParentDeveloper < ApplicationModel
+class ParentDeveloper < ApplicationRecord
   self.table_name = 'developers'
   attr_accessor :after_save_called
   before_validation {|record| record.after_save_called = true}
@@ -57,7 +57,7 @@ class ChildDeveloper < ParentDeveloper
 
 end
 
-class RecursiveCallbackDeveloper < ApplicationModel
+class RecursiveCallbackDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   before_save :on_before_save
@@ -78,7 +78,7 @@ class RecursiveCallbackDeveloper < ApplicationModel
   end
 end
 
-class ImmutableDeveloper < ApplicationModel
+class ImmutableDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   validates_inclusion_of :salary, :in => 50000..200000
@@ -97,7 +97,7 @@ class ImmutableDeveloper < ApplicationModel
     end
 end
 
-class ImmutableMethodDeveloper < ApplicationModel
+class ImmutableMethodDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   validates_inclusion_of :salary, :in => 50000..200000
@@ -117,7 +117,7 @@ class ImmutableMethodDeveloper < ApplicationModel
   end
 end
 
-class OnCallbacksDeveloper < ApplicationModel
+class OnCallbacksDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   before_validation { history << :before_validation }
@@ -137,7 +137,7 @@ class OnCallbacksDeveloper < ApplicationModel
   end
 end
 
-class ContextualCallbacksDeveloper < ApplicationModel
+class ContextualCallbacksDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   before_validation { history << :before_validation }
@@ -163,7 +163,7 @@ class ContextualCallbacksDeveloper < ApplicationModel
   end
 end
 
-class CallbackCancellationDeveloper < ApplicationModel
+class CallbackCancellationDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   attr_reader   :after_save_called, :after_create_called, :after_update_called, :after_destroy_called

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class CallbackDeveloper < ActiveRecord::Base
+class CallbackDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   class << self
@@ -47,7 +47,7 @@ class CallbackDeveloperWithFalseValidation < CallbackDeveloper
   before_validation proc { |model| model.history << [:before_validation, :should_never_get_here] }
 end
 
-class ParentDeveloper < ActiveRecord::Base
+class ParentDeveloper < ApplicationModel
   self.table_name = 'developers'
   attr_accessor :after_save_called
   before_validation {|record| record.after_save_called = true}
@@ -57,7 +57,7 @@ class ChildDeveloper < ParentDeveloper
 
 end
 
-class RecursiveCallbackDeveloper < ActiveRecord::Base
+class RecursiveCallbackDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   before_save :on_before_save
@@ -78,7 +78,7 @@ class RecursiveCallbackDeveloper < ActiveRecord::Base
   end
 end
 
-class ImmutableDeveloper < ActiveRecord::Base
+class ImmutableDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   validates_inclusion_of :salary, :in => 50000..200000
@@ -97,7 +97,7 @@ class ImmutableDeveloper < ActiveRecord::Base
     end
 end
 
-class ImmutableMethodDeveloper < ActiveRecord::Base
+class ImmutableMethodDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   validates_inclusion_of :salary, :in => 50000..200000
@@ -117,7 +117,7 @@ class ImmutableMethodDeveloper < ActiveRecord::Base
   end
 end
 
-class OnCallbacksDeveloper < ActiveRecord::Base
+class OnCallbacksDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   before_validation { history << :before_validation }
@@ -137,7 +137,7 @@ class OnCallbacksDeveloper < ActiveRecord::Base
   end
 end
 
-class ContextualCallbacksDeveloper < ActiveRecord::Base
+class ContextualCallbacksDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   before_validation { history << :before_validation }
@@ -163,7 +163,7 @@ class ContextualCallbacksDeveloper < ActiveRecord::Base
   end
 end
 
-class CallbackCancellationDeveloper < ActiveRecord::Base
+class CallbackCancellationDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   attr_reader   :after_save_called, :after_create_called, :after_update_called, :after_destroy_called

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -332,7 +332,7 @@ module ActiveRecord
       # make sure exceptions are thrown when establish_connection
       # is called with an anonymous class
       def test_anonymous_class_exception
-        anonymous = Class.new(ActiveRecord::Base)
+        anonymous = Class.new(ApplicationRecord)
         handler = ActiveRecord::Base.connection_handler
 
         assert_raises(RuntimeError) {

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -2,7 +2,7 @@ require 'cases/helper'
 require 'models/person'
 require 'models/topic'
 
-class NonExistentTable < ActiveRecord::Base; end
+class NonExistentTable < ApplicationModel; end
 
 class CoreTest < ActiveRecord::TestCase
   fixtures :topics

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -2,7 +2,7 @@ require 'cases/helper'
 require 'models/person'
 require 'models/topic'
 
-class NonExistentTable < ApplicationModel; end
+class NonExistentTable < ApplicationRecord; end
 
 class CoreTest < ActiveRecord::TestCase
   fixtures :topics

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -40,7 +40,7 @@ class DefaultTest < ActiveRecord::TestCase
 end
 
 class DefaultStringsTest < ActiveRecord::TestCase
-  class DefaultString < ApplicationModel; end
+  class DefaultString < ApplicationRecord; end
 
   setup do
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -130,7 +130,7 @@ if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
     end
 
     def with_text_blob_not_null_table
-      klass = Class.new(ActiveRecord::Base)
+      klass = Class.new(ApplicationRecord)
       klass.table_name = 'test_mysql_text_not_null_defaults'
       klass.connection.create_table klass.table_name do |t|
         t.column :non_null_text, :text, :null => false
@@ -147,7 +147,7 @@ if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
     # MySQL uses an implicit default 0 rather than NULL unless in strict mode.
     # We use an implicit NULL so schema.rb is compatible with other databases.
     def test_mysql_integer_not_null_defaults
-      klass = Class.new(ActiveRecord::Base)
+      klass = Class.new(ApplicationRecord)
       klass.table_name = 'test_integer_not_null_default_zero'
       klass.connection.create_table klass.table_name do |t|
         t.column :zero, :integer, :null => false, :default => 0

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -40,7 +40,7 @@ class DefaultTest < ActiveRecord::TestCase
 end
 
 class DefaultStringsTest < ActiveRecord::TestCase
-  class DefaultString < ActiveRecord::Base; end
+  class DefaultString < ApplicationModel; end
 
   setup do
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -22,7 +22,7 @@ private
   end
 end
 
-class NumericData < ApplicationModel
+class NumericData < ApplicationRecord
   self.table_name = 'numeric_data'
 end
 
@@ -557,7 +557,7 @@ class DirtyTest < ActiveRecord::TestCase
   end
 
   if ActiveRecord::Base.connection.supports_migrations?
-    class Testings < ApplicationModel; end
+    class Testings < ApplicationRecord; end
     def test_field_named_field
       ActiveRecord::Base.connection.create_table :testings do |t|
         t.string :field

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -59,7 +59,7 @@ class DirtyTest < ActiveRecord::TestCase
 
   def test_time_attributes_changes_with_time_zone
     in_time_zone 'Paris' do
-      target = Class.new(ActiveRecord::Base)
+      target = Class.new(ApplicationRecord)
       target.table_name = 'pirates'
 
       # New record - no changes.
@@ -86,7 +86,7 @@ class DirtyTest < ActiveRecord::TestCase
 
   def test_setting_time_attributes_with_time_zone_field_to_itself_should_not_be_marked_as_a_change
     in_time_zone 'Paris' do
-      target = Class.new(ActiveRecord::Base)
+      target = Class.new(ApplicationRecord)
       target.table_name = 'pirates'
 
       pirate = target.create
@@ -97,7 +97,7 @@ class DirtyTest < ActiveRecord::TestCase
 
   def test_time_attributes_changes_without_time_zone_by_skip
     in_time_zone 'Paris' do
-      target = Class.new(ActiveRecord::Base)
+      target = Class.new(ApplicationRecord)
       target.table_name = 'pirates'
 
       target.skip_time_zone_conversion_for_attributes = [:created_on]
@@ -125,7 +125,7 @@ class DirtyTest < ActiveRecord::TestCase
   end
 
   def test_time_attributes_changes_without_time_zone
-    target = Class.new(ActiveRecord::Base)
+    target = Class.new(ApplicationRecord)
     target.table_name = 'pirates'
 
     target.time_zone_aware_attributes = false
@@ -207,7 +207,7 @@ class DirtyTest < ActiveRecord::TestCase
 
   def test_nullable_datetime_not_marked_as_changed_if_new_value_is_blank
     in_time_zone 'Edinburgh' do
-      target = Class.new(ActiveRecord::Base)
+      target = Class.new(ApplicationRecord)
       target.table_name = 'topics'
 
       topic = target.create
@@ -572,7 +572,7 @@ class DirtyTest < ActiveRecord::TestCase
 
   def test_datetime_attribute_can_be_updated_with_fractional_seconds
     in_time_zone 'Paris' do
-      target = Class.new(ActiveRecord::Base)
+      target = Class.new(ApplicationRecord)
       target.table_name = 'topics'
 
       written_on = Time.utc(2012, 12, 1, 12, 0, 0).in_time_zone('Paris')

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -22,7 +22,7 @@ private
   end
 end
 
-class NumericData < ActiveRecord::Base
+class NumericData < ApplicationModel
   self.table_name = 'numeric_data'
 end
 
@@ -557,7 +557,7 @@ class DirtyTest < ActiveRecord::TestCase
   end
 
   if ActiveRecord::Base.connection.supports_migrations?
-    class Testings < ActiveRecord::Base; end
+    class Testings < ApplicationModel; end
     def test_field_named_field
       ActiveRecord::Base.connection.create_table :testings do |t|
         t.string :field

--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class TestRecord < ActiveRecord::Base
+class TestRecord < ApplicationModel
 end
 
 class TestDisconnectedAdapter < ActiveRecord::TestCase

--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class TestRecord < ApplicationModel
+class TestRecord < ApplicationRecord
 end
 
 class TestDisconnectedAdapter < ActiveRecord::TestCase

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -132,7 +132,7 @@ class FixturesTest < ActiveRecord::TestCase
       ActiveRecord::Base.table_name_prefix = 'prefix_'
       ActiveRecord::Base.table_name_suffix = '_suffix'
 
-      other_topic_klass = Class.new(ActiveRecord::Base) do
+      other_topic_klass = Class.new(ApplicationRecord) do
         def self.name
           "OtherTopic"
         end
@@ -271,7 +271,7 @@ end
 
 class HasManyThroughFixture < ActiveSupport::TestCase
   def make_model(name)
-    Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }
+    Class.new(ApplicationRecord) { define_singleton_method(:name) { name } }
   end
 
   def test_has_many_through

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -9,6 +9,7 @@ require 'active_record'
 require 'cases/test_case'
 require 'active_support/dependencies'
 require 'active_support/logger'
+require 'models/application_model'
 
 require 'support/config'
 require 'support/connection'

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -9,7 +9,7 @@ require 'active_record'
 require 'cases/test_case'
 require 'active_support/dependencies'
 require 'active_support/logger'
-require 'models/application_model'
+require 'models/application_record'
 
 require 'support/config'
 require 'support/connection'

--- a/activerecord/test/cases/hot_compatibility_test.rb
+++ b/activerecord/test/cases/hot_compatibility_test.rb
@@ -4,7 +4,7 @@ class HotCompatibilityTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
   setup do
-    @klass = Class.new(ActiveRecord::Base) do
+    @klass = Class.new(ApplicationRecord) do
       connection.create_table :hot_compatibilities do |t|
         t.string :foo
         t.string :bar

--- a/activerecord/test/cases/invalid_connection_test.rb
+++ b/activerecord/test/cases/invalid_connection_test.rb
@@ -3,7 +3,7 @@ require "cases/helper"
 class TestAdapterWithInvalidConnection < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class Bird < ApplicationModel
+  class Bird < ApplicationRecord
   end
 
   def setup

--- a/activerecord/test/cases/invalid_connection_test.rb
+++ b/activerecord/test/cases/invalid_connection_test.rb
@@ -3,7 +3,7 @@ require "cases/helper"
 class TestAdapterWithInvalidConnection < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class Bird < ActiveRecord::Base
+  class Bird < ApplicationModel
   end
 
   def setup

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -13,9 +13,9 @@ require 'models/engine'
 require 'models/wheel'
 require 'models/treasure'
 
-class LockWithoutDefault < ActiveRecord::Base; end
+class LockWithoutDefault < ApplicationModel; end
 
-class LockWithCustomColumnWithoutDefault < ActiveRecord::Base
+class LockWithCustomColumnWithoutDefault < ApplicationModel
   self.table_name = :lock_without_defaults_cust
   self.column_defaults # to test @column_defaults caching.
   self.locking_column = :custom_lock_version

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -13,9 +13,9 @@ require 'models/engine'
 require 'models/wheel'
 require 'models/treasure'
 
-class LockWithoutDefault < ApplicationModel; end
+class LockWithoutDefault < ApplicationRecord; end
 
-class LockWithCustomColumnWithoutDefault < ApplicationModel
+class LockWithCustomColumnWithoutDefault < ApplicationRecord
   self.table_name = :lock_without_defaults_cust
   self.column_defaults # to test @column_defaults caching.
   self.locking_column = :custom_lock_version

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -268,7 +268,7 @@ module ActiveRecord
         connection.create_table :testings do |t|
           t.column :title, :string
         end
-        person_klass = Class.new(ActiveRecord::Base)
+        person_klass = Class.new(ApplicationRecord)
         person_klass.table_name = 'testings'
 
         person_klass.connection.add_column "testings", "wealth", :integer, :null => false, :default => 99

--- a/activerecord/test/cases/migration/helper.rb
+++ b/activerecord/test/cases/migration/helper.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
       CONNECTION_METHODS = %w[add_column remove_column rename_column add_index change_column rename_table column_exists? index_exists? add_reference add_belongs_to remove_reference remove_references remove_belongs_to]
 
-      class TestModel < ActiveRecord::Base
+      class TestModel < ApplicationModel
         self.table_name = :test_models
       end
 

--- a/activerecord/test/cases/migration/helper.rb
+++ b/activerecord/test/cases/migration/helper.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
       CONNECTION_METHODS = %w[add_column remove_column rename_column add_index change_column rename_table column_exists? index_exists? add_reference add_belongs_to remove_reference remove_references remove_belongs_to]
 
-      class TestModel < ApplicationModel
+      class TestModel < ApplicationRecord
         self.table_name = :test_models
       end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -11,11 +11,11 @@ require MIGRATIONS_ROOT + "/rename/1_we_need_things"
 require MIGRATIONS_ROOT + "/rename/2_rename_things"
 require MIGRATIONS_ROOT + "/decimal/1_give_me_big_numbers"
 
-class BigNumber < ApplicationModel; end
+class BigNumber < ApplicationRecord; end
 
-class Reminder < ApplicationModel; end
+class Reminder < ApplicationRecord; end
 
-class Thing < ApplicationModel; end
+class Thing < ApplicationRecord; end
 
 class MigrationTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -11,11 +11,11 @@ require MIGRATIONS_ROOT + "/rename/1_we_need_things"
 require MIGRATIONS_ROOT + "/rename/2_rename_things"
 require MIGRATIONS_ROOT + "/decimal/1_give_me_big_numbers"
 
-class BigNumber < ActiveRecord::Base; end
+class BigNumber < ApplicationModel; end
 
-class Reminder < ActiveRecord::Base; end
+class Reminder < ApplicationModel; end
 
-class Thing < ActiveRecord::Base; end
+class Thing < ApplicationModel; end
 
 class MigrationTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false

--- a/activerecord/test/cases/mixin_test.rb
+++ b/activerecord/test/cases/mixin_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class Mixin < ApplicationModel
+class Mixin < ApplicationRecord
 end
 
 # Let us control what Time.now returns for the TouchTest suite

--- a/activerecord/test/cases/mixin_test.rb
+++ b/activerecord/test/cases/mixin_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class Mixin < ActiveRecord::Base
+class Mixin < ApplicationModel
 end
 
 # Let us control what Time.now returns for the TouchTest suite

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -143,18 +143,18 @@ class PrimaryKeysTest < ActiveRecord::TestCase
   end
 
   def test_quoted_primary_key_after_set_primary_key
-    k = Class.new( ActiveRecord::Base )
+    k = Class.new(ApplicationRecord)
     assert_equal k.connection.quote_column_name("id"), k.quoted_primary_key
     k.primary_key = "foo"
     assert_equal k.connection.quote_column_name("foo"), k.quoted_primary_key
   end
 
   def test_two_models_with_same_table_but_different_primary_key
-    k1 = Class.new(ActiveRecord::Base)
+    k1 = Class.new(ApplicationRecord)
     k1.table_name = 'posts'
     k1.primary_key = 'id'
 
-    k2 = Class.new(ActiveRecord::Base)
+    k2 = Class.new(ApplicationRecord)
     k2.table_name = 'posts'
     k2.primary_key = 'title'
 
@@ -170,10 +170,10 @@ class PrimaryKeysTest < ActiveRecord::TestCase
   end
 
   def test_models_with_same_table_have_different_columns
-    k1 = Class.new(ActiveRecord::Base)
+    k1 = Class.new(ApplicationRecord)
     k1.table_name = 'posts'
 
-    k2 = Class.new(ActiveRecord::Base)
+    k2 = Class.new(ApplicationRecord)
     k2.table_name = 'posts'
 
     k1.columns.zip(k2.columns).each do |col1, col2|
@@ -190,7 +190,7 @@ class PrimaryKeyWithNoConnectionTest < ActiveRecord::TestCase
 
     connection = ActiveRecord::Base.remove_connection
 
-    model = Class.new(ActiveRecord::Base)
+    model = Class.new(ApplicationRecord)
     model.primary_key = 'foo'
 
     assert_equal 'foo', model.primary_key

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1521,7 +1521,7 @@ class RelationTest < ActiveRecord::TestCase
     assert !Post.all.respond_to?(:by_lifo)
   end
 
-  class OMGTopic < ActiveRecord::Base
+  class OMGTopic < ApplicationModel
     self.table_name = 'topics'
 
     def self.__omg__

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1521,7 +1521,7 @@ class RelationTest < ActiveRecord::TestCase
     assert !Post.all.respond_to?(:by_lifo)
   end
 
-  class OMGTopic < ApplicationModel
+  class OMGTopic < ApplicationRecord
     self.table_name = 'topics'
 
     def self.__omg__

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -46,7 +46,7 @@ class NamedScopingTest < ActiveRecord::TestCase
   end
 
   def test_method_missing_priority_when_delegating
-    klazz = Class.new(ActiveRecord::Base) do
+    klazz = Class.new(ApplicationRecord) do
       self.table_name = "topics"
       scope :since, Proc.new { where('written_on >= ?', Time.now - 1.day) }
       scope :to,    Proc.new { where('written_on <= ?', Time.now) }
@@ -270,7 +270,7 @@ class NamedScopingTest < ActiveRecord::TestCase
   # has been done by evaluating a string with a plain def statement. For scope
   # names which contain spaces this approach doesn't work.
   def test_spaces_in_scope_names
-    klass = Class.new(ActiveRecord::Base) do
+    klass = Class.new(ApplicationRecord) do
       self.table_name = "topics"
       scope :"title containing space", -> { where("title LIKE '% %'") }
       scope :approved, -> { where(:approved => true) }
@@ -436,7 +436,7 @@ class NamedScopingTest < ActiveRecord::TestCase
   end
 
   def test_eager_default_scope_relations_are_remove
-    klass = Class.new(ActiveRecord::Base)
+    klass = Class.new(ApplicationRecord)
     klass.table_name = 'posts'
 
     assert_raises(ArgumentError) do

--- a/activerecord/test/cases/serialization_test.rb
+++ b/activerecord/test/cases/serialization_test.rb
@@ -54,7 +54,7 @@ class SerializationTest < ActiveRecord::TestCase
     original_root_in_json = ActiveRecord::Base.include_root_in_json
     ActiveRecord::Base.include_root_in_json = true
 
-    klazz = Class.new(ActiveRecord::Base)
+    klazz = Class.new(ApplicationRecord)
     klazz.table_name = 'topics'
     assert klazz.include_root_in_json
 

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -126,7 +126,7 @@ class TimestampTest < ActiveRecord::TestCase
   end
 
   def test_saving_a_record_with_a_belongs_to_that_specifies_touching_a_specific_attribute_the_parent_should_update_that_attribute
-    klass = Class.new(ActiveRecord::Base) do
+    klass = Class.new(ApplicationRecord) do
       def self.name; 'Pet'; end
       belongs_to :owner, :touch => :happy_at
     end
@@ -142,7 +142,7 @@ class TimestampTest < ActiveRecord::TestCase
   end
 
   def test_touching_a_record_with_a_belongs_to_that_uses_a_counter_cache_should_update_the_parent
-    klass = Class.new(ActiveRecord::Base) do
+    klass = Class.new(ApplicationRecord) do
       def self.name; 'Pet'; end
       belongs_to :owner, :counter_cache => :use_count, :touch => true
     end
@@ -159,7 +159,7 @@ class TimestampTest < ActiveRecord::TestCase
   end
 
   def test_touching_a_record_touches_parent_record_and_grandparent_record
-    klass = Class.new(ActiveRecord::Base) do
+    klass = Class.new(ApplicationRecord) do
       def self.name; 'Toy'; end
       belongs_to :pet, :touch => true
     end
@@ -177,11 +177,11 @@ class TimestampTest < ActiveRecord::TestCase
   end
 
   def test_touching_a_record_touches_polymorphic_record
-    klass = Class.new(ActiveRecord::Base) do
+    klass = Class.new(ApplicationRecord) do
       def self.name; 'Toy'; end
     end
 
-    wheel_klass = Class.new(ActiveRecord::Base) do
+    wheel_klass = Class.new(ApplicationRecord) do
       def self.name; 'Wheel'; end
       belongs_to :wheelable, :polymorphic => true, :touch => true
     end
@@ -199,7 +199,7 @@ class TimestampTest < ActiveRecord::TestCase
   end
 
   def test_changing_parent_of_a_record_touches_both_new_and_old_parent_record
-    klass = Class.new(ActiveRecord::Base) do
+    klass = Class.new(ApplicationRecord) do
       def self.name; 'Toy'; end
       belongs_to :pet, touch: true
     end
@@ -225,11 +225,11 @@ class TimestampTest < ActiveRecord::TestCase
   end
 
   def test_changing_parent_of_a_record_touches_both_new_and_old_polymorphic_parent_record
-    klass = Class.new(ActiveRecord::Base) do
+    klass = Class.new(ApplicationRecord) do
       def self.name; 'Toy'; end
     end
 
-    wheel_klass = Class.new(ActiveRecord::Base) do
+    wheel_klass = Class.new(ApplicationRecord) do
       def self.name; 'Wheel'; end
       belongs_to :wheelable, :polymorphic => true, :touch => true
     end
@@ -257,7 +257,7 @@ class TimestampTest < ActiveRecord::TestCase
   end
 
   def test_clearing_association_touches_the_old_record
-    klass = Class.new(ActiveRecord::Base) do
+    klass = Class.new(ApplicationRecord) do
       def self.name; 'Toy'; end
       belongs_to :pet, touch: true
     end

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -5,7 +5,7 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
   fixtures :topics
 
-  class ReplyWithCallbacks < ApplicationModel
+  class ReplyWithCallbacks < ApplicationRecord
     self.table_name = :topics
 
     belongs_to :topic, foreign_key: "parent_id"
@@ -23,7 +23,7 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
     end
   end
 
-  class TopicWithCallbacks < ApplicationModel
+  class TopicWithCallbacks < ApplicationRecord
     self.table_name = :topics
 
     has_many :replies, class_name: "ReplyWithCallbacks", foreign_key: "parent_id"
@@ -284,7 +284,7 @@ end
 class CallbacksOnMultipleActionsTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class TopicWithCallbacksOnMultipleActions < ApplicationModel
+  class TopicWithCallbacksOnMultipleActions < ApplicationRecord
     self.table_name = :topics
 
     after_commit(on: [:create, :destroy]) { |record| record.history << :create_and_destroy }

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -5,7 +5,7 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
   fixtures :topics
 
-  class ReplyWithCallbacks < ActiveRecord::Base
+  class ReplyWithCallbacks < ApplicationModel
     self.table_name = :topics
 
     belongs_to :topic, foreign_key: "parent_id"
@@ -23,7 +23,7 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
     end
   end
 
-  class TopicWithCallbacks < ActiveRecord::Base
+  class TopicWithCallbacks < ApplicationModel
     self.table_name = :topics
 
     has_many :replies, class_name: "ReplyWithCallbacks", foreign_key: "parent_id"
@@ -284,7 +284,7 @@ end
 class CallbacksOnMultipleActionsTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class TopicWithCallbacksOnMultipleActions < ActiveRecord::Base
+  class TopicWithCallbacksOnMultipleActions < ApplicationModel
     self.table_name = :topics
 
     after_commit(on: [:create, :destroy]) { |record| record.history << :create_and_destroy }

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -3,7 +3,7 @@ require 'cases/helper'
 class TransactionIsolationUnsupportedTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class Tag < ApplicationModel
+  class Tag < ApplicationRecord
   end
 
   setup do
@@ -22,11 +22,11 @@ end
 class TransactionIsolationTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class Tag < ApplicationModel
+  class Tag < ApplicationRecord
     self.table_name = 'tags'
   end
 
-  class Tag2 < ApplicationModel
+  class Tag2 < ApplicationRecord
     self.table_name = 'tags'
   end
 

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -3,7 +3,7 @@ require 'cases/helper'
 class TransactionIsolationUnsupportedTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class Tag < ActiveRecord::Base
+  class Tag < ApplicationModel
   end
 
   setup do
@@ -22,11 +22,11 @@ end
 class TransactionIsolationTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
 
-  class Tag < ActiveRecord::Base
+  class Tag < ApplicationModel
     self.table_name = 'tags'
   end
 
-  class Tag2 < ActiveRecord::Base
+  class Tag2 < ApplicationModel
     self.table_name = 'tags'
   end
 

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class TestRecord < ActiveRecord::Base
+class TestRecord < ApplicationModel
 end
 
 class TestUnconnectedAdapter < ActiveRecord::TestCase

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class TestRecord < ApplicationModel
+class TestRecord < ApplicationRecord
 end
 
 class TestUnconnectedAdapter < ActiveRecord::TestCase

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -6,7 +6,7 @@ require 'models/warehouse_thing'
 require 'models/guid'
 require 'models/event'
 
-class Wizard < ApplicationModel
+class Wizard < ApplicationRecord
   self.abstract_class = true
 
   validates_uniqueness_of :name
@@ -30,7 +30,7 @@ class ReplyWithTitleObject < Reply
   def title; ReplyTitle.new; end
 end
 
-class Employee < ApplicationModel
+class Employee < ApplicationRecord
   self.table_name = 'postgresql_arrays'
   validates_uniqueness_of :nicknames
 end

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -6,7 +6,7 @@ require 'models/warehouse_thing'
 require 'models/guid'
 require 'models/event'
 
-class Wizard < ActiveRecord::Base
+class Wizard < ApplicationModel
   self.abstract_class = true
 
   validates_uniqueness_of :name
@@ -30,7 +30,7 @@ class ReplyWithTitleObject < Reply
   def title; ReplyTitle.new; end
 end
 
-class Employee < ActiveRecord::Base
+class Employee < ApplicationModel
   self.table_name = 'postgresql_arrays'
   validates_uniqueness_of :nicknames
 end

--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -94,7 +94,7 @@ class ValidationsTest < ActiveRecord::TestCase
   end
 
   def test_validates_acceptance_of_with_non_existant_table
-    Object.const_set :IncorporealModel, Class.new(ActiveRecord::Base)
+    Object.const_set :IncorporealModel, Class.new(ApplicationRecord)
 
     assert_nothing_raised ActiveRecord::StatementInvalid do
       IncorporealModel.validates_acceptance_of(:incorporeal_column)

--- a/activerecord/test/models/admin/account.rb
+++ b/activerecord/test/models/admin/account.rb
@@ -1,3 +1,3 @@
-class Admin::Account < ActiveRecord::Base
+class Admin::Account < ApplicationModel
   has_many :users
 end

--- a/activerecord/test/models/admin/account.rb
+++ b/activerecord/test/models/admin/account.rb
@@ -1,3 +1,3 @@
-class Admin::Account < ApplicationModel
+class Admin::Account < ApplicationRecord
   has_many :users
 end

--- a/activerecord/test/models/admin/randomly_named_c1.rb
+++ b/activerecord/test/models/admin/randomly_named_c1.rb
@@ -1,3 +1,3 @@
-class Admin::ClassNameThatDoesNotFollowCONVENTIONS < ActiveRecord::Base
+class Admin::ClassNameThatDoesNotFollowCONVENTIONS < ApplicationModel
   self.table_name = :randomly_named_table
 end

--- a/activerecord/test/models/admin/randomly_named_c1.rb
+++ b/activerecord/test/models/admin/randomly_named_c1.rb
@@ -1,3 +1,3 @@
-class Admin::ClassNameThatDoesNotFollowCONVENTIONS < ApplicationModel
+class Admin::ClassNameThatDoesNotFollowCONVENTIONS < ApplicationRecord
   self.table_name = :randomly_named_table
 end

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -1,4 +1,4 @@
-class Admin::User < ApplicationModel
+class Admin::User < ApplicationRecord
   class Coder
     def initialize(default = {})
       @default = default

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -1,4 +1,4 @@
-class Admin::User < ActiveRecord::Base
+class Admin::User < ApplicationModel
   class Coder
     def initialize(default = {})
       @default = default

--- a/activerecord/test/models/aircraft.rb
+++ b/activerecord/test/models/aircraft.rb
@@ -1,4 +1,4 @@
-class Aircraft < ApplicationModel
+class Aircraft < ApplicationRecord
   self.pluralize_table_names = false
   has_many :engines, :foreign_key => "car_id"
 end

--- a/activerecord/test/models/aircraft.rb
+++ b/activerecord/test/models/aircraft.rb
@@ -1,4 +1,4 @@
-class Aircraft < ActiveRecord::Base
+class Aircraft < ApplicationModel
   self.pluralize_table_names = false
   has_many :engines, :foreign_key => "car_id"
 end

--- a/activerecord/test/models/application_model.rb
+++ b/activerecord/test/models/application_model.rb
@@ -1,0 +1,3 @@
+class ApplicationModel < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/activerecord/test/models/application_model.rb
+++ b/activerecord/test/models/application_model.rb
@@ -1,3 +1,0 @@
-class ApplicationModel < ActiveRecord::Base
-  self.abstract_class = true
-end

--- a/activerecord/test/models/application_record.rb
+++ b/activerecord/test/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/activerecord/test/models/arunit2_model.rb
+++ b/activerecord/test/models/arunit2_model.rb
@@ -1,3 +1,3 @@
-class ARUnit2Model < ActiveRecord::Base
+class ARUnit2Model < ApplicationModel
   self.abstract_class = true
 end

--- a/activerecord/test/models/arunit2_model.rb
+++ b/activerecord/test/models/arunit2_model.rb
@@ -1,3 +1,3 @@
-class ARUnit2Model < ApplicationModel
+class ARUnit2Model < ApplicationRecord
   self.abstract_class = true
 end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -1,4 +1,4 @@
-class Author < ActiveRecord::Base
+class Author < ApplicationModel
   has_many :posts
   has_one :post
   has_many :very_special_comments, :through => :posts
@@ -175,7 +175,7 @@ class Author < ActiveRecord::Base
     end
 end
 
-class AuthorAddress < ActiveRecord::Base
+class AuthorAddress < ApplicationModel
   has_one :author
 
   def self.destroyed_author_address_ids
@@ -187,7 +187,7 @@ class AuthorAddress < ActiveRecord::Base
   end
 end
 
-class AuthorFavorite < ActiveRecord::Base
+class AuthorFavorite < ApplicationModel
   belongs_to :author
   belongs_to :favorite_author, :class_name => "Author"
 end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -1,4 +1,4 @@
-class Author < ApplicationModel
+class Author < ApplicationRecord
   has_many :posts
   has_one :post
   has_many :very_special_comments, :through => :posts
@@ -175,7 +175,7 @@ class Author < ApplicationModel
     end
 end
 
-class AuthorAddress < ApplicationModel
+class AuthorAddress < ApplicationRecord
   has_one :author
 
   def self.destroyed_author_address_ids
@@ -187,7 +187,7 @@ class AuthorAddress < ApplicationModel
   end
 end
 
-class AuthorFavorite < ApplicationModel
+class AuthorFavorite < ApplicationRecord
   belongs_to :author
   belongs_to :favorite_author, :class_name => "Author"
 end

--- a/activerecord/test/models/auto_id.rb
+++ b/activerecord/test/models/auto_id.rb
@@ -1,4 +1,4 @@
-class AutoId < ActiveRecord::Base
+class AutoId < ApplicationModel
   self.table_name = "auto_id_tests"
   self.primary_key = "auto_id"
 end

--- a/activerecord/test/models/auto_id.rb
+++ b/activerecord/test/models/auto_id.rb
@@ -1,4 +1,4 @@
-class AutoId < ApplicationModel
+class AutoId < ApplicationRecord
   self.table_name = "auto_id_tests"
   self.primary_key = "auto_id"
 end

--- a/activerecord/test/models/binary.rb
+++ b/activerecord/test/models/binary.rb
@@ -1,2 +1,2 @@
-class Binary < ApplicationModel
+class Binary < ApplicationRecord
 end

--- a/activerecord/test/models/binary.rb
+++ b/activerecord/test/models/binary.rb
@@ -1,2 +1,2 @@
-class Binary < ActiveRecord::Base
+class Binary < ApplicationModel
 end

--- a/activerecord/test/models/bird.rb
+++ b/activerecord/test/models/bird.rb
@@ -1,4 +1,4 @@
-class Bird < ActiveRecord::Base
+class Bird < ApplicationModel
   belongs_to :pirate
   validates_presence_of :name
 

--- a/activerecord/test/models/bird.rb
+++ b/activerecord/test/models/bird.rb
@@ -1,4 +1,4 @@
-class Bird < ApplicationModel
+class Bird < ApplicationRecord
   belongs_to :pirate
   validates_presence_of :name
 

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -1,4 +1,4 @@
-class Book < ActiveRecord::Base
+class Book < ApplicationModel
   has_many :authors
 
   has_many :citations, :foreign_key => 'book1_id'

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -1,4 +1,4 @@
-class Book < ApplicationModel
+class Book < ApplicationRecord
   has_many :authors
 
   has_many :citations, :foreign_key => 'book1_id'

--- a/activerecord/test/models/boolean.rb
+++ b/activerecord/test/models/boolean.rb
@@ -1,2 +1,2 @@
-class Boolean < ActiveRecord::Base
+class Boolean < ApplicationModel
 end

--- a/activerecord/test/models/boolean.rb
+++ b/activerecord/test/models/boolean.rb
@@ -1,2 +1,2 @@
-class Boolean < ApplicationModel
+class Boolean < ApplicationRecord
 end

--- a/activerecord/test/models/bulb.rb
+++ b/activerecord/test/models/bulb.rb
@@ -1,4 +1,4 @@
-class Bulb < ActiveRecord::Base
+class Bulb < ApplicationModel
   default_scope { where(:name => 'defaulty') }
   belongs_to :car, :touch => true
 

--- a/activerecord/test/models/bulb.rb
+++ b/activerecord/test/models/bulb.rb
@@ -1,4 +1,4 @@
-class Bulb < ApplicationModel
+class Bulb < ApplicationRecord
   default_scope { where(:name => 'defaulty') }
   belongs_to :car, :touch => true
 

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -1,4 +1,4 @@
-class Car < ApplicationModel
+class Car < ApplicationRecord
   has_many :bulbs
   has_many :funky_bulbs, class_name: 'FunkyBulb', dependent: :destroy
   has_many :foo_bulbs, -> { where(:name => 'foo') }, :class_name => "Bulb"

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -1,4 +1,4 @@
-class Car < ActiveRecord::Base
+class Car < ApplicationModel
   has_many :bulbs
   has_many :funky_bulbs, class_name: 'FunkyBulb', dependent: :destroy
   has_many :foo_bulbs, -> { where(:name => 'foo') }, :class_name => "Bulb"

--- a/activerecord/test/models/categorization.rb
+++ b/activerecord/test/models/categorization.rb
@@ -1,4 +1,4 @@
-class Categorization < ApplicationModel
+class Categorization < ApplicationRecord
   belongs_to :post
   belongs_to :category
   belongs_to :named_category, :class_name => 'Category', :foreign_key => :named_category_name, :primary_key => :name
@@ -10,7 +10,7 @@ class Categorization < ApplicationModel
   has_many   :authors_using_custom_pk, :class_name => 'Author', :foreign_key => :id,        :primary_key => :category_id
 end
 
-class SpecialCategorization < ApplicationModel
+class SpecialCategorization < ApplicationRecord
   self.table_name = 'categorizations'
   default_scope { where(:special => true) }
 

--- a/activerecord/test/models/categorization.rb
+++ b/activerecord/test/models/categorization.rb
@@ -1,4 +1,4 @@
-class Categorization < ActiveRecord::Base
+class Categorization < ApplicationModel
   belongs_to :post
   belongs_to :category
   belongs_to :named_category, :class_name => 'Category', :foreign_key => :named_category_name, :primary_key => :name
@@ -10,7 +10,7 @@ class Categorization < ActiveRecord::Base
   has_many   :authors_using_custom_pk, :class_name => 'Author', :foreign_key => :id,        :primary_key => :category_id
 end
 
-class SpecialCategorization < ActiveRecord::Base
+class SpecialCategorization < ApplicationModel
   self.table_name = 'categorizations'
   default_scope { where(:special => true) }
 

--- a/activerecord/test/models/category.rb
+++ b/activerecord/test/models/category.rb
@@ -1,4 +1,4 @@
-class Category < ActiveRecord::Base
+class Category < ApplicationModel
   has_and_belongs_to_many :posts
   has_and_belongs_to_many :special_posts, :class_name => "Post"
   has_and_belongs_to_many :other_posts, :class_name => "Post"

--- a/activerecord/test/models/category.rb
+++ b/activerecord/test/models/category.rb
@@ -1,4 +1,4 @@
-class Category < ApplicationModel
+class Category < ApplicationRecord
   has_and_belongs_to_many :posts
   has_and_belongs_to_many :special_posts, :class_name => "Post"
   has_and_belongs_to_many :other_posts, :class_name => "Post"

--- a/activerecord/test/models/citation.rb
+++ b/activerecord/test/models/citation.rb
@@ -1,3 +1,3 @@
-class Citation < ActiveRecord::Base
+class Citation < ApplicationModel
   belongs_to :reference_of, :class_name => "Book", :foreign_key => :book2_id
 end

--- a/activerecord/test/models/citation.rb
+++ b/activerecord/test/models/citation.rb
@@ -1,3 +1,3 @@
-class Citation < ApplicationModel
+class Citation < ApplicationRecord
   belongs_to :reference_of, :class_name => "Book", :foreign_key => :book2_id
 end

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -1,4 +1,4 @@
-class Club < ActiveRecord::Base
+class Club < ApplicationModel
   has_one :membership
   has_many :memberships, :inverse_of => false
   has_many :members, :through => :memberships

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -1,4 +1,4 @@
-class Club < ApplicationModel
+class Club < ApplicationRecord
   has_one :membership
   has_many :memberships, :inverse_of => false
   has_many :members, :through => :memberships

--- a/activerecord/test/models/column_name.rb
+++ b/activerecord/test/models/column_name.rb
@@ -1,3 +1,3 @@
-class ColumnName < ApplicationModel
+class ColumnName < ApplicationRecord
   self.table_name = "colnametests"
 end

--- a/activerecord/test/models/column_name.rb
+++ b/activerecord/test/models/column_name.rb
@@ -1,3 +1,3 @@
-class ColumnName < ActiveRecord::Base
+class ColumnName < ApplicationModel
   self.table_name = "colnametests"
 end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -1,4 +1,4 @@
-class Comment < ApplicationModel
+class Comment < ApplicationRecord
   scope :limit_by, lambda {|l| limit(l) }
   scope :containing_the_letter_e, -> { where("comments.body LIKE '%e%'") }
   scope :not_again, -> { where("comments.body NOT LIKE '%again%'") }

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -1,4 +1,4 @@
-class Comment < ActiveRecord::Base
+class Comment < ApplicationModel
   scope :limit_by, lambda {|l| limit(l) }
   scope :containing_the_letter_e, -> { where("comments.body LIKE '%e%'") }
   scope :not_again, -> { where("comments.body NOT LIKE '%again%'") }

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -1,4 +1,4 @@
-class AbstractCompany < ApplicationModel
+class AbstractCompany < ApplicationRecord
   self.abstract_class = true
 end
 
@@ -174,7 +174,7 @@ end
 class VerySpecialClient < SpecialClient
 end
 
-class Account < ApplicationModel
+class Account < ApplicationRecord
   belongs_to :firm, :class_name => 'Company'
   belongs_to :unautosaved_firm, :foreign_key => "firm_id", :class_name => "Firm", :autosave => false
 

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -1,4 +1,4 @@
-class AbstractCompany < ActiveRecord::Base
+class AbstractCompany < ApplicationModel
   self.abstract_class = true
 end
 
@@ -174,7 +174,7 @@ end
 class VerySpecialClient < SpecialClient
 end
 
-class Account < ActiveRecord::Base
+class Account < ApplicationModel
   belongs_to :firm, :class_name => 'Company'
   belongs_to :unautosaved_firm, :foreign_key => "firm_id", :class_name => "Firm", :autosave => false
 

--- a/activerecord/test/models/company_in_module.rb
+++ b/activerecord/test/models/company_in_module.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/object/with_options'
 
 module MyApplication
   module Business
-    class Company < ApplicationModel
+    class Company < ApplicationRecord
     end
 
     class Firm < Company
@@ -17,15 +17,15 @@ module MyApplication
       belongs_to :firm, :foreign_key => "client_of"
       belongs_to :firm_with_other_name, :class_name => "Firm", :foreign_key => "client_of"
 
-      class Contact < ApplicationModel; end
+      class Contact < ApplicationRecord; end
     end
 
-    class Developer < ApplicationModel
+    class Developer < ApplicationRecord
       has_and_belongs_to_many :projects
       validates_length_of :name, :within => (3..20)
     end
 
-    class Project < ApplicationModel
+    class Project < ApplicationRecord
       has_and_belongs_to_many :developers
     end
 
@@ -34,7 +34,7 @@ module MyApplication
         'prefixed_'
       end
 
-      class Company < ApplicationModel
+      class Company < ApplicationRecord
       end
 
       class Firm < Company
@@ -42,24 +42,24 @@ module MyApplication
       end
 
       module Nested
-        class Company < ApplicationModel
+        class Company < ApplicationRecord
         end
       end
     end
   end
 
   module Billing
-    class Firm < ApplicationModel
+    class Firm < ApplicationRecord
       self.table_name = 'companies'
     end
 
     module Nested
-      class Firm < ApplicationModel
+      class Firm < ApplicationRecord
         self.table_name = 'companies'
       end
     end
 
-    class Account < ApplicationModel
+    class Account < ApplicationRecord
       with_options(:foreign_key => :firm_id) do |i|
         i.belongs_to :firm, :class_name => 'MyApplication::Business::Firm'
         i.belongs_to :qualified_billing_firm, :class_name => 'MyApplication::Billing::Firm'

--- a/activerecord/test/models/company_in_module.rb
+++ b/activerecord/test/models/company_in_module.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/object/with_options'
 
 module MyApplication
   module Business
-    class Company < ActiveRecord::Base
+    class Company < ApplicationModel
     end
 
     class Firm < Company
@@ -17,15 +17,15 @@ module MyApplication
       belongs_to :firm, :foreign_key => "client_of"
       belongs_to :firm_with_other_name, :class_name => "Firm", :foreign_key => "client_of"
 
-      class Contact < ActiveRecord::Base; end
+      class Contact < ApplicationModel; end
     end
 
-    class Developer < ActiveRecord::Base
+    class Developer < ApplicationModel
       has_and_belongs_to_many :projects
       validates_length_of :name, :within => (3..20)
     end
 
-    class Project < ActiveRecord::Base
+    class Project < ApplicationModel
       has_and_belongs_to_many :developers
     end
 
@@ -34,7 +34,7 @@ module MyApplication
         'prefixed_'
       end
 
-      class Company < ActiveRecord::Base
+      class Company < ApplicationModel
       end
 
       class Firm < Company
@@ -42,24 +42,24 @@ module MyApplication
       end
 
       module Nested
-        class Company < ActiveRecord::Base
+        class Company < ApplicationModel
         end
       end
     end
   end
 
   module Billing
-    class Firm < ActiveRecord::Base
+    class Firm < ApplicationModel
       self.table_name = 'companies'
     end
 
     module Nested
-      class Firm < ActiveRecord::Base
+      class Firm < ApplicationModel
         self.table_name = 'companies'
       end
     end
 
-    class Account < ActiveRecord::Base
+    class Account < ApplicationModel
       with_options(:foreign_key => :firm_id) do |i|
         i.belongs_to :firm, :class_name => 'MyApplication::Business::Firm'
         i.belongs_to :qualified_billing_firm, :class_name => 'MyApplication::Billing::Firm'

--- a/activerecord/test/models/computer.rb
+++ b/activerecord/test/models/computer.rb
@@ -1,3 +1,3 @@
-class Computer < ApplicationModel
+class Computer < ApplicationRecord
   belongs_to :developer, :foreign_key=>'developer'
 end

--- a/activerecord/test/models/computer.rb
+++ b/activerecord/test/models/computer.rb
@@ -1,3 +1,3 @@
-class Computer < ActiveRecord::Base
+class Computer < ApplicationModel
   belongs_to :developer, :foreign_key=>'developer'
 end

--- a/activerecord/test/models/contact.rb
+++ b/activerecord/test/models/contact.rb
@@ -28,11 +28,11 @@ module ContactFakeColumns
   end
 end
 
-class Contact < ActiveRecord::Base
+class Contact < ApplicationModel
   extend ContactFakeColumns
 end
 
-class ContactSti < ActiveRecord::Base
+class ContactSti < ApplicationModel
   extend ContactFakeColumns
   column :type, :string
 

--- a/activerecord/test/models/contact.rb
+++ b/activerecord/test/models/contact.rb
@@ -28,11 +28,11 @@ module ContactFakeColumns
   end
 end
 
-class Contact < ApplicationModel
+class Contact < ApplicationRecord
   extend ContactFakeColumns
 end
 
-class ContactSti < ApplicationModel
+class ContactSti < ApplicationRecord
   extend ContactFakeColumns
   column :type, :string
 

--- a/activerecord/test/models/contract.rb
+++ b/activerecord/test/models/contract.rb
@@ -1,4 +1,4 @@
-class Contract < ActiveRecord::Base
+class Contract < ApplicationModel
   belongs_to :company
   belongs_to :developer
 

--- a/activerecord/test/models/contract.rb
+++ b/activerecord/test/models/contract.rb
@@ -1,4 +1,4 @@
-class Contract < ApplicationModel
+class Contract < ApplicationRecord
   belongs_to :company
   belongs_to :developer
 

--- a/activerecord/test/models/country.rb
+++ b/activerecord/test/models/country.rb
@@ -1,4 +1,4 @@
-class Country < ApplicationModel
+class Country < ApplicationRecord
 
   self.primary_key = :country_id
 

--- a/activerecord/test/models/country.rb
+++ b/activerecord/test/models/country.rb
@@ -1,4 +1,4 @@
-class Country < ActiveRecord::Base
+class Country < ApplicationModel
 
   self.primary_key = :country_id
 

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -1,4 +1,4 @@
-class Customer < ApplicationModel
+class Customer < ApplicationRecord
   cattr_accessor :gps_conversion_was_run
 
   composed_of :address, :mapping => [ %w(address_street street), %w(address_city city), %w(address_country country) ], :allow_nil => true

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -1,4 +1,4 @@
-class Customer < ActiveRecord::Base
+class Customer < ApplicationModel
   cattr_accessor :gps_conversion_was_run
 
   composed_of :address, :mapping => [ %w(address_street street), %w(address_city city), %w(address_country country) ], :allow_nil => true

--- a/activerecord/test/models/dashboard.rb
+++ b/activerecord/test/models/dashboard.rb
@@ -1,3 +1,3 @@
-class Dashboard < ActiveRecord::Base
+class Dashboard < ApplicationModel
   self.primary_key = :dashboard_id
 end

--- a/activerecord/test/models/dashboard.rb
+++ b/activerecord/test/models/dashboard.rb
@@ -1,3 +1,3 @@
-class Dashboard < ApplicationModel
+class Dashboard < ApplicationRecord
   self.primary_key = :dashboard_id
 end

--- a/activerecord/test/models/default.rb
+++ b/activerecord/test/models/default.rb
@@ -1,2 +1,2 @@
-class Default < ApplicationModel
+class Default < ApplicationRecord
 end

--- a/activerecord/test/models/default.rb
+++ b/activerecord/test/models/default.rb
@@ -1,2 +1,2 @@
-class Default < ActiveRecord::Base
+class Default < ApplicationModel
 end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -6,7 +6,7 @@ module DeveloperProjectsAssociationExtension2
   end
 end
 
-class Developer < ApplicationModel
+class Developer < ApplicationRecord
   has_and_belongs_to_many :projects do
     def find_most_recent
       order("id DESC").first
@@ -63,18 +63,18 @@ class Developer < ApplicationModel
 
 end
 
-class AuditLog < ApplicationModel
+class AuditLog < ApplicationRecord
   belongs_to :developer, :validate => true
   belongs_to :unvalidated_developer, :class_name => 'Developer'
 end
 
 DeveloperSalary = Struct.new(:amount)
-class DeveloperWithAggregate < ApplicationModel
+class DeveloperWithAggregate < ApplicationRecord
   self.table_name = 'developers'
   composed_of :salary, :class_name => 'DeveloperSalary', :mapping => [%w(salary amount)]
 end
 
-class DeveloperWithBeforeDestroyRaise < ApplicationModel
+class DeveloperWithBeforeDestroyRaise < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, :join_table => 'developers_projects', :foreign_key => 'developer_id'
   before_destroy :raise_if_projects_empty!
@@ -84,18 +84,18 @@ class DeveloperWithBeforeDestroyRaise < ApplicationModel
   end
 end
 
-class DeveloperWithSelect < ApplicationModel
+class DeveloperWithSelect < ApplicationRecord
   self.table_name = 'developers'
   default_scope { select('name') }
 end
 
-class DeveloperWithIncludes < ApplicationModel
+class DeveloperWithIncludes < ApplicationRecord
   self.table_name = 'developers'
   has_many :audit_logs, :foreign_key => :developer_id
   default_scope { includes(:audit_logs) }
 end
 
-class DeveloperFilteredOnJoins < ApplicationModel
+class DeveloperFilteredOnJoins < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
@@ -104,34 +104,34 @@ class DeveloperFilteredOnJoins < ApplicationModel
   end
 end
 
-class DeveloperOrderedBySalary < ApplicationModel
+class DeveloperOrderedBySalary < ApplicationRecord
   self.table_name = 'developers'
   default_scope { order('salary DESC') }
 
   scope :by_name, -> { order('name DESC') }
 end
 
-class DeveloperCalledDavid < ApplicationModel
+class DeveloperCalledDavid < ApplicationRecord
   self.table_name = 'developers'
   default_scope { where("name = 'David'") }
 end
 
-class LazyLambdaDeveloperCalledDavid < ApplicationModel
+class LazyLambdaDeveloperCalledDavid < ApplicationRecord
   self.table_name = 'developers'
   default_scope lambda { where(:name => 'David') }
 end
 
-class LazyBlockDeveloperCalledDavid < ApplicationModel
+class LazyBlockDeveloperCalledDavid < ApplicationRecord
   self.table_name = 'developers'
   default_scope { where(:name => 'David') }
 end
 
-class CallableDeveloperCalledDavid < ApplicationModel
+class CallableDeveloperCalledDavid < ApplicationRecord
   self.table_name = 'developers'
   default_scope OpenStruct.new(:call => where(:name => 'David'))
 end
 
-class ClassMethodDeveloperCalledDavid < ApplicationModel
+class ClassMethodDeveloperCalledDavid < ApplicationRecord
   self.table_name = 'developers'
 
   def self.default_scope
@@ -139,7 +139,7 @@ class ClassMethodDeveloperCalledDavid < ApplicationModel
   end
 end
 
-class ClassMethodReferencingScopeDeveloperCalledDavid < ApplicationModel
+class ClassMethodReferencingScopeDeveloperCalledDavid < ApplicationRecord
   self.table_name = 'developers'
   scope :david, -> { where(:name => 'David') }
 
@@ -148,20 +148,20 @@ class ClassMethodReferencingScopeDeveloperCalledDavid < ApplicationModel
   end
 end
 
-class LazyBlockReferencingScopeDeveloperCalledDavid < ApplicationModel
+class LazyBlockReferencingScopeDeveloperCalledDavid < ApplicationRecord
   self.table_name = 'developers'
   scope :david, -> { where(:name => 'David') }
   default_scope { david }
 end
 
-class DeveloperCalledJamis < ApplicationModel
+class DeveloperCalledJamis < ApplicationRecord
   self.table_name = 'developers'
 
   default_scope { where(:name => 'Jamis') }
   scope :poor, -> { where('salary < 150000') }
 end
 
-class PoorDeveloperCalledJamis < ApplicationModel
+class PoorDeveloperCalledJamis < ApplicationRecord
   self.table_name = 'developers'
 
   default_scope -> { where(:name => 'Jamis', :salary => 50000) }
@@ -173,7 +173,7 @@ class InheritedPoorDeveloperCalledJamis < DeveloperCalledJamis
   default_scope -> { where(:salary => 50000) }
 end
 
-class MultiplePoorDeveloperCalledJamis < ApplicationModel
+class MultiplePoorDeveloperCalledJamis < ApplicationRecord
   self.table_name = 'developers'
 
   default_scope -> { where(:name => 'Jamis') }
@@ -192,14 +192,14 @@ class ModuleIncludedPoorDeveloperCalledJamis < DeveloperCalledJamis
   include SalaryDefaultScope
 end
 
-class EagerDeveloperWithDefaultScope < ApplicationModel
+class EagerDeveloperWithDefaultScope < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope { includes(:projects) }
 end
 
-class EagerDeveloperWithClassMethodDefaultScope < ApplicationModel
+class EagerDeveloperWithClassMethodDefaultScope < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
@@ -208,28 +208,28 @@ class EagerDeveloperWithClassMethodDefaultScope < ApplicationModel
   end
 end
 
-class EagerDeveloperWithLambdaDefaultScope < ApplicationModel
+class EagerDeveloperWithLambdaDefaultScope < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope lambda { includes(:projects) }
 end
 
-class EagerDeveloperWithBlockDefaultScope < ApplicationModel
+class EagerDeveloperWithBlockDefaultScope < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope { includes(:projects) }
 end
 
-class EagerDeveloperWithCallableDefaultScope < ApplicationModel
+class EagerDeveloperWithCallableDefaultScope < ApplicationRecord
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope OpenStruct.new(:call => includes(:projects))
 end
 
-class ThreadsafeDeveloper < ApplicationModel
+class ThreadsafeDeveloper < ApplicationRecord
   self.table_name = 'developers'
 
   def self.default_scope
@@ -238,7 +238,7 @@ class ThreadsafeDeveloper < ApplicationModel
   end
 end
 
-class CachedDeveloper < ApplicationModel
+class CachedDeveloper < ApplicationRecord
   self.table_name = "developers"
   self.cache_timestamp_format = :number
 end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -6,7 +6,7 @@ module DeveloperProjectsAssociationExtension2
   end
 end
 
-class Developer < ActiveRecord::Base
+class Developer < ApplicationModel
   has_and_belongs_to_many :projects do
     def find_most_recent
       order("id DESC").first
@@ -63,18 +63,18 @@ class Developer < ActiveRecord::Base
 
 end
 
-class AuditLog < ActiveRecord::Base
+class AuditLog < ApplicationModel
   belongs_to :developer, :validate => true
   belongs_to :unvalidated_developer, :class_name => 'Developer'
 end
 
 DeveloperSalary = Struct.new(:amount)
-class DeveloperWithAggregate < ActiveRecord::Base
+class DeveloperWithAggregate < ApplicationModel
   self.table_name = 'developers'
   composed_of :salary, :class_name => 'DeveloperSalary', :mapping => [%w(salary amount)]
 end
 
-class DeveloperWithBeforeDestroyRaise < ActiveRecord::Base
+class DeveloperWithBeforeDestroyRaise < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, :join_table => 'developers_projects', :foreign_key => 'developer_id'
   before_destroy :raise_if_projects_empty!
@@ -84,18 +84,18 @@ class DeveloperWithBeforeDestroyRaise < ActiveRecord::Base
   end
 end
 
-class DeveloperWithSelect < ActiveRecord::Base
+class DeveloperWithSelect < ApplicationModel
   self.table_name = 'developers'
   default_scope { select('name') }
 end
 
-class DeveloperWithIncludes < ActiveRecord::Base
+class DeveloperWithIncludes < ApplicationModel
   self.table_name = 'developers'
   has_many :audit_logs, :foreign_key => :developer_id
   default_scope { includes(:audit_logs) }
 end
 
-class DeveloperFilteredOnJoins < ActiveRecord::Base
+class DeveloperFilteredOnJoins < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
@@ -104,34 +104,34 @@ class DeveloperFilteredOnJoins < ActiveRecord::Base
   end
 end
 
-class DeveloperOrderedBySalary < ActiveRecord::Base
+class DeveloperOrderedBySalary < ApplicationModel
   self.table_name = 'developers'
   default_scope { order('salary DESC') }
 
   scope :by_name, -> { order('name DESC') }
 end
 
-class DeveloperCalledDavid < ActiveRecord::Base
+class DeveloperCalledDavid < ApplicationModel
   self.table_name = 'developers'
   default_scope { where("name = 'David'") }
 end
 
-class LazyLambdaDeveloperCalledDavid < ActiveRecord::Base
+class LazyLambdaDeveloperCalledDavid < ApplicationModel
   self.table_name = 'developers'
   default_scope lambda { where(:name => 'David') }
 end
 
-class LazyBlockDeveloperCalledDavid < ActiveRecord::Base
+class LazyBlockDeveloperCalledDavid < ApplicationModel
   self.table_name = 'developers'
   default_scope { where(:name => 'David') }
 end
 
-class CallableDeveloperCalledDavid < ActiveRecord::Base
+class CallableDeveloperCalledDavid < ApplicationModel
   self.table_name = 'developers'
   default_scope OpenStruct.new(:call => where(:name => 'David'))
 end
 
-class ClassMethodDeveloperCalledDavid < ActiveRecord::Base
+class ClassMethodDeveloperCalledDavid < ApplicationModel
   self.table_name = 'developers'
 
   def self.default_scope
@@ -139,7 +139,7 @@ class ClassMethodDeveloperCalledDavid < ActiveRecord::Base
   end
 end
 
-class ClassMethodReferencingScopeDeveloperCalledDavid < ActiveRecord::Base
+class ClassMethodReferencingScopeDeveloperCalledDavid < ApplicationModel
   self.table_name = 'developers'
   scope :david, -> { where(:name => 'David') }
 
@@ -148,20 +148,20 @@ class ClassMethodReferencingScopeDeveloperCalledDavid < ActiveRecord::Base
   end
 end
 
-class LazyBlockReferencingScopeDeveloperCalledDavid < ActiveRecord::Base
+class LazyBlockReferencingScopeDeveloperCalledDavid < ApplicationModel
   self.table_name = 'developers'
   scope :david, -> { where(:name => 'David') }
   default_scope { david }
 end
 
-class DeveloperCalledJamis < ActiveRecord::Base
+class DeveloperCalledJamis < ApplicationModel
   self.table_name = 'developers'
 
   default_scope { where(:name => 'Jamis') }
   scope :poor, -> { where('salary < 150000') }
 end
 
-class PoorDeveloperCalledJamis < ActiveRecord::Base
+class PoorDeveloperCalledJamis < ApplicationModel
   self.table_name = 'developers'
 
   default_scope -> { where(:name => 'Jamis', :salary => 50000) }
@@ -173,7 +173,7 @@ class InheritedPoorDeveloperCalledJamis < DeveloperCalledJamis
   default_scope -> { where(:salary => 50000) }
 end
 
-class MultiplePoorDeveloperCalledJamis < ActiveRecord::Base
+class MultiplePoorDeveloperCalledJamis < ApplicationModel
   self.table_name = 'developers'
 
   default_scope -> { where(:name => 'Jamis') }
@@ -192,14 +192,14 @@ class ModuleIncludedPoorDeveloperCalledJamis < DeveloperCalledJamis
   include SalaryDefaultScope
 end
 
-class EagerDeveloperWithDefaultScope < ActiveRecord::Base
+class EagerDeveloperWithDefaultScope < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope { includes(:projects) }
 end
 
-class EagerDeveloperWithClassMethodDefaultScope < ActiveRecord::Base
+class EagerDeveloperWithClassMethodDefaultScope < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
@@ -208,28 +208,28 @@ class EagerDeveloperWithClassMethodDefaultScope < ActiveRecord::Base
   end
 end
 
-class EagerDeveloperWithLambdaDefaultScope < ActiveRecord::Base
+class EagerDeveloperWithLambdaDefaultScope < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope lambda { includes(:projects) }
 end
 
-class EagerDeveloperWithBlockDefaultScope < ActiveRecord::Base
+class EagerDeveloperWithBlockDefaultScope < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope { includes(:projects) }
 end
 
-class EagerDeveloperWithCallableDefaultScope < ActiveRecord::Base
+class EagerDeveloperWithCallableDefaultScope < ApplicationModel
   self.table_name = 'developers'
   has_and_belongs_to_many :projects, -> { order('projects.id') }, :foreign_key => 'developer_id', :join_table => 'developers_projects'
 
   default_scope OpenStruct.new(:call => includes(:projects))
 end
 
-class ThreadsafeDeveloper < ActiveRecord::Base
+class ThreadsafeDeveloper < ApplicationModel
   self.table_name = 'developers'
 
   def self.default_scope
@@ -238,7 +238,7 @@ class ThreadsafeDeveloper < ActiveRecord::Base
   end
 end
 
-class CachedDeveloper < ActiveRecord::Base
+class CachedDeveloper < ApplicationModel
   self.table_name = "developers"
   self.cache_timestamp_format = :number
 end

--- a/activerecord/test/models/dog.rb
+++ b/activerecord/test/models/dog.rb
@@ -1,4 +1,4 @@
-class Dog < ActiveRecord::Base
+class Dog < ApplicationModel
   belongs_to :breeder, class_name: "DogLover", counter_cache: :bred_dogs_count
   belongs_to :trainer, class_name: "DogLover", counter_cache: :trained_dogs_count
   belongs_to :doglover, foreign_key: :dog_lover_id, class_name: "DogLover", counter_cache: true

--- a/activerecord/test/models/dog.rb
+++ b/activerecord/test/models/dog.rb
@@ -1,4 +1,4 @@
-class Dog < ApplicationModel
+class Dog < ApplicationRecord
   belongs_to :breeder, class_name: "DogLover", counter_cache: :bred_dogs_count
   belongs_to :trainer, class_name: "DogLover", counter_cache: :trained_dogs_count
   belongs_to :doglover, foreign_key: :dog_lover_id, class_name: "DogLover", counter_cache: true

--- a/activerecord/test/models/dog_lover.rb
+++ b/activerecord/test/models/dog_lover.rb
@@ -1,4 +1,4 @@
-class DogLover < ApplicationModel
+class DogLover < ApplicationRecord
   has_many :trained_dogs, class_name: "Dog", foreign_key: :trainer_id, dependent: :destroy
   has_many :bred_dogs, class_name: "Dog", foreign_key: :breeder_id
   has_many :dogs

--- a/activerecord/test/models/dog_lover.rb
+++ b/activerecord/test/models/dog_lover.rb
@@ -1,4 +1,4 @@
-class DogLover < ActiveRecord::Base
+class DogLover < ApplicationModel
   has_many :trained_dogs, class_name: "Dog", foreign_key: :trainer_id, dependent: :destroy
   has_many :bred_dogs, class_name: "Dog", foreign_key: :breeder_id
   has_many :dogs

--- a/activerecord/test/models/edge.rb
+++ b/activerecord/test/models/edge.rb
@@ -1,5 +1,5 @@
 # This class models an edge in a directed graph.
-class Edge < ActiveRecord::Base
+class Edge < ApplicationModel
   belongs_to :source, :class_name => 'Vertex', :foreign_key => 'source_id'
   belongs_to :sink,   :class_name => 'Vertex', :foreign_key => 'sink_id'
 end

--- a/activerecord/test/models/edge.rb
+++ b/activerecord/test/models/edge.rb
@@ -1,5 +1,5 @@
 # This class models an edge in a directed graph.
-class Edge < ApplicationModel
+class Edge < ApplicationRecord
   belongs_to :source, :class_name => 'Vertex', :foreign_key => 'source_id'
   belongs_to :sink,   :class_name => 'Vertex', :foreign_key => 'sink_id'
 end

--- a/activerecord/test/models/electron.rb
+++ b/activerecord/test/models/electron.rb
@@ -1,3 +1,3 @@
-class Electron < ApplicationModel
+class Electron < ApplicationRecord
   belongs_to :molecule
 end

--- a/activerecord/test/models/electron.rb
+++ b/activerecord/test/models/electron.rb
@@ -1,3 +1,3 @@
-class Electron < ActiveRecord::Base
+class Electron < ApplicationModel
   belongs_to :molecule
 end

--- a/activerecord/test/models/engine.rb
+++ b/activerecord/test/models/engine.rb
@@ -1,4 +1,4 @@
-class Engine < ApplicationModel
+class Engine < ApplicationRecord
   belongs_to :my_car, :class_name => 'Car', :foreign_key => 'car_id',  :counter_cache => :engines_count
 end
 

--- a/activerecord/test/models/engine.rb
+++ b/activerecord/test/models/engine.rb
@@ -1,4 +1,4 @@
-class Engine < ActiveRecord::Base
+class Engine < ApplicationModel
   belongs_to :my_car, :class_name => 'Car', :foreign_key => 'car_id',  :counter_cache => :engines_count
 end
 

--- a/activerecord/test/models/entrant.rb
+++ b/activerecord/test/models/entrant.rb
@@ -1,3 +1,3 @@
-class Entrant < ActiveRecord::Base
+class Entrant < ApplicationModel
   belongs_to :course
 end

--- a/activerecord/test/models/entrant.rb
+++ b/activerecord/test/models/entrant.rb
@@ -1,3 +1,3 @@
-class Entrant < ApplicationModel
+class Entrant < ApplicationRecord
   belongs_to :course
 end

--- a/activerecord/test/models/essay.rb
+++ b/activerecord/test/models/essay.rb
@@ -1,4 +1,4 @@
-class Essay < ActiveRecord::Base
+class Essay < ApplicationModel
   belongs_to :writer, :primary_key => :name, :polymorphic => true
   belongs_to :category, :primary_key => :name
   has_one :owner, :primary_key => :name

--- a/activerecord/test/models/essay.rb
+++ b/activerecord/test/models/essay.rb
@@ -1,4 +1,4 @@
-class Essay < ApplicationModel
+class Essay < ApplicationRecord
   belongs_to :writer, :primary_key => :name, :polymorphic => true
   belongs_to :category, :primary_key => :name
   has_one :owner, :primary_key => :name

--- a/activerecord/test/models/event.rb
+++ b/activerecord/test/models/event.rb
@@ -1,3 +1,3 @@
-class Event < ApplicationModel
+class Event < ApplicationRecord
   validates_uniqueness_of :title
 end

--- a/activerecord/test/models/event.rb
+++ b/activerecord/test/models/event.rb
@@ -1,3 +1,3 @@
-class Event < ActiveRecord::Base
+class Event < ApplicationModel
   validates_uniqueness_of :title
 end

--- a/activerecord/test/models/eye.rb
+++ b/activerecord/test/models/eye.rb
@@ -1,4 +1,4 @@
-class Eye < ActiveRecord::Base
+class Eye < ApplicationModel
   attr_reader :after_create_callbacks_stack
   attr_reader :after_update_callbacks_stack
   attr_reader :after_save_callbacks_stack
@@ -32,6 +32,6 @@ class Eye < ActiveRecord::Base
   alias trace_after_save2 trace_after_save
 end
 
-class Iris < ActiveRecord::Base
+class Iris < ApplicationModel
   belongs_to :eye
 end

--- a/activerecord/test/models/eye.rb
+++ b/activerecord/test/models/eye.rb
@@ -1,4 +1,4 @@
-class Eye < ApplicationModel
+class Eye < ApplicationRecord
   attr_reader :after_create_callbacks_stack
   attr_reader :after_update_callbacks_stack
   attr_reader :after_save_callbacks_stack
@@ -32,6 +32,6 @@ class Eye < ApplicationModel
   alias trace_after_save2 trace_after_save
 end
 
-class Iris < ApplicationModel
+class Iris < ApplicationRecord
   belongs_to :eye
 end

--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -1,4 +1,4 @@
-class Face < ActiveRecord::Base
+class Face < ApplicationModel
   belongs_to :man, :inverse_of => :face
   belongs_to :polymorphic_man, :polymorphic => true, :inverse_of => :polymorphic_face
   # These is a "broken" inverse_of for the purposes of testing

--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -1,4 +1,4 @@
-class Face < ApplicationModel
+class Face < ApplicationRecord
   belongs_to :man, :inverse_of => :face
   belongs_to :polymorphic_man, :polymorphic => true, :inverse_of => :polymorphic_face
   # These is a "broken" inverse_of for the purposes of testing

--- a/activerecord/test/models/friendship.rb
+++ b/activerecord/test/models/friendship.rb
@@ -1,4 +1,4 @@
-class Friendship < ActiveRecord::Base
+class Friendship < ApplicationModel
   belongs_to :friend, class_name: 'Person'
   # friend_too exists to test a bug, and probably shouldn't be used elsewhere
   belongs_to :friend_too, foreign_key: 'friend_id', class_name: 'Person', counter_cache: :friends_too_count

--- a/activerecord/test/models/friendship.rb
+++ b/activerecord/test/models/friendship.rb
@@ -1,4 +1,4 @@
-class Friendship < ApplicationModel
+class Friendship < ApplicationRecord
   belongs_to :friend, class_name: 'Person'
   # friend_too exists to test a bug, and probably shouldn't be used elsewhere
   belongs_to :friend_too, foreign_key: 'friend_id', class_name: 'Person', counter_cache: :friends_too_count

--- a/activerecord/test/models/guid.rb
+++ b/activerecord/test/models/guid.rb
@@ -1,2 +1,2 @@
-class Guid < ApplicationModel
+class Guid < ApplicationRecord
 end

--- a/activerecord/test/models/guid.rb
+++ b/activerecord/test/models/guid.rb
@@ -1,2 +1,2 @@
-class Guid < ActiveRecord::Base
+class Guid < ApplicationModel
 end

--- a/activerecord/test/models/interest.rb
+++ b/activerecord/test/models/interest.rb
@@ -1,4 +1,4 @@
-class Interest < ApplicationModel
+class Interest < ApplicationRecord
   belongs_to :man, :inverse_of => :interests
   belongs_to :polymorphic_man, :polymorphic => true, :inverse_of => :polymorphic_interests
   belongs_to :zine, :inverse_of => :interests

--- a/activerecord/test/models/interest.rb
+++ b/activerecord/test/models/interest.rb
@@ -1,4 +1,4 @@
-class Interest < ActiveRecord::Base
+class Interest < ApplicationModel
   belongs_to :man, :inverse_of => :interests
   belongs_to :polymorphic_man, :polymorphic => true, :inverse_of => :polymorphic_interests
   belongs_to :zine, :inverse_of => :interests

--- a/activerecord/test/models/invoice.rb
+++ b/activerecord/test/models/invoice.rb
@@ -1,4 +1,4 @@
-class Invoice < ApplicationModel
+class Invoice < ApplicationRecord
   has_many :line_items, :autosave => true
   before_save {|record| record.balance = record.line_items.map(&:amount).sum }
 end

--- a/activerecord/test/models/invoice.rb
+++ b/activerecord/test/models/invoice.rb
@@ -1,4 +1,4 @@
-class Invoice < ActiveRecord::Base
+class Invoice < ApplicationModel
   has_many :line_items, :autosave => true
   before_save {|record| record.balance = record.line_items.map(&:amount).sum }
 end

--- a/activerecord/test/models/item.rb
+++ b/activerecord/test/models/item.rb
@@ -1,4 +1,4 @@
-class AbstractItem < ApplicationModel
+class AbstractItem < ApplicationRecord
   self.abstract_class = true
   has_one :tagging, :as => :taggable
 end

--- a/activerecord/test/models/item.rb
+++ b/activerecord/test/models/item.rb
@@ -1,4 +1,4 @@
-class AbstractItem < ActiveRecord::Base
+class AbstractItem < ApplicationModel
   self.abstract_class = true
   has_one :tagging, :as => :taggable
 end

--- a/activerecord/test/models/job.rb
+++ b/activerecord/test/models/job.rb
@@ -1,4 +1,4 @@
-class Job < ApplicationModel
+class Job < ApplicationRecord
   has_many :references
   has_many :people, :through => :references
   belongs_to :ideal_reference, :class_name => 'Reference'

--- a/activerecord/test/models/job.rb
+++ b/activerecord/test/models/job.rb
@@ -1,4 +1,4 @@
-class Job < ActiveRecord::Base
+class Job < ApplicationModel
   has_many :references
   has_many :people, :through => :references
   belongs_to :ideal_reference, :class_name => 'Reference'

--- a/activerecord/test/models/joke.rb
+++ b/activerecord/test/models/joke.rb
@@ -1,7 +1,7 @@
-class Joke < ApplicationModel
+class Joke < ApplicationRecord
   self.table_name = 'funny_jokes'
 end
 
-class GoodJoke < ApplicationModel
+class GoodJoke < ApplicationRecord
   self.table_name = 'funny_jokes'
 end

--- a/activerecord/test/models/joke.rb
+++ b/activerecord/test/models/joke.rb
@@ -1,7 +1,7 @@
-class Joke < ActiveRecord::Base
+class Joke < ApplicationModel
   self.table_name = 'funny_jokes'
 end
 
-class GoodJoke < ActiveRecord::Base
+class GoodJoke < ApplicationModel
   self.table_name = 'funny_jokes'
 end

--- a/activerecord/test/models/keyboard.rb
+++ b/activerecord/test/models/keyboard.rb
@@ -1,3 +1,3 @@
-class Keyboard < ApplicationModel
+class Keyboard < ApplicationRecord
   self.primary_key = 'key_number'
 end

--- a/activerecord/test/models/keyboard.rb
+++ b/activerecord/test/models/keyboard.rb
@@ -1,3 +1,3 @@
-class Keyboard < ActiveRecord::Base
+class Keyboard < ApplicationModel
   self.primary_key = 'key_number'
 end

--- a/activerecord/test/models/legacy_thing.rb
+++ b/activerecord/test/models/legacy_thing.rb
@@ -1,3 +1,3 @@
-class LegacyThing < ActiveRecord::Base
+class LegacyThing < ApplicationModel
   self.locking_column = :version
 end

--- a/activerecord/test/models/legacy_thing.rb
+++ b/activerecord/test/models/legacy_thing.rb
@@ -1,3 +1,3 @@
-class LegacyThing < ApplicationModel
+class LegacyThing < ApplicationRecord
   self.locking_column = :version
 end

--- a/activerecord/test/models/lesson.rb
+++ b/activerecord/test/models/lesson.rb
@@ -1,7 +1,7 @@
 class LessonError < Exception
 end
 
-class Lesson < ApplicationModel
+class Lesson < ApplicationRecord
   has_and_belongs_to_many :students
   before_destroy :ensure_no_students
 

--- a/activerecord/test/models/lesson.rb
+++ b/activerecord/test/models/lesson.rb
@@ -1,7 +1,7 @@
 class LessonError < Exception
 end
 
-class Lesson < ActiveRecord::Base
+class Lesson < ApplicationModel
   has_and_belongs_to_many :students
   before_destroy :ensure_no_students
 

--- a/activerecord/test/models/line_item.rb
+++ b/activerecord/test/models/line_item.rb
@@ -1,3 +1,3 @@
-class LineItem < ActiveRecord::Base
+class LineItem < ApplicationModel
   belongs_to :invoice, :touch => true
 end

--- a/activerecord/test/models/line_item.rb
+++ b/activerecord/test/models/line_item.rb
@@ -1,3 +1,3 @@
-class LineItem < ApplicationModel
+class LineItem < ApplicationRecord
   belongs_to :invoice, :touch => true
 end

--- a/activerecord/test/models/liquid.rb
+++ b/activerecord/test/models/liquid.rb
@@ -1,4 +1,4 @@
-class Liquid < ActiveRecord::Base
+class Liquid < ApplicationModel
   self.table_name = :liquid
   has_many :molecules, -> { distinct }
 end

--- a/activerecord/test/models/liquid.rb
+++ b/activerecord/test/models/liquid.rb
@@ -1,4 +1,4 @@
-class Liquid < ApplicationModel
+class Liquid < ApplicationRecord
   self.table_name = :liquid
   has_many :molecules, -> { distinct }
 end

--- a/activerecord/test/models/man.rb
+++ b/activerecord/test/models/man.rb
@@ -1,4 +1,4 @@
-class Man < ActiveRecord::Base
+class Man < ApplicationModel
   has_one :face, :inverse_of => :man
   has_one :polymorphic_face, :class_name => 'Face', :as => :polymorphic_man, :inverse_of => :polymorphic_man
   has_many :interests, :inverse_of => :man

--- a/activerecord/test/models/man.rb
+++ b/activerecord/test/models/man.rb
@@ -1,4 +1,4 @@
-class Man < ApplicationModel
+class Man < ApplicationRecord
   has_one :face, :inverse_of => :man
   has_one :polymorphic_face, :class_name => 'Face', :as => :polymorphic_man, :inverse_of => :polymorphic_man
   has_many :interests, :inverse_of => :man

--- a/activerecord/test/models/matey.rb
+++ b/activerecord/test/models/matey.rb
@@ -1,4 +1,4 @@
-class Matey < ApplicationModel
+class Matey < ApplicationRecord
   belongs_to :pirate
   belongs_to :target, :class_name => 'Pirate'
 end

--- a/activerecord/test/models/matey.rb
+++ b/activerecord/test/models/matey.rb
@@ -1,4 +1,4 @@
-class Matey < ActiveRecord::Base
+class Matey < ApplicationModel
   belongs_to :pirate
   belongs_to :target, :class_name => 'Pirate'
 end

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -1,4 +1,4 @@
-class Member < ApplicationModel
+class Member < ApplicationRecord
   has_one :current_membership
   has_one :selected_membership
   has_one :membership
@@ -29,7 +29,7 @@ class Member < ApplicationModel
   has_one :club_through_many, :through => :current_memberships, :source => :club
 end
 
-class SelfMember < ApplicationModel
+class SelfMember < ApplicationRecord
   self.table_name = "members"
   has_and_belongs_to_many :friends, :class_name => "SelfMember", :join_table => "member_friends"
 end

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -1,4 +1,4 @@
-class Member < ActiveRecord::Base
+class Member < ApplicationModel
   has_one :current_membership
   has_one :selected_membership
   has_one :membership
@@ -29,7 +29,7 @@ class Member < ActiveRecord::Base
   has_one :club_through_many, :through => :current_memberships, :source => :club
 end
 
-class SelfMember < ActiveRecord::Base
+class SelfMember < ApplicationModel
   self.table_name = "members"
   has_and_belongs_to_many :friends, :class_name => "SelfMember", :join_table => "member_friends"
 end

--- a/activerecord/test/models/member_detail.rb
+++ b/activerecord/test/models/member_detail.rb
@@ -1,4 +1,4 @@
-class MemberDetail < ApplicationModel
+class MemberDetail < ApplicationRecord
   belongs_to :member, :inverse_of => false
   belongs_to :organization
   has_one :member_type, :through => :member

--- a/activerecord/test/models/member_detail.rb
+++ b/activerecord/test/models/member_detail.rb
@@ -1,4 +1,4 @@
-class MemberDetail < ActiveRecord::Base
+class MemberDetail < ApplicationModel
   belongs_to :member, :inverse_of => false
   belongs_to :organization
   has_one :member_type, :through => :member

--- a/activerecord/test/models/member_type.rb
+++ b/activerecord/test/models/member_type.rb
@@ -1,3 +1,3 @@
-class MemberType < ActiveRecord::Base
+class MemberType < ApplicationModel
   has_many :members
 end

--- a/activerecord/test/models/member_type.rb
+++ b/activerecord/test/models/member_type.rb
@@ -1,3 +1,3 @@
-class MemberType < ApplicationModel
+class MemberType < ApplicationRecord
   has_many :members
 end

--- a/activerecord/test/models/membership.rb
+++ b/activerecord/test/models/membership.rb
@@ -1,4 +1,4 @@
-class Membership < ActiveRecord::Base
+class Membership < ApplicationModel
   belongs_to :member
   belongs_to :club
 end

--- a/activerecord/test/models/membership.rb
+++ b/activerecord/test/models/membership.rb
@@ -1,4 +1,4 @@
-class Membership < ApplicationModel
+class Membership < ApplicationRecord
   belongs_to :member
   belongs_to :club
 end

--- a/activerecord/test/models/minimalistic.rb
+++ b/activerecord/test/models/minimalistic.rb
@@ -1,2 +1,2 @@
-class Minimalistic < ActiveRecord::Base
+class Minimalistic < ApplicationModel
 end

--- a/activerecord/test/models/minimalistic.rb
+++ b/activerecord/test/models/minimalistic.rb
@@ -1,2 +1,2 @@
-class Minimalistic < ApplicationModel
+class Minimalistic < ApplicationRecord
 end

--- a/activerecord/test/models/minivan.rb
+++ b/activerecord/test/models/minivan.rb
@@ -1,4 +1,4 @@
-class Minivan < ApplicationModel
+class Minivan < ApplicationRecord
   self.primary_key = :minivan_id
 
   belongs_to :speedometer

--- a/activerecord/test/models/minivan.rb
+++ b/activerecord/test/models/minivan.rb
@@ -1,4 +1,4 @@
-class Minivan < ActiveRecord::Base
+class Minivan < ApplicationModel
   self.primary_key = :minivan_id
 
   belongs_to :speedometer

--- a/activerecord/test/models/mixed_case_monkey.rb
+++ b/activerecord/test/models/mixed_case_monkey.rb
@@ -1,4 +1,4 @@
-class MixedCaseMonkey < ActiveRecord::Base
+class MixedCaseMonkey < ApplicationModel
   self.primary_key = 'monkeyID'
 
   belongs_to :man

--- a/activerecord/test/models/mixed_case_monkey.rb
+++ b/activerecord/test/models/mixed_case_monkey.rb
@@ -1,4 +1,4 @@
-class MixedCaseMonkey < ApplicationModel
+class MixedCaseMonkey < ApplicationRecord
   self.primary_key = 'monkeyID'
 
   belongs_to :man

--- a/activerecord/test/models/molecule.rb
+++ b/activerecord/test/models/molecule.rb
@@ -1,4 +1,4 @@
-class Molecule < ApplicationModel
+class Molecule < ApplicationRecord
   belongs_to :liquid
   has_many :electrons
 end

--- a/activerecord/test/models/molecule.rb
+++ b/activerecord/test/models/molecule.rb
@@ -1,4 +1,4 @@
-class Molecule < ActiveRecord::Base
+class Molecule < ApplicationModel
   belongs_to :liquid
   has_many :electrons
 end

--- a/activerecord/test/models/movie.rb
+++ b/activerecord/test/models/movie.rb
@@ -1,3 +1,3 @@
-class Movie < ApplicationModel
+class Movie < ApplicationRecord
   self.primary_key = "movieid"
 end

--- a/activerecord/test/models/movie.rb
+++ b/activerecord/test/models/movie.rb
@@ -1,3 +1,3 @@
-class Movie < ActiveRecord::Base
+class Movie < ApplicationModel
   self.primary_key = "movieid"
 end

--- a/activerecord/test/models/order.rb
+++ b/activerecord/test/models/order.rb
@@ -1,4 +1,4 @@
-class Order < ActiveRecord::Base
+class Order < ApplicationModel
   belongs_to :billing, :class_name => 'Customer', :foreign_key => 'billing_customer_id'
   belongs_to :shipping, :class_name => 'Customer', :foreign_key => 'shipping_customer_id'
 end

--- a/activerecord/test/models/order.rb
+++ b/activerecord/test/models/order.rb
@@ -1,4 +1,4 @@
-class Order < ApplicationModel
+class Order < ApplicationRecord
   belongs_to :billing, :class_name => 'Customer', :foreign_key => 'billing_customer_id'
   belongs_to :shipping, :class_name => 'Customer', :foreign_key => 'shipping_customer_id'
 end

--- a/activerecord/test/models/organization.rb
+++ b/activerecord/test/models/organization.rb
@@ -1,4 +1,4 @@
-class Organization < ActiveRecord::Base
+class Organization < ApplicationModel
   has_many :member_details
   has_many :members, :through => :member_details
 

--- a/activerecord/test/models/organization.rb
+++ b/activerecord/test/models/organization.rb
@@ -1,4 +1,4 @@
-class Organization < ApplicationModel
+class Organization < ApplicationRecord
   has_many :member_details
   has_many :members, :through => :member_details
 

--- a/activerecord/test/models/owner.rb
+++ b/activerecord/test/models/owner.rb
@@ -1,4 +1,4 @@
-class Owner < ActiveRecord::Base
+class Owner < ApplicationModel
   self.primary_key = :owner_id
   has_many :pets, -> { order 'pets.name desc' }
   has_many :toys, :through => :pets

--- a/activerecord/test/models/owner.rb
+++ b/activerecord/test/models/owner.rb
@@ -1,4 +1,4 @@
-class Owner < ApplicationModel
+class Owner < ApplicationRecord
   self.primary_key = :owner_id
   has_many :pets, -> { order 'pets.name desc' }
   has_many :toys, :through => :pets

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -1,4 +1,4 @@
-class Parrot < ApplicationModel
+class Parrot < ApplicationRecord
   self.inheritance_column = :parrot_sti_class
 
   has_and_belongs_to_many :pirates

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -1,4 +1,4 @@
-class Parrot < ActiveRecord::Base
+class Parrot < ApplicationModel
   self.inheritance_column = :parrot_sti_class
 
   has_and_belongs_to_many :pirates

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -1,4 +1,4 @@
-class Person < ApplicationModel
+class Person < ApplicationRecord
   has_many :readers
   has_many :secure_readers
   has_one  :reader
@@ -38,21 +38,21 @@ class Person < ApplicationModel
   scope :females, -> { where(:gender => 'F') }
 end
 
-class PersonWithDependentDestroyJobs < ApplicationModel
+class PersonWithDependentDestroyJobs < ApplicationRecord
   self.table_name = 'people'
 
   has_many :references, :foreign_key => :person_id
   has_many :jobs, :source => :job, :through => :references, :dependent => :destroy
 end
 
-class PersonWithDependentDeleteAllJobs < ApplicationModel
+class PersonWithDependentDeleteAllJobs < ApplicationRecord
   self.table_name = 'people'
 
   has_many :references, :foreign_key => :person_id
   has_many :jobs, :source => :job, :through => :references, :dependent => :delete_all
 end
 
-class PersonWithDependentNullifyJobs < ApplicationModel
+class PersonWithDependentNullifyJobs < ApplicationRecord
   self.table_name = 'people'
 
   has_many :references, :foreign_key => :person_id
@@ -60,7 +60,7 @@ class PersonWithDependentNullifyJobs < ApplicationModel
 end
 
 
-class LoosePerson < ApplicationModel
+class LoosePerson < ApplicationRecord
   self.table_name = 'people'
   self.abstract_class = true
 
@@ -73,7 +73,7 @@ end
 
 class LooseDescendant < LoosePerson; end
 
-class TightPerson < ApplicationModel
+class TightPerson < ApplicationRecord
   self.table_name = 'people'
 
   has_one    :best_friend,    :class_name => 'TightPerson', :foreign_key => :best_friend_id
@@ -85,13 +85,13 @@ end
 
 class TightDescendant < TightPerson; end
 
-class RichPerson < ApplicationModel
+class RichPerson < ApplicationRecord
   self.table_name = 'people'
 
   has_and_belongs_to_many :treasures, :join_table => 'peoples_treasures'
 end
 
-class NestedPerson < ApplicationModel
+class NestedPerson < ApplicationRecord
   self.table_name = 'people'
 
   has_one :best_friend, :class_name => 'NestedPerson', :foreign_key => :best_friend_id
@@ -121,7 +121,7 @@ class Insure
   end
 end
 
-class SerializedPerson < ApplicationModel
+class SerializedPerson < ApplicationRecord
   self.table_name = 'people'
 
   serialize :insures, Insure

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -1,4 +1,4 @@
-class Person < ActiveRecord::Base
+class Person < ApplicationModel
   has_many :readers
   has_many :secure_readers
   has_one  :reader
@@ -38,21 +38,21 @@ class Person < ActiveRecord::Base
   scope :females, -> { where(:gender => 'F') }
 end
 
-class PersonWithDependentDestroyJobs < ActiveRecord::Base
+class PersonWithDependentDestroyJobs < ApplicationModel
   self.table_name = 'people'
 
   has_many :references, :foreign_key => :person_id
   has_many :jobs, :source => :job, :through => :references, :dependent => :destroy
 end
 
-class PersonWithDependentDeleteAllJobs < ActiveRecord::Base
+class PersonWithDependentDeleteAllJobs < ApplicationModel
   self.table_name = 'people'
 
   has_many :references, :foreign_key => :person_id
   has_many :jobs, :source => :job, :through => :references, :dependent => :delete_all
 end
 
-class PersonWithDependentNullifyJobs < ActiveRecord::Base
+class PersonWithDependentNullifyJobs < ApplicationModel
   self.table_name = 'people'
 
   has_many :references, :foreign_key => :person_id
@@ -60,7 +60,7 @@ class PersonWithDependentNullifyJobs < ActiveRecord::Base
 end
 
 
-class LoosePerson < ActiveRecord::Base
+class LoosePerson < ApplicationModel
   self.table_name = 'people'
   self.abstract_class = true
 
@@ -73,7 +73,7 @@ end
 
 class LooseDescendant < LoosePerson; end
 
-class TightPerson < ActiveRecord::Base
+class TightPerson < ApplicationModel
   self.table_name = 'people'
 
   has_one    :best_friend,    :class_name => 'TightPerson', :foreign_key => :best_friend_id
@@ -85,13 +85,13 @@ end
 
 class TightDescendant < TightPerson; end
 
-class RichPerson < ActiveRecord::Base
+class RichPerson < ApplicationModel
   self.table_name = 'people'
 
   has_and_belongs_to_many :treasures, :join_table => 'peoples_treasures'
 end
 
-class NestedPerson < ActiveRecord::Base
+class NestedPerson < ApplicationModel
   self.table_name = 'people'
 
   has_one :best_friend, :class_name => 'NestedPerson', :foreign_key => :best_friend_id
@@ -121,7 +121,7 @@ class Insure
   end
 end
 
-class SerializedPerson < ActiveRecord::Base
+class SerializedPerson < ApplicationModel
   self.table_name = 'people'
 
   serialize :insures, Insure

--- a/activerecord/test/models/pet.rb
+++ b/activerecord/test/models/pet.rb
@@ -1,4 +1,4 @@
-class Pet < ActiveRecord::Base
+class Pet < ApplicationModel
   attr_accessor :current_user
 
   self.primary_key = :pet_id

--- a/activerecord/test/models/pet.rb
+++ b/activerecord/test/models/pet.rb
@@ -1,4 +1,4 @@
-class Pet < ApplicationModel
+class Pet < ApplicationRecord
   attr_accessor :current_user
 
   self.primary_key = :pet_id

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -1,4 +1,4 @@
-class Pirate < ActiveRecord::Base
+class Pirate < ApplicationModel
   belongs_to :parrot, :validate => true
   belongs_to :non_validated_parrot, :class_name => 'Parrot'
   has_and_belongs_to_many :parrots, -> { order('parrots.id ASC') }, :validate => true

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -1,4 +1,4 @@
-class Pirate < ApplicationModel
+class Pirate < ApplicationRecord
   belongs_to :parrot, :validate => true
   belongs_to :non_validated_parrot, :class_name => 'Parrot'
   has_and_belongs_to_many :parrots, -> { order('parrots.id ASC') }, :validate => true

--- a/activerecord/test/models/possession.rb
+++ b/activerecord/test/models/possession.rb
@@ -1,3 +1,3 @@
-class Possession < ActiveRecord::Base
+class Possession < ApplicationModel
   self.table_name = 'having'
 end

--- a/activerecord/test/models/possession.rb
+++ b/activerecord/test/models/possession.rb
@@ -1,3 +1,3 @@
-class Possession < ApplicationModel
+class Possession < ApplicationRecord
   self.table_name = 'having'
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -1,5 +1,5 @@
-class Post < ApplicationModel
-  class CategoryPost < ApplicationModel
+class Post < ApplicationRecord
+  class CategoryPost < ApplicationRecord
     self.table_name = "categories_posts"
     belongs_to :category
     belongs_to :post
@@ -171,7 +171,7 @@ class SubStiPost < StiPost
   self.table_name = Post.table_name
 end
 
-class FirstPost < ApplicationModel
+class FirstPost < ApplicationRecord
   self.table_name = 'posts'
   default_scope { where(:id => 1) }
 
@@ -179,7 +179,7 @@ class FirstPost < ApplicationModel
   has_one  :comment,  :foreign_key => :post_id
 end
 
-class PostWithDefaultInclude < ApplicationModel
+class PostWithDefaultInclude < ApplicationRecord
   self.table_name = 'posts'
   default_scope { includes(:comments) }
   has_many :comments, :foreign_key => :post_id
@@ -190,12 +190,12 @@ class PostWithSpecialCategorization < Post
   default_scope { where(:type => 'PostWithSpecialCategorization').joins(:categorizations).where(:categorizations => { :special => true }) }
 end
 
-class PostWithDefaultScope < ApplicationModel
+class PostWithDefaultScope < ApplicationRecord
   self.table_name = 'posts'
   default_scope { order(:title) }
 end
 
-class SpecialPostWithDefaultScope < ApplicationModel
+class SpecialPostWithDefaultScope < ApplicationRecord
   self.table_name = 'posts'
   default_scope { where(:id => [1, 5,6]) }
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -1,5 +1,5 @@
-class Post < ActiveRecord::Base
-  class CategoryPost < ActiveRecord::Base
+class Post < ApplicationModel
+  class CategoryPost < ApplicationModel
     self.table_name = "categories_posts"
     belongs_to :category
     belongs_to :post
@@ -171,7 +171,7 @@ class SubStiPost < StiPost
   self.table_name = Post.table_name
 end
 
-class FirstPost < ActiveRecord::Base
+class FirstPost < ApplicationModel
   self.table_name = 'posts'
   default_scope { where(:id => 1) }
 
@@ -179,7 +179,7 @@ class FirstPost < ActiveRecord::Base
   has_one  :comment,  :foreign_key => :post_id
 end
 
-class PostWithDefaultInclude < ActiveRecord::Base
+class PostWithDefaultInclude < ApplicationModel
   self.table_name = 'posts'
   default_scope { includes(:comments) }
   has_many :comments, :foreign_key => :post_id
@@ -190,12 +190,12 @@ class PostWithSpecialCategorization < Post
   default_scope { where(:type => 'PostWithSpecialCategorization').joins(:categorizations).where(:categorizations => { :special => true }) }
 end
 
-class PostWithDefaultScope < ActiveRecord::Base
+class PostWithDefaultScope < ApplicationModel
   self.table_name = 'posts'
   default_scope { order(:title) }
 end
 
-class SpecialPostWithDefaultScope < ActiveRecord::Base
+class SpecialPostWithDefaultScope < ApplicationModel
   self.table_name = 'posts'
   default_scope { where(:id => [1, 5,6]) }
 end

--- a/activerecord/test/models/price_estimate.rb
+++ b/activerecord/test/models/price_estimate.rb
@@ -1,4 +1,4 @@
-class PriceEstimate < ActiveRecord::Base
+class PriceEstimate < ApplicationModel
   belongs_to :estimate_of, :polymorphic => true
   belongs_to :thing, polymorphic: true
 end

--- a/activerecord/test/models/price_estimate.rb
+++ b/activerecord/test/models/price_estimate.rb
@@ -1,4 +1,4 @@
-class PriceEstimate < ApplicationModel
+class PriceEstimate < ApplicationRecord
   belongs_to :estimate_of, :polymorphic => true
   belongs_to :thing, polymorphic: true
 end

--- a/activerecord/test/models/project.rb
+++ b/activerecord/test/models/project.rb
@@ -1,4 +1,4 @@
-class Project < ApplicationModel
+class Project < ApplicationRecord
   has_and_belongs_to_many :developers, -> { distinct.order 'developers.name desc, developers.id desc' }
   has_and_belongs_to_many :readonly_developers, -> { readonly }, :class_name => "Developer"
   has_and_belongs_to_many :non_unique_developers, -> { order 'developers.name desc, developers.id desc' }, :class_name => 'Developer'

--- a/activerecord/test/models/project.rb
+++ b/activerecord/test/models/project.rb
@@ -1,4 +1,4 @@
-class Project < ActiveRecord::Base
+class Project < ApplicationModel
   has_and_belongs_to_many :developers, -> { distinct.order 'developers.name desc, developers.id desc' }
   has_and_belongs_to_many :readonly_developers, -> { readonly }, :class_name => "Developer"
   has_and_belongs_to_many :non_unique_developers, -> { order 'developers.name desc, developers.id desc' }, :class_name => 'Developer'

--- a/activerecord/test/models/randomly_named_c1.rb
+++ b/activerecord/test/models/randomly_named_c1.rb
@@ -1,3 +1,3 @@
-class ClassNameThatDoesNotFollowCONVENTIONS < ApplicationModel
+class ClassNameThatDoesNotFollowCONVENTIONS < ApplicationRecord
   self.table_name = :randomly_named_table
 end

--- a/activerecord/test/models/randomly_named_c1.rb
+++ b/activerecord/test/models/randomly_named_c1.rb
@@ -1,3 +1,3 @@
-class ClassNameThatDoesNotFollowCONVENTIONS < ActiveRecord::Base
+class ClassNameThatDoesNotFollowCONVENTIONS < ApplicationModel
   self.table_name = :randomly_named_table
 end

--- a/activerecord/test/models/rating.rb
+++ b/activerecord/test/models/rating.rb
@@ -1,4 +1,4 @@
-class Rating < ApplicationModel
+class Rating < ApplicationRecord
   belongs_to :comment
   has_many :taggings, :as => :taggable
 end

--- a/activerecord/test/models/rating.rb
+++ b/activerecord/test/models/rating.rb
@@ -1,4 +1,4 @@
-class Rating < ActiveRecord::Base
+class Rating < ApplicationModel
   belongs_to :comment
   has_many :taggings, :as => :taggable
 end

--- a/activerecord/test/models/reader.rb
+++ b/activerecord/test/models/reader.rb
@@ -1,18 +1,18 @@
-class Reader < ActiveRecord::Base
+class Reader < ApplicationModel
   belongs_to :post
   belongs_to :person, :inverse_of => :readers
   belongs_to :single_person, :class_name => 'Person', :foreign_key => :person_id, :inverse_of => :reader
   belongs_to :first_post, -> { where(id: [2, 3]) }
 end
 
-class SecureReader < ActiveRecord::Base
+class SecureReader < ApplicationModel
   self.table_name = "readers"
 
   belongs_to :secure_post, :class_name => "Post", :foreign_key => "post_id"
   belongs_to :secure_person, :inverse_of => :secure_readers, :class_name => "Person", :foreign_key => "person_id"
 end
 
-class LazyReader < ActiveRecord::Base
+class LazyReader < ApplicationModel
   self.table_name = "readers"
   default_scope -> { where(skimmer: true) }
 

--- a/activerecord/test/models/reader.rb
+++ b/activerecord/test/models/reader.rb
@@ -1,18 +1,18 @@
-class Reader < ApplicationModel
+class Reader < ApplicationRecord
   belongs_to :post
   belongs_to :person, :inverse_of => :readers
   belongs_to :single_person, :class_name => 'Person', :foreign_key => :person_id, :inverse_of => :reader
   belongs_to :first_post, -> { where(id: [2, 3]) }
 end
 
-class SecureReader < ApplicationModel
+class SecureReader < ApplicationRecord
   self.table_name = "readers"
 
   belongs_to :secure_post, :class_name => "Post", :foreign_key => "post_id"
   belongs_to :secure_person, :inverse_of => :secure_readers, :class_name => "Person", :foreign_key => "person_id"
 end
 
-class LazyReader < ApplicationModel
+class LazyReader < ApplicationRecord
   self.table_name = "readers"
   default_scope -> { where(skimmer: true) }
 

--- a/activerecord/test/models/reference.rb
+++ b/activerecord/test/models/reference.rb
@@ -1,4 +1,4 @@
-class Reference < ApplicationModel
+class Reference < ApplicationRecord
   belongs_to :person
   belongs_to :job
 
@@ -16,7 +16,7 @@ class Reference < ApplicationModel
   end
 end
 
-class BadReference < ApplicationModel
+class BadReference < ApplicationRecord
   self.table_name = 'references'
   default_scope { where(:favourite => false) }
 end

--- a/activerecord/test/models/reference.rb
+++ b/activerecord/test/models/reference.rb
@@ -1,4 +1,4 @@
-class Reference < ActiveRecord::Base
+class Reference < ApplicationModel
   belongs_to :person
   belongs_to :job
 
@@ -16,7 +16,7 @@ class Reference < ActiveRecord::Base
   end
 end
 
-class BadReference < ActiveRecord::Base
+class BadReference < ApplicationModel
   self.table_name = 'references'
   default_scope { where(:favourite => false) }
 end

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -1,4 +1,4 @@
-class Ship < ApplicationModel
+class Ship < ApplicationRecord
   self.record_timestamps = false
 
   belongs_to :pirate

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -1,4 +1,4 @@
-class Ship < ActiveRecord::Base
+class Ship < ApplicationModel
   self.record_timestamps = false
 
   belongs_to :pirate

--- a/activerecord/test/models/ship_part.rb
+++ b/activerecord/test/models/ship_part.rb
@@ -1,4 +1,4 @@
-class ShipPart < ApplicationModel
+class ShipPart < ApplicationRecord
   belongs_to :ship
   has_many :trinkets, :class_name => "Treasure", :as => :looter
   accepts_nested_attributes_for :trinkets, :allow_destroy => true

--- a/activerecord/test/models/ship_part.rb
+++ b/activerecord/test/models/ship_part.rb
@@ -1,4 +1,4 @@
-class ShipPart < ActiveRecord::Base
+class ShipPart < ApplicationModel
   belongs_to :ship
   has_many :trinkets, :class_name => "Treasure", :as => :looter
   accepts_nested_attributes_for :trinkets, :allow_destroy => true

--- a/activerecord/test/models/shop.rb
+++ b/activerecord/test/models/shop.rb
@@ -1,12 +1,12 @@
 module Shop
-  class Collection < ActiveRecord::Base
+  class Collection < ApplicationModel
     has_many :products, :dependent => :nullify
   end
 
-  class Product < ActiveRecord::Base
+  class Product < ApplicationModel
     has_many :variants, :dependent => :delete_all
   end
 
-  class Variant < ActiveRecord::Base
+  class Variant < ApplicationModel
   end
 end

--- a/activerecord/test/models/shop.rb
+++ b/activerecord/test/models/shop.rb
@@ -1,12 +1,12 @@
 module Shop
-  class Collection < ApplicationModel
+  class Collection < ApplicationRecord
     has_many :products, :dependent => :nullify
   end
 
-  class Product < ApplicationModel
+  class Product < ApplicationRecord
     has_many :variants, :dependent => :delete_all
   end
 
-  class Variant < ApplicationModel
+  class Variant < ApplicationRecord
   end
 end

--- a/activerecord/test/models/speedometer.rb
+++ b/activerecord/test/models/speedometer.rb
@@ -1,4 +1,4 @@
-class Speedometer < ActiveRecord::Base
+class Speedometer < ApplicationModel
   self.primary_key = :speedometer_id
   belongs_to :dashboard
 

--- a/activerecord/test/models/speedometer.rb
+++ b/activerecord/test/models/speedometer.rb
@@ -1,4 +1,4 @@
-class Speedometer < ApplicationModel
+class Speedometer < ApplicationRecord
   self.primary_key = :speedometer_id
   belongs_to :dashboard
 

--- a/activerecord/test/models/sponsor.rb
+++ b/activerecord/test/models/sponsor.rb
@@ -1,4 +1,4 @@
-class Sponsor < ActiveRecord::Base
+class Sponsor < ApplicationModel
   belongs_to :sponsor_club, :class_name => "Club", :foreign_key => "club_id"
   belongs_to :sponsorable, :polymorphic => true
   belongs_to :thing, :polymorphic => true, :foreign_type => :sponsorable_type, :foreign_key => :sponsorable_id

--- a/activerecord/test/models/sponsor.rb
+++ b/activerecord/test/models/sponsor.rb
@@ -1,4 +1,4 @@
-class Sponsor < ApplicationModel
+class Sponsor < ApplicationRecord
   belongs_to :sponsor_club, :class_name => "Club", :foreign_key => "club_id"
   belongs_to :sponsorable, :polymorphic => true
   belongs_to :thing, :polymorphic => true, :foreign_type => :sponsorable_type, :foreign_key => :sponsorable_id

--- a/activerecord/test/models/string_key_object.rb
+++ b/activerecord/test/models/string_key_object.rb
@@ -1,3 +1,3 @@
-class StringKeyObject < ActiveRecord::Base
+class StringKeyObject < ApplicationModel
   self.primary_key = :id
 end

--- a/activerecord/test/models/string_key_object.rb
+++ b/activerecord/test/models/string_key_object.rb
@@ -1,3 +1,3 @@
-class StringKeyObject < ApplicationModel
+class StringKeyObject < ApplicationRecord
   self.primary_key = :id
 end

--- a/activerecord/test/models/student.rb
+++ b/activerecord/test/models/student.rb
@@ -1,3 +1,3 @@
-class Student < ActiveRecord::Base
+class Student < ApplicationModel
   has_and_belongs_to_many :lessons
 end

--- a/activerecord/test/models/student.rb
+++ b/activerecord/test/models/student.rb
@@ -1,3 +1,3 @@
-class Student < ApplicationModel
+class Student < ApplicationRecord
   has_and_belongs_to_many :lessons
 end

--- a/activerecord/test/models/subject.rb
+++ b/activerecord/test/models/subject.rb
@@ -1,6 +1,6 @@
 # used for OracleSynonymTest, see test/synonym_test_oracle.rb
 #
-class Subject < ApplicationModel
+class Subject < ApplicationRecord
 
   # added initialization of author_email_address in the same way as in Topic class
   # as otherwise synonym test was failing

--- a/activerecord/test/models/subject.rb
+++ b/activerecord/test/models/subject.rb
@@ -1,6 +1,6 @@
 # used for OracleSynonymTest, see test/synonym_test_oracle.rb
 #
-class Subject < ActiveRecord::Base
+class Subject < ApplicationModel
 
   # added initialization of author_email_address in the same way as in Topic class
   # as otherwise synonym test was failing

--- a/activerecord/test/models/subscriber.rb
+++ b/activerecord/test/models/subscriber.rb
@@ -1,4 +1,4 @@
-class Subscriber < ApplicationModel
+class Subscriber < ApplicationRecord
   self.primary_key = 'nick'
   has_many :subscriptions
   has_many :books, :through => :subscriptions

--- a/activerecord/test/models/subscriber.rb
+++ b/activerecord/test/models/subscriber.rb
@@ -1,4 +1,4 @@
-class Subscriber < ActiveRecord::Base
+class Subscriber < ApplicationModel
   self.primary_key = 'nick'
   has_many :subscriptions
   has_many :books, :through => :subscriptions

--- a/activerecord/test/models/subscription.rb
+++ b/activerecord/test/models/subscription.rb
@@ -1,4 +1,4 @@
-class Subscription < ActiveRecord::Base
+class Subscription < ApplicationModel
   belongs_to :subscriber, :counter_cache => :books_count
   belongs_to :book
 end

--- a/activerecord/test/models/subscription.rb
+++ b/activerecord/test/models/subscription.rb
@@ -1,4 +1,4 @@
-class Subscription < ApplicationModel
+class Subscription < ApplicationRecord
   belongs_to :subscriber, :counter_cache => :books_count
   belongs_to :book
 end

--- a/activerecord/test/models/tag.rb
+++ b/activerecord/test/models/tag.rb
@@ -1,4 +1,4 @@
-class Tag < ActiveRecord::Base
+class Tag < ApplicationModel
   has_many :taggings
   has_many :taggables, :through => :taggings
   has_one  :tagging

--- a/activerecord/test/models/tag.rb
+++ b/activerecord/test/models/tag.rb
@@ -1,4 +1,4 @@
-class Tag < ApplicationModel
+class Tag < ApplicationRecord
   has_many :taggings
   has_many :taggables, :through => :taggings
   has_one  :tagging

--- a/activerecord/test/models/tagging.rb
+++ b/activerecord/test/models/tagging.rb
@@ -2,7 +2,7 @@
 module Taggable
 end
 
-class Tagging < ActiveRecord::Base
+class Tagging < ApplicationModel
   belongs_to :tag, -> { includes(:tagging) }
   belongs_to :super_tag,   :class_name => 'Tag', :foreign_key => 'super_tag_id'
   belongs_to :invalid_tag, :class_name => 'Tag', :foreign_key => 'tag_id'

--- a/activerecord/test/models/tagging.rb
+++ b/activerecord/test/models/tagging.rb
@@ -2,7 +2,7 @@
 module Taggable
 end
 
-class Tagging < ApplicationModel
+class Tagging < ApplicationRecord
   belongs_to :tag, -> { includes(:tagging) }
   belongs_to :super_tag,   :class_name => 'Tag', :foreign_key => 'super_tag_id'
   belongs_to :invalid_tag, :class_name => 'Tag', :foreign_key => 'tag_id'

--- a/activerecord/test/models/task.rb
+++ b/activerecord/test/models/task.rb
@@ -1,4 +1,4 @@
-class Task < ActiveRecord::Base
+class Task < ApplicationModel
   def updated_at
     ending
   end

--- a/activerecord/test/models/task.rb
+++ b/activerecord/test/models/task.rb
@@ -1,4 +1,4 @@
-class Task < ApplicationModel
+class Task < ApplicationRecord
   def updated_at
     ending
   end

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -1,4 +1,4 @@
-class Topic < ApplicationModel
+class Topic < ApplicationRecord
   scope :base, -> { all }
   scope :written_before, lambda { |time|
     if time
@@ -114,7 +114,7 @@ class BlankTopic < Topic
 end
 
 module Web
-  class Topic < ApplicationModel
+  class Topic < ApplicationRecord
     has_many :replies, :dependent => :destroy, :foreign_key => "parent_id", :class_name => 'Web::Reply'
   end
 end

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -1,4 +1,4 @@
-class Topic < ActiveRecord::Base
+class Topic < ApplicationModel
   scope :base, -> { all }
   scope :written_before, lambda { |time|
     if time
@@ -114,7 +114,7 @@ class BlankTopic < Topic
 end
 
 module Web
-  class Topic < ActiveRecord::Base
+  class Topic < ApplicationModel
     has_many :replies, :dependent => :destroy, :foreign_key => "parent_id", :class_name => 'Web::Reply'
   end
 end

--- a/activerecord/test/models/toy.rb
+++ b/activerecord/test/models/toy.rb
@@ -1,4 +1,4 @@
-class Toy < ApplicationModel
+class Toy < ApplicationRecord
   self.primary_key = :toy_id
   belongs_to :pet
 

--- a/activerecord/test/models/toy.rb
+++ b/activerecord/test/models/toy.rb
@@ -1,4 +1,4 @@
-class Toy < ActiveRecord::Base
+class Toy < ApplicationModel
   self.primary_key = :toy_id
   belongs_to :pet
 

--- a/activerecord/test/models/traffic_light.rb
+++ b/activerecord/test/models/traffic_light.rb
@@ -1,4 +1,4 @@
-class TrafficLight < ActiveRecord::Base
+class TrafficLight < ApplicationModel
   serialize :state, Array
   serialize :long_state, Array
 end

--- a/activerecord/test/models/traffic_light.rb
+++ b/activerecord/test/models/traffic_light.rb
@@ -1,4 +1,4 @@
-class TrafficLight < ApplicationModel
+class TrafficLight < ApplicationRecord
   serialize :state, Array
   serialize :long_state, Array
 end

--- a/activerecord/test/models/treasure.rb
+++ b/activerecord/test/models/treasure.rb
@@ -1,4 +1,4 @@
-class Treasure < ActiveRecord::Base
+class Treasure < ApplicationModel
   has_and_belongs_to_many :parrots
   belongs_to :looter, :polymorphic => true
 

--- a/activerecord/test/models/treasure.rb
+++ b/activerecord/test/models/treasure.rb
@@ -1,4 +1,4 @@
-class Treasure < ApplicationModel
+class Treasure < ApplicationRecord
   has_and_belongs_to_many :parrots
   belongs_to :looter, :polymorphic => true
 

--- a/activerecord/test/models/treaty.rb
+++ b/activerecord/test/models/treaty.rb
@@ -1,4 +1,4 @@
-class Treaty < ActiveRecord::Base
+class Treaty < ApplicationModel
 
   self.primary_key = :treaty_id
 

--- a/activerecord/test/models/treaty.rb
+++ b/activerecord/test/models/treaty.rb
@@ -1,4 +1,4 @@
-class Treaty < ApplicationModel
+class Treaty < ApplicationRecord
 
   self.primary_key = :treaty_id
 

--- a/activerecord/test/models/tyre.rb
+++ b/activerecord/test/models/tyre.rb
@@ -1,3 +1,3 @@
-class Tyre < ActiveRecord::Base
+class Tyre < ApplicationModel
   belongs_to :car
 end

--- a/activerecord/test/models/tyre.rb
+++ b/activerecord/test/models/tyre.rb
@@ -1,3 +1,3 @@
-class Tyre < ApplicationModel
+class Tyre < ApplicationRecord
   belongs_to :car
 end

--- a/activerecord/test/models/vegetables.rb
+++ b/activerecord/test/models/vegetables.rb
@@ -1,4 +1,4 @@
-class Vegetable < ActiveRecord::Base
+class Vegetable < ApplicationModel
 
   validates_presence_of :name
 

--- a/activerecord/test/models/vegetables.rb
+++ b/activerecord/test/models/vegetables.rb
@@ -1,4 +1,4 @@
-class Vegetable < ApplicationModel
+class Vegetable < ApplicationRecord
 
   validates_presence_of :name
 

--- a/activerecord/test/models/vertex.rb
+++ b/activerecord/test/models/vertex.rb
@@ -1,5 +1,5 @@
 # This class models a vertex in a directed graph.
-class Vertex < ApplicationModel
+class Vertex < ApplicationRecord
   has_many :sink_edges, :class_name => 'Edge', :foreign_key => 'source_id'
   has_many :sinks, :through => :sink_edges
 

--- a/activerecord/test/models/vertex.rb
+++ b/activerecord/test/models/vertex.rb
@@ -1,5 +1,5 @@
 # This class models a vertex in a directed graph.
-class Vertex < ActiveRecord::Base
+class Vertex < ApplicationModel
   has_many :sink_edges, :class_name => 'Edge', :foreign_key => 'source_id'
   has_many :sinks, :through => :sink_edges
 

--- a/activerecord/test/models/warehouse_thing.rb
+++ b/activerecord/test/models/warehouse_thing.rb
@@ -1,4 +1,4 @@
-class WarehouseThing < ApplicationModel
+class WarehouseThing < ApplicationRecord
   self.table_name = "warehouse-things"
 
   validates_uniqueness_of :value

--- a/activerecord/test/models/warehouse_thing.rb
+++ b/activerecord/test/models/warehouse_thing.rb
@@ -1,4 +1,4 @@
-class WarehouseThing < ActiveRecord::Base
+class WarehouseThing < ApplicationModel
   self.table_name = "warehouse-things"
 
   validates_uniqueness_of :value

--- a/activerecord/test/models/wheel.rb
+++ b/activerecord/test/models/wheel.rb
@@ -1,3 +1,3 @@
-class Wheel < ActiveRecord::Base
+class Wheel < ApplicationModel
   belongs_to :wheelable, :polymorphic => true, :counter_cache => true
 end

--- a/activerecord/test/models/wheel.rb
+++ b/activerecord/test/models/wheel.rb
@@ -1,3 +1,3 @@
-class Wheel < ApplicationModel
+class Wheel < ApplicationRecord
   belongs_to :wheelable, :polymorphic => true, :counter_cache => true
 end

--- a/activerecord/test/models/without_table.rb
+++ b/activerecord/test/models/without_table.rb
@@ -1,3 +1,3 @@
-class WithoutTable < ApplicationModel
+class WithoutTable < ApplicationRecord
   default_scope -> { where(:published => true) }
 end

--- a/activerecord/test/models/without_table.rb
+++ b/activerecord/test/models/without_table.rb
@@ -1,3 +1,3 @@
-class WithoutTable < ActiveRecord::Base
+class WithoutTable < ApplicationModel
   default_scope -> { where(:published => true) }
 end

--- a/activerecord/test/models/zine.rb
+++ b/activerecord/test/models/zine.rb
@@ -1,3 +1,3 @@
-class Zine < ApplicationModel
+class Zine < ApplicationRecord
   has_many :interests, :inverse_of => :zine
 end

--- a/activerecord/test/models/zine.rb
+++ b/activerecord/test/models/zine.rb
@@ -1,3 +1,3 @@
-class Zine < ActiveRecord::Base
+class Zine < ApplicationModel
   has_many :interests, :inverse_of => :zine
 end

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -1035,11 +1035,11 @@ Returns `select` and `option` tags for the collection of existing return values 
 Example object structure for use with this method:
 
 ```ruby
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   belongs_to :author
 end
 
-class Author < ActiveRecord::Base
+class Author < ApplicationRecord
   has_many :posts
   def name_with_initial
     "#{first_name.first}. #{last_name}"
@@ -1071,11 +1071,11 @@ Returns `radio_button` tags for the collection of existing return values of `met
 Example object structure for use with this method:
 
 ```ruby
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   belongs_to :author
 end
 
-class Author < ActiveRecord::Base
+class Author < ApplicationRecord
   has_many :posts
   def name_with_initial
     "#{first_name.first}. #{last_name}"
@@ -1107,11 +1107,11 @@ Returns `check_box` tags for the collection of existing return values of `method
 Example object structure for use with this method:
 
 ```ruby
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   has_and_belongs_to_many :authors
 end
 
-class Author < ActiveRecord::Base
+class Author < ApplicationRecord
   has_and_belongs_to_many :posts
   def name_with_initial
     "#{first_name.first}. #{last_name}"
@@ -1152,12 +1152,12 @@ Returns a string of `option` tags, like `options_from_collection_for_select`, bu
 Example object structure for use with this method:
 
 ```ruby
-class Continent < ActiveRecord::Base
+class Continent < ApplicationRecord
   has_many :countries
   # attribs: id, name
 end
 
-class Country < ActiveRecord::Base
+class Country < ApplicationRecord
   belongs_to :continent
   # attribs: id, name, continent_id
 end

--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -159,6 +159,15 @@ p.name = "Some Book"
 puts p.name # "Some Book"
 ```
 
+Once you subclass `ApplicationRecord`, you get all of the functionality that is
+defined in the `ActiveRecord::Base` class since `ApplicationRecord` is itself a
+subclass of `ActiveRecord::Base`. The `ApplicationRecord` class allows you to
+configure Active Record without stepping over other applications that you would
+possibly be using, since every application you create has its own
+`ApplicationRecord`. Configurations set in `ActiveRecord::Base` are global to all
+applications using Active Record, but configurations set on `ApplicationRecord`
+are local to that application.
+
 Overriding the Naming Conventions
 ---------------------------------
 

--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -130,10 +130,10 @@ Creating Active Record Models
 -----------------------------
 
 It is very easy to create Active Record models. All you have to do is to
-subclass the `ActiveRecord::Base` class and you're good to go:
+subclass the `ApplicationRecord` class and you're good to go:
 
 ```ruby
-class Product < ActiveRecord::Base
+class Product < ApplicationRecord
 end
 ```
 
@@ -170,7 +170,7 @@ You can use the `ActiveRecord::Base.table_name=` method to specify the table
 name that should be used:
 
 ```ruby
-class Product < ActiveRecord::Base
+class Product < ApplicationRecord
   self.table_name = "PRODUCT"
 end
 ```
@@ -191,7 +191,7 @@ It's also possible to override the column that should be used as the table's
 primary key using the `ActiveRecord::Base.primary_key=` method:
 
 ```ruby
-class Product < ActiveRecord::Base
+class Product < ApplicationRecord
   self.primary_key = "product_id"
 end
 ```
@@ -318,7 +318,7 @@ they raise the exception `ActiveRecord::RecordInvalid` if validation fails.
 A quick example to illustrate:
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   validates :name, presence: true
 end
 

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -29,7 +29,7 @@ Callbacks are methods that get called at certain moments of an object's life cyc
 In order to use the available callbacks, you need to register them. You can implement the callbacks as ordinary methods and use a macro-style class method to register them as callbacks:
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   validates :login, :email, presence: true
 
   before_validation :ensure_login_has_a_value
@@ -46,7 +46,7 @@ end
 The macro-style class methods can also receive a block. Consider using this style if the code inside your block is so short that it fits in a single line:
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   validates :login, :email, presence: true
 
   before_create do
@@ -58,7 +58,7 @@ end
 Callbacks can also be registered to only fire on certain lifecycle events:
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   before_validation :normalize_name, on: :create
 
   # :on takes an array as well
@@ -121,7 +121,7 @@ The `after_find` callback will be called whenever Active Record loads a record f
 The `after_initialize` and `after_find` callbacks have no `before_*` counterparts, but they can be registered just like the other Active Record callbacks.
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   after_initialize do |user|
     puts "You have initialized an object!"
   end
@@ -212,11 +212,11 @@ Relational Callbacks
 Callbacks work through model relationships, and can even be defined by them. Suppose an example where a user has many posts. A user's posts should be destroyed if the user is destroyed. Let's add an `after_destroy` callback to the `User` model by way of its relationship to the `Post` model:
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   has_many :posts, dependent: :destroy
 end
 
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   after_destroy :log_destroy_action
 
   def log_destroy_action
@@ -243,7 +243,7 @@ As with validations, we can also make the calling of a callback method condition
 You can associate the `:if` and `:unless` options with a symbol corresponding to the name of a predicate method that will get called right before the callback. When using the `:if` option, the callback won't be executed if the predicate method returns false; when using the `:unless` option, the callback won't be executed if the predicate method returns true. This is the most common option. Using this form of registration it is also possible to register several different predicates that should be called to check if the callback should be executed.
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   before_save :normalize_card_number, if: :paid_with_card?
 end
 ```
@@ -253,7 +253,7 @@ end
 You can also use a string that will be evaluated using `eval` and hence needs to contain valid Ruby code. You should use this option only when the string represents a really short condition:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   before_save :normalize_card_number, if: "paid_with_card?"
 end
 ```
@@ -263,7 +263,7 @@ end
 Finally, it is possible to associate `:if` and `:unless` with a `Proc` object. This option is best suited when writing short validation methods, usually one-liners:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   before_save :normalize_card_number,
     if: Proc.new { |order| order.paid_with_card? }
 end
@@ -274,7 +274,7 @@ end
 When writing conditional callbacks, it is possible to mix both `:if` and `:unless` in the same callback declaration:
 
 ```ruby
-class Comment < ActiveRecord::Base
+class Comment < ApplicationRecord
   after_create :send_email_to_author, if: :author_wants_emails?,
     unless: Proc.new { |comment| comment.post.ignore_comments? }
 end
@@ -300,7 +300,7 @@ end
 When declared inside a class, as above, the callback methods will receive the model object as a parameter. We can now use the callback class in the model:
 
 ```ruby
-class PictureFile < ActiveRecord::Base
+class PictureFile < ApplicationRecord
   after_destroy PictureFileCallbacks.new
 end
 ```
@@ -320,7 +320,7 @@ end
 If the callback method is declared this way, it won't be necessary to instantiate a `PictureFileCallbacks` object.
 
 ```ruby
-class PictureFile < ActiveRecord::Base
+class PictureFile < ApplicationRecord
   after_destroy PictureFileCallbacks
 end
 ```
@@ -344,7 +344,7 @@ end
 By using the `after_commit` callback we can account for this case.
 
 ```ruby
-class PictureFile < ActiveRecord::Base
+class PictureFile < ApplicationRecord
   after_commit :delete_picture_file_from_disk, on: [:destroy]
 
   def delete_picture_file_from_disk

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -22,7 +22,7 @@ Code examples throughout this guide will refer to one or more of the following m
 TIP: All of the following models use `id` as the primary key, unless specified otherwise.
 
 ```ruby
-class Client < ActiveRecord::Base
+class Client < ApplicationRecord
   has_one :address
   has_many :orders
   has_and_belongs_to_many :roles
@@ -30,19 +30,19 @@ end
 ```
 
 ```ruby
-class Address < ActiveRecord::Base
+class Address < ApplicationRecord
   belongs_to :client
 end
 ```
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :client, counter_cache: true
 end
 ```
 
 ```ruby
-class Role < ActiveRecord::Base
+class Role < ApplicationRecord
   has_and_belongs_to_many :clients
 end
 ```
@@ -747,7 +747,7 @@ SELECT "posts".* FROM "posts" WHERE (id > 10) ORDER BY id desc LIMIT 20
 The `reorder` method overrides the default scope order. For example:
 
 ```ruby
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   ..
   ..
   has_many :comments, -> { order('posted_at DESC') }
@@ -870,7 +870,7 @@ This behavior can be turned off by setting `ActiveRecord::Base.lock_optimistical
 To override the name of the `lock_version` column, `ActiveRecord::Base` provides a class attribute called `locking_column`:
 
 ```ruby
-class Client < ActiveRecord::Base
+class Client < ApplicationRecord
   self.locking_column = :lock_client_column
 end
 ```
@@ -946,26 +946,26 @@ Active Record lets you use the names of the [associations](association_basics.ht
 For example, consider the following `Category`, `Post`, `Comments` and `Guest` models:
 
 ```ruby
-class Category < ActiveRecord::Base
+class Category < ApplicationRecord
   has_many :posts
 end
 
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   belongs_to :category
   has_many :comments
   has_many :tags
 end
 
-class Comment < ActiveRecord::Base
+class Comment < ApplicationRecord
   belongs_to :post
   has_one :guest
 end
 
-class Guest < ActiveRecord::Base
+class Guest < ApplicationRecord
   belongs_to :comment
 end
 
-class Tag < ActiveRecord::Base
+class Tag < ApplicationRecord
   belongs_to :post
 end
 ```
@@ -1142,7 +1142,7 @@ Scoping allows you to specify commonly-used queries which can be referenced as m
 To define a simple scope, we use the `scope` method inside the class, passing the query that we'd like to run when this scope is called:
 
 ```ruby
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   scope :published, -> { where(published: true) }
 end
 ```
@@ -1150,7 +1150,7 @@ end
 This is exactly the same as defining a class method, and which you use is a matter of personal preference:
 
 ```ruby
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   def self.published
     where(published: true)
   end
@@ -1160,7 +1160,7 @@ end
 Scopes are also chainable within scopes:
 
 ```ruby
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   scope :published,               -> { where(published: true) }
   scope :published_and_commented, -> { published.where("comments_count > 0") }
 end
@@ -1184,7 +1184,7 @@ category.posts.published # => [published posts belonging to this category]
 Your scope can take arguments:
 
 ```ruby
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   scope :created_before, ->(time) { where("created_at < ?", time) }
 end
 ```
@@ -1198,7 +1198,7 @@ Post.created_before(Time.zone.now)
 However, this is just duplicating the functionality that would be provided to you by a class method.
 
 ```ruby
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   def self.created_before(time)
     where("created_at < ?", time)
   end
@@ -1216,7 +1216,7 @@ category.posts.created_before(time)
 Just like `where` clauses scopes are merged using `AND` conditions.
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   scope :active, -> { where state: 'active' }
   scope :inactive, -> { where state: 'inactive' }
 end
@@ -1245,7 +1245,7 @@ One important caveat is that `default_scope` will be overridden by
 `scope` and `where` conditions.
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   default_scope { where state: 'pending' }
   scope :active, -> { where state: 'active' }
   scope :inactive, -> { where state: 'inactive' }
@@ -1271,7 +1271,7 @@ If we wish for a scope to be applied across all queries to the model we can use 
 `default_scope` method within the model itself.
 
 ```ruby
-class Client < ActiveRecord::Base
+class Client < ApplicationRecord
   default_scope { where("removed_at IS NULL") }
 end
 ```
@@ -1287,7 +1287,7 @@ If you need to do more complex things with a default scope, you can alternativel
 define it as a class method:
 
 ```ruby
-class Client < ActiveRecord::Base
+class Client < ApplicationRecord
   def self.default_scope
     # Should return an ActiveRecord::Relation.
   end
@@ -1490,7 +1490,7 @@ a large or often-running query. However, any model method overrides will
 not be available. For example:
 
 ```ruby
-class Client < ActiveRecord::Base
+class Client < ApplicationRecord
   def name
     "I am #{super}"
   end
@@ -1525,7 +1525,7 @@ Person.ids
 ```
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   self.primary_key = "person_id"
 end
 

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -18,7 +18,7 @@ Validations Overview
 Here's an example of a very simple validation:
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :name, presence: true
 end
 
@@ -78,7 +78,7 @@ method to determine whether an object is already in the database or not.
 Consider the following simple Active Record class:
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
 end
 ```
 
@@ -153,7 +153,7 @@ and returns true if no errors were found in the object, and false otherwise.
 As you saw above:
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :name, presence: true
 end
 
@@ -170,7 +170,7 @@ Note that an object instantiated with `new` will not report errors even if it's
 technically invalid, because validations are not run when using `new`.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :name, presence: true
 end
 
@@ -216,7 +216,7 @@ it doesn't verify the validity of the object as a whole. It only checks to see
 whether there are errors found on an individual attribute of the object.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :name, presence: true
 end
 
@@ -258,7 +258,7 @@ concept. This validation is very specific to web applications and this
 don't have a field for it, the helper will just create a virtual attribute).
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :terms_of_service, acceptance: true
 end
 ```
@@ -269,7 +269,7 @@ It can receive an `:accept` option, which determines the value that will be
 considered acceptance. It defaults to "1" and can be easily changed.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :terms_of_service, acceptance: { accept: 'yes' }
 end
 ```
@@ -281,7 +281,7 @@ and they also need to be validated. When you try to save your object, `valid?`
 will be called upon each one of the associated objects.
 
 ```ruby
-class Library < ActiveRecord::Base
+class Library < ApplicationRecord
   has_many :books
   validates_associated :books
 end
@@ -304,7 +304,7 @@ or a password. This validation creates a virtual attribute whose name is the
 name of the field that has to be confirmed with "_confirmation" appended.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :email, confirmation: true
 end
 ```
@@ -321,7 +321,7 @@ confirmation, make sure to add a presence check for the confirmation attribute
 (we'll take a look at `presence` later on this guide):
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :email, confirmation: true
   validates :email_confirmation, presence: true
 end
@@ -335,7 +335,7 @@ This helper validates that the attributes' values are not included in a given
 set. In fact, this set can be any enumerable object.
 
 ```ruby
-class Account < ActiveRecord::Base
+class Account < ApplicationRecord
   validates :subdomain, exclusion: { in: %w(www us ca jp),
     message: "Subdomain %{value} is reserved." }
 end
@@ -355,7 +355,7 @@ This helper validates the attributes' values by testing whether they match a
 given regular expression, which is specified using the `:with` option.
 
 ```ruby
-class Product < ActiveRecord::Base
+class Product < ApplicationRecord
   validates :legacy_code, format: { with: /\A[a-zA-Z]+\z/,
     message: "only allows letters" }
 end
@@ -369,7 +369,7 @@ This helper validates that the attributes' values are included in a given set.
 In fact, this set can be any enumerable object.
 
 ```ruby
-class Coffee < ActiveRecord::Base
+class Coffee < ApplicationRecord
   validates :size, inclusion: { in: %w(small medium large),
     message: "%{value} is not a valid size" }
 end
@@ -388,7 +388,7 @@ This helper validates the length of the attributes' values. It provides a
 variety of options, so you can specify length constraints in different ways:
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :name, length: { minimum: 2 }
   validates :bio, length: { maximum: 500 }
   validates :password, length: { in: 6..20 }
@@ -411,7 +411,7 @@ number corresponding to the length constraint being used. You can still use the
 `:message` option to specify an error message.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :bio, length: { maximum: 1000,
     too_long: "%{count} characters is the maximum allowed" }
 end
@@ -421,7 +421,7 @@ This helper counts characters by default, but you can split the value in a
 different way using the `:tokenizer` option:
 
 ```ruby
-class Essay < ActiveRecord::Base
+class Essay < ApplicationRecord
   validates :content, length: {
     minimum: 300,
     maximum: 400,
@@ -460,7 +460,7 @@ WARNING. Note that the regular expression above allows a trailing newline
 character.
 
 ```ruby
-class Player < ActiveRecord::Base
+class Player < ApplicationReocrd
   validates :points, numericality: true
   validates :games_played, numericality: { only_integer: true }
 end
@@ -496,7 +496,7 @@ This helper validates that the specified attributes are not empty. It uses the
 is, a string that is either empty or consists of whitespace.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :name, :login, :email, presence: true
 end
 ```
@@ -506,7 +506,7 @@ whether the associated object itself is present, and not the foreign key used
 to map the association.
 
 ```ruby
-class LineItem < ActiveRecord::Base
+class LineItem < ApplicationRecord
   belongs_to :order
   validates :order, presence: true
 end
@@ -516,7 +516,7 @@ In order to validate associated records whose presence is required, you must
 specify the `:inverse_of` option for the association:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   has_many :line_items, inverse_of: :order
 end
 ```
@@ -537,7 +537,7 @@ This helper validates that the specified attributes are absent. It uses the
 is, a string that is either empty or consists of whitespace.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :name, :login, :email, absence: true
 end
 ```
@@ -547,7 +547,7 @@ whether the associated object itself is absent, and not the foreign key used
 to map the association.
 
 ```ruby
-class LineItem < ActiveRecord::Base
+class LineItem < ApplicationRecord
   belongs_to :order
   validates :order, absence: true
 end
@@ -557,7 +557,7 @@ In order to validate associated records whose absence is required, you must
 specify the `:inverse_of` option for the association:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   has_many :line_items, inverse_of: :order
 end
 ```
@@ -580,7 +580,7 @@ with the same value for a column that you intend to be unique. To avoid that,
 you must create a unique index in your database.
 
 ```ruby
-class Account < ActiveRecord::Base
+class Account < ApplicationRecord
   validates :email, uniqueness: true
 end
 ```
@@ -592,7 +592,7 @@ There is a `:scope` option that you can use to specify other attributes that
 are used to limit the uniqueness check:
 
 ```ruby
-class Holiday < ActiveRecord::Base
+class Holiday < ApplicationRecord
   validates :name, uniqueness: { scope: :year,
     message: "should happen once per year" }
 end
@@ -603,7 +603,7 @@ uniqueness constraint will be case sensitive or not. This option defaults to
 true.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :name, uniqueness: { case_sensitive: false }
 end
 ```
@@ -618,7 +618,7 @@ The default error message is _"has already been taken"_.
 This helper passes the record to a separate class for validation.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates_with GoodnessValidator
 end
 
@@ -646,7 +646,7 @@ Like all other validations, `validates_with` takes the `:if`, `:unless` and
 validator class as `options`:
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates_with GoodnessValidator, fields: [:first_name, :last_name]
 end
 
@@ -667,7 +667,7 @@ If your validator is complex enough that you want instance variables, you can
 easily use a plain old Ruby object instead:
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validate do |person|
     GoodnessValidator.new(person).validate
   end
@@ -696,7 +696,7 @@ passed to `validates_each` will be tested against it. In the following example,
 we don't want names and surnames to begin with lower case.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates_each :name, :surname do |record, attr, value|
     record.errors.add(attr, 'must start with upper case') if value =~ /\A[a-z]/
   end
@@ -719,7 +719,7 @@ The `:allow_nil` option skips the validation when the value being validated is
 `nil`.
 
 ```ruby
-class Coffee < ActiveRecord::Base
+class Coffee < ApplicationRecord
   validates :size, inclusion: { in: %w(small medium large),
     message: "%{value} is not a valid size" }, allow_nil: true
 end
@@ -732,7 +732,7 @@ will let validation pass if the attribute's value is `blank?`, like `nil` or an
 empty string for example.
 
 ```ruby
-class Topic < ActiveRecord::Base
+class Topic < ApplicationRecord
   validates :title, length: { is: 5 }, allow_blank: true
 end
 
@@ -757,7 +757,7 @@ new record is created or `on: :update` to run the validation only when a record
 is updated.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   # it will be possible to update email with a duplicated value
   validates :email, uniqueness: true, on: :create
 
@@ -776,7 +776,7 @@ You can also specify validations to be strict and raise
 `ActiveModel::StrictValidationFailed` when the object is invalid.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :name, presence: { strict: true }
 end
 
@@ -786,7 +786,7 @@ Person.new.valid?  # => ActiveModel::StrictValidationFailed: Name can't be blank
 There is also an ability to pass custom exception to `:strict` option
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :token, presence: true, uniqueness: true, strict: TokenGenerationException
 end
 
@@ -810,7 +810,7 @@ to the name of a method that will get called right before validation happens.
 This is the most commonly used option.
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   validates :card_number, presence: true, if: :paid_with_card?
 
   def paid_with_card?
@@ -826,7 +826,7 @@ contain valid Ruby code. You should use this option only when the string
 represents a really short condition.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :surname, presence: true, if: "name.nil?"
 end
 ```
@@ -839,7 +839,7 @@ inline condition instead of a separate method. This option is best suited for
 one-liners.
 
 ```ruby
-class Account < ActiveRecord::Base
+class Account < ApplicationRecord
   validates :password, confirmation: true,
     unless: Proc.new { |a| a.password.blank? }
 end
@@ -851,7 +851,7 @@ Sometimes it is useful to have multiple validations use one condition, it can
 be easily achieved using `with_options`.
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   with_options if: :is_admin? do |admin|
     admin.validates :password, length: { minimum: 10 }
     admin.validates :email, presence: true
@@ -869,7 +869,7 @@ should happen, an `Array` can be used. Moreover, you can apply both `:if` and
 `:unless` to the same validation.
 
 ```ruby
-class Computer < ActiveRecord::Base
+class Computer < ApplicationRecord
   validates :mouse, presence: true,
                     if: ["market.retail?", :desktop?]
                     unless: Proc.new { |c| c.trackpad.present? }
@@ -923,7 +923,7 @@ class EmailValidator < ActiveModel::EachValidator
   end
 end
 
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :email, presence: true, email: true
 end
 ```
@@ -942,7 +942,7 @@ You can pass more than one symbol for each class method and the respective
 validations will be run in the same order as they were registered.
 
 ```ruby
-class Invoice < ActiveRecord::Base
+class Invoice < ApplicationRecord
   validate :expiration_date_cannot_be_in_the_past,
     :discount_cannot_be_greater_than_total_value
 
@@ -965,7 +965,7 @@ possible to control when to run these custom validations by giving an `:on`
 option to the `validate` method, with either: `:create` or `:update`.
 
 ```ruby
-class Invoice < ActiveRecord::Base
+class Invoice < ApplicationRecord
   validate :active_customer, on: :create
 
   def active_customer
@@ -986,7 +986,7 @@ The following is a list of the most commonly used methods. Please refer to the `
 Returns an instance of the class `ActiveModel::Errors` containing all errors. Each key is the attribute name and the value is an array of strings with all errors.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :name, presence: true, length: { minimum: 3 }
 end
 
@@ -1005,7 +1005,7 @@ person.errors.messages # => {}
 `errors[]` is used when you want to check the error messages for a specific attribute. It returns an array of strings with all error messages for the given attribute, each string with one error message. If there are no errors related to the attribute, it returns an empty array.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :name, presence: true, length: { minimum: 3 }
 end
 
@@ -1028,7 +1028,7 @@ person.errors[:name]
 The `add` method lets you manually add messages that are related to particular attributes. You can use the `errors.full_messages` or `errors.to_a` methods to view the messages in the form they might be displayed to a user. Those particular messages get the attribute name prepended (and capitalized). `add` receives the name of the attribute you want to add the message to, and the message itself.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   def a_method_used_for_validation_purposes
     errors.add(:name, "cannot contain the characters !@#%*()_-+=")
   end
@@ -1046,7 +1046,7 @@ person.errors.full_messages
 Another way to do this is using `[]=` setter
 
 ```ruby
-  class Person < ActiveRecord::Base
+  class Person < ApplicationRecord
     def a_method_used_for_validation_purposes
       errors[:name] = "cannot contain the characters !@#%*()_-+="
     end
@@ -1066,7 +1066,7 @@ Another way to do this is using `[]=` setter
 You can add error messages that are related to the object's state as a whole, instead of being related to a specific attribute. You can use this method when you want to say that the object is invalid, no matter the values of its attributes. Since `errors[:base]` is an array, you can simply add a string to it and it will be used as an error message.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   def a_method_used_for_validation_purposes
     errors[:base] << "This person is invalid because ..."
   end
@@ -1078,7 +1078,7 @@ end
 The `clear` method is used when you intentionally want to clear all the messages in the `errors` collection. Of course, calling `errors.clear` upon an invalid object won't actually make it valid: the `errors` collection will now be empty, but the next time you call `valid?` or any method that tries to save this object to the database, the validations will run again. If any of the validations fail, the `errors` collection will be filled again.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :name, presence: true, length: { minimum: 3 }
 end
 
@@ -1101,7 +1101,7 @@ p.errors[:name]
 The `size` method returns the total number of error messages for the object.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   validates :name, presence: true, length: { minimum: 3 }
 end
 

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -384,7 +384,7 @@ The method `with_options` provides a way to factor out common options in a serie
 Given a default options hash, `with_options` yields a proxy object to a block. Within the block, methods called on the proxy are forwarded to the receiver with their options merged. For example, you get rid of the duplication in:
 
 ```ruby
-class Account < ActiveRecord::Base
+class Account < ApplicationRecord
   has_many :customers, dependent: :destroy
   has_many :products,  dependent: :destroy
   has_many :invoices,  dependent: :destroy
@@ -395,7 +395,7 @@ end
 this way:
 
 ```ruby
-class Account < ActiveRecord::Base
+class Account < ApplicationRecord
   with_options dependent: :destroy do |assoc|
     assoc.has_many :customers
     assoc.has_many :products
@@ -573,7 +573,7 @@ NOTE: Defined in `active_support/core_ext/module/aliasing.rb`.
 Model attributes have a reader, a writer, and a predicate. You can alias a model attribute having the corresponding three methods defined for you in one shot. As in other aliasing methods, the new name is the first argument, and the old name is the second (my mnemonic is they go in the same order as if you did an assignment):
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   # let me refer to the email column as "login",
   # possibly meaningful for authentication code
   alias_attribute :login, :email
@@ -881,7 +881,7 @@ The macro `delegate` offers an easy way to forward methods.
 Let's imagine that users in some application have login information in the `User` model but name and other data in a separate `Profile` model:
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   has_one :profile
 end
 ```
@@ -889,7 +889,7 @@ end
 With that configuration you get a user's name via his profile, `user.profile.name`, but it could be handy to still be able to access such attribute directly:
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   has_one :profile
 
   def name
@@ -901,7 +901,7 @@ end
 That is what `delegate` does for you:
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   has_one :profile
 
   delegate :name, to: :profile

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -17,10 +17,10 @@ Why Associations?
 Why do we need associations between models? Because they make common operations simpler and easier in your code. For example, consider a simple Rails application that includes a model for customers and a model for orders. Each customer can have many orders. Without associations, the model declarations would look like this:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
 end
 
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
 end
 ```
 
@@ -43,11 +43,11 @@ end
 With Active Record associations, we can streamline these - and other - operations by declaratively telling Rails that there is a connection between the two models. Here's the revised code for setting up customers and orders:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders, dependent: :destroy
 end
 
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer
 end
 ```
@@ -85,7 +85,7 @@ In the remainder of this guide, you'll learn how to declare and use the various 
 A `belongs_to` association sets up a one-to-one connection with another model, such that each instance of the declaring model "belongs to" one instance of the other model. For example, if your application includes customers and orders, and each order can be assigned to exactly one customer, you'd declare the order model this way:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer
 end
 ```
@@ -118,7 +118,7 @@ end
 A `has_one` association also sets up a one-to-one connection with another model, but with somewhat different semantics (and consequences). This association indicates that each instance of a model contains or possesses one instance of another model. For example, if each supplier in your application has only one account, you'd declare the supplier model like this:
 
 ```ruby
-class Supplier < ActiveRecord::Base
+class Supplier < ApplicationRecord
   has_one :account
 end
 ```
@@ -149,7 +149,7 @@ end
 A `has_many` association indicates a one-to-many connection with another model. You'll often find this association on the "other side" of a `belongs_to` association. This association indicates that each instance of the model has zero or more instances of another model. For example, in an application containing customers and orders, the customer model could be declared like this:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders
 end
 ```
@@ -182,17 +182,17 @@ end
 A `has_many :through` association is often used to set up a many-to-many connection with another model. This association indicates that the declaring model can be matched with zero or more instances of another model by proceeding _through_ a third model. For example, consider a medical practice where patients make appointments to see physicians. The relevant association declarations could look like this:
 
 ```ruby
-class Physician < ActiveRecord::Base
+class Physician < ApplicationRecord
   has_many :appointments
   has_many :patients, through: :appointments
 end
 
-class Appointment < ActiveRecord::Base
+class Appointment < ApplicationRecord
   belongs_to :physician
   belongs_to :patient
 end
 
-class Patient < ActiveRecord::Base
+class Patient < ApplicationRecord
   has_many :appointments
   has_many :physicians, through: :appointments
 end
@@ -238,17 +238,17 @@ WARNING: Automatic deletion of join models is direct, no destroy callbacks are t
 The `has_many :through` association is also useful for setting up "shortcuts" through nested `has_many` associations. For example, if a document has many sections, and a section has many paragraphs, you may sometimes want to get a simple collection of all paragraphs in the document. You could set that up this way:
 
 ```ruby
-class Document < ActiveRecord::Base
+class Document < ApplicationRecord
   has_many :sections
   has_many :paragraphs, through: :sections
 end
 
-class Section < ActiveRecord::Base
+class Section < ApplicationRecord
   belongs_to :document
   has_many :paragraphs
 end
 
-class Paragraph < ActiveRecord::Base
+class Paragraph < ApplicationRecord
   belongs_to :section
 end
 ```
@@ -264,17 +264,17 @@ With `through: :sections` specified, Rails will now understand:
 A `has_one :through` association sets up a one-to-one connection with another model. This association indicates that the declaring model can be matched with one instance of another model by proceeding _through_ a third model. For example, if each supplier has one account, and each account is associated with one account history, then the customer model could look like this:
 
 ```ruby
-class Supplier < ActiveRecord::Base
+class Supplier < ApplicationRecord
   has_one :account
   has_one :account_history, through: :account
 end
 
-class Account < ActiveRecord::Base
+class Account < ApplicationRecord
   belongs_to :supplier
   has_one :account_history
 end
 
-class AccountHistory < ActiveRecord::Base
+class AccountHistory < ApplicationRecord
   belongs_to :account
 end
 ```
@@ -311,11 +311,11 @@ end
 A `has_and_belongs_to_many` association creates a direct many-to-many connection with another model, with no intervening model. For example, if your application includes assemblies and parts, with each assembly having many parts and each part appearing in many assemblies, you could declare the models this way:
 
 ```ruby
-class Assembly < ActiveRecord::Base
+class Assembly < ApplicationRecord
   has_and_belongs_to_many :parts
 end
 
-class Part < ActiveRecord::Base
+class Part < ApplicationRecord
   has_and_belongs_to_many :assemblies
 end
 ```
@@ -352,11 +352,11 @@ If you want to set up a one-to-one relationship between two models, you'll need 
 The distinction is in where you place the foreign key (it goes on the table for the class declaring the `belongs_to` association), but you should give some thought to the actual meaning of the data as well. The `has_one` relationship says that one of something is yours - that is, that something points back to you. For example, it makes more sense to say that a supplier owns an account than that an account owns a supplier. This suggests that the correct relationships are like this:
 
 ```ruby
-class Supplier < ActiveRecord::Base
+class Supplier < ApplicationRecord
   has_one :account
 end
 
-class Account < ActiveRecord::Base
+class Account < ApplicationRecord
   belongs_to :supplier
 end
 ```
@@ -387,11 +387,11 @@ NOTE: Using `t.integer :supplier_id` makes the foreign key naming obvious and ex
 Rails offers two different ways to declare a many-to-many relationship between models. The simpler way is to use `has_and_belongs_to_many`, which allows you to make the association directly:
 
 ```ruby
-class Assembly < ActiveRecord::Base
+class Assembly < ApplicationRecord
   has_and_belongs_to_many :parts
 end
 
-class Part < ActiveRecord::Base
+class Part < ApplicationRecord
   has_and_belongs_to_many :assemblies
 end
 ```
@@ -399,17 +399,17 @@ end
 The second way to declare a many-to-many relationship is to use `has_many :through`. This makes the association indirectly, through a join model:
 
 ```ruby
-class Assembly < ActiveRecord::Base
+class Assembly < ApplicationRecord
   has_many :manifests
   has_many :parts, through: :manifests
 end
 
-class Manifest < ActiveRecord::Base
+class Manifest < ApplicationRecord
   belongs_to :assembly
   belongs_to :part
 end
 
-class Part < ActiveRecord::Base
+class Part < ApplicationRecord
   has_many :manifests
   has_many :assemblies, through: :manifests
 end
@@ -424,15 +424,15 @@ You should use `has_many :through` if you need validations, callbacks, or extra 
 A slightly more advanced twist on associations is the _polymorphic association_. With polymorphic associations, a model can belong to more than one other model, on a single association. For example, you might have a picture model that belongs to either an employee model or a product model. Here's how this could be declared:
 
 ```ruby
-class Picture < ActiveRecord::Base
+class Picture < ApplicationRecord
   belongs_to :imageable, polymorphic: true
 end
 
-class Employee < ActiveRecord::Base
+class Employee < ApplicationRecord
   has_many :pictures, as: :imageable
 end
 
-class Product < ActiveRecord::Base
+class Product < ApplicationRecord
   has_many :pictures, as: :imageable
 end
 ```
@@ -477,7 +477,7 @@ end
 In designing a data model, you will sometimes find a model that should have a relation to itself. For example, you may want to store all employees in a single database model, but be able to trace relationships such as between manager and subordinates. This situation can be modeled with self-joining associations:
 
 ```ruby
-class Employee < ActiveRecord::Base
+class Employee < ApplicationRecord
   has_many :subordinates, class_name: "Employee",
                           foreign_key: "manager_id"
 
@@ -530,7 +530,7 @@ Associations are extremely useful, but they are not magic. You are responsible f
 When you declare a `belongs_to` association, you need to create foreign keys as appropriate. For example, consider this model:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer
 end
 ```
@@ -560,11 +560,11 @@ WARNING: The precedence between model names is calculated using the `<` operator
 Whatever the name, you must manually generate the join table with an appropriate migration. For example, consider these associations:
 
 ```ruby
-class Assembly < ActiveRecord::Base
+class Assembly < ApplicationRecord
   has_and_belongs_to_many :parts
 end
 
-class Part < ActiveRecord::Base
+class Part < ApplicationRecord
   has_and_belongs_to_many :assemblies
 end
 ```
@@ -591,11 +591,11 @@ By default, associations look for objects only within the current module's scope
 ```ruby
 module MyApplication
   module Business
-    class Supplier < ActiveRecord::Base
+    class Supplier < ApplicationRecord
        has_one :account
     end
 
-    class Account < ActiveRecord::Base
+    class Account < ApplicationRecord
        belongs_to :supplier
     end
   end
@@ -607,13 +607,13 @@ This will work fine, because both the `Supplier` and the `Account` class are def
 ```ruby
 module MyApplication
   module Business
-    class Supplier < ActiveRecord::Base
+    class Supplier < ApplicationRecord
        has_one :account
     end
   end
 
   module Billing
-    class Account < ActiveRecord::Base
+    class Account < ApplicationRecord
        belongs_to :supplier
     end
   end
@@ -625,14 +625,14 @@ To associate a model with a model in a different namespace, you must specify the
 ```ruby
 module MyApplication
   module Business
-    class Supplier < ActiveRecord::Base
+    class Supplier < ApplicationRecord
        has_one :account,
         class_name: "MyApplication::Billing::Account"
     end
   end
 
   module Billing
-    class Account < ActiveRecord::Base
+    class Account < ApplicationRecord
        belongs_to :supplier,
         class_name: "MyApplication::Business::Supplier"
     end
@@ -645,11 +645,11 @@ end
 It's normal for associations to work in two directions, requiring declaration on two different models:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders
 end
 
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer
 end
 ```
@@ -667,11 +667,11 @@ c.first_name == o.customer.first_name # => false
 This happens because c and o.customer are two different in-memory representations of the same data, and neither one is automatically refreshed from changes to the other. Active Record provides the `:inverse_of` option so that you can inform it of these relations:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders, inverse_of: :customer
 end
 
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer, inverse_of: :orders
 end
 ```
@@ -726,7 +726,7 @@ When you declare a `belongs_to` association, the declaring class automatically g
 In all of these methods, `association` is replaced with the symbol passed as the first argument to `belongs_to`. For example, given the declaration:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer
 end
 ```
@@ -789,7 +789,7 @@ Does the same as `create_association` above, but raises `ActiveRecord::RecordInv
 While Rails uses intelligent defaults that will work well in most situations, there may be times when you want to customize the behavior of the `belongs_to` association reference. Such customizations can easily be accomplished by passing options and scope blocks when you create the association. For example, this association uses two such options:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer, dependent: :destroy,
     counter_cache: true
 end
@@ -816,7 +816,7 @@ If you set the `:autosave` option to `true`, Rails will save any loaded members 
 If the name of the other model cannot be derived from the association name, you can use the `:class_name` option to supply the model name. For example, if an order belongs to a customer, but the actual name of the model containing customers is `Patron`, you'd set things up this way:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer, class_name: "Patron"
 end
 ```
@@ -826,10 +826,10 @@ end
 The `:counter_cache` option can be used to make finding the number of belonging objects more efficient. Consider these models:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer
 end
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders
 end
 ```
@@ -837,10 +837,10 @@ end
 With these declarations, asking for the value of `@customer.orders.size` requires making a call to the database to perform a `COUNT(*)` query. To avoid this call, you can add a counter cache to the _belonging_ model:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer, counter_cache: true
 end
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders
 end
 ```
@@ -850,10 +850,10 @@ With this declaration, Rails will keep the cache value up to date, and then retu
 Although the `:counter_cache` option is specified on the model that includes the `belongs_to` declaration, the actual column must be added to the _associated_ model. In the case above, you would need to add a column named `orders_count` to the `Customer` model. You can override the default column name if you need to:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer, counter_cache: :count_of_orders
 end
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders
 end
 ```
@@ -871,7 +871,7 @@ WARNING: You should not specify this option on a `belongs_to` association that i
 By convention, Rails assumes that the column used to hold the foreign key on this model is the name of the association with the suffix `_id` added. The `:foreign_key` option lets you set the name of the foreign key directly:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer, class_name: "Patron",
                         foreign_key: "patron_id"
 end
@@ -884,11 +884,11 @@ TIP: In any case, Rails will not create foreign key columns for you. You need to
 The `:inverse_of` option specifies the name of the `has_many` or `has_one` association that is the inverse of this association. Does not work in combination with the `:polymorphic` options.
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders, inverse_of: :customer
 end
 
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer, inverse_of: :orders
 end
 ```
@@ -902,11 +902,11 @@ Passing `true` to the `:polymorphic` option indicates that this is a polymorphic
 If you set the `:touch` option to `:true`, then the `updated_at` or `updated_on` timestamp on the associated object will be set to the current time whenever this object is saved or destroyed:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer, touch: true
 end
 
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders
 end
 ```
@@ -914,7 +914,7 @@ end
 In this case, saving or destroying an order will update the timestamp on the associated customer. You can also specify a particular timestamp attribute to update:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer, touch: :orders_updated_at
 end
 ```
@@ -928,7 +928,7 @@ If you set the `:validate` option to `true`, then associated objects will be val
 There may be times when you wish to customize the query used by `belongs_to`. Such customizations can be achieved via a scope block. For example:
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer, -> { where active: true },
                         dependent: :destroy
 end
@@ -946,7 +946,7 @@ You can use any of the standard [querying methods](active_record_querying.html) 
 The `where` method lets you specify the conditions that the associated object must meet.
 
 ```ruby
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer, -> { where active: true }
 end
 ```
@@ -956,16 +956,16 @@ end
 You can use the `includes` method to specify second-order associations that should be eager-loaded when this association is used. For example, consider these models:
 
 ```ruby
-class LineItem < ActiveRecord::Base
+class LineItem < ApplicationRecord
   belongs_to :order
 end
 
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer
   has_many :line_items
 end
 
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders
 end
 ```
@@ -973,16 +973,16 @@ end
 If you frequently retrieve customers directly from line items (`@line_item.order.customer`), then you can make your code somewhat more efficient by including customers in the association from line items to orders:
 
 ```ruby
-class LineItem < ActiveRecord::Base
+class LineItem < ApplicationRecord
   belongs_to :order, -> { includes :customer }
 end
 
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer
   has_many :line_items
 end
 
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders
 end
 ```
@@ -1030,7 +1030,7 @@ When you declare a `has_one` association, the declaring class automatically gain
 In all of these methods, `association` is replaced with the symbol passed as the first argument to `has_one`. For example, given the declaration:
 
 ```ruby
-class Supplier < ActiveRecord::Base
+class Supplier < ApplicationRecord
   has_one :account
 end
 ```
@@ -1090,7 +1090,7 @@ Does the same as `create_association` above, but raises `ActiveRecord::RecordInv
 While Rails uses intelligent defaults that will work well in most situations, there may be times when you want to customize the behavior of the `has_one` association reference. Such customizations can easily be accomplished by passing options when you create the association. For example, this association uses two such options:
 
 ```ruby
-class Supplier < ActiveRecord::Base
+class Supplier < ApplicationRecord
   has_one :account, class_name: "Billing", dependent: :nullify
 end
 ```
@@ -1122,7 +1122,7 @@ If you set the `:autosave` option to `true`, Rails will save any loaded members 
 If the name of the other model cannot be derived from the association name, you can use the `:class_name` option to supply the model name. For example, if a supplier has an account, but the actual name of the model containing accounts is `Billing`, you'd set things up this way:
 
 ```ruby
-class Supplier < ActiveRecord::Base
+class Supplier < ApplicationRecord
   has_one :account, class_name: "Billing"
 end
 ```
@@ -1148,7 +1148,7 @@ value.
 By convention, Rails assumes that the column used to hold the foreign key on the other model is the name of this model with the suffix `_id` added. The `:foreign_key` option lets you set the name of the foreign key directly:
 
 ```ruby
-class Supplier < ActiveRecord::Base
+class Supplier < ApplicationRecord
   has_one :account, foreign_key: "supp_id"
 end
 ```
@@ -1160,11 +1160,11 @@ TIP: In any case, Rails will not create foreign key columns for you. You need to
 The `:inverse_of` option specifies the name of the `belongs_to` association that is the inverse of this association. Does not work in combination with the `:through` or `:as` options.
 
 ```ruby
-class Supplier < ActiveRecord::Base
+class Supplier < ApplicationRecord
   has_one :account, inverse_of: :supplier
 end
 
-class Account < ActiveRecord::Base
+class Account < ApplicationRecord
   belongs_to :supplier, inverse_of: :account
 end
 ```
@@ -1194,7 +1194,7 @@ If you set the `:validate` option to `true`, then associated objects will be val
 There may be times when you wish to customize the query used by `has_one`. Such customizations can be achieved via a scope block. For example:
 
 ```ruby
-class Supplier < ActiveRecord::Base
+class Supplier < ApplicationRecord
   has_one :account, -> { where active: true }
 end
 ```
@@ -1211,7 +1211,7 @@ You can use any of the standard [querying methods](active_record_querying.html) 
 The `where` method lets you specify the conditions that the associated object must meet.
 
 ```ruby
-class Supplier < ActiveRecord::Base
+class Supplier < ApplicationRecord
   has_one :account, -> { where "confirmed = 1" }
 end
 ```
@@ -1221,16 +1221,16 @@ end
 You can use the `includes` method to specify second-order associations that should be eager-loaded when this association is used. For example, consider these models:
 
 ```ruby
-class Supplier < ActiveRecord::Base
+class Supplier < ApplicationRecord
   has_one :account
 end
 
-class Account < ActiveRecord::Base
+class Account < ApplicationRecord
   belongs_to :supplier
   belongs_to :representative
 end
 
-class Representative < ActiveRecord::Base
+class Representative < ApplicationRecord
   has_many :accounts
 end
 ```
@@ -1238,16 +1238,16 @@ end
 If you frequently retrieve representatives directly from suppliers (`@supplier.account.representative`), then you can make your code somewhat more efficient by including representatives in the association from suppliers to accounts:
 
 ```ruby
-class Supplier < ActiveRecord::Base
+class Supplier < ApplicationRecord
   has_one :account, -> { includes :representative }
 end
 
-class Account < ActiveRecord::Base
+class Account < ApplicationRecord
   belongs_to :supplier
   belongs_to :representative
 end
 
-class Representative < ActiveRecord::Base
+class Representative < ApplicationRecord
   has_many :accounts
 end
 ```
@@ -1308,7 +1308,7 @@ When you declare a `has_many` association, the declaring class automatically gai
 In all of these methods, `collection` is replaced with the symbol passed as the first argument to `has_many`, and `collection_singular` is replaced with the singularized version of that symbol. For example, given the declaration:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders
 end
 ```
@@ -1456,7 +1456,7 @@ Does the same as `collection.create` above, but raises `ActiveRecord::RecordInva
 While Rails uses intelligent defaults that will work well in most situations, there may be times when you want to customize the behavior of the `has_many` association reference. Such customizations can easily be accomplished by passing options when you create the association. For example, this association uses two such options:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders, dependent: :delete_all, validate: :false
 end
 ```
@@ -1488,7 +1488,7 @@ If you set the `:autosave` option to `true`, Rails will save any loaded members 
 If the name of the other model cannot be derived from the association name, you can use the `:class_name` option to supply the model name. For example, if a customer has many orders, but the actual name of the model containing orders is `Transaction`, you'd set things up this way:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders, class_name: "Transaction"
 end
 ```
@@ -1510,7 +1510,7 @@ NOTE: This option is ignored when you use the `:through` option on the associati
 By convention, Rails assumes that the column used to hold the foreign key on the other model is the name of this model with the suffix `_id` added. The `:foreign_key` option lets you set the name of the foreign key directly:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders, foreign_key: "cust_id"
 end
 ```
@@ -1522,11 +1522,11 @@ TIP: In any case, Rails will not create foreign key columns for you. You need to
 The `:inverse_of` option specifies the name of the `belongs_to` association that is the inverse of this association. Does not work in combination with the `:through` or `:as` options.
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders, inverse_of: :customer
 end
 
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer, inverse_of: :orders
 end
 ```
@@ -1540,7 +1540,7 @@ Let's say that `users` table has `id` as the primary_key but it also has
 `guid` column value and not `id` value. This can be achieved like this
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   has_many :todos, primary_key: :guid
 end
 ```
@@ -1570,7 +1570,7 @@ If you set the `:validate` option to `false`, then associated objects will not b
 There may be times when you wish to customize the query used by `has_many`. Such customizations can be achieved via a scope block. For example:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders, -> { where processed: true }
 end
 ```
@@ -1593,7 +1593,7 @@ You can use any of the standard [querying methods](active_record_querying.html) 
 The `where` method lets you specify the conditions that the associated object must meet.
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :confirmed_orders, -> { where "confirmed = 1" },
     class_name: "Order"
 end
@@ -1602,7 +1602,7 @@ end
 You can also set conditions via a hash:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :confirmed_orders, -> { where confirmed: true },
                               class_name: "Order"
 end
@@ -1619,7 +1619,7 @@ The `extending` method specifies a named module to extend the association proxy.
 The `group` method supplies an attribute name to group the result set by, using a `GROUP BY` clause in the finder SQL.
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :line_items, -> { group 'orders.id' },
                         through: :orders
 end
@@ -1630,16 +1630,16 @@ end
 You can use the `includes` method to specify second-order associations that should be eager-loaded when this association is used. For example, consider these models:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders
 end
 
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer
   has_many :line_items
 end
 
-class LineItem < ActiveRecord::Base
+class LineItem < ApplicationRecord
   belongs_to :order
 end
 ```
@@ -1647,16 +1647,16 @@ end
 If you frequently retrieve line items directly from customers (`@customer.orders.line_items`), then you can make your code somewhat more efficient by including line items in the association from customers to orders:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders, -> { includes :line_items }
 end
 
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer
   has_many :line_items
 end
 
-class LineItem < ActiveRecord::Base
+class LineItem < ApplicationRecord
   belongs_to :order
 end
 ```
@@ -1666,7 +1666,7 @@ end
 The `limit` method lets you restrict the total number of objects that will be fetched through an association.
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :recent_orders,
     -> { order('order_date desc').limit(100) },
     class_name: "Order",
@@ -1682,7 +1682,7 @@ The `offset` method lets you specify the starting offset for fetching objects vi
 The `order` method dictates the order in which associated objects will be received (in the syntax used by an SQL `ORDER BY` clause).
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders, -> { order "date_confirmed DESC" }
 end
 ```
@@ -1703,7 +1703,7 @@ Use the `distinct` method to keep the collection free of duplicates. This is
 mostly useful together with the `:through` option.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   has_many :readings
   has_many :posts, through: :readings
 end
@@ -1797,7 +1797,7 @@ When you declare a `has_and_belongs_to_many` association, the declaring class au
 In all of these methods, `collection` is replaced with the symbol passed as the first argument to `has_and_belongs_to_many`, and `collection_singular` is replaced with the singularized version of that symbol. For example, given the declaration:
 
 ```ruby
-class Part < ActiveRecord::Base
+class Part < ApplicationRecord
   has_and_belongs_to_many :assemblies
 end
 ```
@@ -1949,7 +1949,7 @@ Does the same as `collection.create`, but raises `ActiveRecord::RecordInvalid` i
 While Rails uses intelligent defaults that will work well in most situations, there may be times when you want to customize the behavior of the `has_and_belongs_to_many` association reference. Such customizations can easily be accomplished by passing options when you create the association. For example, this association uses two such options:
 
 ```ruby
-class Parts < ActiveRecord::Base
+class Parts < ApplicationRecord
   has_and_belongs_to_many :assemblies, autosave: true,
                                        readonly: true
 end
@@ -1972,7 +1972,7 @@ By convention, Rails assumes that the column in the join table used to hold the 
 TIP: The `:foreign_key` and `:association_foreign_key` options are useful when setting up a many-to-many self-join. For example:
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   has_and_belongs_to_many :friends,
       class_name: "User",
       foreign_key: "this_user_id",
@@ -1989,7 +1989,7 @@ If you set the `:autosave` option to `true`, Rails will save any loaded members 
 If the name of the other model cannot be derived from the association name, you can use the `:class_name` option to supply the model name. For example, if a part has many assemblies, but the actual name of the model containing assemblies is `Gadget`, you'd set things up this way:
 
 ```ruby
-class Parts < ActiveRecord::Base
+class Parts < ApplicationRecord
   has_and_belongs_to_many :assemblies, class_name: "Gadget"
 end
 ```
@@ -1999,7 +1999,7 @@ end
 By convention, Rails assumes that the column in the join table used to hold the foreign key pointing to this model is the name of this model with the suffix `_id` added. The `:foreign_key` option lets you set the name of the foreign key directly:
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   has_and_belongs_to_many :friends,
       class_name: "User",
       foreign_key: "this_user_id",
@@ -2020,7 +2020,7 @@ If you set the `:validate` option to `false`, then associated objects will not b
 There may be times when you wish to customize the query used by `has_and_belongs_to_many`. Such customizations can be achieved via a scope block. For example:
 
 ```ruby
-class Parts < ActiveRecord::Base
+class Parts < ApplicationRecord
   has_and_belongs_to_many :assemblies, -> { where active: true }
 end
 ```
@@ -2043,7 +2043,7 @@ You can use any of the standard [querying methods](active_record_querying.html) 
 The `where` method lets you specify the conditions that the associated object must meet.
 
 ```ruby
-class Parts < ActiveRecord::Base
+class Parts < ApplicationRecord
   has_and_belongs_to_many :assemblies,
     -> { where "factory = 'Seattle'" }
 end
@@ -2052,7 +2052,7 @@ end
 You can also set conditions via a hash:
 
 ```ruby
-class Parts < ActiveRecord::Base
+class Parts < ApplicationRecord
   has_and_belongs_to_many :assemblies,
     -> { where factory: 'Seattle' }
 end
@@ -2069,7 +2069,7 @@ The `extending` method specifies a named module to extend the association proxy.
 The `group` method supplies an attribute name to group the result set by, using a `GROUP BY` clause in the finder SQL.
 
 ```ruby
-class Parts < ActiveRecord::Base
+class Parts < ApplicationRecord
   has_and_belongs_to_many :assemblies, -> { group "factory" }
 end
 ```
@@ -2083,7 +2083,7 @@ You can use the `includes` method to specify second-order associations that shou
 The `limit` method lets you restrict the total number of objects that will be fetched through an association.
 
 ```ruby
-class Parts < ActiveRecord::Base
+class Parts < ApplicationRecord
   has_and_belongs_to_many :assemblies,
     -> { order("created_at DESC").limit(50) }
 end
@@ -2098,7 +2098,7 @@ The `offset` method lets you specify the starting offset for fetching objects vi
 The `order` method dictates the order in which associated objects will be received (in the syntax used by an SQL `ORDER BY` clause).
 
 ```ruby
-class Parts < ActiveRecord::Base
+class Parts < ApplicationRecord
   has_and_belongs_to_many :assemblies,
     -> { order "assembly_name ASC" }
 end
@@ -2140,7 +2140,7 @@ Association callbacks are similar to normal callbacks, but they are triggered by
 You define association callbacks by adding options to the association declaration. For example:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders, before_add: :check_credit_limit
 
   def check_credit_limit(order)
@@ -2154,7 +2154,7 @@ Rails passes the object being added or removed to the callback.
 You can stack callbacks on a single event by passing them as an array:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders,
     before_add: [:check_credit_limit, :calculate_shipping_charges]
 
@@ -2175,7 +2175,7 @@ If a `before_add` callback throws an exception, the object does not get added to
 You're not limited to the functionality that Rails automatically builds into association proxy objects. You can also extend these objects through anonymous modules, adding new finders, creators, or other methods. For example:
 
 ```ruby
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders do
     def find_by_order_prefix(order_number)
       find_by(region_id: order_number[0..2])
@@ -2193,11 +2193,11 @@ module FindRecentExtension
   end
 end
 
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders, -> { extending FindRecentExtension }
 end
 
-class Supplier < ActiveRecord::Base
+class Supplier < ApplicationRecord
   has_many :deliveries, -> { extending FindRecentExtension }
 end
 ```

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -520,7 +520,7 @@ The difference between `next` and `step` is that `step` stops at the next line o
 For example, consider this block of code with an included `debugger` statement:
 
 ```ruby
-class Author < ActiveRecord::Base
+class Author < ApplicationRecord
   has_one :editorial
   has_many :comments
 

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -326,7 +326,7 @@ Turning the model into this:
 
 ```ruby
 module Blorgh
-  class Post < ActiveRecord::Base
+  class Post < ApplicationRecord
     has_many :comments
   end
 end
@@ -775,7 +775,7 @@ end
 ```ruby
 # Blorgh/app/models/post.rb
 
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   has_many :comments
 end
 ```
@@ -796,7 +796,7 @@ end
 ```ruby
 # Blorgh/app/models/post.rb
 
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   has_many :comments
   def summary
     "#{title}"
@@ -813,7 +813,7 @@ Using `Class#class_eval` is great for simple adjustments, but for more complex c
 ```ruby
 # MyApp/app/models/blorgh/post.rb
 
-class Blorgh::Post < ActiveRecord::Base
+class Blorgh::Post < ApplicationRecord
   include Blorgh::Concerns::Models::Post
 
   def time_since_created
@@ -829,7 +829,7 @@ end
 ```ruby
 # Blorgh/app/models/post.rb
 
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   include Blorgh::Concerns::Models::Post
 end
 ```

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -833,12 +833,12 @@ Many apps grow beyond simple forms editing a single object. For example when cre
 Active Record provides model level support via the `accepts_nested_attributes_for` method:
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationModel
   has_many :addresses
   accepts_nested_attributes_for :addresses
 end
 
-class Address < ActiveRecord::Base
+class Address < ApplicationModel
   belongs_to :person
 end
 ```
@@ -924,7 +924,7 @@ private
 You can allow users to delete associated objects by passing `allow_destroy: true` to `accepts_nested_attributes_for`
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   has_many :addresses
   accepts_nested_attributes_for :addresses, allow_destroy: true
 end
@@ -963,7 +963,7 @@ end
 It is often useful to ignore sets of fields that the user has not filled in. You can control this by passing a `:reject_if` proc to `accepts_nested_attributes_for`. This proc will be called with each hash of attributes submitted by the form. If the proc returns `false` then Active Record will not build an associated object for that hash. The example below only tries to build an address if the `kind` attribute is set.
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   has_many :addresses
   accepts_nested_attributes_for :addresses, reject_if: lambda {|attributes| attributes['kind'].blank?}
 end

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -766,7 +766,10 @@ There isn't much to this file - but note that the `Post` class inherits from
 `ApplicationRecord`. Active Record supplies a great deal of functionality to
 your Rails models for free, including basic database CRUD (Create, Read, Update,
 Destroy) operations, data validation, as well as sophisticated search support
-and the ability to relate multiple models to one another.
+and the ability to relate multiple models to one another. All you need to do
+to get all of this functionality is to subclass `ApplicationRecord` (which is
+itself a subclass of `ActiveRecord::Base` where all of the functionality is
+defined).
 
 Rails includes methods to help you validate the data that you send to models.
 Open the `app/models/post.rb` file and edit it:

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -758,12 +758,12 @@ and restart the web server when a change is made.
 The model file, `app/models/post.rb` is about as simple as it can get:
 
 ```ruby
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
 end
 ```
 
 There isn't much to this file - but note that the `Post` class inherits from
-`ActiveRecord::Base`. Active Record supplies a great deal of functionality to
+`ApplicationRecord`. Active Record supplies a great deal of functionality to
 your Rails models for free, including basic database CRUD (Create, Read, Update,
 Destroy) operations, data validation, as well as sophisticated search support
 and the ability to relate multiple models to one another.
@@ -772,7 +772,7 @@ Rails includes methods to help you validate the data that you send to models.
 Open the `app/models/post.rb` file and edit it:
 
 ```ruby
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   validates :title, presence: true,
                     length: { minimum: 5 }
 end
@@ -1181,7 +1181,7 @@ This command will generate four files:
 First, take a look at `app/models/comment.rb`:
 
 ```ruby
-class Comment < ActiveRecord::Base
+class Comment < ApplicationRecord
   belongs_to :post
 end
 ```
@@ -1239,7 +1239,7 @@ association. You've already seen the line of code inside the `Comment` model (ap
 makes each comment belong to a Post:
 
 ```ruby
-class Comment < ActiveRecord::Base
+class Comment < ApplicationRecord
   belongs_to :post
 end
 ```
@@ -1247,7 +1247,7 @@ end
 You'll need to edit `app/models/post.rb` to add the other side of the association:
 
 ```ruby
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   has_many :comments
   validates :title, presence: true,
                     length: { minimum: 5 }
@@ -1612,7 +1612,7 @@ use the `dependent` option of an association to achieve this. Modify the Post
 model, `app/models/post.rb`, as follows:
 
 ```ruby
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   has_many :comments, dependent: :destroy
   validates :title, presence: true,
                     length: { minimum: 5 }

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -754,7 +754,7 @@ This gives you quite powerful means to flexibly adjust your messages to your app
 Consider a User model with a validation for the name attribute like this:
 
 ```ruby
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   validates :name, presence: true
 end
 ```

--- a/guides/source/migrations.md
+++ b/guides/source/migrations.md
@@ -854,7 +854,7 @@ She also adds a validation to the `Product` model for the new column:
 ```ruby
 # app/models/product.rb
 
-class Product < ActiveRecord::Base
+class Product < ApplicationRecord
   validates :flag, inclusion: { in: [true, false] }
 end
 ```
@@ -880,7 +880,7 @@ She also adds a validation to the `Product` model for the new column:
 ```ruby
 # app/models/product.rb
 
-class Product < ActiveRecord::Base
+class Product < ApplicationRecord
   validates :flag, inclusion: { in: [true, false] }
   validates :fuzz, presence: true
 end
@@ -919,7 +919,7 @@ If Alice had done this instead, there would have been no problem:
 # db/migrate/20100513121110_add_flag_to_product.rb
 
 class AddFlagToProduct < ActiveRecord::Migration
-  class Product < ActiveRecord::Base
+  class Product < ApplicationRecord
   end
 
   def change
@@ -936,7 +936,7 @@ end
 # db/migrate/20100515121110_add_fuzz_to_product.rb
 
 class AddFuzzToProduct < ActiveRecord::Migration
-  class Product < ActiveRecord::Base
+  class Product < ApplicationRecord
   end
 
   def change

--- a/guides/source/nested_model_forms.md
+++ b/guides/source/nested_model_forms.md
@@ -23,14 +23,14 @@ If the associated object is an array a form builder will be yielded for each obj
 
 Consider a Person model with an associated Address. When asked to yield a nested FormBuilder for the `:address` attribute, the `fields_for` form helper will look for a method on the Person instance named `address_attributes=`.
 
-### ActiveRecord::Base model
+### ApplicationRecord model
 
-For an ActiveRecord::Base model and association this writer method is commonly defined with the `accepts_nested_attributes_for` class method:
+For an ApplicationRecord model and association this writer method is commonly defined with the `accepts_nested_attributes_for` class method:
 
 #### has_one
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   has_one :address
   accepts_nested_attributes_for :address
 end
@@ -39,7 +39,7 @@ end
 #### belongs_to
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   belongs_to :firm
   accepts_nested_attributes_for :firm
 end
@@ -48,7 +48,7 @@ end
 #### has_many / has_and_belongs_to_many
 
 ```ruby
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   has_many :projects
   accepts_nested_attributes_for :projects
 end
@@ -56,7 +56,7 @@ end
 
 ### Custom model
 
-As you might have inflected from this explanation, you _don't_ necessarily need an ActiveRecord::Base model to use this functionality. The following examples are sufficient to enable the nested model form behavior:
+As you might have inflected from this explanation, you _don't_ necessarily need an ApplicationRecord model to use this functionality. The following examples are sufficient to enable the nested model form behavior:
 
 #### Single associated object
 
@@ -114,7 +114,7 @@ class PeopleController < ApplicationController
 end
 ```
 
-NOTE: Obviously the instantiation of the associated object(s) can become tedious and not DRY, so you might want to move that into the model itself. ActiveRecord::Base provides an `after_initialize` callback which is a good way to refactor this.
+NOTE: Obviously the instantiation of the associated object(s) can become tedious and not DRY, so you might want to move that into the model itself. ApplicationRecord provides an `after_initialize` callback which is a good way to refactor this.
 
 ### Form code
 

--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -227,13 +227,13 @@ like yaffles.
 ```ruby
 # test/dummy/app/models/hickwall.rb
 
-class Hickwall < ActiveRecord::Base
+class Hickwall < ApplicationRecord
   acts_as_yaffle
 end
 
 # test/dummy/app/models/wickwall.rb
 
-class Wickwall < ActiveRecord::Base
+class Wickwall < ApplicationRecord
   acts_as_yaffle yaffle_text_field: :last_tweet
 end
 

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -244,11 +244,11 @@ In each of these cases, the named routes remain the same as if you did not use `
 It's common to have resources that are logically children of other resources. For example, suppose your application includes these models:
 
 ```ruby
-class Magazine < ActiveRecord::Base
+class Magazine < ApplicationRecord
   has_many :ads
 end
 
-class Ad < ActiveRecord::Base
+class Ad < ApplicationRecord
   belongs_to :magazine
 end
 ```

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -155,7 +155,7 @@ NOTE: _Sessions that never expire extend the time-frame for attacks such as cros
 One possibility is to set the expiry time-stamp of the cookie with the session id. However the client can edit cookies that are stored in the web browser so expiring sessions on the server is safer. Here is an example of how to _expire sessions in a database table_. Call `Session.sweep("20 minutes")` to expire sessions that were used longer than 20 minutes ago.
 
 ```ruby
-class Session < ActiveRecord::Base
+class Session < ApplicationRecord
   def self.sweep(time = 1.hour)
     if time.is_a?(String)
       time = time.split.inject { |count, unit| count.to_i.send(unit) }

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -309,7 +309,7 @@ Saved the post without a title
 Now to get this test to pass we can add a model level validation for the _title_ field.
 
 ```ruby
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   validates :title, presence: true
 end
 ```

--- a/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
@@ -1,0 +1,3 @@
+class ApplicationModel < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
@@ -1,4 +1,3 @@
 class ApplicationModel < ActiveRecord::Base
   self.abstract_class = true
-  configs_from Rails.application
 end

--- a/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
@@ -1,3 +1,4 @@
 class ApplicationModel < ActiveRecord::Base
   self.abstract_class = true
+  configs_from Rails.application
 end

--- a/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/models/application_model.rb.tt
@@ -1,3 +1,0 @@
-class ApplicationModel < ActiveRecord::Base
-  self.abstract_class = true
-end

--- a/railties/lib/rails/generators/rails/app/templates/app/models/application_record.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/models/application_record.rb.tt
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -87,11 +87,11 @@ class LoadingTest < ActiveSupport::TestCase
     require "#{rails_root}/config/environment"
     setup_ar!
 
-    assert_equal [ApplicationRecord, ActiveRecord::SchemaMigration], ActiveRecord::Base.descendants
+    assert_equal [ActiveRecord::SchemaMigration, ApplicationRecord], ActiveRecord::Base.descendants
     get "/load"
-    assert_equal [ApplicationRecord, Post], ActiveRecord::Base.descendants
+    assert_equal [ActiveRecord::SchemaMigration, Post, ApplicationRecord], ActiveRecord::Base.descendants
     get "/unload"
-    assert_equal [ApplicationRecord], ActiveRecord::Base.descendants
+    assert_equal [ActiveRecord::SchemaMigration, ApplicationRecord], ActiveRecord::Base.descendants
   end
 
   test "initialize cant be called twice" do

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -87,11 +87,11 @@ class LoadingTest < ActiveSupport::TestCase
     require "#{rails_root}/config/environment"
     setup_ar!
 
-    assert_equal [ActiveRecord::SchemaMigration], ActiveRecord::Base.descendants
+    assert_equal [ApplicationRecord, ActiveRecord::SchemaMigration], ActiveRecord::Base.descendants
     get "/load"
-    assert_equal [ActiveRecord::SchemaMigration, Post], ActiveRecord::Base.descendants
+    assert_equal [ApplicationRecord, Post], ActiveRecord::Base.descendants
     get "/unload"
-    assert_equal [ActiveRecord::SchemaMigration], ActiveRecord::Base.descendants
+    assert_equal [ApplicationRecord], ActiveRecord::Base.descendants
   end
 
   test "initialize cant be called twice" do

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -99,7 +99,7 @@ module ApplicationTests
     end
 
     def test_code_statistics_sanity
-      assert_match "Code LOC: 9     Test LOC: 0     Code to Test Ratio: 1:0.0",
+      assert_match "Code LOC: 8     Test LOC: 0     Code to Test Ratio: 1:0.0",
         Dir.chdir(app_path){ `rake stats` }
     end
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -99,7 +99,7 @@ module ApplicationTests
     end
 
     def test_code_statistics_sanity
-      assert_match "Code LOC: 5     Test LOC: 0     Code to Test Ratio: 1:0.0",
+      assert_match "Code LOC: 8     Test LOC: 0     Code to Test Ratio: 1:0.0",
         Dir.chdir(app_path){ `rake stats` }
     end
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -99,7 +99,7 @@ module ApplicationTests
     end
 
     def test_code_statistics_sanity
-      assert_match "Code LOC: 8     Test LOC: 0     Code to Test Ratio: 1:0.0",
+      assert_match "Code LOC: 9     Test LOC: 0     Code to Test Ratio: 1:0.0",
         Dir.chdir(app_path){ `rake stats` }
     end
 

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -25,7 +25,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
   def test_invokes_default_orm
     run_generator
-    assert_file "app/models/account.rb", /class Account < ActiveRecord::Base/
+    assert_file "app/models/account.rb", /class Account < ApplicationModel/
   end
 
   def test_model_with_parent_option
@@ -44,7 +44,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_file "app/models/admin.rb", /module Admin/
     assert_file "app/models/admin.rb", /def self\.table_name_prefix/
     assert_file "app/models/admin.rb", /'admin_'/
-    assert_file "app/models/admin/account.rb", /class Admin::Account < ActiveRecord::Base/
+    assert_file "app/models/admin/account.rb", /class Admin::Account < ApplicationModel/
   end
 
   def test_migration

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -25,7 +25,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
   def test_invokes_default_orm
     run_generator
-    assert_file "app/models/account.rb", /class Account < ApplicationModel/
+    assert_file "app/models/account.rb", /class Account < ApplicationRecord/
   end
 
   def test_model_with_parent_option
@@ -44,7 +44,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_file "app/models/admin.rb", /module Admin/
     assert_file "app/models/admin.rb", /def self\.table_name_prefix/
     assert_file "app/models/admin.rb", /'admin_'/
-    assert_file "app/models/admin/account.rb", /class Admin::Account < ApplicationModel/
+    assert_file "app/models/admin/account.rb", /class Admin::Account < ApplicationRecord/
   end
 
   def test_migration

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -92,7 +92,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
 
   def test_adds_namespace_to_model
     run_generator
-    assert_file "app/models/test_app/account.rb", /module TestApp/, /  class Account < ActiveRecord::Base/
+    assert_file "app/models/test_app/account.rb", /module TestApp/, /  class Account < ApplicationModel/
   end
 
   def test_model_with_namespace
@@ -100,7 +100,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
     assert_file "app/models/test_app/admin.rb", /module TestApp/, /module Admin/
     assert_file "app/models/test_app/admin.rb", /def self\.table_name_prefix/
     assert_file "app/models/test_app/admin.rb", /'test_app_admin_'/
-    assert_file "app/models/test_app/admin/account.rb", /module TestApp/, /class Admin::Account < ActiveRecord::Base/
+    assert_file "app/models/test_app/admin/account.rb", /module TestApp/, /class Admin::Account < ApplicationModel/
   end
 
   def test_migration
@@ -202,7 +202,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
     run_generator
 
     # Model
-    assert_file "app/models/test_app/product_line.rb", /module TestApp\n  class ProductLine < ActiveRecord::Base/
+    assert_file "app/models/test_app/product_line.rb", /module TestApp\n  class ProductLine < ApplicationModel/
     assert_file "test/models/test_app/product_line_test.rb", /module TestApp\n  class ProductLineTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/product_lines.yml"
     assert_migration "db/migrate/create_test_app_product_lines.rb"
@@ -271,7 +271,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ActiveRecord::Base/
+    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ApplicationModel/
     assert_file "test/models/test_app/admin/role_test.rb", /module TestApp\n  class Admin::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_roles.rb"
@@ -340,7 +340,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin/user/special.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  class Admin::User::Special::Role < ActiveRecord::Base/
+    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  class Admin::User::Special::Role < ApplicationModel/
     assert_file "test/models/test_app/admin/user/special/role_test.rb", /module TestApp\n  class Admin::User::Special::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/user/special/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_user_special_roles.rb"

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -92,7 +92,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
 
   def test_adds_namespace_to_model
     run_generator
-    assert_file "app/models/test_app/account.rb", /module TestApp/, /  class Account < ApplicationModel/
+    assert_file "app/models/test_app/account.rb", /module TestApp/, /  class Account < ApplicationRecord/
   end
 
   def test_model_with_namespace
@@ -100,7 +100,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
     assert_file "app/models/test_app/admin.rb", /module TestApp/, /module Admin/
     assert_file "app/models/test_app/admin.rb", /def self\.table_name_prefix/
     assert_file "app/models/test_app/admin.rb", /'test_app_admin_'/
-    assert_file "app/models/test_app/admin/account.rb", /module TestApp/, /class Admin::Account < ApplicationModel/
+    assert_file "app/models/test_app/admin/account.rb", /module TestApp/, /class Admin::Account < ApplicationRecord/
   end
 
   def test_migration
@@ -202,7 +202,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
     run_generator
 
     # Model
-    assert_file "app/models/test_app/product_line.rb", /module TestApp\n  class ProductLine < ApplicationModel/
+    assert_file "app/models/test_app/product_line.rb", /module TestApp\n  class ProductLine < ApplicationRecord/
     assert_file "test/models/test_app/product_line_test.rb", /module TestApp\n  class ProductLineTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/product_lines.yml"
     assert_migration "db/migrate/create_test_app_product_lines.rb"
@@ -271,7 +271,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ApplicationModel/
+    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ApplicationRecord/
     assert_file "test/models/test_app/admin/role_test.rb", /module TestApp\n  class Admin::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_roles.rb"
@@ -340,7 +340,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin/user/special.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  class Admin::User::Special::Role < ApplicationModel/
+    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  class Admin::User::Special::Role < ApplicationRecord/
     assert_file "test/models/test_app/admin/user/special/role_test.rb", /module TestApp\n  class Admin::User::Special::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/user/special/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_user_special_roles.rb"

--- a/railties/test/generators/resource_generator_test.rb
+++ b/railties/test/generators/resource_generator_test.rb
@@ -61,14 +61,14 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
 
   def test_plural_names_are_singularized
     content = run_generator ["accounts".freeze]
-    assert_file "app/models/account.rb", /class Account < ActiveRecord::Base/
+    assert_file "app/models/account.rb", /class Account < ApplicationModel/
     assert_file "test/models/account_test.rb", /class AccountTest/
     assert_match(/Plural version of the model detected, using singularized version. Override with --force-plural./, content)
   end
 
   def test_plural_names_can_be_forced
     content = run_generator ["accounts", "--force-plural"]
-    assert_file "app/models/accounts.rb", /class Accounts < ActiveRecord::Base/
+    assert_file "app/models/accounts.rb", /class Accounts < ApplicationModel/
     assert_file "test/models/accounts_test.rb", /class AccountsTest/
     assert_no_match(/Plural version of the model detected/, content)
   end

--- a/railties/test/generators/resource_generator_test.rb
+++ b/railties/test/generators/resource_generator_test.rb
@@ -61,14 +61,14 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
 
   def test_plural_names_are_singularized
     content = run_generator ["accounts".freeze]
-    assert_file "app/models/account.rb", /class Account < ApplicationModel/
+    assert_file "app/models/account.rb", /class Account < ApplicationRecord/
     assert_file "test/models/account_test.rb", /class AccountTest/
     assert_match(/Plural version of the model detected, using singularized version. Override with --force-plural./, content)
   end
 
   def test_plural_names_can_be_forced
     content = run_generator ["accounts", "--force-plural"]
-    assert_file "app/models/accounts.rb", /class Accounts < ApplicationModel/
+    assert_file "app/models/accounts.rb", /class Accounts < ApplicationRecord/
     assert_file "test/models/accounts_test.rb", /class AccountsTest/
     assert_no_match(/Plural version of the model detected/, content)
   end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -11,7 +11,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     # Model
-    assert_file "app/models/product_line.rb", /class ProductLine < ApplicationModel/
+    assert_file "app/models/product_line.rb", /class ProductLine < ApplicationRecord/
     assert_file "test/models/product_line_test.rb", /class ProductLineTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/product_lines.yml"
     assert_migration "db/migrate/create_product_lines.rb", /belongs_to :product, index: true/
@@ -127,7 +127,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Model
     assert_file "app/models/admin.rb", /module Admin/
-    assert_file "app/models/admin/role.rb", /class Admin::Role < ApplicationModel/
+    assert_file "app/models/admin/role.rb", /class Admin::Role < ApplicationRecord/
     assert_file "test/models/admin/role_test.rb", /class Admin::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/admin/roles.yml"
     assert_migration "db/migrate/create_admin_roles.rb"

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -11,7 +11,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     # Model
-    assert_file "app/models/product_line.rb", /class ProductLine < ActiveRecord::Base/
+    assert_file "app/models/product_line.rb", /class ProductLine < ApplicationModel/
     assert_file "test/models/product_line_test.rb", /class ProductLineTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/product_lines.yml"
     assert_migration "db/migrate/create_product_lines.rb", /belongs_to :product, index: true/
@@ -127,7 +127,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Model
     assert_file "app/models/admin.rb", /module Admin/
-    assert_file "app/models/admin/role.rb", /class Admin::Role < ActiveRecord::Base/
+    assert_file "app/models/admin/role.rb", /class Admin::Role < ApplicationModel/
     assert_file "test/models/admin/role_test.rb", /class Admin::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/admin/roles.yml"
     assert_migration "db/migrate/create_admin_roles.rb"


### PR DESCRIPTION
This PR creates the `ApplicationModel` class. This class will serve as an intermediate between a model and `ActiveRecord::Base`. Currently, to create a model, one follows the following procedure:

``` ruby
class MyModelName < ActiveRecord::Base
end
```

This inherits directly from `ActiveRecord::Base` and means that all configurations on `ActiveRecord::Base` are global to all of its subclasses (unless the subclass redefines the configuration on its own).

I'm introducing `ApplicationModel` so that models have an intermediary layer for inheritance like so:

``` ruby
class MyModelName < ApplicationModel
end
```

What the `ApplicationModel` class does is allow different sets of configurations to be defined on multiple applications. Each Rails application will have its own `ApplicationModel`. The `ApplicationModel` figures out which application it belongs when it is pulled in through the railtie and `configs_from` is specified.

\cc @spastorino, @josevalim Can you guys take a look? I'm sure there's something I forgot so please let me know.
