### PR TITLE
Support for Postgresql date/time ranges

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Initialize time/date ranges for Postgresql using DateTime::Infinity
+
+    *Serj Krasnov*
+
 *   ActiveRecord::Base#attribute_for_inspect now truncates long arrays (more than 10 elements)
 
     *Jan Bernacki*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -117,7 +117,13 @@ module ActiveRecord
           end
 
           def infinity(options = {})
-            ::Float::INFINITY * (options[:negative] ? -1 : 1)
+            sign = options[:negative] ? -1 : 1
+
+            if [:time, :date].include?(@subtype)
+              ::DateTime::Infinity.new(sign)
+            else
+              ::Float::INFINITY * (sign)
+            end
           end
 
           def infinity?(value)

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -260,10 +260,10 @@ _SQL
 
   def test_daterange_values
     skip "PostgreSQL 9.2 required for range datatypes" unless @connection.supports_ranges?
-    assert_equal Date.new(2012, 1, 2)...Date.new(2012, 1, 5), @first_range.date_range
-    assert_equal Date.new(2012, 1, 3)...Date.new(2012, 1, 4), @second_range.date_range
-    assert_equal Date.new(2012, 1, 3)...Float::INFINITY, @third_range.date_range
-    assert_equal(-Float::INFINITY...Float::INFINITY, @fourth_range.date_range)
+    assert_equal(Date.new(2012, 1, 2)...Date.new(2012, 1, 5), @first_range.date_range)
+    assert_equal(Date.new(2012, 1, 3)...Date.new(2012, 1, 4), @second_range.date_range)
+    assert_equal(Date.new(2012, 1, 3)...DateTime::INFINITY, @third_range.date_range)
+    assert_equal(-DateTime::INFINITY...DateTime::INFINITY, @fourth_range.date_range)
     assert_nil @empty_range.date_range
   end
 
@@ -279,17 +279,17 @@ _SQL
   def test_tsrange_values
     skip "PostgreSQL 9.2 required for range datatypes" unless @connection.supports_ranges?
     tz = ::ActiveRecord::Base.default_timezone
-    assert_equal Time.send(tz, 2010, 1, 1, 14, 30, 0)..Time.send(tz, 2011, 1, 1, 14, 30, 0), @first_range.ts_range
-    assert_equal Time.send(tz, 2010, 1, 1, 14, 30, 0)...Time.send(tz, 2011, 1, 1, 14, 30, 0), @second_range.ts_range
-    assert_equal(-Float::INFINITY...Float::INFINITY, @fourth_range.ts_range)
+    assert_equal(Time.send(tz, 2010, 1, 1, 14, 30, 0)..Time.send(tz, 2011, 1, 1, 14, 30, 0), @first_range.ts_range)
+    assert_equal(Time.send(tz, 2010, 1, 1, 14, 30, 0)...Time.send(tz, 2011, 1, 1, 14, 30, 0), @second_range.ts_range)
+    assert_equal(-DateTime::INFINITY...DateTime::INFINITY, @fourth_range.ts_range)
     assert_nil @empty_range.ts_range
   end
 
   def test_tstzrange_values
     skip "PostgreSQL 9.2 required for range datatypes" unless @connection.supports_ranges?
-    assert_equal Time.parse('2010-01-01 09:30:00 UTC')..Time.parse('2011-01-01 17:30:00 UTC'), @first_range.tstz_range
-    assert_equal Time.parse('2010-01-01 09:30:00 UTC')...Time.parse('2011-01-01 17:30:00 UTC'), @second_range.tstz_range
-    assert_equal(-Float::INFINITY...Float::INFINITY, @fourth_range.tstz_range)
+    assert_equal(Time.parse('2010-01-01 09:30:00 UTC')..Time.parse('2011-01-01 17:30:00 UTC'), @first_range.tstz_range)
+    assert_equal(Time.parse('2010-01-01 09:30:00 UTC')...Time.parse('2011-01-01 17:30:00 UTC'), @second_range.tstz_range)
+    assert_equal(-DateTime::INFINITY...DateTime::INFINITY, @fourth_range.tstz_range)
     assert_nil @empty_range.tstz_range
   end
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add extension for DateTime::Infinity and DateTime::INFINITY constant
+    to facilitate its usage in comparison and range operations.
+
+    *Serj Krasnov*
+
 *   Support :unless_exist in FileStore
 
     *Michael Grosser*

--- a/activesupport/lib/active_support/core_ext/date_time.rb
+++ b/activesupport/lib/active_support/core_ext/date_time.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/date_time/acts_like'
 require 'active_support/core_ext/date_time/calculations'
 require 'active_support/core_ext/date_time/conversions'
+require 'active_support/core_ext/date_time/infinity'
 require 'active_support/core_ext/date_time/zones'

