### PR TITLE
Adding Table Context to Order Hash

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -862,4 +862,34 @@
 
     *Slava Markevich*
 
+*   Prepend original table name to order hash
+
+    With the models
+
+        class Post
+          has_many :comments
+          scope :dewey, -> { order(subject: :desc) }
+        end
+
+        class Comment
+          belongs_to :post
+        end
+
+    And records
+
+        p1 = Post.create(subject: 'Awesomeness')
+        p2 = Post.create(subject: 'Zaniness')
+        c1 = Comment.create(type: 'Cool', post_id: p1.id)
+        c2 = Comment.create(type: 'Cool', post_id: p2.id)
+
+    The call
+
+        Comment.where(type: 'Cool').joins(:post).merge(Post.dewey)
+
+    Should yield
+
+        [c2, c1]
+
+    *Paul Pettengill*
+
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/test/fixtures/posts.yml
+++ b/activerecord/test/fixtures/posts.yml
@@ -28,6 +28,7 @@ authorless:
 sti_comments:
   id: 4
   author_id: 1
+  comments_count: 4
   title: sti comments
   body: hello
   type: Post
@@ -35,6 +36,7 @@ sti_comments:
 sti_post_and_comments:
   id: 5
   author_id: 1
+  comments_count: 3
   title: sti me
   body: hello
   type: StiPost

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -19,6 +19,7 @@ class Post < ActiveRecord::Base
 
   scope :containing_the_letter_a, -> { where("body LIKE '%a%'") }
   scope :ranked_by_comments,      -> { order("comments_count DESC") }
+  scope :ranked_by_comments_hash, -> { order(comments_count: :desc) }
 
   scope :limit_by, lambda {|l| limit(l) }
 
@@ -39,6 +40,8 @@ class Post < ActiveRecord::Base
 
   scope :with_comments, -> { preload(:comments) }
   scope :with_tags, -> { preload(:taggings) }
+
+  scope :comment, -> { order(type: :desc) }
 
   has_many   :comments do
     def find_most_recent


### PR DESCRIPTION
This commit fixes #12604

Prepend original table name to order hash

```
With the models

    class Post
      has_many :comments
      scope :dewey, -> { order(subject: :desc) }
    end

    class Comment
      belongs_to :post
    end

And records

    p1 = Post.create(subject: 'Awesomeness')
    p2 = Post.create(subject: 'Zaniness')
    c1 = Comment.create(type: 'Cool', post_id: p1.id)
    c2 = Comment.create(type: 'Cool', post_id: p2.id)

The call

    Comment.where(type: 'Cool').joins(:post).merge(Post.dewey)

Should yield

    [c2, c1]
```
