### PR TITLE
Allow passing of array and block to layout

### DIFF
--- a/actionview/test/fixtures/users/_user.html.erb
+++ b/actionview/test/fixtures/users/_user.html.erb
@@ -1,0 +1,2 @@
+<%= greeting %>: <%= user.name %>
+<%= yield user %>

--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -28,6 +28,10 @@ class Customer < Struct.new(:name, :id)
   end
 end
 
+class User < Struct.new(:name, :title)
+  include ActiveModel::Conversion
+end
+
 class GoodCustomer < Customer
 end
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -340,6 +340,12 @@ module RenderTestCases
     assert_equal "Before\npartial html\nYield!\nAfter\n", render
   end
 
+  def test_render_layout_with_array_and_block
+    users = [User.new("Mac", "developer"), User.new("Ryman", "pitcher")]
+    render = @controller_view.render(:layout => users, :locals => { :greeting => "Hello" }) { |user| "#{user.title}" }
+    assert_equal "Hello: Mac\ndeveloperHello: Ryman\npitcher", render
+  end
+
   def test_render_inline
     assert_equal "Hello, World!", @view.render(:inline => "Hello, World!")
   end


### PR DESCRIPTION
Fix for #12826 -- Layouts were unable to take arrays, as the docs state they should. 
- This problem starts with the block not getting passed to template.render in collection_with_template.
- From there, we need to get the layout path (from the first object in the array).
- Finally, in collection_with_template, we only want to call layout.render after template.render if a @options[:layout] does not equal @options[:partial]. The reason for this, is that when given an array, we use the first object in it to decide which layout is used. 
  rendering_helper then sets the partial to the layout with: options.merge(:partial => options[:layout])
  We don't actually want to use the partial in this case though; If we were to call layout.render after template.render in this case we'd get un-desirable results when yielding the block.

Let me know if there's a preferable approach to this.
