### PR TITLE
Getting Started Guide: update RubyGems Guides link [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -22,8 +22,8 @@ with Rails. However, to get the most out of it, you need to have some
 prerequisites installed:
 
 * The [Ruby](http://www.ruby-lang.org/en/downloads) language version 1.9.3 or newer
-* The [RubyGems](http://rubygems.org/) packaging system
-    * To learn more about RubyGems, please read the [RubyGems User Guide](http://docs.rubygems.org/read/book/1)
+* The [RubyGems](http://rubygems.org) packaging system
+    * To learn more about RubyGems, please read the [RubyGems Guides](http://guides.rubygems.org)
 * A working installation of the [SQLite3 Database](http://www.sqlite.org)
 
 Rails is a web application framework running on the Ruby programming language.


### PR DESCRIPTION
RubyGems site change, docs are now called RubyGems Guides and hosted on its own subdomain.
