### PR TITLE
Extract common code from number helpers to new delegator method.

### DIFF
--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -105,12 +105,7 @@ module ActionView
       #   number_to_currency(1234567890.50, unit: "&pound;", separator: ",", delimiter: "", format: "%n %u")
       #   # => 1234567890,50 &pound;
       def number_to_currency(number, options = {})
-        return unless number
-        options = escape_unsafe_delimiters_and_separators(options.symbolize_keys)
-
-        wrap_with_output_safety_handling(number, options.delete(:raise)) {
-          ActiveSupport::NumberHelper.number_to_currency(number, options)
-        }
+        delegate_number_helper_method(number, options, :number_to_currency)
       end
 
       # Formats a +number+ as a percentage string (e.g., 65%). You can
@@ -150,12 +145,7 @@ module ActionView
       #
       #   number_to_percentage("98a", raise: true)                         # => InvalidNumberError
       def number_to_percentage(number, options = {})
-        return unless number
-        options = escape_unsafe_delimiters_and_separators(options.symbolize_keys)
-
-        wrap_with_output_safety_handling(number, options.delete(:raise)) {
-          ActiveSupport::NumberHelper.number_to_percentage(number, options)
-        }
+        delegate_number_helper_method(number, options, :number_to_percentage)
       end
 
       # Formats a +number+ with grouped thousands using +delimiter+
@@ -188,11 +178,7 @@ module ActionView
       #
       #  number_with_delimiter("112a", raise: true)              # => raise InvalidNumberError
       def number_with_delimiter(number, options = {})
-        options = escape_unsafe_delimiters_and_separators(options.symbolize_keys)
-
-        wrap_with_output_safety_handling(number, options.delete(:raise)) {
-          ActiveSupport::NumberHelper.number_to_delimited(number, options)
-        }
+        delegate_number_helper_method(number, options, :number_to_delimited)
       end
 
       # Formats a +number+ with the specified level of
@@ -237,11 +223,7 @@ module ActionView
       #   number_with_precision(1111.2345, precision: 2, separator: ',', delimiter: '.')
       #   # => 1.111,23
       def number_with_precision(number, options = {})
-        options = escape_unsafe_delimiters_and_separators(options.symbolize_keys)
-
-        wrap_with_output_safety_handling(number, options.delete(:raise)) {
-          ActiveSupport::NumberHelper.number_to_rounded(number, options)
-        }
+        delegate_number_helper_method(number, options, :number_to_rounded)
       end
 
       # Formats the bytes in +number+ into a more understandable
@@ -293,11 +275,7 @@ module ActionView
       #   number_to_human_size(1234567890123, precision: 5)        # => "1.1229 TB"
       #   number_to_human_size(524288000, precision: 5)            # => "500 MB"
       def number_to_human_size(number, options = {})
-        options = escape_unsafe_delimiters_and_separators(options.symbolize_keys)
-
-        wrap_with_output_safety_handling(number, options.delete(:raise)) {
-          ActiveSupport::NumberHelper.number_to_human_size(number, options)
-        }
+        delegate_number_helper_method(number, options, :number_to_human_size)
       end
 
       # Pretty prints (formats and approximates) a number in a way it
@@ -399,14 +377,19 @@ module ActionView
       #  number_to_human(0.34, units: :distance)                # => "34 centimeters"
       #
       def number_to_human(number, options = {})
-        options = escape_unsafe_delimiters_and_separators(options.symbolize_keys)
-
-        wrap_with_output_safety_handling(number, options.delete(:raise)) {
-          ActiveSupport::NumberHelper.number_to_human(number, options)
-        }
+        delegate_number_helper_method(number, options, :number_to_human)
       end
 
       private
+
+      def delegate_number_helper_method(number, options, method)
+        return unless number
+        options = escape_unsafe_delimiters_and_separators(options.symbolize_keys)
+
+        wrap_with_output_safety_handling(number, options.delete(:raise)) {
+          ActiveSupport::NumberHelper.public_send(method, number, options)
+        }
+      end
 
       def escape_unsafe_delimiters_and_separators(options)
         options[:separator] = ERB::Util.html_escape(options[:separator]) if options[:separator] && !options[:separator].html_safe?


### PR DESCRIPTION
Extract common code from number helpers to new delegator method `delegate_number_helper_method`.
