### PR TITLE
Prevent stack overflow when serializing self-referential data as JSON

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -75,11 +75,11 @@ module ActiveSupport
           # By default, the options hash is not passed to the children data structures
           # to avoid undesiarable result. Develoers must opt-in by implementing
           # custom #as_json methods (e.g. Hash#as_json and Array#as_json).
-          def jsonify(value)
+          def jsonify(value, processed_objects = [])
             if value.is_a?(Hash)
-              Hash[value.map { |k, v| [jsonify(k), jsonify(v)] }]
+              Hash[value.map { |k, v| [jsonify(k, processed_objects), jsonify(v, processed_objects)] }]
             elsif value.is_a?(Array)
-              value.map { |v| jsonify(v) }
+              value.map { |v| jsonify(v, processed_objects) }
             elsif value.is_a?(String)
               EscapedString.new(value)
             elsif value.is_a?(Numeric)
@@ -90,8 +90,8 @@ module ActiveSupport
               false
             elsif value == nil
               nil
-            else
-              jsonify value.as_json
+            elsif !processed_objects.include?(value)
+              jsonify value.as_json, (processed_objects << value)
             end
           end
 


### PR DESCRIPTION
I originally encountered this problem when dealing with the following data structure:

``` ruby
class Group < ActiveRecord::Base
  has_many :memberships
  has_many :users, through: :memberships

  def as_json(options = {})
    super(options.merge(include: [:users]))
  end
end

class User < ActiveRecord::Base
  has_many :memberships
  has_many :groups, through: :memberships

  def as_json(options = {})
    super(options.merge(include: [:groups]))
  end  
end
```

I had situations in which I needed to display all the groups in which a user was a member and others in which I needed to display all the users who were members in a group.  While I was able to work around this issue by using the higher-level membership object in the following manner

``` ruby
class Membership < ActiveRecord::Base
  belongs_to :user
  belongs_to :group

  def as_json(options = {})
    super(options.merge(methods: [:user, :group]))
  end
end
```

this change did require some significant restructuring of the application, specifically removing the cyclical references between user and group and only consuming memberships.

I believe something like the reference tracking in this commit would make structures of this nature easier to work with and allow for creating more nuanced API interfaces.
