### PR TITLE
Tell how to Create a Database in Error Message

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   When connecting to a non-existant postgresql database, the error:
+    `ActiveRecord::NoDatabaseError` will now be raised. When being used with Rails
+    the error message will include information on how to create a database:
+    `rake db:create`
+
+    *Richard Schneeman*
+
 *   Do not raise `'can not touch on a new record object'` exception on destroying already destroyed
     `belongs_to` association with `touch: true` option
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -865,6 +865,12 @@ module ActiveRecord
           PostgreSQLColumn.money_precision = (postgresql_version >= 80300) ? 19 : 10
 
           configure_connection
+        rescue ::PG::Error => error
+          if error.message.include?("does not exist")
+            raise ActiveRecord::NoDatabaseError.new(error.message)
+          else
+            raise error
+          end
         end
 
         # Configures the encoding, verbosity, schema search path, and time zone of the connection.

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -94,6 +94,18 @@ module ActiveRecord
   class PreparedStatementInvalid < ActiveRecordError
   end
 
+  # Raised when a given database does not exist
+  class NoDatabaseError < ActiveRecordError
+    def initialize(message)
+      super extend_message(message)
+    end
+
+    # can be over written to add additional error information.
+    def extend_message(message)
+      message
+    end
+  end
+
   # Raised on attempt to save stale record. Record is stale when it's being saved in another query after
   # instantiation, for example, when two users edit the same wiki page and one starts editing and saves
   # the page before the other.

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -122,6 +122,14 @@ module ActiveRecord
     # and then establishes the connection.
     initializer "active_record.initialize_database" do |app|
       ActiveSupport.on_load(:active_record) do
+
+        class ActiveRecord::NoDatabaseError
+          def extend_message(message)
+            message << "Run `$ bin/rake db:create db:migrate` to create your database"
+            message
+          end
+        end
+
         self.configurations = app.config.database_configuration || {}
         establish_connection
       end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -10,6 +10,13 @@ module ActiveRecord
         @connection.exec_query('create table ex(id serial primary key, number integer, data character varying(255))')
       end
 
+      def test_bad_connection
+        assert_raise ActiveRecord::NoDatabaseError do
+          connection = ActiveRecord::Base.postgresql_connection(database: "should_not_exist-cinco-dog-db", adapter: "postgresql")
+          connection.exec_query('drop table if exists ex')
+        end
+      end
+
       def test_valid_column
         column = @connection.columns('ex').find { |col| col.name == 'id' }
         assert @connection.valid_type?(column.type)


### PR DESCRIPTION
Currently if you attempt to use a database that does not exist  you get an error:

```
PG::ConnectionBad FATAL:  database "db_error" does not exist
```

The solution is easy, create and migrate your database however new developers may not know these commands by memory. Instead of requiring the developer to search for a solution, tell them how to fix the problem in the error message:

```
ActiveRecord::NoDatabase: FATAL:  database "db_error" does not exist
Run `$ bundle exec rake db:create` and `$ bundle exec rake db:migrate` to create your database
```

Active Record should not know about `rake db:migrate` so this additional information needs to come from the railtie. Potential alternative implementation suggestions are welcome.
