### PR TITLE
Add No Touching

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Added `ActiveRecord::Base.no_touching`, which allows ignoring touch on models.
+
+    Examples:
+
+      Post.no_touching do
+        Post.first.touch
+      end
+
+    *Sam Stephenson*, *Damien Mathieu*
+
 *   Prevent the counter cache from being decremented twice when destroying
     a record on a has_many :through association.
 

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -45,6 +45,7 @@ module ActiveRecord
   autoload :Migrator, 'active_record/migration'
   autoload :ModelSchema
   autoload :NestedAttributes
+  autoload :NoTouching
   autoload :Persistence
   autoload :QueryCache
   autoload :Querying

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -295,6 +295,7 @@ module ActiveRecord #:nodoc:
     extend Delegation::DelegateCache
 
     include Persistence
+    include NoTouching
     include ReadonlyAttributes
     include ModelSchema
     include Inheritance

--- a/activerecord/lib/active_record/no_touching.rb
+++ b/activerecord/lib/active_record/no_touching.rb
@@ -1,0 +1,52 @@
+module ActiveRecord
+  # = Active Record No Touching
+  module NoTouching
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Lets you selectively disable calls to `touch` for the
+      # duration of a block.
+      #
+      # ==== Examples
+      #   ActiveRecord::Base.no_touching do
+      #     Project.first.touch  # does nothing
+      #     Message.first.touch  # does nothing
+      #   end
+      #
+      #   Project.no_touching do
+      #     Project.first.touch  # does nothing
+      #     Message.first.touch  # works, but does not touch the associated project
+      #   end
+      #
+      def no_touching(&block)
+        NoTouching.apply_to(self, &block)
+      end
+    end
+
+    class << self
+      def apply_to(klass) #:nodoc:
+        klasses.push(klass)
+        yield
+      ensure
+        klasses.pop
+      end
+
+      def applied_to?(klass) #:nodoc:
+        klasses.any? { |k| k >= klass }
+      end
+
+      private
+        def klasses
+          Thread.current[:no_touching_classes] ||= []
+        end
+    end
+
+    def no_touching?
+      NoTouching.applied_to?(self.class)
+    end
+
+    def touch(*)
+      super unless no_touching?
+    end
+  end
+end


### PR DESCRIPTION
This adds `#no_touching` on all ActiveRecord models, allowing to ignore touching for the duration of a block.
## Example:

```
ActiveRecord::Base.no_touching do
  Post.first.touch #=> Does nothing
end

Comment.no_touching do
  Comment.first.touch #=> Does nothing
  Post.first.touch #=> Updates, but won't update related comments if there are any
end
```

cc @dhh
