### PR TITLE
Use bcrypt's public cost attr, not internal constant

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## unreleased ##
 
+*   Fix `has_secure_password` to honor bcrypt-ruby's cost attribute.
+
+    *T.J. Schuck*
+
 *   `inclusion` / `exclusion` validations with ranges will only use the faster
     `Range#cover` for numerical ranges, and the more accurate `Range#include?`
     for non-numerical ones.

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -101,7 +101,7 @@ module ActiveModel
       def password=(unencrypted_password)
         unless unencrypted_password.blank?
           @password = unencrypted_password
-          cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine::DEFAULT_COST
+          cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
           self.password_digest = BCrypt::Password.create(unencrypted_password, cost: cost)
         end
       end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -82,6 +82,14 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_equal BCrypt::Engine::DEFAULT_COST, @user.password_digest.cost
   end
 
+  test "Password digest cost honors bcrypt cost attribute when min_cost is false" do
+    ActiveModel::SecurePassword.min_cost = false
+    BCrypt::Engine.cost = 5
+
+    @user.password = "secret"
+    assert_equal BCrypt::Engine.cost, @user.password_digest.cost
+  end
+
   test "Password digest cost can be set to bcrypt min cost to speed up tests" do
     ActiveModel::SecurePassword.min_cost = true
 


### PR DESCRIPTION
Backport to 4-0-stable, requested by @jeremy on https://github.com/rails/rails/pull/12339
