### PR TITLE
Instrument the generation of Action Mailer messages

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,8 @@
+* Instrument the generation of Action Mailer messages. The time it takes to
+  generate a message is written to the log.
+
+  *Daniel Schierbeck*
+
 * invoke mailer defaults as procs only if they are procs, do not convert
   with to_proc.  That an object is convertible to a proc does not mean it's
   meant to be always used as a proc.  Fixes #11533

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -511,11 +511,18 @@ module ActionMailer
       process(method_name, *args) if method_name
     end
 
-    def process(*args) #:nodoc:
-      lookup_context.skip_default_locale!
+    def process(method_name, *args) #:nodoc:
+      payload = {
+        :mailer => self.class.name,
+        :action => method_name
+      }
 
-      super
-      @_message = NullMail.new unless @_mail_was_called
+      ActiveSupport::Notifications.instrument("process.action_mailer", payload) do
+        lookup_context.skip_default_locale!
+
+        super
+        @_message = NullMail.new unless @_mail_was_called
+      end
     end
 
     class NullMail #:nodoc:

--- a/actionmailer/lib/action_mailer/log_subscriber.rb
+++ b/actionmailer/lib/action_mailer/log_subscriber.rb
@@ -19,6 +19,13 @@ module ActionMailer
       debug(event.payload[:mail])
     end
 
+    # An email was generated.
+    def process(event)
+      mailer = event.payload[:mailer]
+      action = event.payload[:action]
+      debug("\n#{mailer}##{action}: processed outbound mail in #{event.duration.round(1)}ms")
+    end
+
     # Use the logger configured for ActionMailer::Base
     def logger
       ActionMailer::Base.logger

--- a/actionmailer/test/log_subscriber_test.rb
+++ b/actionmailer/test/log_subscriber_test.rb
@@ -24,10 +24,13 @@ class AMLogSubscriberTest < ActionMailer::TestCase
   def test_deliver_is_notified
     BaseMailer.welcome.deliver
     wait
+
     assert_equal(1, @logger.logged(:info).size)
     assert_match(/Sent mail to system@test.lindsaar.net/, @logger.logged(:info).first)
-    assert_equal(1, @logger.logged(:debug).size)
-    assert_match(/Welcome/, @logger.logged(:debug).first)
+
+    assert_equal(2, @logger.logged(:debug).size)
+    assert_match(/BaseMailer#welcome: processed outbound mail in [\d.]+ms/, @logger.logged(:debug).first)
+    assert_match(/Welcome/, @logger.logged(:debug).second)
   end
 
   def test_receive_is_notified


### PR DESCRIPTION
Currently, only the time spent _sending_ a mail is instrumented in Action Mailer. The time it takes to render the views and building the mail object itself is not instrumented at all.

This PR adds very basic instrumentation. More data, such as view rendering time, database time, and really anything, can be added later.
