### PR TITLE
prevent global timezone state from leaking out of test cases.

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -589,38 +589,28 @@ _SQL
   end
 
   def test_timestamp_with_zone_values_with_rails_time_zone_support
-    old_tz         = ActiveRecord::Base.time_zone_aware_attributes
-    old_default_tz = ActiveRecord::Base.default_timezone
+    with_timezone_config default: :utc, aware_attributes: true do
+      @connection.reconnect!
 
-    ActiveRecord::Base.time_zone_aware_attributes = true
-    ActiveRecord::Base.default_timezone = :utc
-
-    @connection.reconnect!
-
-    @first_timestamp_with_zone = PostgresqlTimestampWithZone.find(1)
-    assert_equal Time.utc(2010,1,1, 11,0,0), @first_timestamp_with_zone.time
-    assert_instance_of Time, @first_timestamp_with_zone.time
+      @first_timestamp_with_zone = PostgresqlTimestampWithZone.find(1)
+      assert_equal Time.utc(2010,1,1, 11,0,0), @first_timestamp_with_zone.time
+      assert_instance_of Time, @first_timestamp_with_zone.time
+    end
   ensure
-    ActiveRecord::Base.default_timezone = old_default_tz
-    ActiveRecord::Base.time_zone_aware_attributes = old_tz
     @connection.reconnect!
   end
 
   def test_timestamp_with_zone_values_without_rails_time_zone_support
-    old_tz         = ActiveRecord::Base.time_zone_aware_attributes
-    old_default_tz = ActiveRecord::Base.default_timezone
+    with_timezone_config default: :local, aware_attributes: false do
+      @connection.reconnect!
+      # make sure to use a non-UTC time zone
+      @connection.execute("SET time zone 'America/Jamaica'", 'SCHEMA')
 
-    ActiveRecord::Base.time_zone_aware_attributes = false
-    ActiveRecord::Base.default_timezone = :local
-
-    @connection.reconnect!
-
-    @first_timestamp_with_zone = PostgresqlTimestampWithZone.find(1)
-    assert_equal Time.local(2010,1,1, 11,0,0), @first_timestamp_with_zone.time
-    assert_instance_of Time, @first_timestamp_with_zone.time
+      @first_timestamp_with_zone = PostgresqlTimestampWithZone.find(1)
+      assert_equal Time.utc(2010,1,1, 11,0,0), @first_timestamp_with_zone.time
+      assert_instance_of Time, @first_timestamp_with_zone.time
+    end
   ensure
-    ActiveRecord::Base.default_timezone = old_default_tz
-    ActiveRecord::Base.time_zone_aware_attributes = old_tz
     @connection.reconnect!
   end
 end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -78,12 +78,6 @@ end
 class BasicsTest < ActiveRecord::TestCase
   fixtures :topics, :companies, :developers, :projects, :computers, :accounts, :minimalistics, 'warehouse-things', :authors, :categorizations, :categories, :posts
 
-  def setup
-    ActiveRecord::Base.time_zone_aware_attributes = false
-    ActiveRecord::Base.default_timezone = :local
-    Time.zone = nil
-  end
-
   def test_generated_methods_modules
     modules = Computer.ancestors
     assert modules.include?(Computer::GeneratedFeatureMethods)
@@ -234,7 +228,7 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_preserving_time_objects_with_local_time_conversion_to_default_timezone_utc
     with_env_tz 'America/New_York' do
-      with_active_record_default_timezone :utc do
+      with_timezone_config default: :utc do
         time = Time.local(2000)
         topic = Topic.create('written_on' => time)
         saved_time = Topic.find(topic.id).reload.written_on
@@ -247,7 +241,7 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_preserving_time_objects_with_time_with_zone_conversion_to_default_timezone_utc
     with_env_tz 'America/New_York' do
-      with_active_record_default_timezone :utc do
+      with_timezone_config default: :utc do
         Time.use_zone 'Central Time (US & Canada)' do
           time = Time.zone.local(2000)
           topic = Topic.create('written_on' => time)
