### PR TITLE
Move the JSON extension require statements to the right place.

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -1,7 +1,14 @@
 # Hack to load json gem first so we can overwrite its to_json.
 require 'json'
 require 'bigdecimal'
+require 'active_support/core_ext/big_decimal/conversions' # for #to_s
+require 'active_support/core_ext/hash/except'
+require 'active_support/core_ext/hash/slice'
+require 'active_support/core_ext/object/instance_variables'
 require 'time'
+require 'active_support/core_ext/time/conversions'
+require 'active_support/core_ext/date_time/conversions'
+require 'active_support/core_ext/date/conversions'
 
 # The JSON gem adds a few modules to Ruby core classes containing :to_json definition, overwriting
 # their default behavior. That said, we need to define the basic to_json method in all of them,

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -3,14 +3,6 @@
 require 'active_support/core_ext/object/json'
 require 'active_support/core_ext/module/delegation'
 
-require 'active_support/core_ext/big_decimal/conversions' # for #to_s
-require 'active_support/core_ext/hash/except'
-require 'active_support/core_ext/hash/slice'
-require 'active_support/core_ext/object/instance_variables'
-require 'active_support/core_ext/time/conversions'
-require 'active_support/core_ext/date_time/conversions'
-require 'active_support/core_ext/date/conversions'
-
 module ActiveSupport
   class << self
     delegate :use_standard_json_time_format, :use_standard_json_time_format=,


### PR DESCRIPTION
In [1], I made server fixes to #12203 which I apparently didn't port
over. The problem is partially addressed in #12710, this commit fixes
the rest.

The requires being moved here are used for in the `to_json` and
`as_json` extensions, so there should be required there instead.

Sorry guys :disappointed_relieved:

[1] https://github.com/chancancode/rails/commit/e15f488c087e7568a814a4a65b233114578b58b7
