### PR TITLE
involve sti_name and find_sti_class in subclass_from_attrs method

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -173,8 +173,8 @@ module ActiveRecord
       def subclass_from_attrs(attrs)
         subclass_name = attrs.with_indifferent_access[inheritance_column]
 
-        if subclass_name.present? && subclass_name != self.name
-          subclass = subclass_name.safe_constantize
+        if subclass_name.present? && subclass_name != sti_name
+          subclass = find_sti_class(subclass_name)
 
           unless descendants.include?(subclass)
             raise ActiveRecord::SubclassNotFound.new("Invalid single-table inheritance type: #{subclass_name} is not a subclass of #{name}")


### PR DESCRIPTION
This is needed when parent class override `find_sti_class` and `sti_name` methods

``` ruby
class Identity < ActiveRecord::Base
  self.inheritance_column = :provider

  class << self
    def find_sti_class(type_name)
      ActiveSupport::Dependencies.constantize "Identity::#{type_name.titleize}"
    end

    def sti_name
      name.demodulize.downcase
    end
  end
end

class Identity::Facebook < Identity
end

class Identity::Twitter < Identity
end
```

Without this fix `Identity.new provider: 'facebook'` raises "ActiveRecord::SubclassNotFound: Invalid single-table inheritance type: facebook is not a subclass of Identity" error
