### PR TITLE
[JRuby] Fix incorrect RUBY_ENGINE value 

### DIFF
--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -62,3 +62,12 @@ end
 def restore_delivery_method
   ActionMailer::Base.delivery_method = @old_delivery_method
 end
+
+# Skips the current run on Rubinius using Minitest::Assertions#skip
+def rubinius_skip(message = '')
+  skip message if RUBY_ENGINE == 'rbx'
+end
+# Skips the current run on JRuby using Minitest::Assertions#skip
+def jruby_skip(message = '')
+  skip message if defined?(JRUBY_VERSION)
+end

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -351,3 +351,12 @@ module Backoffice
     class ImagesController < ResourcesController; end
   end
 end
+
+# Skips the current run on Rubinius using Minitest::Assertions#skip
+def rubinius_skip(message = '')
+  skip message if RUBY_ENGINE == 'rbx'
+end
+# Skips the current run on JRuby using Minitest::Assertions#skip
+def jruby_skip(message = '')
+  skip message if defined?(JRUBY_VERSION)
+end

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -37,10 +37,8 @@ module StaticTests
   end
 
   def test_served_static_file_with_non_english_filename
-    if RUBY_ENGINE == 'jruby '
-      skip "Stop skipping if following bug gets fixed: " \
+    jruby_skip "Stop skipping if following bug gets fixed: " \
       "http://jira.codehaus.org/browse/JRUBY-7192"
-    end
     assert_html "means hello in Japanese\n", get("/foo/#{Rack::Utils.escape("こんにちは.html")}")
   end
 

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -331,3 +331,11 @@ module ActionDispatch
   end
 end
 
+# Skips the current run on Rubinius using Minitest::Assertions#skip
+def rubinius_skip(message = '')
+  skip message if RUBY_ENGINE == 'rbx'
+end
+# Skips the current run on JRuby using Minitest::Assertions#skip
+def jruby_skip(message = '')
+  skip message if defined?(JRUBY_VERSION)
+end

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -34,5 +34,5 @@ end
 
 # Skips the current run on JRuby using Minitest::Assertions#skip
 def jruby_skip(message = '')
-  skip message if RUBY_ENGINE == 'jruby'
+  skip message if defined?(JRUBY_VERSION)
 end

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -17,3 +17,12 @@ module TestApp
     secrets.secret_key_base = 'b3c631c314c0bbca50c1b2843150fe33'
   end
 end
+
+# Skips the current run on Rubinius using Minitest::Assertions#skip
+def rubinius_skip(message = '')
+  skip message if RUBY_ENGINE == 'rbx'
+end
+# Skips the current run on JRuby using Minitest::Assertions#skip
+def jruby_skip(message = '')
+  skip message if defined?(JRUBY_VERSION)
+end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -458,14 +458,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_spring_binstubs
-    skip "spring doesn't run on JRuby" if defined?(JRUBY_VERSION)
+    jruby_skip "spring doesn't run on JRuby"
     generator.stubs(:bundle_command).with('install')
     generator.expects(:bundle_command).with('exec spring binstub --all').once
     quietly { generator.invoke_all }
   end
 
   def test_spring_no_fork
-    skip "spring doesn't run on JRuby" if defined?(JRUBY_VERSION)
+    jruby_skip "spring doesn't run on JRuby"
     Process.stubs(:respond_to?).with(:fork).returns(false)
     run_generator
 


### PR DESCRIPTION
fix the typo in `RUBY_ENGINE` value, so is matches RUBY_ENGINE.

``` ruby
jruby-1.7.9 :001 > RUBY_ENGINE
"jruby"
```

 This way test is actually skipped on JRuby. let me know, if this needs to be changed to use `defined(JRUBY_VERSION)`. 
#11700
