### PR TITLE
Trap OpenSSL::Cipher::CipherError for JRuby

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+* For JRuby, trap OpenSSL::Cipher::CipherError that arises from having a
+  weak encyption policy, and rewrite error message to indicate how the
+  user can avoid this error in their applications
+
+  *Hiro Asari*
+
 *   Allow attaching event subscribers to ActiveSupport::Notifications namespaces
     before they're defined. Essentially, this means instead of this:
 

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -77,6 +77,16 @@ module ActiveSupport
       encrypted_data << cipher.final
 
       [encrypted_data, iv].map {|v| ::Base64.strict_encode64(v)}.join("--")
+    rescue OpenSSLCipherError => ce
+      # older versions of JRuby has a typo in error message
+      if defined?(JRUBY_VERSION) &&
+        (ce.message =~ /\Akey length too? short\z|possibly you need to install/)
+        raise OpenSSLCipherError.new(
+          "Unlimited strength crypto unavailable on this JVM. See http://wiki.jruby.org/UnlimitedStrengthCrypto"
+        )
+      else
+        raise ce
+      end
     end
 
     def _decrypt(encrypted_message)


### PR DESCRIPTION
We need to check the error message, since `CipherError` can arise for
different reasons.
The error message checking is unfortunately rather iffy, since older
versions of JRuby had a typo in the error message.
