### PR TITLE
raise ArgumentError exception

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -37,6 +37,8 @@ module ActiveRecord
       def not(opts, *rest)
         where_value = @scope.send(:build_where, opts, rest).map do |rel|
           case rel
+          when NilClass
+            raise ArgumentError, 'Invalid argument for .where.not(), got nil.'
           when Arel::Nodes::In
             Arel::Nodes::NotIn.new(rel.left, rel.right)
           when Arel::Nodes::Equality

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -23,6 +23,12 @@ module ActiveRecord
       assert_equal([expected], relation.where_values)
     end
 
+    def test_not_with_nil
+      assert_raise ArgumentError do
+        Post.where.not(nil)
+      end
+    end
+
     def test_not_in
       expected = Arel::Nodes::NotIn.new(Post.arel_table[@name], %w[hello goodbye])
       relation = Post.where.not(title: %w[hello goodbye])


### PR DESCRIPTION
If `Model.where.not` is called with `nil` argument then `ArgumentError` exception will be raised.

Before:

``` ruby
User.where.not(nil) # => 'SELECT `users`.* FROM `users`  WHERE (NOT (NULL))'
```

After:

``` ruby
User.where.not(nil) # => ArgumentError, 'Invalid argument for .where.not(), got nil.'
```
