### PR TITLE
Fix ActiveModel::Errors#has_key? returning nil

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -94,7 +94,7 @@ module ActiveModel
     #   person.errors.include?(:name) # => true
     #   person.errors.include?(:age)  # => false
     def include?(attribute)
-      (v = messages[attribute]) && v.any?
+      messages[attribute].present?
     end
     # aliases include?
     alias :has_key? :include?

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -51,7 +51,7 @@ class ErrorsTest < ActiveModel::TestCase
   def test_has_key?
     errors = ActiveModel::Errors.new(self)
     errors[:foo] = 'omg'
-    assert errors.has_key?(:foo), 'errors should have key :foo'
+    assert_equal true, errors.has_key?(:foo), 'errors should have key :foo'
   end
 
   def test_has_no_key

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -54,6 +54,11 @@ class ErrorsTest < ActiveModel::TestCase
     assert errors.has_key?(:foo), 'errors should have key :foo'
   end
 
+  def test_has_no_key
+    errors = ActiveModel::Errors.new(self)
+    assert_equal false, errors.has_key?(:name), 'errors should not have key :name'
+  end
+
   test "clear errors" do
     person = Person.new
     person.validate!


### PR DESCRIPTION
From the [doc](http://api.rubyonrails.org/classes/ActiveModel/Errors.html#method-i-has_key-3F), this method should return `false`and not `nil` if there is no errors for this key
