### PR TITLE
Getting Started Guide: Fix code container in Chapter 5.2 [ci-skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -522,6 +522,7 @@ Edit the `form_for` line inside `app/views/posts/new.html.erb` to look like this
 In this example, the `posts_path` helper is passed to the `:url` option.
 To see what Rails will do with this, we look back at the output of
 `rake routes`:
+
 ```bash
 $ rake routes
    Prefix Verb   URI Pattern               Controller#Action
@@ -535,6 +536,7 @@ edit_post GET    /posts/:id/edit(.:format) posts#edit
           DELETE /posts/:id(.:format)      posts#destroy
      root        /                         welcome#index
 ```
+
 The `posts_path` helper tells Rails to point the form
 to the URI Pattern associated with the `posts` prefix; and
 the form will (by default) send a `POST` request


### PR DESCRIPTION
Generated HTML is not wrapping bash content in a code_container class, due to missing line breaks.

![getting started guide - chapter 5 2 screen shot 2013-09-28 at 1 41 47 am](https://f.cloud.github.com/assets/360276/1227138/6c4764f4-278c-11e3-9f90-fd1c055d38c3.png)
