### PR TITLE
Change pluralize method to return the singular form of a word if the count is 0 and the last argument to true.

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -195,8 +195,17 @@ module ActionView
       #
       #   pluralize(0, 'person')
       #   # => 0 people
-      def pluralize(count, singular, plural = nil)
-        word = if (count == 1 || count =~ /^1(\.0+)?$/)
+      #
+      # If you specify +zero_is_singular+ to true and if +count+ is zero, the
+      # method returns the singualar form.
+      #
+      #   pluralize(0, 'person', nil, true)
+      #   # => 0 person
+      #
+      #   pluralize(0, 'person', 'users', true)
+      #   # => 0 person
+      def pluralize(count, singular, plural = nil, zero_is_singular = false)
+        word = if singular?(count, zero_is_singular)
           singular
         else
           plural || singular.pluralize
@@ -444,6 +453,15 @@ module ActionView
           end
 
           return affix, part.join(separator)
+        end
+
+        def singular?(count, zero_is_singular)
+          case (count ||= 0)
+          when Integer then count == 1 || zero_is_singular && count == 0
+          when String  then count =~ /^#{zero_is_singular ? '0|1' : '1'}(\.0+)?$/
+          else
+            false
+          end
         end
     end
   end

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -359,6 +359,29 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("10 buffaloes", pluralize(10, "buffalo"))
     assert_equal("1 berry", pluralize(1, "berry"))
     assert_equal("12 berries", pluralize(12, "berry"))
+    assert_equal("0 counts", pluralize(0, "count"))
+    assert_equal("0.0 counts", pluralize('0.0', "count"))
+    assert_equal("0.00 counts", pluralize('0.00', "count"))
+  end
+
+  def test_pluralization_with_zero_singular
+    assert_equal("1 count", pluralize(1, "count", nil, true))
+    assert_equal("2 counts", pluralize(2, "count", nil, true))
+    assert_equal("1 count", pluralize('1', "count", nil, true))
+    assert_equal("2 counts", pluralize('2', "count", nil, true))
+    assert_equal("1,066 counts", pluralize('1,066', "count", nil, true))
+    assert_equal("1.25 counts", pluralize('1.25', "count", nil, true))
+    assert_equal("1.0 count", pluralize('1.0', "count", nil, true))
+    assert_equal("1.00 count", pluralize('1.00', "count", nil, true))
+    assert_equal("2 counters", pluralize(2, "count", "counters", true))
+    assert_equal("0 count", pluralize(nil, "count", "counters", true))
+    assert_equal("2 people", pluralize(2, "person", nil, true))
+    assert_equal("10 buffaloes", pluralize(10, "buffalo", nil, true))
+    assert_equal("1 berry", pluralize(1, "berry", nil, true))
+    assert_equal("12 berries", pluralize(12, "berry", nil, true))
+    assert_equal("0 count", pluralize(0, "count", nil, true))
+    assert_equal("0.0 count", pluralize('0.0', "count", nil, true))
+    assert_equal("0.00 count", pluralize('0.00', "count", nil, true))
   end
 
   def test_cycle_class


### PR DESCRIPTION
Hi, 

Currently with the ActionView::Helpers::TextHelper#pluralize method, we can't deal with the specific language rule about the zero value. For instance, in french, we use the singular form with the zero value:
- 0 cats <> 0 chat
- 1 cat == 1 chat
- 2 cats == 2 chats

This pull request tries to solve this problem.

Thanks.
