### PR TITLE
methods and outputs indented

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -10,7 +10,7 @@ require 'active_support/core_ext/string/inflections'
 class Hash
   # Returns a string containing an XML representation of its receiver:
   #
-  #   {'foo' => 1, 'bar' => 2}.to_xml
+  #   { foo: 1, bar: 2 }.to_xml
   #   # =>
   #   # <?xml version="1.0" encoding="UTF-8"?>
   #   # <hash>
@@ -43,7 +43,10 @@ class Hash
   #     end
   #
   #     { foo: Foo.new }.to_xml(skip_instruct: true)
-  #     # => "<hash><bar>fooing!</bar></hash>"
+  #     # =>
+  #     # <hash>
+  #     #   <bar>fooing!</bar>
+  #     # </hash>
   #
   # * Otherwise, a node with +key+ as tag is created with a string representation of
   #   +value+ as text node. If +value+ is +nil+ an attribute "nil" set to "true" is added.
@@ -201,7 +204,7 @@ module ActiveSupport
       end
 
       def become_empty_string?(value)
-        # {"string" => true}
+        # { "string" => true }
         # No tests fail when the second term is removed.
         value['type'] == 'string' && value['nil'] != 'true'
       end

--- a/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
@@ -1,13 +1,13 @@
 class Hash
   # Returns a new hash with +self+ and +other_hash+ merged recursively.
   #
-  #   h1 = { x: { y: [4,5,6] }, z: [7,8,9] }
-  #   h2 = { x: { y: [7,8,9] }, z: 'xyz' }
+  #   h1 = { x: { y: [4, 5, 6] }, z: [7, 8, 9] }
+  #   h2 = { x: { y: [7, 8, 9] }, z: 'xyz' }
   #
-  #   h1.deep_merge(h2) #=> {x: {y: [7, 8, 9]}, z: "xyz"}
-  #   h2.deep_merge(h1) #=> {x: {y: [4, 5, 6]}, z: [7, 8, 9]}
+  #   h1.deep_merge(h2) # => {:x=>{:y=>[7, 8, 9]}, :z=>"xyz"}
+  #   h2.deep_merge(h1) # => {:x=>{:y=>[4, 5, 6]}, :z=>[7, 8, 9]}
   #   h1.deep_merge(h2) { |key, old, new| Array.wrap(old) + Array.wrap(new) }
-  #   #=> {:x=>{:y=>[4, 5, 6, 7, 8, 9]}, :z=>[7, 8, 9, "xyz"]}
+  #   # => {:x=>{:y=>[4, 5, 6, 7, 8, 9]}, :z=>[7, 8, 9, "xyz"]}
   def deep_merge(other_hash, &block)
     dup.deep_merge!(other_hash, &block)
   end

--- a/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb
+++ b/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb
@@ -18,5 +18,6 @@ class Hash
   #
   #   b = { b: 1 }
   #   { a: b }.with_indifferent_access['a'] # calls b.nested_under_indifferent_access
+  #   # => {"b"=>32}
   alias nested_under_indifferent_access with_indifferent_access
 end

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -4,7 +4,7 @@ class Hash
   #  hash = { name: 'Rob', age: '28' }
   #
   #  hash.transform_keys{ |key| key.to_s.upcase }
-  #  # => { "NAME" => "Rob", "AGE" => "28" }
+  #  # => {"NAME"=>"Rob", "AGE"=>"28"}
   def transform_keys
     result = {}
     each_key do |key|
@@ -27,7 +27,7 @@ class Hash
   #   hash = { name: 'Rob', age: '28' }
   #
   #   hash.stringify_keys
-  #   #=> { "name" => "Rob", "age" => "28" }
+  #   # => {"name"=>"Rob", "age"=>"28"}
   def stringify_keys
     transform_keys{ |key| key.to_s }
   end
@@ -44,7 +44,7 @@ class Hash
   #   hash = { 'name' => 'Rob', 'age' => '28' }
   #
   #   hash.symbolize_keys
-  #   #=> { name: "Rob", age: "28" }
+  #   # => {"name"=>"Rob", "age"=>"28"}
   def symbolize_keys
     transform_keys{ |key| key.to_sym rescue key }
   end
@@ -78,7 +78,7 @@ class Hash
   #  hash = { person: { name: 'Rob', age: '28' } }
   #
   #  hash.deep_transform_keys{ |key| key.to_s.upcase }
-  #  # => { "PERSON" => { "NAME" => "Rob", "AGE" => "28" } }
+  #  # => {"PERSON"=>{"NAME"=>"Rob", "AGE"=>"28"}}
   def deep_transform_keys(&block)
     result = {}
     each do |key, value|
@@ -105,7 +105,7 @@ class Hash
   #   hash = { person: { name: 'Rob', age: '28' } }
   #
   #   hash.deep_stringify_keys
-  #   # => { "person" => { "name" => "Rob", "age" => "28" } }
+  #   # => {"person"=>{"name"=>"Rob", "age"=>"28"}}
   def deep_stringify_keys
     deep_transform_keys{ |key| key.to_s }
   end
@@ -124,7 +124,7 @@ class Hash
   #   hash = { 'person' => { 'name' => 'Rob', 'age' => '28' } }
   #
   #   hash.deep_symbolize_keys
-  #   # => { person: { name: "Rob", age: "28" } }
+  #   # => {:person=>{:name=>"Rob", :age=>"28"}}
   def deep_symbolize_keys
     deep_transform_keys{ |key| key.to_sym rescue key }
   end


### PR DESCRIPTION
Updated outputs as displayed on console, used new ruby syntax while initialising hash in the examples, indented methods.
