### PR TITLE
Correct the version number to 4 in guides[ci skip]

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -117,7 +117,7 @@
       name: The Rails Initialization Process
       work_in_progress: true
       url: initialization.html
-      description: This guide explains the internals of the Rails initialization process as of Rails 3.1
+      description: This guide explains the internals of the Rails initialization process as of Rails 4
 -
   name: Extending Rails
   documents:


### PR DESCRIPTION
Reference To:  [The Rails Initialization Process](https://github.com/rails/rails/blob/17c29a0df0da5414570b025b642e90968e96cddc/guides/source/initialization.md#the-rails-initialization-process)

> This guide explains the internals of the initialization process in Rails as of Rails 4. It is an extremely in-depth guide and recommended for advanced Rails developers.
