### PR TITLE
Make remote_ip detection properly handle private IPv6 addresses

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Properly treat the entire IPv6 User Local Address space as private for
+    purposes of remote IP detection. Also handle uppercase private IPv6
+    addresses.
+
+    Fixes #12638.
+
+    *Caleb Spare*
+
 *   Add `params` option to `button_to` form helper, which renders the given hash
     as hidden form fields.
 

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -31,7 +31,7 @@ module ActionDispatch
     TRUSTED_PROXIES = %r{
       ^127\.0\.0\.1$                | # localhost IPv4
       ^::1$                         | # localhost IPv6
-      ^fc00:                        | # private IPv6 range fc00
+      ^[fF][cCdD]                   | # private IPv6 range fc00::/7
       ^10\.                         | # private IPv4 range 10.x.x.x
       ^172\.(1[6-9]|2[0-9]|3[0-1])\.| # private IPv4 range 172.16.0.0 .. 172.31.255.255
       ^192\.168\.                     # private IPv4 range 192.168.x.x

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -120,8 +120,11 @@ class RequestTest < ActiveSupport::TestCase
     request = stub_request 'HTTP_X_FORWARDED_FOR' => 'unknown,::1'
     assert_equal nil, request.remote_ip
 
-    request = stub_request 'HTTP_X_FORWARDED_FOR' => '2001:0db8:85a3:0000:0000:8a2e:0370:7334, fe80:0000:0000:0000:0202:b3ff:fe1e:8329, ::1, fc00::'
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => '2001:0db8:85a3:0000:0000:8a2e:0370:7334, fe80:0000:0000:0000:0202:b3ff:fe1e:8329, ::1, fc00::, fc01::, fdff'
     assert_equal 'fe80:0000:0000:0000:0202:b3ff:fe1e:8329', request.remote_ip
+
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => 'FE00::, FDFF::'
+    assert_equal 'FE00::', request.remote_ip
 
     request = stub_request 'HTTP_X_FORWARDED_FOR' => 'not_ip_address'
     assert_equal nil, request.remote_ip


### PR DESCRIPTION
Fixes #12638.

I didn't see any relevant tests to change.
