### PR TITLE
Ability to specify multiple contexts when defining a validation.

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -72,8 +72,8 @@ module ActiveModel
       #   end
       #
       # Options:
-      # * <tt>:on</tt> - Specifies the context where this validation is active
-      #   (e.g. <tt>:on => :create</tt> or <tt>:on => :custom_validation_context</tt>)
+      # * <tt>:on</tt> - Specifies the contexts where this validation is active
+      #   (e.g. <tt>:on => :create</tt> or <tt>:on => :custom_validation_context</tt> or <tt>:on => [:create, :custom_validation_context]</tt>)
       # * <tt>:allow_nil</tt> - Skip validation if attribute is +nil+.
       # * <tt>:allow_blank</tt> - Skip validation if attribute is blank.
       # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
@@ -134,7 +134,7 @@ module ActiveModel
         if options.key?(:on)
           options = options.dup
           options[:if] = Array.wrap(options[:if])
-          options[:if].unshift("validation_context == :#{options[:on]}")
+          options[:if].unshift("#{Array.wrap(options[:on]).map(&:to_sym)}.include?(validation_context)")
         end
         args << options
         set_callback(:validate, *args, &block)

--- a/activemodel/test/cases/validations/validations_context_test.rb
+++ b/activemodel/test/cases/validations/validations_context_test.rb
@@ -36,4 +36,15 @@ class ValidationsContextTest < ActiveModel::TestCase
     assert topic.invalid?(:create), "Validation does run on create if 'on' is set to create"
     assert topic.errors[:base].include?(ERROR_MESSAGE)
   end
+
+  test "with a class that adds errors on multiple contexts and validating a new model" do
+    Topic.validates_with(ValidatorThatAddsErrors, on: [:context1, :context2])
+    topic = Topic.new
+    assert topic.invalid?(:context1), "Validation does run on context 1"
+    assert topic.errors[:base].include?(ERROR_MESSAGE)
+
+    topic = Topic.new
+    assert topic.invalid?(:context2), "Validation does run on context 2"
+    assert topic.errors[:base].include?(ERROR_MESSAGE)
+  end
 end


### PR DESCRIPTION
Example:
validates_presence_of :name, on: [:update, :custom_validation_context]
