### PR TITLE
Remove size alias for length validation

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -438,8 +438,6 @@ provide a personalized message or use `presence: true` instead. When
 `:in` or `:within` have a lower limit of 1, you should either provide a
 personalized message or call `presence` prior to `length`.
 
-The `size` helper is an alias for `length`.
-
 ### `numericality`
 
 This helper validates that your attributes have only numeric values. By


### PR DESCRIPTION
Removed `The `size` helper is an alias for `length`.` line. If you use this "nonexistent" helper, you will get an error message like this: 

```
ArgumentError: Unknown validator: 'SizeValidator'
...
```

Maybe wanted to say `validates_size_of` helper is an alias for `validates_length_of`.
