### PR TITLE
Drop unused param `should_be_quoted` to `PostgreSQLColumn#array_to_string`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -67,7 +67,7 @@ module ActiveRecord
           end
         end
 
-        def array_to_string(value, column, adapter, should_be_quoted = false)
+        def array_to_string(value, column, adapter)
           casted_values = value.map do |val|
             if String === val
               if val == "NULL"


### PR DESCRIPTION
Drop unused param `should_be_quoted` to `PostgreSQLColumn#array_to_string`
