### PR TITLE
Allow Pathname for require dependency

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -198,9 +198,11 @@ module ActiveSupport #:nodoc:
         Dependencies.require_or_load(file_name)
       end
 
+      # Files required this way can be reloaded in development mode
       def require_dependency(file_name, message = "No such file to load -- %s")
+        file_name = file_name.to_path if file_name.respond_to?(:to_path)
         unless file_name.is_a?(String)
-          raise ArgumentError, "the file name must be a String -- you passed #{file_name.inspect}"
+          raise ArgumentError, "the file name must either be a String or implement #to_path -- you passed #{file_name.inspect}"
         end
 
         Dependencies.depend_on(file_name, message)

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -35,6 +35,17 @@ class DependenciesTest < ActiveSupport::TestCase
     assert_equal expected.path, e.path
   end
 
+  def test_require_dependency_accepts_an_object_which_implements_to_path
+    o = Object.new
+    def o.to_path; 'dependencies/service_one'; end
+    assert_nothing_raised {
+      require_dependency o
+    }
+    assert defined?(ServiceOne)
+  ensure
+    remove_constants(:ServiceOne)
+  end
+
   def test_tracking_loaded_files
     require_dependency 'dependencies/service_one'
     require_dependency 'dependencies/service_two'


### PR DESCRIPTION
For background see #12411 and [rubyonrails-core discussion](https://groups.google.com/d/msg/rubyonrails-core/ESAONvNYZL4/2nArYViw8JQJ)

Example use case

``` ruby
require_dependency Rails.root.join('lib','null_logger')
# raises exception
# ArgumentError: the file name must be a String -- you passed #<Pathname:/path/to/app/lib/null_logger>
```

I would argue `require_dependency` should also accept a pathname, just like `require` does.

I think that `require_dependency Rails.root.join('lib','null_logger').to_s` is a workaround proves this point

[underlying Rails code](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/dependencies.rb#L201)

``` ruby
      def require_dependency(file_name, message = "No such file to load -- %s")
        unless file_name.is_a?(String)
          raise ArgumentError, "the file name must be a String -- you passed #{file_name.inspect}"
        end

        Dependencies.depend_on(file_name, message)
      end
```
