### PR TITLE
guides: configuring: fixing explanation of :after_initialize hook

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -610,7 +610,7 @@ Rails has 5 initialization events which can be hooked into (listed in the order 
 
 * `before_eager_load`: This is run directly before eager loading occurs, which is the default behavior for the `production` environment and not for the `development` environment.
 
-* `after_initialize`: Run directly after the initialization of the application, but before the application initializers are run.
+* `after_initialize`: Run directly after the initialization of the application, after the application initializers in `config/initializers` are run.
 
 To define an event for these hooks, use the block syntax within a `Rails::Application`, `Rails::Railtie` or `Rails::Engine` subclass:
 


### PR DESCRIPTION
:after_initialize runs after config/initializers, not before.

Under 3.1, the document says

> `config.after_initialize` takes a block which will be run after Rails has finished initializing the application. That includes the initialization of the framework itself, engines, and all the application's initializers in config/initializers.

Under 6, the document says:

> `after_initialize`: Run directly after the initialization of the application, but before the application initializers are run.

This is wrong, as its name suggests, `after_initialize` is run _after_ the initializers in `config/initializers` have run. I also did a quick test with Rails 4.0.0:

```
cd /tmp/
rails new test_initialization_hooks
```

Hook into `:after_initialize`:

```
# config/application.rb
module TestInitializationHooks
  class Application < Rails::Application
    config.after_initialize do
      Rails.logger.info "This is the :after_initialize hook."
    end
  end
end
```

Create an initializer on `config/initializers`:

```
# config/initializers/test_initialization_hooks.rb
Rails.logger.info 'This is config/initializers/test_initialization_hooks.rb'
```

Then, after testing to start the application in both development and production with `RAILS_ENV=development rails s` and `RAILS_ENV=production rails s`, the log files show:

```
/tmp/test_initialization_hooks$ tail log/development.log 
This is config/initializers/test_initialization_hooks.rb
This is the :after_initialize hook.
```

And likewise:

```
/tmp/test_initialization_hooks$ tail log/production.log 
I, [2013-10-01T13:27:22.657053 #8578]  INFO -- : This is config/initializers/test_initialization_hooks.rb
I, [2013-10-01T13:27:23.129267 #8578]  INFO -- : This is the :after_initialize hook.
```

The `:after_initialize` hooks runs after the initializers found in `config/initializers`, not before.
