### PR TITLE
Added Object#not_in? for better readability and convenience

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Added `Object#not_in?` method for better readability and convenience.
+
+    Example:
+
+        profiles = ['developer', 'tester', 'designer']
+        'artist'.not_in?(profiles) # => true
+
+    *Kuldeep Aggarwal*
+
 *   Unify `cattr_*` interface: allow to pass a block to `cattr_reader`.
 
     Example:

--- a/activesupport/lib/active_support/core_ext/object/exclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/exclusion.rb
@@ -1,0 +1,15 @@
+class Object
+  # Returns true if this object is not included in the argument. Argument must
+  # be any object which responds to +#include?+. Usage:
+  #
+  #   profiles = ['developer', 'tester', 'designer']
+  #   'artist'.not_in?(profiles) # => true
+  #
+  # This will throw an ArgumentError if the argument doesn't respond
+  # to +#include?+.
+  def not_in?(another_object)
+    !another_object.include?(self)
+  rescue NoMethodError
+    raise ArgumentError.new("The parameter passed to #not_in? must respond to #include?")
+  end
+end

--- a/activesupport/test/core_ext/object/exclusion_test.rb
+++ b/activesupport/test/core_ext/object/exclusion_test.rb
@@ -1,0 +1,50 @@
+require 'abstract_unit'
+require 'active_support/core_ext/object/exclusion'
+
+class NotInTest < ActiveSupport::TestCase
+  def test_in_array
+    assert 3.not_in?([1,2])
+    assert !1.not_in?([1,2])
+  end
+
+  def test_in_hash
+    h = { a: 100, b: 200 }
+    assert !:a.not_in?(h)
+    assert :z.not_in?(h)
+  end
+
+  def test_in_string
+    assert !"lo".not_in?("hello")
+    assert "ol".not_in?("hello")
+    assert !?h.not_in?("hello")
+  end
+
+  def test_in_range
+    assert !25.not_in?(1..50)
+    assert 75.not_in?(1..50)
+  end
+
+  def test_in_set
+    s = Set.new([1,2])
+    assert !1.not_in?(s)
+    assert 3.not_in?(s)
+  end
+
+  module A
+  end
+  class B
+    include A
+  end
+  class C < B
+  end
+
+  def test_in_module
+    assert !A.not_in?(B)
+    assert !A.not_in?(C)
+    assert A.not_in?(A)
+  end
+  
+  def test_no_method_catching
+    assert_raise(ArgumentError) { 1.not_in?(1) }
+  end
+end


### PR DESCRIPTION
numbers = [1, 2, 4]
a = 4
if a > 3 and !a.in?(numbers)
  #.....
end

now it can be written as and will be more readable:

if a > 3 and a.not_in?(numbers)
  #.....
end
