### PR TITLE
form_tag with action parameter explicitly inside hash does not work

### DIFF
--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -1285,7 +1285,7 @@ Creates a field set for grouping HTML form elements.
 Creates a file upload field.
 
 ```html+erb
-<%= form_tag {action: "post"}, {multipart: true} do %>
+<%= form_tag "post", {multipart: true} do %>
   <label for="file">File to Upload</label> <%= file_field_tag "file" %>
   <%= submit_tag %>
 <% end %>


### PR DESCRIPTION
I tested it with rails 4 and ruby 2.0.0-rc2. Please see the screenshot of the exception i am getting.

<a href='http://postimg.org/image/4heyn6d55/' target='_blank'><img src='http://s28.postimg.org/4heyn6d55/syntax_error.jpg' border='0' alt="syntax error" /></a>

The form_tag description is given here
http://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-form_tag
