### PR TITLE
Make the application name snake cased when it contains spaces

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Make the application name snake cased when it contains spaces
+
+    The application name is used to fill the `database.yml` and
+    `session_store.rb` files ; previously, if the provided name
+    contained whitespaces, it led to unexpected names in these files.
+
+    *Robin Dupret*
+
 *   Added `--model-name` option to `ScaffoldControllerGenerator`.
 
     *yalab*

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -239,7 +239,7 @@ module Rails
       end
 
       def app_name
-        @app_name ||= (defined_app_const_base? ? defined_app_name : File.basename(destination_root)).tr(".", "_")
+        @app_name ||= (defined_app_const_base? ? defined_app_name : File.basename(destination_root)).tr('\\', '').tr(". ", "_")
       end
 
       def defined_app_name

--- a/railties/lib/rails/generators/testing/assertions.rb
+++ b/railties/lib/rails/generators/testing/assertions.rb
@@ -21,7 +21,7 @@ module Rails
         #     end
         #   end
         def assert_file(relative, *contents)
-          absolute = File.expand_path(relative, destination_root)
+          absolute = File.expand_path(relative, destination_root).shellescape
           assert File.exists?(absolute), "Expected file #{relative.inspect} to exist, but does not"
 
           read = File.read(absolute) if block_given? || !contents.empty?

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -367,6 +367,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_match(/run  bundle install/, output)
   end
 
+  def test_application_name_with_spaces
+    path = File.join(destination_root, "foo bar".shellescape)
+
+    # This also applies to MySQL apps but not with SQLite
+    run_generator [path, "-d", 'postgresql']
+
+    assert_file "foo bar/config/database.yml", /database: foo_bar_development/
+    assert_file "foo bar/config/initializers/session_store.rb", /key: '_foo_bar/
+  end
+
 protected
 
   def action(*args, &block)


### PR DESCRIPTION
Hello,

This pull request fixes the application name used to fill the `database.yml` and `session_store.rb` files ; previously, if the provided name contained whitespaces, it led to unexpected names in these files.

Since Shellwords.escape adds backslashes to escape spaces, the app_name should remove them and replace any space with an underscore (just like periods previously).

Also improve the assert_file helper to work with paths containing spaces using String#shellescape.

/cc @senny By the way, sorry, this patch fixes two problems but the solution is the same so I thought it was ok not to open another PR just for the provided test ; if you want to, let me know.

Have a nice day.
