### PR TITLE
Raise NoDatabaseError when db does not exist

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -27,10 +27,10 @@
 
     *Carlos Antonio da Silva*
 
-*   When connecting to a non-existant postgresql database, the error:
+*   When connecting to a non-existant database, the error:
     `ActiveRecord::NoDatabaseError` will now be raised. When being used with Rails
     the error message will include information on how to create a database:
-    `rake db:create`
+    `rake db:create`. Supported adapters: postgresql, mysql, mysql2, sqlite3
 
     *Richard Schneeman*
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -18,6 +18,12 @@ module ActiveRecord
       client = Mysql2::Client.new(config)
       options = [config[:host], config[:username], config[:password], config[:database], config[:port], config[:socket], 0]
       ConnectionAdapters::Mysql2Adapter.new(client, logger, options, config)
+    rescue Mysql2::Error => error
+      if error.message.include?("Unknown database")
+        raise ActiveRecord::NoDatabaseError.new(error.message)
+      else
+        raise error
+      end
     end
   end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -34,6 +34,12 @@ module ActiveRecord
       default_flags |= Mysql::CLIENT_FOUND_ROWS if Mysql.const_defined?(:CLIENT_FOUND_ROWS)
       options = [host, username, password, database, port, socket, default_flags]
       ConnectionAdapters::MysqlAdapter.new(mysql, logger, options, config)
+    rescue Mysql::Error => error
+      if error.message.include?("Unknown database")
+        raise ActiveRecord::NoDatabaseError.new(error.message)
+      else
+        raise error
+      end
     end
   end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -31,6 +31,12 @@ module ActiveRecord
       db.busy_timeout(ConnectionAdapters::SQLite3Adapter.type_cast_config_to_integer(config[:timeout])) if config[:timeout]
 
       ConnectionAdapters::SQLite3Adapter.new(db, logger, config)
+    rescue Errno::ENOENT => error
+      if error.message.include?("No such file or directory")
+        raise ActiveRecord::NoDatabaseError.new(error.message)
+      else
+        raise error
+      end
     end
   end
 

--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -16,6 +16,20 @@ module ActiveRecord
         eosql
       end
 
+      def test_bad_connection_mysql
+        assert_raise ActiveRecord::NoDatabaseError do
+          connection = ActiveRecord::Base.mysql_connection(adapter: "mysql", database: "should_not_exist-cinco-dog-db")
+          connection.exec_query('drop table if exists ex')
+        end
+      end
+
+      def test_bad_connection_mysql2
+        assert_raise ActiveRecord::NoDatabaseError do
+          connection = ActiveRecord::Base.mysql2_connection(adapter: "mysql2", database: "should_not_exist-cinco-dog-db")
+          connection.exec_query('drop table if exists ex')
+        end
+      end
+
       def test_valid_column
         column = @conn.columns('ex').find { |col| col.name == 'id' }
         assert @conn.valid_type?(column.type)

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -26,6 +26,13 @@ module ActiveRecord
         ActiveSupport::Notifications.subscribe('sql.active_record', @subscriber)
       end
 
+      def test_bad_connection
+        assert_raise ActiveRecord::NoDatabaseError do
+          connection = ActiveRecord::Base.sqlite3_connection(adapter: "sqlite3", database: "/tmp/should/_not/_exist/-cinco-dog.db")
+          connection.exec_query('drop table if exists ex')
+        end
+      end
+
       def test_connect_with_url
         original_connection = ActiveRecord::Base.remove_connection
         tf = Tempfile.open 'whatever'


### PR DESCRIPTION
Building on the work of #13427 this PR adds a helpful error message to the adapters: mysql, mysql2, and sqlite3
