### PR TITLE
ActiveSupport::Inflector.singularize not working for some words ending in "series"

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `ActiveSupport::Inflector.singularize` not working for words ending in "series".
+
+    *Lihan Li*
+
 *   Add `ActiveSupport::Testing::TimeHelpers#travel` and `#travel_to`. These methods change current
     time to the given time or time difference by stubbing `Time.now` and `Date.today` to return the
     time or date after the difference calculation, or the time or date that got passed into the

--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -35,7 +35,6 @@ module ActiveSupport
     inflect.singular(/(tive)s$/i, '\1')
     inflect.singular(/([lr])ves$/i, '\1f')
     inflect.singular(/([^aeiouy]|qu)ies$/i, '\1y')
-    inflect.singular(/(s)eries$/i, '\1eries')
     inflect.singular(/(m)ovies$/i, '\1ovie')
     inflect.singular(/(x|ch|ss|sh)es$/i, '\1')
     inflect.singular(/^(m|l)ice$/i, '\1ouse')
@@ -59,6 +58,6 @@ module ActiveSupport
     inflect.irregular('move', 'moves')
     inflect.irregular('zombie', 'zombies')
 
-    inflect.uncountable(%w(equipment information rice money species series fish sheep jeans police))
+    inflect.uncountable(%w(equipment information rice money species series subseries miniseries fish sheep jeans police))
   end
 end

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -70,10 +70,11 @@ class InflectorTest < ActiveSupport::TestCase
 
 
   def test_overwrite_previous_inflectors
-    assert_equal("series", ActiveSupport::Inflector.singularize("series"))
-    ActiveSupport::Inflector.inflections.singular "series", "serie"
-    assert_equal("serie", ActiveSupport::Inflector.singularize("series"))
-    ActiveSupport::Inflector.inflections.uncountable "series" # Return to normal
+    with_dup do
+      assert_equal("series", ActiveSupport::Inflector.singularize("series"))
+      ActiveSupport::Inflector.inflections.singular "series", "serie"
+      assert_equal("serie", ActiveSupport::Inflector.singularize("series"))
+    end
   end
 
   MixtureToTitleCase.each_with_index do |(before, titleized), index|

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -108,6 +108,8 @@ module InflectorTestCases
     "database"    => "databases",
 
     "miniseries"  => "miniseries",
+    "subseries"   => "subseries",
+    "nusery"      => "nuseries",
 
     # regression tests against improper inflection regexes
     "|ice"        => "|ices",

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -107,6 +107,8 @@ module InflectorTestCases
 
     "database"    => "databases",
 
+    "miniseries"  => "miniseries",
+
     # regression tests against improper inflection regexes
     "|ice"        => "|ices",
     "|ouse"       => "|ouses",


### PR DESCRIPTION
Right now singularize returns the same word for all words that end in "series", however this isn't right for words like "nuseries" or "miseries". So I've removed the /(s)eries$/i rule and added all uncountable *series words to the uncountable array. Also the test_overwrite_previous_inflectors test was adding a new inflection and not properly removing it, so I wrapped it in with_dup (I had to fix this bug because the inflection it added was affecting the behavior of my new test cases).

http://www.scrabblefinder.com/ends-with/series/
