### PR TITLE
Ensure ActionView::Digestor.cache is correctly cleaned up

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Ensure ActionView::Digestor.cache is correctly cleaned up when
+    combining recursive templates with ActionView::Resolver.caching = false
+    
+    *wyaeld*
+
 *   Fix `collection_check_boxes` generated hidden input to use the name attribute provided
     in the options hash.
 

--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -36,12 +36,12 @@ module ActionView
         end
 
         # Store the actual digest if config.cache_template_loading is true
-        klass.new(name, format, finder, options).digest.tap do |digest|
-          @@cache[cache_key] = digest if ActionView::Resolver.caching?
-        end
-      rescue Exception
-        @@cache.delete_pair(cache_key, false) if pre_stored # something went wrong, make sure not to corrupt the @@cache
-        raise
+        digest = klass.new(name, format, finder, options).digest
+        @@cache[cache_key] = digest if ActionView::Resolver.caching?
+        digest
+      ensure
+        # something went wrong or ActionView::Resolver.caching? is false, make sure not to corrupt the @@cache
+        @@cache.delete_pair(cache_key, false) if pre_stored || !digest 
       end
     end
 

--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -35,13 +35,13 @@ module ActionView
           Digestor
         end
 
-        # Store the actual digest if config.cache_template_loading is true
         digest = klass.new(name, format, finder, options).digest
+        # Store the actual digest if config.cache_template_loading is true
         @@cache[cache_key] = digest if ActionView::Resolver.caching?
         digest
       ensure
         # something went wrong or ActionView::Resolver.caching? is false, make sure not to corrupt the @@cache
-        @@cache.delete_pair(cache_key, false) if pre_stored || !digest 
+        @@cache.delete_pair(cache_key, false) if pre_stored && !digest 
       end
     end
 

--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -37,11 +37,11 @@ module ActionView
 
         digest = klass.new(name, format, finder, options).digest
         # Store the actual digest if config.cache_template_loading is true
-        @@cache[cache_key] = digest if ActionView::Resolver.caching?
+        @@cache[cache_key] = stored_digest = digest if ActionView::Resolver.caching?
         digest
       ensure
         # something went wrong or ActionView::Resolver.caching? is false, make sure not to corrupt the @@cache
-        @@cache.delete_pair(cache_key, false) if pre_stored && !digest 
+        @@cache.delete_pair(cache_key, false) if pre_stored && !stored_digest 
       end
     end
 

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -217,6 +217,32 @@ class TemplateDigestorTest < ActionView::TestCase
     ActionView::Resolver.caching = resolver_before
   end
 
+  def test_digest_cache_cleanup_with_recursion
+    first_digest = digest("level/_recursion")
+    second_digest = digest("level/_recursion")
+
+    assert first_digest
+
+    # If the cache is cleaned up correctly, subsequent digests should return the same
+    assert_equal first_digest, second_digest 
+  end
+
+  def test_digest_cache_cleanup_with_recursion_and_template_caching_off
+    resolver_before = ActionView::Resolver.caching
+    ActionView::Resolver.caching = false
+    
+    first_digest = digest("level/_recursion")
+    second_digest = digest("level/_recursion")
+
+    assert first_digest
+
+    # If the cache is cleaned up correctly, subsequent digests should return the same
+    assert_equal first_digest, second_digest 
+
+    ActionView::Resolver.caching = resolver_before
+  end
+
+
   private
     def assert_logged(message)
       old_logger = ActionView::Base.logger


### PR DESCRIPTION
when combining recursive templates with ActionView::Resolver.caching = false

Fixes #12521
