### PR TITLE
fix default select when from is used

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Improve the default select when from is used.
+
+    Previously, if you did something like Topic.from(:temp_topics), it
+    would generate SQL like:
+
+      SELECT topics.* FROM temp_topics;
+
+    Which is useless, cause obviously there's not a topics table to select
+    from. So one would always have to include a select to override the
+    default behavior. Now the default if you use from is just *:
+
+      SELECT * FROM temp_topics;
+
+    Which may not be what you want in all cases, but is at least usable
+    in some cases.
+
+    *Cody Cutrer*
+
 *   Fix `PostgreSQL` insert to properly extract table name from multiline string SQL.
 
     Previously, executing an insert SQL in `PostgreSQL` with a command like this:

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -982,8 +982,10 @@ module ActiveRecord
     end
 
     def build_select(arel, selects)
-      unless selects.empty?
+      if !selects.empty?
         arel.project(*selects)
+      elsif from_value
+        arel.project(Arel.star)
       else
         arel.project(@klass.arel_table[Arel.star])
       end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -151,6 +151,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal relation.to_a, Comment.select('a.*').from(relation, :a).to_a
   end
 
+  def test_finding_with_subquery_without_select
+    relation = Topic.where(:approved => true)
+    assert_equal relation.to_a, Topic.from(relation).to_a
+  end
+
   def test_finding_with_conditions
     assert_equal ["David"], Author.where(:name => 'David').map(&:name)
     assert_equal ['Mary'],  Author.where(["name = ?", 'Mary']).map(&:name)


### PR DESCRIPTION
two reasons:

1) I've created a temporary table filled with data from another table, and I'm iterating over it. So I want to get a Topic model back, but the temp table is temp_topics.

2) Using a recursive query with postgresql, it looks like:

WITH RECURSIVE t AS (SELECT \* FROM topics UNION ALL <some more stuff>) SELECT \* from t.

I want to get a Topic model back, but from the query's perspective the table's name is t (it _has_ to be aliased).
