### PR TITLE
Fixes incorrect spelling of `action_on_unpermitted_parameters` in guide

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -309,7 +309,7 @@ The schema dumper adds one additional configuration option:
 
 * `config.action_controller.permit_all_parameters` sets all the parameters for mass assignment to be permitted by default. The default value is `false`.
 
-* `config.action_controller.action_on_unpermitted_params` enables logging or raising an exception if parameters that are not explicitly permitted are found. Set to `:log` or `:raise` to enable. The default value is `:log` in development and test environments, and `false` in all other environments.
+* `config.action_controller.action_on_unpermitted_parameters` enables logging or raising an exception if parameters that are not explicitly permitted are found. Set to `:log` or `:raise` to enable. The default value is `:log` in development and test environments, and `false` in all other environments.
 
 ### Configuring Action Dispatch
 


### PR DESCRIPTION
See [actionpack/test/controller/parameters/raise_on_unpermitted_params_test.rb](https://github.com/rails/rails/blob/master/actionpack/test/controller/parameters/raise_on_unpermitted_params_test.rb)
