### PR TITLE
Fix typecasting array of integers

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -144,7 +144,7 @@ module ActiveRecord
 
           def quote_and_escape(value)
             case value
-            when "NULL"
+            when "NULL", Numeric
               value
             else
               "\"#{value.gsub(/"/,"\\\"")}\""

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -66,6 +66,12 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert_equal([nil], @column.type_cast('{NULL}'))
   end
 
+  def test_type_cast_integers
+    x = PgArray.new(ratings: ['1', '2'])
+    assert x.save!
+    assert_equal(['1', '2'], x.ratings)
+  end
+
   def test_rewrite
     @connection.execute "insert into pg_arrays (tags) VALUES ('{1,2,3}')"
     x = PgArray.first


### PR DESCRIPTION
When typecasting an array of integers, if the value happens to be provided as strings (in forms for example), `quote_and_escape` will receive a `Numeric` and try gsubing on it.
This fixes it, returning the value without modifying it.

Closes #13444
