### PR TITLE
[ci skip] Update rake middleware output in Rails on Rack guide.

### DIFF
--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -118,10 +118,9 @@ $ rake middleware
 For a freshly generated Rails application, this might produce something like:
 
 ```ruby
-use Rack::Sendfile
 use ActionDispatch::Static
 use Rack::Lock
-use #<ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x000000029a0838>
+use #<ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x0000010706ad80>
 use Rack::Runtime
 use Rack::MethodOverride
 use ActionDispatch::RequestId


### PR DESCRIPTION
`use Rack::Sendfile` is gone. :cry:
