### PR TITLE
Fix use of store with hstore

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix use of store with Hstore columns
+
+    When usings Hstore columns with store on these columns, ActiveRecord was
+    unable to save the record.
+
+    *Jure Triglav*, *Robin Dupret*
+
 *   ActiveRecord::Base#attribute_for_inspect now truncates long arrays (more than 10 elements)
 
     *Jan Bernacki*

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -67,8 +67,10 @@ module ActiveRecord
 
     module ClassMethods
       def store(store_attribute, options = {})
-        serialize store_attribute, IndifferentCoder.new(options[:coder])
-        store_accessor(store_attribute, options[:accessors]) if options.has_key? :accessors
+        unless store_column?(store_attribute)
+          serialize store_attribute, IndifferentCoder.new(options[:coder])
+        end
+        store_accessor(store_attribute, options[:accessors])
       end
 
       def store_accessor(store_attribute, *keys)
@@ -99,6 +101,10 @@ module ActiveRecord
           include mod
           mod
         end
+      end
+
+      def store_column?(column_name)
+        columns_hash[column_name.to_s].respond_to?(:accessor)
       end
     end
 

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -111,6 +111,15 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     assert_equal "GMT", x.timezone
   end
 
+  def test_save_with_store
+    Hstore.store :settings, accessors: [:intelligence, :charisma]
+
+    x = Hstore.new
+    x.intelligence = 'notsomuch'
+    x.charisma = 'plenty'
+    x.save!
+  end
+
   def test_gen1
     assert_equal(%q(" "=>""), @column.class.hstore_to_string({' '=>''}))
   end

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -121,4 +121,13 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
     x = JsonDataType.first
     assert_equal "640×1136", x.resolution
   end
+
+  def test_save_with_store
+    JsonDataType.store :settings, accessors: [:url, :extension]
+
+    x = JsonDataType.new
+    x.url = 'kitten'
+    x.extension = 'jpg'
+    x.save!
+  end
 end


### PR DESCRIPTION
Hello,

This is a rebase of #11561. Here are the explanations:

We need to exclude the serialization of `hstore` type columns when using `store` in the model. Thus, any model with stored attributes can be saved if these attributes are Hstore columns.

/cc @senny

Have a nice day.
