### PR TITLE
Change all "can not"s to the correct "cannot"

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -762,8 +762,8 @@ module ActionView
       #   text_field(:post, :title, class: "create_input")
       #   # => <input type="text" id="post_title" name="post[title]" value="#{@post.title}" class="create_input" />
       #
-      #   text_field(:session, :user, onchange: "if ($('#session_user').val() === 'admin') { alert('Your login can not be admin!'); }")
-      #   # => <input type="text" id="session_user" name="session[user]" value="#{@session.user}" onchange="if ($('#session_user').val() === 'admin') { alert('Your login can not be admin!'); }"/>
+      #   text_field(:session, :user, onchange: "if ($('#session_user').val() === 'admin') { alert('Your login cannot be admin!'); }")
+      #   # => <input type="text" id="session_user" name="session[user]" value="#{@session.user}" onchange="if ($('#session_user').val() === 'admin') { alert('Your login cannot be admin!'); }"/>
       #
       #   text_field(:snippet, :code, size: 20, class: 'code_input')
       #   # => <input type="text" id="snippet_code" name="snippet[code]" size="20" value="#{@snippet.code}" class="code_input" />

--- a/activemodel/README.rdoc
+++ b/activemodel/README.rdoc
@@ -109,7 +109,7 @@ behavior out of the box:
       attr_reader   :errors
 
       def validate!
-        errors.add(:name, "can not be nil") if name.nil?
+        errors.add(:name, "cannot be nil") if name.nil?
       end
 
       def self.human_attribute_name(attr, options = {})
@@ -118,7 +118,7 @@ behavior out of the box:
     end
 
     person.errors.full_messages
-    # => ["Name can not be nil"]
+    # => ["Name cannot be nil"]
 
   {Learn more}[link:classes/ActiveModel/Errors.html]
 

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -23,7 +23,7 @@ module ActiveModel
   #     attr_reader   :errors
   #
   #     def validate!
-  #       errors.add(:name, "can not be nil") if name == nil
+  #       errors.add(:name, "cannot be nil") if name == nil
   #     end
   #
   #     # The following methods are needed to be minimally implemented
@@ -51,8 +51,8 @@ module ActiveModel
   # The above allows you to do:
   #
   #   person = Person.new
-  #   person.validate!            # => ["can not be nil"]
-  #   person.errors.full_messages # => ["name can not be nil"]
+  #   person.validate!            # => ["cannot be nil"]
+  #   person.errors.full_messages # => ["name cannot be nil"]
   #   # etc..
   class Errors
     include Enumerable
@@ -80,7 +80,7 @@ module ActiveModel
 
     # Clear the error messages.
     #
-    #   person.errors.full_messages # => ["name can not be nil"]
+    #   person.errors.full_messages # => ["name cannot be nil"]
     #   person.errors.clear
     #   person.errors.full_messages # => []
     def clear
@@ -90,7 +90,7 @@ module ActiveModel
     # Returns +true+ if the error messages include an error for the given key
     # +attribute+, +false+ otherwise.
     #
-    #   person.errors.messages        # => {:name=>["can not be nil"]}
+    #   person.errors.messages        # => {:name=>["cannot be nil"]}
     #   person.errors.include?(:name) # => true
     #   person.errors.include?(:age)  # => false
     def include?(attribute)
@@ -101,8 +101,8 @@ module ActiveModel
 
     # Get messages for +key+.
     #
-    #   person.errors.messages   # => {:name=>["can not be nil"]}
-    #   person.errors.get(:name) # => ["can not be nil"]
+    #   person.errors.messages   # => {:name=>["cannot be nil"]}
+    #   person.errors.get(:name) # => ["cannot be nil"]
     #   person.errors.get(:age)  # => nil
     def get(key)
       messages[key]
@@ -110,7 +110,7 @@ module ActiveModel
 
     # Set messages for +key+ to +value+.
     #
-    #   person.errors.get(:name) # => ["can not be nil"]
+    #   person.errors.get(:name) # => ["cannot be nil"]
     #   person.errors.set(:name, ["can't be nil"])
     #   person.errors.get(:name) # => ["can't be nil"]
     def set(key, value)
