### PR TITLE
Fix incorrect serialization state after loading

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Allow repeated serialization of AR objects with store attributes
+
+    Before:
+
+        YAML.dump(YAML.load(YAML.dump obj)) #=> TypeError
+
+    After:
+
+        YAML.dump(YAML.load(YAML.dump obj)) #=> obj.to_yaml
+
+    Fixes #13861
+
+    *Jason Nochlin*
+
 *   Handle aliased attributes `select()`, `order()` and `reorder()`.
 
     *Tsutomu Kuroda*

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -76,6 +76,11 @@ module ActiveRecord
       end
 
       class Attribute < Struct.new(:coder, :value, :state) # :nodoc:
+        def initialize(*args)
+          super
+          repair_state
+        end
+
         def unserialized_value(v = value)
           state == :serialized ? unserialize(v) : value
         end
@@ -93,6 +98,11 @@ module ActiveRecord
           self.state = :serialized
           self.value = coder.dump(value)
         end
+
+        private
+          def repair_state
+            self.state = :unserialized if value.is_a?(ActiveSupport::HashWithIndifferentAccess)
+          end
       end
 
       # This is only added to the model when serialize is called, which

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -166,4 +166,11 @@ class StoreTest < ActiveRecord::TestCase
   test "YAML coder initializes the store when a Nil value is given" do
     assert_equal({}, @john.params)
   end
+
+  test "attributes can be serialized/deserialized repeatedly" do
+    dumped = YAML.dump @john
+    loaded = YAML.load dumped
+
+    assert YAML.dump loaded
+  end
 end


### PR DESCRIPTION
Fixes #13861 

Self-contained gist (tested on ruby 2.0.0-p353): https://gist.github.com/hundredwatt/8668163

Exception:  `TypeError: no implicit conversion of ActiveSupport::HashWithIndifferentAccess into String`
