### PR TITLE
Add ActiveRecord::Relation#destroy_all! method

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -145,7 +145,7 @@ module ActiveRecord
     # that no changes should be made (since they can't be persisted).
     #
     # There's a series of callbacks associated with <tt>destroy</tt>. If
-    # the <tt>before_destroy</tt> callback return +false+ the action is cancelled
+    # the <tt>before_destroy</tt> callback returns +false+ the action is cancelled
     # and <tt>destroy</tt> returns +false+. See
     # ActiveRecord::Callbacks for further details.
     def destroy
@@ -160,7 +160,7 @@ module ActiveRecord
     # that no changes should be made (since they can't be persisted).
     #
     # There's a series of callbacks associated with <tt>destroy!</tt>. If
-    # the <tt>before_destroy</tt> callback return +false+ the action is cancelled
+    # the <tt>before_destroy</tt> callback returns +false+ the action is cancelled
     # and <tt>destroy!</tt> raises ActiveRecord::RecordNotDestroyed. See
     # ActiveRecord::Callbacks for further details.
     def destroy!

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     delegate :first_or_create, :first_or_create!, :first_or_initialize, to: :all
     delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, to: :all
     delegate :find_by, :find_by!, to: :all
-    delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, to: :all
+    delegate :destroy, :destroy_all, :destroy_all!, :delete, :delete_all, :update, :update_all, to: :all
     delegate :find_each, :find_in_batches, to: :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -382,7 +382,44 @@ module ActiveRecord
       if conditions
         where(conditions).destroy_all
       else
-        to_a.each {|object| object.destroy }.tap { reset }
+        to_a.each { |object| object.destroy }.tap { reset }
+      end
+    end
+
+    # Destroys the records matching +conditions+ by instantiating each
+    # record and calling its +destroy!+ method. Each object's callbacks are
+    # executed (including <tt>:dependent</tt> association options). Returns the
+    # collection of objects that were destroyed; each will be frozen, to
+    # reflect that no changes should be made (since they can't be persisted). If
+    # the <tt>before_destroy</tt> callback of an object returns +false+ the action
+    # is cancelled and <tt>destroy_all!</tt> raises
+    # ActiveRecord::RecordNotDestroyed. See ActiveRecord::Callbacks for further
+    # details.
+    #
+    # Note: Instantiation, callback execution, and deletion of each
+    # record can be time consuming when you're removing many records at
+    # once. It generates at least one SQL +DELETE+ query per record (or
+    # possibly more, to enforce your callbacks). If you want to delete many
+    # rows quickly, without concern for their associations or callbacks, use
+    # +delete_all+ instead.
+    #
+    # ==== Parameters
+    #
+    # * +conditions+ - A string, array, or hash that specifies which records
+    #   to destroy. If omitted, all records are destroyed. See the
+    #   Conditions section in the introduction to ActiveRecord::Base for
+    #   more information.
+    #
+    # ==== Examples
+    #
+    #   Person.destroy_all!("last_login < '2004-04-04'")
+    #   Person.destroy_all!(status: "inactive")
+    #   Person.where(age: 0..18).destroy_all!
+    def destroy_all!(conditions = nil)
+      if conditions
+        where(conditions).destroy_all!
+      else
+        to_a.each { |object| object.destroy! }.tap { reset }
       end
     end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -129,6 +129,18 @@ class PersistenceTest < ActiveRecord::TestCase
     end
   end
 
+  def test_destroy_all!
+    conditions = "author_name = 'Mary'"
+    topics_by_mary = Topic.all.merge!(:where => conditions, :order => 'id').to_a
+    assert ! topics_by_mary.empty?
+
+    assert_difference('Topic.count', -topics_by_mary.size) do
+      destroyed = Topic.destroy_all!(conditions).sort_by(&:id)
+      assert_equal topics_by_mary, destroyed
+      assert destroyed.all? { |topic| topic.frozen? }, "destroyed topics should be frozen"
+    end
+  end
+
   def test_destroy_many
     clients = Client.all.merge!(:order => 'id').find([2, 3])
 

--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,1 +1,5 @@
+*   Added ```ActiveRecord::Relation#destroy_all!``` method
+    
+    *Brian John*
+
 Please check [4-1-stable](https://github.com/rails/rails/blob/4-1-stable/guides/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
The `destroy_all!` method is useful for when you want to destroy a collection of objects but want the behavior of `destroy!`.  If the `before_destroy` callback returns `false` for an object being destroyed an `ActiveRecord::RecordNotDestroyed` error will be raised.

I couldn't think of a way to keep this DRY with respect to the `destroy_all` method without getting too fancy, suggestions welcome of course!
