### PR TITLE
Fix mounting engines inside a resources block

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix generating a path for engine inside a resources block (#8533)
+
+    *Piotr Sarnacki*
+
 *   Add Mime::Type.register "text/vcard", :vcf to the default list of mime types
 
     *DHH*

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -502,11 +502,12 @@ module ActionDispatch
           raise "A rack application must be specified" unless path
 
           options[:as]  ||= app_name(app)
+          target_as       = name_for_action(options[:as], path)
           options[:via] ||= :all
 
           match(path, options.merge(:to => app, :anchor => false, :format => false))
 
-          define_generate_prefix(app, options[:as])
+          define_generate_prefix(app, target_as)
           self
         end
 

--- a/actionpack/test/dispatch/mount_test.rb
+++ b/actionpack/test/dispatch/mount_test.rb
@@ -5,7 +5,7 @@ class TestRoutingMount < ActionDispatch::IntegrationTest
 
   class FakeEngine
     def self.routes
-      Object.new
+      @routes ||= ActionDispatch::Routing::RouteSet.new
     end
 
     def self.call(env)
@@ -27,10 +27,21 @@ class TestRoutingMount < ActionDispatch::IntegrationTest
     scope "/its_a" do
       mount SprocketsApp, :at => "/sprocket"
     end
+
+    resources :users do
+      mount FakeEngine, :at => "/fakeengine", :as => :fake_mounted_at_resource
+    end
   end
 
   def app
     Router
+  end
+
+  def test_app_name_is_properly_generated_when_engine_is_mounted_in_resources
+    assert Router.mounted_helpers.method_defined?(:user_fake_mounted_at_resource),
+          "A mounted helper should be defined with a parent's prefix"
+    assert Router.named_routes.routes[:user_fake_mounted_at_resource],
+          "A named route should be defined with a parent's prefix"
   end
 
   def test_trailing_slash_is_not_removed_from_path_info


### PR DESCRIPTION
From a commit message

```
When a route is mounted inside a resources block, it's automatically
prefixed, so a following code:

    resources :users do
      mount Blog::Engine => '/blog'
    end

will generate a user_blog path helper.

In order to access engine helpers, we also use "mounted_helpers", a list
of helpers associated with each mounted engine, so a path to blog's post
can be generated using user_blog.post_path(user, post).

The problem I'm fixing here is that mount used a raw :as option, without
taking nestings into account. As a result, blog was added to a route set
as a `user_blog`, but helper was generated for just `blog`.

This commit applies the proper logic for defining a helper for a mounted
engine nested in resources or resource block.

(closes #8533)
```
