### PR TITLE
Fixed sequence_name for postgres adapter to work in case when there are no sequence for given table.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -904,7 +904,7 @@ module ActiveRecord
 
       # Returns the sequence name for a table's primary key or some other specified key.
       def default_sequence_name(table_name, pk = nil) #:nodoc:
-        serial_sequence(table_name, pk || 'id').split('.').last
+        serial_sequence(table_name, pk || 'id').to_s.split('.').last
       rescue ActiveRecord::StatementInvalid
         "#{table_name}_#{pk || 'id'}_seq"
       end


### PR DESCRIPTION
I have a table in postgresql which doesn't have sequence for primary key :

```
SELECT pg_get_serial_sequence('default_taxes', 'id');
 pg_get_serial_sequence 
------------------------

(1 row)
```

Calling DefaultTax.sequence_name cause following exception :

```
> DefaultTax.sequence_name
NoMethodError: undefined method `split' for nil:NilClass
        from /var/proj/pb-dev3/vendor/gems/ruby/1.9.1/gems/activerecord-3.2.15/lib/active_record/connection_adapters/postgresql_adapter.rb:907:in `default_sequence_name'
        from /var/proj/pb-dev3/vendor/gems/ruby/1.9.1/gems/activerecord-3.2.15/lib/active_record/model_schema.rb:196:in `reset_sequence_name'
        from /var/proj/pb-dev3/vendor/gems/ruby/1.9.1/gems/activerecord-3.2.15/lib/active_record/model_schema.rb:185:in `sequence_name'
        from (irb):1
        from /var/proj/pb-dev3/vendor/gems/ruby/1.9.1/gems/railties-3.2.15/lib/rails/commands/console.rb:47:in `start'
        from /var/proj/pb-dev3/vendor/gems/ruby/1.9.1/gems/railties-3.2.15/lib/rails/commands/console.rb:8:in `start'
        from /var/proj/pb-dev3/vendor/gems/ruby/1.9.1/gems/railties-3.2.15/lib/rails/commands.rb:41:in `<top (required)>'
        from script/rails:6:in `require'
        from script/rails:6:in `<main>'
```

This fix converts the result from the `serial_sequence` function into string to avoid calling split on nil.

This issue does not exists in rails 4.0.0
