### PR TITLE
Address test_merging_where_relations failure by adding order

### DIFF
--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -135,7 +135,7 @@ class MergingDifferentRelationsTest < ActiveRecord::TestCase
 
   test "merging where relations" do
     hello_by_bob = Post.where(body: "hello").joins(:author).
-      merge(Author.where(name: "Bob")).pluck("posts.id")
+      merge(Author.where(name: "Bob")).order("posts.id").pluck("posts.id")
 
     assert_equal [posts(:misc_by_bob).id,
                   posts(:other_by_bob).id], hello_by_bob


### PR DESCRIPTION
This pull request addresses the following failure tested with Oracle enhanced adapter.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/relation/merging_test.rb -n test_merging_where_relations
Using oracle
Run options: -n test_merging_where_relations --seed 27043

# Running:

F

Finished in 0.205834s, 4.8583 runs/s, 4.8583 assertions/s.

  1) Failure:
MergingDifferentRelationsTest#test_merging_where_relations [test/cases/relation/merging_test.rb:140]:
Expected: [8, 10]
  Actual: [10, 8]

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

This is because in relational database, query results do not guarantee any order without order by statement.
In my test environment Oracle does not return as other database does.

i.e.
- The generated SQL statement and its results by PostgreSQL adapter without this patch

``` sql
activerecord_unittest=# SELECT posts.id FROM "posts" INNER JOIN "authors" ON "authors"."id" = "posts"."author_id" WHERE "posts"."body" = 'hello' AND "authors"."name" = 'Bob';
 id
----
  8
 10
(2 rows)

activerecord_unittest=#
```
- The generated SQL statement and its results by Oracle enhanced adapter without this patch

``` sql
SQL> SELECT posts.id FROM "POSTS" INNER JOIN "AUTHORS" ON "AUTHORS"."ID" = "POSTS"."AUTHOR_ID" WHERE "POSTS"."BODY" = 'hello' AND "AUTHORS"."NAME" = 'Bob';

    ID
----------
    10
     8

SQL>
```

By adding `order("posts.id")` in this testcase, this test successfuly finishes every sqlite3, mysql, mysql2, postgresql and oracle-enhanced adapters.
- Generated PostgreSQL adapter SQL statement with this patch

``` sql
SELECT posts.id FROM "posts" INNER JOIN "authors" ON "authors"."id" = "posts"."author_id" WHERE "posts"."body" = 'hello' AND "authors"."name" = 'Bob' ORDER BY posts.id
```
- Generated Oracle enhanced adapter SQL statement with this patch

``` sql
SELECT posts.id FROM "POSTS" INNER JOIN "AUTHORS" ON "AUTHORS"."ID" = "POSTS"."AUTHOR_ID" WHERE "POSTS"."BODY" = 'hello' AND "AUTHORS"."NAME" = 'Bob' ORDER BY posts.id
```

I was thinking and trying to find to compare methods to compare each array elements ignoring its order but was not able to find one.
