### PR TITLE
Restore DATABASE_URL even if it's nil in connection_handler test

### DIFF
--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -14,7 +14,7 @@ module ActiveRecord
       end
 
       def teardown
-        ENV["DATABASE_URL"] = @previous_database_url if @previous_database_url
+        ENV["DATABASE_URL"] = @previous_database_url
       end
 
       def test_string_connection


### PR DESCRIPTION
- We have to restore DATABASE_URL to its previous state irrespective of previous value is nil or not
