### PR TITLE
Fixes interpolation on SafeBuffer

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -183,15 +183,14 @@ module ActiveSupport #:nodoc:
     end
 
     def %(args)
-      args = Array(args).map do |arg|
-        if !html_safe? || arg.html_safe?
-          arg
-        else
-          ERB::Util.h(arg)
-        end
+      case args
+      when Hash
+        escaped_args = Hash[args.map { |k,arg| [k, html_escape_interpolated_argument(arg)] }]
+      else
+        escaped_args = Array(args).map { |arg| html_escape_interpolated_argument(arg) }
       end
 
-      self.class.new(super(args))
+      self.class.new(super(escaped_args))
     end
 
     def html_safe?
@@ -223,6 +222,12 @@ module ActiveSupport #:nodoc:
           end                                       # end
         EOT
       end
+    end
+
+    private
+
+    def html_escape_interpolated_argument(arg)
+      (!html_safe? || arg.html_safe?) ? arg : ERB::Util.h(arg)
     end
   end
 end

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -140,4 +140,29 @@ class SafeBufferTest < ActiveSupport::TestCase
     # should still be unsafe
     assert !y.html_safe?, "should not be safe"
   end
+
+  test 'Should work with interpolation (array argument)' do
+    x = 'foo %s bar'.html_safe % ['qux']
+    assert_equal 'foo qux bar', x
+  end
+
+  test 'Should work with interpolation (hash argument)' do
+    x = 'foo %{x} bar'.html_safe % { x: 'qux' }
+    assert_equal 'foo qux bar', x
+  end
+
+  test 'Should escape unsafe interpolated args' do
+    x = 'foo %{x} bar'.html_safe % { x: '<br/>' }
+    assert_equal 'foo &lt;br/&gt; bar', x
+  end
+
+  test 'Should not escape safe interpolated args' do
+    x = 'foo %{x} bar'.html_safe % { x: '<br/>'.html_safe }
+    assert_equal 'foo <br/> bar', x
+  end
+
+  test 'Should interpolate to a safe string' do
+    x = 'foo %{x} bar'.html_safe % { x: 'qux' }
+    assert x.html_safe?, 'should be safe'
+  end
 end


### PR DESCRIPTION
Interpolation was untested and did not work with hash arguments.

Adds
- support for interpolation with hash argument
- tests for the above
- tests for safe/unsafe interpolation

Original discussion in #13310 which was PRd to `4-0-stable`.
