### PR TITLE
Meaningful info on PG::ActiveSqlTransaction error [WIP]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -733,8 +733,9 @@ module ActiveRecord
         end
 
         # See http://www.postgresql.org/docs/9.1/static/errcodes-appendix.html
-        FOREIGN_KEY_VIOLATION = "23503"
-        UNIQUE_VIOLATION      = "23505"
+        FOREIGN_KEY_VIOLATION  = "23503"
+        UNIQUE_VIOLATION       = "23505"
+        ACTIVE_SQL_TRANSACTION = "25001"
 
         def translate_exception(exception, message)
           return exception unless exception.respond_to?(:result)
@@ -744,6 +745,8 @@ module ActiveRecord
             RecordNotUnique.new(message, exception)
           when FOREIGN_KEY_VIOLATION
             InvalidForeignKey.new(message, exception)
+          when ACTIVE_SQL_TRANSACTION
+            ActiveSqlTransaction.new(message, exception)
           else
             super
           end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -69,6 +69,10 @@ module ActiveRecord
     end
   end
 
+  # Raised when executed query cannot be run in transaction
+  class ActiveSqlTransaction < StatementInvalid
+  end
+
   # Defunct wrapper class kept for compatibility.
   # +StatementInvalid+ wraps the original exception now.
   class WrappedDatabaseException < StatementInvalid

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -597,6 +597,9 @@ module ActiveRecord
       else
         send(direction)
       end
+    rescue ActiveRecord::ActiveSqlTransaction => e
+      puts "\n\e[31mThe query you were trying to execute cannot be run in transaction block. Consider adding `disable_ddl_transaction!` on top of your migration class. Go to http://guides.rubyonrails.org/migrations.html for more information.\e[0m\n\n"
+      raise e
     ensure
       @connection = nil
     end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -182,6 +182,18 @@ module ActiveRecord
     test "type_to_sql returns a String for unmapped types" do
       assert_equal "special_db_type", @connection.type_to_sql(:special_db_type)
     end
+
+    def test_active_sql_transaction_is_translated_to_specific_exception
+      if @connection.adapter_name == "PostgreSQL"
+        assert_raises(ActiveRecord::ActiveSqlTransaction) do
+          @connection.execute %{
+            BEGIN;
+            CREATE  INDEX CONCURRENTLY index_accounts_on_firm_id ON accounts(firm_id);
+            COMMIT;
+          }
+        end
+      end
+    end
   end
 
   class AdapterTestWithoutTransaction < ActiveRecord::TestCase


### PR DESCRIPTION
Currently when performing sql queries that cannot be run in transaction in migrations, like `create index concurrently` in postgresql, error message is not very meaningful. This is my try on adding better hint to make life of RoR newbies little bit easier.

This is marked as WIP for 2 reasons:
1. This is postgresql only so far.
2. I am not sure about design of this solution. I tried to do it in cleaner way, but this is what I came up with so far.

I would appreciate any help on this :heart:.

Currently this looks like: 
![active-sql-transaction](https://f.cloud.github.com/assets/295545/1984766/032ae100-8432-11e3-95ad-1657fa81dfd4.png)
