### PR TITLE
Tag every log line when using TaggedLogging

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Tag every log line when using TaggedLogging instead of only tagging the
+    first one. This allows much easier grepping through log files.
+
+    *Daniel Schierbeck*
+
 *   Disable the ability to iterate over Range of AS::TimeWithZone 
     due to significant performance issues.
 

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -17,7 +17,7 @@ module ActiveSupport
     module Formatter # :nodoc:
       # This method is invoked when a log event occurs.
       def call(severity, timestamp, progname, msg)
-        super(severity, timestamp, progname, "#{tags_text}#{msg}")
+        super(severity, timestamp, progname, add_tags_to_msg(msg))
       end
 
       def tagged(*tags)
@@ -46,7 +46,18 @@ module ActiveSupport
       end
 
       private
-        def tags_text
+        def add_tags_to_msg(msg)
+          tags_text = generate_tags_text
+
+          if tags_text
+            # Replaces all line beginnings with the tags text.
+            msg.split("\n").map {|line| "#{tags_text}#{line}"}.join("\n")
+          else
+            msg
+          end
+        end
+
+        def generate_tags_text
           tags = current_tags
           if tags.any?
             tags.collect { |tag| "[#{tag}] " }.join

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -1,6 +1,7 @@
 require 'abstract_unit'
 require 'active_support/logger'
 require 'active_support/tagged_logging'
+require 'active_support/core_ext/string/strip'
 
 class TaggedLoggingTest < ActiveSupport::TestCase
   class MyLogger < ::ActiveSupport::Logger
@@ -98,5 +99,21 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     end
 
     assert_equal "[BCX] [Jason] Funky time\n[BCX] Junky time!\n", @output.string
+  end
+
+  test "tags each line of the message" do
+    @logger.tagged("BCX") do
+      @logger.info <<-MESSAGE.strip_heredoc
+        An old silent pond...
+        A frog jumps into the pond,
+        splash! Silence again.
+      MESSAGE
+    end
+
+    assert_equal <<-LOG.strip_heredoc, @output.string
+      [BCX] An old silent pond...
+      [BCX] A frog jumps into the pond,
+      [BCX] splash! Silence again.
+    LOG
   end
 end


### PR DESCRIPTION
We're using TaggedLogging to tag log lines with e.g. the customer account on which the request took place. Being able to grep the logs for specific customers, request id's and so forth is incredibly valuable, but also a bit tedious right now. The existing TaggedLogging only tags the first line in a multi-line log entry, so for instance, we will see this in our logs:

```
[Account: something] This is a very important
log line that's very difficult to find.
```

This pull request changes TaggedLogging such that _every_ line in the log entry gets tagged, i.e.

```
[Account: something] This is a very important
[Account: something] log line that's very difficult to find.
```
