### PR TITLE
Improve Errors when Controller Name or Action isn't specfied

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -226,11 +226,13 @@ module ActionDispatch
               action     = action.to_s     unless action.is_a?(Regexp)
 
               if controller.blank? && segment_keys.exclude?(:controller)
-                raise ArgumentError, "missing :controller"
+                message = "Missing :controller key on routes definition, please check your routes."
+                raise ArgumentError, message
               end
 
               if action.blank? && segment_keys.exclude?(:action)
-                raise ArgumentError, "missing :action"
+                message = "Missing :action key on routes definition, please check your routes."
+                raise ArgumentError, message
               end
 
               if controller.is_a?(String) && controller !~ /\A[a-z_0-9\/]*\z/


### PR DESCRIPTION
These errors occur when, there routes are wrongly defined. 

example, the following lines would cause a missing :action error

```
root "welcomeindex"
root "welcome/index"
```

Mostly beginners are expected to hit these errors, so lets improve the error message a bit to make their learning experience bit better.
