### PR TITLE
Updating docs for config.action_view.erb_trim_mode

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -374,7 +374,7 @@ encrypted cookies salt value. Defaults to `'signed encrypted cookie'`.
 
 * `config.action_view.logger` accepts a logger conforming to the interface of Log4r or the default Ruby Logger class, which is then used to log information from Action View. Set to `nil` to disable logging.
 
-* `config.action_view.erb_trim_mode` gives the trim mode to be used by ERB. Rails now uses Erubis as the default engine. See the [Erubis documentation](http://www.kuwata-lab.com/erubis/users-guide.06.html#topics-trimspaces) for more information.
+* `config.action_view.erb_trim_mode` gives the trim mode to be used by ERB. Since Rails 3 the default engine has changed to [Erubis](http://www.kuwata-lab.com/erubis/users-guide.06.html#topics-trimspaces) and now the only mode it understands for trimming is '-'. Below is an example of how you can trim white spaces in ERB or Erubis syntax.
 
    ```erb
    <%= @person -%>          # or <%= @person =%>

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -374,7 +374,12 @@ encrypted cookies salt value. Defaults to `'signed encrypted cookie'`.
 
 * `config.action_view.logger` accepts a logger conforming to the interface of Log4r or the default Ruby Logger class, which is then used to log information from Action View. Set to `nil` to disable logging.
 
-* `config.action_view.erb_trim_mode` gives the trim mode to be used by ERB. It defaults to `'-'`. See the [ERB documentation](http://www.ruby-doc.org/stdlib/libdoc/erb/rdoc/) for more information.
+* `config.action_view.erb_trim_mode` gives the trim mode to be used by ERB. Rails now uses Erubis as the default engine. See the [Erubis documentation](http://www.kuwata-lab.com/erubis/users-guide.06.html#topics-trimspaces) for more information.
+
+   ```erb
+   <%= @person -%>          # or <%= @person =%>
+   ```
+
 
 * `config.action_view.embed_authenticity_token_in_remote_forms` allows you to set the default behavior for `authenticity_token` in forms with `:remote => true`. By default it's set to false, which means that remote forms will not include `authenticity_token`, which is helpful when you're fragment-caching the form. Remote forms get the authenticity from the `meta` tag, so embedding is unnecessary unless you support browsers without JavaScript. In such case you can either pass `:authenticity_token => true` as a form option or set this config setting to `true`
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -374,7 +374,7 @@ encrypted cookies salt value. Defaults to `'signed encrypted cookie'`.
 
 * `config.action_view.logger` accepts a logger conforming to the interface of Log4r or the default Ruby Logger class, which is then used to log information from Action View. Set to `nil` to disable logging.
 
-* `config.action_view.erb_trim_mode` gives the trim mode to be used by ERB. Since Rails 3 the default engine has changed to [Erubis](http://www.kuwata-lab.com/erubis/users-guide.06.html#topics-trimspaces) and now the only mode it understands for trimming is '-'. Below is an example of how you can trim white spaces in ERB or Erubis syntax.
+* `config.action_view.erb_trim_mode` gives the trim mode to be used by ERB. Since Rails 3 the default engine has changed to [Erubis](http://www.kuwata-lab.com/erubis/users-guide.06.html#topics-trimspaces) and now the only trim mode it understands for trimming is '-'. Below is an example of how you can trim white spaces in ERB or Erubis syntax.
 
    ```erb
    <%= @person -%>          # or <%= @person =%>


### PR DESCRIPTION
I would like to help resolve #12963.
This  documents that Erubis is now the default engine being used by Rails. This also adds an ERB example to remove trailing white spaces. 
