### PR TITLE
replacing dirty's changed_attributes with original_values

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -158,8 +158,8 @@ module ActiveModel
 
     # Handle <tt>*_changed?</tt> for +method_missing+.
     def attribute_changed?(attr, options = {}) #:nodoc:
-      value_pairs = [original_values[attr], __send__(attr)]
-      result = changed_attributes.key?(attr)
+      value_pairs = attribute_change(attr)
+      result = ! value_pairs.nil?
       result &&= options[:to].hash == value_pairs.last.hash if options.key?(:to)
       result &&= options[:from].hash == value_pairs.first.hash if options.key?(:from)
       result
@@ -178,6 +178,10 @@ module ActiveModel
     end
 
     private
+
+      def _field_changed?(attr, old, value)
+        old != value
+      end
 
       # Removes current changes and makes them accessible through +previous_changes+.
       def changes_applied
@@ -199,7 +203,7 @@ module ActiveModel
         if original_values.key?(attr)
           old = original_values[attr]
           value = __send__(attr)
-          [old, value] if attribute_changed?(attr)
+          [old, value] if changed_attributes.key?(attr)
         end
       end
 
@@ -227,7 +231,7 @@ module ActiveModel
       # Handle <tt>reset_*!</tt> for +method_missing+.
       def reset_attribute!(attr)
         attr = attr.to_s
-        if attribute_changed?(attr)
+        if original_values.key?(attr)
           __send__("#{attr}=", original_values[attr])
           reset_change(attr)
         end

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -181,6 +181,7 @@ module ActiveModel
 
     # mark a column as not changed (but don't change the value)
     def reset_change(attr)
+      #remove:
       changed_attributes_on_way_out.delete(attr)
       original_values.delete(attr)
     end
@@ -194,6 +195,7 @@ module ActiveModel
       # Removes current changes and makes them accessible through +previous_changes+.
       def changes_applied
         @previously_changed = changes
+        #remove:
         @changed_attributes = {}
         @original_values = nil
       end
@@ -201,6 +203,7 @@ module ActiveModel
       # Removes all dirty data: current changes and previous changes
       def reset_changes
         @previously_changed = {}
+        #remove:
         @changed_attributes = {}
         @original_values = nil
       end

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -162,6 +162,11 @@ module ActiveModel
       attribute_changed?(attr) ? changed_attributes[attr] : __send__(attr)
     end
 
+    # mark a column as not changed (but don't change the value)
+    def reset_change(attr)
+      changed_attributes.delete(attr)
+    end
+
     private
 
       # Removes current changes and makes them accessible through +previous_changes+.
@@ -184,9 +189,13 @@ module ActiveModel
       # Handle <tt>*_will_change!</tt> for +method_missing+.
       def attribute_will_change!(attr)
         return if attribute_changed?(attr)
+        set_original_value(attr)
+      end
 
+      def set_original_value(*args)
+        attr = args.first
         begin
-          value = __send__(attr)
+          value = args.length < 2 ? __send__(attr) : args[1]
           value = value.duplicable? ? value.clone : value
         rescue TypeError, NoMethodError
         end
@@ -198,7 +207,7 @@ module ActiveModel
       def reset_attribute!(attr)
         if attribute_changed?(attr)
           __send__("#{attr}=", changed_attributes[attr])
-          changed_attributes.delete(attr)
+          reset_change(attr)
         end
       end
   end

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -203,7 +203,7 @@ module ActiveModel
         if original_values.key?(attr)
           old = original_values[attr]
           value = __send__(attr)
-          [old, value] if changed_attributes.key?(attr)
+          [old, value] if _field_changed?(attr, old, value) || (changed_attributes.key?(attr))
         end
       end
 

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -160,10 +160,6 @@ module ActiveModel
       end
     end
 
-    def changed_attributes_on_way_out
-      @changed_attributes ||= ActiveSupport::HashWithIndifferentAccess.new
-    end
-
     # Handle <tt>*_changed?</tt> for +method_missing+.
     def attribute_changed?(attr, options = {}) #:nodoc:
       value_pairs = attribute_change(attr)
