### PR TITLE
Remove method redefined warnings for test suite

### DIFF
--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -42,7 +42,7 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
   end
 
   def test_join_association_conditions_support_string_and_arel_expressions
-    assert_equal 0, Author.joins(:welcome_posts_with_comment).count
+    assert_equal 0, Author.joins(:welcome_posts_with_one_comment).count
     assert_equal 1, Author.joins(:welcome_posts_with_comments).count
   end
 

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -29,7 +29,7 @@ class Author < ActiveRecord::Base
   has_many :thinking_posts, -> { where(:title => 'So I was thinking') }, :dependent => :delete_all, :class_name => 'Post'
   has_many :welcome_posts, -> { where(:title => 'Welcome to the weblog') }, :class_name => 'Post'
 
-  has_many :welcome_posts_with_comment,
+  has_many :welcome_posts_with_one_comment,
            -> { where(title: 'Welcome to the weblog').where('comments_count = ?', 1) },
            class_name: 'Post'
   has_many :welcome_posts_with_comments,


### PR DESCRIPTION
has_many definitions with "name" as singular and as plural e.g.
  has_many :welcome_posts_with_comment
  has_many :welcome_posts_with_comments

Ruby mentions it with:

lib/active_record/associations/builder/collection_association.rb:65:
  warning: method redefined; discarding old welcome_posts_with_comment_ids
lib/active_record/associations/builder/collection_association.rb:65:
  warning: previous definition of welcome_posts_with_comment_ids was here
lib/active_record/associations/builder/collection_association.rb:75:
  warning: method redefined; discarding old welcome_posts_with_comment_ids=
lib/active_record/associations/builder/collection_association.rb:75:
  warning: previous definition of welcome_posts_with_comment_ids= was here
