### PR TITLE
Fixes failing test for JRuby

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -113,6 +113,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     FileUtils.mv(app_root, app_moved_root)
 
+    # make sure we are in correct dir
+    FileUtils.cd(app_moved_root)
+
     generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true },
                                                                destination_root: app_moved_root, shell: @shell
     generator.send(:app_const)


### PR DESCRIPTION
in JRuby FileUtils do not change
current dir when moving files

``` ruby
p Dir.pwd
run_generator [app_root]
p Dir.pwd
FileUtils.mv(app_root, app_moved_root, :verbose => true)
p Dir.pwd
```

```
"/Users/arunagw/checkouts/rails/railties"
"/Users/arunagw/checkouts/rails/railties/test/fixtures/tmp/myapp"
mv /Users/arunagw/checkouts/rails/railties/test/fixtures/tmp/myapp /Users/arunagw/checkouts/rails/railties/test/fixtures/tmp/myapp_moved
"/Users/arunagw/checkouts/rails/railties/test/fixtures/tmp/myapp"
```

We need to cd in new Dir.
