### PR TITLE
Added warning when user tried to create model with pluralize name.

### DIFF
--- a/railties/lib/rails/generators/model_helpers.rb
+++ b/railties/lib/rails/generators/model_helpers.rb
@@ -1,0 +1,26 @@
+require 'rails/generators/active_model'
+
+module Rails
+  module Generators
+    module ModelHelpers # :nodoc:
+      PLURAL_MODEL_NAME_WARN_MESSAGE = 'Plural version of the model detected, using singularized version. Override with --force-plural or setup custom inflection rules for this noun before running the generator.'
+      mattr_accessor :skip_warn
+
+      def self.included(base) #:nodoc:
+        base.class_option :force_plural, type: :boolean, default: false, desc: 'Forces the use of a plural model name'
+      end
+
+      def initialize(args, *_options)
+        super
+        if name == name.pluralize && name.singularize != name.pluralize && !options[:force_plural]
+          unless ModelHelpers.skip_warn
+            say PLURAL_MODEL_NAME_WARN_MESSAGE
+            ModelHelpers.skip_warn = true
+          end
+          name.replace name.singularize
+          assign_names!(name)
+        end
+      end
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/model/model_generator.rb
+++ b/railties/lib/rails/generators/rails/model/model_generator.rb
@@ -1,6 +1,10 @@
+require 'rails/generators/model_helpers'
+
 module Rails
   module Generators
     class ModelGenerator < NamedBase # :nodoc:
+      include Rails::Generators::ModelHelpers
+
       argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
       hook_for :orm, required: true
     end

--- a/railties/lib/rails/generators/resource_helpers.rb
+++ b/railties/lib/rails/generators/resource_helpers.rb
@@ -1,14 +1,14 @@
 require 'rails/generators/active_model'
+require 'rails/generators/model_helpers'
 
 module Rails
   module Generators
     # Deal with controller names on scaffold and add some helpers to deal with
     # ActiveModel.
     module ResourceHelpers # :nodoc:
-      mattr_accessor :skip_warn
 
       def self.included(base) #:nodoc:
-        base.class_option :force_plural, type: :boolean, desc: "Forces the use of a plural ModelName"
+        base.send :include, Rails::Generators::ModelHelpers
         base.class_option :model_name, type: :string, desc: "ModelName to be used"
       end
 
@@ -19,15 +19,6 @@ module Rails
         if options[:model_name]
           self.name = options[:model_name]
           assign_names!(self.name)
-        end
-
-        if name == name.pluralize && name.singularize != name.pluralize && !options[:force_plural]
-          unless ResourceHelpers.skip_warn
-            say "Plural version of the model detected, using singularized version. Override with --force-plural."
-            ResourceHelpers.skip_warn = true
-          end
-          name.replace name.singularize
-          assign_names!(name)
         end
 
         assign_controller_names!(controller_name.pluralize)

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -34,6 +34,13 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_no_migration "db/migrate/create_accounts.rb"
   end
 
+  def test_plural_names_are_singularized
+    content = run_generator ["accounts".freeze]
+    assert_file "app/models/account.rb", /class Account < ActiveRecord::Base/
+    assert_file "test/models/account_test.rb", /class AccountTest/
+    assert_match(/Plural version of the model detected, using singularized version. Override with --force-plural or setup custom inflection rules for this noun before running the generator./, content)
+  end
+
   def test_model_with_underscored_parent_option
     run_generator ["account", "--parent", "admin/account"]
     assert_file "app/models/account.rb", /class Account < Admin::Account/

--- a/railties/test/generators/resource_generator_test.rb
+++ b/railties/test/generators/resource_generator_test.rb
@@ -63,7 +63,7 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
     content = run_generator ["accounts".freeze]
     assert_file "app/models/account.rb", /class Account < ActiveRecord::Base/
     assert_file "test/models/account_test.rb", /class AccountTest/
-    assert_match(/Plural version of the model detected, using singularized version. Override with --force-plural./, content)
+    assert_match(/Plural version of the model detected, using singularized version. Override with --force-plural or setup custom inflection rules for this noun before running the generator./, content)
   end
 
   def test_plural_names_can_be_forced


### PR DESCRIPTION
This PR will generate singularized model and its corresponding files even if user(specially newbies) mistaken provide pluralized model name.

```
Before

$ rails g model posts title:string
      invoke  active_record
      create    db/migrate/20120621124605_create_posts.rb
      create    app/models/posts.rb
      invoke    test_unit
      create      test/unit/posts_test.rb
      create      test/fixtures/posts.yml

After

$ rails g model posts title:string
Plural version of the model detected, using singularized version. Override with --force-plural.
      invoke  active_record
      create    db/migrate/20131228115512_create_post.rb
      create    app/models/post.rb
      invoke    test_unit
      create      test/models/post_test.rb
      create      test/fixtures/posts.yml
```

And if user still wants to add plural model name then `--force-plural` option can be used. like:

```
$ rails g model posts title:string  --force-plural
      invoke  active_record
      create    db/migrate/20131228130740_create_posts.rb
      create    app/models/posts.rb
      invoke    test_unit
      create      test/models/posts_test.rb
      create      test/fixtures/posts.yml
```
