### PR TITLE
Allow Pathnames to be added to eager load paths

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support for Pathnames in eager load paths.
+
+    *Mike Pack*
+
 *   Fixed missing line and shadow on service pages(404, 422, 500).
 
     *Dmitry Korotkov*

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -465,7 +465,7 @@ module Rails
     # files inside eager_load paths.
     def eager_load!
       config.eager_load_paths.each do |load_path|
-        matcher = /\A#{Regexp.escape(load_path)}\/(.*)\.rb\Z/
+        matcher = /\A#{Regexp.escape(load_path.to_s)}\/(.*)\.rb\Z/
         Dir.glob("#{load_path}/**/*.rb").sort.each do |file|
           require_dependency file.sub(matcher, '\1')
         end

--- a/railties/test/application/initializers/load_path_test.rb
+++ b/railties/test/application/initializers/load_path_test.rb
@@ -71,6 +71,20 @@ module ApplicationTests
       assert Zoo
     end
 
+    test "eager loading accepts Pathnames" do
+      app_file "lib/foo.rb", <<-RUBY
+        module Foo; end
+      RUBY
+
+      add_to_config <<-RUBY
+        config.eager_load = true
+        config.eager_load_paths << Pathname.new("#{app_path}/lib")
+      RUBY
+
+      require "#{app_path}/config/environment"
+      assert Foo
+    end
+
     test "load environment with global" do
       $initialize_test_set_from_env = nil
       app_file "config/environments/development.rb", <<-RUBY


### PR DESCRIPTION
It seems convenient to allow `Pathname`s to be registered for eager loading:

``` ruby
module MyApp
  class Application < Rails::Application
    config.eager_load_paths << Rails.root.join('lib')
  end
end
```

In most cases the eager load paths are strings, but calling `to_s` on anything added should provide more flexibility.
