### PR TITLE
mem_cache_store requires dalli, so only accept dalli/client

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   MemCacheStore should only accept a Dalli::Client, or create one.
+
+    *arthurnn*
+
 *   Don't lazy load the `tzinfo` library as it causes problems on Windows.
 
     Fixes #13553

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -46,6 +46,9 @@ module ActiveSupport
         options = addresses.extract_options!
         super(options)
 
+        unless [String, Dalli::Client, NilClass].include?(addresses.first.class)
+          raise ArgumentError, "First argument must be an empty array, an array of hosts or a Dalli::Client instance."
+        end
         if addresses.first.is_a?(Dalli::Client)
           @data = addresses.first
         else

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -41,17 +41,12 @@ module ActiveSupport
       #
       # If no addresses are specified, then MemCacheStore will connect to
       # localhost port 11211 (the default memcached port).
-      #
-      # Instead of addresses one can pass in a MemCache-like object. For example:
-      #
-      #   require 'memcached' # gem install memcached; uses C bindings to libmemcached
-      #   ActiveSupport::Cache::MemCacheStore.new(Memcached::Rails.new("localhost:11211"))
       def initialize(*addresses)
         addresses = addresses.flatten
         options = addresses.extract_options!
         super(options)
 
-        if addresses.first.respond_to?(:get)
+        if addresses.first.is_a?(Dalli::Client)
           @data = addresses.first
         else
           mem_cache_options = options.dup

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -110,6 +110,14 @@ class CacheStoreSettingTest < ActiveSupport::TestCase
     assert_kind_of(ActiveSupport::Cache::MemCacheStore, store)
   end
 
+  def test_mem_cache_fragment_cache_store_with_not_dalli_client
+    Dalli::Client.expects(:new).never
+    memcache = Object.new
+    assert_raises(ArgumentError) do
+      ActiveSupport::Cache.lookup_store :mem_cache_store, memcache
+    end
+  end
+
   def test_mem_cache_fragment_cache_store_with_multiple_servers
     Dalli::Client.expects(:new).with(%w[localhost 192.168.1.1], {})
     store = ActiveSupport::Cache.lookup_store :mem_cache_store, "localhost", '192.168.1.1'

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -110,14 +110,6 @@ class CacheStoreSettingTest < ActiveSupport::TestCase
     assert_kind_of(ActiveSupport::Cache::MemCacheStore, store)
   end
 
-  def test_mem_cache_fragment_cache_store_with_given_mem_cache_like_object
-    Dalli::Client.expects(:new).never
-    memcache = Object.new
-    def memcache.get() true end
-    store = ActiveSupport::Cache.lookup_store :mem_cache_store, memcache
-    assert_kind_of(ActiveSupport::Cache::MemCacheStore, store)
-  end
-
   def test_mem_cache_fragment_cache_store_with_multiple_servers
     Dalli::Client.expects(:new).with(%w[localhost 192.168.1.1], {})
     store = ActiveSupport::Cache.lookup_store :mem_cache_store, "localhost", '192.168.1.1'


### PR DESCRIPTION
`:mem_cache_store` require `Dalli`, rescue `Dalli` exceptions, and follow `Dalli` API.
Memcached gem, for instance, doesnt work anymore, as the API are different.

As we already require one client, we should make sure that client works, and not accept others, and if someone wants to use another memcache client they can write their own store adapter.

review @rafaelfranca @carlosantoniodasilva

That might need a Changelog entry, or/and throw an error if not a `Dalli::Client` given.. let me know, I can add both.
