### PR TITLE
Fix test-error introduced by #10635.

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -39,8 +39,9 @@ module ActiveSupport
       if data.present? && digest.present? && secure_compare(digest, generate_digest(data))
         begin
           @serializer.load(::Base64.strict_decode64(data))
-        rescue ArgumentError
-          raise InvalidSignature
+        rescue ArgumentError => argument_error
+          raise InvalidSignature if argument_error.message =~ %r{invalid base64}
+          raise
         end
       else
         raise InvalidSignature

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -55,6 +55,20 @@ class MessageVerifierTest < ActiveSupport::TestCase
     ActiveSupport.use_standard_json_time_format = prev
   end
 
+  def test_raise_error_when_argument_class_is_not_loaded
+    # To generate the valid message below:
+    #
+    #   AutoloadClass = Struct.new(:foo)
+    #   valid_message = @verifier.generate(foo: AutoloadClass.new('foo'))
+    #
+    valid_message = "BAh7BjoIZm9vbzonTWVzc2FnZVZlcmlmaWVyVGVzdDo6QXV0b2xvYWRDbGFzcwY6CUBmb29JIghmb28GOgZFVA==--f3ef39a5241c365083770566dc7a9eb5d6ace914"
+    exception = assert_raise(ArgumentError, NameError) do
+      @verifier.verify(valid_message)
+    end
+    assert_includes ["uninitialized constant MessageVerifierTest::AutoloadClass",
+                    "undefined class/module MessageVerifierTest::AutoloadClass"], exception.message
+  end
+
   def assert_not_verified(message)
     assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
       @verifier.verify(message)


### PR DESCRIPTION
PR #10635 introduced rescue from `ArgumentError` thrown by `Base64.strict_decode64`.

This broke natural order of things for `StaleSessionCheck#stale_session_check!` which tried auto_loading a class based on `ArgumentError` message , and later retrying the `Marshal#load` of class, successfully allowing auto_loading.

  This PR tries to fix this behavior by forwarding `ArgumentError` 's not raised  by `Base64.strict_decode64` , as is, ahead to `StaleSessionCheck#stale_session_check!`
