### PR TITLE
random test order fixes for PostgreSQL

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -49,6 +49,7 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     ensure
       # Restore column(s) dropped by `drop extension hstore cascade;`
       load_schema
+      ActiveRecord::FixtureSet.reset_cache
     end
 
     def test_column

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -35,6 +35,8 @@ class DefaultTest < ActiveRecord::TestCase
       # older postgres versions represent the default with escapes ("\\012" for a newline)
       assert( "--- []\n\n" == Default.columns_hash['multiline_default'].default ||
                "--- []\\012\\012" == Default.columns_hash['multiline_default'].default)
+    ensure
+      Default.reset_column_information
     end
   end
 end

--- a/activerecord/test/cases/reload_models_test.rb
+++ b/activerecord/test/cases/reload_models_test.rb
@@ -6,6 +6,8 @@ class ReloadModelsTest < ActiveRecord::TestCase
   fixtures :pets
 
   def test_has_one_with_reload
+    old_owner_class = Owner
+
     pet = Pet.find_by_name('parrot')
     pet.owner = Owner.find_by_name('ashley')
 
@@ -18,5 +20,8 @@ class ReloadModelsTest < ActiveRecord::TestCase
     pet = Pet.find_by_name('parrot')
     pet.owner = Owner.find_by_name('ashley')
     assert_equal pet.owner, Owner.find_by_name('ashley')
+
+    Object.class_eval { remove_const :Owner }
+    Object.class_eval { const_set :Owner, old_owner_class }
   end
 end


### PR DESCRIPTION
I fixed some failing test cases (not ALL) while running the tests in random order. 
