### PR TITLE
Start Running tests on Stable JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install:
 rvm:
   - 1.9.3
   - 2.0.0
-  - jruby-head
   - rbx-2.1.1
+  - jruby-19mode
 env:
   - "GEM=railties"
   - "GEM=ap,am,amo,as,av"
@@ -16,8 +16,8 @@ env:
   - "GEM=ar:postgresql"
 matrix:
   allow_failures:
-    - rvm: jruby-head
     - rvm: rbx-2.1.1
+    - rvm: jruby-19mode
 notifications:
   email: false
   irc:


### PR DESCRIPTION
Fixes for LOT of bugs have now landed in Jruby 1.7.6, thus we no longer need to run tests against the master.

for broken tests that are still remaning, I think this what we should do:
1. If problem is in rails - we fix that test/code
2. if its a JRuby bug - we skip that test & file a bug report for jruby.

About status of failing tests:
1. ap,am,amo,as - few encoding related tests are the problem. otherwise rails tests runs just fine on Jruby  :+1: 
2. ar - still lots of failing tests
3. railties - still red
#11700
