### PR TITLE
dont use belongs_to as it creates assemblies_id and parts_id

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -341,8 +341,8 @@ class CreateAssembliesAndParts < ActiveRecord::Migration
     end
 
     create_table :assemblies_parts, id: false do |t|
-      t.belongs_to :assembly
-      t.belongs_to :part
+      t.integer :assembly_id
+      t.integer :part_id
     end
   end
 end


### PR DESCRIPTION
the guides had two different versions of the same migration. the one using `belongs_to` is broken as it creates the wrong foreign-key fields
