### PR TITLE
Added :nodoc: for `attribute_changed?` and `attribute_was` [ci skip]

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -149,12 +149,12 @@ module ActiveModel
     end
 
     # Handle <tt>*_changed?</tt> for +method_missing+.
-    def attribute_changed?(attr)
+    def attribute_changed?(attr) # :nodoc:
       changed_attributes.include?(attr)
     end
 
     # Handle <tt>*_was</tt> for +method_missing+.
-    def attribute_was(attr)
+    def attribute_was(attr) # :nodoc:
       attribute_changed?(attr) ? changed_attributes[attr] : __send__(attr)
     end
 


### PR DESCRIPTION
These methods were made "public" in 47617ecd so that `method_missing`
can invoke them without going through `send`, but they aren't meant
for consumption from outside of Rails.

cc @tenderlove
fyi @senny
