### PR TITLE
Let validates_inclusion_of accept Time and DateTime ranges

### DIFF
--- a/activemodel/lib/active_model/validations/clusivity.rb
+++ b/activemodel/lib/active_model/validations/clusivity.rb
@@ -30,12 +30,18 @@ module ActiveModel
         @delimiter ||= options[:in] || options[:within]
       end
 
-      # In Ruby 1.9 <tt>Range#include?</tt> on non-numeric ranges checks all possible values in the
-      # range for equality, which is slower but more accurate. <tt>Range#cover?</tt> uses
-      # the previous logic of comparing a value with the range endpoints, which is fast
-      # but is only accurate on numeric ranges.
+      # In Ruby 1.9 <tt>Range#include?</tt> on non-number-or-time-ish ranges checks all
+      # possible values in the range for equality, which is slower but more accurate.
+      # <tt>Range#cover?</tt> uses the previous logic of comparing a value with the range
+      # endpoints, which is fast but is only accurate on Numeric, Time, or DateTime ranges.
       def inclusion_method(enumerable)
-        (enumerable.is_a?(Range) && enumerable.first.is_a?(Numeric)) ? :cover? : :include?
+        return :include? unless enumerable.is_a?(Range)
+        case enumerable.first
+        when Numeric, Time, DateTime
+          :cover?
+        else
+          :include?
+        end
       end
     end
   end

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'cases/helper'
+require 'active_support/all'
 
 require 'models/topic'
 require 'models/person'
@@ -18,6 +19,27 @@ class InclusionValidationTest < ActiveModel::TestCase
     assert Topic.new("title" => "aaa", "content" => "abc").valid?
     assert Topic.new("title" => "abc", "content" => "abc").valid?
     assert Topic.new("title" => "bbb", "content" => "abc").valid?
+  end
+
+  def test_validates_inclusion_of_time_range
+    Topic.validates_inclusion_of(:created_at, in: 1.year.ago..Time.now)
+    assert Topic.new(title: 'aaa', created_at: 2.years.ago).invalid?
+    assert Topic.new(title: 'aaa', created_at: 3.months.ago).valid?
+    assert Topic.new(title: 'aaa', created_at: 37.weeks.from_now).invalid?
+  end
+
+  def test_validates_inclusion_of_date_range
+    Topic.validates_inclusion_of(:created_at, in: 1.year.until(Date.today)..Date.today)
+    assert Topic.new(title: 'aaa', created_at: 2.years.until(Date.today)).invalid?
+    assert Topic.new(title: 'aaa', created_at: 3.months.until(Date.today)).valid?
+    assert Topic.new(title: 'aaa', created_at: 37.weeks.since(Date.today)).invalid?
+  end
+
+  def test_validates_inclusion_of_date_time_range
+    Topic.validates_inclusion_of(:created_at, in: 1.year.until(DateTime.current)..DateTime.current)
+    assert Topic.new(title: 'aaa', created_at: 2.years.until(DateTime.current)).invalid?
+    assert Topic.new(title: 'aaa', created_at: 3.months.until(DateTime.current)).valid?
+    assert Topic.new(title: 'aaa', created_at: 37.weeks.since(DateTime.current)).invalid?
   end
 
   def test_validates_inclusion_of

--- a/activemodel/test/models/topic.rb
+++ b/activemodel/test/models/topic.rb
@@ -6,7 +6,7 @@ class Topic
     super | [ :message ]
   end
 
-  attr_accessor :title, :author_name, :content, :approved
+  attr_accessor :title, :author_name, :content, :approved, :created_at
   attr_accessor :after_validation_performed
 
   after_validation :perform_after_validation


### PR DESCRIPTION
``` ruby
validates_inclusion_of :created_at, 1.year.ago..Time.now
```

raises

```
TypeError: can't iterate from Time
```

since #10774 was merged.
This PR fixes the regression.

I think we'd better backport this to 4-0-stable before shipping 4.0.1 stable release.
