### PR TITLE
19% reduction is string object allocations per request

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -67,7 +67,7 @@ module AbstractController
         meths.each do |meth|
           _helpers.class_eval <<-ruby_eval, __FILE__, __LINE__ + 1
             def #{meth}(*args, &blk)                               # def current_user(*args, &blk)
-              controller.send(%(#{meth}), *args, &blk)             #   controller.send(:current_user, *args, &blk)
+              controller.send(%(#{meth}).freeze, *args, &blk)             #   controller.send(:current_user, *args, &blk)
             end                                                    # end
           ruby_eval
         end

--- a/actionview/lib/action_view/helpers/active_model_helper.rb
+++ b/actionview/lib/action_view/helpers/active_model_helper.rb
@@ -42,7 +42,7 @@ module ActionView
       end
 
       def tag_generate_errors?(options)
-        options['type'] != 'hidden'
+        options['type'.freeze] != 'hidden'.freeze
       end
     end
   end

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -427,7 +427,9 @@ module ActionView
       def submit_tag(value = "Save changes", options = {})
         options = options.stringify_keys
 
-        tag :input, { "type" => "submit", "name" => "commit", "value" => value }.update(options)
+        tag :input, { "type".freeze => "submit".freeze,
+                      "name".freeze => "commit".freeze,
+                      "value".freeze => value }.update(options)
       end
 
       # Creates a button element that defines a <tt>submit</tt> button,

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -65,7 +65,7 @@ module ActionView
       #   tag("div", data: {name: 'Stephen', city_state: %w(Chicago IL)})
       #   # => <div data-name="Stephen" data-city-state="[&quot;Chicago&quot;,&quot;IL&quot;]" />
       def tag(name, options = nil, open = false, escape = true)
-        "<#{name}#{tag_options(options, escape) if options}#{open ? ">" : " />"}".html_safe
+        "<#{name}#{tag_options(options, escape) if options}#{open ? ">".freeze : " />".freeze}".html_safe
       end
 
       # Returns an HTML block tag of type +name+ surrounding the +content+. Add
@@ -141,7 +141,7 @@ module ActionView
           return if options.blank?
           attrs = []
           options.each_pair do |key, value|
-            if key.to_s == 'data' && value.is_a?(Hash)
+            if key.to_s == 'data'.freeze && value.is_a?(Hash)
               value.each_pair do |k, v|
                 attrs << data_tag_option(k, v, escape)
               end
@@ -151,7 +151,7 @@ module ActionView
               attrs << tag_option(key, value, escape)
             end
           end
-          " #{attrs.sort! * ' '}".html_safe unless attrs.empty?
+          " #{attrs.sort! * ' '.freeze}".html_safe unless attrs.empty?
         end
 
         def data_tag_option(key, value, escape)

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -58,33 +58,39 @@ module ActionView
           end
         end
 
+        NAME      = 'name'.freeze
+        ID        = 'id'.freeze
+        INDEX     = 'index'.freeze
+        MULTIPLE  = 'multiple'.freeze
+        NAMESPACE = 'namespace'.freeze
+
         def add_default_name_and_id_for_value(tag_value, options)
           if tag_value.nil?
             add_default_name_and_id(options)
           else
-            specified_id = options["id"]
+            specified_id = options[ID]
             add_default_name_and_id(options)
 
-            if specified_id.blank? && options["id"].present?
-              options["id"] += "_#{sanitized_value(tag_value)}"
+            if specified_id.blank? && options[ID].present?
+              options[ID] += "_#{sanitized_value(tag_value)}"
             end
           end
         end
 
         def add_default_name_and_id(options)
-          if options.has_key?("index")
-            options["name"] ||= options.fetch("name"){ tag_name_with_index(options["index"], options["multiple"]) }
-            options["id"] = options.fetch("id"){ tag_id_with_index(options["index"]) }
-            options.delete("index")
+          if options.has_key?(INDEX)
+            options[NAME] ||= options.fetch(NAME){ tag_name_with_index(options[INDEX], options["multiple"]) }
+            options[ID] = options.fetch(ID){ tag_id_with_index(options[INDEX]) }
+            options.delete(INDEX)
           elsif defined?(@auto_index)
-            options["name"] ||= options.fetch("name"){ tag_name_with_index(@auto_index, options["multiple"]) }
-            options["id"] = options.fetch("id"){ tag_id_with_index(@auto_index) }
+            options[NAME] ||= options.fetch(NAME){ tag_name_with_index(@auto_index, options["multiple"]) }
+            options[ID] = options.fetch(ID){ tag_id_with_index(@auto_index) }
           else
-            options["name"] ||= options.fetch("name"){ tag_name(options["multiple"]) }
-            options["id"] = options.fetch("id"){ tag_id }
+            options[NAME] ||= options.fetch(NAME){ tag_name(options[MULTIPLE]) }
+            options[ID] = options.fetch(ID){ tag_id }
           end
 
-          options["id"] = [options.delete('namespace'), options["id"]].compact.join("_").presence
+          options[ID] = [options.delete(NAMESPACE), options[ID]].compact.join("_".freeze).presence
         end
 
         def tag_name(multiple = false)
@@ -104,7 +110,7 @@ module ActionView
         end
 
         def sanitized_object_name
-          @sanitized_object_name ||= @object_name.gsub(/\]\[|[^-a-zA-Z0-9:.]/, "_").sub(/_$/, "")
+          @sanitized_object_name ||= @object_name.gsub(/\]\[|[^-a-zA-Z0-9:.]/, "_".freeze).sub(/_$/, "".freeze)
         end
 
         def sanitized_method_name

--- a/actionview/lib/action_view/helpers/tags/check_box.rb
+++ b/actionview/lib/action_view/helpers/tags/check_box.rb
@@ -56,7 +56,17 @@ module ActionView
         end
 
         def hidden_field_for_checkbox(options)
-          @unchecked_value ? tag("input", options.slice("name", "disabled", "form").merge!("type" => "hidden", "value" => @unchecked_value)) : "".html_safe
+          @unchecked_value ? input_tag(options, @unchecked_value) : "".freeze.html_safe
+        end
+
+        def input_tag(options, unchecked_value)
+          name = "input".freeze
+          new_options = options.slice("name".freeze,
+                                      "disabled".freeze,
+                                      "form".freeze).merge!(
+                                        "type".freeze => "hidden".freeze,
+                                        "value".freeze => unchecked_value)
+          tag(name, new_options)
         end
       end
     end

--- a/actionview/lib/action_view/helpers/tags/label.rb
+++ b/actionview/lib/action_view/helpers/tags/label.rb
@@ -16,22 +16,25 @@ module ActionView
           super(object_name, method_name, template_object, options)
         end
 
+        FOR = 'for'.freeze
+        ID  = 'id'.freeze
+
         def render(&block)
           options = @options.stringify_keys
-          tag_value = options.delete("value")
+          tag_value = options.delete("value".freeze)
           name_and_id = options.dup
 
-          if name_and_id["for"]
-            name_and_id["id"] = name_and_id["for"]
+          if name_and_id[FOR]
+            name_and_id[ID] = name_and_id[FOR]
           else
-            name_and_id.delete("id")
+            name_and_id.delete(ID)
           end
 
           add_default_name_and_id_for_value(tag_value, name_and_id)
-          options.delete("index")
-          options.delete("namespace")
-          options.delete("multiple")
-          options["for"] = name_and_id["id"] unless options.key?("for")
+          options.delete("index".freeze)
+          options.delete("namespace".freeze)
+          options.delete("multiple".freeze)
+          options[FOR] = name_and_id[ID] unless options.key?(FOR)
 
           if block_given?
             content = @template_object.capture(&block)
@@ -42,11 +45,11 @@ module ActionView
 
                         if object.respond_to?(:to_model)
                           key = object.class.model_name.i18n_key
-                          i18n_default = ["#{key}.#{method_and_value}".to_sym, ""]
+                          i18n_default = ["#{key}.#{method_and_value}".to_sym, "".freeze]
                         end
 
-                        i18n_default ||= ""
-                        I18n.t("#{@object_name}.#{method_and_value}", :default => i18n_default, :scope => "helpers.label").presence
+                        i18n_default ||= "".freeze
+                        I18n.t("#{@object_name}.#{method_and_value}", :default => i18n_default, :scope => "helpers.label".freeze).presence
                       else
                         @content.to_s
                       end
@@ -58,7 +61,7 @@ module ActionView
             content ||= @method_name.humanize
           end
 
-          label_tag(name_and_id["id"], content, options)
+          label_tag(name_and_id[ID], content, options)
         end
       end
     end

--- a/actionview/lib/action_view/helpers/tags/text_field.rb
+++ b/actionview/lib/action_view/helpers/tags/text_field.rb
@@ -2,19 +2,22 @@ module ActionView
   module Helpers
     module Tags # :nodoc:
       class TextField < Base # :nodoc:
+        SIZE  = "size".freeze
+        VALUE = "value".freeze
+
         def render
           options = @options.stringify_keys
-          options["size"] = options["maxlength"] unless options.key?("size")
-          options["type"] ||= field_type
-          options["value"] = options.fetch("value") { value_before_type_cast(object) } unless field_type == "file"
-          options["value"] &&= ERB::Util.html_escape(options["value"])
+          options[SIZE] = options["maxlength".freeze] unless options.key?(SIZE)
+          options["type".freeze] ||= field_type
+          options[VALUE] = options.fetch(VALUE) { value_before_type_cast(object) } unless field_type == "file".freeze
+          options[VALUE] &&= ERB::Util.html_escape(options[VALUE])
           add_default_name_and_id(options)
-          tag("input", options)
+          tag("input".freeze, options)
         end
 
         class << self
           def field_type
-            @field_type ||= self.name.split("::").last.sub("Field", "").downcase
+            @field_type ||= self.name.split("::".freeze).last.sub("Field".freeze, "".freeze).downcase
           end
         end
 

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -158,7 +158,7 @@ module ActionView
       # name instead of the prefix.
       def normalize_name(name, prefixes) #:nodoc:
         prefixes = prefixes.presence
-        parts    = name.to_s.split('/')
+        parts    = name.to_s.split('/'.freeze)
         parts.shift if parts.first.empty?
         name     = parts.pop
 

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -18,7 +18,7 @@ module ActionView
             src << "@output_buffer.safe_append='"
             src << "\n" * @newline_pending if @newline_pending > 0
             src << escape_text(text)
-            src << "';"
+            src << "'.freeze;"
 
             @newline_pending = 0
           end
@@ -67,7 +67,7 @@ module ActionView
 
         def flush_newline_if_pending(src)
           if @newline_pending > 0
-            src << "@output_buffer.safe_append='#{"\n" * @newline_pending}';"
+            src << "@output_buffer.safe_append='#{"\n" * @newline_pending}'.freeze;"
             @newline_pending = 0
           end
         end

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -42,9 +42,9 @@ module ActiveModel
     # Specify +options+ with additional translating options.
     def human_attribute_name(attribute, options = {})
       options   = { count: 1 }.merge!(options)
-      parts     = attribute.to_s.split(".")
+      parts     = attribute.to_s.split(".".freeze)
       attribute = parts.pop
-      namespace = parts.join("/") unless parts.empty?
+      namespace = parts.join("/".freeze) unless parts.empty?
       attributes_scope = "#{self.i18n_scope}.attributes"
 
       if namespace

--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -87,7 +87,7 @@ module ActiveSupport
       event.end = finished
       event.payload.merge!(payload)
 
-      method = name.split('.').first
+      method = name.split('.'.freeze, 2).first
       send(method, event)
     end
 


### PR DESCRIPTION
Benchmark is here:

  https://github.com/tenderlove/ko1-test-app/blob/d4acd6aba86e3be3a16368296277bc973db8d1a7/perf.rake#L96-L109

I ran it like this:

`KO1TEST_PATH=/users/sign_in RAILS_ENV=production rake -f perf.rake allocated_objects`

It runs against a basic devise login page.

I started with `{:T_STRING=>1688.029}` per request, and after this patch is applied it's `{:T_STRING=>1380.029}` per request.
## Merits
- Eliminates _many_ string object allocations per request
- Savings grow as your ERb templates grow (the patch freezes string literals in ERb templates)
## Demerits
- `freeze` eliminates allocations on Ruby 2.1, but is extra overhead on Ruby <= 2.0
