### PR TITLE
Postgres schema: Constrain sequence search classid

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -6,6 +6,11 @@
 
     *Matthew Draper*
 
+*   `pk_and_sequence_for` now ensures that only the pg_depend entries
+    pointing to pg_class, and thus only sequence objects, are considered.
+
+    *Josh Williams*
+
 *   `where.not` adds `references` for `includes` like normal `where` calls do.
 
     Fixes #14406.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -327,6 +327,7 @@ module ActiveRecord
               AND attr.attrelid     = cons.conrelid
               AND attr.attnum       = cons.conkey[1]
               AND cons.contype      = 'p'
+              AND dep.classid       = 'pg_class'::regclass
               AND dep.refobjid      = '#{quote_table_name(table)}'::regclass
           end_sql
 


### PR DESCRIPTION
The pk_an_sequence_for query previously joined against pg_class's oid
for rows in pg_depend, but pg_depend's objid may point to other system
tables, such as pg_attrdef.  If a row in one of those other tables
coincidentally has the same oid as an (unrelated) sequence, that
sequence name may be returned instead of the real one.

This ensures that only the pg_depend entries pointing to pg_class are
considered.
