### PR TITLE
[ci skip] Add a type modifier in migrations.md.

### DIFF
--- a/guides/source/migrations.md
+++ b/guides/source/migrations.md
@@ -301,6 +301,7 @@ braces. You can use the following modifiers:
 * `precision`    Defines the precision for the `decimal` fields
 * `scale`        Defines the scale for the `decimal` fields
 * `polymorphic`  Adds a `type` column for `belongs_to` associations
+* `null`         Allows or disallows `NULL` values in the column.
 
 For instance, running
 


### PR DESCRIPTION
Also I found out that the `documents.yml`  change the title of this article to "Rails Database Migrations", but the migrations.md stays in "Active Record Migrations" cc @fxn 
