### PR TITLE
Extract method refactoring for Rails::Server#start

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -61,30 +61,10 @@ module Rails
     end
 
     def start
-      url = "#{options[:SSLEnable] ? 'https' : 'http'}://#{options[:Host]}:#{options[:Port]}"
-      puts "=> Booting #{ActiveSupport::Inflector.demodulize(server)}"
-      puts "=> Rails #{Rails.version} application starting in #{Rails.env} on #{url}"
-      puts "=> Run `rails server -h` for more startup options"
-      if options[:Host].to_s.match(/0\.0\.0\.0/)
-        puts "=> Notice: server is listening on all interfaces (#{options[:Host]}). Consider using 127.0.0.1 (--binding option)"
-      end
-      trap(:INT) { exit }
-      puts "=> Ctrl-C to shutdown server" unless options[:daemonize]
-
-      #Create required tmp directories if not found
-      %w(cache pids sessions sockets).each do |dir_to_make|
-        FileUtils.mkdir_p(File.join(Rails.root, 'tmp', dir_to_make))
-      end
-
-      if options[:log_stdout]
-        wrapped_app # touch the app so the logger is set up
-
-        console = ActiveSupport::Logger.new($stdout)
-        console.formatter = Rails.logger.formatter
-        console.level = Rails.logger.level
-
-        Rails.logger.extend(ActiveSupport::Logger.broadcast(console))
-      end
+      print_boot_information
+      trap_interrupt_and_print_interrupt_information
+      create_tmp_directories
+      log_to_stdout if options[:log_stdout]
 
       super
     ensure
@@ -124,5 +104,39 @@ module Rails
         config:       File.expand_path("config.ru")
       })
     end
+
+    private
+
+      def print_boot_information
+        url = "#{ options[:SSLEnable] ? 'https' : 'http' }://#{ options[:Host] }:#{ options[:Port] }"
+        puts "=> Booting #{ ActiveSupport::Inflector.demodulize(server) }"
+        puts "=> Rails #{ Rails.version } application starting in #{ Rails.env } on #{ url }"
+        puts "=> Run `rails server -h` for more startup options"
+
+        if options[:Host].to_s.match(/0\.0\.0\.0/)
+          puts "=> Notice: server is listening on all interfaces (#{ options[:Host] }). Consider using 127.0.0.1 (--binding option)"
+        end
+      end
+
+      def trap_interrupt_and_print_interrupt_information
+        trap(:INT) { exit }
+        puts "=> Ctrl-C to shutdown server" unless options[:daemonize]
+      end
+
+      def create_tmp_directories
+        %w(cache pids sessions sockets).each do |dir_to_make|
+          FileUtils.mkdir_p(File.join(Rails.root, 'tmp', dir_to_make))
+        end
+      end
+
+      def log_to_stdout
+        wrapped_app # touch the app so the logger is set up
+
+        console = ActiveSupport::Logger.new($stdout)
+        console.formatter = Rails.logger.formatter
+        console.level = Rails.logger.level
+
+        Rails.logger.extend(ActiveSupport::Logger.broadcast(console))
+      end
   end
 end

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -62,7 +62,7 @@ module Rails
 
     def start
       print_boot_information
-      trap_interrupt_and_print_interrupt_information
+      trap(:INT) { exit }
       create_tmp_directories
       log_to_stdout if options[:log_stdout]
 
@@ -116,10 +116,7 @@ module Rails
         if options[:Host].to_s.match(/0\.0\.0\.0/)
           puts "=> Notice: server is listening on all interfaces (#{ options[:Host] }). Consider using 127.0.0.1 (--binding option)"
         end
-      end
 
-      def trap_interrupt_and_print_interrupt_information
-        trap(:INT) { exit }
         puts "=> Ctrl-C to shutdown server" unless options[:daemonize]
       end
 


### PR DESCRIPTION
The `start` method is large enough to consider being refactored. It consists of 4 non related pieces of code that can be extracted into private methods as shown in this [commit](https://github.com/notalex/rails/commit/6c244dd5fc6e02f280cbcb2acef61f2fa44071bd). I have introduced just a single method extraction here as I would like to discuss before extracting more methods out of `start`. We can discuss whether we need all 4 of the method extractions or some or none.
