### PR TITLE
Backport Rails 3.2.16 Security Fixes to Rails 3.1.x

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -242,13 +242,13 @@ module ActionDispatch
 
     # Override Rack's GET method to support indifferent access
     def GET
-      @env["action_dispatch.request.query_parameters"] ||= (normalize_parameters(super) || {})
+      @env["action_dispatch.request.query_parameters"] ||= deep_munge(normalize_parameters(super) || {})
     end
     alias :query_parameters :GET
 
     # Override Rack's POST method to support indifferent access
     def POST
-      @env["action_dispatch.request.request_parameters"] ||= (normalize_parameters(super) || {})
+      @env["action_dispatch.request.request_parameters"] ||= deep_munge(normalize_parameters(super) || {})
     end
     alias :request_parameters :POST
 

--- a/actionpack/lib/action_view/helpers/number_helper.rb
+++ b/actionpack/lib/action_view/helpers/number_helper.rb
@@ -130,7 +130,7 @@ module ActionView
 
         begin
           value = number_with_precision(number, options.merge(:raise => true))
-          format.gsub(/%n/, value).gsub(/%u/, unit).html_safe
+          format.gsub(/%n/, ERB::Util.html_escape(value)).gsub(/%u/, ERB::Util.html_escape(unit)).html_safe
         rescue InvalidNumberError => e
           if options[:raise]
             raise

--- a/actionpack/lib/action_view/helpers/translation_helper.rb
+++ b/actionpack/lib/action_view/helpers/translation_helper.rb
@@ -1,24 +1,14 @@
 require 'action_view/helpers/tag_helper'
 require 'i18n/exceptions'
 
-module I18n
-  class ExceptionHandler
-    include Module.new {
-      def call(exception, locale, key, options)
-        exception.is_a?(MissingTranslation) && options[:rescue_format] == :html ? super.html_safe : super
-      end
-    }
-  end
-end
-
 module ActionView
   # = Action View Translation Helpers
   module Helpers
     module TranslationHelper
       # Delegates to <tt>I18n#translate</tt> but also performs three additional functions.
       #
-      # First, it'll pass the <tt>:rescue_format => :html</tt> option to I18n so that any
-      # thrown +MissingTranslation+ messages will be turned into inline spans that
+      # First, it will ensure that any thrown +MissingTranslation+ messages will be turned 
+      # into inline spans that:
       #
       #   * have a "translation-missing" class set,
       #   * contain the missing key as a title attribute and
@@ -44,7 +34,9 @@ module ActionView
       # naming convention helps to identify translations that include HTML tags so that
       # you know what kind of output to expect when you call translate in a template.
       def translate(key, options = {})
-        options.merge!(:rescue_format => :html) unless options.key?(:rescue_format)
+        # If the user has specified rescue_format then pass it all through, otherwise use
+        # raise and do the work ourselves
+        options[:raise] = true unless options.key?(:raise) || options.key?(:rescue_format)
         if html_safe_translation_key?(key)
           html_safe_options = options.dup
           options.except(*I18n::RESERVED_KEYS).each do |name, value|
@@ -58,6 +50,9 @@ module ActionView
         else
           I18n.translate(scope_key_by_partial(key), options)
         end
+      rescue I18n::MissingTranslationData => e
+        keys = I18n.normalize_keys(e.locale, e.key, e.options[:scope])
+        content_tag('span', keys.last.to_s.titleize, :class => 'translation_missing', :title => "translation missing: #{keys.join('.')}")
       end
       alias :t :translate
 

--- a/actionpack/test/dispatch/request/query_string_parsing_test.rb
+++ b/actionpack/test/dispatch/request/query_string_parsing_test.rb
@@ -11,6 +11,17 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
       head :ok
     end
   end
+  class EarlyParse
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      # Trigger a Rack parse so that env caches the query params
+      Rack::Request.new(env).params
+      @app.call(env)
+    end
+  end
 
   def teardown
     TestController.last_query_parameters = nil
@@ -120,6 +131,10 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
         set.draw do
           match ':action', :to => ::QueryStringParsingTest::TestController
         end
+        @app = self.class.build_app(set) do |middleware|
+          middleware.use(EarlyParse)
+        end
+
 
         get "/parse", actual
         assert_response :ok

--- a/actionpack/test/template/number_helper_test.rb
+++ b/actionpack/test/template/number_helper_test.rb
@@ -51,10 +51,11 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal("($1,234,567,890.50)", number_to_currency(-1234567890.50, {:negative_format => "(%u%n)"}))
     assert_equal("$1,234,567,892", number_to_currency(1234567891.50, {:precision => 0}))
     assert_equal("$1,234,567,890.5", number_to_currency(1234567890.50, {:precision => 1}))
-    assert_equal("&pound;1234567890,50", number_to_currency(1234567890.50, {:unit => "&pound;", :separator => ",", :delimiter => ""}))
+    assert_equal("&pound;1234567890,50", number_to_currency(1234567890.50, {:unit => raw("&pound;"), :separator => ",", :delimiter => ""}))
+    assert_equal("&amp;pound;1234567890,50", number_to_currency(1234567890.50, {:unit => "&pound;", :separator => ",", :delimiter => ""}))
     assert_equal("$1,234,567,890.50", number_to_currency("1234567890.50"))
-    assert_equal("1,234,567,890.50 K&#269;", number_to_currency("1234567890.50", {:unit => "K&#269;", :format => "%n %u"}))
-    assert_equal("1,234,567,890.50 - K&#269;", number_to_currency("-1234567890.50", {:unit => "K&#269;", :format => "%n %u", :negative_format => "%n - %u"}))
+    assert_equal("1,234,567,890.50 K&#269;", number_to_currency("1234567890.50", {:unit => raw("K&#269;"), :format => "%n %u"}))
+    assert_equal("1,234,567,890.50 - K&#269;", number_to_currency("-1234567890.50", {:unit => raw("K&#269;"), :format => "%n %u", :negative_format => "%n - %u"}))
   end
 
   def test_number_to_percentage

--- a/actionpack/test/template/translation_helper_test.rb
+++ b/actionpack/test/template/translation_helper_test.rb
@@ -30,7 +30,7 @@ class TranslationHelperTest < ActiveSupport::TestCase
   end
 
   def test_delegates_to_i18n_setting_the_rescue_format_option_to_html
-    I18n.expects(:translate).with(:foo, :locale => 'en', :rescue_format => :html).returns("")
+    I18n.expects(:translate).with(:foo, :locale => 'en', :raise=>true).returns("")
     translate :foo, :locale => 'en'
   end
 


### PR DESCRIPTION
This fixes the following CVEs based off of @NZKoz's work for [Rails 3.2.16](https://github.com/rails/rails/commit/64226302d82493d9bf67aa9e4fa52b4e0269ee3d)
- [CVE-2013-6417](https://groups.google.com/forum/#!topic/ruby-security-ann/niK4drpSHT4)
- [CVE-2013-4491](https://groups.google.com/forum/#!topic/ruby-security-ann/pLrh6DUw998)
- [CVE-2013-6415](https://groups.google.com/forum/#!topic/ruby-security-ann/9WiRn2nhfq0)
- [CVE-2013-6414](https://groups.google.com/forum/#!topic/ruby-security-ann/A-ebV4WxzKg)
