### PR TITLE
Raise an error when AS::JSON.decode is called with options

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Calling ActiveSupport::JSON.decode with unsupported options now raises an error.
+
+    *Godfrey Chan*
+
 *   Support :unless_exist in FileStore
 
     *Michael Grosser*

--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -14,7 +14,14 @@ module ActiveSupport
       #   ActiveSupport::JSON.decode("{\"team\":\"rails\",\"players\":\"36\"}")
       #   => {"team" => "rails", "players" => "36"}
       def decode(json, options = {})
-        data = ::JSON.parse(json, options.merge(create_additions: false, quirks_mode: true))
+        if options.present?
+          raise ArgumentError, "In Rails 4.1, ActiveSupport::JSON.decode no longer " \
+            "accepts an options hash for MultiJSON. MultiJSON reached its end of life " \
+            "and has been removed."
+        end
+
+        data = ::JSON.parse(json, quirks_mode: true)
+
         if ActiveSupport.parse_json_times
           convert_dates_from(data)
         else

--- a/activesupport/test/json/decoding_test.rb
+++ b/activesupport/test/json/decoding_test.rb
@@ -98,10 +98,8 @@ class TestJSONDecoding < ActiveSupport::TestCase
     assert_raise(ActiveSupport::JSON.parse_error) { ActiveSupport::JSON.decode(%()) }
   end
 
-  def test_cannot_force_json_unmarshalling
-    encodeded = %q({"json_class":"TestJSONDecoding::Foo"})
-    decodeded = {"json_class"=>"TestJSONDecoding::Foo"}
-    assert_equal decodeded, ActiveSupport::JSON.decode(encodeded, create_additions: true)
+  def test_cannot_pass_unsupported_options
+    assert_raise(ArgumentError) { ActiveSupport::JSON.decode("", create_additions: true) }
   end
 end
 


### PR DESCRIPTION
Rails 4.1 has switched away from MultiJson, and does not currently support any options on `ActiveSupport::JSON.decode`. Passing in unsupported options (i.e. any non-empty options hash) will now raise an ArgumentError.

Rationale:
1. We cannot guarantee the underlying JSON parser won't change in the future, hence we cannot guarantee a consistent set of options the method could take
2. The `json` gem, which happens to be the current JSON parser, takes many dangerous options that is irrelevant to the purpose of AS's JSON decoding API
3. To reserve the options hash for future use, e.g. overriding default global options like ActiveSupport.parse_json_times

This change _DOES NOT_ introduce any changes in the public API. The signiture of the method is still decode(json_text, options). The difference is this method previously accepted undocumented options which does different things when the underlying adapter changes. It now correctly raises an ArgumentError when it encounters options that it does not recognize (and currently it does not support any options).
