### PR TITLE
Removed redundant field name in the guide

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -337,7 +337,7 @@ set. In fact, this set can be any enumerable object.
 ```ruby
 class Account < ActiveRecord::Base
   validates :subdomain, exclusion: { in: %w(www us ca jp),
-    message: "Subdomain %{value} is reserved." }
+    message: "%{value} is reserved." }
 end
 ```
 


### PR DESCRIPTION
Fixes: #13108
[ci skip]
