### PR TITLE
Standardize all JSON encoded times to use 3 decimal fractional seconds

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix ActiveSupport `Time#to_json` and `DateTime#to_json` to return 3 decimal
+    places worth of fractional seconds, similar to `TimeWithZone`.
+
+    *Ryan Glover*
+
 *   Removed circular reference protection in JSON encoder, deprecated
     ActiveSupport::JSON::Encoding::CircularReferenceError.
 

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -180,7 +180,7 @@ end
 class Time
   def as_json(options = nil) #:nodoc:
     if ActiveSupport.use_standard_json_time_format
-      xmlschema
+      xmlschema(3)
     else
       %(#{strftime("%Y/%m/%d %H:%M:%S")} #{formatted_offset(false)})
     end
@@ -200,7 +200,7 @@ end
 class DateTime
   def as_json(options = nil) #:nodoc:
     if ActiveSupport.use_standard_json_time_format
-      xmlschema
+      xmlschema(3)
     else
       strftime('%Y/%m/%d %H:%M:%S %z')
     end

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -71,8 +71,8 @@ class TestJSONEncoding < ActiveSupport::TestCase
   DateTimeTests = [[ DateTime.civil(2005,2,1,15,15,10), %("2005/02/01 15:15:10 +0000") ]]
 
   StandardDateTests     = [[ Date.new(2005,2,1), %("2005-02-01") ]]
-  StandardTimeTests     = [[ Time.utc(2005,2,1,15,15,10), %("2005-02-01T15:15:10Z") ]]
-  StandardDateTimeTests = [[ DateTime.civil(2005,2,1,15,15,10), %("2005-02-01T15:15:10+00:00") ]]
+  StandardTimeTests     = [[ Time.utc(2005,2,1,15,15,10), %("2005-02-01T15:15:10.000Z") ]]
+  StandardDateTimeTests = [[ DateTime.civil(2005,2,1,15,15,10), %("2005-02-01T15:15:10.000+00:00") ]]
   StandardStringTests   = [[ 'this is the <string>', %("this is the <string>")]]
 
   def sorted_json(json)
@@ -184,7 +184,7 @@ class TestJSONEncoding < ActiveSupport::TestCase
     prev = ActiveSupport.use_standard_json_time_format
     ActiveSupport.use_standard_json_time_format = true
     with_env_tz 'US/Eastern' do
-      assert_equal %("2005-02-01T15:15:10-05:00"), ActiveSupport::JSON.encode(Time.local(2005,2,1,15,15,10))
+      assert_equal %("2005-02-01T15:15:10.000-05:00"), ActiveSupport::JSON.encode(Time.local(2005,2,1,15,15,10))
     end
   ensure
     ActiveSupport.use_standard_json_time_format = prev

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -60,7 +60,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     ActiveSupport.use_standard_json_time_format = true
     encryptor = ActiveSupport::MessageEncryptor.new(SecureRandom.hex(64), SecureRandom.hex(64), :serializer => JSONSerializer.new)
     message = encryptor.encrypt_and_sign({ :foo => 123, 'bar' => Time.utc(2010) })
-    exp = { "foo" => 123, "bar" => "2010-01-01T00:00:00Z" }
+    exp = { "foo" => 123, "bar" => "2010-01-01T00:00:00.000Z" }
     assert_equal exp, encryptor.decrypt_and_verify(message)
   ensure
     ActiveSupport.use_standard_json_time_format = prev

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -49,7 +49,7 @@ class MessageVerifierTest < ActiveSupport::TestCase
     ActiveSupport.use_standard_json_time_format = true
     verifier = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!", :serializer => JSONSerializer.new)
     message = verifier.generate({ :foo => 123, 'bar' => Time.utc(2010) })
-    exp = { "foo" => 123, "bar" => "2010-01-01T00:00:00Z" }
+    exp = { "foo" => 123, "bar" => "2010-01-01T00:00:00.000Z" }
     assert_equal exp, verifier.verify(message)
   ensure
     ActiveSupport.use_standard_json_time_format = prev


### PR DESCRIPTION
`TimeWithZone` uses three decimal places, so should `Time` and `DateTime`

https://github.com/rails/rails/pull/12226
