### PR TITLE
"generates" applies to "collection radio" so it should be singular

### DIFF
--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -17,14 +17,14 @@ class FormCollectionsHelperTest < ActionView::TestCase
   end
 
   # COLLECTION RADIO BUTTONS
-  test 'collection radio accepts a collection and generate inputs from value method' do
+  test 'collection radio accepts a collection and generates inputs from value method' do
     with_collection_radio_buttons :user, :active, [true, false], :to_s, :to_s
 
     assert_select 'input[type=radio][value=true]#user_active_true'
     assert_select 'input[type=radio][value=false]#user_active_false'
   end
 
-  test 'collection radio accepts a collection and generate inputs from label method' do
+  test 'collection radio accepts a collection and generates inputs from label method' do
     with_collection_radio_buttons :user, :active, [true, false], :to_s, :to_s
 
     assert_select 'label[for=user_active_true]', 'true'


### PR DESCRIPTION
I accidentally pushed this change to docrails before realizing that it's technically a code change, so I'm opening this pull request (and rolling back my change to docrails).