@@ -181,8 +177,6 @@ module ActiveModel
 
     # mark a column as not changed (but don't change the value)
     def reset_change(attr)
-      #remove:
-      changed_attributes_on_way_out.delete(attr)
       original_values.delete(attr)
     end
 
@@ -195,16 +189,12 @@ module ActiveModel
       # Removes current changes and makes them accessible through +previous_changes+.
       def changes_applied
         @previously_changed = changes
-        #remove:
-        @changed_attributes = {}
         @original_values = nil
       end
 
       # Removes all dirty data: current changes and previous changes
       def reset_changes
         @previously_changed = {}
-        #remove:
-        @changed_attributes = {}
         @original_values = nil
       end
 
@@ -226,18 +216,14 @@ module ActiveModel
       # attr, old_value (optional), new_value (optional)
       def set_original_value(*args)
         attr = args.first.to_s
+        return if original_values.key?(attr)
         begin
           value = args.length < 2 ? __send__(attr) : args[1]
           value = value.duplicable? ? value.clone : value
         rescue TypeError, NoMethodError
         end
 
-        if ! original_values.key?(attr)
-          original_values[attr] = value
-        end
-        if ! changed_attributes_on_way_out.key?(attr) && (args.length < 3 || _field_changed?(attr, value, args[2]))
-          changed_attributes_on_way_out[attr] = value
-        end
+        original_values[attr] = value
       end
 
       # Handle <tt>reset_*!</tt> for +method_missing+.

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -153,6 +153,14 @@ module ActiveModel
     #   person.name = 'robert'
     #   person.changed_attributes # => {"name" => "bob"}
     def changed_attributes
+      changes.tap do |ch|
+        ch.keys.each do |attr|
+          ch[attr] = ch[attr].first
+        end
+      end
+    end
+
+    def changed_attributes_on_way_out
       @changed_attributes ||= ActiveSupport::HashWithIndifferentAccess.new
     end
 
@@ -173,7 +181,7 @@ module ActiveModel
 
     # mark a column as not changed (but don't change the value)
     def reset_change(attr)
-      changed_attributes.delete(attr)
+      changed_attributes_on_way_out.delete(attr)
       original_values.delete(attr)
     end
 
@@ -203,7 +211,7 @@ module ActiveModel
         if original_values.key?(attr)
           old = original_values[attr]
           value = __send__(attr)
-          [old, value] if _field_changed?(attr, old, value) || (changed_attributes.key?(attr))
+          [old, value] if _field_changed?(attr, old, value)
         end
       end
 
@@ -224,8 +232,8 @@ module ActiveModel
         if ! original_values.key?(attr)
           original_values[attr] = value
         end
-        if ! changed_attributes.key?(attr) && (args.length < 3 || _field_changed?(attr, value, args[2]))
-          changed_attributes[attr] = value
+        if ! changed_attributes_on_way_out.key?(attr) && (args.length < 3 || _field_changed?(attr, value, args[2]))
+          changed_attributes_on_way_out[attr] = value
         end
       end
 

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -153,10 +153,9 @@ module ActiveModel
     #   person.name = 'robert'
     #   person.changed_attributes # => {"name" => "bob"}
     def changed_attributes
-      changes.tap do |ch|
-        ch.keys.each do |attr|
-          ch[attr] = ch[attr].first
-        end
+      ch = changes
+      ch.each do |key, value|
+        ch[key] = value.first
       end
     end
 

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -212,8 +212,9 @@ module ActiveModel
         set_original_value(attr)
       end
 
+      # attr, old_value (optional), new_value (optional)
       def set_original_value(*args)
-        attr = args.first
+        attr = args.first.to_s
         begin
           value = args.length < 2 ? __send__(attr) : args[1]
           value = value.duplicable? ? value.clone : value
@@ -223,7 +224,7 @@ module ActiveModel
         if ! original_values.key?(attr)
           original_values[attr] = value
         end
-        if ! changed_attributes.key?(attr) && (args.length < 3 || value != args[2])
+        if ! changed_attributes.key?(attr) && (args.length < 3 || _field_changed?(attr, value, args[2]))
           changed_attributes[attr] = value
         end
       end

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -90,7 +90,7 @@ module ActiveRecord::Associations::Builder
     end
 
     def self.touch_record(o, foreign_key, name, touch) # :nodoc:
