### PR TITLE
Define `alias_antonym` to quickly create "opposite" methods.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add `alias_antonym` as a quick way to define methods that return the
+    opposite of some other method, so you can do this:
+
+    class ParityChecker
+      class << self
+        def even?(n)
+          n % 2 == 0
+        end
+
+        alias_antonym :odd?, :even?
+      end
+    end
+
+    ParityChecker.even?(5) # => false
+    ParityChecker.odd?(5) # => true
+
+    *Ulysse Carion*
+    
 *   Fix `slice!` deleting the default value of the hash.
 
     *Antonio Santos*

--- a/activesupport/lib/active_support/core_ext/module/aliasing.rb
+++ b/activesupport/lib/active_support/core_ext/module/aliasing.rb
@@ -66,4 +66,26 @@ class Module
       def #{new_name}=(v); self.#{old_name} = v; end  # def subject=(v); self.title = v; end
     STR
   end
+
+  # Allows you to define "antonym" or "opposite" methods, which
+  # simply return the negated value of what's returned by another
+  # method.
+  #
+  #   class ParityChecker
+  #     class << self
+  #       def even?(n)
+  #         n % 2 == 0
+  #       end
+  #
+  #       alias_antonym :odd?, :even?
+  #     end
+  #   end
+  #
+  #   ParityChecker.even?(5) # => false
+  #   ParityChecker.odd?(5) # => true
+  def alias_antonym(new_name, old_name)
+    define_method(new_name) do |*args|
+      !send(old_name, *args)
+    end
+  end
 end

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -492,3 +492,25 @@ class MethodAliasingTest < ActiveSupport::TestCase
     assert FooClassWithBarMethod.public_method_defined?(:duck)
   end
 end
+
+class ParityChecker
+  class << self
+    def even?(n)
+      n % 2 == 0
+    end
+
+    alias_antonym :odd?, :even?
+  end
+end
+
+class AliasAntonymTest < ActiveSupport::TestCase
+  test "alias_antonym defines a new opposite method" do
+    assert_respond_to ParityChecker, :odd?
+
+    assert ParityChecker.even?(4)
+    assert_not ParityChecker.odd?(4)
+
+    assert_not ParityChecker.even?(5)
+    assert ParityChecker.odd?(5)
+  end
+end


### PR DESCRIPTION
Defining "antonym" (aka "opposite" or "inverse") methods that return precisely the opposite of what another method returns is a pretty common idiom in both Rails and other applications, so I thought it might be a decent idea to encapsulate this pattern in a method `alias_antonym`.

An example in action:

``` ruby
class ParityChecker
  class << self
    def even?(n)
      n % 2 == 0
    end

    alias_antonym :odd?, :even?
  end
end

ParityChecker.even?(5) # => false
ParityChecker.odd?(5) # => true
```

Unlike `alias_method`, `alias_antonym` doesn't make a copy of a method because that wouldn't make any sense. Instead, it just defines `new_method` as `not old_method`. I suppose this makes the "alias" part of the name kinda misleading, but I couldn't think of a better name at the time.

This is my first time submitting to a real PR to Rails, so I apologize if I missed any steps in the process.
