### PR TITLE
typo: should be 'DateTime.civil_from_format' and not 'DateTime.civil_from_fromat'

### DIFF
--- a/guides/source/4_1_release_notes.md
+++ b/guides/source/4_1_release_notes.md
@@ -518,7 +518,7 @@ for detailed changes.
 
 * Removed deprecated `Module#local_constant_names` in favor of `Module#local_constants`.
 
-* Removed deprecated `DateTime.local_offset` in favor of `DateTime.civil_from_fromat`.
+* Removed deprecated `DateTime.local_offset` in favor of `DateTime.civil_from_format`.
 
 * Removed deprecated `Logger` core extensions (`core_ext/logger.rb`).
 


### PR DESCRIPTION
See here:  http://apidock.com/rails/DateTime/civil_from_format/class
