### PR TITLE
Fix query counters when testing with IdentityMap on 3.2

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -656,7 +656,9 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_inverse_on_before_validate
     firm = companies(:first_firm)
     assert_queries(1) do
-      firm.clients_of_firm << Client.new("name" => "Natural Company")
+      client = Client.new("name" => "Natural Company")
+      client.touch_firm_on_validate = true
+      firm.clients_of_firm << client
     end
   end
 

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -126,8 +126,9 @@ class Client < Company
   has_many :accounts, :through => :firm
   belongs_to :account
 
+  attr_accessor :touch_firm_on_validate
   validate do
-    firm
+    firm if touch_firm_on_validate
   end
 
   class RaisedOnSave < RuntimeError; end


### PR DESCRIPTION
### Problem

When counting the number of queries(e.g. IdentityMap), we cannot touch `firm` when saving a `Client`
### Solution

Add a instance var, which if set to true would touch the parent.

review @rafaelfranca
If you wanna to cherry-pick this to master is ok too.
