### PR TITLE
Clarify HTML Safe Translations

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -654,7 +654,7 @@ I18n.default_locale = :de
 
 ### Using Safe HTML Translations
 
-Keys with a '_html' suffix and keys named 'html' are marked as HTML safe. Use them in views without escaping.
+Keys with a '_html' suffix and keys named 'html' are marked as HTML safe. When you use them in views the HTML will not be escaped.
 
 ```yaml
 # config/locales/en.yml


### PR DESCRIPTION
I think it's confusing to say "Use them in views without escaping." We
use all keys in views without escaping - the escaping is done for us
automatically _unless_ we call html_safe or the key ends in _html.
