### PR TITLE
Link for "New Post" is added in Getting Started guide [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1268,6 +1268,7 @@ together.
 
 ```html+erb
 <h1>Listing Posts</h1>
+<%= link_to 'New post', new_post_path %>
 <table>
   <tr>
     <th>Title</th>


### PR DESCRIPTION
- Earlier(line number 862) it is said to add <%= link_to 'New post', new_post_path %> on posts index page before table tag. But when posts index page html is shown, "New Post" link is missing.
  So aaded "New Post" link in this commit
