### PR TITLE
Fixes #13810 `rake routes` error when mount `Rails::Engine` with empty routes

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `rake routes` error when `Rails::Engine` with empty routes is mounted.
+
+    Fixes #13810.
+
+    *Maurizio De Santis*
+
 *   Automatically convert dashes to underscores for shorthand routes, e.g:
 
         get '/our-work/latest'

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -194,9 +194,9 @@ module ActionDispatch
         end
 
         def widths(routes)
-          [routes.map { |r| r[:name].length }.max,
-           routes.map { |r| r[:verb].length }.max,
-           routes.map { |r| r[:path].length }.max]
+          [routes.map { |r| r[:name].length }.max || 0,
+           routes.map { |r| r[:verb].length }.max || 0,
+           routes.map { |r| r[:path].length }.max || 0]
         end
     end
 

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -54,6 +54,27 @@ module ActionDispatch
         ], output
       end
 
+      def test_displaying_routes_for_engines_without_routes
+        engine = Class.new(Rails::Engine) do
+          def self.inspect
+            "Blog::Engine"
+          end
+        end
+        engine.routes.draw do
+        end
+
+        output = draw do
+          mount engine => "/blog", as: "blog"
+        end
+
+        assert_equal [
+          "Prefix Verb URI Pattern Controller#Action",
+          "  blog      /blog       Blog::Engine",
+          "",
+          "Routes for Blog::Engine:"
+        ], output
+      end
+
       def test_cart_inspect
         output = draw do
           get '/cart', :to => 'cart#show'


### PR DESCRIPTION
This fixes an error which raises up when in a Rails app `config/routes.rb` is mounted a `Rails::Engine` with empty routes, f.e.:
##### Rails app `lib/my_engine.rb`

``` ruby
class MyEngine < ::Rails::Engine ; end
MyEngine.routes.draw do ; end
```
##### Rails app `config/initializers/my_engine.rb`

``` ruby
require 'my_engine'
```
##### Rails app `config/routes.rb`

``` ruby
Rails.application.routes.draw do
  mount MyEngine => 'my-engine'
end
```
##### Rails app `rake routes --trace`

```
$ rake routes --trace
** Invoke routes (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute routes
rake aborted!
comparison of Fixnum with nil failed
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/actionpack-4.1.0.beta1/lib/action_dispatch/routing/inspector.rb:183:in `each'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/actionpack-4.1.0.beta1/lib/action_dispatch/routing/inspector.rb:183:in `max'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/actionpack-4.1.0.beta1/lib/action_dispatch/routing/inspector.rb:183:in `map'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/actionpack-4.1.0.beta1/lib/action_dispatch/routing/inspector.rb:183:in `draw_section'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/actionpack-4.1.0.beta1/lib/action_dispatch/routing/inspector.rb:163:in `section'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/actionpack-4.1.0.beta1/lib/action_dispatch/routing/inspector.rb:105:in `block in format'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/actionpack-4.1.0.beta1/lib/action_dispatch/routing/inspector.rb:103:in `each'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/actionpack-4.1.0.beta1/lib/action_dispatch/routing/inspector.rb:103:in `format'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/railties-4.1.0.beta1/lib/rails/tasks/routes.rake:6:in `block in <top (required)>'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/task.rb:236:in `call'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/task.rb:236:in `block in execute'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/task.rb:231:in `each'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/task.rb:231:in `execute'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/task.rb:175:in `block in invoke_with_call_chain'
/.rbenv/versions/2.1.0/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/task.rb:168:in `invoke_with_call_chain'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/task.rb:161:in `invoke'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/application.rb:149:in `invoke_task'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/application.rb:106:in `each'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/application.rb:106:in `block in top_level'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/application.rb:115:in `run_with_threads'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/application.rb:100:in `top_level'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/application.rb:78:in `block in run'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/application.rb:165:in `standard_exception_handling'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/lib/rake/application.rb:75:in `run'
/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rake-10.1.1/bin/rake:33:in `<top (required)>'
/.rbenv/versions/2.1.0/bin/rake:19:in `load'
/.rbenv/versions/2.1.0/bin/rake:19:in `<main>'
/.rbenv/versions/2.1.0/bin/ruby_executable_hooks:15:in `eval'
/.rbenv/versions/2.1.0/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => routes
```
