### PR TITLE
Make sure #extract! will keep `permitted` value

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Make sure that `#extract!` will keep the `permitted` state of the original
+    `ActionController::Parameters` object.
+
+    Fixes #13830.
+
+    *Robin Dupret*
+
 *   Fix `rake routes` error when `Rails::Engine` with empty routes is mounted.
 
     Fixes #13810.

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -326,6 +326,14 @@ module ActionController
       end
     end
 
+    # Override Hash#extract! in order to make the permitted
+    # attribute's value kept.
+    def extract!(*keys) # :nodoc:
+      super.tap do |result|
+        result.permitted = @permitted
+      end
+    end
+
     protected
       def permitted=(new_permitted)
         @permitted = new_permitted

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -260,4 +260,9 @@ class ParametersPermitTest < ActiveSupport::TestCase
   test "permitting parameters as an array" do
     assert_equal "32", @params[:person].permit([ :age ])[:age]
   end
+
+  test "extract! kept current permitted state" do
+    @params.permit!
+    assert @params.extract!(:person).permitted?
+  end
 end


### PR DESCRIPTION
Hello,

This is just a little pull request that makes `#extract!` keep the `@permitted` value when calling on an `ActionController::Parameters` object. Previously, it was relying on its superclass' (i.e.`HashWithIndifferentAccess` which is inheriting from `Hash`).

Let me know if you want me to do any backport to the strong_parameters repository.

Fixes #13830.

Have a nice day.
