### PR TITLE
Install Spring preloader when generating new applications

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   The [Spring application
+    preloader](https://github.com/jonleighton/spring) is now installed
+    by default for new applications. It uses the development group of
+    the Gemfile, so will not be installed in production.
+
+    *Jon Leighton*
+
 *   Uses .railsrc while creating new plugin if it is available.
     Fixes #10700.
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -237,6 +237,7 @@ module Rails
 
       public_task :run_bundle
       public_task :replay_template
+      public_task :generate_spring_binstubs
 
     protected
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -437,6 +437,34 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "foo bar/config/initializers/session_store.rb", /key: '_foo_bar/
   end
 
+  def test_spring
+    run_generator
+    assert_file "Gemfile", /gem 'spring'/
+  end
+
+  def test_spring_binstubs
+    generator.stubs(:bundle_command).with('install')
+    generator.expects(:bundle_command).with('exec spring binstub --all').once
+    quietly { generator.invoke_all }
+  end
+
+  def test_spring_no_fork
+    Process.stubs(:respond_to?).with(:fork).returns(false)
+    run_generator
+
+    assert_file "Gemfile" do |content|
+      assert_no_match(/spring/, content)
+    end
+  end
+
+  def test_skip_spring
+    run_generator [destination_root, "--skip-spring"]
+
+    assert_file "Gemfile" do |content|
+      assert_no_match(/spring/, content)
+    end
+  end
+
 protected
 
   def action(*args, &block)

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -26,9 +26,15 @@ module SharedGeneratorTests
     default_files.each { |path| assert_file path }
   end
 
-  def test_generation_runs_bundle_install
-    generator([destination_root]).expects(:bundle_command).with('install').once
+  def assert_generates_with_bundler(options = {})
+    generator([destination_root], options)
+    generator.expects(:bundle_command).with('install').once
+    generator.stubs(:bundle_command).with('exec spring binstub --all')
     quietly { generator.invoke_all }
+  end
+
+  def test_generation_runs_bundle_install
+    assert_generates_with_bundler
   end
 
   def test_plugin_new_generate_pretend
@@ -96,15 +102,13 @@ module SharedGeneratorTests
   end
 
   def test_dev_option
-    generator([destination_root], dev: true).expects(:bundle_command).with('install').once
-    quietly { generator.invoke_all }
+    assert_generates_with_bundler dev: true
     rails_path = File.expand_path('../../..', Rails.root)
     assert_file 'Gemfile', /^gem\s+["']rails["'],\s+path:\s+["']#{Regexp.escape(rails_path)}["']$/
   end
 
   def test_edge_option
-    generator([destination_root], edge: true).expects(:bundle_command).with('install').once
-    quietly { generator.invoke_all }
+    assert_generates_with_bundler edge: true
     assert_file 'Gemfile', %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["']$}
   end
 


### PR DESCRIPTION
We have discussed among the core team about installing spring in newly generated applications by default. Here's my proposed integration.
