### PR TITLE
Adds implicit conversion of regclass to text

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -352,6 +352,7 @@ module ActiveRecord
         alias_type 'interval', 'text'
         alias_type 'macaddr',  'text'
         alias_type 'uuid',     'text'
+        alias_type 'regclass', 'text'
 
         register_type 'money', OID::Money.new
         register_type 'bytea', OID::Bytea.new


### PR DESCRIPTION
In the following example

``` ruby
class Transaction < ActiveRecord::Base
  belongs_to :account
  scope :with_type, -> do 
    select "#{self.name.underscore.pluralize}.*, #{self.name.underscore.pluralize}.tableoid::regclass as table_name"
  end
end
```

Calling `Transaction.with_type` will generate a warning like:

> unknown OID: table_name(2205) (SELECT  game_transactions.*, game_transactions.tableoid::regclass as table_name FROM "game_transactions"  WHERE "game_transactions"."account_id" = $1 AND "game_transactions"."id" = 226 LIMIT 1)

This commit ensures that we implicitly just convert the regclass to text to get rid of this warning.
