### PR TITLE
Remove tzinfo dependency from Action Pack

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -21,10 +21,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', version
 
-  s.add_dependency 'rack',          '~> 1.5.2'
-  s.add_dependency 'rack-test',     '~> 0.6.2'
+  s.add_dependency 'rack',      '~> 1.5.2'
+  s.add_dependency 'rack-test', '~> 0.6.2'
 
-  s.add_development_dependency 'actionview',    version
-  s.add_development_dependency 'activemodel',   version
-  s.add_development_dependency 'tzinfo',        '~> 0.3.37'
+  s.add_development_dependency 'actionview',  version
+  s.add_development_dependency 'activemodel', version
 end


### PR DESCRIPTION
This gem is used by Active Support but it should not be a dependency of Action Pack.
