### PR TITLE
Cleanup identitymap logger from LogSubscriber

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
     def initialize
       super
-      @odd_or_even = false
+      @odd = false
     end
 
     def render_bind(column, value)
@@ -60,17 +60,8 @@ module ActiveRecord
       debug "  #{name}  #{sql}#{binds}"
     end
 
-    def identity(event)
-      return unless logger.debug?
-
-      name = color(event.payload[:name], odd? ? CYAN : MAGENTA, true)
-      line = odd? ? color(event.payload[:line], nil, true) : event.payload[:line]
-
-      debug "  #{name}  #{line}"
-    end
-
     def odd?
-      @odd_or_even = !@odd_or_even
+      @odd = !@odd
     end
 
     def logger


### PR DESCRIPTION
Removing old `identity` method that was responsible for logging identity map operations.
Also renaming the `odd_or_even` ivar to `odd`.

review @carlosantoniodasilva @rafaelfranca 
