### PR TITLE
Use bcrypt cost attr instead of internal constant

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -103,7 +103,7 @@ module ActiveModel
       def password=(unencrypted_password)
         unless unencrypted_password.blank?
           @password = unencrypted_password
-          cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine::DEFAULT_COST
+          cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
           self.password_digest = BCrypt::Password.create(unencrypted_password, cost: cost)
         end
       end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -75,11 +75,11 @@ class SecurePasswordTest < ActiveModel::TestCase
     end
   end
 
-  test "Password digest cost defaults to bcrypt default cost when min_cost is false" do
+  test "Password digest cost defaults to bcrypt cost when min_cost is false" do
     ActiveModel::SecurePassword.min_cost = false
 
     @user.password = "secret"
-    assert_equal BCrypt::Engine::DEFAULT_COST, @user.password_digest.cost
+    assert_equal BCrypt::Engine.cost, @user.password_digest.cost
   end
 
   test "Password digest cost can be set to bcrypt min cost to speed up tests" do


### PR DESCRIPTION
Currently, if you're using bcrypt-ruby in a Rails app, you can't re-set the default cost to match your own business concerns.

The current recommendation is doing something like `BCrypt::Engine::DEFAULT_COST = 12` in your `config/environments/production.rb` to set a higher cost, or a lower value if you want auth requests to be a little snappier (like for an API that requires basic auth with every request).

Re-setting the constant works, but causes a "`warning: already initialized constant DEFAULT_COST`", which makes sense, because, y'know, "constant".

A `BCrypt::Engine.cost` attribute was added to bcrypt-ruby to allow setting the value externally, defaulting internally to `DEFAULT_COST`.

See https://github.com/codahale/bcrypt-ruby/pull/63, https://github.com/codahale/bcrypt-ruby/pull/64, and https://github.com/codahale/bcrypt-ruby/pull/65.

This pull request allows users to use the correct `BCrypt::Engine.cost` attribute in their apps, and the bcrypt-ruby implementation is backwards compatible to still support resetting the constant.
