### PR TITLE
Fix Guide HTML validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'uglifier', '>= 1.3.0', require: false
 
 group :doc do
   gem 'sdoc', '~> 0.4.0'
-  gem 'redcarpet', '~> 2.2.2', platforms: :ruby
+  gem 'redcarpet', '~> 3.1.0', platforms: :ruby
   gem 'w3c_validators'
   gem 'kindlerb'
 end

--- a/guides/rails_guides.rb
+++ b/guides/rails_guides.rb
@@ -24,11 +24,11 @@ begin
   require 'redcarpet'
 rescue LoadError
   # This can happen if doc:guides is executed in an application.
-  $stderr.puts('Generating guides requires Redcarpet 2.1.1+.')
+  $stderr.puts('Generating guides requires Redcarpet 3.1.0+.')
   $stderr.puts(<<ERROR) if bundler?
 Please add
 
-  gem 'redcarpet', '~> 2.1.1'
+  gem 'redcarpet', '~> 3.1.0'
 
 to the Gemfile, run
 

--- a/guides/rails_guides/helpers.rb
+++ b/guides/rails_guides/helpers.rb
@@ -39,7 +39,7 @@ module RailsGuides
     def author(name, nick, image = 'credits_pic_blank.gif', &block)
       image = "images/#{image}"
 
-      result = content_tag(:img, nil, :src => image, :class => 'left pic', :alt => name, :width => 91, :height => 91)
+      result = tag(:img, :src => image, :class => 'left pic', :alt => name, :width => 91, :height => 91)
       result << content_tag(:h3, name)
       result << content_tag(:p, capture(&block))
       content_tag(:div, result, :class => 'clearfix', :id => nick)

--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -79,10 +79,10 @@ module RailsGuides
       def generate_structure
         @headings_for_index = []
         if @body.present?
-          @body = Nokogiri::HTML(@body).tap do |doc|
+          @body = Nokogiri::HTML.fragment(@body).tap do |doc|
             hierarchy = []
 
-            doc.at('body').children.each do |node|
+            doc.children.each do |node|
               if node.name =~ /^h[3-6]$/
                 case node.name
                 when 'h3'
@@ -116,7 +116,7 @@ module RailsGuides
             end
           end
 
-          @index = Nokogiri::HTML(engine.render(raw_index)).tap do |doc|
+          @index = Nokogiri::HTML.fragment(engine.render(raw_index)).tap do |doc|
             doc.at('ol')[:class] = 'chapters'
           end.to_html
 
@@ -130,8 +130,8 @@ module RailsGuides
       end
 
       def generate_title
-        if heading = Nokogiri::HTML(@header).at(:h2)
-          @title = "#{heading.text} — Ruby on Rails Guides".html_safe
+        if heading = Nokogiri::HTML.fragment(@header).at(:h2)
+          @title = "#{heading.text} — Ruby on Rails Guides"
         else
           @title = "Ruby on Rails Guides"
         end

--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -15,7 +15,7 @@ module RailsGuides
 HTML
       end
 
-      def header(text, header_level)
+      def header(text, header_level, anchor)
         # Always increase the heading level by, so we can use h1, h2 heading in the document
         header_level += 1
 

--- a/guides/source/2_3_release_notes.md
+++ b/guides/source/2_3_release_notes.md
@@ -594,7 +594,7 @@ The internals of the various <code>rake gem</code> tasks have been substantially
 * Various files in /public that deal with CGI and FCGI dispatching are no longer generated in every Rails application by default (you can still get them if you need them by adding `--with-dispatchers` when you run the `rails` command, or add them later with `rake rails:update:generate_dispatchers`).
 * Rails Guides have been converted from AsciiDoc to Textile markup.
 * Scaffolded views and controllers have been cleaned up a bit.
