### PR TITLE
single quotes for controller generated routes

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -231,7 +231,7 @@ Rails will create several files and a route for you.
 
 ```bash
 create  app/controllers/welcome_controller.rb
- route  get "welcome/index"
+ route  get 'welcome/index'
 invoke  erb
 create    app/views/welcome
 create    app/views/welcome/index.html.erb
@@ -272,13 +272,13 @@ Open the file `config/routes.rb` in your editor.
 
 ```ruby
 Rails.application.routes.draw do
-  get "welcome/index"
+  get 'welcome/index'
 
   # The priority is based upon order of creation:
   # first created -> highest priority.
   #
   # You can have the root of your site routed with "root"
-  # root "welcome#index"
+  # root 'welcome#index'
   #
   # ...
 ```
@@ -295,7 +295,7 @@ root 'welcome#index'
 ```
 
 `root 'welcome#index'` tells Rails to map requests to the root of the
-application to the welcome controller's index action and `get "welcome/index"`
+application to the welcome controller's index action and `get 'welcome/index'`
 tells Rails to map requests to <http://localhost:3000/welcome/index> to the
 welcome controller's index action. This was created earlier when you ran the
 controller generator (`rails generate controller welcome index`).
@@ -328,7 +328,7 @@ Blog::Application.routes.draw do
 
   resources :posts
 
-  root "welcome#index"
+  root 'welcome#index'
 end
 ```
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Write controller generated routes in routes.rb with single quotes.
+
+    *Cristian Mircea Messel*
+
 *   Only lookup `config.log_level` for stdlib `::Logger` instances.
     Assign it as is for third party loggers like `Log4r::Logger`.
 

--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -23,7 +23,7 @@ module Rails
         # Will generate -
         # namespace :foo do
         #   namespace :bar do
-        #     get "baz/index"
+        #     get 'baz/index'
         #   end
         # end
         def generate_routing_code(action)
@@ -36,8 +36,8 @@ module Rails
           end.join
 
           # Create route
-          #     get "baz/index"
-          route = indent(%{get "#{file_name}/#{action}"\n}, depth * 2)
+          #     get 'baz/index'
+          route = indent(%{get '#{file_name}/#{action}'\n}, depth * 2)
 
           # Create `end` ladder
           #   end

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -67,7 +67,7 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
 
   def test_add_routes
     run_generator
-    assert_file "config/routes.rb", /get "account\/foo"/, /get "account\/bar"/
+    assert_file "config/routes.rb", /get 'account\/foo'/, /get 'account\/bar'/
   end
 
   def test_invokes_default_template_engine_even_with_no_action
@@ -91,6 +91,6 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
 
   def test_namespaced_routes_are_created_in_routes
     run_generator ["admin/dashboard", "index"]
-    assert_file "config/routes.rb", /namespace :admin do\n\s+get "dashboard\/index"\n/
+    assert_file "config/routes.rb", /namespace :admin do\n\s+get 'dashboard\/index'\n/
   end
 end

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -63,7 +63,7 @@ class NamespacedControllerGeneratorTest < NamespacedGeneratorTestCase
 
   def test_routes_should_not_be_namespaced
     run_generator
-    assert_file "config/routes.rb", /get "account\/foo"/, /get "account\/bar"/
+    assert_file "config/routes.rb", /get 'account\/foo'/, /get 'account\/bar'/
   end
 
   def test_invokes_default_template_engine_even_with_no_action


### PR DESCRIPTION
Write routes in route.rb with single quotes

```
get 'welcome/index'
```

instead of

```
get "welcome/index"
```
