### PR TITLE
PostgreSQL implementation of SchemaStatements#index_name_exists?

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   PostgreSQL implementation of SchemaStatements#index_name_exists?
+
+    The database agnostic implementation does not detect with indexes that are
+    not supported by the ActiveRecord schema dumper. For example, expressions
+    indexes would not be detected.
+
+    This fixes #11018.
+
+    *Jonathan Baudanza*
+
 *   Currently Active Record can be configured via the environment variable
     `DATABASE_URL` or by manually injecting a hash of values which is what Rails does,
     reading in `database.yml` and setting Active Record appropriately. Active Record

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -126,6 +126,19 @@ module ActiveRecord
           SQL
         end
 
+        def index_name_exists?(table_name, index_name, default)
+          exec_query(<<-SQL, 'SCHEMA').rows.first[0].to_i > 0
+            SELECT COUNT(*)
+            FROM pg_class t
+            INNER JOIN pg_index d ON t.oid = d.indrelid
+            INNER JOIN pg_class i ON d.indexrelid = i.oid
+            WHERE i.relkind = 'i'
+              AND i.relname = '#{index_name}'
+              AND t.relname = '#{table_name}'
+              AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname = ANY (current_schemas(false)) )
+          SQL
+        end
+
         # Returns an array of indexes for the given table.
         def indexes(table_name, name = nil)
            result = query(<<-SQL, 'SCHEMA')

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -240,6 +240,18 @@ class SchemaTest < ActiveRecord::TestCase
     assert_nothing_raised { with_schema_search_path nil }
   end
 
+  def test_index_name_exists
+    with_schema_search_path(SCHEMA_NAME) do
+      assert @connection.index_name_exists?(TABLE_NAME, INDEX_A_NAME, true)
+      assert @connection.index_name_exists?(TABLE_NAME, INDEX_B_NAME, true)
+      assert @connection.index_name_exists?(TABLE_NAME, INDEX_C_NAME, true)
+      assert @connection.index_name_exists?(TABLE_NAME, INDEX_D_NAME, true)
+      assert @connection.index_name_exists?(TABLE_NAME, INDEX_E_NAME, true)
+      assert @connection.index_name_exists?(TABLE_NAME, INDEX_E_NAME, true)
+      assert_not @connection.index_name_exists?(TABLE_NAME, 'missing_index', true)
+    end
+  end
+
   def test_dump_indexes_for_schema_one
     do_dump_index_tests_for_schema(SCHEMA_NAME, INDEX_A_COLUMN, INDEX_B_COLUMN_S1, INDEX_D_COLUMN, INDEX_E_COLUMN)
   end


### PR DESCRIPTION
The default implementation of `#index_name_exists?` calls `#indexes` and then matches the index name. The problem with this approach is that `#indexes` does not return indexes that are not compatible with the schema dumper. For example, expression indexes will be skipped.

This PR fixes #11018
