### PR TITLE
Always compact array parameters rather than setting them to nil

### DIFF
--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -9,7 +9,6 @@ module ActionDispatch
             when Array
               v.grep(Hash) { |x| deep_munge(x) }
               v.compact!
-              hash[k] = nil if v.empty?
             when Hash
               deep_munge(v)
             end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -32,7 +32,7 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
 
   test "nils are stripped from collections" do
     assert_parses(
-      {"person" => nil},
+      {"person" => []},
       "{\"person\":[null]}", { 'CONTENT_TYPE' => 'application/json' }
     )
     assert_parses(
@@ -40,7 +40,7 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
       "{\"person\":[\"foo\",null]}", { 'CONTENT_TYPE' => 'application/json' }
     )
     assert_parses(
-      {"person" => nil},
+      {"person" => []},
       "{\"person\":[null, null]}", { 'CONTENT_TYPE' => 'application/json' }
     )
   end

--- a/actionpack/test/dispatch/request/query_string_parsing_test.rb
+++ b/actionpack/test/dispatch/request/query_string_parsing_test.rb
@@ -84,8 +84,8 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
     assert_parses({"action" => nil}, "action")
     assert_parses({"action" => {"foo" => nil}}, "action[foo]")
     assert_parses({"action" => {"foo" => { "bar" => nil }}}, "action[foo][bar]")
-    assert_parses({"action" => {"foo" => { "bar" => nil }}}, "action[foo][bar][]")
-    assert_parses({"action" => {"foo" => nil }}, "action[foo][]")
+    assert_parses({"action" => {"foo" => { "bar" => [] }}}, "action[foo][bar][]")
+    assert_parses({"action" => {"foo" => [] }}, "action[foo][]")
     assert_parses({"action"=>{"foo"=>[{"bar"=>nil}]}}, "action[foo][][bar]")
   end
 

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -225,13 +225,13 @@ module ActionView
       # ==== Examples
       #
       #   image_alt('rails.png')
-      #   # => <img alt="Rails" src="/assets/rails.png" />
+      #   # => Rails
       #
       #   image_alt('hyphenated-file-name.png')
-      #   # => <img alt="Hyphenated file name" src="/assets/hyphenated-file-name.png" />
+      #   # => Hyphenated file name
       #
       #   image_alt('underscored_file_name.png')
-      #   # => <img alt="Underscored file name" src="/assets/underscored_file_name.png" />
+      #   # => Underscored file name
       def image_alt(src)
         File.basename(src, '.*').sub(/-[[:xdigit:]]{32}\z/, '').tr('-_', ' ').capitalize
       end

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -224,13 +224,13 @@ module ActionView
       #
       # ==== Examples
       #
-      #   image_tag('rails.png')
+      #   image_alt('rails.png')
       #   # => <img alt="Rails" src="/assets/rails.png" />
       #
-      #   image_tag('hyphenated-file-name.png')
+      #   image_alt('hyphenated-file-name.png')
       #   # => <img alt="Hyphenated file name" src="/assets/hyphenated-file-name.png" />
       #
-      #   image_tag('underscored_file_name.png')
+      #   image_alt('underscored_file_name.png')
       #   # => <img alt="Underscored file name" src="/assets/underscored_file_name.png" />
       def image_alt(src)
         File.basename(src, '.*').sub(/-[[:xdigit:]]{32}\z/, '').tr('-_', ' ').capitalize

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -424,13 +424,14 @@ module ActiveRecord
 
       protected
 
-      def log(sql, name = "SQL", binds = [])
+      def log(sql, name = "SQL", binds = [], statement_name = nil)
         @instrumenter.instrument(
           "sql.active_record",
-          :sql           => sql,
-          :name          => name,
-          :connection_id => object_id,
-          :binds         => binds) { yield }
+          :sql            => sql,
+          :name           => name,
+          :connection_id  => object_id,
+          :statement_name => statement_name,
+          :binds          => binds) { yield }
       rescue => e
         message = "#{e.class.name}: #{e.message}: #{sql}"
         @logger.error message if @logger

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -134,35 +134,31 @@ module ActiveRecord
         end
 
         def exec_query(sql, name = 'SQL', binds = [])
-          log(sql, name, binds) do
-            result = without_prepared_statement?(binds) ? exec_no_cache(sql, binds) :
-                                                          exec_cache(sql, binds)
+          result = without_prepared_statement?(binds) ? exec_no_cache(sql, name, binds) :
+                                                        exec_cache(sql, name, binds)
 
