### PR TITLE
test case for #limit added - picking latest value from limit

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -121,6 +121,10 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal 1, Topic.limit(1).to_a.length
   end
 
+  def test_limit_should_take_value_from_latest_limit
+    assert_equal 1, Topic.limit(2).limit(1).to_a.length
+  end
+
   def test_invalid_limit
     assert_raises(ArgumentError) do
       Topic.limit("asdfadf").to_a


### PR DESCRIPTION
Test case added for the case specified in documentation of `ActiveRecord#limit` where `limit` picks the value from latest `limit` applied to the relation.

for e.g.

``` ruby
Topic.limit(2).limit(1).to_sql => "SELECT  \"players\".* FROM \"players\"  LIMIT 1"
```

Hence picking up the latest value supplied in `limit`
