### PR TITLE
Resolver test cases

### DIFF
--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -57,6 +57,16 @@ module ActiveRecord
 
           assert_match "Could not load 'active_record/connection_adapters/non-existing_adapter'", error.message
         end
+
+        def test_url_host_db_for_sqlite3
+          spec = resolve 'sqlite3://foo:bar@dburl:9000/foo_test'
+          assert_equal('/foo_test', spec[:database])
+        end
+
+        def test_url_host_memory_db_for_sqlite3
+          spec = resolve 'sqlite3://foo:bar@dburl:9000/:memory:'
+          assert_equal(':memory:', spec[:database])
+        end
       end
     end
   end


### PR DESCRIPTION
 I was working to fix failed builds and then I come to know that test cases had been failed because of fbb79b5. So I sent a PR #13439 in which I come to know that my PR has just reverted the code which was added in the above commit(fbb79b5) so added test cases for the same commit.
1. Added new test cases for `Resolver#connection_url_to_hash`
2. Modified the condition to find `database` name(this might be cosmetic change, can revert if required).
