### PR TITLE
Change all `MiniTest` to `Minitest`

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -211,7 +211,7 @@ module ActionDispatch
         def fail_on(exception_class)
           yield
         rescue exception_class => e
-          raise MiniTest::Assertion, e.message
+          raise Minitest::Assertion, e.message
         end
     end
   end

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -137,7 +137,7 @@ module ActionDispatch
     class Session
       DEFAULT_HOST = "www.example.com"
 
-      include MiniTest::Assertions
+      include Minitest::Assertions
       include TestProcess, RequestHelpers, Assertions
 
       %w( status status_message headers body redirect? ).each do |method|

--- a/actionpack/test/assertions/response_assertions_test.rb
+++ b/actionpack/test/assertions/response_assertions_test.rb
@@ -19,7 +19,7 @@ module ActionDispatch
           @response = FakeResponse.new sym
           assert_response sym
 
-          assert_raises(MiniTest::Assertion) {
+          assert_raises(Minitest::Assertion) {
             assert_response :unauthorized
           }
         end
@@ -29,11 +29,11 @@ module ActionDispatch
         @response = FakeResponse.new 400
         assert_response 400
 
-        assert_raises(MiniTest::Assertion) {
+        assert_raises(Minitest::Assertion) {
           assert_response :unauthorized
         }
 
-        assert_raises(MiniTest::Assertion) {
+        assert_raises(Minitest::Assertion) {
           assert_response 500
         }
       end
@@ -42,11 +42,11 @@ module ActionDispatch
         @response = FakeResponse.new 401
         assert_response :unauthorized
 
-        assert_raises(MiniTest::Assertion) {
+        assert_raises(Minitest::Assertion) {
           assert_response :ok
         }
 
-        assert_raises(MiniTest::Assertion) {
+        assert_raises(Minitest::Assertion) {
           assert_response :success
         }
       end

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -5,7 +5,7 @@ module ActiveRecord
   class Migration
     class TableTest < ActiveRecord::TestCase
       def setup
-        @connection = MiniTest::Mock.new
+        @connection = Minitest::Mock.new
       end
 
       def teardown

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -174,7 +174,7 @@ class DeprecationTest < ActiveSupport::TestCase
       ActiveSupport::Deprecation.warn 'abc'
       ActiveSupport::Deprecation.warn 'def'
     end
-  rescue MiniTest::Assertion
+  rescue Minitest::Assertion
     flunk 'assert_deprecated should match any warning in block, not just the last one'
   end
 

--- a/activesupport/test/test_test.rb
+++ b/activesupport/test/test_test.rb
@@ -21,10 +21,10 @@ class AssertDifferenceTest < ActiveSupport::TestCase
     assert_equal true, assert_not(nil)
     assert_equal true, assert_not(false)
 
-    e = assert_raises(MiniTest::Assertion) { assert_not true }
+    e = assert_raises(Minitest::Assertion) { assert_not true }
     assert_equal 'Expected true to be nil or false', e.message
 
-    e = assert_raises(MiniTest::Assertion) { assert_not true, 'custom' }
+    e = assert_raises(Minitest::Assertion) { assert_not true, 'custom' }
     assert_equal 'custom', e.message
   end
 
@@ -73,7 +73,7 @@ class AssertDifferenceTest < ActiveSupport::TestCase
   end
 
   def test_array_of_expressions_identify_failure
-    assert_raises(MiniTest::Assertion) do
+    assert_raises(Minitest::Assertion) do
       assert_difference ['@object.num', '1 + 1'] do
         @object.increment
       end
@@ -81,7 +81,7 @@ class AssertDifferenceTest < ActiveSupport::TestCase
   end
 
   def test_array_of_expressions_identify_failure_when_message_provided
-    assert_raises(MiniTest::Assertion) do
+    assert_raises(Minitest::Assertion) do
       assert_difference ['@object.num', '1 + 1'], 1, 'something went wrong' do
         @object.increment
       end

--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -29,7 +29,7 @@ end
 require 'minitest/autorun'
 require 'rack/test'
 
-class BugTest < MiniTest::Unit::TestCase
+class BugTest < Minitest::Unit::TestCase
   include Rack::Test::Methods
 
   def test_returns_success

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -25,7 +25,7 @@ class Comment < ActiveRecord::Base
   belongs_to :post
 end
 
-class BugTest < MiniTest::Unit::TestCase
+class BugTest < Minitest::Unit::TestCase
   def test_association_stuff
     post = Post.create!
     post.comments << Comment.create!

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -11,7 +11,7 @@ require 'rails/generators/test_case'
 # Config Rails backtrace in tests.
 require 'rails/backtrace_cleaner'
 if ENV["BACKTRACE"].nil?
-  MiniTest.backtrace_filter = Rails.backtrace_cleaner
+  Minitest.backtrace_filter = Rails.backtrace_cleaner
 end
 
 if defined?(ActiveRecord::Base)

--- a/railties/test/configuration/middleware_stack_proxy_test.rb
+++ b/railties/test/configuration/middleware_stack_proxy_test.rb
@@ -39,7 +39,7 @@ module Rails
         @stack.swap :foo
         @stack.delete :foo
 
-        mock = MiniTest::Mock.new
+        mock = Minitest::Mock.new
         mock.expect :send, nil, [:swap, :foo]
         mock.expect :send, nil, [:delete, :foo]
 
@@ -50,7 +50,7 @@ module Rails
       private
 
       def assert_playback(msg_name, args)
-        mock = MiniTest::Mock.new
+        mock = Minitest::Mock.new
         mock.expect :send, nil, [msg_name, args]
         @stack.merge_into(mock)
         mock.verify


### PR DESCRIPTION
Change all `MiniTest` to `Minitest` since, `MiniTest` namespace has been renamed to `Minitest` 
Ref: https://github.com/seattlerb/minitest/blob/master/History.txt
