### PR TITLE
HTML-escape backtick for IE

### DIFF
--- a/actionview/test/template/erb_util_test.rb
+++ b/actionview/test/template/erb_util_test.rb
@@ -39,13 +39,13 @@ class ErbUtilTest < ActiveSupport::TestCase
 
   def test_rest_in_ascii
     (0..127).to_a.map {|int| int.chr }.each do |chr|
-      next if %('"&<>).include?(chr)
+      next if %('"&<>`).include?(chr)
       assert_equal chr, html_escape(chr)
     end
   end
 
   def test_html_escape_once
-    assert_equal '1 &lt;&gt;&amp;&quot;&#39; 2 &amp; 3', html_escape_once('1 <>&"\' 2 &amp; 3')
+    assert_equal '1 &lt;&gt;&amp;&quot;&#39;&#96; 2 &amp; 3', html_escape_once('1 <>&"\'` 2 &amp; 3')
   end
 
   def test_html_escape_once_returns_unsafe_strings_when_passed_unsafe_strings

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -27,4 +27,8 @@
 
     *Nick Sutterer*
 
+*   Add backtick character to characters to be escaped by `ERB::Util::HTML_ESCAPE`
+
+    *T.J. Schuck*
+
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/kernel/singleton_class'
 
 class ERB
   module Util
-    HTML_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;', '"' => '&quot;', "'" => '&#39;' }
+    HTML_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;', '"' => '&quot;', "'" => '&#39;', "`" => '&#96;' }
     JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003E', '<' => '\u003C' }
     HTML_ESCAPE_ONCE_REGEXP = /["><']|&(?!([a-zA-Z]+|(#\d+));)/
     JSON_ESCAPE_REGEXP = /[&"><]/
@@ -21,7 +21,7 @@ class ERB
       if s.html_safe?
         s
       else
-        s.gsub(/[&"'><]/, HTML_ESCAPE).html_safe
+        s.gsub(/[&"'><`]/, HTML_ESCAPE).html_safe
       end
     end
 


### PR DESCRIPTION
IE supports using the backtick for delimiting attributes.  This pull request adds it to the list of characters to be HTML-escaped.

See also:
- https://news.ycombinator.com/item?id=2525126
- https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet#Grave_accent_obfuscation
- http://html5sec.org/#59
