### PR TITLE
removed unnecessary test case

### DIFF
--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -619,16 +619,11 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal [author_address.id], AuthorAddress.destroyed_author_address_ids
   end
 
-  def test_invalid_belongs_to_dependent_option_nullify_raises_exception
-    assert_raise ArgumentError do
+  def test_belongs_to_invalid_dependent_option_raises_exception
+    error = assert_raise ArgumentError do
       Class.new(Author).belongs_to :special_author_address, :dependent => :nullify
     end
-  end
-
-  def test_invalid_belongs_to_dependent_option_restrict_raises_exception
-    assert_raise ArgumentError do
-      Class.new(Author).belongs_to :special_author_address, :dependent => :restrict
-    end
+    assert_equal error.message, 'The :dependent option must be one of [:destroy, :delete], but is :nullify'
   end
 
   def test_attributes_are_being_set_when_initialized_from_belongs_to_association_with_where_clause

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -864,8 +864,12 @@ end
 Counter cache columns are added to the containing model's list of read-only attributes through `attr_readonly`.
 
 ##### `:dependent`
+If you set the `:dependent` option to:
 
-If you set the `:dependent` option to `:destroy`, then deleting this object will call the `destroy` method on the associated object to delete that object. If you set the `:dependent` option to `:delete`, then deleting this object will delete the associated object _without_ calling its `destroy` method. If you set the `:dependent` option to `:restrict`, then attempting to delete this object will result in a `ActiveRecord::DeleteRestrictionError` if there are any associated objects.
+* `:destroy`, when the object is destroyed, `destroy` will be called on its
+associated objects.
+* `:delete`, when the object is destroyed, all its associated objects will be
+deleted directly from the database without calling their `destroy` method.
 
 WARNING: You should not specify this option on a `belongs_to` association that is connected with a `has_many` association on the other class. Doing so can lead to orphaned records in your database.
 


### PR DESCRIPTION
This [test case](https://github.com/rails/rails/blob/master/activerecord/test/cases/associations/belongs_to_associations_test.rb#L622)  is sufficient to test invalid option for `belongs_to` `:dependent` options. So, [this](https://github.com/rails/rails/blob/master/activerecord/test/cases/associations/belongs_to_associations_test.rb#L628) is not required and if it is required then atleast we should use an existing valid `dependent` option other than`:delete, and :destroy` as `:restrict` is not used anymore in rails.
