### PR TITLE
Fix reverse of record_state after rollback

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix reverse of record state (new_record and id) after rollback
+
+    Fixes #7807
+
+    *Ivan Antropov*
+
 *   Previously, the `has_one` macro incorrectly accepted the `counter_cache`
     option, but never actually supported it. Now it will raise an `ArgumentError`
     when using `has_one` with `counter_cache`.

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -118,7 +118,7 @@ module ActiveRecord
       end
 
       def add_record(record)
-        if record.has_transactional_callbacks?
+        if record.has_transactional_callbacks? || record.has_remembered_start_transaction_state?
           records << record
         else
           record.set_transaction_state(@state)

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -337,11 +337,17 @@ module ActiveRecord
       status
     end
 
+    def has_remembered_start_transaction_state?
+      @_start_transaction_state.any?
+    end
+
     protected
 
     # Save the new record state and id of a record so it can be restored later if a transaction fails.
     def remember_transaction_record_state #:nodoc:
-      @_start_transaction_state[:id] = id if has_attribute?(self.class.primary_key)
+      if has_attribute?(self.class.primary_key) && !@_start_transaction_state.include?(:id)
+        @_start_transaction_state[:id] = id
+      end
       unless @_start_transaction_state.include?(:new_record)
         @_start_transaction_state[:new_record] = @new_record
       end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -566,8 +566,6 @@ class TestDefaultAutosaveAssociationOnNewRecord < ActiveRecord::TestCase
 end
 
 class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
-
   def setup
     super
     @pirate = Pirate.create(:catchphrase => "Don' botharrr talkin' like one, savvy?")

--- a/activerecord/test/cases/habtm_destroy_order_test.rb
+++ b/activerecord/test/cases/habtm_destroy_order_test.rb
@@ -3,6 +3,8 @@ require "models/lesson"
 require "models/student"
 
 class HabtmDestroyOrderTest < ActiveRecord::TestCase
+  self.use_transactional_fixtures = false
+
   test "may not delete a lesson with students" do
     sicp = Lesson.new(:name => "SICP")
     ben = Student.new(:name => "Ben Bitdiddle")

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -5,6 +5,7 @@ require 'models/developer'
 require 'models/book'
 require 'models/author'
 require 'models/post'
+require 'models/binary'
 
 class TransactionTest < ActiveRecord::TestCase
   self.use_transactional_fixtures = false
@@ -520,6 +521,24 @@ class TransactionTest < ActiveRecord::TestCase
 
     assert !transaction.state.rolledback?
     assert transaction.state.committed?
+  end
+
+  def test_transactions_state_after_rollback
+    binary = Binary.new
+    assert_equal true, binary.instance_eval { @new_record }
+    assert_nil binary.id
+
+    begin
+      Binary.transaction do
+        binary.save!
+        binary.save!
+        raise "exception"
+      end
+    rescue
+    end
+
+    assert_equal true, binary.instance_eval { @new_record }
+    assert_nil binary.id
   end
 
   private


### PR DESCRIPTION
Fix reverse of record_state(new_record and id) after rollback.
Fix #7807
