### PR TITLE
Add +capitalize+ option to Inflector.humanize

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `capitalize` option to Inflector.humanize, so strings can be humanized without being capitalized:
+
+        'employee_salary'.humanize                    # => "Employee salary"
+        'employee_salary'.humanize(capitalize: false) # => "employee salary"
+
+    *claudiob*
+
 *   Fixed Object#as_json and Struct#as_json not working properly with options. They now take
     the same options as Hash#as_json:
 

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -190,13 +190,19 @@ class String
     ActiveSupport::Inflector.classify(self)
   end
 
-  # Capitalizes the first word, turns underscores into spaces, and strips '_id'.
+  # Capitalizes the first word, turns underscores into spaces, and strips a
+  # trailing '_id' if present.
   # Like +titleize+, this is meant for creating pretty output.
   #
-  #   'employee_salary'.humanize # => "Employee salary"
-  #   'author_id'.humanize       # => "Author"
-  def humanize
-    ActiveSupport::Inflector.humanize(self)
+  # The capitalization of the first word can be turned off by setting the
+  # optional parameter +capitalize+ to false.
+  # By default, this parameter is true.
+  #
+  #   'employee_salary'.humanize              # => "Employee salary"
+  #   'author_id'.humanize                    # => "Author"
+  #   'author_id'.humanize(capitalize: false) # => "author"
+  def humanize(options = {})
+    ActiveSupport::Inflector.humanize(self, options)
   end
 
   # Creates a foreign key name from a class name.

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -98,20 +98,26 @@ module ActiveSupport
       word
     end
 
-    # Capitalizes the first word and turns underscores into spaces and strips a
-    # trailing "_id", if any. Like +titleize+, this is meant for creating pretty
-    # output.
+    # Capitalizes the first word, turns underscores into spaces, and strips a
+    # trailing '_id' if present.
+    # Like +titleize+, this is meant for creating pretty output.
     #
-    #   'employee_salary'.humanize # => "Employee salary"
-    #   'author_id'.humanize       # => "Author"
-    def humanize(lower_case_and_underscored_word)
+    # The capitalization of the first word can be turned off by setting the
+    # optional parameter +capitalize+ to false.
+    # By default, this parameter is true.
+    #
+    #   humanize('employee_salary')              # => "Employee salary"
+    #   humanize('author_id')                    # => "Author"
+    #   humanize('author_id', capitalize: false) # => "author"
+    def humanize(lower_case_and_underscored_word, options = {})
       result = lower_case_and_underscored_word.to_s.dup
       inflections.humans.each { |(rule, replacement)| break if result.sub!(rule, replacement) }
       result.gsub!(/_id$/, "")
       result.tr!('_', ' ')
-      result.gsub(/([a-z\d]*)/i) { |match|
+      result.gsub!(/([a-z\d]*)/i) { |match|
         "#{inflections.acronyms[match] || match.downcase}"
-      }.gsub(/^\w/) { $&.upcase }
+      }
+      options.fetch(:capitalize, true) ? result.gsub(/^\w/) { $&.upcase } : result
     end
 
     # Capitalizes all the words and replaces some characters in the string to

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -155,6 +155,12 @@ class StringInflectionsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_humanize_without_capitalize
+    UnderscoreToHumanWithoutCapitalize.each do |underscore, human|
+      assert_equal(human, underscore.humanize(capitalize: false))
+    end
+  end
+
   def test_ord
     assert_equal 97, 'a'.ord
     assert_equal 97, 'abc'.ord
@@ -270,7 +276,7 @@ class StringInflectionsTest < ActiveSupport::TestCase
   def test_truncate_should_not_be_html_safe
     assert !"Hello World!".truncate(12).html_safe?
   end
-  
+
   def test_remove
     assert_equal "Summer", "Fast Summer".remove(/Fast /)
     assert_equal "Summer", "Fast Summer".remove!(/Fast /)

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -287,6 +287,12 @@ class InflectorTest < ActiveSupport::TestCase
     end
   end
 
+  def test_humanize_without_capitalize
+    UnderscoreToHumanWithoutCapitalize.each do |underscore, human|
+      assert_equal(human, ActiveSupport::Inflector.humanize(underscore, capitalize: false))
+    end
+  end
+
   def test_humanize_by_rule
     ActiveSupport::Inflector.inflections do |inflect|
       inflect.human(/_cnt$/i, '\1_count')

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -212,6 +212,12 @@ module InflectorTestCases
     "underground"     => "Underground"
   }
 
+  UnderscoreToHumanWithoutCapitalize = {
+    "employee_salary" => "employee salary",
+    "employee_id"     => "employee",
+    "underground"     => "underground"
+  }
+
   MixtureToTitleCase = {
     'active_record'         => 'Active Record',
     'ActiveRecord'          => 'Active Record',

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1772,6 +1772,12 @@ The method `humanize` gives you a sensible name for display out of an attribute 
 "comments_count".humanize # => "Comments count"
 ```
 
+The capitalization of the first word can be turned off by setting the optional parameter `capitalize` to false:
+
+```ruby
+"author_id".humanize(capitalize: false) # => "author"
+```
+
 The helper method `full_messages` uses `humanize` as a fallback to include attribute names:
 
 ```ruby


### PR DESCRIPTION
So strings can be humanized without being capitalized:

```
'employee_salary'.humanize                    # => "Employee salary"
'employee_salary'.humanize(capitalize: false) # => "employee salary"
```
