### PR TITLE
[Regression 3.2 -> 4.0] Fix bugs with changed attributes tracking when transaction gets rollback

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -428,7 +428,6 @@ module ActiveRecord
       @destroyed_by_association = nil
       @new_record               = true
       @txn                      = nil
-      @_start_transaction_state = {}
       @transaction_state        = nil
       @reflects_state           = [false]
     end


### PR DESCRIPTION
The most common scenario to demonstrate the bug:

``` ruby
assert !model.approved?
Topic.transaction do
  model.approved = true
  model.save!
  raise ActiveRecord::Rollback
end
model.save!
assert @first.reload.approved
```

In the last `#save!` call will not save model in DB because `#changes` from AR::Dirty is not properly rollback to the beginning of transaction state.

I've made a 4 different scenarios in test cases to be sure my patch covers everything. If you would consider some of them an overkill please just let me know.
