### PR TITLE
Fixes double escaping of HTML-safe strings by the truncate command

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -66,8 +66,9 @@ module ActionView
       # Pass a block if you want to show extra content when the text is truncated.
       #
       # The result is marked as HTML-safe, but it is escaped by default, unless <tt>:escape</tt> is
-      # +false+. Care should be taken if +text+ contains HTML tags or entities, because truncation
-      # may produce invalid HTML (such as unbalanced or incomplete tags).
+      # +false+. If the passed +text+ is HTML-safe and you want to escape it again you must pass the
+      # <tt>escape: true</tt> as an option. Care should be taken if +text+ contains HTML tags or 
+      # entities, because truncation may produce invalid HTML (such as unbalanced or incomplete tags).
       #
       #   truncate("Once upon a time in a world far far away")
       #   # => "Once upon a time in a world..."
@@ -92,11 +93,11 @@ module ActionView
       def truncate(text, options = {}, &block)
         if text
           length  = options.fetch(:length, 30)
-          content = text.truncate(length, options)
+          escape  = text.html_safe? && !options[:escape] ? false : options.fetch(:escape, true)
 
-          options[:escape] = false if text.html_safe? && !content.html_safe? && options[:escape] != true
+          content = text.truncate(length, options).to_str
 
-          content = options[:escape] == false ? content.html_safe : ERB::Util.html_escape(content)
+          content = escape ? ERB::Util.html_escape(content) : content.html_safe
           content << capture(&block) if block_given? && text.length > length
           content
         end

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -92,8 +92,10 @@ module ActionView
       def truncate(text, options = {}, &block)
         if text
           length  = options.fetch(:length, 30)
-
           content = text.truncate(length, options)
+
+          options[:escape] = false if text.html_safe? && !content.html_safe? && options[:escape] != true
+
           content = options[:escape] == false ? content.html_safe : ERB::Util.html_escape(content)
           content << capture(&block) if block_given? && text.length > length
           content

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -136,6 +136,10 @@ class TextHelperTest < ActionView::TestCase
     assert_equal "Hello &gt; W...", truncate("Hello &gt; World!".html_safe, :length => 15)
   end
 
+  def test_truncate_should_not_escape_an_umodified_html_safe_input
+    assert_equal "Hello &gt; World!", truncate("Hello &gt; World!".html_safe, :length => 30)
+  end
+
   def test_truncate_should_not_escape_the_input_with_escape_false
     assert_equal "Hello <sc...", truncate("Hello <script>code!</script>World!!", :length => 12, :escape => false)
   end

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -128,6 +128,14 @@ class TextHelperTest < ActionView::TestCase
     assert_equal "Hello &lt;sc...", truncate("Hello <script>code!</script>World!!", :length => 12)
   end
 
+  def test_truncate_should_always_escape_if_true
+    assert_equal "Hello &amp;gt; W...", truncate("Hello &gt; World!", :length => 15, :escape => true)
+  end
+
+  def test_truncate_should_not_escape_a_html_safe_input
+    assert_equal "Hello &gt; W...", truncate("Hello &gt; World!".html_safe, :length => 15)
+  end
+
   def test_truncate_should_not_escape_the_input_with_escape_false
     assert_equal "Hello <sc...", truncate("Hello <script>code!</script>World!!", :length => 12, :escape => false)
   end

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -140,6 +140,10 @@ class TextHelperTest < ActionView::TestCase
     assert_equal "Hello &gt; World!", truncate("Hello &gt; World!".html_safe, :length => 30)
   end
 
+  def test_truncate_should_escape_an_umodified_html_safe_input_if_escape_true
+    assert_equal "Hello &amp;gt; World!", truncate("Hello &gt; World!".html_safe, :length => 30, :escape => true)
+  end
+  
   def test_truncate_should_not_escape_the_input_with_escape_false
     assert_equal "Hello <sc...", truncate("Hello <script>code!</script>World!!", :length => 12, :escape => false)
   end


### PR DESCRIPTION
Resolves #13721
