### PR TITLE
Warnings removed for ruby trunk

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -96,7 +96,7 @@ module ActionDispatch
     def source_fragment(path, line)
       return unless Rails.respond_to?(:root) && Rails.root
       full_path = Rails.root.join(path)
-      if File.exists?(full_path)
+      if File.exist?(full_path)
         File.open(full_path, "r") do |file|
           start = [line - 3, 0].max
           lines = file.each_line.drop(start).take(6)

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -381,7 +381,7 @@ module RenderTestCases
   def test_render_ignores_templates_with_malformed_template_handlers
     ActiveSupport::Deprecation.silence do
       %w(malformed malformed.erb malformed.html.erb malformed.en.html.erb).each do |name|
-        assert File.exists?(File.expand_path("#{FIXTURE_LOAD_PATH}/test/malformed/#{name}~")), "Malformed file (#{name}~) which should be ignored does not exists"
+        assert File.exist?(File.expand_path("#{FIXTURE_LOAD_PATH}/test/malformed/#{name}~")), "Malformed file (#{name}~) which should be ignored does not exists"
         assert_raises(ActionView::MissingTemplate) { @view.render(:file => "test/malformed/#{name}") }
       end
     end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -629,7 +629,7 @@ module ActiveRecord
     def copy(destination, sources, options = {})
       copied = []
 
-      FileUtils.mkdir_p(destination) unless File.exists?(destination)
+      FileUtils.mkdir_p(destination) unless File.exist?(destination)
 
       destination_migrations = ActiveRecord::Migrator.migrations(destination)
       last = destination_migrations.last

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -271,7 +271,7 @@ db_namespace = namespace :db do
       desc 'Clear a db/schema_cache.dump file.'
       task :clear => [:environment, :load_config] do
         filename = File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "schema_cache.dump")
-        FileUtils.rm(filename) if File.exists?(filename)
+        FileUtils.rm(filename) if File.exist?(filename)
       end
     end
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -146,7 +146,7 @@ module ActiveRecord
       end
 
       def check_schema_file(filename)
