### PR TITLE
Less stupid translation helper (with blocks for interpolation)

### DIFF
--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -5,7 +5,7 @@ module ActionView
   # = Action View Translation Helpers
   module Helpers
     module TranslationHelper
-      # Delegates to <tt>I18n#translate</tt> but also performs three additional functions.
+      # Delegates to <tt>I18n#translate</tt> but also performs four additional functions.
       #
       # First, it will ensure that any thrown +MissingTranslation+ messages will be turned 
       # into inline spans that:
@@ -33,6 +33,22 @@ module ActionView
       # a safe HTML string that won't be escaped by other HTML helper methods. This
       # naming convention helps to identify translations that include HTML tags so that
       # you know what kind of output to expect when you call translate in a template.
+      #
+      # Fourth, a block can be given to set interpolation variables directly or,
+      # optionally, through blocks as well:
+      #
+      #   translate('mr') {|t| t.name 'Fogg'}  # whereas mr: "Mr. %{name}"
+      #
+      #   translate('mr') do |t|
+      #     t.name() { 'Fogg' }
+      #   end
+      #
+      #   <% t('mr') do |t| %>
+      #     <% t.name do %>
+      #       <b><%= mister.name %><b>
+      #     <% end %>
+      #   <% end %>
+      #
       def translate(key, options = {})
         options[:default] = wrap_translate_defaults(options[:default]) if options[:default]
 

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -36,6 +36,12 @@ module ActionView
       def translate(key, options = {})
         options[:default] = wrap_translate_defaults(options[:default]) if options[:default]
 
+        if block_given?
+          i = Interpolator.new(self)
+          yield i
+          options = i.variables.merge(options)
+        end
+
         # If the user has specified rescue_format then pass it all through, otherwise use
         # raise and do the work ourselves
         if options.key?(:raise) || options.key?(:rescue_format)
@@ -76,6 +82,24 @@ module ActionView
       alias :l :localize
 
       private
+        class Interpolator
+          attr_reader :variables
+
+          def initialize(context)
+            @variables = {}
+            @context = context
+          end
+
+          private
+          # NOTE an alternative solution would be to define methods per interpolation variables
+          def method_missing(meth, *args, &block)
+            variables[meth] =
+              args[0] ||
+              @context.respond_to?(:output_buffer) && @context.capture(&block) ||
+              block.try(:call)
+          end
+        end
+
         def scope_key_by_partial(key)
           if key.to_s.first == "."
             if @virtual_path

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -43,7 +43,7 @@ module ActionView
       #     t.name() { 'Fogg' }
       #   end
       #
-      #   <% t('mr') do |t| %>
+      #   <%= translate('mr') do |t| %>
       #     <% t.name do %>
       #       <b><%= mister.name %><b>
       #     <% end %>

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -75,7 +75,7 @@ class TranslationHelperTest < ActiveSupport::TestCase
   end
 
   def test_finds_array_of_translations_scoped_by_partial
-    assert_equal 'Foo Bar', @view.render(:file => 'translations/templates/array').strip
+    assert_equal 'Foo Bar', view.render(:file => 'translations/templates/array').strip
   end
 
   def test_default_lookup_scoped_by_partial
@@ -115,6 +115,9 @@ class TranslationHelperTest < ActiveSupport::TestCase
         t.word 'World'
       end
     )
+  end
+
+  def test_translate_interpolates_with_a_block_and_a_variable_is_set_through_a_block_too
     assert_equal(
       '<a>Hello World</a>',
       translate(:'translations.interpolated_html') do |t|
@@ -123,14 +126,23 @@ class TranslationHelperTest < ActiveSupport::TestCase
         end
       end
     )
+  end
+
+  def test_translate_interpolates_with_a_block_and_a_variable_is_captured_in_through_a_block_in_a_view
     assert_equal(
       '<a>Hello World</a>',
-      @view.translate(:'translations.interpolated_html') do |t|
+      view.translate(:'translations.interpolated_html') do |t|
         t.word do
-          @view.output_buffer << 'World'
+          view.output_buffer << 'World'
           nil
         end
       end
+    )
+    assert_equal(
+      '<a>Hello <big>World</big></a>',
+      view.render(
+        :inline => "<%= translate(:'translations.interpolated_html') do |t| %><% t.word do %><big>World</big><% end %><% end %>"
+      )
     )
   end
 

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -104,6 +104,36 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal '<a>Hello &lt;World&gt;</a>', translate(:'translations.interpolated_html', :word => stub(:to_s => "<World>"))
   end
 
+  def test_translate_doesnt_escape_html_safe_interpolations_in_translations_with_a_html_suffix
+    assert_equal '<a>Hello <b>World</b></a>', translate(:'translations.interpolated_html', :word => '<b>World</b>'.html_safe)
+  end
+
+  def test_translate_interpolates_with_a_block
+    assert_equal(
+      '<a>Hello World</a>',
+      translate(:'translations.interpolated_html') do |t|
+        t.word 'World'
+      end
+    )
+    assert_equal(
+      '<a>Hello World</a>',
+      translate(:'translations.interpolated_html') do |t|
+        t.word do
+          'World'
+        end
+      end
+    )
+    assert_equal(
+      '<a>Hello World</a>',
+      @view.translate(:'translations.interpolated_html') do |t|
+        t.word do
+          @view.output_buffer << 'World'
+          nil
+        end
+      end
+    )
+  end
+
   def test_translate_with_html_count
     assert_equal '<a>One 1</a>', translate(:'translations.count_html', :count => 1)
     assert_equal '<a>Other 2</a>', translate(:'translations.count_html', :count => 2)


### PR DESCRIPTION
Translations made unobtrusively powerful! Please see the example usage in the updated method rdoc.

Tested with the latest rails-dev-box.
