### PR TITLE
Add documentation for after_touch [ci skip]

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -23,11 +23,14 @@ module ActiveRecord
   # Check out <tt>ActiveRecord::Transactions</tt> for more details about <tt>after_commit</tt> and
   # <tt>after_rollback</tt>.
   #
+  # Additionally, an <tt>after_touch</tt> callback is triggered whenever an
+  # object is touched.
+  #
   # Lastly an <tt>after_find</tt> and <tt>after_initialize</tt> callback is triggered for each object that
   # is found and instantiated by a finder, with <tt>after_initialize</tt> being triggered after new objects
   # are instantiated as well.
   #
-  # That's a total of twelve callbacks, which gives you immense power to react and prepare for each state in the
+  # There are nineteen callbacks in total, which give you immense power to react and prepare for each state in the
   # Active Record life cycle. The sequence for calling <tt>Base#save</tt> for an existing record is similar,
   # except that each <tt>_create</tt> callback is replaced by the corresponding <tt>_update</tt> callback.
   #

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -401,7 +401,8 @@ module ActiveRecord
     end
 
     # Saves the record with the updated_at/on attributes set to the current time.
-    # Please note that no validation is performed and no callbacks are executed.
+    # Please note that no validation is performed and only the +after_touch+
+    # callback is executed.
     # If an attribute name is passed, that attribute is updated along with
     # updated_at/on attributes.
     #


### PR DESCRIPTION
Looks like the `after_touch` callback is not documented anywhere. 
I think it deserves to be recognized as any other callback :lollipop:

Please review my commit and tell me what you think  :hammer: 
