### PR TITLE
Raise RuntimeErrors with inspectable and MRI-independent messages.

### DIFF
--- a/actionpack/test/controller/new_base/render_streaming_test.rb
+++ b/actionpack/test/controller/new_base/render_streaming_test.rb
@@ -4,7 +4,7 @@ module RenderStreaming
   class BasicController < ActionController::Base
     self.view_paths = [ActionView::FixtureResolver.new(
       "render_streaming/basic/hello_world.html.erb" => "Hello world",
-      "render_streaming/basic/boom.html.erb" => "<%= nil.invalid! %>",
+      "render_streaming/basic/boom.html.erb" => "<%= raise 'Ruby was here!' %>",
       "layouts/application.html.erb" => "<%= yield %>, I'm here!",
       "layouts/boom.html.erb" => "<body class=\"<%= nil.invalid! %>\"<%= yield %></body>"
     )]
@@ -90,7 +90,7 @@ module RenderStreaming
       begin
         get "/render_streaming/basic/template_exception"
         io.rewind
-        assert_match "(undefined method `invalid!' for nil:NilClass)", io.read
+        assert_match "Ruby was here!", io.read
       ensure
         ActionView::Base.logger = _old
       end

--- a/actionpack/test/controller/new_base/render_template_test.rb
+++ b/actionpack/test/controller/new_base/render_template_test.rb
@@ -14,7 +14,7 @@ module RenderTemplate
       "test/with_json.html.erb"    => "<%= render :template => 'test/with_json', :formats => [:json] %>",
       "test/with_json.json.erb"    => "<%= render :template => 'test/final', :formats => [:json]  %>",
       "test/final.json.erb"        => "{ final: json }",
-      "test/with_error.html.erb"   => "<%= idontexist %>"
+      "test/with_error.html.erb"   => "<%= raise 'i do not exist' %>"
     )]
 
     def index
@@ -132,7 +132,7 @@ module RenderTemplate
     test "rendering a template with error properly excerts the code" do
       get :with_error
       assert_status 500
-      assert_match "undefined local variable or method `idontexist", response.body
+      assert_match "i do not exist", response.body
     end
   end
 


### PR DESCRIPTION
See the commit messages for explanations.
