### PR TITLE
Ensure backward compatibility between Minitest 5 and 4

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -29,6 +29,9 @@ end
 require 'minitest/autorun'
 require 'rack/test'
 
+# Ensure backward compatibility with Minitest 4
+Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
+
 class BugTest < Minitest::Test
   include Rack::Test::Methods
 

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -4,6 +4,9 @@ require 'active_record'
 require 'minitest/autorun'
 require 'logger'
 
+# Ensure backward compatibility with Minitest 4
+Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
+
 # This connection will do for database-independent bug reports.
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
 ActiveRecord::Base.logger = Logger.new(STDOUT)


### PR DESCRIPTION
Hello,

Just a pull request that define `Minitest::Test` in case we are running the bug report gist under Minitest 4 and avoid relying on `MiniTest::Unit::TestCase` to avoid displaying warning on version five.

Reference : #13502

Have a nice day.
