### PR TITLE
Fix ActiveSupport::Inflector.pluralize behavior for words that consist of non-ASCII characters

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -372,7 +372,7 @@ module ActiveSupport
     def apply_inflections(word, rules)
       result = word.to_s.dup
 
-      if word.empty? || inflections.uncountables.include?(result.downcase[/\b\w+\Z/])
+      if word.empty? || inflections.uncountables.include?(result.downcase[/\b\p{Word}+\Z/])
         result
       else
         rules.each { |(rule, replacement)| break if result.sub!(rule, replacement) }

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'abstract_unit'
 require 'active_support/inflector'
 
@@ -29,6 +30,14 @@ class InflectorTest < ActiveSupport::TestCase
 
   def test_pluralize_empty_string
     assert_equal "", ActiveSupport::Inflector.pluralize("")
+  end
+
+  def test_pluralize_for_words_with_non_ascii_characters
+    ActiveSupport::Inflector.inflections do |inflect|
+      inflect.uncountable "猫"
+    end
+    assert_equal "猫", ActiveSupport::Inflector.pluralize("猫")
+    ActiveSupport::Inflector.inflections.uncountables.pop
   end
 
   ActiveSupport::Inflector.inflections.uncountable.each do |word|


### PR DESCRIPTION
This PR fixes behavior of `ActiveSupport::Inflector.pluralize`.

The code below returns "猫" in 3.2, but "猫s" in 4.0.

``` ruby
ActiveSupport::Inflector.inflections do |inflect|
  inflect.uncountable "猫"
end
"猫".pluralize
```
