### PR TITLE
updated unicode version

### DIFF
--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -11,7 +11,7 @@ module ActiveSupport
       NORMALIZATION_FORMS = [:c, :kc, :d, :kd]
 
       # The Unicode version that is supported by the implementation
-      UNICODE_VERSION = '6.2.0'
+      UNICODE_VERSION = '6.3.0'
 
       # The default normalization used for operations that require
       # normalization. It can be set to any of the normalizations


### PR DESCRIPTION
I was testing how Active Support encode, decode works and reading about unicode
Found from here - http://www.unicode.org/versions/Unicode6.3.0/ that unicode latest version is 6.3.0
Would it be feasible to update the unicode version ?
