### PR TITLE
Add exclude_nils option to as_json.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,9 +1,23 @@
+*   `as_json` now accepts a `exclude_nils` option to skip nil attributes in the
+    resulting JSON output. This option peacefully coexists with the `except`
+    and `include` options.
+
+          hash = {foo: 'bar', baz: nil}
+
+          hash.to_json
+          => "{\"foo\":\"bar\",\"baz\":null}"
+
+          hash.to_json(:exclude_nils => true)
+          => "{\"foo\":\"bar\"}"
+
+    *Corey Ehmke*
+
 *   `require_dependency` accepts objects that respond to `to_path`, in
     particular `Pathname` instances.
 
     *Benjamin Fleischer*
 
-*   Disable the ability to iterate over Range of AS::TimeWithZone 
+*   Disable the ability to iterate over Range of AS::TimeWithZone
     due to significant performance issues.
 
     *Bogdan Gusiev*

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -284,14 +284,15 @@ end
 
 class Hash
   def as_json(options = nil) #:nodoc:
-    # create a subset of the hash by applying :only or :except
+    # create a subset of the hash by applying options
     subset = if options
+      hash = options[:exclude_nils] ?  self.reject{|key,value| value.nil?} : self
       if attrs = options[:only]
-        slice(*Array(attrs))
+        hash.slice(*Array(attrs))
       elsif attrs = options[:except]
-        except(*Array(attrs))
+        hash.except(*Array(attrs))
       else
-        self
+        hash
       end
     else
       self

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -166,6 +166,10 @@ class TestJSONEncoding < ActiveSupport::TestCase
     assert_equal %({"b":2}), ActiveSupport::JSON.encode({'foo' => 'bar', :b => 2, :c => 3}, :except => ['foo', :c])
   end
 
+  def test_hash_should_allow_nil_filtering_with_exclude_nils
+    assert_equal %({"foo":"bar"}), ActiveSupport::JSON.encode({'foo' => 'bar', :b => nil}, :exclude_nils => true)
+  end
+
   def test_time_to_json_includes_local_offset
     prev = ActiveSupport.use_standard_json_time_format
     ActiveSupport.use_standard_json_time_format = true


### PR DESCRIPTION
`as_json` now accepts a `exclude_nils` option to 
skip nil attributes in the resulting JSON output.
This option peacefully coexists with the `except`
and `include` options.
