### PR TITLE
db:test:clone and prepare must load environment

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   db:test:clone and db:test:prepare must load Rails environment
+
+    db:test:clone and db:test:prepare use ActiveRecord::Base. configurations,
+    so we need to load the rails environment, otherwise the config wont be in place.
+
+    *arthurnn*
+
 *   Create a whitelist of delegable methods to `Array`.
 
     Currently `Relation` directly delegates methods to `Array`. With this change,

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -343,7 +343,7 @@ db_namespace = namespace :db do
     end
 
     # desc "Recreate the test database from a fresh schema"
-    task :clone do
+    task :clone => :environment do
       case ActiveRecord::Base.schema_format
         when :ruby
           db_namespace["test:clone_schema"].invoke
@@ -364,7 +364,7 @@ db_namespace = namespace :db do
     end
 
     # desc 'Check for pending migrations and load the test schema'
-    task :prepare => :load_config do
+    task :prepare => [:environment, :load_config] do
       unless ActiveRecord::Base.configurations.blank?
         db_namespace['test:load'].invoke
       end
@@ -401,4 +401,3 @@ namespace :railties do
 end
 
 task 'test:prepare' => ['db:test:prepare', 'db:test:load', 'db:abort_if_pending_migrations']
-

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -208,7 +208,8 @@ module ApplicationTests
       add_to_config "config.active_record.schema_format = :sql"
       output = Dir.chdir(app_path) do
         `rails generate scaffold user username:string;
-         bundle exec rake db:migrate db:test:clone 2>&1 --trace`
+         bundle exec rake db:migrate;
+         bundle exec rake db:test:clone 2>&1 --trace`
       end
       assert_match(/Execute db:test:clone_structure/, output)
     end
@@ -217,7 +218,8 @@ module ApplicationTests
       add_to_config "config.active_record.schema_format = :sql"
       output = Dir.chdir(app_path) do
         `rails generate scaffold user username:string;
-         bundle exec rake db:migrate db:test:prepare 2>&1 --trace`
+         bundle exec rake db:migrate;
+         bundle exec rake db:test:prepare 2>&1 --trace`
       end
       assert_match(/Execute db:test:load_structure/, output)
     end


### PR DESCRIPTION
`db:test:clone` and `db:test:prepare` use
`ActiveRecord::Base.` configurations, so we need to load the rails
environment, otherwise the config wont be in place.

(Just realize that when upgrading a rails3.2 to 4 app)

review @rafaelfranca @tenderlove

Would be awesome to commit this to 4-0-stable too.
