### PR TITLE
Light support for postgres expression indexes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     # Abstract representation of an index definition on a table. Instances of
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#indexes
-    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using, :function) #:nodoc:
+    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using, :functions) #:nodoc:
     end
 
     # Abstract representation of a column definition. Instances of this type

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     # Abstract representation of an index definition on a table. Instances of
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#indexes
-    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using) #:nodoc:
+    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using, :function) #:nodoc:
     end
 
     # Abstract representation of a column definition. Instances of this type

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -763,11 +763,19 @@ module ActiveRecord
             option_strings = add_index_sort_order(option_strings, column_names, options)
           end
 
-          column_names.map do |name|
+          if options[:functions]
+            functions = Array(options[:functions])
+            if functions.length != column_names.length
+              raise(ArgumentError,
+                  "The number of functions must match the number of column names")
+            end
+          end
+
+          column_names.each_with_index.map do |name, index|
             quoted = quote_column_name(name)
 
-            if supports_index_functions? && options[:function]
-              quoted = "#{options[:function]}(#{quoted})"
+            if supports_index_functions? && functions
+              quoted = "#{functions[index]}(#{quoted})"
             end
 
             quoted + option_strings[name]
@@ -782,7 +790,7 @@ module ActiveRecord
           column_names = Array(column_name)
           index_name   = index_name(table_name, column: column_names)
 
-          options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :using, :algorithm, :type, :function)
+          options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :using, :algorithm, :type, :functions)
 
           index_type = options[:unique] ? "UNIQUE" : ""
           index_type = options[:type].to_s if options.key?(:type)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -763,7 +763,15 @@ module ActiveRecord
             option_strings = add_index_sort_order(option_strings, column_names, options)
           end
 
-          column_names.map {|name| quote_column_name(name) + option_strings[name]}
+          column_names.map do |name|
+            quoted = quote_column_name(name)
+
+            if supports_index_functions? && options[:function]
+              quoted = "#{options[:function]}(#{quoted})"
+            end
+
+            quoted + option_strings[name]
+          end
         end
 
         def options_include_default?(options)
@@ -774,7 +782,7 @@ module ActiveRecord
           column_names = Array(column_name)
           index_name   = index_name(table_name, column: column_names)
 
-          options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :using, :algorithm, :type)
+          options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :using, :algorithm, :type, :function)
 
           index_type = options[:unique] ? "UNIQUE" : ""
           index_type = options[:type].to_s if options.key?(:type)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -202,6 +202,11 @@ module ActiveRecord
         false
       end
 
+      # Can this adapter apply a SQL function to values before they are indexed?
+      def supports_index_functions?
+        false
+      end
+
       # Does this adapter support explain? As of this writing sqlite3,
       # mysql2, and postgresql are the only ones that do.
       def supports_explain?

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -198,7 +198,7 @@ module ActiveRecord
 
             functions = nil if functions.compact.empty?
 
-            if index_supported && !column_names.empty?
+            if index_supported && column_names.any?
               # add info on sort order for columns (only desc order is explicitly specified, asc is the default)
               desc_order_columns = inddef.scan(/(\w+) DESC/).flatten
               orders = desc_order_columns.any? ? Hash[desc_order_columns.map {|order_column| [order_column, :desc]}] : {}

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -483,6 +483,10 @@ module ActiveRecord
         true
       end
 
+      def supports_index_functions?
+        true
+      end
+
       def supports_transaction_isolation?
         true
       end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -198,11 +198,10 @@ HEADER
             index_orders = (index.orders || {})
             statement_parts << ('order: ' + index.orders.inspect) unless index_orders.empty?
 
-            statement_parts << ('where: ' + index.where.inspect) if index.where
-
-            statement_parts << ('using: ' + index.using.inspect) if index.using
-
-            statement_parts << ('type: ' + index.type.inspect) if index.type
+            %w(where using type function).each do |attr|
+              value = index.public_send(attr)
+              statement_parts << ("#{attr}: " + value.inspect) if value
+            end
 
             '  ' + statement_parts.join(', ')
           end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -198,7 +198,7 @@ HEADER
             index_orders = (index.orders || {})
             statement_parts << ('order: ' + index.orders.inspect) unless index_orders.empty?
 
