### PR TITLE
Convert CDATA input to string before gsub'ing

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -114,7 +114,7 @@ module ActionView
       #   cdata_section("hello]]>world")
       #   # => <![CDATA[hello]]]]><![CDATA[>world]]>
       def cdata_section(content)
-        splitted = content.gsub(']]>', ']]]]><![CDATA[>')
+        splitted = content.to_s.gsub(']]>', ']]]]><![CDATA[>')
         "<![CDATA[#{splitted}]]>".html_safe
       end
 

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -96,6 +96,10 @@ class TagHelperTest < ActionView::TestCase
     assert_equal "<![CDATA[<hello world>]]>", cdata_section("<hello world>")
   end
 
+  def test_cdata_section_with_string_conversion
+    assert_equal "<![CDATA[]]>", cdata_section(nil)
+  end
+
   def test_cdata_section_splitted
     assert_equal "<![CDATA[hello]]]]><![CDATA[>world]]>", cdata_section("hello]]>world")
     assert_equal "<![CDATA[hello]]]]><![CDATA[>world]]]]><![CDATA[>again]]>", cdata_section("hello]]>world]]>again")


### PR DESCRIPTION
Rails 3.2 API allowed arbitrary input for cdata_section; this change re-introduces the old behaviour.

If it is deemed worthy to be merged, does it make sense to add it to 4.0-STABLE as well?
