### PR TITLE
Partial fix of database url tests

### DIFF
--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -143,7 +143,7 @@ module ActiveRecord
     def test_establishes_connection_for_the_given_environment
       ActiveRecord::Tasks::DatabaseTasks.stubs(:create).returns true
 
-      ActiveRecord::Base.expects(:establish_connection).with('development')
+      ActiveRecord::Base.expects(:establish_connection).with(:development)
 
       ActiveRecord::Tasks::DatabaseTasks.create_current(
         ActiveSupport::StringInquirer.new('development')

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -129,7 +129,7 @@ module ApplicationTests
            bundle exec rake db:migrate db:structure:dump`
           structure_dump = File.read("db/structure.sql")
           assert_match(/CREATE TABLE \"books\"/, structure_dump)
-          `bundle exec rake db:drop db:structure:load`
+          `bundle exec rake environment db:drop db:structure:load`
           assert_match(/#{expected[:database]}/,
                         ActiveRecord::Base.connection_config[:database])
           require "#{app_path}/app/models/book"

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -20,9 +20,12 @@ module ApplicationTests
       end
 
       def set_database_url
-        ENV['DATABASE_URL'] = File.join("sqlite3://:@localhost", database_url_db_name)
+        ENV['RAILS_DATABASE_URL'] = File.join("sqlite3://:@localhost", database_url_db_name)
         # ensure it's using the DATABASE_URL
         FileUtils.rm_rf("#{app_path}/config/database.yml")
+        File.open("#{app_path}/config/database.yml", 'w') do |f|
+          f << {ENV['RAILS_ENV'] => '<%= ENV["RAILS_DATABASE_URL"] %>'}.to_yaml
+        end
       end
 
       def expected

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -24,7 +24,7 @@ module ApplicationTests
         # ensure it's using the DATABASE_URL
         FileUtils.rm_rf("#{app_path}/config/database.yml")
         File.open("#{app_path}/config/database.yml", 'w') do |f|
-          f << {ENV['RAILS_ENV'] => '<%= ENV["RAILS_DATABASE_URL"] %>'}.to_yaml
+          f << {ENV['RAILS_ENV'] => %Q{<%= ENV['RAILS_DATABASE_URL'] %>}}.to_yaml
         end
       end
 


### PR DESCRIPTION
Prior to #13463 when `DATABASE_URL` was set, Rails automagically used that value instead of the database.yml. There are tests in dbs_test that expect this to still be true. After that PR, `RAILS_DATABASE_URL` is expected to be read into the YAML file via ERB, this PR fixes that behavior.

Note: this does not entirely fix the tests. It seems that `ActiveRecord::Tasks::DatabaseTasks.current_config` does not process the url string correctly (convert it into a hash), and `ActiveRecord::Tasks::DatabaseTasks.structure_load(current_config, filename)` as well as other methods in `DatabaseTasks` expect a hash.

It seems like we should involve the resolver somewhere in this process to correctly convert the database url, I do not know the best place for that /cc @josevalim
