### PR TITLE
Refactored object rendering in RenderingHelper#render into it's own method

### DIFF
--- a/actionview/test/fixtures/customers/_customer.xml.erb
+++ b/actionview/test/fixtures/customers/_customer.xml.erb
@@ -1,0 +1,1 @@
+<greeting><%= greeting %></greeting><name><%= customer.name %></name>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -304,6 +304,16 @@ module RenderTestCases
     assert_equal "Hola: david", @controller_view.render('customer_greeting', :greeting => 'Hola', :customer_greeting => Customer.new("david"))
   end
 
+  def test_render_partial_with_object_uses_render_partial_path
+    assert_equal "Hello: lifo",
+      @controller_view.render(:partial => Customer.new("lifo"), :locals => {:greeting => "Hello"})
+  end
+
+  def test_render_partial_with_object_and_format_uses_render_partial_path
+    assert_equal "<greeting>Hello</greeting><name>lifo</name>",
+      @controller_view.render(:partial => Customer.new("lifo"), :formats => :xml, :locals => {:greeting => "Hello"})
+  end
+
   def test_render_partial_using_object
     assert_equal "Hello: lifo",
       @controller_view.render(Customer.new("lifo"), :greeting => "Hello")


### PR DESCRIPTION
## Problem

In many projects I've needed to render a json snippet into a html page (usually when I'm using a client side js-framework that needs a json representation of a server-side object). To do this I render my object to json and embed it in a script tag, which makes it available on page load without needing a separate request for data.

However, to do this at present requires something like this:

``` ruby
render partial: @something.to_partial_path, object: @something, formats: :json
```

This is because although it's easy to render an object in the same format as the parent template (ie. `render @something`), it is not possible to pass any rendering options unless you use the (more verbose) hash syntax for render. The same issue exists if you'd like to render an object on the page using a layout. This seems unnecessarily difficult and verbose, for something that (to me) seems like a fairly common problem.
## Solution

In this pull request I've refactored the code in RenderingHelper that's responsible for rending an object out into it's own method, which can be called directly, so that the code above becomes:

``` ruby
render_object @something, formats: :json
```

This makes it far easier to pass rendering options when rendering an object. It is fully backwards compatible. It also makes the code cleaner (imho) because it separates out the two different code paths in render and makes it more obvious what each is doing (i.e. rendering an object vs rendering some kind of template).
