### PR TITLE
Implement the Dirty API with the Enum feature correctly.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Make enum fields work as expected with the `ActiveModel::Dirty` API.
+
+    Before this change, using the dirty API would have surprising results:
+
+        conversation = Conversation.new
+        conversation.status = :active
+        conversation.status = :archived
+        conversation.status_was # => 0
+
+    After this change, the same code would result in:
+
+        conversation = Conversation.new
+        conversation.status = :active
+        conversation.status = :archived
+        conversation.status_was # => "active"
+
+    *Rafael Mendonça França*
+
 *   Ensure `second` through `fifth` methods act like the `first` finder.
 
     The famous ordinal Array instance methods defined in ActiveSupport

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -45,7 +45,6 @@ module ActiveRecord
 
         save_changed_attribute(attr, value)
 
-        # Carry on.
         super(attr, value)
       end
 

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -43,6 +43,13 @@ module ActiveRecord
       def write_attribute(attr, value)
         attr = attr.to_s
 
+        save_changed_attribute(attr, value)
+
+        # Carry on.
+        super(attr, value)
+      end
+
+      def save_changed_attribute(attr, value)
         # The attribute already has an unsaved change.
         if attribute_changed?(attr)
           old = changed_attributes[attr]
@@ -51,9 +58,6 @@ module ActiveRecord
           old = clone_attribute_value(:read_attribute, attr)
           changed_attributes[attr] = old if _field_changed?(attr, old, value)
         end
-
-        # Carry on.
-        super(attr, value)
       end
 
       def update_record(*)

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -123,14 +123,26 @@ module ActiveRecord
       def _enum_methods_module
         @_enum_methods_module ||= begin
           mod = Module.new do
-            def save_changed_attribute(attr_name, value)
-              if self.class.enum_attribute?(attr_name)
-                old = clone_attribute_value(:read_attribute, attr_name)
-                changed_attributes[attr_name] = self.class.public_send(attr_name.pluralize).key old
-              else
-                super
+            private
+              def save_changed_attribute(attr_name, value)
+                if self.class.enum_attribute?(attr_name)
+                  if attribute_changed?(attr_name)
+                    old = changed_attributes[attr_name]
+
+                    if self.class.public_send(attr_name.pluralize)[old] == value
+                      changed_attributes.delete(attr_name)
+                    end
+                  else
+                    old = clone_attribute_value(:read_attribute, attr_name)
+
+                    if old != value
+                      changed_attributes[attr_name] = self.class.public_send(attr_name.pluralize).key old
+                    end
+                  end
+                else
+                  super
+                end
               end
-            end
           end
           include mod
           mod

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -63,12 +63,20 @@ module ActiveRecord
   #
   #   Conversation.where("status <> ?", Conversation.statuses[:archived])
   module Enum
+    DEFINED_ENUMS = [] # :nodoc:
+
+    def enum_attribute?(attr_name) # :nodoc:
+      DEFINED_ENUMS.include?(attr_name.to_sym)
+    end
+
     def enum(definitions)
       klass = self
       definitions.each do |name, values|
         # statuses = { }
         enum_values = ActiveSupport::HashWithIndifferentAccess.new
         name        = name.to_sym
+
+        DEFINED_ENUMS.unshift name
 
         # def self.statuses statuses end
         klass.singleton_class.send(:define_method, name.to_s.pluralize) { enum_values }
@@ -114,7 +122,16 @@ module ActiveRecord
     private
       def _enum_methods_module
         @_enum_methods_module ||= begin
-          mod = Module.new
+          mod = Module.new do
+            def save_changed_attribute(attr_name, value)
+              if self.class.enum_attribute?(attr_name)
+                old = clone_attribute_value(:read_attribute, attr_name)
+                changed_attributes[attr_name] = self.class.public_send(attr_name.pluralize).key old
+              else
+                super
+              end
+            end
+          end
           include mod
           mod
         end

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -66,7 +66,7 @@ module ActiveRecord
     DEFINED_ENUMS = {} # :nodoc:
 
     def enum_mapping_for(attr_name) # :nodoc:
-      DEFINED_ENUMS[attr_name.to_sym]
+      DEFINED_ENUMS[attr_name.to_s]
     end
 
     def enum(definitions)
