### PR TITLE
Backport relation merger updates from 9675c7d to 4-0-stable

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -107,13 +107,29 @@ module ActiveRecord
       def merge_multi_values
         lhs_wheres = relation.where_values
         rhs_wheres = values[:where] || []
+
         lhs_binds  = relation.bind_values
         rhs_binds  = values[:bind] || []
 
         removed, kept = partition_overwrites(lhs_wheres, rhs_wheres)
 
-        relation.where_values = kept + rhs_wheres
-        relation.bind_values  = filter_binds(lhs_binds, removed) + rhs_binds
+        where_values = kept + rhs_wheres
+        bind_values  = filter_binds(lhs_binds, removed) + rhs_binds
+
+        conn = relation.klass.connection
+        bviter = bind_values.each.with_index
+        where_values.map! do |node|
+          if Arel::Nodes::Equality === node && Arel::Nodes::BindParam === node.right
+            (column, _), i = bviter.next
+            substitute = conn.substitute_at column, i
+            Arel::Nodes::Equality.new(node.left, substitute)
+          else
+            node
+          end
+        end
+
+        relation.where_values = where_values
+        relation.bind_values  = bind_values
 
         if values[:reordering]
           # override any order specified in the original relation

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -9,6 +9,9 @@ module ActiveRecord
     fixtures :posts, :comments, :authors
 
     class FakeKlass < Struct.new(:table_name, :name)
+      def self.connection
+        Post.connection
+      end
     end
 
     def test_construction
@@ -214,6 +217,10 @@ module ActiveRecord
       def arel_table
         Post.arel_table
       end
+
+      def connection
+        Post.connection
+      end
     end
 
     def relation
@@ -298,7 +305,7 @@ module ActiveRecord
       assert_equal({foo: 'bar'}, relation.create_with_value)
     end
 
-    test 'merge!' do
+    def test_merge!
       assert relation.merge!(where: :foo).equal?(relation)
       assert_equal [:foo], relation.where_values
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1609,4 +1609,21 @@ class RelationTest < ActiveRecord::TestCase
     merged = left.merge(right)
     assert_equal [], merged.bind_values
   end
+
+  def test_merging_reorders_bind_params
+    post         = Post.first
+    id_column    = Post.columns_hash['id']
+    title_column = Post.columns_hash['title']
+
+    bv = Post.connection.substitute_at id_column, 0
+
+    right  = Post.where(id: bv)
+    right.bind_values += [[id_column, post.id]]
+
+    left   = Post.where(title: bv)
+    left.bind_values += [[title_column, post.title]]
+
+    merged = left.merge(right)
+    assert_equal post, merged.first
+  end
 end


### PR DESCRIPTION
At @rafaelfranca's request, this backports commit 9675c7d into the 4-0-stable branch to fix #10995. All tests are passing.

This is the first time I've ever attempted backporting; any feedback is greatly appreciated!
