### PR TITLE
New method ActiveRecord::QueryMethods#unwhere

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Added ActiveRecord::QueryMethods#unwhere which will unscope existing, named where conditions.
+
+    Examples:
+
+        Post.where(author: 'X', trashed: true).unwhere(:trashed) #=> WHERE `author` = 'X'
+        Post.where(trashed: false).unwhere(:trashed)             #=> Post.all
+        Post.where(active: true).where(trashed: true).unwhere    #=> Post.all
+
+    *Juanjo Bazán*
+
 *   Fix bug where has_one associaton record update result in crash, when replaced with itself.
 
     Fixes #12834.

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, to: :all
     delegate :find_each, :find_in_batches, to: :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
-             :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly,
+             :where, :rewhere, :unwhere, :preload, :eager_load, :includes, :from, :lock, :readonly,
              :having, :create_with, :uniq, :distinct, :references, :none, :unscope, to: :all
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, to: :all
     delegate :pluck, :ids, to: :all

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -562,6 +562,20 @@ module ActiveRecord
       unscope(where: conditions.keys).where(conditions)
     end
 
+    # Allows you to remove a previously set where condition for a given attribute.
+    # If not attributes are specified, the complete where clause is unscoped.
+    #
+    #   Post.where(author: 'X', trashed: true, active: false).unwhere(:trashed, :active) #=> WHERE `author` = 'X'
+    #   Post.where(author: 'X', trashed: true).unwhere(:trashed)                         #=> WHERE `author` = 'X'
+    #   Post.where(author: 'X', trashed: true).unwhere                                   #=> Post.all
+    #   Post.where(trashed: false).unwhere(:trashed)                                     #=> Post.all
+    #
+    # This is short-hand for unscope(where: attributes). Note that if attributes are specified we're only unscoping
+    # conditions for the named attribute(s), not the entire where statement.
+    def unwhere(*attributes)
+      attributes.present? ? unscope(where: attributes) : unscope(:where)
+    end
+
     # Allows to specify a HAVING clause. Note that you can't use HAVING
     # without also specifying a GROUP clause.
     #

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -28,6 +28,11 @@ module ActiveRecord
       assert_equal posts(:welcome), Post.rewhere(title: 'Welcome to the weblog').first
     end
 
+    def test_unwhere_on_root
+      assert_equal Post.all, Post.unwhere(:title)
+      assert_equal Post.all, Post.unwhere
+    end
+
     def test_belongs_to_shallow_where
       author = Author.new
       author.id = 1


### PR DESCRIPTION
ActiveRecord::QueryMethods#**unwhere**  unscopes selectively existing, named where conditions.

``` ruby
Post.where(author: 'X', trashed: true).unwhere(:trashed) #=> WHERE `author` = 'X'
Post.where(trashed: false).unwhere(:trashed)             #=> Post.all
Post.where(active: true).where(trashed: true).unwhere    #=> Post.all
```

`unwhere` complements `rewhere`, and it's also a short-hand for a common feature.
