### PR TITLE
Added some clues in example code in getting started guide

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -771,6 +771,9 @@ As we did before, we need to add the `show` action in
 def show
   @post = Post.find(params[:id])
 end
+
+private
+  def post_params
 ```
 
 A couple of things to note. We use `Post.find` to find the post we're


### PR DESCRIPTION
Fixed: #12679

In order that most of reader missed word `action` and place `show` action to the `private` block,
added `private` statement in example code for 5.7 Chapter to help to find correct place for `show` action.

/cc @fxn
