### PR TITLE
Support local in TextHelper.pluralize()

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -3,6 +3,13 @@
 
     *Olivier Kaluzny*
 
+*   Added `config.action_view.raise_on_missing_translations` to define whether an
+    error should be raised for missing translations.
+
+    Fixes #13196
+
+    *Kassio Borges*
+
 *   Improved ERB dependency detection. New argument types and formattings for the `render`
     calls can be matched.
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,5 +1,5 @@
-*   The `pluralize` helper accepts a language as `locale` to define which language to use
-    Default is current locale
+*   The `pluralize` helper accepts a language as `locale` to define which language to use.
+    Default is current locale.
 
     *Olivier Kaluzny*
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,9 +1,7 @@
-*   Added `config.action_view.raise_on_missing_translations` to define whether an
-    error should be raised for missing translations.
+*   The `pluralize` helper accepts a language as `locale` to define which language to use
+    Default is current locale
 
-    Fixes #13196
-
-    *Kassio Borges*
+    *Olivier Kaluzny*
 
 *   Improved ERB dependency detection. New argument types and formattings for the `render`
     calls can be matched.

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,5 +1,5 @@
-*   The `pluralize` helper accepts a language as `locale` to define which language to use.
-    Default is current locale.
+*   The `pluralize` helper accepts a new `locale` argument to determine which language to use.
+    Defaults to the current I18n locale.
 
     *Olivier Kaluzny*
 

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -195,7 +195,7 @@ module ActionView
       #
       #   pluralize(0, 'person')
       #   # => 0 people
-      def pluralize(count, singular, plural = nil, locale = :en)
+      def pluralize(count, singular, plural = nil, locale = I18n.locale)
         word = if (count == 1 || count =~ /^1(\.0+)?$/)
           singular
         else

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -195,11 +195,11 @@ module ActionView
       #
       #   pluralize(0, 'person')
       #   # => 0 people
-      def pluralize(count, singular, plural = nil)
+      def pluralize(count, singular, plural = nil, locale = :en)
         word = if (count == 1 || count =~ /^1(\.0+)?$/)
           singular
         else
-          plural || singular.pluralize
+          plural || singular.pluralize(locale)
         end
 
         "#{count || 0} #{word}"

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -182,7 +182,8 @@ module ActionView
 
       # Attempts to pluralize the +singular+ word unless +count+ is 1. If
       # +plural+ is supplied, it will use that when count is > 1, otherwise
-      # it will use the Inflector to determine the plural form.
+      # it will use the Inflector to determine the plural form. You can set
+      # +locale+ used to pluralize (defaults to current locale)
       #
       #   pluralize(1, 'person')
       #   # => 1 person
@@ -195,6 +196,9 @@ module ActionView
       #
       #   pluralize(0, 'person')
       #   # => 0 people
+      #
+      #   pluralize(2, 'journal', nil, :fr)
+      #   # => 2 journaux
       def pluralize(count, singular, plural = nil, locale = I18n.locale)
         word = if (count == 1 || count =~ /^1(\.0+)?$/)
           singular

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -183,7 +183,7 @@ module ActionView
       # Attempts to pluralize the +singular+ word unless +count+ is 1. If
       # +plural+ is supplied, it will use that when count is > 1, otherwise
       # it will use the Inflector to determine the plural form. You can set
-      # +locale+ used to pluralize (defaults to current locale).
+      # the +locale+ used to pluralize (defaults to current locale).
       #
       #   pluralize(1, 'person')
       #   # => 1 person

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -183,7 +183,7 @@ module ActionView
       # Attempts to pluralize the +singular+ word unless +count+ is 1. If
       # +plural+ is supplied, it will use that when count is > 1, otherwise
       # it will use the Inflector to determine the plural form. You can set
