### PR TITLE
Ignore the config/secrets.yml

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+# Ignore application secrets
+/config/secrets.yml
+
 # Ignore bundler config.
 /.bundle
 


### PR DESCRIPTION
The whole point of the `config/secrets.yml` file was to remove sensitive information from the repository. If it is not ignored (at least by default), sensitive information could still leak accidentally if developers forget to add this when creating new applications.
- [ ] Not sure how to do this myself, but `rake update:rails` should add this to the `.gitignore`.
