### PR TITLE
setup Bundler in engines `bin/rails` stub.

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
@@ -3,5 +3,9 @@
 ENGINE_ROOT = File.expand_path('../..', __FILE__)
 ENGINE_PATH = File.expand_path('../../lib/<%= name -%>/engine', __FILE__)
 
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
 require 'rails/all'
 require 'rails/engine/commands'


### PR DESCRIPTION
This is necessary when bundling gems locally using `BUNDLE_PATH`.
Without this patch `bin/rails` fails with:

```
/Users/senny/.rbenv/versions/2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- rails/all (LoadError)
    from /Users/senny/.rbenv/versions/2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from bin/rails:7:in `<main>'
```

I wasn't sure what's the best way to test this, without effectively calling bundle and using a `BUNDLE_PATH`, which would take some time.
