### PR TITLE
Add chainable indempotent 'not' method to StringInquirer.

### DIFF
--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -4,11 +4,20 @@ module ActiveSupport
   # in a StringInquirer object so instead of calling this:
   #
   #   Rails.env == 'production'
+  #   Rails.env != 'production'
   #
   # you can call this:
   #
   #   Rails.env.production?
+  #   Rails.env.not.production?
   class StringInquirer < String
+
+      attr_accessor :negated
+
+      def not
+        self.dup.tap{ |s| s.negated = !s.negated }
+      end
+
     private
 
       def respond_to_missing?(method_name, include_private = false)
@@ -17,7 +26,7 @@ module ActiveSupport
 
       def method_missing(method_name, *arguments)
         if method_name[-1] == '?'
-          self == method_name[0..-2]
+          (self == method_name[0..-2]) ^ self.negated
         else
           super
         end

--- a/activesupport/test/string_inquirer_test.rb
+++ b/activesupport/test/string_inquirer_test.rb
@@ -13,6 +13,18 @@ class StringInquirerTest < ActiveSupport::TestCase
     assert_not @string_inquirer.development?
   end
 
+  def test_negated_match
+    assert_not @string_inquirer.not.production?
+  end
+
+  def test_negated_miss
+    assert @string_inquirer.not.development?
+  end
+
+  def test_idempotence
+    assert @string_inquirer.not.production? == @string_inquirer.not.production?
+  end
+
   def test_missing_question_mark
     assert_raise(NoMethodError) { @string_inquirer.production }
   end


### PR DESCRIPTION
This is just a little sugar on StringInquirer, but
- StringInquirer is already just sugar
- I've been using this patch often enough, long enough I figured others might like it

I use StringInquirer extensively, most frequently in non-Rails apps to wrap ENV variables into meaningful predicate methods on various classes and modules in my library. This often leads to code like

`if not Git::Repository.host.github?`

Since this is sugar anyhow, I prefer the more natural

`if Git::Repository.host.not.github?`

Discuss/dismiss away.
