### PR TITLE
Fix header Content-Type: #<Mime::NullType:...> in localized template

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix header Content-Type: #<Mime::NullType:...> in localized template
+
+    When localized template has no format in the template name,
+    now the response has the default and correct `content-type`.
+    
+    Fix #13064.
+
+   *Angelo Capilleri*
+
 *   Better error message for typos in assert_response argument.
 
     When the response type argument to `assert_response` is not a known

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -34,7 +34,7 @@ module ActionController
 
     def _process_format(format)
       super
-      self.content_type ||= format.to_s
+      self.content_type ||= format.to_s unless format.nil? #here test if format is Mime::NullTye istance, no if is a NillClass or FalseClass
     end
 
     # Normalize arguments by catching blocks and setting them on :update.

--- a/actionpack/test/controller/localized_templates_test.rb
+++ b/actionpack/test/controller/localized_templates_test.rb
@@ -34,4 +34,15 @@ class LocalizedTemplatesTest < ActionController::TestCase
     get :hello_world
     assert_equal "Gutten Tag", @response.body
   end
+
+  def test_localized_template_has_correct_header_with_no_format_in_template_name
+    old_locale = I18n.locale
+    I18n.locale = :it
+
+    get :hello_world
+    assert_equal "Ciao Mondo", @response.body
+    assert_equal "text/html",  @response.content_type
+  ensure
+    I18n.locale = old_locale
+  end
 end

--- a/actionpack/test/fixtures/localized/hello_world.it.erb
+++ b/actionpack/test/fixtures/localized/hello_world.it.erb
@@ -1,0 +1,1 @@
+Ciao Mondo


### PR DESCRIPTION
This PR fixes #13064 regression bug introduced by the #8085

Now in _process_format when the format is a Mime::NullType nothing is written in self.content_type.
In this way the method Response#assign_default_content_type_and_charset can
write the the default mime_type.
