### PR TITLE
Incorrect infinity and NaN conversion to Ruby values in postgresql adapter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Fix `PostgreSQLAdapter::OID::Float#type_cast` to convert Infinity and
+    NaN PostgreSQL values into a native Ruby `Float::INFINITY` and `Float::NAN`
+
+    Example:
+
+        # Before
+        Point.create(value: 1.0/0)
+        Point.last.value # => 0.0
+
+        # After
+        Point.create(value: 1.0/0)
+        Point.last.value # => Infinity
+
+    *Innokenty Mikhailov*
+
 *   The PostgreSQL adapter supports custom domains. Fixes #14305.
 
     *Yves Senn*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -255,8 +255,15 @@ This is not reliable and will be removed in the future.
 
           def type_cast(value)
             return if value.nil?
+            return value unless ::String === value
 
-            value.to_f
+            case value
+              when 'Infinity' then ::Float::INFINITY
+              when '-Infinity' then -::Float::INFINITY
+              when 'NaN' then ::Float::NAN
+            else
+              value.to_f
+            end
           end
         end
 

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -50,7 +50,11 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
     @second_money = PostgresqlMoney.find(2)
 
     @connection.execute("INSERT INTO postgresql_numbers (id, single, double) VALUES (1, 123.456, 123456.789)")
+    @connection.execute("INSERT INTO postgresql_numbers (id, single, double) VALUES (2, '-Infinity', 'Infinity')")
+    @connection.execute("INSERT INTO postgresql_numbers (id, single, double) VALUES (3, 123.456, 'NaN')")
     @first_number = PostgresqlNumber.find(1)
+    @second_number = PostgresqlNumber.find(2)
+    @third_number = PostgresqlNumber.find(3)
 
     @connection.execute("INSERT INTO postgresql_times (id, time_interval, scaled_time_interval) VALUES (1, '1 year 2 days ago', '3 weeks ago')")
     @first_time = PostgresqlTime.find(1)
@@ -154,6 +158,9 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
   def test_number_values
     assert_equal 123.456, @first_number.single
     assert_equal 123456.789, @first_number.double
+    assert_equal -::Float::INFINITY, @second_number.single
+    assert_equal ::Float::INFINITY, @second_number.double
+    assert_same ::Float::NAN, @third_number.double
   end
 
   def test_time_values


### PR DESCRIPTION
Active Record successfully stores Ruby Infinity value in a Postgresql DB column of double precision type.
However it fails to convert it back to Ruby Float::INFINITY when the record is fetched from DB.
The issue can be illustrated with the code below:
While the value is correctly stored as 'Infinity' when it is accessed through AR instance - it's converted to 0.

It looks like the problem is in the type cast which is simply `to_f` for the float values.
Thus - in case 'Infinity' or 'NaN' in database it converts it to 0.

**update** - all below is fixed
The naive fix in this PR is rather to start the discussion and clarify is this really an issue or I'm just missing something.
For example after applying this fix `Point.create` starts throwing an exception `Infinity (FloatDomainError)` - that's because OID::Float#type_cast is called with Float::INFINITY as an argument.

```
require 'active_record'
require 'pg'

ActiveRecord::Base.establish_connection(
  database: 'infinity',
  adapter: 'postgresql',
  username: 'postgres'
)

ActiveRecord::Base.connection.instance_eval do
  create_table :points, force: true do |t|
    t.column :value, :float
  end
end

class Point < ActiveRecord::Base; end
infinity = 1.0/0
Point.create(value: infinity)
point = Point.first
p Point.connection.execute("select value from points limit 1").to_a #=> [{"value"=>"Infinity"}]
p point.read_attribute_before_type_cast('value') #=> "Infinity"
p point.value #=> 0.0 when it should be Float::INFINITY
```
