### PR TITLE
Fix header Content-Type: #<Mime::NullType:...> in localized template

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*  Fix header `Content-Type: #<Mime::NullType:...>` in localized template.
+
+   When localized template has no format in the template name,
+   the response now has the default and correct `content-type`.
+
+   Fixes #13064.
+
+   *Angelo Capilleri*
+
 *   Fix regression with `simple_format` not having access to the `raw` method
     when included in isolation, introduced with the security fix in Rails 4.0.2.
 

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -14,7 +14,7 @@ module ActionController
     def render(*args) #:nodoc:
       raise ::AbstractController::DoubleRenderError if response_body
       super
-      self.content_type ||= Mime[lookup_context.rendered_format].to_s
+      _process_format(lookup_context.rendered_format)
       response_body
     end
 
@@ -34,6 +34,11 @@ module ActionController
     end
 
     private
+
+    def _process_format(format)
+      # format is a Mime::NullType instance here then this condition can't be changed to `if format`
+      self.content_type ||= Mime[format] unless format.nil?
+    end
 
     # Normalize arguments by catching blocks and setting them on :update.
     def _normalize_args(action=nil, options={}, &blk) #:nodoc:

--- a/actionpack/test/controller/localized_templates_test.rb
+++ b/actionpack/test/controller/localized_templates_test.rb
@@ -34,4 +34,15 @@ class LocalizedTemplatesTest < ActionController::TestCase
     get :hello_world
     assert_equal "Gutten Tag", @response.body
   end
+
+  def test_localized_template_has_correct_header_with_no_format_in_template_name
+    old_locale = I18n.locale
+    I18n.locale = :it
+
+    get :hello_world
+    assert_equal "Ciao Mondo", @response.body
+    assert_equal "text/html",  @response.content_type
+  ensure
+    I18n.locale = old_locale
+  end
 end

--- a/actionpack/test/fixtures/localized/hello_world.it.erb
+++ b/actionpack/test/fixtures/localized/hello_world.it.erb
@@ -1,0 +1,1 @@
+Ciao Mondo


### PR DESCRIPTION
This PR is the backport of #13141.
It fixes #13064 regression bug introduced by the #8085
