### PR TITLE
Add Enum type to postgresql adapter's oids to prevent unknown OID warnings

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Dynamically register PostgreSQL enum OIDs. This prevents "unknown OID"
+    warnings on enum columns.
+
+    *Dieter Komendera*
+
 *   `includes` is able to detect the right preloading strategy when string
     joins are involved.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -229,6 +229,12 @@ This is not reliable and will be removed in the future.
           end
         end
 
+        class Enum < Type
+          def type_cast(value)
+            value.to_s
+          end
+        end
+
         class Hstore < Type
           def type_cast_for_write(value)
             ConnectionAdapters::PostgreSQLColumn.hstore_to_string value

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -801,6 +801,12 @@ module ActiveRecord
           leaves, nodes = nodes.partition { |row| row['typelem'] == '0' }
           arrays, nodes = nodes.partition { |row| row['typinput'] == 'array_in' }
 
+          # populate the enum types
+          enums, leaves = leaves.partition { |row| row['typinput'] == 'enum_in' }
+          enums.each do |row|
+            type_map[row['oid'].to_i] = OID::Enum.new
+          end
+
           # populate the base types
           leaves.find_all { |row| OID.registered_type? row['typname'] }.each do |row|
             type_map[row['oid'].to_i] = OID::NAMES[row['typname']]

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -23,6 +23,8 @@ class PostgresqlEnumTest < ActiveRecord::TestCase
         t.column :current_mood, :mood
       end
     end
+    # reload type map after creating the enum type
+    @connection.send(:reload_type_map)
   end
 
   def test_enum_mapping
@@ -34,5 +36,31 @@ class PostgresqlEnumTest < ActiveRecord::TestCase
     enum.save!
 
     assert_equal "happy", enum.reload.current_mood
+  end
+
+  def test_invalid_enum_update
+    @connection.execute "INSERT INTO postgresql_enums VALUES (1, 'sad');"
+    enum = PostgresqlEnum.first
+    enum.current_mood = "angry"
+
+    assert_raise ActiveRecord::StatementInvalid do
+      enum.save
+    end
+  end
+
+  def test_no_oid_warning
+    @connection.execute "INSERT INTO postgresql_enums VALUES (1, 'sad');"
+    stderr_output = capture(:stderr) {
+        enum = PostgresqlEnum.first
+    }
+
+    assert stderr_output.blank?
+  end
+
+  def test_enum_type_cast
+    enum = PostgresqlEnum.new
+    enum.current_mood = :happy
+
+    assert_equal "happy", enum.current_mood
   end
 end


### PR DESCRIPTION
Currently whenever ActiveRecord retrieves a row from postgres which has an enum column, a warning is printed, e.g.

```
unknown OID: enum(75561) (SELECT  "postgresql_enums".* FROM "postgresql_enums"  WHERE "postgresql_enums"."id" = $1 LIMIT 1)
```

This patch adds an Enum type for postgres and registers enums in the type map, preventing the warnings.
The patch also changes the return values from enums to symbols from strings., which I think would be the proper way to do it. Though I recognise this might break existing apps using enums and expecting strings being returned, so it might be better to just let it be strings?

Related to #7814
