### PR TITLE
Change favicon_link_tag helper mimetype from image/vnd.microsoft.icon to image/x-icon.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Change `favicon_link_tag` default mimetype from `image/vnd.microsoft.icon` to
+    `image/x-icon`.
+
+    Before:
+    
+        #=> favicon_link_tag 'myicon.ico'
+        <link href="/assets/myicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />
+
+    After:
+
+        #=> favicon_link_tag 'myicon.ico'
+        <link href="/assets/myicon.ico" rel="shortcut icon" type="image/x-icon" />
+
+    *Geoffroy Lorieux*
+
 *   Remove wrapping div with inline styles for hidden form fields.
 
     We are dropping HTML 4.01 and XHTML strict compliance since input tags directly

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -149,12 +149,12 @@ module ActionView
       # ==== Options
       #
       # * <tt>:rel</tt>   - Specify the relation of this link, defaults to 'shortcut icon'
-      # * <tt>:type</tt>  - Override the auto-generated mime type, defaults to 'image/vnd.microsoft.icon'
+      # * <tt>:type</tt>  - Override the auto-generated mime type, defaults to 'image/x-icon'
       #
       # ==== Examples
       #
       #   favicon_link_tag 'myicon.ico'
-      #   # => <link href="/assets/myicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />
+      #   # => <link href="/assets/myicon.ico" rel="shortcut icon" type="image/x-icon" />
       #
       # Mobile Safari looks for a different <link> tag, pointing to an image that
       # will be used if you add the page to the home screen of an iPod Touch, iPhone, or iPad.
@@ -165,7 +165,7 @@ module ActionView
       def favicon_link_tag(source='favicon.ico', options={})
         tag('link', {
           :rel  => 'shortcut icon',
-          :type => 'image/vnd.microsoft.icon',
+          :type => 'image/x-icon',
           :href => path_to_image(source)
         }.merge!(options.symbolize_keys))
       end

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -195,9 +195,9 @@ class AssetTagHelperTest < ActionView::TestCase
   }
 
   FaviconLinkToTag = {
-    %(favicon_link_tag) => %(<link href="/images/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />),
-    %(favicon_link_tag 'favicon.ico') => %(<link href="/images/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />),
-    %(favicon_link_tag 'favicon.ico', :rel => 'foo') => %(<link href="/images/favicon.ico" rel="foo" type="image/vnd.microsoft.icon" />),
+    %(favicon_link_tag) => %(<link href="/images/favicon.ico" rel="shortcut icon" type="image/x-icon" />),
+    %(favicon_link_tag 'favicon.ico') => %(<link href="/images/favicon.ico" rel="shortcut icon" type="image/x-icon" />),
+    %(favicon_link_tag 'favicon.ico', :rel => 'foo') => %(<link href="/images/favicon.ico" rel="foo" type="image/x-icon" />),
     %(favicon_link_tag 'favicon.ico', :rel => 'foo', :type => 'bar') => %(<link href="/images/favicon.ico" rel="foo" type="bar" />),
     %(favicon_link_tag 'mb-icon.png', :rel => 'apple-touch-icon', :type => 'image/png') => %(<link href="/images/mb-icon.png" rel="apple-touch-icon" type="image/png" />)
   }


### PR DESCRIPTION
Although the official IANA-registered MIME type for ICO files is image/vnd.microsoft.icon,
registered in 2003, it was submitted to IANA by a third party and is not recognised by Microsoft products.
The MIME type image/x-icon should be used since is the one recognised by the major browsers on the market.
