### PR TITLE
Inline syntax for variants

### DIFF
--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -215,7 +215,7 @@ module ActionController #:nodoc:
       raise ArgumentError, "respond_to takes either types or a block, never both" if mimes.any? && block_given?
 
       if collector = retrieve_collector_from_mimes(mimes, &block)
-        response = collector.response(request.variant)
+        response = collector.response
         response ? response.call : render({})
       end
     end
@@ -357,7 +357,7 @@ module ActionController #:nodoc:
       if collector = retrieve_collector_from_mimes(&block)
         options = resources.size == 1 ? {} : resources.extract_options!
         options = options.clone
-        options[:default_response] = collector.response(request.variant)
+        options[:default_response] = collector.response
         (options.delete(:responder) || self.class.responder).call(self, resources, options)
       end
     end
@@ -390,7 +390,7 @@ module ActionController #:nodoc:
     # is available.
     def retrieve_collector_from_mimes(mimes=nil, &block) #:nodoc:
       mimes ||= collect_mimes_from_class_level
-      collector = Collector.new(mimes)
+      collector = Collector.new(mimes, request.variant)
       block.call(collector) if block_given?
       format = collector.negotiate_format(request)
 
@@ -428,8 +428,10 @@ module ActionController #:nodoc:
       include AbstractController::Collector
       attr_accessor :format
 
-      def initialize(mimes)
+      def initialize(mimes, variant = nil)
         @responses = {}
+        @variant = variant
+
         mimes.each { |mime| @responses["Mime::#{mime.upcase}".constantize] = nil }
       end
 
@@ -444,15 +446,19 @@ module ActionController #:nodoc:
 
       def custom(mime_type, &block)
         mime_type = Mime::Type.lookup(mime_type.to_s) unless mime_type.is_a?(Mime::Type)
-        @responses[mime_type] ||= block
+        @responses[mime_type] ||= if block_given?
+          block
+        else
+          VariantFilter.new(@variant)
+        end
       end
 
-      def response(variant)
+      def response
         response = @responses.fetch(format, @responses[Mime::ALL])
-        if response.nil? || response.arity == 0
+        if response.is_a?(VariantFilter) || response.nil? || response.arity == 0
           response
         else
-          lambda { response.call VariantFilter.new(variant) }
+          lambda { response.call VariantFilter.new(@variant) }
         end
       end
 

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -430,7 +430,7 @@ module ActionController #:nodoc:
 
       def initialize(mimes)
         @responses = {}
-        mimes.each { |mime| send(mime) }
+        mimes.each { |mime| @responses["Mime::#{mime.upcase}".constantize] = nil }
       end
 
       def any(*args, &block)

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -175,6 +175,12 @@ class RespondToController < ActionController::Base
     end
   end
 
+  def variant_inline_syntax
+    respond_to do |format|
+      format.html.phone { render text: "phone" }
+    end
+  end
+
   protected
     def set_layout
       case action_name
@@ -554,10 +560,16 @@ class RespondToControllerTest < ActionController::TestCase
     assert_equal "tablet", @response.body
   end
 
-
   def test_no_variant_in_variant_setup
     get :variant_plus_none_for_format
     assert_equal "text/html", @response.content_type
     assert_equal "none", @response.body
+  end
+
+  def test_variant_inline_syntax
+    @request.variant = :phone
+    get :variant_inline_syntax
+    assert_equal "text/html", @response.content_type
+    assert_equal "phone", @response.body
   end
 end


### PR DESCRIPTION
In most cases, when setting variant specific code, you're not sharing any code within format.

Inline syntax can vastly simplify defining variants in those situations:

``` ruby
  respond_to do |format|
    format.js { render "trash" }
    format.html do |variant|
      variant.phone { redirect_to progress_path }
      variant.none  { render "trash" }
    end
  end
```

Becomes:

``` ruby
  respond_to do |format|
    format.js         { render "trash" }
    format.html.phone { redirect_to progress_path }
    format.html.none  { render "trash" }
  end
```

:tropical_drink: 
