### PR TITLE
Use ping first to check connection status for mysql_adapter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use MySQL's ping method to check status of connection for mysql adapter.
+
+    *TroySK*
+
 *   Create a whitelist of delegable methods to `Array`.
 
     Currently `Relation` directly delegates methods to `Array`. With this change,

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -167,7 +167,9 @@ module ActiveRecord
       # CONNECTION MANAGEMENT ====================================
 
       def active?
-        if @connection.respond_to?(:stat)
+        if @connection.respond_to?(:ping)
+          @connection.ping
+        elsif @connection.respond_to?(:stat)
           @connection.stat
         else
           @connection.query 'select 1'


### PR DESCRIPTION
MySQL's stat is a very resource hungry method. Replacing it with ping lowers the CPU utilization by a good factor on large Ruby on Rails deployments.
