### PR TITLE
Always check to see if methods exist after calling define_attribute_methods

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -161,12 +161,9 @@ module ActiveRecord
     # If we haven't generated any methods yet, generate them, then
     # see if we've created the method we're looking for.
     def method_missing(method, *args, &block) # :nodoc:
-      if self.class.define_attribute_methods
-        if respond_to_without_attributes?(method)
-          send(method, *args, &block)
-        else
-          super
-        end
+      self.class.define_attribute_methods
+      if respond_to_without_attributes?(method)
+        send(method, *args, &block)
       else
         super
       end


### PR DESCRIPTION
Addresses the bug isolated in #12607 where two threads that both dispatch into `method_missing` will result in only one of them successfully calling the newly-created method.

No idea how to test this, especially since the bug only appears in a threaded environment under very specific timing conditions.
