### PR TITLE
Don't ignore joins from association scopes in preloader

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Merge joins from association scopes when using .includes() or .joins()
+
+    Fixes #12492.
+
+    *Mike Campbell*
+
 *   Prevent the inversed association from being reloaded on save.
 
     Fixes #9499.

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -118,6 +118,7 @@ module ActiveRecord
 
           scope.select!   preload_values[:select] || values[:select] || table[Arel.star]
           scope.includes! preload_values[:includes] || values[:includes]
+          scope.joins! preload_values[:joins] || values[:joins]
 
           if preload_values.key? :order
             scope.order! preload_values[:order]

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -400,6 +400,9 @@ module ActiveRecord
     end
 
     def joins!(*args) # :nodoc:
+      args.reject!(&:blank?)
+      args.flatten!
+
       self.joins_values += args
       self
     end


### PR DESCRIPTION
Pull request for https://github.com/rails/rails/issues/12492

It'll need a test adding; I was hoping someone else might be able to help me with that. This fixes my example in the original issue and the test suite doesn't break!
