### PR TITLE
return correct id when passed as `non-integer`

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -496,7 +496,7 @@ module ActiveRecord
       attributes_values = arel_attributes_with_values_for_create(attribute_names)
 
       new_id = self.class.unscoped.insert attributes_values
-      self.id ||= new_id if self.class.primary_key
+      self.id = new_id if self.class.primary_key
 
       @new_record = false
       id

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -49,6 +49,8 @@ module ActiveRecord
         end
       end
 
+      primary_key_value = nil if primary_key_value == 0
+
       im = arel.create_insert
       im.into @table
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -185,6 +185,14 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal("New Topic", topic_reloaded.title)
   end
 
+  def test_create_with_id
+    topic = Topic.new
+    topic.id = "New Topic"
+    topic.save
+    topic_reloaded = Topic.find(topic.id)
+    assert_equal(topic_reloaded.id, topic.id)
+  end
+
   def test_save!
     topic = Topic.new(:title => "New Topic")
     assert topic.save!


### PR DESCRIPTION
solves issue #13052
