### PR TITLE
Require action_view explicitly in AC::Base

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -1,5 +1,6 @@
 require 'active_support/concern'
 require 'active_support/core_ext/class/attribute'
+require 'action_view/view_paths'
 require 'set'
 
 module AbstractController

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -1,3 +1,4 @@
+require 'action_view'
 require "action_controller/log_subscriber"
 require "action_controller/metal/params_wrapper"
 


### PR DESCRIPTION
We're including AV modules directly in AC::Base (#13189) thus we need to load ActionView explicitly. Found this thanks to active_model_serializers test failure (https://travis-ci.org/rails-api/active_model_serializers/jobs/15050182#L92)
