### PR TITLE
modified regex for finding table_name from a multiline sql query in postgresql

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Fix `PostgreSQL` insert to properly extract table name from multiline string SQL.
+
+    Previously, executing an insert SQL in `PostgreSQL` with a command like this:
+
+        insert into articles(
+          number)
+        values(
+          5152
+        )
+
+    would not work because the adapter was unable to extract the correct `articles`
+    table name.
+
+    *Kuldeep Aggarwal*
+
 *   `Relation` no longer has mutator methods like `#map!` and `#delete_if`. Convert
     to an `Array` by calling `#to_a` before using these methods.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -969,7 +969,7 @@ module ActiveRecord
         end
 
         def extract_table_ref_from_insert_sql(sql)
-          sql[/into\s+([^\(]*).*values\s*\(/i]
+          sql[/into\s+([^\(]*).*values\s*\(/im]
           $1.strip if $1
         end
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -62,6 +62,18 @@ module ActiveRecord
         assert_equal expect, id
       end
 
+      def test_multiline_insert_sql
+        id = @connection.insert_sql(<<-SQL)
+        insert into ex(
+          number)
+        values(
+          5152
+        )
+        SQL
+        expect = @connection.query('select max(id) from ex').first.first
+        assert_equal expect, id
+      end
+
       def test_insert_sql_with_returning_disabled
         connection = connection_without_insert_returning
         id = connection.insert_sql("insert into postgresql_partitioned_table_parent (number) VALUES (1)")


### PR DESCRIPTION
In Postgresql, while inserting a sql query we find the table name using `RegExp` defined in `#extract_table_ref_from_insert_sql`.

``` ruby
Before:
sql_query = <<-SQL
    insert into articles(
      number)
    values(
      5152
    )
    SQL
 extract_table_ref_from_insert_sql(sql_query) # => nil


After:
sql_query = <<-SQL
    insert into articles(
      number)
    values(
      5152
    )
    SQL
 extract_table_ref_from_insert_sql(sql_query) # => articles

```

Fixes issue #13378
