### PR TITLE
ActiveSupport::Inflector.underscore messes up acronyms under namespaces

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix the underscore inflection of acronyms directly after module names, as in
+    `"API::RESTful".underscore => "api/restful"`
+
+    *Alexandros Giouzenis*
+
 *   Fix `slice!` deleting the default value of the hash.
 
     *Antonio Santos*

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -90,7 +90,7 @@ module ActiveSupport
     #   'SSLError'.underscore.camelize # => "SslError"
     def underscore(camel_cased_word)
       word = camel_cased_word.to_s.gsub('::', '/')
-      word.gsub!(/(?:([A-Za-z\d])|^)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1}#{$1 && '_'}#{$2.downcase}" }
+      word.gsub!(/(?:([A-Za-z\d])|(\/)|^)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1}#{$2}#{$1 && '_'}#{$3.downcase}" }
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
       word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
       word.tr!("-", "_")

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -118,6 +118,7 @@ class InflectorTest < ActiveSupport::TestCase
       ["HTTP::Get",         "http/get",           "HTTP/get",           "HTTP/Get"],
       ["SSLError",          "ssl_error",          "SSL error",          "SSL Error"],
       ["RESTful",           "restful",            "RESTful",            "RESTful"],
+      ["API::RESTful",      "api/restful",        "API/RESTful",        "API/RESTful"],
       ["RESTfulController", "restful_controller", "RESTful controller", "RESTful Controller"],
       ["IHeartW3C",         "i_heart_w3c",        "I heart W3C",        "I Heart W3C"],
       ["PhDRequired",       "phd_required",       "PhD required",       "PhD Required"],


### PR DESCRIPTION
For example:

``` ruby
ActiveSupport::Inflector.inflections do |inflect|
  inflect.acronym 'ISP'
  inflect.acronym 'ISPs'
end

"ISP".pluralize.underscore 
  => "isps" (ok)
"SomeISP".pluralize.underscore 
  => "some_isps" (ok)
"Provider::ISP".pluralize.underscore
  => "provider/is_ps" (should be provider/isps)
```
