### PR TITLE
Correct `as_json` return example to display miliseconds

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -147,7 +147,7 @@ module ActiveSupport
     #
     #   # With ActiveSupport::JSON::Encoding.use_standard_json_time_format = true
     #   Time.utc(2005,2,1,15,15,10).in_time_zone.to_json
-    #   # => "2005-02-01T15:15:10Z"
+    #   # => "2005-02-01T15:15:10.000Z"
     #
     #   # With ActiveSupport::JSON::Encoding.use_standard_json_time_format = false
     #   Time.utc(2005,2,1,15,15,10).in_time_zone.to_json


### PR DESCRIPTION
As of 28ab79d7 TimeWithZone#as_json returns 3 decimal places of
sub-second accuracy. This just updates the example on the api docs
reflect that change.
