### PR TITLE
newline at end of structure.sql file

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -287,6 +287,7 @@ db_namespace = namespace :db do
       if ActiveRecord::Base.connection.supports_migrations?
         File.open(filename, "a") do |f|
           f.puts ActiveRecord::Base.connection.dump_schema_information
+          f.print "\n"
         end
       end
       db_namespace['structure:dump'].reenable


### PR DESCRIPTION
a nitpick to make `db/structure.sql` more git-friendly avoiding the 'no newline at end of file" warnings:

![screen shot 2013-10-09 at 12 27 53 pm](https://f.cloud.github.com/assets/10403/1300364/f3c346fe-3110-11e3-9e0f-026f51c86b8e.png)
