### PR TITLE
Change Relation#all to Relation#load [ci skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1301,7 +1301,7 @@ especially useful if a `default_scope` is specified in the model and should not 
 applied for this particular query.
 
 ```ruby
-Client.unscoped.all
+Client.unscoped.load
 ```
 
 This method removes all scoping and will do a normal query on the table.


### PR DESCRIPTION
Using `all` method with a `Relation` object is deprecated, so I changed it to `load` method. Original message from rails console:

```
DEPRECATION WARNING: Relation#all is deprecated. If you want to eager-load a relation, 
you can call #load (e.g.`Post.where(published: true).load`). If you want to get an array of 
records from a relation, you can call #to_a (e.g. `Post.where(published: true).to_a`).
```
