### PR TITLE
Closes #12293. Strong parameters should permit nested number as key.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Strong parameters should permit nested number as key.
+
+    Fixes #12293
+
+    *kennyj*
+
 *   Fix regex used to detect URI schemes in `redirect_to` to be consistent with
     RFC 3986.
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -334,13 +334,17 @@ module ActionController
       def each_element(object)
         if object.is_a?(Array)
           object.map { |el| yield el }.compact
-        elsif object.is_a?(Hash) && object.keys.all? { |k| k =~ /\A-?\d+\z/ }
+        elsif fields_for_style?(object)
           hash = object.class.new
           object.each { |k,v| hash[k] = yield v }
           hash
         else
           yield object
         end
+      end
+
+      def fields_for_style?(object)
+        object.is_a?(Hash) && object.all? { |k, v| k =~ /\A-?\d+\z/ && v.is_a?(Hash) }
       end
 
       def unpermitted_parameters!(params)

--- a/actionpack/test/controller/parameters/nested_parameters_test.rb
+++ b/actionpack/test/controller/parameters/nested_parameters_test.rb
@@ -169,4 +169,19 @@ class NestedParametersTest < ActiveSupport::TestCase
 
     assert_filtered_out permitted[:book][:authors_attributes]['-1'], :age_of_death
   end
+
+  test "nested number as key" do
+    params = ActionController::Parameters.new({
+      product: {
+        properties: {
+          '0' => "prop0",
+          '1' => "prop1"
+        }
+      }
+    })
+    params = params.require(:product).permit(:properties => ["0"])
+    assert_not_nil        params[:properties]["0"]
+    assert_nil            params[:properties]["1"]
+    assert_equal "prop0", params[:properties]["0"]
+  end
 end


### PR DESCRIPTION
Closes #12293

Strong parameters should permit nested number as key.
Fields for style presume a value to be hash.
But a value is string depending on the situation,  

It seems that the issue of original reporter is solved.

/cc @guilleiguaran
