### PR TITLE
Set STI type column correctly when calling becomes!

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -195,7 +195,7 @@ module ActiveRecord
     # share the same set of attributes.
     def becomes!(klass)
       became = becomes(klass)
-      became.public_send("#{klass.inheritance_column}=", klass.sti_name) unless self.class.descends_from_active_record?
+      became.public_send("#{klass.inheritance_column}=", (klass.sti_name unless klass.descends_from_active_record?))
       became
     end
 


### PR DESCRIPTION
The becomes! method is currently broken and need to be called a second time to correctly set the type column when changing from the base model to a sub-class.
