### PR TITLE
Declare block as optional parameter on instrument method to highlight that possibility

### DIFF
--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -154,7 +154,7 @@ module ActiveSupport
         notifier.publish(name, *args)
       end
 
-      def instrument(name, payload = {})
+      def instrument(name, payload = {}, &block)
         if notifier.listening?(name)
           instrumenter.instrument(name, payload) { yield payload if block_given? }
         else


### PR DESCRIPTION
The arguments on the instrument method don't clarify that it is possible to pass a block to it. The previous examples at the ActiveSupport::Notifications class shows it, but the actual method declaration doesn't. I added it for consistency with the other methods.
