### PR TITLE
Fix typo in image_tag documentation

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -176,7 +176,7 @@ module ActionView
       # ==== Options
       #
       # You can add HTML attributes using the +options+. The +options+ supports
-      # three additional keys for convenience and conformance:
+      # two additional keys for convenience and conformance:
       #
       # * <tt>:alt</tt>  - If no alt text is given, the file name part of the
       #   +source+ is used (capitalized and without the extension)


### PR DESCRIPTION
image_tag only supports `:alt` and `:size` as additional keys, not three.
