### PR TITLE
Prevent String#blank? from blowing up on invalid UTF-8 bytes

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -124,7 +124,7 @@ module ActiveSupport #:nodoc:
   class SafeBuffer < String
     UNSAFE_STRING_METHODS = %w(
       capitalize chomp chop delete downcase gsub lstrip next reverse rstrip
-      slice squeeze strip sub succ swapcase tr tr_s upcase prepend
+      slice squeeze strip sub succ swapcase tr tr_s upcase
     )
 
     alias_method :original_concat, :concat
@@ -169,11 +169,13 @@ module ActiveSupport #:nodoc:
       self[0, 0]
     end
 
-    def concat(value)
-      if !html_safe? || value.html_safe?
-        super(value)
-      else
-        super(ERB::Util.h(value))
+    %w[concat prepend].each do |method_name|
+      define_method method_name do |value|
+        if !html_safe? || value.html_safe?
+          super(value)
+        else
+          super(ERB::Util.h(value))
+        end
       end
     end
     alias << concat

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -608,6 +608,19 @@ class OutputSafetyTest < ActiveSupport::TestCase
     assert !@other_combination.html_safe?
   end
 
+  test "Prepending safe onto unsafe yields unsafe" do
+    @string.prepend "other".html_safe
+    assert !@string.html_safe?
+    assert_equal @string, "otherhello"
+  end
+
+  test "Prepending unsafe unto safe yields escaped safe" do
+    other = "other".html_safe
+    other.prepend "<foo>"
+    assert other.html_safe?
+    assert_equal other, "&lt;foo&gt;other"
+  end
+
   test "Concatting safe onto unsafe yields unsafe" do
     @other_string = "other"
 


### PR DESCRIPTION
Current behavior:

``` ruby
"\x82\xAC\xEF".blank? # => ArgumentError
```
