### PR TITLE
Add docs about behaviour of replacing a has_one associate object.

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1213,7 +1213,8 @@ module ActiveRecord
       #   Returns the associated object. +nil+ is returned if none is found.
       # [association=(associate)]
       #   Assigns the associate object, extracts the primary key, sets it as the foreign key,
-      #   and saves the associate object.
+      #   and saves the associate object. To avoid database inconsistencies, permanently deletes an existing
+      #   associated object when assigning a new one, even if the new one isn't saved to database.
       # [build_association(attributes = {})]
       #   Returns a new object of the associated type that has been instantiated
       #   with +attributes+ and linked to this object through a foreign key, but has not


### PR DESCRIPTION
Add docs about behaviour of replacing a has_one associate object that the previous one is deleted even if the new one doesn't get persisted to database.

 Fixes #13197 . [ci skip]
