### PR TITLE
Configurable name for schema_migrations table

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow for the name of the schema_migrations table to be configured.
+
+    *Jerad Phelps*
+
 *   `NullRelation#pluck` takes a list of columns
 
     The method signature in `NullRelation` was updated to mimic that in

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -34,6 +34,12 @@ module ActiveRecord
 
       ##
       # :singleton-method:
+      # Accessor for the name of the schema migrations table. By default, the value is "schema_migrations"
+      class_attribute :schema_migrations_table_name, instance_accessor: false
+      self.schema_migrations_table_name = "schema_migrations"
+
+      ##
+      # :singleton-method:
       # Indicates whether table names should be the pluralized versions of the corresponding class names.
       # If true, the default table name for a Product class will be +products+. If false, it would just be +product+.
       # See table_name for the full rules on table/class naming. This is true, by default.

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -7,11 +7,11 @@ module ActiveRecord
     class << self
 
       def table_name
-        "#{table_name_prefix}schema_migrations#{table_name_suffix}"
+        "#{table_name_prefix}#{ActiveRecord::Base.schema_migrations_table_name}#{table_name_suffix}"
       end
 
       def index_name
-        "#{table_name_prefix}unique_schema_migrations#{table_name_suffix}"
+        "#{table_name_prefix}unique_#{ActiveRecord::Base.schema_migrations_table_name}#{table_name_suffix}"
       end
 
       def table_exists?

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -311,14 +311,23 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_schema_migrations_table_name
+    original_schema_migrations_table_name = ActiveRecord::Migrator.schema_migrations_table_name
+
+    assert_equal "schema_migrations", ActiveRecord::Migrator.schema_migrations_table_name
     ActiveRecord::Base.table_name_prefix = "prefix_"
     ActiveRecord::Base.table_name_suffix = "_suffix"
     Reminder.reset_table_name
     assert_equal "prefix_schema_migrations_suffix", ActiveRecord::Migrator.schema_migrations_table_name
+    ActiveRecord::Base.schema_migrations_table_name = "changed"
+    Reminder.reset_table_name
+    assert_equal "prefix_changed_suffix", ActiveRecord::Migrator.schema_migrations_table_name
     ActiveRecord::Base.table_name_prefix = ""
     ActiveRecord::Base.table_name_suffix = ""
     Reminder.reset_table_name
-    assert_equal "schema_migrations", ActiveRecord::Migrator.schema_migrations_table_name
+    assert_equal "changed", ActiveRecord::Migrator.schema_migrations_table_name
+  ensure
+    ActiveRecord::Base.schema_migrations_table_name = original_schema_migrations_table_name
+    Reminder.reset_table_name
   end
 
   def test_proper_table_name_on_migrator

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -261,6 +261,8 @@ config.middleware.delete "Rack::MethodOverride"
 
 * `config.active_record.table_name_suffix` lets you set a global string to be appended to table names. If you set this to `_northwest`, then the Customer class will look for `customers_northwest` as its table. The default is an empty string.
 
+* `config.active_record.schema_migrations_table_name` lets you set a string to be used as the name of the schema migrations table.
+
 * `config.active_record.pluralize_table_names` specifies whether Rails will look for singular or plural table names in the database. If set to true (the default), then the Customer class will use the `customers` table. If set to false, then the Customer class will use the `customer` table.
 
 * `config.active_record.default_timezone` determines whether to use `Time.local` (if set to `:local`) or `Time.utc` (if set to `:utc`) when pulling dates and times from the database. The default is `:utc` for Rails, although Active Record defaults to `:local` when used outside of Rails.


### PR DESCRIPTION
When multiple applications point to the same database schema, it'd be beneficial to allow each application have its own schema_migrations table.

This PR makes the name of the schema_migrations table configurable via config.active_record.schema_migrations_table_name.

I'd love any feedback!
