### PR TITLE
Deprecate the delegation of Array methods in ActiveRecord::Delegation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Deprecate the delegation of Array `#delete_if`, `#keep_if`, `#pop`,
+    `#shift`, `#delete_at` and `#compact` methods for associations.
+    To use them, instead first call `#to_a` on the association to access the
+    array to be acted on.
+
+    *Lauro Caetano*
+
 *   Deprecate the delegation of Array bang methods for associations.
     To use them, instead first call `#to_a` on the association to access the
     array to be acted on.

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -118,7 +118,7 @@ module ActiveRecord
 
     def array_delegable?(method)
       defined = Array.method_defined?(method)
-      if defined && method.to_s.ends_with?('!')
+      if defined && method_deprecated?(method)
         ActiveSupport::Deprecation.warn(
           "Association will no longer delegate #{method} to #to_a as of Rails 4.2. You instead must first call #to_a on the association to expose the array to be acted on."
         )
@@ -136,6 +136,12 @@ module ActiveRecord
       else
         super
       end
+    end
+
+    private
+
+    def method_deprecated?(method)
+      method.to_s.ends_with?('!') || method.to_s == 'delete_if'
     end
   end
 end

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -138,10 +138,11 @@ module ActiveRecord
       end
     end
 
-    private
-
     def method_deprecated?(method)
-      method.to_s.ends_with?('!') || method.to_s == 'delete_if'
+      deprecated_methods = [:delete_if, :keep_if, :pop,
+                            :shift, :delete_at, :compact]
+
+      method.to_s.ends_with?('!') || deprecated_methods.include?(method)
     end
   end
 end

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -78,7 +78,7 @@ module ActiveRecord
     end
 
     [:compact!, :flatten!, :reject!, :reverse!, :rotate!,
-      :shuffle!, :slice!, :sort!, :sort_by!].each do |method|
+      :shuffle!, :slice!, :sort!, :sort_by!, :delete_if].each do |method|
       test "##{method} delegation is deprecated" do
         assert_deprecated do
           assert_responds(target, method)

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -18,7 +18,8 @@ module ActiveRecord
           else
             target.send(method, 1)
           end
-        else
+        when 1
+          target.send(method, 1) else
           raise NotImplementedError
         end
       end
@@ -44,7 +45,8 @@ module ActiveRecord
     end
 
     [:compact!, :flatten!, :reject!, :reverse!, :rotate!,
-      :shuffle!, :slice!, :sort!, :sort_by!].each do |method|
+      :shuffle!, :slice!, :sort!, :sort_by!, :delete_if,
+      :keep_if, :pop, :shift, :delete_at, :compact].each do |method|
       test "##{method} delegation is deprecated" do
         assert_deprecated do
           assert_responds(target, method)
@@ -78,7 +80,8 @@ module ActiveRecord
     end
 
     [:compact!, :flatten!, :reject!, :reverse!, :rotate!,
-      :shuffle!, :slice!, :sort!, :sort_by!, :delete_if].each do |method|
+      :shuffle!, :slice!, :sort!, :sort_by!, :delete_if,
+      :keep_if, :pop, :shift, :delete_at, :compact].each do |method|
       test "##{method} delegation is deprecated" do
         assert_deprecated do
           assert_responds(target, method)


### PR DESCRIPTION
This PR is related to: #12213.

Deprecate the delegation of Array `#delete_if`, `#keep_if`, `#pop`, `#shift`, `#delete_at` and `#compact` methods for associations.
