### PR TITLE
Dont return id when quoted_id method exists

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -43,7 +43,7 @@ module ActiveRecord
       # SQLite does not understand dates, so this method will convert a Date
       # to a String.
       def type_cast(value, column)
-        return value.id if value.respond_to?(:quoted_id)
+        return value.quoted_id if value.respond_to?(:quoted_id)
 
         case value
         when String, ActiveSupport::Multibyte::Chars

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -87,14 +87,14 @@ module ActiveRecord
         def test_quoted_id
           quoted_id_obj = Class.new {
             def quoted_id
-              "'zomg'"
+              "'10'"
             end
 
             def id
               10
             end
           }.new
-          assert_equal 10, @conn.type_cast(quoted_id_obj, nil)
+          assert_equal "'10'", @conn.type_cast(quoted_id_obj, nil)
         end
       end
     end


### PR DESCRIPTION
### Problem

If for some reason value responds to `quoted_id` and it doesnt to `id`, things :bomb: 
### Solution

Check and return `quoted_id` if it responds to it.
#### Further explanation:

We(Shopify) have a patch on the Numeric class to always quote numerics as strings, to prevent security vulnerabilities.
Rails uses the `type_cast` method in different places, for example on the uniqueness validator https://github.com/rails/rails/blob/4-0-stable/activerecord/lib/active_record/validations/uniqueness.rb#L68 .
So if any Number value goes to the `type_cast` this would explode.
This is a problem not just for us, but for everyone that define a `quoted_id` method and not the `id` method. Thats why I felt like this should be fixed on rails, and not only in our source.

Also just a few lines before there is a check if quoted_id exist and if so, it returns the quoted_id. (https://github.com/arthurnn/rails/blob/3cae95e88c2c1711ba89bd3a4345875f3b0efb5b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L10).

review @tenderlove @rafaelfranca @carlosantoniodasilva
cc @dylanahsmith
