### PR TITLE
add default_scope as an option in uniqueness validation

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -18,11 +18,11 @@ module ActiveRecord
         relation = build_relation(finder_class, table, attribute, value)
         relation = relation.and(table[finder_class.primary_key.to_sym].not_eq(record.id)) if record.persisted?
         relation = scope_relation(record, table, relation)
-        relation = finder_class.unscoped.where(relation)
+        relation = (options[:default_scope] ? finder_class.where(relation) : finder_class.unscoped.where(relation))
         relation = relation.merge(options[:conditions]) if options[:conditions]
 
         if relation.exists?
-          error_options = options.except(:case_sensitive, :scope, :conditions)
+          error_options = options.except(:case_sensitive, :scope, :conditions, :default_scope)
           error_options[:value] = value
 
           record.errors.add(attribute, :taken, error_options)

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -63,6 +63,27 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert t2.save, "Should now save t2 as unique"
   end
 
+  def test_validate_uniqueness_with_default_scope
+    Topic.validates_uniqueness_of(:title, :default_scope => true)
+    Topic.class_eval do
+      default_scope { where(:deleted_at => nil) }
+    end
+
+    t = Topic.new("title" => "I'm uniqué!")
+    assert t.save, "Should save t as unique"
+
+
+    t2 = Topic.new("title" => "I'm uniqué!")
+    assert !t2.valid?, "Shouldn't be valid"
+    assert !t2.save, "Shouldn't save t2 as unique"
+    assert_equal ["has already been taken"], t2.errors[:title]
+
+    t.update(:deleted_at => Time.current)
+
+    t2 = Topic.new("title" => "I'm uniqué!")
+    assert t2.save, "Should save t as unique"
+  end
+
   def test_validate_uniqueness_with_alias_attribute
     Topic.alias_attribute :new_title, :title
     Topic.validates_uniqueness_of(:new_title)

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -669,6 +669,7 @@ ActiveRecord::Schema.define do
     t.datetime :written_on
     t.time     :bonus_time
     t.date     :last_read
+    t.datetime :deleted_at
     # use VARCHAR2(4000) instead of CLOB datatype as CLOB data type has many limitations in
     # Oracle SELECT WHERE clause which causes many unit test failures
     if current_adapter?(:OracleAdapter)


### PR DESCRIPTION
Uniqueness validation doesn't consider default_scope, but sometimes it is required to have default_scope like in case of soft_delete!
