### PR TITLE
Perf: avoid dupes add fallback logic for coders

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -109,13 +109,14 @@ module ActiveRecord
         # We use #[] first as a perf optimization for non-nil values. See https://gist.github.com/jonleighton/3552829.
         name = attr_name.to_s
         @attributes_cache[name] || @attributes_cache.fetch(name) {
-          column = @columns_hash.fetch(name) {
-            return @attributes.fetch(name) {
-              if name == 'id' && self.class.primary_key != name
-                read_attribute(self.class.primary_key)
-              end
-            }
-          }
+          column = @column_types_override[name] if @column_types_override
+          column ||= @column_types[name]
+
+          return @attributes.fetch(name) {
+            if name == 'id' && self.class.primary_key != name
+              read_attribute(self.class.primary_key)
+            end
+          } unless column
 
           value = @attributes.fetch(name) {
             return block_given? ? yield(name) : nil

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -168,7 +168,8 @@ module ActiveRecord
       defaults.each { |k, v| defaults[k] = v.dup if v.duplicable? }
 
       @attributes   = self.class.initialize_attributes(defaults)
-      @columns_hash = self.class.column_types.dup
+      @column_types_override = nil
+      @column_types = self.class.column_types
 
       init_internals
       init_changed_attributes
@@ -193,7 +194,8 @@ module ActiveRecord
     #   post.title # => 'hello world'
     def init_with(coder)
       @attributes   = self.class.initialize_attributes(coder['attributes'])
-      @columns_hash = self.class.column_types.merge(coder['column_types'] || {})
+      @column_types_override = coder['column_types']
+      @column_types = self.class.column_types
 
       init_internals
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -383,9 +383,10 @@ module ActiveRecord
         end
 
       @attributes.update(fresh_object.instance_variable_get('@attributes'))
-      @columns_hash = fresh_object.instance_variable_get('@columns_hash')
 
-      @attributes_cache = {}
+      @column_types           = self.class.column_types
+      @column_types_override  = fresh_object.instance_variable_get('@columns_types_override')
+      @attributes_cache       = {}
       self
     end
 

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -245,7 +245,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     Topic.create(content: myobj)
 
     Topic.all.each do |topic|
-      type = topic.instance_variable_get("@columns_hash")["content"]
+      type = Topic.column_types["content"]
       assert !type.instance_variable_get("@column").is_a?(ActiveRecord::AttributeMethods::Serialization::Type)
     end
   end


### PR DESCRIPTION
This had a pretty significant perf improvement, will run numbers tomorrow and add to the ticket, it changes semantics of @column_hash , nonetheless all the tests seem to pass.

It avoids fairly significant repetitive copies of columns in a table on each instance. If this is found to be safe its a strong candidate for backport into 4.0.  
