### PR TITLE
Relation merge made to always return clone

### DIFF
--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -29,14 +29,14 @@ module ActiveRecord
     def merge(other)
       if other.is_a?(Array)
         to_a & other
-      elsif other
-        spawn.merge!(other)
       else
-        self
+        spawn.merge!(other)
       end
     end
 
     def merge!(other) # :nodoc:
+      return self unless other
+
       if !other.is_a?(Relation) && other.respond_to?(:to_proc)
         instance_exec(&other)
       else


### PR DESCRIPTION
The `merge` method of `Relation` is expected to return a copy of relation as opposed to `merge!`. However if you pass a `nil` or `false` into, it returns `self` which is a very tricky violation of interface. As the result you may appear in the situation where you accidentally modify a scope that you expected to save untouched.

This tiny fix makes it return a copy no matter what arguments you pass.
