### PR TITLE
Fix a typo in the code of Testing guide.

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -534,7 +534,7 @@ instance variable:
 
 ```ruby
 # setting a HTTP Header
-@request.headers["Accepts"] = "text/plain, text/html"
+@request.headers["Accept"] = "text/plain, text/html"
 get :index # simulate the request with custom header
 
 # setting a CGI variable


### PR DESCRIPTION
Hi,

I've replaced the word «Accepts» by «Accept» in the example of custom request headers.

The field «Accepts» doesn't exist in the [headers of HTTP 1.1](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1). The correct value is «Accept».

The current [code](http://guides.rubyonrails.org/testing.html#setting-headers-and-cgi-variables) is:

``` ruby
# setting a HTTP Header
@request.headers["Accepts"] = "text/plain, text/html"
get :index # simulate the request with custom header
```

and must be:

``` ruby
# setting a HTTP Header
@request.headers["Accept"] = "text/plain, text/html"
get :index # simulate the request with custom header
```

Thanks.
