### PR TITLE
Configurable name for schema_migrations table

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -34,6 +34,12 @@ module ActiveRecord
 
       ##
       # :singleton-method:
+      # Accessor for the name of the schema migrations table.  By default, the value is "schema_migrations"
+      class_attribute :schema_migrations_table_name, instance_writer: false
+      self.schema_migrations_table_name = "schema_migrations"
+
+      ##
+      # :singleton-method:
       # Indicates whether table names should be the pluralized versions of the corresponding class names.
       # If true, the default table name for a Product class will be +products+. If false, it would just be +product+.
       # See table_name for the full rules on table/class naming. This is true, by default.

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -6,11 +6,11 @@ module ActiveRecord
   class SchemaMigration < ActiveRecord::Base
 
     def self.table_name
-      "#{Base.table_name_prefix}schema_migrations#{Base.table_name_suffix}"
+      "#{Base.table_name_prefix}#{Base.schema_migrations_table_name}#{Base.table_name_suffix}"
     end
 
     def self.index_name
-      "#{Base.table_name_prefix}unique_schema_migrations#{Base.table_name_suffix}"
+      "#{Base.table_name_prefix}unique_#{Base.schema_migrations_table_name}#{Base.table_name_suffix}"
     end
 
     def self.create_table(limit=nil)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -316,14 +316,18 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_schema_migrations_table_name
+    assert_equal "schema_migrations", ActiveRecord::Migrator.schema_migrations_table_name
     ActiveRecord::Base.table_name_prefix = "prefix_"
     ActiveRecord::Base.table_name_suffix = "_suffix"
     Reminder.reset_table_name
     assert_equal "prefix_schema_migrations_suffix", ActiveRecord::Migrator.schema_migrations_table_name
+    ActiveRecord::Base.schema_migrations_table_name = "changed"
+    Reminder.reset_table_name
+    assert_equal "prefix_changed_suffix", ActiveRecord::Migrator.schema_migrations_table_name
     ActiveRecord::Base.table_name_prefix = ""
     ActiveRecord::Base.table_name_suffix = ""
     Reminder.reset_table_name
-    assert_equal "schema_migrations", ActiveRecord::Migrator.schema_migrations_table_name
+    assert_equal "changed", ActiveRecord::Migrator.schema_migrations_table_name
   end
 
   def test_proper_table_name


### PR DESCRIPTION
When multiple applications point to the same database schema, it'd be beneficial to allow each application have its own schema_migrations table.

This PR makes the name of the schema_migrations table configurable via config.active_record.schema_migrations_table_name.

I'd love any feedback!
