### PR TITLE
Remove `DatabaseStatements#case_sensitive_equality_operator`. It has been deprecated already.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -305,10 +305,6 @@ module ActiveRecord
         "DEFAULT VALUES"
       end
 
-      def case_sensitive_equality_operator
-        "="
-      end
-
       def limited_update_conditions(where_sql, quoted_table_name, quoted_primary_key)
         "WHERE #{quoted_primary_key} IN (SELECT #{quoted_primary_key} FROM #{quoted_table_name} #{where_sql})"
       end


### PR DESCRIPTION
It seems that `DatabaseStatements#case_sensitive_equality_operator` has been deprecated. It is not called already.
