### PR TITLE
Copy changed_attributes across to newly become'd records

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -181,6 +181,7 @@ module ActiveRecord
       became = klass.new
       became.instance_variable_set("@attributes", @attributes)
       became.instance_variable_set("@attributes_cache", @attributes_cache)
+      became.instance_variable_set("@changed_attributes", @changed_attributes)
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became.instance_variable_set("@errors", errors)

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -152,6 +152,20 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal original_errors, client.errors
   end
 
+  def test_dupd_becomes_persists_changes_from_the_original
+    original = topics(:first)
+    copy = original.dup.becomes(Reply)
+    copy.save!
+    assert_equal "The First Topic", Topic.find(copy.id).title
+  end
+
+  def test_becomes_includes_changed_attributes
+    company = Company.new(name: "37signals")
+    client = company.becomes(Client)
+    assert_equal "37signals", client.name
+    assert_equal %w{name}, client.changed
+  end
+
   def test_delete_many
     original_count = Topic.count
     Topic.delete(deleting = [1, 2])


### PR DESCRIPTION
Without this, the original record's values won't get saved, since the partial insertions support (https://github.com/rails/rails/commit/144e8691cbfb8bba77f18cfe68d5e7fd48887f5e) checks for changed values and thinks there are none.

I was running into this when copying an STI record from one subtype to another, with : 

``` ruby
foo = Foo.last
bar = foo.dup.becomes(Bar)
bar.save
```

and bar would be missing attributes from Foo.  This problem shows up anytime after https://github.com/rails/rails/commit/144e8691cbfb8bba77f18cfe68d5e7fd48887f5e, so the above worked fine in Rails 3.2
