### PR TITLE
Don't replace squash DateTime#default_inspect

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -52,7 +52,7 @@ class DateTime
   def readable_inspect
     to_s(:rfc822)
   end
-  alias_method :default_inspect, :inspect
+  alias_method :default_inspect, :inspect if instance_methods(false).include?(:inspect)
   alias_method :inspect, :readable_inspect
 
   # Returns DateTime with local offset for given year if format is local else

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -32,6 +32,11 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal datetime.readable_inspect, datetime.inspect
   end
 
+  def test_readable_inspect_does_not_clobber_default_inspect
+    datetime = DateTime.new(2005, 2, 21, 14, 30, 0)
+    assert_match(/#<DateTime: 2005-02-21T.+\(\(\d+j,\d+s,\d+n\),.\d+s,\d+j\)/, datetime.default_inspect)
+  end
+
   def test_custom_date_format
     Time::DATE_FORMATS[:custom] = '%Y%m%d%H%M%S'
     assert_equal '20050221143000', DateTime.new(2005, 2, 21, 14, 30, 0).to_s(:custom)


### PR DESCRIPTION
It looks like `core_ext/date` and `core_ext/date_time` alias `default_inspect` to `inspect`. This ends up with you not being able to get the default inspect any more.