@@ -262,18 +256,20 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_preserving_time_objects_with_utc_time_conversion_to_default_timezone_local
     with_env_tz 'America/New_York' do
-      time = Time.utc(2000)
-      topic = Topic.create('written_on' => time)
-      saved_time = Topic.find(topic.id).reload.written_on
-      assert_equal time, saved_time
-      assert_equal [0, 0, 0, 1, 1, 2000, 6, 1, false, "UTC"], time.to_a
-      assert_equal [0, 0, 19, 31, 12, 1999, 5, 365, false, "EST"], saved_time.to_a
+      with_timezone_config default: :local do
+        time = Time.utc(2000)
+        topic = Topic.create('written_on' => time)
+        saved_time = Topic.find(topic.id).reload.written_on
+        assert_equal time, saved_time
+        assert_equal [0, 0, 0, 1, 1, 2000, 6, 1, false, "UTC"], time.to_a
+        assert_equal [0, 0, 19, 31, 12, 1999, 5, 365, false, "EST"], saved_time.to_a
+      end
     end
   end
 
   def test_preserving_time_objects_with_time_with_zone_conversion_to_default_timezone_local
     with_env_tz 'America/New_York' do
-      with_active_record_default_timezone :local do
+      with_timezone_config default: :local do
         Time.use_zone 'Central Time (US & Canada)' do
           time = Time.zone.local(2000)
           topic = Topic.create('written_on' => time)
@@ -493,25 +489,25 @@ class BasicsTest < ActiveRecord::TestCase
   # Oracle, and Sybase do not have a TIME datatype.
   unless current_adapter?(:OracleAdapter, :SybaseAdapter)
     def test_utc_as_time_zone
-      Topic.default_timezone = :utc
-      attributes = { "bonus_time" => "5:42:00AM" }
-      topic = Topic.find(1)
-      topic.attributes = attributes
-      assert_equal Time.utc(2000, 1, 1, 5, 42, 0), topic.bonus_time
-      Topic.default_timezone = :local
+      with_timezone_config default: :utc do
+        attributes = { "bonus_time" => "5:42:00AM" }
+        topic = Topic.find(1)
+        topic.attributes = attributes
+        assert_equal Time.utc(2000, 1, 1, 5, 42, 0), topic.bonus_time
+      end
     end
 
     def test_utc_as_time_zone_and_new
-      Topic.default_timezone = :utc
-      attributes = { "bonus_time(1i)"=>"2000",
-                     "bonus_time(2i)"=>"1",
-                     "bonus_time(3i)"=>"1",
-                     "bonus_time(4i)"=>"10",
-                     "bonus_time(5i)"=>"35",
-                     "bonus_time(6i)"=>"50" }
-      topic = Topic.new(attributes)
-      assert_equal Time.utc(2000, 1, 1, 10, 35, 50), topic.bonus_time
-      Topic.default_timezone = :local
+      with_timezone_config default: :utc do
+        attributes = { "bonus_time(1i)"=>"2000",
+          "bonus_time(2i)"=>"1",
+          "bonus_time(3i)"=>"1",
+          "bonus_time(4i)"=>"10",
+          "bonus_time(5i)"=>"35",
+          "bonus_time(6i)"=>"50" }
+        topic = Topic.new(attributes)
+        assert_equal Time.utc(2000, 1, 1, 10, 35, 50), topic.bonus_time
+      end
     end
   end
 
@@ -634,12 +630,14 @@ class BasicsTest < ActiveRecord::TestCase
     # Oracle, and Sybase do not have a TIME datatype.
     return true if current_adapter?(:OracleAdapter, :SybaseAdapter)
 
