### PR TITLE
Fix rename column with long name.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Truncate the index name if it exceeds the `allowed_index_name_length` while
+    renaming a column.
+
+    Fixes #12585
+
+    *Lauro Caetano*
+
 *   An `ArgumentError` is now raised on a call to `Relation#where.not(nil)`.
 
     Example:

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -831,11 +831,20 @@ module ActiveRecord
           column_name, new_column_name = column_name.to_s, new_column_name.to_s
           indexes(table_name).each do |index|
             next unless index.columns.include?(new_column_name)
+
             old_columns = index.columns.dup
             old_columns[old_columns.index(new_column_name)] = column_name
-            generated_index_name = index_name(table_name, column: old_columns)
-            if generated_index_name == index.name
-              rename_index table_name, generated_index_name, index_name(table_name, column: index.columns)
+            old_index_name = index_name(table_name, column: old_columns)
+            max_index_name_length = allowed_index_name_length - 1
+
+            if old_index_name == index.name
+              new_index_name = index_name(table_name, column: index.columns)
+
+              if new_index_name.size > max_index_name_length
+                new_index_name = new_index_name[0..max_index_name_length]
+              end
+
+              rename_index table_name, old_index_name, new_index_name
             end
           end
         end

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -49,6 +49,30 @@ module ActiveRecord
         assert_equal ['foo'], TestModel.all.map(&:nick_name)
       end
 
+      def test_rename_column_renames_long_indexes
+        add_column :test_models, :column_with_long_long_long_long_long_name, :string
+        add_index :test_models, :column_with_long_long_long_long_long_name
+
+        rename_column :test_models,
+          :column_with_long_long_long_long_long_name,
+          :column_with_long_long_long_long_long_long_long_long_name
+
+        indexed_column = connection.indexes('test_models').map(&:columns).first
+        assert_equal ['column_with_long_long_long_long_long_long_long_long_name'], indexed_column
+      end
+
+      def test_rename_column_does_not_rename_long_indexes_with_custom_naming
+        add_column :test_models, :column_with_long_long_long_long_long_name, :string
+        add_index :test_models,
+          :column_with_long_long_long_long_long_name, name: :custom_name
+
+        rename_column :test_models,
+          :column_with_long_long_long_long_long_name,
+          :column_with_long_long_long_long_long_long_long_long_name
+
+        assert_equal ['custom_name'], connection.indexes('test_models').map(&:name)
+      end
+
       def test_rename_column_preserves_default_value_not_null
         add_column 'test_models', 'salary', :integer, :default => 70000
 


### PR DESCRIPTION
It was raising an error when renaming columns with long names. In order to prevent that, we check if the `new_index_name` length is greater than the `allowed_index_name_length`. If exceeds, we truncate it.

Closes #12585

cc @rafaelfranca
