### PR TITLE
Implicit render should set actual content type

### DIFF
--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -2,7 +2,10 @@ module ActionController
   module ImplicitRender
     def send_action(method, *args)
       ret = super
-      default_render unless performed?
+      unless performed?
+        lookup_context.rendered_format = nil
+        default_render
+      end
       ret
     end
 

--- a/actionpack/test/controller/content_type_test.rb
+++ b/actionpack/test/controller/content_type_test.rb
@@ -60,6 +60,14 @@ class ContentTypeTest < ActionController::TestCase
     @controller.logger = ActiveSupport::Logger.new(nil)
   end
 
+  def test_set_content_type_for_implicit_render
+    get :render_default_content_types_for_respond_to, :format => :js
+    assert_equal "text/javascript", @response.content_type
+
+    get :render_default_for_erb, :format => :html
+    assert_equal "text/html", @response.content_type
+  end
+
   # :ported:
   def test_render_defaults
     get :render_defaults


### PR DESCRIPTION
Implicit render is not setting actual content type if there's been any other format rendered.
For instance:

``` ruby
def action
  string = render_to_string :template =>"template", :formats => [:js]
end
```

with test 

``` ruby
test "content_type"
  get :action
  assert_equal "text/html", response.content_type
end
```

will fail and set `Content-Type="text/javascript; charset=utf-8"` in header, even though html is processed and rendered.