@@ -119,8 +119,8 @@ module ActiveModel
 
     # Delete messages for +key+. Returns the deleted messages.
     #
-    #   person.errors.get(:name)    # => ["can not be nil"]
-    #   person.errors.delete(:name) # => ["can not be nil"]
+    #   person.errors.get(:name)    # => ["cannot be nil"]
+    #   person.errors.delete(:name) # => ["cannot be nil"]
     #   person.errors.get(:name)    # => nil
     def delete(key)
       messages.delete(key)
@@ -129,8 +129,8 @@ module ActiveModel
     # When passed a symbol or a name of a method, returns an array of errors
     # for the method.
     #
-    #   person.errors[:name]  # => ["can not be nil"]
-    #   person.errors['name'] # => ["can not be nil"]
+    #   person.errors[:name]  # => ["cannot be nil"]
+    #   person.errors['name'] # => ["cannot be nil"]
     def [](attribute)
       get(attribute.to_sym) || set(attribute.to_sym, [])
     end
@@ -175,15 +175,15 @@ module ActiveModel
 
     # Returns all message values.
     #
-    #   person.errors.messages # => {:name=>["can not be nil", "must be specified"]}
-    #   person.errors.values   # => [["can not be nil", "must be specified"]]
+    #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
+    #   person.errors.values   # => [["cannot be nil", "must be specified"]]
     def values
       messages.values
     end
 
     # Returns all message keys.
     #
-    #   person.errors.messages # => {:name=>["can not be nil", "must be specified"]}
+    #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
     #   person.errors.keys     # => [:name]
     def keys
       messages.keys
@@ -211,7 +211,7 @@ module ActiveModel
     # Returns +true+ if no errors are found, +false+ otherwise.
     # If the error message is a string it can be empty.
     #
-    #   person.errors.full_messages # => ["name can not be nil"]
+    #   person.errors.full_messages # => ["name cannot be nil"]
     #   person.errors.empty?        # => false
     def empty?
       all? { |k, v| v && v.empty? && !v.is_a?(String) }
@@ -238,8 +238,8 @@ module ActiveModel
     # object. You can pass the <tt>:full_messages</tt> option. This determines
     # if the json object should contain full messages or not (false by default).
     #
-    #   person.errors.as_json                      # => {:name=>["can not be nil"]}
-    #   person.errors.as_json(full_messages: true) # => {:name=>["name can not be nil"]}
+    #   person.errors.as_json                      # => {:name=>["cannot be nil"]}
+    #   person.errors.as_json(full_messages: true) # => {:name=>["name cannot be nil"]}
     def as_json(options=nil)
       to_hash(options && options[:full_messages])
     end
@@ -247,8 +247,8 @@ module ActiveModel
     # Returns a Hash of attributes with their error messages. If +full_messages+
     # is +true+, it will contain full messages (see +full_message+).
     #
-    #   person.errors.to_hash       # => {:name=>["can not be nil"]}
-    #   person.errors.to_hash(true) # => {:name=>["name can not be nil"]}
+    #   person.errors.to_hash       # => {:name=>["cannot be nil"]}
+    #   person.errors.to_hash(true) # => {:name=>["name cannot be nil"]}
     def to_hash(full_messages = false)
       if full_messages
         messages = {}

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -11,7 +11,7 @@ class ErrorsTest < ActiveModel::TestCase
     attr_reader   :errors
 
     def validate!
-      errors.add(:name, "can not be nil") if name == nil
+      errors.add(:name, "cannot be nil") if name == nil
     end
 
     def read_attribute_for_validation(attr)
@@ -104,8 +104,8 @@ class ErrorsTest < ActiveModel::TestCase
   test "adding errors using conditionals with Person#validate!" do
     person = Person.new
     person.validate!
-    assert_equal ["name can not be nil"], person.errors.full_messages
-    assert_equal ["can not be nil"], person.errors[:name]
+    assert_equal ["name cannot be nil"], person.errors.full_messages
+    assert_equal ["cannot be nil"], person.errors[:name]
   end
 
   test "assign error" do
@@ -116,8 +116,8 @@ class ErrorsTest < ActiveModel::TestCase
 
   test "add an error message on a specific attribute" do
     person = Person.new
