### PR TITLE
form_tag with parameters fixed [ ci skip ]

### DIFF
--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -1285,7 +1285,7 @@ Creates a field set for grouping HTML form elements.
 Creates a file upload field.
 
 ```html+erb
-<%= form_tag {action: "post"}, {multipart: true} do %>
+<%= form_tag({action:"post"}, multipart: true) do %>
   <label for="file">File to Upload</label> <%= file_field_tag "file" %>
   <%= submit_tag %>
 <% end %>


### PR DESCRIPTION
Follow Up to #13296

 form_tag {action: "post"}, {multipart: true} gives syntax error.
Fixed it by removing hash braces from second parameter.
