### PR TITLE
allow for arrays to be defined as symbol

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -384,7 +384,7 @@ module ActiveRecord
         def change_column(table_name, column_name, type, options = {})
           clear_cache!
           quoted_table_name = quote_table_name(table_name)
-          sql_type = type_to_sql(type, options[:limit], options[:precision], options[:scale])
+          sql_type = type_to_sql(type, options[:limit], options[:precision], options[:scale]).to_s
           sql_type << "[]" if options[:array]
           execute "ALTER TABLE #{quoted_table_name} ALTER COLUMN #{quote_column_name(column_name)} TYPE #{sql_type}"
 

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -28,6 +28,17 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert @column.array
   end
 
+  def test_change_column_with_interger_array_to_bigint_array_with_symbol
+    @connection.add_column :pg_arrays, :some_ids, :integer, array: true
+    @connection.change_column :pg_arrays, :some_ids, :bigint, array: true
+
+    PgArray.reset_column_information
+    column = PgArray.columns.find { |c| c.name == 'some_ids' }
+
+    assert_equal 'bigint', column.sql_type
+    assert column.array
+  end
+
   def test_change_column_with_array
     @connection.add_column :pg_arrays, :snippets, :string, array: true, default: []
     @connection.change_column :pg_arrays, :snippets, :text, array: true, default: "{}"


### PR DESCRIPTION
`change_colum :table, :column, :bigint, array: true` didn't work because
the array option tried to string concat: `:bigint << '[]'`

I don't know if this is the right place to convert the possible symbol
to a string. If it's wrong please let me know a better place and I will
change this.