-            %w(where using type function).each do |attr|
+            %w(where using type functions).each do |attr|
               value = index.public_send(attr)
               statement_parts << ("#{attr}: " + value.inspect) if value
             end

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -24,7 +24,8 @@ class SchemaTest < ActiveRecord::TestCase
     'email character varying(50)',
     'description character varying(100)',
     'name_vector tsvector',
-    'moment timestamp without time zone default now()'
+    'moment timestamp without time zone default now()',
+    'active boolean default true'
   ]
   PK_TABLE_NAME = 'table_with_pk'
   UNMATCHED_SEQUENCE_NAME = 'unmatched_primary_key_default_value_seq'
@@ -56,8 +57,8 @@ class SchemaTest < ActiveRecord::TestCase
     @connection.execute "CREATE TABLE #{SCHEMA_NAME}.\"#{TABLE_NAME}.table\" (#{COLUMNS.join(',')})"
     @connection.execute "CREATE TABLE #{SCHEMA_NAME}.\"#{CAPITALIZED_TABLE_NAME}\" (#{COLUMNS.join(',')})"
     @connection.execute "CREATE SCHEMA #{SCHEMA2_NAME} CREATE TABLE #{TABLE_NAME} (#{COLUMNS.join(',')})"
-    @connection.execute "CREATE INDEX #{INDEX_A_NAME} ON #{SCHEMA_NAME}.#{TABLE_NAME}  USING btree (#{INDEX_A_COLUMN});"
-    @connection.execute "CREATE INDEX #{INDEX_A_NAME} ON #{SCHEMA2_NAME}.#{TABLE_NAME}  USING btree (#{INDEX_A_COLUMN});"
+    @connection.execute "CREATE INDEX #{INDEX_A_NAME} ON #{SCHEMA_NAME}.#{TABLE_NAME}  USING btree (#{INDEX_A_COLUMN}) WHERE active;"
+    @connection.execute "CREATE INDEX #{INDEX_A_NAME} ON #{SCHEMA2_NAME}.#{TABLE_NAME}  USING btree (#{INDEX_A_COLUMN}) WHERE active;"
     @connection.execute "CREATE INDEX #{INDEX_B_NAME} ON #{SCHEMA_NAME}.#{TABLE_NAME}  USING btree (#{INDEX_B_COLUMN_S1});"
     @connection.execute "CREATE INDEX #{INDEX_B_NAME} ON #{SCHEMA2_NAME}.#{TABLE_NAME}  USING btree (#{INDEX_B_COLUMN_S2});"
     @connection.execute "CREATE INDEX #{INDEX_C_NAME} ON #{SCHEMA_NAME}.#{TABLE_NAME}  USING gin (#{INDEX_C_COLUMN});"
@@ -358,6 +359,8 @@ class SchemaTest < ActiveRecord::TestCase
         do_dump_index_assertions_for_one_index(indexes[1], INDEX_B_NAME, second_index_column_name)
         do_dump_index_assertions_for_one_index(indexes[2], INDEX_D_NAME, third_index_column_name)
         do_dump_index_assertions_for_one_index(indexes[3], INDEX_E_NAME, fourth_index_column_name)
+
+        assert_equal 'active', indexes[0].where
 
         indexes.select{|i| i.name != INDEX_E_NAME}.each do |index|
            assert_equal :btree, index.using

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -195,8 +195,24 @@ module ActiveRecord
         end
 
         def test_index_functions
-          connection.add_index("testings", "last_name", :function => "lower")
+          connection.add_index("testings", "last_name", :functions => "lower")
           assert connection.index_exists?("testings", "last_name")
+
+          connection.add_index("testings",
+              ["first_name", "last_name", "administrator"],
+              name: 'test_composite_index',
+              functions: ["lower", "upper", nil])
+
+          index = connection.indexes("testings").find do |i|
+            i.columns == ["first_name", "last_name", "administrator"]
+          end
+          assert_not_nil index
+          assert_equal ["lower", "upper", nil], index.functions
+
+          assert_raise ArgumentError do
+            # pass in an incorrect number of functions
+            connection.add_index :testings, :foo, unique: true, :functions => ["lower", "upper"]
+          end
 
           connection.remove_index("testings", "last_name")
           assert !connection.index_exists?("testings", "last_name")

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -193,6 +193,14 @@ module ActiveRecord
           connection.remove_index("testings", "last_name")
           assert !connection.index_exists?("testings", "last_name")
         end
