### PR TITLE
Should raise error when options[:raise] is true

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix regression when using `ActionView::Helpers::TranslationHelper#translate` with
+    `options[:raise]`.
+
+    This regression was introduced at ec16ba75a5493b9da972eea08bae630eba35b62f.
+
+    *Shota Fukumori (sora_h)*
+
 *   Fix formatting for `rake routes` when a section is shorter than a header.
 
     *Sıtkı Bağdat*

--- a/actionpack/lib/action_view/helpers/translation_helper.rb
+++ b/actionpack/lib/action_view/helpers/translation_helper.rb
@@ -38,7 +38,13 @@ module ActionView
 
         # If the user has specified rescue_format then pass it all through, otherwise use
         # raise and do the work ourselves
-        options[:raise] = true unless options.key?(:raise) || options.key?(:rescue_format)
+        if options.key?(:raise) || options.key?(:rescue_format)
+          raise_error = options[:raise] || options[:rescue_format]
+        else
+          raise_error = false
+          options[:raise] = true
+        end
+
         if html_safe_translation_key?(key)
           html_safe_options = options.dup
           options.except(*I18n::RESERVED_KEYS).each do |name, value|
@@ -53,6 +59,8 @@ module ActionView
           I18n.translate(scope_key_by_partial(key), options)
         end
       rescue I18n::MissingTranslationData => e
+        raise e if raise_error
+
         keys = I18n.normalize_keys(e.locale, e.key, e.options[:scope])
         content_tag('span', keys.last.to_s.titleize, :class => 'translation_missing', :title => "translation missing: #{keys.join('.')}")
       end

--- a/actionpack/test/template/translation_helper_test.rb
+++ b/actionpack/test/template/translation_helper_test.rb
@@ -53,6 +53,12 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal false, translate(:"translations.missing", :rescue_format => nil).html_safe?
   end
 
+  def test_raises_missing_translation_message_wrapped_with_raise_option
+    assert_raise(I18n::MissingTranslationData) do
+      translate(:"translations.missing", :raise => true)
+    end
+  end
+
   def test_i18n_translate_defaults_to_nil_rescue_format
     expected = 'translation missing: en.translations.missing'
     assert_equal expected, I18n.translate(:"translations.missing")


### PR DESCRIPTION
Before ec16ba75a5493b9da972eea08bae630eba35b62f, 
ActionView::Helpers::TranslationHelper#translate has raised errors with 
specifying options[:raise] to true.

This should work by this fix:

```
begin
 t(:"translations.missing", raise: true)
```

   rescue I18n::MissingTranslationData
     p :hello!
   end
