### PR TITLE
removed unnecessary method definition of `schema_creation`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -31,10 +31,6 @@ module ActiveRecord
         end
       end
 
-      def schema_creation
-        SchemaCreation.new self
-      end
-
       class Column < ConnectionAdapters::Column # :nodoc:
         attr_reader :collation, :strict, :extra
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -33,10 +33,6 @@ module ActiveRecord
         end
       end
 
-      def schema_creation
-        SchemaCreation.new self
-      end
-
       module SchemaStatements
         # Drops the database specified on the +name+ attribute
         # and creates it again using the provided +options+.


### PR DESCRIPTION
`schema_creation` method is already defined in class `AbstractAdapter`, class `PostgreSQLAdapter` and `AbstractMysqlAdapter` need not to redefine it with the same definition.