@@ -114,7 +114,7 @@ module ActiveRecord
             define_method("#{value}!") { update! name => value }
           end
 
-          DEFINED_ENUMS[name] = enum_values
+          DEFINED_ENUMS[name.to_s] = enum_values
         end
       end
     end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -91,6 +91,38 @@ class EnumTest < ActiveRecord::TestCase
     assert @book.attribute_changed?(:status, from: old_status, to: 'published')
   end
 
+  test "enum didn't change" do
+    old_status = @book.status
+    @book.status = old_status
+    assert_not @book.attribute_changed?(:status)
+  end
+
+  test "persist changes that are dirty" do
+    old_status = @book.status
+    @book.status = :published
+    assert @book.attribute_changed?(:status)
+    @book.status = :written
+    assert @book.attribute_changed?(:status)
+  end
+
+  test "reverted changes that are not dirty" do
+    old_status = @book.status
+    @book.status = :published
+    assert @book.attribute_changed?(:status)
+    @book.status = old_status
+    assert_not @book.attribute_changed?(:status)
+  end
+
+  test "reverted changes are not dirty going from nil to value and back" do
+    book = Book.create!(nullable_status: nil)
+
+    book.nullable_status = :married
+    assert book.attribute_changed?(:nullable_status)
+
+    book.nullable_status = nil
+    assert_not book.attribute_changed?(:nullable_status)
+  end
+
   test "assign non existing value raises an error" do
     e = assert_raises(ArgumentError) do
       @book.status = :unknown

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -51,6 +51,46 @@ class EnumTest < ActiveRecord::TestCase
     assert @book.written?
   end
 
+  test "enum changed attributes" do
+    old_status = @book.status
+    @book.status = :published
+    assert_equal old_status, @book.changed_attributes[:status]
+  end
+
+  test "enum changes" do
+    old_status = @book.status
+    @book.status = :published
+    assert_equal [old_status, 'published'], @book.changes[:status]
+  end
+
+  test "enum attribute was" do
+    old_status = @book.status
+    @book.status = :published
+    assert_equal old_status, @book.attribute_was(:status)
+  end
+
+  test "enum attribute changed" do
+    @book.status = :published
+    assert @book.attribute_changed?(:status)
+  end
+
+  test "enum attribute changed to" do
+    @book.status = :published
+    assert @book.attribute_changed?(:status, to: 'published')
+  end
+
+  test "enum attribute changed from" do
+    old_status = @book.status
+    @book.status = :published
+    assert @book.attribute_changed?(:status, from: old_status)
+  end
+
+  test "enum attribute changed from old status to new status" do
+    old_status = @book.status
+    @book.status = :published
+    assert @book.attribute_changed?(:status, from: old_status, to: 'published')
+  end
+
   test "assign non existing value raises an error" do
     e = assert_raises(ArgumentError) do
       @book.status = :unknown

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -9,6 +9,7 @@ class Book < ActiveRecord::Base
 
   enum status: [:proposed, :written, :published]
   enum read_status: {unread: 0, reading: 2, read: 3}
+  enum nullable_status: [:single, :married]
 
   def published!
     super

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -97,6 +97,7 @@ ActiveRecord::Schema.define do
     t.column :name, :string
     t.column :status, :integer, default: 0
     t.column :read_status, :integer, default: 0
+    t.column :nullable_status, :integer
   end
 
   create_table :booleans, force: true do |t|


### PR DESCRIPTION
## Problem

When using the Dirty API, the enum feature was returning the raw value of the attribute. This make some behavior weird like the following:

``` ruby
conversation.status = :active
conversation.status = :archived
conversation.status_was # => 0
```
## Solution

In #13489 was proposed to override `read_attribute` method but this would be too dangerous since the attribute accessor would always return the string representation of the enum value what make difficult to get the integer value. Also `read_attribute` was made to represent the value read from the database, type casted to its column type.

What we want to solve is the Dirty feature methods and these methods use an internal storage of the values. To fix our problem, instead of changing the way the attribute is represented in all the Active Record features we can only change the way the enum values are written in the internal store of the Dirty feature.

To make this fix possible I extracted a new hook in `ActiveRecord::Dirty` to make possible to we override only the change attribute feature without overriding the whole `write_attribute` method.

cc @chancancode @dhh @tenderlove 

Closes #13489.
