### PR TITLE
Fix retrieving duplicated columns with mysql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -420,10 +420,17 @@ module ActiveRecord
           if result
             types = {}
             result.fetch_fields.each { |field|
+              name  = field.name
+              index = 1
+              while types.key?(name)
+                name = "#{field.name}_#{index}"
+                index += 1
+              end
+
               if field.decimals > 0
-                types[field.name] = Fields::Decimal.new
+                types[name] = Fields::Decimal.new
               else
-                types[field.name] = Fields.find_type field
+                types[name] = Fields.find_type field
               end
             }
             result_set = ActiveRecord::Result.new(types.keys, result.to_a, types)


### PR DESCRIPTION
This fixes SQL queries with MySQL where the same name is used several times for the same column, therefore [breaking the build](https://travis-ci.org/rails/rails/jobs/15329752#L1172).

When a field is named several times, second and further occurencies get prepended the name "_x" where x is the index.
