### PR TITLE
integration test support for the options request method

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -62,6 +62,12 @@ module ActionDispatch
         process :head, path, parameters, headers_or_env
       end
 
+      # Performs an OPTIONS request with the given parameters. See +#get+ for more
+      # details.
+      def options(path, parameters = nil, headers_or_env = nil)
+        process :options, path, parameters, headers_or_env
+      end
+
       # Performs an XMLHttpRequest request with the given parameters, mirroring
       # a request from the Prototype library.
       #

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -117,6 +117,12 @@ class SessionTest < ActiveSupport::TestCase
     @session.head(path,params,headers)
   end
 
+  def test_options
+    path = "/index"; params = "blah"; headers = {:location => 'blah'}
+    @session.expects(:process).with(:options,path,params,headers)
+    @session.options(path,params,headers)
+  end
+
   def test_xml_http_request_get
     path = "/index"; params = "blah"; headers = {:location => 'blah'}
     headers_after_xhr = headers.merge(
@@ -234,7 +240,7 @@ class IntegrationTestUsesCorrectClass < ActionDispatch::IntegrationTest
     @integration_session.stubs(:generic_url_rewriter)
     @integration_session.stubs(:process)
 
-    %w( get post head patch put delete ).each do |verb|
+    %w( get post head options patch put delete ).each do |verb|
       assert_nothing_raised("'#{verb}' should use integration test methods") { __send__(verb, '/') }
     end
   end


### PR DESCRIPTION
this adds support, in integration tests (ActionDispatch::IntegrationTest), to call "options" similar to the currently supported get, post, head.. and the rest. ie:

```
def test_options_for_search
  options '/search'
  assert_response :success
  # etc
end
```

options is a real enough request method, and it is clumsy to test it without this added method.

re: http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html

i imagine that "options" is a tricky thing to name a method, but i don't see any conflicts near this space.

let me know and i'll CHANGELOG.
