### PR TITLE
Added method "on:" that allows a user to use has_secure_password on update or create

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -58,10 +58,11 @@ module ActiveModel
 
         if options.fetch(:validations, true)
           validates_confirmation_of :password, if: :should_confirm_password?
-          validates_presence_of     :password, on: :create
+          validates_presence_of     :password, on: options.fetch(:on, :create)
           validates_presence_of     :password_confirmation, if: :should_confirm_password?
 
-          before_create { raise "Password digest missing on new record" if password_digest.blank? }
+          digest_grammar = options[:on] == :update ? 'updated' : 'new'
+          send "before_#{options.fetch(:on, :create).to_s}", -> { raise "Password digest missing on #{digest_grammar} record" if password_digest.blank? }
         end
 
         if respond_to?(:attributes_protected_by_default)

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -1,5 +1,6 @@
 require 'cases/helper'
 require 'models/user'
+require 'models/member'
 require 'models/oauthed_user'
 require 'models/visitor'
 require 'models/administrator'
@@ -9,6 +10,7 @@ class SecurePasswordTest < ActiveModel::TestCase
     ActiveModel::SecurePassword.min_cost = true
 
     @user = User.new
+    @member = Member.new
     @visitor = Visitor.new
     @oauthed_user = OauthedUser.new
   end
@@ -66,6 +68,23 @@ class SecurePasswordTest < ActiveModel::TestCase
     @user.password = "supersecretpassword"
     assert_nothing_raised do
       @user.run_callbacks :create
+    end
+  end
+
+  test "Member should be created with blank digest" do
+    assert_nothing_raised do
+      @member.run_callbacks :create
+    end
+  end
+
+  test "Member should not be updated with blank digest" do
+    assert_raise RuntimeError do
+      @member.run_callbacks :update
+    end
+
+    @member.password = "sekritpasswerd"
+    assert_nothing_raised do
+      @member.run_callbacks :update
     end
   end
 

--- a/activemodel/test/models/member.rb
+++ b/activemodel/test/models/member.rb
@@ -1,0 +1,11 @@
+class Member
+  extend ActiveModel::Callbacks
+  include ActiveModel::Validations
+  include ActiveModel::SecurePassword
+  
+  define_model_callbacks :update, :create
+
+  has_secure_password on: :update
+
+  attr_accessor :password_digest, :password_salt
+end


### PR DESCRIPTION
This commit allows a choice of when to use `has_secure_password`, either on `create` or `update`. When `has_secure_password on: :update` is called, the class will not check password creation on create but will check on update.

My use case is I am running a centrally managed application and I don't create passwords for users automatically; rather, I have the user activate their account and create their password on activation. 
