### PR TITLE
Fixed- Machine dependent AR test cases

### DIFF
--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -18,7 +18,8 @@ module ActiveRecord
 
       def test_bad_connection_mysql
         assert_raise ActiveRecord::NoDatabaseError do
-          connection = ActiveRecord::Base.mysql_connection(adapter: "mysql", database: "should_not_exist-cinco-dog-db")
+          configuration = ActiveRecord::Base.configurations['arunit'].merge(database: 'should_not_exist-cinco-dog-db')
+          connection = ActiveRecord::Base.mysql_connection(configuration)
           connection.exec_query('drop table if exists ex')
         end
       end

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -15,7 +15,8 @@ class MysqlConnectionTest < ActiveRecord::TestCase
 
   def test_bad_connection
     assert_raise ActiveRecord::NoDatabaseError do
-      connection = ActiveRecord::Base.mysql2_connection(adapter: "mysql2", database: "should_not_exist-cinco-dog-db")
+      configuration = ActiveRecord::Base.configurations['arunit'].merge(database: 'should_not_exist-cinco-dog-db')
+      connection = ActiveRecord::Base.mysql2_connection(configuration)
       connection.exec_query('drop table if exists ex')
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -12,7 +12,8 @@ module ActiveRecord
 
       def test_bad_connection
         assert_raise ActiveRecord::NoDatabaseError do
-          connection = ActiveRecord::Base.postgresql_connection(database: "should_not_exist-cinco-dog-db", adapter: "postgresql")
+          configuration = ActiveRecord::Base.configurations['arunit'].merge(database: 'should_not_exist-cinco-dog-db')
+          connection = ActiveRecord::Base.postgresql_connection(configuration)
           connection.exec_query('drop table if exists ex')
         end
       end


### PR DESCRIPTION
This is a follow up to https://github.com/rails/rails/pull/13469, and https://github.com/rails/rails/pull/13478
When user tried to execute test cases(either for a particular adapter or for all adapters), like:

```
$rake test_mysql2

  1) Failure:
MysqlConnectionTest#test_bad_connection [/Volumes/kd/projects/kd-rails/activerecord/test/cases/adapters/mysql2/connection_test.rb:17]:
[ActiveRecord::NoDatabaseError] exception expected, not
Class: <Mysql2::Error>
Message: <"Access denied for user 'root'@'localhost' (using password: NO)">
---Backtrace---
/Users/kd/.rvm/gems/ruby-1.9.3-p448/gems/mysql2-0.3.14/lib/mysql2/client.rb:67:in `connect'
/Users/kd/.rvm/gems/ruby-1.9.3-p448/gems/mysql2-0.3.14/lib/mysql2/client.rb:67:in `initialize'
/Volumes/kd/projects/kd-rails/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb:18:in `new'
/Volumes/kd/projects/kd-rails/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb:18:in `mysql2_connection'
/Volumes/kd/projects/kd-rails/activerecord/test/cases/adapters/mysql2/connection_test.rb:18:in `block in test_bad_connection'
---------------


```

then all the test cases passed except `test_bad_connection` test and it is because the user has configured custom password for the adapter. This PR uses `ActiveRecord::Base.configurations` for executing `test_bad_connection` test case.
