### PR TITLE
Creates multiline_link_to_unless_current

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -328,6 +328,7 @@ module ActionView
       # specialize the default behavior (e.g., show a "Start Here" link rather
       # than the link's text).
       #
+      #
       # ==== Examples
       # Let's say you have a navigation menu...
       #
@@ -361,6 +362,27 @@ module ActionView
       #     %>
       def link_to_unless_current(name, options = {}, html_options = {}, &block)
         link_to_unless current_page?(options), name, options, html_options, &block
+      end
+
+      # Creates a link tag with the result of yielding the block, unless the current
+      # request URI is the same as the links, in which case only the result of yielding
+      # the block is returned.
+      #
+      # ==== Examples
+      # If you want to create a link with html elements inside, you can do:
+      #
+      #    <%= multiline_link_to_unless_current({action: "index"}) do %>
+      #           <p>This is an explanation of the link<p>
+      #           <span>Go Back</span>
+      #    <% end %>
+      def multiline_link_to_unless_current(options = {}, html_options = {}, &block)
+        raise ArgumentError, "missing a block" unless block_given?
+
+        if current_page?(options)
+          block.arity <= 1 ? capture(&block) : capture(options, html_options, &block)
+        else
+          link_to options, html_options, &block
+        end
       end
 
       # Creates a link tag of the given +name+ using a URL created by the set of

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -473,6 +473,19 @@ class UrlHelperTest < ActiveSupport::TestCase
       link_to_unless_current("Listing", "http://www.example.com/")
   end
 
+  def test_multiline_link_unless_current
+    @request = request_for_url("/show")
+
+    assert_equal %{<a href="http://www.example.com/"><p>This is an explanation of the link</p><span>Listing</span></a>},
+      multiline_link_to_unless_current("http://www.example.com/") {
+        "<p>This is an explanation of the link</p><span>Listing</span>".html_safe
+      }
+    assert_equal %{<a href="/"><p>This is an explanation of the link</p><span>Listing</span></a>},
+      multiline_link_to_unless_current("/") {
+        "<p>This is an explanation of the link</p><span>Listing</span>".html_safe
+      }
+  end
+
   def test_mail_to
     assert_dom_equal %{<a href="mailto:david@loudthinking.com">david@loudthinking.com</a>}, mail_to("david@loudthinking.com")
     assert_dom_equal %{<a href="mailto:david@loudthinking.com">David Heinemeier Hansson</a>}, mail_to("david@loudthinking.com", "David Heinemeier Hansson")


### PR DESCRIPTION
Allows the same idea of `link_to_unless_current`, but for
links with multiple HTML elements.
