### PR TITLE
Use ENV['SECRET_KEY_BASE'] if is set.

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -46,7 +46,7 @@ module Rails
         @log_formatter                 = ActiveSupport::Logger::SimpleFormatter.new
         @eager_load                    = nil
         @secret_token                  = nil
-        @secret_key_base               = nil
+        @secret_key_base               = ENV["SECRET_KEY_BASE"]
 
         @assets = ActiveSupport::OrderedOptions.new
         @assets.enabled                  = true

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -117,9 +117,12 @@ module TestHelpers
         end
       end
 
+      unless options[:do_not_set_secret_key_base]
+        add_to_config 'config.secret_key_base = "3b7cd727ee24e8444053437c36cc66c4"'
+      end
+
       add_to_config <<-RUBY
         config.eager_load = false
-        config.secret_key_base = "3b7cd727ee24e8444053437c36cc66c4"
         config.session_store :cookie_store, key: "_myapp_session"
         config.active_support.deprecation = :log
         config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
This allows you to set ENV['SECRET_KEY_BASE'] for encrypting the cookie and
Rails will pick it up automatically, like DATABASE_URL.
