### PR TITLE
Fix FileStore#cleanup to no longer rely on missing each_key method

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix ActiveSupport::Cache::FileStore#cleanup to no longer rely on missing each_key method.
+
+    *Murray Steele*
+
 *   Ensure that autoloaded constants in all-caps nestings are marked as
     autoloaded.
 

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -33,7 +33,8 @@ module ActiveSupport
       # Premptively iterates through all stored keys and removes the ones which have expired.
       def cleanup(options = nil)
         options = merged_options(options)
-        each_key(options) do |key|
+        search_dir(cache_path) do |fname|
+          key = file_path_key(fname)
           entry = read_entry(key, options)
           delete_entry(key, options) if entry && entry.expired?
         end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -709,6 +709,18 @@ class FileStoreTest < ActiveSupport::TestCase
     @cache.send(:read_entry, "winston", {})
     assert @buffer.string.present?
   end
+
+  def test_cleanup_removes_all_expired_entries
+    time = Time.now
+    @cache.write('foo', 'bar', expires_in: 10)
+    @cache.write('baz', 'qux')
+    @cache.write('quux', 'corge', expires_in: 20)
+    Time.stubs(:now).returns(time + 15)
+    @cache.cleanup
+    assert_not @cache.exist?('foo')
+    assert @cache.exist?('baz')
+    assert @cache.exist?('quux')
+  end
 end
 
 class MemoryStoreTest < ActiveSupport::TestCase


### PR DESCRIPTION
This is based on the work by @bdurand in https://github.com/rails/rails/pull/3395, but I just want it to work as it apparently used to and remove all expired entries rather than extend the functionality.  So, we just replace `each_key` with some `search_dir` magic, rather than adding the `:not_accessed_in` option.
