### PR TITLE
polymorphic belongs_to association with touch: true updates old record correctly

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Polymorphic belongs_to associations with the `touch: true` option set update the timestamps of
+    the old and new owner correctly when moved between owners of different types.
+
+    Example:
+
+        class Rating < ActiveRecord::Base
+          belongs_to :rateable, polymorphic: true, touch: true
+        end
+
+        rating = Rating.create rateable: Song.find(1)
+        rating.update_attributes rateable: Book.find(2) # => timestamps of Song(1) and Book(2) are updated
+
+    *Severin Schoepke*
+
 *   Improve formatting of migration exception messages: make them easier to read
     with line breaks before/after, and improve the error for pending migrations.
 

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -91,7 +91,13 @@ module ActiveRecord::Associations::Builder
       old_foreign_id = o.changed_attributes[foreign_key]
 
       if old_foreign_id
-        klass      = o.association(name).klass
+        association = o.association(name)
+        reflection = association.reflection
+        if reflection.polymorphic?
+          klass = o.public_send("#{reflection.foreign_type}_was").constantize
+        else
+          klass = association.klass
+        end
         old_record = klass.find_by(klass.primary_key => old_foreign_id)
 
         if old_record


### PR DESCRIPTION
An example:

``` ruby
class Book < ActiveRecord::Base
  has_many :comments
end

class Song < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :commentable, polymorphic: true, touch: true
end

comment = Comment.create commentable: Book.find(1)

# the commentable's timestamp is updated when the comment changes
comment.update_attributes text: 'lorem ipsum'
# => Book.find(1).updated_at == Time.now

# Both the old and new commentable's timestamp is updated when the
# commentable changes to another instance of the same class
comment.update_attributes commentable: Book.find(2)
# => Book.find(1).updated_at == Time.now
# => Book.find(2).updated_at == Time.now

# Only the new commentable's timestamp is updated when the
# commentable changes to an instance of another class
comment.update_attributes commentable: Song.find(3)
# => Book.find(2).updated_at == Time.now
# => Song.find(3).updated_at != Time.now !!
```

Given you have a comments model with a polymorphic commentable association (e.g. books and songs) with the touch option set. Every time you update a comment its commentable should be touched.
This was working when you changed attributes on the comment or when you moved the comment from one book to another. However, it was not working when moving a comment from a book to a song.

**This is now fixed**: I added failing tests for the missing case and made them pass. However, the code is not the nicest. So, improvement suggestions welcome!
