### PR TITLE
make sure order quote symbol arguments

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -285,7 +285,7 @@ module ActiveRecord
 
     def limited_ids_for(relation)
       values = @klass.connection.columns_for_distinct(
-        "#{quoted_table_name}.#{quoted_primary_key}", relation.order_values)
+        "#{quoted_table_name}.#{quoted_primary_key}", relation.arel.orders)
 
       relation = relation.except(:select).select(values).distinct!
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1036,11 +1036,6 @@ module ActiveRecord
       references = order_args.grep(String)
       references.map! { |arg| arg =~ /^([a-zA-Z]\w*)\.(\w+)/ && $1 }.compact!
       references!(references) if references.any?
-
-      # if a symbol is given we prepend the quoted table name
-      order_args.map! do |arg|
-        arg.is_a?(Symbol) ? Arel::Nodes::Ascending.new(klass.arel_table[arg]) : arg
-      end
     end
 
     # Checks to make sure that the arguments are not blank. Note that if some

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1179,12 +1179,24 @@ class EagerAssociationTest < ActiveRecord::TestCase
     }
   end
 
-  test "works in combination with order(:symbol) and reorder(:symbol)" do
+  test "works in combination with order(:symbol), order(key: direction), reorder(:symbol) and reorder(key: direction)" do
     author = Author.includes(:posts).references(:posts).order(:name).find_by('posts.title IS NOT NULL')
     assert_equal authors(:bob), author
+    
+    author = Author.includes(:posts).references(:posts).order(name: :asc).find_by('posts.title IS NOT NULL')
+    assert_equal authors(:bob), author
+    
+    author = Author.includes(:posts).references(:posts).order(name: :desc).find_by('posts.title IS NOT NULL')
+    assert_equal authors(:mary), author
 
     author = Author.includes(:posts).references(:posts).reorder(:name).find_by('posts.title IS NOT NULL')
     assert_equal authors(:bob), author
+    
+    author = Author.includes(:posts).references(:posts).reorder(name: :asc).find_by('posts.title IS NOT NULL')
+    assert_equal authors(:bob), author
+    
+    author = Author.includes(:posts).references(:posts).reorder(name: :desc).find_by('posts.title IS NOT NULL')
+    assert_equal authors(:mary), author
   end
 
   test "preloading with a polymorphic association and using the existential predicate" do

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -35,15 +35,7 @@ module ActiveRecord
       assert relation.order!('name ASC').equal?(relation)
       assert_equal ['name ASC'], relation.order_values
     end
-
-    test '#order! with symbol prepends the table name' do
-      assert relation.order!(:name).equal?(relation)
-      node = relation.order_values.first
-      assert node.ascending?
-      assert_equal :name, node.expr.name
-      assert_equal "posts", node.expr.relation.name
-    end
-
+    
     test '#order! on non-string does not attempt regexp match for references' do
       obj = Object.new
       obj.expects(:=~).never
@@ -95,15 +87,6 @@ module ActiveRecord
       assert relation.reorder!('bar').equal?(relation)
       assert_equal ['bar'], relation.order_values
       assert relation.reordering_value
-    end
-
-    test '#reorder! with symbol prepends the table name' do
-      assert relation.reorder!(:name).equal?(relation)
-      node = relation.order_values.first
-
-      assert node.ascending?
-      assert_equal :name, node.expr.name
-      assert_equal "posts", node.expr.relation.name
     end
 
     test 'reverse_order!' do


### PR DESCRIPTION
Current order implementation [contains symbol parsing and converting it to `Arel::Nodes::Ordering`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation/query_methods.rb#L1013)
But this code will be never executed, because we [preprocess symbol params and convert it to `Arel::Nodes::Ascending`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation/query_methods.rb#L1042).
But when we convert it to `Arel::Nodes::Ascending` it has issues with some values(for example `:key`, [see here #2601](https://github.com/rails/rails/issues/2601#issuecomment-27401690))

So i removed symbol preprocessing and leave all calculation on `build_order` method

Also this pull fixes `limited_ids_for` method for postgresql adapter, which is [passing `order_values`(raw values that we pass to order) to `columns_for_distinct`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L474). So for symbol(after i removed preprocessing) and hash arguments it will raise `NoMethodError`, because [there is no `to_sql` method](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L476)
