### PR TITLE
Fix querying an array field with empty arrays.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Fixed wrong sql generated when querying an array field with empty array values.
+
+    Example:
+
+         With a table as
+         create_table :figures do |t|
+           t.string :spheres, array: true, null: false, default: []
+         end
+
+         Figure.where(spheres: []).to_sql
+         Figure.where.not(spheres: []).to_sql
+         Figure.where(spheres: [[]]).to_sql
+         all now handle and generate proper SQL queries.
+
+    Fixes #13479 .
+
+    *Vipul A M*, *Robert Fruchtman*, *Tadas Tamošauskas*
+
 *   Deprecated use of string argument as a configuration lookup in `ActiveRecord::Base.establish_connection`. Instead, a symbol must be given.
 
     *José Valim*

--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -5,7 +5,7 @@ module ActiveRecord
         values = value.map { |x| x.is_a?(Base) ? x.id : x }
         ranges, values = values.partition { |v| v.is_a?(Range) }
 
-        values_predicate = if values.include?(nil)
+        values_predicate = if values.empty? || values.include?(nil)
           values = values.compact
 
           case values.length

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -138,6 +138,14 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert_equal [], pg_array.reload.tags
   end
 
+  def test_querying_with_empty_array
+    refute_match /WHERE 1=0/, PgArray.where(tags: []).to_sql
+    refute_match /WHERE \(1=1\)/, PgArray.where.not(tags: []).to_sql
+    assert_no_raise do
+      PgArray.where.not(tags: [[]]).to_sql
+    end
+  end
+
   private
   def assert_cycle field, array
     # test creation


### PR DESCRIPTION
Previously for an array field, when a nil value was passed for querying it was compacted, and proper handling

of value in such compacted array was done there onwards to generate SQL.

This commit tried to expand this behavior to handle empty arrays the same way as an array with nil values,
for proper SQL generation while querying an array field.

Fixes #13479 .
