### PR TITLE
Require bigdecimal before monkey-patching it

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -1,5 +1,6 @@
 # Hack to load json gem first so we can overwrite its to_json.
 require 'json'
+require 'bigdecimal'
 
 # The JSON gem adds a few modules to Ruby core classes containing :to_json definition, overwriting
 # their default behavior. That said, we need to define the basic to_json method in all of them,

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -3,7 +3,6 @@
 require 'active_support/core_ext/object/json'
 require 'active_support/core_ext/module/delegation'
 
-require 'bigdecimal'
 require 'active_support/core_ext/big_decimal/conversions' # for #to_s
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/hash/slice'


### PR DESCRIPTION
Hello,

If we try to monkey-patch the class before requiring it, then a "superclass mismatch" (`TypeError`) error is raised and the build can't run correctly.

Fixes #12708.

Have a nice day.