-    attributes = {
-      "bonus_time" => "5:42:00AM"
-    }
-    topic = Topic.find(1)
-    topic.attributes = attributes
-    assert_equal Time.local(2000, 1, 1, 5, 42, 0), topic.bonus_time
+    with_timezone_config default: :local do
+      attributes = {
+        "bonus_time" => "5:42:00AM"
+      }
+      topic = Topic.find(1)
+      topic.attributes = attributes
+      assert_equal Time.local(2000, 1, 1, 5, 42, 0), topic.bonus_time
+    end
   end
 
   def test_attributes_on_dummy_time_with_invalid_time
@@ -827,19 +825,18 @@ class BasicsTest < ActiveRecord::TestCase
   # TODO: extend defaults tests to other databases!
   if current_adapter?(:PostgreSQLAdapter)
     def test_default
-      tz = Default.default_timezone
-      Default.default_timezone = :local
-      default = Default.new
-      Default.default_timezone = tz
+      with_timezone_config default: :local do
+        default = Default.new
 
-      # fixed dates / times
-      assert_equal Date.new(2004, 1, 1), default.fixed_date
-      assert_equal Time.local(2004, 1,1,0,0,0,0), default.fixed_time
+        # fixed dates / times
+        assert_equal Date.new(2004, 1, 1), default.fixed_date
+        assert_equal Time.local(2004, 1,1,0,0,0,0), default.fixed_time
 
-      # char types
-      assert_equal 'Y', default.char1
-      assert_equal 'a varchar field', default.char2
-      assert_equal 'a text field', default.char3
+        # char types
+        assert_equal 'Y', default.char1
+        assert_equal 'a varchar field', default.char2
+        assert_equal 'a text field', default.char3
+      end
     end
 
     class Geometric < ActiveRecord::Base; end

--- a/activerecord/test/cases/column_test.rb
+++ b/activerecord/test/cases/column_test.rb
@@ -112,13 +112,11 @@ module ActiveRecord
       end
 
       def test_string_to_time_with_timezone
-        old = ActiveRecord::Base.default_timezone
         [:utc, :local].each do |zone|
-          ActiveRecord::Base.default_timezone = zone
-          assert_equal Time.utc(2013, 9, 4, 0, 0, 0), Column.string_to_time("Wed, 04 Sep 2013 03:00:00 EAT")
+          with_timezone_config default: zone do
+            assert_equal Time.utc(2013, 9, 4, 0, 0, 0), Column.string_to_time("Wed, 04 Sep 2013 03:00:00 EAT")
+          end
         end
-      rescue
-        ActiveRecord::Base.default_timezone = old
       end
     end
   end

--- a/activerecord/test/cases/date_time_test.rb
+++ b/activerecord/test/cases/date_time_test.rb
@@ -5,7 +5,7 @@ require 'models/task'
 class DateTimeTest < ActiveRecord::TestCase
   def test_saves_both_date_and_time
     with_env_tz 'America/New_York' do
-      with_active_record_default_timezone :utc do
+      with_timezone_config default: :utc do
         time_values = [1807, 2, 10, 15, 30, 45]
         # create DateTime value with local time zone offset
         local_offset = Rational(Time.local(*time_values).utc_offset, 86400)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -479,7 +479,7 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_condition_utc_time_interpolation_with_default_timezone_local
     with_env_tz 'America/New_York' do
-      with_active_record_default_timezone :local do
+      with_timezone_config default: :local do
         topic = Topic.first
         assert_equal topic, Topic.all.merge!(:where => ['written_on = ?', topic.written_on.getutc]).first
       end
@@ -488,7 +488,7 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_hash_condition_utc_time_interpolation_with_default_timezone_local
     with_env_tz 'America/New_York' do
-      with_active_record_default_timezone :local do
+      with_timezone_config default: :local do
         topic = Topic.first
         assert_equal topic, Topic.all.merge!(:where => {:written_on => topic.written_on.getutc}).first
       end
@@ -497,7 +497,7 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_condition_local_time_interpolation_with_default_timezone_utc
     with_env_tz 'America/New_York' do
