### PR TITLE
Add asset path to asset tag helper

### DIFF
--- a/actionpack/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/asset_tag_helper.rb
@@ -320,6 +320,11 @@ module ActionView
       end
       alias_method :path_to_font, :font_path # aliased to avoid conflicts with an font_path named route
 
+      def asset_path(source)
+        asset_paths.compute_public_path(source, '')
+      end
+      alias_method :path_to_asset, :asset_path # aliased to avoid conflicts with an asset_path named route
+
       # Returns an html image tag for the +source+. The +source+ can be a full
       # path or a file that exists in your public images directory.
       #

--- a/actionpack/test/template/asset_tag_helper_test.rb
+++ b/actionpack/test/template/asset_tag_helper_test.rb
@@ -223,6 +223,24 @@ class AssetTagHelperTest < ActionView::TestCase
     %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="multiple.ogg" /><source src="multiple.avi" /></video>)
   }
 
+ AssetPathToTag = {
+    %(asset_path("xml"))          => %(/assets/xml),
+    %(asset_path("xml.wav"))      => %(/assets/xml.wav),
+    %(asset_path("dir/xml.wav"))  => %(/assets/dir/xml.wav),
+    %(asset_path("/dir/xml.wav")) => %(/dir/xml.wav),
+    %(asset_path("http://www.outside.com/foo.wav")) => %(http://www.outside.com/foo.wav),
+    %(asset_path("HTTP://www.outside.com/foo.wav")) => %(HTTP://www.outside.com/foo.wav)
+  }
+
+  PathToAssetToTag = {
+    %(path_to_asset("xml"))          => %(/assets/xml),
+    %(path_to_asset("xml.wav"))      => %(/assets/xml.wav),
+    %(path_to_asset("dir/xml.wav"))  => %(/assets/dir/xml.wav),
+    %(path_to_asset("/dir/xml.wav")) => %(/dir/xml.wav),
+    %(path_to_asset("http://www.outside.com/foo.wav")) => %(http://www.outside.com/foo.wav),
+    %(path_to_asset("HTTP://www.outside.com/foo.wav")) => %(HTTP://www.outside.com/foo.wav)
+  }
+
  AudioPathToTag = {
     %(audio_path("xml"))          => %(/audios/xml),
     %(audio_path("xml.wav"))      => %(/audios/xml.wav),
@@ -513,6 +531,14 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_audio_tag
     AudioLinkToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_asset_path
+    AssetPathToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_path_to_asset_alias_for_asset_path
+    PathToAssetToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
 
   def test_timebased_asset_id


### PR DESCRIPTION
Two tests are failing:

```
[12/93] AssetTagHelperTest#test_asset_path = 0.00 s
  1) Failure:
test_asset_path(AssetTagHelperTest) [template/asset_tag_helper_test.rb:537]:
<"/assets/xml"> expected to be == to
<"//xml">.

[65/93] AssetTagHelperTest#test_path_to_asset_alias_for_asset_path = 0.00 s
  2) Failure:
test_path_to_asset_alias_for_asset_path(AssetTagHelperTest) [template/asset_tag_helper_test.rb:541]:
<"/assets/xml"> expected to be == to
<"//xml">.
```

These two still have to be fixed in order to merge this. My (long and very possibly wrong) guess is that `ActionView::Helpers::AssetTagHelper::AssetPaths` is not figuring out those paths are actually assets.

I also plan to add tests to other assets, as this is basically a copy and paste from `audio_path` and `path_to_asset` tests.
