### PR TITLE
Short arrays in record.inspect

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   ActiveRecord::Base#attribute_for_inspect now truncates long arrays (more than 10 elements)
+
+    *Jan Bernacki*
+
 *   Allow for the name of the schema_migrations table to be configured.
 
     *Jerad Phelps*

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -245,9 +245,10 @@ module ActiveRecord
 
     # Returns an <tt>#inspect</tt>-like string for the value of the
     # attribute +attr_name+. String attributes are truncated upto 50
-    # characters, and Date and Time attributes are returned in the
-    # <tt>:db</tt> format. Other attributes return the value of
-    # <tt>#inspect</tt> without modification.
+    # characters, Date and Time attributes are returned in the
+    # <tt>:db</tt> format, Array attributes are truncated upto 10 values.
+    # Other attributes return the value of <tt>#inspect</tt> without
+    # modification.
     #
     #   person = Person.create!(name: 'David Heinemeier Hansson ' * 3)
     #
@@ -256,6 +257,9 @@ module ActiveRecord
     #
     #   person.attribute_for_inspect(:created_at)
     #   # => "\"2012-10-22 00:15:07\""
+    #
+    #   person.attribute_for_inspect(:tag_ids)
+    #   # => "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...]"
     def attribute_for_inspect(attr_name)
       value = read_attribute(attr_name)
 
@@ -263,6 +267,9 @@ module ActiveRecord
         "#{value[0, 50]}...".inspect
       elsif value.is_a?(Date) || value.is_a?(Time)
         %("#{value.to_s(:db)}")
+      elsif value.is_a?(Array) && value.size > 10
+        inspected = value.first(10).inspect
+        %(#{inspected[0...-1]}, ...])
       else
         value.inspect
       end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -113,6 +113,11 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert_equal(PgArray.last.tags, tag_values)
   end
 
+  def test_attribute_for_inspect_for_array_field
+    record = PgArray.new { |a| a.ratings = (1..11).to_a }
+    assert_equal("[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...]", record.attribute_for_inspect(:ratings))
+  end
+
   private
   def assert_cycle field, array
     # test creation


### PR DESCRIPTION
Since we have array-columns (pg) `record.inspect` may outputs very long string.

So this is a fix for arrays...

I'm not sure how to test it, because I haven't found any fixture with array.

But it works. Here is a proof :)

![screenshot 2013-10-26 17 57 19](https://f.cloud.github.com/assets/348907/1413688/c6bc199e-3e47-11e3-82ca-ce8f82ac09a9.png)
