### PR TITLE
Make outer joins on proper parent

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -114,7 +114,7 @@ module ActiveRecord
             walk join_root, oj.join_root
           else
             oj.join_root.children.flat_map { |child|
-              make_outer_joins join_root, child
+              make_outer_joins oj.join_root, child
             }
           end
         }


### PR DESCRIPTION
Outer joins were being built on the root relation klass rather than the
one specified in the join dependency root

Noticed this one while trying to figure out how to upgrade the hacks in ransack after the latest refactoring in JoinDependency api.

// @tenderlove
