### PR TITLE
Make fixtures generate IDs according to their limit

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Make fixtures generate IDs according to the defined limit
+
+    If the primary key field's limit was defined at the schema definition
+    level, previously fixtures would generate a random ID which maximum
+    would be 2^30 - 1 and would not take the limit into account.
+
+    Fixes #12901.
+
+    *Robin Dupret*, *Jacob Evan Shreve*, *Anton Kalyaev*
+
 *   Polymorphic `belongs_to` associations with the `touch: true` option set update the timestamps of
     the old and new owner correctly when moved between owners of different types.
 

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -671,7 +671,8 @@ class FasterFixturesTest < ActiveRecord::TestCase
 end
 
 class FoxyFixturesTest < ActiveRecord::TestCase
-  fixtures :parrots, :parrots_pirates, :pirates, :treasures, :mateys, :ships, :computers, :developers, :"admin/accounts", :"admin/users"
+  fixtures :parrots, :parrots_pirates, :pirates, :treasures, :mateys, :ships,
+           :computers, :developers, :"admin/accounts", :"admin/users", :binaries
 
   def test_identifies_strings
     assert_equal(ActiveRecord::FixtureSet.identify("foo"), ActiveRecord::FixtureSet.identify("foo"))
@@ -685,6 +686,12 @@ class FoxyFixturesTest < ActiveRecord::TestCase
   def test_identifies_consistently
     assert_equal 207281424, ActiveRecord::FixtureSet.identify(:ruby)
     assert_equal 1066363776, ActiveRecord::FixtureSet.identify(:sapphire_2)
+  end
+
+  def test_identifies_on_id_fields_with_limit
+    # The id field has a limit of 3
+    fixture = ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, "binaries")
+    assert Binary.last.id <= 2 ** (3 * 8 - 1)
   end
 
   TIMESTAMP_COLUMNS = %w(created_at created_on updated_at updated_on)

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -79,7 +79,8 @@ ActiveRecord::Schema.define do
     t.integer     :value
   end
 
-  create_table :binaries, force: true do |t|
+  create_table :binaries, force: true, id: false do |t|
+    t.primary_key :id, :primary_key, limit: 3
     t.string :name
     t.binary :data
     t.binary :short_data, limit: 2048
@@ -803,7 +804,6 @@ ActiveRecord::Schema.define do
     t.string :employable_type
     t.integer :department_id
   end
-
 
   except 'SQLite' do
     # fk_test_has_fk should be before fk_test_has_pk


### PR DESCRIPTION
Hello,

If the primary key field's limit was defined at the schema definition level, previously fixtures would generate a random ID which maximum would be 2^30 - 1 and would not take into account the limit.

Fixes #12901

Have a nice day.
