### PR TITLE
Serialize postgres arrays, hstore and json values correctly in AR update methods. Fixes #12261

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fixed `update_column`, `update_columns`, and `update_all` to correctly serialize
+    values for array, hstore and json column types in postgres.
+
+    Fixes #12261
+
+    *Tadas Tamosauskas*
+
 *   Fixed `ActiveRecord::Associations::CollectionAssociation#find`
     when using `has_many` association with `:inverse_of` and finding an array of one element,
     it should return an array of one element too.

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -113,6 +113,12 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert_equal(PgArray.last.tags, tag_values)
   end
 
+  def test_update_all
+    PgArray.create! tags: ["one", "two", "three"]
+    PgArray.update_all tags: ["four", "five"]
+    assert_equal ["four", "five"], PgArray.first.tags
+  end
+
   private
   def assert_cycle field, array
     # test creation

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -190,6 +190,12 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     assert_cycle("a\nb" => "c\nd")
   end
 
+  def test_update_all
+    Hstore.create! tags: { "one" => "two" }
+    Hstore.update_all tags: { "three" => "four" }
+    assert_equal({ "three" => "four" }, Hstore.first.tags)
+  end
+
   private
   def assert_cycle hash
     # test creation

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -96,4 +96,10 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
     x.payload = ['v1', {'k2' => 'v2'}, 'v3']
     assert x.save!
   end
+
+  def test_update_all
+    JsonDataType.create! payload: { "one" => "two" }
+    JsonDataType.update_all payload: { "three" => "four" }
+    assert_equal({ "three" => "four" }, JsonDataType.first.payload)
+  end
 end


### PR DESCRIPTION
Closes #12261

As described in #12261 the column information was not being passed in for sanitization methods, therefore db-adaptor-specific quoting could not trigger resulting in an exception => https://gist.github.com/senny/6725398. 

The bug applies to `update_column`, `update_columns` and `update_all` methods on columns of type `array`, `hstore` and `json`(maybe even more).

The suggested version of `quote_bound_value` now explicitly checks for array, hstore and json type columns, which is not flexible nor elegant, so it might need some refactoring, suggestions welcome.

@senny thanks for your help!
