### PR TITLE
Fix header Content-Type: #<Mime::NullType:...> in localized template

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -300,6 +300,10 @@ module Mime
       nil
     end
 
+    def to_a
+      []
+    end
+
     def respond_to_missing?(method, include_private = false)
       method.to_s.ends_with? '?'
     end

--- a/actionpack/test/controller/localized_templates_test.rb
+++ b/actionpack/test/controller/localized_templates_test.rb
@@ -34,4 +34,13 @@ class LocalizedTemplatesTest < ActionController::TestCase
     get :hello_world
     assert_equal "Gutten Tag", @response.body
   end
+
+  def test_localized_template_has_correct_header
+    old_locale = I18n.locale
+    I18n.locale = :it
+
+    get :hello_world
+    assert_equal "Ciao Mondo", @response.body
+    assert_equal "text/html",  @response.content_type
+  end
 end

--- a/actionpack/test/fixtures/localized/hello_world.it.erb
+++ b/actionpack/test/fixtures/localized/hello_world.it.erb
@@ -1,0 +1,1 @@
+Ciao Mondo


### PR DESCRIPTION
This PR fixes #13064 regression bug introduced by the #8085

Ideally the NullType object would act like NilClass unfortunately
that appears to be hardwired into MRI, as we know nil.to_a -> []
