### PR TITLE
Create a blacklist to disallow mutator methods to be delegated to Array

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   `Relation` no longer has mutator methods like `#map!` and `#delete_if`. Convert
+    to an `Array` by calling `#to_a` before using these methods.
+
+    It intends to prevent odd bugs and confusion in code that call mutator
+    methods directly on the `Relation`.
+
+    Example:
+
+        # Instead of this
+        Author.where(name: 'Hank Moody').compact!
+
+        # Now you have to do this
+        authors = Author.where(name: 'Hank Moody').to_a
+        authors.compact!
+
+    *Lauro Caetano*
+
 *   Better support for `where()` conditions that use a `belongs_to`
     association name.
 
@@ -79,21 +96,6 @@
     so we need to load the Rails environment, otherwise the config wont be in place.
 
     *arthurnn*
-
-*   Create a whitelist of delegable methods to `Array`.
-
-    Currently `Relation` directly delegates methods to `Array`. With this change,
-    only the methods present in this whitelist will be delegated.
-
-    The whitelist contains:
-
-        #&, #+, #[], #all?, #collect, #detect, #each, #each_cons, #each_with_index,
-        #flat_map, #group_by, #include?, #length, #map, #none?, :one?, #reverse, #sample,
-        #second, #sort, #sort_by, #to_ary, #to_set, #to_xml, #to_yaml
-
-    To use any other method, instead first call `#to_a` on the association.
-
-    *Lauro Caetano*
 
 *   Use the right column to type cast grouped calculations with custom expressions.
 

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -26,15 +26,22 @@ module ActiveRecord
   end
 
   module DelegationWhitelistBlacklistTests
-    ActiveRecord::Delegation::ARRAY_DELEGATES.each do |method|
+    ARRAY_DELEGATES = [
+      :+, :-, :|, :&, :[],
+      :all?, :collect, :detect, :each, :each_cons, :each_with_index,
+      :exclude?, :find_all, :flat_map, :group_by, :include?, :length,
+      :map, :none?, :one?, :partition, :reject, :reverse,
+      :sample, :second, :sort, :sort_by, :third,
+      :to_ary, :to_set, :to_xml, :to_yaml
+    ]
+
+    ARRAY_DELEGATES.each do |method|
       define_method "test_delegates_#{method}_to_Array" do
         assert_respond_to target, method
       end
     end
 
-    [:compact!, :flatten!, :reject!, :reverse!, :rotate!,
-     :shuffle!, :slice!, :sort!, :sort_by!, :delete_if,
-     :keep_if, :pop, :shift, :delete_at, :compact].each do |method|
+    ActiveRecord::Delegation::BLACKLISTED_ARRAY_METHODS.each do |method|
       define_method "test_#{method}_is_not_delegated_to_Array" do
         assert_raises(NoMethodError) { call_method(target, method) }
       end

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -156,6 +156,23 @@ end
 ActiveRecord::FixtureSet.context_class.send :include, FixtureFileHelpers
 ```
 
+### Mutator methods called on Relation
+
+`Relation` no longer has mutator methods like `#map!` and `#delete_if`. Convert
+to an `Array` by calling `#to_a` before using these methods.
+
+It intends to prevent odd bugs and confusion in code that call mutator
+methods directly on the `Relation`.
+
+```ruby
+# Instead of this
+Author.where(name: 'Hank Moody').compact!
+
+# Now you have to do this
+authors = Author.where(name: 'Hank Moody').to_a
+authors.compact!
+```
+
 Upgrading from Rails 3.2 to Rails 4.0
 -------------------------------------
 


### PR DESCRIPTION
This change was necessary because the whitelist wouldn't work.
It would be painful for users trying to update their applications.

Related with: #12129
