### PR TITLE
[ci skip] Add some comment about downcase url encoded string. 

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -7,11 +7,13 @@ module ActionDispatch
         # Normalizes URI path.
         #
         # Strips off trailing slash and ensures there is a leading slash.
+        # Also converts downcase url encoded string to uppercase.
         #
         #   normalize_path("/foo")  # => "/foo"
         #   normalize_path("/foo/") # => "/foo"
         #   normalize_path("foo")   # => "/foo"
         #   normalize_path("")      # => "/"
+        #   normalize_path("/%ab")  # => "/%AB"
         def self.normalize_path(path)
           path = "/#{path}"
           path.squeeze!('/')


### PR DESCRIPTION
See #12276.
Sorry, I forgot to update document.

The behavior of `normalize_path` is changed.

cc/ @rafaelfranca 
