### PR TITLE
Mention find_each in find_in_batches doc [ci skip]

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -64,6 +64,8 @@ module ActiveRecord
     #     group.each { |person| person.party_all_night! }
     #   end
     #
+    # To be yielded each record one by one, use #find_each instead.
+    #
     # ==== Options
     # * <tt>:batch_size</tt> - Specifies the size of the batch. Default to 1000.
     # * <tt>:start</tt> - Specifies the starting point for the batch processing.


### PR DESCRIPTION
Small doc addition. I was actually looking for `find_each` but could only remember `find_in_batches`...
