### PR TITLE
update_all does not work when updating binary columns

### DIFF
--- a/activerecord/test/cases/binary_test.rb
+++ b/activerecord/test/cases/binary_test.rb
@@ -45,5 +45,17 @@ unless current_adapter?(:SybaseAdapter, :DB2Adapter, :FirebirdAdapter)
         assert_equal data, bin.reload.data, 'Reloaded data differs from original'
       end
     end
+
+    def test_upate_all_binary
+      Binary.create!
+
+      data = File.read(ASSETS_ROOT + "/#{FIXTURES.first}")
+      data.force_encoding('ASCII-8BIT')
+      data.freeze
+
+      Binary.update_all(:data => data)
+
+      assert_equal data, Binary.first.data, 'Data differs from original after update all'
+    end
   end
 end

--- a/activerecord/test/cases/binary_test.rb
+++ b/activerecord/test/cases/binary_test.rb
@@ -46,7 +46,7 @@ unless current_adapter?(:SybaseAdapter, :DB2Adapter, :FirebirdAdapter)
       end
     end
 
-    def test_upate_all_binary
+    def test_update_all_binary
       Binary.create!
 
       data = File.read(ASSETS_ROOT + "/#{FIXTURES.first}")


### PR DESCRIPTION
Running update_all on an active record model to update a binary column
ends up with an SQL escaping error of `incomplete multibyte character`.

This issue is not present on the latest rails 3.2 but is present on rails 4 and on master.

I've added a failing test here, but no fix. Here is the error:

```
PG::Error: incomplete multibyte character

    /Users/mario/Work/rails/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb:126:in `escape_string'
    /Users/mario/Work/rails/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb:126:in `quote_string'
    /Users/mario/Work/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:15:in `quote'
    /Users/mario/Work/rails/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb:19:in `quote'
    /Users/mario/Work/rails/activerecord/lib/active_record/sanitization.rb:163:in `quote_bound_value'
    /Users/mario/Work/rails/activerecord/lib/active_record/sanitization.rb:104:in `block in sanitize_sql_hash_for_assignment'
    /Users/mario/Work/rails/activerecord/lib/active_record/sanitization.rb:103:in `each'
    /Users/mario/Work/rails/activerecord/lib/active_record/sanitization.rb:103:in `map'
    /Users/mario/Work/rails/activerecord/lib/active_record/sanitization.rb:103:in `sanitize_sql_hash_for_assignment'
    /Users/mario/Work/rails/activerecord/lib/active_record/sanitization.rb:39:in `sanitize_sql_for_assignment'
    /Users/mario/Work/rails/activerecord/lib/active_record/relation.rb:308:in `update_all'
    /Users/mario/Work/rails/activerecord/lib/active_record/querying.rb:7:in `update_all'
    test/cases/binary_test.rb:56:in `test_upate_all_binary'
```
