### PR TITLE
Ensure Active Record connection consistency

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -1,5 +1,8 @@
 module ActiveRecord
   module ConnectionHandling
+    RAILS_ENV   = -> { Rails.env if defined?(Rails) }
+    DEFAULT_ENV = -> { RAILS_ENV.call || "default_env" }
+
     # Establishes the connection to the database. Accepts a hash as input where
     # the <tt>:adapter</tt> key must be specified with the name of a database adapter (in lower-case)
     # example for regular databases (MySQL, Postgresql, etc):
@@ -41,9 +44,10 @@ module ActiveRecord
     #
     # The exceptions AdapterNotSpecified, AdapterNotFound and ArgumentError
     # may be returned on an error.
-    def establish_connection(spec = ENV["DATABASE_URL"])
-      resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new configurations
-      spec = resolver.spec(spec)
+    def establish_connection(spec = nil)
+      spec     ||= DEFAULT_ENV.call.to_sym
+      resolver =   ConnectionAdapters::ConnectionSpecification::Resolver.new configurations
+      spec     =   resolver.spec(spec)
 
       unless respond_to?(spec.adapter_method)
         raise AdapterNotFound, "database configuration specifies nonexistent #{spec.config[:adapter]} adapter"
@@ -51,6 +55,56 @@ module ActiveRecord
 
       remove_connection
       connection_handler.establish_connection self, spec
+    end
+
+    class MergeAndResolveDefaultUrlConfig # :nodoc:
+      def initialize(raw_configurations, url = ENV['DATABASE_URL'])
+        @raw_config = raw_configurations.dup
+        @url        = url
+      end
+
+      # Returns fully resolved connection hashes.
+      # Merges connection information from `ENV['DATABASE_URL']` if available.
+      def resolve
+        ConnectionAdapters::ConnectionSpecification::Resolver.new(config).resolve_all
+      end
+
+      private
+        def config
+          if @url
+            raw_merged_into_default
+          else
+            @raw_config
+          end
+        end
+
+        def raw_merged_into_default
+          default = default_url_hash
+
+          @raw_config.each do |env, values|
+            default[env] = values || {}
+            default[env].merge!("url" => @url) { |h, v1, v2| v1 || v2 } if default[env].is_a?(Hash)
+          end
+          default
+        end
+
+        # When the raw configuration is not present and ENV['DATABASE_URL']
+        # is available we return a hash with the connection information in
+        # the connection URL. This hash responds to any string key with
+        # resolved connection information.
+        def default_url_hash
+          if @raw_config.blank?
+            Hash.new do |hash, key|
+              hash[key] = if key.is_a? String
+                 ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(@url).to_hash
+              else
+                nil
+              end
+            end
+          else
+            {}
+          end
+        end
     end
 
     # Returns the connection currently associated with the class. This can

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -42,8 +42,15 @@ module ActiveRecord
       #         'database' => 'db/production.sqlite3'
       #      }
       #   }
-      mattr_accessor :configurations, instance_writer: false
+      def self.configurations=(config)
+        @@configurations = ActiveRecord::ConnectionHandling::MergeAndResolveDefaultUrlConfig.new(config).resolve
+      end
       self.configurations = {}
+
+      # Returns fully resolved configurations hash
+      def self.configurations
+        @@configurations
+      end
 
       ##
       # :singleton-method:

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -40,19 +40,7 @@ module ActiveRecord
 
       namespace :db do
         task :load_config do
-          configuration = if ENV["DATABASE_URL"]
-            { Rails.env => ENV["DATABASE_URL"] }
-          else
-            Rails.application.config.database_configuration || {}
-          end
-
-          resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(configuration)
-
-          configuration.each do |key, value|
-            configuration[key] = resolver.resolve(value) if value
-          end
-
-          ActiveRecord::Tasks::DatabaseTasks.database_configuration = configuration
+          ActiveRecord::Tasks::DatabaseTasks.database_configuration = Rails.application.config.database_configuration
 
           if defined?(ENGINE_PATH) && engine = Rails::Engine.find(ENGINE_PATH)
             if engine.paths['db/migrate'].existent