-      old_foreign_id = o.changed_attributes[foreign_key]
+      old_foreign_id = o.attribute_was(foreign_key) if o.attribute_changed?(foreign_key)
 
       if old_foreign_id
         association = o.association(name)

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -84,7 +84,7 @@ module ActiveRecord
             counter = cached_counter_attribute_name(reflection)
             owner.class.update_counters(owner.id, counter => difference)
             owner[counter] += difference
-            owner.changed_attributes.delete(counter) # eww
+            owner.reset_change(counter) # eww
           end
         end
 

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -44,7 +44,7 @@ module ActiveRecord
 
         # The attribute already has an unsaved change.
         if attribute_changed?(attr)
-          old = changed_attributes[attr]
+          old = original_values[attr]
           reset_change(attr) unless _field_changed?(attr, old, value)
         else
           old = clone_attribute_value(:read_attribute, attr)
@@ -83,7 +83,7 @@ module ActiveRecord
       # Serialized attributes should always be written in case they've been
       # changed in place.
       def keys_for_partial_write
-        changed | (attributes.keys & self.class.serialized_attributes.keys)
+        changed
       end
 
       def _field_changed?(attr, old, value)

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -86,6 +86,15 @@ module ActiveRecord
         changed
       end
 
+      def attribute_change(attr)
+        attr = attr.to_s
+        if original_values.key?(attr)
+          old = original_values[attr]
+          value = __send__(attr)
+          [old, value] if _field_changed?(attr, old, value) || (changed_attributes_on_way_out.key?(attr))
+        end
+      end
+
       def _field_changed?(attr, old, value)
         if column = column_for_attribute(attr)
           if column.number? && (changes_from_nil_to_empty_string?(column, old, value) ||

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -41,7 +41,10 @@ module ActiveRecord
       # Wrap write_attribute to remember original attribute value.
       def write_attribute(attr, value)
         attr = attr.to_s
+        #goal to do something like this (and not deal with attribute_changed?:
+        ##set_original_value(attr)
 
+        # BEGIN
         # The attribute already has an unsaved change.
         if attribute_changed?(attr)
           old = original_values[attr]
@@ -50,6 +53,7 @@ module ActiveRecord
           old = clone_attribute_value(:read_attribute, attr)
           set_original_value(attr, old, value)
         end
+        # END
 
         # Carry on.
         super(attr, value)
@@ -91,7 +95,28 @@ module ActiveRecord
         if original_values.key?(attr)
           old = original_values[attr]
           value = __send__(attr)
+          #for numbers and stuff, want to do a quick compare before type_casting - but not working
+          #test_value =__send__("#{attr}_before_type_cast")
+
+          # if changed_attributes_on_way_out.key?(attr) != _field_changed?(attr, old, test_value)
+          #   ###puts [
+          #   ###  attr,
+          #   ###  "old=#{old}",
+          #   ###  "changed=#{changed_attributes.key?(attr) ? changed_attributes[attr] : "doesnt have it"}",
+          #   ###  "attributes=#{@attributes[attr]}",
+          #   ###  "value=#{value}",
+          #   ###  "before_typecast=#{__send__("#{attr}_before_type_cast")}",
+          #   ###  _field_changed?(attr, old, value) ? "field_changed" : "field_NOT_changed",
+          #   ###  old == @attributes[attr] ? "attr_same" : "attr_changed"
+          #   ###].inspect #if attr == "zine_id"
+
+          #   ###puts("   via #{caller[0..4].reverse.map {|c| c[/`.*'/][1..-2]}.join(" -> ") }") if attr == "zine_id"
+          #   binding.pry
+          # end
+          #remove:
           [old, value] if _field_changed?(attr, old, value) || (changed_attributes_on_way_out.key?(attr))
+          #goal to do something like this:
+          #[old, value] if _field_changed?(attr, old, test_value)
         end
       end
 

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -41,21 +41,7 @@ module ActiveRecord
       # Wrap write_attribute to remember original attribute value.
       def write_attribute(attr, value)
         attr = attr.to_s
-        #goal to do something like this (and not deal with attribute_changed?:
-        ##set_original_value(attr)
-
-        # BEGIN
-        # The attribute already has an unsaved change.
-        if attribute_changed?(attr)
-          old = original_values[attr]
-          reset_change(attr) unless _field_changed?(attr, old, value)
-        else
-          old = clone_attribute_value(:read_attribute, attr)
-          set_original_value(attr, old, value)
-        end
-        # END
-
-        # Carry on.
+        set_original_value(attr)
         super(attr, value)
       end
 
@@ -72,6 +58,7 @@ module ActiveRecord
 
     def set_original_value(*args)
       attr = args.first
+      return if original_values.key?(attr)
       args << clone_attribute_value(:read_attribute, attr) if args.length < 2
       super(*args)
     end
@@ -95,28 +82,7 @@ module ActiveRecord
         if original_values.key?(attr)
           old = original_values[attr]
           value = __send__(attr)
-          #for numbers and stuff, want to do a quick compare before type_casting - but not working
-          #test_value =__send__("#{attr}_before_type_cast")
-
-          # if changed_attributes_on_way_out.key?(attr) != _field_changed?(attr, old, test_value)
-          #   ###puts [
-          #   ###  attr,
-          #   ###  "old=#{old}",
-          #   ###  "changed=#{changed_attributes.key?(attr) ? changed_attributes[attr] : "doesnt have it"}",
-          #   ###  "attributes=#{@attributes[attr]}",
-          #   ###  "value=#{value}",
-          #   ###  "before_typecast=#{__send__("#{attr}_before_type_cast")}",
-          #   ###  _field_changed?(attr, old, value) ? "field_changed" : "field_NOT_changed",
-          #   ###  old == @attributes[attr] ? "attr_same" : "attr_changed"
-          #   ###].inspect #if attr == "zine_id"
-
-          #   ###puts("   via #{caller[0..4].reverse.map {|c| c[/`.*'/][1..-2]}.join(" -> ") }") if attr == "zine_id"
-          #   binding.pry
-          # end
-          #remove:
-          [old, value] if _field_changed?(attr, old, value) || (changed_attributes_on_way_out.key?(attr))
-          #goal to do something like this:
-          #[old, value] if _field_changed?(attr, old, test_value)
+          [old, value] if _field_changed?(attr, old, value)
         end
       end
 

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -63,7 +63,15 @@ module ActiveRecord
           end
         }
       end
