### PR TITLE
Fix typos: the indefinite articles(a -> an).

### DIFF
--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -17,7 +17,7 @@ module ActionDispatch
       def call(env)
         req = Request.new(env)
 
-        # If any of the path parameters has a invalid encoding then
+        # If any of the path parameters has an invalid encoding then
         # raise since it's likely to trigger errors further on.
         req.symbolized_path_parameters.each do |key, value|
           unless value.valid_encoding?

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -28,7 +28,7 @@ module ActionDispatch
         def call(env)
           params = env[PARAMETERS_KEY]
 
-          # If any of the path parameters has a invalid encoding then
+          # If any of the path parameters has an invalid encoding then
           # raise since it's likely to trigger errors further on.
           params.each do |key, value|
             next unless value.respond_to?(:valid_encoding?)

--- a/guides/source/3_2_release_notes.md
+++ b/guides/source/3_2_release_notes.md
@@ -227,7 +227,7 @@ Action Pack
 
 #### Deprecations
 
-* Deprecated implied layout lookup in controllers whose parent had a explicit layout set:
+* Deprecated implied layout lookup in controllers whose parent had an explicit layout set:
 
     ```ruby
     class ApplicationController
@@ -254,7 +254,7 @@ Action Pack
 
 * Added `ActionDispatch::RequestId` middleware that'll make a unique X-Request-Id header available to the response and enables the `ActionDispatch::Request#uuid` method. This makes it easy to trace requests from end-to-end in the stack and to identify individual requests in mixed logs like Syslog.
 
-* The `ShowExceptions` middleware now accepts a exceptions application that is responsible to render an exception when the application fails. The application is invoked with a copy of the exception in `env["action_dispatch.exception"]` and with the `PATH_INFO` rewritten to the status code.
+* The `ShowExceptions` middleware now accepts an exceptions application that is responsible to render an exception when the application fails. The application is invoked with a copy of the exception in `env["action_dispatch.exception"]` and with the `PATH_INFO` rewritten to the status code.
 
 * Allow rescue responses to be configured through a railtie as in `config.action_dispatch.rescue_responses`.
 

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -327,7 +327,7 @@ class ProductsController < ApplicationController
 end
 ```
 
-Instead of a options hash, you can also simply pass in a model, Rails will use the `updated_at` and `cache_key` methods for setting `last_modified` and `etag`:
+Instead of an options hash, you can also simply pass in a model, Rails will use the `updated_at` and `cache_key` methods for setting `last_modified` and `etag`:
 
 ```ruby
 class ProductsController < ApplicationController

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -103,7 +103,7 @@ numbers. New applications filter out passwords by adding the following `config.f
 
 * `config.force_ssl` forces all requests to be under HTTPS protocol by using `ActionDispatch::SSL` middleware.
 
-* `config.log_formatter` defines the formatter of the Rails logger. This option defaults to a instance of `ActiveSupport::Logger::SimpleFormatter` for all modes except production, where it defaults to `Logger::Formatter`.
+* `config.log_formatter` defines the formatter of the Rails logger. This option defaults to an instance of `ActiveSupport::Logger::SimpleFormatter` for all modes except production, where it defaults to `Logger::Formatter`.
 
 * `config.log_level` defines the verbosity of the Rails logger. This option defaults to `:debug` for all modes except production, where it defaults to `:info`.
 

--- a/railties/lib/rails/app_rails_loader.rb
+++ b/railties/lib/rails/app_rails_loader.rb
@@ -49,7 +49,7 @@ EOS
         # call to generate a new application, so restore the original cwd.
         Dir.chdir(original_cwd) and return if Pathname.new(Dir.pwd).root?
 
-        # Otherwise keep moving upwards in search of a executable.
+        # Otherwise keep moving upwards in search of an executable.
         Dir.chdir('..')
       end
     end

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -293,7 +293,7 @@ module ApplicationTests
 
     test "precompile should handle utf8 filenames" do
       filename = "レイルズ.png"
-      app_file "app/assets/images/#{filename}", "not a image really"
+      app_file "app/assets/images/#{filename}", "not an image really"
       add_to_config "config.assets.precompile = [ /\.png$/, /application.(css|js)$/ ]"
 
       precompile!
@@ -305,7 +305,7 @@ module ApplicationTests
       require "#{app_path}/config/environment"
 
       get "/assets/#{URI.parser.escape(asset_path)}"
-      assert_match "not a image really", last_response.body
+      assert_match "not an image really", last_response.body
       assert_file_exists("#{app_path}/public/assets/#{asset_path}")
     end
 

--- a/railties/test/application/multiple_applications_test.rb
+++ b/railties/test/application/multiple_applications_test.rb
@@ -110,7 +110,7 @@ module ApplicationTests
 
       assert_equal 0, $run_count, "Without loading the initializers, the count should be 0"
 
-      # Set config.eager_load to false so that a eager_load warning doesn't pop up
+      # Set config.eager_load to false so that an eager_load warning doesn't pop up
       AppTemplate::Application.new { config.eager_load = false }.initialize!
 
       assert_equal 3, $run_count, "There should have been three initializers that incremented the count"

--- a/railties/test/paths_test.rb
+++ b/railties/test/paths_test.rb
@@ -180,7 +180,7 @@ class PathsTest < ActiveSupport::TestCase
     assert_equal 1, @root.eager_load.select {|p| p == @root["app"].expanded.first }.size
   end
 
-  test "paths added to a eager_load path should be added to the eager_load collection" do
+  test "paths added to an eager_load path should be added to the eager_load collection" do
     @root["app"] = "/app"
     @root["app"].eager_load!
     @root["app"] << "/app2"


### PR DESCRIPTION
I've git-grepped 'a a', 'a i', 'a u', 'a e', 'a o' and fixed all typos. ref #12126
Sorry for my insignificant PR.
