### PR TITLE
Custom flash should be defined only for the class that defines it and it's subclasses

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix custom flash type definition. Misusage of the `_flash_types` class variable
+    caused an error when reloading controllers with custom flash types.
+
+    Fixes #12057
+
+    *Ricardo de Cillo*
+
 *   Do not break params filtering on `nil` values.
 
     Fixes #12149.

--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -37,7 +37,7 @@ module ActionController #:nodoc:
           end
           helper_method type
 
-          _flash_types << type
+          self._flash_types += [type]
         end
       end
     end

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -214,6 +214,18 @@ class FlashTest < ActionController::TestCase
     get :redirect_with_foo_flash
     assert_equal "for great justice", @controller.send(:flash)[:foo]
   end
+
+  class SubclassesTestController < TestController; end
+
+  def test_add_flash_type_to_subclasses
+    TestController.add_flash_types :foo
+    assert SubclassesTestController._flash_types.include?(:foo)
+  end
+
+  def test_do_not_add_flash_type_to_parent_class
+    SubclassesTestController.add_flash_types :bar
+    assert_not TestController._flash_types.include?(:bar)
+  end
 end
 
 class FlashIntegrationTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
This fixes https://github.com/rails/rails/issues/12057
