### PR TITLE
Cycle object should accept an array

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   A Cycle object should accept an array and cycle through it as it would with a set of comma-separated objects.
+
+        arr = [1,2,3]
+        cycle(arr) # => '1'
+        cycle(arr) # => '2'
+        cycle(arr) # => '3'
+
+    Previously, it would return the array as a string, because it took the array as a single object:
+
+        arr = [1,2,3]
+        cycle(arr) # => '[1,2,3]'
+        cycle(arr) # => '[1,2,3]'
+        cycle(arr) # => '[1,2,3]'
+
+    *Kristian Freeman*
+
 *   Use `set_backtrace` instead of instance variable `@backtrace` in ActionView exceptions
 
     *Shimpei Makimoto*

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -314,7 +314,7 @@ module ActionView
         options = values.extract_options!
         name = options.fetch(:name, 'default')
 
-        values.unshift(first_value)
+        values.unshift(*first_value)
 
         cycle = get_cycle(name)
         unless cycle && cycle.values == values

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -381,6 +381,13 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("3", cycle("one", 2, "3"))
   end
 
+  def test_cycle_with_array
+    array = [1, 2, 3]
+    assert_equal("1", cycle(array))
+    assert_equal("2", cycle(array))
+    assert_equal("3", cycle(array))
+  end
+
   def test_cycle_with_no_arguments
     assert_raise(ArgumentError) { cycle }
   end


### PR DESCRIPTION
A Cycle object should accept an array and cycle through it as it would with a set of comma-separated objects.

``` ruby
arr = [1,2,3]
cycle(arr) # => "1"
cycle(arr) # => "2"
cycle(arr) # => "3"
```

Previously, it would return the array as a string, because it took the array as a single object: 

``` ruby
arr = [1,2,3]
cycle(arr) # => "[1,2,3]"
cycle(arr) # => "[1,2,3]"
cycle(arr) # => "[1,2,3]"
```
