### PR TITLE
Add positional information to eval call so that this information will be used in printing correct location where the exception occurred.

### DIFF
--- a/railties/lib/rails/commands/runner.rb
+++ b/railties/lib/rails/commands/runner.rb
@@ -50,5 +50,5 @@ elsif File.exist?(code_or_file)
   $0 = code_or_file
   Kernel.load code_or_file
 else
-  eval(code_or_file)
+  eval(code_or_file, binding, __FILE__, __LINE__)
 end


### PR DESCRIPTION
- Without this the location of exception is always the line on which
  'eval' is called
- But if the exception occurs in a gem outside of Rails, then that
  location is not printed in stacktrace
