### PR TITLE
Call `rails plugin new yaffle` in the plugins guide. [ci skip]

### DIFF
--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -34,9 +34,15 @@ different rails applications using RubyGems and Bundler if desired.
 
 
 Rails ships with a `rails plugin new` command which creates a
- skeleton for developing any kind of Rails extension with the ability
- to run integration tests using a dummy Rails application. See usage
- and options by asking for help:
+skeleton for developing any kind of Rails extension with the ability
+to run integration tests using a dummy Rails application. Create your 
+plugin with the command:
+
+```bash
+$ rails plugin new yaffle
+```
+
+See usage and options by asking for help:
 
 ```bash
 $ rails plugin --help


### PR DESCRIPTION
In reading the RailsGuides for plugins, I think I noticed a shortcoming: at no point is the command `rails plugin new yaffle` ever spelled out, but it seems as if it's expected that the reader run this command.

Omitting this step was a bit confusing for me, so I've made this step explicit in case others might be confused too.
