### PR TITLE
Avoid invalid UTF-8 exception in invalid SQL statement handler.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Avoid invalid UTF-8 exception in invalid SQL statement handler.
+
+    The mysql connection adapter tries to provide a helpful message for a
+    certain class of invalid SQL statement exceptions. The logic for detecting
+    if an exception falls into that class is now resilient to exceptions due
+    to UTF-8 encoding errors. This lets the application developer see and debug
+    the original exception instead of a cryptic `invalid byte sequence in
+    UTF-8`.
+
+    *Victor Costan*
+
 *   Fix validation on uniqueness of empty association.
 
     *Evgeny Li*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -299,7 +299,12 @@ module ActiveRecord
           log(sql, name) { @connection.query(sql) }
         end
       rescue ActiveRecord::StatementInvalid => exception
-        if exception.message.split(":").first =~ /Packets out of order/
+        begin
+          message_start = exception.message.split(":").first
+        rescue ArgumentError  # Most likely an encoding error.
+          message_start = ''
+        end
+        if message_start =~ /Packets out of order/
           raise ActiveRecord::StatementInvalid.new("'Packets out of order' error was received from the database. Please update your mysql bindings (gem install mysql) and read http://dev.mysql.com/doc/mysql/en/password-hashing.html for more information. If you're on Windows, use the Instant Rails installer to get the updated mysql bindings.", exception.original_exception)
         else
           raise

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -89,6 +89,15 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     @connection.execute "DROP TABLE `bar_baz`"
   end
 
+  def test_execute_non_utf8_exception
+    invalid_utf8 = [0x80].pack('C*').force_encoding(Encoding::UTF_8)
+    @connection.instance_variable_get(:@connection).stubs(:query).raises(ActiveRecord::StatementInvalid, invalid_utf8)
+
+    assert_raises(ActiveRecord::StatementInvalid, invalid_utf8) do
+      @connection.execute('SELECT VERSION();')
+    end
+  end
+
   private
 
   def run_without_connection


### PR DESCRIPTION
The mysql connection adapter tries to provide a helpful message for a certain class of invalid SQL statement exceptions. However, if the exception has invalid UTF-8 characters, the handler raises a UTF-8 exception that is not very helpful for debugging.

In most cases, the original message from mysql is very helpful in tracing errors, even if it has binary garbage in it.

Arguably, mysql2 should not create String instances that have invalid UTF-8 encodings. At the same time, I think that the `rescue ''` should clause should still be there to guard the `split` call in the exception handler.
