### PR TITLE
Fixed AR warnings while executing test suites

### DIFF
--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -61,8 +61,10 @@ module ActiveRecord::Associations::Builder
     def self.define_readers(mixin, name)
       super
 
+      _method_name = "#{name.to_s.singularize}_ids"
+      mixin.remove_possible_method _method_name
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name.to_s.singularize}_ids
+        def #{ _method_name }
           association(:#{name}).ids_reader
         end
       CODE
@@ -71,8 +73,10 @@ module ActiveRecord::Associations::Builder
     def self.define_writers(mixin, name)
       super
 
+      _method_name = "#{name.to_s.singularize}_ids="
+      mixin.remove_possible_method _method_name
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name.to_s.singularize}_ids=(ids)
+        def #{ _method_name }(ids)
           association(:#{name}).ids_writer(ids)
         end
       CODE


### PR DESCRIPTION
Removed warnings when test suites of AR are executed:

```
  /Volumes/kd/projects/kd-rails/activerecord/lib/active_record/associations/builder/collection_association.rb:65: warning: method redefined; discarding old welcome_posts_with_comment_ids
  /Volumes/kd/projects/kd-rails/activerecord/lib/active_record/associations/builder/collection_association.rb:65: warning: previous definition of welcome_posts_with_comment_ids was here
  /Volumes/kd/projects/kd-rails/activerecord/lib/active_record/associations/builder/collection_association.rb:75: warning: method redefined; discarding old welcome_posts_with_comment_ids=
  /Volumes/kd/projects/kd-rails/activerecord/lib/active_record/associations/builder/collection_association.rb:75: warning: previous definition of welcome_posts_with_comment_ids= was here
```
