### PR TITLE
Fix mistaken guide how to extend association proxy with module

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -2197,11 +2197,11 @@ module FindRecentExtension
 end
 
 class Customer < ActiveRecord::Base
-  has_many :orders, -> { extending FindRecentExtension }
+  has_many :orders, -> { include FindRecentExtension }
 end
 
 class Supplier < ActiveRecord::Base
-  has_many :deliveries, -> { extending FindRecentExtension }
+  has_many :deliveries, -> { include FindRecentExtension }
 end
 ```
 


### PR DESCRIPTION
There is no method `extending` for `Module`. It should be only `include` here. Tested by me both cases `exdend` and `include`. Only `include` works.

This is my code which I used to test code:

``` ruby
module AssociationExtensions
  module UniqMetaIds
    def uniq_meta_ids
      select(:meta_id).uniq.pluck(:meta_id)
    end
  end
end

class MetaService < ActiveRecord::Base
  has_many :meta_settings do
    include AssociationExtensions::UniqMetaIds
  end
end

describe MetaService do
  describe '#meta_settings' do
    it { expect(subject.meta_settings.uniq_meta_ids).to be_blank }
  end
end
```
