### PR TITLE
Fixed behavior of `validates_numericality_of` validation `even` and `odd` options with not true values

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixed `validates_numericality_of` validation. It behaves as expected when receives
+    not true values for `even` and `odd` options (not validate that option).
+
+   *Ancor Cruz*
+
 *   Fix `has_secure_password` to honor bcrypt-ruby's cost attribute.
 
     *T.J. Schuck*

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -39,7 +39,7 @@ module ActiveModel
         options.slice(*CHECKS.keys).each do |option, option_value|
           case option
           when :odd, :even
-            unless value.to_i.send(CHECKS[option])
+            if option_value && !value.to_i.send(CHECKS[option])
               record.errors.add(attr_name, option, filtered_options(value))
             end
           else

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -92,11 +92,23 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!([-1, 1])
   end
 
+  def test_validates_numericality_with_odd_false
+    Topic.validates_numericality_of :approved, odd: false
+
+    valid!([-2, 2, -1, 1])
+  end
+
   def test_validates_numericality_with_even
     Topic.validates_numericality_of :approved, even: true
 
     invalid!([-1, 1], 'must be even')
     valid!([-2, 2])
+  end
+
+  def test_validates_numericality_with_even_false
+    Topic.validates_numericality_of :approved, even: false
+
+    valid!([-2, 2, -1, 1])
   end
 
   def test_validates_numericality_with_greater_than_less_than_and_even


### PR DESCRIPTION
Validation will look like:

```
class Booking < ActiveRecord::Base
  validates :guests, numericality: { integer_only: true, even: :even_only?, greater_than: 1 }

  def even_only?; return true or false; end
end
```

instead of:

```
class Booking < ActiveRecord::Base
  validates :guests, numericality: { integer_only: true, greater_than: 1 }
  validates :guests, numericality: { even: true }, if: :even_only?

  def even_only?; return true or false; end
end
```
