### PR TITLE
Do not expect database user with app name to exist

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
@@ -6,12 +6,19 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  username: <%= app_name %>
-  password:
 
 development:
   <<: *default
   database: <%= app_name %>_development
+
+  # The specified database role being used to connect to postgres.
+  # To create additional roles in postgres see `$ createuser --help`.
+  # When left blank, postgres will use the default role. This is
+  # the same name as the operating system user that initialized the database.
+  #username: <%= app_name %>
+
+  # The password associated with the postgres role (username).
+  #password:
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
@@ -20,12 +20,19 @@ default: &default
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5
-  username: <%= app_name %>
-  password:
 
 development:
   <<: *default
   database: <%= app_name %>_development
+
+  # The specified database role being used to connect to postgres.
+  # To create additional roles in postgres see `$ createuser --help`.
+  # When left blank, postgres will use the default role. This is
+  # the same name as the operating system user that initialized the database.
+  #username: <%= app_name %>
+
+  # The password associated with the postgres role (username).
+  #password:
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have


### PR DESCRIPTION
Do not expect database user with app name to exist

By default when creating a project with `--database=postgresql` the `config/database.yml` file that is generated has a user specified that is the same as the app name

```
development:
  adapter: postgresql
  encoding: unicode
  database: <%= app_name %>_development
  pool: 5
  username: <%= app_name %>
  password:
```

This is counterintuitive and would rarely be valid. By default postgres creates a user with the current user name (http://www.postgresql.org/docs/9.3/static/database-roles.html) "it will have the same name as the operating system user that initialized the database cluster":

```
$ whoami
schneems
```

If the `username` is left out postgresql will assume that you wish to log in as the default user

```
$ psql -c '\du'
                             List of roles
 Role name |                   Attributes                   | Member of
-----------+------------------------------------------------+-----------
 schneems  | Superuser, Create role, Create DB, Replication | {}
```

A good sensible default then for auto generated `database.yml` files is to remove the `username`, and have postgres attempt to connect to the database as the currently logged in user.

Instead of submitting with a blank password, don't submit a password.
