### PR TITLE
Move default production database to URL sub key

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/frontbase.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/frontbase.yml
@@ -25,4 +25,5 @@ test:
 
 # Do not keep production credentials in the repository,
 # instead read the configuration from the environment.
-production: <%%= ENV["RAILS_DATABASE_URL"] %>
+production:
+  url: <%%= ENV["RAILS_DATABASE_URL"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
@@ -63,4 +63,5 @@ test:
 
 # Do not keep production credentials in the repository,
 # instead read the configuration from the environment.
-production: <%%= ENV["RAILS_DATABASE_URL"] %>
+production:
+  url: <%%= ENV["RAILS_DATABASE_URL"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
@@ -55,4 +55,5 @@ test:
 
 # Do not keep production credentials in the repository,
 # instead read the configuration from the environment.
-production: <%%= ENV["RAILS_DATABASE_URL"] %>
+production:
+  url: <%%= ENV["RAILS_DATABASE_URL"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
@@ -44,4 +44,5 @@ test:
 
 # Do not keep production credentials in the repository,
 # instead read the configuration from the environment.
-production: <%%= ENV["RAILS_DATABASE_URL"] %>
+production:
+  url: <%%= ENV["RAILS_DATABASE_URL"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
@@ -20,4 +20,5 @@ test:
 
 # Do not keep production credentials in the repository,
 # instead read the configuration from the environment.
-production: <%%= ENV["RAILS_DATABASE_URL"] %>
+production:
+  url: <%%= ENV["RAILS_DATABASE_URL"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
@@ -38,4 +38,5 @@ test:
 # Example:
 #   mysql2://myuser:mypass@localhost/somedatabase
 #
-production: <%%= ENV["RAILS_DATABASE_URL"] %>
+production:
+  url: <%%= ENV["RAILS_DATABASE_URL"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
@@ -34,4 +34,5 @@ test:
 
 # Do not keep production credentials in the repository,
 # instead read the configuration from the environment.
-production: <%%= ENV["RAILS_DATABASE_URL"] %>
+production:
+  url: <%%= ENV["RAILS_DATABASE_URL"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
@@ -65,4 +65,5 @@ test:
 # Example:
 #   postgres://myuser:mypass@localhost/somedatabase
 #
-production: <%%= ENV["RAILS_DATABASE_URL"] %>
+production:
+  url: <%%= ENV["RAILS_DATABASE_URL"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml
@@ -24,6 +24,7 @@ test:
 # instead read the configuration from the environment.
 #
 # Example:
-#   sqlite3://myuser:mypass@localhost/somedatabase
+#   sqlite3://myuser:mypass@localhost/full/path/to/somedatabase
 #
-production: <%%= ENV["RAILS_DATABASE_URL"] %>
+production:
+  url: <%%= ENV["RAILS_DATABASE_URL"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
@@ -44,4 +44,5 @@ test:
 
 # Do not keep production credentials in the repository,
 # instead read the configuration from the environment.
-production: <%%= ENV["RAILS_DATABASE_URL"] %>
+production:
+  url: <%%= ENV["RAILS_DATABASE_URL"] %>

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -24,7 +24,11 @@ module ApplicationTests
         # ensure it's using the DATABASE_URL
         FileUtils.rm_rf("#{app_path}/config/database.yml")
         File.open("#{app_path}/config/database.yml", 'w') do |f|
-          f << {ENV['RAILS_ENV'] => %Q{<%= ENV['RAILS_DATABASE_URL'] %>}}.to_yaml
+          yaml = <<-YAML.strip_heredoc
+            #{ENV['RAILS_ENV']}:
+              url: <%= ENV['RAILS_DATABASE_URL'] %>
+          YAML
+          f << yaml
         end
       end
 


### PR DESCRIPTION
By using the URL sub key in the `database.yml` by default we are exposing the ability to set other attributes such as `pool` or `reap_frequency` without need of modifying the URL to contain non-connection specific information.
