### PR TITLE
Fix scope application on model creation with default_scope class method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   `scope_attributes?` is now based on ``scope_attributes.any?`` and therefore
+     does not ignore attributes defined in class method.
+
+    Example:
+
+        class Developer < ActiveRecord::Base
+          def self.default_scope
+            where(:name => 'Adrien')
+          end
+        end
+        Developer.new.name => 'Adrien' # Used to be nil
+
+
+    *Adrien Siami*
+
 *   Fixed a problem where count used with a grouping was not returning a Hash.
 
     Fixes #14721.

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -41,7 +41,7 @@ module ActiveRecord
 
         # Are there default attributes associated with this scope?
         def scope_attributes? # :nodoc:
-          current_scope || default_scopes.any?
+          scope_attributes.any?
         end
 
         # Adds a class method for retrieving and querying objects. A \scope

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -65,6 +65,11 @@ class DefaultScopingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_default_scope_with_conditions_hash_as_class_method
+    assert_equal Developer.where(name: 'David').map(&:id).sort, ClassMethodDeveloperCalledDavid.all.map(&:id).sort
+    assert_equal 'David', ClassMethodDeveloperCalledDavid.create!.name
+  end
+
   def test_default_scope_with_inheritance
     wheres = InheritedPoorDeveloperCalledJamis.all.where_values_hash
     assert_equal "Jamis", wheres['name']


### PR DESCRIPTION
The doc states that the developer can define its own `default_scope` method.

However, when doing that, the scope attributes aren't applied on a model creation.

Example :

``` ruby
class DeveloperClassMethod < ActiveRecord::Base
  def self.default_scope
    where(:name => 'Adrien')
  end
end

class Developer < ActiveRecord::Base
  default_scope { where(:name => 'Adrien') }
end

Developer.new.name # => 'Adrien'
DeveloperClassMethod.new.name # => nil
```

This is due to the `scope_attributes?` method that only looks in the `default_scopes` array and does not call the `default_scope` class method if defined

I've replaced its content by `scope_attributes.any?`, I think it's more clear this way and it does what the name of the method suggests.

I've also added a test to assess this issue.

Please let me know if what do you think of this.

Cheers,

Adrien.
