### PR TITLE
Allow any version of BCrypt

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -44,7 +44,6 @@ module ActiveModel
         # This is to avoid ActiveModel (and by extension the entire framework)
         # being dependent on a binary library.
         begin
-          gem 'bcrypt-ruby', '~> 3.1.2'
           require 'bcrypt'
         rescue LoadError
           $stderr.puts "You don't have bcrypt-ruby installed in your application. Please add it to your Gemfile and run bundle install"


### PR DESCRIPTION
The documentation and Gemfile generator already contain a suggested version restriction.  It would be really really nice if Rails allowed developers to use a later version to take advantage of new features.  For instance, we're on Rails 3.2.x and are locked to bcrypt ~3.0.0 so we can't use 3.1.x.  :-1:
