### PR TITLE
Move mysql2 test for when adapter will be loaded

### DIFF
--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -23,13 +23,6 @@ module ActiveRecord
         end
       end
 
-      def test_bad_connection_mysql2
-        assert_raise ActiveRecord::NoDatabaseError do
-          connection = ActiveRecord::Base.mysql2_connection(adapter: "mysql2", database: "should_not_exist-cinco-dog-db")
-          connection.exec_query('drop table if exists ex')
-        end
-      end
-
       def test_valid_column
         column = @conn.columns('ex').find { |col| col.name == 'id' }
         assert @conn.valid_type?(column.type)

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -13,6 +13,13 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     super
   end
 
+  def test_bad_connection
+    assert_raise ActiveRecord::NoDatabaseError do
+      connection = ActiveRecord::Base.mysql2_connection(adapter: "mysql2", database: "should_not_exist-cinco-dog-db")
+      connection.exec_query('drop table if exists ex')
+    end
+  end
+
   def test_no_automatic_reconnection_after_timeout
     assert @connection.active?
     @connection.update('set @@wait_timeout=1')


### PR DESCRIPTION
When run with only the Mysql adapter, we get this failure: https://travis-ci.org/rails/rails/jobs/15937907#L2416

Porting the test over to only run when mysql2 is loaded
