### PR TITLE
Implement an internal stub method to make time travel not dependent on mocha

### DIFF
--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -60,9 +60,9 @@ module ActiveSupport
       # This method is to make sure the stubs are automatically removed at the end of each
       # test.
       def after_teardown #:nodoc:
-        super
         Time.internal_unstub :now
         Date.internal_unstub :today
+        super
       end
 
       # Change current time to the time in the future or in the past by a given time difference by

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -2,7 +2,7 @@ require 'minitest/mock'
 require 'active_support/concurrency/latch'
 require 'monitor'
 
-class Object
+module InternalStub # :nodoc:
   def internal_stub(name, *args, &block) # :nodoc:
     key             = [object_id, name]
     stub_locks      = Thread.current[:stubs] ||= {}
@@ -43,6 +43,14 @@ class Object
       lock[:use].release
       lock[:undefined].await
     end
+end
+
+class Time
+  extend InternalStub
+end
+
+class Date
+  extend InternalStub
 end
 
 module ActiveSupport

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -57,9 +57,9 @@ module ActiveSupport
   module Testing
     # Containing helpers that helps you test passage of time.
     module TimeHelpers
-      # This teardown method is to make sure the stubs are automatically removed at the end of each
+      # This method is to make sure the stubs are automatically removed at the end of each
       # test.
-      def teardown #:nodoc:
+      def after_teardown #:nodoc:
         super
         Time.internal_unstub :now
         Date.internal_unstub :today

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -3,7 +3,7 @@ require 'active_support/concurrency/latch'
 require 'monitor'
 
 class Object
-  def internal_stub(name, *args, &block)
+  def internal_stub(name, *args, &block) # :nodoc:
     key             = [object_id, name]
     stub_locks      = Thread.current[:stubs] ||= {}
 
@@ -27,7 +27,7 @@ class Object
     defined_latch.await
   end
 
-  def internal_unstub(name)
+  def internal_unstub(name) # :nodoc:
     stub_locks = Thread.current[:stubs]
     return unless stub_locks
 


### PR DESCRIPTION
Before this patch time travel feature depends on mocha's stub feature.
Since mocha is not a Rails dependency we can't depend on this specific
library.

We choose to use our own implementation to avoid adding one more
dependency to Rails.

Fixes #13380.

I'm wondering if we should include these internal stubs method only in Date and Time classes or if we should move this feature to another file to make it available to our users.

cc @dhh @senny @tenderlove 
