### PR TITLE
Display value when raising due to unscope() issues

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -877,7 +877,7 @@ module ActiveRecord
           subrelation = (rel.left.kind_of?(Arel::Attributes::Attribute) ? rel.left : rel.right)
           subrelation.name == target_value
         else
-          raise "unscope(where: #{target_value.inspect}) failed: unscoping #{rel.class} is unimplemented."
+          raise "unscope(where: #{target_value.inspect}) failed: unscoping #{rel.class} \"#{rel}\" is unimplemented."
         end
       end
 


### PR DESCRIPTION
Hopefully make it easier to debug errors. e.g

Before:

```
RuntimeError:
   unscope(where: "deleted_at") failed: unscoping String is unimplemented.
```

After:

```
RuntimeError:
   unscope(where: "deleted_at") failed: unscoping String "'t'='t'" is unimplemented.
```
