### PR TITLE
Support PostgreSQL materialized views

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Enable support for materialized views on PostgreSQL >= 9.3.
+
+    *Dave Lee*
+
 *   Previously, the `has_one` macro incorrectly accepted the `counter_cache`
     option, but never actually supported it. Now it will raise an `ArgumentError`
     when using `has_one` with `counter_cache`.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -150,12 +150,11 @@ module ActiveRecord
         # - "schema.name".table_name
         # - "schema.name"."table.name"
         def quote_table_name(name)
-          schema, name_part = extract_pg_identifier_from_name(name.to_s)
+          schema, table_name = Utils.extract_schema_and_table(name.to_s)
 
-          unless name_part
-            quote_column_name(schema)
+          if schema.blank?
+            quote_column_name(table_name)
           else
-            table_name, name_part = extract_pg_identifier_from_name(name_part)
             "#{quote_column_name(schema)}.#{quote_column_name(table_name)}"
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -104,14 +104,11 @@ module ActiveRecord
           schema, table = Utils.extract_schema_and_table(name.to_s)
           return false unless table
 
-          binds = [[nil, table]]
-          binds << [nil, schema] if schema
-
           exec_query(<<-SQL, 'SCHEMA').rows.first[0].to_i > 0
               SELECT COUNT(*)
               FROM pg_class c
               LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
-              WHERE c.relkind in ('v','r')
+              WHERE c.relkind IN ('r','v','m') -- (r)elation/table, (v)iew, (m)aterialized view
               AND c.relname = '#{table.gsub(/(^"|"$)/,'')}'
               AND n.nspname = #{schema ? "'#{schema}'" : 'ANY (current_schemas(false))'}
           SQL

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -109,7 +109,7 @@ module ActiveRecord
               FROM pg_class c
               LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
               WHERE c.relkind IN ('r','v','m') -- (r)elation/table, (v)iew, (m)aterialized view
-              AND c.relname = '#{table.gsub(/(^"|"$)/,'')}'
+              AND c.relname = '#{table}'
               AND n.nspname = #{schema ? "'#{schema}'" : 'ANY (current_schemas(false))'}
           SQL
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -645,6 +645,10 @@ module ActiveRecord
         postgresql_version >= 90200
       end
 
+      def supports_materialized_views?
+        postgresql_version >= 90300
+      end
+
       def enable_extension(name)
         exec_query("CREATE EXTENSION IF NOT EXISTS \"#{name}\"").tap {
           reload_type_map

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -944,16 +944,6 @@ module ActiveRecord
           end_sql
         end
 
-        def extract_pg_identifier_from_name(name)
-          match_data = name.start_with?('"') ? name.match(/\"([^\"]+)\"/) : name.match(/([^\.]+)/)
-
-          if match_data
-            rest = name[match_data[0].length, name.length]
-            rest = rest[1, rest.length] if rest.start_with? "."
-            [match_data[1], (rest.length > 0 ? rest : nil)]
-          end
-        end
-
         def extract_table_ref_from_insert_sql(sql)
           sql[/into\s+([^\(]*).*values\s*\(/i]
           $1.strip if $1

--- a/activerecord/test/cases/adapters/postgresql/view_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/view_test.rb
@@ -5,6 +5,7 @@ module ViewTestConcern
 
   included do
     self.use_transactional_fixtures = false
+    mattr_accessor :view_type
   end
 
   SCHEMA_NAME = 'test_schema'
@@ -20,9 +21,6 @@ module ViewTestConcern
   end
 
   def setup
-    # Derive type of view (view, materialized_view), from class name.
-    view_type = self.class.name.chomp('Test').underscore
-
     ThingView.table_name = "#{SCHEMA_NAME}.#{view_type}_things"
 
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/adapters/postgresql/view_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/view_test.rb
@@ -2,19 +2,7 @@ require "cases/helper"
 
 module ViewTestConcern
   extend ActiveSupport::Concern
-end
 
-class ViewTest < ActiveRecord::TestCase
-  include ViewTestConcern
-end
-
-if ActiveRecord::Base.connection.supports_materialized_views?
-  class MaterializedViewTest < ActiveRecord::TestCase
-    include ViewTestConcern
-  end
-end
-
-module ViewTestConcern
   included do
     self.use_transactional_fixtures = false
   end
@@ -64,4 +52,16 @@ module ViewTestConcern
       end
     end
 
+end
+
+class ViewTest < ActiveRecord::TestCase
+  include ViewTestConcern
+  self.view_type = 'view'
+end
+
+if ActiveRecord::Base.connection.supports_materialized_views?
+  class MaterializedViewTest < ActiveRecord::TestCase
+    include ViewTestConcern
+    self.view_type = 'materialized_view'
+  end
 end


### PR DESCRIPTION
The change is pretty minimal, the query used in `#table_exists?` has been expanded to include materialized views in the kinds of relations it includes in its search.

In order to share the existing view tests, I made the previous test class into a concern that is then included into separate `ViewTest` and `MaterializedViewTest` classes, the latter only if PostgreSQL is at least version 9.3. ~~The test class then uses the name of the test to determine the type of view to create and test against.~~
