### PR TITLE
Add back yaml_initialize hook to AR::Core for Syck deserialization support

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add back `#yaml_initialize` method for Syck deserialization
+
+    `ActiveRecord::Core#yaml_initialize` has been added back to support deserialization using
+    the Syck engine. This is to facilitate migration from Syck to Psych. Serialization support
+    will not been restored for Syck, Psych should be used to serialize YAML once its been
+    parsed with Syck.
+ 
+    *Blake Mesdag*, *arthurnn*
+ 
 *   Don't try to get the subclass if the inheritance column doesn't exist
 
     The `subclass_from_attrs` method is called even if the column specified by

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -373,6 +373,17 @@ module ActiveRecord
       !_rollback_callbacks.empty? || !_commit_callbacks.empty? || !_create_callbacks.empty?
     end
 
+    # Required to deserialize Syck properly.
+    if YAML.const_defined?(:ENGINE) && YAML::ENGINE.syck?
+      ActiveSupport::Deprecation.warn(
+        "Syck is deprecated and support for serialization has been removed." \
+        " ActiveRecord::Core#yaml_initialize will be removed in 4.1 which will break deserialization support with Syck."
+      )
+      def yaml_initialize(tag, coder) # :nodoc:
+        init_with(coder)
+      end
+    end
+
     private
 
     # Updates the attributes on this particular ActiveRecord object so that


### PR DESCRIPTION
Forgot to retarget #13722 to 4-0-stable and the signature of the method was off. 

This adds back the ActiveRecord::Core#yaml_initialize to support proper deserialization of yaml objects with the Syck engine with a deprecation warning.

/cc @arthurnn
