### PR TITLE
Skip `include_values` from through associations chains for building association scope

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Do not add to scope includes values from through associations.
+    Fixed bug when providing `includes` in through association scope, and fetching targets.
+
+    Example:
+        class Vendor < ActiveRecord::Base
+          has_many :relationships, -> { includes(:user) }
+          has_many :users, through: :relationships
+        end
+
+        vendor = Vendor.first
+
+        # Before
+
+        vendor.users.to_a # => Raises exception: not found `:user` for `User`
+
+        # After
+
+        vendor.users.to_a # => No exception is raised
+
+
+    Fixes: #12242, #9517, #10240
+
+    *Paul Nikitochkin*
+
 *   Type cast json values on write, so that the value is consistent
     with reading from the database.
 

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -78,7 +78,8 @@ module ActiveRecord
             scope = scope.joins(join(foreign_table, constraint))
           end
 
-          klass = i == 0 ? self.klass : reflection.klass
+          is_first_chain = i == 0
+          klass = is_first_chain ? self.klass : reflection.klass
 
           # Exclude the scope of the association itself, because that
           # was already merged in the #scope method.
@@ -89,7 +90,10 @@ module ActiveRecord
               scope.merge! item.except(:where, :includes, :bind)
             end
 
-            scope.includes! item.includes_values
+            if is_first_chain
+              scope.includes! item.includes_values
+            end
+
             scope.where_values += item.where_values
             scope.order_values |= item.order_values
           end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1085,4 +1085,8 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     readers(:michael_authorless).update(first_post_id: 1)
     assert_equal [posts(:thinking)], person.reload.first_posts
   end
+
+  def test_has_many_through_with_includes_in_through_association_scope
+    posts(:welcome).author_address_extra_with_address.to_a
+  end
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -65,6 +65,9 @@ class Post < ActiveRecord::Base
   has_many :author_favorites, :through => :author
   has_many :author_categorizations, :through => :author, :source => :categorizations
   has_many :author_addresses, :through => :author
+  has_many :author_address_extra_with_address,
+    through: :author_with_address,
+    source: :author_address_extra
 
   has_many :comments_with_interpolated_conditions,
     ->(p) { where "#{"#{p.aliased_table_name}." rescue ""}body = ?", 'Thank you for the welcome' },


### PR DESCRIPTION
In order that target scope builds without include values from through associations,
skip adding include values from through associations scope chains on building association scope.

Fixes: #12242, #9517, #10240
