### PR TITLE
Deprecate `ActionController::RecordIdentifier`.

### DIFF
--- a/actionpack/lib/action_controller/record_identifier.rb
+++ b/actionpack/lib/action_controller/record_identifier.rb
@@ -1,0 +1,6 @@
+require 'action_view/record_identifier'
+
+ActiveSupport::Deprecation.warn "'ActionController::RecordIdentifier' is deprecated. Please require 'action_view/record_identifier' and use 'ActionView::RecordIdentifier' instead."
+module ActionController
+  RecordIdentifier = ActionView::RecordIdentifier
+end


### PR DESCRIPTION
This module was moved on the `ActionView` extraction, but 3rd party gems [like webrat](https://github.com/brynary/webrat/blob/master/lib/webrat/adapters/rails.rb#L2-L6) are including the `RecordIdentifier` module on its own and they will break on the 4.0 -> 4.1 upgrade. 

There might be more modules out there that might be worth adding the deprecation too - let me know and we can deprecate everything under the same commit/PR.

/cc @strzalek @carlosantoniodasilva @rafaelfranca
