### PR TITLE
Move Rack::Cache after ActionDispatch::Static in the middleware stack

### DIFF
--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -11,11 +11,6 @@ module Rails
 
       def build_stack
         ActionDispatch::MiddlewareStack.new.tap do |middleware|
-          if rack_cache = load_rack_cache
-            require "action_dispatch/http/rack_cache"
-            middleware.use ::Rack::Cache, rack_cache
-          end
-
           if config.force_ssl
             middleware.use ::ActionDispatch::SSL, config.ssl_options
           end
@@ -24,6 +19,11 @@ module Rails
 
           if config.serve_static_assets
             middleware.use ::ActionDispatch::Static, paths["public"].first, config.static_cache_control
+          end
+
+          if rack_cache = load_rack_cache
+            require "action_dispatch/http/rack_cache"
+            middleware.use ::Rack::Cache, rack_cache
           end
 
           middleware.use ::Rack::Lock unless allow_concurrency?

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -61,7 +61,7 @@ module ApplicationTests
 
       boot!
 
-      assert_equal "Rack::Cache", middleware.first
+      assert middleware.include?("Rack::Cache")
     end
 
     test "ActiveRecord::Migration::CheckPending is present when active_record.migration_error is set to :page_load" do


### PR DESCRIPTION
I'd like to propose that Rack::Cache should come later in the middleware stack, after the Static requests are handled. Currently, it is at the beginning.

My reasoning is that Rack::Cache often requires a roundtrip to memcache, which will generally be slower than a trip to disk performed by ActionDispatch::Static.

Also, If Rack::Cache is configured to use the local disk instead of memcache, we ideally want it downstream of Rack::Sendfile.

This change will put Rack::Cache after the following middleware components:

```
ActionDispatch::SSL
Rack::Sendfile
ActionDispatch::Static
```

I can't think of any reason why the output of these middleware components should be cached. LMK if I missed something. Thanks!
