### PR TITLE
Fix some edge cases for select with selected option

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix some edge cases for AV `select` helper with `:selected` option
+
+    *Bogdan Gusiev*
+
 *   Ability to pass block to `select` helper
 
         <%= select(report, "campaign_ids") do %>

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -119,7 +119,8 @@ module ActionView
           html_options = html_options.stringify_keys
           add_default_name_and_id(html_options)
           options[:include_blank] ||= true unless options[:prompt] || select_not_required?(html_options)
-          select = content_tag("select", add_options(option_tags, options, value(object)), html_options)
+          value = options.fetch(:selected) { value(object) }
+          select = content_tag("select", add_options(option_tags, options, value), html_options)
 
           if html_options["multiple"] && options.fetch(:include_hidden, true)
             tag("input", :disabled => html_options["disabled"], :name => html_options["name"], :type => "hidden", :value => "") + select

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -798,6 +798,22 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_not_existing_method_with_selected_value
+    @post = Post.new
+    assert_dom_equal(
+      "<select id=\"post_locale\" name=\"post[locale]\"><option value=\"en\">en</option>\n<option value=\"ru\" selected=\"selected\">ru</option></select>",
+      select("post", "locale", %w( en ru ), :selected => 'ru')
+    )
+  end
+
+  def test_select_with_prompt_and_selected_value
+    @post = Post.new
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"><option value=\"one\">one</option>\n<option selected=\"selected\" value=\"two\">two</option></select>",
+      select("post", "category", %w( one two ), :selected => 'two', :prompt => true)
+    )
+  end
+  
   def test_select_with_disabled_array
     @post = Post.new
     @post.category = "<mus>"


### PR DESCRIPTION
Select should use selected option as value when specified in all layers
This is not always true right now. That is why prompt option could not
work correctly. See tests for examples.
