### PR TITLE
[ci skip] escape unintended url in docs

### DIFF
--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -73,7 +73,7 @@ module ActionController
   #   <input type="text" name="post[address]" value="hyacintvej">
   #
   # A request stemming from a form holding these inputs will include <tt>{ "post" => { "name" => "david", "address" => "hyacintvej" } }</tt>.
-  # If the address input had been named "post[address][street]", the params would have included
+  # If the address input had been named \"post[address][street]", the params would have included
   # <tt>{ "post" => { "address" => { "street" => "hyacintvej" } } }</tt>. There's no limit to the depth of the nesting.
   #
   # == Sessions


### PR DESCRIPTION
In the docs for ActionController::Base , what was intended to be post[address][street] was turning into post[street] where post was a hyperlink whose url was 'address'. I escaped the whole thing so rdoc will not parse it as a url.
