### PR TITLE
Fixed rails dbconsole to support DATABASE_URL

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ENV['DATABASE_URL']` support in `rails dbconsole`. Fixes #13320.
+
+    *Huiming Teo*
+
 *   Add `Application#message_verifier` method to return a message verifier.
 
     This verifier can be used to generate and verify signed messages in the application.

--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -81,14 +81,11 @@ module Rails
 
     def config
       @config ||= begin
-        cfg = begin
-          YAML.load(ERB.new(IO.read("config/database.yml")).result)
-        rescue SyntaxError, StandardError
-          require APP_PATH
-          Rails.application.config.database_configuration
-        end
-
-        cfg[environment] || abort("No database is configured for the environment '#{environment}'")
+        require APP_PATH
+        ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(
+          ENV['DATABASE_URL'],
+          (Rails.application.config.database_configuration || {})
+        ).spec.config.stringify_keys
       end
     end
 


### PR DESCRIPTION
Fixes #13320.

**Problem**
`rails dbconsole` raises error when `ENV['DATABASE_URL']` exists and `config/database.yml` removed (see rails/rails/issues/13320).

**Solution**
ActiveRecord and `rake db:*` uses `ConnectionSpecification::Resolver` to loads DATABASE_URL properly. This patch modifies `rails dbconsole` to use the same class.
