### PR TITLE
Clarify how `default_scope` is overridden

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1241,8 +1241,8 @@ User.active.merge(User.inactive)
 # => SELECT "users".* FROM "users" WHERE "users"."state" = 'inactive'
 ```
 
-One important caveat is that `default_scope` will be overridden by
-`scope` and `where` conditions.
+However, any constraints in a `default_scope` will be overridden by
+constraints on the same columns in `scope` and `where` conditions.
 
 ```ruby
 class User < ActiveRecord::Base
@@ -1259,6 +1259,9 @@ User.active
 
 User.where(state: 'inactive')
 # => SELECT "users".* FROM "users" WHERE "users"."state" = 'inactive'
+
+User.where(name: 'John')
+# => SELECT "users".* FROM "users" WHERE "users"."state" = 'pending' AND "users"."name" = 'John'
 ```
 
 As you can see above the `default_scope` is being overridden by both


### PR DESCRIPTION
It's important that the overriding is _per column_. A `where` on a column not mentioned in the `default_scope` doesn't drop the `default_scope` condition.
