### PR TITLE
Don't delete :action option when rendering using respond_with

### DIFF
--- a/actionpack/lib/action_controller/metal/responder.rb
+++ b/actionpack/lib/action_controller/metal/responder.rb
@@ -133,7 +133,7 @@ module ActionController #:nodoc:
       @resource = resources.last
       @resources = resources
       @options = options
-      @action = options.delete(:action)
+      @action = options[:action]
       @default_response = options.delete(:default_response)
     end
 


### PR DESCRIPTION
Suggested fix for https://github.com/rails/rails/issues/12253
