### PR TITLE
[Documentation] Add a missing validation to I18n docs

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -843,6 +843,7 @@ So, for example, instead of the default error message `"can not be blank"` you c
 | numericality | :equal_to                 | :equal_to                 | count         |
 | numericality | :less_than                | :less_than                | count         |
 | numericality | :less_than_or_equal_to    | :less_than_or_equal_to    | count         |
+| numericality | :only_integer             | :not_an_integer           | -             |
 | numericality | :odd                      | :odd                      | -             |
 | numericality | :even                     | :even                     | -             |
 


### PR DESCRIPTION
The guide was missing a description of the error message interpolation for `validates_numericality_of` with the `:only_integer` option.
