### PR TITLE
Fix enum writers when using integers

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -1,5 +1,6 @@
 module ActiveRecord
-  # Declare an enum attribute where the values map to integers in the database, but can be queried by name. Example:
+  # Declare an enum attribute where the values map to integers in the database,
+  # but can be queried by name. Example:
   #
   #   class Conversation < ActiveRecord::Base
   #     enum status: [ :active, :archived ]
@@ -22,6 +23,10 @@ module ActiveRecord
   #   conversation.status = nil
   #   conversation.status.nil? # => true
   #   conversation.status      # => nil
+  #
+  # Scopes based on the allowed values of the enum field will be provided
+  # as well. With the above example, it will create an +active+ and +archived+
+  # scope.
   #
   # You can set the default value from the database declaration, like:
   #

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -67,7 +67,7 @@ module ActiveRecord
         _enum_methods_module.module_eval do
           # def status=(value) self[:status] = STATUS[value] end
           define_method("#{name}=") { |value|
-            unless enum_values.has_key?(value) || value.blank?
+            unless enum_values.has_key?(value) || enum_values.has_value?(value) || value.blank?
               raise ArgumentError, "'#{value}' is not a valid #{name}"
             end
             self[name] = enum_values[value]

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -16,7 +16,7 @@ class EnumTest < ActiveRecord::TestCase
     assert @book.unread?
   end
 
-  test "query state with symbol" do
+  test "query state with strings" do
     assert_equal "proposed", @book.status
     assert_equal "unread", @book.read_status
   end
@@ -77,5 +77,14 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal 0, Book::STATUS[:proposed]
     assert_equal 1, Book::STATUS["written"]
     assert_equal 2, Book::STATUS[:published]
+  end
+
+  test "first_or_initialize with enums' scopes" do
+    class Issue < ActiveRecord::Base
+      enum status: [:open, :closed]
+    end
+
+    assert Issue.open.empty?
+    assert Issue.open.first_or_initialize
   end
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -327,6 +327,10 @@ ActiveRecord::Schema.define do
     t.string     :color
   end
 
+  create_table :issues, force: true do |t|
+    t.integer :status
+  end
+
   create_table :items, force: true do |t|
     t.column :name, :string
   end


### PR DESCRIPTION
Hello,

This is just a little pull request that resolves some issues mentioned in #13530. Basically, the problem is described in [this gist](https://gist.github.com/robin850/6e3dd87e4dc34833aeac). Previously, a call to:

``` ruby
Book.where(status: 0).first_or_initialize
```

Would fail (an `ArgumentError` would be raised) because only the symbol version of the enum was checked when calling its writer method. I guess that `find_or_initialize` is calling it through the `initialize` (new) method.

I also added a mention about the scopes generated dynamically based on the allowed values of the field in the documentation.

I'm not really comfortable with Active Record and its internals so I'm certainly not very clear ; therefore, sorry. Let me know if I should update anything.

By the way, the issue mentioned above is not totally resolved since the `where` method doesn't generate the same queries with either a symbol or a numeric value on enum fields.

Have a nice day.
