### PR TITLE
Failing test for save issue with association named record

### DIFF
--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -12,6 +12,7 @@ require 'models/tag'
 require 'models/tagging'
 require 'models/person'
 require 'models/reader'
+require 'models/student'
 require 'models/parrot'
 require 'models/ship_part'
 require 'models/ship'
@@ -84,6 +85,11 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_raise(ArgumentError, 'ActiveRecord should have barked on bad collection keys') do
       Class.new(ActiveRecord::Base).has_many(:wheels, :name => 'wheels')
     end
+  end
+
+  def test_save_model_with_association_named_record
+    student = Student.create!(:name => "John Doe")
+    assert student.persisted?
   end
 
   def test_should_construct_new_finder_sql_after_create

--- a/activerecord/test/models/student.rb
+++ b/activerecord/test/models/student.rb
@@ -1,3 +1,4 @@
 class Student < ActiveRecord::Base
   has_and_belongs_to_many :lessons
+  belongs_to :record, class_name: 'Ship'
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -627,6 +627,7 @@ ActiveRecord::Schema.define do
 
   create_table :students, :force => true do |t|
     t.string :name
+    t.integer :record_id
   end
 
   create_table :subscribers, :force => true, :id => false do |t|


### PR DESCRIPTION
In Rails 4, when we add an association named `record`, the model is never persisted even if `save!` and `create!` does not raise and `save` and `create` return true.
This is probably due to the use of `record` method in AR code then it would useful to have a Warning / Error to prevent this odd behavior.

[UPDATE]
As this MR breaks other test I wrote a gist which demonstrate the issue : https://gist.github.com/bobbus/7137420
