### PR TITLE
Fix the assertion for not inclusion of turbolinks on application.js.

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -202,7 +202,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "app/assets/javascripts/application.js" do |contents|
-      assert_no_match %r{^//=\s+turbolinks\s}, contents
+      assert_no_match %r{^//= require turbolinks}, contents
     end
   ensure
     template.close


### PR DESCRIPTION
We were asserting if `//= turbolinks` was not present while the correct is
asserting that `//= require turbolinks` is not present.

cc @guilleiguaran @carlosantoniodasilva

I'm sorry for missing this on the other PR.
Thanks!
