### PR TITLE
Fix ActiveRecord::Callbacks sample code [ci skip]

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -128,7 +128,7 @@ module ActiveRecord
   #       record.credit_card_number = decrypt(record.credit_card_number)
   #     end
   #
-  #     alias_method :after_find, :after_save
+  #     alias_method :after_initialize, :after_save
   #
   #     private
   #       def encrypt(value)
@@ -163,7 +163,7 @@ module ActiveRecord
   #       record.send("#{@attribute}=", decrypt(record.send("#{@attribute}")))
   #     end
   #
-  #     alias_method :after_find, :after_save
+  #     alias_method :after_initialize, :after_save
   #
   #     private
   #       def encrypt(value)


### PR DESCRIPTION
Callback caller class uses `after_initialize` hook,
but Callback callee defines `after_find`.

Current sample code causes following error.

```
NoMethodError: undefined method `after_initialize' for #<EncryptionWrapper:0x007fe4931fa5c0>
```
