### PR TITLE
adding load_path to include active_model in the load path of example

### DIFF
--- a/activemodel/examples/validations.rb
+++ b/activemodel/examples/validations.rb
@@ -1,3 +1,4 @@
+require File.expand_path('../../../load_paths', __FILE__)
 require 'active_model'
 
 class Person


### PR DESCRIPTION
similar to activerecord/examples/simple.rb
