### PR TITLE
Checks to see if the record contains the foreign_key to set the inverse automatically

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Checks to see if the record contains the foreign_key to set the inverse automatically
+
+    *Edo Balvers*
+
 *   `.unscope` now removes conditions specified in `default_scope`.
 
     *Jon Leighton*

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -226,7 +226,12 @@ module ActiveRecord
         # Returns true if inverse association on the given record needs to be set.
         # This method is redefined by subclasses.
         def invertible_for?(record)
-          inverse_reflection_for(record)
+          foreign_key_for?(record) && inverse_reflection_for(record)
+        end
+
+        # Returns true if record contains the foreign_key
+        def foreign_key_for?(record)
+          record.attributes.has_key? reflection.foreign_key
         end
 
         # This should be implemented to return the values of the relevant key(s) on the owner,

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -460,6 +460,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal ['id'], posts(:welcome).comments.select(:id).first.attributes.keys
   end
 
+   def test_select_without_foreign_key
+    assert_equal companies(:first_firm).accounts.first.credit_limit, companies(:first_firm).accounts.select(:credit_limit).first.credit_limit
+   end
+
   def test_adding
     force_signal37_to_load_all_clients_of_firm
     natural = Client.new("name" => "Natural Company")


### PR DESCRIPTION
Fixes #12866: if the record attributes do not contain the foreign_key as a consequence of a limited select, it should not automatically set the inverse relation.
