### PR TITLE
ActiveRecord: set primary_key default as 'id' which table does not have primary_key.

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -89,8 +89,8 @@ module ActiveRecord
           when :table_name_with_underscore
             base_name.foreign_key
           else
-            primary_key = connection.schema_cache.primary_keys(table_name)
-            if ActiveRecord::Base != self && table_exists? && primary_key.present?
+            if ActiveRecord::Base != self && table_exists? && 
+              (primary_key = connection.schema_cache.primary_keys(table_name)).present?
               primary_key 
             else
               'id'

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -90,7 +90,8 @@ module ActiveRecord
             base_name.foreign_key
           else
             if ActiveRecord::Base != self && table_exists? && 
-              (primary_key = connection.schema_cache.primary_keys(table_name)).present?
+              ((primary_key = connection.schema_cache.primary_keys(table_name)).present? ||
+              !connection.schema_cache.columns(table_name).include?('id'))
               primary_key 
             else
               'id'

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -89,8 +89,9 @@ module ActiveRecord
           when :table_name_with_underscore
             base_name.foreign_key
           else
-            if ActiveRecord::Base != self && table_exists?
-              connection.schema_cache.primary_keys(table_name)
+            primary_key = connection.schema_cache.primary_keys(table_name)
+            if ActiveRecord::Base != self && table_exists? && primary_key.present?
+              primary_key 
             else
               'id'
             end


### PR DESCRIPTION
ActiveRecord: set primary_key default as 'id' which table does not have primary_key.
