### PR TITLE
Migrations Guide: Fix line length [ci skip]

### DIFF
--- a/guides/source/migrations.md
+++ b/guides/source/migrations.md
@@ -1040,8 +1040,8 @@ this, then you should set the schema format to `:sql`.
 Instead of using Active Record's schema dumper, the database's structure will
 be dumped using a tool specific to the database (via the `db:structure:dump`
 Rake task) into `db/structure.sql`. For example, for PostgreSQL, the `pg_dump`
-utility is used. For MySQL, this file will contain the output of `SHOW CREATE
-TABLE` for the various tables.
+utility is used. For MySQL, this file will contain the output of
+`SHOW CREATE TABLE` for the various tables.
 
 Loading these schemas is simply a question of executing the SQL statements they
 contain. By definition, this will create a perfect copy of the database's


### PR DESCRIPTION
Inline code in Chapter 7.2 is extending to 2 lines.

![migrations-guide-screen-shot-2013-09-28-at-3 53 16-am](https://f.cloud.github.com/assets/360276/1230751/fb4b0b3a-2802-11e3-991d-9cf073f7dc44.png)
