### PR TITLE
fix delete_or_destroy on association

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -457,7 +457,7 @@ module ActiveRecord
         end
 
         def delete_or_destroy(records, method)
-          records = records.flatten
+          records = records.is_a?(Array) ? records.flatten : [records]
           records.each { |record| raise_on_type_mismatch!(record) }
           existing_records = records.reject { |r| r.new_record? }
 


### PR DESCRIPTION
This fix CI..
### Problem

When having a `inverse_of`, `.find` method in the association will return the actual object if the given id match with the object in memory. In that case the `delete_or_destroy` could receive one record only, and we cannot call `flatten` if one record given.
### Solution

Only call flatten if it is an array.

related to #12359:
As on that PR I added a `inverse_of` for `clients_of_firm`, the destroy stopped working as it had this other bug.

review @rafaelfranca
