### PR TITLE
set encoding UTF-8 for accepting multibyte character

### DIFF
--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'cases/helper'
 require 'models/company'
 require 'models/developer'


### PR DESCRIPTION
Fixes: Builds were failing because we are using `Multibyte characters` in one of our test case, but no encoding is set.
