### PR TITLE
Remove require 'models/administrator', Administrator is not used in secure password test

### DIFF
--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -2,7 +2,6 @@ require 'cases/helper'
 require 'models/user'
 require 'models/oauthed_user'
 require 'models/visitor'
-require 'models/administrator'
 
 class SecurePasswordTest < ActiveModel::TestCase
   setup do


### PR DESCRIPTION
 ref f8c9a4d3e88181cee644f91e1342bfe896ca64c6
