### PR TITLE
Remove duplicate merge

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -535,7 +535,6 @@ module ActiveRecord
       }
 
       binds = Hash[bind_values.find_all(&:first).map { |column, v| [column.name, v] }]
-      binds.merge!(Hash[bind_values.find_all(&:first).map { |column, v| [column.name, v] }])
 
       Hash[equalities.map { |where|
         name = where.left.name


### PR DESCRIPTION
https://github.com/rails/rails/commit/2eecc0d8dccf7f12518e05a72192eb853e5ee474 considered default_scope and local scope, but https://github.com/rails/rails/commit/94924dc32baf78f13e289172534c2e71c9c8cade simplifed default scope.
So, this merging became meaningless.