+
     private
+
+    def set_original_value(*args)
+      attr = args.first
+      args << clone_attribute_value(:read_attribute, attr) if args.length < 2
+      super(*args)
+    end
+
       def update_record(*)
         partial_writes? ? super(keys_for_partial_write) : super
       end

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -48,13 +48,21 @@ module ActiveRecord
           reset_change(attr) unless _field_changed?(attr, old, value)
         else
           old = clone_attribute_value(:read_attribute, attr)
-          set_original_value(attr, old) if _field_changed?(attr, old, value)
+          set_original_value(attr, old, value)
         end
 
         # Carry on.
         super(attr, value)
       end
 
+      def read_attribute(attr)
+        super.tap { |value|
+          attr = attr.to_s
+          if attr != "" && attribute_names.include?(attr)
+            set_original_value(attr, value, value)
+          end
+        }
+      end
     private
       def update_record(*)
         partial_writes? ? super(keys_for_partial_write) : super

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -46,12 +46,12 @@ module ActiveRecord
       end
 
       def read_attribute(attr)
-        super.tap { |value|
+        super.tap do |value|
           attr = attr.to_s
           if attr != "" && attribute_names.include?(attr)
             set_original_value(attr, value, value)
           end
-        }
+        end
       end
 
     private
@@ -75,15 +75,6 @@ module ActiveRecord
       # changed in place.
       def keys_for_partial_write
         changed
