### PR TITLE
Revert "ask the fixture set for the sql statements" to address #13356

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -286,10 +286,6 @@ module ActiveRecord
       # Inserts the given fixture into the table. Overridden in adapters that require
       # something beyond a simple insert (eg. Oracle).
       def insert_fixture(fixture, table_name)
-        execute fixture_sql(fixture, table_name), 'Fixture Insert'
-      end
-
-      def fixture_sql(fixture, table_name)
         columns = schema_cache.columns_hash(table_name)
 
         key_list   = []
@@ -298,7 +294,7 @@ module ActiveRecord
           quote(value, columns[name])
         end
 
-        "INSERT INTO #{quote_table_name(table_name)} (#{key_list.join(', ')}) VALUES (#{value_list.join(', ')})"
+        execute "INSERT INTO #{quote_table_name(table_name)} (#{key_list.join(', ')}) VALUES (#{value_list.join(', ')})", 'Fixture Insert'
       end
 
       def empty_insert_statement_value


### PR DESCRIPTION
This pull request addresses a kind of regression failure reported in #13356 and  rsim/oracle-enhanced#391 by reverting commit 026d0555685087845b74dd87a0417b5a164b1c13.

``` ruby
$ cd activerecord
$ ARCONN=oracle ruby -Itest test/cases/fixtures_test.rb -n test_binary_in_fixtures
Using oracle
Run options: -n test_binary_in_fixtures --seed 36745

# Running:

F

Finished in 1.152086s, 0.8680 runs/s, 0.8680 assertions/s.

  1) Failure:
FixturesTest#test_binary_in_fixtures [test/cases/fixtures_test.rb:248]:
--- expected
+++ actual
@@ -1,20 +1 @@
-"\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x01\x00H\x00H\x00\x00\xFF\xDB\x00C\x00\r\t\t
-
... snip ...
```

After revertng 026d0555685087845b74dd87a0417b5a164b1c13 All sqlite3, mysql, mysql2 and postgresql adapter unit tests have passed. Since Rails 4.1 is coming soon, I want to Oracle enhanced adapter support Rails 4.1 soon.
