### PR TITLE
Update date_helper.rb

### DIFF
--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'date'
 require 'action_view/helpers/tag_helper'
 require 'active_support/core_ext/array/extract_options'

--- a/actionpack/lib/action_view/helpers/date_helper.rb
+++ b/actionpack/lib/action_view/helpers/date_helper.rb
@@ -174,7 +174,7 @@ module ActionView
       # * <tt>:use_short_month</tt>   - Set to true if you want to use abbreviated month names instead of full
       #   month names (e.g. "Feb" instead of "February").
       # * <tt>:add_month_numbers</tt>  - Set to true if you want to use both month numbers and month names (e.g.
-      #   "2 - February" instead of "February").
+      #   "2 – February" instead of "February").
       # * <tt>:use_month_names</tt>   - Set to an array with 12 month names if you want to customize month names.
       #   Note: You can also use Rails' i18n functionality for this.
       # * <tt>:date_separator</tt>    - Specifies a string to separate the date fields. Default is "" (i.e. nothing).
@@ -585,7 +585,7 @@ module ActionView
       #   select_month(Date.today, use_month_numbers: true)
       #
       #   # Generates a select field for months that defaults to the current month that
-      #   # will use keys like "1 - January", "3 - March".
+      #   # will use keys like "1 – January", "3 – March".
       #   select_month(Date.today, add_month_numbers: true)
       #
       #   # Generates a select field for months that defaults to the current month that
@@ -868,14 +868,14 @@ module ActionView
         #  month_name(1) => '01'
         #
         # If <tt>:add_month_numbers</tt> option is passed
-        #  month_name(1) => "1 - January"
+        #  month_name(1) => "1 – January"
         def month_name(number)
           if @options[:use_month_numbers]
             number
           elsif @options[:use_two_digit_numbers]
             sprintf "%02d", number
           elsif @options[:add_month_numbers]
-            "#{number} - #{month_names[number]}"
+            "#{number} – #{month_names[number]}"
           else
             month_names[number]
           end

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -320,7 +320,7 @@ class DateHelperTest < ActionView::TestCase
 
   def test_select_month_with_numbers_and_names
     expected = %(<select id="date_month" name="date[month]">\n)
-    expected << %(<option value="1">1 - January</option>\n<option value="2">2 - February</option>\n<option value="3">3 - March</option>\n<option value="4">4 - April</option>\n<option value="5">5 - May</option>\n<option value="6">6 - June</option>\n<option value="7">7 - July</option>\n<option value="8" selected="selected">8 - August</option>\n<option value="9">9 - September</option>\n<option value="10">10 - October</option>\n<option value="11">11 - November</option>\n<option value="12">12 - December</option>\n)
+    expected << %(<option value="1">1 – January</option>\n<option value="2">2 – February</option>\n<option value="3">3 – March</option>\n<option value="4">4 – April</option>\n<option value="5">5 – May</option>\n<option value="6">6 – June</option>\n<option value="7">7 – July</option>\n<option value="8" selected="selected">8 – August</option>\n<option value="9">9 – September</option>\n<option value="10">10 – October</option>\n<option value="11">11 – November</option>\n<option value="12">12 – December</option>\n)
     expected << "</select>\n"
 
     assert_dom_equal expected, select_month(Time.mktime(2003, 8, 16), :add_month_numbers => true)
@@ -329,7 +329,7 @@ class DateHelperTest < ActionView::TestCase
 
   def test_select_month_with_numbers_and_names_with_abbv
     expected = %(<select id="date_month" name="date[month]">\n)
-    expected << %(<option value="1">1 - Jan</option>\n<option value="2">2 - Feb</option>\n<option value="3">3 - Mar</option>\n<option value="4">4 - Apr</option>\n<option value="5">5 - May</option>\n<option value="6">6 - Jun</option>\n<option value="7">7 - Jul</option>\n<option value="8" selected="selected">8 - Aug</option>\n<option value="9">9 - Sep</option>\n<option value="10">10 - Oct</option>\n<option value="11">11 - Nov</option>\n<option value="12">12 - Dec</option>\n)
+    expected << %(<option value="1">1 – Jan</option>\n<option value="2">2 – Feb</option>\n<option value="3">3 – Mar</option>\n<option value="4">4 – Apr</option>\n<option value="5">5 – May</option>\n<option value="6">6 – Jun</option>\n<option value="7">7 – Jul</option>\n<option value="8" selected="selected">8 – Aug</option>\n<option value="9">9 – Sep</option>\n<option value="10">10 – Oct</option>\n<option value="11">11 – Nov</option>\n<option value="12">12 – Dec</option>\n)
     expected << "</select>\n"
 
     assert_dom_equal expected, select_month(Time.mktime(2003, 8, 16), :add_month_numbers => true, :use_short_month => true)

--- a/actionpack/test/template/date_helper_test.rb
+++ b/actionpack/test/template/date_helper_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'abstract_unit'
 
 class DateHelperTest < ActionView::TestCase


### PR DESCRIPTION
It's more appropriate to use an en dash here rather than a hyphen. Hyphens should be reserved for compound words.
