### PR TITLE
Serialized comparing

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -159,7 +159,7 @@ module ActiveModel
 
     # Handle <tt>*_was</tt> for +method_missing+.
     def attribute_was(attr) # :nodoc:
-      attribute_changed?(attr) ? changed_attributes[attr] : __send__(attr)
+      changed_attributes.include?(attr) ? changed_attributes[attr] : __send__(attr)
     end
 
     private
@@ -178,7 +178,7 @@ module ActiveModel
 
       # Handle <tt>*_change</tt> for +method_missing+.
       def attribute_change(attr)
-        [changed_attributes[attr], __send__(attr)] if attribute_changed?(attr)
+        [changed_attributes[attr], __send__(attr)] if changed_attributes.include?(attr)
       end
 
       # Handle <tt>*_will_change!</tt> for +method_missing+.

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -87,8 +87,6 @@ module ActiveRecord
         partial_writes? ? super(keys_for_partial_write) : super
       end
 
-      # Serialized attributes should always be written in case they've been
-      # changed in place.
       def keys_for_partial_write
         changed
       end

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -168,6 +168,10 @@ module ActiveRecord
           @attributes_hashes.keys.select { |attr| changed_hash?(attr) }
         end
 
+        def attribute_changed?(attr)
+          super || changed_hash?(attr)
+        end
+
         def changed_hash?(attr)
           @attributes_hashes[attr] &&
             (@attributes_hashes[attr] != __send__(attr).hash)

--- a/activerecord/test/cases/attribute_methods/serialization_test.rb
+++ b/activerecord/test/cases/attribute_methods/serialization_test.rb
@@ -1,4 +1,5 @@
 require "cases/helper"
+require 'models/topic'
 
 module ActiveRecord
   module AttributeMethods
@@ -23,6 +24,75 @@ module ActiveRecord
         type = Serialization::Type.new(FakeColumn.new)
         type.type_cast(value)
         assert_equal "Hello world", type.type_cast(value)
+      end
+
+      def test_attribute_hash_mutation
+        topic = Topic.create!(:content => {:a => "a"})
+        assert !topic.content_changed?
+        assert !topic.changed?
+        assert_equal [], topic.changed_hashes
+        assert !topic.changed_hashes?
+
+        topic.content[:a] = "b"
+        assert topic.changed_hash?("content")
+        assert_equal ["content"], topic.changed_hashes
+        assert topic.changed_hashes?
+        assert topic.changed?
+
+        topic.content[:a] = "a"
+        assert !topic.changed_hash?("content")
+        assert !topic.changed?
+
+        topic = Topic.find_by_id!(topic.id)
+        assert !topic.changed_hashes?
+        topic.content[:a] = "b"
+        assert topic.changed_hash?("content")
+      end
+
+
+      def test_changed_should_detect_when_serialized_attribute_changes
+        topic = Topic.create!(:content => {:a => "a"})
+        topic.content[:b] = "b"
+        assert topic.content_changed?
+        assert topic.changed?
+        assert_equal({:a => "a", :b => "b"}, topic.content_was) #bug
+        assert_equal nil, topic.content_change #bug
+        topic.save!
+        assert !topic.content_changed?
+        assert !topic.changed?
+        assert_equal "b", topic.content[:b]
+        topic.reload
+        assert_equal "b", topic.content[:b]
+      end
+
+      def test_save_should_update_timestamps_when_serialized_attributes_change
+        topic = Topic.create!(:content => {:a => "a"})
+        topic.save!
+
+        updated_at = topic.updated_at
+        topic.content[:hello] = 'world'
+        topic.save!
+
+        assert_not_equal updated_at, topic.updated_at
+        assert_equal 'world', topic.content[:hello]
+      end
+
+      def test_save_should_not_update_timestamps_when_serialized_are_unchanged
+        topic = Topic.create!(:content => {:a => "a"})
+        topic.save!
+
+        updated_at = topic.updated_at
+        topic.save!
+
+        assert_equal updated_at, topic.updated_at
+      end
+
+      def test_save_should_not_save_serialized_attribute_if_not_present
+        Topic.create!(:author_name => 'Bill', :content => {:a => "a"})
+        topic = Topic.select('id, author_name').first
+        topic.update_columns author_name: 'John'
+        topic = Topic.first
+        assert_not_nil topic.content
       end
     end
   end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -341,29 +341,6 @@ class DirtyTest < ActiveRecord::TestCase
     assert !topic.approved_changed?
   end
 
-  def test_attribute_hash_mutation
-    topic = Topic.create!(:content => {:a => "a"})
-    assert !topic.content_changed?
-    assert !topic.changed?
-    assert_equal [], topic.changed_hashes
-    assert !topic.changed_hashes?
-
-    topic.content[:a] = "b"
-    assert topic.changed_hash?("content")
-    assert_equal ["content"], topic.changed_hashes
-    assert topic.changed_hashes?
-    assert topic.changed?
-
-    topic.content[:a] = "a"
-    assert !topic.changed_hash?("content")
-    assert !topic.changed?
-
-    topic = Topic.find_by_id!(topic.id)
-    assert !topic.changed_hashes?
-    topic.content[:a] = "b"
-    assert topic.changed_hash?("content")
-  end
-
   def test_partial_update
     pirate = Pirate.new(:catchphrase => 'foo')
     old_updated_on = 1.hour.ago.beginning_of_day
@@ -463,42 +440,6 @@ class DirtyTest < ActiveRecord::TestCase
     assert !pirate.changed?
     assert !pirate.parrot_id_changed?
     assert !pirate.catchphrase_changed?
-  end
-
-  def test_save_should_store_serialized_attributes_even_with_partial_writes
-    with_partial_writes(Topic) do
-      topic = Topic.create!(:content => {:a => "a"})
-      topic.content[:b] = "b"
-      assert topic.changed?
-      topic.save!
-      assert_equal "b", topic.content[:b]
-      topic.reload
-      assert_equal "b", topic.content[:b]
-    end
-  end
-
-  def test_save_always_should_update_timestamps_when_serialized_attributes_are_present
-    with_partial_writes(Topic) do
-      topic = Topic.create!(:content => {:a => "a"})
-      topic.save!
-
-      updated_at = topic.updated_at
-      topic.content[:hello] = 'world'
-      topic.save!
-
-      assert_not_equal updated_at, topic.updated_at
-      assert_equal 'world', topic.content[:hello]
-    end
-  end
-
-  def test_save_should_not_save_serialized_attribute_with_partial_writes_if_not_present
-    with_partial_writes(Topic) do
-      Topic.create!(:author_name => 'Bill', :content => {:a => "a"})
-      topic = Topic.select('id, author_name').first
-      topic.update_columns author_name: 'John'
-      topic = Topic.first
-      assert_not_nil topic.content
-    end
   end
 
   def test_previous_changes


### PR DESCRIPTION
For models with serialized attributes, use the hash code to determine if a column has changed.

Only save changed columns to database.

This is in response to rails#8328

---

I found working with `ActiveRecord` and the `Dirty` concept a little tricky because `Core` is so high in the ancestors chain. Since `Core` comes before `Dirty` or `Serialized`, the only extension point is to modify `Core` or the `Behavior` injected by the `serialize :attribute` call. This PR is the latter.

Thanks again to @rafaelfranca for your previous review.

--Keenan
