### PR TITLE
fixes issue if grouped association ids are all NULL in calculation

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -298,7 +298,11 @@ module ActiveRecord
 
       if association
         key_ids     = calculated_data.collect { |row| row[group_aliases.first] }
-        key_records = association.klass.base_class.find(key_ids)
+        if key_ids.any?
+          key_records = association.klass.base_class.find(key_ids)
+        else
+          key_records = []
+        end
         key_records = Hash[key_records.map { |r| [r.id, r] }]
       end
 


### PR DESCRIPTION
If you execute calculation grouped by association field and there are only NULL values, it throws ActiveRecord::RecordNotFound. It is diff just to show where the problem is better than in words, if anyone repairs it to other branch or in different style, please do that :)
