### PR TITLE
Renamed generated_feature_methods to generated_association_methods.

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -83,7 +83,7 @@ module ActiveRecord::Associations::Builder
     # Post.first.comments and Post.first.comments= methods are defined by this method...
 
     def define_accessors(model)
-      mixin = model.generated_feature_methods
+      mixin = model.generated_association_methods
       define_readers(mixin)
       define_writers(mixin)
     end

--- a/activerecord/lib/active_record/associations/builder/singular_association.rb
+++ b/activerecord/lib/active_record/associations/builder/singular_association.rb
@@ -12,7 +12,7 @@ module ActiveRecord::Associations::Builder
 
     def define_accessors(model)
       super
-      define_constructors(model.generated_feature_methods) if constructable?
+      define_constructors(model.generated_association_methods) if constructable?
     end
 
     # Defines the (build|create)_association methods for belongs_to or has_one association

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -91,12 +91,12 @@ module ActiveRecord
       def initialize_generated_modules
         super
 
-        generated_feature_methods
+        generated_association_methods
       end
 
-      def generated_feature_methods
-        @generated_feature_methods ||= begin
-          mod = const_set(:GeneratedFeatureMethods, Module.new)
+      def generated_association_methods
+        @generated_association_methods ||= begin
+          mod = const_set(:GeneratedAssociationMethods, Module.new)
           include mod
           mod
         end

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -335,7 +335,7 @@ module ActiveRecord
       # the helper methods defined below. Makes it seem like the nested
       # associations are just regular associations.
       def generate_association_writer(association_name, type)
-        generated_feature_methods.module_eval <<-eoruby, __FILE__, __LINE__ + 1
+        generated_association_methods.module_eval <<-eoruby, __FILE__, __LINE__ + 1
           if method_defined?(:#{association_name}_attributes=)
             remove_method(:#{association_name}_attributes=)
           end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -86,11 +86,11 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_generated_methods_modules
     modules = Computer.ancestors
-    assert modules.include?(Computer::GeneratedFeatureMethods)
-    assert_equal(Computer::GeneratedFeatureMethods, Computer.generated_feature_methods)
-    assert(modules.index(Computer.generated_attribute_methods) > modules.index(Computer.generated_feature_methods),
-           "generated_attribute_methods must be higher in inheritance hierarchy than generated_feature_methods")
-    assert_not_equal Computer.generated_feature_methods, Post.generated_feature_methods
+    assert modules.include?(Computer::GeneratedAssociationMethods)
+    assert_equal(Computer::GeneratedAssociationMethods, Computer.generated_association_methods)
+    assert(modules.index(Computer.generated_attribute_methods) > modules.index(Computer.generated_association_methods),
+           "generated_attribute_methods must be higher in inheritance hierarchy than generated_association_methods")
+    assert_not_equal Computer.generated_association_methods, Post.generated_association_methods
     assert(modules.index(Computer.generated_attribute_methods) < modules.index(ActiveRecord::Base.ancestors[1]))
   end
 


### PR DESCRIPTION
In the regional ruby community, we read rails sources.

From the experience of that time, I think the name of `generated_feature_methods` method is not clearly.
So I renamed it to `generated_association_methods`.

I'm not good at English. If this is clearly enough already, please close this PR.
