### PR TITLE
Delete in memory association record.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Delete in-memory association record when target record is deleted
+    for hm:t case.
+
+    Fixes #9548.
+
+    *Neeraj Singh*
+
 *   Previously, the `has_one` macro incorrectly accepted the `counter_cache`
     option, but never actually supported it. Now it will raise an `ArgumentError`
     when using `has_one` with `counter_cache`.

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -468,6 +468,9 @@ module ActiveRecord
           delete_records(existing_records, method) if existing_records.any?
           records.each { |record| target.delete(record) }
 
+          # remove association records for has_many :through case
+          delete_through_records(records) if reflection.is_a?(ActiveRecord::Reflection::ThroughReflection)
+
           records.each { |record| callback(:after_remove, record) }
         end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1098,4 +1098,18 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   def test_has_many_through_with_includes_in_through_association_scope
     assert_not_empty posts(:welcome).author_address_extra_with_address
   end
+
+  def test_has_many_through_should_delete_in_memory_association_record
+    person = Person.new(first_name: "Peter")
+    post = Post.new(title: "Cats & Dogs", body: "are pets")
+
+    person.posts << post
+    assert person.posts.include?(post)
+
+    person.posts.delete(post)
+    assert_not person.posts.include?(post), "should not contain the post after deletion but did."
+
+    person.save!
+    assert_not person.posts.include?(post)
+  end
 end


### PR DESCRIPTION
When target record is deleted then in-memory association
record should be deleted for hm:t case.

Fixes #9548.

This is an updated version of #10499
