### PR TITLE
Fix Class#singleton_class? for Ruby 2.1 compatability

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -109,7 +109,10 @@ class Class
   end
 
   private
-  def singleton_class?
-    ancestors.first != self
+
+  unless respond_to?(:singleton_class?)
+    def singleton_class?
+      ancestors.first != self
+    end
   end
 end


### PR DESCRIPTION
This is a backport of https://github.com/rails/rails/pull/12532 to Rails 3.2
