### PR TITLE
Make Time, DateTime, & TimeWithZone JSON encode use same number of decimals

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -19,6 +19,7 @@ module ActiveSupport
     delegate :use_standard_json_time_format, :use_standard_json_time_format=,
       :escape_html_entities_in_json, :escape_html_entities_in_json=,
       :encode_big_decimal_as_string, :encode_big_decimal_as_string=,
+      :json_time_decimal_precision, :json_time_decimal_precision=,
       :to => :'ActiveSupport::JSON::Encoding'
   end
 
@@ -120,6 +121,14 @@ module ActiveSupport
         # If false, serializes BigDecimal objects as numeric instead of wrapping
         # them in a string.
         attr_accessor :encode_big_decimal_as_string
+
+        # Number of decimal places to show for fractional seconds when using
+        # ISO 8601 format for times. Default 0.
+        attr_writer :json_time_decimal_precision
+
+        def json_time_decimal_precision
+          @json_time_decimal_precision ||= 0
+        end
 
         attr_accessor :escape_regex
         attr_reader :escape_html_entities_in_json
@@ -316,7 +325,7 @@ end
 class Time
   def as_json(options = nil) #:nodoc:
     if ActiveSupport.use_standard_json_time_format
-      xmlschema
+      xmlschema(ActiveSupport::JSON::Encoding.json_time_decimal_precision)
     else
       %(#{strftime("%Y/%m/%d %H:%M:%S")} #{formatted_offset(false)})
     end
@@ -336,7 +345,7 @@ end
 class DateTime
   def as_json(options = nil) #:nodoc:
     if ActiveSupport.use_standard_json_time_format
-      xmlschema
+      xmlschema(ActiveSupport::JSON::Encoding.json_time_decimal_precision)
     else
       strftime('%Y/%m/%d %H:%M:%S %z')
     end

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -34,7 +34,6 @@ module ActiveSupport
   #   t.is_a?(Time)                         # => true
   #   t.is_a?(ActiveSupport::TimeWithZone)  # => true
   class TimeWithZone
-
     # Report class name as 'Time' to thwart type checking.
     def self.name
       'Time'
@@ -144,6 +143,9 @@ module ActiveSupport
     # You can get %Y/%m/%d %H:%M:%S +offset style by setting
     # <tt>ActiveSupport::JSON::Encoding.use_standard_json_time_format</tt>
     # to +false+.
+    # You can specify the number of decimal places for fractional seconds by setting
+    # <tt>ActiveSupport::TimeWithZone.json_time_decimal_precision</tt>
+    # to a digit
     #
     #   # With ActiveSupport::JSON::Encoding.use_standard_json_time_format = true
     #   Time.utc(2005,2,1,15,15,10).in_time_zone.to_json
@@ -154,7 +156,7 @@ module ActiveSupport
     #   # => "2005/02/01 15:15:10 +0000"
     def as_json(options = nil)
       if ActiveSupport::JSON::Encoding.use_standard_json_time_format
-        xmlschema(3)
+        xmlschema(ActiveSupport::JSON::Encoding.json_time_decimal_precision)
       else
         %(#{time.strftime("%Y/%m/%d %H:%M:%S")} #{formatted_offset(false)})
       end

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -73,16 +73,29 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     ActiveSupport.use_standard_json_time_format = old
   end
 
+  def test_to_json_with_use_standard_json_time_format_config_set_to_true_with_xmlschema_fraction_digits_set
+    old, ActiveSupport.use_standard_json_time_format = ActiveSupport.use_standard_json_time_format, true
+    ActiveSupport.json_time_decimal_precision = 0
+    assert_equal "\"1999-12-31T19:00:00-05:00\"", ActiveSupport::JSON.encode(@twz)
+    ActiveSupport.json_time_decimal_precision = 3
+    assert_equal "\"1999-12-31T19:00:00.000-05:00\"", ActiveSupport::JSON.encode(@twz)
+    ActiveSupport.json_time_decimal_precision = 6
+    assert_equal "\"1999-12-31T19:00:00.000000-05:00\"", ActiveSupport::JSON.encode(@twz)
+  ensure
+    ActiveSupport.use_standard_json_time_format = old
+    ActiveSupport.json_time_decimal_precision = nil
+  end
+
   def test_to_json_with_use_standard_json_time_format_config_set_to_true
     old, ActiveSupport.use_standard_json_time_format = ActiveSupport.use_standard_json_time_format, true
-    assert_equal "\"1999-12-31T19:00:00.000-05:00\"", ActiveSupport::JSON.encode(@twz)
+    assert_equal "\"1999-12-31T19:00:00-05:00\"", ActiveSupport::JSON.encode(@twz)
   ensure
     ActiveSupport.use_standard_json_time_format = old
   end
 
   def test_to_json_when_wrapping_a_date_time
     twz = ActiveSupport::TimeWithZone.new(DateTime.civil(2000), @time_zone)
-    assert_equal '"1999-12-31T19:00:00.000-05:00"', ActiveSupport::JSON.encode(twz)
+    assert_equal '"1999-12-31T19:00:00-05:00"', ActiveSupport::JSON.encode(twz)
   end
 
   def test_nsec

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -176,6 +176,24 @@ class TestJSONEncoding < ActiveSupport::TestCase
     ActiveSupport.use_standard_json_time_format = prev
   end
 
+  def test_time_to_json_respects_json_time_decimal_precision
+    prev = ActiveSupport.json_time_decimal_precision
+    ActiveSupport.json_time_decimal_precision = 3
+    with_env_tz 'US/Eastern' do
+      assert_equal %("2005-02-01T15:15:10.000-05:00"), ActiveSupport::JSON.encode(Time.local(2005,2,1,15,15,10))
+    end
+  ensure
+    ActiveSupport.json_time_decimal_precision = prev
+  end
+
+  def test_date_time_to_json_respects_json_time_decimal_precision
+    prev = ActiveSupport.json_time_decimal_precision
+    ActiveSupport.json_time_decimal_precision = 3
+    assert_equal %("2005-02-01T15:15:10.000+00:00"), ActiveSupport::JSON.encode(DateTime.new(2005,2,1,15,15,10))
+  ensure
+    ActiveSupport.json_time_decimal_precision = prev
+  end
+
   def test_hash_with_time_to_json
     prev = ActiveSupport.use_standard_json_time_format
     ActiveSupport.use_standard_json_time_format = false


### PR DESCRIPTION
Can set ActiveSupport.json_time_decimal_precision to number of decimal places
to show when using ISO 8601 standard for dates and times.
