### PR TITLE
Optimize none? and one? relation query methods to use LIMIT 1 and COUNT.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Use SQL COUNT and LIMIT 1 queries for `none?` and `one?` methods if no block or limit is given,
+    instead of loading the entire collection to memory.
+    This applies to relations (e.g. `User.all`) as well as associations (e.g. `account.users`)
+
+        # Before:
+
+        users.none?
+        # SELECT "users".* FROM "users"
+
+        users.one?
+        # SELECT "users".* FROM "users"
+
+        # After:
+
+        users.none?
+        # SELECT 1 AS one FROM "users" LIMIT 1
+
+        users.one?
+        # SELECT COUNT(*) FROM "users"
+
+    *Eugene Gilburg*
+
 *   Allow for the name of the schema_migrations table to be configured.
 
     *Jerad Phelps*

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -301,7 +301,8 @@ module ActiveRecord
       end
 
       # Returns true if the collections is not empty.
-      # Equivalent to +!collection.empty?+.
+      # If block given, loads all records and checks for one or more matches.
+      # Otherwise, equivalent to +!collection.empty?+.
       def any?
         if block_given?
           load_target.any? { |*block_args| yield(*block_args) }
@@ -311,7 +312,8 @@ module ActiveRecord
       end
 
       # Returns true if the collection has more than 1 record.
-      # Equivalent to +collection.size > 1+.
+      # If block given, loads all records and checks for two or more matches.
+      # Otherwise, equivalent to +collection.size > 1+.
       def many?
         if block_given?
           load_target.many? { |*block_args| yield(*block_args) }

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -30,7 +30,15 @@ module ActiveRecord
       true
     end
 
+    def none?
+      true
+    end
+
     def any?
+      false
+    end
+
+    def one?
       false
     end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -247,12 +247,30 @@ module ActiveRecord
       limit_value == 0 ? true : !exists?
     end
 
+    # Returns true if there are no records.
+    def none?
+      if block_given?
+        to_a.none? { |*block_args| yield(*block_args) }
+      else
+        empty?
+      end
+    end
+
     # Returns true if there are any records.
     def any?
       if block_given?
         to_a.any? { |*block_args| yield(*block_args) }
       else
         !empty?
+      end
+    end
+
+    # Returns true if there is exactly one record.
+    def one?
+      if block_given?
+        to_a.one? { |*block_args| yield(*block_args) }
+      else
+        limit_value ? to_a.one? : size == 1
       end
     end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1492,6 +1492,82 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 2, firm.clients.size
   end
 
+  def test_calling_none_should_count_instead_of_loading_association
+    firm = companies(:first_firm)
+    assert_queries(1) do
+      firm.clients.none?  # use count query
+    end
+    assert !firm.clients.loaded?
+  end
+
+  def test_calling_none_on_loaded_association_should_not_use_query
+    firm = companies(:first_firm)
+    firm.clients.collect  # force load
+    assert_no_queries { assert ! firm.clients.none? }
+  end
+
+  def test_calling_none_should_defer_to_collection_if_using_a_block
+    firm = companies(:first_firm)
+    assert_queries(1) do
+      firm.clients.expects(:size).never
+      firm.clients.none? { true }
+    end
+    assert firm.clients.loaded?
+  end
+
+  def test_calling_none_should_return_true_if_none
+    firm = companies(:another_firm)
+    assert firm.clients_like_ms.none?
+    assert_equal 0, firm.clients_like_ms.size
+  end
+
+  def test_calling_none_should_return_false_if_any
+    firm = companies(:first_firm)
+    assert !firm.limited_clients.none?
+    assert_equal 1, firm.limited_clients.size
+  end
+
+  def test_calling_one_should_count_instead_of_loading_association
+    firm = companies(:first_firm)
+    assert_queries(1) do
+      firm.clients.one?  # use count query
+    end
+    assert !firm.clients.loaded?
+  end
+
+  def test_calling_one_on_loaded_association_should_not_use_query
+    firm = companies(:first_firm)
+    firm.clients.collect  # force load
+    assert_no_queries { assert ! firm.clients.one? }
+  end
+
+  def test_calling_one_should_defer_to_collection_if_using_a_block
+    firm = companies(:first_firm)
+    assert_queries(1) do
+      firm.clients.expects(:size).never
+      firm.clients.one? { true }
+    end
+    assert firm.clients.loaded?
+  end
+
+  def test_calling_one_should_return_false_if_zero
+    firm = companies(:another_firm)
+    assert ! firm.clients_like_ms.one?
+    assert_equal 0, firm.clients_like_ms.size
+  end
+
+  def test_calling_one_should_return_true_if_one
+    firm = companies(:first_firm)
+    assert firm.limited_clients.one?
+    assert_equal 1, firm.limited_clients.size
+  end
+
+  def test_calling_one_should_return_false_if_more_than_one
+    firm = companies(:first_firm)
+    assert ! firm.clients.one?
+    assert_equal 2, firm.clients.size
+  end
+
   def test_joins_with_namespaced_model_should_use_correct_type
     old = ActiveRecord::Base.store_full_sti_class
     ActiveRecord::Base.store_full_sti_class = true

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -287,7 +287,9 @@ class RelationTest < ActiveRecord::TestCase
       assert_equal 0,     Developer.none.size
       assert_equal 0,     Developer.none.count
       assert_equal true,  Developer.none.empty?
