### PR TITLE
Calling reset on a collection association should unload the assocation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Calling reset on a collection association should unload the assocation.
+
+    Fixes #13777.
+ 
+    *Kelsey Schlarman*
+
 *   Make enum fields work as expected with the `ActiveModel::Dirty` API.
 
     Before this change, using the dirty API would have surprising results:

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1004,6 +1004,27 @@ module ActiveRecord
         proxy_association.reload
         self
       end
+
+      # Unloads the association
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets # fetches pets from the database
+      #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
+      #
+      #   person.pets # uses the pets cache
+      #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
+      #
+      #   person.pets.reset # clears the pets cache
+      #
+      #   person.pets  # fetches pets from the database
+      #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
+      def reset
+        proxy_association.reset
+        proxy_association.reset_scope
+      end
     end
   end
 end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -255,6 +255,15 @@ class AssociationProxyTest < ActiveRecord::TestCase
       assert_equal man, man.interests.where("1=1").first.man
     end
   end
+
+  def test_reset_unloads_target
+    david = authors(:david)
+    david.posts.reload
+
+    assert david.posts.loaded?
+    david.posts.reset
+    assert !david.posts.loaded?
+  end
 end
 
 class OverridingAssociationsTest < ActiveRecord::TestCase


### PR DESCRIPTION
Need to define #reset on CollectionProxy.
