### PR TITLE
Fixes interpolation on ActiveSupport::SafeBuffer

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -143,12 +143,11 @@ module ActiveSupport #:nodoc:
     end
 
     def %(args)
-      escaper = ->(arg) { (!html_safe? || arg.html_safe?) ? arg : ERB::Util.h(arg) }
       case args
       when Hash
-        escaped_args = Hash[args.map { |k,arg| [k, escaper.call(arg)] }]
+        escaped_args = Hash[args.map { |k,arg| [k, _argument_escaper(arg)] }]
       else
-        escaped_args = Array(args).map { |arg| escaper.call(arg) }
+        escaped_args = Array(args).map { |arg| _argument_escaper(arg) }
       end
 
       self.class.new(super(escaped_args))
@@ -183,6 +182,12 @@ module ActiveSupport #:nodoc:
           end                                       # end
         EOT
       end
+    end
+
+    private
+
+    def _argument_escaper(arg)
+      (!html_safe? || arg.html_safe?) ? arg : ERB::Util.h(arg)
     end
   end
 end

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -145,9 +145,9 @@ module ActiveSupport #:nodoc:
     def %(args)
       case args
       when Hash
-        escaped_args = Hash[args.map { |k,arg| [k, _argument_escaper(arg)] }]
+        escaped_args = Hash[args.map { |k,arg| [k, html_escape_interpolated_argument(arg)] }]
       else
-        escaped_args = Array(args).map { |arg| _argument_escaper(arg) }
+        escaped_args = Array(args).map { |arg| html_escape_interpolated_argument(arg) }
       end
 
       self.class.new(super(escaped_args))
@@ -186,7 +186,7 @@ module ActiveSupport #:nodoc:
 
     private
 
-    def _argument_escaper(arg)
+    def html_escape_interpolated_argument(arg)
       (!html_safe? || arg.html_safe?) ? arg : ERB::Util.h(arg)
     end
   end

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -143,15 +143,15 @@ module ActiveSupport #:nodoc:
     end
 
     def %(args)
-      args = Array(args).map do |arg|
-        if !html_safe? || arg.html_safe?
-          arg
-        else
-          ERB::Util.h(arg)
-        end
+      escaper = ->(arg) { (!html_safe? || arg.html_safe?) ? arg : ERB::Util.h(arg) }
+      case args
+      when Hash
+        escaped_args = Hash[args.map { |k,arg| [k, escaper.call(arg)] }]
+      else
+        escaped_args = Array(args).map { |arg| escaper.call(arg) }
       end
 
-      self.class.new(super(args))
+      self.class.new(super(escaped_args))
     end
 
     def html_safe?

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -143,11 +143,11 @@ class SafeBufferTest < ActiveSupport::TestCase
 
   test 'Should work with interpolation (array argument)' do
     x = 'foo %s bar'.html_safe % ['qux']
-    assert_equal x, 'foo qux bar'
+    assert_equal 'foo qux bar', x
   end
 
   test 'Should work with interpolation (hash argument)' do
     x = 'foo %{x} bar'.html_safe % { x: 'qux' }
-    assert_equal x, 'foo qux bar'
+    assert_equal 'foo qux bar', x
   end
 end

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -140,4 +140,14 @@ class SafeBufferTest < ActiveSupport::TestCase
     # should still be unsafe
     assert !y.html_safe?, "should not be safe"
   end
+
+  test 'Should work with interpolation (array argument)' do
+    x = 'foo %s bar'.html_safe % ['qux']
+    assert_equal x, 'foo qux bar'
+  end
+
+  test 'Should work with interpolation (hash argument)' do
+    x = 'foo %{x} bar'.html_safe % { x: 'qux' }
+    assert_equal x, 'foo qux bar'
+  end
 end

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -150,4 +150,19 @@ class SafeBufferTest < ActiveSupport::TestCase
     x = 'foo %{x} bar'.html_safe % { x: 'qux' }
     assert_equal 'foo qux bar', x
   end
+
+  test 'Should escape unsafe interpolated args' do
+    x = 'foo %{x} bar'.html_safe % { x: '<br/>' }
+    assert_equal 'foo &lt;br/&gt; bar', x
+  end
+
+  test 'Should not escape safe interpolated args' do
+    x = 'foo %{x} bar'.html_safe % { x: '<br/>'.html_safe }
+    assert_equal 'foo <br/> bar', x
+  end
+
+  test 'Should interpolate to a safe string' do
+    x = 'foo %{x} bar'.html_safe % { x: 'qux' }
+    assert x.html_safe?, 'should be safe'
+  end
 end


### PR DESCRIPTION
Interpolation was untested and did not work with hash arguments:

``` ruby
"%{x}".html_safe % { x: 1 }
```

would break.

Adds tests for both array and hash arguments, and adds hash support.
