### PR TITLE
Remove deep munge

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Remove deep_munge
+
+    `deep_munge` is no longer used in Rails code, and functions itself are
+    deprecated.
+
+    Fixes #11044, #8832
+
+    *Bernard Potocki*
+
 *   Introducing Variants
 
     We often want to render different html/json/xml templates for phones,

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -271,7 +271,7 @@ module ActionDispatch
 
     # Override Rack's GET method to support indifferent access
     def GET
-      @env["action_dispatch.request.query_parameters"] ||= Utils.deep_munge((normalize_encode_params(super) || {}))
+      @env["action_dispatch.request.query_parameters"] ||= normalize_encode_params(super) || {}
     rescue TypeError => e
       raise ActionController::BadRequest.new(:query, e)
     end
@@ -279,7 +279,7 @@ module ActionDispatch
 
     # Override Rack's POST method to support indifferent access
     def POST
-      @env["action_dispatch.request.request_parameters"] ||= Utils.deep_munge((normalize_encode_params(super) || {}))
+      @env["action_dispatch.request.request_parameters"] ||= normalize_encode_params(super) || {}
     rescue TypeError => e
       raise ActionController::BadRequest.new(:request, e)
     end
@@ -307,11 +307,6 @@ module ActionDispatch
 
       Utils.deep_munge(hash)
     end
-
-    protected
-      def parse_query(qs)
-        Utils.deep_munge(super)
-      end
 
     private
       def check_method(name)

--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -43,7 +43,7 @@ module ActionDispatch
         when :json
           data = ActiveSupport::JSON.decode(request.raw_post)
           data = {:_json => data} unless data.is_a?(Hash)
-          Request::Utils.deep_munge(data).with_indifferent_access
+          data.with_indifferent_access
         else
           false
         end

--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -1,9 +1,14 @@
+require 'active_support/deprecation'
+
 module ActionDispatch
   class Request < Rack::Request
     class Utils # :nodoc:
       class << self
         # Remove nils from the params hash
         def deep_munge(hash)
+          ActiveSupport::Deprecation.warn(
+            "This method has been removed. Please stop using it."
+          )
           hash.each do |k, v|
             case v
             when Array

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -30,17 +30,17 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
-  test "nils are stripped from collections" do
+  test "nils are not stripped from collections" do
     assert_parses(
-      {"person" => nil},
+      {"person" => [nil]},
       "{\"person\":[null]}", { 'CONTENT_TYPE' => 'application/json' }
     )
     assert_parses(
-      {"person" => ['foo']},
+      {"person" => ['foo', nil]},
       "{\"person\":[\"foo\",null]}", { 'CONTENT_TYPE' => 'application/json' }
     )
     assert_parses(
-      {"person" => nil},
+      {"person" => [nil,nil]},
       "{\"person\":[null, null]}", { 'CONTENT_TYPE' => 'application/json' }
     )
   end

--- a/actionpack/test/dispatch/request/query_string_parsing_test.rb
+++ b/actionpack/test/dispatch/request/query_string_parsing_test.rb
@@ -95,13 +95,13 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
     assert_parses({"action" => nil}, "action")
     assert_parses({"action" => {"foo" => nil}}, "action[foo]")
     assert_parses({"action" => {"foo" => { "bar" => nil }}}, "action[foo][bar]")
-    assert_parses({"action" => {"foo" => { "bar" => nil }}}, "action[foo][bar][]")
-    assert_parses({"action" => {"foo" => nil }}, "action[foo][]")
+    assert_parses({"action" => {"foo" => { "bar" => [nil] }}}, "action[foo][bar][]")
+    assert_parses({"action" => {"foo" => [nil] }}, "action[foo][]")
     assert_parses({"action"=>{"foo"=>[{"bar"=>nil}]}}, "action[foo][][bar]")
   end
 
-  def test_array_parses_without_nil
-    assert_parses({"action" => ['1']}, "action[]=1&action[]")
+  def test_array_parses_with_nil
+    assert_parses({"action" => ['1',nil]}, "action[]=1&action[]")
   end
 
   test "query string with empty key" do


