### PR TITLE
fix simple_format escapes own output when sanitize is set to true

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,6 +1,10 @@
+*   Fix `simple_format` escapes own output when passing `sanitize: true`
+
+    *Paul Seidemann*
+
 *   Ensure ActionView::Digestor.cache is correctly cleaned up when
     combining recursive templates with ActionView::Resolver.caching = false
-    
+
     *wyaeld*
 
 *   Fix `collection_check_boxes` generated hidden input to use the name attribute provided

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -268,7 +268,7 @@ module ActionView
           content_tag(wrapper_tag, nil, html_options)
         else
           paragraphs.map! { |paragraph|
-            content_tag(wrapper_tag, paragraph, html_options, options[:sanitize])
+            content_tag(wrapper_tag, paragraph, html_options, false)
           }.join("\n\n").html_safe
         end
       end

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -42,6 +42,11 @@ class TextHelperTest < ActionView::TestCase
     assert_equal "<p><b> test with unsafe string </b></p>", simple_format("<b> test with unsafe string </b><script>code!</script>")
   end
 
+  def test_simple_format_should_sanitize_input_when_sanitize_option_is_true
+    assert_equal '<p><b> test with unsafe string </b></p>',
+      simple_format('<b> test with unsafe string </b><script>code!</script>', {}, sanitize: true)
+  end
+
   def test_simple_format_should_not_sanitize_input_when_sanitize_option_is_false
     assert_equal "<p><b> test with unsafe string </b><script>code!</script></p>", simple_format("<b> test with unsafe string </b><script>code!</script>", {}, :sanitize => false)
   end


### PR DESCRIPTION
this fixes #12757
