### PR TITLE
Correct error in ActiveRecord Querying guide

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1358,7 +1358,7 @@ COMMIT
 
 The new record might not be saved to the database; that depends on whether validations passed or not (just like `create`).
 
-Suppose we want to set the 'locked' attribute to true if we're
+Suppose we want to set the 'locked' attribute to false if we're
 creating a new record, but we don't want to include it in the query. So
 we want to find the client named "Andy", or if that client doesn't
 exist, create a client named "Andy" which is not locked.


### PR DESCRIPTION
In the section for using find_or_create_by, there are two examples which set additional attributes in a newly created record, which are not included in the query for an existing record. One example uses create_with and the other uses a block. In both examples, the 'locked' attribute of the newly-created record is set to false, but the explanation of the documentation stated 'Suppose we want to set the locked attribute to true', which is inconsistent with the examples. This change corrects the explanation to say 'false'.
