### PR TITLE
avoiding the call on String#join

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -196,9 +196,9 @@ module ActionDispatch # :nodoc:
     # Returns the content of the response as a string. This contains the contents
     # of any calls to <tt>render</tt>.
     def body
-      strings = []
-      each { |part| strings << part.to_s }
-      strings.join
+      string = ''
+      each { |part| string << part.to_s }
+      string
     end
 
     EMPTY = " "


### PR DESCRIPTION
For the code given below:

``` ruby
require 'rubygems'
require 'benchmark'

string_array = ['a', 'b', 'c', 'd']

def old_method(string_array)
  strings = []
  string_array.each { |part| strings << part.to_s }
  strings.join
end

def new_method(string_array)
  string = ''
  string_array.each { |part| string << part.to_s }
  string  
end



TIMES = 500_000
Benchmark.bmbm do |b|
  b.report('old') do
    TIMES.times do
      old_method(string_array)
    end
  end

  b.report('new') do
    TIMES.times do
      new_method(string_array)
    end
  end
end
```

Benchmark results are:

```
Rehearsal ---------------------------------------
old   0.710000   0.020000   0.730000 (  0.736706)
new   0.440000   0.000000   0.440000 (  0.438176)
------------------------------ total: 1.170000sec

          user     system      total        real
old   0.730000   0.020000   0.750000 (  0.755124)
new   0.430000   0.000000   0.430000 (  0.435200)
```
