### PR TITLE
Make xhr?/xml_http_request? actually return true/false

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -192,7 +192,7 @@ module ActionDispatch
     # (case-insensitive). All major JavaScript libraries send this header with
     # every Ajax request.
     def xml_http_request?
-      @env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i
+      !!(@env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i)
     end
     alias :xhr? :xml_http_request?
 


### PR DESCRIPTION
The comments say 'Returns true' but it doesn't, it returns 0 this can be an annoying gotcha
