### PR TITLE
Fix issue with Kernel#silence_stream leaking file descriptors

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix file descriptor being leaked on each call to `Kernel.silence_stream`
+
+    *Mario Visic*
+
 *   Ensure `config.i18n.enforce_available_locales` is set before any other
     configuration option.
 

--- a/activesupport/lib/active_support/core_ext/kernel/reporting.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/reporting.rb
@@ -48,6 +48,7 @@ module Kernel
     yield
   ensure
     stream.reopen(old_stream)
+    old_stream.close
   end
 
   # Blocks and ignores any exception passed as argument if raised within the block.

--- a/activesupport/test/core_ext/kernel_test.rb
+++ b/activesupport/test/core_ext/kernel_test.rb
@@ -38,6 +38,22 @@ class KernelTest < ActiveSupport::TestCase
     # Skip if we can't STDERR.tell
   end
 
+  def test_silence_stream
+    old_stream_position = STDOUT.tell
+    silence_stream(STDOUT) { STDOUT.puts 'hello world' }
+    assert_equal old_stream_position, STDOUT.tell
+  rescue Errno::ESPIPE
+    # Skip if we can't stream.tell
+  end
+
+  def test_silence_stream_closes_file_descriptors
+    stream     = StringIO.new
+    dup_stream = StringIO.new
+    stream.stubs(:dup).returns(dup_stream)
+    dup_stream.expects(:close)
+    silence_stream(stream) { stream.puts 'hello world' }
+  end
+
   def test_quietly
     old_stdout_position, old_stderr_position = STDOUT.tell, STDERR.tell
     quietly do


### PR DESCRIPTION
Calling Kernel#silence_stream creates a new file descriptor which isn't
closed after it is used. As a result calling silence_stream multiple
times leads to a build up of loose file descriptors and can cause issues
in environments where garbage collection isn't run often.

The test I added which checks the object space is a bit slow (takes around 4ms on my machine for the one test). Any suggestions to improve this would be appreciated.
