### PR TITLE
Add config.middleware.clear operation

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -118,6 +118,10 @@ module ActionDispatch
       middlewares.freeze.reverse.inject(app) { |a, e| e.build(a) }
     end
 
+    def clear
+      middlewares.clear
+    end
+
   protected
 
     def assert_index(index, where)

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -63,6 +63,10 @@ module Rails
         @operations << [__method__, args, block]
       end
 
+      def clear(*args, &block)
+        @operations << [__method__, args, block]
+      end
+
       def merge_into(other) #:nodoc:
         @operations.each do |operation, args, block|
           other.send(operation, *args, &block)

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -118,6 +118,16 @@ module ApplicationTests
       assert !middleware.include?("ActionDispatch::Static")
     end
 
+    test "can clear stack" do
+      add_to_config %{
+        initializer :clear_middleware do
+          config.middleware.clear
+        end
+      }
+      boot!
+      assert middleware.empty?
+    end
+
     test "includes exceptions middlewares even if action_dispatch.show_exceptions is disabled" do
       add_to_config "config.action_dispatch.show_exceptions = false"
       boot!


### PR DESCRIPTION
This commit adds config.middleware.clear operation, which
removes all middlewares added to MiddlewareStack.

Related Issue: #13299
