### PR TITLE
Don't parallelize tests running on jruby

### DIFF
--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -7,7 +7,7 @@ module ActiveSupport
 
       def self.included(klass) #:nodoc:
         klass.class_eval do
-          parallelize_me!
+          parallelize_me! unless RUBY_ENGINE == 'jruby'
         end
       end
 


### PR DESCRIPTION
Running tests using Minitest's `parallelize_me!` leads to the following
error:

``` ruby

ArgumentError: marshal data too short
        load at org/jruby/RubyMarshal.java:150
         run at
/home/travis/build/rails/rails/activesupport/lib/active_support/testing/isolation.rb:82
  _run_suite at
/home/travis/build/rails/rails/vendor/bundle/jruby/1.9/gems/minitest-4.7.5/lib/minitest/unit.rb:933
        each at
/home/travis/build/rails/rails/vendor/bundle/jruby/1.9/gems/minitest-4.7.5/lib/minitest/parallel_each.rb:45
rake aborted!
```

Full Log here:
https://s3.amazonaws.com/archive.travis-ci.org/jobs/16812844/log.txt

Above Error Occurs in many railties, ap, amo, av when tests are run on jruby. with this patch, atleast the tests would compete & not due due weird threading issues. 
#11700
