### PR TITLE
Log type-casted value(s) after `ActiveRecord::RecordNotFound` error.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Log type-casted value(s) after `ActiveRecord::RecordNotFound` error. This makes it
+    more transparent what values are actually sent to the database.
+
+        irb(main):002:0> Event.find("im-no-integer")
+        # Before: ... WHERE `events`.`id` = 0 LIMIT 1
+        # ActiveRecord::RecordNotFound: Couldn't find Reference with 'id'=im-no-integer
+
+        # After: ... WHERE `events`.`id` = 0 LIMIT 1
+        # ActiveRecord::RecordNotFound: Couldn't find Reference with 'id'=0
+
+    *Kuldeep Aggarwal*
+
 *   Reset the collection association when calling `reset` on it.
 
     Before:

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -311,9 +311,10 @@ module ActiveRecord
       conditions = " [#{conditions}]" if conditions
 
       if Array(ids).size == 1
-        error = "Couldn't find #{@klass.name} with '#{primary_key}'=#{ids}#{conditions}"
+        error = "Couldn't find #{@klass.name} with '#{primary_key}'=#{connection.type_cast(ids, columns_hash[primary_key])}#{conditions}"
       else
         error = "Couldn't find all #{@klass.name.pluralize} with '#{primary_key}': "
+        ids.map! { |id| connection.type_cast(id, columns_hash[primary_key]) }
         error << "(#{ids.join(", ")})#{conditions} (found #{result_size} results, but was looking for #{expected_size})"
       end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -980,6 +980,20 @@ class FinderTest < ActiveRecord::TestCase
     assert_nothing_raised(ActiveRecord::StatementInvalid) { Topic.offset("3").to_a }
   end
 
+  def test_find_one_message
+    e = assert_raises(ActiveRecord::RecordNotFound) do
+      Post.find 'Test1'
+    end
+    assert_equal %q{Couldn't find Post with 'id'=0}, e.message
+  end
+
+  def test_find_some_message
+    e = assert_raises(ActiveRecord::RecordNotFound) do
+      Post.find 'Test1', 'Test2'
+    end
+    assert_equal %q{Couldn't find all Posts with 'id': (0, 0) (found 0 results, but was looking for 2)}, e.message
+  end
+
   protected
     def bind(statement, *vars)
       if vars.first.is_a?(Hash)


### PR DESCRIPTION
``` ruby
  irb(main):002:0> Event.find("im-no-integer")
  # Before: ... WHERE `events`.`id` = 0 LIMIT 1
  # ActiveRecord::RecordNotFound: Couldn't find Reference with 'id'=im-no-integer

  # After: ... WHERE `events`.`id` = 0 LIMIT 1
  # ActiveRecord::RecordNotFound: Couldn't find Reference with 'id'=0

```
