### PR TITLE
TypeError: superclass mismatch for class PostgreSQLAdapter

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
@@ -1,38 +1,40 @@
 require 'cases/helper'
 
-module ActiveRecord::ConnectionAdapters
-  class PostgreSQLAdapter < AbstractAdapter
-    class InactivePGconn
-      def query(*args)
-        raise PGError
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgreSQLAdapter < AbstractAdapter
+      class InactivePGconn
+        def query(*args)
+          raise PGError
+        end
+
+        def status
+          PGconn::CONNECTION_BAD
+        end
       end
 
-      def status
-        PGconn::CONNECTION_BAD
-      end
-    end
+      class StatementPoolTest < ActiveRecord::TestCase
+        def test_cache_is_per_pid
+          return skip('must support fork') unless Process.respond_to?(:fork)
 
-    class StatementPoolTest < ActiveRecord::TestCase
-      def test_cache_is_per_pid
-        return skip('must support fork') unless Process.respond_to?(:fork)
+          cache = StatementPool.new nil, 10
+          cache['foo'] = 'bar'
+          assert_equal 'bar', cache['foo']
 
-        cache = StatementPool.new nil, 10
-        cache['foo'] = 'bar'
-        assert_equal 'bar', cache['foo']
+          pid = fork {
+            lookup = cache['foo'];
+            exit!(!lookup)
+          }
 
-        pid = fork {
-          lookup = cache['foo'];
-          exit!(!lookup)
-        }
+          Process.waitpid pid
+          assert $?.success?, 'process should exit successfully'
+        end
 
-        Process.waitpid pid
-        assert $?.success?, 'process should exit successfully'
-      end
-
-      def test_dealloc_does_not_raise_on_inactive_connection
-        cache = StatementPool.new InactivePGconn.new, 10
-        cache['foo'] = 'bar'
-        assert_nothing_raised { cache.clear }
+        def test_dealloc_does_not_raise_on_inactive_connection
+          cache = StatementPool.new InactivePGconn.new, 10
+          cache['foo'] = 'bar'
+          assert_nothing_raised { cache.clear }
+        end
       end
     end
   end


### PR DESCRIPTION
We shouldn't override PostgreSQLAdapter's superclass inheritance while monkeypatching. Changing Inheritance section leads to following error on JRuby

```
TypeError: superclass mismatch for class PostgreSQLAdapter
```

After this change,
**Jruby**: The above error no longer appear. Tests are still failing but they do run. Progress!
**MRI**: No change, all green(tested by running `rake test_postgresql`) But I don't want to break MRI while trying to fix jruby. so lets  wait for travis CI build to run all tests to before we merge this in.

Thanks to @asanghi pairing with me on this. 
#11700

cc: @arunagw, @guilleiguaran
