### PR TITLE
Fix an activesupport inflector test changing the inflector but not reverting all its changes afterwards

### DIFF
--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -70,10 +70,11 @@ class InflectorTest < ActiveSupport::TestCase
 
 
   def test_overwrite_previous_inflectors
-    assert_equal("series", ActiveSupport::Inflector.singularize("series"))
-    ActiveSupport::Inflector.inflections.singular "series", "serie"
-    assert_equal("serie", ActiveSupport::Inflector.singularize("series"))
-    ActiveSupport::Inflector.inflections.uncountable "series" # Return to normal
+    with_dup do
+      assert_equal("series", ActiveSupport::Inflector.singularize("series"))
+      ActiveSupport::Inflector.inflections.singular "series", "serie"
+      assert_equal("serie", ActiveSupport::Inflector.singularize("series"))
+    end
   end
 
   MixtureToTitleCase.each_with_index do |(before, titleized), index|

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -63,6 +63,7 @@ module InflectorTestCases
     "news"        => "news",
 
     "series"      => "series",
+    "miniseries"  => "miniseries",
     "species"     => "species",
 
     "quiz"        => "quizzes",


### PR DESCRIPTION
Since the inflector code is frozen this pull request contains just a fix for a bug I found in the inflector_test. The test_overwrite_previous_inflectors test is adding an inflection but not entirely removing it when the test has completed. This is changing the behavior of the inflector for all tests that run afterwards.

How the method behaves in production and in tests before test_overwrite_previous_inflectors.

``` ruby
ActiveSupport::Inflector.singularize("miniseries") # => 'miniseries'
```

How the method behaves in all tests that run after test_overwrite_previous_inflectors before my fix.

``` ruby
ActiveSupport::Inflector.singularize("miniseries") # => 'miniserie'
```
