### PR TITLE
Fixes problem with replacing has_one association record with itself

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix bug where has_one associaton record update result in crash, when replaced with itself.
+
+    Fixes #12834.
+
+    *Denis Redozubov*, *Sergio Cambra*
+
 *   Log bind variables after they are type casted. This makes it more
     transparent what values are actually sent to the database.
 

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -26,11 +26,13 @@ module ActiveRecord
         load_target
 
         return self.target if !(target || record)
-        if (target != record) || record.changed?
+
+        assigning_another_record = target != record
+        if assigning_another_record || record.changed?
           save &&= owner.persisted?
 
           transaction_if(save) do
-            remove_target!(options[:dependent]) if target && !target.destroyed?
+            remove_target!(options[:dependent]) if target && !target.destroyed? && assigning_another_record
 
             if record
               set_owner_attributes(record)


### PR DESCRIPTION
```
ActiveRecord::Schema.define do
  create_table :users do |t|
  end

  create_table :addresses do |t|
    t.integer :user_id
    t.string :street
  end
end

class User < ActiveRecord::Base
  has_one :address, :dependent => :destroy
end

class Address < ActiveRecord::Base
  belongs_to :user
end

 user = User.create!
 address = user.create_address
 address.street = '1 Some St.'
 user.address = address
```

Fails with "can't modify frozen Hash" when attempting to save update has_one association.

full test gist: https://gist.github.com/scambra/7320315

discussion here: https://github.com/rails/rails/issues/12775
