### PR TITLE
AR::Base#attributes! returns hash with indifferent access

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -260,6 +260,10 @@ module ActiveRecord
       }
     end
 
+    def attributes!
+      attributes.with_indifferent_access
+    end
+
     # Returns an <tt>#inspect</tt>-like string for the value of the
     # attribute +attr_name+. String attributes are truncated upto 50
     # characters, Date and Time attributes are returned in the

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -27,6 +27,12 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     ActiveRecord::Base.send(:attribute_method_matchers).concat(@old_matchers)
   end
 
+  def test_attributes!
+    attributes = Category.new(name: 'Test category').attributes!
+    assert_equal 'Test category', attributes['name']
+    assert_equal 'Test category', attributes[:name]
+  end
+
   def test_attribute_for_inspect
     t = topics(:first)
     t.title = "The First Topic Now Has A Title With\nNewlines And More Than 50 Characters"


### PR DESCRIPTION
Reopening [this issue](https://github.com/rails/rails/pull/551) as @jeremy said he would consider this change for Rails 4 and as many people seem to want this change.    Appended a bang so as to not break API compatibility.
