### PR TITLE
Fix an issue where router can't recognize downcased url encoding path.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix an issue where router can't recognize downcased url encoding path.
+
+    Fixes #12269
+
+    *kennyj*
+
 *   Fix custom flash type definition. Misusage of the `_flash_types` class variable
     caused an error when reloading controllers with custom flash types.
 

--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -16,6 +16,7 @@ module ActionDispatch
           path = "/#{path}"
           path.squeeze!('/')
           path.sub!(%r{/+\Z}, '')
+          path.gsub!(/(%[a-f0-9]{2}+)/) { $1.upcase }
           path = '/' if path == ''
           path
         end

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1904,6 +1904,10 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
     assert_equal({:controller => 'news', :action => 'index'}, @routes.recognize_path(URI.parser.escape('こんにちは/世界'), :method => :get))
   end
 
+  def test_downcased_unicode_path
+    assert_equal({:controller => 'news', :action => 'index'}, @routes.recognize_path(URI.parser.escape('こんにちは/世界').downcase, :method => :get))
+  end
+
   private
     def sort_extras!(extras)
       if extras.length == 2


### PR DESCRIPTION
Closes #12269.

Rails 4 unicode routes is not working with Passenger (I tested passenger standalone), because Passenger passes downcased url encoding path.

I've tested this issue with my fix on webrick, thin and passenger-standalone.
It works fine all. 
