### PR TITLE
Escape only plus instead of using Rack::Utils.escape

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -20,7 +20,7 @@ module ActionDispatch
       match = matches.detect { |m| File.file?(m) }
       if match
         match.sub!(@compiled_root, '')
-        ::Rack::Utils.escape(match)
+        match.gsub('+', '%2B')
       end
     end
 


### PR DESCRIPTION
This pr fixes https://github.com/rails/rails/issues/11816

`Rack::Utils.escape` comes to be used to fix [this matter (#5058)](https://github.com/rails/rails/issues/5058).

When matched string is passed to `Rack::File`, they unescape `env["PATH_INFO"]` with `Rack::Utils.unescape`.
`Rack::Utils.unescape` is nothing but `URI.decode_www_form_component`.
https://github.com/rack/rack/blob/master/lib/rack/utils.rb#L45-L47

`URI.decode_www_form_component` decodes + to SP.
http://www.ruby-doc.org/stdlib-2.0.0/libdoc/uri/rdoc/URI.html#method-c-decode_www_form_component

So I think we only care plus to be escaped here and it prevents https://github.com/rails/rails/issues/11816.
