### PR TITLE
Data corruption risk: Roll back open transactions when the running thread is killed.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -191,7 +191,11 @@ module ActiveRecord
         raise
       ensure
         begin
-          commit_transaction unless error
+          if Thread.current.status == 'aborting'
+            rollback_transaction
+          elsif !error
+            commit_transaction
+          end
         rescue Exception
           transaction.rollback unless transaction.state.completed?
           raise

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -492,6 +492,37 @@ class TransactionTest < ActiveRecord::TestCase
     assert topic.frozen?, 'not frozen'
   end
 
+  # The behavior of killed threads having a status of "aborting" was changed
+  # in Ruby 2.0, so Thread#kill on 1.9 will prematurely commit the transaction
+  # and there's nothing we can do about it.
+  unless RUBY_VERSION.start_with? '1.9'
+    def test_rollback_when_thread_killed
+      queue = Queue.new
+      thread = Thread.new do
+        Topic.transaction do
+          @first.approved  = true
+          @second.approved = false
+          @first.save
+
+          queue.push nil
+          sleep
+
+          @second.save
+        end
+      end
+
+      queue.pop
+      thread.kill
+      thread.join
+
+      assert @first.approved?, "First should still be changed in the objects"
+      assert !@second.approved?, "Second should still be changed in the objects"
+
+      assert !Topic.find(1).approved?, "First shouldn't have been approved"
+      assert Topic.find(2).approved?, "Second should still be approved"
+    end
+  end
+
   def test_restore_active_record_state_for_all_records_in_a_transaction
     topic_without_callbacks = Class.new(ActiveRecord::Base) do
       self.table_name = 'topics'


### PR DESCRIPTION
This is a fix for this issue:

http://coderrr.wordpress.com/2011/05/03/beware-of-threadkill-or-your-activerecord-transactions-are-in-danger-of-being-partially-committed/

In a nutshell: When the Ruby process exits, Thread#kill is used to end all threads that are still running (aside from the main one). Thread#kill runs ensure blocks but not rescue blocks, which means that if one of those threads is in the middle of a transaction, it will be prematurely committed rather than rolled back, which is bad bad news.

Luckily, Ruby 2.0+ sets a thread's status to "aborting" when it is killed, so it's a simple fix to check for it in the ensure block. The problem is not fixable on Ruby 1.9, so the spec doesn't run there.
