### PR TITLE
update cache on background thread when race_condition_ttl option set

### DIFF
--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -371,7 +371,9 @@ module CacheStoreBehavior
       assert_equal 'bar', @cache.read('foo')
       "baz"
     end
-    assert_equal "baz", result
+    assert_equal "bar", result
+    Thread.list.reject {|t| t == Thread.current }.each(&:join)
+    assert_equal "baz", @cache.read('foo')
   end
 
   def test_race_condition_protection_is_limited
@@ -383,12 +385,14 @@ module CacheStoreBehavior
       "baz"
     end
     assert_equal "baz", result
+    Thread.list.reject {|t| t == Thread.current }.each(&:join)
+    assert_equal "baz", @cache.read('foo')
   end
 
   def test_race_condition_protection_is_safe
     time = Time.now
     @cache.write('foo', 'bar', :expires_in => 60)
-    Time.stubs(:now).returns(time + 61)
+    Time.stubs(:now).returns(time + 59)
     begin
       @cache.fetch('foo', :race_condition_ttl => 10) do
         assert_equal 'bar', @cache.read('foo')


### PR DESCRIPTION
Currently the `Cache#fetch` method has a `race_condition_ttl` option which kinda fakes hit with stale data while the the cache is updated by other. But.... There will be a poor request that must wait for the cache to be updated while others are simply reading the _cool_ stale data. So I think we could also give that request the stale data while we update the cache in the background...

I think it makes sense to do this. So just submitted this PR :) 
Probably not the best solution but this is just a WIP that probably someone else could take and make it better.

btw First PR to Rails :tada: 
