### PR TITLE
Inverse of on build

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## unreleased ##
+*   Move .set_inverse_instance call to association.build_record method. Everytime a new record is build
+    using the association, we need to try to set the inverse_of relation.
+
+    Fixes #10371.
+
+    *arthurnn*
 
 *   When calling the method .find_or_initialize_by_* from a collection_proxy
     it should set the inverse_of relation even when the entry was found on the db.

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -240,6 +240,7 @@ module ActiveRecord
             skip_assign = [reflection.foreign_key, reflection.type].compact
             attributes = create_scope.except(*(record.changed - skip_assign))
             record.assign_attributes(attributes, :without_protection => true)
+            set_inverse_instance(record)
           end
         end
     end

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -350,7 +350,6 @@ module ActiveRecord
         end
 
         callback(:after_add, record)
-        set_inverse_instance(record)
 
         record
       end

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -125,8 +125,10 @@ class InverseHasOneTests < ActiveRecord::TestCase
   end
 
   def test_parent_instance_should_be_shared_with_newly_created_child
-    m = Man.find(:first)
+    m = Man.create
     f = m.create_face(:description => 'haunted')
+
+    assert_equal m.object_id, f.man.object_id
     assert_not_nil f.man
     assert_equal m.name, f.man.name, "Name of man should be the same before changes to parent instance"
     m.name = 'Bongo'


### PR DESCRIPTION
### Problem

When building a new relations(any type of relation) we need to setup the inverse_of association.
See https://github.com/rails/rails/issues/10371
### Solution

Call `.set_inverse_instance` on the association parent. Also remove `set_inverse_instance` from `add_to_target` on collection, as we build it before, and we dont need that extra call.

review @rafaelfranca @robin850