@@ -137,7 +125,7 @@ module ActiveRecord
           end
         end
 
-        self.configurations = app.config.database_configuration || {}
+        self.configurations = Rails.application.config.database_configuration
         establish_connection
       end
     end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -2,7 +2,7 @@ require 'active_record'
 
 db_namespace = namespace :db do
   task :load_config do
-    ActiveRecord::Base.configurations = ActiveRecord::Tasks::DatabaseTasks.database_configuration || {}
+    ActiveRecord::Base.configurations       = ActiveRecord::Tasks::DatabaseTasks.database_configuration || {}
     ActiveRecord::Migrator.migrations_paths = ActiveRecord::Tasks::DatabaseTasks.migrations_paths
   end
 

--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -81,10 +81,11 @@ module Rails
 
     def config
       @config ||= begin
-        require APP_PATH
-        ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(
-          Rails.application.config.database_configuration || {}
-        ).resolve(ENV["DATABASE_URL"])
+        if configurations[environment].blank?
+          raise ActiveRecord::AdapterNotSpecified, "'#{environment}' database is not configured. Available configuration: #{configurations.inspect}"
+        else
+          configurations[environment]
+        end
       end
     end
 
@@ -97,6 +98,12 @@ module Rails
     end
 
     protected
+
+    def configurations
+      require APP_PATH
+      ActiveRecord::Base.configurations = Rails.application.config.database_configuration
+      ActiveRecord::Base.configurations
+    end
 
     def parse_arguments(arguments)
       options = {}

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -223,7 +223,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   private
 
   def app_db_config(results)
-    Rails.application.config.stubs(:database_configuration).returns(results)
+    Rails.application.config.stubs(:database_configuration).returns(results || {})
   end
 
   def dbconsole


### PR DESCRIPTION
Currently Active Record can be configured via the environment variable `DATABASE_URL` or by manually injecting a hash of values which is what Rails does, reading in `database.yml` and setting Active Record appropriately. Active Record expects to be able to use `DATABASE_URL` without the use of Rails, and we cannot rip out this functionality without deprecating. This presents a problem though when both config is set, and a `DATABASE_URL` is present. Currently the `DATABASE_URL` should "win" and none of the values in `database.yml` are used. This is somewhat unexpected to me if I were to set values such as `pool` in the `production:` group of `database.yml` they are ignored.

There are many ways that active record initiates a connection today:
- Stand Alone (without rails)
  - `rake db:<tasks>`
  - `ActiveRecord.establish_connection`
- With Rails
  - `rake db:<tasks>`
  - `rails <server> | <console>`
  - `rails dbconsole`

We should make all of these behave exactly the same way. The best way to do this is to put all of this logic in one place so it is guaranteed to be used.

Here is my prosed matrix of how this behavior should work:

```
No database.yml
No DATABASE_URL
=> Error
```

```
database.yml present
No DATABASE_URL
=> Use database.yml configuration
```

```
No database.yml
DATABASE_URL present
=> use DATABASE_URL configuration
```

```
database.yml present
DATABASE_URL present
=> Merged into `url` sub key. If both specify `url` sub key, the `database.yml` `url`
   sub key "wins". If other paramaters `adapter` or `database` are specified in YAML,
   they are discarded as the `url` sub key "wins".
```
### Implementation

Current implementation uses `ActiveRecord::Base.configurations` to resolve and merge all connection information before returning. This is achieved through a utility class: `ActiveRecord::ConnectionHandling::MergeAndResolveDefaultUrlConfig`.

To understand the exact behavior of this class, it is best to review the behavior in activerecord/test/cases/connection_adapters/connection_handler_test.rb though it should match the above proposal.
