### PR TITLE
Using #count instead of delegating to array for #one? in ActiveRecord::Delegation::Relation

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -265,6 +265,11 @@ module ActiveRecord
       end
     end
 
+    # Returns true if there is only one record
+    def one?
+      loaded? ? @records.one? : count == 1
+    end
+
     # Scope all queries to the current scope.
     #
     #   Comment.where(post_id: 1).scoping do


### PR DESCRIPTION
I noticed that whenever I send `#one?` to an ActiveRecord Relation, it delegates the message to `#to_a` which is not really optimal.

```
>> Product.all.class
=> ActiveRecord::Relation::ActiveRecord_Relation_Product
>> Product.all.one?
  Product Load (118.6ms)  SELECT "products".* FROM "products"
=> false
>> Product.all.any?
   (1.0ms)  SELECT COUNT(*) FROM "products"
=> true
>> Product.all.count == 1
   (1.2ms)  SELECT COUNT(*) FROM "products"
=> false
>>
```

If you guys think this is ok I think I could write some tests.
I just noticed that this should probably also go in ActiveRecord::Associations::CollectionAssociation
