### PR TITLE
Assigning nil to a polymorphic belongs_to should nullify its _type column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix regression that assigning nil to a polymorphic belongs_to should nullify its _type column
+
+    This regression was introduced at 1678e959e973de32287b65c52ebc6cce87148951
+
+    *Vipul A M*
+
 *   `Relation` no longer has mutator methods like `#map!` and `#delete_if`. Convert
     to an `Array` by calling `#to_a` before using these methods.
 

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -14,6 +14,11 @@ module ActiveRecord
           owner[reflection.foreign_type] = record.class.base_class.name
         end
 
+        def remove_keys
+          super
+          owner[reflection.foreign_type] = nil
+        end
+
         def different_target?(record)
           super || record.class != klass
         end


### PR DESCRIPTION
Assigning nil to a polymorphic belongs_to should nullify its _type column

Fixes failing test introduced at c141dfc838a5dca9f197814410fa5d44c143129c by @jeremy
The regression was introduced by 1678e959e973de32287b65c52ebc6cce87148951
