### PR TITLE
Fix type cast on group sum with custom expression

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Use the right column to type cast grouped calculations with custom expressions.
+
+    Fixes: #13230
+
+    Example:
+
+            # Before
+            Account.group(:firm_name).sum('0.01 * credit_limit')
+            # => { '37signals' => '0.5' }
+
+            # After
+            Account.group(:firm_name).sum('0.01 * credit_limit')
+            # => { '37signals' => 0.5 }
+
+    *Paul Nikitochkin*
+
 *   Polymorphic `belongs_to` associations with the `touch: true` option set update the timestamps of
     the old and new owner correctly when moved between owners of different types.
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -311,7 +311,9 @@ module ActiveRecord
         }
         key = key.first if key.size == 1
         key = key_records[key] if associated
-        [key, type_cast_calculated_value(row[aggregate_alias], column_for(column_name), operation)]
+
+        column_type = calculated_data.column_types.fetch(aggregate_alias) { column_for(column_name) }
+        [key, type_cast_calculated_value(row[aggregate_alias], column_type, operation)]
       end]
     end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -211,6 +211,10 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 19.83, NumericData.sum(:bank_balance)
   end
 
+  def test_should_return_type_casted_values_with_group_and_expression
+    assert_equal 0.5, Account.group(:firm_name).sum('0.01 * credit_limit')['37signals']
+  end
+
   def test_should_group_by_summed_field_with_conditions
     c = Account.where('firm_id > 1').group(:firm_id).sum(:credit_limit)
     assert_nil        c[1]


### PR DESCRIPTION
For PG adapters with custom expression and grouped result
of aggregate functions have not found correct column type
for it. Extract column type from query result.

Closes #13230
