### PR TITLE
docs: Replace an unpleasant grammatical construct.

### DIFF
--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -144,7 +144,7 @@ use Rack::ETag
 run MyApp::Application.routes
 ```
 
-Purpose of each of this middlewares is explained in the [Internal Middlewares](#internal-middleware-stack) section.
+The default middlewares shown here (and some others) are each summarized in the [Internal Middlewares](#internal-middleware-stack) section, below.
 
 ### Configuring Middleware Stack
 


### PR DESCRIPTION
The wording of the statement "Purpose of each of this middlewares is explained in the Internal Middlewares section." is not grammatically ideal. This patch resolves it by rewording the statement, and appending a direction marker to the reference.
