### PR TITLE
add rubysl gem if RUBY_ENGINE is rbx

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -31,3 +31,7 @@ end
 # Use debugger
 # gem 'debugger', group: [:development, :test]
 <% end -%>
+
+<% if RUBY_ENGINE == 'rbx' -%>
+  gem 'rubysl', '~> 2.0'
+<% end %>


### PR DESCRIPTION
after the app creation when I try to launch rails command
the following exception is raised using Rubinius 2:

```
An exception occurred running bin/rails:

 (LoadError)
The library "delegate" is a provided by the "rubysl-delegate" gem and needs to be
installed to be loaded.

If using Bundler, add this library or the standard library meta-gem to the
Gemfile as follows:

  gem "rubysl-delegate", "~> 2.0"

    OR

  gem "rubysl", "~> 2.0"
```

....
