### PR TITLE
Allow session serializer key in config.session_store

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -49,6 +49,20 @@
 
     *Alessandro Diaferia*
 
+*   Add `:serializer` option for `config.session_store :cookie_store`. This
+    changes default serializer when using `:cookie_store` to
+    `ActionDispatch::Session::MarshalSerializer` which is wrapper on Marshal.
+
+    It is also possible to pass:
+
+    * `:json_serializer` which is secure wrapper on JSON using `JSON.parse` and
+      `JSON.generate` methods with quirks mode;
+    * any other Symbol or String like `:my_custom_serializer` which will be
+      camelized and constantized in `ActionDispatch::Session` namespace;
+    * serializer object with `load` and `dump` methods defined.
+
+    *Łukasz Sarnacki*
+
 *   Allow an absolute controller path inside a module scope. Fixes #12777.
 
     Example:

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -82,10 +82,12 @@ module ActionDispatch
   end
 
   module Session
-    autoload :AbstractStore, 'action_dispatch/middleware/session/abstract_store'
-    autoload :CookieStore,   'action_dispatch/middleware/session/cookie_store'
-    autoload :MemCacheStore, 'action_dispatch/middleware/session/mem_cache_store'
-    autoload :CacheStore,    'action_dispatch/middleware/session/cache_store'
+    autoload :AbstractStore,     'action_dispatch/middleware/session/abstract_store'
+    autoload :CookieStore,       'action_dispatch/middleware/session/cookie_store'
+    autoload :MemCacheStore,     'action_dispatch/middleware/session/mem_cache_store'
+    autoload :CacheStore,        'action_dispatch/middleware/session/cache_store'
+    autoload :JsonSerializer,    'action_dispatch/middleware/session/json_serializer'
+    autoload :MarshalSerializer, 'action_dispatch/middleware/session/marshal_serializer'
   end
 
   mattr_accessor :test_app

--- a/actionpack/lib/action_dispatch/middleware/session/json_serializer.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/json_serializer.rb
@@ -1,0 +1,13 @@
+module ActionDispatch
+  module Session
+    class JsonSerializer
+      def self.load(value)
+        JSON.parse(value, quirks_mode: true)
+      end
+
+      def self.dump(value)
+        JSON.generate(value, quirks_mode: true)
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/middleware/session/marshal_serializer.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/marshal_serializer.rb
@@ -1,0 +1,14 @@
+module ActionDispatch
+  module Session
+    class MarshalSerializer
+      def self.load(value)
+        Marshal.load(value)
+      end
+
+      def self.dump(value)
+        Marshal.dump(value)
+      end
+    end
+  end
+end
+

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -12,7 +12,7 @@ module ActiveSupport
   # This can be used in situations similar to the <tt>MessageVerifier</tt>, but
   # where you don't want users to be able to determine the value of the payload.
   #
-  #   salt  = SecureRandom.random_bytes(64) 
+  #   salt  = SecureRandom.random_bytes(64)
   #   key   = ActiveSupport::KeyGenerator.new('password').generate_key(salt) # => "\x89\xE0\x156\xAC..."
   #   crypt = ActiveSupport::MessageEncryptor.new(key)                       # => #<ActiveSupport::MessageEncryptor ...>
   #   encrypted_data = crypt.encrypt_and_sign('my secret data')              # => "NlFBTTMwOUV5UlA1QlNEN2xkY2d6eThYWWh..."

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -381,6 +381,28 @@ You can also pass a `:domain` key and specify the domain name for the cookie:
 YourApp::Application.config.session_store :cookie_store, key: '_your_app_session', domain: ".example.com"
 ```
 
+You can pass `:serializer` key to specify serializer for serializing session:
+
+```ruby
+YourApp::Application.config.session_store :cookie_store, key: '_your_app_session', serializer: :json_serializer
+```
+
+Default serializer is `:marshal_serializer`. When Symbol or String is passed it
+will look for appropriate class in `ActionDispatch::Session` namespace, so
+passing `:my_custom_serializer` would load
+`ActionDispatch::Session::MyCustomSerializer`.
+
+```ruby
+YourApp::Application.config.session_store :cookie_store, key: '_your_app_session', serializer: :my_custom_serializer
+```
+
+It is also possible to pass serializer object with defined `load` and `dump`
+public methods:
+
+```ruby
+YourApp::Application.config.session_store :cookie_store, key: '_your_app_session', serializer: MyCustomSerializer
+```
+
 Rails sets up (for the CookieStore) a secret key used for signing the session data. This can be changed in `config/initializers/secret_token.rb`
 
 ```ruby

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -205,7 +205,8 @@ module Rails
           "action_dispatch.http_auth_salt" => config.action_dispatch.http_auth_salt,
           "action_dispatch.signed_cookie_salt" => config.action_dispatch.signed_cookie_salt,
           "action_dispatch.encrypted_cookie_salt" => config.action_dispatch.encrypted_cookie_salt,
-          "action_dispatch.encrypted_signed_cookie_salt" => config.action_dispatch.encrypted_signed_cookie_salt
+          "action_dispatch.encrypted_signed_cookie_salt" => config.action_dispatch.encrypted_signed_cookie_salt,
+          "action_dispatch.session_serializer" => config.session_options[:serializer]
         })
       end
     end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: <%= "'_#{app_name}_session'" %>
+Rails.application.config.session_store :cookie_store, key: <%= "'_#{app_name}_session'" %>, serializer: :json_serializer

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -433,7 +433,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_new_hash_style
     run_generator [destination_root]
     assert_file "config/initializers/session_store.rb" do |file|
-      assert_match(/config.session_store :cookie_store, key: '_.+_session'/, file)
+      assert_match(/config.session_store :cookie_store, key: '_.+_session', serializer: :json_serializer/, file)
     end
   end
 


### PR DESCRIPTION
MessageEncryptor has :serializer option, where any serializer object can be passed. 
This commit make it possible to set serializer from configuration level.

There are predefined serializers and custom serializer can be passed
by adding custom class to ActionDispatch::Session.

This was suggested in #12881
