### PR TITLE
Removed warnings: setting `changed_attributes` instance variable if it is already initialized.

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -181,7 +181,7 @@ module ActiveRecord
       became = klass.new
       became.instance_variable_set("@attributes", @attributes)
       became.instance_variable_set("@attributes_cache", @attributes_cache)
-      became.instance_variable_set("@changed_attributes", @changed_attributes)
+      became.instance_variable_set("@changed_attributes", @changed_attributes) if defined?(@changed_attributes)
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became.instance_variable_set("@errors", errors)


### PR DESCRIPTION
This is a follow up to #13474 

The warning appears when `Model#becomes` is called. It only happens when the model was not changed before the `becomes` call.

**no warning:**

``` ruby
post = Post.first
post.title = "new"
post.becomes(Article)
```

**warning:**

``` ruby
post = Post.first
post.becomes(Article)
```

```
/Users/senny/Projects/rails/activerecord/lib/active_record/persistence.rb:184: warning: instance variable @changed_attributes not initialized
```

**solution:**

This PR solves the problem by accessing `@changed_attributes` only if it has been defined previously.
