### PR TITLE
Remove outdated info about chaining #unscope with a #scope [ci skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1306,8 +1306,8 @@ Client.unscoped.load
 
 This method removes all scoping and will do a normal query on the table.
 
-Note that chaining `unscoped` with a `scope` does not work. In these cases, it is
-recommended that you use the block form of `unscoped`:
+Alternatively, you can also pass a block to the `unscoped` method to generate
+several queries removing any default scope:
 
 ```ruby
 Client.unscoped {


### PR DESCRIPTION
Deleted lines says: _"chaining unscoped with a scope does not work"_, but it works. `#unscoped` method returns an `ActiveRecord::Relation` object everytime, so we can chain another scope with it.
