### PR TITLE
Only run _rollback callbacks if top-level transaction

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -301,10 +301,10 @@ module ActiveRecord
     # Call the +after_rollback+ callbacks. The +force_restore_state+ argument indicates if the record
     # state should be rolled back to the beginning or just to the last savepoint.
     def rolledback!(force_restore_state = false) #:nodoc:
-      run_callbacks :rollback
+      run_callbacks :rollback if force_restore_state
     ensure
       restore_transaction_record_state(force_restore_state)
-      clear_transaction_record_state
+      clear_transaction_record_state if force_restore_state
     end
 
     # Add the record to the current transaction so that the +after_rollback+ and +after_commit+ callbacks

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -512,11 +512,6 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :before_validation,           :object ],
       [ :before_validation,           :block  ],
       [ :before_validation, :returning_false  ],
-      [ :after_rollback, :block  ],
-      [ :after_rollback, :object ],
-      [ :after_rollback, :proc   ],
-      [ :after_rollback, :string ],
-      [ :after_rollback, :method ],
     ], david.history
   end
 

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -221,7 +221,7 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
     assert_equal 1, @first.commits
     assert_equal 0, @first.rollbacks
     assert_equal 0, @second.commits
-    assert_equal 1, @second.rollbacks
+    assert_equal 0, @second.rollbacks
   end
 
   def test_only_call_after_rollback_on_records_rolled_back_to_a_savepoint_when_release_savepoint_fails
@@ -235,7 +235,6 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
       @first.save
       Topic.transaction(:requires_new => true) do
         @first.save!
-        raise ActiveRecord::Rollback
       end
       Topic.transaction(:requires_new => true) do
         @first.save!
@@ -243,8 +242,9 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
       end
     end
 
+
     assert_equal 1, @first.commits
-    assert_equal 2, @first.rollbacks
+    assert_equal 0, @first.rollbacks
   end
 
   def test_after_transaction_callbacks_should_prevent_callbacks_from_being_called


### PR DESCRIPTION
_commit callbacks are triggered only when it is closing a top-level transaction, we should try to preserve the same behaviour on _rollback callbacks.

thoughts? @jeremy @rafaelfranca @tenderlove
