### PR TITLE
Prevent invalid code when using dynamic finders with reserved ruby word.

### DIFF
--- a/activerecord/lib/active_record/dynamic_matchers.rb
+++ b/activerecord/lib/active_record/dynamic_matchers.rb
@@ -84,13 +84,18 @@ module ActiveRecord
         "#{finder}(#{attributes_hash})"
       end
 
+      # The parameters in the signature may have reserved Ruby words, in order
+      # to prevent errors, we start each param name with `_`.
+      #
       # Extended in activerecord-deprecated_finders
       def signature
-        attribute_names.join(', ')
+        attribute_names.map { |name| "_#{name}" }.join(', ')
       end
 
+      # Given that the parameters starts with `_`, the finder needs to use the
+      # same parameter name.
       def attributes_hash
-        "{" + attribute_names.map { |name| ":#{name} => #{name}" }.join(',') + "}"
+        "{" + attribute_names.map { |name| ":#{name} => _#{name}" }.join(',') + "}"
       end
 
       def finder

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -12,6 +12,7 @@ require 'models/developer'
 require 'models/customer'
 require 'models/toy'
 require 'models/matey'
+require 'models/dog'
 
 class FinderTest < ActiveRecord::TestCase
   fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :customers, :categories, :categorizations
@@ -639,6 +640,13 @@ class FinderTest < ActiveRecord::TestCase
   def test_find_by_one_attribute_bang
     assert_equal topics(:first), Topic.find_by_title!("The First Topic")
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find_by_title!("The First Topic!") }
+  end
+
+  def test_find_by_on_attribute_that_is_a_reserved_word
+    dog_alias = 'Dog'
+    dog = Dog.create(alias: dog_alias)
+
+    assert_equal dog, Dog.find_by_alias(dog_alias)
   end
 
   def test_find_by_one_attribute_that_is_an_alias

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -245,6 +245,7 @@ ActiveRecord::Schema.define do
     t.integer :trainer_id
     t.integer :breeder_id
     t.integer :dog_lover_id
+    t.string  :alias
   end
 
   create_table :edges, force: true, id: false do |t|


### PR DESCRIPTION
Prevent invalid code when using dynamic finders with Ruby's reserved words. The dynamic finder was creating the method signature with the parameters name, which may have reserved words and this way creating invalid Ruby code.

Closes: #13261

```
Example:

    # Before
    Dog.find_by_alias('dog name')

    # Was creating this method
    def self.find_by_alias(alias, options = {})

    # After
    Dog.find_by_alias('dog name')

    # Will create this method
    def self.find_by_alias(_alias, options = {})
```
