### PR TITLE
JSON gem compatibility

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Improved compatibility with the stdlib JSON gem.
+
+    Previously, calling `::JSON.{generate,dump}` sometimes causes unexpected
+    failures such as intridea/multi_json#86.
+
+    `::JSON.{generate,dump}` now bypasses the ActiveSupport JSON encoder
+    completely and yields the same result with or without ActiveSupport. This
+    means that it will **not** call `as_json` and will ignore any options that
+    the JSON gem does not natively understand. To invoke ActiveSupport's JSON
+    encoder instead, use `obj.to_json(options)` or
+    `ActiveSupport::JSON.encode(obj, options)`.
+
+    *Godfrey Chan*
+
 *   Fix Active Support `Time#to_json` and `DateTime#to_json` to return 3 decimal
     places worth of fractional seconds, similar to `TimeWithZone`.
 

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -9,18 +9,36 @@ require 'time'
 require 'active_support/core_ext/time/conversions'
 require 'active_support/core_ext/date_time/conversions'
 require 'active_support/core_ext/date/conversions'
+require 'active_support/core_ext/module/aliasing'
 
 # The JSON gem adds a few modules to Ruby core classes containing :to_json definition, overwriting
 # their default behavior. That said, we need to define the basic to_json method in all of them,
 # otherwise they will always use to_json gem implementation, which is backwards incompatible in
 # several cases (for instance, the JSON implementation for Hash does not work) with inheritance
 # and consequently classes as ActiveSupport::OrderedHash cannot be serialized to json.
+# 
+# On the other hand, we should avoid conflict with ::JSON.{generate,dump}(obj). Unfortunately, the
+# JSON gem's encoder relies on its own to_json implementation to encode objects. Since it always
+# passes a ::JSON::State object as the only argument to to_json, we can detect that and forward the
+# calls to the original to_json method.
+# 
+# It should be noted that when using ::JSON.{generate,dump} directly, ActiveSupport's encoder is
+# bypassed completely. This means that as_json won't be invoked and the JSON gem will simply
+# ignore any options it does not natively understand. This also means that ::JSON.{generate,dump}
+# should give exactly the same results with or without active support.
 [Object, Array, FalseClass, Float, Hash, Integer, NilClass, String, TrueClass].each do |klass|
   klass.class_eval do
-    # Dumps object in JSON (JavaScript Object Notation). See www.json.org for more info.
-    def to_json(options = nil)
-      ActiveSupport::JSON.encode(self, options)
+    def to_json_with_active_support_encoder(options = nil)
+      if options.is_a?(::JSON::State)
+        # Called from JSON.{generate,dump}, forward it to JSON gem's to_json
+        self.to_json_without_active_support_encoder(options)
+      else
+        # to_json is being invoked directly, use ActiveSupport's encoder
+        ActiveSupport::JSON.encode(self, options)
+      end
     end
+
+    alias_method_chain :to_json, :active_support_encoder
   end
 end
 

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -32,6 +32,19 @@ class TestJSONEncoding < ActiveSupport::TestCase
     end
   end
 
+  class HashWithAsJson < Hash
+    attr_accessor :as_json_called
+
+    def initialize(*)
+      super
+    end
+
+    def as_json(options={})
+      @as_json_called = true
+      super
+    end
+  end
+
   TrueTests     = [[ true,  %(true)  ]]
   FalseTests    = [[ false, %(false) ]]
   NilTests      = [[ nil,   %(null)  ]]
@@ -365,6 +378,38 @@ class TestJSONEncoding < ActiveSupport::TestCase
     assert_equal nil,   nil.as_json
     assert_equal true,  true.as_json
     assert_equal false, false.as_json
+  end
+
+  def test_json_gem_dump_by_passing_active_support_encoder
+    h = HashWithAsJson.new
+    h[:foo] = "hello"
+    h[:bar] = "world"
+
+    assert_equal %({"foo":"hello","bar":"world"}), JSON.dump(h)
+    assert_nil h.as_json_called
+  end
+
+  def test_json_gem_generate_by_passing_active_support_encoder
+    h = HashWithAsJson.new
+    h[:foo] = "hello"
+    h[:bar] = "world"
+
+    assert_equal %({"foo":"hello","bar":"world"}), JSON.generate(h)
+    assert_nil h.as_json_called
+  end
+
+  def test_json_gem_pretty_generate_by_passing_active_support_encoder
+    h = HashWithAsJson.new
+    h[:foo] = "hello"
+    h[:bar] = "world"
+
+    assert_equal <<EXPECTED.chomp, JSON.pretty_generate(h)
+{
+  "foo": "hello",
+  "bar": "world"
+}
+EXPECTED
+    assert_nil h.as_json_called
   end
 
   protected


### PR DESCRIPTION
This is extracted from #12183 as an isolated PR. I documented the current state of JSON-gem-vs-active-support incompatibility [here](https://github.com/intridea/multi_json/pull/138#issuecomment-24468223). Clearly, you cannot currently use the JSON gem's `dump` or `generate` method in conjunction with ActiveSupport's JSON encoder, otherwise, things may break unexpectedly on certain input at runtime with a cryptic error. This limitation is not currently very well known. It's probably safe to assume that the situation is going to get worse as we move to Ruby 1.9+ (where the JSON gem ships with the stdlib) and as multi_json is being EOL'ed and removed from Rails 4.1 (many gem authors simply replaced `MultiJson.dump` with `::JSON.{dump,generate}`.

To improve the situation, we can do one of the following things:
1. **Do nothing**: This feels irresponsible, especially when we know that this is going to fail in subtle and non-obvious way in seemingly (to the user) unpredictable manner.
2. **Document this behaviour and warn people about using JSON gem together with Rails**: this doesn't really help, who read documentations? In practice, this would have the same effect as 1.
3. **Boycott JSON gem, override `::JSON.{dump,generate}` to raise an exception when ActiveSupport::JSON is loaded**: while this might be ideal from a purist perspective, I'm afraid this is a non-starter – even some of our dependencies are currently using `::JSON.{dump,generate}` in their codebase.
4. **Make it possible for AS::JSON and JSON gem to coexist in peace**: this is what I propose to do. It seems like the only reasonable and responsible thing to do.

With this PR, calling `::JSON.{generate,dump}` will invoke the JSON gem's encoder. It will **not** invoke any of the `ActiveSupport::JSON` logic, i.e. it will bypass `as_json` and ignore any options that it does not natively understand (e.g. `only`, `except`, etc). Instead of using the ad-hoc approach in #9295, this PR changes our version of `to_json` to add some triage code. The end result is that invoking `::JSON.{generate,dump}` will yield the same result before and after `ActiveSupport::JSON` is loaded.

If I get a :+1: from core, I'll can clean things up, add the changelog, etc.

cc @jeremy
