### PR TITLE
added one test case and example for ActiveRecord::Base.to_param method

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -81,6 +81,10 @@ module ActiveRecord
       #   user.id         # => 123
       #   user_path(user) # => "/users/123-fancy-pants"
       #
+      #   user = User.find_by(name: 'David HeinemeierHansson')
+      #   user.id         # => 125
+      #   user_path(user) # => "/users/125-david"
+      #
       # Because the generated param begins with the record's +id+, it is
       # suitable for passing to +find+. In a controller, for example:
       #

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -34,6 +34,12 @@ class IntegrationTest < ActiveRecord::TestCase
     assert_equal '4-a-a-a-a-a-a-a-a-a', firm.to_param
   end
 
+  def test_to_param_class_method_truncates_edge_case
+    firm = Firm.find(4)
+    firm.name = 'David HeinemeierHansson'
+    assert_equal '4-david', firm.to_param
+  end
+
   def test_to_param_class_method_squishes
     firm = Firm.find(4)
     firm.name = "ab \n" * 100


### PR DESCRIPTION
Follow up to: #12894 

Added One More Example for `ActiveRecord::Base.to_param` to clear the `truncation` effect of the `to_param` method and its test case.
