### PR TITLE
Reduce allocations when extracting AR models

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_part.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_part.rb
@@ -62,7 +62,19 @@ module ActiveRecord
         end
 
         def extract_record(row)
-          Hash[column_names_with_alias.map{|cn, an| [cn, row[an]]}]
+          # This code is performance critical as it is called per row.
+          # see: https://github.com/rails/rails/pull/12185
+          hash = {}
+
+          index = 0
+          length = column_names_with_alias.length
+          while index < length
+            column_name,alias_name = column_names_with_alias[index]
+            hash[column_name] = row[alias_name]
+            index += 1
+          end
+
+          hash
         end
 
         def record_id(row)


### PR DESCRIPTION
Similar to: https://github.com/rails/rails/pull/12065

Reduce the allocations when extracting rows from a join dependency

For a typical home page request at Discourse this reduced the objects allocated by 2000 and the memory allocated by 100k 

(analyzed using https://github.com/SamSaffron/memory_profiler )

This is extremely safe and can be backported to rails 4 , cc @tenderlove
