### PR TITLE
Hotfix/send file live issue

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -160,7 +160,7 @@ module ActionController
 
     def response_body=(body)
       super
-      response.stream.close if response
+      response.close if response
     end
 
     def set_response!(request)


### PR DESCRIPTION
This addresses issue #12381

ActionController::Live::response_body= method calls

```
response.stream.close
```

without actually checking for the stream instance to implement close method.
This is an issue when using send_file which sets a FileBody instance as response_body and doesn't have a close method.

Calling response.close fixes the issue because the base implementation (ActionDispatch::Response) actually closes the stream checking via respond_to(:close) and so avoiding any NoMethodError exception.
