### PR TITLE
avoid merging when value is blank i.e. {}

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -433,7 +433,7 @@ module ActionMailer
       #
       # Aliased by ::default_options=
       def default(value = nil)
-        self.default_params = default_params.merge(value).freeze if value
+        self.default_params = default_params.merge(value).freeze if value.present?
         default_params
       end
       # Allows to set defaults through app configuration:


### PR DESCRIPTION
For the code given below:

``` ruby
require 'rubygems'
require 'benchmark'

default_params = { 'a' => 1, 'b' => 2 }
value = {}

TIMES = 500_000
Benchmark.bmbm do |b|
  b.report('old') do
    TIMES.times do
      default_params.merge(value).freeze if value
    end
  end

  b.report('new') do
    TIMES.times do
      default_params.merge(value).freeze if value.present?
    end
  end
end
```

Benchmark results are:

```
Rehearsal ---------------------------------------
old   0.970000   0.010000   0.980000 (  0.968846)
new   0.060000   0.000000   0.060000 (  0.059513)
------------------------------ total: 1.040000sec

          user     system      total        real
old   0.940000   0.000000   0.940000 (  0.951799)
new   0.060000   0.000000   0.060000 (  0.060904)
```
