### PR TITLE
Fixed json_escape (again)

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,4 +1,7 @@
 *   Fixed a long-standing bug in `json_escape` that causes quotation marks to be stripped.
+    This method also escapes the \u2028 and \u2029 unicode newline characters which are
+    treated as \n in JavaScript. This matches the behaviour of the AS::JSON encoder. (The
+    original change in the encoder was introduced in #10534.)
 
     *Godfrey Chan*
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fixed a long-standing bug in `json_escape` that causes quotation marks to be stripped.
+
+    *Godfrey Chan*
+
 *   `ActionView::MissingTemplate` includes underscore when raised for a partial.
 
     Fixes #13002.

--- a/actionview/test/template/erb_util_test.rb
+++ b/actionview/test/template/erb_util_test.rb
@@ -33,7 +33,8 @@ class ErbUtilTest < ActiveSupport::TestCase
     ['"&"', '"\u0026"'],
     ['"</script>"', '"\u003c/script\u003e"'],
     ['["</script>"]', '["\u003c/script\u003e"]'],
-    ['{"name":"</script>"}', '{"name":"\u003c/script\u003e"}']
+    ['{"name":"</script>"}', '{"name":"\u003c/script\u003e"}'],
+    [%({"name":"d\u2028h\u2029h"}), '{"name":"d\u2028h\u2029h"}']
   ]
 
   def test_html_escape

--- a/actionview/test/template/erb_util_test.rb
+++ b/actionview/test/template/erb_util_test.rb
@@ -31,9 +31,9 @@ class ErbUtilTest < ActiveSupport::TestCase
     ['1', '1'],
     ['null', 'null'],
     ['"&"', '"\u0026"'],
-    ['"</script>"', '"\u003C/script\u003E"'],
-    ['["</script>"]', '["\u003C/script\u003E"]'],
-    ['{"name":"</script>"}', '{"name":"\u003C/script\u003E"}']
+    ['"</script>"', '"\u003c/script\u003e"'],
+    ['["</script>"]', '["\u003c/script\u003e"]'],
+    ['{"name":"</script>"}', '{"name":"\u003c/script\u003e"}']
   ]
 
   def test_html_escape

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -4,9 +4,9 @@ require 'active_support/core_ext/kernel/singleton_class'
 class ERB
   module Util
     HTML_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;', '"' => '&quot;', "'" => '&#39;' }