-    person.errors.add(:name, "can not be blank")
-    assert_equal ["can not be blank"], person.errors[:name]
+    person.errors.add(:name, "cannot be blank")
+    assert_equal ["cannot be blank"], person.errors[:name]
   end
 
   test "add an error with a symbol" do
@@ -129,15 +129,15 @@ class ErrorsTest < ActiveModel::TestCase
 
   test "add an error with a proc" do
     person = Person.new
-    message = Proc.new { "can not be blank" }
+    message = Proc.new { "cannot be blank" }
     person.errors.add(:name, message)
-    assert_equal ["can not be blank"], person.errors[:name]
+    assert_equal ["cannot be blank"], person.errors[:name]
   end
 
   test "added? detects if a specific error was added to the object" do
     person = Person.new
-    person.errors.add(:name, "can not be blank")
-    assert person.errors.added?(:name, "can not be blank")
+    person.errors.add(:name, "cannot be blank")
+    assert person.errors.added?(:name, "cannot be blank")
   end
 
   test "added? handles symbol message" do
@@ -148,7 +148,7 @@ class ErrorsTest < ActiveModel::TestCase
 
   test "added? handles proc messages" do
     person = Person.new
-    message = Proc.new { "can not be blank" }
+    message = Proc.new { "cannot be blank" }
     person.errors.add(:name, message)
     assert person.errors.added?(:name, message)
   end
@@ -161,9 +161,9 @@ class ErrorsTest < ActiveModel::TestCase
 
   test "added? matches the given message when several errors are present for the same attribute" do
     person = Person.new
-    person.errors.add(:name, "can not be blank")
+    person.errors.add(:name, "cannot be blank")
     person.errors.add(:name, "is invalid")
-    assert person.errors.added?(:name, "can not be blank")
+    assert person.errors.added?(:name, "cannot be blank")
   end
 
   test "added? returns false when no errors are present" do
@@ -174,52 +174,52 @@ class ErrorsTest < ActiveModel::TestCase
   test "added? returns false when checking a nonexisting error and other errors are present for the given attribute" do
     person = Person.new
     person.errors.add(:name, "is invalid")
-    assert !person.errors.added?(:name, "can not be blank")
+    assert !person.errors.added?(:name, "cannot be blank")
   end
 
   test "size calculates the number of error messages" do
     person = Person.new
-    person.errors.add(:name, "can not be blank")
+    person.errors.add(:name, "cannot be blank")
     assert_equal 1, person.errors.size
   end
 
   test "to_a returns the list of errors with complete messages containing the attribute names" do
     person = Person.new
-    person.errors.add(:name, "can not be blank")
-    person.errors.add(:name, "can not be nil")
-    assert_equal ["name can not be blank", "name can not be nil"], person.errors.to_a
+    person.errors.add(:name, "cannot be blank")
+    person.errors.add(:name, "cannot be nil")
+    assert_equal ["name cannot be blank", "name cannot be nil"], person.errors.to_a
   end
 
   test "to_hash returns the error messages hash" do
     person = Person.new
-    person.errors.add(:name, "can not be blank")
-    assert_equal({ name: ["can not be blank"] }, person.errors.to_hash)
+    person.errors.add(:name, "cannot be blank")
+    assert_equal({ name: ["cannot be blank"] }, person.errors.to_hash)
   end
 
   test "full_messages creates a list of error messages with the attribute name included" do
     person = Person.new
-    person.errors.add(:name, "can not be blank")
-    person.errors.add(:name, "can not be nil")
-    assert_equal ["name can not be blank", "name can not be nil"], person.errors.full_messages
+    person.errors.add(:name, "cannot be blank")
+    person.errors.add(:name, "cannot be nil")
+    assert_equal ["name cannot be blank", "name cannot be nil"], person.errors.full_messages
   end
 
   test "full_messages_for contains all the error messages for the given attribute" do
     person = Person.new
-    person.errors.add(:name, "can not be blank")
-    person.errors.add(:name, "can not be nil")
-    assert_equal ["name can not be blank", "name can not be nil"], person.errors.full_messages_for(:name)
+    person.errors.add(:name, "cannot be blank")
+    person.errors.add(:name, "cannot be nil")
+    assert_equal ["name cannot be blank", "name cannot be nil"], person.errors.full_messages_for(:name)
   end
 
   test "full_messages_for does not contain error messages from other attributes" do
     person = Person.new
