### PR TITLE
ActiveModel numericality validator :only_integer should allow integer BigDecimal values

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   The numericality validator option :only_integer will now allow integer BigDecimal values.
+
+    Example:
+
+      class Beach
+        include ActiveModel::Validations
+        attr_accessor :grains_of_sand
+        validates_numericality_of :grains_of_sand, only_integer: true
+      end
+
+      ipanema = Beach.new
+      ipanema.grains_of_sand = BigDecimal.new('1000000000000000000.1')
+      ipanema.valid? # => false
+      ipanema.grains_of_sand = BigDecimal.new('1000000000000000000')
+      ipanema.valid? # => true
+
+    *Johnny Shields*
+
 *   Assigning an unknown attribute key to an `ActiveModel` instance during initialization
     will now raise `ActiveModel::AttributeAssignment::UnknownAttributeError` instead of
     `NoMethodError`

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -71,7 +71,11 @@ module ActiveModel
       end
 
       def parse_raw_value_as_an_integer(raw_value)
-        raw_value.to_i if raw_value.to_s =~ /\A[+-]?\d+\z/
+        if raw_value.to_s =~ /\A[+-]?\d+\z/
+          raw_value.to_i
+        elsif defined?(BigDecimal) && raw_value.is_a?(BigDecimal) && raw_value == raw_value.fix
+          raw_value
+        end
       end
 
       def filtered_options(value)

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -13,47 +13,48 @@ class NumericalityValidationTest < ActiveModel::TestCase
 
   NIL = [nil]
   BLANK = ["", " ", " \t \r \n"]
-  BIGDECIMAL_STRINGS = %w(12345678901234567890.1234567890) # 30 significant digits
+  BIGDECIMAL_FLOAT = [BigDecimal.new('12345678901234567890.1234567890')] # 30 significant digits
+  BIGDECIMAL_INTEGER = [BigDecimal.new('123456789012345678901234567890')] # 30 significant digits
   FLOAT_STRINGS = %w(0.0 +0.0 -0.0 10.0 10.5 -10.5 -0.0001 -090.1 90.1e1 -90.1e5 -90.1e-5 90e-5)
   INTEGER_STRINGS = %w(0 +0 -0 10 +10 -10 0090 -090)
   FLOATS = [0.0, 10.0, 10.5, -10.5, -0.0001] + FLOAT_STRINGS
   INTEGERS = [0, 10, -10] + INTEGER_STRINGS
-  BIGDECIMAL = BIGDECIMAL_STRINGS.collect! { |bd| BigDecimal.new(bd) }
+  BIGDECIMALS = BIGDECIMAL_FLOAT + BIGDECIMAL_INTEGER
   JUNK = ["not a number", "42 not a number", "0xdeadbeef", "0xinvalidhex", "0Xdeadbeef", "00-1", "--3", "+-3", "+3-1", "-+019.0", "12.12.13.12", "123\nnot a number"]
   INFINITY = [1.0/0.0]
 
   def test_default_validates_numericality_of
     Topic.validates_numericality_of :approved
     invalid!(NIL + BLANK + JUNK)
-    valid!(FLOATS + INTEGERS + BIGDECIMAL + INFINITY)
+    valid!(FLOATS + INTEGERS + BIGDECIMALS + INFINITY)
   end
 
   def test_validates_numericality_of_with_nil_allowed
     Topic.validates_numericality_of :approved, allow_nil: true
 
     invalid!(JUNK + BLANK)
-    valid!(NIL + FLOATS + INTEGERS + BIGDECIMAL + INFINITY)
+    valid!(NIL + FLOATS + INTEGERS + BIGDECIMALS + INFINITY)
   end
 
   def test_validates_numericality_of_with_integer_only
     Topic.validates_numericality_of :approved, only_integer: true
 
-    invalid!(NIL + BLANK + JUNK + FLOATS + BIGDECIMAL + INFINITY)
-    valid!(INTEGERS)
+    invalid!(NIL + BLANK + JUNK + FLOATS + BIGDECIMAL_FLOAT + INFINITY)
+    valid!(INTEGERS + BIGDECIMAL_INTEGER)
   end
 
   def test_validates_numericality_of_with_integer_only_and_nil_allowed
     Topic.validates_numericality_of :approved, only_integer: true, allow_nil: true
 
-    invalid!(JUNK + BLANK + FLOATS + BIGDECIMAL + INFINITY)
-    valid!(NIL + INTEGERS)
+    invalid!(JUNK + BLANK + FLOATS + BIGDECIMAL_FLOAT + INFINITY)
+    valid!(NIL + INTEGERS + BIGDECIMAL_INTEGER)
   end
 
   def test_validates_numericality_of_with_integer_only_and_symbol_as_value
     Topic.validates_numericality_of :approved, only_integer: :condition_is_true_but_its_not
 
     invalid!(NIL + BLANK + JUNK)
-    valid!(FLOATS + INTEGERS + BIGDECIMAL + INFINITY)
+    valid!(FLOATS + INTEGERS + BIGDECIMALS + INFINITY)
   end
 
   def test_validates_numericality_of_with_integer_only_and_proc_as_value
@@ -61,7 +62,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
     Topic.validates_numericality_of :approved, only_integer: Proc.new(&:allow_only_integers?)
 
     invalid!(NIL + BLANK + JUNK)
-    valid!(FLOATS + INTEGERS + BIGDECIMAL + INFINITY)
+    valid!(FLOATS + INTEGERS + BIGDECIMALS + INFINITY)
   end
 
   def test_validates_numericality_with_greater_than


### PR DESCRIPTION
Some databases can only accept 8-byte Integers, and require BigDecimal type for very large numbers.
