### PR TITLE
When deleting a previously deleted model, simply returns

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   When trying to remove a previously deleted migration,
+    does nothing.
+
+    Fixes #13588
+
+    *Thales Oliveira*
+
 *   `test_help.rb` now automatically checks/maintains your test datbase
     schema. (Use `config.active_record.maintain_test_schema = false` to
     disable.)

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,7 +1,7 @@
 *   When trying to remove a previously deleted migration,
     does nothing.
 
-    Fixes #13588
+    Fixes #13588.
 
     *Thales Oliveira*
 

--- a/railties/lib/rails/generators/migration.rb
+++ b/railties/lib/rails/generators/migration.rb
@@ -54,6 +54,8 @@ module Rails
             raise Error, "Another migration is already named #{@migration_file_name}: #{destination}. Use --force to remove the old migration file and replace it."
           end
           destination = File.join(migration_dir, "#{@migration_number}_#{@migration_file_name}.rb")
+        elsif behavior == :revoke && (destination.nil? || !File.exist?(destination)) && (source.nil? || !File.exist?(source))
+          return
         end
 
         template(source, destination, config)

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -356,6 +356,15 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_does_nothing_when_migration_was_already_removed
+    run_generator
+    run_generator ["Account"], behavior: :revoke
+
+    output = run_generator ["Account"], behavior: :revoke
+
+    assert_no_match(/create_accounts/, output)
+  end
+
   private
     def assert_generated_fixture(path, parsed_contents)
       fixture_file = File.new File.expand_path(path, destination_root)


### PR DESCRIPTION
Closes #13588

Basically, 'create_migration_file' method on railties AR model_generator.rb was using this path: "../../migration/templates/create_table_migration.rb" (the template file for table creation migration) as argument for migration_template method at migration.rb. Initially I was going just to fix just this, but I thought it might be interesting to show a message to the user in case the file was already deleted.

Feedback would be much appreciated <3
