### PR TITLE
avoid deprecation warning in sample code

### DIFF
--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -3,12 +3,12 @@ module ActiveRecord
     # Locking::Pessimistic provides support for row-level locking using
     # SELECT ... FOR UPDATE and other lock types.
     #
-    # Pass <tt>lock: true</tt> to <tt>ActiveRecord::Base.find</tt> to obtain an exclusive
+    # Chain <tt>ActiveRecord::Base#find</tt> to <tt>ActiveRecord::QueryMethods#lock</tt> to obtain an exclusive
     # lock on the selected rows:
     #   # select * from accounts where id=1 for update
-    #   Account.find(1, lock: true)
+    #   Account.lock.find(1)
     #
-    # Pass <tt>lock: 'some locking clause'</tt> to give a database-specific locking clause
+    # Call <tt>lock('some locking clause')</tt> to use a database-specific locking clause
     # of your own such as 'LOCK IN SHARE MODE' or 'FOR UPDATE NOWAIT'. Example:
     #
     #   Account.transaction do


### PR DESCRIPTION
If using `Account.find(1, lock: true)` , printed message similar to the following:

> DEPRECATION WARNING: Passing options to #find is deprecated. Please build a scope and then call #find on it.

So I modified sample code.
