### PR TITLE
MySQL: set collation_connection to be the same as collation_database

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -822,6 +822,10 @@ module ActiveRecord
           encoding << ", "
         end
 
+        unless @config[:collation]
+          collation = "collation_connection = @@SESSION.collation_database, "
+        end
+
         # Gather up all of the SET variables...
         variable_assignments = variables.map do |k, v|
           if v == ':default' || v == :default
@@ -833,7 +837,7 @@ module ActiveRecord
         end.compact.join(', ')
 
         # ...and send them all in one query
-        @connection.query  "SET #{encoding} #{variable_assignments}"
+        @connection.query  "SET #{encoding} #{collation} #{variable_assignments}"
       end
 
       def extract_foreign_key_action(structure, name, action) # :nodoc:

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -134,6 +134,14 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     assert_equal 'utf8_general_ci', ARUnit2Model.connection.show_variable('collation_connection')
   end
 
+  def test_mysql_collation_connection_defaults_to_collation_database
+    run_without_connection do |orig_connection|
+      ActiveRecord::Base.establish_connection(orig_connection.except(:collation))
+      rows = ActiveRecord::Base.connection.select_rows "SELECT @@SESSION.collation_connection = @@SESSION.collation_database"
+      assert_equal [["1"]], rows, "'collation_connection' is different from 'collation_database'"
+    end
+  end
+
   def test_mysql_default_in_strict_mode
     result = @connection.exec_query "SELECT @@SESSION.sql_mode"
     assert_equal [["STRICT_ALL_TABLES"]], result.rows

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -70,6 +70,14 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     assert_equal 'utf8_general_ci', ARUnit2Model.connection.show_variable('collation_connection')
   end
 
+  def test_mysql_collation_connection_defaults_to_collation_database
+    run_without_connection do |orig_connection|
+      ActiveRecord::Base.establish_connection(orig_connection.except(:collation))
+      rows = ActiveRecord::Base.connection.select_rows "SELECT @@SESSION.collation_connection = @@SESSION.collation_database"
+      assert_equal [[1]], rows, "'collation_connection' is different from 'collation_database'"
+    end
+  end
+
   # TODO: Below is a straight up copy/paste from mysql/connection_test.rb
   # I'm not sure what the correct way is to share these tests between
   # adapters in minitest.


### PR DESCRIPTION
This patch would fix #748, which seems to have been closed automatically.
