### PR TITLE
rack dependency version updated from ~> 1.4.5 to >= 1.4.5

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activemodel',   version)
   s.add_dependency('rack-cache',    '~> 1.2')
   s.add_dependency('builder',       '~> 3.0.0')
-  s.add_dependency('rack',          '~> 1.4.5')
+  s.add_dependency('rack',          '>= 1.4.5')
   s.add_dependency('rack-test',     '~> 0.6.1')
   s.add_dependency('journey',       '~> 1.0.4')
   s.add_dependency('sprockets',     '~> 2.2.1')


### PR DESCRIPTION
This made to avoid version conflicts for rack with gems that depend on the latest 1.5.2 release
