### PR TITLE
Remove block argument when not used on the method body to avoid performance penalties with its conversion to a proc

### DIFF
--- a/actionpack/test/controller/new_base/middleware_test.rb
+++ b/actionpack/test/controller/new_base/middleware_test.rb
@@ -28,7 +28,7 @@ module MiddlewareTest
 
   class BlockMiddleware
     attr_accessor :configurable_message
-    def initialize(app, &block)
+    def initialize(app)
       @app = app
       yield(self) if block_given?
     end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -783,7 +783,7 @@ module ActiveRecord
         self.new(:up, migrations, target_version).migrate
       end
 
-      def down(migrations_paths, target_version = nil, &block)
+      def down(migrations_paths, target_version = nil)
         migrations = migrations(migrations_paths)
         migrations.select! { |m| yield m } if block_given?
 

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -166,7 +166,7 @@ module ActiveSupport
         notifier.subscribe(*args, &block)
       end
 
-      def subscribed(callback, *args, &block)
+      def subscribed(callback, *args)
         subscriber = subscribe(*args, &callback)
         yield
       ensure


### PR DESCRIPTION
With this closed pull request:

https://github.com/rails/rails/pull/12353

I learned that using &block as an explicit argument to a method is slow. It seems to be related to the conversion of the block to a proc object on every call. I did some benchmarks with different ruby interpreters, one of them using a mandatory proc object as an argument to use it with "call" instead of "yield", and the results point out that the conversion can make the method invocation up to x4 slower consistently on the different ruby interpreters:

https://gist.github.com/carlosparamio/6760567

So took the opportunity to take a look at the different Rails gems, and removed all the cases I found that still were declaring the block as an argument, to scratch those few milliseconds on their invocations.