-        unless File.exists?(filename)
+        unless File.exist?(filename)
           message = %{#{filename} doesn't exist yet. Run `rake db:migrate` to create it, then try again.}
           message << %{ If you do not intend to use a database, you should instead alter #{Rails.root}/config/application.rb to limit the frameworks that will be loaded.} if defined?(::Rails)
           Kernel.abort message

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -140,7 +140,7 @@ def load_schema
 
   load SCHEMA_ROOT + "/schema.rb"
 
-  if File.exists?(adapter_specific_schema_file)
+  if File.exist?(adapter_specific_schema_file)
     load adapter_specific_schema_file
   end
 ensure

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -710,8 +710,8 @@ class CopyMigrationsTest < ActiveRecord::TestCase
     @existing_migrations = Dir[@migrations_path + "/*.rb"]
 
     copied = ActiveRecord::Migration.copy(@migrations_path, {:bukkits => MIGRATIONS_ROOT + "/to_copy"})
-    assert File.exists?(@migrations_path + "/4_people_have_hobbies.bukkits.rb")
-    assert File.exists?(@migrations_path + "/5_people_have_descriptions.bukkits.rb")
+    assert File.exist?(@migrations_path + "/4_people_have_hobbies.bukkits.rb")
+    assert File.exist?(@migrations_path + "/5_people_have_descriptions.bukkits.rb")
     assert_equal [@migrations_path + "/4_people_have_hobbies.bukkits.rb", @migrations_path + "/5_people_have_descriptions.bukkits.rb"], copied.map(&:filename)
 
     expected = "# This migration comes from bukkits (originally 1)"
@@ -734,10 +734,10 @@ class CopyMigrationsTest < ActiveRecord::TestCase
     sources[:bukkits] = MIGRATIONS_ROOT + "/to_copy"
     sources[:omg] = MIGRATIONS_ROOT + "/to_copy2"
     ActiveRecord::Migration.copy(@migrations_path, sources)
-    assert File.exists?(@migrations_path + "/4_people_have_hobbies.bukkits.rb")
-    assert File.exists?(@migrations_path + "/5_people_have_descriptions.bukkits.rb")
-    assert File.exists?(@migrations_path + "/6_create_articles.omg.rb")
-    assert File.exists?(@migrations_path + "/7_create_comments.omg.rb")
+    assert File.exist?(@migrations_path + "/4_people_have_hobbies.bukkits.rb")
+    assert File.exist?(@migrations_path + "/5_people_have_descriptions.bukkits.rb")
+    assert File.exist?(@migrations_path + "/6_create_articles.omg.rb")
+    assert File.exist?(@migrations_path + "/7_create_comments.omg.rb")
 
     files_count = Dir[@migrations_path + "/*.rb"].length
     ActiveRecord::Migration.copy(@migrations_path, sources)
@@ -752,8 +752,8 @@ class CopyMigrationsTest < ActiveRecord::TestCase
 
     Time.travel_to(Time.utc(2010, 7, 26, 10, 10, 10)) do
       copied = ActiveRecord::Migration.copy(@migrations_path, {:bukkits => MIGRATIONS_ROOT + "/to_copy_with_timestamps"})
-      assert File.exists?(@migrations_path + "/20100726101010_people_have_hobbies.bukkits.rb")
-      assert File.exists?(@migrations_path + "/20100726101011_people_have_descriptions.bukkits.rb")
+      assert File.exist?(@migrations_path + "/20100726101010_people_have_hobbies.bukkits.rb")
+      assert File.exist?(@migrations_path + "/20100726101011_people_have_descriptions.bukkits.rb")
       expected = [@migrations_path + "/20100726101010_people_have_hobbies.bukkits.rb",
                   @migrations_path + "/20100726101011_people_have_descriptions.bukkits.rb"]
       assert_equal expected, copied.map(&:filename)
@@ -777,10 +777,10 @@ class CopyMigrationsTest < ActiveRecord::TestCase
 
     Time.travel_to(Time.utc(2010, 7, 26, 10, 10, 10)) do
       copied = ActiveRecord::Migration.copy(@migrations_path, sources)
-      assert File.exists?(@migrations_path + "/20100726101010_people_have_hobbies.bukkits.rb")
-      assert File.exists?(@migrations_path + "/20100726101011_people_have_descriptions.bukkits.rb")
-      assert File.exists?(@migrations_path + "/20100726101012_create_articles.omg.rb")
-      assert File.exists?(@migrations_path + "/20100726101013_create_comments.omg.rb")
+      assert File.exist?(@migrations_path + "/20100726101010_people_have_hobbies.bukkits.rb")
+      assert File.exist?(@migrations_path + "/20100726101011_people_have_descriptions.bukkits.rb")
+      assert File.exist?(@migrations_path + "/20100726101012_create_articles.omg.rb")
+      assert File.exist?(@migrations_path + "/20100726101013_create_comments.omg.rb")
       assert_equal 4, copied.length
 
       files_count = Dir[@migrations_path + "/*.rb"].length
@@ -797,8 +797,8 @@ class CopyMigrationsTest < ActiveRecord::TestCase
 
     Time.travel_to(Time.utc(2010, 2, 20, 10, 10, 10)) do
       ActiveRecord::Migration.copy(@migrations_path, {:bukkits => MIGRATIONS_ROOT + "/to_copy_with_timestamps"})
-      assert File.exists?(@migrations_path + "/20100301010102_people_have_hobbies.bukkits.rb")
-      assert File.exists?(@migrations_path + "/20100301010103_people_have_descriptions.bukkits.rb")
+      assert File.exist?(@migrations_path + "/20100301010102_people_have_hobbies.bukkits.rb")
+      assert File.exist?(@migrations_path + "/20100301010103_people_have_descriptions.bukkits.rb")
 
       files_count = Dir[@migrations_path + "/*.rb"].length
       copied = ActiveRecord::Migration.copy(@migrations_path, {:bukkits => MIGRATIONS_ROOT + "/to_copy_with_timestamps"})
@@ -815,7 +815,7 @@ class CopyMigrationsTest < ActiveRecord::TestCase
     @existing_migrations = Dir[@migrations_path + "/*.rb"]
 
     copied = ActiveRecord::Migration.copy(@migrations_path, {:bukkits => MIGRATIONS_ROOT + "/magic"})
-    assert File.exists?(@migrations_path + "/4_currencies_have_symbols.bukkits.rb")
+    assert File.exist?(@migrations_path + "/4_currencies_have_symbols.bukkits.rb")
     assert_equal [@migrations_path + "/4_currencies_have_symbols.bukkits.rb"], copied.map(&:filename)
 
     expected = "# coding: ISO-8859-15\n# This migration comes from bukkits (originally 1)"
@@ -872,8 +872,8 @@ class CopyMigrationsTest < ActiveRecord::TestCase
 
     Time.travel_to(Time.utc(2010, 7, 26, 10, 10, 10)) do
       copied = ActiveRecord::Migration.copy(@migrations_path, {:bukkits => MIGRATIONS_ROOT + "/to_copy_with_timestamps"})
-      assert File.exists?(@migrations_path + "/20100726101010_people_have_hobbies.bukkits.rb")
-      assert File.exists?(@migrations_path + "/20100726101011_people_have_descriptions.bukkits.rb")
+      assert File.exist?(@migrations_path + "/20100726101010_people_have_hobbies.bukkits.rb")
+      assert File.exist?(@migrations_path + "/20100726101011_people_have_descriptions.bukkits.rb")
       assert_equal 2, copied.length
     end
   ensure
@@ -887,8 +887,8 @@ class CopyMigrationsTest < ActiveRecord::TestCase
 
     Time.travel_to(Time.utc(2010, 7, 26, 10, 10, 10)) do
       copied = ActiveRecord::Migration.copy(@migrations_path, {:bukkits => MIGRATIONS_ROOT + "/to_copy_with_timestamps"})
-      assert File.exists?(@migrations_path + "/20100726101010_people_have_hobbies.bukkits.rb")
-      assert File.exists?(@migrations_path + "/20100726101011_people_have_descriptions.bukkits.rb")
+      assert File.exist?(@migrations_path + "/20100726101010_people_have_hobbies.bukkits.rb")
+      assert File.exist?(@migrations_path + "/20100726101011_people_have_descriptions.bukkits.rb")
       assert_equal 2, copied.length
     end
   ensure

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -159,8 +159,8 @@ module ActiveRecord
       filename = "awesome-file.sql"
 
       ActiveRecord::Tasks::DatabaseTasks.structure_dump @configuration, filename, '/rails/root'
-      assert File.exists?(dbfile)
-      assert File.exists?(filename)
+      assert File.exist?(dbfile)
+      assert File.exist?(filename)
     ensure
       FileUtils.rm_f(filename)
       FileUtils.rm_f(dbfile)
@@ -182,7 +182,7 @@ module ActiveRecord
 
       open(filename, 'w') { |f| f.puts("select datetime('now', 'localtime');") }
       ActiveRecord::Tasks::DatabaseTasks.structure_load @configuration, filename, '/rails/root'
-      assert File.exists?(dbfile)
+      assert File.exist?(dbfile)
     ensure
       FileUtils.rm_f(filename)
       FileUtils.rm_f(dbfile)

--- a/activesupport/lib/active_support/core_ext/file/atomic.rb
+++ b/activesupport/lib/active_support/core_ext/file/atomic.rb
@@ -23,7 +23,7 @@ class File
     yield temp_file
     temp_file.close
 
-    if File.exists?(file_name)
+    if File.exist?(file_name)
       # Get original file permissions
       old_stat = stat(file_name)
     else


### PR DESCRIPTION
Same as 4d4ff531b8807ee88a3fc46875c7e76f613956fb