-      end
-
-      def attribute_change(attr)
-        attr = attr.to_s
-        if original_values.key?(attr)
-          old = original_values[attr]
-          value = __send__(attr)
-          [old, value] if _field_changed?(attr, old, value)
-        end
       end
 
       def _field_changed?(attr, old, value)

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -38,7 +38,6 @@ module ActiveRecord
         end
       end
 
-    private
       # Wrap write_attribute to remember original attribute value.
       def write_attribute(attr, value)
         attr = attr.to_s
@@ -46,16 +45,17 @@ module ActiveRecord
         # The attribute already has an unsaved change.
         if attribute_changed?(attr)
           old = changed_attributes[attr]
-          changed_attributes.delete(attr) unless _field_changed?(attr, old, value)
+          reset_change(attr) unless _field_changed?(attr, old, value)
         else
           old = clone_attribute_value(:read_attribute, attr)
-          changed_attributes[attr] = old if _field_changed?(attr, old, value)
+          set_original_value(attr, old) if _field_changed?(attr, old, value)
         end
 
         # Carry on.
         super(attr, value)
       end
 
+    private
       def update_record(*)
         partial_writes? ? super(keys_for_partial_write) : super
       end

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -125,7 +125,7 @@ module ActiveRecord
 
         def _field_changed?(attr, old, value)
           if self.class.serialized_attributes.include?(attr)
-            old != value
+            old.hash != value.hash
           else
             super
           end

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -35,9 +35,7 @@ module ActiveRecord
             method_body, line = <<-EOV, __LINE__ + 1
               def #{attr_name}=(time)
                 time_with_zone = time.respond_to?(:in_time_zone) ? time.in_time_zone : nil
