### PR TITLE
Requires Autoload to avoid errors when loading just "active_support/core_ext"

### DIFF
--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -1,3 +1,5 @@
+require 'active_support/dependencies/autoload'
+
 module ActiveSupport
   module NumberHelper
     extend ActiveSupport::Autoload


### PR DESCRIPTION
Currently:

```
$ irb -Iactivesupport/lib
irb(main):001:0> require 'active_support/core_ext'
NameError: uninitialized constant ActiveSupport::Autoload
```
