### PR TITLE
Add missing information for `id` field when used with `select`

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -84,7 +84,7 @@ module ActiveRecord
       #
       # Be careful because this also means you're initializing a model
       # object with only the fields that you've selected. If you attempt
-      # to access a field that is not in the initialized record you'll
+      # to access a field except +id+ that is not in the initialized record you'll
       # receive:
       #
       #   person.pets.select(:name).first.person_id


### PR DESCRIPTION
As given in the example:

``` ruby
person.pets.select(:name)
# => [
 #<Pet id: nil, name: "Fancy-Fancy">,
 #<Pet id: nil, name: "Spook">,
 #<Pet id: nil, name: "Choo-Choo">
#]
```

So calling on `person.pets.select(:name).first.id` will not raise:

``` ruby
ActiveModel::MissingAttributeError: missing attribute: id
```
