### PR TITLE
[ci skip] removed singulars section from classify doc

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -182,10 +182,6 @@ class String
   #
   #   'egg_and_hams'.classify # => "EggAndHam"
   #   'posts'.classify        # => "Post"
-  #
-  # Singular names are not handled correctly.
-  #
-  #   'business'.classify # => "Business"
   def classify
     ActiveSupport::Inflector.classify(self)
   end


### PR DESCRIPTION
Removed senseless part of the docs of classify. Related to #13077
