### PR TITLE
Added `absence` parameter to pluralization table

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -833,6 +833,7 @@ So, for example, instead of the default error message `"can not be blank"` you c
 | confirmation | -                         | :confirmation             | -             |
 | acceptance   | -                         | :accepted                 | -             |
 | presence     | -                         | :blank                    | -             |
+| absence      | -                         | :present                  | -             |
 | length       | :within, :in              | :too_short                | count         |
 | length       | :within, :in              | :too_long                 | count         |
 | length       | :is                       | :wrong_length             | count         |


### PR DESCRIPTION
Hello, a read the contributing rules [here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation), but [here]() I saw scary warning `DO NOT OPEN PULL REQUESTS IN HERE`.
Then, after reading [this](http://weblog.rubyonrails.org/2013/6/14/docrails-back-to-the-roots/):

> You can either ask for commit bit if you'd like to contribute to docrails regularly (please contact anyone from the core team), or else propose documentation changes to Rails itself via pull requests to rails/rails.

So, I got here. =)
If I did something wrong, please point me to make a contribution.

Now in the case.
This small pull-request add missing `absence` parameter to table in section `5.1.2 Error Message Interpolation` in `Rails Internationalization (I18n) API`.
