### PR TITLE
fix truncation in ActiveRecord::Calculations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   When the field of aggregate functions in `ActiveRecord::Calculations` have complex expressions
+    their result is not type casted to the `column type`.
+    It allows to get the `result` without unexpected truncation.
+
+    Fixes #12937.
+
+    Example:
+
+        Account.sum(:credit_limit) # => is type casted
+
+        Account.sum("2.1 * accounts.credit_limit") # => is not type casted
+
+        Account.sum("accounts.credit_limit") # => is not type casted
+
+    *Angelo Capilleri*
+
 *   Allow single table inheritance instantiation to work when storing
     demodulized class names.
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -348,8 +348,8 @@ module ActiveRecord
     end
 
     def type_for(field)
-      field_name = field.respond_to?(:name) ? field.name.to_s : field.to_s.split('.').last
-      @klass.type_for_attribute(field_name)
+      field = field.name if field.respond_to?(:name)
+      @klass.type_for_attribute(field.to_s)
     end
 
     def type_cast_calculated_value(value, type, operation = nil)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -416,6 +416,25 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 0, Account.where('1 = 2').sum("2 * credit_limit")
   end
 
+  def test_complex_expression_not_lose_data_when_returns_different_type_than_column_type
+    credit_limit_sum = 318 * 2.112
+    assert_equal credit_limit_sum, Account.sum("credit_limit * 2.112")
+    assert_equal credit_limit_sum, Account.sum("2.112 * accounts.credit_limit")
+    assert_equal credit_limit_sum, Account.sum("accounts.credit_limit * 2.112")
+
+    credit_limit_maximum = 60 * 2.112
+    assert_equal credit_limit_maximum, Account.maximum("accounts.credit_limit * 2.112")
+    assert_equal credit_limit_maximum, Account.maximum("credit_limit * 2.112")
+
+    credit_limit_minimum = 50 * 2.112
+    assert_equal credit_limit_minimum, Account.minimum("accounts.credit_limit * 2.112")
+    assert_equal credit_limit_minimum, Account.minimum("credit_limit * 2.112")
+
+    credit_limit_average = 53 * 2.112
+    assert_equal credit_limit_average, Account.average("accounts.credit_limit * 2.112")
+    assert_equal credit_limit_average, Account.average("credit_limit * 2.112")
+  end
+
   def test_count_with_from_option
     assert_equal Company.count(:all), Company.from('companies').count(:all)
     assert_equal Account.where("credit_limit = 50").count(:all),

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -52,6 +52,15 @@ Don't forget to review the difference, to see if there were any unexpected chang
 
 Upgrading from Rails 4.2 to Rails 5.0
 -------------------------------------
+### Complex expressions in `ActiveRecord::Calculations#calculation`
+
+In Rails 4.2 the aggregate methods in [`ActiveRecord::Calculations#calculation`](http://guides.rubyonrails.org/active_record_querying.html#calculations)
+type cast the result to the column type and the result could be truncated when the fields are complex.
+For example with expressions like `Pet.sum('2.1 * age')` or `Pet.avg('2.1 * age')`
+the result is always an `integer`(given `age` as `integer` column type).
+
+In Rails 5.0 the result is not type casted to the column type when the fields are complex.
+For example `Pet.sum('2.1 * age')` and `Pet.avg('2.1 * age')` returns a `float`.
 
 ### Halting callback chains by returning `false`
 


### PR DESCRIPTION
This PR fixes a wrong conversion to column_type in
`ActiveRecord::Calculations#calculation`
when the calculation has complex fields and the result
is a different type than the column.

This prevent truncation of result and allows the user
to have the original data type of result

  Before:

```
  Account.sum("2.1 * accounts.credit_limit") => 667
```

  After:

```
  Account.sum("2.1 * accounts.credit_limit") => 667.8
```

Fixes #12937
