### PR TITLE
Fix ActiveRecord::Migrator#needs_migration? inconsistency (fix #10856)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `ActiveRecord::Migrator#needs_migration?` may return `false` when
+    there are pending migrations actually (fix #10856).
+
+    *Alexey Chernenkov*
+
 *   Deprecate unused `ActiveRecord::Base.symbolized_base_class`
     and `ActiveRecord::Base.symbolized_sti_name` without replacement.
 

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -12,6 +12,7 @@ require 'active_support/logger'
 
 require 'support/config'
 require 'support/connection'
+require 'support/migration'
 
 # TODO: Move all these random hacks into the ARTest namespace and into the support/ dir
 

--- a/activerecord/test/migrations/valid_do_nothing/1_valid_do_nothing_first.rb
+++ b/activerecord/test/migrations/valid_do_nothing/1_valid_do_nothing_first.rb
@@ -1,0 +1,7 @@
+class ValidDoNothingFirst < ActiveRecord::Migration
+  def self.up
+  end
+
+  def self.down
+  end
+end

--- a/activerecord/test/migrations/valid_do_nothing/2_valid_do_nothing_second.rb
+++ b/activerecord/test/migrations/valid_do_nothing/2_valid_do_nothing_second.rb
@@ -1,0 +1,7 @@
+class ValidDoNothingSecond < ActiveRecord::Migration
+  def self.up
+  end
+
+  def self.down
+  end
+end

--- a/activerecord/test/migrations/valid_do_nothing/3_valid_do_nothing_third.rb
+++ b/activerecord/test/migrations/valid_do_nothing/3_valid_do_nothing_third.rb
@@ -1,0 +1,7 @@
+class ValidDoNothingThird < ActiveRecord::Migration
+  def self.up
+  end
+
+  def self.down
+  end
+end

--- a/activerecord/test/support/migration.rb
+++ b/activerecord/test/support/migration.rb
@@ -1,0 +1,12 @@
+module ARTest
+  module Migration
+    def self.with_migrations_path(path)
+      old_path = ActiveRecord::Migrator.migrations_paths
+      ActiveRecord::Migrator.migrations_paths = path
+      yield
+    ensure
+      ActiveRecord::Migrator.migrations_paths = old_path
+    end
+  end
+end
+

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -62,7 +62,6 @@ module ApplicationTests
 
       require "#{app_path}/config/environment"
       ActiveRecord::Migrator.stubs(:needs_migration?).returns(true)
-      ActiveRecord::NullMigration.any_instance.stubs(:mtime).returns(1)
 
       get "/foo"
       assert_equal 500, last_response.status


### PR DESCRIPTION
Issue (see #10856 too):
  Consider the situation when there are 3 migrations:
    \* 1st is up,
    \* 2nd is down,
    \* 3rd is up.
  In such case `ActiveRecord::Migrator.needs_migration?` returns `false`,
  but it should return `true`.

Consequences:
  Pending migrations check in development environment will not work
  (see `config.active_record.migration_error` option).

Solution:
  Consider all migrations while checking for pending ones
  (not only the latest migration).

Tests were added for the issue and `ActiveRecord::Migration::CheckPending`
middleware.
