### PR TITLE
Refactor File.expand_path usage to remove additional File.join

### DIFF
--- a/actionview/test/actionpack/abstract/helper_test.rb
+++ b/actionview/test/actionpack/abstract/helper_test.rb
@@ -52,7 +52,7 @@ module AbstractController
     class AbstractInvalidHelpers < AbstractHelpers
       include ActionController::Helpers
 
-      path = File.join(File.expand_path('../../../fixtures', __FILE__), "helpers_missing")
+      path = File.expand_path('../../../fixtures/helpers_missing', __FILE__)
       $:.unshift(path)
       self.helpers_path = path
     end

--- a/railties/bin/rails
+++ b/railties/bin/rails
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-git_path = File.join(File.expand_path('../../..', __FILE__), '.git')
+git_path = File.expand_path('../../../.git', __FILE__)
 
 if File.exist?(git_path)
   railties_path = File.expand_path('../../lib', __FILE__)

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -324,7 +324,7 @@ module Rails
       end
 
       def self.default_rc_file
-        File.join(File.expand_path('~'), '.railsrc')
+        File.expand_path('~/.railsrc')
       end
 
       private


### PR DESCRIPTION
`File.join` might not be required when `File.expand_path` is being used, unless we want to make it work on windows. I feel that removing the extra `File.join` part simplifies the code. If there is actually an advantage in using File.join with expand_path, it would be good to know.
