### PR TITLE
use enum labels as form values. Achieved by `_before_type_cast`.

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -87,6 +87,9 @@ module ActiveRecord
           # def status() STATUS.key self[:status] end
           define_method(name) { enum_values.key self[name] }
 
+          # def status_before_type_cast() STATUS.key self[:status] end
+          define_method("#{name}_before_type_cast") { enum_values.key self[name] }
+
           pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
           pairs.each do |value, i|
             enum_values[value] = i

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -88,4 +88,8 @@ class EnumTest < ActiveRecord::TestCase
     assert Book.written.create.written?
     assert Book.read.create.read?
   end
+
+  test "_before_type_cast returns the enum label (required for form fields)" do
+    assert_equal "proposed", @book.status_before_type_cast
+  end
 end


### PR DESCRIPTION
Closes #13650, #13672

This is an alternate implementation to solve #13650. Currently form fields
contain the enum value (eg. "1"). This breaks because the setter `enum=`
expects the label (eg. "active").

ActiveRecord::Enum allows you to use labels in your application but store numbers.
We should make sure that all parts after AR are dealing with labels and not the
underlying mapping to a number.

This patch defines `_before_type_cast` on every enum column to return the label.
This method is later used to fetch the value to display in form fields.

I deliberately copied the implementation of the enum getter instead of delegating to it.
This allows you to overwrite the getter and for example return a `Value Object` but have it
still work for form fields.
