### PR TITLE
Improve ERB dependency detection

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Improved ERB dependency detection. New argument types and formattings for the `render`
+    calls can be matched.
+
+    Fixes #13074 and #13116
+
+    *João Britto*
+
 *   Use `display:none` instead of `display:inline` for hidden fields
 
     Fixes #6403

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -147,12 +147,34 @@ class ERBTrackerTest < Minitest::Test
   end
 
   def test_finds_dependencies_with_quotes_within
-    template = FakeTemplate.new("
-      <%# render \"single/quote's\" %>
-      <%# render 'double/quote\"s' %>
-    ", :erb)
+    template = FakeTemplate.new(%{
+      <%# render "single/quote's" %>
+      <%# render 'double/quote"s' %>
+    }, :erb)
+
     tracker = make_tracker("quotes/_single_and_double", template)
 
     assert_equal ["single/quote's", 'double/quote"s'], tracker.dependencies
+  end
+
+  def test_finds_dependencies_with_extra_spaces
+    template = FakeTemplate.new(%{
+      <%= render              "header" %>
+      <%= render    partial:  "form" %>
+      <%= render              @message %>
+      <%= render ( @message.events ) %>
+      <%= render    :collection => @message.comments,
+                    :partial =>    "comments/comment" %>
+    }, :erb)
+
+    tracker = make_tracker("spaces/_extra", template)
+
+    assert_equal [
+      "spaces/header",
+      "spaces/form",
+      "messages/message",
+      "events/event",
+      "comments/comment"
+    ], tracker.dependencies
   end
 end

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'abstract_unit'
 require 'action_view/dependency_tracker'
 
@@ -52,23 +54,105 @@ class ERBTrackerTest < Minitest::Test
 
   def test_dependency_of_erb_template_with_number_in_filename
     template = FakeTemplate.new("<%# render 'messages/message123' %>", :erb)
-    tracker = make_tracker('messages/_message123', template)
+    tracker = make_tracker("messages/_message123", template)
 
     assert_equal ["messages/message123"], tracker.dependencies
   end
 
   def test_finds_dependency_in_correct_directory
     template = FakeTemplate.new("<%# render(message.topic) %>", :erb)
-    tracker = make_tracker('messages/_message', template)
+    tracker = make_tracker("messages/_message", template)
 
     assert_equal ["topics/topic"], tracker.dependencies
   end
 
   def test_finds_dependency_in_correct_directory_with_underscore
     template = FakeTemplate.new("<%# render(message_type.messages) %>", :erb)
-    tracker = make_tracker('message_types/_message_type', template)
+    tracker = make_tracker("message_types/_message_type", template)
 
     assert_equal ["messages/message"], tracker.dependencies
   end
-end
 
+  def test_dependency_of_erb_template_with_no_spaces_after_render
+    template = FakeTemplate.new("<%# render'messages/message' %>", :erb)
+    tracker = make_tracker("messages/_message", template)
+
+    assert_equal ["messages/message"], tracker.dependencies
+  end
+
+  def test_finds_no_dependency_when_render_begins_the_name_of_an_identifier
+    template = FakeTemplate.new("<%# rendering 'it useless' %>", :erb)
+    tracker = make_tracker("resources/_resource", template)
+
+    assert_equal [], tracker.dependencies
+  end
+
+  def test_finds_no_dependency_when_render_ends_the_name_of_another_method
+    template = FakeTemplate.new("<%# surrender 'to reason' %>", :erb)
+    tracker = make_tracker("resources/_resource", template)
+
+    assert_equal [], tracker.dependencies
+  end
+
+  def test_finds_dependency_on_multiline_render_calls
+    template = FakeTemplate.new("<%#
+      render :object => @all_posts,
+             :partial => 'posts' %>", :erb)
+
+    tracker = make_tracker("some/_little_posts", template)
+
+    assert_equal ["some/posts"], tracker.dependencies
+  end
+
+  def test_finds_multiple_unrelated_odd_dependencies
+    template = FakeTemplate.new("
+      <%# render('shared/header', title: 'Title') %>
+      <h2>Section title</h2>
+      <%# render@section %>
+    ", :erb)
+
+    tracker = make_tracker("multiple/_dependencies", template)
+
+    assert_equal ["shared/header", "sections/section"], tracker.dependencies
+  end
+
+  def test_finds_dependencies_for_all_kinds_of_identifiers
+    template = FakeTemplate.new("
+      <%# render $globals %>
+      <%# render @instance_variables %>
+      <%# render @@class_variables %>
+    ", :erb)
+
+    tracker = make_tracker("identifiers/_all", template)
+
+    assert_equal [
+      "globals/global",
+      "instance_variables/instance_variable",
+      "class_variables/class_variable"
+    ], tracker.dependencies
+  end
+
+  def test_finds_dependencies_on_method_chains
+    template = FakeTemplate.new("<%# render @parent.child.grandchildren %>", :erb)
+    tracker = make_tracker("method/_chains", template)
+
+    assert_equal ["grandchildren/grandchild"], tracker.dependencies
+  end
+
+  def test_finds_dependencies_with_special_characters
+    template = FakeTemplate.new("<%# render @pokémon, partial: 'ピカチュウ' %>", :erb)
+    tracker = make_tracker("special/_characters", template)
+
+    assert_equal ["special/ピカチュウ"], tracker.dependencies
+  end
+
+  def test_finds_dependencies_with_quotes_within
+    template = FakeTemplate.new("
+      <%# render \"single/quote's\" %>
+      <%# render 'double/quote\"s' %>
+    ", :erb)
+    tracker = make_tracker("quotes/_single_and_double", template)
+
+    assert_equal ["single/quote's", 'double/quote"s'], tracker.dependencies
+  end
+end


### PR DESCRIPTION
Following the discussion started on #13116, I thought it might be worth giving a shot at some of the issues we have identified.

The current implementation can't handle some special cases of oddly-formatted Ruby. Now we are able to detect them:
- Multi-line arguments on the `render` call
- Strings containing quotes, e.g. `"something's wrong"`
- Multiple kinds of identifiers - instance variables, class variables and globals
- Method chains as arguments for the `render` call
- "Glued" identifiers, e.g. `render@things`, `render:partial => 'partial'`, etc.

Also, this fix reduces the rate of "false positives" which showed up when we had calls/access to identifiers containing `render`, like `surrender` and `rendering`.

Related: #13074.

**Update:**

There is still one edge case for false positives which will be virtually impossible to avoid whithout actually parsing the template: when we have `render` inside a string, as in:

``` erb
<%= content_tag :p, 'Then we render something nice.' %>
<%# "somethings/something" %>
```

For obvious reasons :bomb:. But I guess that will not be such an issue. What we have got so far is probably about as far as we can go with a human-readable regex.
