### PR TITLE
test boolean and number json param parsing

### DIFF
--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -23,6 +23,13 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
+  test "parses boolean and number json params for application json" do
+    assert_parses(
+      {"item" => {"enabled" => false, "count" => 10}},
+      "{\"item\": {\"enabled\": false, \"count\": 10}}", { 'CONTENT_TYPE' => 'application/json' }
+    )
+  end
+
   test "parses json params for application jsonrequest" do
     assert_parses(
       {"person" => {"name" => "David"}},


### PR DESCRIPTION
Adding test case to illustrate that json objects(boolean, numbers) are parsed as objects.

review @chancancode @rafaelfranca
