### PR TITLE
assign_attributes should return if arguments are blank

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -15,6 +15,7 @@ module ActiveRecord
       if !new_attributes.respond_to?(:stringify_keys)
         raise ArgumentError, "When assigning attributes, you must pass a hash as an argument."
       end
+      return if new_attributes.blank?
 
       attributes                  = new_attributes.stringify_keys
       multi_parameter_attributes  = []


### PR DESCRIPTION
If you are passed an empty hash, then `assign_attributes` doesn't need to do any work and can just return early. This should fix the failing Agile Web Development tests that @rubys mentioned here: https://github.com/rails/rails/pull/9860#issuecomment-25023457.

For example, if `assign_attributes({})` is called, we can just return prematurely because it is obvious that no attributes need to be updated.
