### PR TITLE
fix Mysql sum return integer instead of float

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Added `ActiveRecord::Calculations#column_name_from_field` to get the correct name
+    of a colum from a field in `ActiveRecord::Calculations#column_for`.
+
+    Fixes #12937
+
+    *Angelo Capilleri*
+
 *   Polymorphic belongs_to associations with the `touch: true` option set update the timestamps of
     the old and new owner correctly when moved between owners of different types.
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -338,14 +338,14 @@ module ActiveRecord
     end
 
     def column_for(field)
-      field_name = field.respond_to?(:name) ? field.name.to_s : field.to_s.split('.').last
+      field_name =  field.respond_to?(:name) ? field.name.to_s : field.to_s.split(".").detect {|x| @klass.columns_hash[x]}
       @klass.columns_hash[field_name]
     end
 
     def type_cast_calculated_value(value, column, operation = nil)
       case operation
         when 'count'   then value.to_i
-        when 'sum'     then type_cast_using_column(value || 0, column)
+        when 'sum'     then value.nil? ? 0 : value
         when 'average' then value.respond_to?(:to_d) ? value.to_d : value
         else type_cast_using_column(value, column)
       end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -396,6 +396,11 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 0, Account.where('1 = 2').sum("2 * credit_limit")
   end
 
+  def test_sum_expression_return_float_when_the_sum_result_is_a_float_and_field_include_table_name
+    assert_equal 667.8, Account.sum("2.1 * accounts.credit_limit")
+    assert_equal 667.8, Account.sum("accounts.credit_limit * 2.1")
+  end
+
   def test_count_with_from_option
     assert_equal Company.count(:all), Company.from('companies').count(:all)
     assert_equal Account.where("credit_limit = 50").count(:all),


### PR DESCRIPTION
This PR fix a wrong conversion to integer in sum
calculation when the table name is included in
the fied of sum.

It fixes two main bugs:
- the wrong stripped column_name from an expression like
  `table_name.column_name * 2.1`  in `column_name_from_field`
- No `type_cast_using_column`of value in `sum` because
  it could have an expression like  `table_name.column_name * 2.1`
  where `column_name` type is integer but the result is no integer
  
  Before:
  
  ```
  Account.sum("2.1 * accounts.credit_limit") => 667
  ```
  
  After:
  
  ```
  Account.sum("2.1 * accounts.credit_limit") => 667.8
  ```

Fixes #12937
