### PR TITLE
Make ActionDispatch::Request::Session#fetch behave like Hash#fetch

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -85,9 +85,7 @@
 
 *   Add `session#fetch` method
 
-    fetch behaves similarly to [Hash#fetch](http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-fetch),
-    with the exception that the returned value is always saved into the session.
-
+    fetch behaves like [Hash#fetch](http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-fetch).  
     It returns a value from the hash for the given key.
     If the key can’t be found, there are several options:
 

--- a/actionpack/test/dispatch/request/session_test.rb
+++ b/actionpack/test/dispatch/request/session_test.rb
@@ -68,13 +68,12 @@ module ActionDispatch
         assert_equal '1', session.fetch(:one)
 
         assert_equal '2', session.fetch(:two, '2')
-        assert_equal '2', session.fetch(:two)
+        assert_nil session.fetch(:two, nil)
 
         assert_equal 'three', session.fetch(:three) {|el| el.to_s }
-        assert_equal 'three', session.fetch(:three)
 
         assert_raise KeyError do
-          session.fetch(:four)
+          session.fetch(:three)
         end
       end
 


### PR DESCRIPTION
`Session#fetch` was mutating the session when given a default argument and/or a block. Since `Session` duck-types as a `Hash`, it should behave like one in these cases.
