### PR TITLE
`$SAFE = 4;` has been removed with Ruby 2.1

### DIFF
--- a/activesupport/test/core_ext/thread_test.rb
+++ b/activesupport/test/core_ext/thread_test.rb
@@ -72,17 +72,4 @@ class ThreadExt < ActiveSupport::TestCase
     end
   end
 
-  def test_thread_variable_security
-    rubinius_skip "$SAFE is not supported on Rubinius."
-
-    t = Thread.new { sleep }
-
-    assert_raises(SecurityError) do
-      Thread.new { $SAFE = 4; t.thread_variable_get(:foo) }.join
-    end
-
-    assert_raises(SecurityError) do
-      Thread.new { $SAFE = 4; t.thread_variable_set(:foo, :baz) }.join
-    end
-  end
 end


### PR DESCRIPTION
`$SAFE = 4;` has been deprecated with Ruby 2.1
For background -
https://bugs.ruby-lang.org/issues/8468
Changset - https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/41259/diff/test/ruby/test_thread.rb
