### PR TITLE
make cycle detection on autosave works on a thread level

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixed `stack level too deep` error when creating a children object on a parent callback.
+    This error was only happening when the inverse_of relation was set.
+
+    *arthurnn*
+
 *   `has_and_belongs_to_many` is now transparently implemented in terms of
     `has_many :through`.  Behavior should remain the same, if not, it is a bug.
 

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -190,7 +190,6 @@ class InverseHasOneTests < ActiveRecord::TestCase
     assert_equal m.name, f.man.name, "Name of man should be the same after changes to child-owned instance"
   end
 
-
   def test_parent_instance_should_be_shared_with_eager_loaded_child_on_find
     m = Man.all.merge!(:where => {:name => 'Gordon'}, :includes => :face).first
     f = m.face
@@ -256,6 +255,14 @@ class InverseHasOneTests < ActiveRecord::TestCase
 
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Man.first.dirty_face }
+  end
+
+  def test_create_inverse_on_callback
+    man = Man.new
+    man.auto_create_face = true
+    man.save!
+    assert_not_nil man.face
+    assert man.persisted?
   end
 end
 

--- a/activerecord/test/models/man.rb
+++ b/activerecord/test/models/man.rb
@@ -7,4 +7,10 @@ class Man < ActiveRecord::Base
   has_one :dirty_face, :class_name => 'Face', :inverse_of => :dirty_man
   has_many :secret_interests, :class_name => 'Interest', :inverse_of => :secret_man
   has_one :mixed_case_monkey
+
+  attr_accessor :auto_create_face
+  before_create do
+    create_face! if auto_create_face
+  end
+
 end


### PR DESCRIPTION
Fixes `stack level too deep` error when creating a children object on a parent callback.
This error was only happening when the inverse_of relation was set.

[related #12413]

review @rafaelfranca @tenderlove

(I will submit another patch for 3.2 in a second)
