### PR TITLE
Add port to default pid filename

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -24,7 +24,7 @@ module Rails
                   "Default: development") { |v| options[:environment] = v }
           opts.on("-P", "--pid=pid", String,
                   "Specifies the PID file.",
-                  "Default: tmp/pids/server.pid") { |v| options[:pid] = v }
+                  "Default: tmp/pids/server.[PORT].pid") { |v| options[:pid] = v }
 
           opts.separator ""
 
@@ -95,14 +95,18 @@ module Rails
 
     def default_options
       super.merge({
-        Port:               3000,
+        Port:               default_port,
         DoNotReverseLookup: true,
         environment:        (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || "development").dup,
         daemonize:          false,
         debugger:           false,
-        pid:                File.expand_path("tmp/pids/server.pid"),
+        pid:                File.expand_path("tmp/pids/server.#{default_port}.pid"),
         config:             File.expand_path("config.ru")
       })
+    end
+
+    def default_port
+      3000
     end
 
     private


### PR DESCRIPTION
This should make it easier for users to start multiple servers
with `rails server -p` in the same app directory without being
bumped by `A server is already running. Check /path/to/app/tmp/pids/server.pid`.

Adding the port number to the pid's filename is a sensible and
unixy default IMHO.
