### PR TITLE
Fix inconsistency in ActiveRecord::ConnectionAdapters::Column's handing of two-digit dates

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   two-digit date conversions fixed for ActiveRecord::ConnectionAdapters::Column
+  
+    *Jonathan Chapman*
+
 *   Deprecate unused `ActiveRecord::Base.symbolized_base_class`
     and `ActiveRecord::Base.symbolized_sti_name` without replacement.
 

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -234,7 +234,7 @@ module ActiveRecord
           end
 
           def fallback_string_to_date(string)
-            new_date(*::Date._parse(string, false).values_at(:year, :mon, :mday))
+            new_date(*::Date._parse(string, true).values_at(:year, :mon, :mday))
           end
 
           def fallback_string_to_time(string)

--- a/activerecord/test/cases/column_test.rb
+++ b/activerecord/test/cases/column_test.rb
@@ -118,6 +118,12 @@ module ActiveRecord
           end
         end
       end
+
+      def test_type_cast_two_digit_date
+        [Column.new("field", nil, "datetime"), Column.new("field", nil, "date")].each do |column|
+          assert_equal Date.parse("10/11/12"), column.type_cast("10/11/12")
+        end
+      end
     end
   end
 end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix two-digit date conversions for String and TimeZone extensions
+
+    *Jonathan Chapman*
+
 *   Don't lazy load the `tzinfo` library as it causes problems on Windows.
 
     Fixes #13553

--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -5,7 +5,7 @@ class String
   # Converts a string to a Time value.
   # The +form+ can be either :utc or :local (default :local).
   #
-  # The time is parsed using Time.parse method.
+  # The time is parsed using Date.parse method.
   # If +form+ is :local, then the time is in the system timezone.
   # If the date part is missing then the current date is used and if
   # the time part is missing then it is assumed to be 00:00:00.
@@ -16,8 +16,9 @@ class String
   #   "2012-12-13T06:12".to_time         # => 2012-12-13 06:12:00 +0100
   #   "2012-12-13T06:12".to_time(:utc)   # => 2012-12-13 05:12:00 UTC
   #   "12/13/2012".to_time               # => ArgumentError: argument out of range
+  #   "13/12/4".to_time                  # => 2013-12-04 00:00:00 +0100
   def to_time(form = :local)
-    parts = Date._parse(self, false)
+    parts = Date._parse(self, true)
     return if parts.empty?
 
     now = Time.now
@@ -40,8 +41,9 @@ class String
   #   "01/01/2012".to_date # => Sun, 01 Jan 2012
   #   "2012-12-13".to_date # => Thu, 13 Dec 2012
   #   "12/13/2012".to_date # => ArgumentError: invalid date
+  #   "13/12/4".to_date    # => Wed, 04 Dec 2013
   def to_date
-    ::Date.parse(self, false) unless blank?
+    ::Date.parse(self, true) unless blank?
   end
 
   # Converts a string to a DateTime value.
@@ -50,7 +52,8 @@ class String
   #   "01/01/2012 23:59:59".to_datetime # => Sun, 01 Jan 2012 23:59:59 +0000
   #   "2012-12-13 12:50".to_datetime    # => Thu, 13 Dec 2012 12:50:00 +0000
   #   "12/13/2012".to_datetime          # => ArgumentError: invalid date
+  #   "13/12/4".to_datetime             # => Wed, 04 Dec 2013 00:00:00 +0000
   def to_datetime
-    ::DateTime.parse(self, false) unless blank?
+    ::DateTime.parse(self, true) unless blank?
   end
 end

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -282,7 +282,7 @@ module ActiveSupport
     #   Time.zone.now               # => Fri, 31 Dec 1999 14:00:00 HST -10:00
     #   Time.zone.parse('22:30:00') # => Fri, 31 Dec 1999 22:30:00 HST -10:00
     def parse(str, now=now)
-      parts = Date._parse(str, false)
+      parts = Date._parse(str, true)
       return if parts.empty?
 
       time = Time.new(

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -466,6 +466,18 @@ class StringConversionsTest < ActiveSupport::TestCase
     assert_equal Date.new(Date.today.year, 2, 3), "Feb 3rd".to_date
   end
 
+  def test_two_digit_date_string_to_date
+    assert_equal Date.new(2013, 12, 4), "13/12/4".to_date
+  end
+
+  def test_two_digit_date_string_to_time
+    assert_equal Date.new(2013, 12, 4), "13/12/4".to_time.to_date
+  end
+
+  def test_two_digit_date_string_to_datetime
+    assert_equal Date.new(2013, 12, 4), "13/12/4".to_datetime.to_date
+  end
+
   protected
     def with_env_tz(new_tz = 'US/Eastern')
       old_tz, ENV['TZ'] = ENV['TZ'], new_tz

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -270,6 +270,11 @@ class TimeZoneTest < ActiveSupport::TestCase
     end
   end
 
+  def test_parse_with_two_digit_year
+    zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
+    assert_equal Date.parse('13/12/4'), zone.parse('13/12/4').to_date
+  end
+
   def test_utc_offset_lazy_loaded_from_tzinfo_when_not_passed_in_to_initialize
     tzinfo = TZInfo::Timezone.get('America/New_York')
     zone = ActiveSupport::TimeZone.create(tzinfo.name, nil, tzinfo)


### PR DESCRIPTION
ActiveRecord currently converts two-digit non ISO date strings to `:datetime`, but fails when converting to `:date`. Commit `7ef3bc7` demonstrates this behavior with a test, `3763cb2` fixes it. ActiveRecord test suite is otherwise unaffected by the change.

This bug is also present in `3.2-stable`, discovered while upgrading from 3.2.13 -> 3.2.16.
