### PR TITLE
Improve formatting of ActiveRecord migration exception messages

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -2,40 +2,47 @@ require "active_support/core_ext/module/attribute_accessors"
 require 'set'
 
 module ActiveRecord
-  # Exception that can be raised to stop migrations from going backwards.
-  class IrreversibleMigration < ActiveRecordError
+  class MigrationError < ActiveRecordError#:nodoc:
+    def initialize(message = nil)
+      message = "\n\n#{message}\n\n" if message
+      super
+    end
   end
 
-  class DuplicateMigrationVersionError < ActiveRecordError#:nodoc:
+  # Exception that can be raised to stop migrations from going backwards.
+  class IrreversibleMigration < MigrationError
+  end
+
+  class DuplicateMigrationVersionError < MigrationError#:nodoc:
     def initialize(version)
       super("Multiple migrations have the version number #{version}")
     end
   end
 
-  class DuplicateMigrationNameError < ActiveRecordError#:nodoc:
+  class DuplicateMigrationNameError < MigrationError#:nodoc:
     def initialize(name)
       super("Multiple migrations have the name #{name}")
     end
   end
 
-  class UnknownMigrationVersionError < ActiveRecordError #:nodoc:
+  class UnknownMigrationVersionError < MigrationError #:nodoc:
     def initialize(version)
       super("No migration with version number #{version}")
     end
   end
 
-  class IllegalMigrationNameError < ActiveRecordError#:nodoc:
+  class IllegalMigrationNameError < MigrationError#:nodoc:
     def initialize(name)
       super("Illegal name for migration file: #{name}\n\t(only lower case letters, numbers, and '_' allowed)")
     end
   end
 
-  class PendingMigrationError < ActiveRecordError#:nodoc:
+  class PendingMigrationError < MigrationError#:nodoc:
     def initialize
       if defined?(Rails)
-        super("Migrations are pending; run 'bin/rake db:migrate RAILS_ENV=#{::Rails.env}' to resolve this issue.")
+        super("Migrations are pending. To resolve this issue, run:\n\n\tbin/rake db:migrate RAILS_ENV=#{::Rails.env}")
       else
-        super("Migrations are pending; run 'bin/rake db:migrate' to resolve this issue.")
+        super("Migrations are pending. To resolve this issue, run:\n\n\tbin/rake db:migrate")
       end
     end
   end


### PR DESCRIPTION
Two changes to AR exception messages during migrations. Rationale: the context in which these exceptions happen is very often when a migration is invoked by a human in a console session, either during development or when deploying. So, improving the readability is highly beneficial.
1. for all messages, add two newlines above and two new newlines below
2. for the "you forgot to migrate" message (happens to me daily within guard), make the command to fix the problem easier to find and copy.

With an 80-column terminal...
### before

![image](https://f.cloud.github.com/assets/6097/1285871/e4fcf556-2fb8-11e3-8c7c-89750cdeb3d1.png)
### after

![image](https://f.cloud.github.com/assets/6097/1285874/007e221e-2fb9-11e3-948c-70f875f1593f.png)
