### PR TITLE
remove nil in NullType#ref.

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -299,9 +299,7 @@ module Mime
       true
     end
 
-    def ref
-      nil
-    end
+    def ref; end
 
     def respond_to_missing?(method, include_private = false)
       method.to_s.ends_with? '?'


### PR DESCRIPTION
Return Nil is implicit in a method and this syntax is used in the others
classes
