### PR TITLE
support creating temporary tables from queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Respect temporary option when dropping tables with MySQL
+
+    Normal DROP TABLE also works, but commits the transaction.
+
+    *Cody Cutrer*
+
+*   Add option to create tables from a query.
+
+    *Cody Cutrer*
+
 *   Create a whitelist of delegable methods to `Array`.
 
     Currently `Relation` directly delegates methods to `Array`. With this change,

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -34,9 +34,10 @@ module ActiveRecord
 
           def visit_TableDefinition(o)
             create_sql = "CREATE#{' TEMPORARY' if o.temporary} TABLE "
-            create_sql << "#{quote_table_name(o.name)} ("
-            create_sql << o.columns.map { |c| accept c }.join(', ')
-            create_sql << ") #{o.options}"
+            create_sql << "#{quote_table_name(o.name)} "
+            create_sql << "(#{o.columns.map { |c| accept c }.join(', ')}) " unless o.as
+            create_sql << "#{o.options}"
+            create_sql << " AS #{@conn.to_sql(o.as)}" if o.as
             create_sql
           end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -49,14 +49,15 @@ module ActiveRecord
       # An array of ColumnDefinition objects, representing the column changes
       # that have been defined.
       attr_accessor :indexes
-      attr_reader :name, :temporary, :options
+      attr_reader :name, :temporary, :options, :as
 
-      def initialize(types, name, temporary, options)
+      def initialize(types, name, temporary, options, as = nil)
         @columns_hash = {}
         @indexes = {}
         @native = types
         @temporary = temporary
         @options = options
+        @as = as
         @name = name
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -492,6 +492,10 @@ module ActiveRecord
         rename_table_indexes(table_name, new_name)
       end
 
+      def drop_table(table_name, options = {})
+        execute "DROP#{' TEMPORARY' if options[:temporary]} TABLE #{quote_table_name(table_name)}"
+      end
+
       def rename_index(table_name, old_name, new_name)
         if (version[0] == 5 && version[1] >= 7) || version[0] >= 6
           execute "ALTER TABLE #{quote_table_name(table_name)} RENAME INDEX #{quote_table_name(old_name)} TO #{quote_table_name(new_name)}"

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -973,8 +973,8 @@ module ActiveRecord
           $1.strip if $1
         end
 
-        def create_table_definition(name, temporary, options)
-          TableDefinition.new native_database_types, name, temporary, options
+        def create_table_definition(name, temporary, options, as = nil)
+          TableDefinition.new native_database_types, name, temporary, options, as
         end
 
         def update_table_definition(table_name, base)

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -65,6 +65,15 @@ module ActiveRecord
         assert_nil index_c.using
         assert_equal :fulltext, index_c.type
       end
+
+      def test_drop_temporary_table
+        @connection.transaction do
+          @connection.create_table(:temp_table, temporary: true)
+          # if it doesn't properly say DROP TEMPORARY TABLE, the transaction commit
+          # will complain that no transaction is active
+          @connection.drop_table(:temp_table, temporary: true)
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -443,6 +443,32 @@ class MigrationTest < ActiveRecord::TestCase
     Person.connection.drop_table :binary_testings rescue nil
   end
 
+  def test_create_table_with_query
+    Person.connection.drop_table :table_from_query_testings rescue nil
+    Person.connection.create_table(:person, force: true)
+
+    Person.connection.create_table :table_from_query_testings, as: "SELECT id FROM person"
+
+    columns = Person.connection.columns(:table_from_query_testings)
+    assert_equal 1, columns.length
+    assert_equal "id", columns.first.name
+
+    Person.connection.drop_table :table_from_query_testings rescue nil
+  end
+
+  def test_create_table_with_query_from_relation
+    Person.connection.drop_table :table_from_query_testings rescue nil
+    Person.connection.create_table(:person, force: true)
+
+    Person.connection.create_table :table_from_query_testings, as: Person.select(:id)
+
+    columns = Person.connection.columns(:table_from_query_testings)
+    assert_equal 1, columns.length
+    assert_equal "id", columns.first.name
+
+    Person.connection.drop_table :table_from_query_testings rescue nil
+  end
+
   if current_adapter? :OracleAdapter
     def test_create_table_with_custom_sequence_name
       # table name is 29 chars, the standard sequence name will


### PR DESCRIPTION
also override drop_table in AbstractMySQLAdapter to properly drop
temporary tables without committing the transaction
