### PR TITLE
Support extended grapheme clusters and UAX 29

### DIFF
--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -94,6 +94,12 @@ module ActiveSupport
             # GB3. CR X LF
             if previous == database.boundary[:cr] and current == database.boundary[:lf]
               false
+            # GB4. (Control|CR|LF) ÷
+            elsif previous and in_char_class?(previous, [:control,:cr,:lf])
+              true
+            # GB5. ÷ (Control|CR|LF)
+            elsif in_char_class?(current, [:control,:cr,:lf])
+              true
             # GB6. L X (L|V|LV|LVT)
             elsif database.boundary[:l] === previous and in_char_class?(current, [:l,:v,:lv,:lvt])
               false
@@ -103,8 +109,17 @@ module ActiveSupport
             # GB8. (LVT|T) X (T)
             elsif in_char_class?(previous, [:lvt,:t]) and database.boundary[:t] === current
               false
+            # GB8a. Regional_Indicator X Regional_Indicator
+            elsif database.boundary[:regional_indicator] === previous and database.boundary[:regional_indicator] === current
+              false
             # GB9. X Extend
             elsif database.boundary[:extend] === current
+              false
+            # GB9a. X SpacingMark
+            elsif database.boundary[:spacingmark] === current
+              false
+            # GB9b. Prepend X
+            elsif database.boundary[:prepend] === previous
               false
             # GB10. Any ÷ Any
             else

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -89,19 +89,29 @@ module ActiveSupport
           pos += 1
           previous = codepoints[pos-1]
           current = codepoints[pos]
-          if (
-              # CR X LF
-              ( previous == database.boundary[:cr] and current == database.boundary[:lf] ) or
-              # L X (L|V|LV|LVT)
-              ( database.boundary[:l] === previous and in_char_class?(current, [:l,:v,:lv,:lvt]) ) or
-              # (LV|V) X (V|T)
-              ( in_char_class?(previous, [:lv,:v]) and in_char_class?(current, [:v,:t]) ) or
-              # (LVT|T) X (T)
-              ( in_char_class?(previous, [:lvt,:t]) and database.boundary[:t] === current ) or
-              # X Extend
-              (database.boundary[:extend] === current)
-            )
-          else
+
+          should_break =
+            # GB3. CR X LF
+            if previous == database.boundary[:cr] and current == database.boundary[:lf]
+              false
+            # GB6. L X (L|V|LV|LVT)
+            elsif database.boundary[:l] === previous and in_char_class?(current, [:l,:v,:lv,:lvt])
+              false
+            # GB7. (LV|V) X (V|T)
+            elsif in_char_class?(previous, [:lv,:v]) and in_char_class?(current, [:v,:t])
+              false
+            # GB8. (LVT|T) X (T)
+            elsif in_char_class?(previous, [:lvt,:t]) and database.boundary[:t] === current
+              false
+            # GB9. X Extend
+            elsif database.boundary[:extend] === current
+              false
+            # GB10. Any ÷ Any
+            else
+              true
+            end
+
+          if should_break
             unpacked << codepoints[marker..pos-1]
             marker = pos
           end

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -600,28 +600,54 @@ class MultibyteCharsExtrasTest < ActiveSupport::TestCase
       ['abc', 3],
       ['こにちわ', 4],
       [[0x0924, 0x094D, 0x0930].pack('U*'), 2],
+      # GB3
       [%w(cr lf), 1],
+      # GB4
+      [%w(cr n), 2],
+      [%w(lf n), 2],
+      [%w(control n), 2],
+      [%w(cr extend), 2],
+      [%w(lf extend), 2],
+      [%w(control extend), 2],
+      # GB 5
+      [%w(n cr), 2],
+      [%w(n lf), 2],
+      [%w(n control), 2],
+      [%w(extend cr), 2],
+      [%w(extend lf), 2],
+      [%w(extend control), 2],
+      # GB 6
       [%w(l l), 1],
       [%w(l v), 1],
       [%w(l lv), 1],
       [%w(l lvt), 1],
+      # GB7
       [%w(lv v), 1],
       [%w(lv t), 1],
       [%w(v v), 1],
       [%w(v t), 1],
+      # GB8
       [%w(lvt t), 1],
       [%w(t t), 1],
+      # GB8a
+      [%w(r r), 1],
+      # GB9
       [%w(n extend), 1],
+      # GB9a
+      [%w(n spacingmark), 1],
+      # GB10
       [%w(n n), 2],
+      # Other
       [%w(n cr lf n), 3],
-      [%w(n l v t), 2]
+      [%w(n l v t), 2],
+      [%w(cr extend n), 3],
     ].each do |input, expected_length|
       if input.kind_of?(Array)
         str = string_from_classes(input)
       else
         str = input
       end
-      assert_equal expected_length, chars(str).grapheme_length
+      assert_equal expected_length, chars(str).grapheme_length, input.inspect
     end
   end
 
