### PR TITLE
Calling reset_session inside of a controller with a NullSessionHash raises a nil exception.

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -124,6 +124,9 @@ module ActionController #:nodoc:
             @loaded = true
           end
 
+          # no-op
+          def destroy; end
+
           def exists?
             true
           end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -78,6 +78,11 @@ class RequestForgeryProtectionControllerUsingNullSession < ActionController::Bas
     cookies.encrypted[:foo] = 'bar'
     render :nothing => true
   end
+
+  def try_to_reset_session
+    reset_session
+    render :nothing => true
+  end
 end
 
 class FreeCookieController < RequestForgeryProtectionControllerUsingResetSession
@@ -318,6 +323,11 @@ class RequestForgeryProtectionControllerUsingNullSessionTest < ActionController:
 
   test 'should allow to set encrypted cookies' do
     post :encrypted
+    assert_response :ok
+  end
+
+  test 'should allow reset_session' do
+    post :try_to_reset_session
     assert_response :ok
   end
 end


### PR DESCRIPTION
For example:

``` ruby
class FoobarsController < ApplicationController
  protect_from_forgery :with => :null_session

  # Posting to this action with an invalid authenticity token will raise an exception.
  def create
    reset_session
  end
end
```

Raising the following:

```
NoMethodError: undefined method `destroy_session' for nil:NilClass
    /Users/jon/.rvm/gems/ruby-1.9.2-p180/gems/rack-1.5.2/lib/rack/session/abstract/id.rb:85:in `destroy'
    /Users/jon/work/rails/actionpack/lib/action_dispatch/http/request.rb:257:in `reset_session'
    /Users/jon/work/rails/actionpack/lib/action_controller/metal/rack_delegation.rb:22:in `reset_session'
    /Users/jon/work/rails/actionpack/test/controller/request_forgery_protection_test.rb:83:in `try_to_reset_session'
    /Users/jon/work/rails/actionpack/lib/action_controller/metal/implicit_render.rb:4:in `send_action'
```

I've included a simple fix and a test case.
