### PR TITLE
Include environment in db:setup task

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -173,7 +173,7 @@ db_namespace = namespace :db do
   end
 
   desc 'Create the database, load the schema, and initialize with the seed data (use db:reset to also drop the database first)'
-  task :setup => ['db:schema:load_if_ruby', 'db:structure:load_if_sql', :seed]
+  task :setup => [:environment, 'db:schema:load_if_ruby', 'db:structure:load_if_sql', :seed]
 
   desc 'Load the seed data from db/seeds.rb'
   task :seed do


### PR DESCRIPTION
If railties (engines) contain migrations 'rake db:schema:load' imports all migrations in schema_migrations table, while 'rake db:setup' does not.

On the same project, which includes engines that have migrations on their own, running:
- rake db:schema:load produces:

```
mysql> select count(1) from schema_migrations;
+----------+
| count(1) |
+----------+
|      240 |
+----------+
```
- while rake db:setup produces:

```
mysql> select count(1) from schema_migrations;
+----------+
| count(1) |
+----------+
|      127 |
+----------+
```

The correct one is the first one, that includes all migrations. I can call db:create, db:schema:load and db:seed separately for now, but I'd like to use db:setup as one command only is always better than three.

I'd be happy to add a test case if possible.
