### PR TITLE
Create a whitelist of methods to be delegated to Array.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Create a whitelist of delegable methods to `Array`.
+
+    Currently `Relation` directly delegates methods to `Array`. With this change,
+    only the methods present in this whitelist will be delegated.
+
+    The whitelist contains:
+
+        #&, #+, #[], #all?, #collect, #detect, #each, #each_cons, #each_with_index,
+        #flat_map, #group_by, #include?, #length, #map, #none?, :one?, #reverse, #sample,
+        #second, #sort, #sort_by, #to_ary, #to_set, #to_xml, #to_yaml
+
+    To use any other method, instead first call `#to_a` on the association.
+
+    *Lauro Caetano*
+
 *   Use the right column to type cast grouped calculations with custom expressions.
 
     Fixes #13230.
@@ -448,12 +463,6 @@
     Fixes #11963.
 
     *Paul Nikitochkin*
-
-*   Deprecate the delegation of Array bang methods for associations.
-    To use them, instead first call `#to_a` on the association to access the
-    array to be acted on.
-
-    *Ben Woosley*
 
 *   `CollectionAssociation#first`/`#last` (e.g. `has_many`) use a `LIMIT`ed
     query to fetch results rather than loading the entire collection.

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -68,7 +68,7 @@ module ActiveRecord
               RUBY
             else
               define_method method do |*args, &block|
-                scoping { @klass.send(method, *args, &block) }
+                scoping { @klass.public_send(method, *args, &block) }
               end
             end
           end
@@ -87,10 +87,10 @@ module ActiveRecord
       def method_missing(method, *args, &block)
         if @klass.respond_to?(method)
           self.class.delegate_to_scoped_klass(method)
-          scoping { @klass.send(method, *args, &block) }
+          scoping { @klass.public_send(method, *args, &block) }
         elsif arel.respond_to?(method)
           self.class.delegate method, :to => :arel
-          arel.send(method, *args, &block)
+          arel.public_send(method, *args, &block)
         else
           super
         end
@@ -118,9 +118,9 @@ module ActiveRecord
 
     def method_missing(method, *args, &block)
       if @klass.respond_to?(method)
-        scoping { @klass.send(method, *args, &block) }
+        scoping { @klass.public_send(method, *args, &block) }
       elsif arel.respond_to?(method)
-        arel.send(method, *args, &block)
+        arel.public_send(method, *args, &block)
       else
         super
       end

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -6,22 +6,21 @@ module ActiveRecord
   class DelegationTest < ActiveRecord::TestCase
     fixtures :posts
 
-    def assert_responds(target, method)
-      assert target.respond_to?(method)
-      assert_nothing_raised do
-        method_arity = target.to_a.method(method).arity
+    def call_method(target, method)
+      method_arity = target.to_a.method(method).arity
 
-        if method_arity.zero?
+      if method_arity.zero?
+        target.send(method)
+      elsif method_arity < 0
+        if method == :shuffle!
           target.send(method)
-        elsif method_arity < 0
-          if method == :shuffle!
-            target.send(method)
-          else
-            target.send(method, 1)
-          end
         else
-          raise NotImplementedError
+          target.send(method, 1)
         end
+       elsif method_arity == 1
+        target.send(method, 1)
+      else
+        raise NotImplementedError
       end
     end
   end
@@ -31,31 +30,20 @@ module ActiveRecord
       Post.first.comments
     end
 
-    [:map, :collect].each do |method|
-      test "##{method} is delegated" do
-        assert_responds(target, method)
-        assert_equal(target.pluck(:body), target.send(method) {|post| post.body })
-      end
-
-      test "##{method}! is not delegated" do
-        assert_deprecated do
-          assert_responds(target, "#{method}!")
-        end
+    [:&, :+, :[], :all?, :collect, :detect, :each, :each_cons,
+     :each_with_index, :flat_map, :group_by, :include?, :length,
+     :map, :none?, :one?, :reverse, :sample, :second, :sort, :sort_by,
+     :to_ary, :to_set, :to_xml, :to_yaml].each do |method|
+      test "association delegates #{method} to Array" do
+        assert_respond_to target, method
       end
     end
 
     [:compact!, :flatten!, :reject!, :reverse!, :rotate!,
-      :shuffle!, :slice!, :sort!, :sort_by!].each do |method|
-      test "##{method} delegation is deprecated" do
-        assert_deprecated do
-          assert_responds(target, method)
-        end
-      end
-    end
-
-    [:select!, :uniq!].each do |method|
-      test "##{method} is implemented" do
-        assert_responds(target, method)
+     :shuffle!, :slice!, :sort!, :sort_by!, :delete_if,
+     :keep_if, :pop, :shift, :delete_at, :compact].each do |method|
+      test "#{method} is not delegated to Array" do
+        assert_raises(NoMethodError) { call_method(target, method) }
       end
     end
   end
@@ -64,36 +52,23 @@ module ActiveRecord
     fixtures :comments
 
     def target
-      Comment.where(body: 'Normal type')
+      Comment.all
     end
 
-    [:map, :collect].each do |method|
-      test "##{method} is delegated" do
-        assert_responds(target, method)
-        assert_equal(target.pluck(:body), target.send(method) {|post| post.body })
-      end
-
-      test "##{method}! is not delegated" do
-        assert_deprecated do
-          assert_responds(target, "#{method}!")
-        end
+    [:&, :+, :[], :all?, :collect, :detect, :each, :each_cons,
+     :each_with_index, :flat_map, :group_by, :include?, :length,
+     :map, :none?, :one?, :reverse, :sample, :second, :sort, :sort_by,
+     :to_ary, :to_set, :to_xml, :to_yaml].each do |method|
+      test "relation delegates #{method} to Array" do
+        assert_respond_to target, method
       end
     end
 
     [:compact!, :flatten!, :reject!, :reverse!, :rotate!,
-      :shuffle!, :slice!, :sort!, :sort_by!].each do |method|
-      test "##{method} delegation is deprecated" do
-        assert_deprecated do
-          assert_responds(target, method)
-        end
-      end
-    end
-
-    [:select!, :uniq!].each do |method|
-      test "##{method} triggers an immutable error" do
-        assert_raises ActiveRecord::ImmutableRelation do
-          assert_responds(target, method)
-        end
+     :shuffle!, :slice!, :sort!, :sort_by!, :delete_if,
+     :keep_if, :pop, :shift, :delete_at, :compact].each do |method|
+      test "#{method} is not delegated to Array" do
+        assert_raises(NoMethodError) { call_method(target, method) }
       end
     end
   end

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -10,15 +10,15 @@ module ActiveRecord
       method_arity = target.to_a.method(method).arity
 
       if method_arity.zero?
-        target.send(method)
+        target.public_send(method)
       elsif method_arity < 0
         if method == :shuffle!
-          target.send(method)
+          target.public_send(method)
         else
-          target.send(method, 1)
+          target.public_send(method, 1)
         end
        elsif method_arity == 1
-        target.send(method, 1)
+        target.public_send(method, 1)
       else
         raise NotImplementedError
       end


### PR DESCRIPTION
Deprecate the delegation of `Array` methods for association. Only the methods that are in the whitelist would be delegated.

This PR completes the work initiated by this commit: https://github.com/rails/rails/commit/1a40be02113287d9a003f8224e91b9f623857f4b

Also it is a alternative implementation for https://github.com/rails/rails/pull/12227.

I'm not sure if the whitelist is correct, for that reason I'd :heart: your review.

Thanks!
