### PR TITLE
Better error message for typos in assert_response argument.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Better error message for typos in assert_response argument.
+
+    When the response type argument to `assert_response` is not a known
+    response type, `assert_response` now throws an ArgumentError with a clear
+    message. This is intended to help debug typos in the response type.
+
+    *Victor Costan*
+
 *   Fix formatting for `rake routes` when a section is shorter than a header.
 
     *Sıtkı Bağdat*

--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -27,6 +27,9 @@ module ActionDispatch
             assert @response.send("#{type}?"), message
           else
             code = Rack::Utils::SYMBOL_TO_STATUS_CODE[type]
+            if code.nil?
+              raise ArgumentError, "Invalid response type :#{type}"
+            end
             assert_equal code, @response.response_code, message
           end
         else

--- a/actionpack/test/assertions/response_assertions_test.rb
+++ b/actionpack/test/assertions/response_assertions_test.rb
@@ -50,6 +50,14 @@ module ActionDispatch
           assert_response :success
         }
       end
+
+      def test_assert_response_sym_typo
+        @response = FakeResponse.new 200
+
+        assert_raises(ArgumentError) {
+          assert_response :succezz
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
This patch makes it really easy to debug errors like `assert_response :succcess` (did you see the typo there?)

The current error message requires a bit of guesswork. The new one is really, really clear.
