### PR TITLE
In Relation#empty? use #exists? instead of #count.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make `Relation#empty?` use `exists?` instead of `count`.
+
+    *Szymon Nowak*
+
 *   `rake db:structure:dump` no longer crashes when the port was specified as `Fixnum`.
 
     *Kenta Okamoto*

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -244,8 +244,7 @@ module ActiveRecord
     def empty?
       return @records.empty? if loaded?
 
-      c = count(:all)
-      c.respond_to?(:zero?) ? c.zero? : c.empty?
+      limit_value == 0 ? true : !exists?
     end
 
     # Returns true if there are any records.


### PR DESCRIPTION
I opened almost exactly the same issue about 2 years ago, but for collections (https://github.com/rails/rails/issues/3179). This time for `Relation` and with pull request!

Right now 

``` ruby
User.all.empty?
```

generates 

``` sql
SELECT COUNT(*) FROM `users`
```

query if records are not loaded. After this change it will call `exists?` and thus generate 

``` sql
SELECT 1 AS one FROM `users` LIMIT 1
```

which should execute faster, especially if there are some additional conditions.

There are no tests, because I'm not sure how to write one for it, but if anyone has some suggestions, I'll add one.
