### PR TITLE
Updating routes.md to match rails 4 behaviour with namespaced/scoped mul...

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -813,7 +813,7 @@ You can also use root inside namespaces and scopes as well. For example:
 
 ```ruby
 namespace :admin do
-  root to: "admin#index"
+  root to: "admin#index", as: :admin_root
 end
 
 root to: "home#index"


### PR DESCRIPTION
...tiple root-routes

Since Rails 4 it is not possible to have multiple root-routes even if they are in different scopes/namespaces, everyone but one has to be named explicitely.
