### PR TITLE
Update postgres hstore casting to handle null-terminated strings.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Update postgres hstore to correctly handle null-terminated strings.
+
+    *Steve Cosman*
+
 *   Reset the collection association when calling `reset` on it.
 
     Before:

--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -137,7 +137,7 @@ module ActiveRecord
               if value == ""
                 '""'
               else
-                '"%s"' % value.to_s.gsub(/(["\\])/, '\\\\\1')
+                '"%s"' % value.to_s.gsub(/\0.*/, '').gsub(/(["\\])/, '\\\\\1')
               end
             end
           end

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -220,6 +220,24 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
       assert_cycle('ca' => 'cà', 'ac' => 'àc')
     end
 
+    def test_null_char
+      input = {"a" => "b\0c", "d\0e" => "f", "g\u0000h" => "j\u0000k"}
+      expected = {}
+      input.each {|k,v| expected[Hstore.connection.quote_string(k)] = Hstore.connection.quote_string(v) }
+
+      # test creation
+      x = Hstore.create!(:tags => input)
+      x.reload
+      assert_equal(expected, x.tags)
+
+      # test updating
+      x = Hstore.create!(:tags => {})
+      x.tags = input
+      x.save!
+      x.reload
+      assert_equal(expected, x.tags)
+    end
+
     def test_multiline
       assert_cycle("a\nb" => "c\nd")
     end


### PR DESCRIPTION
This is needed because ruby doesn't null terminate strings, but the PG connection adapter does. Without this, trying to use a string containing null in an hstore will always result in invalid SQL ("Unexpected end of string").

I chose to truncate the string at the first \0 to be consistent with PG.connection.quote_string and the C PQescapeStringConn. This is the same behaviour AR silently applies to text/varchar so I think it's a good fit.

To test:
ARCONN=postgresql ruby -Itest test/cases/adapters/postgresql/hstore_test.rb
