### PR TITLE
clean up remaining log flushing support

### DIFF
--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -30,10 +30,6 @@ module ActiveSupport
   # After configured, whenever a "sql.active_record" notification is published,
   # it will properly dispatch the event (ActiveSupport::Notifications::Event) to
   # the sql method.
-  #
-  # Log subscriber also has some helpers to deal with logging and automatically
-  # flushes all logs when the request finishes (via action_dispatch.callback
-  # notification) in a Rails environment.
   class LogSubscriber < Subscriber
     # Embed in a String to clear all previous ANSI sequences.
     CLEAR   = "\e[0m"
@@ -63,11 +59,6 @@ module ActiveSupport
 
       def log_subscribers
         subscribers
-      end
-
-      # Flush all log_subscribers' logger.
-      def flush_all!
-        logger.flush if logger.respond_to?(:flush)
       end
     end
 

--- a/activesupport/lib/active_support/log_subscriber/test_helper.rb
+++ b/activesupport/lib/active_support/log_subscriber/test_helper.rb
@@ -52,11 +52,9 @@ module ActiveSupport
       class MockLogger
         include ActiveSupport::Logger::Severity
 
-        attr_reader :flush_count
         attr_accessor :level
 
         def initialize(level = DEBUG)
-          @flush_count = 0
           @level = level
           @logged = Hash.new { |h,k| h[k] = [] }
         end
@@ -71,10 +69,6 @@ module ActiveSupport
 
         def logged(level)
           @logged[level].compact.map { |l| l.to_s.strip }
-        end
-
-        def flush
-          @flush_count += 1
         end
 
         ActiveSupport::Logger::Severity.constants.each do |severity|

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -67,10 +67,5 @@ module ActiveSupport
     def tagged(*tags)
       formatter.tagged(*tags) { yield self }
     end
-
-    def flush
-      clear_tags!
-      super if defined?(super)
-    end
   end
 end

--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -94,20 +94,6 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
     wait
   end
 
-  def test_flushes_loggers
-    ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
-    ActiveSupport::LogSubscriber.flush_all!
-    assert_equal 1, @logger.flush_count
-  end
-
-  def test_flushes_the_same_logger_just_once
-    ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
-    ActiveSupport::LogSubscriber.attach_to :another, @log_subscriber
-    ActiveSupport::LogSubscriber.flush_all!
-    wait
-    assert_equal 1, @logger.flush_count
-  end
-
   def test_logging_does_not_die_on_failures
     ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
     instrument "puke.my_log_subscriber"

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -3,15 +3,9 @@ require 'active_support/logger'
 require 'active_support/tagged_logging'
 
 class TaggedLoggingTest < ActiveSupport::TestCase
-  class MyLogger < ::ActiveSupport::Logger
-    def flush(*)
-      info "[FLUSHED]"
-    end
-  end
-
   setup do
     @output = StringIO.new
-    @logger = ActiveSupport::TaggedLogging.new(MyLogger.new(@output))
+    @logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(@output))
   end
 
   test 'sets logger.formatter if missing and extends it with a tagging API' do
@@ -77,18 +71,6 @@ class TaggedLoggingTest < ActiveSupport::TestCase
       @logger.info "Funky time"
     end
     assert_equal "[OMG] Cool story bro\n[BCX] Funky time\n", @output.string
-  end
-
-  test "keeps tags on flush" do
-    @logger.tagged("BCX") do
-      Thread.new do
-        @logger.tagged("OMG") do
-          @logger.flush
-          @logger.info "Cool story bro"
-        end
-      end.join
-    end
-    assert_equal "[OMG] [FLUSHED]\n[OMG] Cool story bro\n", @output.string
   end
 
   test "mixed levels of tagging" do

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -79,7 +79,7 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     assert_equal "[OMG] Cool story bro\n[BCX] Funky time\n", @output.string
   end
 
-  test "cleans up the taggings on flush" do
+  test "keeps tags on flush" do
     @logger.tagged("BCX") do
       Thread.new do
         @logger.tagged("OMG") do
@@ -88,7 +88,7 @@ class TaggedLoggingTest < ActiveSupport::TestCase
         end
       end.join
     end
-    assert_equal "[FLUSHED]\nCool story bro\n", @output.string
+    assert_equal "[OMG] [FLUSHED]\n[OMG] Cool story bro\n", @output.string
   end
 
   test "mixed levels of tagging" do

--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -6,7 +6,7 @@ require 'rack/body_proxy'
 
 module Rails
   module Rack
-    # Sets log tags, logs the request, calls the app, and flushes the logs.
+    # Sets log tags, logs the request, and calls the app.
     class Logger < ActiveSupport::LogSubscriber
       def initialize(app, taggers = nil)
         @app          = app
@@ -41,8 +41,6 @@ module Rails
       rescue Exception
         finish(request)
         raise
-      ensure
-        ActiveSupport::LogSubscriber.flush_all!
       end
 
       # Started GET "/session/new" for 127.0.0.1 at 2012-09-26 14:51:42 -0700


### PR DESCRIPTION
Currently, `ActiveSupport::TaggedLogging#flush` will clear out any tags before trying to call flush on the wrapped `Logger`, which no longer happens. The tag clearing logic appears to have been intentional when it was [originally committed](https://github.com/rails/rails/commit/6c126015a676c376f1646713fbb739049a783238#diff-f5b84c8292ccf226ce319abbd6953fa0R40) but we have been unable to imagine the use case.

This seems like an odd coupling. The coupled behaviors (clearing tags + flushing buffered logging to file) no longer appear to benefit Rails' own code, but can cause bugs when other code attempts to use `Rails.logger.tagged{...}`.
### Rails' Code

The only place where I can find Rails calling `#flush` is via [`ActiveSupport::LogSubscriber.flush_all!`](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/log_subscriber.rb#L69). And the only place where I can find Rails calling that is from [`Rails::Rack::Logger#call_app`](https://github.com/rails/rails/blob/master/railties/lib/rails/rack/logger.rb#L45).

In this case, the `#flush` logic is redundant because the next operation after `#call_app` - when tags are in use - is to pop the request's tags back off the stack. That ends up being a noop because the stack was just emptied.
### Our Bug

I added a tag to our `Delayed::Job` workers so I could associate output with specific processes. I noticed that the tag was disappearing shortly after the process started, and eventually tracked it down to a particular job using the urbanairship gem, which still [flushes after logging](https://github.com/groupon/urbanairship/blob/master/lib/urbanairship.rb#L171).
### The Cleanup

Minimally, I would like to remove `ActiveSupport::TaggedLogging#flush`.

But at that point, I think there is no remaining logger that will `respond_to?(:flush)`, which means that `ActiveSupport::LogSubscriber#flush_all!` is no longer effective and can also be removed. So I've cleaned up all the tendrils.
