### PR TITLE
Hstore arrays fix (follow up for #11444)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Perform necessary deeper encoding when hstore is inside an array.
+
+    Fixes #11135.
+
+    *Josh Goodall*, *Genadi Samokovarov*
+
 *   Properly detect if a connection is still active before using it
     in multi-threaded environments.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -35,11 +35,11 @@ module ActiveRecord
           end
         end
 
-        def hstore_to_string(object)
+        def hstore_to_string(object, array_member = false)
           if Hash === object
-            object.map { |k,v|
-              "#{escape_hstore(k)}=>#{escape_hstore(v)}"
-            }.join ','
+            string = object.map { |k, v| "#{escape_hstore(k)}=>#{escape_hstore(v)}" }.join(',')
+            string = escape_hstore(string) if array_member
+            string
           else
             object
           end
@@ -49,10 +49,10 @@ module ActiveRecord
           if string.nil?
             nil
           elsif String === string
-            Hash[string.scan(HstorePair).map { |k,v|
+            Hash[string.scan(HstorePair).map { |k, v|
               v = v.upcase == 'NULL' ? nil : v.gsub(/\A"(.*)"\Z/m,'\1').gsub(/\\(.)/, '\1')
               k = k.gsub(/\A"(.*)"\Z/m,'\1').gsub(/\\(.)/, '\1')
-              [k,v]
+              [k, v]
             }]
           else
             string

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -121,7 +121,7 @@ module ActiveRecord
             end
           when Hash
             case column.sql_type
-            when 'hstore' then PostgreSQLColumn.hstore_to_string(value)
+            when 'hstore' then PostgreSQLColumn.hstore_to_string(value, array_member)
             when 'json' then PostgreSQLColumn.json_to_string(value)
             else super(value, column)
             end


### PR DESCRIPTION
I took #11444, rebased it to the current master and addressed @senny comments.

I'm getting the following error locally, and I'm not currently sure if its happening because of the changes:

```
  1) Error:
TimestampTest#test_bc_timestamp:
ActiveRecord::StatementInvalid: PG::DatetimeFieldOverflow: ERROR:  date/time field value out of range: "0000-01-01 07:52:57.000000 BC"
: INSERT INTO "developers" ("created_at", "created_on", "name", "updated_at", "updated_on") VALUES ($1, $2, $3, $4, $5) RETURNING "id"
    /vagrant/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:818:in `get_last_result'
   ...
```

Using this as a test bed to see if it also fails on Travis :)
