### PR TITLE
Datatypes should be typecasted

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,35 @@
+*   Result should return type_casted values
+
+    The `type_cast` should be done earlier. `select_*` uses the values
+    provided by the `result` class, so it makes sense to use the `type_cast`
+    method from the adapters and passed into the class (`column_types`).
+
+    Example:
+        create_table :documents do |t|
+            t.string :tags, array: true, default: []
+            t.integer :tag_ids, array: true, default: []
+        end
+
+        Person.create(
+          tags: ["cfabianski", "cedric"],
+          tag_ids: [4, 8, 9]
+        )
+
+        query = Person.where(["? = ANY (tags)", "cfabianski"])
+        row   = Person.connection.select_one(query)
+
+        # Before
+
+        => {"id" => "1", tags" => "{cfabianski,cedric}", "tag_ids" => "{4,8,9}"}
+
+        # After
+
+        => {"id" => 1, "tags" => ["cfabianski", "cedric"], "tag_ids" => [4, 8, 9]}
+
+    Note: /!\ This is not backwards compatible /!\
+
+    *Cédric Fabianski*
+
 *   Fix uninitialized constant TransactionState error when Marshall.load is used on an Active Record result.
     Fixes #12790
 

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -426,7 +426,7 @@ module ActiveRecord
           if result
             types = {}
             result.fetch_fields.each { |field|
-              if field.decimals > 0
+              if field.decimals > 0 && field.decimals != 31
                 types[field.name] = Fields::Decimal.new
               else
                 types[field.name] = Fields.find_type field

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -107,7 +107,10 @@ module ActiveRecord
             length = columns.length
 
             while index < length
-              hash[columns[index]] = row[index]
+              column = columns[index]
+              value  = row[index]
+
+              hash[column] = column_type(column).type_cast(value)
               index += 1
             end
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -47,18 +47,18 @@ module ActiveRecord
 
       def test_insert_sql_with_proprietary_returning_clause
         id = @connection.insert_sql("insert into ex (number) values(5150)", nil, "number")
-        assert_equal "5150", id
+        assert_equal 5150, id
       end
 
       def test_insert_sql_with_quoted_schema_and_table_name
         id = @connection.insert_sql('insert into "public"."ex" (number) values(5150)')
-        expect = @connection.query('select max(id) from ex').first.first
+        expect = @connection.query('select max(id) from ex').first.first.to_i
         assert_equal expect, id
       end
 
       def test_insert_sql_with_no_space_after_table_name
         id = @connection.insert_sql("insert into ex(number) values(5150)")
-        expect = @connection.query('select max(id) from ex').first.first
+        expect = @connection.query('select max(id) from ex').first.first.to_i
         assert_equal expect, id
       end
 

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -172,7 +172,7 @@ class QueryCacheTest < ActiveRecord::TestCase
         assert_instance_of Fixnum,
          Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
       else
-        assert_instance_of String, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
+        assert_instance_of Fixnum, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
       end
     end
   end

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -2,6 +2,25 @@ require "cases/helper"
 
 module ActiveRecord
   class ResultTest < ActiveRecord::TestCase
+    def result_column_types
+      Result.new(
+        ['col_1', 'col_2'],
+        [
+          ['1', 'row 1 col 2'],
+          ['2', 'row 2 col 2']
+        ],
+        {
+          'col_1' => Class.new { def type_cast(v); v.to_i; end }.new
+        })
+    end
+
+    def test_hash_rows_with_column_types_returns_type_casted_values
+      assert_equal [
+        {'col_1' => 1, 'col_2' => 'row 1 col 2'},
+        {'col_1' => 2, 'col_2' => 'row 2 col 2'}
+      ], result_column_types.to_hash
+    end
+
     def result
       Result.new(['col_1', 'col_2'], [
         ['row 1 col 1', 'row 1 col 2'],


### PR DESCRIPTION
**Result should return type_casted values**
The `type_cast` should be done earlier. `select_*` uses the values
provided by the `result` class, so it makes sense to use the `type_cast`
method from the adapters and passed into the class (`column_types`).

_before_

```
Person.create(
  tags: ["cfabianski", "cedric"],
  tag_ids: [4, 8, 9]
)

query = Person.where(["? = ANY (tags)", "cfabianski"])
row   = Person.connection.select_one(query)

=> {"id" => "1", tags" => "{cfabianski,cedric}", "tag_ids" => "{4,8,9}"}
```

_after_

```
Person.create(
  tags: ["cfabianski", "cedric"],
  tag_ids: [4, 8, 9]
)

query = Person.where(["? = ANY (tags)", "cfabianski"])
row   = Person.connection.select_one(query)

=> {"id" => 1, "tags" => [cfabianski, cedric], "tag_ids" => [4, 8, 9]}
```

This would be awesome to have IMO, though, I have some pain with these 2 tests [[1]](https://github.com/rails/rails/blob/master/activerecord/test/cases/fixtures_test.rb#L248)[[2]](https://github.com/rails/rails/blob/master/activerecord/test/cases/binary_test.rb#L45) that fail only with postgres and because of the `flowers.jpg` file apparently :confused:

If someone has any idea, please let me know :smiley: 
