### PR TITLE
Gather all AbstractController exceptions in errors.rb

### DIFF
--- a/actionpack/lib/abstract_controller.rb
+++ b/actionpack/lib/abstract_controller.rb
@@ -11,6 +11,7 @@ module AbstractController
   autoload :Callbacks
   autoload :Collector
   autoload :DoubleRenderError, "abstract_controller/rendering"
+  autoload :Errors
   autoload :Helpers
   autoload :Logger
   autoload :Rendering

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -5,12 +5,6 @@ require 'active_support/descendants_tracker'
 require 'active_support/core_ext/module/anonymous'
 
 module AbstractController
-  class Error < StandardError #:nodoc:
-  end
-
-  class ActionNotFound < StandardError #:nodoc:
-  end
-
   # <tt>AbstractController::Base</tt> is a low-level API. Nobody should be
   # using it directly, and subclasses (like ActionController::Base) are
   # expected to provide their own +render+ method, since rendering means

--- a/actionpack/lib/abstract_controller/errors.rb
+++ b/actionpack/lib/abstract_controller/errors.rb
@@ -1,0 +1,15 @@
+module AbstractController
+  class AbstractControllerError < StandardError #:nodoc:
+  end
+
+  class ActionNotFound < AbstractControllerError #:nodoc:
+  end
+
+  class DoubleRenderError < AbstractControllerError #:nondoc:
+    DEFAULT_MESSAGE = "Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like \"redirect_to(...) and return\"."
+
+    def initialize(message = nil)
+      super(message || DEFAULT_MESSAGE)
+    end
+  end
+end

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -2,14 +2,6 @@ require 'active_support/concern'
 require 'active_support/core_ext/class/attribute'
 
 module AbstractController
-  class DoubleRenderError < Error
-    DEFAULT_MESSAGE = "Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like \"redirect_to(...) and return\"."
-
-    def initialize(message = nil)
-      super(message || DEFAULT_MESSAGE)
-    end
-  end
-
   module Rendering
     extend ActiveSupport::Concern
 

--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -1,3 +1,5 @@
+require 'abstract_controller/errors'
+
 module ActionController
   module ImplicitRender
     def send_action(method, *args)

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -1,5 +1,5 @@
 module ActionController
-  class RedirectBackError < AbstractController::Error #:nodoc:
+  class RedirectBackError < AbstractController::AbstractControllerError #:nodoc:
     DEFAULT_MESSAGE = 'No HTTP_REFERER was set in the request to this action, so redirect_to :back could not be called successfully. If this is a test, make sure to specify request.env["HTTP_REFERER"].'
 
     def initialize(message = nil)

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -1,3 +1,5 @@
+require 'abstract_controller/errors'
+
 module ActionController
   module Rendering
     extend ActiveSupport::Concern


### PR DESCRIPTION
It feels cleaner for me to have it grouped in one place. Also in other parts of framework we're using this pattern.

I don't have strong opinion on this though. What do you think?
