### PR TITLE
Clean up `require ‘active_support/deprecation’` and remove circular require

### DIFF
--- a/activesupport/lib/active_support/all.rb
+++ b/activesupport/lib/active_support/all.rb
@@ -1,4 +1,3 @@
 require 'active_support'
-require 'active_support/deprecation'
 require 'active_support/time'
 require 'active_support/core_ext'

--- a/activesupport/lib/active_support/core_ext/module/deprecation.rb
+++ b/activesupport/lib/active_support/core_ext/module/deprecation.rb
@@ -1,5 +1,3 @@
-require 'active_support/deprecation/method_wrappers'
-
 class Module
   #   deprecate :foo
   #   deprecate bar: 'message'


### PR DESCRIPTION
When I do `require 'active_support/core_ext'`,
I'm getting `NameError: uninitialized constant ActiveSupport::Deprecation::MethodWrapper`

With this commit 77b587f942bf3768e5b680ac5e9f24c03a40c607 `require 'active_support/deprecation'` was removed from `date_time/calculations.rb`, this file was loaded before `require 'active_support/core_ext/module/deprecation'` and was the reason why it had worked. Anyway I consider `require 'active_support/deprecation/method_wrappers'` useless because it just defines a module that has to be mixed into `Deprecation`.
