### PR TITLE
Restore disconnection-handling for PostgresqlAdapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -116,16 +116,20 @@ module ActiveRecord
 
         # Queries the database and returns the results in an Array-like object
         def query(sql, name = nil) #:nodoc:
-          log(sql, name) do
-            result_as_array @connection.async_exec(sql)
+          synchronize do
+            log(sql, name) do
+              result_as_array @connection.async_exec(sql)
+            end
           end
         end
 
         # Executes an SQL statement, returning a PGresult object on success
         # or raising a PGError exception otherwise.
         def execute(sql, name = nil)
-          log(sql, name) do
-            @connection.async_exec(sql)
+          synchronize do
+            log(sql, name) do
+              @connection.async_exec(sql)
+            end
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -578,7 +578,8 @@ module ActiveRecord
 
       # Is this connection alive and ready for queries?
       def active?
-        @connection.connect_poll != PG::PGRES_POLLING_FAILED
+        @connection.query 'SELECT 1'
+        true
       rescue PGError
         false
       end


### PR DESCRIPTION
Per #12867, #verify! is currently failing to recognise that the PostgreSQL connection has gone away.

The only way to truly confirm we can send a query is to do so, as was the case before 34c7e73.

So we need to put that behaviour back, while adding locking to protect against the reaper hitting a connection while it's in use.

Commits are currently split for easier discussion; this will obviously need to be squashed and changelogged before merge.

/cc @tenderlove
