### PR TITLE
Make Kernel#silence_stream & Kernel#capture thread safe, stop turning STDOUT into /dev/null.

### DIFF
--- a/activesupport/lib/active_support/core_ext/kernel/reporting.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/reporting.rb
@@ -43,8 +43,7 @@ module Kernel
   #
   #   puts 'But this will'
   def silence_stream(stream)
-    @@stream_monitor ||= Monitor.new
-    @@stream_monitor.synchronize do
+    stream_monitor.synchronize do
       begin
         old_stream = stream.dup
         stream.reopen(RbConfig::CONFIG['host_os'] =~ /mswin|mingw/ ? 'NUL:' : '/dev/null')
@@ -85,20 +84,24 @@ module Kernel
   #   stream = capture(:stderr) { system('echo error 1>&2') }
   #   stream # => "error\n"
   def capture(stream)
-    stream = stream.to_s
-    captured_stream = Tempfile.new(stream)
-    stream_io = eval("$#{stream}")
-    origin_stream = stream_io.dup
-    stream_io.reopen(captured_stream)
+    stream_monitor.synchronize do
+      begin
+        stream = stream.to_s
+        captured_stream = Tempfile.new(stream)
+        stream_io = eval("$#{stream}")
+        origin_stream = stream_io.dup
+        stream_io.reopen(captured_stream)
 
-    yield
+        yield
 
-    stream_io.rewind
-    return captured_stream.read
-  ensure
-    captured_stream.close
-    captured_stream.unlink
-    stream_io.reopen(origin_stream)
+        stream_io.rewind
+        return captured_stream.read
+      ensure
+        captured_stream.close
+        captured_stream.unlink
+        stream_io.reopen(origin_stream)
+      end
+    end
   end
   alias :silence :capture
 
@@ -111,5 +114,12 @@ module Kernel
         yield
       end
     end
+  end
+
+  # Shared monitor for stream access (such as STDOUT)
+  #  to ensure thread safe IO.reopen calls
+  #
+  def stream_monitor
+    @stream_monitor ||= Monitor.new
   end
 end

--- a/activesupport/test/core_ext/kernel_test.rb
+++ b/activesupport/test/core_ext/kernel_test.rb
@@ -30,8 +30,8 @@ class KernelTest < ActiveSupport::TestCase
   end
 
   def test_silence_stream_is_thread_safe
-    $current_stdout  = STDOUT.dup
-    original_stdout  = $current_stdout.inspect
+    $current_stdout = STDOUT.dup
+    original_stdout = $current_stdout.inspect
 
     threads = []
     4.times do |i|
@@ -48,6 +48,27 @@ class KernelTest < ActiveSupport::TestCase
     assert_nothing_raised { threads.each(&:join) }
 
     assert_equal $current_stdout.inspect, original_stdout
+  ensure
+    $current_stdout = nil
+  end
+
+  def test_capture_is_thread_safe
+    $stdout_test = STDOUT.dup
+    original_stdout = $stdout_test.inspect
+
+    threads = []
+    4.times do |i|
+      threads << Thread.new(i) do
+        capture(:stdout_test) { $stdout_test.print "hello" }
+        capture(:stdout_test) { $stdout_test.print "hello also" }
+      end
+    end
+
+    assert_nothing_raised { threads.each(&:join) }
+
+    assert_equal $stdout_test.inspect, original_stdout
+  ensure
+    $stdout_test = nil
   end
 
   def test_silence_stderr


### PR DESCRIPTION
During an upgrade from Rails 3 -> 4, I noticed our log output was completely 'freezing', both in console and file logs whenever running features.

In the end this was tracked down to https://github.com/rails/activerecord-session_store running a `Kernel#quietly` command when finding the session. It looks like `silence_stream` isn't thread safe.

The issue being: 

https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/kernel/reporting.rb#L46

```
 def silence_stream(stream)
    old_stream = stream.dup
    stream.reopen(RbConfig::CONFIG['host_os'] =~ /mswin|mingw/ ? 'NUL:' : '/dev/null')
    stream.sync = true
    yield
  ensure
    stream.reopen(old_stream)
  end
```

If another thread has picked up a global `STDOUT` and replaced it via `reopen` to `dev/null` then the last thread wins, effectively leaving `STDOUT` as `/dev/null` and giving the appearance of anything using `STDOUT` such as test output as stopping.

I've given the test a shot, and can make it consistently fail without the synchronise changes. If anyone has any tips on how to test it I'd love to know, I'm not sure this is the best way.

The same issue was present for `capture(stream)` also, and the scenario of using both `capture` and `silence_stream` in multiple threads together. As such I've added another commit that shares the same monitor lock and tested the same error produced from `capture(stream)`. I did write a test for the combination of both (if they both have their own unique thread safe monitor and not shared), but felt it was overkill, I can add back if you'd like.
