### PR TITLE
Make logging to stdout work again with implicit `development` env

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -1,6 +1,7 @@
 require 'fileutils'
 require 'optparse'
 require 'action_dispatch'
+require 'rails'
 
 module Rails
   class Server < ::Rack::Server
@@ -32,7 +33,7 @@ module Rails
 
         opt_parser.parse! args
 
-        options[:log_stdout] = options[:daemonize].blank? && options[:environment] == "development"
+        options[:log_stdout] = options[:daemonize].blank? && (options[:environment] || Rails.env) == "development"
         options[:server]     = args.shift
         options
       end

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -27,26 +27,62 @@ class Rails::ServerTest < ActiveSupport::TestCase
   end
 
   def test_environment_with_rails_env
-    with_rails_env 'production' do
-      server = Rails::Server.new
-      assert_equal 'production', server.options[:environment]
+    with_rack_env nil do
+      with_rails_env 'production' do
+        server = Rails::Server.new
+        assert_equal 'production', server.options[:environment]
+      end
     end
   end
 
   def test_environment_with_rack_env
-    with_rack_env 'production' do
-      server = Rails::Server.new
-      assert_equal 'production', server.options[:environment]
+    with_rails_env nil do
+      with_rack_env 'production' do
+        server = Rails::Server.new
+        assert_equal 'production', server.options[:environment]
+      end
     end
   end
 
   def test_log_stdout
-    args    = ["-e", "development"]
-    options = Rails::Server::Options.new.parse!(args)
-    assert_equal true, options[:log_stdout]
+    with_rack_env nil do
+      with_rails_env nil do
+        args    = []
+        options = Rails::Server::Options.new.parse!(args)
+        assert_equal true, options[:log_stdout]
 
-    args    = ["-e", "production"]
-    options = Rails::Server::Options.new.parse!(args)
-    assert_equal false, options[:log_stdout]
+        args    = ["-e", "development"]
+        options = Rails::Server::Options.new.parse!(args)
+        assert_equal true, options[:log_stdout]
+
+        args    = ["-e", "production"]
+        options = Rails::Server::Options.new.parse!(args)
+        assert_equal false, options[:log_stdout]
+
+        with_rack_env 'development' do
+          args    = []
+          options = Rails::Server::Options.new.parse!(args)
+          assert_equal true, options[:log_stdout]
+        end
+
+        with_rack_env 'production' do
+          args    = []
+          options = Rails::Server::Options.new.parse!(args)
+          assert_equal false, options[:log_stdout]
+        end
+
+        with_rails_env 'development' do
+          args    = []
+          options = Rails::Server::Options.new.parse!(args)
+          assert_equal true, options[:log_stdout]
+        end
+
+        with_rails_env 'production' do
+          args    = []
+          options = Rails::Server::Options.new.parse!(args)
+          assert_equal false, options[:log_stdout]
+        end
+      end
+    end
   end
 end

--- a/railties/test/env_helpers.rb
+++ b/railties/test/env_helpers.rb
@@ -1,7 +1,10 @@
+require 'rails'
+
 module EnvHelpers
   private
 
   def with_rails_env(env)
+    Rails.instance_variable_set :@_env, nil
     switch_env 'RAILS_ENV', env do
       switch_env 'RACK_ENV', nil do
         yield
@@ -10,6 +13,7 @@ module EnvHelpers
   end
 
   def with_rack_env(env)
+    Rails.instance_variable_set :@_env, nil
     switch_env 'RACK_ENV', env do
       switch_env 'RAILS_ENV', nil do
         yield


### PR DESCRIPTION
PR #11060 disabled logging of `rails server` to stdout in non-development environments. It did so by checking whether `-e development` was passed explicitly. However, development environment can also be set using the `RAILS_ENV` or `RACK_ENV` variables or by not specifying an environment at all. In these cases, logging to stdout was suppressed, too. This means that simply running `rails server` would no longer output anything. This PR fixes the problem and adds further tests.
