### PR TITLE
Avoid raising a NameError on FreeBSD using Date

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Use `remove_possible_method` instead of `remove_method` to avoid
+    a `NameError` to be thrown on FreeBSD with the `Date` object.
+
+    *Rafael Mendonça França*, *Robin Dupret*
+
 *   `blank?` and `present?` commit to return singletons.
 
     *Xavier Noria*, *Pavel Pravosud*

--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -1,6 +1,7 @@
 require 'date'
 require 'active_support/inflector/methods'
 require 'active_support/core_ext/date/zones'
+require 'active_support/core_ext/module/remove_method'
 
 class Date
   DATE_FORMATS = {
@@ -19,8 +20,10 @@ class Date
   # Ruby 1.9 has Date#to_time which converts to localtime only.
   remove_method :to_time
 
-  # Ruby 1.9 has Date#xmlschema which converts to a string without the time component.
-  remove_method :xmlschema
+  # Ruby 1.9 has Date#xmlschema which converts to a string without the time
+  # component. This removal may generate an issue on FreeBSD, that's why we
+  # need to use remove_possible_method here
+  remove_possible_method :xmlschema
 
   # Convert to a formatted string. See DATE_FORMATS for predefined formats.
   #


### PR DESCRIPTION
Hello

This is just a little pull request to address #11723. The `Date` object has a `xmlschema` method starting with Ruby 1.9 so we were assuming that we could safely remove this method and redefine it later but the call to remove_method throws a `NameError` on FreeBSD so we should rely on `remove_possible_method` instead.

This call is actually needed to avoid warnings when running the test suite.

Have a nice day.
