### PR TITLE
fix .find when inverse is loaded

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fixed `ActiveRecord::Associations::CollectionAssociation#find`
+    when using `has_many` association with `:inverse_of` and finding an array of one element,
+    it should return an array of one element too.
+
+    *arthurnn*
+
 *   Callbacks on has_many should access the in memory parent if a inverse_of is set.
 
     *arthurnn*

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -80,14 +80,13 @@ module ActiveRecord
           load_target.find(*args) { |*block_args| yield(*block_args) }
         else
           if options[:inverse_of] && loaded?
-            args = args.flatten
-            raise RecordNotFound, "Couldn't find #{scope.klass.name} without an ID" if args.blank?
-
+            args_flatten = args.flatten
+            raise RecordNotFound, "Couldn't find #{scope.klass.name} without an ID" if args_flatten.blank?
             result = find_by_scan(*args)
 
             result_size = Array(result).size
-            if !result || result_size != args.size
-              scope.raise_record_not_found_exception!(args, result_size, args.size)
+            if !result || result_size != args_flatten.size
+              scope.raise_record_not_found_exception!(args_flatten, result_size, args_flatten.size)
             else
               result
             end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -337,6 +337,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::RecordNotFound) { firm.clients.find(2, 99) }
   end
 
+  def test_find_ids_and_inverse_of
+    force_signal37_to_load_all_clients_of_firm
+
+    firm = companies(:first_firm)
+    client = firm.clients_of_firm.find(3)
+    assert_kind_of Client, client
+
+    client_ary = firm.clients_of_firm.find([3])
+    assert_kind_of Array, client_ary
+    assert_equal client, client_ary.first
+  end
+
   def test_find_all
     firm = Firm.all.merge!(:order => "id").first
     assert_equal 2, firm.clients.where("#{QUOTED_TYPE} = 'Client'").to_a.length


### PR DESCRIPTION
### Goal

`.find([1])` should return an Array of entries, even when a invese object is in memory already.
### Problem

`.find` was not returning an Array when, inverse object was in memory, and calling `find([1])` passing only one element.
### Solution

Dont call `.flatten` on args before passing to `find_by_scan` method, otherwise `expects_array` var will always be false.

[related #12359] => CI is red in there because we added a `:inverse_of` on `Firm.clients_of_firm`. which revealed this issue.

review @rafaelfranca 
