### PR TITLE
Compare unserialized value when assigning serialized attributes to changed_attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Use unserialized value of an serialized attribute when comparing to the original
+    value during the initialization of the `changed_attributes` hash.
+
+    Example:
+        class User < ActiveRecord::Base
+          serialize :name
+        end
+
+        user = User.new
+
+        # Before
+        user.changes # => {"name"=>[nil, nil]}
+
+        # After
+        user.changes # => {}
+
+
+    Fixes #12505
+
+    *Ben Atkins*
+
 *   ActiveRecord::Base#attribute_for_inspect now truncates long arrays (more than 10 elements)
 
     *Jan Bernacki*

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -429,7 +429,10 @@ module ActiveRecord
       # optimistic locking) won't get written unless they get marked as changed
       self.class.columns.each do |c|
         attr, orig_value = c.name, c.default
-        changed_attributes[attr] = orig_value if _field_changed?(attr, orig_value, @attributes[attr])
+        # if the attribute is marked with `serialize`, need to compare the unserialized value to the original value
+        new_value = @attributes[attr].is_a?(ActiveRecord::AttributeMethods::Serialization::Attribute) ?
+          @attributes[attr].unserialized_value : @attributes[attr]
+        changed_attributes[attr] = orig_value if _field_changed?(attr, orig_value, new_value)
       end
     end
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -429,9 +429,10 @@ module ActiveRecord
       # optimistic locking) won't get written unless they get marked as changed
       self.class.columns.each do |c|
         attr, orig_value = c.name, c.default
+        new_value = @attributes[attr]
         # if the attribute is marked with `serialize`, need to compare the unserialized value to the original value
-        new_value = @attributes[attr].is_a?(ActiveRecord::AttributeMethods::Serialization::Attribute) ?
-          @attributes[attr].unserialized_value : @attributes[attr]
+        new_value = new_value.unserialized_value if new_value.is_a?(ActiveRecord::AttributeMethods::Serialization::Attribute)
+
         changed_attributes[attr] = orig_value if _field_changed?(attr, orig_value, new_value)
       end
     end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -19,6 +19,11 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     assert_equal %w(content), Topic.serialized_attributes.keys
   end
 
+  def test_active_model_dirty_serialized_attribute
+    topic = Topic.new
+    assert !topic.content_changed?
+  end
+
   def test_serialized_attribute
     Topic.serialize("content", MyObject)
 


### PR DESCRIPTION
This is my attempt at a fix for #12505.  Not certain that I put the test in the proper location, but it seemed like a logical spot.
