### PR TITLE
support multiple calculations in a single query

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Support for multiple calculations in a single query
+
+     Example:
+
+       File.calculate([:count, :sum], :file_size) # => { count: 125, sum: 124098 }
+
+    *Cody Cutrer*
+
 *   Deprecate unused `ActiveRecord::Base.symbolized_base_class`
     and `ActiveRecord::Base.symbolized_sti_name` without replacement.
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -451,6 +451,18 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
 
+  def test_multiple_calculations
+    assert_equal({ :average => 53.0, :sum => 318, :count => 6 },
+        Account.calculate([:average, :sum, :count], :credit_limit))
+  end
+
+  def test_multiple_grouped_calculations
+    c = Account.group(:firm_id).calculate([:average, :sum, :count], :credit_limit)
+    assert_equal({ :average => 50, :sum => 50, :count => 1 }, c[1])
+    assert_equal({ :average => 52.5, :sum => 105, :count => 2 }, c[6])
+    assert_equal({ :average => 60, :sum => 60, :count => 1 }, c[2])
+  end
+
   def test_from_option_with_specified_index
     if Edge.connection.adapter_name == 'MySQL' or Edge.connection.adapter_name == 'Mysql2'
       assert_equal Edge.count(:all), Edge.from('edges USE INDEX(unique_edge_index)').count(:all)


### PR DESCRIPTION
to reduce code duplication of looping over the multiple operations, execute_simple_calculation and execute_grouped_calculation were combined. calculating and selecting on the group is skipped by an if in the function, and the final loop short-circuits out of constructing the hash for the simple case by just returning
