### PR TITLE
fix broken url/formatting in Asset pipeline guide

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -151,8 +151,7 @@ environments. You can enable or disable it in your configuration through the
 More reading:
 
 * [Optimize caching](http://code.google.com/speed/page-speed/docs/caching.html)
-* [Revving Filenames: don't use
-* querystring](http://www.stevesouders.com/blog/2008/08/23/revving-filenames-dont-use-querystring/)
+* [Revving Filenames: don't use querystring](http://www.stevesouders.com/blog/2008/08/23/revving-filenames-dont-use-querystring/)
 
 
 How to Use the Asset Pipeline


### PR DESCRIPTION
this url corrently looks like this:
![s](https://f.cloud.github.com/assets/235844/1503023/46069056-48a4-11e3-89b2-171ee368a1e5.png)

this patch fixes the broken url/formatting
