### PR TITLE
Add configuration option to optionally disable deep_munge

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add option to skip deep_munge
+
+    Some of users would prefer to skip deep_munge while parsing params.
+    With this flag you can return to pre-3.2.10 behavior:
+
+        config.action_dispatch.perform_deep_munge = false
+
+    Please be aware of possible security issue when using this option:
+    [CVE-2013-0155](https://groups.google.com/forum/#!topic/rubyonrails-security/t1WFuuQyavI)
+
+    *Bernard Potocki*
+
 *   Introducing Variants
 
     We often want to render different html/json/xml templates for phones,

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -16,6 +16,7 @@ module ActionDispatch
     config.action_dispatch.signed_cookie_salt = 'signed cookie'
     config.action_dispatch.encrypted_cookie_salt = 'encrypted cookie'
     config.action_dispatch.encrypted_signed_cookie_salt = 'signed encrypted cookie'
+    config.action_dispatch.perform_deep_munge = true
 
     config.action_dispatch.default_headers = {
       'X-Frame-Options' => 'SAMEORIGIN',
@@ -28,6 +29,7 @@ module ActionDispatch
     initializer "action_dispatch.configure" do |app|
       ActionDispatch::Http::URL.tld_length = app.config.action_dispatch.tld_length
       ActionDispatch::Request.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
+      ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge
       ActionDispatch::Response.default_charset = app.config.action_dispatch.default_charset || app.config.encoding
       ActionDispatch::Response.default_headers = app.config.action_dispatch.default_headers
 

--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -1,9 +1,15 @@
 module ActionDispatch
   class Request < Rack::Request
     class Utils # :nodoc:
+
+      mattr_accessor :perform_deep_munge
+      self.perform_deep_munge = true
+
       class << self
         # Remove nils from the params hash
         def deep_munge(hash)
+          return hash unless perform_deep_munge
+
           hash.each do |k, v|
             case v
             when Array

--- a/actionpack/test/dispatch/request/query_string_parsing_test.rb
+++ b/actionpack/test/dispatch/request/query_string_parsing_test.rb
@@ -104,6 +104,21 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
     assert_parses({"action" => ['1']}, "action[]=1&action[]")
   end
 
+  test "perform_deep_munge" do
+    ActionDispatch::Request::Utils.perform_deep_munge = false
+    begin
+      assert_parses({"action" => nil}, "action")
+      assert_parses({"action" => {"foo" => nil}}, "action[foo]")
+      assert_parses({"action" => {"foo" => {"bar" => nil}}}, "action[foo][bar]")
+      assert_parses({"action" => {"foo" => {"bar" => [nil]}}}, "action[foo][bar][]")
+      assert_parses({"action" => {"foo" => [nil]}}, "action[foo][]")
+      assert_parses({"action" => {"foo" => [{"bar" => nil}]}}, "action[foo][][bar]")
+      assert_parses({"action" => ['1',nil]}, "action[]=1&action[]")
+    ensure
+      ActionDispatch::Request::Utils.perform_deep_munge = true
+    end
+  end
+
   test "query string with empty key" do
     assert_parses(
       { "action" => "create_customer", "full_name" => "David Heinemeier Hansson" },


### PR DESCRIPTION
In relation to #13157 I tried to add option to disable deep_munge if developer is willing to do so. Deep munge is enabled by default to protect those who are unaware of risk, while allowing to disable it if advanced parameter parsing is required in given application.
