### PR TITLE
Address ERROR:  date/time field value out of range in PostgreSQL

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -88,7 +88,7 @@ class TimestampTest < ActiveRecord::TestCase
     unless current_adapter?(:PostgreSQLAdapter)
       return skip("only tested on postgresql")
     end
-    date = Date.new(0) - 1.second
+    date = Date.new(0).yesterday
     Developer.create!(:name => "aaron", :updated_at => date)
     assert_equal date, Developer.find_by_name("aaron").updated_at
   end


### PR DESCRIPTION
This pull request addresses the following error tested with Ruby 2.0.0p247, PostgreSQL 9.3 with environment TZ=America/New_York.

This error does not reproduce using the same version of ruby and PostgreSQL with TZ=Asia/Tokyo.

"0000-01-01 04:56:01.000000 BC" looks generated incorrectly in TZ=America/New_York
- Date.new(0) - 1.second at TZ=America/New_York

``` ruby
(rdb:2) Date.new(0) - 1.second
-0001-12-31 23:59:59 -0456
```
- Date.new(0) - 1.second at  TZ=Asia/Tokyo.

``` ruby
(rdb:2) Date.new(0) - 1.second
-0001-12-31 23:59:59 +0918
```

``` ruby
$ ARCONN=postgresql ruby -Itest test/cases/adapters/postgresql/timestamp_test.rb -n test_bc_timestamp
Using postgresql
Run options: -n test_bc_timestamp --seed 55811

# Running:

E

Finished in 0.168296s, 5.9419 runs/s, 0.0000 assertions/s.

  1) Error:
TimestampTest#test_bc_timestamp:
ActiveRecord::StatementInvalid: PG::DatetimeFieldOverflow: ERROR:  date/time field value out of range: "0000-01-01 04:56:01.000000 BC"
: INSERT INTO "developers" ("created_at", "created_on", "name", "updated_at", "updated_on") VALUES ($1, $2, $3, $4, $5) RETURNING "id"
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:775:in `get_last_result'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:775:in `exec_cache'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:139:in `block in exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:430:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:425:in `log'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:137:in `exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:183:in `exec_insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:94:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:63:in `insert'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:486:in `create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:67:in `create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:303:in `block in create_record'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:113:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:113:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:166:in `block in halting'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:215:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:215:in `block in halting_and_conditional'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:215:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:215:in `block in halting_and_conditional'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:215:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:215:in `block in halting_and_conditional'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:215:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:215:in `block in halting_and_conditional'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:215:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:215:in `block in halting_and_conditional'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:215:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:215:in `block in halting_and_conditional'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:86:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:86:in `run_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:303:in `create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:57:in `create_record'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:466:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:299:in `block in create_or_update'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:113:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:113:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:166:in `block in halting'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:86:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:86:in `run_callbacks'
    /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:299:in `create_or_update'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:128:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:57:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:277:in `block in save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:329:in `block in with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:200:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:208:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:200:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:326:in `with_transaction_returning_status'
    /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:277:in `save!'
    /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:41:in `create!'
    test/cases/adapters/postgresql/timestamp_test.rb:92:in `test_bc_timestamp'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```
