### PR TITLE
activerecord: Initialize Migration with version from MigrationProxy.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Initialize version on Migration objects so that it can be used in a migration,
+    and it will be included in the announce message.
+
+    *Dylan Thacker-Smith*
+
 *   Fixed ActiveRecord::Store nil conversion TypeError when using YAML coder.
     In case the YAML passed as paramter is nil, uses an empty string.
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -759,7 +759,7 @@ module ActiveRecord
 
       def load_migration
         require(File.expand_path(filename))
-        name.constantize.new
+        name.constantize.new(name, version)
       end
 
   end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -79,6 +79,10 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Migrator.migrations_paths = old_path
   end
 
+  def test_migration_version
+    ActiveRecord::Migrator.run(:up, MIGRATIONS_ROOT + "/version_check", 20131219224947)
+  end
+
   def test_create_table_with_force_true_does_not_drop_nonexisting_table
     if Person.connection.table_exists?(:testings2)
       Person.connection.drop_table :testings2

--- a/activerecord/test/migrations/version_check/20131219224947_migration_version_check.rb
+++ b/activerecord/test/migrations/version_check/20131219224947_migration_version_check.rb
@@ -1,0 +1,8 @@
+class MigrationVersionCheck < ActiveRecord::Migration
+  def self.up
+    raise "incorrect migration version" unless version == 20131219224947
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
## Problem

When running migrations with `rake db:migrate`, notice how the output to standard output looks like the following.

```
==  CreateUserTable: migrating ================================================
==  CreateUserTable: migrated (0.0000s) =======================================
```

This output is done through Migration#announce, delegated from MigrationProxy, as follows

From 
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/migration.rb#L596

``` ruby
    def announce(message)
      text = "#{version} #{name}: #{message}"
      length = [0, 75 - text.length].max
      write "== %s %s" % [text, "=" * length]
    end
```

The output is supposed to include a version, but the version is always `nil` within the migration.  The MigrationProxy has the version, but initializes the Migration with the default parameters (i.e. `version = nil`)

This missing version can also be a problem when trying to use the version within a migration.  Our use case for doing this is to update a schema_migrations table on each shard, so a migration that succeeds on one shard, then fails on another, can be retried only on the shards it still needs to run on.
## Solution

Initialize the Migration loaded from a MigrationProxy with the version.
## Backport

This can be cherry-picked without conflict onto the 4-0-stable or 3-2-stable branch.
