### PR TITLE
Require time before monkey-patching it

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -1,6 +1,7 @@
 # Hack to load json gem first so we can overwrite its to_json.
 require 'json'
 require 'bigdecimal'
+require 'time'
 
 # The JSON gem adds a few modules to Ruby core classes containing :to_json definition, overwriting
 # their default behavior. That said, we need to define the basic to_json method in all of them,

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -7,7 +7,6 @@ require 'active_support/core_ext/big_decimal/conversions' # for #to_s
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/object/instance_variables'
-require 'time'
 require 'active_support/core_ext/time/conversions'
 require 'active_support/core_ext/date_time/conversions'
 require 'active_support/core_ext/date/conversions'


### PR DESCRIPTION
Hello,

This pull request has the same goal as #12710 but for the time module this time. This time it should fix the Active Model test suite in isolation avoiding a `TypeError` to be raised about the superclass of the `DateTime` object.

Here is the [error](https://travis-ci.org/rails/rails/jobs/13310160#L1866) on Travis.

Have a nice day.
