### PR TITLE
`datetime` and `timestamp` array attributes are saving correctly.

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -14,6 +14,8 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
       @connection.create_table('pg_arrays') do |t|
         t.string 'tags', array: true
         t.integer 'ratings', array: true
+        t.datetime :datetimes, array: true, default: []
+        t.timestamp :timestamps, array: true, default: []
       end
     end
     @column = PgArray.columns.find { |c| c.name == 'tags' }
@@ -136,6 +138,24 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
 
     PgArray.update_all tags: []
     assert_equal [], pg_array.reload.tags
+  end
+
+  def test_datetime_with_timezone_awareness
+    with_timezone_config aware_attributes: true do
+      PgArray.reset_column_information
+      current_time = [Time.current]
+      record = PgArray.create!(datetimes: current_time)
+      assert_equal current_time, record.datetimes
+    end
+  end
+
+  def test_timestamp_with_timezone_awareness
+    with_timezone_config aware_attributes: true do
+      PgArray.reset_column_information
+      current_time = [Time.current]
+      record = PgArray.create!(timestamps: current_time)
+      assert_equal current_time, record.timestamps
+    end
   end
 
   private


### PR DESCRIPTION
fixes #13402

In PG adapter, when attributes are of `datetime` or `timestamp` type and can store `array`, then they are not saving properly if `Model.time_zone_aware_attributes = true`. [Here is the gist](https://gist.github.com/kuldeepaggarwal/8306031)
