### PR TITLE
Fix loading a sql structure file on postgres when the file's path has whitespace in it

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix a bug where rake db:structure:load crashed when the path contained
+    spaces.
+
+    *Kevin Mook*
+
 *   `ActiveRecord::QueryMethods#unscope` unscopes negative equality
 
     Allows you to call `#unscope` on a relation with negative equality 

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -59,7 +59,7 @@ module ActiveRecord
 
       def structure_load(filename)
         set_psql_env
-        Kernel.system("psql -q -f #{filename} #{configuration['database']}")
+        Kernel.system("psql -q -f #{Shellwords.escape(filename)} #{configuration['database']}")
       end
 
       private

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -231,6 +231,13 @@ module ActiveRecord
 
       ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
     end
+
+    def test_structure_load_accepts_path_with_spaces
+      filename = "awesome file.sql"
+      Kernel.expects(:system).with("psql -q -f awesome\\ file.sql my-app-db")
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+    end
   end
 
 end


### PR DESCRIPTION
This pull request fixes a bug where loading a postgres structure.sql file that has whitespaces in the filename, fails.

Note: I tried to write a unit test that failed without this code, but was unable to get the test to fail. I tried to model my test after the DatabaseTasksStructureLoadTest in activerecord/test/cases/tasks/database_tasks_test.rb, but it appears that test doesn't actually invoke PostgreSQLDatabaseTasks' structure_load method. This might be due to ActiveRecord::Tasks::PostgreSQLDatabaseTasks being stubbed out?

I'm happy to include a test if someone can help me figure out how to properly test it, otherwise this pull request passes all tests and I have verified it does indeed solve the bug.

If one cares to reproduce the bug directly, simply make a postgres project in a directory with spaces in the path (~/code/some project with spaces/) and run "RAILS_ENV=test rake db:test:prepare". Without this pull request, the "db:test:prepare" rake task will fail with an error similar to "psql: FATAL:  role "with" does not exist"
