### PR TITLE
Skipping debugger from plugin Gemfile for JRuby

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile
@@ -39,5 +39,7 @@ end
 <% end -%>
 
 <% end -%>
+<% unless defined?(JRUBY_VERSION) -%>
 # To use debugger
 # gem 'debugger'
+<% end -%>

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -58,6 +58,17 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "test/integration/navigation_test.rb", /ActionDispatch::IntegrationTest/
   end
 
+  def test_inclusion_of_debugger
+    run_generator [destination_root, '--full']
+    if defined?(JRUBY_VERSION)
+      assert_file "Gemfile" do |content|
+        assert_no_match(/debugger/, content)
+      end
+    else
+      assert_file "Gemfile", /# gem 'debugger'/
+    end
+  end
+
   def test_generating_test_files_in_full_mode_without_unit_test_files
     run_generator [destination_root, "-T", "--full"]
 


### PR DESCRIPTION
I think we can move all this login from template to generators. 

I will open another PR for refactor those templates.
