### PR TITLE
pass app config to controller helper proxy

### DIFF
--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -73,7 +73,11 @@ module ActionController
 
       # Provides a proxy to access helpers methods from outside the view.
       def helpers
-        @helper_proxy ||= ActionView::Base.new.extend(_helpers)
+        @helper_proxy ||= begin 
+          proxy = ActionView::Base.new
+          proxy.config = config.inheritable_copy
+          proxy.extend(_helpers)
+        end
       end
 
       # Overwrite modules_for_helpers to accept :all as argument, which loads

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -201,6 +201,12 @@ class HelperTest < ActiveSupport::TestCase
     # fun/pdf_helper.rb
     assert methods.include?(:foobar)
   end
+  
+  def test_helper_proxy_config
+    AllHelpersController.config.my_var = 'smth'
+    
+    assert_equal 'smth', AllHelpersController.helpers.config.my_var
+  end
 
   private
     def expected_helper_methods


### PR DESCRIPTION
After this fix application config become available when calling helper outisde of view

config/application.rb

``` ruby
#...
config.asset_host = 'http://mycdn.com'
#...
```

Somewhere else

``` ruby
ActionController::Base.helpers.asset_path('fallback.png')
# => http://mycdn.com/assets/fallback.png
```
