### PR TITLE
Improve usage example for model generator decimal field

### DIFF
--- a/railties/lib/rails/generators/rails/model/USAGE
+++ b/railties/lib/rails/generators/rails/model/USAGE
@@ -60,7 +60,7 @@ Available field types:
     For decimal, two integers separated by a comma in curly braces will be used
     for precision and scale:
 
-        `rails generate model product price:decimal{10,2}`
+        `rails generate model product 'price:decimal{10,2}'`
 
     You can add a `:uniq` or `:index` suffix for unique or standard indexes
     respectively:


### PR DESCRIPTION
We should wrap parameters to quotes when pass parameters with curly braces to decimal generator because the shell (tested in `bash` and `zsh`) transforms them to several params. Example:

``` shell
$ echo p{1,2}
p1 p2
```

So actual example (`rails generate model product price:decimal{10,2}`) generates migration like this:

``` ruby
class CreateProducts < ActiveRecord::Migration
  def change
    create_table :products do |t|
      t.decimal10 :price
      t.decimal2 :price

      t.timestamps
    end
  end
end
```

Fixed version of the command (`rails generate model product 'price:decimal{10,2}'`) generates correct migration:

``` ruby
class CreateProducts < ActiveRecord::Migration
  def change
    create_table :products do |t|
      t.decimal :price, precision: 10, scale: 2

      t.timestamps
    end
  end
end
```
