### PR TITLE
session#fetch doesn't behave exactly like Hash#fetch.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,6 +1,8 @@
 *   Add `session#fetch` method
 
-    fetch behaves like [Hash#fetch](http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-fetch).  
+    fetch behaves similarly to [Hash#fetch](http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-fetch),
+    with the exception that the returned value is always saved into the session.
+
     It returns a value from the hash for the given key.
     If the key can’t be found, there are several options:
 

--- a/actionpack/test/dispatch/request/session_test.rb
+++ b/actionpack/test/dispatch/request/session_test.rb
@@ -63,11 +63,15 @@ module ActionDispatch
 
       def test_fetch
         session = Session.create(store, {}, {})
-        session['one'] = '1'
 
+        session['one'] = '1'
         assert_equal '1', session.fetch(:one)
+
         assert_equal '2', session.fetch(:two, '2')
+        assert_equal '2', session.fetch(:two)
+
         assert_equal 'three', session.fetch(:three) {|el| el.to_s }
+        assert_equal 'three', session.fetch(:three)
 
         assert_raise KeyError do
           session.fetch(:four)


### PR DESCRIPTION
Mention it in the changelog and add a test checking for regressions.

Hash#fetch isn't adding the defaultly returned value.
However, in the session, saving it is the behavior we should expect.

See discussion in #12692
