### PR TITLE
Fix: ActiveRecord::Store TypeError conversion when using YAML coder

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fixed ActiveRecord::Store nil conversion TypeError when using YAML coder.
+    In case the YAML passed as paramter is nil, uses an empty string.
+
+    Fixes #13570.
+
+    *Thales Oliveira*
+
 *   Deprecate unused `ActiveRecord::Base.symbolized_base_class`
     and `ActiveRecord::Base.symbolized_sti_name` without replacement.
 

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -178,7 +178,7 @@ module ActiveRecord
       end
 
       def load(yaml)
-        self.class.as_indifferent_hash(@coder.load(yaml))
+        self.class.as_indifferent_hash(@coder.load(yaml || ''))
       end
 
       def self.as_indifferent_hash(obj)

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -162,4 +162,8 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal [:color], first_model.stored_attributes[:data]
     assert_equal [:width, :height], second_model.stored_attributes[:data]
   end
+
+  test "YAML coder initializes the store when a Nil value is given" do
+    assert_equal({}, @john.params)
+  end
 end

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -14,6 +14,7 @@ class Admin::User < ActiveRecord::Base
   end
 
   belongs_to :account
+  store :params, accessors: [ :color ], coder: YAML
   store :settings, :accessors => [ :color, :homepage ]
   store_accessor :settings, :favorite_food
   store :preferences, :accessors => [ :remember_login ]

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define do
     t.string :preferences, null: true, default: '', limit: 1024
     t.string :json_data, null: true, limit: 1024
     t.string :json_data_empty, null: true, default: "", limit: 1024
+    t.text :params
     t.references :account
   end
 


### PR DESCRIPTION
As on PR #13575, after GitHub trolling us hehe (: cc @senny

Closes #13570
