### PR TITLE
Default cipher for ActiveSupport::MessageEncryptor is too strong for JRuby

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Provide a means of configuring cipher for
+    `ActionDispatch::Cookies::EncryptedCookieJar`.
+
+    *Hiro Asari*
+
 *   Fix regex used to detect URI schemes in `redirect_to` to be consistent with
     RFC 3986.
 

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -87,6 +87,7 @@ module ActionDispatch
     SIGNED_COOKIE_SALT = "action_dispatch.signed_cookie_salt".freeze
     ENCRYPTED_COOKIE_SALT = "action_dispatch.encrypted_cookie_salt".freeze
     ENCRYPTED_SIGNED_COOKIE_SALT = "action_dispatch.encrypted_signed_cookie_salt".freeze
+    ENCRYPTED_COOKIE_CIPHER = "action_dispatch.encrypted_cookie_cipher".freeze
     SECRET_TOKEN = "action_dispatch.secret_token".freeze
     SECRET_KEY_BASE = "action_dispatch.secret_key_base".freeze
 
@@ -208,6 +209,7 @@ module ActionDispatch
         { signed_cookie_salt: env[SIGNED_COOKIE_SALT] || '',
           encrypted_cookie_salt: env[ENCRYPTED_COOKIE_SALT] || '',
           encrypted_signed_cookie_salt: env[ENCRYPTED_SIGNED_COOKIE_SALT] || '',
+          encrypted_cookie_cipher: env[ENCRYPTED_COOKIE_CIPHER],
           secret_token: env[SECRET_TOKEN],
           secret_key_base: env[SECRET_KEY_BASE],
           upgrade_legacy_signed_cookies: env[SECRET_TOKEN].present? && env[SECRET_KEY_BASE].present?
@@ -435,7 +437,8 @@ module ActionDispatch
         @options = options
         secret = key_generator.generate_key(@options[:encrypted_cookie_salt])
         sign_secret = key_generator.generate_key(@options[:encrypted_signed_cookie_salt])
-        @encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret)
+        cipher = @options[:encrypted_cookie_cipher]
+        @encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret, :cipher => cipher)
       end
 
       def [](name)

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -180,6 +180,7 @@ class CookiesTest < ActionController::TestCase
     @request.env["action_dispatch.signed_cookie_salt"] = "b3c631c314c0bbca50c1b2843150fe33"
     @request.env["action_dispatch.encrypted_cookie_salt"] = "b3c631c314c0bbca50c1b2843150fe33"
     @request.env["action_dispatch.encrypted_signed_cookie_salt"] = "b3c631c314c0bbca50c1b2843150fe33"
+    @request.env["action_dispatch.encrypted_cookie_cipher"] = "aes-128-cbc"
     @request.host = "www.nextangle.com"
   end
 
@@ -522,6 +523,7 @@ class CookiesTest < ActionController::TestCase
     @request.env["action_dispatch.secret_key_base"] = "c3b95688f35581fad38df788add315ff"
     @request.env["action_dispatch.encrypted_cookie_salt"] = "4433796b79d99a7735553e316522acee"
     @request.env["action_dispatch.encrypted_signed_cookie_salt"] = "00646eb40062e1b1deff205a27cd30f9"
+    @request.env["action_dispatch.encrypted_cookie_cipher"] = "aes-128-cbc"
 
     legacy_value = ActiveSupport::MessageVerifier.new("b3c631c314c0bbca50c1b2843150fe33").generate('bar')
 
@@ -533,7 +535,8 @@ class CookiesTest < ActionController::TestCase
     key_generator = @request.env["action_dispatch.key_generator"]
     secret = key_generator.generate_key(@request.env["action_dispatch.encrypted_cookie_salt"])
     sign_secret = key_generator.generate_key(@request.env["action_dispatch.encrypted_signed_cookie_salt"])
-    encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret)
+    cipher = @request.env["action_dispatch.encrypted_cookie_cipher"]
+    encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret, cipher: cipher)
     assert_equal 'bar', encryptor.decrypt_and_verify(@response.cookies["foo"])
   end
 


### PR DESCRIPTION
The default cipher for `ActiveSupport::MessageEncryptor` ([aes-256-cbc](https://github.com/rails/rails/blob/051d289030a6cb86590cd1b619eae1879b48458a/activesupport/lib/active_support/message_encryptor.rb#L49)) is too strong for JRuby without installing [Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files](http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html). While some users have figured out how [this](http://jira.codehaus.org/browse/JRUBY-7093) [problem](https://github.com/jruby/jruby/issues/919) [manifests](http://deployingjruby.blogspot.com/2013/05/how-to-run-rails-400rc1-on-jruby.html), it is far from obvious how to solve this problem, and I would like to have a reasonable workaround.

A couple of possible solutions:
1. Change the default with a smaller key size, say 'aes-128-cbc'. Given that there are applications in the wild which assume 'aes-256-cbc', this is probably not a good way to address this problem.
2. Provide a means of specifying cipher for `EncryptedCookieJar`. Within Rails, `EncryptedCookieJar` appears to be the only thing that uses `MessageEncryptor`. If there is an option to specify a reasonable cipher, we can advise JRuby users to deal with the encryption strength effectively.

This PR aims to realize the latter approach.
