### PR TITLE
Add #cache_key_without_timestamp

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -56,5 +56,21 @@ module ActiveRecord
         "#{self.class.model_name.cache_key}/#{id}"
       end
     end
+    
+    # Returns a cache key that can be used to identify this record.
+    # Timestamp is not included to allow custom caching expiration
+    # (e.g. Cookie based caching with expiration)
+    #
+    #   Product.new.cache_key     # => "products/new"
+    #   Product.find(5).cache_key # => "products/5" (updated_at not available)
+    #   Person.find(5).cache_key  # => "people/5" (updated_at available)
+    def cache_key_without_timestamp
+      case
+      when new_record?
+        "#{self.class.model_name.cache_key}/new"
+      else
+        "#{self.class.model_name.cache_key}/#{id}"
+      end
+    end
   end
 end

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -81,4 +81,21 @@ class IntegrationTest < ActiveRecord::TestCase
     dev.touch
     assert_not_equal key, dev.cache_key
   end
+
+  def test_cache_key_without_for_new_record
+    dev = Developer.new
+    assert_match(/\/new$/, dev.cache_key)
+  end
+  
+  def test_cache_key_without_for_existing_record_with_nil_updated_timestamps
+    dev = Developer.first
+    dev.update_columns(updated_at: nil, updated_on: nil)
+    assert_match(/\/#{dev.id}$/, dev.cache_key)
+  end
+  
+  def test_cache_key_without_for_existing_record_with_updated_timestamps
+    dev = Developer.first
+    dev.touch
+    assert_match(/\/#{dev.id}$/, dev.cache_key)
+  end
 end

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -82,20 +82,20 @@ class IntegrationTest < ActiveRecord::TestCase
     assert_not_equal key, dev.cache_key
   end
 
-  def test_cache_key_without_for_new_record
+  def test_cache_key_without_timestamp_for_new_record
     dev = Developer.new
-    assert_match(/\/new$/, dev.cache_key)
+    assert_match(/\/new$/, dev.cache_key_without_timestamp)
   end
-  
-  def test_cache_key_without_for_existing_record_with_nil_updated_timestamps
+
+  def test_cache_key_without_timestamp_for_existing_record_with_nil_updated_timestamps
     dev = Developer.first
     dev.update_columns(updated_at: nil, updated_on: nil)
-    assert_match(/\/#{dev.id}$/, dev.cache_key)
+    assert_match(/\/#{dev.id}$/, dev.cache_key_without_timestamp)
   end
-  
-  def test_cache_key_without_for_existing_record_with_updated_timestamps
+
+  def test_cache_key_without_timestamp_for_existing_record_with_updated_timestamps
     dev = Developer.first
     dev.touch
-    assert_match(/\/#{dev.id}$/, dev.cache_key)
+    assert_match(/\/#{dev.id}$/, dev.cache_key_without_timestamp)
   end
 end


### PR DESCRIPTION
Sometime I need a universal cache key for caching with Javascript and Cookie
By scoping with a unique key in a page and the record 
But the timestamp in cache key would invalid the cache earlier than expected