-      with_active_record_default_timezone :utc do
+      with_timezone_config default: :utc do
         topic = Topic.first
         assert_equal topic, Topic.all.merge!(:where => ['written_on = ?', topic.written_on.getlocal]).first
       end
@@ -506,7 +506,7 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_hash_condition_local_time_interpolation_with_default_timezone_utc
     with_env_tz 'America/New_York' do
-      with_active_record_default_timezone :utc do
+      with_timezone_config default: :utc do
         topic = Topic.first
         assert_equal topic, Topic.all.merge!(:where => {:written_on => topic.written_on.getlocal}).first
       end

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -23,17 +23,12 @@ class IntegrationTest < ActiveRecord::TestCase
   end
 
   def test_cache_key_for_existing_record_is_not_timezone_dependent
-    ActiveRecord::Base.time_zone_aware_attributes = true
-
-    Time.zone = 'UTC'
     utc_key = Developer.first.cache_key
 
-    Time.zone = 'EST'
-    est_key = Developer.first.cache_key
-
-    assert_equal utc_key, est_key
-  ensure
-    Time.zone = 'UTC'
+    with_timezone_config zone: "EST" do
+      est_key = Developer.first.cache_key
+      assert_equal utc_key, est_key
+    end
   end
 
   def test_cache_key_format_for_existing_record_with_updated_at

--- a/activerecord/test/cases/multiparameter_attributes_test.rb
+++ b/activerecord/test/cases/multiparameter_attributes_test.rb
@@ -5,16 +5,6 @@ require 'models/customer'
 class MultiParameterAttributeTest < ActiveRecord::TestCase
   fixtures :topics
 
-  def setup
-    ActiveRecord::Base.time_zone_aware_attributes = false
-    ActiveRecord::Base.default_timezone = :local
-    Time.zone = nil
-  end
-
-  def teardown
-    ActiveRecord::Base.default_timezone = :utc
-  end
-
   def test_multiparameter_attributes_on_date
     attributes = { "last_read(1i)" => "2004", "last_read(2i)" => "6", "last_read(3i)" => "24" }
     topic = Topic.find(1)
@@ -86,13 +76,15 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
   end
 
   def test_multiparameter_attributes_on_time
-    attributes = {
-      "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
-      "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
-    }
-    topic = Topic.find(1)
-    topic.attributes = attributes
-    assert_equal Time.local(2004, 6, 24, 16, 24, 0), topic.written_on
+    with_timezone_config default: :local do
+      attributes = {
+        "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
+        "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
+      }
+      topic = Topic.find(1)
+      topic.attributes = attributes
+      assert_equal Time.local(2004, 6, 24, 16, 24, 0), topic.written_on
+    end
   end
 
   def test_multiparameter_attributes_on_time_with_no_date
@@ -152,13 +144,15 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
   end
 
   def test_multiparameter_attributes_on_time_will_ignore_hour_if_missing
-    attributes = {
-      "written_on(1i)" => "2004", "written_on(2i)" => "12", "written_on(3i)" => "12",
-      "written_on(5i)" => "12", "written_on(6i)" => "02"
-    }
-    topic = Topic.find(1)
-    topic.attributes = attributes
-    assert_equal Time.local(2004, 12, 12, 0, 12, 2), topic.written_on
+    with_timezone_config default: :local do
+      attributes = {
+        "written_on(1i)" => "2004", "written_on(2i)" => "12", "written_on(3i)" => "12",
+        "written_on(5i)" => "12", "written_on(6i)" => "02"
+      }
+      topic = Topic.find(1)
+      topic.attributes = attributes
+      assert_equal Time.local(2004, 12, 12, 0, 12, 2), topic.written_on
+    end
   end
 
   def test_multiparameter_attributes_on_time_will_ignore_hour_if_blank
@@ -180,6 +174,7 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
     topic.attributes = attributes
     assert_nil topic.written_on
   end
