### PR TITLE
Fixing bug with assert_template and options :partial and :locals

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix issue with `ActionController::TemplateAssertions#assert_template` where options
+    `:partial` and `:locals` can cause a NoMethodException when the wrong partial
+    template name is supplied
+
 *   Fix regression when using `ActionView::Helpers::TranslationHelper#translate` with
     `options[:raise]`.
 

--- a/actionpack/test/template/test_case_test.rb
+++ b/actionpack/test/template/test_case_test.rb
@@ -296,10 +296,19 @@ module ActionView
   end
 
   class RenderTemplateTest < ActionView::TestCase
-    test "supports specifying partials" do
+    test "supports specifying partials (passing)" do
       controller.controller_path = "test"
       render(:template => "test/calling_partial_with_layout")
       assert_template :partial => "_partial_for_use_in_layout"
+    end
+
+    test "supports specifying partials (failing)" do
+      controller.controller_path = "test"
+      render(:template => "test/calling_partial_with_layout")
+      assert_raise ActiveSupport::TestCase::Assertion,
+          /expecting partial <_wrong_template> but action rendered <_partial_for_use_in_layout>/ do
+        assert_template :partial => "_wrong_template"
+      end
     end
 
     test "supports specifying locals (passing)" do
@@ -313,6 +322,15 @@ module ActionView
       render(:template => "test/calling_partial_with_layout")
       assert_raise ActiveSupport::TestCase::Assertion, /Somebody else.*David/m do
         assert_template :partial => "_partial_for_use_in_layout", :locals => { :name => "Somebody Else" }
+      end
+    end
+
+    test "supports specifying locals (failing with wrong template name)" do
+      controller.controller_path = "test"
+      render(:template => "test/calling_partial_with_layout")
+      assert_raise ActiveSupport::TestCase::Assertion,
+            /expecting partial <_adrian_has_monkey_balls> but action rendered <_partial_for_use_in_layout>/ do
+        assert_template :partial => "_adrian_has_monkey_balls", :locals => { :name => "Somebody Else" }
       end
     end
   end


### PR DESCRIPTION
Addressing Issue: https://github.com/rails/rails/issues/13694

Fixed an issue with assert_template. If you asserted the wrong
partial template, and specified the :locals option it would raise a
NoMethodException with the following error message:

  "undefined method `[]' for nil:NilClass"

Altered the method to first check the template was rendered
before checking the locals.

NB: I also noticed that the assert_template with :partial and
:layout option is neither tested nor will it actually work at all.
I opted however to leave it for another day/commit.
