### PR TITLE
Fix regression on has many association callback repeating records.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fixed regression on has many association, where calling a child from parent in child's callback
+    results in same child records getting added repeatedly to target.
+
+    Fixes #13387.
+
+    *Vipul A M*, *Jon Hinson*
+
 *   Deprecate half-baked support for PostgreSQL range values with excluding beginnings.
     We currently map PostgreSQL ranges to Ruby ranges. This conversion is not fully
     possible because the Ruby range does not support excluded beginnings.

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -102,6 +102,15 @@ module ActiveRecord
         @association_scope = nil
       end
 
+      # Returns if a reversible instance has been set
+      def inverse_instance_set?(record)
+        if invertible_for?(record)
+          record.association(inverse_reflection_for(record).name).inversed
+        else
+          false
+        end
+      end
+
       # Set the inverse association, if possible
       def set_inverse_instance(record)
         if invertible_for?(record)

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -388,7 +388,7 @@ module ActiveRecord
         callback(:before_add, record) unless skip_callbacks
         yield(record) if block_given?
 
-        if association_scope.distinct_value && index = @target.index(record)
+        if (inverse_instance_set?(record) || association_scope.distinct_value) && index = @target.index(record)
           @target[index] = record
         else
           @target << record

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -22,6 +22,8 @@ require 'models/engine'
 require 'models/categorization'
 require 'models/minivan'
 require 'models/speedometer'
+require 'models/zine'
+require 'models/interest'
 
 class HasManyAssociationsTestForReorderWithJoinDependency < ActiveRecord::TestCase
   fixtures :authors, :posts, :comments
@@ -1830,4 +1832,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
       end
     end
   end
+
+  test "calling child from parent in child callback doesn't add extra repeated records to target" do
+    man = Zine.create!
+    man.interests << Interest.new
+
+    assert_equal 1, man.interests.count
+    assert_equal 1, man.interests.to_a.count
+  end
+
 end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -20,6 +20,7 @@ require 'models/molecule'
 require 'models/electron'
 require 'models/man'
 require 'models/interest'
+require 'models/zine'
 
 class AssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :developers_projects,

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -7,6 +7,7 @@ require "models/parrot"
 require "models/treasure"
 require "models/man"
 require "models/interest"
+require 'models/zine'
 require "models/owner"
 require "models/pet"
 require 'active_support/hash_with_indifferent_access'

--- a/activerecord/test/cases/validations/association_validation_test.rb
+++ b/activerecord/test/cases/validations/association_validation_test.rb
@@ -5,6 +5,7 @@ require 'models/reply'
 require 'models/owner'
 require 'models/pet'
 require 'models/man'
+require 'models/zine'
 require 'models/interest'
 
 class AssociationValidationTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/validations/presence_validation_test.rb
+++ b/activerecord/test/cases/validations/presence_validation_test.rb
@@ -2,6 +2,7 @@
 require "cases/helper"
 require 'models/man'
 require 'models/face'
+require 'models/zine'
 require 'models/interest'
 require 'models/speedometer'
 require 'models/dashboard'

--- a/activerecord/test/models/interest.rb
+++ b/activerecord/test/models/interest.rb
@@ -2,4 +2,10 @@ class Interest < ActiveRecord::Base
   belongs_to :man, :inverse_of => :interests
   belongs_to :polymorphic_man, :polymorphic => true, :inverse_of => :polymorphic_interests
   belongs_to :zine, :inverse_of => :interests
+
+  after_save :check_if_fun
+
+  def check_if_fun
+    zine && zine.validate_i_am_fun
+  end
 end

--- a/activerecord/test/models/zine.rb
+++ b/activerecord/test/models/zine.rb
@@ -1,3 +1,7 @@
 class Zine < ActiveRecord::Base
   has_many :interests, :inverse_of => :zine
+
+  def validate_i_am_fun
+    !interests.to_a.any?{|i| i.topic =~ /boringz/}
+  end
 end


### PR DESCRIPTION
3af4ae82e587b12664626e7b22bc6cc21ebbca2e introduced a regression on has many association, where calling a child from parent in child's callback

resulted in same child records getting added repeatedly to target.

Fixes #13387.
