### PR TITLE
Fix a writing mistake

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -528,7 +528,7 @@ If you validate the presence of an object associated via a `has_one` or
 Since `false.blank?` is true, if you want to validate the presence of a boolean
 field you should use `validates :field_name, inclusion: { in: [true, false] }`.
 
-The default error message is _"can't be empty"_.
+The default error message is _"can't be blank"_.
 
 ### `absence`
 


### PR DESCRIPTION
A small mistake found in the line of `The default error is "can't be empty"` for `:presence` helper. `empty` word changed to `blank`.
