### PR TITLE
Fix humanize for Mongodb's "_id"

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix "_id".humanize
+
+    Before this patch it returns ""
+    After this patch it returns " id"
+
+    *Bogdan Gusiev*
+
 *   Add `SecureRandom::uuid_v3` and `SecureRandom::uuid_v5` to support stable
     UUID fixtures on PostgreSQL.
 

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -113,7 +113,7 @@ module ActiveSupport
     def humanize(lower_case_and_underscored_word, options = {})
       result = lower_case_and_underscored_word.to_s.dup
       inflections.humans.each { |(rule, replacement)| break if result.sub!(rule, replacement) }
-      result.gsub!(/_id$/, "")
+      result.sub!(/(?!^)_id$/, "")
       result.tr!('_', ' ')
       result.gsub!(/([a-z\d]*)/i) { |match|
         "#{inflections.acronyms[match] || match.downcase}"

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -210,7 +210,8 @@ module InflectorTestCases
   UnderscoreToHuman = {
     "employee_salary" => "Employee salary",
     "employee_id"     => "Employee",
-    "underground"     => "Underground"
+    "underground"     => "Underground",
+    "_id"             => " id"
   }
 
   UnderscoreToHumanWithoutCapitalize = {


### PR DESCRIPTION
Currently `'_id'.humanize` returns empty string
Dont think this is desired behavior. Changed it to ignore leading underscore if any.