@@ -686,7 +712,7 @@ class MultibyteCharsExtrasTest < ActiveSupport::TestCase
     # Characters from the character classes as described in UAX #29
     character_from_class = {
       :l => 0x1100, :v => 0x1160, :t => 0x11A8, :lv => 0xAC00, :lvt => 0xAC01, :cr => 0x000D, :lf => 0x000A,
-      :extend => 0x094D, :n => 0x64
+      :extend => 0x094D, :n => 0x64, :spacingmark => 0x0903, :r => 0x1F1E6, :control => 0x0001
     }
     classes.collect do |k|
       character_from_class[k.intern]

--- a/activesupport/test/multibyte_grapheme_break_conformance.rb
+++ b/activesupport/test/multibyte_grapheme_break_conformance.rb
@@ -1,0 +1,76 @@
+# encoding: utf-8
+
+require 'abstract_unit'
+
+require 'fileutils'
+require 'open-uri'
+require 'tmpdir'
+
+class Downloader
+  def self.download(from, to)
+    unless File.exist?(to)
+      $stderr.puts "Downloading #{from} to #{to}"
+      unless File.exist?(File.dirname(to))
+        system "mkdir -p #{File.dirname(to)}"
+      end
+      open(from) do |source|
+        File.open(to, 'w') do |target|
+          source.each_line do |l|
+            target.write l
+          end
+        end
+       end
+     end
+  end
+end
+
+class MultibyteGraphemeBreakConformanceTest < ActiveSupport::TestCase
+  TEST_DATA_URL = "http://www.unicode.org/Public/#{ActiveSupport::Multibyte::Unicode::UNICODE_VERSION}/ucd/auxiliary"
+  TEST_DATA_FILE = '/GraphemeBreakTest.txt'
+  CACHE_DIR = File.join(Dir.tmpdir, 'cache')
+
+  def setup
+    FileUtils.mkdir_p(CACHE_DIR)
+    Downloader.download(TEST_DATA_URL + TEST_DATA_FILE, CACHE_DIR + TEST_DATA_FILE)
+  end
+
+  def test_breaks
+    each_line_of_break_tests do |*cols|
+      *clusters, comment = *cols
+      packed = ActiveSupport::Multibyte::Unicode.pack_graphemes(clusters)
+      assert_equal clusters, ActiveSupport::Multibyte::Unicode.unpack_graphemes(packed), comment
+    end
+  end
+
+  protected
+    def each_line_of_break_tests(&block)
+      lines = 0
+      max_test_lines = 0 # Don't limit below 21, because that's the header of the testfile
+      File.open(File.join(CACHE_DIR, TEST_DATA_FILE), 'r') do | f |
+        until f.eof? || (max_test_lines > 21 and lines > max_test_lines)
+          lines += 1
+          line = f.gets.chomp!
+          next if (line.empty? || line =~ /^\#/)
+
+          cols, comment = line.split("#")
+          # Cluster breaks are represented by ÷
+          clusters = cols.split("÷").map{|e| e.strip}.reject{|e| e.empty? }
+          clusters = clusters.map do |cluster|
+            # Codepoints within each cluster are separated by ×
+            codepoints = cluster.split("×").map{|e| e.strip}.reject{|e| e.empty? }
+            # codepoints are in hex in the test suite, pack wants them as integers
+            codepoints.map{|codepoint| codepoint.to_i(16)}
+          end
+
+          # The tests contain a solitary U+D800 <Non Private Use High
+          # Surrogate, First> character, which Ruby does not allow to stand
+          # alone in a UTF-8 string. So we'll just skip it.
+          next if clusters.flatten.include?(0xd800)
+
+          clusters << comment.strip
+
+          yield(*clusters)
+        end
+      end
+    end
+end

--- a/activesupport/test/multibyte_normalization_conformance.rb
+++ b/activesupport/test/multibyte_normalization_conformance.rb
@@ -25,7 +25,7 @@ class Downloader
   end
 end
 
-class MultibyteConformanceTest < ActiveSupport::TestCase
+class MultibyteNormalizationConformanceTest < ActiveSupport::TestCase
   include MultibyteTestHelpers
 
   UNIDATA_URL = "http://www.unicode.org/Public/#{ActiveSupport::Multibyte::Unicode::UNICODE_VERSION}/ucd"


### PR DESCRIPTION
http://www.unicode.org/reports/tr29/tr29-21.html is the version of UAX 29 that corresponds to Unicode 6.2.0. `Unicode.unpack_graphemes` now implements all the rules listed there, including the ones for extended grapheme clusters.

I added a new optional test, `test/multibyte_grapheme_break_conformance.rb`, that is heavily based on `test/multibyte_normalization_conformance.rb`, which runs the Unicode test suite.

Fixes #12872.
