### PR TITLE
Don't set the missing key on Error messages hash

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -132,7 +132,7 @@ module ActiveModel
     #   person.errors[:name]  # => ["can not be nil"]
     #   person.errors['name'] # => ["can not be nil"]
     def [](attribute)
-      get(attribute.to_sym) || set(attribute.to_sym, [])
+      get(attribute.to_sym)
     end
 
     # Adds to the supplied attribute the supplied error message.


### PR DESCRIPTION
Fixes #12248 - Calling ActiveModel::Errors#[] changes state of the message hash for no reason.
