### PR TITLE
Fix test_file? function, ./test/**/*_test.rb should be a test file too.

### DIFF
--- a/railties/lib/rails/test_unit/sub_test_task.rb
+++ b/railties/lib/rails/test_unit/sub_test_task.rb
@@ -81,7 +81,7 @@ module Rails
       end
 
       def test_file?(file)
-        file =~ /^(test|\.\/test)/ && File.file?(file) && !File.directory?(file)
+        file =~ /^(\.\/)?test/ && File.file?(file) && !File.directory?(file)
       end
 
       def opt_names

--- a/railties/lib/rails/test_unit/sub_test_task.rb
+++ b/railties/lib/rails/test_unit/sub_test_task.rb
@@ -81,7 +81,7 @@ module Rails
       end
 
       def test_file?(file)
-        file =~ /^test/ && File.file?(file) && !File.directory?(file)
+        file =~ /^(test|\.\/test)/ && File.file?(file) && !File.directory?(file)
       end
 
       def opt_names


### PR DESCRIPTION
`rake test ./test/**/*_test.rb` should be run the single test

``` ruby
require 'test_helper'

class PostTest < ActiveSupport::TestCase
  test "the truth" do
    assert true
  end
end
```

before:

``` ruby
=> rake test ./test/models/post_test.rb
Run options: --seed 7653

# Running:

........

Finished in 0.108402s, 73.7994 runs/s, 129.1489 assertions/s.

8 runs, 14 assertions, 0 failures, 0 errors, 0 skips
```

after:

``` ruby
=> rake test ./test/models/post_test.rb
Run options: --seed 8353

# Running:

.

Finished in 0.006665s, 150.0375 runs/s, 150.0375 assertions/s.

1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```
