### PR TITLE
Add inverse of add target

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -350,6 +350,7 @@ module ActiveRecord
         end
 
         callback(:after_add, record)
+        set_inverse_instance(record)
 
         record
       end

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -290,6 +290,19 @@ class InverseHasManyTests < ActiveRecord::TestCase
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Man.find(:first).secret_interests }
   end
+
+  def test_child_instance_should_point_to_parent_without_saving
+    man = Man.new
+    i = Interest.create(:topic => 'Industrial Revolution Re-enactment')
+
+    man.interests << i
+    assert_not_nil i.man
+
+    i.man.name = "Charles"
+    assert_equal i.man.name, man.name
+
+    assert !man.persisted?
+  end
 end
 
 class InverseBelongsToTests < ActiveRecord::TestCase


### PR DESCRIPTION
Follow up with fix for https://github.com/rails/rails/pull/12413.

Add back `set_inverse_instance` on `.add_to_target`
We must have it in there too, so when an existent record is being concat to another, we will have the inverse relation.

This line is there on master. So we should add it back.
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/collection_association.rb#L378

review @rafaelfranca
