### PR TITLE
Fix validation on uniqueness

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix validation on uniqueness of empty association.
+
+    *Evgeny Li*
+
 *   Make `ActiveRecord::Relation#unscope` affect relations it is merged in to.
 
     *Jon Leighton*

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -48,7 +48,7 @@ module ActiveRecord
       def build_relation(klass, table, attribute, value) #:nodoc:
         if reflection = klass.reflect_on_association(attribute)
           attribute = reflection.foreign_key
-          value = value.attributes[reflection.primary_key_column.name]
+          value = value.attributes[reflection.primary_key_column.name] unless value.nil?
         end
 
         column = klass.columns_hash[attribute.to_s]

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -35,6 +35,11 @@ class Employee < ActiveRecord::Base
   validates_uniqueness_of :nicknames
 end
 
+class TopicWithUniqEvent < Topic
+  belongs_to :event, foreign_key: :parent_id
+  validates :event, uniqueness: true
+end
+
 class UniquenessValidationTest < ActiveRecord::TestCase
   fixtures :topics, 'warehouse-things', :developers
 
@@ -375,5 +380,19 @@ class UniquenessValidationTest < ActiveRecord::TestCase
       assert e2.errors[:nicknames].any?, "Should have errors for nicknames"
       assert_equal ["has already been taken"], e2.errors[:nicknames], "Should have uniqueness message for nicknames"
     end
+  end
+
+  def test_validate_uniqueness_on_existing_relation
+    event = Event.create
+    assert TopicWithUniqEvent.create(event: event).valid?
+
+    topic = TopicWithUniqEvent.new(event: event)
+    assert_not topic.valid?
+    assert_equal ['has already been taken'], topic.errors[:event]
+  end
+
+  def test_validate_uniqueness_on_empty_relation
+    topic = TopicWithUniqEvent.new
+    assert topic.valid?
   end
 end


### PR DESCRIPTION
In case if I set validation on uniqueness of relation

``` ruby
class Foo < ActiveRecord::Base
  belongs_to :bar
  validates :bar, uniqueness: true
end

Foo.new.valid?
```

and it doesn't exist, I have an error: 

```
  NoMethodError - undefined method `attributes' for nil:NilClass:
  activerecord (4.0.1.rc4) lib/active_record/validations/uniqueness.rb:56:in `build_relation'
```

To fix it I suggest adding the condition
