### PR TITLE
Do not discard query parameters on requests that use wrap_parameters

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Do not discard query parameters that form a hash with the same root key as
+    the wrapper_key for a request using wrap_parameters
+
+    *Josh Jordan*
+
 *   Ensure that `request.filtered_parameters` is reset between calls to `process`
     in `ActionController::TestCase`.
 

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -188,6 +188,26 @@ class ParamsWrapperTest < ActionController::TestCase
       assert_parameters({ 'username' => 'sikachu', 'title' => 'Developer', 'user' => { 'username' => 'sikachu', 'title' => 'Developer' }})
     end
   end
+
+  def test_preserves_query_string_params
+    with_default_wrapper_options do
+      @request.env['CONTENT_TYPE'] = 'application/json'
+      get :parse, { 'user' => { 'username' => 'nixon' } }
+      assert_parameters(
+        {'user' => { 'username' => 'nixon' } }
+      )
+    end
+  end
+
+  def test_empty_parameter_set
+    with_default_wrapper_options do
+      @request.env['CONTENT_TYPE'] = 'application/json'
+      post :parse, {}
+      assert_parameters(
+        {'user' => { } }
+      )
+    end
+  end
 end
 
 class NamespacedParamsWrapperTest < ActionController::TestCase


### PR DESCRIPTION
This PR fixes the case where the GET parameters tried to form a hash, but `wrap_parameters` caused them to be overwritten by an empty hash.

To expand on what the test case shows, we ran into a realistic example wherein we had query string parameters that  matched the format of a form POST, so that we could reuse a particular controller action elsewhere in our application. Think of something like this:

```
link_to 'Search', search_path(search: { term: 'bill' }), remote: true
```

This allows compatibility with the same controller action you might use for a form that looks like this:

```
form_for @search do |f|
  f.text_field :term
  f.submit
end
```

Strangely, because of the current implementation of `ActionController::ParamsWrapper`, this caused a failure when used with content-type `application/json` (which, in our application, is wrapped), but not with a plain 'ol HTML request (which is not). I find this to be confusing and don't see a reason to discard GET parameters in this case.

All existing test cases pass.
