### PR TITLE
Ability to turn off auto save of serialized attributes

### DIFF
--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -71,7 +71,7 @@ module ActiveRecord
     end
 
     def should_record_timestamps?
-      self.record_timestamps && (!partial_writes? || changed? || (attributes.keys & self.class.serialized_attributes.keys).present?)
+      self.record_timestamps && (!partial_writes? || changed? || maybe_changed?)
     end
 
     def timestamp_attributes_for_create_in_model


### PR DESCRIPTION
Currently, serialized attributes are saved to the database on every save.

This change introduces `safe_serialized_attributes` which will turn this behavior off.

If serialized attribtues are changed inplace, then the user can use `attribute_will_change!`.

``` ruby
topic = Topic.create!(:content => {:a => "a"})

topic.save! #saves to database
topic.save! #saves to database
Topic.safe_serialized_attributes = false
topic.save! #no longer saves to database

topic.content_will_change!
topic.content[:b] = "b"
topic.save! #saves to database
topic.save! #no longer saves to database
```

This is one option for rails#8328
