### PR TITLE
Negate null argument while reverting change_column_null_migration

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,7 +1,16 @@
+*   Negate `null` argument of `change_column_null` method when
+    reverting migration. This will ensure that `NOT NULL` constraint
+    is reverted correctly.
+
+    Fixes #13576
+
+    *Nishant Modak*, *Prathamesh Sonpatki*
+
 *   `change_table` now uses the current adapter's `update_table_definition`
     method to retrieve a specific table definition.
     This ensures that `change_table` and `create_table` will use
     similar objects.
+
     Fixes #13577 and #13503.
 
     *Nishant Modak*, *Prathamesh Sonpatki*, *Rafael Mendonça França*

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -639,12 +639,7 @@ module ActiveRecord
       arg_list = arguments.map{ |a| a.inspect } * ', '
 
       say_with_time "#{method}(#{arg_list})" do
-        unless @connection.respond_to? :revert
-          unless arguments.empty? || method == :execute
-            arguments[0] = proper_table_name(arguments.first, table_name_options)
-            arguments[1] = proper_table_name(arguments.second, table_name_options) if method == :rename_table
-          end
-        end
+        modify_arguments(method, arguments)
         return super unless connection.respond_to?(method)
         connection.send(method, *arguments, &block)
       end
@@ -728,6 +723,17 @@ module ActiveRecord
         super # use normal delegation to record the block
       else
         yield
+      end
+    end
+
+    def modify_arguments(method, arguments)
+      if @connection.respond_to? :revert
+        arguments[2] = !arguments[2] if method == :change_column_null
+      else
+        unless arguments.empty? || method == :execute
+          arguments[0] = proper_table_name(arguments.first, table_name_options)
+          arguments[1] = proper_table_name(arguments.second, table_name_options) if method == :rename_table
+        end
       end
     end
   end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -308,6 +308,23 @@ module ActiveRecord
         assert_equal 2000, connection.select_values("SELECT money FROM testings").first.to_i
       end
 
+      def test_change_column_null
+        connection.create_table :testings do |t|
+          t.column :foo, :integer
+        end
+        notnull_migration = Class.new(ActiveRecord::Migration) do
+          def change
+            change_column_null :testings, :foo, false
+          end
+        end
+        notnull_migration.new.suppress_messages do
+          notnull_migration.migrate(:up)
+          assert_equal false, connection.columns(:testings).find{ |c| c.name == "foo"}.null
+          notnull_migration.migrate(:down)
+          assert connection.columns(:testings).find{ |c| c.name == "foo"}.null
+        end
+      end
+
       def test_column_exists
         connection.create_table :testings do |t|
           t.column :foo, :string


### PR DESCRIPTION
  null argument should be negated based on the direction of migration
  while reverting change_column_null_migration so that NOT NULL constraint is set up or
  dropped accordingly.

  Fixes #13576
