### PR TITLE
Using activerecord-jdbcsqlite3-adapter

### DIFF
--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -293,7 +293,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile" do |contents|
       assert_no_match('gemspec', contents)
       assert_match(/gem "rails", "~> #{Rails.version}"/, contents)
-      assert_match(/group :development do\n  gem "sqlite3"\nend/, contents)
+      assert_match_sqlite3(contents)
       assert_no_match(/# gem "jquery-rails"/, contents)
     end
   end
@@ -304,7 +304,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile" do |contents|
       assert_no_match('gemspec', contents)
       assert_match(/gem "rails", "~> #{Rails.version}"/, contents)
-      assert_match(/group :development do\n  gem "sqlite3"\nend/, contents)
+      assert_match_sqlite3(contents)
     end
   end
 
@@ -346,5 +346,13 @@ protected
 
   def default_files
     ::DEFAULT_PLUGIN_FILES
+  end
+
+  def assert_match_sqlite3(contents)
+    unless defined?(JRUBY_VERSION)
+      assert_match(/group :development do\n  gem "sqlite3"\nend/, contents)
+    else
+      assert_match(/group :development do\n  gem "activerecord-jdbcsqlite3-adapter"\nend/, contents)
+    end
   end
 end


### PR DESCRIPTION
PluginGeneratorTest needs to have
activerecord-jdbcsqlite3-adapter to pass under JRuby
