### PR TITLE
Alternative implementation to make time travel not dependent on mocha

### DIFF
--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -1,6 +1,6 @@
 module ActiveSupport
   module Testing
-    class SimpleStubs
+    class SimpleStubs # :nodoc:
       Stub = Struct.new(:object, :method_name, :original_method)
 
       def initialize
@@ -29,11 +29,13 @@ module ActiveSupport
         @stubs = {}
       end
 
-      def unstub_object(stub)
-        stub.object.singleton_class.send :undef_method, stub.method_name
-        stub.object.singleton_class.send :alias_method, stub.method_name, stub.original_method
-        stub.object.singleton_class.send :undef_method, stub.original_method
-      end
+      private
+
+        def unstub_object(stub)
+          stub.object.singleton_class.send :undef_method, stub.method_name
+          stub.object.singleton_class.send :alias_method, stub.method_name, stub.original_method
+          stub.object.singleton_class.send :undef_method, stub.original_method
+        end
     end
 
     # Containing helpers that helps you test passage of time.
@@ -91,9 +93,11 @@ module ActiveSupport
         end
       end
 
-      def simple_stubs
-        @simple_stubs ||= SimpleStubs.new
-      end
+      private
+
+        def simple_stubs
+          @simple_stubs ||= SimpleStubs.new
+        end
     end
   end
 end

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -32,9 +32,10 @@ module ActiveSupport
       private
 
         def unstub_object(stub)
-          stub.object.singleton_class.send :undef_method, stub.method_name
-          stub.object.singleton_class.send :alias_method, stub.method_name, stub.original_method
-          stub.object.singleton_class.send :undef_method, stub.original_method
+          singleton_class = stub.object.singleton_class
+          singleton_class.send :undef_method, stub.method_name
+          singleton_class.send :alias_method, stub.method_name, stub.original_method
+          singleton_class.send :undef_method, stub.original_method
         end
     end
 

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -38,13 +38,8 @@ module ActiveSupport
 
     # Containing helpers that helps you test passage of time.
     module TimeHelpers
-      def before_setup
-        super
-        @simple_stubs = SimpleStubs.new
-      end
-
       def after_teardown #:nodoc:
-        @simple_stubs.unstub_all!
+        simple_stubs.unstub_all!
         super
       end
 
@@ -87,13 +82,17 @@ module ActiveSupport
       #   end
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       def travel_to(date_or_time, &block)
-        @simple_stubs.stub_object(Time, :now, date_or_time.to_time)
-        @simple_stubs.stub_object(Date, :today, date_or_time.to_date)
+        simple_stubs.stub_object(Time, :now, date_or_time.to_time)
+        simple_stubs.stub_object(Date, :today, date_or_time.to_date)
 
         if block_given?
           block.call
-          @simple_stubs.unstub_all!
+          simple_stubs.unstub_all!
         end
+      end
+
+      def simple_stubs
+        @simple_stubs ||= SimpleStubs.new
       end
     end
   end

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -23,7 +23,7 @@ module ActiveSupport
       end
 
       def unstub_all!
-        @stubs.each do |_, stub|
+        @stubs.each_value do |stub|
           unstub_object(stub)
         end
         @stubs = {}

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -14,8 +14,11 @@ module ActiveSupport
           unstub_object(stub)
         end
 
-        @stubs[key] = Stub.new(object, method_name, object.method(method_name))
+        new_name = "__simple_stub__#{method_name}"
 
+        @stubs[key] = Stub.new(object, method_name, new_name)
+
+        object.singleton_class.send :alias_method, new_name, method_name
         object.define_singleton_method(method_name) { return_value }
       end
 
@@ -27,7 +30,9 @@ module ActiveSupport
       end
 
       def unstub_object(stub)
-        stub.object.define_singleton_method(stub.method_name, stub.original_method)
+        stub.object.singleton_class.send :undef_method, stub.method_name
+        stub.object.singleton_class.send :alias_method, stub.method_name, stub.original_method
+        stub.object.singleton_class.send :undef_method, stub.original_method
       end
     end
 


### PR DESCRIPTION
This is an alternative implementation to https://github.com/rails/rails/pull/13655.

Before this patch time travel feature depends on mocha's stub feature.
Since mocha is not a Rails dependency we can't depend on this specific library.

We choose to use our own implementation to avoid adding one more dependency to Rails.

This implementation is using an internal stub implementation instead of minitest to make possible to RSpec users use this methods without any problem.

Fixes #13380.

Thank you @myronmarston for the help.
