### PR TITLE
HashWithIndifferentAccess#update respects #to_hash

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `HashWithIndifferentAccess` better respects `#to_hash` on objects it's
+    given. In particular, `.new`, `#update`, `#merge`, `#replace` all accept
+    objects which respond to `#to_hash`, even if those objects are not Hashes
+    directly.
+
+    *Peter Jaros*
+
 *   Deprecate `Class#superclass_delegating_accessor`, use `Class#class_attribute` instead.
 
     *Akshay Vishnoi*

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -55,9 +55,9 @@ module ActiveSupport
     end
 
     def initialize(constructor = {})
-      if constructor.is_a?(Hash)
+      if constructor.respond_to?(:to_hash)
         super()
-        update(constructor)
+        update(constructor.to_hash)
       else
         super(constructor)
       end
@@ -72,6 +72,7 @@ module ActiveSupport
     end
 
     def self.new_from_hash_copying_default(hash)
+      hash = hash.to_hash
       new(hash).tap do |new_hash|
         new_hash.default = hash.default
       end
@@ -125,7 +126,7 @@ module ActiveSupport
       if other_hash.is_a? HashWithIndifferentAccess
         super(other_hash)
       else
-        other_hash.each_pair do |key, value|
+        other_hash.to_hash.each_pair do |key, value|
           if block_given? && key?(key)
             value = yield(convert_key(key), self[key], value)
           end


### PR DESCRIPTION
Hash#update converts its argument with #to_hash before looking at its values.
This change makes HashWithIndifferentAccess do the same thing.

I'd like to write a test to go with this, but I couldn't find a test for
HashWithIndifferentAccess. Is there one?

---
- [x] Test (in `test/core_ext/has_ext_test.rb`)
- [x] Changelog entry
