### PR TITLE
Fix code blocks identation on AR and AS CHANGELOGs

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -342,13 +342,13 @@
 *   Reset @column_defaults when assigning `locking_column`.
     We had a potential problem. For example:
 
-    class Post < ActiveRecord::Base
-      self.column_defaults  # if we call this unintentionally before setting locking_column ...
-      self.locking_column = 'my_locking_column'
-    end
+      class Post < ActiveRecord::Base
+        self.column_defaults  # if we call this unintentionally before setting locking_column ...
+        self.locking_column = 'my_locking_column'
+      end
 
-    Post.column_defaults["my_locking_column"]
-    => nil # expected value is 0 !
+      Post.column_defaults["my_locking_column"]
+      => nil # expected value is 0 !
 
     *kennyj*
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -22,14 +22,14 @@
 
     You can do this:
 
-      class JokeSubscriber < ActiveSupport::Subscriber
-        # This is much easier to read!
-        attach_to "active_record"
+        class JokeSubscriber < ActiveSupport::Subscriber
+          # This is much easier to read!
+          attach_to "active_record"
 
-        def sql(event)
-          puts "A rabbi and a priest walk into a bar..."
+          def sql(event)
+            puts "A rabbi and a priest walk into a bar..."
+          end
         end
-      end
 
     This should make it easier to read and understand these subscribers.
 


### PR DESCRIPTION
I was checking the CHANGELOGs through the GitHub UI and noticed the broken code blocks, so there you go :heart:.
