### PR TITLE
Don't swallow exceptions in transctional statements

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -314,27 +314,19 @@ module ActiveRecord
 
       def begin_db_transaction
         execute "BEGIN"
-      rescue
-        # Transactions aren't supported
       end
 
       def begin_isolated_db_transaction(isolation)
         execute "SET TRANSACTION ISOLATION LEVEL #{transaction_isolation_levels.fetch(isolation)}"
         begin_db_transaction
-      rescue
-        # Transactions aren't supported
       end
 
       def commit_db_transaction #:nodoc:
         execute "COMMIT"
-      rescue
-        # Transactions aren't supported
       end
 
       def rollback_db_transaction #:nodoc:
         execute "ROLLBACK"
-      rescue
-        # Transactions aren't supported
       end
 
       # In the simple case, MySQL allows us to place JOINs directly into the UPDATE

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -468,8 +468,6 @@ module ActiveRecord
 
       def begin_db_transaction #:nodoc:
         exec_query "BEGIN"
-      rescue Mysql::Error
-        # Transactions aren't supported
       end
 
       private

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -164,27 +164,6 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     end
   end
 
-  def test_mysql_begin_db_transaction_can_throw_an_exception
-    @connection.expects(:exec_query).with('BEGIN').raises('OH NOES')
-    assert_raise RuntimeError do
-      @connection.begin_db_transaction
-    end
-  end
-
-  def test_mysql_commit_db_transaction_can_throw_an_exception
-    @connection.expects(:execute).with('COMMIT').raises('OH NOES')
-    assert_raise RuntimeError do
-      @connection.commit_db_transaction
-    end
-  end
-
-  def test_mysql_rollback_db_transaction_can_throw_an_exception
-    @connection.expects(:execute).with('ROLLBACK').raises('OH NOES')
-    assert_raise RuntimeError do
-      @connection.rollback_db_transaction
-    end
-  end
-
   private
 
   def run_without_connection

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -89,27 +89,6 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     @connection.execute "DROP TABLE `bar_baz`"
   end
 
-  def test_mysql_begin_db_transaction_can_throw_an_exception
-    @connection.expects(:execute).with('BEGIN').raises('OH NOES')
-    assert_raise RuntimeError do
-      @connection.begin_db_transaction
-    end
-  end
-
-  def test_mysql_commit_db_transaction_can_throw_an_exception
-    @connection.expects(:execute).with('COMMIT').raises('OH NOES')
-    assert_raise RuntimeError do
-      @connection.commit_db_transaction
-    end
-  end
-
-  def test_mysql_rollback_db_transaction_can_throw_an_exception
-    @connection.expects(:execute).with('ROLLBACK').raises('OH NOES')
-    assert_raise RuntimeError do
-      @connection.rollback_db_transaction
-    end
-  end
-
   private
 
   def run_without_connection


### PR DESCRIPTION
The MySQL connection adapater swallows all StandardError exceptions, which includes `Mysql::Error` and `Mysql2::Error`. The comment in the exception clause claims errors thrown here indicate that transactions aren't supported by the server but that isn't necessarily true. It's possible the MySQL server has gone away and swallowing a failed commit may let the application return a successful response when the data has not been saved. Also, replication libraries like Galera require that the application handle exceptions thrown at BEGIN/COMMIT.

I'm unable to determine what version of MySQL threw an exception for transactional statements. I tried as far back as 3.23.49 with InnoDB disabled but BEGIN & COMMIT statements do not throw an error. If there's a real case for this logic to continue, we could instead push this behavior into a configuration setting.

The exception swallowing has been there since the beginning: db045dbbf60b53dbe013ef25554fd013baf88134
## Backstory

I found this behavior while moving our application to Percona XtraDB Cluster, which uses Galera for synchronous replication. We found a case where a transaction failed the certification process, and therefore threw an exception when COMMIT was called, but the exception was swallowed and the response to the client was an erroneous 200.
