### PR TITLE
Fixes #12423 - Additional select columns are removed when using includes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   If an alias was specified, it will be accessible from the resulting objects on joins
+
+    Saves the alias when querying with associations
+
+    *Edo Balvers*
+
 *   `NullRelation#pluck` takes a list of columns
 
     The method signature in `NullRelation` was updated to mimic that in

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -26,7 +26,7 @@ module ActiveRecord
           @reflection      = reflection
           @alias_tracker   = alias_tracker
           @join_type       = join_type
-          @aliased_prefix  = "t#{ index }"
+          @aliased_prefix  = "#{ALIASED_PREFIX}#{ index }"
           @tables          = construct_tables.reverse
         end
 

--- a/activerecord/lib/active_record/associations/join_dependency/join_base.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_base.rb
@@ -14,7 +14,7 @@ module ActiveRecord
         end
 
         def aliased_prefix
-          "t0"
+          "#{ALIASED_PREFIX}0"
         end
 
         def table

--- a/activerecord/lib/active_record/associations/join_dependency/join_part.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_part.rb
@@ -21,6 +21,8 @@ module ActiveRecord
 
         delegate :table_name, :column_names, :primary_key, :to => :base_klass
 
+        ALIASED_PREFIX = '__t'
+
         def initialize(base_klass, parent)
           @base_klass = base_klass
           @parent = parent
@@ -92,7 +94,7 @@ module ActiveRecord
             index += 1
           end
 
-          hash
+          hash.merge(row.select{ |key, _| !key.start_with?(ALIASED_PREFIX) })
         end
 
         def record_id(row)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -494,6 +494,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 1, query.to_a.size
   end
 
+  def test_additional_select_attributes_on_join
+    q = Comment.includes(:post).references(:posts).select("'foo' as foo").first
+    assert_equal 'foo', q.foo
+  end
+
   def test_loading_with_one_association
     posts = Post.preload(:comments)
     post = posts.find { |p| p.id == 1 }


### PR DESCRIPTION
Fixes #12423 - Additional select columns are removed when using includes.
