### PR TITLE
Fixed typo in documentation

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -225,13 +225,13 @@ module ActionView
       # ==== Examples
       #
       #   image_alt('rails.png')
-      #   # => <img alt="Rails" src="/assets/rails.png" />
+      #   # => Rails
       #
       #   image_alt('hyphenated-file-name.png')
-      #   # => <img alt="Hyphenated file name" src="/assets/hyphenated-file-name.png" />
+      #   # => Hyphenated file name
       #
       #   image_alt('underscored_file_name.png')
-      #   # => <img alt="Underscored file name" src="/assets/underscored_file_name.png" />
+      #   # => Underscored file name
       def image_alt(src)
         File.basename(src, '.*').sub(/-[[:xdigit:]]{32}\z/, '').tr('-_', ' ').capitalize
       end

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -224,13 +224,13 @@ module ActionView
       #
       # ==== Examples
       #
-      #   image_tag('rails.png')
+      #   image_alt('rails.png')
       #   # => <img alt="Rails" src="/assets/rails.png" />
       #
-      #   image_tag('hyphenated-file-name.png')
+      #   image_alt('hyphenated-file-name.png')
       #   # => <img alt="Hyphenated file name" src="/assets/hyphenated-file-name.png" />
       #
-      #   image_tag('underscored_file_name.png')
+      #   image_alt('underscored_file_name.png')
       #   # => <img alt="Underscored file name" src="/assets/underscored_file_name.png" />
       def image_alt(src)
         File.basename(src, '.*').sub(/-[[:xdigit:]]{32}\z/, '').tr('-_', ' ').capitalize


### PR DESCRIPTION
The documentation for `image_alt()` showed examples using "image_tag()"
