### PR TITLE
Remove extra whitespace

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -22,8 +22,8 @@ Rails.application.configure do
   <%- unless options.skip_active_record? -%>
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
-  <%- end -%>
 
+  <%- end -%>
   <%- unless options.skip_sprockets? -%>
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large


### PR DESCRIPTION
When generating an app with --skip_active_record, an extra
line of whitespace was included unnecessarily.

It's the little things that matter to me.
