### PR TITLE
Fix segmentation fault in Ruby 2.0.0-p353.

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -99,6 +99,14 @@ module ActiveSupport
 
     private
 
+      # We define it as a workaround to Ruby 2.0.0-p353 bug.
+      # For more information, check rails/rails#13055.
+      # It should be dropped once a new Ruby patch-level
+      # release after 2.0.0-p353 happens.
+      def ===(other) #:nodoc:
+        value === other
+      end
+
       def method_missing(method, *args, &block) #:nodoc:
         value.send(method, *args, &block)
       end

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -158,6 +158,11 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal '172800', 2.days.to_json
   end
 
+  def test_case_when
+    cased = case 1.day when 1.day then "ok" end
+    assert_equal cased, "ok"
+  end
+
   protected
     def with_env_tz(new_tz = 'US/Eastern')
       old_tz, ENV['TZ'] = ENV['TZ'], new_tz


### PR DESCRIPTION
In Ruby 2.0.0-p353 there was a [commit](https://github.com/ruby/ruby/commit/66915c507777c5e3a978fa73de25db763efd9206) that switched case matching from actual sending `===` method to magic lookup, that does not see it in `method_missing`. It's hard to predict how exactly and when exactly this bug will be solved so here I suggest a solution of defining it in Duration directly.

In Ruby 2.0.0-p353 without the added fix added test crashes to segmentation fault.
