### PR TITLE
Add default_proc copying in HashWithIndifferentAccess

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add default_proc copying for `HashWithIndifferentAccess.new_from_hash_copying_default`, `HashWithIndifferentAccess#dup`, `HashWithIndifferentAccess#to_hash`
+
+    *Ivan Yurchenko*
+
 *   Add `Date#middle_of_day`, `DateTime#middle_of_day` and `Time#middle_of_day` methods.
 
     Also added `midday`, `noon`, `at_midday`, `at_noon` and `at_middle_of_day` as aliases.

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -73,7 +73,11 @@ module ActiveSupport
 
     def self.new_from_hash_copying_default(hash)
       new(hash).tap do |new_hash|
-        new_hash.default = hash.default
+        if hash.default_proc
+          new_hash.default_proc = hash.default_proc
+        else
+          new_hash.default = hash.default
+        end
       end
     end
 
@@ -178,7 +182,11 @@ module ActiveSupport
     # Returns an exact copy of the hash.
     def dup
       self.class.new(self).tap do |new_hash|
-        new_hash.default = default
+        if default_proc
+          new_hash.default_proc = default_proc
+        else
+          new_hash.default = default
+        end
       end
     end
 
@@ -237,7 +245,8 @@ module ActiveSupport
       each do |key, value|
         _new_hash[convert_key(key)] = convert_value(value, for: :to_hash)
       end
-      Hash.new(default).merge!(_new_hash)
+      hash_base = default_proc ? Hash.new(&default_proc) : Hash.new(default)
+      hash_base.merge!(_new_hash)
     end
 
     protected

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1379,6 +1379,24 @@ class HashToXmlTest < ActiveSupport::TestCase
     assert_equal 3, hash_wia.default
   end
 
+  def test_should_copy_the_default_proc_when_converting_to_hash_with_indifferent_access
+    hash = Hash.new { |h, k| h[k] = "key #{k} of class #{k.class}" }
+    hash_wia = hash.with_indifferent_access
+    assert_equal 'key foo of class String', hash_wia[:foo]
+  end
+
+  def test_should_copy_the_default_proc_when_dup_hash_with_indifferent_access
+    prc = proc { }
+    hash_wia = HashWithIndifferentAccess.new(&prc).dup
+    assert_equal prc, hash_wia.default_proc
+  end
+
+  def test_should_copy_the_default_proc_when_converting_to_hash
+    prc = proc { }
+    hash = HashWithIndifferentAccess.new(&prc).to_hash
+    assert_equal prc, hash.default_proc
+  end
+
   # The XML builder seems to fail miserably when trying to tag something
   # with the same name as a Kernel method (throw, test, loop, select ...)
   def test_kernel_method_names_to_xml


### PR DESCRIPTION
Add default_proc copying for `HashWithIndifferentAccess.new_from_hash_copying_default`, `HashWithIndifferentAccess#dup`, `HashWithIndifferentAccess#to_hash`
