### PR TITLE
Allow filtering params based on parent keys

### DIFF
--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -720,8 +720,11 @@ class RequestTest < ActiveSupport::TestCase
       before_filter['barg'] = {'bargain'=>'gain', 'blah'=>'bar', 'bar'=>{'bargain'=>{'blah'=>'foo'}}}
       after_filter['barg']  = {'bargain'=>'niag', 'blah'=>'[FILTERED]', 'bar'=>{'bargain'=>{'blah'=>'[FILTERED]'}}}
 
-      before_filter['credit_card'] = {'code'=>'foo', 'bar'=>'baz'}
+      before_filter['credit_card']  = {'code'=>'foo', 'bar'=>'baz'}
+      before_filter['source']       = {'code'=>'foo', 'bar'=>'baz'}
+
       after_filter['credit_card'] = {'code'=>'oof', 'bar'=>'baz'}
+      after_filter['source']      = {'code'=>'foo', 'bar'=>'baz'}
 
       assert_equal after_filter, parameter_filter.filter(before_filter)
     end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -712,9 +712,16 @@ class RequestTest < ActiveSupport::TestCase
         value.reverse! if key =~ /bargain/
       }
 
+      filter_words << lambda { |key, value, parents|
+        value.reverse! if parents.last == 'credit_card' && key == 'code'
+      }
+
       parameter_filter = ActionDispatch::Http::ParameterFilter.new(filter_words)
       before_filter['barg'] = {'bargain'=>'gain', 'blah'=>'bar', 'bar'=>{'bargain'=>{'blah'=>'foo'}}}
       after_filter['barg']  = {'bargain'=>'niag', 'blah'=>'[FILTERED]', 'bar'=>{'bargain'=>{'blah'=>'[FILTERED]'}}}
+
+      before_filter['credit_card'] = {'code'=>'foo', 'bar'=>'baz'}
+      after_filter['credit_card'] = {'code'=>'oof', 'bar'=>'baz'}
 
       assert_equal after_filter, parameter_filter.filter(before_filter)
     end


### PR DESCRIPTION
Some parameters on APIs have ambiguous names
that cannot be filtered altogether.

For example, it makes sense not to filter :code in

```
{ file: { code: '<% source %>' }}
```

It makes sense however to filter it in

```
{ credit_card: { code: '424242424242' }}
```

This PR allows the use of lambda to achieve such
results.
