### PR TITLE
handle `:namespace` form option in collection labels

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Handle `:namespace` form option in collection labels
+
+    *Vasiliy Ermolovich*
+
 *   Fix `form_for` when both `namespace` and `as` options are present
 
     `as` option no longer overwrites `namespace` option when generating

--- a/actionview/lib/action_view/helpers/tags/collection_helpers.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_helpers.rb
@@ -18,7 +18,8 @@ module ActionView
           end
 
           def label(label_html_options={}, &block)
-            @template_object.label(@object_name, @sanitized_attribute_name, @text, label_html_options, &block)
+            html_options = label_html_options.merge(@input_html_options)
+            @template_object.label(@object_name, @sanitized_attribute_name, @text, html_options, &block)
           end
         end
 

--- a/actionview/lib/action_view/helpers/tags/label.rb
+++ b/actionview/lib/action_view/helpers/tags/label.rb
@@ -30,6 +30,7 @@ module ActionView
           add_default_name_and_id_for_value(tag_value, name_and_id)
           options.delete("index")
           options.delete("namespace")
+          options.delete("multiple")
           options["for"] = name_and_id["id"] unless options.key?("for")
 
           if block_given?

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1282,6 +1282,24 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_with_namespace_and_with_collection_radio_buttons
+    post = Post.new
+    def post.active; false; end
+
+    form_for(post, namespace: 'foo') do |f|
+      concat f.collection_radio_buttons(:active, [true, false], :to_s, :to_s)
+    end
+
+    expected = whole_form("/posts", "foo_new_post", "new_post") do
+      "<input id='foo_post_active_true' name='post[active]' type='radio' value='true' />" +
+      "<label for='foo_post_active_true'>true</label>" +
+      "<input checked='checked' id='foo_post_active_false' name='post[active]' type='radio' value='false' />" +
+      "<label for='foo_post_active_false'>false</label>"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_for_with_collection_check_boxes
     post = Post.new
     def post.tag_ids; [1, 3]; end
@@ -1356,6 +1374,24 @@ class FormHelperTest < ActionView::TestCase
       "Tag 3</label>" +
       "<input name='post[tag_ids][]' type='hidden' value='' />"+
       "<input id='post_id' name='post[id]' type='hidden' value='1' />"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_with_namespace_and_with_collection_check_boxes
+    post = Post.new
+    def post.tag_ids; [1]; end
+    collection = [[1, "Tag 1"]]
+
+    form_for(post, namespace: 'foo') do |f|
+      concat f.collection_check_boxes(:tag_ids, collection, :first, :last)
+    end
+
+    expected = whole_form("/posts", "foo_new_post", "new_post") do
+      "<input checked='checked' id='foo_post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1' />" +
+      "<label for='foo_post_tag_ids_1'>Tag 1</label>" +
+      "<input name='post[tag_ids][]' type='hidden' value='' />"
     end
 
     assert_dom_equal expected, output_buffer


### PR DESCRIPTION
originally this issue was opened in Simple Form https://github.com/plataformatec/simple_form/issues/884
