### PR TITLE
Fix regression with custom init

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -110,7 +110,8 @@ module ActiveRecord
         name = attr_name.to_s
         @attributes_cache[name] || @attributes_cache.fetch(name) {
           column = @column_types_override[name] if @column_types_override
-          column ||= @column_types[name]
+          column ||= @column_types[name] if @column_types
+          column ||= self.class.columns_hash[name]
 
           return @attributes.fetch(name) {
             if name == 'id' && self.class.primary_key != name


### PR DESCRIPTION
under some conditions eg: https://github.com/parndt/rails-pull-12188 models are being initialized without init or init_with being called (triggered from create!) 

this change ensures we fall back to the models schema if we don't have a cached ref

it uses columns_hash as it is guaranteed to be a hash (column_types can be nil in some conditions)  
