### PR TITLE
don't let StrongParameters mutate the hash with fetch

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -284,7 +284,14 @@ module ActionController
     #   params.fetch(:none, 'Francesco')    # => "Francesco"
     #   params.fetch(:none) { 'Francesco' } # => "Francesco"
     def fetch(key, *args)
-      convert_hashes_to_parameters(key, super)
+      value = super
+      # Don't rely on +convert_hashes_to_parameters+
+      # so as to not mutate via a +fetch+
+      if value.is_a?(Hash)
+        value = self.class.new(value)
+        value.permit! if permitted?
+      end
+      value
     rescue KeyError
       raise ActionController::ParameterMissing.new(key)
     end

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -147,6 +147,12 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert_equal :foo, e.param
   end
 
+  test "fetch with a default value of a hash does not mutate the object" do
+    params = ActionController::Parameters.new({})
+    params.fetch :foo, {}
+    assert_equal nil, params[:foo]
+  end
+
   test "fetch doesnt raise ParameterMissing exception if there is a default" do
     assert_equal "monkey", @params.fetch(:foo, "monkey")
     assert_equal "monkey", @params.fetch(:foo) { "monkey" }


### PR DESCRIPTION
right now `.fetch` just dispatches to `convert_hashes_to_parameters` which if given an empty hash as the default and the key doesn't exist mutates the hash, setting setting the given default value as the new value. This is a significant change from what `Hash#fetch` does.

Big thanks to @bemurphy, whose implementation I stole from here: https://github.com/rails/strong_parameters/pull/102/files
