### PR TITLE
Fix stream closing when sending file with `ActionController::Live` included.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix stream closing when sending file with `ActionController::Live` included.
+
+    Fixes #12381
+
+    *Alessandro Diaferia*
+
 *   Better error message for typos in assert_response argument.
 
     When the response type argument to `assert_response` is not a known

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -234,7 +234,7 @@ module ActionController
 
     def response_body=(body)
       super
-      response.stream.close if response
+      response.close if response
     end
 
     def set_response!(request)

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -25,6 +25,10 @@ class SendFileController < ActionController::Base
   end
 end
 
+class SendFileWithActionControllerLive < SendFileController
+  include ActionController::Live
+end
+
 class SendFileTest < ActionController::TestCase
   tests SendFileController
   include TestFileUtils
@@ -195,5 +199,15 @@ class SendFileTest < ActionController::TestCase
       assert_nothing_raised { assert_not_nil process(method) }
       assert_equal 200, @response.status
     end
+  end
+
+  tests SendFileWithActionControllerLive
+
+  def test_send_file_with_action_controller_live
+    @controller = SendFileWithActionControllerLive.new
+    @controller.options = { :content_type => "application/x-ruby" }
+
+    response = process('file')
+    assert_equal 200, response.status
   end
 end


### PR DESCRIPTION
It was raising `NoMethodError` for `ActionController::DataStreaming::FileBody`
Fixes #12381
Updated version of #12382
