### PR TITLE
Reduce Duration#inspect to a single series of transformations

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -70,12 +70,10 @@ module ActiveSupport
     alias :until :ago
 
     def inspect #:nodoc:
-      val_for = parts.inject(::Hash.new(0)) { |h,(l,r)| h[l] += r; h }
-      [:years, :months, :days, :minutes, :seconds].
-        select {|unit| val_for[unit].nonzero?}.
-        tap {|units| units << :seconds if units.empty?}.
-        map {|unit| [unit, val_for[unit]]}.
-        map {|unit, val| "#{val} #{val == 1 ? unit.to_s.chop : unit.to_s}"}.
+      parts.
+        reduce(::Hash.new(0)) { |h,(l,r)| h[l] += r; h }.
+        sort_by {|unit,  _ | [:years, :months, :days, :minutes, :seconds].index(unit)}.
+        map     {|unit, val| "#{val} #{val == 1 ? unit.to_s.chop : unit.to_s}"}.
         to_sentence(:locale => :en)
     end
 

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -27,6 +27,7 @@ class DurationTest < ActiveSupport::TestCase
   def test_equals
     assert 1.day == 1.day
     assert 1.day == 1.day.to_i
+    assert 1.day.to_i == 1.day
     assert !(1.day == 'foo')
   end
 
@@ -37,6 +38,8 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal '6 months and -2 days',            (6.months - 2.days).inspect
     assert_equal '10 seconds',                      10.seconds.inspect
     assert_equal '10 years, 2 months, and 1 day',   (10.years + 2.months + 1.day).inspect
+    assert_equal '10 years, 2 months, and 1 day',   (10.years + 1.month  + 1.day + 1.month).inspect
+    assert_equal '10 years, 2 months, and 1 day',   (1.day + 10.years + 2.months).inspect
     assert_equal '7 days',                          1.week.inspect
     assert_equal '14 days',                         1.fortnight.inspect
   end


### PR DESCRIPTION
- eliminates need for temp local Hash

Also added a couple of examples to DurationTest to specify:
- duration can be defined with units out of order e.g. 1.month + 1.year + 1.second + 1.day
- equality with a Fixnum works regardless of which operand is on which side of the operator

This benchmarks faster than the current version under many circumstances. [I had previously stated that it was slower](https://github.com/rails/rails/pull/11856), but I had only benchmarked `1.year + 1.day + 1.month + 2.minutes + 1.day` with 10,000 repetitions. At 5k reps it roughly breaks even, and at 1k reps the new version is consistently faster. Also, with 3 parts e.g. `1.year + 1.day + 1.month` the new version is faster even at 10k reps. 
