### PR TITLE
Run Tests against JRuby master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
 rvm:
   - 1.9.3
   - 2.0.0
-  - jruby-19mode
+  - jruby-head
   - rbx-19mode
 env:
   - "GEM=railties"


### PR DESCRIPTION
Many of the failing tests in rails test suite fail because of missing encoding support, example #11739

And according to recent announcement, lot of encoding issues have been fixed in current master.  http://ruby.11.x6.nabble.com/Big-encoding-patches-landed-on-master-td4993719.html

So lets test against JRuby master & incase there are still bugs. it would be easier to report them to JRuby.
#11700
