### PR TITLE
Use String#scrub when available to tidy bytes

### DIFF
--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -212,37 +212,43 @@ module ActiveSupport
         codepoints
       end
 
-      # Replaces all ISO-8859-1 or CP1252 characters by their UTF-8 equivalent
-      # resulting in a valid UTF-8 string.
-      #
-      # Passing +true+ will forcibly tidy all bytes, assuming that the string's
-      # encoding is entirely CP1252 or ISO-8859-1.
-      def tidy_bytes(string, force = false)
-        return string if string.empty?
-
-        if force
-          return string.encode(Encoding::UTF_8, Encoding::Windows_1252, invalid: :replace, undef: :replace)
+      # Ruby >= 2.1 has String#scrub, which is faster than the workaround used for < 2.1.
+      if RUBY_VERSION >= '2.1'
+        # Replaces all ISO-8859-1 or CP1252 characters by their UTF-8 equivalent
+        # resulting in a valid UTF-8 string.
+        #
+        # Passing +true+ will forcibly tidy all bytes, assuming that the string's
+        # encoding is entirely CP1252 or ISO-8859-1.
+        def tidy_bytes(string, force = false)
+          return string if string.empty?
+          return recode_windows1252_chars(string) if force
+          string.scrub { |bad| recode_windows1252_chars(bad) }
         end
+      else
+        def tidy_bytes(string, force = false)
+          return string if string.empty?
+          return recode_windows1252_chars(string) if force
 
-        # We can't transcode to the same format, so we choose a nearly-identical encoding.
-        # We're going to 'transcode' bytes from UTF-8 when possible, then fall back to
-        # CP1252 when we get errors. The final string will be 'converted' back to UTF-8
-        # before returning.
-        reader = Encoding::Converter.new(Encoding::UTF_8, Encoding::UTF_8_MAC)
+          # We can't transcode to the same format, so we choose a nearly-identical encoding.
+          # We're going to 'transcode' bytes from UTF-8 when possible, then fall back to
+          # CP1252 when we get errors. The final string will be 'converted' back to UTF-8
+          # before returning.
+          reader = Encoding::Converter.new(Encoding::UTF_8, Encoding::UTF_8_MAC)
 
-        source = string.dup
-        out = ''.force_encoding(Encoding::UTF_8_MAC)
+          source = string.dup
+          out = ''.force_encoding(Encoding::UTF_8_MAC)
 
-        loop do
-          reader.primitive_convert(source, out)
-          _, _, _, error_bytes, _ = reader.primitive_errinfo
-          break if error_bytes.nil?
-          out << error_bytes.encode(Encoding::UTF_8_MAC, Encoding::Windows_1252, invalid: :replace, undef: :replace)
+          loop do
+            reader.primitive_convert(source, out)
+            _, _, _, error_bytes, _ = reader.primitive_errinfo
+            break if error_bytes.nil?
+            out << error_bytes.encode(Encoding::UTF_8_MAC, Encoding::Windows_1252, invalid: :replace, undef: :replace)
+          end
+
+          reader.finish
+
+          out.encode!(Encoding::UTF_8)
         end
-
-        reader.finish
-
-        out.encode!(Encoding::UTF_8)
       end
 
       # Returns the KC normalization of the string by default. NFKC is
@@ -371,14 +377,8 @@ module ActiveSupport
         end.pack('U*')
       end
 
-      def tidy_byte(byte)
-        if byte < 160
-          [database.cp1252[byte] || byte].pack("U").unpack("C*")
-        elsif byte < 192
-          [194, byte]
-        else
-          [195, byte - 64]
-        end
+      def recode_windows1252_chars(string)
+        string.encode(Encoding::UTF_8, Encoding::Windows_1252, invalid: :replace, undef: :replace)
       end
 
       def database


### PR DESCRIPTION
Continuing on the fine work by @burke in rails/rails#10355 this makes `tidy_bytes` use `String#scrub` on Ruby 2.1 and up. This yields another performance bump running the following benchmark - adapted from @burke's original to ensure we're measuring the performance when bytes are actually being changed:

``` ruby
require 'benchmark'
require 'active_support/multibyte'

single_byte_cases = {
  "\x21" => "!",   # Valid ASCII byte, low
  "\x41" => "A",   # Valid ASCII byte, mid
  "\x7E" => "~",   # Valid ASCII byte, high
  "\x80" => "€",   # Continuation byte, low (cp125)
  "\x94" => "”",   # Continuation byte, mid (cp125)
  "\x9F" => "Ÿ",   # Continuation byte, high (cp125)
  "\xC0" => "À",   # Overlong encoding, start of 2-byte sequence, but codepoint < 128
  "\xC1" => "Á",   # Overlong encoding, start of 2-byte sequence, but codepoint < 128
  "\xC2" => "Â",   # Start of 2-byte sequence, low
  "\xC8" => "È",   # Start of 2-byte sequence, mid
  "\xDF" => "ß",   # Start of 2-byte sequence, high
  "\xE0" => "à",   # Start of 3-byte sequence, low
  "\xE8" => "è",   # Start of 3-byte sequence, mid
  "\xEF" => "ï",   # Start of 3-byte sequence, high
  "\xF0" => "ð",   # Start of 4-byte sequence
  "\xF1" => "ñ",   # Unused byte
  "\xFF" => "ÿ",   # Restricted byte
  "\x00" => "\x00" # null char
}

str = single_byte_cases.keys.join

u = ActiveSupport::Multibyte::Unicode

res = Benchmark.realtime do
  10_000.times do
    u.tidy_bytes(str)
  end
end

puts "tidy_bytes took #{res / 10}ms"
```

On: ruby 2.1.0p0 (2013-12-25 revision 44422) [x86_64-darwin13.0]

Without change: tidy_bytes took 0.2071831ms
With change: tidy_bytes took 0.11698470000000001ms
