### PR TITLE
Bump Jbuilder version to 2.0.0

### DIFF
--- a/guides/code/getting_started/Gemfile
+++ b/guides/code/getting_started/Gemfile
@@ -28,7 +28,7 @@ group :doc do
 end
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 1.2'
+gem 'jbuilder', '~> 2.0'
 
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.1.2'

--- a/guides/code/getting_started/Gemfile.lock
+++ b/guides/code/getting_started/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
       multi_json (~> 1.0)
     hike (1.2.3)
     i18n (0.6.4)
-    jbuilder (1.4.2)
+    jbuilder (2.0.0)
       activesupport (>= 3.0.0)
       multi_json (>= 1.2.0)
     jquery-rails (3.0.2)
@@ -110,7 +110,7 @@ PLATFORMS
 
 DEPENDENCIES
   coffee-rails
-  jbuilder (~> 1.2)
+  jbuilder (~> 2.0)
   jquery-rails
   rails (= 4.0.0)
   sass-rails

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -329,7 +329,7 @@ module Rails
 
       def jbuilder_gemfile_entry
         comment = 'Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder'
-        GemfileEntry.version('jbuilder', '~> 1.2', comment)
+        GemfileEntry.version('jbuilder', '~> 2.0', comment)
       end
 
       def sdoc_gemfile_entry


### PR DESCRIPTION
New version deprecates some old APIs, implements template dependency tracking and Russian Doll caching friendly.
