### PR TITLE
SQLite3 Adapter datatypes cleanup

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -55,6 +55,21 @@ module ActiveRecord
     class SQLite3Adapter < AbstractAdapter
       include Savepoints
 
+      NATIVE_DATABASE_TYPES = {
+        primary_key:  'INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL',
+        string:       { name: "varchar", limit: 255 },
+        text:         { name: "text" },
+        integer:      { name: "integer" },
+        float:        { name: "float" },
+        decimal:      { name: "decimal" },
+        datetime:     { name: "datetime" },
+        timestamp:    { name: "datetime" },
+        time:         { name: "time" },
+        date:         { name: "date" },
+        binary:       { name: "blob" },
+        boolean:      { name: "boolean" }
+      }
+
       class Version
         include Comparable
 
@@ -195,20 +210,7 @@ module ActiveRecord
       end
 
       def native_database_types #:nodoc:
-        {
-          :primary_key => default_primary_key_type,
-          :string      => { :name => "varchar", :limit => 255 },
-          :text        => { :name => "text" },
-          :integer     => { :name => "integer" },
-          :float       => { :name => "float" },
-          :decimal     => { :name => "decimal" },
-          :datetime    => { :name => "datetime" },
-          :timestamp   => { :name => "datetime" },
-          :time        => { :name => "time" },
-          :date        => { :name => "date" },
-          :binary      => { :name => "blob" },
-          :boolean     => { :name => "boolean" }
-        }
+        NATIVE_DATABASE_TYPES
       end
 
       # Returns the current database encoding format as a string, eg: 'UTF-8'
@@ -589,10 +591,6 @@ module ActiveRecord
 
         def sqlite_version
           @sqlite_version ||= SQLite3Adapter::Version.new(select_value('select sqlite_version(*)'))
-        end
-
-        def default_primary_key_type
-          'INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL'
         end
 
         def translate_exception(exception, message)


### PR DESCRIPTION
Remove `default_primary_key_type`  and extract contains of `native_database_types` to a constant since they aren't conditional now in SQLite3Adapter. Makes it more like other adapters.

https://github.com/rails/rails/pull/11833 made this possible.
