### PR TITLE
Make sure inverse_of is visible on the has_many callbacks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,6 +1,10 @@
+*   Callbacks on has_many should access the in memory parent if a inverse_of is set.
+
+    *arthurnn*
+
 *   `ActiveRecord::ConnectionAdapters.string_to_time` respects
     string with timezone (e.g. Wed, 04 Sep 2013 20:30:00 JST).
- 
+
     Fixes: #12278
 
     *kennyj*

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -32,6 +32,7 @@ module ActiveRecord
 
       def insert_record(record, validate = true, raise = false)
         set_owner_attributes(record)
+        set_inverse_instance(record)
 
         if raise
           record.save!(:validate => validate)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -518,6 +518,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_inverse_on_before_validate
+    firm = companies(:first_firm)
+    assert_queries(1) do
+      firm.clients_of_firm << Client.new("name" => "Natural Company")
+    end
+  end
+
   def test_new_aliased_to_build
     company = companies(:first_firm)
     new_client = assert_no_queries { company.clients_of_firm.new("name" => "Another Client") }

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -39,7 +39,7 @@ class Firm < Company
   has_many :unsorted_clients, :class_name => "Client"
   has_many :unsorted_clients_with_symbol, :class_name => :Client
   has_many :clients_sorted_desc, -> { order "id DESC" }, :class_name => "Client"
-  has_many :clients_of_firm, -> { order "id" }, :foreign_key => "client_of", :class_name => "Client"
+  has_many :clients_of_firm, -> { order "id" }, :foreign_key => "client_of", :class_name => "Client", :inverse_of => :firm
   has_many :clients_ordered_by_name, -> { order "name" }, :class_name => "Client"
   has_many :unvalidated_clients_of_firm, :foreign_key => "client_of", :class_name => "Client", :validate => false
   has_many :dependent_clients_of_firm, -> { order "id" }, :foreign_key => "client_of", :class_name => "Client", :dependent => :destroy
@@ -116,6 +116,10 @@ class Client < Company
   belongs_to :bob_firm, -> { where :name => "Bob" }, :class_name => "Firm", :foreign_key => "client_of"
   has_many :accounts, :through => :firm, :source => :accounts
   belongs_to :account
+
+  validate do
+    firm
+  end
 
   class RaisedOnSave < RuntimeError; end
   attr_accessor :raise_on_save


### PR DESCRIPTION
### Problem

When inserting a children object and the children element has a callback that call its parent, even having the `inverse_of`, it does an extra query to populate the parent object.
### Solution

When insert the record, we need to load the inverse instance before calling save, so the callbacks will have access to it.

review @rafaelfranca @carlosantoniodasilva

Also I would :green_heart:  to have that backported to rails 3.2 if possible.
