### PR TITLE
Save association when primary key is manually set

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Save `has_one` association when primary key is manually set.
+
+    Fixes #12302
+
+    *Lauro Caetano*
+
 *   Make `Relation#empty?` use `exists?` instead of `count`.
 
     *Szymon Nowak*

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -384,7 +384,8 @@ module ActiveRecord
             record.destroy
           else
             key = reflection.options[:primary_key] ? send(reflection.options[:primary_key]) : id
-            if autosave != false && (new_record? || record.new_record? || record[reflection.foreign_key] != key || autosave)
+            if autosave != false && (autosave || new_record? || record_changed?(reflection, record, key))
+
               unless reflection.through_reflection
                 record[reflection.foreign_key] = key
               end
@@ -395,6 +396,11 @@ module ActiveRecord
             end
           end
         end
+      end
+
+      # If the record is new or it has changed, returns true.
+      def record_changed?(reflection, record, key)
+        record.new_record? || record[reflection.foreign_key] != key || record.attribute_changed?(reflection.foreign_key)
       end
 
       # Saves the associated record if it's new or <tt>:autosave</tt> is enabled.

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -524,4 +524,15 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_equal 'new name', pirate.ship.reload.name
   end
 
+  def test_has_one_autosave_with_primary_key_manually_set
+    post = Post.create(id: 1234, title: "Some title", body: 'Some content')
+    author = Author.new(id: 33, name: 'Hank Moody')
+
+    author.post = post
+    author.save
+    author.reload
+
+    assert_not_nil author.post
+    assert_equal author.post, post
+  end
 end


### PR DESCRIPTION
`has_one` association was not saved with primary key manually set. The method `save_has_one_association` wasn't verifying if the relation was changed.

Fixes #12302
