### PR TITLE
Sanitize helper only accepts strings

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   `HTML::Sanitizer#sanitize` now raise an ArgumentError when called with something
+    else than a String.
+
+        sanitize(Object.new) # => ArgumentError
+
+    Previously, it would have failed on `.empty?` and thrown a NoMethodError.
+
+        sanitize(Object.new) # => NoMethodError
+
+    *Christian Blais*
+
 *   A Cycle object should accept an array and cycle through it as it would with a set of
     comma-separated objects.
 

--- a/actionview/lib/action_view/vendor/html-scanner/html/sanitizer.rb
+++ b/actionview/lib/action_view/vendor/html-scanner/html/sanitizer.rb
@@ -11,7 +11,11 @@ module HTML
     end
 
     def sanitizeable?(text)
-      !(text.nil? || text.empty? || !text.index("<"))
+      return false if text.nil?
+      raise ArgumentError, "You should pass a string to sanitize"
+      return false unless text.present?
+      return false unless text.index("<")
+      true
     end
 
   protected
@@ -60,7 +64,11 @@ module HTML
     self.included_tags = Set.new(%w(a href))
 
     def sanitizeable?(text)
-      !(text.nil? || text.empty? || !((text.index("<a") || text.index("<href")) && text.index(">")))
+      return false if text.nil?
+      raise ArgumentError, "You should pass a string to sanitize"
+      return false unless text.present?
+      return false unless (text.index("<a") || text.index("<href")) && text.index(">")
+      true
     end
 
   protected

--- a/actionview/test/template/html-scanner/sanitizer_test.rb
+++ b/actionview/test/template/html-scanner/sanitizer_test.rb
@@ -101,6 +101,15 @@ class SanitizerTest < ActionController::TestCase
     assert_sanitized ''
   end
 
+  def test_should_raise_on_non_string_text
+    sanitizer = HTML::WhiteListSanitizer.new
+    e = assert_raise(ArgumentError) do
+      sanitizer.sanitize(Object.new)
+    end
+
+    assert_equal "You should pass a string to sanitize", e.message
+  end
+
   def test_should_allow_custom_tags
     text = "<u>foo</u>"
     sanitizer = HTML::WhiteListSanitizer.new


### PR DESCRIPTION
With this patch, `HTML::Sanitizer#sanitize` now raise an `ArgumentError` when called with something else than a String.

```
sanitize(Object.new) # => ArgumentError
```

Previously, it would have failed on `.empty?` and thrown a NoMethodError.

```
sanitize(Object.new) # => NoMethodError
```
