### PR TITLE
Support MySQL 5.7 explain

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/explain_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/explain_test.rb
@@ -10,15 +10,15 @@ module ActiveRecord
         def test_explain_for_one_query
           explain = Developer.where(:id => 1).explain
           assert_match %(EXPLAIN for: SELECT `developers`.* FROM `developers`  WHERE `developers`.`id` = 1), explain
-          assert_match %(developers | const), explain
+          assert_match /developers |.* const/, explain
         end
 
         def test_explain_with_eager_loading
           explain = Developer.where(:id => 1).includes(:audit_logs).explain
           assert_match %(EXPLAIN for: SELECT `developers`.* FROM `developers`  WHERE `developers`.`id` = 1), explain
-          assert_match %(developers | const), explain
+          assert_match /developers |.* const/, explain
           assert_match %(EXPLAIN for: SELECT `audit_logs`.* FROM `audit_logs`  WHERE `audit_logs`.`developer_id` IN (1)), explain
-          assert_match %(audit_logs | ALL), explain
+          assert_match /audit_logs |.* ALL/, explain
         end
       end
     end


### PR DESCRIPTION
This pull request addresses these two failures with MySQL 5.7.3 m13.
MySQL 5.7.3 m13 changes explain format, adding `partitions`.

``` ruby
$ ARCONN=mysql2 ruby -Itest test/cases/adapters/mysql2/explain_test.rb
Using mysql2
Run options: --seed 5764

# Running:

FF

Finished in 0.038367s, 52.1285 runs/s, 208.5141 assertions/s.

  1) Failure:
ActiveRecord::ConnectionAdapters::Mysql2Adapter::ExplainTest#test_explain_for_one_query [test/cases/adapters/mysql2/explain_test.rb:13]:
Expected /developers\ \|\ const/ to match EXPLAIN for: SELECT `developers`.* FROM `developers`  WHERE `developers`.`id` = 1
+----+-------------+------------+------------+-------+---------------+---------+---------+-------+------+----------+-------+
| id | select_type | table      | partitions | type  | possible_keys | key     | key_len | ref   | rows | filtered | Extra |
+----+-------------+------------+------------+-------+---------------+---------+---------+-------+------+----------+-------+
|  1 | SIMPLE      | developers | NULL       | const | PRIMARY       | PRIMARY | 4       | const |    1 |    100.0 | NULL  |
+----+-------------+------------+------------+-------+---------------+---------+---------+-------+------+----------+-------+
1 row in set (0.00 sec)
.


  2) Failure:
ActiveRecord::ConnectionAdapters::Mysql2Adapter::ExplainTest#test_explain_with_eager_loading [test/cases/adapters/mysql2/explain_test.rb:19]:
Expected /developers\ \|\ const/ to match EXPLAIN for: SELECT `developers`.* FROM `developers`  WHERE `developers`.`id` = 1
+----+-------------+------------+------------+-------+---------------+---------+---------+-------+------+----------+-------+
| id | select_type | table      | partitions | type  | possible_keys | key     | key_len | ref   | rows | filtered | Extra |
+----+-------------+------------+------------+-------+---------------+---------+---------+-------+------+----------+-------+
|  1 | SIMPLE      | developers | NULL       | const | PRIMARY       | PRIMARY | 4       | const |    1 |    100.0 | NULL  |
+----+-------------+------------+------------+-------+---------------+---------+---------+-------+------+----------+-------+
1 row in set (0.00 sec)

EXPLAIN for: SELECT `audit_logs`.* FROM `audit_logs`  WHERE `audit_logs`.`developer_id` IN (1)
+----+-------------+------------+------------+------+---------------+------+---------+------+------+----------+-------------+
| id | select_type | table      | partitions | type | possible_keys | key  | key_len | ref  | rows | filtered | Extra       |
+----+-------------+------------+------------+------+---------------+------+---------+------+------+----------+-------------+
|  1 | SIMPLE      | audit_logs | NULL       | ALL  | NULL          | NULL | NULL    | NULL |    1 |    100.0 | Using where |
+----+-------------+------------+------------+------+---------------+------+---------+------+------+----------+-------------+
1 row in set (0.00 sec)
.

2 runs, 8 assertions, 2 failures, 0 errors, 0 skips
$
```

It requires #13247 fixed.
