### PR TITLE
Remove `DEFAULT NULL` for primary key column to support MySQL 5.7.3

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -148,7 +148,7 @@ module ActiveRecord
       QUOTED_TRUE, QUOTED_FALSE = '1', '0'
 
       NATIVE_DATABASE_TYPES = {
-        :primary_key => "int(11) DEFAULT NULL auto_increment PRIMARY KEY",
+        :primary_key => "int(11) auto_increment PRIMARY KEY",
         :string      => { :name => "varchar", :limit => 255 },
         :text        => { :name => "text" },
         :integer     => { :name => "int", :limit => 4 },

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -71,7 +71,7 @@ class MysqlConnectionTest < ActiveRecord::TestCase
   def test_exec_no_binds
     @connection.exec_query('drop table if exists ex')
     @connection.exec_query(<<-eosql)
-      CREATE TABLE `ex` (`id` int(11) DEFAULT NULL auto_increment PRIMARY KEY,
+      CREATE TABLE `ex` (`id` int(11) auto_increment PRIMARY KEY,
         `data` varchar(255))
     eosql
     result = @connection.exec_query('SELECT id, data FROM ex')
@@ -93,7 +93,7 @@ class MysqlConnectionTest < ActiveRecord::TestCase
   def test_exec_with_binds
     @connection.exec_query('drop table if exists ex')
     @connection.exec_query(<<-eosql)
-      CREATE TABLE `ex` (`id` int(11) DEFAULT NULL auto_increment PRIMARY KEY,
+      CREATE TABLE `ex` (`id` int(11) auto_increment PRIMARY KEY,
         `data` varchar(255))
     eosql
     @connection.exec_query('INSERT INTO ex (id, data) VALUES (1, "foo")')
@@ -109,7 +109,7 @@ class MysqlConnectionTest < ActiveRecord::TestCase
   def test_exec_typecasts_bind_vals
     @connection.exec_query('drop table if exists ex')
     @connection.exec_query(<<-eosql)
-      CREATE TABLE `ex` (`id` int(11) DEFAULT NULL auto_increment PRIMARY KEY,
+      CREATE TABLE `ex` (`id` int(11) auto_increment PRIMARY KEY,
         `data` varchar(255))
     eosql
     @connection.exec_query('INSERT INTO ex (id, data) VALUES (1, "foo")')

--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -10,7 +10,7 @@ module ActiveRecord
         @conn.exec_query('drop table if exists ex')
         @conn.exec_query(<<-eosql)
           CREATE TABLE `ex` (
-            `id` int(11) DEFAULT NULL auto_increment PRIMARY KEY,
+            `id` int(11) auto_increment PRIMARY KEY,
             `number` integer,
             `data` varchar(255))
         eosql
@@ -75,7 +75,7 @@ module ActiveRecord
         @conn.exec_query('drop table if exists ex_with_non_standard_pk')
         @conn.exec_query(<<-eosql)
           CREATE TABLE `ex_with_non_standard_pk` (
-            `code` INT(11) DEFAULT NULL auto_increment,
+            `code` INT(11) auto_increment,
              PRIMARY KEY  (`code`))
         eosql
         pk, seq = @conn.pk_and_sequence_for('ex_with_non_standard_pk')
@@ -87,7 +87,7 @@ module ActiveRecord
         @conn.exec_query('drop table if exists ex_with_custom_index_type_pk')
         @conn.exec_query(<<-eosql)
           CREATE TABLE `ex_with_custom_index_type_pk` (
-            `id` INT(11) DEFAULT NULL auto_increment,
+            `id` INT(11) auto_increment,
              PRIMARY KEY  USING BTREE (`id`))
         eosql
         pk, seq = @conn.pk_and_sequence_for('ex_with_custom_index_type_pk')


### PR DESCRIPTION
This pull request addresses ActiveRecord unit tests error with MySQL 5.7.3_m13.

``` ruby
Mysql::Error: All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead: CREATE TABLE `accounts` (`id` int(11) DEFAULT NULL auto_increment PRIMARY KEY, `firm_id` int(11), `firm_name` varchar(255), `credit_limit` int(11)) ENGINE=InnoDB (ActiveRecord::StatementInvalid)
```

It would probably because of this [fix](http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-3.html)

``` quote
Columns in a PRIMARY KEY must be NOT NULL, but if declared explicitly as NULL produced no error. Now an error occurs. For example, a statement such as CREATE TABLE t (i INT NULL PRIMARY KEY) is rejected. The same occurs for similar ALTER TABLE statements. (Bug #13995622, Bug #66987, Bug #15967545, Bug #16545198)
```

Also I was trying to find the reason why primary column can be `DEFAULT NULL` but it is set from the beginning.
https://github.com/rails/rails/commit/eac7cf0b0608132673220d9045b8ff51dc0804e1

``` ruby
 :primary_key => "int(11) DEFAULT NULL auto_increment PRIMARY KEY",
```
