### PR TITLE
Set Session Time Zone While Connecting to Mysql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -747,6 +747,12 @@ module ActiveRecord
         # Turn this off. http://dev.rubyonrails.org/ticket/6778
         variables[:sql_auto_is_null] = 0
 
+        if ActiveRecord::Base.default_timezone.eql?:utc
+          variables[:time_zone] = '+00:00'
+        else
+          variables[:time_zone] = DateTime.now.zone
+        end
+
         # Increase timeout so the server doesn't disconnect us.
         wait_timeout = @config[:wait_timeout]
         wait_timeout = 2147483 unless wait_timeout.is_a?(Fixnum)


### PR DESCRIPTION
Mysql sets the time zone for all the connections as `SYSTEM` which is the time zone of the system where mysql-server is running. In my case it is `+05:30`. It stores all the values in `UTC` while it accepts and returns all values in the timezone set as `session time_zone`.

Default timezone for rails4 is `:local` whereas AR default for rails4 is `UTC` . So when I set a timestamp field by doing `Time.now`, AR converts the time into `UTC` and sends it to Mysql. Mysql assumes the incoming value to be in `+05:30` and hence converts it to `UTC` before storing. So, the conversion to `UTC` is happening twice.

This problem can be solved by letting AR know what Mysql session time_zone is.
`config.active_record.default_timezone = :local`

But the problem is if mysql server is to be moved to a separate machine with different time zone setting, our rails application needs to aware of this change and `config.active_record.default_timezone` must be changed accordingly for a consistent behavior.

This dependency can be removed if AR sets the `session time_zone` to whatever is set as `config.active_record.default_timezone` while connecting to the mysql server.
It can be done at the same time when AR sets variables like `wait_timeout` and etc.

Please point out if I am missing something.
