### PR TITLE
Skip test which is broken on jruby

### DIFF
--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -37,6 +37,10 @@ module StaticTests
   end
 
   def test_served_static_file_with_non_english_filename
+    if RUBY_ENGINE == 'jruby '
+      skip "Stop skiping if following bug gets fixed: " \
+      "http://jira.codehaus.org/browse/JRUBY-7192"
+    end
     assert_html "means hello in Japanese\n", get("/foo/#{Rack::Utils.escape("こんにちは.html")}")
   end
 


### PR DESCRIPTION
This test is broken from quite a while & is expected to remain broken as
encoding issues are hardest to fix in JRuby. so lets skip this test for
now.

Related bug report: http://jira.codehaus.org/browse/JRUBY-7192
#11700
