### PR TITLE
Fix AR::Migrator to create schema_migrations table for MySQL "utf8mb4" encoding

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -892,7 +892,7 @@ module ActiveRecord
 
       validate(@migrations)
 
-      ActiveRecord::SchemaMigration.create_table
+      ActiveRecord::Schema.suppress_messages{ ActiveRecord::Schema.initialize_schema_migrations_table }
     end
 
     def current_version

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -4,21 +4,35 @@ module ActiveRecord
   module ConnectionAdapters
     class Mysql2Adapter
       class SchemaMigrationsTest < ActiveRecord::TestCase
+        def setup
+          super
+          @conn = ActiveRecord::Base.connection
+          @smtn = ActiveRecord::Migrator.schema_migrations_table_name
+          @config = @conn.instance_variable_get(:@config)
+        end
+
         def test_initializes_schema_migrations_for_encoding_utf8mb4
-          conn = ActiveRecord::Base.connection
+          @conn.drop_table(@smtn) if @conn.table_exists?(@smtn)
+          original_encoding = @config[:encoding]
+          @config[:encoding] = 'utf8mb4'
 
-          smtn = ActiveRecord::Migrator.schema_migrations_table_name
-          conn.drop_table(smtn) if conn.table_exists?(smtn)
+          @conn.initialize_schema_migrations_table
 
-          config = conn.instance_variable_get(:@config)
-          original_encoding = config[:encoding]
-
-          config[:encoding] = 'utf8mb4'
-          conn.initialize_schema_migrations_table
-
-          assert conn.column_exists?(smtn, :version, :string, limit: Mysql2Adapter::MAX_INDEX_LENGTH_FOR_UTF8MB4)
+          assert @conn.column_exists?(@smtn, :version, :string, limit: Mysql2Adapter::MAX_INDEX_LENGTH_FOR_UTF8MB4)
         ensure
-          config[:encoding] = original_encoding
+          @config[:encoding] = original_encoding
+        end
+
+        def test_initializes_schema_migrations_through_migrator_for_encoding_utf8mb4
+          @conn.drop_table(@smtn) if @conn.table_exists?(@smtn)
+          original_encoding = @config[:encoding]
+          @config[:encoding] = 'utf8mb4'
+
+          ActiveRecord::Migrator.new(:up, [])
+
+          assert @conn.column_exists?(@smtn, :version, :string, limit: Mysql2Adapter::MAX_INDEX_LENGTH_FOR_UTF8MB4)
+        ensure
+          @config[:encoding] = original_encoding
         end
       end
     end


### PR DESCRIPTION
conditions:
- Mysql2Adapter
- encoding: "utf8mb4"

steps to reproduce:

``` sh
rake db:create
rake db:migrate
```

>    Mysql2::Error: Specified key was too long; max key length is 767 bytes: CREATE UNIQUE INDEX `unique_schema_migrations`  ON `schema_migrations` (`version`)

This commit https://github.com/rails/rails/commit/8744632fb5649cf26cdcd1518a3554ece95a401b fixed `db:schema:load`, but didn't apply to `db:migrate`.

refs #9855
