### PR TITLE
Removes (redundant?) sentence fragment in intro text

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -1,8 +1,6 @@
 The Rails Command Line
 ======================
 
-Rails comes with every command line tool you'll need to
-
 After reading this guide, you will know:
 
 * How to create a Rails application.


### PR DESCRIPTION
It looks like a remnant from the 3.2 guide.
