### PR TITLE
Minor doc fix of ActiveModel::Naming.

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -263,10 +263,10 @@ module ActiveModel
     # namespaced models regarding whether it's inside isolated engine.
     #
     #   # For isolated engine:
-    #   ActiveModel::Naming.route_key(Blog::Post) #=> post
+    #   ActiveModel::Naming.singular_route_key(Blog::Post) #=> "post"
     #
     #   # For shared engine:
-    #   ActiveModel::Naming.route_key(Blog::Post) #=> blog_post
+    #   ActiveModel::Naming.singular_route_key(Blog::Post) #=> "blog_post"
     def self.singular_route_key(record_or_class)
       model_name_from_record_or_class(record_or_class).singular_route_key
     end
@@ -275,10 +275,10 @@ module ActiveModel
     # namespaced models regarding whether it's inside isolated engine.
     #
     #   # For isolated engine:
-    #   ActiveModel::Naming.route_key(Blog::Post) #=> posts
+    #   ActiveModel::Naming.route_key(Blog::Post) #=> "posts"
     #
     #   # For shared engine:
-    #   ActiveModel::Naming.route_key(Blog::Post) #=> blog_posts
+    #   ActiveModel::Naming.route_key(Blog::Post) #=> "blog_posts"
     #
     # The route key also considers if the noun is uncountable and, in
     # such cases, automatically appends _index.
@@ -290,10 +290,10 @@ module ActiveModel
     # namespaced models regarding whether it's inside isolated engine.
     #
     #   # For isolated engine:
-    #   ActiveModel::Naming.param_key(Blog::Post) #=> post
+    #   ActiveModel::Naming.param_key(Blog::Post) #=> "post"
     #
     #   # For shared engine:
-    #   ActiveModel::Naming.param_key(Blog::Post) #=> blog_post
+    #   ActiveModel::Naming.param_key(Blog::Post) #=> "blog_post"
     def self.param_key(record_or_class)
       model_name_from_record_or_class(record_or_class).param_key
     end


### PR DESCRIPTION
- qoute example line's result when it kind of String
- right ("singular_route_key") method in example
