### PR TITLE
Exit when an exception occurs while creating/dropping the database

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -69,9 +69,6 @@ module ActiveRecord
         class_for_adapter(configuration['adapter']).new(*arguments).create
       rescue DatabaseAlreadyExists
         $stderr.puts "#{configuration['database']} already exists"
-      rescue Exception => error
-        $stderr.puts error, *(error.backtrace)
-        $stderr.puts "Couldn't create database for #{configuration.inspect}"
       end
 
       def create_all
@@ -92,9 +89,6 @@ module ActiveRecord
       def drop(*arguments)
         configuration = arguments.first
         class_for_adapter(configuration['adapter']).new(*arguments).drop
-      rescue Exception => error
-        $stderr.puts error, *(error.backtrace)
-        $stderr.puts "Couldn't drop #{configuration['database']}"
       end
 
       def drop_all


### PR DESCRIPTION
The `create` and `drop` tasks currently rescue from `Exception`, print the error, and then continue happily along. This means that a command running these tasks returns a successful exit code even when they fail to do the only thing they’re supposed to do. This seems wrong, and results in unexpected behavior when scripting or chaining tasks. (Often there is an open connection to the database which blocks dropping.)

All other tasks here (e.g. `purge`, `structure_dump`, `structure_load`, `load_seed`, etc.) allow exceptions to bubble up. This change will allow `create` & `drop` to fail in the same way they do.

I haven’t added tests simply because it feels excessive to test for an exception being raised when it’s not actually raised in this method (and none of the other methods here test such a case). Arguably this change would delete tests that tested the exception rescuing, but no such (unit) tests appear to exist.
