### PR TITLE
Add missing av/railtie require

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -3,6 +3,7 @@ require "action_controller"
 require "action_dispatch/railtie"
 require "abstract_controller/railties/routes_helpers"
 require "action_controller/railties/helpers"
+require "action_view/railtie"
 
 module ActionController
   class Railtie < Rails::Railtie #:nodoc:


### PR DESCRIPTION
This breaks plugins and some apps after upgrading to 4.1 beta. We shouldn't require users to do this, this should be included by default.

Ref: #13384
