### PR TITLE
Removes unused code related to DatabaseTasks.

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -145,10 +145,6 @@ module ActiveRecord
     autoload :MySQLDatabaseTasks,  'active_record/tasks/mysql_database_tasks'
     autoload :PostgreSQLDatabaseTasks,
       'active_record/tasks/postgresql_database_tasks'
-
-    autoload :FirebirdDatabaseTasks, 'active_record/tasks/firebird_database_tasks'
-    autoload :SqlserverDatabaseTasks, 'active_record/tasks/sqlserver_database_tasks'
-    autoload :OracleDatabaseTasks, 'active_record/tasks/oracle_database_tasks'
   end
 
   autoload :TestFixtures, 'active_record/fixtures'


### PR DESCRIPTION
I found some unused code related to DatabaseTasks.

When I removed Oracle / SqlServer / Firebird Tasks, I also should have removed this code.

Related to https://github.com/rails/rails/commit/42d0d1832f3354dbbd61163c2bb9a7a50227d98b , https://github.com/rails/rails/commit/6b16b2f0f3f3a6800640024f729b862c05d1aa2d , https://github.com/rails/rails/commit/6649140120a5a6456d7fc63841d90d19a78b3b8c
