### PR TITLE
Closes #12278. AR::ConnectionAdapters::Column.string_to_time method respects string with timezone.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `ActiveRecord::ConnectionAdapters.string_to_time` respects
+    string with timezone (e.g. Wed, 04 Sep 2013 20:30:00 JST).
+ 
+    Fixes: #12278
+
+    *kennyj*
+
 *   Calling `update_attributes` will now throw an `ArgumentError` whenever it
     gets a `nil` argument. More specifically, it will throw an error if the
     argument that it gets passed does not respond to to `stringify_keys`.

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -203,11 +203,19 @@ module ActiveRecord
             end
           end
 
-          def new_time(year, mon, mday, hour, min, sec, microsec)
+          def new_time(year, mon, mday, hour, min, sec, microsec, offset = nil)
             # Treat 0000-00-00 00:00:00 as nil.
             return nil if year.nil? || (year == 0 && mon == 0 && mday == 0)
 
-            Time.send(Base.default_timezone, year, mon, mday, hour, min, sec, microsec) rescue nil
+            if offset
+              time = Time.utc(year, mon, mday, hour, min, sec, microsec) rescue nil
+              return nil unless time
+
+              time -= offset
+              Base.default_timezone == :utc ? time : time.getlocal
+            else
+              Time.public_send(Base.default_timezone, year, mon, mday, hour, min, sec, microsec) rescue nil
+            end
           end
 
           def fast_string_to_date(string)
@@ -232,7 +240,7 @@ module ActiveRecord
             time_hash = Date._parse(string)
             time_hash[:sec_fraction] = microseconds(time_hash)
 
-            new_time(*time_hash.values_at(:year, :mon, :mday, :hour, :min, :sec, :sec_fraction))
+            new_time(*time_hash.values_at(:year, :mon, :mday, :hour, :min, :sec, :sec_fraction, :offset))
           end
       end
 

--- a/activerecord/test/cases/column_test.rb
+++ b/activerecord/test/cases/column_test.rb
@@ -110,6 +110,16 @@ module ActiveRecord
         assert_equal 1800, column.type_cast(30.minutes)
         assert_equal 7200, column.type_cast(2.hours)
       end
+
+      def test_string_to_time_with_timezone
+        old = ActiveRecord::Base.default_timezone
+        [:utc, :local].each do |zone|
+          ActiveRecord::Base.default_timezone = zone
+          assert_equal Time.utc(2013, 9, 4, 0, 0, 0), Column.string_to_time("Wed, 04 Sep 2013 03:00:00 EAT")
+        end
+      rescue
+        ActiveRecord::Base.default_timezone = old
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #12278.

In current implementation, `AR::ConnectionAdapters::Column.string_to_time` method ignores timezone.

If with timezone (e.g. Wed, 04 Sep 2013 20:30:00 JST), the method should respects its timezone.
