### PR TITLE
TextHelper#simple_format attempts to call undefined raw method

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -31,6 +31,8 @@ module ActionView
 
       include SanitizeHelper
       include TagHelper
+      include OutputSafetyHelper
+
       # The preferred method of outputting text in your views is to use the
       # <%= "text" %> eRuby syntax. The regular _puts_ and _print_ methods
       # do not operate as expected in an eRuby code block. If you absolutely must

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -21,6 +21,11 @@ class TextHelperTest < ActionView::TestCase
     assert simple_format("<b> test with html tags </b>").html_safe?
   end
 
+  def test_simple_format_included_in_isolation
+    helper_klass = Class.new { include ActionView::Helpers::TextHelper }
+    assert helper_klass.new.simple_format("<b> test with html tags </b>").html_safe?
+  end
+
   def test_simple_format
     assert_equal "<p></p>", simple_format(nil)
 


### PR DESCRIPTION
`TextHelper#simple_format` attempts to use the `raw` method which is defined in the `OutputSafetyHelper` helper, but is not actually included in the module.

This is a problem when you only want to include this helper in isolation, for example:

``` ruby
class MyClass
  include ActionView::Helpers::TextHelper
end

MyClass.new.simple_format('hi') #=> NoMethodError: undefined method `raw' for #<MyClass:0x007f83099a3d08>
```

I've added the tests + fix in seperate commits, feel free to cherry-pick just the implementation if the test is not required.

This issue is present in rails 4.0.2, rails 4.0.1 was fine.
