### PR TITLE
Clarify that visiting http://localhost:3000 should be done in a browser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ independently outside Rails.
 
    Run with `--help` or `-h` for options.
 
-4. Go to http://localhost:3000 and you'll see: "Welcome aboard: You're riding Ruby on Rails!"
+4. Using a browser, go to http://localhost:3000 and you'll see: "Welcome aboard: You're riding Ruby on Rails!"
 
 5. Follow the guidelines to start developing your application. You may find
    the following resources handy:


### PR DESCRIPTION
Prefix with 'Using a browser', when directing to 'go to http://localhost:3000'
I have taught users who typed the address in a terminal window instead of using a browser so this will clarify that you use a browser.
