### PR TITLE
Allow "url" sub key in database.yml configuration

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Connection specification now accepts a "url" key. The value of this
+    key is expected to contain a database URL. The database URL will be
+    expanded into a hash and merged.
+
+    *Richard Schneeman*
+
 *   An `ArgumentError` is now raised on a call to `Relation#where.not(nil)`.
 
     Example:

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -223,7 +223,15 @@ module ActiveRecord
           end
         end
 
+        # Accepts a hash. Expands the "url" key that contains a
+        # URL database connection to a full connection
+        # hash and merges with the rest of the hash.
+        # Connection details inside of the "url" key win any merge conflicts
         def resolve_hash_connection(spec)
+          if url = spec.delete("url")
+            connection_hash = resolve_string_connection(url)
+            spec.merge!(connection_hash)
+          end
           spec
         end
 

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -31,6 +31,24 @@ module ActiveRecord
             "encoding" => "utf8" }, spec)
         end
 
+        def test_url_sub_key
+          spec = resolve :production, 'production' => {"url" => 'abstract://foo?encoding=utf8'}
+          assert_equal({
+            "adapter"  => "abstract",
+            "host"     => "foo",
+            "encoding" => "utf8" }, spec)
+        end
+
+        def test_url_sub_key_merges_correctly
+          hash = {"url" => 'abstract://foo?encoding=utf8&', "adapter" => "sqlite3", "host" => "bar", "pool" => "3"}
+          spec = resolve :production, 'production' => hash
+          assert_equal({
+            "adapter"  => "abstract",
+            "host"     => "foo",
+            "encoding" => "utf8",
+            "pool"     => "3" }, spec)
+        end
+
         def test_url_host_no_db
           spec = resolve 'abstract://foo?encoding=utf8'
           assert_equal({


### PR DESCRIPTION
Currently a developer can pass in a YAML configuration that fully specifies connection information:

```
production:
  database: triage_production
  adapter: password
  pool: 5
```

They can also pass in a string that specifies a connection URL directly to an environment key:

```
production: postgresql://localhost/foo
```

This PR allows the use of both a connection url and specifying connection attributes via YAML through the use of the "url" sub key:

```
production:
  url: postgresql://localhost/foo
  pool: 3
```

This will allow developers to inherit Active Record options such as `pool` from `&defaults` and still use a secure connection url such as `<%= ENV['DATABASE_URL'] %>`. The URL is expanded into a hash and then merged back into the YAML hash. If there are any conflicts, the values from the connection URL are preferred. 

Talked this over with @josevalim
