### PR TITLE
Update fixture class name deprecation warning to give more information about caller

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -462,7 +462,7 @@ module ActiveRecord
         @class_names.delete_if { |k,klass|
           unless klass.is_a? Class
             klass = klass.safe_constantize
-            ActiveSupport::Deprecation.warn("The ability to pass in strings as a class name will be removed in Rails 4.2, consider using the class itself instead.")
+            ActiveSupport::Deprecation.warn("The ability to pass in strings as a class name to `set_fixture_class` will be removed in Rails 4.2. Use the class itself instead.")
           end
           !insert_class(@class_names, k, klass)
         }
@@ -568,7 +568,7 @@ module ActiveRecord
       @model_class = nil
 
       if class_name.is_a?(String)
-        ActiveSupport::Deprecation.warn("The ability to pass in strings as a class name will be removed in Rails 4.2, consider using the class itself instead.")
+        ActiveSupport::Deprecation.warn("The ability to pass in strings as a class name to `FixtureSet.new` will be removed in Rails 4.2. Use the class itself instead.")
       end
 
       if class_name.is_a?(Class) # TODO: Should be an AR::Base type class, or any?


### PR DESCRIPTION
I buried way too much time into a 4.1.0.beta1 upgrade trying to figure out why I was getting this deprecation warning:

> The ability to pass in strings as a class name will be removed in Rails 4.2, consider using the class itself instead.

After lots of debugging caller stacks, it turns out it comes from passing a class-name-as-string into `set_fixture_class` specifically (or `FixtureSet.new`, but I believe that's only used internally).

This just updates the copy of the deprecation warning to hopefully save some other poor souls some time.
