### PR TITLE
Adding Hash#compact and Hash#compact! methods

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added `Hash#compact` and `Hash#compact!` for removing items with nil value from hash.
+
+    *Celestino Gomes*
+
 *   Maintain proleptic gregorian in Time#advance
 
     `Time#advance` uses `Time#to_date` and `Date#advance` to calculate a new date.

--- a/activesupport/lib/active_support/core_ext/hash.rb
+++ b/activesupport/lib/active_support/core_ext/hash.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext/hash/compact'
 require 'active_support/core_ext/hash/conversions'
 require 'active_support/core_ext/hash/deep_merge'
 require 'active_support/core_ext/hash/except'

--- a/activesupport/lib/active_support/core_ext/hash/compact.rb
+++ b/activesupport/lib/active_support/core_ext/hash/compact.rb
@@ -1,0 +1,20 @@
+class Hash
+  # Returns a hash with non +nil+ values.
+  # 
+  #   hash = { a: true, b: false, c: nil}
+  #   hash.compact # => { a: true, b: false}
+  #   hash # => { a: true, b: false, c: nil}
+  #   { c: nil }.compact # => {}
+  def compact
+    self.select { |_, value| !value.nil? }
+  end
+  
+  # Replaces current hash with non +nil+ values.
+  # 
+  #   hash = { a: true, b: false, c: nil}
+  #   hash.compact! # => { a: true, b: false}
+  #   hash # => { a: true, b: false}
+  def compact!
+    self.reject! { |_, value| value.nil? }
+  end
+end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -54,6 +54,8 @@ class HashExtTest < ActiveSupport::TestCase
     assert_respond_to h, :deep_stringify_keys!
     assert_respond_to h, :to_options
     assert_respond_to h, :to_options!
+    assert_respond_to h, :compact
+    assert_respond_to h, :compact!
   end
 
   def test_transform_keys
@@ -864,6 +866,32 @@ class HashExtTest < ActiveSupport::TestCase
     original = { :a => 'x', :b => 'y' }
     original.expects(:delete).never
     original.except(:a)
+  end
+
+  def test_compact
+    hash_contain_nil_value = @symbols.merge(z: nil)
+    hash_with_only_nil_values = { a: nil, b: nil }
+    
+    h = hash_contain_nil_value.dup
+    assert_equal(@symbols, h.compact)
+    assert_equal(hash_contain_nil_value, h)
+    
+    h = hash_with_only_nil_values.dup
+    assert_equal({}, h.compact)
+    assert_equal(hash_with_only_nil_values, h)
+  end
+
+  def test_compact!
+    hash_contain_nil_value = @symbols.merge(z: nil)
+    hash_with_only_nil_values = { a: nil, b: nil }
+    
+    h = hash_contain_nil_value.dup
+    assert_equal(@symbols, h.compact!)
+    assert_equal(@symbols, h)
+    
+    h = hash_with_only_nil_values.dup
+    assert_equal({}, h.compact!)
+    assert_equal({}, h)
   end
 end
 

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2907,6 +2907,16 @@ The method `with_indifferent_access` returns an `ActiveSupport::HashWithIndiffer
 
 NOTE: Defined in `active_support/core_ext/hash/indifferent_access.rb`.
 
+### Compacting
+
+The methods `compact` and `compact!` return a Hash without items with `nil` value. 
+
+```ruby
+{a: 1, b: 2, c: nil}.compact # => {a: 1, b: 2}
+```
+
+NOTE: Defined in `active_support/core_ext/hash/compact.rb`.
+
 Extensions to `Regexp`
 ----------------------
 


### PR DESCRIPTION
Example:

```
hash = { a: true, b: false, c: nil }
hash.compact # => { a: true, b: false }
```

Benchmark for better solution:

https://gist.github.com/tinogomes/8332883
