### PR TITLE
Explicitly exit with status "1" for create and drop failures

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Exit with non-zero status for failed database rake tasks.
+
+    *Jay Hayes*
+
 *   Remove deprecated method `ActiveRecord::Base.quoted_locking_column`.
 
     *Akshay Vishnoi*

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -88,9 +88,11 @@ module ActiveRecord
         class_for_adapter(configuration['adapter']).new(*arguments).create
       rescue DatabaseAlreadyExists
         $stderr.puts "#{configuration['database']} already exists"
+        raise
       rescue Exception => error
         $stderr.puts error, *(error.backtrace)
         $stderr.puts "Couldn't create database for #{configuration.inspect}"
+        raise
       end
 
       def create_all
@@ -110,6 +112,7 @@ module ActiveRecord
       rescue Exception => error
         $stderr.puts error, *(error.backtrace)
         $stderr.puts "Couldn't drop #{configuration['database']}"
+        raise
       end
 
       def drop_all

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -1,4 +1,5 @@
 require 'cases/helper'
+require 'active_record/tasks/database_tasks'
 
 module ActiveRecord
   class MysqlDBCreateTest < ActiveRecord::TestCase
@@ -61,7 +62,9 @@ module ActiveRecord
         ActiveRecord::StatementInvalid.new("Can't create database 'dev'; database exists:")
       )
 
-      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+      assert_raises(ActiveRecord::Tasks::DatabaseAlreadyExists) do
+        ActiveRecord::Tasks::DatabaseTasks.create @configuration
+      end
     end
   end
 

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -1,4 +1,5 @@
 require 'cases/helper'
+require 'active_record/tasks/database_tasks'
 
 module ActiveRecord
   class PostgreSQLDBCreateTest < ActiveRecord::TestCase
@@ -59,7 +60,9 @@ module ActiveRecord
       $stderr.expects(:puts).
         with("Couldn't create database for #{@configuration.inspect}")
 
-      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+      assert_raises(Exception) do
+        ActiveRecord::Tasks::DatabaseTasks.create @configuration
+      end
     end
 
     def test_create_when_database_exists_outputs_info_to_stderr
@@ -69,7 +72,9 @@ module ActiveRecord
         ActiveRecord::StatementInvalid.new('database "my-app-db" already exists')
       )
 
-      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+      assert_raises(ActiveRecord::Tasks::DatabaseAlreadyExists) do
+        ActiveRecord::Tasks::DatabaseTasks.create @configuration
+      end
     end
   end
 

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -1,5 +1,6 @@
 require 'cases/helper'
 require 'pathname'
+require 'active_record/tasks/database_tasks'
 
 module ActiveRecord
   class SqliteDBCreateTest < ActiveRecord::TestCase
@@ -27,7 +28,9 @@ module ActiveRecord
 
       $stderr.expects(:puts).with("#{@database} already exists")
 
-      ActiveRecord::Tasks::DatabaseTasks.create @configuration, '/rails/root'
+      assert_raises(ActiveRecord::Tasks::DatabaseAlreadyExists) do
+        ActiveRecord::Tasks::DatabaseTasks.create @configuration, '/rails/root'
+      end
     end
 
     def test_db_create_with_file_does_nothing
@@ -36,7 +39,9 @@ module ActiveRecord
 
       ActiveRecord::Base.expects(:establish_connection).never
 
-      ActiveRecord::Tasks::DatabaseTasks.create @configuration, '/rails/root'
+      assert_raises(ActiveRecord::Tasks::DatabaseAlreadyExists) do
+        ActiveRecord::Tasks::DatabaseTasks.create @configuration, '/rails/root'
+      end
     end
 
     def test_db_create_establishes_a_connection
@@ -52,7 +57,9 @@ module ActiveRecord
       $stderr.expects(:puts).
         with("Couldn't create database for #{@configuration.inspect}")
 
-      ActiveRecord::Tasks::DatabaseTasks.create @configuration, '/rails/root'
+      assert_raises(Exception) do
+        ActiveRecord::Tasks::DatabaseTasks.create @configuration, '/rails/root'
+      end
     end
   end
 


### PR DESCRIPTION
Second attempt at this PR. This feature was merged previously and subsequently [reverted](https://github.com/rails/rails/commit/728096542aef4820440b2d758cfdc579b399f1e6) due to a [change in functionality for `db:setup`](https://github.com/rails/rails/commit/22f80ae57b26907f662b7fd50a7270a6381e527e#commitcomment-4640676).

---

The regression was due to rake failing out early for required tasks in the pipeline of `db:setup`. My fix was to create a "soft fail" version of `db:create` (`db:try_create`) that is used in that pipeline to prevent early failure. For the sake of DRY, I also created an undocumented `db:create!` which does not suppress the stacktrace. Is that sane?

Also I noticed a curious thing in the dependencies of some of the nested tasks. I'll leave a comment in the code for input. I didn't want another change to affect this PR.

cc @rafaelfranca, @rubys