+
   def test_multiparameter_attributes_on_time_with_seconds_will_ignore_date_if_empty
     attributes = {
       "written_on(1i)" => "", "written_on(2i)" => "", "written_on(3i)" => "",
@@ -191,56 +186,56 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
   end
 
   def test_multiparameter_attributes_on_time_with_utc
-    ActiveRecord::Base.default_timezone = :utc
-    attributes = {
-      "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
-      "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
-    }
-    topic = Topic.find(1)
-    topic.attributes = attributes
-    assert_equal Time.utc(2004, 6, 24, 16, 24, 0), topic.written_on
+    with_timezone_config default: :utc do
+      attributes = {
+        "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
+        "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
+      }
+      topic = Topic.find(1)
+      topic.attributes = attributes
+      assert_equal Time.utc(2004, 6, 24, 16, 24, 0), topic.written_on
+    end
   end
 
   def test_multiparameter_attributes_on_time_with_time_zone_aware_attributes
-    ActiveRecord::Base.time_zone_aware_attributes = true
-    ActiveRecord::Base.default_timezone = :utc
-    Time.zone = ActiveSupport::TimeZone[-28800]
-    attributes = {
-      "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
-      "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
-    }
-    topic = Topic.find(1)
-    topic.attributes = attributes
-    assert_equal Time.utc(2004, 6, 24, 23, 24, 0), topic.written_on
-    assert_equal Time.utc(2004, 6, 24, 16, 24, 0), topic.written_on.time
-    assert_equal Time.zone, topic.written_on.time_zone
+    with_timezone_config default: :utc, aware_attributes: true, zone: -28800 do
+      attributes = {
+        "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
+        "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
+      }
+      topic = Topic.find(1)
+      topic.attributes = attributes
+      assert_equal Time.utc(2004, 6, 24, 23, 24, 0), topic.written_on
+      assert_equal Time.utc(2004, 6, 24, 16, 24, 0), topic.written_on.time
+      assert_equal Time.zone, topic.written_on.time_zone
+    end
   end
 
   def test_multiparameter_attributes_on_time_with_time_zone_aware_attributes_false
-    Time.zone = ActiveSupport::TimeZone[-28800]
-    attributes = {
-      "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
-      "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
-    }
-    topic = Topic.find(1)
-    topic.attributes = attributes
-    assert_equal Time.local(2004, 6, 24, 16, 24, 0), topic.written_on
-    assert_equal false, topic.written_on.respond_to?(:time_zone)
+    with_timezone_config default: :local, aware_attributes: false, zone: -28800 do
+      attributes = {
+        "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
+        "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
+      }
+      topic = Topic.find(1)
+      topic.attributes = attributes
+      assert_equal Time.local(2004, 6, 24, 16, 24, 0), topic.written_on
+      assert_equal false, topic.written_on.respond_to?(:time_zone)
+    end
   end
 
   def test_multiparameter_attributes_on_time_with_skip_time_zone_conversion_for_attributes
-    ActiveRecord::Base.time_zone_aware_attributes = true
-    ActiveRecord::Base.default_timezone = :utc
-    Time.zone = ActiveSupport::TimeZone[-28800]
-    Topic.skip_time_zone_conversion_for_attributes = [:written_on]
-    attributes = {
-      "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
-      "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
-    }
-    topic = Topic.find(1)
-    topic.attributes = attributes
-    assert_equal Time.utc(2004, 6, 24, 16, 24, 0), topic.written_on
-    assert_equal false, topic.written_on.respond_to?(:time_zone)
+    with_timezone_config default: :utc, aware_attributes: true, zone: -28800 do
+      Topic.skip_time_zone_conversion_for_attributes = [:written_on]
+      attributes = {
+        "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
+        "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
+      }
+      topic = Topic.find(1)
+      topic.attributes = attributes
+      assert_equal Time.utc(2004, 6, 24, 16, 24, 0), topic.written_on
+      assert_equal false, topic.written_on.respond_to?(:time_zone)
+    end
   ensure
     Topic.skip_time_zone_conversion_for_attributes = []
   end
@@ -248,28 +243,29 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
   # Oracle, and Sybase do not have a TIME datatype.
   unless current_adapter?(:OracleAdapter, :SybaseAdapter)
     def test_multiparameter_attributes_on_time_only_column_with_time_zone_aware_attributes_does_not_do_time_zone_conversion
-      ActiveRecord::Base.time_zone_aware_attributes = true
-      ActiveRecord::Base.default_timezone = :utc
-      Time.zone = ActiveSupport::TimeZone[-28800]
-      attributes = {
-        "bonus_time(1i)" => "2000", "bonus_time(2i)" => "1", "bonus_time(3i)" => "1",
-        "bonus_time(4i)" => "16", "bonus_time(5i)" => "24"
-      }
-      topic = Topic.find(1)
-      topic.attributes = attributes
-      assert_equal Time.utc(2000, 1, 1, 16, 24, 0), topic.bonus_time
-      assert topic.bonus_time.utc?
+      with_timezone_config default: :utc, aware_attributes: true, zone: -28800 do
+        attributes = {
+          "bonus_time(1i)" => "2000", "bonus_time(2i)" => "1", "bonus_time(3i)" => "1",
+          "bonus_time(4i)" => "16", "bonus_time(5i)" => "24"
+        }
+        topic = Topic.find(1)
+        topic.attributes = attributes
+        assert_equal Time.utc(2000, 1, 1, 16, 24, 0), topic.bonus_time
+        assert topic.bonus_time.utc?
+      end
     end
   end
 
   def test_multiparameter_attributes_on_time_with_empty_seconds
-    attributes = {
-      "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
-      "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => ""
-    }
-    topic = Topic.find(1)
-    topic.attributes = attributes
-    assert_equal Time.local(2004, 6, 24, 16, 24, 0), topic.written_on
+    with_timezone_config default: :local do
+      attributes = {
+        "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
+        "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => ""
+      }
+      topic = Topic.find(1)
+      topic.attributes = attributes
+      assert_equal Time.local(2004, 6, 24, 16, 24, 0), topic.written_on
+    end
   end
 
   def test_multiparameter_attributes_setting_time_attribute

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -53,28 +53,28 @@ module ActiveRecord
       end
 
       def test_quoted_time_utc
-        with_active_record_default_timezone :utc do
+        with_timezone_config default: :utc do
           t = Time.now
           assert_equal t.getutc.to_s(:db), @quoter.quoted_date(t)
         end
       end
 
       def test_quoted_time_local
-        with_active_record_default_timezone :local do
+        with_timezone_config default: :local do
           t = Time.now
           assert_equal t.getlocal.to_s(:db), @quoter.quoted_date(t)
         end
       end
 
       def test_quoted_time_crazy
-        with_active_record_default_timezone :asdfasdf do
+        with_timezone_config default: :asdfasdf do
           t = Time.now
           assert_equal t.getlocal.to_s(:db), @quoter.quoted_date(t)
         end
       end
 
       def test_quoted_datetime_utc
-        with_active_record_default_timezone :utc do
+        with_timezone_config default: :utc do
           t = DateTime.now
           assert_equal t.getutc.to_s(:db), @quoter.quoted_date(t)
         end
@@ -83,7 +83,7 @@ module ActiveRecord
       ###
       # DateTime doesn't define getlocal, so make sure it does nothing
       def test_quoted_datetime_local
-        with_active_record_default_timezone :local do
+        with_timezone_config default: :local do
           t = DateTime.now
           assert_equal t.to_s(:db), @quoter.quoted_date(t)
         end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -211,16 +211,15 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_serialize_attribute_via_select_method_when_time_zone_available
-    ActiveRecord::Base.time_zone_aware_attributes = true
-    Topic.serialize(:content, MyObject)
+    with_timezone_config aware_attributes: true do
+      Topic.serialize(:content, MyObject)
 
-    myobj = MyObject.new('value1', 'value2')
-    topic = Topic.create(content: myobj)
+      myobj = MyObject.new('value1', 'value2')
+      topic = Topic.create(content: myobj)
 
-    assert_equal(myobj, Topic.select(:content).find(topic.id).content)
-    assert_raise(ActiveModel::MissingAttributeError) { Topic.select(:id).find(topic.id).content }
-  ensure
-    ActiveRecord::Base.time_zone_aware_attributes = false
+      assert_equal(myobj, Topic.select(:content).find(topic.id).content)
+      assert_raise(ActiveModel::MissingAttributeError) { Topic.select(:id).find(topic.id).content }
+    end
   end
 
   def test_serialize_attribute_can_be_serialized_in_an_integer_column

--- a/activerecord/test/cases/xml_serialization_test.rb
+++ b/activerecord/test/cases/xml_serialization_test.rb
@@ -161,21 +161,17 @@ end
 
 class DefaultXmlSerializationTimezoneTest < ActiveRecord::TestCase
   def test_should_serialize_datetime_with_timezone
-    timezone, Time.zone = Time.zone, "Pacific Time (US & Canada)"
-
-    toy = Toy.create(:name => 'Mickey', :updated_at => Time.utc(2006, 8, 1))
-    assert_match %r{<updated-at type=\"dateTime\">2006-07-31T17:00:00-07:00</updated-at>}, toy.to_xml
-  ensure
-    Time.zone = timezone
+    with_timezone_config zone: "Pacific Time (US & Canada)" do
+      toy = Toy.create(:name => 'Mickey', :updated_at => Time.utc(2006, 8, 1))
+      assert_match %r{<updated-at type=\"dateTime\">2006-07-31T17:00:00-07:00</updated-at>}, toy.to_xml
+    end
   end
 
   def test_should_serialize_datetime_with_timezone_reloaded
-    timezone, Time.zone = Time.zone, "Pacific Time (US & Canada)"
-
-    toy = Toy.create(:name => 'Minnie', :updated_at => Time.utc(2006, 8, 1)).reload
-    assert_match %r{<updated-at type=\"dateTime\">2006-07-31T17:00:00-07:00</updated-at>}, toy.to_xml
-  ensure
-    Time.zone = timezone
+    with_timezone_config zone: "Pacific Time (US & Canada)" do
+      toy = Toy.create(:name => 'Minnie', :updated_at => Time.utc(2006, 8, 1)).reload
+      assert_match %r{<updated-at type=\"dateTime\">2006-07-31T17:00:00-07:00</updated-at>}, toy.to_xml
+    end
   end
 end
 

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -5,16 +5,10 @@ class YamlSerializationTest < ActiveRecord::TestCase
   fixtures :topics
 
   def test_to_yaml_with_time_with_zone_should_not_raise_exception
-    tz = Time.zone
-    Time.zone = ActiveSupport::TimeZone["Pacific Time (US & Canada)"]
-    ActiveRecord::Base.time_zone_aware_attributes = true
-
-    topic = Topic.new(:written_on => DateTime.now)
-    assert_nothing_raised { topic.to_yaml }
-
-  ensure
-    Time.zone = tz
-    ActiveRecord::Base.time_zone_aware_attributes = false
+    with_timezone_config aware_attributes: true, zone: "Pacific Time (US & Canada)" do
+      topic = Topic.new(:written_on => DateTime.now)
+      assert_nothing_raised { topic.to_yaml }
+    end
   end
 
   def test_roundtrip


### PR DESCRIPTION
This patch prevents leaks on the following global variables:
- `Time.zone`
- `ActiveRecord::Base.default_timezone`
- `ActiveRecord::Base.time_zone_aware_attributes`

The new helper `with_timezone_config` allows to adjust the state for a single test-case and makes sure to restore the initial state. I removed all other assignments to this global state from the test-cases.
