### PR TITLE
Remove type from remove_column example

### DIFF
--- a/guides/source/migrations.md
+++ b/guides/source/migrations.md
@@ -179,7 +179,7 @@ generates
 ```ruby
 class RemovePartNumberFromProducts < ActiveRecord::Migration
   def change
-    remove_column :products, :part_number, :string
+    remove_column :products, :part_number
   end
 end
 ```


### PR DESCRIPTION
I want to remove the type in the example to remove a column because it leads to confusion.
