### PR TITLE
Remove HelperyTestHelper not used in any test

### DIFF
--- a/actionpack/test/fixtures/helpers/helpery_test_helper.rb
+++ b/actionpack/test/fixtures/helpers/helpery_test_helper.rb
@@ -1,5 +1,0 @@
-module HelperyTestHelper
-  def helpery_test
-    "Default"
-  end
-end


### PR DESCRIPTION
HelperyTestHelper was introduced in 66ef922 by @josevalim
to pair with HelperyTestController. This test controller was
later removed in e10a253 by @strzalek, leaving HelperyTestHelper unused.
