### PR TITLE
Tokenizer's constructor shouldn't modify it's argument

### DIFF
--- a/actionview/lib/action_view/vendor/html-scanner/html/tokenizer.rb
+++ b/actionview/lib/action_view/vendor/html-scanner/html/tokenizer.rb
@@ -23,8 +23,7 @@ module HTML #:nodoc:
 
     # Create a new Tokenizer for the given text.
     def initialize(text)
-      text.encode!
-      @scanner = StringScanner.new(text)
+      @scanner = StringScanner.new(text.encode)
       @position = 0
       @line = 0
       @current_line = 1

--- a/actionview/test/template/html-scanner/tokenizer_test.rb
+++ b/actionview/test/template/html-scanner/tokenizer_test.rb
@@ -2,6 +2,10 @@ require 'abstract_unit'
 
 class TokenizerTest < ActiveSupport::TestCase
 
+  def test_constructor_should_not_modify_its_argument
+    assert_nothing_raised { HTML::Tokenizer.new("".freeze) }
+  end
+
   def test_blank
     tokenize ""
     assert_end


### PR DESCRIPTION
The string that was passed in was getting re-encoded in-place:

``` ruby
Encoding.default_internal = 'UTF-8'
enye = "\xF1".force_encoding('ISO-8859-1')
puts enye.encoding #=> ISO-8859-1
HTML::Tokenizer.new(enye)
puts enye.encoding #=> UTF-8
# Oh no! Who re-encoded my enye in-place?!?
```

I found this after the `strip_tags` helper was giving me a `cannot modify frozen string` error, which raised the question: why is it modifying my string anyways?
