### PR TITLE
Object#presence should take a block

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -23,6 +23,10 @@ class Object
   # Returns object if it's <tt>present?</tt> otherwise returns +nil+.
   # <tt>object.presence</tt> is equivalent to <tt>object.present? ? object : nil</tt>.
   #
+  # If a block is given and the object is <tt>present?</tt> the
+  # object is yielded into the block and the return value of
+  # <tt>object.presence</tt>> is the return value of the block
+  #
   # This is handy for any representation of objects where blank is the same
   # as not present at all. For example, this simplifies a common check for
   # HTTP POST/query parameters:
@@ -35,7 +39,13 @@ class Object
   #
   #   region = params[:state].presence || params[:country].presence || 'US'
   def presence
-    self if present?
+    return nil if blank?
+
+    if block_given?
+      yield self
+    else
+      self
+    end
   end
 end
 

--- a/activesupport/test/core_ext/blank_test.rb
+++ b/activesupport/test/core_ext/blank_test.rb
@@ -29,4 +29,14 @@ class BlankTest < ActiveSupport::TestCase
     BLANK.each { |v| assert_equal nil, v.presence, "#{v.inspect}.presence should return nil" }
     NOT.each   { |v| assert_equal v,   v.presence, "#{v.inspect}.presence should return self" }
   end
+
+  def test_presence_yield
+    BLANK.each do |v|
+      assert_equal nil, v.presence { |it| true }
+    end
+
+    NOT.each do |v| 
+      assert_equal [true, v], v.presence { |it| [true, it] }
+    end
+  end
 end


### PR DESCRIPTION
In order to have parallel behavior with methods like #each, presence should
yield to a provided block if the object is present.  This is
similar to an anaphoric if in Scheme, and is discussed at length here:

https://github.com/raganwald/homoiconic/blob/master/2012/05/anaphora.md

You can achieve similar functionality by appending `try` in its block
form to a presence call - but having presence evaluate the block itself
avoids the (confusing) call to try.
