### PR TITLE
Accept Proc as Cache#Entry expires_in option

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support of Proc to `Cache#Entry` `:expires_in` option.
+
+    *MasterLambaster*
+
 *   `require_dependency` accepts objects that respond to `to_path`, in
     particular `Pathname` instances.
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -610,7 +610,7 @@ module ActiveSupport
         end
         @created_at = Time.now.to_f
         @expires_in = options[:expires_in]
-        @expires_in = @expires_in.to_f if @expires_in
+        @expires_in = (@expires_in.is_a?(Proc) ? @expires_in.call(self) : @expires_in).to_f if @expires_in
       end
 
       def value

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -610,7 +610,13 @@ module ActiveSupport
         end
         @created_at = Time.now.to_f
         @expires_in = options[:expires_in]
-        @expires_in = (@expires_in.is_a?(Proc) ? @expires_in.call(self) : @expires_in).to_f if @expires_in
+        if @expires_in
+          @expires_in = if @expires_in.is_a?(Proc)
+            @expires_in.call(self)
+          else
+            @expires_in
+          end.to_f
+        end
       end
 
       def value

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -219,7 +219,10 @@ module ActiveSupport
       #
       # Setting <tt>:expires_in</tt> will set an expiration time on the cache.
       # All caches support auto-expiring content after a specified number of
-      # seconds. This value can be specified as an option to the constructor
+      # seconds. The expires_in can be either a static value or a Proc. If it
+      # is a Proc, it will be invoked when cache entry is created that you can
+      # use application logic to control expiration time.
+      # This value can be specified as an option to the constructor
       # (in which case all entries will be affected), or it can be supplied to
       # the +fetch+ or +write+ method to effect just one entry.
       #

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -1024,4 +1024,11 @@ class CacheEntryTest < ActiveSupport::TestCase
     assert_equal "hello", entry.value
     assert_equal true, entry.expired?
   end
+
+  def test_accepts_proc_for_expires_in_option
+    now = Time.now
+    Time.stubs(:now).returns(now)
+    entry = ActiveSupport::Cache::Entry.new("value", :expires_in => Proc.new { 60 })
+    assert_equal now.to_f+60, entry.expires_at
+  end
 end


### PR DESCRIPTION
Allow passing a proc as expires_in option for cache entry.
One of the main reasons is to allow passing dynamic expiration time for `caches_action` that can't be changed after server start or any other store options that's passed as is to cache stored adapter.
