### PR TITLE
Remove surprise if from show_exception middleware

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -29,8 +29,11 @@ module ActionDispatch
     def call(env)
       @app.call(env)
     rescue Exception => exception
-      raise exception if env['action_dispatch.show_exceptions'] == false
-      render_exception(env, exception)
+      if env['action_dispatch.show_exceptions'] == false
+        raise exception
+      else
+        render_exception(env, exception)
+      end
     end
 
     private


### PR DESCRIPTION
This increase the readability within the rescue block.

/cc @rafaelfranca 
