### PR TITLE
Enable memcached service on travis for running cache tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,6 @@ notifications:
     rooms:
       - secure: "YA1alef1ESHWGFNVwvmVGCkMe4cUy4j+UcNvMUESraceiAfVyRMAovlQBGs6\n9kBRm7DHYBUXYC2ABQoJbQRLDr/1B5JPf/M8+Qd7BKu8tcDC03U01SMHFLpO\naOs/HLXcDxtnnpL07tGVsm0zhMc5N8tq4/L3SHxK7Vi+TacwQzI="
 bundler_args: --path vendor/bundle --without test
+services:
+  - memcached
+


### PR DESCRIPTION
Enable memcached service on travis for running cache tests.

Not sure, if its intentional not to run the service.

Also http://about.travis-ci.org/blog/2013-11-18-upcoming-build-environment-updates/ states the service is not
started automatically on boot as before.
