### PR TITLE
DRYing up method_missing code; Initializing Codepoint object with default values

### DIFF
--- a/activesupport/bin/generate_tables
+++ b/activesupport/bin/generate_tables
@@ -28,12 +28,6 @@ module ActiveSupport
 
         def initialize
           @ucd = Unicode::UnicodeDatabase.new
-
-          default = Codepoint.new
-          default.combining_class = 0
-          default.uppercase_mapping = 0
-          default.lowercase_mapping = 0
-          @ucd.codepoints = Hash.new(default)
         end
 
         def parse_codepoints(line)

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -56,11 +56,10 @@ module ActiveSupport #:nodoc:
 
       # Forward all undefined methods to the wrapped string.
       def method_missing(method, *args, &block)
+        result = @wrapped_string.__send__(method, *args, &block)
         if method.to_s =~ /!$/
-          result = @wrapped_string.__send__(method, *args, &block)
           self if result
         else
-          result = @wrapped_string.__send__(method, *args, &block)
           result.kind_of?(String) ? chars(result) : result
         end
       end

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -287,6 +287,13 @@ module ActiveSupport
       class Codepoint
         attr_accessor :code, :combining_class, :decomp_type, :decomp_mapping, :uppercase_mapping, :lowercase_mapping
 
+        # Initializing Codepoint object with default values
+        def initialize
+          @combining_class = 0
+          @uppercase_mapping = 0
+          @lowercase_mapping = 0
+        end
+
         def swapcase_mapping
           uppercase_mapping > 0 ? uppercase_mapping : lowercase_mapping
         end


### PR DESCRIPTION
Drying up method_missing code in activesupport/lib/active_support/multibyte/chars.rb

Initializing Codepoint object with default values.
