### PR TITLE
Inconsistent Association#include?

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -471,6 +471,12 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_association_include
+    post = Post.includes(:comments).first
+    comment = post.comments.first
+    assert_equal post.comments.include?(comment), true
+  end
+
   def test_default_scope_with_conditions_string
     assert_equal Developer.where(name: 'David').map(&:id).sort, DeveloperCalledDavid.all.map(&:id).sort
     assert_nil DeveloperCalledDavid.create!.name


### PR DESCRIPTION
**What happens:** Calling `include?` on Association objects sometimes returns an integer, sometimes a boolean.
**Expected:** `include?` should always return true or false.
**Occurs using:** Ruby 2.0.0p247, Rails 4.0.0
### To reproduce
1. Create association: **user has_many locations**
2. Run this:

``` ruby
    user.locations.include?(location)
    => 1

    puts user.locations
    => #<Location:...>
    user.locations.include?(location)
    => true
```

`puts` is required to get the expected output with Association#include?
