### PR TITLE
Better error description on a missing constant/module within another

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -456,7 +456,7 @@ module ActiveSupport #:nodoc:
         raise ArgumentError, "A copy of #{from_mod} has been removed from the module tree but is still active!"
       end
 
-      raise NameError, "#{from_mod} is not missing constant #{const_name}!" if from_mod.const_defined?(const_name, false)
+      raise NameError, "'#{from_mod}' is missing constant/module '#{const_name}'!" if from_mod.const_defined?(const_name, false)
 
       qualified_name = qualified_name_for from_mod, const_name
       path_suffix = qualified_name.underscore


### PR DESCRIPTION
This active support exception was originally committed 7 years ago (https://github.com/rails/rails/commit/2b37d59976268013b7e518e5af244947f688d315), I believe a typo in the error message made it so far and managed to confuse many (including me) along the way (http://stackoverflow.com/questions/4056894/rails-production-env-object-is-not-missing-constant).

Original error message for this case would come up as something like this:

```
NameError: ParentModule is not missing constant ChildModule!
```

Suggest fix would report as:

```
NameError: 'ParentModule' is missing constant/module 'ChildModule'!
```
