### PR TITLE
Failing test for String#to with negative index

### DIFF
--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -172,6 +172,7 @@ class StringInflectionsTest < ActiveSupport::TestCase
 
     assert_equal "llo", s.from(2)
     assert_equal "hel", s.to(2)
+    assert_equal "hell", s.to(-2)
 
     assert_equal "h", s.first
     assert_equal "he", s.first(2)


### PR DESCRIPTION
Broken by https://github.com/rails/rails/commit/2ef1fb2c455ca53a0c1e1768f50824926ce28bd3
cc @amatsuda
