### PR TITLE
Use first path of migrations_paths to generate new migrations

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       def create_migration_file
         set_local_assigns!
         validate_file_name!
-        migration_template @migration_template, "db/migrate/#{file_name}.rb"
+        migration_template @migration_template, "#{migrations_path}/#{file_name}.rb"
       end
 
       protected
@@ -49,6 +49,10 @@ module ActiveRecord
         else
           attribute.name.singularize.foreign_key
         end.to_sym
+      end
+
+      def migrations_path
+        Tasks::DatabaseTasks.migrations_paths.first
       end
 
       private


### PR DESCRIPTION
This simplifies a lot to maintain separate gems to use AR migrations as a standalone project, like the active_record_migrations gem, since there would be no longer a need to use a new generator:

https://github.com/rosenfeld/active_record_migrations/blob/master/lib/active_record_migrations/generators/migration.rb
