### PR TITLE
Enum doc fixes

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -88,12 +88,13 @@ module ActiveRecord
       end
     end
 
-    def _enum_methods_module
-      @_enum_methods_module ||= begin
-        mod = Module.new
-        include mod
-        mod
+    private
+      def _enum_methods_module
+        @_enum_methods_module ||= begin
+          mod = Module.new
+          include mod
+          mod
+        end
       end
-    end
   end
 end


### PR DESCRIPTION
I noticed `_enum_methods_module` is showing up on the docs, so it should either be kept private or `:nodoc:`'ed. I privated it and tests still pass, so that's what I went with. Also, it seems like the docs are really describing the `enum` method/marco not the module, so I moved it (I'm not 100% sure about this). 
