### PR TITLE
SQLite3: Rollback only if in a transaction.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Avoid rolling back transactions twice when using SQLite3. As the driver may
+    rollback a statement or a transaction on error, the caller must check the
+    state of the transaction
+    (http://www.sqlite.org/lang_transaction.html).
+
+    Fixes: #13638
+
+    *Timur Alperovich*
+
 *   Deprecate unused `ActiveRecord::Base.symbolized_base_class`
     and `ActiveRecord::Base.symbolized_sti_name` without replacement.
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -356,7 +356,9 @@ module ActiveRecord
       end
 
       def rollback_db_transaction #:nodoc:
-        log('rollback transaction',nil) { @connection.rollback }
+        if @connection.transaction_active?
+          log('rollback transaction',nil) { @connection.rollback }
+        end
       end
 
       # SCHEMA STATEMENTS ========================================

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -395,6 +395,20 @@ module ActiveRecord
         assert @conn.respond_to?(:disable_extension)
       end
 
+      def test_transaction_rollback_active
+        SQLite3::Database.any_instance.expects(:transaction_active?).once.
+            returns(false)
+        SQLite3::Database.any_instance.expects(:rollback).never
+        @conn.rollback_db_transaction
+      end
+
+      def test_transaction_rollback_outside
+        SQLite3::Database.any_instance.expects(:transaction_active?).once.
+            returns(true)
+        SQLite3::Database.any_instance.expects(:rollback).once.returns()
+        @conn.rollback_db_transaction
+      end
+
       private
 
       def assert_logged logs


### PR DESCRIPTION
SQLite3 may rollback a transaction on its own and callers should check
whether the transaction is active on errors.

Fixes: #13638