-      # +locale+ used to pluralize (defaults to current locale)
+      # +locale+ used to pluralize (defaults to current locale).
       #
       #   pluralize(1, 'person')
       #   # => 1 person

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -498,12 +498,11 @@ class TextHelperTest < ActionView::TestCase
   # This helper is implemented by setting @__instance__ because in some tests
   # there are module functions that access ActiveSupport::Inflector.inflections,
   # so we need to replace the singleton itself.
-  # Copy from with_dup method activesupport/test/inflector_test.rb
+  # Copy from with_dup method activesupport/test/inflector_test.rb.
   def inflector_with_dup
     original = ActiveSupport::Inflector::Inflections.instance_variable_get(:@__instance__)
     ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, original.dup)
   ensure
     ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, original)
   end
-
 end

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -345,6 +345,7 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_pluralization
+    ActiveSupport::Inflector::inflections(:fr).plural 'journal', 'journaux'
     assert_equal("1 count", pluralize(1, "count"))
     assert_equal("2 counts", pluralize(2, "count"))
     assert_equal("1 count", pluralize('1', "count"))
@@ -359,6 +360,8 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("10 buffaloes", pluralize(10, "buffalo"))
     assert_equal("1 berry", pluralize(1, "berry"))
     assert_equal("12 berries", pluralize(12, "berry"))
+    assert_equal("2 journaux", pluralize(2, "journal", nil, :fr))
+    assert_equal("1 journal", pluralize(1, "journal", nil, :fr))
   end
 
   def test_cycle_class

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -367,7 +367,6 @@ class TextHelperTest < ActionView::TestCase
     end
   end
 
-
   def test_cycle_class
     value = Cycle.new("one", 2, "3")
     assert_equal("one", value.to_s)

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -345,7 +345,6 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_pluralization
-    ActiveSupport::Inflector::inflections(:fr).plural 'journal', 'journaux'
     assert_equal("1 count", pluralize(1, "count"))
     assert_equal("2 counts", pluralize(2, "count"))
     assert_equal("1 count", pluralize('1', "count"))
@@ -360,10 +359,14 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("10 buffaloes", pluralize(10, "buffalo"))
     assert_equal("1 berry", pluralize(1, "berry"))
     assert_equal("12 berries", pluralize(12, "berry"))
-    assert_equal("2 journaux", pluralize(2, "journal", nil, :fr))
-    assert_equal("1 journal", pluralize(1, "journal", nil, :fr))
-    ActiveSupport::Inflector::inflections(:fr).clear(:plurals)
+
+    inflector_with_dup do
+      ActiveSupport::Inflector::inflections(:fr).plural 'journal', 'journaux'
+      assert_equal("2 journaux", pluralize(2, "journal", nil, :fr))
+      assert_equal("1 journal", pluralize(1, "journal", nil, :fr))
+    end
   end
+
 
   def test_cycle_class
     value = Cycle.new("one", 2, "3")
@@ -488,4 +491,19 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("red", cycle("red", "blue"))
     assert_equal(%w{Specialized Fuji Giant}, @cycles)
   end
+
+  # Dups the singleton and yields, restoring the original inflections later.
+  # Use this in tests what modify the state of the singleton.
+  #
+  # This helper is implemented by setting @__instance__ because in some tests
+  # there are module functions that access ActiveSupport::Inflector.inflections,
+  # so we need to replace the singleton itself.
+  # Copy from with_dup method activesupport/test/inflector_test.rb
+  def inflector_with_dup
+    original = ActiveSupport::Inflector::Inflections.instance_variable_get(:@__instance__)
+    ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, original.dup)
+  ensure
+    ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, original)
+  end
+
 end

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -362,6 +362,7 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("12 berries", pluralize(12, "berry"))
     assert_equal("2 journaux", pluralize(2, "journal", nil, :fr))
     assert_equal("1 journal", pluralize(1, "journal", nil, :fr))
+    ActiveSupport::Inflector::inflections(:fr).clear(:plurals)
   end
 
   def test_cycle_class


### PR DESCRIPTION
Add support for locale in TextHelper.pluralize(). Make argument optional and :en by default. Unless, the helper use String.pluralize without local, and it's always :en 