-* `script/server` now accepts a <tt>--path</tt> argument to mount a Rails application from a specific path.
+* `script/server` now accepts a `--path` argument to mount a Rails application from a specific path.
 * If any configured gems are missing, the gem rake tasks will skip loading much of the environment. This should solve many of the "chicken-and-egg" problems where rake gems:install couldn't run because gems were missing.
 * Gems are now unpacked exactly once. This fixes issues with gems (hoe, for instance) which are packed with read-only permissions on the files.
 
@@ -618,4 +618,4 @@ A few pieces of older code are deprecated in this release:
 Credits
 -------
 
-Release notes compiled by [Mike Gunderloy](http://afreshcup.com.) This version of the Rails 2.3 release notes was compiled based on RC2 of Rails 2.3.
+Release notes compiled by [Mike Gunderloy](http://afreshcup.com). This version of the Rails 2.3 release notes was compiled based on RC2 of Rails 2.3.

--- a/guides/source/3_0_release_notes.md
+++ b/guides/source/3_0_release_notes.md
@@ -608,4 +608,4 @@ Credits
 
 See the [full list of contributors to Rails](http://contributors.rubyonrails.org/) for the many people who spent many hours making Rails 3. Kudos to all of them.
 
-Rails 3.0 Release Notes were compiled by [Mikel Lindsaar](http://lindsaar.net.)
+Rails 3.0 Release Notes were compiled by [Mikel Lindsaar](http://lindsaar.net).

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -17,7 +17,7 @@ After reading this guide, you will know:
 Introduction to instrumentation
 -------------------------------
 
-The instrumentation API provided by Active Support allows developers to provide hooks which other developers may hook into. There are several of these within the Rails framework, as described below in <TODO: link to section detailing each hook point>. With this API, developers can choose to be notified when certain events occur inside their application or another piece of Ruby code.
+The instrumentation API provided by Active Support allows developers to provide hooks which other developers may hook into. There are several of these within the Rails framework, as described below in (TODO: link to section detailing each hook point). With this API, developers can choose to be notified when certain events occur inside their application or another piece of Ruby code.
 
 For example, there is a hook provided within Active Record that is called every time Active Record uses an SQL query on a database. This hook could be **subscribed** to, and used to track the number of queries during a certain action. There's another hook around the processing of an action of a controller. This could be used, for instance, to track how long a specific action has taken.
 

--- a/guides/source/index.html.erb
+++ b/guides/source/index.html.erb
@@ -9,6 +9,7 @@ Ruby on Rails Guides
 <% content_for :index_section do %>
 <div id="subCol">
   <dl>
+    <dt></dt>
     <dd class="kindle">Rails Guides are also available for <%= link_to 'Kindle', @mobi %>.</dd>
     <dd class="work-in-progress">Guides marked with this icon are currently being worked on and will not be available in the Guides Index menu. While still useful, they may contain incomplete information and even errors. You can help by reviewing them and posting your comments and corrections.</dd>
   </dl>

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -78,7 +77,6 @@
           </select>
         </li>
       </ul>
-      </div>
     </div>
   </div>
   <hr class="hide" />

--- a/guides/w3c_validator.rb
+++ b/guides/w3c_validator.rb
@@ -60,6 +60,8 @@ module RailsGuides
     def guides_to_validate
       guides = Dir["./output/*.html"]
       guides.delete("./output/layout.html")
+      guides.delete("./output/_license.html")
+      guides.delete("./output/_welcome.html")
       ENV.key?('ONLY') ? select_only(guides) : guides
     end
 


### PR DESCRIPTION
Hi!

The [Ruby on Rails Guides Guidelines](http://edgeguides.rubyonrails.org/ruby_on_rails_guides_guidelines.html) say that you should make sure all guides are valid HTML and that `bundle exec rake guides:generate` should be run with `WARNINGS=1` to make sure our internal links are valid. To my surprise, there were quite a few validation errors!

Now, `rake guides:validate` returns no errors and `rake guides:generate WARNINGS=1` returns no warnings.

I left these commits small and separate, please instruct if you wish me to squash them.

Expect a PR soon moving the guides to HTML5, hopefully it won't be too much work!
