### PR TITLE
Removed redefined blank? methods

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -45,59 +45,6 @@ class Object
   end
 end
 
-class NilClass
-  # +nil+ is blank:
-  #
-  #   nil.blank? # => true
-  #
-  # @return [true]
-  def blank?
-    true
-  end
-end
-
-class FalseClass
-  # +false+ is blank:
-  #
-  #   false.blank? # => true
-  #
-  # @return [true]
-  def blank?
-    true
-  end
-end
-
-class TrueClass
-  # +true+ is not blank:
-  #
-  #   true.blank? # => false
-  #
-  # @return [false]
-  def blank?
-    false
-  end
-end
-
-class Array
-  # An array is blank if it's empty:
-  #
-  #   [].blank?      # => true
-  #   [1,2,3].blank? # => false
-  #
-  # @return [true, false]
-  alias_method :blank?, :empty?
-end
-
-class Hash
-  # A hash is blank if it's empty:
-  #
-  #   {}.blank?                # => true
-  #   { key: 'value' }.blank?  # => false
-  #
-  # @return [true, false]
-  alias_method :blank?, :empty?
-end
-
 class String
   BLANK_RE = /\A[[:space:]]*\z/
 
@@ -115,17 +62,5 @@ class String
   # @return [true, false]
   def blank?
     BLANK_RE === self
-  end
-end
-
-class Numeric #:nodoc:
-  # No number is blank:
-  #
-  #   1.blank? # => false
-  #   0.blank? # => false
-  #
-  # @return [false]
-  def blank?
-    false
   end
 end


### PR DESCRIPTION
Removed redefined blank? methods From Nil, False, True, Array, Hash, Numeric classes because all of them inherits the blank? method from Object class.
