### PR TITLE
track the saving state so before callbacks dont loop

### DIFF
--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -94,7 +94,6 @@ class InverseHasOneTests < ActiveRecord::TestCase
     assert_equal m.name, f.man.name, "Name of man should be the same after changes to child-owned instance"
   end
 
-
   def test_parent_instance_should_be_shared_with_eager_loaded_child_on_find
     m = Man.find(:first, :conditions => {:name => 'Gordon'}, :include => :face)
     f = m.face
@@ -162,6 +161,17 @@ class InverseHasOneTests < ActiveRecord::TestCase
 
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Man.find(:first).dirty_face }
+  end
+
+  def test_create_inverse_on_callback
+    man = Man.new(:name => "arthurnn")
+    man.auto_create_face = true
+    man.save!
+    assert_not_nil man.face
+    assert man.persisted?
+
+    man.reload
+    assert_not_nil man.face
   end
 end
 

--- a/activerecord/test/models/man.rb
+++ b/activerecord/test/models/man.rb
@@ -6,4 +6,9 @@ class Man < ActiveRecord::Base
   # These are "broken" inverse_of associations for the purposes of testing
   has_one :dirty_face, :class_name => 'Face', :inverse_of => :dirty_man
   has_many :secret_interests, :class_name => 'Interest', :inverse_of => :secret_man
+
+  attr_accessor :auto_create_face
+  before_create do
+    create_face! if auto_create_face
+  end
 end


### PR DESCRIPTION
### Problem

`stack level too deep`
This is because the `belongs_to` reference auto saves the parent,(when the parent is set) and when having a `inverse_of` relation, the child will set the parent in memory, which on the `save_belongs_to_association` callback will try to save the parent again. So we would loop in the before_callbacks.
### Solution

We track the saving state, so inside the `save_belongs_to_association` we only save the parent if it isn't in saving state.

review @tenderlove @rafaelfranca

If you guys like this solution I can patch this to rails 4/master too.
