### PR TITLE
Enhance errors while retrieving database config

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -109,6 +109,8 @@ module Rails
         raise "YAML syntax error occurred while parsing #{paths["config/database"].first}. " \
               "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \
               "Error: #{e.message}"
+      rescue => e
+        raise e, "Cannot load `Rails.application.database_configuration`:\n#{e.message}", e.backtrace
       end
 
       def log_level


### PR DESCRIPTION
Right now if there is an error retrieving database configuration the intent of the error (what the code was trying to do while you got the error) could be more explicit. 

Instead of this error:

```
Invalid DATABASE_URL: nil
(erb):9:in `rescue in <main>'
(erb):6:in `<main>'
/Users/schneems/.rbenv/versions/2.1.0/lib/ruby/2.1.0/erb.rb:850:in `eval'
/Users/schneems/.rbenv/versions/2.1.0/lib/ruby/2.1.0/erb.rb:850:in `result'
/Users/schneems/Documents/projects/rails/railties/lib/rails/application/configuration.rb:98:in `database_configuration'
/Users/schneems/Documents/projects/rails/activerecord/lib/active_record/railtie.rb:41:in `block in <class:Railtie>'
/Users/schneems/Documents/projects/rails/railties/lib/rails/railtie.rb:237:in `instance_exec'
/Users/schneems/Documents/projects/rails/railties/lib/rails/railtie.rb:237:in `block in run_tasks_blocks'
/Users/schneems/Documents/projects/rails/railties/lib/rails/railtie.rb:237:in `each'
/Users/schneems/Documents/projects/rails/railties/lib/rails/railtie.rb:237:in `run_tasks_blocks'
/Users/schneems/Documents/projects/rails/railties/lib/rails/application.rb:339:in `block in run_tasks_blocks'
/Users/schneems/Documents/projects/rails/railties/lib/rails/engine/railties.rb:13:in `each'
```

I propose we issue this error:

```
Cannot load `Rails.application.database_configuration`:
Invalid DATABASE_URL: nil
(erb):9:in `rescue in <main>'
(erb):6:in `<main>'
/Users/schneems/.rbenv/versions/2.1.0/lib/ruby/2.1.0/erb.rb:850:in `eval'
/Users/schneems/.rbenv/versions/2.1.0/lib/ruby/2.1.0/erb.rb:850:in `result'
/Users/schneems/Documents/projects/rails/railties/lib/rails/application/configuration.rb:98:in `database_configuration'
/Users/schneems/Documents/projects/rails/activerecord/lib/active_record/railtie.rb:41:in `block in <class:Railtie>'
/Users/schneems/Documents/projects/rails/railties/lib/rails/railtie.rb:237:in `instance_exec'
/Users/schneems/Documents/projects/rails/railties/lib/rails/railtie.rb:237:in `block in run_tasks_blocks'
/Users/schneems/Documents/projects/rails/railties/lib/rails/railtie.rb:237:in `each'
/Users/schneems/Documents/projects/rails/railties/lib/rails/railtie.rb:237:in `run_tasks_blocks'
/Users/schneems/Documents/projects/rails/railties/lib/rails/application.rb:339:in `block in run_tasks_blocks'
/Users/schneems/Documents/projects/rails/railties/lib/rails/engine/railties.rb:13:in `each'
```
