### PR TITLE
Reindex bind params for sub-queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   For PG queries with bind values in base query and in sub-queries generates bad indexes for bind params
+    of prepared constraints in sub-queries. Added re-indexing of bind params on build where values
+    for sub-queries.
+
+    Fixes #12753.
+
+    Example:
+
+        posts.comments.to_sql
+        # => SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = $1
+
+        posts.comments.where(id: posts.comments).to_sql
+        # Before:
+        # => SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = $1 AND
+        #    "comments"."id" IN
+        #    (SELECT "comments"."id" FROM "comments"  WHERE "comments"."post_id" = $1)
+        # After:
+        # => SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = $1 AND
+        #    "comments"."id" IN
+        #    (SELECT "comments"."id" FROM "comments"  WHERE "comments"."post_id" = $2)
+
+    *Paul Nikitochkin*
+
 *   When a `group` is set, `sum`, `size`, `average`, `minimum` and `maximum`
     on a NullRelation should return a Hash.
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -35,7 +35,8 @@ module ActiveRecord
       #    User.where.not(name: "Jon", role: "admin")
       #    # SELECT * FROM users WHERE name != 'Jon' AND role != 'admin'
       def not(opts, *rest)
-        where_value = @scope.send(:build_where, opts, rest).map do |rel|
+        where_value, _ = @scope.send(:build_where, opts, rest)
+        where_value.map! do |rel|
           case rel
           when NilClass
             raise ArgumentError, 'Invalid argument for .where.not(), got nil.'
@@ -579,7 +580,10 @@ WARNING
       else
         references!(PredicateBuilder.references(opts)) if Hash === opts
 
-        self.where_values += build_where(opts, rest)
+        where_values, bind_values = build_where(opts, rest)
+
+        self.bind_values += bind_values
+        self.where_values += where_values
         self
       end
     end
@@ -607,7 +611,8 @@ WARNING
     def having!(opts, *rest) # :nodoc:
       references!(PredicateBuilder.references(opts)) if Hash === opts
 
-      self.having_values += build_where(opts, rest)
+      where_value, _ = build_where(opts, rest)
+      self.having_values += where_value
       self
     end
 
@@ -947,24 +952,43 @@ WARNING
     def build_where(opts, other = [])
       case opts
       when String, Array
-        [@klass.send(:sanitize_sql, other.empty? ? opts : ([opts] + other))]
+        values = Hash === other.first ? other.first.values : other
+
+        bind_values = build_bind_values(values)
+        where_values = [@klass.send(:sanitize_sql, other.empty? ? opts : ([opts] + other))]
+
+        [where_values, bind_values]
       when Hash
         opts = PredicateBuilder.resolve_column_aliases(klass, opts)
         attributes = @klass.send(:expand_hash_conditions_for_aggregates, opts)
 
-        bv_len = bind_values.length
-        tmp_opts, bind_values = create_binds(opts, bv_len)
-        self.bind_values += bind_values
+        bind_values = build_bind_values(attributes.values)
+        where_values = PredicateBuilder.build_from_hash(klass, attributes, table)
 
-        attributes = @klass.send(:expand_hash_conditions_for_aggregates, tmp_opts)
-        attributes.values.grep(ActiveRecord::Relation) do |rel|
-          self.bind_values += rel.bind_values
-        end
-
-        PredicateBuilder.build_from_hash(klass, attributes, table)
+        [where_values, reindex_bind_values(bind_values, where_values)]
       else
-        [opts]
+        [[opts], []]
       end
+    end
+
+    def build_bind_values(values)
+      values.grep(ActiveRecord::Relation).inject([]) { |a, rel| a + rel.bind_values }
+    end
+
+    def reindex_bind_values(bind_values, where_values, bv_base = self.bind_values.size)
+      if bind_values.present?
+        bv_index = 0
+        where_values.grep(Arel::Nodes::Node).each do |node|
+          node.each do |n|
+            if Arel::Nodes::Equality === n && Arel::Nodes::BindParam === n.right
+              n.right = connection.substitute_at(bind_values[bv_index].first, bv_base + bv_index)
+              bv_index += 1
+            end
+          end
+        end
+      end
+
+      bind_values
     end
 
     def create_binds(opts, idx)

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -9,7 +9,7 @@ require 'models/topic'
 
 module ActiveRecord
   class WhereTest < ActiveRecord::TestCase
-    fixtures :posts, :edges, :authors
+    fixtures :posts, :edges, :authors, :comments
 
     def test_where_copies_bind_params
       author = authors(:david)
@@ -178,6 +178,11 @@ module ActiveRecord
       [[], {}, nil, ""].each do |blank|
         assert_equal 4, Edge.where(blank).order("sink_id").to_a.size
       end
+    end
+
+    def test_remove_duplicated_binds_on_adding_subquery
+      comments = Post.first.comments
+      assert_equal 2, comments.where(id: comments).count
     end
   end
 end


### PR DESCRIPTION
On building where values in `where!` with relation as hash constraint
added reindexing of bind params positions to be linked with corresponded
bind values

Fixes #12753
