### PR TITLE
Made it possible to specify an explicit format or layout when passing an object to RenderHelper#render

### DIFF
--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -24,7 +24,8 @@ module ActionView
             view_renderer.render(self, options)
           end
         else
-          view_renderer.render_partial(self, :partial => options, :locals => locals)
+          object, locals, options = options, locals.slice!(:formats, :layout), locals
+          view_renderer.render_partial(self, options.merge(:partial => object, :locals => locals))
         end
       end
 

--- a/actionview/test/fixtures/customers/_customer.xml.erb
+++ b/actionview/test/fixtures/customers/_customer.xml.erb
@@ -1,0 +1,1 @@
+<greeting><%= greeting %></greeting><name><%= customer.name %></name>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -309,6 +309,16 @@ module RenderTestCases
       @controller_view.render(Customer.new("lifo"), :greeting => "Hello")
   end
 
+  def test_render_partial_using_object_and_explicit_format
+    assert_equal "<greeting>Hello</greeting><name>lifo</name>",
+      @controller_view.render(Customer.new("lifo"), :greeting => "Hello", formats: :xml)
+  end
+
+  def test_render_partial_using_object_and_layout
+    assert_equal '<b class="lifo">Hello: lifo</b>',
+      @controller_view.render(Customer.new("lifo"), :greeting => "Hello", :layout => 'test/b_layout_for_partial_with_object')
+  end
+
   def test_render_partial_using_collection
     customers = [ Customer.new("Amazon"), Customer.new("Yahoo") ]
     assert_equal "Hello: AmazonHello: Yahoo",


### PR DESCRIPTION
## Problem

When you call `<%= render @something %>` in an action view template, you can pass a hash of options, all of which are interpreted as locals in the appropriate partial for `@something`. If you'd like to be able to render `@something` in a format that's different to that of the parent template (eg. you have a html template but want to render `@something` as xml, or json) then the only way to do this is to call render like this:

```
<%= render partial: @something.to_partial_path, object: @something, formats: :xml %>
```

Which seems very verbose and unintuitive. I would have expected `render` to understand something like this instead:

```
<%= render @something, formats: :xml %>`
```

But it does not (`formats` is passed to the partial for `@something` as a local and the format is unchanged from the calling view).
## Solution

This pull request makes the `render` call above work, by interpreting arguments to `render` named `formats` or `layout` as options to `render` instead of locals. It makes the api for `render` more intuitive, at the expense of adding special case behaviour.
