### PR TITLE
Fix merging conditions for *_througn with STI case

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Prevent merging target_scope conditions for *_through with STI case
+
+    Fixes: #12474
+
+    *Ivan Antropov*
+
 *   Make ActiveRecord::Relation#unscope affect relations it is merged in
     to.
 

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -17,7 +17,7 @@ module ActiveRecord
             scope.merge!(
               reflection.klass.all.
                 except(:select, :create_with, :includes, :preload, :joins, :eager_load)
-            )
+            ) if reflection.table_name != scope.table.name
           end
           scope
         end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -24,6 +24,7 @@ require 'models/categorization'
 require 'models/member'
 require 'models/membership'
 require 'models/club'
+require 'models/task'
 
 class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :posts, :readers, :people, :comments, :authors, :categories, :taggings, :tags,
@@ -1095,7 +1096,16 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal [posts(:thinking)], person.reload.first_posts
   end
 
+  test "has many through with STI" do
+    program  = MainTask.create! name: "Program"
+    function = program.sub_tasks.create! name: "Function"
+    command  = function.elementary_tasks.create! name: "Command"
+
+    assert_equal [command], program.elementary_tasks.to_a
+  end
+
   def test_has_many_through_with_includes_in_through_association_scope
     assert_not_empty posts(:welcome).author_address_extra_with_address
   end
+
 end

--- a/activerecord/test/models/task.rb
+++ b/activerecord/test/models/task.rb
@@ -1,5 +1,21 @@
 class Task < ActiveRecord::Base
+  belongs_to :parent
+
   def updated_at
     ending
   end
+end
+
+class MainTask < Task
+  has_many :sub_tasks, foreign_key: "parent_id"
+  has_many :elementary_tasks, through: :sub_tasks, foreign_key: "parent_id"
+end
+
+class SubTask < Task
+  belongs_to :main_task, foreign_key: "parent_id"
+  has_many :elementary_tasks, foreign_key: "parent_id"
+end
+
+class ElementaryTask < Task
+  belongs_to :sub_task, foreign_key: "parent_id"
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -659,6 +659,9 @@ ActiveRecord::Schema.define do
   create_table :tasks, force: true do |t|
     t.datetime :starting
     t.datetime :ending
+    t.string   :name
+    t.string   :type
+    t.integer  :parent_id
   end
 
   create_table :topics, force: true do |t|


### PR DESCRIPTION
Fix #12474, by preventing merging of conditions of target_scope for *_through case with STI
