### PR TITLE
Use `SchemaStatements#initialize_schema_migrations_table` instead of `ActiveRecord::SchemaMigration.create_table`.

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -896,7 +896,7 @@ module ActiveRecord
 
       validate(@migrations)
 
-      ActiveRecord::SchemaMigration.create_table
+      Base.connection.initialize_schema_migrations_table
     end
 
     def current_version


### PR DESCRIPTION
I think that should use `SchemaStatements#initialize_schema_migrations_table` instead of `ActiveRecord::SchemaMigration.create_table`.

Otherwise, https://github.com/rails/rails/commit/8744632f is not called from `db:migrate`.
