### PR TITLE
`end_travel` to remove stubs from `travel` and `travel_to`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -11,12 +11,18 @@
         Time.now # => 2013-11-10 15:34:49 -05:00
         Date.today # => Sun, 10 Nov 2013
 
+        end_travel
+        Time.now # => 2013-11-09 15:34:49 -05:00
+
     Example for `#travel_to`:
 
         Time.now # => 2013-11-09 15:34:49 -05:00
         travel_to Time.new(2004, 11, 24, 01, 04, 44)
         Time.now # => 2004-11-24 01:04:44 -05:00
         Date.today # => Wed, 24 Nov 2004
+
+        end_travel
+        Time.now # => 2013-11-09 15:34:49 -05:00
 
     Both of these methods also accept a block, which will return the current time back to its
     original state at the end of the block:

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -10,6 +10,7 @@ module ActiveSupport
       #   travel 1.day
       #   Time.current # => Sun, 10 Nov 2013 15:34:49 EST -05:00
       #   Date.current # => Sun, 10 Nov 2013
+      #   end_travel   # return to the original state
       #
       # This method also accepts a block, which will return the current time back to its original
       # state at the end of the block:
@@ -31,6 +32,7 @@ module ActiveSupport
       #   travel_to Time.new(2004, 11, 24, 01, 04, 44)
       #   Time.current # => Wed, 24 Nov 2004 01:04:44 EST -05:00
       #   Date.current # => Wed, 24 Nov 2004
+      #   end_travel   # return to the original state
       #
       # This method also accepts a block, which will return the current time back to its original
       # state at the end of the block:
@@ -46,9 +48,15 @@ module ActiveSupport
 
         if block_given?
           block.call
-          Time.unstub :now
-          Date.unstub :today
+          end_travel
         end
+      end
+
+      # Remove stubs from +Time.now+ and +Date.today+. This method restores the original
+      # state when +travel+ or +travel_to+ was used.
+      def end_travel
+        Time.unstub :now
+        Date.unstub :today
       end
     end
   end

--- a/activesupport/test/test_test.rb
+++ b/activesupport/test/test_test.rb
@@ -201,4 +201,17 @@ class TimeHelperTest < ActiveSupport::TestCase
     assert_not_equal expected_time, Time.now
     assert_not_equal Date.new(2004, 11, 24), Date.today
   end
+
+  def test_end_travel_to_remove_the_stubs
+    real_now = Time.now
+    real_today = Date.today
+
+    travel_to Time.new(1976, 04, 23, 12, 45, 05)
+    assert Time.now < real_now
+    assert Date.today < real_today
+
+    end_travel
+    assert Time.now >= real_now
+    assert Date.today >= real_today
+  end
 end


### PR DESCRIPTION
This is a follow up to #12824.

This patch introduces a new method called `end_travel` to remove the stubs from `Time.now` and `Date.today`. This is useful to set your tim in `setup` hooks and return to the original state in `teardown`.

To illustrate I updated a test within AR that used some custom stubbing logic.

I'm opening the PR to discuss and find the best name for the method `end_travel`. While brainstorming we thought about `untravel`, `return`, `go_back`, `back` and settled for `end_travel`.
