### PR TITLE
Upgrade minitest version

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'i18n',       '~> 0.6', '>= 0.6.4'
   s.add_dependency 'json',       '~> 1.7', '>= 1.7.7'
   s.add_dependency 'tzinfo',     '~> 1.1'
-  s.add_dependency 'minitest',   '~> 5.0'
+  s.add_dependency 'minitest',   '~> 5.1'
   s.add_dependency 'thread_safe','~> 0.1'
 end


### PR DESCRIPTION
We made a change in #13213 that depends on a new file that's only in
minitest 5.1.0+, so the version should be updated. ~~Also, previously
we were locking minitest to 5.x (~> 5.0), but it seems like the
minitest gem is going to introduce breaking changes in minor releases,
so we should probably be more specific about our requirement by
locking it down to the minor version as well (~> 5.1.0).~~

/cc @arunagw @tenderlove
