### PR TITLE
Fix typo. This test isn't executed even in the postgresql.

### DIFF
--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -299,7 +299,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
     def test_schema_dump_includes_uuid_shorthand_definition
       output = standard_dump
-      if %r{create_table "poistgresql_uuids"} =~ output
+      if %r{create_table "postgresql_uuids"} =~ output
         assert_match %r{t.uuid "guid"}, output
       end
     end


### PR DESCRIPTION
The assertion inside test_schema_dump_includes_uuid_shorthand_definition isn't executed, because typo.
