### PR TITLE
Prepare generated Gemfile for Capistrano 3

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -25,7 +25,7 @@ end
 # gem 'unicorn'
 
 # Use Capistrano for deployment
-# gem 'capistrano', group: :development
+# gem 'capistrano-rails', group: :development
 
 <% unless defined?(JRUBY_VERSION) -%>
 # Use debugger


### PR DESCRIPTION
Capistrano 3 is now rails-less, so we need to encourage developers to use capistrano-rails gem.

More details: http://www.capistranorb.com/documentation/frameworks/ruby-on-rails/
