### PR TITLE
Extract `.next_migration_number` into module for third party generators.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make `next_migration_number` accessible for third party generators.
+
+    *Yves Senn*
+
 *   Objects intiantiated using a null relationship will now retain the
     attributes of the where clause.
 

--- a/activerecord/lib/rails/generators/active_record.rb
+++ b/activerecord/lib/rails/generators/active_record.rb
@@ -1,22 +1,16 @@
 require 'rails/generators/named_base'
-require 'rails/generators/migration'
 require 'rails/generators/active_model'
+require 'rails/generators/active_record/migration'
 require 'active_record'
 
 module ActiveRecord
   module Generators # :nodoc:
     class Base < Rails::Generators::NamedBase # :nodoc:
-      include Rails::Generators::Migration
+      include ActiveRecord::Generators::Migration
 
       # Set the current directory as base for the inherited generators.
       def self.base_root
         File.dirname(__FILE__)
-      end
-
-      # Implement the required interface for Rails::Generators::Migration.
-      def self.next_migration_number(dirname)
-        next_migration_number = current_migration_number(dirname) + 1
-        ActiveRecord::Migration.next_migration_number(next_migration_number)
       end
     end
   end

--- a/activerecord/lib/rails/generators/active_record/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration.rb
@@ -1,0 +1,18 @@
+require 'rails/generators/migration'
+
+module ActiveRecord
+  module Generators # :nodoc:
+    module Migration
+      extend ActiveSupport::Concern
+      include Rails::Generators::Migration
+
+      module ClassMethods
+        # Implement the required interface for Rails::Generators::Migration.
+        def next_migration_number(dirname)
+          next_migration_number = current_migration_number(dirname) + 1
+          ActiveRecord::Migration.next_migration_number(next_migration_number)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Many third party generators, who need to generate migrations copy the `.next_migration_number` method. This is necessary because most of the time you can't extend `ActiveRecord::Generators::Base` because it's superclass is `Rails::Generators::NamedBase`. Some examples:
- [queue classic](https://github.com/ryandotsmith/queue_classic/blob/master/lib/generators/queue_classic/install_generator.rb#L14-L17)
- [paper trail](https://github.com/airblade/paper_trail/blob/master/lib/generators/paper_trail/install_generator.rb#L19-L21)
- [acts as taggable](https://github.com/mbleigh/acts-as-taggable-on/blob/master/lib/generators/acts_as_taggable_on/migration/migration_generator.rb#L22-L30)

This copying has the negative effect that over time every implementation will be slightly different and falls out of sync.

This PR bundles the necessary functionality for Active Record Migration generators inside a new module `ActiveRecord::Generators::Migration`. This module gets `migration_template` working without any further configuration.