-            types = {}
-            fields = result.fields
-            fields.each_with_index do |fname, i|
-              ftype = result.ftype i
-              fmod  = result.fmod i
-              types[fname] = OID::TYPE_MAP.fetch(ftype, fmod) { |oid, mod|
-                warn "unknown OID: #{fname}(#{oid}) (#{sql})"
-                OID::Identity.new
-              }
-            end
-
-            ret = ActiveRecord::Result.new(fields, result.values, types)
-            result.clear
-            return ret
+          types = {}
+          fields = result.fields
+          fields.each_with_index do |fname, i|
+            ftype = result.ftype i
+            fmod  = result.fmod i
+            types[fname] = OID::TYPE_MAP.fetch(ftype, fmod) { |oid, mod|
+              warn "unknown OID: #{fname}(#{oid}) (#{sql})"
+              OID::Identity.new
+            }
           end
+
+          ret = ActiveRecord::Result.new(fields, result.values, types)
+          result.clear
+          return ret
         end
 
         def exec_delete(sql, name = 'SQL', binds = [])
-          log(sql, name, binds) do
-            result = without_prepared_statement?(binds) ? exec_no_cache(sql, binds) :
-                                                          exec_cache(sql, binds)
-            affected = result.cmd_tuples
-            result.clear
-            affected
-          end
+          result = without_prepared_statement?(binds) ? exec_no_cache(sql, name, binds) :
+                                                        exec_cache(sql, name, binds)
+          affected = result.cmd_tuples
+          result.clear
+          affected
         end
         alias :exec_update :exec_delete
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -772,12 +772,10 @@ module ActiveRecord
         end
 
         def exec_cache(sql, name, binds)
-          stmt_key = prepare_statement(sql)
-
           log(sql, name, binds) do
             begin
-              # Clear the queue
-              @connection.get_last_result
+              stmt_key = prepare_statement(sql)
+
               @connection.send_query_prepared(stmt_key, binds.map { |col, val|
                 type_cast(val, col)
               })
@@ -816,6 +814,8 @@ module ActiveRecord
           unless @statements.key? sql_key
             nextkey = @statements.next_key
             @connection.prepare nextkey, sql
+            # Clear the queue
+            @connection.get_last_result
             @statements[sql_key] = nextkey
           end
           @statements[sql_key]

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -774,7 +774,7 @@ module ActiveRecord
         def exec_cache(sql, name, binds)
           stmt_key = prepare_statement(sql)
 
-          log(sql, name, binds) do
+          log(sql, name, binds, stmt_key) do
             @connection.send_query_prepared(stmt_key, binds.map { |col, val|
               type_cast(val, col)
             })

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -767,35 +767,39 @@ module ActiveRecord
 
         FEATURE_NOT_SUPPORTED = "0A000" # :nodoc:
 
-        def exec_no_cache(sql, binds)
-          @connection.async_exec(sql)
+        def exec_no_cache(sql, name, binds)
+          log(sql, name, binds) { @connection.async_exec(sql) }
         end
 
-        def exec_cache(sql, binds)
+        def exec_cache(sql, name, binds)
           stmt_key = prepare_statement(sql)
 
-          # Clear the queue
-          @connection.get_last_result
-          @connection.send_query_prepared(stmt_key, binds.map { |col, val|
-            type_cast(val, col)
-          })
-          @connection.block
-          @connection.get_last_result
-        rescue PGError => e
-          # Get the PG code for the failure.  Annoyingly, the code for
-          # prepared statements whose return value may have changed is
-          # FEATURE_NOT_SUPPORTED.  Check here for more details:
-          # http://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/backend/utils/cache/plancache.c#l573
-          begin
-            code = e.result.result_error_field(PGresult::PG_DIAG_SQLSTATE)
-          rescue
-            raise e
-          end
-          if FEATURE_NOT_SUPPORTED == code
-            @statements.delete sql_key(sql)
-            retry
-          else
-            raise e
+          log(sql, name, binds) do
+            begin
+              # Clear the queue
+              @connection.get_last_result
+              @connection.send_query_prepared(stmt_key, binds.map { |col, val|
+                type_cast(val, col)
+              })
+              @connection.block
+              @connection.get_last_result
+            rescue PGError => e
+              # Get the PG code for the failure.  Annoyingly, the code for
+              # prepared statements whose return value may have changed is
+              # FEATURE_NOT_SUPPORTED.  Check here for more details:
+              # http://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/backend/utils/cache/plancache.c#l573
+              begin
+                code = e.result.result_error_field(PGresult::PG_DIAG_SQLSTATE)
+              rescue
+                raise e
+              end
+              if FEATURE_NOT_SUPPORTED == code
+                @statements.delete sql_key(sql)
+                retry
+              else
+                raise e
+              end
+            end
           end
         end
 

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -5,21 +5,6 @@ module ActiveRecord
     class NonExistentTable < ActiveRecord::Base
     end
 
