### PR TITLE
Correctly send the string given to lock! and reload(:lock) to the lock scope - fixes #13788

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Correctly send an user provided statement to a `lock!()` call.
+
+        person.lock! 'FOR SHARE NOWAIT'
+        # Before: SELECT * ... LIMIT 1 FOR UPDATE
+        # After: SELECT * ... LIMIT 1 FOR SHARE NOWAIT
+
+    Fixes #13788.
+
+    *Maurício Linhares*
+
 *   Handle aliased attributes `select()`, `order()` and `reorder()`.
 
     *Tsutomu Kuroda*

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -389,7 +389,7 @@ module ActiveRecord
 
       fresh_object =
         if options && options[:lock]
-          self.class.unscoped { self.class.lock.find(id) }
+          self.class.unscoped { self.class.lock(options[:lock]).find(id) }
         else
           self.class.unscoped { self.class.find(id) }
         end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -431,6 +431,17 @@ unless current_adapter?(:SybaseAdapter, :OpenBaseAdapter) || in_memory_db?
       assert_equal old, person.reload.first_name
     end
 
+    if current_adapter?(:PostgreSQLAdapter)
+      def test_lock_sending_custom_lock_statement
+        Person.transaction do
+          person = Person.find(1)
+          assert_sql(/LIMIT 1 FOR SHARE NOWAIT/) do
+            person.lock!('FOR SHARE NOWAIT')
+          end
+        end
+      end
+    end
+
     if current_adapter?(:PostgreSQLAdapter, :OracleAdapter)
       def test_no_locks_no_wait
         first, second = duel { Person.find 1 }


### PR DESCRIPTION
Fixes #13788 

As per the documentation at [lock!](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/locking/pessimistic.rb#L61), if the `:lock` option is a string it should use the given SQL to generate the lock statement.

This change fixes this issue and also includes two new tests to make sure this behaviour is maintained.
