### PR TITLE
Fix syntax error in atom_feed example [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/atom_feed_helper.rb
+++ b/actionview/lib/action_view/helpers/atom_feed_helper.rb
@@ -64,7 +64,7 @@ module ActionView
       #         'xmlns:openSearch' => 'http://a9.com/-/spec/opensearch/1.1/'}) do |feed|
       #       feed.title("My great blog!")
       #       feed.updated((@posts.first.created_at))
-      #       feed.tag!(openSearch:totalResults, 10)
+      #       feed.tag!('openSearch:totalResults', 10)
       #
       #       @posts.each do |post|
       #         feed.entry(post) do |entry|


### PR DESCRIPTION
Builder's #tag! takes either String or Symbol as the first parameter (see http://builder.rubyforge.org/classes/Builder/XmlBase.html#M000017).

This is also wrong on `4.0-stable` and `3-2-stable`.
