### PR TITLE
Add missing tests for invalid names in `rails plugin new` generator

### DIFF
--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -35,6 +35,12 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
     content = capture(:stderr){ run_generator [File.join(destination_root, "43things")] }
     assert_equal "Invalid plugin name 43things. Please give a name which does not start with numbers.\n", content
+
+    content = capture(:stderr){ run_generator [File.join(destination_root, "plugin")] }
+    assert_equal "Invalid plugin name plugin. Please give a name which does not match one of the reserved rails words.\n", content
+
+    content = capture(:stderr){ run_generator [File.join(destination_root, "Digest")] }
+    assert_equal "Invalid plugin name Digest, constant Digest is already in use. Please choose another plugin name.\n", content
   end
 
   def test_camelcase_plugin_name_underscores_filenames


### PR DESCRIPTION
- Test for: Invalid plugin name because of reserved rails word.
- Test for: Invalid plugin name because of constant name that is already in use.
