### PR TITLE
Add 'e' var on rescue DalliError, in order to log it

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -85,7 +85,7 @@ module ActiveSupport
         instrument(:increment, name, :amount => amount) do
           @data.incr(escape_key(namespaced_key(name, options)), amount)
         end
-      rescue Dalli::DalliError
+      rescue Dalli::DalliError => e
         logger.error("DalliError (#{e}): #{e.message}") if logger
         nil
       end
@@ -99,7 +99,7 @@ module ActiveSupport
         instrument(:decrement, name, :amount => amount) do
           @data.decr(escape_key(namespaced_key(name, options)), amount)
         end
-      rescue Dalli::DalliError
+      rescue Dalli::DalliError => e
         logger.error("DalliError (#{e}): #{e.message}") if logger
         nil
       end


### PR DESCRIPTION
Pretty small, but it could cause :bomb: behaviour if not there.

Also, need to backport to 4.0.0

review @guilleiguaran @rafaelfranca
