### PR TITLE
Refer to Rails.env from AR only when Rails is defined

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -32,7 +32,11 @@ module ActiveRecord
 
   class PendingMigrationError < ActiveRecordError#:nodoc:
     def initialize
-      super("Migrations are pending; run 'bin/rake db:migrate RAILS_ENV=#{::Rails.env}' to resolve this issue.")
+      if defined?(Rails)
+        super("Migrations are pending; run 'bin/rake db:migrate RAILS_ENV=#{::Rails.env}' to resolve this issue.")
+      else
+        super("Migrations are pending; run 'bin/rake db:migrate' to resolve this issue.")
+      end
     end
   end
 


### PR DESCRIPTION
AR migration.rb depends on `Rails` constant here in an error message, but AR doesn't actually always depend on Rails, so this code could sometimes cause another weird error: "NameError: uninitialized constant Rails"

I'm not sure if this really is a problem, and what is a desirable way to address the problem if it actually is a problem, so let me ask the core team as a PR.
