### PR TITLE
Extend association support in PredicateBuilder AR:B.where to include has_one and has_many

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,32 @@
+*   Support for `where()` queries that use `has_one` and `has_many` keys
+
+    Support for association names in `where` queries previously worked
+    for `belongs_to` associations, but not for `has_many` or `has_one`
+    associations.
+
+    Given:
+
+        class Author < ActiveRecord::Base
+          has_many :posts
+          has_one :post
+        end
+
+    The existing behavior is as follows:
+    In master, we are currently unable to select based on has_one association
+    names, because it uses the wrong table name for the table.
+
+        authors_of_published_posts = Author.where(
+          posts: { id: Post.where(published: true) }
+        ).joins(:posts)
+        authors_has_one_post = Author.where(
+          post: { id: Post.where(published: true) }
+        ).joins(:posts) # => invalid sql
+
+    This commit adds support for this style of where conditions:
+
+        Author.where(posts: Post.where(published: true)).joins(:posts)
+        Author.where(post: Post.where(published: true)).joins(:posts)
+
 *   Better support for `where()` conditions that use a `belongs_to`
     association name.
 

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -144,6 +144,36 @@ module ActiveRecord
       assert_equal expected.to_sql, actual.to_sql
     end
 
+    def test_has_one_where
+      post = Post.new
+      post.id = 1
+
+      expected = Author.where(posts: { id: post.id }).joins(:posts).to_sql
+      actual   = Author.where(post: post).joins(:posts).to_sql
+
+      assert_equal expected, actual
+    end
+
+    def test_has_many_where
+      post = Post.new
+      post.id = 1
+
+      expected = Author.where(posts: { id: post.id }).joins(:posts).to_sql
+      actual   = Author.where(posts: post).joins(:posts).to_sql
+
+      assert_equal expected, actual
+    end
+
+    def test_has_many_polymorphic_where
+      estimate = PriceEstimate.new
+      estimate.id = 1
+
+      expected = Treasure.where(price_estimates: { id: estimate }).joins(:price_estimates).to_sql
+      actual   = Treasure.where(price_estimates: estimate).joins(:price_estimates).to_sql
+
+      assert_equal expected, actual
+    end
+
     def test_aliased_attribute
       expected = Topic.where(heading: 'The First Topic')
       actual   = Topic.where(title: 'The First Topic')


### PR DESCRIPTION
**Description:**

Support for association names in `where` queries previously worked for `belongs_to` associations, but not for `has_one` or `has_many` associations. The SQL generated for `has_one`/`has_many` queries would actually be very confusingly wrong, using the wrong table and column entirely.

Given:

```
class Author < ActiveRecord::Base
  has_many :posts
  has_one :post
end
```

Existing ActiveRecord on master supports the behavior as follows (has_one is not well supported in current master, so an example is not included)

```
authors_of_published_posts = Author.where(posts: { id: Post.where(published: true) }).joins(:posts)
```

This pull request adds support for this style of where conditions, thus filling out the support for association names in queries.

```
Author.where(posts: Post.where(published: true)).joins(:posts)
Author.where(post: Post.where(published: true)).joins(:posts)
```

**Why we need this:**

ActiveRecord currently supports calling `where()` with hash arguments of the form `where(belongs_to_association: <#ActiveRecord::Base ...>)`. This completes that features by generating the correct queries when `has_*` associations are used.

Currently we treat all `has_*` associations as `belongs_to` associations in the query and put the wrong foreign key into the query based on this incorrect assumption.

Adding support for these association keys is straight forward. Every key in the conditions hash already gets `reflect_on_association` called on it. This patch just takes the correct steps for `has_*` associations instead of inserting bad SQL into the query based on a valid assumption by the programmer.
