### PR TITLE
Fixes a typo from a7713765 [ci skip]

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -891,7 +891,7 @@ def new
 end
 ```
 
-The `fields_for` yields a form builder. The parameters' name will be what
+The `fields_for` helper yields a form builder. The parameters' name will be what
 `accepts_nested_attributes_for` expects. For example when creating a user with
 2 addresses, the submitted parameters would look like:
 


### PR DESCRIPTION
@robin850, anything else we should fix? (I'm a bit unsure about "parameters' name" vs "parameters' names", I _think_ the latter is correct, if you want we can fix that too. Or we can let other people fix that in the future, if it bothers anyone :P
