### PR TITLE
Move finish_template as the last public method defined in the generator

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -226,14 +226,14 @@ module Rails
         build(:vendor)
       end
 
-      def finish_template
-        build(:leftovers)
-      end
-
       def delete_js_folder_skipping_javascript
         if options[:skip_javascript]
           remove_dir 'app/assets/javascripts'
         end
+      end
+
+      def finish_template
+        build(:leftovers)
       end
 
       public_task :run_bundle


### PR DESCRIPTION
This moves the [recently added](https://github.com/rails/rails/commit/84e261b9309d362a210ed55941f2852ec4230038) `delete_js_folder_skipping_javascript` method before `finish_template` which should be the last public method defined. 
This ensures a less misleading execution order in the generator.

I discovered it by reading through [thoughtbot/suspenders](https://github.com/thoughtbot/suspenders/blob/master/lib/suspenders/generators/app_generator.rb#L18-21) code, which overrides `finish_template` to do some additional customizations before calling `super`.

PS: I'm fairly new to Rails source code and enjoying digging it :heart: 
