### PR TITLE
Even faster blank

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -90,7 +90,7 @@ class String
   #   '　'.blank?               # => true
   #   ' something here '.blank? # => false
   def blank?
-    self =~ /\A[[:space:]]*\z/
+    self.strip == ''
   end
 end
 


### PR DESCRIPTION
```
require 'benchmark'

iterations = 1_000_000
strings = ['', ' ', '  ', '   ', '     ', 'test', '   h   '*10,' '*100+'a'+' '*100]

Benchmark.bmbm(40) do |b|
  b.report('str =~ /\A[[:space:]]*\z/') do
    iterations.times{ strings.each{ |str| str =~ /\A[[:space:]]*\z/ } }
  end
  b.report('strip') do
    iterations.times{ strings.each{ |str| str.strip == '' } }
  end 
end
```

```
Rehearsal ----------------------------------------------------------------------------
str =~ /\A[[:space:]]*\z/                  8.260000   0.020000   8.280000 (  8.295657)
strip                                      7.470000   0.020000   7.490000 (  7.508503)
------------------------------------------------------------------ total: 15.770000sec

                                               user     system      total        real
str =~ /\A[[:space:]]*\z/                  7.930000   0.010000   7.940000 (  7.946118)
strip                                      7.290000   0.020000   7.310000 (  7.318493)
```
