### PR TITLE
Use sass-rails 4.0.0

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -308,7 +308,7 @@ module Rails
                                     'Use SCSS for stylesheets')
         else
           gems << GemfileEntry.version('sass-rails',
-                                     '~> 4.0.0.rc1',
+                                     '~> 4.0.1',
                                      'Use SCSS for stylesheets')
         end
 


### PR DESCRIPTION
Finding sass-rails version is 4.0.0.rc1 when I create new app by `rails new` in Rails 4.1.0.beta1.
Rails 4.0.0 already use sass-rails version 4.0.0. 
So just change sass-rails version 4.0.0 instead of 4.0.0.rc1.
