### PR TITLE
Add Application#message_verifier method to return a message verifier

### DIFF
--- a/guides/source/4_1_release_notes.md
+++ b/guides/source/4_1_release_notes.md
@@ -164,6 +164,7 @@ for detailed changes.
 
 * Exposed `MiddlewareStack#unshift` to environment configuration. ([Pull Request](https://github.com/rails/rails/pull/12479))
 
+* Add `Application#message_verifier` method to return a message verifier. ([Pull Request](https://github.com/rails/rails/pull/12995))
 
 Action Mailer
 -------------

--- a/guides/source/4_1_release_notes.md
+++ b/guides/source/4_1_release_notes.md
@@ -124,6 +124,17 @@ See
 [active_record/enum.rb](https://github.com/rails/rails/blob/4-1-stable/activerecord/lib/active_record/enum.rb#L2-L42)
 for a detailed write up.
 
+### Application message verifier.
+
+Create a message verifier that can be used to generate and verify signed
+messages in the application.
+
+```ruby
+message = Rails.application.message_verifier('salt').generate('my sensible data')
+Rails.application.message_verifier('salt').verify(message)
+# => 'my sensible data'
+```
+
 Documentation
 -------------
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,9 +1,9 @@
-*   Add `Application#verifier` method to return a application's message verifier.
+*   Add `Application#message_verifier` method to return a application's message verifier.
 
     This verifier can be used to generate and verify signed messages in the application.
 
-        message = Rails.application.verifier.generate('my sensible data')
-        Rails.application.verifier.verify(message)
+        message = Rails.application.message_verifier.generate('my sensible data')
+        Rails.application.message_verifier.verify(message)
         # => 'my sensible data'
 
     See the `ActiveSupport::MessageVerifier` documentation to more information.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -6,15 +6,12 @@
         Rails.application.message_verifier.verify(message)
         # => 'my sensible data'
 
-    It is recommended to not use the same verifier to different things, so you can get different
+    It is recommended not not use the same verifier for different things, so you can get different
     verifiers passing the name argument.
 
         message = Rails.application.message_verifier('cookies').generate('my sensible cookie data')
 
-    By default all the verifiers will share the same salt, so messages generates by one can be
-    verifier by another one.
-
-    See the `ActiveSupport::MessageVerifier` documentation to more information.
+    See the `ActiveSupport::MessageVerifier` documentation for more information.
 
     *Rafael Mendonça França*
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -2,8 +2,8 @@
 
     This verifier can be used to generate and verify signed messages in the application.
 
-        message = Rails.application.message_verifier.generate('my sensible data')
-        Rails.application.message_verifier.verify(message)
+        message = Rails.application.message_verifier('salt').generate('my sensible data')
+        Rails.application.message_verifier('salt').verify(message)
         # => 'my sensible data'
 
     It is recommended not to use the same verifier for different things, so you can get different

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,10 +1,18 @@
-*   Add `Application#message_verifier` method to return a application's message verifier.
+*   Add `Application#message_verifier` method to return a message verifier.
 
     This verifier can be used to generate and verify signed messages in the application.
 
         message = Rails.application.message_verifier.generate('my sensible data')
         Rails.application.message_verifier.verify(message)
         # => 'my sensible data'
+
+    It is recommended to not use the same verifier to different things, so you can get different
+    verifiers passing the name argument.
+
+        message = Rails.application.message_verifier('cookies').generate('my sensible cookie data')
+
+    By default all the verifiers will share the same salt, so messages generates by one can be
+    verifier by another one.
 
     See the `ActiveSupport::MessageVerifier` documentation to more information.
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `Application#verifier` method to return a application's message verifier.
+
+    This verifier can be used to generate and verify signed messages in the application.
+
+        message = Rails.application.verifier.generate('my sensible data')
+        Rails.application.verifier.verify(message)
+        # => 'my sensible data'
+
+    See the `ActiveSupport::MessageVerifier` documentation to more information.
+
+    *Rafael Mendonça França*
+
 *   The [Spring application
     preloader](https://github.com/jonleighton/spring) is now installed
     by default for new applications. It uses the development group of

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -6,7 +6,7 @@
         Rails.application.message_verifier.verify(message)
         # => 'my sensible data'
 
-    It is recommended not not use the same verifier for different things, so you can get different
+    It is recommended not to use the same verifier for different things, so you can get different
     verifiers passing the name argument.
 
         message = Rails.application.message_verifier('cookies').generate('my sensible cookie data')

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -162,13 +162,13 @@ module Rails
     #
     # This verify can be used to generate and verify signed messages in the application.
     #
-    #     message = Rails.application.verifier.generate('my sensible data')
-    #     Rails.application.verifier.verify(message)
+    #     message = Rails.application.message_verifier.generate('my sensible data')
+    #     Rails.application.message_verifier.verify(message)
     #     # => 'my sensible data'
     #
     # See the +ActiveSupport::MessageVerifier+ documentation to more information.
-    def verifier
-      @verifier ||= begin
+    def message_verifier
+      @message_verifier ||= begin
         if config.respond_to?(:message_verifier_salt)
           salt = config.message_verifier_salt
         end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -164,7 +164,8 @@ module Rails
     #
     # This verify can be used to generate and verify signed messages in the application.
     #
-    # By default all the verifiers will share the same salt.
+    # It is recommended not to use the same verifier for different things, so you can get different
+    # verifiers passing the +verifier_name+ argument.
     #
     # ==== Parameters
     #
@@ -176,15 +177,10 @@ module Rails
     #     Rails.application.message_verifier.verify(message)
     #     # => 'my sensible data'
     #
-    # See the +ActiveSupport::MessageVerifier+ documentation to more information.
+    # See the +ActiveSupport::MessageVerifier+ documentation for more information.
     def message_verifier(verifier_name = 'default')
       @message_verifiers[verifier_name] ||= begin
-        if config.respond_to?(:message_verifier_salt)
-          salt = config.message_verifier_salt
-        end
-
-        salt = salt || 'application verifier'
-        secret = key_generator.generate_key(salt)
+        secret = key_generator.generate_key(verifier_name)
         ActiveSupport::MessageVerifier.new(secret)
       end
     end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -158,6 +158,18 @@ module Rails
       end
     end
 
+    def verifier
+      @verifier ||= begin
+        if config.respond_to?(:message_verifier_salt)
+          salt = config.message_verifier_salt
+        end
+
+        salt = salt || 'application verifier'
+        secret = key_generator.generate_key(salt)
+        ActiveSupport::MessageVerifier.new(secret)
+      end
+    end
+
     # Stores some of the Rails initial environment parameters which
     # will be used by middlewares and engines to configure themselves.
     def env_config

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -1,6 +1,7 @@
 require 'fileutils'
 require 'active_support/core_ext/object/blank'
 require 'active_support/key_generator'
+require 'active_support/message_verifier'
 require 'rails/engine'
 
 module Rails

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -160,9 +160,9 @@ module Rails
       end
     end
 
-    # Return a message verifier object.
+    # Returns a message verifier object.
     #
-    # This verify can be used to generate and verify signed messages in the application.
+    # This verifier can be used to generate and verify signed messages in the application.
     #
     # It is recommended not to use the same verifier for different things, so you can get different
     # verifiers passing the +verifier_name+ argument.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -169,18 +169,18 @@ module Rails
     #
     # ==== Parameters
     #
-    # * +verifier_name+ - the name of verifier you want to get.
+    # * +salt+ - the salt that will be used to generate the secret key of the verifier.
     #
     # ==== Examples
     #
-    #     message = Rails.application.message_verifier.generate('my sensible data')
-    #     Rails.application.message_verifier.verify(message)
+    #     message = Rails.application.message_verifier('salt').generate('my sensible data')
+    #     Rails.application.message_verifier('salt').verify(message)
     #     # => 'my sensible data'
     #
     # See the +ActiveSupport::MessageVerifier+ documentation for more information.
-    def message_verifier(verifier_name = 'default')
-      @message_verifiers[verifier_name] ||= begin
-        secret = key_generator.generate_key(verifier_name)
+    def message_verifier(salt)
+      @message_verifiers[salt] ||= begin
+        secret = key_generator.generate_key(salt)
         ActiveSupport::MessageVerifier.new(secret)
       end
     end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -108,12 +108,13 @@ module Rails
 
     def initialize(initial_variable_values = {}, &block)
       super()
-      @initialized      = false
-      @reloaders        = []
-      @routes_reloader  = nil
-      @app_env_config   = nil
-      @ordered_railties = nil
-      @railties         = nil
+      @initialized       = false
+      @reloaders         = []
+      @routes_reloader   = nil
+      @app_env_config    = nil
+      @ordered_railties  = nil
+      @railties          = nil
+      @message_verifiers = {}
 
       add_lib_to_load_path!
       ActiveSupport.run_load_hooks(:before_configuration, self)
@@ -159,17 +160,25 @@ module Rails
       end
     end
 
-    # Return the application's message verifier.
+    # Return a message verifier object.
     #
     # This verify can be used to generate and verify signed messages in the application.
+    #
+    # By default all the verifiers will share the same salt.
+    #
+    # ==== Parameters
+    #
+    # * +verifier_name+ - the name of verifier you want to get.
+    #
+    # ==== Examples
     #
     #     message = Rails.application.message_verifier.generate('my sensible data')
     #     Rails.application.message_verifier.verify(message)
     #     # => 'my sensible data'
     #
     # See the +ActiveSupport::MessageVerifier+ documentation to more information.
-    def message_verifier
-      @message_verifier ||= begin
+    def message_verifier(verifier_name = 'default')
+      @message_verifiers[verifier_name] ||= begin
         if config.respond_to?(:message_verifier_salt)
           salt = config.message_verifier_salt
         end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -158,6 +158,15 @@ module Rails
       end
     end
 
+    # Return the application's message verifier.
+    #
+    # This verify can be used to generate and verify signed messages in the application.
+    #
+    #     message = Rails.application.verifier.generate('my sensible data')
+    #     Rails.application.verifier.verify(message)
+    #     # => 'my sensible data'
+    #
+    # See the +ActiveSupport::MessageVerifier+ documentation to more information.
     def verifier
       @verifier ||= begin
         if config.respond_to?(:message_verifier_salt)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -274,19 +274,13 @@ module ApplicationTests
         app.config.session_store :disabled
       end
 
-      class ::OmgController < ActionController::Base
-        def index
-          render text: Rails.application.message_verifier.generate("some_value")
-        end
-      end
+      message = app.message_verifier.generate("some_value")
 
-      get "/"
-
-      assert_equal 'some_value', Rails.application.message_verifier.verify(last_response.body)
+      assert_equal 'some_value', Rails.application.message_verifier.verify(message)
 
       secret = app.key_generator.generate_key('default')
       verifier = ActiveSupport::MessageVerifier.new(secret)
-      assert_equal 'some_value', verifier.verify(last_response.body)
+      assert_equal 'some_value', verifier.verify(message)
     end
 
     test "application verifier can build different verifiers" do

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -284,27 +284,7 @@ module ApplicationTests
 
       assert_equal 'some_value', Rails.application.message_verifier.verify(last_response.body)
 
-      secret = app.key_generator.generate_key('application verifier')
-      verifier = ActiveSupport::MessageVerifier.new(secret)
-      assert_equal 'some_value', verifier.verify(last_response.body)
-    end
-
-    test "application verifier use the configure salt" do
-      make_basic_app do |app|
-        app.config.secret_key_base = 'b3c631c314c0bbca50c1b2843150fe33'
-        app.config.session_store :disabled
-        app.config.message_verifier_salt = 'another salt'
-      end
-
-      class ::OmgController < ActionController::Base
-        def index
-          render text: Rails.application.message_verifier.generate("some_value")
-        end
-      end
-
-      get "/"
-
-      secret = app.key_generator.generate_key('another salt')
+      secret = app.key_generator.generate_key('default')
       verifier = ActiveSupport::MessageVerifier.new(secret)
       assert_equal 'some_value', verifier.verify(last_response.body)
     end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -276,13 +276,13 @@ module ApplicationTests
 
       class ::OmgController < ActionController::Base
         def index
-          render text: Rails.application.verifier.generate("some_value")
+          render text: Rails.application.message_verifier.generate("some_value")
         end
       end
 
       get "/"
 
-      assert_equal 'some_value', Rails.application.verifier.verify(last_response.body)
+      assert_equal 'some_value', Rails.application.message_verifier.verify(last_response.body)
 
       secret = app.key_generator.generate_key('application verifier')
       verifier = ActiveSupport::MessageVerifier.new(secret)
@@ -298,7 +298,7 @@ module ApplicationTests
 
       class ::OmgController < ActionController::Base
         def index
-          render text: Rails.application.verifier.generate("some_value")
+          render text: Rails.application.message_verifier.generate("some_value")
         end
       end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -309,6 +309,16 @@ module ApplicationTests
       assert_equal 'some_value', verifier.verify(last_response.body)
     end
 
+    test "application verifier can build different verifiers" do
+      make_basic_app do |app|
+        app.config.secret_key_base = 'b3c631c314c0bbca50c1b2843150fe33'
+        app.config.session_store :disabled
+      end
+
+      assert_equal Rails.application.message_verifier.object_id, Rails.application.message_verifier.object_id
+      assert_not_equal Rails.application.message_verifier.object_id, Rails.application.message_verifier('text').object_id
+    end
+
     test "protect from forgery is the default in a new app" do
       make_basic_app
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -289,8 +289,18 @@ module ApplicationTests
         app.config.session_store :disabled
       end
 
-      assert_equal Rails.application.message_verifier.object_id, Rails.application.message_verifier.object_id
-      assert_not_equal Rails.application.message_verifier.object_id, Rails.application.message_verifier('text').object_id
+      default_verifier = app.message_verifier
+      text_verifier = app.message_verifier('text')
+
+      message = text_verifier.generate('some_value')
+
+      assert_equal 'some_value', text_verifier.verify(message)
+      assert_raises ActiveSupport::MessageVerifier::InvalidSignature do
+        default_verifier.verify(message)
+      end
+
+      assert_equal default_verifier.object_id, app.message_verifier.object_id
+      assert_not_equal default_verifier.object_id, text_verifier.object_id
     end
 
     test "protect from forgery is the default in a new app" do

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -274,11 +274,11 @@ module ApplicationTests
         app.config.session_store :disabled
       end
 
-      message = app.message_verifier.generate("some_value")
+      message = app.message_verifier('salt').generate("some_value")
 
-      assert_equal 'some_value', Rails.application.message_verifier.verify(message)
+      assert_equal 'some_value', Rails.application.message_verifier('salt').verify(message)
 
-      secret = app.key_generator.generate_key('default')
+      secret = app.key_generator.generate_key('salt')
       verifier = ActiveSupport::MessageVerifier.new(secret)
       assert_equal 'some_value', verifier.verify(message)
     end
@@ -289,7 +289,7 @@ module ApplicationTests
         app.config.session_store :disabled
       end
 
-      default_verifier = app.message_verifier
+      default_verifier = app.message_verifier('salt')
       text_verifier = app.message_verifier('text')
 
       message = text_verifier.generate('some_value')
@@ -299,7 +299,7 @@ module ApplicationTests
         default_verifier.verify(message)
       end
 
-      assert_equal default_verifier.object_id, app.message_verifier.object_id
+      assert_equal default_verifier.object_id, app.message_verifier('salt').object_id
       assert_not_equal default_verifier.object_id, text_verifier.object_id
     end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -268,6 +268,47 @@ module ApplicationTests
       assert_equal 'some_value', verifier.verify(last_response.body)
     end
 
+    test "application verifier can be used in the entire application" do
+      make_basic_app do |app|
+        app.config.secret_key_base = 'b3c631c314c0bbca50c1b2843150fe33'
+        app.config.session_store :disabled
+      end
+
+      class ::OmgController < ActionController::Base
+        def index
+          render text: Rails.application.verifier.generate("some_value")
+        end
+      end
+
+      get "/"
+
+      assert_equal 'some_value', Rails.application.verifier.verify(last_response.body)
+
+      secret = app.key_generator.generate_key('application verifier')
+      verifier = ActiveSupport::MessageVerifier.new(secret)
+      assert_equal 'some_value', verifier.verify(last_response.body)
+    end
+
+    test "application verifier use the configure salt" do
+      make_basic_app do |app|
+        app.config.secret_key_base = 'b3c631c314c0bbca50c1b2843150fe33'
+        app.config.session_store :disabled
+        app.config.message_verifier_salt = 'another salt'
+      end
+
+      class ::OmgController < ActionController::Base
+        def index
+          render text: Rails.application.verifier.generate("some_value")
+        end
+      end
+
+      get "/"
+
+      secret = app.key_generator.generate_key('another salt')
+      verifier = ActiveSupport::MessageVerifier.new(secret)
+      assert_equal 'some_value', verifier.verify(last_response.body)
+    end
+
     test "protect from forgery is the default in a new app" do
       make_basic_app
 


### PR DESCRIPTION
This verifier can be used to generate and verify signed messages in the application.

``` ruby
message = Rails.application.message_verifier.generate('my sensible data')
Rails.application.message_verifier.verify(message)
# => 'my sensible data'
```

It is recommended to not use the same verifier to different things, so you can get different verifiers passing the name argument.

``` ruby
message = Rails.application.message_verifier('cookies').generate('my sensible cookie data')
```

By default all the verifiers will share the same salt, so messages generated by one can be verifier by another one.

We recommend to use different salts to different verifiers and you can configure using `config.message_verifier_salts`.

``` ruby
Rails.application.config.message_verifier_salts = { 'cookies' => 'cookies salt' }
```

See the [`ActiveSupport::MessageVerifier` documentation](http://api.rubyonrails.org/classes/ActiveSupport/MessageVerifier.html) for more information.
