### PR TITLE
Update the gitignore generator template to ignore secrets.yml

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore secrets.yml
+/config/secrets.yml
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal


### PR DESCRIPTION
Committing secret keys and tokens should not be on by default. Repo access should NOT also mean AWS access, Stripe/Braintree access, etc.
