### PR TITLE
Make missed association exception message more informative

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   For missed association exception message
+    which is raised in `ActiveRecord::Associations::Preloader` class
+    added owner record class name in order to simplify to find problem code.
+
+    *Paul Nikitochkin*
+
 *   `has_and_belongs_to_many` is now transparently implemented in terms of
     `has_many :through`.  Behavior should remain the same, if not, it is a bug.
 

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -153,13 +153,13 @@ module ActiveRecord
         records.group_by do |record|
           reflection = record.class.reflect_on_association(association)
 
-          reflection || raise_config_error(association)
+          reflection || raise_config_error(record, association)
         end
       end
 
-      def raise_config_error(association)
+      def raise_config_error(record, association)
         raise ActiveRecord::ConfigurationError,
-              "Association named '#{association}' was not found; " \
+              "Association named '#{association}' was not found on #{record.class.name}; " \
               "perhaps you misspelled it?"
       end
 


### PR DESCRIPTION
Add target class name, which should have missed association on preload,
into exception message to simplify detecting problem part.
