### PR TITLE
Rails config for raise on missing translations

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Added `config.action_view.raise_on_missing_translations` to define whether an
+    error should be raised for missing translations.
+
+    Fixes #13196
+
+    *Kassio Borges*
+
 *   Improved ERB dependency detection. New argument types and formattings for the `render`
     calls can be matched.
 

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -153,6 +153,10 @@ module ActionView #:nodoc:
     # Specify default_formats that can be rendered.
     cattr_accessor :default_formats
 
+    # Specify whether an error should be raised for missing translations
+    cattr_accessor :raise_on_missing_translations
+    @@raise_on_missing_translations = false
+
     class_attribute :_routes
     class_attribute :logger
 

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -38,10 +38,10 @@ module ActionView
 
         # If the user has specified rescue_format then pass it all through, otherwise use
         # raise and do the work ourselves
-        if options.key?(:raise) || options.key?(:rescue_format)
-          raise_error = options[:raise] || options[:rescue_format]
-        else
-          raise_error = false
+        options[:raise] ||= ActionView::Base.raise_on_missing_translations
+
+        raise_error = options[:raise] || options.key?(:rescue_format)
+        unless raise_error
           options[:raise] = true
         end
 

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -53,6 +53,16 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal false, translate(:"translations.missing", :rescue_format => nil).html_safe?
   end
 
+  def test_raises_missing_translation_message_with_raise_config_option
+    ActionView::Base.raise_on_missing_translations = true
+
+    assert_raise(I18n::MissingTranslationData) do
+      translate("translations.missing")
+    end
+  ensure
+    ActionView::Base.raise_on_missing_translations = false
+  end
+
   def test_raises_missing_translation_message_with_raise_option
     assert_raise(I18n::MissingTranslationData) do
       translate(:"translations.missing", :raise => true)

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -386,6 +386,8 @@ encrypted cookies salt value. Defaults to `'signed encrypted cookie'`.
 
     The default setting is `true`, which uses the partial at `/admin/posts/_post.erb`. Setting the value to `false` would render `/posts/_post.erb`, which is the same behavior as rendering from a non-namespaced controller such as `PostsController`.
 
+* `config.action_view.raise_on_missing_translations` determines whether an error should be raised for missing translations
+
 ### Configuring Action Mailer
 
 There are a number of settings available on `config.action_mailer`:

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -35,4 +35,7 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
   <%- end -%>
+
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -33,4 +33,7 @@ Rails.application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
 end


### PR DESCRIPTION
Add a config to setup whether raise exception for missing translation or
not.

Fixes #13196