-    class SQLSubscriber
-      attr_reader :logged
-
-      def initialize
-        @logged = []
-      end
-
-      def start(name, id, payload)
-        @logged << [payload[:sql], payload[:name], payload[:binds]]
-      end
-
-      def finish(name, id, payload)
-      end
-    end
-
     def setup
       super
       @subscriber = SQLSubscriber.new

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -81,6 +81,16 @@ module ActiveRecord
       assert_equal 'SCHEMA', @subscriber.logged[0][1]
     end
 
+    def test_statement_key_is_logged
+      bindval = 1
+      @connection.exec_query('SELECT $1::integer', 'SQL', [[nil, bindval]])
+      name = @subscriber.payloads.last[:statement_name]
+      assert name
+      res = @connection.exec_query("EXPLAIN (FORMAT JSON) EXECUTE #{name}(#{bindval})")
+      plan = res.column_types['QUERY PLAN'].type_cast res.rows.first.first
+      assert_operator plan.length, :>, 0
+    end
+
     # Must have with_manual_interventions set to true for this
     # test to run.
     # When prompted, restart the PostgreSQL server with the

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -446,6 +446,19 @@ class InverseHasManyTests < ActiveRecord::TestCase
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Man.first.secret_interests }
   end
+
+  def test_child_instance_should_point_to_parent_without_saving
+    man = Man.new
+    i = Interest.create(:topic => 'Industrial Revolution Re-enactment')
+
+    man.interests << i
+    assert_not_nil i.man
+
+    i.man.name = "Charles"
+    assert_equal i.man.name, man.name
+
+    assert !man.persisted?
+  end
 end
 
 class InverseBelongsToTests < ActiveRecord::TestCase

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -121,12 +121,15 @@ end
 
 class SQLSubscriber
   attr_reader :logged
+  attr_reader :payloads
 
   def initialize
     @logged = []
+    @payloads = []
   end
 
   def start(name, id, payload)
+    @payloads << payload
     @logged << [payload[:sql], payload[:name], payload[:binds]]
   end
 

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -119,21 +119,6 @@ class << Time
   end
 end
 
-module LogIntercepter
-  attr_accessor :logged, :intercepted
-  def self.extended(base)
-    base.logged = []
-  end
-  def log(sql, name = 'SQL', binds = [], &block)
-    if @intercepted
-      @logged << [sql, name, binds]
-      yield
-    else
-      super(sql, name,binds, &block)
-    end
-  end
-end
-
 class SQLSubscriber
   attr_reader :logged
 

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -134,6 +134,21 @@ module LogIntercepter
   end
 end
 
+class SQLSubscriber
+  attr_reader :logged
+
+  def initialize
+    @logged = []
+  end
+
+  def start(name, id, payload)
+    @logged << [payload[:sql], payload[:name], payload[:binds]]
+  end
+
+  def finish(name, id, payload); end
+end
+
+
 module InTimeZone
   private
 

--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -11,7 +11,6 @@ module Rails
       def initialize(app, taggers = nil)
         @app          = app
         @taggers      = taggers || []
-        @instrumenter = ActiveSupport::Notifications.instrumenter
       end
 
       def call(env)
@@ -33,7 +32,8 @@ module Rails
           logger.debug ''
         end
 
-        @instrumenter.start 'request.action_dispatch', request: request
+        instrumenter = ActiveSupport::Notifications.instrumenter
+        instrumenter.start 'request.action_dispatch', request: request
         logger.info started_request_message(request)
         resp = @app.call(env)
         resp[2] = ::Rack::BodyProxy.new(resp[2]) { finish(request) }
@@ -70,7 +70,8 @@ module Rails
       private
 
       def finish(request)
-        @instrumenter.finish 'request.action_dispatch', request: request
+        instrumenter = ActiveSupport::Notifications.instrumenter
+        instrumenter.finish 'request.action_dispatch', request: request
       end
 
       def development?


### PR DESCRIPTION
Rebase reapplication of #9569, thanks to @collectiveidea and @laserlemon

The CVE-2013-0155 security vulnerability outlines how array parameters
containing nil values can be dangerous when accepted directly into
Active Record finder methods. The previous fix has been to detect array
parameters with nil values and to clobber the entire array into nil.

Instead, compacting the array solves the security issue and causes less
surprise in the case where array parameters are expected, as is often
the case when accepting nested attributes for collections.