### PR DESCRIPTION
### Rationale:

After implementing `strong_params` in Rails 4.0 `deep_munge` become rather issue than solution. Instead of fixing one [simple example](https://groups.google.com/forum/#!topic/rubyonrails-security/t1WFuuQyavI) it introduced series of bugs that prevented a lot of people in making [valid API](https://github.com/rails/rails/pull/11044)'s and even [nested attributes](https://github.com/rails/rails/issues/8832). This lead to some pretty [insane solutions](https://github.com/rails/rails/pull/8862) that introduce even more confusion. In the mean time a lot of applications are still on Rails 3.2.10 just to prevent invalid JSON parsing, or applying [patch](https://github.com/rails/rails/issues/8832#issuecomment-12131852) to remove `deep_munge`.
### Why deep_munge was introduced:

`deep_munge` was introduced as solution to simple example:

``` ruby
unless params[:token].nil? 
  user = User.find_by_token(params[:token]) 
  user.reset_password! 
end
```

The problem was situation where attacker crafted request so it will set `params[:token] = [nil]`.

`deep_munge` solution to it is compacting all arrays and changing empty array to nil:

``` ruby
def deep_munge(hash)
  hash.each do |k, v|
    case v
    when Array
      v.grep(Hash) { |x| deep_munge(x) }
      v.compact!
      hash[k] = nil if v.empty?
    when Hash
      deep_munge(v)
    end
  end

  hash
end
```
### What kind of bugs deep_munge introduced:

This table shows what kind of behavior will we get when passing JSON:

| JSON | Hash |
| --- | --- |
| {"person":null} | {'person' => nil} |
| {"person":[]} | {'person' => nil} |
| {"person":[null]} | {'person' => nil} |
| {"person":[null, null, ...]} | {'person' => nil} |
| {"person":["foo", null]} | {'person' => ["foo"]} |

It's obvious that current behavior prevents all `nil`s in params. A lot of API's allows them, so braking JSON spec is probably not a solution. It also makes confusion by changing type of passed argument from Array to NilClass - that prevents strong params to work in some cases.

Second type of error is breaking [nested attributes](https://github.com/rails/rails/issues/8832) - at this point passing empty array will error. To explain it further: without proper hack to default behavior it's impossible to pass nested attributes for empty collection. So we have core functionality that is not working.
### What kind of bugs deep_munge is not supporting:

Let's stay with example that was shown as CVE-2013-0155 and behavior with `deep_munge` in place:

``` ruby
unless params[:token].nil? 
  user = User.find_by_token(params[:token]) 
  user.reset_password! 
end
```

If this code stays then it creates false feeling of security, while it made hacking application just a little more harder to hack. Let's consider that attacker knows how long token is - he can pass array of tokens and try to hit one of them. For longer tokens it will be harder, but thanks to no limit of POST request he can try thousands of tokens in one batch - until he hit one of them. It's harder to guess, but still far from calling "secure". In properly written application this code would look like that:

``` ruby
User.find_by_token!(params[:token].to_s) 
user.reset_password! 
```

This assures only one key is passed and default type is not relevant. I'm pretty sure that most of advanced developers are doing it this way (or using something similar) instead of checking `nil?`.

For new developers we should invest in educating them instead of dumbing them down with false security feeling and reinforcing bad habits. CVE-2013-0155 is only one of multiple situations when newcomers should learn convention and good habits instead of using half-measures to cover potential bugs in code - we can't cover them all.
### Related issues:
- #11044
- #8832
- #8862
- #8845
- #8855
- #8870

It's been 11 months since @rafaelfranca said that [you are working on fix](https://github.com/rails/rails/pull/8870#issuecomment-12107571) - since this time all I can see is spreading this bug instead of fixing it. `deep_munge` was supposed to be feature (fix for bug that in reality was just programmer writing bad code), but instead it's bug that introduces a lot of other problems (including invalid handling of JSON by default which is not obvious and always hard to debug). Please just remove it.
