### PR TITLE
Make slice! honor default hash value/proc

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `slice!` deleting the default value of the hash.
+
+    *Antonio Santos*
+
 *   `require_dependency` accepts objects that respond to `to_path`, in
     particular `Pathname` instances.
 

--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -26,6 +26,8 @@ class Hash
     keys.map! { |key| convert_key(key) } if respond_to?(:convert_key, true)
     omit = slice(*self.keys - keys)
     hash = slice(*keys)
+    hash.default      = default
+    hash.default_proc = default_proc if default_proc
     replace(hash)
     omit
   end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -781,6 +781,24 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal 'bender', slice['login']
   end
 
+  def test_slice_bang_does_not_override_default
+    hash = Hash.new(0)
+    hash.update(a: 1, b: 2)
+
+    hash.slice!(:a)
+
+    assert_equal 0, hash[:c]
+  end
+
+  def test_slice_bang_does_not_override_default_proc
+    hash = Hash.new { |h, k| h[k] = [] }
+    hash.update(a: 1, b: 2)
+
+    hash.slice!(:a)
+
+    assert_equal [], hash[:c]
+  end
+
   def test_extract
     original = {:a => 1, :b => 2, :c => 3, :d => 4}
     expected = {:a => 1, :b => 2}


### PR DESCRIPTION
I ran yesterday into an issue that turned to be caused by `slice!` removing the
default proc from a hash. That is not consistent with how the bang methods in Hash
work normally.

I don't know if this is intended, here it is the fix just in case.

See below for an example:

```
[1] pry(main)> h1 = Hash.new { |h,k| h[k] = [] }
=> {}
[2] pry(main)> h1.update(a: 1, b: 2)
=> {:a=>1, :b=>2}
[3] pry(main)> h1[:c]
=> []
[4] pry(main)> h1.select! { |k, v| k == :a }
=> {:a=>1}
[5] pry(main)> h1
=> {:a=>1}
[6] pry(main)> h1[:c]
=> []
[7] pry(main)> h1.default_proc
=> #<Proc:0x007f97dabd4d80@(pry):1>
[8] pry(main)> require 'active_support'
=> true
[9] pry(main)> h2 = Hash.new { |h, k| h[k] = [] }
=> {}
[10] pry(main)> h2.update(a: 1, b: 2)
=> {:a=>1, :b=>2}
[11] pry(main)> h2[:c]
=> []
[12] pry(main)> h2.slice!(:a)
=> {:b => 2, :c=>[]}
[13] pry(main)> h2
=> {:a=>1}
[14] pry(main)> h2[:c]
=> nil
[15] pry(main)> h2.default_proc
=> nil
```

Cheers
