### PR TITLE
Fix PostgreSQL range tests on fresh DB

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -16,7 +16,7 @@ if ActiveRecord::Base.connection.supports_ranges?
       @connection = ActiveRecord::Base.connection
       begin
         @connection.transaction do
-          @connection.create_table('json_data_type') do |t|
+          @connection.create_table('postgresql_ranges') do |t|
             t.daterange :date_range
             t.numrange :num_range
             t.tsrange :ts_range
@@ -29,7 +29,7 @@ if ActiveRecord::Base.connection.supports_ranges?
         return skip "do not test on PG without range"
       end
 
-      insert_range(id: 1,
+      insert_range(id: 101,
                    date_range: "[''2012-01-02'', ''2012-01-04'']",
                    num_range: "[0.1, 0.2]",
                    ts_range: "[''2010-01-01 14:30'', ''2011-01-01 14:30'']",
@@ -37,7 +37,7 @@ if ActiveRecord::Base.connection.supports_ranges?
                    int4_range: "[1, 10]",
                    int8_range: "[10, 100]")
 
-      insert_range(id: 2,
+      insert_range(id: 102,
                    date_range: "(''2012-01-02'', ''2012-01-04'')",
                    num_range: "[0.1, 0.2)",
                    ts_range: "[''2010-01-01 14:30'', ''2011-01-01 14:30'')",
@@ -45,7 +45,7 @@ if ActiveRecord::Base.connection.supports_ranges?
                    int4_range: "(1, 10)",
                    int8_range: "(10, 100)")
 
-      insert_range(id: 3,
+      insert_range(id: 103,
                    date_range: "(''2012-01-02'',]",
                    num_range: "[0.1,]",
                    ts_range: "[''2010-01-01 14:30'',]",
@@ -53,7 +53,7 @@ if ActiveRecord::Base.connection.supports_ranges?
                    int4_range: "(1,]",
                    int8_range: "(10,]")
 
-      insert_range(id: 4,
+      insert_range(id: 104,
                    date_range: "[,]",
                    num_range: "[,]",
                    ts_range: "[,]",
@@ -61,7 +61,7 @@ if ActiveRecord::Base.connection.supports_ranges?
                    int4_range: "[,]",
                    int8_range: "[,]")
 
-      insert_range(id: 5,
+      insert_range(id: 105,
                    date_range: "(''2012-01-02'', ''2012-01-02'')",
                    num_range: "(0.1, 0.1)",
                    ts_range: "(''2010-01-01 14:30'', ''2010-01-01 14:30'')",
@@ -70,11 +70,11 @@ if ActiveRecord::Base.connection.supports_ranges?
                    int8_range: "(10, 10)")
 
       @new_range = PostgresqlRange.new
-      @first_range = PostgresqlRange.find(1)
-      @second_range = PostgresqlRange.find(2)
-      @third_range = PostgresqlRange.find(3)
-      @fourth_range = PostgresqlRange.find(4)
-      @empty_range = PostgresqlRange.find(5)
+      @first_range = PostgresqlRange.find(101)
+      @second_range = PostgresqlRange.find(102)
+      @third_range = PostgresqlRange.find(103)
+      @fourth_range = PostgresqlRange.find(104)
+      @empty_range = PostgresqlRange.find(105)
     end
 
     def test_data_type_of_range_types


### PR DESCRIPTION
The changes in c4044b2 meant the tests would error on a fresh DB.

Correcting the name of the table we're creating is self-explanatory.

But we must also move away from the low IDs, because we're not touching the freshly-created primary key sequence; when the time comes, `@new_range` will be assigned an ID of 1.

---

I assume this is currently passing for anyone whose `activerecord_unittest` DB pre-dates c4044b2... if true, I imagine this change is likely to fail (well, skip) for those people.

That being the case, I see three options:
1. Introduce a DROP TABLE IF EXISTS before the create_table in setup (ugly)
2. Move the table creation back to postgresql_specific_schema.rb with all the rest (it was presumably moved for a reason)
3. Declare everyone needs to drop & recreate their testing DB (ugh)

/cc @senny
