### PR TITLE
Add ability to set a prefix name for routes which have hyphen

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add ability to set a prefix name for routes which have hyphen(s).
+
+        get '/contact-us' => 'pages#contact'
+        get '/about-us'   => 'pages#about_us'
+
+    The above routes will inspected to
+
+            Prefix Verb URI Pattern           Controller#Action
+        contact_us GET  /contact-us(.:format) pages#contact
+          about_us GET  /about-us(.:format)   pages#about_us
+
+    *Amr Tamimi*
+
 *   Fix `Encoding::CompatibilityError` when public path is UTF-8
 
     In #5337 we forced the path encoding to ASCII-8BIT to prevent static file handling

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1436,7 +1436,7 @@ module ActionDispatch
           path = path_for_action(action, options.delete(:path))
           action = action.to_s.dup
 
-          if action =~ /^[\w\/]+$/
+          if action =~ /^[\w\-\/]+$/
             options[:action] ||= action unless action.include?("/")
           else
             action = nil
@@ -1632,6 +1632,7 @@ module ActionDispatch
             when :root
               [name_prefix, collection_name, prefix]
             else
+              prefix.gsub!(/\-/, '_') if prefix.is_a?(String)
               [name_prefix, member_name, prefix]
             end
 

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -37,6 +37,7 @@ module ActionDispatch
         end
         engine.routes.draw do
           get '/cart', :to => 'cart#show'
+          get '/view-cart', :to => 'cart#show'
         end
 
         output = draw do
@@ -50,7 +51,8 @@ module ActionDispatch
           "         blog      /blog                    Blog::Engine",
           "",
           "Routes for Blog::Engine:",
-          "  cart GET  /cart(.:format) cart#show"
+          "     cart GET  /cart(.:format)      cart#show",
+          "view_cart GET  /view-cart(.:format) cart#show"
         ], output
       end
 

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -30,10 +30,12 @@ module ActionDispatch
         draw do
           get 'foo', to: SimpleApp.new('foo#index')
           get 'bar', to: SimpleApp.new('bar#index')
+          get 'foo-bar', to: SimpleApp.new('bar#index')
         end
 
         assert_equal '/foo', url_helpers.foo_path
         assert_equal '/bar', url_helpers.bar_path
+        assert_equal '/foo-bar', url_helpers.foo_bar_path
       end
 
       test "url helpers are updated when route is updated" do


### PR DESCRIPTION
With current Rails when you have in your routes

``` ruby
get '/contact_us' => 'pages#contact'
get '/about_us'   => 'pages#about_us'
```

you'll get this inspection: 

``` shell
           Prefix Verb  URI Pattern                  Controller#Action
       contact_us GET   /contact_us(.:format)        pages#contact
         about_us GET   /about_us(.:format)          pages#about_us
```

---

But when your routes are with hyphen (dash), like so:

``` ruby
get '/contact-us' => 'pages#contact'
get '/about-us'   => 'pages#about_us'
```

you'll get this: 

``` shell
           Prefix Verb  URI Pattern                  Controller#Action
                  GET   /contact-us(.:format)        pages#contact
                  GET   /about-us(.:format)          pages#about_us
```

Which does lead that theres no helper methods for these routes i.e. `about_us_path`, `contact_us_path`.

For this pull request, it will convert the hyphens to underscores in paths so it'll be familiar to Ruby to translate it to a method.

This is will be the inspection for the latest routes above:

``` shell
           Prefix Verb  URI Pattern                  Controller#Action
       contact_us GET   /contact-us(.:format)        pages#contact
         about_us GET   /about-us(.:format)          pages#about_us
```
