### PR TITLE
Active Record's subclass_from_attributes shouldn't assume :type is for STI unless there is a type column.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Don't try to get the subclass if the inheritance column doesn't exist
+
+    The `subclass_from_attrs` method is called even if the column specified by
+    the `inheritance_column` setting doesn't exist. This prevents setting associations
+    via the attributes hash if the association name clashes with the value of the setting,
+    typically `:type`. This worked previously in Rails 3.2.
+
+    *Ujjwal Thaakar*
+
 *   Enum mappings are now exposed via class methods instead of constants.
 
     Example:

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -18,13 +18,17 @@ module ActiveRecord
         if abstract_class? || self == Base
           raise NotImplementedError, "#{self} is an abstract class and cannot be instantiated."
         end
-        if (attrs = args.first).is_a?(Hash)
-          if subclass = subclass_from_attrs(attrs)
-            return subclass.new(*args, &block)
-          end
+
+        attrs = args.first
+        if subclass_from_attributes?(attrs)
+          subclass = subclass_from_attributes(attrs)
         end
-        # Delegate to the original .new
-        super
+
+        if subclass
+          subclass.new(*args, &block)
+        else
+          super
+        end
       end
 
       # Returns +true+ if this does not need STI type condition. Returns
@@ -172,7 +176,11 @@ module ActiveRecord
       # is not self or a valid subclass, raises ActiveRecord::SubclassNotFound
       # If this is a StrongParameters hash, and access to inheritance_column is not permitted,
       # this will ignore the inheritance column and return nil
-      def subclass_from_attrs(attrs)
+      def subclass_from_attributes?(attrs)
+        columns_hash.include?(inheritance_column) && attrs.is_a?(Hash)
+      end
+
+      def subclass_from_attributes(attrs)
         subclass_name = attrs.with_indifferent_access[inheritance_column]
 
         if subclass_name.present? && subclass_name != self.name

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -1,10 +1,11 @@
-require "cases/helper"
+require 'cases/helper'
 require 'models/company'
 require 'models/person'
 require 'models/post'
 require 'models/project'
 require 'models/subscriber'
 require 'models/vegetables'
+require 'models/shop'
 
 class InheritanceTest < ActiveRecord::TestCase
   fixtures :companies, :projects, :subscribers, :accounts, :vegetables
@@ -366,5 +367,11 @@ class InheritanceComputeTypeTest < ActiveRecord::TestCase
     assert_nothing_raised { assert_kind_of Firm::FirmOnTheFly, Firm.find(foo.id) }
   ensure
     ActiveRecord::Base.store_full_sti_class = true
+  end
+
+  def test_sti_type_from_attributes_disabled_in_non_sti_class
+    phone = Shop::Product::Type.new(name: 'Phone')
+    product = Shop::Product.new(:type => phone)
+    assert product.save
   end
 end

--- a/activerecord/test/models/shop.rb
+++ b/activerecord/test/models/shop.rb
@@ -5,6 +5,11 @@ module Shop
 
   class Product < ActiveRecord::Base
     has_many :variants, :dependent => :delete_all
+    belongs_to :type
+
+    class Type < ActiveRecord::Base
+      has_many :products
+    end
   end
 
   class Variant < ActiveRecord::Base

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -557,7 +557,12 @@ ActiveRecord::Schema.define do
 
   create_table :products, force: true do |t|
     t.references :collection
+    t.references :type
     t.string     :name
+  end
+
+  create_table :product_types, force: true do |t|
+    t.string :name
   end
 
   create_table :projects, force: true do |t|


### PR DESCRIPTION
Active Record's subclass_from_attrs assumes type is for STI whether or not type exists as a column or not. This fixes this bug allowing you to use type as a reference in non-STI classes.

``` ruby
# Activate the gem you are reporting the issue against.
gem 'activerecord', '4.0.2'
require 'active_record'
require 'minitest/autorun'
require 'logger'

# Ensure backward compatibility with Minitest 4
Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :products do |t|
    t.references :type
    t.string :name
  end

  add_index :products, :type_id

  create_table :product_types do |t|
    t.string :name
  end

  add_index :product_types, :name, unique: true
end

class Product < ActiveRecord::Base
  class Type < ActiveRecord::Base
    has_many :products
  end

  belongs_to :type
end

class BugTest < Minitest::Test
  def test_sti_type_from_attributes_disabled_in_non_sti_class
    phone = Product::Type.new(name: 'Phone')
    product = Product.new(:type => phone)
    assert product.save
  end
end
```
