### PR TITLE
Move the null mime type to request.format

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -66,14 +66,15 @@
 
     *Łukasz Strzałkowski*
 
-*   Fix header `Content-Type: #<Mime::NullType:...>` in localized template.
+*   Fix render of localized templates without an explicit format using wrong
+    content header and not passing correct formats to template due to the
+    introduction of the `NullType` for mimes.
 
-    When localized template has no format in the template name,
-    the response now has the default and correct `content-type`.
+    Templates like `hello.it.erb` were subject to this issue.
 
     Fixes #13064.
 
-    *Angelo Capilleri*
+    *Angelo Capilleri*, *Carlos Antonio da Silva*
 
 *   Try to escape each part of a url correctly when using a redirect route.
 

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -22,7 +22,7 @@ module AbstractController
     def render(*args, &block)
       options = _normalize_render(*args, &block)
       self.response_body = render_to_body(options)
-      _process_format(rendered_format)
+      _process_format(rendered_format) if rendered_format
       self.response_body
     end
 

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -34,8 +34,7 @@ module ActionController
 
     def _process_format(format)
       super
-      # format is a Mime::NullType instance here then this condition can't be changed to `if format`
-      self.content_type ||= format.to_s unless format.nil?
+      self.content_type ||= format.to_s
     end
 
     # Normalize arguments by catching blocks and setting them on :update.

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -50,7 +50,7 @@ module ActionDispatch
       #   GET /posts/5       | request.format => Mime::HTML or MIME::JS, or request.accepts.first
       #
       def format(view_path = [])
-        formats.first
+        formats.first || Mime::NullType.instance
       end
 
       def formats

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -28,7 +28,7 @@ module Mime
   class << self
     def [](type)
       return type if type.is_a?(Type)
-      Type.lookup_by_extension(type) || NullType.instance
+      Type.lookup_by_extension(type)
     end
 
     def fetch(type)

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -144,7 +144,7 @@ class SendFileTest < ActionController::TestCase
     }
 
     @controller.headers = {}
-    assert !@controller.send(:send_file_headers!, options)
+    assert_raise(ArgumentError) { @controller.send(:send_file_headers!, options) }
   end
 
   def test_send_file_headers_guess_type_from_extension


### PR DESCRIPTION
TLDR: always return an object that responds to the query methods from request.format, and do not touch Mime::Type[] lookup to avoid bugs.

_Please do not merge._

---

Long version:

The initial issue was about being able to do checks like request.format.html? for request with an unknown format, where request.format would be nil.

This is where the issue came from at first in #7837 and #8085 (merged in cba05887dc3b56a46a9fe2779b6b228880b49622), but the implementation went down the path of adding this to the mime type lookup logic.

This unfortunately introduced subtle bugs, for instance in the merged commit [a test related to send_file had to be changed](https://github.com/rails/rails/commit/cba05887dc3b56a46a9fe2779b6b228880b49622#diff-00933fde66bed68a3d2ec7400b2c0b79L147) to accomodate the introduction of the NullType.

Later another bug was found in #13064, related to the content-type being shown as `#<Mime::NullType:...>` for templates with localized extensions but no format included. This one was fixed in #13133, merged in 43962d6ec50f918c9970bd3cd4b6ee5c7f7426ed.

Besides that, custom handlers were not receiving the proper template formats anymore when passing through the rendering process, because of the NullType addition. That was found while migrating an application from 3.2 to 4.0 that uses the Markerb gem (a custom handler that generates both text and html emails from a markdown template).

---

This changes the implementation moving away from returning this null object from the mime lookup, and still fixes the initial issue where request.format.zomg? would raise an exception for unknown formats due to request.format being nil.

It is worth noticing that [all tests](https://github.com/rails/rails/commit/cba05887dc3b56a46a9fe2779b6b228880b49622#diff-cd75c7c20db7e5ab5d2534f7f28227b8R594) that [were added](https://github.com/rails/rails/commit/43962d6ec50f918c9970bd3cd4b6ee5c7f7426ed#diff-38f248f3c2154919879939f3fd0dee42R38) by this "feature" have been kept and are working fine. If that's acceptable I'll backport to 4-0-stable accordingly.
