### PR TITLE
Update String#blank? to use fastest implementation

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -92,7 +92,7 @@ class String
   #   '　'.blank?               # => true
   #   ' something here '.blank? # => false
   def blank?
-    self =~ BLANK_MATCHER
+    BLANK_MATCHER === self
   end
 end
 


### PR DESCRIPTION
See discussion in #13517

``` ruby
require "benchmark/ips"

BLANK_MATCHER = /\A[[:space:]]*\z/

Benchmark.ips do |x|
  x.report("==="){ BLANK_MATCHER === "string" }
  x.report("!! =~"){ !!("string" =~ BLANK_MATCHER) }
  x.report("original"){ "string" =~ BLANK_MATCHER }
end
```

Results for ruby 2.0.0p353:

```
Calculating -------------------------------------
                 ===     54480 i/100ms
               !! =~     56299 i/100ms
            original     56963 i/100ms
-------------------------------------------------
                 ===  1384704.9 (±7.0%) i/s -    6918960 in   5.029491s
               !! =~  1384745.8 (±6.2%) i/s -    6924777 in   5.022844s
            original  1369771.6 (±9.7%) i/s -    6778597 in   5.025367s
```

Results for ruby 2.1.0p0

```
Calculating -------------------------------------
                 ===     53584 i/100ms
               !! =~     57575 i/100ms
            original     59324 i/100ms
-------------------------------------------------
                 ===  1657918.6 (±5.1%) i/s -    8305520 in   5.023902s
               !! =~  1475822.7 (±7.7%) i/s -    7369600 in   5.027467s
            original  1602640.1 (±7.1%) i/s -    8008740 in   5.024903s
```
