### PR TITLE
Do not count query for all_constraints and all_tab_cols tested with Oracle

### DIFF
--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -77,7 +77,7 @@ module ActiveRecord
     # FIXME: this needs to be refactored so specific database can add their own
     # ignored SQL, or better yet, use a different notification for the queries
     # instead examining the SQL content.
-    oracle_ignored     = [/^select .*nextval/i, /^SAVEPOINT/, /^ROLLBACK TO/, /^\s*select .* from all_triggers/im]
+    oracle_ignored     = [/^select .*nextval/i, /^SAVEPOINT/, /^ROLLBACK TO/, /^\s*select .* from all_triggers/im, /^\s*select .* from all_constraints/im, /^\s*select .* from all_tab_cols/im]
     mysql_ignored      = [/^SHOW TABLES/i, /^SHOW FULL FIELDS/, /^SHOW CREATE TABLE /i]
     postgresql_ignored = [/^\s*select\b.*\bfrom\b.*pg_namespace\b/im, /^\s*select\b.*\battname\b.*\bfrom\b.*\bpg_attribute\b/im, /^SHOW search_path/i]
     sqlite3_ignored =    [/^\s*SELECT name\b.*\bFROM sqlite_master/im]


### PR DESCRIPTION
This pull request addresses following failures when tested with Oracle database.
Queries for metadata such as all_constraints and all_tab_cols sometimes cause failures for these tests.
- Query for all_constraints cause failure

``` ruby
  4) Failure:
DirtyTest#test_partial_update [/home/yahonda/git/rails/activerecord/test/cases/dirty_test.rb:349]:
3 instead of 2 queries were executed.
Queries:
INSERT INTO "PIRATES" ("CATCHPHRASE", "CREATED_ON", "ID", "NON_VALIDATED_PARROT_ID", "PARROT_ID", "UPDATED_ON") VALUES (:a1, :a2, :a3, :a4, :a5, :a6)
SELECT cc.column_name FROM all_constraints c, all_cons_columns cc WHERE c.owner = 'ARUNIT' AND c.table_name = 'PIRATES' AND c.constraint_type = 'P' AND cc.owner = c.owner AND cc.constraint_name = c.constraint_name
UPDATE "PIRATES" SET "CATCHPHRASE" = :a1, "CREATED_ON" = :a2, "ID" = :a3, "NON_VALIDATED_PARROT_ID" = :a4, "PARROT_ID" = :a5, "UPDATED_ON" = :a6 WHERE "PIRATES"."ID" = 10007.
Expected: 2
  Actual: 3
```
- Query for all_tab_cols cause failure

``` ruby
7) Failure:
EachTest#test_find_in_batches_should_use_any_column_as_primary_key_when_start_is_not_specified [/home/yahonda/git/rails/activerecord/test/cases/batches_test.rb:167]:
5 instead of 4 queries were executed.
Queries:
SELECT * FROM (SELECT "SUBSCRIBERS".* FROM "SUBSCRIBERS" ORDER BY "SUBSCRIBERS"."NICK" ASC) WHERE ROWNUM <= 1
SELECT column_name AS name, data_type AS sql_type, data_default, nullable, virtual_column, hidden_column, data_type_owner AS sql_type_owner, DECODE(data_type, 'NUMBER', data_precision, 'FLOAT', data_precision, 'VARCHAR2', DECODE(char_used, 'C', char_length, data_length), 'RAW', DECODE(char_used, 'C', char_length, data_length), 'CHAR', DECODE(char_used, 'C', char_length, data_length), NULL) AS limit, DECODE(data_type, 'NUMBER', data_scale, NULL) AS scale FROM all_tab_cols WHERE owner = 'ARUNIT' AND table_name = 'SUBSCRIBERS' AND hidden_column = 'NO' ORDER BY column_id
SELECT * FROM (SELECT "SUBSCRIBERS".* FROM "SUBSCRIBERS" WHERE ("SUBSCRIBERS"."NICK" > 'alterself') ORDER BY "SUBSCRIBERS"."NICK" ASC) WHERE ROWNUM <= 1
SELECT * FROM (SELECT "SUBSCRIBERS".* FROM "SUBSCRIBERS" WHERE ("SUBSCRIBERS"."NICK" > 'swistak') ORDER BY "SUBSCRIBERS"."NICK" ASC) WHERE ROWNUM <= 1
SELECT * FROM (SELECT "SUBSCRIBERS".* FROM "SUBSCRIBERS" WHERE ("SUBSCRIBERS"."NICK" > 'webster132') ORDER BY "SUBSCRIBERS"."NICK" ASC) WHERE ROWNUM <= 1.
Expected: 4
Actual: 5
```

There are other failures caused by other reasons with Oracle enhanced adapter. then please ignore 4) or 7) .

This commit does not cause regressions for all bundled adapters.
