### PR TITLE
Better support for AR:B.where(belongs_to_assoc: val) which previously generated invalid SQL

### DIFF
--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -35,6 +35,21 @@ module ActiveRecord
       assert_equal Post.where(author_id: 1).to_sql, Post.where(author: author).to_sql
     end
 
+    def test_belongs_to_nil_where
+      assert_equal Post.where(author_id: nil).to_sql, Post.where(author: nil).to_sql
+    end
+
+    def test_belongs_to_array_value_where
+      assert_equal Post.where(author_id: [1,2]).to_sql, Post.where(author: [1,2]).to_sql
+    end
+
+    def test_belongs_to_nested_relation_where
+      expected = Post.where(author_id: Author.where(id: [1,2])).to_sql
+      actual   = Post.where(author:    Author.where(id: [1,2])).to_sql
+
+      assert_equal expected, actual
+    end
+
     def test_belongs_to_nested_where
       parent = Comment.new
       parent.id = 1
@@ -51,6 +66,25 @@ module ActiveRecord
 
       expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: 1)
       actual   = PriceEstimate.where(estimate_of: treasure)
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+    def test_polymorphic_nested_array_where
+      treasure = Treasure.new
+      treasure.id = 1
+      hidden = HiddenTreasure.new
+      hidden.id = 2
+
+      expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: [treasure, hidden])
+      actual   = PriceEstimate.where(estimate_of: [treasure, hidden])
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+    def test_polymorphic_nested_relation_where
+      expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: Treasure.where(id: [1,2]))
+      actual   = PriceEstimate.where(estimate_of: Treasure.where(id: [1,2]))
 
       assert_equal expected.to_sql, actual.to_sql
     end


### PR DESCRIPTION
Using the name of an association in `where` previously worked only
if the value was a single `ActiveRecrd::Base` object. e.g.

```
Post.where(author: Author.first)
```

Any other values, including `nil`, would cause invalid SQL to be
generated. This change supports arguments in the `where` query
conditions where the key is a `belongs_to` association name and the
value is `nil`, an `Array` of `ActiveRecord::Base` objects, or an
`ActiveRecord::Relation` object.

```
# Given the Post model
class Post < ActiveRecord::Base
  belongs_to :author
end

# nil value finds records where the association is not set
Post.where(author: nil)
# SELECT "posts".* FROM "posts" WHERE "posts"."author_id" IS NULL

# Array values find records where the association foreign key
# matches the ids of the passed ActiveRecord models, resulting
# in the same query as Post.where(author_id: [1,2])
authors_array = [Author.find(1), Author.find(2)]
Post.where(author: authors_array)

# ActiveRecord::Relation values find records using the same
# query as Post.where(author_id: Author.where(last_name: "Emde"))
Post.where(author: Author.where(last_name: "Emde"))
```

Polymorphic `belongs_to` associations will continue to be handled
appropriately, with the polymorphic `association_type` field added
to the query to match the base class of the value. This feature
previously only worked when the value was a single `ActveRecord::Base`.

```
class Post < ActiveRecord::Base
  belongs_to :author, polymorphic: true
end

Post.where(author: Author.where(last_name: "Emde"))
# Generates a query similar to:
Post.where(author_id: Author.where(last_name: "Emde"), author_type: "Author")
```
