### PR TITLE
Enclose interpolation of variables with braces to be more consistent.

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -119,19 +119,19 @@ module RailsGuides
     end
 
     def mobi
-      "ruby_on_rails_guides_#@version%s.mobi" % (@lang.present? ? ".#@lang" : '')
+      "ruby_on_rails_guides_#{@version}%s.mobi" % (@lang.present? ? ".#{@lang}" : '')
     end
 
     def initialize_dirs(output)
       @guides_dir = File.join(File.dirname(__FILE__), '..')
-      @source_dir = "#@guides_dir/source/#@lang"
+      @source_dir = "#{@guides_dir}/source/#{@lang}"
       @output_dir = if output
-        output
-      elsif kindle?
-        "#@guides_dir/output/kindle/#@lang"
-      else
-        "#@guides_dir/output/#@lang"
-      end.sub(%r</$>, '')
+                      output
+                    elsif kindle?
+                      "#{@guides_dir}/output/kindle/#{@lang}"
+                    else
+                      "#{@guides_dir}/output/#{@lang}"
+                    end.sub(%r</$>, '')
     end
 
     def create_output_dir_if_needed


### PR DESCRIPTION
Enclose interpolation of variables with braces to be more consistent and clear about the operation in guides generator.

Not sure if preferable but would be good to have. 
cc @fxn
