### PR TITLE
Enabled quirks mode on JSON.parse, fixes broken test in af9caae

### DIFF
--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -14,7 +14,7 @@ module ActiveSupport
       #   ActiveSupport::JSON.decode("{\"team\":\"rails\",\"players\":\"36\"}")
       #   => {"team" => "rails", "players" => "36"}
       def decode(json, options = {})
-        data = ::JSON.parse(json, options.merge(create_additions: false))
+        data = ::JSON.parse(json, options.merge(create_additions: false, quirks_mode: true))
         if ActiveSupport.parse_json_times
           convert_dates_from(data)
         else


### PR DESCRIPTION
It turns out that ActionPack depends on the decoder to parse JSON
"fragments" (e.g. '"a string"', '1', 'null', etc), so we need to
enable quirks mode on JSON.parse. Also added coverage on the decoder
side to prevent regression.
