### PR TITLE
Fix for titles of info pages

### DIFF
--- a/railties/lib/rails/info_controller.rb
+++ b/railties/lib/rails/info_controller.rb
@@ -13,10 +13,12 @@ class Rails::InfoController < ActionController::Base # :nodoc:
 
   def properties
     @info = Rails::Info.to_html
+    @page_title = 'Properties'
   end
 
   def routes
     @routes_inspector = ActionDispatch::Routing::RoutesInspector.new(_routes.routes)
+    @page_title = 'Routes'
   end
 
   protected

--- a/railties/lib/rails/templates/layouts/application.html.erb
+++ b/railties/lib/rails/templates/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Routes</title>
+  <title><%= @page_title %></title>
   <style>
     body { background-color: #fff; color: #333; }
 


### PR DESCRIPTION
Both `/rails/info/properties` and `/rails/info/routes` have same html `title` attribute as _Routes_. This commit includes a fix for the titles.
