### PR TITLE
counter cache should be aware of self-referential belongs_to association

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -22,6 +22,7 @@ module ActiveRecord::Associations::Builder
     def add_counter_cache_callbacks(reflection)
       cache_column = reflection.counter_cache_column
       foreign_key = reflection.foreign_key
+      class_name = reflection.options[:class_name] || name.to_s.camelize
 
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
         def belongs_to_counter_cache_after_create_for_#{name}
@@ -43,8 +44,8 @@ module ActiveRecord::Associations::Builder
         def belongs_to_counter_cache_after_update_for_#{name}
           if (@_after_create_counter_called ||= false)
             @_after_create_counter_called = false
-          elsif self.#{foreign_key}_changed? && !new_record? && defined?(#{name.to_s.camelize})
-            model = #{name.to_s.camelize}
+          elsif self.#{foreign_key}_changed? && !new_record? && defined?(#{class_name})
+            model = #{class_name}
             foreign_key_was = self.#{foreign_key}_was
             foreign_key = self.#{foreign_key}
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -489,6 +489,17 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal 17, reply.replies.size
   end
 
+  def test_self_referential_counter_cache
+    parent = Topic.create :title => "Are you there?"
+    assert_equal 0, parent[:self_replies_count]
+
+    Topic.create :title => "Here"
+
+    child = Topic.find_by_title("Here")
+    child.update_attributes(self_parent_id: parent.id)
+    assert_equal 1, parent.reload[:self_replies_count]
+  end
+
   def test_association_assignment_sticks
     post = Post.first
 

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -39,6 +39,9 @@ class Topic < ActiveRecord::Base
   has_many :unique_replies, :dependent => :destroy, :foreign_key => "parent_id"
   has_many :silly_unique_replies, :dependent => :destroy, :foreign_key => "parent_id"
 
+  belongs_to :parent_message, :class_name => "Topic", :foreign_key => "self_parent_id", :inverse_of => :child_messages, :counter_cache => "self_replies_count"
+  has_many :child_messages, :dependent => :destroy, :class_name => "Topic", :foreign_key => "self_parent_id", :inverse_of => :parent_message
+
   serialize :content
 
   before_create  :default_written_on

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -677,7 +677,9 @@ ActiveRecord::Schema.define do
     end
     t.boolean  :approved, :default => true
     t.integer  :replies_count, :default => 0
+    t.integer  :self_replies_count, :default => 0
     t.integer  :parent_id
+    t.integer  :self_parent_id
     t.string   :parent_title
     t.string   :type
     t.string   :group


### PR DESCRIPTION
counter cache is currently not working in rails 4-0-stable when using self-referential belongs_to association. 
eg. 

```
class Message
  belongs_to :parent_message, class_name: 'Message', foreign_key: 'parent_id', inverse_of: :replies, counter_cache: :replies_count
end
```
