### PR TITLE
Remove unused AV helper fixtures from e10a2531

### DIFF
--- a/actionview/test/fixtures/helpers/fun/games_helper.rb
+++ b/actionview/test/fixtures/helpers/fun/games_helper.rb
@@ -1,5 +1,0 @@
-module Fun
-  module GamesHelper
-    def stratego() "Iz guuut!" end
-  end
-end

--- a/actionview/test/fixtures/helpers/fun/pdf_helper.rb
+++ b/actionview/test/fixtures/helpers/fun/pdf_helper.rb
@@ -1,5 +1,0 @@
-module Fun
-  module PdfHelper
-    def foobar() 'baz' end
-  end
-end

--- a/actionview/test/fixtures/helpers/just_me_helper.rb
+++ b/actionview/test/fixtures/helpers/just_me_helper.rb
@@ -1,3 +1,0 @@
-module JustMeHelper
-  def me() "mine!" end
-end

--- a/actionview/test/fixtures/helpers/me_too_helper.rb
+++ b/actionview/test/fixtures/helpers/me_too_helper.rb
@@ -1,3 +1,0 @@
-module MeTooHelper
-  def me() "me too!" end
-end


### PR DESCRIPTION
Several fixtures for helpers are removed. They were introduced in
ActionView by @strzalek (e10a2531) but never referenced in any test.
