### PR TITLE
AbsC::Rendering and ViewPaths

### DIFF
--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -40,6 +40,8 @@ module ActionView
       ActiveSupport.on_load(:action_controller) do
         ActionController::Base.superclass.send(:include, ActionView::Layouts)
         ActionView::RoutingUrlFor.send(:include, ActionDispatch::Routing::UrlFor)
+        # Support backwards compatibility
+        AbstractController::Rendering.send(:include, ActionView::ViewPaths)
       end
     end
 


### PR DESCRIPTION
As discussed with core team and suggested by @jeremy we'd like to support breaking change caused by AV extraction described here: https://github.com/rails/rails/issues/12979

I don't know sane way to print deprecation warning though, as it's not straight forward in this case. We can do something like in 436e3f3, however this is breaking half of tests as `ActionMailer::Base`, `ActionController::Base` consts, obviously, in most places are undefined. So we could check if they're defined, but as we have 2 const to check it will mean that I'd have to have 2 ifs with 2 same warning (can't do `array.all?` etc). Either I'm missing something or there's no other way. Do you have any other ideas? Maybe we should give up on deprecation warning?

This is _WIP_ and I'd like to ask for help here. Thanks!
