### PR TITLE
Give `reset_scope` duties to reset also scope for `CollectionProxy`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Since `CollectionProxy` descendants from `Relation` and `bind_values`
+    defined right on `Relation` that when the `@owner` is saved it resets just
+    association scope but CollectionProxy is still the same and has wrong
+    `bind_values`. It worked properly on ~> 3.0 because `CollectionProxy` wasn't
+    Relation and `bind_values` was invoked right on `scoped`. When the behavior
+    had changed it worked properly for a while because `CollectionProxy` was
+    recreated each time in association reader. But it got broken since it cached
+    in instance variable `@proxy` (it's correct behavior).
+
+    *Dmitry Vorotilin*
+
 *   Migration dump UUID default functions to schema.rb.
 
     Fixes #10751.

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -98,6 +98,9 @@ module ActiveRecord
 
       def reset_scope
         @association_scope = nil
+        if defined?(@proxy) && @proxy
+          @proxy.merge!(scope(nullify: false))
+        end
       end
 
       # Set the inverse association, if possible

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -919,6 +919,20 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, Client.where(client_of: firm.id).size
   end
 
+  def test_has_many_assignment_on_new_record_and_autosave_reset_scope
+    author = Author.new(name: 'Dmitry')
+    author.posts = [Post.new(title: 'Title', body: 'Text')]
+
+    # Accessing collection proxy that merges association scope
+    # This call happens on validate presence for example
+    author.posts
+
+    author.save
+
+    author.posts.update_all(title: 'Changed')
+    assert_equal 'Changed', author.reload.posts.take.title
+  end
+
   def test_delete_all_association_with_primary_key_deletes_correct_records
     firm = Firm.first
     # break the vanilla firm_id foreign key


### PR DESCRIPTION
Since `CollectionProxy` descendants from `Relation` and `bind_values` defined
right on `Relation` that when the `@owner` is saved it resets just association
scope but `CollectionProxy` is still the same and has wrong bind_values.
It worked properly before this commit c86a32d7451c5d901620ac58630460915292f88b
because was invoked right on `scoped`. And after this commit for a while because
`CollectionProxy` was recreated each time in association reader. But it got broken
since it cached in instance variable `@proxy` (it's correct behavior).

Attached test will produce this query on `update_all` if we remove fix:
`UPDATE "posts" SET "title" = 'Changed' WHERE "posts"."author_id" = ?  [["author_id", nil]]`
but ought to add author_id.
