### PR TITLE
clean up security guide: his => their [ci skip]

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -81,7 +81,7 @@ Here are some general guidelines on sessions.
 * _Do not store large objects in a session_. Instead you should store them in the database and save their id in the session. This will eliminate synchronization headaches and it won't fill up your session storage space (depending on what session storage you chose, see below).
 This will also be a good idea, if you modify the structure of an object and old versions of it are still in some user's cookies. With server-side session storages you can clear out the sessions, but with client-side storages, this is hard to mitigate.
 
-* _Critical data should not be stored in session_. If the user clears his cookies or closes the browser, they will be lost. And with a client-side session storage, the user can read the data.
+* _Critical data should not be stored in session_. If the user clears their cookies or closes the browser, they will be lost. And with a client-side session storage, the user can read the data.
 
 ### Session Storage
 


### PR DESCRIPTION
Update the Ruby on Rails Security Guide to follow the [API Documentation Guidelines](https://github.com/rails/rails/blob/master/guides/source/api_documentation_guidelines.md) by changing 'his' to 'their'

Thanks
