### PR TITLE
Include view render time in Action Mailer instrumentation

### DIFF
--- a/actionmailer/lib/action_mailer/log_subscriber.rb
+++ b/actionmailer/lib/action_mailer/log_subscriber.rb
@@ -7,9 +7,17 @@ module ActionMailer
     # An email was delivered.
     def deliver(event)
       return unless logger.info?
-      recipients = Array(event.payload[:to]).join(', ')
-      info("\nSent mail to #{recipients} (#{event.duration.round(1)}ms)")
-      debug(event.payload[:mail])
+
+      payload   = event.payload
+      additions = ActionMailer::Base.log_deliver(payload)
+
+      recipients = Array(payload[:to]).join(', ')
+
+      message = "\nSent mail to #{recipients} in #{event.duration.round(1)}ms"
+      message << " (#{additions.join(' | ')})" unless additions.blank?
+
+      info(message)
+      debug(payload[:mail])
     end
 
     # An email was received.

--- a/actionmailer/test/log_subscriber_test.rb
+++ b/actionmailer/test/log_subscriber_test.rb
@@ -23,9 +23,13 @@ class AMLogSubscriberTest < ActionMailer::TestCase
 
   def test_deliver_is_notified
     BaseMailer.welcome.deliver
+
     wait
+
     assert_equal(1, @logger.logged(:info).size)
     assert_match(/Sent mail to system@test.lindsaar.net/, @logger.logged(:info).first)
+    assert_match(/Views: ([\d.]+)ms/, @logger.logged(:info).first)
+
     assert_equal(1, @logger.logged(:debug).size)
     assert_match(/Welcome/, @logger.logged(:debug).first)
   end


### PR DESCRIPTION
Includes the view render time in the Action Mailer instrumentation, outputting it in the log.

I'd also like to get the database time in there, but I think that would require a bigger refactoring. I've started work on it, but I'd prefer to get this in first.
