### PR TITLE
Replace with gsub! in ActiveSupport::Inflector

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -117,7 +117,8 @@ module ActiveSupport
       result.gsub!(/([a-z\d]*)/i) { |match|
         "#{inflections.acronyms[match] || match.downcase}"
       }
-      options.fetch(:capitalize, true) ? result.gsub(/^\w/) { $&.upcase } : result
+      result.gsub!(/^\w/) { $&.upcase } if options.fetch(:capitalize, true)
+      result
     end
 
     # Capitalizes all the words and replaces some characters in the string to


### PR DESCRIPTION
- No reason to create a new String, as result is a dup of input.
- Consistent with other gsub! usage in Inflector.
- All ActiveSupport tests pass.
