### PR TITLE
MySQL version 4.1 was EOL on December 31, 2009

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
@@ -1,4 +1,4 @@
-# MySQL.  Versions 4.1 and 5.0 are recommended.
+# MySQL.  Versions 5.0+ are recommended.
 #
 # Install the MYSQL driver
 #   gem install mysql2


### PR DESCRIPTION
We should at least recommend modern versions of MySQL to users.

/cc http://www.mysql.com/support/eol-notice.html
