### PR TITLE
allow user to set virtual attributes with becomes/becomes!

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -177,7 +177,7 @@ module ActiveRecord
     #
     # Note: The new instance will share a link to the same attributes as the original class.
     # So any change to the attributes in either instance will affect the other.
-    def becomes(klass)
+    def becomes(klass, *virtual_attributes)
       became = klass.new
       became.instance_variable_set("@attributes", @attributes)
       became.instance_variable_set("@attributes_cache", @attributes_cache)
@@ -185,6 +185,9 @@ module ActiveRecord
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became.instance_variable_set("@errors", errors)
+      virtual_attributes.each do |attr|
+        became.public_send("#{ attr }=", send(attr))
+      end
       became
     end
 
@@ -194,8 +197,8 @@ module ActiveRecord
     #
     # Note: The old instance's sti column value will be changed too, as both objects
     # share the same set of attributes.
-    def becomes!(klass)
-      became = becomes(klass)
+    def becomes!(klass, *virtual_attributes)
+      became = becomes(klass, *virtual_attributes)
       became.public_send("#{klass.inheritance_column}=", klass.sti_name) unless self.class.descends_from_active_record?
       became
     end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -166,6 +166,13 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal %w{name}, client.changed
   end
 
+  def test_becomes_includes_virtual_attributes
+    company = Company.new(name: '37signals', alias_name: 'Rails')
+    client = company.becomes(Client, :alias_name)
+    assert_equal '37signals', client.name
+    assert_equal 'Rails', client.alias_name
+  end
+
   def test_delete_many
     original_count = Topic.count
     Topic.delete(deleting = [1, 2])

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -5,6 +5,8 @@ end
 class Company < AbstractCompany
   self.sequence_name = :companies_nonstd_seq
 
+  attr_accessor :alias_name
+
   validates_presence_of :name
 
   has_one :dummy_account, :foreign_key => "firm_id", :class_name => "Account"


### PR DESCRIPTION
Previously `Model#becomes` and `Model#becomes!` sets only those values which are `persisted` in the database but with this PR, they will be able to pass a list of `virtual attributes` to `Model#becomes` that needs to set. like:

``` ruby
class Client < ActiveRecord::Base
  attr_accessor :alias_name
end

class Company < Client
end

# Before
company = Company.new(name: '37signals', alias_name: 'Rails')
client = company.becomes(Client)
client.alias_name # => nil

# After
company = Company.new(name: '37signals', alias_name: 'Rails')
client = company.becomes(Client, :alias_name)
client.alias_name # => 'Rails'

```
