### PR TITLE
Update workaround for "Outside the Scope of Strong Parameters"

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -328,9 +328,7 @@ the job done:
 
 ```ruby
 def product_params
-  params.require(:product).permit(:name).tap do |whitelisted|
-    whitelisted[:data] = params[:product][:data]
-  end
+  params.require(:product).permit(:name, { data: params[:product][:data].keys })
 end
 ```
 

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -328,7 +328,7 @@ the job done:
 
 ```ruby
 def product_params
-  params.require(:product).permit(:name, { data: params[:product][:data].keys })
+  params.require(:product).permit(:name, { data: params[:product][:data].try(:keys) })
 end
 ```
 


### PR DESCRIPTION
The previous example of how to permit a hash of unknown keys used `tap`, but had the side effect of logging an "Unpermitted parameters" message despite being a successful workaround. The proposed workaround is ever so slightly better, imo, because it won't result in an "Unpermitted parameters" message being logged.

Additionally, and maybe this is just me, but as fun as it was to look up what the heck `tap` is, the use of it seems inelegant to me.
