### PR TITLE
[ci skip] Clarified language for how ActionMailer default options works

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -410,7 +410,7 @@ There are a number of settings available on `config.action_mailer`:
 
 * `config.action_mailer.perform_deliveries` specifies whether mail will actually be delivered and is true by default. It can be convenient to set it to false for testing.
 
-* `config.action_mailer.default_options` configures Action Mailer defaults. Use to set options like `from` or `reply_to` for every mailer. These default to:
+* `config.action_mailer.default_options` configures Action Mailer defaults. It accepts a hash of options like `from` or `reply_to` for every mailer. The defaults are initially set to a hash with the following keys:
 
     ```ruby
     :mime_version => "1.0",


### PR DESCRIPTION
It wasn't entirely clear to me whether the default options specified in the doc were the only ones set at the start, so I checked in the code and they are. I clarified that. 
