### PR TITLE
set `i18n.enforce_available_locales` before `i18n.default_locale`.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Ensure `config.i18n.enforce_available_locales` is set before any other
+    configuration option.
+
+    *Yves Senn*
+
 *   Added `Date#all_week/month/quarter/year` for generating date ranges.
 
     *Dmitriy Meremyanin*

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -31,6 +31,11 @@ module I18n
 
       fallbacks = app.config.i18n.delete(:fallbacks)
 
+      if app.config.i18n.has_key?(:enforce_available_locales)
+        # this option needs to be set before `default_locale=` to work properly.
+        I18n.enforce_available_locales = app.config.i18n.delete(:enforce_available_locales)
+      end
+
       app.config.i18n.each do |setting, value|
         case setting
         when :railties_load_path

--- a/railties/test/application/initializers/i18n_test.rb
+++ b/railties/test/application/initializers/i18n_test.rb
@@ -183,5 +183,16 @@ en:
       load_app
       assert_fallbacks ca: [:ca, :"es-ES", :es, :'en-US', :en]
     end
+
+    test "config.i18n.enforce_available_locales is set before config.i18n.default_locale is" do
+      add_to_config <<-RUBY
+        config.i18n.default_locale = :it
+        config.i18n.enforce_available_locales = true
+      RUBY
+
+      assert_raises(I18n::InvalidLocale) do
+        load_app
+      end
+    end
   end
 end


### PR DESCRIPTION
Related to #13159 

There is order dependence between `enforce_available_locales` and `default_locale`. `enforce_available_locales` must be set beforehand to make sure it's up to date when the `default_locale` is set.
