### PR TITLE
Update guides welcome page to point to version 3.2.16

### DIFF
--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -15,8 +15,8 @@
 </p>
 <% end %>
 <p>
-  The guides for Rails 3.2.x are available at <a href="http://guides.rubyonrails.org/v3.2.15/">http://guides.rubyonrails.org/v3.2.15/</a>.
+  The guides for Rails 3.2.x are available at <a href="http://guides.rubyonrails.org/v3.2.16/">http://guides.rubyonrails.org/v3.2.16/</a>.
 </p>
 <p>
-  The guides for Rails 2.3.x are available at <a href="http://guides.rubyonrails.org/v2.3.11/">http://guides.rubyonrails.org/v2.3.11/</a>.
+  The guides for Rails 2.3.x are available at <a href="http://guides.rubyonrails.org/v2.3.18/">http://guides.rubyonrails.org/v2.3.18/</a>.
 </p>


### PR DESCRIPTION
I can see these links are broken already 

http://guides.rubyonrails.org/v3.2.16

http://guides.rubyonrails.org/v3.2.15
