### PR TITLE
Rails new generator --skip-turbolinks option

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -40,6 +40,9 @@ module Rails
         class_option :skip_sprockets,     type: :boolean, aliases: '-S', default: false,
                                           desc: 'Skip Sprockets files'
 
+        class_option :skip_turbolinks,    type: :boolean, default: false,
+                                          desc: "Skip Turbolinks on Gemfile and asset files"
+
         class_option :database,           type: :string, aliases: '-d', default: 'sqlite3',
                                           desc: "Preconfigure for selected database (options: #{DATABASES.join('/')})"
 
@@ -231,6 +234,13 @@ module Rails
             #{javascript_runtime_gemfile_entry}
             # Use #{options[:javascript]} as the JavaScript library
             gem '#{options[:javascript]}-rails'
+          GEMFILE
+        end
+      end
+
+      def turbolinks_gemfile_entry
+        unless options[:skip_javascript] || options[:skip_turbolinks]
+          <<-GEMFILE.gsub(/^[ \t]+/, '')
 
             # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
             gem 'turbolinks'

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -6,6 +6,7 @@ source 'https://rubygems.org'
 
 <%= assets_gemfile_entry %>
 <%= javascript_gemfile_entry -%>
+<%= turbolinks_gemfile_entry -%>
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.2'

--- a/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/application.js.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/application.js.tt
@@ -13,6 +13,8 @@
 <% unless options[:skip_javascript] -%>
 //= require <%= options[:javascript] %>
 //= require <%= options[:javascript] %>_ujs
+<% end -%>
+<% unless options[:skip_javascript] || options[:skip_turbolinks] -%>
 //= require turbolinks
 <% end -%>
 //= require_tree .

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title><%= camelized %></title>
-  <%- if options[:skip_javascript] -%>
+  <%- if options[:skip_javascript] || options[:skip_turbolinks] -%>
   <%%= stylesheet_link_tag    "application", media: "all" %>
   <%%= javascript_include_tag "application" %>
   <%- else -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -305,6 +305,20 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_turbolinks_is_skipped_if_required
+    run_generator [destination_root, "--skaip-turbolinks"]
+    assert_file "app/assets/javascripts/application.js" do |contents|
+      assert_no_match %r{^//=\s+turbolinks\s}, contents
+    end
+    assert_file "app/views/layouts/application.html.erb" do |contents|
+      assert_match(/stylesheet_link_tag\s+"application", media: "all" %>/, contents)
+      assert_match(/javascript_include_tag\s+"application" \%>/, contents)
+    end
+    assert_file "Gemfile" do |content|
+      assert_no_match(/turbolinks/, content)
+    end
+  end
+
   def test_inclusion_of_debugger
     run_generator
     assert_file "Gemfile", /# gem 'debugger'/


### PR DESCRIPTION
With this option you will be able to choose if you want to include code
related to turbolinks on the new application template or not.

--skip-javascript is not enough because on some cases you do
want to use javascript without turbolinks.
