### PR TITLE
Let `unscope` ignore non Arel scope.where_values

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -883,8 +883,6 @@ module ActiveRecord
         when Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality, Arel::Nodes::NotEqual
           subrelation = (rel.left.kind_of?(Arel::Attributes::Attribute) ? rel.left : rel.right)
           subrelation.name == target_value
-        else
-          raise "unscope(where: #{target_value.inspect}) failed: unscoping #{rel.class} \"#{rel}\" is unimplemented."
         end
       end
 

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -149,6 +149,16 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_equal expected, received
   end
 
+  def test_unscope_string_where_clauses_involved
+    dev_relation = Developer.order('salary DESC').where("created_at > ?", 1.year.ago)
+    expected = dev_relation.collect { |dev| dev.name }
+
+    dev_ordered_relation = DeveloperOrderedBySalary.where(name: 'Jamis').where("created_at > ?", 1.year.ago)
+    received = dev_ordered_relation.unscope(where: [:name]).collect { |dev| dev.name }
+
+    assert_equal expected, received
+  end
+
   def test_unscope_with_grouping_attributes
     expected = Developer.order('salary DESC').collect { |dev| dev.name }
     received = DeveloperOrderedBySalary.group(:name).unscope(:group).collect { |dev| dev.name }


### PR DESCRIPTION
It looks like `unscope` could be less agressive? So we could do thinks such as:

``` ruby
User.where(name: 'Jamis').where("created_at > ?", 1.year.ago).unscope(where: [:name])
```

without raising an exception?
