### PR TITLE
Fix to_param when attribute has multibyte character

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -98,8 +98,10 @@ module ActiveRecord
           super()
         else
           define_method :to_param do
-            if (default = super()) && (result = send(method_name).to_s).present?
-              "#{default}-#{result.squish.truncate(20, separator: /\s/, omission: nil).parameterize}"
+            if (default = super()) &&
+                 (result = send(method_name).to_s).present? &&
+                   (param = result.squish.truncate(20, separator: /\s/, omission: nil).parameterize).present?
+              "#{default}-#{param}"
             else
               default
             end

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -46,6 +46,12 @@ class IntegrationTest < ActiveRecord::TestCase
     assert_equal '4-ab-ab-ab-ab-ab-ab', firm.to_param
   end
 
+  def test_to_param_class_method_multibyte_character
+    firm = Firm.find(4)
+    firm.name = "戦場ヶ原 ひたぎ"
+    assert_equal '4', firm.to_param
+  end
+
   def test_to_param_class_method_uses_default_if_blank
     firm = Firm.find(4)
     firm.name = nil


### PR DESCRIPTION
When attribute has only multibyte character, to_param returns id + "-". I think it is not pretty.
