### PR TITLE
Extend serializable_hash methods in order to pass parameters to a method

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -107,7 +107,14 @@ module ActiveModel
       hash = {}
       attribute_names.each { |n| hash[n] = read_attribute_for_serialization(n) }
 
-      Array(options[:methods]).each { |m| hash[m.to_s] = send(m) if respond_to?(m) }
+      Array(options[:methods]).each do |m| 
+        if m.is_a?(Array)
+          method = m[0]
+          hash[method.to_s] = send(method, *m[1..-1]) if respond_to?(method)
+        else
+          hash[m.to_s] = send(m) if respond_to?(m)
+        end
+      end
 
       serializable_add_includes(options) do |association, records, opts|
         hash[association.to_s] = if records.respond_to?(:to_ary)

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -16,8 +16,8 @@ class SerializationTest < ActiveModel::TestCase
       instance_values.except("address", "friends")
     end
 
-    def foo
-      'i_am_foo'
+    def foo(bar = '')
+      'i_am_foo' + bar
     end
   end
 
@@ -60,6 +60,11 @@ class SerializationTest < ActiveModel::TestCase
   def test_method_serializable_hash_should_work_with_methods_option
     expected = {"name"=>"David", "gender"=>"male", "foo"=>"i_am_foo", "email"=>"david@example.com"}
     assert_equal expected, @user.serializable_hash(methods: [:foo])
+  end
+
+  def test_method_serializable_hash_should_work_with_methods_option
+    expected = {"name"=>"David", "gender"=>"male", "foo"=>"i_am_foobar", "email"=>"david@example.com"}
+    assert_equal expected, @user.serializable_hash(methods: [[:foo, 'bar']])
   end
 
   def test_method_serializable_hash_should_work_with_only_and_methods


### PR DESCRIPTION
Hi,

Many times I need to call methods with parameters using `as_json` but cannot because the API is not expecting this behavior.

Here is the API I am suggesting:

``` Ruby
class User
   attr_accessor :name

  def initialize(age)
      @age = age
  end

  def make_me_older(years)
    @age + years  
  end
end

User.new(10).serializable_hash(methods: [:age, [:make_me_older, 10]]
=> {"make_me_older"=> 18}
```

This idea is to pass an array where the first element is the method name and all the other elements are parameters to the method.

Greg
