### PR TITLE
Add back yaml_initialize hook to AR::Core for Syck deserialization support

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add back #yaml_initialize method for Syck deserialization
+
+    *Blake Mesdag* *Arthur Neves*
+
 *   Enable partial indexes for sqlite >= 3.8.0
 
     See http://www.sqlite.org/partialindex.html

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -373,6 +373,17 @@ module ActiveRecord
       !_rollback_callbacks.empty? || !_commit_callbacks.empty? || !_create_callbacks.empty?
     end
 
+    # Required to deserialize Syck properly.
+    if YAML.const_defined?(:ENGINE) && YAML::ENGINE.syck?
+      ActiveSupport::Deprecation.warn(
+        "Syck is deprecated and support for serialization has been removed." \
+        " ActiveRecord::Base.yaml_initialize will be removed which will break deserialization support with Syck."
+      )
+      def yaml_initialize # :nodoc:
+        init_with(coder)
+      end
+    end
+
     private
 
     # Updates the attributes on this particular ActiveRecord object so that


### PR DESCRIPTION
This adds back the ActiveRecord::Core#yaml_initialize to support proper deserialization of yaml objects with the Syck engine with a deprecation warning.
