### PR TITLE
form_tag with action parameter explicitly inside hash does not work

### DIFF
--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -1285,7 +1285,7 @@ Creates a field set for grouping HTML form elements.
 Creates a file upload field.
 
 ```html+erb
-<%= form_tag {action: "post"}, {multipart: true} do %>
+<%= form_tag "post", {multipart: true} do %>
   <label for="file">File to Upload</label> <%= file_field_tag "file" %>
   <%= submit_tag %>
 <% end %>

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -1285,7 +1285,7 @@ Creates a field set for grouping HTML form elements.
 Creates a file upload field.
 
 ```html+erb
-<%= form_tag {action: "post"}, {multipart: true} do %>
+<%= form_tag ({action:"post"}, {multipart: true}) do %>
   <label for="file">File to Upload</label> <%= file_field_tag "file" %>
   <%= submit_tag %>
 <% end %>

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -1285,7 +1285,7 @@ Creates a field set for grouping HTML form elements.
 Creates a file upload field.
 
 ```html+erb
-<%= form_tag "post", {multipart: true} do %>
+<%= form_tag ({action:"post"}, {multipart: true}) do %>
   <label for="file">File to Upload</label> <%= file_field_tag "file" %>
   <%= submit_tag %>
 <% end %>


### PR DESCRIPTION
I am using rails-4.0.1 and ruby 2.0.0-rc2.
Please see the screenshot of the exception.

<a href="http://oi42.tinypic.com/2gt90uh.jpg" target="_blank"><img src="http://i42.tinypic.com/2gt90uh.png" border="0" alt="Image and video hosting by TinyPic"></a>

The form_tag description is here:
http://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-form_tag
