### PR TITLE
Allows using relation name when querying joins/includes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   When joining or including records, when querying the relation, you
+    can use either the table name or the relation name:
+
+    Example:
+        Author.joins(:posts_with_comments).where(posts: { id: 1})
+        # or
+        Author.joins(:posts_with_comments).where(posts_with_comments: { id: 1 })
+
+    *Dan McClain*
+
 *   `change_column_default` allows `[]` as argument to `change_column_default`.
 
     Fixes #11586.

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -15,6 +15,17 @@ module ActiveRecord
       hash
     end
 
+    def self.resolve_relation_names(klass, relation, hash)
+      joins_includes_values = relation.joins_values + relation.includes_values
+      hash = hash.dup
+      hash.keys.grep(Symbol) do |key|
+        if joins_includes_values.include?(key) && association = klass.reflect_on_association(key)
+          hash[association.table_name.to_sym] = hash.delete key
+        end
+      end
+      hash
+    end
+
     def self.build_from_hash(klass, attributes, default_table)
       queries = []
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -545,9 +545,14 @@ WARNING
     #    User.joins(:posts).where("posts.created_at < ?", Time.now)
     #
     # For hash conditions, you can either use the table name in the key, or use a sub-hash.
+    # The name of the sub-hash can be the table name or the relation name.
     #
     #    User.joins(:posts).where({ "posts.published" => true })
-    #    User.joins(:posts).where({ posts: { published: true } })
+    #
+    #    # Sub-hashes can either be the table name or the relation name
+    #    User.joins(:commented_on_posts).where({ posts: { published: true } })
+    #    # or
+    #    User.joins(:commented_on_posts).where({ commented_on_posts: { published: true } })
     #
     # === no argument
     #
@@ -950,6 +955,7 @@ WARNING
         [@klass.send(:sanitize_sql, other.empty? ? opts : ([opts] + other))]
       when Hash
         opts = PredicateBuilder.resolve_column_aliases(klass, opts)
+        opts = PredicateBuilder.resolve_relation_names(klass, self, opts)
         attributes = @klass.send(:expand_hash_conditions_for_aggregates, opts)
 
         bv_len = bind_values.length

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -144,6 +144,13 @@ module ActiveRecord
       assert_equal expected.to_sql, actual.to_sql
     end
 
+    def test_nested_where_with_renamed_relation
+      expected = Author.joins(:posts_with_comments).where(posts: { id: 1})
+      actual   = Author.joins(:posts_with_comments).where(posts_with_comments: { id: 1})
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
     def test_aliased_attribute
       expected = Topic.where(heading: 'The First Topic')
       actual   = Topic.where(title: 'The First Topic')


### PR DESCRIPTION
When joining or including records, when querying the relation, you can use either the table name or the relation name:

Example:

``` ruby
Author.joins(:posts_with_comments).where(posts: { id: 1})
# or
Author.joins(:posts_with_comments).where(posts_with_comments: { id: 1})
```
