### PR TITLE
Fix `singleton_class?`

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -118,7 +118,10 @@ class Class
   end
 
   private
-    def singleton_class?
-      ancestors.first != self
+
+    unless respond_to?(:singleton_class?)
+      def singleton_class?
+        ancestors.first != self
+      end
     end
 end


### PR DESCRIPTION
Due to changes from http://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/39628 current `singleton_class?` implementation fails.
Changed based on reference from http://bugs.ruby-lang.org/issues/7609
