### PR TITLE
Don't call #as_json on children of Array and Hash with nil when no arguments are passed

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -164,7 +164,7 @@ end
 
 class Array
   def as_json(options = nil) #:nodoc:
-    map { |v| v.as_json(options && options.dup) }
+    map { |v| options ? v.as_json(options.dup) : v.as_json }
   end
 
   def encode_json(encoder) #:nodoc:
@@ -187,7 +187,7 @@ class Hash
       self
     end
 
-    Hash[subset.map { |k, v| [k.to_s, v.as_json(options && options.dup)] }]
+    Hash[subset.map { |k, v| [k.to_s, options ? v.as_json(options.dup) : v.as_json] }]
   end
 
   def encode_json(encoder) #:nodoc:

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -32,6 +32,12 @@ class TestJSONEncoding < ActiveSupport::TestCase
     end
   end
 
+  class OptionsTest
+    def as_json(options = :default)
+      options
+    end
+  end
+
   class HashWithAsJson < Hash
     attr_accessor :as_json_called
 
@@ -330,6 +336,16 @@ class TestJSONEncoding < ActiveSupport::TestCase
     hash = {"foo" => f, "other_hash" => {"foo" => "other_foo", "test" => "other_test"}}
     assert_equal({"foo"=>{"foo"=>"hello","bar"=>"world"},
                   "other_hash" => {"foo"=>"other_foo","test"=>"other_test"}}, ActiveSupport::JSON.decode(hash.to_json))
+  end
+
+  def test_hash_as_json_without_options
+    json = { foo: OptionsTest.new }.as_json
+    assert_equal({"foo" => :default}, json)
+  end
+
+  def test_array_as_json_without_options
+    json = [ OptionsTest.new ].as_json
+    assert_equal([:default], json)
   end
 
   def test_struct_encoding


### PR DESCRIPTION
This is breaking definitions like these:

``` ruby
def as_json(options = {})
  # Do something with options, for example:
  if options.key? :something
    ...
  else
    ...
  end
end
```

This is more or less how it works before 240863a1 because the way it used to go through the Encoder object, which ensures options is never nil.

([Example](https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/serializable.rb#L4))

/cc @jeremy 
