### PR TITLE
Fix DB Console tests

### DIFF
--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -216,7 +216,7 @@ module ApplicationTests
         require "#{app_path}/config/environment"
         orig_database_url = ENV.delete("DATABASE_URL")
         orig_rails_env, Rails.env = Rails.env, 'development'
-        database_url_db_name = "db/database_url_db.sqlite3"
+        database_url_db_name = File.join(app_path, "db/database_url_db.sqlite3")
         ENV["DATABASE_URL"] = "sqlite3://:@localhost/#{database_url_db_name}"
         ActiveRecord::Base.establish_connection
         assert ActiveRecord::Base.connection

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -16,11 +16,11 @@ module ApplicationTests
       end
 
       def database_url_db_name
-        "db/database_url_db.sqlite3"
+        File.join(app_path, "db/database_url_db.sqlite3")
       end
 
       def set_database_url
-        ENV['DATABASE_URL'] = "sqlite3://:@localhost/#{database_url_db_name}"
+        ENV['DATABASE_URL'] = File.join("sqlite3://:@localhost", database_url_db_name)
         # ensure it's using the DATABASE_URL
         FileUtils.rm_rf("#{app_path}/config/database.yml")
       end
@@ -60,7 +60,7 @@ module ApplicationTests
           `rails generate model book title:string;
            bundle exec rake db:migrate`
           output = `bundle exec rake db:migrate:status`
-          assert_match(/database:\s+\S+#{expected[:database]}/, output)
+          assert_match(%r{database:\s+\S*#{Regexp.escape(expected[:database])}}, output)
           assert_match(/up\s+\d{14}\s+Create books/, output)
         end
       end

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -38,36 +38,38 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   end
 
   def test_config_with_database_url_only
-    ENV['DATABASE_URL'] = 'sqlite3://foo:bar@localhost:9000/foo_test?pool=5&timeout=3000'
+    ENV['DATABASE_URL'] = 'postgresql://foo:bar@localhost:9000/foo_test?pool=5&timeout=3000'
     app_db_config(nil)
-    assert_equal Rails::DBConsole.new.config.sort, {
-      "adapter"=> "sqlite3",
-      "host"=> "localhost",
-      "port"=> 9000,
-      "database"=> "foo_test",
-      "username"=> "foo",
-      "password"=> "bar",
-      "pool"=> "5",
-      "timeout"=> "3000"
+    expected = {
+      "adapter"  => "postgresql",
+      "host"     => "localhost",
+      "port"     => 9000,
+      "database" => "foo_test",
+      "username" => "foo",
+      "password" => "bar",
+      "pool"     => "5",
+      "timeout"  => "3000"
     }.sort
+    assert_equal expected, Rails::DBConsole.new.config.sort
   end
 
   def test_config_choose_database_url_if_exists
-    ENV['DATABASE_URL'] = 'sqlite3://foo:bar@dburl:9000/foo_test?pool=5&timeout=3000'
+    host = "database-url-host.com"
+    ENV['DATABASE_URL'] = "postgresql://foo:bar@#{host}:9000/foo_test?pool=5&timeout=3000"
     sample_config = {
       "test" => {
-        "adapter"=> "sqlite3",
-        "host"=> "localhost",
-        "port"=> 9000,
-        "database"=> "foo_test",
-        "username"=> "foo",
-        "password"=> "bar",
-        "pool"=> "5",
-        "timeout"=> "3000"
+        "adapter"  => "postgresql",
+        "host"     => "not-the-#{host}",
+        "port"     => 9000,
+        "database" => "foo_test",
+        "username" => "foo",
+        "password" => "bar",
+        "pool"     => "5",
+        "timeout"  => "3000"
       }
     }
     app_db_config(sample_config)
-    assert_equal Rails::DBConsole.new.config["host"], "dburl"
+    assert_equal host, Rails::DBConsole.new.config["host"]
   end
 
   def test_env


### PR DESCRIPTION
The build is broken: https://travis-ci.org/rails/rails/builds/15824530

This commit fixes that.

The problem: Sqlite expects the `database` part to be an absolute path. That prompted this change to be committed to master: https://github.com/rails/rails/commit/fbb79b517f3127ba620fedd01849f9628b78d6ce

This change provides correct behavior. Unfortunately tests were introduced in https://github.com/rails/rails/commit/971d5107cd4cd08c22a85d34546f4ba03ed5c925 that were relying on the incorrect behavior. We can avoid the fix by changing to another database url such as `mysql` or `postgresql`

In addition to fixing the failure, the assertions are changed so that the "expected" value comes before "actual" value.

More tests fixed by specifying absolute paths rather then relative.
