### PR TITLE
[ci skip] Replace touch method to running callbacks list

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -157,10 +157,13 @@ The following methods trigger callbacks:
 * `save!`
 * `save(validate: false)`
 * `toggle!`
+* `touch`
 * `update_attribute`
 * `update`
 * `update!`
 * `valid?`
+
+NOTE: The `touch` method triggers only `after_touch` callback. 
 
 Additionally, the `after_find` callback is triggered by the following finder methods:
 
@@ -189,7 +192,6 @@ Just as with validations, it is also possible to skip callbacks by using the fol
 * `increment`
 * `increment_counter`
 * `toggle`
-* `touch`
 * `update_column`
 * `update_columns`
 * `update_all`

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -157,6 +157,7 @@ The following methods trigger callbacks:
 * `save!`
 * `save(validate: false)`
 * `toggle!`
+* `touch`
 * `update_attribute`
 * `update`
 * `update!`
@@ -189,7 +190,6 @@ Just as with validations, it is also possible to skip callbacks by using the fol
 * `increment`
 * `increment_counter`
 * `toggle`
-* `touch`
 * `update_column`
 * `update_columns`
 * `update_all`


### PR DESCRIPTION
`touch` method was listed in _Skipping Callbacks_ list, but it triggers `after_touch` callback, so I replaced it.
