### PR TITLE
Option to skip turbolinks

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Remove turbolinks when generating a new application based on a template that skips it.
+
+    Example
+        Skips turbolinks adding `add_gem_entry_filter { |gem| gem.name != "turbolinks" }`
+        to the template.
+
+    *Lauro Caetano*
+
 *   Instrument an `load_config_initializer.railties` event on each load of configuration initializer
     from `config/initializers`. Subscribers should be attached before `load_config_initializers`
     initializer completed.

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -113,7 +113,7 @@ module Rails
       end
 
       def add_gem_entry_filter
-        @gem_filter = lambda { |next_filter,entry|
+        @gem_filter = lambda { |next_filter, entry|
           yield(entry) && next_filter.call(entry)
         }.curry[@gem_filter]
       end

--- a/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/application.js.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/application.js.tt
@@ -13,6 +13,8 @@
 <% unless options[:skip_javascript] -%>
 //= require <%= options[:javascript] %>
 //= require <%= options[:javascript] %>_ujs
+<% if gemfile_entries.any? { |m| m.name == "turbolinks" } -%>
 //= require turbolinks
+<% end -%>
 <% end -%>
 //= require_tree .

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -182,7 +182,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     template.unlink
   end
 
-  def test_application_html_checks_gems
+  def test_skip_turbolinks_when_it_is_not_on_gemfile
     template = Tempfile.open 'my_template'
     template.puts 'add_gem_entry_filter { |gem| gem.name != "turbolinks" }'
     template.flush
@@ -191,11 +191,18 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile" do |contents|
       assert_no_match 'turbolinks', contents
     end
-    assert_file "Gemfile" do |contents|
-      assert_no_match 'turbolinks', contents
-    end
+
     assert_file "app/views/layouts/application.html.erb" do |contents|
       assert_no_match 'turbolinks', contents
+    end
+
+    assert_file "app/views/layouts/application.html.erb" do |contents|
+      assert_no_match(/stylesheet_link_tag\s+"application", media: "all", "data-turbolinks-track" => true/, contents)
+      assert_no_match(/javascript_include_tag\s+"application", "data-turbolinks-track" => true/, contents)
+    end
+
+    assert_file "app/assets/javascripts/application.js" do |contents|
+      assert_no_match %r{^//=\s+turbolinks\s}, contents
     end
   ensure
     template.close


### PR DESCRIPTION
Add an option to skip turbolinks when generating a new application.

cc @rafaelfranca
