### PR TITLE
Generating proper migration when ActiveRecord::Base.pluralize_table_names = false

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix Generation of proper migration when
+    ActiveRecord::Base.pluralize_table_names = false.
+
+    Previously, generation a migration like this:
+
+        rails g migration add_column_name_to_user name
+
+    would not generating the correct table name.
+
+    Fixes #13426.
+
+    *Kuldeep Aggarwal*
+
 *   `touch` accepts many attributes to be touched at once.
 
     Example:

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -23,16 +23,16 @@ module ActiveRecord
         case file_name
         when /^(add|remove)_.*_(?:to|from)_(.*)/
           @migration_action = $1
-          @table_name       = $2.pluralize
+          @table_name       = normalize_table_name($2)
         when /join_table/
           if attributes.length == 2
             @migration_action = 'join'
-            @join_tables      = attributes.map(&:plural_name)
+            @join_tables      = pluralize_table_names? ? attributes.map(&:plural_name) : attributes.map(&:singular_name)
 
             set_index_names
           end
         when /^create_(.+)/
-          @table_name = $1.pluralize
+          @table_name = normalize_table_name($1)
           @migration_template = "create_table_migration.rb"
         end
       end
@@ -60,6 +60,10 @@ module ActiveRecord
           unless file_name =~ /^[_a-z0-9]+$/
             raise IllegalMigrationNameError.new(file_name)
           end
+        end
+
+        def normalize_table_name(_table_name)
+          pluralize_table_names? ? _table_name.pluralize : _table_name.singularize
         end
     end
   end

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -94,6 +94,10 @@ module Rails
         name.sub(/_id$/, '').pluralize
       end
 
+      def singular_name
+        name.sub(/_id$/, '').singularize
+      end
+
       def human_name
         name.humanize
       end


### PR DESCRIPTION
Earlier, when `pluralize_table_names = false`, then if we try to create new migration then it does not consider the `ActiveRecord::Base.pluralize_table_names` configuration and always pluaralizing the table name.

``` ruby
Before
rails g migration add_column_test1_to_user test1
# => 
class AddColumnTest1ToUser < ActiveRecord::Migration
  def change
    add_column :users, :test1, :string
  end
end


Now:
rails g migration add_column_test1_to_user test1
# =>
class AddColumnTest1ToUser < ActiveRecord::Migration
  def change
    add_column :user, :test1, :string
  end
end
```

fixes #13426
