### PR TITLE
Pluck on NullRelation should accept a list of columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `NullRelation#pluck` takes a list of columns
+
+    The method signature in `NullRelation` was updated to mimic that in
+    `Calculations`.
+
+    *Derek Prior*
+
 *   `scope_chain` should not be mutated for other reflections.
 
     Currently `scope_chain` uses same array for building different

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       @records = []
     end
 
-    def pluck(_column_name)
+    def pluck(*column_names)
       []
     end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -274,7 +274,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_none_chained_to_methods_firing_queries_straight_to_db
     assert_no_queries do
-      assert_equal [],    Developer.none.pluck(:id) # => uses select_all
+      assert_equal [],    Developer.none.pluck(:id, :name)
       assert_equal 0,     Developer.none.delete_all
       assert_equal 0,     Developer.none.update_all(:name => 'David')
       assert_equal 0,     Developer.none.delete(1)


### PR DESCRIPTION
In Rails 4, `pluck` was updated to accept a list of columns, but the `NullRelation`
was never updated to match that signature. As a result, calling `pluck`
with multiple columns on a `NullRelation` results in an `ArgumentError`.
