### PR TITLE
[Proposal] Add capability to extend all relations on model with modules or block

### DIFF
--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -45,8 +45,8 @@ module ActiveRecord
 
         @cache = Marshal.load(Marshal.dump(@cache))
 
-        assert_equal 12, @cache.columns('posts').size
-        assert_equal 12, @cache.columns_hash('posts').size
+        assert_equal 13, @cache.columns('posts').size
+        assert_equal 13, @cache.columns_hash('posts').size
         assert @cache.tables('posts')
         assert_equal 'id', @cache.primary_keys('posts')
       end

--- a/activerecord/test/cases/extend_relation_test.rb
+++ b/activerecord/test/cases/extend_relation_test.rb
@@ -1,0 +1,63 @@
+require 'cases/helper'
+require 'models/post'
+require 'models/author'
+
+module ActiveRecord
+  class ExtendRelationTest < ActiveRecord::TestCase
+    fixtures :posts, :authors
+
+    module MyRelationExtension
+      def find(id)
+        where(slug: id).first or super
+      end
+    end
+
+    def setup
+      Post.extend_relation(MyRelationExtension)
+    end
+
+    def teardown
+      Post.relation_extensions = []
+    end
+
+    def test_extends_relation
+      post = posts(:welcome)
+      assert_equal post, Post.find('welcome-to-the-weblog')
+    end
+
+    def test_association_extends_relation
+      post = posts(:welcome)
+      author = authors(:david)
+      assert_equal post, author.posts.find('welcome-to-the-weblog')
+    end
+
+    def test_chained_association_extends_relation
+      post = posts(:welcome)
+      author = authors(:david)
+      assert_equal post, author.posts.where(type: 'Post').find('welcome-to-the-weblog')
+    end
+
+    def test_accepts_block
+      Post.extend_relation { def foo; 'foo'; end }
+      author = authors(:david)
+      assert_equal Post.all.foo, 'foo'
+      assert_equal author.posts.foo, 'foo'
+    end
+
+    def test_accepts_multiple_modules_and_block
+      module1 = Module.new { def foo; 'foo'; end }
+      module2 = Module.new { def bar; 'bar'; end }
+      Post.extend_relation(module1, module2) { def baz; 'baz'; end }
+      assert_equal Post.all.foo, 'foo'
+      assert_equal Post.all.bar, 'bar'
+      assert_equal Post.all.baz, 'baz'
+    end
+
+    def test_relation_extensions
+      assert_equal Post.all.relation_extensions, [MyRelationExtension]
+      mod = Module.new
+      Post.extend_relation(mod)
+      assert_equal Post.all.relation_extensions, [MyRelationExtension, mod]
+    end
+  end
+end

--- a/activerecord/test/fixtures/posts.yml
+++ b/activerecord/test/fixtures/posts.yml
@@ -7,6 +7,7 @@ welcome:
   taggings_count: 1
   tags_count: 1
   type: Post
+  slug: welcome-to-the-weblog
 
 thinking:
   id: 2
@@ -17,6 +18,7 @@ thinking:
   taggings_count: 1
   tags_count: 1
   type: SpecialPost
+  slug: so-i-was-thinking
 
 authorless:
   id: 3

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -538,6 +538,7 @@ ActiveRecord::Schema.define do
       t.text    :body, null: false
     end
     t.string  :type
+    t.string  :slug
     t.integer :comments_count, default: 0
     t.integer :taggings_count, default: 0
     t.integer :taggings_with_delete_all_count, default: 0


### PR DESCRIPTION
Problem: We want to extend all relations on a given model with custom methods (add or override finders or factory methods, etc.) without monkeypatching `ActiveRecord::Relation` itself.

Currently it is possible to extend a relation with [`ActiveRecord::Relation#extending`](https://github.com/rails/rails/blob/17c29a0df0da5414570b025b642e90968e96cddc/activerecord/lib/active_record/relation/query_methods.rb#L788), e.g. `Post.all.extending(MyModule).where(...)`, and it is also possible to [extend association proxies with a block](https://github.com/rails/rails/blob/17c29a0df0da5414570b025b642e90968e96cddc/activerecord/lib/active_record/associations.rb#L444), which allows you to add custom methods to a given association on a given model.

Both of these entrypoints are too local for the case where we want to extend _all_ relations on a given model. The only way to do this is to patch core AR methods such as AR::Relation#relation.

At least two gems do this: I wrote a patch in [Globalize](https://github.com/globalize/globalize) and @norman did something similar in [FriendlyId (v 4.x)](https://github.com/norman/friendly_id/tree/4.0-stable). Making the relation extensions work on associations as well requires yet more hacking (see e.g. norman/friendly_id#452).

The proposal here is the simplest way I can imagine to provide an entrypoint that avoids the need for such patching: a method (`extend_relation`) which accepts one or more modules and/or a block (just like `extending`) and saves those in a class attribute on the model itself, and then when creating relations just extend the relation with those modules. This works for associations as well.

cc @tenderlove
