### PR TITLE
Check MySQL connection using ping

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -234,8 +234,8 @@ module ActiveRecord
       # CONNECTION MANAGEMENT ====================================
 
       def active?
-        if @connection.respond_to?(:stat)
-          @connection.stat
+        if @connection.respond_to?(:ping)
+          @connection.ping
         else
           @connection.query 'select 1'
         end


### PR DESCRIPTION
On high-load Ruby-on-Rails sites there are a number of app servers to help scaling issues. MySQL's stat method to quite resource hungry and can overload the server when there are multiple app servers. MySQL's ping is a much better approach.
