### PR TITLE
Fix ActionMailer config loading regression.

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -41,11 +41,15 @@ module ActionMailer
       end
     end
 
-    initializer "action_mailer.configure_mailer_previews", before: :set_autoload_paths do |app|
+    initializer "action_mailer.configure_mailer_previews", before: :set_routes_reloader_hook do |app|
       if Rails.env.development?
         options = app.config.action_mailer
         options.preview_path ||= defined?(Rails.root) ? "#{Rails.root}/test/mailers/previews" : nil
         app.config.autoload_paths << options.preview_path
+        # Ensure preview path is autoloaded
+        ActiveSupport::Dependencies.autoload_paths << options.preview_path
+        # Freeze so future modifications will fail rather than do nothing mysteriously
+        app.config.autoload_paths.freeze
       end
     end
   end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -562,7 +562,6 @@ module Rails
       ActiveSupport::Dependencies.autoload_once_paths.unshift(*_all_autoload_once_paths)
 
       # Freeze so future modifications will fail rather than do nothing mysteriously
-      config.autoload_paths.freeze
       config.eager_load_paths.freeze
       config.autoload_once_paths.freeze
     end


### PR DESCRIPTION
https://github.com/rails/rails/commit/d6dec7fcb6b8fddf8c170182d4fe64ecfc7b2261 added mail-preview feature that defined

`before: :set_autoload_paths` initializer, making all action_mailer initializers to be preloaded,
causing environment configs to be disregarded by action_mailer.

This moves `action_mailer.configure_mailer_previews` initializer to load as Railtie initializer to maintain correct behaviour.
Also since we affect `app.config.autoload_paths` don't freeze it in engine, but in AM initializer.

Fixes #13372
