### PR TITLE
Update the files under the public directory upgrading

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Update the files under the public directory when upgrading
+
+    While running `bin/rake rails:update`, the files under the public
+    directory should be updated as the ones under config or bin.
+
+    Fixes #13499.
+
+    *Robin Dupret*
+
 *   Configure `secrets.yml` and `database.yml` to read configuration
     from the system environment by default for production.
 

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -1,6 +1,6 @@
 namespace :rails do
   desc "Update configs and some other initially generated files (or use just update:configs or update:bin)"
-  task update: [ "update:configs", "update:bin" ]
+  task update: [ "update:configs", "update:bin", "update:public" ]
 
   desc "Applies the template supplied by LOCATION=(/path/to/template) or URL"
   task :template do
@@ -61,6 +61,11 @@ namespace :rails do
     # desc "Adds new executables to the application bin/ directory"
     task :bin do
       invoke_from_app_generator :create_bin_files
+    end
+
+    # desc "Update the static files under the public/ directory"
+    task :public do
+      invoke_from_app_generator :create_public_files
     end
   end
 end


### PR DESCRIPTION
Hello,

This pull request allows updating the files under the `public` directory when upgrading an application through `bin/rake rails:update` (just like files under `config` and `bin`). As far as I can see, there is no way to test this feature so I've tested with an application pointing to my local repository and everything seems fine. 

Fixes #13499.

Have a nice day.
