### PR TITLE
Remove unused assignment to fix warnings in enum test.

### DIFF
--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -98,7 +98,6 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "persist changes that are dirty" do
-    old_status = @book.status
     @book.status = :published
     assert @book.attribute_changed?(:status)
     @book.status = :written


### PR DESCRIPTION
Remove unused assignment to fix warnings in enum test.

cc @rafaelfranca
