### PR TITLE
Test order dependency fixes

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -624,20 +624,24 @@ class FixturesBrokenRollbackTest < ActiveRecord::TestCase
 end
 
 class LoadAllFixturesTest < ActiveRecord::TestCase
-  self.fixture_path = FIXTURES_ROOT + "/all"
-  fixtures :all
-
   def test_all_there
+    self.class.fixture_path = FIXTURES_ROOT + "/all"
+    self.class.fixtures :all
+
     assert_equal %w(admin/accounts admin/users developers people tasks), fixture_table_names.sort
+  ensure
+    ActiveRecord::FixtureSet.reset_cache
   end
 end
 
 class LoadAllFixturesWithPathnameTest < ActiveRecord::TestCase
-  self.fixture_path = Pathname.new(FIXTURES_ROOT).join('all')
-  fixtures :all
-
   def test_all_there
+    self.class.fixture_path = Pathname.new(FIXTURES_ROOT).join('all')
+    self.class.fixtures :all
+
     assert_equal %w(admin/accounts admin/users developers people tasks), fixture_table_names.sort
+  ensure
+    ActiveRecord::FixtureSet.reset_cache
   end
 end
 

--- a/activerecord/test/cases/validations/i18n_generate_message_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_generate_message_validation_test.rb
@@ -55,22 +55,30 @@ class I18nGenerateMessageValidationTest < ActiveRecord::TestCase
   end
 
   test "translation for 'taken' can be overridden" do
-    I18n.backend.store_translations "en", {errors: {attributes: {title: {taken: "Custom taken message" }}}}
-    assert_equal "Custom taken message", @topic.errors.generate_message(:title, :taken, :value => 'title')
+    reset_i18n_load_path do
+      I18n.backend.store_translations "en", {errors: {attributes: {title: {taken: "Custom taken message" }}}}
+      assert_equal "Custom taken message", @topic.errors.generate_message(:title, :taken, :value => 'title')
+    end
   end
 
   test "translation for 'taken' can be overridden in activerecord scope" do
-    I18n.backend.store_translations "en", {activerecord: {errors: {messages: {taken: "Custom taken message" }}}}
-    assert_equal "Custom taken message", @topic.errors.generate_message(:title, :taken, :value => 'title')
+    reset_i18n_load_path do
+      I18n.backend.store_translations "en", {activerecord: {errors: {messages: {taken: "Custom taken message" }}}}
+      assert_equal "Custom taken message", @topic.errors.generate_message(:title, :taken, :value => 'title')
+    end
   end
 
   test "translation for 'taken' can be overridden in activerecord model scope" do
-    I18n.backend.store_translations "en", {activerecord: {errors: {models: {topic: {taken: "Custom taken message" }}}}}
-    assert_equal "Custom taken message", @topic.errors.generate_message(:title, :taken, :value => 'title')
+    reset_i18n_load_path do
+      I18n.backend.store_translations "en", {activerecord: {errors: {models: {topic: {taken: "Custom taken message" }}}}}
+      assert_equal "Custom taken message", @topic.errors.generate_message(:title, :taken, :value => 'title')
+    end
   end
 
   test "translation for 'taken' can be overridden in activerecord attributes scope" do
-    I18n.backend.store_translations "en", {activerecord: {errors: {models: {topic: {attributes: {title: {taken: "Custom taken message" }}}}}}}
-    assert_equal "Custom taken message", @topic.errors.generate_message(:title, :taken, :value => 'title')
+    reset_i18n_load_path do
+      I18n.backend.store_translations "en", {activerecord: {errors: {models: {topic: {attributes: {title: {taken: "Custom taken message" }}}}}}}
+      assert_equal "Custom taken message", @topic.errors.generate_message(:title, :taken, :value => 'title')
+    end
   end
 end


### PR DESCRIPTION
Worked with @tenderlove today to fix the rest of the test order dependency issues across the rails tests. This will allow us to remove the monkeypatch on minitest in activesupport/lib/active_support/test_case.rb

I can't run all the tests because I don't have all the databases set up, but this gives me a clean run on activesupport, which is where I had the most problems when I originally put the monkeypatch in.
