### PR TITLE
ActiveRecord::Enum, model.status_was return a String value, not integer

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -216,8 +216,9 @@
 
         # conversation.update! status: 1
         conversation.archived!
-        conversation.archived? # => true
-        conversation.status    # => "archived"
+        conversation.archived?  # => true
+        conversation.status     # => "archived"
+        conversation.status_was # => "active"
 
         # conversation.update! status: 1
         conversation.status = :archived

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -12,8 +12,9 @@ module ActiveRecord
   #
   #   # conversation.update! status: 1
   #   conversation.archived!
-  #   conversation.archived? # => true
-  #   conversation.status    # => "archived"
+  #   conversation.archived?  # => true
+  #   conversation.status     # => "archived"
+  #   conversation.status_was # => "active"
   #
   #   # conversation.update! status: 1
   #   conversation.status = "archived"
@@ -70,6 +71,10 @@ module ActiveRecord
 
           # def direction() DIRECTION.key self[:direction] end
           define_method(name) { enum_values.key self[name] }
+          
+          define_method("#{name}_was") {
+            enum_values.key self.changed_attributes["#{name}"]
+          }
 
           pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
           pairs.each do |value, i|

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -63,4 +63,10 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal 1, Book::STATUS["written"]
     assert_equal 2, Book::STATUS[:published]
   end
+  
+  test "enum key_was value be a String" do
+    @book.status = :proposed
+    @book.status = :written
+    assert_equal "proposed", @book.status_was
+  end
 end


### PR DESCRIPTION
``` ruby
class Conversation < ActiveRecord::Base
  enum status: { active: 0, archived: 1 }
end
```

Before:

``` ruby
conversation.status = :active
conversation.status = :archived
conversation.status_was # => 0
```

After:

``` ruby
conversation.status_was # => "active"
```
