### PR TITLE
Use set_backtrace instead of @backtrace in ActionView error

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use `set_backtrace` instead of instance variable `@backtrace` in ActionView exceptions
+
+    *Shimpei Makimoto*
+
 *   Fix `simple_format` escapes own output when passing `sanitize: true`
 
     *Paul Seidemann*

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -56,13 +56,13 @@ module ActionView
     class Error < ActionViewError #:nodoc:
       SOURCE_CODE_RADIUS = 3
 
-      attr_reader :original_exception, :backtrace
+      attr_reader :original_exception
 
       def initialize(template, original_exception)
         super(original_exception.message)
         @template, @original_exception = template, original_exception
         @sub_templates = nil
-        @backtrace = original_exception.backtrace
+        set_backtrace(original_exception.backtrace)
       end
 
       def file_name

--- a/actionview/test/template/template_error_test.rb
+++ b/actionview/test/template/template_error_test.rb
@@ -6,6 +6,13 @@ class TemplateErrorTest < ActiveSupport::TestCase
     assert_equal "original", error.message
   end
 
+  def test_provides_original_backtrace
+    original_exception = Exception.new
+    original_exception.set_backtrace(%W[ foo bar baz ])
+    error = ActionView::Template::Error.new("test", original_exception)
+    assert_equal %W[ foo bar baz ], error.backtrace
+  end
+
   def test_provides_useful_inspect
     error = ActionView::Template::Error.new("test", Exception.new("original"))
     assert_equal "#<ActionView::Template::Error: original>", error.inspect


### PR DESCRIPTION
This pull req fixes handling of backtraces of `ActionView::Template::Error`.

`ActionView::Template::Error` wraps some other exceptions and delegates its backtrace to the original ones.
However, backtrace in `ActionView::Template::Error` is an instance variable and the variable overwrites `Exception#backtrace`.
It may cause unexpected troubles such as ruby/ruby#434.
So I introduce `set_backtrace` instead of `@backtrace` for `ActionView::Template::Error`.
