### PR TITLE
Make equalites between Numeric and Duration consistent.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Ensure Numeric and Duration are comparable 
+ 
+        1.seconds == 1 #=> true
+        1 == 1.seconds #=> true
+
+    *wenchaojiang*
+
 *   Ensure that autoloaded constants in all-caps nestings are marked as
     autoloaded.
 

--- a/activesupport/lib/active_support/core_ext/numeric/time.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/time.rb
@@ -61,6 +61,16 @@ class Numeric
   end
   alias :fortnight :fortnights
 
+  # override :== to make Duration and Numeric comparable
+  alias :numeric_equal :==
+  def ==(other)
+    if other.to_a(ActiveSupport::Duration) 
+      other == self 
+    else
+      numeric_equal(self) 
+    end 
+  end 
+
   # Reads best without arguments:  10.minutes.ago
   def ago(time = ::Time.current)
     time - self

--- a/activesupport/lib/active_support/core_ext/numeric/time.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/time.rb
@@ -67,7 +67,7 @@ class Numeric
     if other.to_a(ActiveSupport::Duration) 
       other == self 
     else
-      numeric_equal(self) 
+      numeric_equal(other) 
     end 
   end 
 

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -28,6 +28,7 @@ class DurationTest < ActiveSupport::TestCase
     assert 1.day == 1.day
     assert 1.day == 1.day.to_i
     assert !(1.day == 'foo')
+    assert 1 == 1.second
   end
 
   def test_inspect


### PR DESCRIPTION
i.e.
1.seconds == 1 # true
1 == 1.seconds # true

Currently on master, it is
1.seconds == 1 # true
1 == 1.seconds # false
Intuitively, equality should be keep same if we swap two sides.
