### PR TITLE
Improve readability of sentence in partial-renderer docs [ci skip]

### DIFF
--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -159,7 +159,7 @@ module ActionView
   #   </div>
   #
   # If a collection is given, the layout will be rendered once for each item in
-  # the collection. Just think these two snippets have the same output:
+  # the collection. For example, these two snippets have the same output:
   #
   #   <%# app/views/users/_user.html.erb %>
   #   Name: <%= user.name %>


### PR DESCRIPTION
Improve sentence in docs, from:

"Just think these two snippets have the same output:"

to: "For example, these two snippets have the same output:"
