### PR TITLE
Allow options for :enum and provide :nested option to create namespaced scopes and methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -334,7 +334,7 @@
     Example:
 
         class Conversation < ActiveRecord::Base
-          enum status: [:active, :archived]
+          enum :status, [:active, :archived]
         end
 
         Conversation::STATUS # => { active: 0, archived: 1 }

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -14,16 +14,19 @@ class EnumTest < ActiveRecord::TestCase
     assert_not @book.published?
 
     assert @book.unread?
+    assert @book.nested_status_proposed?
   end
 
   test "query state with symbol" do
     assert_equal "proposed", @book.status
     assert_equal "unread", @book.read_status
+    assert_equal "proposed", @book.nested_status
   end
 
   test "find via scope" do
     assert_equal @book, Book.proposed.first
     assert_equal @book, Book.unread.first
+    assert_equal @book, Book.nested_status_proposed.first
   end
 
   test "update by declaration" do

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -7,8 +7,9 @@ class Book < ActiveRecord::Base
   has_many :subscriptions
   has_many :subscribers, through: :subscriptions
 
-  enum status: [:proposed, :written, :published]
-  enum read_status: {unread: 0, reading: 2, read: 3}
+  enum :status, [:proposed, :written, :published]
+  enum :read_status, {unread: 0, reading: 2, read: 3}
+  enum :nested_status, [:proposed, :written, :published], nested: true
 
   def published!
     super

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define do
     t.column :name, :string
     t.column :status, :integer, default: 0
     t.column :read_status, :integer, default: 0
+    t.column :nested_status, :integer, default: 0
   end
 
   create_table :booleans, force: true do |t|


### PR DESCRIPTION
This one is related to #13389 and should solve problems (1), (2) and (3) by allowing to create namespaces in such cases.

What is provided by this pull request?

``` ruby
class Conversation < ActiveRecord::Base
  enum :status, [ :active, :archived ], nested: true
end

Conversation.status_active

conversation.status_active!
conversation.status_active? # => true
conversation.status  # => "active"
Conversation::STATUS # => { "active" => 0, "archived" => 1 }
```

Unfortunately I had to change API of enum from

``` ruby
class Conversation < ActiveRecord::Base
  enum status: [ :active, :archived ]
end
```

to:

``` ruby
class Conversation < ActiveRecord::Base
  enum :status, [ :active, :archived ]
end
```

to make sure that options are extracted. If anyone has idea how to implement it without changing API then I will be glad to modify this pull request, but we might also think about potential other options in future and try to change API now - it's up to community.

**EDIT**: I'm considering changing option from "nested" to "prefix", but I will gladly hear what community have to say.