+
+        def test_index_functions
+          connection.add_index("testings", "last_name", :function => "lower")
+          assert connection.index_exists?("testings", "last_name")
+
+          connection.remove_index("testings", "last_name")
+          assert !connection.index_exists?("testings", "last_name")
+        end
       end
 
       private

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -198,7 +198,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
   def test_schema_dumps_index_functions
     index_definition = standard_dump.split(/\n/).grep(/add_index.*company_lower_name_index/).first.strip
     if current_adapter?(:PostgreSQLAdapter)
-      assert_equal 'add_index "companies", ["name"], name: "company_lower_name_index", using: :btree, function: "lower"', index_definition
+      assert_equal 'add_index "companies", ["name"], name: "company_lower_name_index", using: :btree, functions: ["lower"]', index_definition
     elsif current_adapter?(:MysqlAdapter) || current_adapter?(:Mysql2Adapter)
       assert_equal 'add_index "companies", ["name"], name: "company_lower_name_index", using: :btree', index_definition
     else

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -195,6 +195,17 @@ class SchemaDumperTest < ActiveRecord::TestCase
     end
   end
 
+  def test_schema_dumps_index_functions
+    index_definition = standard_dump.split(/\n/).grep(/add_index.*company_lower_name_index/).first.strip
+    if current_adapter?(:PostgreSQLAdapter)
+      assert_equal 'add_index "companies", ["name"], name: "company_lower_name_index", using: :btree, function: "lower"', index_definition
+    elsif current_adapter?(:MysqlAdapter) || current_adapter?(:Mysql2Adapter)
+      assert_equal 'add_index "companies", ["name"], name: "company_lower_name_index", using: :btree', index_definition
+    else
+      assert_equal 'add_index "companies", ["name"], name: "company_lower_name_index"', index_definition
+    end
+  end
+
   def test_schema_dump_should_honor_nonstandard_primary_keys
     output = standard_dump
     match = output.match(%r{create_table "movies"(.*)do})

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -189,7 +189,7 @@ ActiveRecord::Schema.define do
   add_index :companies, [:firm_id, :type, :rating], name: "company_index"
   add_index :companies, [:firm_id, :type], name: "company_partial_index", where: "rating > 10"
   add_index :companies, :name, name: 'company_name_index', using: :btree
-  add_index :companies, :name, name: 'company_lower_name_index', using: :btree, function: 'lower'
+  add_index :companies, :name, name: 'company_lower_name_index', using: :btree, functions: 'lower'
 
   create_table :vegetables, force: true do |t|
     t.string :name

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -189,6 +189,7 @@ ActiveRecord::Schema.define do
   add_index :companies, [:firm_id, :type, :rating], name: "company_index"
   add_index :companies, [:firm_id, :type], name: "company_partial_index", where: "rating > 10"
   add_index :companies, :name, name: 'company_name_index', using: :btree
+  add_index :companies, :name, name: 'company_lower_name_index', using: :btree, function: 'lower'
 
   create_table :vegetables, force: true do |t|
     t.string :name


### PR DESCRIPTION
This PR allows you to generate indexes that are wrapped in a SQL function. For example:

``` ruby
add_index :users, :email, unique: true, function: 'lower'
```

will generate:

``` sql
CREATE UNIQUE INDEX index_users_on_lower_email_index ON users (LOWER(email))
```

This allows you to index for the common postgres use case:

``` ruby
user = User.where('LOWER(email) = LOWER(?)', params[:email]).first
if user && user.authenticate(params[:password])
...
```

The schema dumper will currently only dump functions on single column indexes, but I can extend to support composite indexes if there is interest.

This PR only allows for simple expressions such as `lower(email)`. To use more complex expressions, it's probably better to use the SQL schema dumper.
### EDIT

I've updated the API to support functions on multiple columns. For example:

``` ruby
add_index :users, [:first_name, :last_name, :active], functions: ['lower', 'lower', nil]
```
