### PR TITLE
Documentation Fix: Remove broken link on rails 3 guide

### DIFF
--- a/guides/source/3_0_release_notes.md
+++ b/guides/source/3_0_release_notes.md
@@ -73,8 +73,6 @@ You can see an example of how that works at [Rails Upgrade is now an Official Pl
 
 Aside from Rails Upgrade tool, if you need more help, there are people on IRC and [rubyonrails-talk](http://groups.google.com/group/rubyonrails-talk) that are probably doing the same thing, possibly hitting the same issues. Be sure to blog your own experiences when upgrading so others can benefit from your knowledge!
 
-More information - [The Path to Rails 3: Approaching the upgrade](http://omgbloglol.com/post/353978923/the-path-to-rails-3-approaching-the-upgrade)
-
 Creating a Rails 3.0 application
 --------------------------------
 


### PR DESCRIPTION
As raised in https://github.com/rails/rails/issues/12300

I have simply removed the link as I could not find a cached copy.  I did try Google cache at http://webcache.googleusercontent.com/search?q=cache:http://omgbloglol.com/post/353978923/the-path-to-rails-3-approaching-the-upgrade but it was not found.
