### PR TITLE
Dynamically define PostgreSQL Range OIDs

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support for user created range types in PostgreSQL.
+
+    *Yves Senn*
+
 *   Default scopes are no longer overriden by chained conditions.
 
     Before this change when you defined a `default_scope` in a model

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Deprecate half-baked support for PostgreSQL range values with excluding beginnings.
+    We currently map PostgreSQL ranges to Ruby ranges. This conversion is not fully
+    possible because the Ruby range does not support excluded beginnings.
+
+    The current solution of incrementing the beginning is not correct and is now
+    deprecated. For subtypes where we don't know how to increment (e.g. `#succ`
+    is not defined) it will raise an ArgumentException for ranges with excluding
+    beginnings.
+
+    *Yves Senn*
+
 *   Support for user created range types in PostgreSQL.
 
     *Yves Senn*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -135,6 +135,18 @@ module ActiveRecord
             extracted = extract_bounds(value)
             from = type_cast_single extracted[:from]
             to = type_cast_single extracted[:to]
+
+            if !infinity?(from) && extracted[:exclude_start]
+              if from.respond_to?(:succ)
+                from = from.succ
+                ActiveSupport::Deprecation.warn <<-MESSAGE
+Excluding the beginning of a Range is only partialy supported through `#succ`.
+This is not reliable and will be removed in the future.
+                MESSAGE
+              else
+                raise ArgumentError, "The Ruby Range object does not support excluding the beginning of a Range. (unsupported value: '#{value}')"
+              end
+            end
             ::Range.new(from, to, extracted[:exclude_end])
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -6,6 +6,10 @@ module ActiveRecord
       module OID
         class Type
           def type; end
+
+          def infinity(options = {})
+            ::Float::INFINITY * (options[:negative] ? -1 : 1)
+          end
         end
 
         class Identity < Type
@@ -109,23 +113,19 @@ module ActiveRecord
           def extract_bounds(value)
             from, to = value[1..-2].split(',')
             {
-              from:          (value[1] == ',' || from == '-infinity') ? infinity(:negative => true) : from,
-              to:            (value[-2] == ',' || to == 'infinity') ? infinity : to,
+              from:          (value[1] == ',' || from == '-infinity') ? @subtype.infinity(negative: true) : from,
+              to:            (value[-2] == ',' || to == 'infinity') ? @subtype.infinity : to,
               exclude_start: (value[0] == '('),
               exclude_end:   (value[-1] == ')')
             }
-          end
-
-          def infinity(options = {})
-            ::Float::INFINITY * (options[:negative] ? -1 : 1)
           end
 
           def infinity?(value)
             value.respond_to?(:infinite?) && value.infinite?
           end
 
-          def to_integer(value)
-            infinity?(value) ? value : value.to_i
+          def type_cast_single(value)
+            infinity?(value) ? value : @subtype.type_cast(value)
           end
 
           def type_cast(value)
@@ -133,27 +133,8 @@ module ActiveRecord
             return value if value.is_a?(::Range)
 
             extracted = extract_bounds(value)
-
-            case @subtype
-            when :date
-              from  = ConnectionAdapters::Column.value_to_date(extracted[:from])
-              from -= 1.day if extracted[:exclude_start]
-              to    = ConnectionAdapters::Column.value_to_date(extracted[:to])
-            when :decimal
-              from  = BigDecimal.new(extracted[:from].to_s)
-              # FIXME: add exclude start for ::Range, same for timestamp ranges
-              to    = BigDecimal.new(extracted[:to].to_s)
-            when :time
-              from = ConnectionAdapters::Column.string_to_time(extracted[:from])
-              to   = ConnectionAdapters::Column.string_to_time(extracted[:to])
-            when :integer
-              from = to_integer(extracted[:from]) rescue value ? 1 : 0
-              from -= 1 if extracted[:exclude_start]
-              to   = to_integer(extracted[:to]) rescue value ? 1 : 0
-            else
-              return value
-            end
-
+            from = type_cast_single extracted[:from]
+            to = type_cast_single extracted[:to]
             ::Range.new(from, to, extracted[:exclude_end])
           end
         end
@@ -221,6 +202,10 @@ module ActiveRecord
             return if value.nil?
 
             ConnectionAdapters::Column.value_to_decimal value
+          end
+
+          def infinity(options = {})
+            BigDecimal.new("Infinity") * (options[:negative] ? -1 : 1)
           end
         end
 
@@ -330,13 +315,6 @@ module ActiveRecord
         alias_type    'int4', 'int2'
         alias_type    'int8', 'int2'
         alias_type    'oid',  'int2'
-
-        register_type 'daterange', OID::Range.new(:date)
-        register_type 'numrange', OID::Range.new(:decimal)
-        register_type 'tsrange', OID::Range.new(:time)
-        register_type 'int4range', OID::Range.new(:integer)
-        alias_type    'tstzrange', 'tsrange'
-        alias_type    'int8range', 'int4range'
 
         register_type 'numeric', OID::Decimal.new
         register_type 'text', OID::Identity.new


### PR DESCRIPTION
This patch improves the current support for PostgreSQL Ranges by:
- Adding support for custom range types
- Removing branches in the current range implementation
- Deprecating half-baked support for PG range values with excluding beginnings.
### dynamically define PostgreSQL OID range types.

This gets AR working with custom defined range types. It also
removes the need for subtype specific branches in `OID::Range`.

This expands the interface of all `OID` types with the `infinity` method.
It's responsible to provide a value for positive and negative infinity.
### deprecate support for pg ranges with excluding beginnings.

The Ruby Range object does not support excluding beginnings.
We currently support excluding beginnings for some subtypes using
manually by incrementing them (now using the `#succ` method).
This is approach is flawed as it's not equal to an excluding beginning.

This commit deprecates the current support for excluding beginnings.
It also raises an `ArgumentError` for subtypes that do not implement the `succ`
method.

This is a temporary solution to get rid of the broken state. We might still
add complete support for excluding beginnings afterwards. (Probably with a
new `PGRange` object, which acts like a `Range` but has excluding beginnings (see #14010).
