### PR TITLE
Expose MiddlewareStack#unshift to environment configuration

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Expose MiddlewareStack#unshift to environment configuration.
+
+    *Ben Pickles*
+
 *   Include `web-console` into newly generated applications' Gemfile.
 
     *Genadi Samokovarov*

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -59,6 +59,10 @@ module Rails
         @operations << [__method__, args, block]
       end
 
+      def unshift(*args, &block)
+        @operations << [__method__, args, block]
+      end
+
       def merge_into(other) #:nodoc:
         @operations.each do |operation, args, block|
           other.send(operation, *args, &block)

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -144,6 +144,12 @@ module ApplicationTests
       assert_equal "Rack::Config", middleware.second
     end
 
+    test 'unshift middleware' do
+      add_to_config 'config.middleware.unshift Rack::Config'
+      boot!
+      assert_equal 'Rack::Config', middleware.first
+    end
+
     test "Rails.cache does not respond to middleware" do
       add_to_config "config.cache_store = :memory_store"
       boot!


### PR DESCRIPTION
Although #6372 added `#unshift` to the middleware stack this is not exposed in the environment configuration files.

I wanted to be able to add basic auth to my app and ensure that it was the first middleware to be hit, although I _could_ use `#insert_before` my stack differs between environments. This change ensures that the following is possible:

``` ruby
config.middleware.unshift Rack::Auth::Basic, 'Restricted Area' do |user, pwd|
  [user, pwd] == ['admin', 'admin']
end
```
