### PR TITLE
Fix `PredicateBuilder` to handle nil value passed to Relation#find_by`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Fix `PredicateBuilder` to handle nil value passed to `Relation#find_by` in case of an association
+    attribute.
+
+    For example, with:
+
+        class Author < ActiveRecord::Base
+        end
+
+        class Favorite < ActiveRecord::Base
+          belongs_to :author
+        end
+
+    Allows usage of:
+
+        Favorite.find_by(author: nil)
+
+    *Vipul A M*
+
 *   Previously, the `has_one` macro incorrectly accepted the `counter_cache`
     option, but never actually supported it. Now it will raise an `ArgumentError`
     when using `has_one` with `counter_cache`.

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -55,13 +55,15 @@ module ActiveRecord
       #
       # For polymorphic relationships, find the foreign key and type:
       # PriceEstimate.where(estimate_of: treasure)
-      if klass && value.is_a?(Base) && reflection = klass.reflect_on_association(column.to_sym)
+      reflection = klass.reflect_on_association(column.to_sym) if klass
+
+      if reflection && value.is_a?(Base)
         if reflection.polymorphic?
           queries << build(table[reflection.foreign_type], value.class.base_class)
         end
-
-        column = reflection.foreign_key
       end
+
+      column = reflection.foreign_key if reflection
 
       queries << build(table[column], value)
       queries

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -868,6 +868,10 @@ class FinderTest < ActiveRecord::TestCase
     assert_nothing_raised(ActiveRecord::StatementInvalid) { Topic.offset("3").to_a }
   end
 
+  def test_find_by_with_null_association
+    assert_nil AuthorFavorite.find_by(author: nil)
+  end
+
   protected
     def bind(statement, *vars)
       if vars.first.is_a?(Hash)


### PR DESCRIPTION
Fix `PredicateBuilder` to handle nil value passed to Relation#find_by` in case of an association attribute.

 Fixes #13075
