### PR TITLE
Rails config for raise on missing translations

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,14 +1,9 @@
-*   Do not discard query parameters that form a hash with the same root key as
-    the `wrapper_key` for a request using `wrap_parameters`.
+*   Added `config.action_view.raise_on_missing_translations` to define whether
+    an error should be raised for missing translations.
 
-    *Josh Jordan*
+    Fixes #13196
 
-*   Ensure that `request.filtered_parameters` is reset between calls to `process`
-    in `ActionController::TestCase`.
-
-    Fixes #13803.
-
-    *Andrew White*
+    *Kassio Borges*
 
 *   Fix `rake routes` error when `Rails::Engine` with empty routes is mounted.
 

--- a/actionpack/lib/action_view/base.rb
+++ b/actionpack/lib/action_view/base.rb
@@ -149,6 +149,10 @@ module ActionView #:nodoc:
     # Specify default_formats that can be rendered.
     cattr_accessor :default_formats
 
+    # Specify whether an error should be raised for missing translations
+    cattr_accessor :raise_on_missing_translations
+    @@raise_on_missing_translations = false
+
     class_attribute :_routes
     class_attribute :logger
 

--- a/actionpack/lib/action_view/helpers/translation_helper.rb
+++ b/actionpack/lib/action_view/helpers/translation_helper.rb
@@ -38,10 +38,10 @@ module ActionView
 
         # If the user has specified rescue_format then pass it all through, otherwise use
         # raise and do the work ourselves
-        if options.key?(:raise) || options.key?(:rescue_format)
-          raise_error = options[:raise] || options[:rescue_format]
-        else
-          raise_error = false
+        options[:raise] ||= ActionView::Base.raise_on_missing_translations
+
+        raise_error = options[:raise] || options.key?(:rescue_format)
+        unless raise_error
           options[:raise] = true
         end
 

--- a/actionpack/test/template/translation_helper_test.rb
+++ b/actionpack/test/template/translation_helper_test.rb
@@ -53,6 +53,16 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal false, translate(:"translations.missing", :rescue_format => nil).html_safe?
   end
 
+  def test_raises_missing_translation_message_with_raise_config_option
+    ActionView::Base.raise_on_missing_translations = true
+
+    assert_raise(I18n::MissingTranslationData) do
+      translate("translations.missing")
+    end
+  ensure
+    ActionView::Base.raise_on_missing_translations = false
+  end
+
   def test_raises_missing_translation_message_with_raise_option
     assert_raise(I18n::MissingTranslationData) do
       translate(:"translations.missing", :raise => true)

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -360,6 +360,8 @@ The schema dumper adds one additional configuration option:
 
     The default setting is `true`, which uses the partial at `/admin/posts/_post.erb`. Setting the value to `false` would render `/posts/_post.erb`, which is the same behavior as rendering from a non-namespaced controller such as `PostsController`.
 
+* `config.action_view.raise_on_missing_translations` determines whether an error should be raised for missing translations
+
 ### Configuring Action Mailer
 
 There are a number of settings available on `config.action_mailer`:

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -30,4 +30,7 @@
   # number of complex assets.
   config.assets.debug = true
   <%- end -%>
+
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -33,4 +33,7 @@
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
 end


### PR DESCRIPTION
Add a config to setup whether raise exception for missing translation or
not.

This is a [backport](https://github.com/rails/rails/pull/13832).
