### PR TITLE
Add an option `in` for the numeric validation of the model attributes.

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -8,6 +8,24 @@ module ActiveModel
 
       RESERVED_OPTIONS = CHECKS.keys + [:only_integer]
 
+      def initialize(options)
+        if options[:in]
+          unless options[:in].is_a?(Range) && options[:in].first.is_a?(Numeric)
+            raise ArgumentError, ":in must be a range of numeric"
+          end
+
+          if options[:in].exclude_end?
+            options.merge!(less_than: options[:in].last)
+          else
+            options.merge!(less_than_or_equal_to: options[:in].last)
+          end
+          options.merge!(greater_than_or_equal_to: options[:in].first)
+          options.delete(:in)
+        end
+
+        super
+      end
+
       def check_validity!
         keys = CHECKS.keys - [:odd, :even]
         options.slice(*keys).each do |option, value|

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -160,12 +160,46 @@ class NumericalityValidationTest < ActiveModel::TestCase
     Person.reset_callbacks(:validate)
   end
 
+  def test_validates_numericality_with_range_values
+    Topic.validates_numericality_of :approved, in: 1..4
+
+    invalid!([0], 'must be greater than or equal to 1')
+    invalid!([5], 'must be less than or equal to 4')
+    valid!([1, 2, 3, 4])
+  end
+
+  def test_validates_numericality_with_range_values_excluded
+    Topic.validates_numericality_of :approved, in: 1...4
+
+    invalid!([0], 'must be greater than or equal to 1')
+    invalid!([4], 'must be less than 4')
+    valid!([1, 2, 3])
+  end
+
+  def test_validates_numericality_with_range_values_and_only_integer
+    Topic.validates_numericality_of :approved, in: 1..4, only_integer: true
+
+    invalid!([0.5], 'must be an integer')
+    valid!([1, 2, 3, 4])
+  end
+
+  def test_validates_numericality_with_priority_range
+    Topic.validates_numericality_of :approved,
+      in: 1...4, greater_than_or_equal_to: 0, less_than_or_equal_to: 4
+
+    invalid!([0], 'must be greater than or equal to 1')
+    invalid!([4], 'must be less than 4')
+    valid!([1, 2, 3])
+  end
+
   def test_validates_numericality_with_invalid_args
     assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, greater_than_or_equal_to: "foo" }
     assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, less_than_or_equal_to: "foo" }
     assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, greater_than: "foo" }
     assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, less_than: "foo" }
     assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, equal_to: "foo" }
+    assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, in: "foo" }
+    assert_raise(ArgumentError){ Topic.validates_numericality_of :approved, in: 'f'..'o' }
   end
 
   private


### PR DESCRIPTION
Hi,

I sent a message on the Core list without pertinent answers. Thus, this pull request will able to refactor this code:

``` ruby
class Person
  validates_numericality_of :age, greater_than_or_equal_to: 1, less_than_or_equal_to: 100
end
```

in:

``` ruby
class Person
  validates_numericality_of :age, in: 1..100
end
```

Although, we can use `validates_inclusion_of`, It will be more consistent to define the same kind of options for one same attribute.

Thanks
