### PR TITLE
Calculation methods on models (maximum and minimum) for datetime fields should return values in the current timezone.

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -18,6 +18,7 @@ class NumericData < ActiveRecord::Base
 end
 
 class CalculationsTest < ActiveRecord::TestCase
+  include InTimeZone
   fixtures :companies, :accounts, :topics
 
   def test_should_sum_field
@@ -52,6 +53,75 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_type_cast_calculated_value_should_convert_db_averages_of_fixnum_class_to_decimal
     assert_equal 0, NumericData.all.send(:type_cast_calculated_value, 0, nil, 'avg')
     assert_equal 53.0, NumericData.all.send(:type_cast_calculated_value, 53, nil, 'avg')
+  end
+
+  def test_calculated_datetime_value_should_have_same_timezone_as_value_returned_from_attribute
+    tz = "Pacific Time (US & Canada)"
+    in_time_zone tz do
+      Topic.time_zone_aware_attributes = true
+      Topic.skip_time_zone_conversion_for_attributes = []
+      # We have to reset the column information on the model so that it creates attributes
+      # that are time zone aware (ActiveRecord::Base.time_zone_aware_attributes)
+      Topic.reset_column_information
+      written_on_maximum = Topic.maximum(:written_on)
+      topic_with_maximum_written_on_value = topics(:third)
+      assert_equal topic_with_maximum_written_on_value.written_on.time_zone, written_on_maximum.time_zone
+    end
+  end
+
+  def test_calculated_value_type_cast_should_convert_datetime_field_to_current_timezone
+    tz = "Pacific Time (US & Canada)"
+    in_time_zone tz do
+      Topic.time_zone_aware_attributes = true
+      Topic.skip_time_zone_conversion_for_attributes = []
+      Topic.reset_column_information
+      written_on_maximum = Topic.maximum(:written_on)
+      assert_equal ActiveSupport::TimeZone[tz], written_on_maximum.time_zone
+    end
+  end
+
+  def test_calculated_value_type_cast_for_datetime_should_honor_time_zone_aware_attributes_flag
+    tz = "Pacific Time (US & Canada)"
+    in_time_zone tz do
+      Topic.time_zone_aware_attributes = false
+      Topic.skip_time_zone_conversion_for_attributes = []
+      Topic.reset_column_information
+      written_on_maximum = Topic.maximum(:written_on)
+      assert written_on_maximum.utc?
+    end
+  end
+
+  def test_calculated_value_type_cast_for_datetime_should_honor_skip_time_zone_conversion_for_attributes_flag
+    tz = "Pacific Time (US & Canada)"
+    in_time_zone tz do
+      Topic.time_zone_aware_attributes = true
+      Topic.skip_time_zone_conversion_for_attributes = [:written_on]
+      Topic.reset_column_information
+      written_on_maximum = Topic.maximum(:written_on)
+      assert written_on_maximum.utc?
+    end
+  end
+
+  def test_calculated_group_value_type_cast_should_convert_datetime_field_to_current_timezone
+    tz = "Pacific Time (US & Canada)"
+    in_time_zone tz do
+      Topic.time_zone_aware_attributes = true
+      Topic.skip_time_zone_conversion_for_attributes = []
+      Topic.reset_column_information
+      results = Topic.group(:approved).maximum(:written_on)
+      assert_equal ActiveSupport::TimeZone[tz], results[true].time_zone
+    end
+  end
+
+  def test_calculated_group_key_value_type_cast_should_convert_datetime_field_to_current_timezone
+    tz = "Pacific Time (US & Canada)"
+    in_time_zone tz do
+      Topic.time_zone_aware_attributes = true
+      Topic.skip_time_zone_conversion_for_attributes = []
+      Topic.reset_column_information
+      results = Topic.group(:written_on).count(:id)
+      assert_equal ActiveSupport::TimeZone[tz], results.keys.first.time_zone
+    end
   end
 
   def test_should_get_maximum_of_field

--- a/activerecord/test/cases/multiparameter_attributes_test.rb
+++ b/activerecord/test/cases/multiparameter_attributes_test.rb
@@ -213,6 +213,7 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
 
   def test_multiparameter_attributes_on_time_with_time_zone_aware_attributes_false
     with_timezone_config default: :local, aware_attributes: false, zone: -28800 do
+      Topic.reset_column_information
       attributes = {
         "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
         "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
@@ -227,6 +228,7 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
   def test_multiparameter_attributes_on_time_with_skip_time_zone_conversion_for_attributes
     with_timezone_config default: :utc, aware_attributes: true, zone: -28800 do
       Topic.skip_time_zone_conversion_for_attributes = [:written_on]
+      Topic.reset_column_information
       attributes = {
         "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
         "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"


### PR DESCRIPTION
Calculation methods should act the same as attributes on the model and be timezone aware.

Currently values returned from calculations on models return dates/times in UTC. For example:

```
Topic.maximum(:written_on) => 2014-01-13 17:56:44 UTC
```

Selecting that column will return the value converted to the current timezone if time_zone_aware_attributes is true and it's not been excluded with skip_time_zone_conversion_for_attributes:

```
Topic.pluck(:written_on).first => Mon, 13 Jan 2014 17:56:44 GMT +00:00
```

or

```
topic = Topic.first
topic.written_on => Mon, 13 Jan 2014 17:56:44 GMT +00:00
```

This pull request makes it so calculated values also honor the time_zone_aware_attributes flag and the skip_time_zone_conversion_for_attributes array:

```
Topic.maximum(:written_on) => Mon, 13 Jan 2014 17:56:44 GMT +00:00
```

Let me know if it needs any cleaning up or changes. Thanks!
