### PR TITLE
Adds template dependencies rake task from cache_digests gem.

### DIFF
--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -48,5 +48,9 @@ module ActionView
         ActionMailer::Base.send(:include, ActionView::Layouts)
       end
     end
+
+    rake_tasks do
+      load "action_view/tasks/dependencies.rake"
+    end
   end
 end

--- a/actionview/lib/action_view/tasks/dependencies.rake
+++ b/actionview/lib/action_view/tasks/dependencies.rake
@@ -1,0 +1,17 @@
+namespace :cache_digests do
+  desc 'Lookup nested dependencies for TEMPLATE (like messages/show or comments/_comment.html)'
+  task :nested_dependencies => :environment do
+    abort 'You must provide TEMPLATE for the task to run' unless ENV['TEMPLATE'].present?
+    template, format = ENV['TEMPLATE'].split(".")
+    format ||= :html
+    puts JSON.pretty_generate ActionView::Digestor.new(template, format, ApplicationController.new.lookup_context).nested_dependencies
+  end
+
+  desc 'Lookup first-level dependencies for TEMPLATE (like messages/show or comments/_comment.html)'
+  task :dependencies => :environment do
+    abort 'You must provide TEMPLATE for the task to run' unless ENV['TEMPLATE'].present?
+    template, format = ENV['TEMPLATE'].split(".")
+    format ||= :html
+    puts JSON.pretty_generate ActionView::Digestor.new(template, format, ApplicationController.new.lookup_context).dependencies
+  end
+end


### PR DESCRIPTION
This adds the rake tasks `cache_digests:dependencies` and `cache_digests:nested_dependencies` from `cache_digests` gem.

Like proposed in rails/cache_digests/issues/58
