### PR TITLE
Allow using hash for Relation#select to define aliases.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Allow using hash for Relation#select to define aliases.
+
+    Also allow a subquery as the key.
+
+    Example:
+
+        User.select(id: :alternate_id, "COALESCE(display_name, name)": :my_name,
+          Transaction.select("COUNT(*)").where("user_id=users.id") => :transaction_count)
+        # => SELECT "users"."id" AS alternate_id, COALESCE(display_name, name) AS my_name,
+          (SELECT COUNT(*) FROM transactions WHERE user_id=users.id) transaction_count
+
+    *Cody Cutrer*
+
 *   Make enum fields work as expected with the `ActiveModel::Dirty` API.
 
     Before this change, using the dirty API would have surprising results:

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1517,6 +1517,18 @@ class RelationTest < ActiveRecord::TestCase
     assert !Post.all.respond_to?(:by_lifo)
   end
 
+  test "alias of non-table column with select" do
+    assert_equal 'abc', Post.select("'abc'" => "tenderlove").first.tenderlove
+  end
+
+  test "alias of table column with select" do
+    assert_equal [1, 2, 3], Post.select(:id => :other_id).order(:id).limit(3).map(&:other_id)
+  end
+
+  test "alias of subquery column with select" do
+    assert_equal 1, Post.select(Post.select("1").limit(1) => :subquery).first.subquery
+  end
+
   def test_unscope_removes_binds
     left  = Post.where(id: Arel::Nodes::BindParam.new('?'))
     column = Post.columns_hash['id']


### PR DESCRIPTION
Also allow a subquery as the key
