### PR TITLE
Improve consistency of distance_of_time_in_words method

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -143,6 +143,7 @@ module ActionView
 
       # Like <tt>distance_of_time_in_words</tt>, but where <tt>to_time</tt> is fixed to <tt>Time.now</tt>.
       #
+      #   time_ago_in_words(nil)                                # => none
       #   time_ago_in_words(3.minutes.from_now)                 # => 3 minutes
       #   time_ago_in_words(3.minutes.ago)                      # => 3 minutes
       #   time_ago_in_words(Time.now - 15.hours)                # => about 15 hours

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -47,6 +47,7 @@ module ActionView
       #   60-89 secs      # => 1 minute
       #
       #   from_time = Time.now
+      #   distance_of_time_in_words(nil)                                                              # => none
       #   distance_of_time_in_words(from_time, from_time + 50.minutes)                                # => about 1 hour
       #   distance_of_time_in_words(from_time, 50.minutes.from_now)                                   # => about 1 hour
       #   distance_of_time_in_words(from_time, from_time + 15.seconds)                                # => less than a minute
@@ -71,12 +72,19 @@ module ActionView
 
         from_time = from_time.to_time if from_time.respond_to?(:to_time)
         to_time = to_time.to_time if to_time.respond_to?(:to_time)
-        from_time, to_time = to_time, from_time if from_time > to_time
-        distance_in_minutes = ((to_time - from_time)/60.0).round
-        distance_in_seconds = (to_time - from_time).round
+
+        distance_in_minutes, distance_in_seconds = nil
+
+        if from_time.present? && to_time.present?
+          from_time, to_time = to_time, from_time if from_time > to_time
+          distance_in_minutes = ((to_time - from_time)/60.0).round
+          distance_in_seconds = (to_time - from_time).round
+        end
 
         I18n.with_options :locale => options[:locale], :scope => options[:scope] do |locale|
           case distance_in_minutes
+            when nil then
+              return locale.t(:none)
             when 0..1
               return distance_in_minutes == 0 ?
                      locale.t(:less_than_x_minutes, :count => 1) :

--- a/actionview/lib/action_view/locale/en.yml
+++ b/actionview/lib/action_view/locale/en.yml
@@ -36,6 +36,7 @@
       almost_x_years:
         one:   "almost 1 year"
         other: "almost %{count} years"
+      none: "none"
     prompts:
       year:   "Year"
       month:  "Month"

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -191,6 +191,10 @@ class DateHelperTest < ActionView::TestCase
     assert_equal "1 minute", distance_of_time_in_words(60.seconds, 0, :include_seconds => true)
   end
 
+  def test_distance_in_words_with_no_dates
+    assert_equal "none", distance_of_time_in_words(nil)
+  end
+
   def test_time_ago_in_words
     assert_equal "about 1 year", time_ago_in_words(1.year.ago - 1.day)
   end

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -199,6 +199,11 @@ class DateHelperTest < ActionView::TestCase
     assert_equal "about 1 year", time_ago_in_words(1.year.ago - 1.day)
   end
 
+
+  def test_time_ago_in_words
+    assert_equal "none", time_ago_in_words(nil)
+  end
+
   def test_select_day
     expected = %(<select id="date_day" name="date[day]">\n)
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -730,6 +730,7 @@ datetime_select("post", "published_on")
 Reports the approximate distance in time between two Time or Date objects or integers as seconds. Set `include_seconds` to true if you want more detailed approximations.
 
 ```ruby
+distance_of_time_in_words(nil)   # => none
 distance_of_time_in_words(Time.now, Time.now + 15.seconds)        # => less than a minute
 distance_of_time_in_words(Time.now, Time.now + 15.seconds, include_seconds: true)  # => less than 20 seconds
 ```
@@ -832,6 +833,7 @@ select_year(Date.today, start_year: 1900, end_year: 2009)
 Like `distance_of_time_in_words`, but where `to_time` is fixed to `Time.now`.
 
 ```ruby
+time_ago_in_words(nil)  # => none
 time_ago_in_words(3.minutes.from_now)  # => 3 minutes
 ```
 


### PR DESCRIPTION
this commit improve the consistency of the method by:
- ensure that we always return the distance of time in words #=> none
- ensure that we don't get a NoMethodError when the from_time param is nil
### Example

If we need

``` ruby
def last_time_entry(time)
  if time
   distance_of_time_in_words(time)
  else
    "never"
  end
end
```

we can do instead:

``` YAML
# In locale
datetime:
  distance_in_words:
    none: never
```

``` ruby
# In code
def last_time_entry(time)
   distance_of_time_in_words(time)
end
```
