### PR TITLE
We want to allow aria-* to pass like data-* in tag options

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support for aria-* style attributes similar to data-* HTML element attributes.
+
+    *Kurtis Rainbolt-Greene*
+
 *   Add mailer previews feature based on 37 Signals mail_view gem
 
     *Andrew White*

--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,7 +1,3 @@
-*   Support for aria-* style attributes similar to data-* HTML element attributes.
-
-    *Kurtis Rainbolt-Greene*
-
 *   Add mailer previews feature based on 37 Signals mail_view gem
 
     *Andrew White*

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support for aria-* style attributes similar to data-* HTML element attributes.
+
+    *Kurtis Rainbolt-Greene*
+
 *   The `video_tag` helper accepts a number as `:size`
 
     The `:size` option of the `video_tag` helper now can be specified

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -92,6 +92,11 @@ class TagHelperTest < ActionView::TestCase
       content_tag('p', "limelight", data: { number: 1, string: 'hello', string_with_quotes: 'double"quote"party"' })
   end
 
+  def test_content_tag_with_aria_attributes
+    assert_dom_equal('<p aria-maxvalue="100" aria-minvalue="1" aria-string-with-quotes="double&quot;quote&quot;party&quot;">limelight</p>',
+      content_tag('p', "limelight", aria: { maxvalue: 100, minvalue: "1", string_with_quotes: 'double"quote"party"' }))
+  end
+
   def test_cdata_section
     assert_equal "<![CDATA[<hello world>]]>", cdata_section("<hello world>")
   end
@@ -130,5 +135,13 @@ class TagHelperTest < ActionView::TestCase
       assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo" />',
         tag('a', { data => { a_float: 3.14, a_big_decimal: BigDecimal.new("-123.456"), a_number: 1, string: 'hello', symbol: :foo, array: [1, 2, 3], hash: { key: 'value'}, string_with_quotes: 'double"quote"party"' } })
     }
+  end
+
+  def test_aria_attributes
+    ['aria', :aria].each do |data|
+      dom = '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-array="[1,2,3]" aria-hash="{&quot;key&quot;:&quot;value&quot;}" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />'
+      content = tag('a', { data => { a_float: 3.14, a_big_decimal: BigDecimal.new("-123.456"), a_number: 1, string: 'hello', symbol: :foo, array: [1, 2, 3], hash: { key: 'value'}, string_with_quotes: 'double"quote"party"' } })
+      assert_dom_equal(dom, content)
+    end
   end
 end


### PR DESCRIPTION
Exactly like `data-*` attributes on HTML elements it is now common to
pass `aria-*` style attributes to tags (bootstrap for example). The
spec is defined here
http://rawgithub.com/w3c/aria-in-html/master/index.html

In this PR I’ve cleaned up some of the previous tag option formatting
to be a bit faster, smaller to reason, and opens up to future additions
of similar hash-like options. If for instance we wanted to add the
`rails-*` hash-like we’d just change `HASHLIKE_ATTRIBUTE_KEYS` to
`[‘data’, ‘aria’, ‘rails’]`
