### PR TITLE
Removal of javascript related files when creating an app

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Removal of all javascript stuff (gems and files) when generating a new
+    application using the `--skip-javascript` option.
+
+    *Robin Dupret*
+
 *   Make the application name snake cased when it contains spaces
 
     The application name is used to fill the `database.yml` and

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -207,13 +207,6 @@ module Rails
           gem 'uglifier', '>= 1.3.0'
         GEMFILE
 
-        if options[:skip_javascript]
-          gemfile += <<-GEMFILE
-            #{coffee_gemfile_entry}
-            #{javascript_runtime_gemfile_entry}
-          GEMFILE
-        end
-
         gemfile.gsub(/^[ \t]+/, '')
       end
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -129,7 +129,9 @@ module Rails
     end
 
     def vendor_javascripts
-      empty_directory_with_keep_file 'vendor/assets/javascripts'
+      unless options[:skip_javascript]
+        empty_directory_with_keep_file 'vendor/assets/javascripts'
+      end
     end
 
     def vendor_stylesheets
@@ -223,6 +225,12 @@ module Rails
 
       def finish_template
         build(:leftovers)
+      end
+
+      def delete_js_folder_skipping_javascript
+        if options[:skip_javascript]
+          remove_dir 'app/assets/javascripts'
+        end
       end
 
       public_task :apply_rails_template, :run_bundle

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -4,7 +4,6 @@
   <title><%= camelized %></title>
   <%- if options[:skip_javascript] -%>
   <%%= stylesheet_link_tag    "application", media: "all" %>
-  <%%= javascript_include_tag "application" %>
   <%- else -%>
   <%%= stylesheet_link_tag    "application", media: "all", "data-turbolinks-track" => true %>
   <%%= javascript_include_tag "application", "data-turbolinks-track" => true %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -298,15 +298,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_javascript_is_skipped_if_required
     run_generator [destination_root, "--skip-javascript"]
-    assert_file "app/assets/javascripts/application.js" do |contents|
-      assert_no_match %r{^//=\s+require\s}, contents
-    end
+
+    assert_no_file "app/assets/javascripts"
+    assert_no_file "vendor/assets/javascripts"
+
     assert_file "app/views/layouts/application.html.erb" do |contents|
       assert_match(/stylesheet_link_tag\s+"application", media: "all" %>/, contents)
-      assert_match(/javascript_include_tag\s+"application" \%>/, contents)
+      assert_no_match(/javascript_include_tag\s+"application" \%>/, contents)
     end
+
     assert_file "Gemfile" do |content|
-      assert_match(/coffee-rails/, content)
+      assert_no_match(/coffee-rails/, content)
     end
   end
 


### PR DESCRIPTION
Hello,

A little pull request to fix the behavior introduced in 0417bc8. The coffee-rails and javascript runtime gems were added even when passing the `--skip-javascript` option but this is not the desired behavior.

Also remove the unnecessary generated files as well (e.g. `vendor/assets/javascripts`).

Have a nice day.
