### PR TITLE
adding :default_call and :default options to class_attribute

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -73,9 +73,11 @@ class Class
     instance_reader = options.fetch(:instance_accessor, true) && options.fetch(:instance_reader, true)
     instance_writer = options.fetch(:instance_accessor, true) && options.fetch(:instance_writer, true)
     instance_predicate = options.fetch(:instance_predicate, true)
+    default_call = options[:default_call]
+    default_val = options[:default]
 
     attrs.each do |name|
-      define_singleton_method(name) { nil }
+      default_call ? define_singleton_method(name, default_call) : define_singleton_method(name) { default_val }
       define_singleton_method("#{name}?") { !!public_send(name) } if instance_predicate
 
       ivar = "@#{name}"

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -1,17 +1,7 @@
 require 'abstract_unit'
 require 'active_support/core_ext/class/attribute'
 
-class ClassAttributeTest < ActiveSupport::TestCase
-  def setup
-    @klass = Class.new { class_attribute :setting }
-    @sub = Class.new(@klass)
-  end
-
-  test 'defaults to nil' do
-    assert_nil @klass.setting
-    assert_nil @sub.setting
-  end
-
+module NonDefaultRelatedClassAttributeBehavior
   test 'inheritable' do
     @klass.setting = 1
     assert_equal 1, @sub.setting
@@ -88,4 +78,46 @@ class ClassAttributeTest < ActiveSupport::TestCase
     val = @klass.send(:setting=, 1)
     assert_equal 1, val
   end
+end
+
+class ClassAttributeTest < ActiveSupport::TestCase
+  def setup
+    @klass = Class.new { class_attribute :setting }
+    @sub = Class.new(@klass)
+  end
+
+  test 'defaults to nil' do
+    assert_nil @klass.setting
+    assert_nil @sub.setting
+  end
+
+  include NonDefaultRelatedClassAttributeBehavior
+end
+
+class ClassAttributeDefaultCallTest < ActiveSupport::TestCase
+  def setup
+    @klass = Class.new { class_attribute :setting, default_call: -> { 5 } }
+    @sub = Class.new(@klass)
+  end
+
+  test 'defaults to return value of calling default_call proc' do
+    assert_equal 5, @klass.setting
+    assert_equal 5, @sub.setting
+  end
+
+  include NonDefaultRelatedClassAttributeBehavior
+end
+
+class ClassAttributeDefaultTest < ActiveSupport::TestCase
+  def setup
+    @klass = Class.new { class_attribute :setting, default: 6 }
+    @sub = Class.new(@klass)
+  end
+
+  test 'defaults to return value of calling default_call proc' do
+    assert_equal 6, @klass.setting
+    assert_equal 6, @sub.setting
+  end
+
+  include NonDefaultRelatedClassAttributeBehavior
 end


### PR DESCRIPTION
Instead of starting up discussion about it on core list, wanted to submit so you could see a suggestion for class_attribute.

I know that currently default value can be done via just `self.name_of_attribute = (some value)`, but I need the ability to call a proc and get its value, where in my case the value is dependent on the class name where the module that uses class_attribute is located, so I thought it might be nice to go ahead and have an option for both a default value and a default proc to call to get the default value of one or more attributes, but most likely just one. Could potentially change to take a block, but that might not be as clear as to the intent of the block.

Suggestions welcome.
