### PR TITLE
Fix bug when validating the uniqueness of an aliased attribute.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix bug when validating the uniqueness of an aliased attribute.
+
+    Fixes #12402.
+
+    *Lauro Caetano*
+
 *   Checks to see if the record contains the foreign key to set the inverse automatically.
 
     *Edo Balvers*

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -56,7 +56,15 @@ module ActiveRecord
           value = value.attributes[reflection.primary_key_column.name]
         end
 
-        column = klass.columns_hash[attribute.to_s]
+        attribute_name = attribute.to_s
+
+        # the attribute may be an aliased attribute
+        if klass.attribute_aliases[attribute_name]
+          attribute = klass.attribute_aliases[attribute_name]
+          attribute_name = attribute.to_s
+        end
+
+        column = klass.columns_hash[attribute_name]
         value  = klass.connection.type_cast(value, column)
         value  = value.to_s[0, column.limit] if value && column.limit && column.text?
 

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -58,6 +58,14 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert t2.save, "Should now save t2 as unique"
   end
 
+  def test_validate_uniqueness_with_alias_attribute
+    Topic.alias_attribute :new_title, :title
+    Topic.validates_uniqueness_of(:new_title)
+
+    topic = Topic.new(new_title: 'abc')
+    assert topic.valid?
+  end
+
   def test_validates_uniqueness_with_nil_value
     Topic.validates_uniqueness_of(:title)
 


### PR DESCRIPTION
When validating the uniqueness of an aliased attribute, it was raising an error. To fix that, we have to check if the record being validated is an aliased attribute.

Closes #12402

/cc @rafaelfranca
