### PR TITLE
Bump bcrypt-ruby version to support Ruby 2.0 on Windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gemspec
 gem 'mocha', '~> 0.14', require: false
 
 gem 'rack-cache', '~> 1.2'
-gem 'bcrypt-ruby', '~> 3.1.0'
+gem 'bcrypt-ruby', '~> 3.1.2'
 gem 'jquery-rails', '~> 2.2.0'
 gem 'turbolinks'
 gem 'coffee-rails', '~> 4.0.0'

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -20,9 +20,9 @@ module ActiveModel
       # value to the password_confirmation attribute and the validation
       # will not be triggered.
       #
-      # You need to add bcrypt-ruby (~> 3.1.0) to Gemfile to use #has_secure_password:
+      # You need to add bcrypt-ruby (~> 3.1.2) to Gemfile to use #has_secure_password:
       #
-      #   gem 'bcrypt-ruby', '~> 3.1.0'
+      #   gem 'bcrypt-ruby', '~> 3.1.2'
       #
       # Example using Active Record (which automatically includes ActiveModel::SecurePassword):
       #
@@ -46,7 +46,7 @@ module ActiveModel
         # This is to avoid ActiveModel (and by extension the entire framework)
         # being dependent on a binary library.
         begin
-          gem 'bcrypt-ruby', '~> 3.1.0'
+          gem 'bcrypt-ruby', '~> 3.1.2'
           require 'bcrypt'
         rescue LoadError
           $stderr.puts "You don't have bcrypt-ruby installed in your application. Please add it to your Gemfile and run bundle install"

--- a/guides/code/getting_started/Gemfile
+++ b/guides/code/getting_started/Gemfile
@@ -31,7 +31,7 @@ end
 gem 'jbuilder', '~> 1.2'
 
 # To use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.1.0'
+# gem 'bcrypt-ruby', '~> 3.1.2'
 
 # Use unicorn as the app server
 # gem 'unicorn'

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -16,7 +16,7 @@ group :doc do
 end
 
 # Use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.1.0'
+# gem 'bcrypt-ruby', '~> 3.1.2'
 
 # Use unicorn as the app server
 # gem 'unicorn'


### PR DESCRIPTION
bcrypt-ruby version 3.1.0 had a bug that caused it to not work on Windows at all — see https://github.com/codahale/bcrypt-ruby/issues/72

Version 3.1.1 fixed the bug, but limited bcrypt-ruby to only work on Ruby 1.9 on Windows — https://github.com/codahale/bcrypt-ruby/pull/73

Version 3.1.2 (the most current stable version) adds fat-binary support for Rubies 1.8, 1.9, and 2.0 for Windows, and works for 32 and 64 bit Windows — https://github.com/codahale/bcrypt-ruby/pull/78

This just updates to the version that should work on the most platforms.
