### PR TITLE
Remove helper fixtures not used in any test

### DIFF
--- a/actionpack/test/fixtures/helpers/abc_helper.rb
+++ b/actionpack/test/fixtures/helpers/abc_helper.rb
@@ -1,5 +1,3 @@
 module AbcHelper
   def bare_a() end
-  def bare_b() end
-  def bare_c() end
 end

--- a/actionview/test/fixtures/helpers/abc_helper.rb
+++ b/actionview/test/fixtures/helpers/abc_helper.rb
@@ -1,5 +1,3 @@
 module AbcHelper
   def bare_a() end
-  def bare_b() end
-  def bare_c() end
 end


### PR DESCRIPTION
The fixture for module AbcHelper defines three functions bare_a,
bare_b and bare_c, but only bare_a is used in the code that tests
helper functions.
