### PR TITLE
AR::Base#becomes should include changed attributes

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -187,6 +187,23 @@ module ActiveRecord
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became.instance_variable_set("@errors", errors)
+
+      became_changed_attributes =
+        if became.instance_variable_defined?("@changed_attributes")
+          became.instance_variable_get("@changed_attributes")
+        end
+      changed_attributes =
+        if instance_variable_defined?("@changed_attributes")
+          @changed_attributes
+        end
+      if changed_attributes && became_changed_attributes
+        changed_attributes.merge!(became_changed_attributes)
+      elsif became_changed_attributes
+        changed_attributes = became_changed_attributes
+      end
+      @changed_attributes = changed_attributes
+      became.instance_variable_set("@changed_attributes", @changed_attributes)
+
       became
     end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -152,6 +152,13 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal original_errors, client.errors
   end
 
+  def test_becomes_includes_changed_attributes
+    company = Company.new(:name => "Three's")
+    client = company.becomes(Client)
+    assert_includes client.changed_attributes, 'type'
+    assert_includes client.changed_attributes, 'name'
+  end
+
   def test_delete_many
     original_count = Topic.count
     Topic.delete(deleting = [1, 2])


### PR DESCRIPTION
ActiveRecord::Base#becomes does not currently copy `@changed_attributes`.  This can cause validations to be skipped in the new object.

``` ruby
class Company < ActiveRecord::Base
end

class Client < Company
end

company = Company.new(:name => "Three's")
company.changed_attributes
=> {"type"=>nil, "email"=>""}

client = company.becomes(Client)
client.changed_attributes
{"type"=>nil}
```
