### PR TITLE
corrected RENDER_DEPENDENCY regex

### DIFF
--- a/actionview/lib/action_view/dependency_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker.rb
@@ -37,8 +37,8 @@ module ActionView
       #   render(message.topics) => render("topics/topic")
       RENDER_DEPENDENCY = /
         render\s*                     # render, followed by optional whitespace
-        \(?                           # start an optional parenthesis for the render call
-        (partial:|:partial\s+=>)?\s*  # naming the partial, used with collection -- 1st capture
+        [\(\s+]                       # start with either parenthesis or at least a whitespace for the render call
+        (partial:|:partial\s*=>)?\s*  # naming the partial, used with collection -- 1st capture
         ([@a-z"'][@\w\/\."']+)        # the template name itself -- 2nd capture
       /x
 

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -70,5 +70,12 @@ class ERBTrackerTest < Minitest::Test
 
     assert_equal ["messages/message"], tracker.dependencies
   end
+
+  def test_finds_no_dependency_when_general_word_starts_with_render
+    template = FakeTemplate.new("<%# renderings %>", :erb)
+    tracker = make_tracker('ings/ing', template)
+
+    assert_equal [], tracker.dependencies
+  end
 end
 

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -77,5 +77,26 @@ class ERBTrackerTest < Minitest::Test
 
     assert_equal [], tracker.dependencies
   end
+
+  def test_finds_no_dependency_when_no_space_between_render_and_filename
+    template = FakeTemplate.new("<%# render'messages/message' %>", :erb)
+    tracker = make_tracker('messages/_message', template)
+
+    assert_equal [], tracker.dependencies
+  end
+
+  def test_finds_no_dependency_when_no_space_between_render_and_partial
+    template = FakeTemplate.new("<%# render:partial => 'messages/message' %>", :erb)
+    tracker = make_tracker('messages/_message', template)
+
+    assert_equal [], tracker.dependencies
+  end
+
+  def test_dependency_of_erb_partials
+    template = FakeTemplate.new("<%# render :partial=> 'messages/message' %>", :erb)
+    tracker = make_tracker('messages/_message', template)
+
+    assert_equal ['messages/message'], tracker.dependencies
+  end
 end
 


### PR DESCRIPTION
fixed-issue https://github.com/rails/rails/issues/13074, regex was passing any word which starts with `render`, like: 

``` ruby
* renderable 
* renderings
* renderers
* rendering
```
