### PR TITLE
Fix railties tests in master

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -93,7 +93,8 @@ module TestHelpers
     # Build an application by invoking the generator and going through the whole stack.
     def build_app(options = {})
       @prev_rails_env = ENV['RAILS_ENV']
-      ENV['RAILS_ENV'] = 'development'
+      ENV['RAILS_ENV']             = 'development'
+      ENV['RAILS_SECRET_KEY_BASE'] ||= SecureRandom.hex(16)
 
       FileUtils.rm_rf(app_path)
       FileUtils.cp_r(app_template_path, app_path)


### PR DESCRIPTION
Tests are failing due to missing env var on master https://travis-ci.org/rails/rails/jobs/15930622#L641

This adds an environment variable `ENV['RAILS_SECRET_KEY_BASE']` so these tests will pass.
