### PR TITLE
Correct error in Utils.normalize_path that changed paths improperly

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -18,7 +18,7 @@ module ActionDispatch
           path = "/#{path}"
           path.squeeze!('/')
           path.sub!(%r{/+\Z}, '')
-          path.gsub!(/(%[a-f0-9]{2}+)/) { $1.upcase }
+          path.gsub!(/(%[a-f0-9]{2})/) { $1.upcase }
           path = '/' if path == ''
           path
         end

--- a/actionpack/test/journey/router/utils_test.rb
+++ b/actionpack/test/journey/router/utils_test.rb
@@ -15,6 +15,14 @@ module ActionDispatch
         def test_uri_unescape
           assert_equal "a/b c+d", Utils.unescape_uri("a%2Fb%20c+d")
         end
+
+        def test_normalize_path_not_greedy
+          assert_equal "/foo%20bar%20baz", Utils.normalize_path("/foo%20bar%20baz")
+        end
+
+        def test_normalize_path_uppercase
+          assert_equal "/foo%AAbar%AAbaz", Utils.normalize_path("/foo%aabar%aabaz")
+        end
       end
     end
   end


### PR DESCRIPTION
We were using Rails 4.0.1rc2 and discovered a bad regular expression in path normalization. This expression:

``` ruby
/(%[a-f0-9]{2}+)/
```

Is intended to match percent-encoded characters but, in fact, matches everything until it meets a character that isn't between a-f or 0-9. Removing the plus fixes the problem, so only the two characters immediately following the % will be matched and uppercased. Tests attached.
