### PR TITLE
test for interacting with #mail post-message creation

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -616,6 +616,21 @@ class BaseTest < ActiveSupport::TestCase
 
     assert_equal('Testing', AfterActionMailer.welcome['X-Special-Header'].to_s)
   end
+  
+  test "accessing the mail message doesn't erase set headers" do
+    class AfterActionMailer < ActionMailer::Base
+      after_action :a_callback!
+
+      def welcome ; mail(subject: 'test me') ; end
+
+      private
+      def a_callback!
+        mail.delivery_method.settings.merge!(some: 'thing')
+      end
+    end
+
+    assert_equal('test me', AfterActionMailer.welcome.subject.to_s)
+  end
 
   test "adding an inline attachment using a before_action" do
     class DefaultInlineAttachmentMailer < ActionMailer::Base


### PR DESCRIPTION
so I'm not sure the best way to fix this, but calling ActionMailer::Base#mail a second time seems to result in mail data being reset. I ran into this trying to log mail data in an after_action, but it can also be done within the mailer method. I wrote a failing test case using a code example taken just about straight out of docs:
http://edgeguides.rubyonrails.org/action_mailer_basics.html#action-mailer-callbacks

my solution for now is just to use `@_message`, but basically it seems like this shouldn't overwrite already-set headers if the new header is blank (line 716 in action_mailer/base.rb)