-    JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003e', '<' => '\u003c' }
+    JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003e', '<' => '\u003c', "\u2028" => '\u2028', "\u2029" => '\u2029' }
     HTML_ESCAPE_ONCE_REGEXP = /["><']|&(?!([a-zA-Z]+|(#\d+));)/
-    JSON_ESCAPE_REGEXP = /[&><]/
+    JSON_ESCAPE_REGEXP = /[\u2028\u2029&><]/u
 
     # A utility method for escaping HTML tag characters.
     # This method is also aliased as <tt>h</tt>.
@@ -50,9 +50,11 @@ class ERB
 
     # A utility method for escaping HTML entities in JSON strings. Specifically, the
     # &, > and < characters are replaced with their equivilant unicode escaped form -
-    # \u0026, \u003e, and \u003c. These sequences has identical meaning as the original
-    # characters inside the context of a JSON string, so assuming the input is a valid
-    # and well-formed JSON value, the output will have equivilant meaning when parsed:
+    # \u0026, \u003e, and \u003c. The Unicode sequences \u2028 and \u2029 are also
+    # escaped as then are treated as newline characters in some JavaScript engines. 
+    # These sequences has identical meaning as the original characters inside the
+    # context of a JSON string, so assuming the input is a valid and well-formed
+    # JSON value, the output will have equivilant meaning when parsed:
     # 
     #   json = JSON.generate({ name: "</script><script>alert('PWNED!!!')</script>"})
     #   # => "{\"name\":\"</script><script>alert('PWNED!!!')</script>\"}"

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -4,7 +4,7 @@ require 'active_support/core_ext/kernel/singleton_class'
 class ERB
   module Util
     HTML_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;', '"' => '&quot;', "'" => '&#39;' }
-    JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003E', '<' => '\u003C' }
+    JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003e', '<' => '\u003c' }
     HTML_ESCAPE_ONCE_REGEXP = /["><']|&(?!([a-zA-Z]+|(#\d+));)/
     JSON_ESCAPE_REGEXP = /[&><]/
 

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -5,6 +5,7 @@ class ERB
   module Util
     HTML_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;', '"' => '&quot;', "'" => '&#39;' }
     JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003e', '<' => '\u003c', "\u2028" => '\u2028', "\u2029" => '\u2029' }
+    HTML_ESCAPE_REGEXP = /[&"'><]/
     HTML_ESCAPE_ONCE_REGEXP = /["><']|&(?!([a-zA-Z]+|(#\d+));)/
     JSON_ESCAPE_REGEXP = /[\u2028\u2029&><]/u
 
@@ -21,7 +22,7 @@ class ERB
       if s.html_safe?
         s
       else
-        s.gsub(/[&"'><]/, HTML_ESCAPE).html_safe
+        s.gsub(HTML_ESCAPE_REGEXP, HTML_ESCAPE).html_safe
       end
     end
 

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -6,7 +6,7 @@ class ERB
     HTML_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;', '"' => '&quot;', "'" => '&#39;' }
     JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003E', '<' => '\u003C' }
     HTML_ESCAPE_ONCE_REGEXP = /["><']|&(?!([a-zA-Z]+|(#\d+));)/
-    JSON_ESCAPE_REGEXP = /[&"><]/
+    JSON_ESCAPE_REGEXP = /[&><]/
 
     # A utility method for escaping HTML tag characters.
     # This method is also aliased as <tt>h</tt>.
@@ -48,17 +48,54 @@ class ERB
 
     module_function :html_escape_once
 
-    # A utility method for escaping HTML entities in JSON strings
-    # using \uXXXX JavaScript escape sequences for string literals:
-    #
-    #   json_escape('is a > 0 & a < 10?')
-    #   # => is a \u003E 0 \u0026 a \u003C 10?
-    #
-    # Note that after this operation is performed the output is not
-    # valid JSON. In particular double quotes are removed:
-    #
-    #   json_escape('{"name":"john","created_at":"2010-04-28T01:39:31Z","id":1}')
-    #   # => {name:john,created_at:2010-04-28T01:39:31Z,id:1}
+    # A utility method for escaping HTML entities in JSON strings. Specifically, the
+    # &, > and < characters are replaced with their equivilant unicode escaped form -
+    # \u0026, \u003e, and \u003c. These sequences has identical meaning as the original
+    # characters inside the context of a JSON string, so assuming the input is a valid
+    # and well-formed JSON value, the output will have equivilant meaning when parsed:
+    # 
+    #   json = JSON.generate({ name: "</script><script>alert('PWNED!!!')</script>"})
+    #   # => "{\"name\":\"</script><script>alert('PWNED!!!')</script>\"}"
+    # 
+    #   json_escape(json)
+    #   # => "{\"name\":\"\\u003C/script\\u003E\\u003Cscript\\u003Ealert('PWNED!!!')\\u003C/script\\u003E\"}"
+    # 
+    #   JSON.parse(json) == JSON.parse(json_escape(json))
+    #   # => true
+    # 
+    # The intended use case for this method is to escape JSON strings before including
+    # them inside a script tag to avoid XSS vulnerability:
+    # 
+    #   <script type="application/javascript">
+    #     var currentUser = <%= json_escape current_user.to_json %>;
+    #   </script>
+    # 
+    # WARNING: this helper only works with valid JSON. Using this on non-JSON values
+    # will open up serious XSS vulnerabilities. For example, if you replace the
+    # +current_user.to_json+ in the example above with user input instead, the browser
+    # will happily eval() that string as JavaScript.
+    # 
+    # The escaping performed in this method is identical to those performed in the
+    # ActiveSupport JSON encoder when +ActiveSupport.escape_html_entities_in_json+ is
+    # set to true. Because this transformation is idempotent, this helper can be
+    # applied even if +ActiveSupport.escape_html_entities_in_json+ is already true.
+    # 
+    # Therefore, when you are unsure if +ActiveSupport.escape_html_entities_in_json+
+    # is enabled, or if you are unsure where your JSON string originated from, it
+    # is recommended that you always apply this helper (other libraries, such as the
+    # JSON gem, does not provide this kind of protection by default; also some gems
+    # might override +#to_json+ to bypass ActiveSupport's encoder).
+    # 
+    # The output of this helper method is marked as HTML safe so that you can directly
+    # include it inside a +<script>+ tag as shown above.
+    # 
+    # However, it is NOT safe to use the output of this inside an HTML attribute,
+    # because quotation marks are not escaped. Doing so might break your page's layout.
+    # If you intend to use this inside an HTML attribute, you should use the 
+    # +html_escape+ helper (or its +h+ alias) instead:
+    # 
+    #   <div data-user-info="<%= h current_user.to_json %>">...</div>
+    # 
     def json_escape(s)
       result = s.to_s.gsub(JSON_ESCAPE_REGEXP, JSON_ESCAPE)
       s.html_safe? ? result.html_safe : result


### PR DESCRIPTION
# TL;DR

The [original implementation](https://github.com/rails/rails/commit/0ff7a2d89fc95dcb0a32ed92aab7156b0778a7ea) of this helper had a bug that was never fixed for the past six years, let's fix it now.
# Long Version

So apparently we tried this multiple times before ([LH1485](https://rails.lighthouseapp.com/projects/8994/tickets/1485), #6094 and #11526). I'll try this one more time so we can fix this for real before Rails 4.1 ships :grin: (or remove it!)

As a reminder, this is what `json_escape` currently does:
1. Given a String `s`...
2. It replaces all occurrences of & to \u0026
3. It replaces all occurrences of > to \u003E
4. It replaces all occurrences of < to \u003C
5. The kicker: **it removes all occurrences of " (the double quotation mark)**

Operations 2-4 are just the standard HTML entities escaping performed by the [AS JSON encoder](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/json/encoding.rb#L42-L44), which is harmless. Operation 5, however, destroys the JSON string completely.

~~I know @NZKoz said this is working as intended, but respectfully I think he might have misinterpreted the [original implementation](https://github.com/rails/rails/commit/0ff7a2d89fc95dcb0a32ed92aab7156b0778a7ea).~~ It appears to me that @technoweenie probably just [forgot to delete](https://github.com/rails/rails/commit/0ff7a2d89fc95dcb0a32ed92aab7156b0778a7ea) the `"` from the regex after copy and pasting it from `escape_html`.
### What could this possibly protect you against?

We can also try to reason about this. There are a few scenarios that you would want a string "escaped" for "json" that could possibly warrant the creation of such helper.

1 To use it inside a JSON string value:

```
<%# users/show.json.erb -%>
{"id":user.id,"name":"<%= json_escape(user.name) %>"}
```

Because the original helper specifically escapes HTML entities, we can probably rule out this as the intended purpose. Escaping HTML entities only makes sense if the output of this helper goes into an HTML file.

2 To use it inside a JSON string value in a JSON string inside an HTML template:

``` html
<code>{"id":user.id,"name":"<%= json_escape(user.name) %>"}</code>
```

This is also unlikely, because you wouldn't want to use "\uXXXX" here, because the browser would just display that. Instead, you can just use `html_escape` here.

3 To use it inside a JSON string value in a JSON string inside a `<script>` tag inside an HTML template: 

``` html
<script>
var user = {"id":user.id,"name":"<%= json_escape(user.name) %>"};
</script>
```

This is getting closer, because we the "\uXXXX" sequences here will have identical meaning as their original values. However, this is still not quite right, because you'd have to do a lot more escaping than what this helper does (unicode control characters, slashes, etc), plus if you want to do that you would just replace " with \" like the JSON spec says, instead of removing them.

4 The string is already an encoded JSON string, and you want to use it inside an attribute:

``` html
<div data-user-info="<%= json_escape(user.to_json) %>">...</div>
```

While this is a valid use case, if you wanted to do this, you can just call html_escape on it and everything would work fine, so nope.

5 The string is already an encoded JSON string, and you want to use it a JavaScript string:

``` html
<script>
var user = "<%= json_escape(user.to_json) %>";
</script>
```

While this is a valid use case, if you wanted to do this, you would also have to escape single quotes, new lines etc (which is what the `escape_javascript` helper does, btw, although it doesn't exists back then), so nope.

6 The string is already an encoded JSON string, and you want to use it as a JavaScript variable:

``` html
<script>
var user = <%= json_escape(user.to_json) %>;
</script>
```

This is a very common use case, and everything else fits the bill perfectly, except the bug where it strips double quotation marks.

Since I cannot think of additional use cases where the current behaviour is useful, the copy-and-paste-error explanation + use case number 6 seems most likely.
#### But we already have ActiveSupport.escape_html_entities_in_json, do we still need this?

Yes, because...

1 the JSON string might be encoded in a different library:

``` html
<script>
var user = <%= JSON.generate(user.as_json) %>; // <---- OOPS!
</script>
```

2 we fight with other libraries over `to_json`, so in some cases calling `to_json` might go through a different encoder

3 if we don't have this, this is what most people would probably end up doing:

``` html
<script>
var user = <%= raw user.to_json %>; // <---- OOPS (sometimes)!
</script>
```

...which would be bad if something sets `ActiveSupport.escape_html_entities_in_json` to false, or if something overrode `#to_json`, or if they used a third-party encoder and the author "forgot" to honor `ActiveSupport.escape_html_entities_in_json`.

Since the operation (if the bug is fixed) is idempotent, it seems safer that we suggest doing this all the time:

``` html
<script>
var user = <%= json_escape user.to_json %>;
</script>
```

Of course, we can always remove/deprecate this and suggest something like this instead:

``` html
<script>
var user = JSON.parse("<%= j user.to_json %>");
</script>
```

But given that I know my string is already well-formed JSON (hence well-formed JavaScript), this seems to be a waste and a lot of trouble.