-    person.errors.add(:name, "can not be blank")
-    person.errors.add(:email, "can not be blank")
-    assert_equal ["name can not be blank"], person.errors.full_messages_for(:name)
+    person.errors.add(:name, "cannot be blank")
+    person.errors.add(:email, "cannot be blank")
+    assert_equal ["name cannot be blank"], person.errors.full_messages_for(:name)
   end
 
   test "full_messages_for returns an empty list in case there are no errors for the given attribute" do
     person = Person.new
-    person.errors.add(:name, "can not be blank")
+    person.errors.add(:name, "cannot be blank")
     assert_equal [], person.errors.full_messages_for(:email)
   end
 
@@ -230,22 +230,22 @@ class ErrorsTest < ActiveModel::TestCase
 
   test "full_message returns the given message with the attribute name included" do
     person = Person.new
-    assert_equal "name can not be blank", person.errors.full_message(:name, "can not be blank")
-    assert_equal "name_test can not be blank", person.errors.full_message(:name_test, "can not be blank")
+    assert_equal "name cannot be blank", person.errors.full_message(:name, "cannot be blank")
+    assert_equal "name_test cannot be blank", person.errors.full_message(:name_test, "cannot be blank")
   end
 
   test "as_json creates a json formatted representation of the errors hash" do
     person = Person.new
     person.validate!
 
-    assert_equal({ name: ["can not be nil"] }, person.errors.as_json)
+    assert_equal({ name: ["cannot be nil"] }, person.errors.as_json)
   end
 
   test "as_json with :full_messages option creates a json formatted representation of the errors containing complete messages" do
     person = Person.new
     person.validate!
 
-    assert_equal({ name: ["name can not be nil"] }, person.errors.as_json(full_messages: true))
+    assert_equal({ name: ["name cannot be nil"] }, person.errors.as_json(full_messages: true))
   end
 
   test "generate_message works without i18n_scope" do

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -104,7 +104,7 @@
 
     *Richard Schneeman*
 
-*   Do not raise `'can not touch on a new record object'` exception on destroying
+*   Do not raise `'cannot touch on a new record object'` exception on destroying
     already destroyed `belongs_to` association with `touch: true` option.
 
     Fixes #13445.

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -75,13 +75,13 @@ module ActiveRecord
 
   class EagerLoadPolymorphicError < ActiveRecordError #:nodoc:
     def initialize(reflection)
-      super("Can not eagerly load the polymorphic association #{reflection.name.inspect}")
+      super("Cannot eagerly load the polymorphic association #{reflection.name.inspect}")
     end
   end
 
   class ReadOnlyAssociation < ActiveRecordError #:nodoc:
     def initialize(reflection)
-      super("Can not add to a has_many :through association. Try adding to #{reflection.through_reflection.name.inspect}.")
+      super("Cannot add to a has_many :through association. Try adding to #{reflection.through_reflection.name.inspect}.")
     end
   end
 

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -112,7 +112,7 @@ module ActiveRecord
 
       # Finds an object in the collection responding to the +id+. Uses the same
       # rules as <tt>ActiveRecord::Base.find</tt>. Returns <tt>ActiveRecord::RecordNotFound</tt>
-      # error if the object can not be found.
+      # error if the object cannot be found.
       #
       #   class Person < ActiveRecord::Base
       #     has_many :pets

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -16,7 +16,7 @@ module ActiveRecord
       # instance of the given subclass instead of the base class.
       def new(*args, &block)
         if abstract_class? || self == Base
-          raise NotImplementedError, "#{self} is an abstract class and can not be instantiated."
+          raise NotImplementedError, "#{self} is an abstract class and cannot be instantiated."
         end
         if (attrs = args.first).is_a?(Hash)
           if subclass = subclass_from_attrs(attrs)

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -265,7 +265,7 @@ module ActiveRecord
     # This method raises an +ActiveRecord::ActiveRecordError+ when called on new
     # objects, or when at least one of the attributes is marked as readonly.
     def update_columns(attributes)
