### PR TITLE
Use the given name in html_options for the hidden field in collection_ch...

### DIFF
--- a/actionview/lib/action_view/helpers/tags/collection_check_boxes.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_check_boxes.rb
@@ -27,7 +27,8 @@ module ActionView
 
           # Append a hidden field to make sure something will be sent back to the
           # server if all check boxes are unchecked.
-          hidden = @template_object.hidden_field_tag("#{tag_name}[]", "", :id => nil)
+          hidden_name = @html_options[:name] || "#{tag_name}[]"
+          hidden = @template_object.hidden_field_tag(hidden_name, "", :id => nil)
 
           rendered_collection + hidden
         end

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -179,6 +179,13 @@ class FormCollectionsHelperTest < ActionView::TestCase
     assert_select "input[type=hidden][name='user[category_ids][]'][value=]", :count => 1
   end
 
+  test 'collection check boxes generates a hidden field using the given :name in :html_options' do
+    collection = [Category.new(1, 'Category 1'), Category.new(2, 'Category 2')]
+    with_collection_check_boxes :user, :category_ids, collection, :id, :name, {}, {name: "user[other_category_ids][]"}
+
+    assert_select "input[type=hidden][name='user[other_category_ids][]'][value=]", :count => 1
+  end
+
   test 'collection check boxes accepts a collection and generate a serie of checkboxes with labels for label method' do
     collection = [Category.new(1, 'Category 1'), Category.new(2, 'Category 2')]
     with_collection_check_boxes :user, :category_ids, collection, :id, :name


### PR DESCRIPTION
The collection_check_boxes method ignores the :name from :html_options when generating a hidden field. This pull request will use :name if it exists, and use the default otherwise. Test included.
