### PR TITLE
Favor canonical environment variables for secrets

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/secrets.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/secrets.yml
@@ -19,4 +19,4 @@ test:
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
-  secret_key_base: <%%= ENV["RAILS_SECRET_KEY_BASE"] %>
+  secret_key_base: <%%= ENV["SECRET_KEY_BASE"] %>

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -93,8 +93,8 @@ module TestHelpers
     # Build an application by invoking the generator and going through the whole stack.
     def build_app(options = {})
       @prev_rails_env = ENV['RAILS_ENV']
-      ENV['RAILS_ENV']             = 'development'
-      ENV['RAILS_SECRET_KEY_BASE'] ||= SecureRandom.hex(16)
+      ENV['RAILS_ENV']       =   "development"
+      ENV['SECRET_KEY_BASE'] ||= SecureRandom.hex(16)
 
       FileUtils.rm_rf(app_path)
       FileUtils.cp_r(app_template_path, app_path)


### PR DESCRIPTION
Prefixing an environment variable with `RAILS_` should be used when there is otherwise a conflict, such as `RAILS_ENV` or if it is being used for a very Rails specific value.

If we remove the prefix of `RAILS_` in the case of `RAILS_SECRET_KEY_BASE` then we can push for a pseudo standard among other frameworks that will accept a common environment key `SECRET_KEY_BASE` to keep your app secure. This is beneficial for containerized deployments such as docker, Heroku, etc. So that the container need to know one less thing about your app (it can just set it no-matter what language or framework you are using). 

This change also allows the defaults to be consistent with the way the secret key is accessed so `secrets.secret_key_base` is aliased to `SECRET_KEY_BASE` instead of `RAILS_SECRET_KEY_BASE`.
