### PR TITLE
fix host_db extraction for sqlite3, Fixes build #12796

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -74,7 +74,7 @@ module ActiveRecord
                        if '/:memory:' == config.path
                          ':memory:'
                        else
-                         config.path
+                         config.path.sub(%r{^/}, "")
                        end
                      else
                        config.path.sub(%r{^/},"")

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -34,6 +34,18 @@ module ActiveRecord
             encoding: "utf8" }, spec)
         end
 
+        def test_url_host_db_for_sqlite
+          spec = resolve 'sqlite3://foo:bar@dburl:9000/foo_test?encoding=utf8'
+          assert_equal({
+            adapter:  "sqlite3",
+            username: 'foo',
+            password: 'bar',
+            port: 9000,
+            database: "foo_test",
+            host:     "dburl",
+            encoding: "utf8" }, spec)
+        end
+
         def test_url_port
           spec = resolve 'abstract://foo:123?encoding=utf8'
           assert_equal({


### PR DESCRIPTION
Fixes `Resolver#connection_url_to_hash`,

``` ruby
Before
 'sqlite3://foo:bar@dburl:9000/foo_test?encoding=utf8' # => database: '/foo_test'

After
 'sqlite3://foo:bar@dburl:9000/foo_test?encoding=utf8' # => database: 'foo_test'
```
