### PR TITLE
1.9.3-style in form_helper documentation [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -827,7 +827,7 @@ module ActionView
       #   file_field(:user, :avatar)
       #   # => <input type="file" id="user_avatar" name="user[avatar]" />
       #
-      #   file_field(:post, :image, :multiple => true)
+      #   file_field(:post, :image, multiple: true)
       #   # => <input type="file" id="post_image" name="post[image]" multiple="true" />
       #
       #   file_field(:post, :attached, accept: 'text/html')
@@ -1192,7 +1192,7 @@ module ActionView
     #
     # The +div_radio_button+ code from above can now be used as follows:
     #
-    #   <%= form_for @person, :builder => MyFormBuilder do |f| %>
+    #   <%= form_for @person, builder: MyFormBuilder do |f| %>
     #     I am a child: <%= f.div_radio_button(:admin, "child") %>
     #     I am an adult: <%= f.div_radio_button(:admin, "adult") %>
     #   <% end -%>
@@ -1703,7 +1703,7 @@ module ActionView
       #   file_field(:user, :avatar)
       #   # => <input type="file" id="user_avatar" name="user[avatar]" />
       #
-      #   file_field(:post, :image, :multiple => true)
+      #   file_field(:post, :image, multiple: true)
       #   # => <input type="file" id="post_image" name="post[image]" multiple="true" />
       #
       #   file_field(:post, :attached, accept: 'text/html')


### PR DESCRIPTION
I found some old-style ruby syntax in Rails form_helper documentation.

Actually, big part have 1.9.3 syntax, but these 3 lines not. It seems ugly
