### PR TITLE
Allocate one less object using html_safe during content_tag construction

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -151,7 +151,7 @@ module ActionView
               attrs << tag_option(key, value, escape)
             end
           end
-          " #{attrs.sort! * ' '}".html_safe unless attrs.empty?
+          " #{attrs.sort! * ' '}" unless attrs.empty?
         end
 
         def data_tag_option(key, value, escape)


### PR DESCRIPTION
This call to `html_safe` is unnecessary because `content_tag_string` already calls `html_safe` on `tag_options`. All ActionView tests are still passing. 