--- a/activesupport/lib/active_support/core_ext/date_time/infinity.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/infinity.rb
@@ -1,0 +1,38 @@
+class DateTime
+  # Add additional behaviour to DateTime::Infinity to make it usable in ranges, comparison and operations with durations
+  #
+  # === Examples
+  # DateTime::INFINITY > DateTime.civil(2018, 1, 1, 0, 0, 0)        # => true
+  # -DateTime::INFINITY > Time.now                                  # => false
+  # DateTime::INFINITY + 1.day                                      # => #<DateTime::Infinity:0x0...>
+  # (Time.now .. DateTime::INFINITY).include?(Time.now - 1.minute)  # => false
+  # (Time.now .. DateTime::INFINITY).include?(Time.now + 1.minute)  # => true
+  class Infinity < Date::Infinity
+
+    def <=>(other)
+      case other
+      when Date, Time
+        @d
+      else
+        super
+      end
+    end
+
+    def to_datetime
+      self
+    end
+
+    def change(other)
+      if other.is_a?(Numeric)
+        self
+      else
+        raise ArgumentError, "expected numeric"
+      end
+    end
+
+    alias_method :-, :change
+    alias_method :+, :change
+  end
+
+  INFINITY = Infinity.new
+end

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -17,6 +17,7 @@ module ActiveSupport
     # Adds another Duration or a Numeric to this Duration. Numeric values
     # are treated as seconds.
     def +(other)
+      return other if other.is_a?(::DateTime::Infinity)
       if Duration === other
         Duration.new(value + other.value, @parts + other.parts)
       else

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -347,6 +347,32 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal 500000000, DateTime.civil(2000, 1, 1, 0, 0, Rational(1,2)).nsec
   end
 
+  def test_infinity_comparison
+    assert_equal(1, DateTime::INFINITY <=> DateTime.civil(2018, 1, 1, 0, 0, 0))
+    assert_equal(-1, -DateTime::INFINITY <=> DateTime.civil(2018, 1, 1, 0, 0, 0))
+    assert_equal(-1, DateTime.civil(2018, 1, 1, 0, 0, 0) <=> DateTime::INFINITY )
+    assert_equal(1, DateTime.civil(2018, 1, 1, 0, 0, 0) <=> -DateTime::INFINITY)
+    assert_equal(1, DateTime::INFINITY <=> Time.utc(2018, 1, 1, 0, 0, 1))
+    assert_equal(-1, -DateTime::INFINITY <=> Time.utc(2018, 1, 1, 0, 0, 1))
+    assert_equal(-1, Time.utc(2018, 1, 1, 0, 0, 1) <=> DateTime::INFINITY)
+    assert_equal(1, Time.utc(2018, 1, 1, 0, 0, 1) <=> -DateTime::INFINITY)
+    assert_equal(1, DateTime::INFINITY <=> Date.new(2018, 1, 1))
+    assert_equal(-1, -DateTime::INFINITY <=> Date.new(2018, 1, 1))
+    assert_equal(-1, Date.new(2018, 1, 1) <=> DateTime::INFINITY)
+    assert_equal(1, Date.new(2018, 1, 1) <=> -DateTime::INFINITY)
+  end
+
+  def test_infinity_ranges
+    assert_equal true, ( Date.new(2018, 1, 1) .. DateTime::INFINITY ).include?(Date.new(2018, 1, 2))
+    assert_equal false, ( Date.new(2018, 1, 1) .. DateTime::INFINITY ).include?(Date.new(2017, 12, 1))
+    assert_equal true, ( -DateTime::INFINITY .. Time.utc(2018, 1, 1, 0, 0, 1)).include?(Time.utc(2018, 1, 1, 0, 0, 1))
+    assert_equal false, ( -DateTime::INFINITY .. Time.utc(2018, 1, 1, 0, 0, 1)).include?(Time.utc(2018, 1, 1, 0, 0, 2))
+  end
+
+  def test_infinity_modification
+    assert_equal(DateTime::INFINITY, DateTime::INFINITY - 1.day)
+  end
+
   protected
     def with_env_tz(new_tz = 'US/Eastern')
       old_tz, ENV['TZ'] = ENV['TZ'], new_tz

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -133,6 +133,11 @@ class DurationTest < ActiveSupport::TestCase
     end
   end
 
+  def test_changes_to_infinity
+    assert_equal(DateTime::INFINITY, 2.month + DateTime::INFINITY)
+    assert_equal(-DateTime::INFINITY, 2.month - DateTime::INFINITY)
+  end
+
   def test_delegation_with_block_works
     counter = 0
     assert_nothing_raised do


### PR DESCRIPTION
Hi

I ran into a problem with time ranges in Postgresql. During initialization of ActiveRecord objects we got:

```
ArgumentError: bad value for range
    .../activerecord-4.0.0/lib/active_record/connection_adapters/postgresql/oid.rb:162:in `initialize'
```

It doesn't work because following code is not valid ruby code: `(Time.now .. Float::INFINITY)`

I think that `DateTime::Infinity` is better candidate to set infinite bounds for those ranges. Mostly because it allows to maintain similar behaviour between Time, Date and DateTime objects. I made a small extension to make it more predictable in comparison operations and modifications using durations.
