### PR TITLE
Default I18n.enforce_available_locales to true

### DIFF
--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -20,6 +20,9 @@ ActionMailer::Base.send(:include, ActionView::Layouts)
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveSupport::Deprecation.debug = true
 
+# Disable available locale checks to avoid warnings running the test suite.
+I18n.enforce_available_locales = false
+
 # Bogus template processors
 ActionView::Template.register_template_handler :haml, lambda { |template| "Look its HAML!".inspect }
 ActionView::Template.register_template_handler :bak, lambda { |template| "Lame backup".inspect }

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -43,6 +43,9 @@ Thread.abort_on_exception = true
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveSupport::Deprecation.debug = true
 
+# Disable available locale checks to avoid warnings running the test suite.
+I18n.enforce_available_locales = false
+
 # Register danish language for testing
 I18n.backend.store_translations 'da', {}
 I18n.backend.store_translations 'pt-BR', {}

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -42,6 +42,9 @@ Thread.abort_on_exception = true
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveSupport::Deprecation.debug = true
 
+# Disable available locale checks to avoid warnings running the test suite.
+I18n.enforce_available_locales = false
+
 # Register danish language for testing
 I18n.backend.store_translations 'da', {}
 I18n.backend.store_translations 'pt-BR', {}

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -20,6 +20,9 @@ Thread.abort_on_exception = true
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveSupport::Deprecation.debug = true
 
+# Disable available locale checks to avoid warnings running the test suite.
+I18n.enforce_available_locales = false
+
 # Connect to the database
 ARTest.connect
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Default the new `I18n.enforce_available_locales` config to `true`, meaning
+    `I18n` will make sure that all locales passed to it must be declared in the
+    `available_locales` list.
+
+    To disable it add the following configuration to your application:
+
+        config.i18n.enforce_available_locales = false
+
+    This also ensures I18n configuration is properly initialized taking the new
+    option into account, to avoid their deprecations while booting up the app.
+
+    *Carlos Antonio da Silva*, *Yves Senn*
+
 *   Introduce Module#concerning: a natural, low-ceremony way to separate
     responsibilities within a class.
 
@@ -48,11 +61,6 @@
 *   Fix file descriptor being leaked on each call to `Kernel.silence_stream`.
 
     *Mario Visic*
-
-*   Ensure `config.i18n.enforce_available_locales` is set before any other
-    configuration option.
-
-    *Yves Senn*
 
 *   Added `Date#all_week/month/quarter/year` for generating date ranges.
 

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.rdoc_options.concat ['--encoding',  'UTF-8']
 
-  s.add_dependency 'i18n',       '~> 0.6', '>= 0.6.4'
+  s.add_dependency 'i18n',       '~> 0.6', '>= 0.6.9'
   s.add_dependency 'json',       '~> 1.7', '>= 1.7.7'
   s.add_dependency 'tzinfo',     '~> 1.1'
   s.add_dependency 'minitest',   '~> 5.1'

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -24,6 +24,9 @@ Thread.abort_on_exception = true
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveSupport::Deprecation.debug = true
 
+# Disable available locale checks to avoid warnings running the test suite.
+I18n.enforce_available_locales = false
+
 # Skips the current run on Rubinius using Minitest::Assertions#skip
 def rubinius_skip(message = '')
   skip message if RUBY_ENGINE == 'rbx'

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -156,6 +156,23 @@ end
 ActiveRecord::FixtureSet.context_class.send :include, FixtureFileHelpers
 ```
 
+### I18n enforcing available locales
+
+Rails 4.1 now defaults the I18n option `enforce_available_locales` to `true`,
+meaning that it will make sure that all locales passed to it must be declared in
+the `available_locales` list.
+
+To disable it (and allow I18n to accept *any* locale option) add the following
+configuration to your application:
+
+```ruby
+config.i18n.enforce_available_locales = false
+```
+
+Note that this option was added as a security measure, to ensure user input could
+not be used as locale information unless previously known, so it's recommended not
+to disable this option unless you have a strong reason for doing so.
+
 Upgrading from Rails 3.2 to Rails 4.0
 -------------------------------------
 

--- a/railties/test/application/initializers/i18n_test.rb
+++ b/railties/test/application/initializers/i18n_test.rb
@@ -184,14 +184,48 @@ en:
       assert_fallbacks ca: [:ca, :"es-ES", :es, :'en-US', :en]
     end
 
-    test "config.i18n.enforce_available_locales is set before config.i18n.default_locale is" do
+    test "config.i18n.enforce_available_locales is set to true by default and avoids I18n warnings" do
       add_to_config <<-RUBY
         config.i18n.default_locale = :it
-        config.i18n.enforce_available_locales = true
       RUBY
 
-      assert_raises(I18n::InvalidLocale) do
-        load_app
+      output = capture(:stderr) { load_app }
+      assert_no_match %r{deprecated.*enforce_available_locales}, output
+      assert_equal true, I18n.enforce_available_locales
+
+      assert_raise I18n::InvalidLocale do
+        I18n.locale = :es
+      end
+    end
+
+    test "disable config.i18n.enforce_available_locales" do
+      add_to_config <<-RUBY
+        config.i18n.enforce_available_locales = false
+        config.i18n.default_locale = :fr
+      RUBY
+
+      output = capture(:stderr) { load_app }
+      assert_no_match %r{deprecated.*enforce_available_locales}, output
+      assert_equal false, I18n.enforce_available_locales
+
+      assert_nothing_raised do
+        I18n.locale = :es
+      end
+    end
+
+    test "default config.i18n.enforce_available_locales does not override I18n.enforce_available_locales" do
+      I18n.enforce_available_locales = false
+
+      add_to_config <<-RUBY
+        config.i18n.default_locale = :fr
+      RUBY
+
+      output = capture(:stderr) { load_app }
+      assert_no_match %r{deprecated.*enforce_available_locales}, output
+      assert_equal false, I18n.enforce_available_locales
+
+      assert_nothing_raised do
+        I18n.locale = :es
       end
     end
   end


### PR DESCRIPTION
We will default this option to true from now on to ensure users properly handle their list of available locales whenever necessary. This option was added as a security measure and thus Rails will follow it defaulting to secure option.

Also improve the handling of I18n config options in its railtie, taking the new enforce_available_locales option into account, by setting it as the last one in the process. This ensures no other configuration will trigger a deprecation warning due to that setting.
