### PR TITLE
Raise an exception when model without primary key calls .find_with_ids

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Raise an exception when model without primary key calls `.find_with_ids`.
+
+    *Shimpei Makimoto*
+
 *   Make `Relation#empty?` use `exists?` instead of `count`.
 
     *Szymon Nowak*

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -297,6 +297,8 @@ module ActiveRecord
     protected
 
     def find_with_ids(*ids)
+      raise UnknownPrimaryKey.new(@klass) if primary_key.nil?
+
       expects_array = ids.first.kind_of?(Array)
       return ids.first if expects_array && ids.first.empty?
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -11,6 +11,7 @@ require 'models/project'
 require 'models/developer'
 require 'models/customer'
 require 'models/toy'
+require 'models/matey'
 
 class FinderTest < ActiveRecord::TestCase
   fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :customers, :categories, :categorizations
@@ -858,6 +859,12 @@ class FinderTest < ActiveRecord::TestCase
     end
   ensure
     Toy.reset_primary_key
+  end
+
+  def test_find_without_primary_key
+    assert_raises(ActiveRecord::UnknownPrimaryKey) do
+      Matey.find(1)
+    end
   end
 
   def test_finder_with_offset_string


### PR DESCRIPTION
I fixed exception handling for `.find` of models without primary key.

Now `.find` by models without primary key raises `StatementInvalid` exception by the invalid SQL query, but I think an exception should be raised before building a query.

```
irb(main):001:0> Post.find(1)
  Post Load (0.3ms)  SELECT  `posts`.* FROM `posts`  WHERE `posts`.`` = 1 LIMIT 1
Mysql2::Error: Unknown column 'posts.' in 'where clause': SELECT  `posts`.* FROM `posts`  WHERE `posts`.`` = 1 LIMIT 1
ActiveRecord::StatementInvalid: Mysql2::Error: Unknown column 'posts.' in 'where clause': SELECT  `posts`.* FROM `posts`  WHERE `posts`.`` = 1 LIMIT 1
    from /Users/makimoto/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bundler/gems/rails-dd37ff81d131/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:293:in `query'
```

By this PR `AR::UnknownPrimaryKey` are raised when `Model.primary_key` is `nil` and `Model.find` calls.

```
irb(main):001:0> Post.find(1)
ActiveRecord::UnknownPrimaryKey: Unknown primary key for table posts in model Post.
    from /Users/makimoto/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bundler/gems/rails-dd37ff81d131/activerecord/lib/active_record/relation/finder_methods.rb:301:in `find_with_ids'
```