-                previous_time = attribute_changed?("#{attr_name}") ? changed_attributes["#{attr_name}"] : read_attribute(:#{attr_name})
                 write_attribute(:#{attr_name}, time)
-                #{attr_name}_will_change! if previous_time != time_with_zone
                 @attributes_cache["#{attr_name}"] = time_with_zone
               end
             EOV

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -248,6 +248,7 @@ module ActiveRecord
 
       run_callbacks(:initialize) unless _initialize_callbacks.empty?
 
+      #remove:
       @changed_attributes = {}
       @original_values = nil
       init_changed_attributes

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -249,6 +249,7 @@ module ActiveRecord
       run_callbacks(:initialize) unless _initialize_callbacks.empty?
 
       @changed_attributes = {}
+      @original_values = nil
       init_changed_attributes
 
       @aggregation_cache = {}

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -248,8 +248,6 @@ module ActiveRecord
 
       run_callbacks(:initialize) unless _initialize_callbacks.empty?
 
-      #remove:
-      @changed_attributes = {}
       @original_values = nil
       init_changed_attributes
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -441,8 +441,7 @@ module ActiveRecord
       # Intentionally avoid using #column_defaults since overridden defaults (as is done in
       # optimistic locking) won't get written unless they get marked as changed
       self.class.columns.each do |c|
-        attr, orig_value = c.name, c.default
-        set_original_value(attr, orig_value) if _field_changed?(attr, orig_value, @attributes[attr])
+        set_original_value(c.name, c.default, @attributes[c.name])
       end
     end
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -441,7 +441,7 @@ module ActiveRecord
       # optimistic locking) won't get written unless they get marked as changed
       self.class.columns.each do |c|
         attr, orig_value = c.name, c.default
-        changed_attributes[attr] = orig_value if _field_changed?(attr, orig_value, @attributes[attr])
+        set_original_value(attr, orig_value) if _field_changed?(attr, orig_value, @attributes[attr])
       end
     end
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -182,6 +182,7 @@ module ActiveRecord
       became.instance_variable_set("@attributes", @attributes)
       became.instance_variable_set("@attributes_cache", @attributes_cache)
       became.instance_variable_set("@changed_attributes", @changed_attributes) if defined?(@changed_attributes)
+      became.instance_variable_set("@original_values", @original_values) if defined?(@original_values)
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became.instance_variable_set("@errors", errors)
@@ -443,7 +444,7 @@ module ActiveRecord
 
         changes[self.class.locking_column] = increment_lock if locking_enabled?
 
-        changed_attributes.except!(*changes.keys)
+        changes.keys.each { |change| reset_change(change)}
         primary_key = self.class.primary_key
         self.class.unscoped.where(primary_key => self[primary_key]).update_all(changes) == 1
       end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -181,6 +181,7 @@ module ActiveRecord
       became = klass.new
       became.instance_variable_set("@attributes", @attributes)
       became.instance_variable_set("@attributes_cache", @attributes_cache)
+      #remove:
       became.instance_variable_set("@changed_attributes", @changed_attributes) if defined?(@changed_attributes)
       became.instance_variable_set("@original_values", @original_values) if defined?(@original_values)
       became.instance_variable_set("@new_record", new_record?)

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -181,8 +181,6 @@ module ActiveRecord
       became = klass.new
       became.instance_variable_set("@attributes", @attributes)
       became.instance_variable_set("@attributes_cache", @attributes_cache)
-      #remove:
-      became.instance_variable_set("@changed_attributes", @changed_attributes) if defined?(@changed_attributes)
       became.instance_variable_set("@original_values", @original_values) if defined?(@original_values)
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -131,10 +131,7 @@ module ActiveRecord
 
         def self.write(object, attribute, key, value)
           prepare(object, attribute)
-          if value != read(object, attribute, key)
-            object.public_send :"#{attribute}_will_change!"
-            object.public_send(attribute)[key] = value
-          end
+          object.public_send(attribute)[key] = value
         end
 
         def self.prepare(object, attribute)

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -112,7 +112,7 @@ module ActiveRecord
     def clear_timestamp_attributes
       all_timestamp_attributes_in_model.each do |attribute_name|
         self[attribute_name] = nil
-        changed_attributes.delete(attribute_name)
+        reset_change(attribute_name)
       end
     end
   end

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -71,7 +71,6 @@ module ActiveRecord
     end
 
     def should_record_timestamps?
-      #self.record_timestamps && (!partial_writes? || changed? || (attributes.keys & self.class.serialized_attributes.keys).present?)
       self.record_timestamps && (!partial_writes? || changed?)
     end
 

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -71,7 +71,8 @@ module ActiveRecord
     end
 
     def should_record_timestamps?
-      self.record_timestamps && (!partial_writes? || changed? || (attributes.keys & self.class.serialized_attributes.keys).present?)
+      #self.record_timestamps && (!partial_writes? || changed? || (attributes.keys & self.class.serialized_attributes.keys).present?)
+      self.record_timestamps && (!partial_writes? || changed?)
     end
 
     def timestamp_attributes_for_create_in_model

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -225,7 +225,6 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
     assert_equal 2, Topic.find(topic.id).content["two"]
 
-    topic.content_will_change!
     topic.content["three"] = 3
     topic.save
 

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -310,12 +310,7 @@ class DirtyTest < ActiveRecord::TestCase
     pirate = Pirate.create!(:catchphrase => 'arr')
 
     pirate.catchphrase << ' matey'
-    assert !pirate.catchphrase_changed?
-
     assert pirate.catchphrase_will_change!
-    assert pirate.catchphrase_changed?
-    assert_equal ['arr matey', 'arr matey'], pirate.catchphrase_change
-
     pirate.catchphrase << '!'
     assert pirate.catchphrase_changed?
     assert_equal ['arr matey', 'arr matey!'], pirate.catchphrase_change

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -313,7 +313,7 @@ class DirtyTest < ActiveRecord::TestCase
     assert pirate.catchphrase_will_change!
     pirate.catchphrase << '!'
     assert pirate.catchphrase_changed?
-    assert_equal ['arr matey', 'arr matey!'], pirate.catchphrase_change
+    assert_equal ['arr', 'arr matey!'], pirate.catchphrase_change
   end
 
   def test_association_assignment_changes_foreign_key


### PR DESCRIPTION
I was curious what the code would look like without all the tracking of `@changed_attributes`, but instead just storing the `@original_values` for active model/record attributes.

It only stores the original_values upon `attribute_read` / `attribute_write`.

I got it close. The last commit (that removes `@changed_attribtues`) breaks the test that detects when a numeric field is changing from `0` to 'foo', along with one of the date tests.

requesting comments