+      assert_equal true, Developer.none.none?
       assert_equal false, Developer.none.any?
+      assert_equal false, Developer.none.one?
       assert_equal false, Developer.none.many?
     end
   end
@@ -994,6 +996,38 @@ class RelationTest < ActiveRecord::TestCase
 
     assert posts.many?
     assert ! posts.limit(1).many?
+  end
+
+  def test_none
+    posts = Post.all
+    assert_queries(1) do
+      assert ! posts.none? # Uses COUNT()
+    end
+
+    assert ! posts.loaded?
+
+    assert_queries(1) do
+      assert posts.none? {|p| p.id < 0 }
+      assert ! posts.none? {|p| p.id == 1 }
+    end
+
+    assert posts.loaded?
+  end
+
+  def test_one
+    posts = Post.all
+    assert_queries(1) do
+      assert ! posts.one? # Uses COUNT()
+    end
+
+    assert ! posts.loaded?
+
+    assert_queries(1) do
+      assert ! posts.one? {|p| p.id < 3 }
+      assert posts.one? {|p| p.id == 1 }
+    end
+
+    assert posts.loaded?
   end
 
   def test_build


### PR DESCRIPTION
I was surprised to find out that relation's `none?` method was loading the entire collection as an array,
even if no block or limit was given. This contrasts how `any?` and `many?` work, which is to use `LIMIT 1` and `COUNT` respectively, if no block and limit is given.

IMO it's more natural to use `.none?` query rather than either `empty?` (because `empty?` is an Array method while `none?` is an Enumerable method and thus seems more suitable for a generic set such a a set of database rows). I therefore changed `none?` to follow the already existing behavior for `any?` and `many?`. 

I also implemented an optimized `one?` for similar reasons and for completion sake - just as me, others could be surprised that `one?` behaves differently than `any?` and `many?`, and I don't see a drawback to being consistent in providing an efficient implementation if possible.

This change applies to relations (e.g. `User.all`) as well as associations (e.g. `account.users`).

Before:

``` ruby
users.none?
SELECT "users".* FROM "users"

users.one?
SELECT "users".* FROM "users"
```

After:

``` ruby
users.none?
SELECT 1 AS one FROM "users" LIMIT 1

users.one?
SELECT COUNT(*) FROM "users"
```

`NullRelation` has been updated to short-curciut `none?` and `one?`, as it already does with `any?` and `many?`.

Also, improved method documentation a bit.

I added the (appropriately modified) same set of tests as present for `any?` and `many?` methods in `relations_test.rb` and `associations/has_many_association_test.rb` unit tests.
