### PR TITLE
Fix an error if mysql port is provided when dumping the database structure

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -59,7 +59,7 @@ module ActiveRecord
         args.concat(["--result-file", "#{filename}"])
         args.concat(["--no-data"])
         args.concat(["#{configuration['database']}"])
-        unless Kernel.system(*args)
+        unless Kernel.system(args.join(' '))
           $stderr.puts "Could not dump the database structure. "\
                        "Make sure `mysqldump` is in your PATH and check the command output for warnings."
         end
@@ -69,7 +69,7 @@ module ActiveRecord
         args = prepare_command_options('mysql')
         args.concat(['--execute', %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}])
         args.concat(["--database", "#{configuration['database']}"])
-        Kernel.system(*args)
+        Kernel.system(args.join(' '))
       end
 
       private


### PR DESCRIPTION
Fix an error if the mysql port is provided in num like this when running `rake db:structure:dump`:

``` shell
no implicit conversion of Fixnum into String
activerecord-4.0.0/lib/active_record/tasks/mysql_database_tasks.rb:62:in `system'
activerecord-4.0.0/lib/active_record/tasks/mysql_database_tasks.rb:62:in `structure_dump'
activerecord-4.0.0/lib/active_record/tasks/database_tasks.rb:142:in `structure_dump'
activerecord-4.0.0/lib/active_record/railties/databases.rake:288:in `block (3 levels) in <top (required)>'
```
