### PR TITLE
Fixing issue with activerecord serialization not being able to dump a record after loading it from YAML - fixes #13861

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   ActiveRecord objects can now be correctly dumped, loaded and dumped again without issues.
+
+    Previously, if you did `YAML.dump`, `YAML.load` and then `YAML.dump` again
+    in an ActiveRecord model that used serialization it would fail at the last
+    dump due to the fields not being correctly serialized before being dumped
+    to YAML. Now it is possible to dump and load the same object as many times
+    as needed without any issues.
+
+    Fixes #13861.
+
+    *Maurício Linhares*
+
 *   `find_in_batches` now returns an `Enumerator` when called without a block, so that it
     can be chained with other `Enumerable` methods.
 

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -278,6 +278,11 @@ module ActiveRecord
       }
     end
 
+    # Placeholder so it can be overriden when needed by serialization
+    def attributes_for_coder # :nodoc:
+      attributes
+    end
+
     # Returns an <tt>#inspect</tt>-like string for the value of the
     # attribute +attr_name+. String attributes are truncated upto 50
     # characters, Date and Time attributes are returned in the

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -76,6 +76,7 @@ module ActiveRecord
       end
 
       class Attribute < Struct.new(:coder, :value, :state) # :nodoc:
+
         def unserialized_value(v = value)
           state == :serialized ? unserialize(v) : value
         end
@@ -162,6 +163,16 @@ module ActiveRecord
             @attributes[name].serialized_value
           else
             super
+          end
+        end
+
+        def attributes_for_coder
+          attribute_names.each_with_object({}) do |name,attrs|
+            attrs[name] = if self.class.serialized_attributes.include?(name)
+                @attributes[name].serialized_value
+              else
+                read_attribute(name)
+            end
           end
         end
       end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -275,7 +275,7 @@ module ActiveRecord
     #   Post.new.encode_with(coder)
     #   coder # => {"attributes" => {"id" => nil, ... }}
     def encode_with(coder)
-      coder['attributes'] = attributes
+      coder['attributes'] = attributes_for_coder
     end
 
     # Returns true if +comparison_object+ is the same exact object, or +comparison_object+

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -166,4 +166,27 @@ class StoreTest < ActiveRecord::TestCase
   test "YAML coder initializes the store when a Nil value is given" do
     assert_equal({}, @john.params)
   end
+
+  test "attributes_for_coder should return stored fields already serialized" do
+    attributes = {
+      "id" => @john.id,
+      "name"=> @john.name,
+      "settings" => "--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess\ncolor: black\n",
+      "preferences" => "--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess\nremember_login: true\n",
+      "json_data" => "{\"height\":\"tall\"}", "json_data_empty"=>"{\"is_a_good_guy\":true}",
+      "params" => "--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess {}\n",
+      "account_id"=> @john.account_id }
+    assert_equal attributes, @john.attributes_for_coder
+  end
+
+  test "dump, load and dump again a model" do
+    dumped = YAML.dump( @john )
+    loaded = YAML.load( dumped )
+    assert_equal @john, loaded
+
+    second_dump = YAML.dump( loaded )
+    assert_equal dumped, second_dump
+    assert_equal @john, YAML.load( second_dump )
+  end
+
 end


### PR DESCRIPTION
This is a backwards incompatible change for people using `store/serialization`.

This PR fixes the issue raised at https://github.com/rails/rails/issues/13861

The main issue is that [encode_with](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/core.rb#L277) says that the attributes value that is set to the `coder` object is the same that gets set at [init_with](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/core.rb#L205) and while this is true, `init_with` calls `self.class.initialize_attributes(coder['attributes'])` without setting the `:serialized` option and creates the `Serialization::Attibute` object with the `serialized` field set to true as can be seen [here](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/attribute_methods/serialization.rb#L105), but the YAML produced by a `YAML.dump` call is like this:

``` yaml
--- !ruby/object:Admin::User
attributes:
  id: 721854607
  name: John Doe
  settings: !ruby/hash:ActiveSupport::HashWithIndifferentAccess
    color: black
  preferences: !ruby/hash:ActiveSupport::HashWithIndifferentAccess
    remember_login: true
  json_data: !ruby/hash:ActiveSupport::HashWithIndifferentAccess
    height: tall
  json_data_empty: !ruby/hash:ActiveSupport::HashWithIndifferentAccess
    is_a_good_guy: true
  params: !ruby/hash:ActiveSupport::HashWithIndifferentAccess {}
  account_id: 
```

The `json_data` field that should have been a JSON string, since it's store `:coder` turns it into JSON before saving it, was saved just like any YAML field. Now, when you `YAML.load` the content above you will get the following error:

```
TypeError: no implicit conversion of ActiveSupport::HashWithIndifferentAccess into String
```

And it happens because the `init_with` method expected to receive a JSON string at the `json_data` field and not the `ActiveSupport::HashWithIndifferentAccess`, since `:serialized` will be set to true. That's why at the original issue description @hundredwatt says that calling `record.reload` works, because when you call `reload` at the object `init_with` is called with the data as it comes from the database column, that will be a JSON string and not a real hash object.

The solution here was creating a separate `attributes_for_coder` method that the serialization code can override when needed to generate the encoded value for the field so it can be safely dumped and then loaded back again through the correct process.
