### PR TITLE
Add presence query methods for associations.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add presence query methods for associations.
+
+    Example:
+
+        class User < ActiveRecord::Base
+          has_many :tasks
+        end
+
+        user = User.first
+        user.tasks? # shorthand for user.tasks.present?
+
+    *Tomas Varneckas*
+
 *   Use strings to represent non-string `order_values`.
 
     *Yves Senn*

--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -22,6 +22,7 @@ module ActiveRecord::Associations::Builder
       extension = define_extensions model, name, &block
       reflection = create_reflection model, name, scope, options, extension
       define_accessors model, reflection
+      define_query_methods model, reflection
       define_callbacks model, reflection
       reflection
     end
@@ -106,6 +107,16 @@ module ActiveRecord::Associations::Builder
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}=(value)
           association(:#{name}).writer(value)
+        end
+      CODE
+    end
+
+    def self.define_query_methods(model, reflection)
+      mixin = model.generated_association_methods
+      name = reflection.name
+      mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
+        def #{name}?(*args)
+          #{name}(*args).present?
         end
       CODE
     end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -20,6 +20,9 @@ require 'models/molecule'
 require 'models/electron'
 require 'models/man'
 require 'models/interest'
+require 'models/contract'
+require 'models/car'
+require 'models/bulb'
 
 class AssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :developers_projects,
@@ -136,6 +139,65 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_equal ['foo'], firm.association_with_references.references_values
   end
 
+  def test_has_many_query_method
+    company = Company.create!(:name => 'Example')
+
+    assert !company.contracts?
+
+    company.contracts.create!
+    company.reload
+
+    assert company.contracts?
+  end
+
+  def test_has_many_through_query_method
+    company = Company.create!(:name => 'Example')
+    developer = Developer.create!(:name => 'Bob')
+
+    assert !company.developers?
+
+    company.contracts.create!(:developer => developer)
+    company.reload
+
+    assert company.developers?
+  end
+
+  def test_has_one_query_method
+    car = Car.create!
+    assert !car.bulb?
+
+    Bulb.create!(:car => car)
+    car.reload
+
+    assert car.bulb?
+  end
+
+  def test_belongs_to_query_method
+    contract = Contract.create!
+
+    assert !contract.developer?
+
+    developer = Developer.create!(:name => 'Bob')
+    contract.update(:developer => developer)
+    contract.reload
+
+    assert contract.developer?
+  end
+
+  def test_habtm_query_method
+    developer = Developer.create!(:name => 'Bob')
+    project = Project.create!
+
+    assert !developer.projects?
+    assert !project.developers?
+
+    developer.projects << project
+    developer.reload
+    project.reload
+
+    assert developer.projects?
+    assert project.developers?
+  end
 end
 
 class AssociationProxyTest < ActiveRecord::TestCase


### PR DESCRIPTION
Allows associations be queried for presence just like attributes:

```
class User < ActiveRecord::Base
  has_many :tools
end

user = User.first
user.name? # => true, regular attribute query method
user.tools? # => true, checks whether user has any tools
```

These are equivalent:

```
user.tools?
user.tools.present?
```

Motivation:
When extracting model attributes into models I have to change all `foo?` calls into `foo.present?`.
With this change it's more uniform and less painful.
