### PR TITLE
Make it possible to remove unused enum values by setting them to `nil`.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Make it possible to replace unused enum values with `nil`. Also, the implicit mapping
+    of enum values is now part of the public API.
+
+    *Godfrey Chan*
+
 *   Improve formatting of migration exception messages: make them easier to read
     with line breaks before/after, and improve the error for pending migrations.
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -63,4 +63,22 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal 1, Book::STATUS["written"]
     assert_equal 2, Book::STATUS[:published]
   end
+
+  test "implicit mapping with skipped values" do
+    model = Class.new(ActiveRecord::Base) { enum category: [:a, nil, :c, :d, nil] }
+    categories = model.const_get(:CATEGORY)
+    assert_equal 3, categories.size
+    assert_equal 0, categories[:a]
+    assert_equal 2, categories[:c]
+    assert_equal 3, categories[:d]
+  end
+
+  test "explict mapping with skipped values" do
+    model = Class.new(ActiveRecord::Base) { enum category: { a: 0, b: nil, c: 2, d: 3, e: nil } }
+    categories = model.const_get(:CATEGORY)
+    assert_equal 3, categories.size
+    assert_equal 0, categories[:a]
+    assert_equal 2, categories[:c]
+    assert_equal 3, categories[:d]
+  end
 end


### PR DESCRIPTION
The intent is to make it clear that 1. the implementation is sensitive to positional changes 2. the implicit mapping is part of the public API (it has to be, otherwise it won't work across versions).

Also made it possible to replace unused enum values with `nil`, so you can easily clean out old unused values and are not forced to drop into the explicitly mapping syntax.
