### PR TITLE
avoiding calling of #option_value_selected? two times

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -361,7 +361,7 @@ module ActionView
           text, value = option_text_and_value(element).map { |item| item.to_s }
 
           html_attributes[:selected] = option_value_selected?(value, selected)
-          html_attributes[:disabled] = disabled && option_value_selected?(value, disabled)
+          html_attributes[:disabled] = disabled && html_attributes[:selected]
           html_attributes[:value] = value
 
           content_tag_string(:option, text, html_attributes)


### PR DESCRIPTION
In `options_for_select` we are calling `option_value_selected?` two times, whereas in `option_value_selected?` we are checking `array.include? value`.
We can save around 50% time. Here are the benchmarks: https://gist.github.com/akshay-vishnoi/7638030
