### PR TITLE
Release notes fixes

### DIFF
--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -184,7 +184,7 @@ module ActionController #:nodoc:
     # Formats can have different variants.
     #
     # The request variant is a specialization of the request format, like <tt>:tablet</tt>,
-    # <tt>:phone</tt>, or <tt>:desktop<tt>.
+    # <tt>:phone</tt>, or <tt>:desktop</tt>.
     #
     # We often want to render different html/json/xml templates for phones,
     # tablets, and desktop browsers. Variants make it easy.

--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -22,7 +22,7 @@ module ActiveSupport
   # <tt>BacktraceCleaner#remove_silencers!</tt>, which will restore the
   # backtrace to a pristine state. If you need to reconfigure an existing
   # BacktraceCleaner so that it does not filter or modify the paths of any lines
-  # of the backtrace, you can call <tt>BacktraceCleaner#remove_filters!<tt>
+  # of the backtrace, you can call <tt>BacktraceCleaner#remove_filters!</tt>
   # These two methods will give you a completely untouched backtrace.
   #
   # Inspired by the Quiet Backtrace gem by Thoughtbot.

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -39,6 +39,33 @@ NOTE: User defined rake tasks will run in the `development` environment by
 default. If you want them to run in other environments consult the
 [Spring README](https://github.com/jonleighton/spring#rake).
 
+### `config/secrets.yml`
+
+If you want to use the new `secrets.yml` convention to store your application's
+secrets, you need to:
+
+1. Create a `secrets.yml` file in your `config` folder with the following content:
+
+    ```yaml
+    development:
+      secret_key_base:
+
+    test:
+      secret_key_base:
+
+    production:
+      secret_key_base:
+    ```
+
+2. Copy the existing `secret_key_base` from the `secret_token.rb` initializer to
+   `secrets.yml` under the `production` section.
+
+3. Remove the `secret_token.rb` initializer.
+
+4. Use `rake secret` to generate new keys for the `development` and `test` sections.
+
+5. Restart your server.
+
 ### Changes in JSON handling
 
 The are a few major changes related to JSON handling in Rails 4.1.


### PR DESCRIPTION
A series of fixes for the 4.1 release notes

Todo: 
- [x] Add Action Mailer previews to the release notes
- [x] Add secrets.yml to the release notes
- [x] Add concerning

I can squash and add [ci skips] after this has been reviewed, there are a few things I'm not too sure about (variants -> Action Pack request variant) so keeping them isolated makes it easier to revert those if needed.
