### PR TITLE
Remove broken Commmand Line guide link

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -56,8 +56,6 @@ Rails will set you up with what seems like a huge amount of stuff for such a tin
 
 The `rails server` command launches a small web server named WEBrick which comes bundled with Ruby. You'll use this any time you want to access your application through a web browser.
 
-INFO: WEBrick isn't your only option for serving Rails. We'll get to that [later](#server-with-different-backends).
-
 With no further work, `rails server` will run our new shiny Rails app:
 
 ```bash


### PR DESCRIPTION
The Ruby on Rails Guides Guide recommends:

> To generate all the guides, just cd into the guides directory, run bundle install and execute: rake guides:generate
> It is also recommended that you work with WARNINGS=1. This detects duplicate IDs and warns about broken    internal links.

Currently, on master, that produces one warning:

```
Generating command_line.md as command_line.html
*** BROKEN LINK: #server-with-different-backends, perhaps you meant #rails-with-databases-and-scm.
```

This PR removes that broken link. I have removed the entire line, because the section it is referring to has been removed (there is no discussion, as far as I can tell, in any Rails Guides about webservers other than Webrick.)
