### PR TITLE
#type_cast - improve performance & readability

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -207,9 +207,14 @@ module ActiveRecord
       end
 
       def type_cast(value, column)
-        return super unless value == true || value == false
-
-        value ? 1 : 0
+        case value
+        when TrueClass
+          1
+        when FalseClass
+          0
+        else
+          super
+        end
       end
 
       # MySQL 4 technically support transaction isolation, but it is affected by a bug


### PR DESCRIPTION
- Number of Comparison of variable `value` when:
  
  ```
  Condition                   Old Method      New Method
  value == true                   2                1
  value == false                  3                2
  value not boolean               2                2
  ```
- Avoiding short-circuiting
