### PR TITLE
Migrations: reference to be the same type as primary key in the referenced table

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -255,7 +255,10 @@ module ActiveRecord
         polymorphic = options.delete(:polymorphic)
         index_options = options.delete(:index)
         args.each do |col|
-          column("#{col}_id", :integer, options)
+          foreign_key_type = if Base.connection.table_exists?(col.to_s.pluralize)
+            Base.connection.columns(col.to_s.pluralize).detect{ |col| col.name == Base.get_primary_key(col) }.type
+          end
+          column("#{col}_id", foreign_key_type || :integer, options)
           column("#{col}_type", :string, polymorphic.is_a?(Hash) ? polymorphic : options) if polymorphic
           index(polymorphic ? %w(id type).map { |t| "#{col}_#{t}" } : "#{col}_id", index_options.is_a?(Hash) ? index_options : {}) if index_options
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -604,7 +604,10 @@ module ActiveRecord
       def add_reference(table_name, ref_name, options = {})
         polymorphic = options.delete(:polymorphic)
         index_options = options.delete(:index)
-        add_column(table_name, "#{ref_name}_id", :integer, options)
+        foreign_key_type = if table_exists?(ref_name.to_s.pluralize)
+          columns(ref_name.to_s.pluralize).detect{ |col| col.name == Base.get_primary_key(ref_name) }.type
+        end
+        add_column(table_name, "#{ref_name}_id", foreign_key_type || :integer, options)
         add_column(table_name, "#{ref_name}_type", :string, polymorphic.is_a?(Hash) ? polymorphic : options) if polymorphic
         add_index(table_name, polymorphic ? %w[id type].map{ |t| "#{ref_name}_#{t}" } : "#{ref_name}_id", index_options.is_a?(Hash) ? index_options : {}) if index_options
       end


### PR DESCRIPTION
Currently when you run a migration for `posts` table that have  `t.belongs_to :user` or `add_reference :posts, :user`, it will generate `user_id` with type of `integer` — and it'll be **ALWAYS `integer`**.

But what if the `User` model has a primary key of string type? The generator will not take a look to see what type to set for the reference, it'll be set to `integer` and the relation will not work as expected.
#### Example:
##### Migration files:

`1_create_users.rb`:

``` ruby
class CreateUser < ActiveRecord::Migration
  def change
    create_table :users, id: false do |t|
      t.string :id, primary: true, limit: 23
      t.string :name

      t.timestamps
    end
  end
end
```

`2_create_posts.rb`:

``` ruby
class CreatePosts < ActiveRecord::Migration
  def change
    create_table :posts do |t|
      t.string :title
      t.belongs_to :user

      t.timestamps
    end
    # add_reference(:posts, :user)
  end
end
```
##### Models:

`user.rb`:

``` ruby
class User < ActiveRecord::Base
  self.primary_key = :id

  before_validation :generate_safe_random_id, on: :create
  def generate_safe_random_id
    self.id = SecureRandom.urlsafe_base64(17)
  end
end
```

`post.rb`:

``` ruby
class Post < ActiveRecord::Base
  belongs_to :user
end

```

---

**_Notice:**_ The type of the reference will be detected only if the referenced table has already created. So if the migrations of creating `posts` table run first the `user_id` type will fallback to `integer`.

---

I haven't written any tests for this but I tried it on an example app (I will write tests once the concept is accepted).