-      raise ActiveRecordError, "can not update on a new record object" unless persisted?
+      raise ActiveRecordError, "cannot update on a new record object" unless persisted?
 
       attributes.each_key do |key|
         verify_readonly_attribute(key.to_s)
@@ -427,7 +427,7 @@ module ActiveRecord
     #   ball.touch(:updated_at)   # => raises ActiveRecordError
     #
     def touch(name = nil)
-      raise ActiveRecordError, "can not touch on a new record object" unless persisted?
+      raise ActiveRecordError, "cannot touch on a new record object" unless persisted?
 
       attributes = timestamp_attributes_for_update_in_model
       attributes << name if name

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -176,14 +176,14 @@ class InheritanceTest < ActiveRecord::TestCase
     e = assert_raises(NotImplementedError) do
       AbstractCompany.new
     end
-    assert_equal("AbstractCompany is an abstract class and can not be instantiated.", e.message)
+    assert_equal("AbstractCompany is an abstract class and cannot be instantiated.", e.message)
   end
 
   def test_new_with_ar_base
     e = assert_raises(NotImplementedError) do
       ActiveRecord::Base.new
     end
-    assert_equal("ActiveRecord::Base is an abstract class and can not be instantiated.", e.message)
+    assert_equal("ActiveRecord::Base is an abstract class and cannot be instantiated.", e.message)
   end
 
   def test_new_with_invalid_type

--- a/guides/code/getting_started/config/environments/production.rb
+++ b/guides/code/getting_started/config/environments/production.rb
@@ -66,7 +66,7 @@ Blog::Application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation can not be found).
+  # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
   # Send deprecation notices to registered listeners.

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -675,7 +675,7 @@ end
 
 Note that the filter in this case uses `send` because the `logged_in?` method is private and the filter is not run in the scope of the controller. This is not the recommended way to implement this particular filter, but in more simple cases it might be useful.
 
-The second way is to use a class (actually, any object that responds to the right methods will do) to handle the filtering. This is useful in cases that are more complex and can not be implemented in a readable and reusable way using the two other methods. As an example, you could rewrite the login filter again to use a class:
+The second way is to use a class (actually, any object that responds to the right methods will do) to handle the filtering. This is useful in cases that are more complex and cannot be implemented in a readable and reusable way using the two other methods. As an example, you could rewrite the login filter again to use a class:
 
 ```ruby
 class ApplicationController < ActionController::Base

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -824,7 +824,7 @@ This way you can provide special translations for various error messages at diff
 
 The translated model name, translated attribute name, and value are always available for interpolation.
 
-So, for example, instead of the default error message `"can not be blank"` you could use the attribute name like this : `"Please fill in your %{attribute}"`.
+So, for example, instead of the default error message `"cannot be blank"` you could use the attribute name like this : `"Please fill in your %{attribute}"`.
 
 * `count`, where available, can be used for pluralization if present:
 
@@ -926,7 +926,7 @@ Customize your I18n Setup
 
 ### Using Different Backends
 
-For several reasons the Simple backend shipped with Active Support only does the "simplest thing that could possibly work" _for Ruby on Rails_[^3] ... which means that it is only guaranteed to work for English and, as a side effect, languages that are very similar to English. Also, the simple backend is only capable of reading translations but can not dynamically store them to any format.
+For several reasons the Simple backend shipped with Active Support only does the "simplest thing that could possibly work" _for Ruby on Rails_[^3] ... which means that it is only guaranteed to work for English and, as a side effect, languages that are very similar to English. Also, the simple backend is only capable of reading translations but cannot dynamically store them to any format.
 
 That does not mean you're stuck with these limitations, though. The Ruby I18n gem makes it very easy to exchange the Simple backend implementation with something else that fits better for your needs. E.g. you could exchange it with Globalize's Static backend:
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -70,7 +70,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation can not be found).
+  # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
   # Send deprecation notices to registered listeners.


### PR DESCRIPTION
Overly pedantic?  Possibly.

But we should at least be correct and [consistent](https://github.com/rails/rails/blob/88c3fd1ef1f3bbd4f8fdc15887cc382a287fbd10/activerecord/lib/active_record/associations.rb#L70-L80).  The word is "cannot", one word, not "can not", two words.
