### PR TITLE
SQLite3: Always close statements.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Ensure SQLite3 statements are closed on errors.
+
+    Fixes: #13631
+
+	*Timur Alperovich*
+
 *   Enable partial indexes for sqlite >= 3.8.0
 
     See http://www.sqlite.org/partialindex.html

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -299,9 +299,12 @@ module ActiveRecord
           # Don't cache statements if they are not prepared
           if without_prepared_statement?(binds)
             stmt    = @connection.prepare(sql)
-            cols    = stmt.columns
-            records = stmt.to_a
-            stmt.close
+            begin
+              cols    = stmt.columns
+              records = stmt.to_a
+            ensure
+              stmt.close
+            end
             stmt = records
           else
             cache = @statements[sql] ||= {

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -401,6 +401,21 @@ module ActiveRecord
         assert @conn.respond_to?(:disable_extension)
       end
 
+      def test_statement_closed
+        db = SQLite3::Database.new(ActiveRecord::Base.
+            configurations['arunit']['database'])
+        statement = SQLite3::Statement.new(db,
+            'CREATE TABLE statement_test (number integer not null)')
+        statement.stubs(:step).raises(SQLite3::BusyException, 'busy')
+        statement.stubs(:columns).once.returns([])
+        statement.expects(:close).once
+        SQLite3::Statement.stubs(:new).returns(statement)
+
+        assert_raise ActiveRecord::StatementInvalid do
+          @conn.exec_query 'select * from statement_test'
+        end
+      end
+
       private
 
       def assert_logged logs


### PR DESCRIPTION
SQLite3 adapter must make sure to close statements after queries.

Fixes: #13631
