### PR TITLE
Routing blank instead of nil and empty

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Replaced the presence check for parameterized_arg in route_set.rb from nil? || empty? to blank?
+    Besides being cleaner, it doesn't fail when the result of to_param does not respond_to empty?
+
+    *Herman verschooten*
+     
 *   Add `params` option to `button_to` form helper, which renders the given hash
     as hidden form fields.
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -188,7 +188,7 @@ module ActionDispatch
               @path_parts.zip(args) do |part, arg|
                 parameterized_arg = arg.to_param
 
-                if parameterized_arg.nil? || parameterized_arg.empty?
+                if parameterized_arg.blank?
                   raise_generation_error(args)
                 end
 
@@ -210,7 +210,7 @@ module ActionDispatch
               @path_parts.zip(args) do |part, arg|
                 parameterized_arg = arg.to_param
 
-                if parameterized_arg.nil? || parameterized_arg.empty?
+                if parameterized_arg.blank?
                   missing_keys << part
                 end
 

--- a/actionpack/test/routing/helper_test.rb
+++ b/actionpack/test/routing/helper_test.rb
@@ -9,6 +9,12 @@ module ActionDispatch
         end
       end
 
+      class Dog
+        def to_param
+          15
+        end
+      end
+
       def test_exception
         rs = ::ActionDispatch::Routing::RouteSet.new
         rs.draw do
@@ -25,6 +31,18 @@ module ActionDispatch
         assert_raises ActionController::UrlGenerationError do
           x.new.pond_duck_path Duck.new
         end
+      end
+
+      def test_do_not_fail_on_numeric
+        rs = ::ActionDispatch::Routing::RouteSet.new
+        rs.draw do
+          resources :dogs
+        end
+
+        x = Class.new {
+          include rs.url_helpers
+        }
+        assert_equal '/dogs/15/edit', x.new.edit_dog_path(Dog.new)
       end
     end
   end


### PR DESCRIPTION
As I explained in rails/rails#12660 I discovered a problem with a numeric result from to_param, it causes an error on empty? not existing for fixnum. I replaced the 2 occurrences of the nil? || empty? test with a single one for blank?
I also added a test to show it is now working.
