### PR TITLE
Use bcrypt's public cost attr instead of internal constant

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `has_secure_password` to honor bcrypt-ruby's cost attribute.
+
+    *T.J. Schuck*
+
 *   Updated the `ActiveModel::Dirty#changed_attributes` method to be indifferent between using
     symbols and strings as keys.
 

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -103,7 +103,7 @@ module ActiveModel
       def password=(unencrypted_password)
         unless unencrypted_password.blank?
           @password = unencrypted_password
-          cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine::DEFAULT_COST
+          cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
           self.password_digest = BCrypt::Password.create(unencrypted_password, cost: cost)
         end
       end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -82,6 +82,14 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_equal BCrypt::Engine::DEFAULT_COST, @user.password_digest.cost
   end
 
+  test "Password digest cost honors bcrypt cost attribute when min_cost is false" do
+    ActiveModel::SecurePassword.min_cost = false
+    BCrypt::Engine.cost = 5
+
+    @user.password = "secret"
+    assert_equal BCrypt::Engine.cost, @user.password_digest.cost
+  end
+
   test "Password digest cost can be set to bcrypt min cost to speed up tests" do
     ActiveModel::SecurePassword.min_cost = true
 


### PR DESCRIPTION
This is a follow-up to https://github.com/rails/rails/pull/12326, with a test case to show that this is actually a bug.

This _does not_ add an option to Rails, like https://github.com/rails/rails/pull/285 did. This is merely using the new public API of bcrypt-ruby introduced in version 3.1.0 -- [cost should be accessed externally by the `BCrypt::Engine.cost` attribute](https://github.com/codahale/bcrypt-ruby#cost-factors).  It continues to default to the old `DEFAULT_COST` constant internally, but can additionally be set externally if desired.

As it stands now, if a user uses the provided and recommented `cost` accessor from bcrypt-ruby, Rails will ignore it and set it _back_ to `DEFAULT_COST` [here](https://github.com/tjschuck/rails/blob/dd13722c264a84e81ce15a6ec168c84d4db460ca/activemodel/lib/active_model/secure_password.rb#L106).

The new test clarifies this error, and fails without the provided change.

/cc @jeremy
