### PR TITLE
Set NameError#name

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Set NameError#name with class name when failed to load the class for association.
+
+    *Chulki Lee*
+
 *   Fix bug in `becomes!` when changing from the base model to a STI sub-class.
 
     Fixes #13272.

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -126,7 +126,7 @@ module ActiveRecord
             end
           end
 
-          raise NameError, "uninitialized constant #{candidates.first}"
+          raise NameError.new("uninitialized constant #{candidates.first}", candidates.first)
         end
       end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1301,9 +1301,11 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_compute_type_nonexistent_constant
-    assert_raises NameError do
+    e = assert_raises NameError do
       ActiveRecord::Base.send :compute_type, 'NonexistentModel'
     end
+    assert_equal 'uninitialized constant ActiveRecord::Base::NonexistentModel', e.message
+    assert_equal 'ActiveRecord::Base::NonexistentModel', e.name
   end
 
   def test_compute_type_no_method_error


### PR DESCRIPTION
`NameError` exception has `name` attribute (at least from [1.8.6](http://ruby-doc.org/core-1.8.6/NameError.html)). Having the class name in exception class make easy to find class name without parsing error message. e.g. https://github.com/thoughtbot/shoulda-matchers/pull/411
