### PR TITLE
Translate new unique constraint error message for sqlite >= 3.8.2

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -595,7 +595,11 @@ module ActiveRecord
 
         def translate_exception(exception, message)
           case exception.message
-          when /column(s)? .* (is|are) not unique/
+          # SQLite 3.8.2 returns a newly formatted error message:
+          #   UNIQUE constraint failed: *table_name*.*column_name*
+          # Older versions of SQLite return:
+          #   column *column_name* is not unique
+          when /column(s)? .* (is|are) not unique/, /UNIQUE constraint failed: .*/
             RecordNotUnique.new(message, exception)
           else
             super


### PR DESCRIPTION
The new version of sqlite (3.8.2) is handling the error message for unique constraint differently so the old check is not enough.

I was getting the following test failure using sqlite `3.8.2` (and using sqlite3 gem at `1.3.7` and rails at `4.0.2`):

```
1) Failure:
ActiveRecord::AdapterTest#test_uniqueness_violations_are_translated_to_specific_exception [/builddir/build/BUILD/rubygem-activerecord-4.0.2/usr/share/gems/gems/activerecord-4.0.2/test/cases/adapter_test.rb:141]:
[ActiveRecord::RecordNotUnique] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"SQLite3::ConstraintException: UNIQUE constraint failed: subscribers.nick: INSERT INTO subscribers(nick) VALUES('me')">
---Backtrace---
/usr/share/gems/gems/sqlite3-1.3.7/lib/sqlite3/statement.rb:108:in `step'
/usr/share/gems/gems/sqlite3-1.3.7/lib/sqlite3/statement.rb:108:in `block in each'
/usr/share/gems/gems/sqlite3-1.3.7/lib/sqlite3/statement.rb:107:in `loop'
/usr/share/gems/gems/sqlite3-1.3.7/lib/sqlite3/statement.rb:107:in `each'
/usr/share/gems/gems/sqlite3-1.3.7/lib/sqlite3/database.rb:149:in `map'
/usr/share/gems/gems/sqlite3-1.3.7/lib/sqlite3/database.rb:149:in `block in execute'
/usr/share/gems/gems/sqlite3-1.3.7/lib/sqlite3/database.rb:95:in `prepare'
/usr/share/gems/gems/sqlite3-1.3.7/lib/sqlite3/database.rb:134:in `execute'
```

This PR resolves this issue by checking the new returning error message as well.
