### PR TITLE
Remove warnings in test suite

### DIFF
--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -14,7 +14,7 @@ class Admin::User < ActiveRecord::Base
   end
 
   belongs_to :account
-  store :params, accessors: [ :color ], coder: YAML
+  store :params, accessors: [ :token ], coder: YAML
   store :settings, :accessors => [ :color, :homepage ]
   store_accessor :settings, :favorite_food
   store :preferences, :accessors => [ :remember_login ]


### PR DESCRIPTION
lib/active_record/store.rb:79: warning: method redefined; discarding old color=
lib/active_record/store.rb:79: warning: previous definition of color= was here
lib/active_record/store.rb:83: warning: method redefined; discarding old color
lib/active_record/store.rb:83: warning: previous definition of color was here
