### PR TITLE
#compute_asset_host - return nil if host is not defined

### DIFF
--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -194,7 +194,9 @@ module ActionView
         host = config.asset_host if defined? config.asset_host
         host ||= request.base_url if request && options[:protocol] == :request
 
-        if host.respond_to?(:call)
+        if !(defined? host)
+          return
+        elsif host.respond_to?(:call)
           arity = host.respond_to?(:arity) ? host.arity : host.method(:call).arity
           args = [source]
           args << request if request && (arity > 1 || arity < 0)


### PR DESCRIPTION
`compute_asset_host` may raise `NameError` exception when
1. `config.asset_host` is not defined, and
2. `request` is not set OR `options[:protocol]` is other than `:request`
