### PR TITLE
cast json values on write to be consistent with reading from the db.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Type cast json values on write, so that the value is consistent
+    with reading from the database.
+
+    Example:
+
+        x = JsonDataType.new tags: {"string" => "foo", :symbol => :bar}
+
+        # Before:
+        x.tags # => {"string" => "foo", :symbol => :bar}
+
+        # After:
+        x.tags # => {"string" => "foo", "symbol" => "bar"}
+
+    *Severin Schoepke*
+
 *   `ActiveRecord::Store` works together with PG `hstore` columns.
     Fixes #12452.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -249,6 +249,10 @@ module ActiveRecord
         end
 
         class Json < Type
+          def type_cast_for_write(value)
+            ConnectionAdapters::PostgreSQLColumn.json_to_string value
+          end
+
           def type_cast(value)
             return if value.nil?
 

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -49,6 +49,13 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
     JsonDataType.reset_column_information
   end
 
+  def test_cast_value_on_write
+    x = JsonDataType.new payload: {"string" => "foo", :symbol => :bar}
+    assert_equal({"string" => "foo", "symbol" => "bar"}, x.payload)
+    x.save
+    assert_equal({"string" => "foo", "symbol" => "bar"}, x.reload.payload)
+  end
+
   def test_type_cast_json
     assert @column
 


### PR DESCRIPTION
This is analog to what commit 5ac2341fab689344991b2a4817bd2bc8b3edac9d did with hstore fields...

/cc @senny
