### PR TITLE
Ensure format is uniform when used as cache key

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -66,7 +66,9 @@ module ActionView
       def self.get(details)
         if details[:formats]
           details = details.dup
-          details[:formats] &= Mime::SET.symbols
+          details[:formats] = Mime::SET.symbols.select do |symbol|
+            details[:formats].include?(symbol) || details[:formats].any? { |string| string == symbol.to_s }
+          end
         end
         @details_keys[details] ||= new
       end

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -149,9 +149,18 @@ class LookupContextTest < ActiveSupport::TestCase
     keys << @lookup_context.details_key
     assert_equal 3, keys.uniq.size
 
+    @lookup_context.formats = ['html']
+    keys << @lookup_context.details_key
+    assert_equal 3, keys.uniq.size
+
     @lookup_context.formats = nil
     keys << @lookup_context.details_key
     assert_equal 3, keys.uniq.size
+
+    @lookup_context.formats = [:xml]
+    keys << @lookup_context.details_key
+    assert_equal 4, keys.uniq.size
+
   end
 
   test "gives the key forward to the resolver, so it can be used as cache key" do


### PR DESCRIPTION
Ensure that format is a symbol before using it as a cache key, this ensures
that differing formats will cause differing cache keys regardless of
string/symbol, and that similar formats will hit any existing cache.

The weird way of checking is done to reduce the possibility of DDoS through
symbol creation.

Fixes #13208 too.
