### PR TITLE
drop extra variable creation and change `map` to `map!` to prevent new a...

### DIFF
--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -96,8 +96,7 @@ module ActionController
       def all_helpers_from_path(path)
         helpers = Array(path).flat_map do |_path|
           extract = /^#{Regexp.quote(_path.to_s)}\/?(.*)_helper.rb$/
-          names = Dir["#{_path}/**/*_helper.rb"].map { |file| file.sub(extract, '\1') }
-          names.sort!
+          Dir["#{_path}/**/*_helper.rb"].map! { |file| file.sub(extract, '\1') }.sort!
         end
         helpers.uniq!
         helpers


### PR DESCRIPTION
...rray creation using `map`
