### PR TITLE
set encoding for pipe to binary mode

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1380,6 +1380,8 @@ class BasicsTest < ActiveRecord::TestCase
       })
 
       rd, wr = IO.pipe
+      rd.binmode
+      wr.binmode
 
       ActiveRecord::Base.connection_handler.clear_all_connections!
 

--- a/activerecord/test/cases/connection_management_test.rb
+++ b/activerecord/test/cases/connection_management_test.rb
@@ -31,6 +31,8 @@ module ActiveRecord
           object_id = ActiveRecord::Base.connection.object_id
 
           rd, wr = IO.pipe
+          rd.binmode
+          wr.binmode
 
           pid = fork {
             rd.close

--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -37,6 +37,8 @@ module ActiveSupport
       module Forking
         def run_in_isolation(&blk)
           read, write = IO.pipe
+          read.binmode
+          write.binmode
 
           pid = fork do
             read.close


### PR DESCRIPTION
railties/lib/rails.rb specifies default internal and encodings of UTF_8.  If that ever gets required before a test using a pipe runs, writing the data to the pipe will fail unless we set the read and write of the pipe to binary mode. 

This gist contains a simple example of that: https://gist.github.com/annaswims/8481896
