### PR TITLE
Don't load test env by default

### DIFF
--- a/railties/lib/rails/test_unit/railtie.rb
+++ b/railties/lib/rails/test_unit/railtie.rb
@@ -1,4 +1,4 @@
-if defined?(Rake.application) && Rake.application.top_level_tasks.grep(/^(default$|test(:|$))/).any?
+if defined?(Rake.application) && Rake.application.top_level_tasks.grep(/^test(?::|$)/).any?
   ENV['RAILS_ENV'] ||= 'test'
 end
 


### PR DESCRIPTION
After those two commits
999835a8e5a34afb41af54f3cb14562a6c759a04
58476a7a936e05bef0a767dc14b404c8a230a15b

default env in usual rails application (where `rails/all` is used) for `bundle exec rake -T` command became `test`.

This is confusing at least for me (I was sure that `development` env is default) and leads to "strange" errors in some applications.

cc @tenderlove
