### PR TITLE
create indexes inline in CREATE TABLE for MySQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Create indexes inline in CREATE TABLE for MySQL
+
+    This is important, because adding an index on a temporary table after it has been created
+    would commit the transaction.
+
+    Example:
+
+        create_table :temp, temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query" do |t|
+          t.index :zip
+        end
+        # => CREATE TEMPORARY TABLE temp (INDEX (zip)) AS SELECT id, name, zip FROM a_really_complicated_query
+
+    *Cody Cutrer*
+
 *   Make enum fields work as expected with the `ActiveModel::Dirty` API.
 
     Before this change, using the dirty API would have surprising results:

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -219,6 +219,12 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support creating indexes in the same statement as
+      # creating the table? As of this writing, only mysql does.
+      def supports_indexes_in_create?
+        false
+      end
+
       # This is meant to be implemented by the adapters that support extensions
       def disable_extension(name)
       end

--- a/activerecord/test/cases/adapters/mysql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/active_schema_test.rb
@@ -116,6 +116,17 @@ class ActiveSchemaTest < ActiveRecord::TestCase
     end
   end
 
+  def test_indexes_in_create
+    begin
+      ActiveRecord::Base.connection.stubs(:index_name_exists?).returns(false)
+      expected = "CREATE TEMPORARY TABLE `temp` (INDEX `index_temp_on_zip` (`zip`)) ENGINE=InnoDB AS SELECT id, name, zip FROM a_really_complicated_query"
+      actual = ActiveRecord::Base.connection.create_table(:temp, temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query") do |t|
+        t.index :zip
+      end
+      assert_equal expected, actual
+    end
+  end
+
   private
     def with_real_execute
       ActiveRecord::Base.connection.singleton_class.class_eval do

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -116,6 +116,17 @@ class ActiveSchemaTest < ActiveRecord::TestCase
     end
   end
 
+  def test_indexes_in_create
+    begin
+      ActiveRecord::Base.connection.stubs(:index_name_exists?).returns(false)
+      expected = "CREATE TEMPORARY TABLE `temp` (INDEX `index_temp_on_zip` (`zip`)) ENGINE=InnoDB AS SELECT id, name, zip FROM a_really_complicated_query"
+      actual = ActiveRecord::Base.connection.create_table(:temp, temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query") do |t|
+        t.index :zip
+      end
+      assert_equal expected, actual
+    end
+  end
+
   private
     def with_real_execute
       ActiveRecord::Base.connection.singleton_class.class_eval do


### PR DESCRIPTION
This is important, because adding an index on a temporary table after
it has been created would commit the transaction
