### PR TITLE
Make static error pages responsive

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/public/404.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/404.html
@@ -2,17 +2,23 @@
 <html>
 <head>
   <title>The page you were looking for doesn't exist (404)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   body {
     background-color: #EFEFEF;
     color: #2E2F30;
     text-align: center;
     font-family: arial, sans-serif;
+    margin: 0;
   }
 
   div.dialog {
-    width: 25em;
-    margin: 4em auto 0 auto;
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  div.dialog > div {
     border: 1px solid #CCC;
     border-right-color: #999;
     border-left-color: #999;
@@ -21,7 +27,7 @@
     border-top-left-radius: 9px;
     border-top-right-radius: 9px;
     background-color: white;
-    padding: 7px 4em 0 4em;
+    padding: 7px 12% 0;
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
@@ -31,10 +37,9 @@
     line-height: 1.5em;
   }
 
-  body > p {
-    width: 33em;
-    margin: 0 auto 1em;
-    padding: 1em 0;
+  div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
     background-color: #F7F7F7;
     border: 1px solid #CCC;
     border-right-color: #999;
@@ -44,7 +49,7 @@
     border-bottom-right-radius: 4px;
     border-top-color: #DADADA;
     color: #666;
-    box-shadow:0 3px 8px rgba(50, 50, 50, 0.17);
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
   </style>
 </head>
@@ -52,9 +57,11 @@
 <body>
   <!-- This file lives in public/404.html -->
   <div class="dialog">
-    <h1>The page you were looking for doesn't exist.</h1>
-    <p>You may have mistyped the address or the page may have moved.</p>
+    <div>
+      <h1>The page you were looking for doesn't exist.</h1>
+      <p>You may have mistyped the address or the page may have moved.</p>
+    </div>
+    <p>If you are the application owner check the logs for more information.</p>
   </div>
-  <p>If you are the application owner check the logs for more information.</p>
 </body>
 </html>

--- a/railties/lib/rails/generators/rails/app/templates/public/422.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/422.html
@@ -2,17 +2,23 @@
 <html>
 <head>
   <title>The change you wanted was rejected (422)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   body {
     background-color: #EFEFEF;
     color: #2E2F30;
     text-align: center;
     font-family: arial, sans-serif;
+    margin: 0;
   }
 
   div.dialog {
-    width: 25em;
-    margin: 4em auto 0 auto;
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  div.dialog > div {
     border: 1px solid #CCC;
     border-right-color: #999;
     border-left-color: #999;
@@ -21,7 +27,7 @@
     border-top-left-radius: 9px;
     border-top-right-radius: 9px;
     background-color: white;
-    padding: 7px 4em 0 4em;
+    padding: 7px 12% 0;
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
@@ -31,10 +37,9 @@
     line-height: 1.5em;
   }
 
-  body > p {
-    width: 33em;
-    margin: 0 auto 1em;
-    padding: 1em 0;
+  div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
     background-color: #F7F7F7;
     border: 1px solid #CCC;
     border-right-color: #999;
@@ -44,7 +49,7 @@
     border-bottom-right-radius: 4px;
     border-top-color: #DADADA;
     color: #666;
-    box-shadow:0 3px 8px rgba(50, 50, 50, 0.17);
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
   </style>
 </head>
@@ -52,9 +57,11 @@
 <body>
   <!-- This file lives in public/422.html -->
   <div class="dialog">
-    <h1>The change you wanted was rejected.</h1>
-    <p>Maybe you tried to change something you didn't have access to.</p>
+    <div>
+      <h1>The change you wanted was rejected.</h1>
+      <p>Maybe you tried to change something you didn't have access to.</p>
+    </div>
+    <p>If you are the application owner check the logs for more information.</p>
   </div>
-  <p>If you are the application owner check the logs for more information.</p>
 </body>
 </html>

--- a/railties/lib/rails/generators/rails/app/templates/public/500.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/500.html
@@ -2,17 +2,23 @@
 <html>
 <head>
   <title>We're sorry, but something went wrong (500)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   body {
     background-color: #EFEFEF;
     color: #2E2F30;
     text-align: center;
     font-family: arial, sans-serif;
+    margin: 0;
   }
 
   div.dialog {
-    width: 25em;
-    margin: 4em auto 0 auto;
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  div.dialog > div {
     border: 1px solid #CCC;
     border-right-color: #999;
     border-left-color: #999;
@@ -21,7 +27,7 @@
     border-top-left-radius: 9px;
     border-top-right-radius: 9px;
     background-color: white;
-    padding: 7px 4em 0 4em;
+    padding: 7px 12% 0;
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
@@ -31,10 +37,9 @@
     line-height: 1.5em;
   }
 
-  body > p {
-    width: 33em;
-    margin: 0 auto 1em;
-    padding: 1em 0;
+  div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
     background-color: #F7F7F7;
     border: 1px solid #CCC;
     border-right-color: #999;
@@ -44,7 +49,7 @@
     border-bottom-right-radius: 4px;
     border-top-color: #DADADA;
     color: #666;
-    box-shadow:0 3px 8px rgba(50, 50, 50, 0.17);
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
   </style>
 </head>
@@ -52,8 +57,10 @@
 <body>
   <!-- This file lives in public/500.html -->
   <div class="dialog">
-    <h1>We're sorry, but something went wrong.</h1>
+    <div>
+      <h1>We're sorry, but something went wrong.</h1>
+    </div>
+    <p>If you are the application owner check the logs for more information.</p>
   </div>
-  <p>If you are the application owner check the logs for more information.</p>
 </body>
 </html>

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -73,7 +73,7 @@ module ApplicationTests
 
       assert_nothing_raised(ActionController::RoutingError) do
         get '/foo'
-        assert_match "The page you were looking for doesn't exist.", last_response.body
+        assert_match "The page you were looking for doesn't exist.", last_response.body
       end
     end
 


### PR DESCRIPTION
Let’s show mobiles some love.
## Before

![before](https://f.cloud.github.com/assets/436043/1340264/326a3b72-3627-11e3-9fba-3a6ba3a33256.png)
## After

![after](https://f.cloud.github.com/assets/436043/1340265/38b60bb4-3627-11e3-9ccf-de5ec4c6dc64.png)
