### PR TITLE
Remove the default 255 char limit on string columns in Postgres

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Removed default length on string columns in PostgreSQL.
+
+    *Toms Mikoss*
+
 *   Improve the default select when `from` is used.
 
     Previously, if you did something like Topic.from(:temp_topics), it

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -408,7 +408,7 @@ module ActiveRecord
 
       NATIVE_DATABASE_TYPES = {
         primary_key: "serial primary key",
-        string:      { name: "character varying", limit: 255 },
+        string:      { name: "character varying" },
         text:        { name: "text" },
         integer:     { name: "integer" },
         float:       { name: "float" },

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -61,7 +61,10 @@ module ActiveRecord
 
         column = klass.columns_hash[attribute_name]
         value  = klass.connection.type_cast(value, column)
-        value  = value.to_s[0, column.limit] if value && column.limit && column.text?
+        if value && column.text?
+          value = value.to_s
+          value = value[0, column.limit] if column.limit
+        end
 
         if !options[:case_sensitive] && value && column.text?
           # will use SQL LOWER function before comparison, unless it detects a case insensitive collation

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -663,7 +663,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :topics, force: true do |t|
-    t.string   :title
+    t.string   :title, limit: 255
     t.string   :author_name
     t.string   :author_email_address
     t.datetime :written_on


### PR DESCRIPTION
The underlying storage for varchar and text is the same in PG - defining column limits where application logic does not call for them only makes the database do unnecessary work.

See http://www.postgresql.org/docs/9.3/static/datatype-character.html for additional information.
