### PR TITLE
Clarified that readers do not have to add any code to config/routes.rb /...

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -754,15 +754,7 @@ If you submit the form again now, Rails will complain about not finding
 the `show` action. That's not very useful though, so let's add the
 `show` action before proceeding.
 
-As we have seen in the output of `rake routes`, the route for `show` action is
-as follows:
-
-```ruby
-post GET    /posts/:id(.:format)      posts#show
-```
-
-The special syntax `:id` tells rails that this route expects an `:id`
-parameter, which in our case will be the id of the post.
+NOTE. As we have seen in the output of `rake routes`, the route for `show` action is: `post GET    /posts/:id(.:format)      posts#show`. The special syntax `:id` tells rails that this route expects an `:id` parameter, which in our case will be the id of the post.
 
 As we did before, we need to add the `show` action in
 `app/controllers/posts_controller.rb` and its respective view.


### PR DESCRIPTION
... switched from a code block to a NOTE block to remove the visual cue of adding code that comes with a code block.
