### PR TITLE
fix CollectionAssociation's comments

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -4,7 +4,7 @@ module ActiveRecord
     #
     # CollectionAssociation is an abstract class that provides common stuff to
     # ease the implementation of association proxies that represent
-    # collections. See the class hierarchy in AssociationProxy.
+    # collections. See the class hierarchy in Association.
     #
     #   CollectionAssociation:
     #     HasManyAssociation => has_many


### PR DESCRIPTION
change CollectionAssociation's comments to say Association instead of AssociationProxy to match changes for 3.1 removing Association proxy.

``` ruby
    # CollectionAssociation is an abstract class that provides common stuff to
    # ease the implementation of association proxies that represent
    # collections. See the class hierarchy in ~~AssociationProxy~~ => Association.
    #
    #   CollectionAssociation:
    #     HasManyAssociation => has_many
    #       HasManyThroughAssociation + ThroughAssociation => has_many :through
```

to match this change from the release notes

``` ruby
* `ActiveRecord::Associations::AssociationProxy` has been split. There is now an 
`Association` class (and subclasses) which are responsible for operating on associations, 
and then a separate, thin wrapper called `CollectionProxy`, which proxies collection 
associations. This prevents namespace pollution, separates concerns, and will allow further 
refactorings.
```
