### PR TITLE
Fix mysql to support duplicated column names

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -419,14 +419,19 @@ module ActiveRecord
 
           if result
             types = {}
+            fields = []
             result.fetch_fields.each { |field|
+              field_name = field.name
+              fields << field_name
+
               if field.decimals > 0
-                types[field.name] = Fields::Decimal.new
+                types[field_name] = Fields::Decimal.new
               else
-                types[field.name] = Fields.find_type field
+                types[field_name] = Fields.find_type field
               end
             }
-            result_set = ActiveRecord::Result.new(types.keys, result.to_a, types)
+
+            result_set = ActiveRecord::Result.new(fields, result.to_a, types)
             result.free
           else
             result_set = ActiveRecord::Result.new([], [])

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -855,7 +855,7 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_with_limiting_with_custom_select
     posts = Post.references(:authors).merge(
-      :includes => :author, :select => ' posts.*, authors.id as "author_id"',
+      :includes => :author, :select => 'posts.*, authors.id as "author_id"',
       :limit => 3, :order => 'posts.id'
     ).to_a
     assert_equal 3, posts.size


### PR DESCRIPTION
This will fix the [broken test](https://github.com/rails/rails/commit/4a2650836680f51490e999c3c8441a2f9adff96e)  `test_with_limiting_with_custom_select`.

The query's result was built in a hash with column name as key, if the
result have a duplicated column name the last value was
overriding the first one.
