### PR TITLE
Only use BINARY for mysql case sensitive uniqueness check when column has a case insensitive collation.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Only use BINARY for mysql case sensitive uniqueness check when column has a case insensitive collation.
+
+    *Ryuta Kamizono*
+
 *   Fix validation on uniqueness of empty association.
 
     *Evgeny Li*

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -334,6 +334,11 @@ module ActiveRecord
         node
       end
 
+      def case_sensitive_comparison(table, attribute, column, value)
+        value = case_sensitive_modifier(value) unless value.nil?
+        table[attribute].eq(value)
+      end
+
       def case_insensitive_comparison(table, attribute, column, value)
         table[attribute].lower.eq(table.lower(value))
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -585,6 +585,14 @@ module ActiveRecord
         Arel::Nodes::Bin.new(node)
       end
 
+      def case_sensitive_comparison(table, attribute, column, value)
+        if column.case_sensitive?
+          table[attribute].eq(value)
+        else
+          super
+        end
+      end
+
       def case_insensitive_comparison(table, attribute, column, value)
         if column.case_sensitive?
           super

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -59,8 +59,7 @@ module ActiveRecord
           # will use SQL LOWER function before comparison, unless it detects a case insensitive collation
           klass.connection.case_insensitive_comparison(table, attribute, column, value)
         else
-          value = klass.connection.case_sensitive_modifier(value) unless value.nil?
-          table[attribute].eq(value)
+          klass.connection.case_sensitive_comparison(table, attribute, column, value)
         end
       end
 

--- a/activerecord/test/cases/adapters/mysql/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql/case_sensitivity_test.rb
@@ -3,9 +3,9 @@ require 'models/person'
 
 class MysqlCaseSensitivityTest < ActiveRecord::TestCase
   class CollationTest < ActiveRecord::Base
-    validates_uniqueness_of :string_cs_column, :case_sensitive => false
-    validates_uniqueness_of :string_ci_column, :case_sensitive => false
   end
+
+  repair_validations(CollationTest)
 
   def test_columns_include_collation_different_from_table
     assert_equal 'utf8_bin', CollationTest.columns_hash['string_cs_column'].collation
@@ -18,6 +18,7 @@ class MysqlCaseSensitivityTest < ActiveRecord::TestCase
   end
 
   def test_case_insensitive_comparison_for_ci_column
+    CollationTest.validates_uniqueness_of(:string_ci_column, :case_sensitive => false)
     CollationTest.create!(:string_ci_column => 'A')
     invalid = CollationTest.new(:string_ci_column => 'a')
     queries = assert_sql { invalid.save }
@@ -26,10 +27,29 @@ class MysqlCaseSensitivityTest < ActiveRecord::TestCase
   end
 
   def test_case_insensitive_comparison_for_cs_column
+    CollationTest.validates_uniqueness_of(:string_cs_column, :case_sensitive => false)
     CollationTest.create!(:string_cs_column => 'A')
     invalid = CollationTest.new(:string_cs_column => 'a')
     queries = assert_sql { invalid.save }
     cs_uniqueness_query = queries.detect { |q| q.match(/string_cs_column/) }
     assert_match(/lower/i, cs_uniqueness_query)
+  end
+
+  def test_case_sensitive_comparison_for_ci_column
+    CollationTest.validates_uniqueness_of(:string_ci_column, :case_sensitive => true)
+    CollationTest.create!(:string_ci_column => 'A')
+    invalid = CollationTest.new(:string_ci_column => 'A')
+    queries = assert_sql { invalid.save }
+    ci_uniqueness_query = queries.detect { |q| q.match(/string_ci_column/) }
+    assert_match(/binary/i, ci_uniqueness_query)
+  end
+
+  def test_case_sensitive_comparison_for_cs_column
+    CollationTest.validates_uniqueness_of(:string_cs_column, :case_sensitive => true)
+    CollationTest.create!(:string_cs_column => 'A')
+    invalid = CollationTest.new(:string_cs_column => 'A')
+    queries = assert_sql { invalid.save }
+    cs_uniqueness_query = queries.detect { |q| q.match(/string_cs_column/) }
+    assert_no_match(/binary/i, cs_uniqueness_query)
   end
 end


### PR DESCRIPTION
I think that should use BINARY for mysql case sensitive uniqueness check when column has a case insensitive collation.

If use BINARY in MySQL, index is not used efficiently.

```
CREATE TABLE `users` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `username` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
  `created_at` datetime DEFAULT NULL,
  `updated_at` datetime DEFAULT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `idx_username` (`username`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8
```

Do not use BINARY:

```
> EXPLAIN SELECT * FROM users WHERE username = 'kamipo@facebook.com';
+----+-------------+-------+-------+---------------+--------------+---------+-------+------+-------+
| id | select_type | table | type  | possible_keys | key          | key_len | ref   | rows | Extra |
+----+-------------+-------+-------+---------------+--------------+---------+-------+------+-------+
|  1 | SIMPLE      | users | const | idx_username  | idx_username | 767     | const |    1 | NULL  |
+----+-------------+-------+-------+---------------+--------------+---------+-------+------+-------+
```

Use BINARY in MySQL 5.5 and earlier:

```
> EXPLAIN SELECT * FROM users WHERE username = BINARY 'kamipo@facebook.com';
+----+-------------+-------+-------+---------------+--------------+---------+------+------+-------------+
| id | select_type | table | type  | possible_keys | key          | key_len | ref  | rows | Extra       |
+----+-------------+-------+-------+---------------+--------------+---------+------+------+-------------+
|  1 | SIMPLE      | users | range | idx_username  | idx_username | 767     | NULL |    1 | Using where |
+----+-------------+-------+-------+---------------+--------------+---------+------+------+-------------+
```

Use BINARY in MySQL 5.6(optimizer_switch='index_condition_pushdown=on') and later:

```
> SET optimizer_switch='index_condition_pushdown=on';
> EXPLAIN SELECT * FROM users WHERE username = BINARY 'kamipo@facebook.com';
+----+-------------+-------+-------+---------------+--------------+---------+------+------+-----------------------+
| id | select_type | table | type  | possible_keys | key          | key_len | ref  | rows | Extra                 |
+----+-------------+-------+-------+---------------+--------------+---------+------+------+-----------------------+
|  1 | SIMPLE      | users | range | idx_username  | idx_username | 767     | NULL |    1 | Using index condition |
+----+-------------+-------+-------+---------------+--------------+---------+------+------+-----------------------+
```
