### PR TITLE
Add `travel_back` to remove stubs from `travel` and `travel_to` and remove auto-rollback after each test case

### DIFF
--- a/activerecord/test/cases/mixin_test.rb
+++ b/activerecord/test/cases/mixin_test.rb
@@ -6,8 +6,12 @@ end
 class TouchTest < ActiveRecord::TestCase
   fixtures :mixins
 
-  def setup
+  setup do
     travel_to Time.now
+  end
+
+  teardown do
+    travel_back
   end
 
   def test_update

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `travel_back` to remove stubs from `travel` and `travel_to`.
+
+    *Rafael Mendonça França*
+
 *   Remove the deprecation about the `#filter` method.
 
     Filter objects should now rely on method corresponding to the filter type

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Remove behavior that automatically remove the Date/Time stubs, added by `travel`
+    and `travel_to` methods, after each test case.
+
+    Now users have to use the `travel_back` or the block version of `travel` and
+    `travel_to` methods to clean the stubs.
+
+    *Rafael Mendonça França*
+
 *   Add `travel_back` to remove stubs from `travel` and `travel_to`.
 
     *Rafael Mendonça França*

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -42,7 +42,7 @@ module ActiveSupport
     # Containing helpers that helps you test passage of time.
     module TimeHelpers
       def after_teardown #:nodoc:
-        simple_stubs.unstub_all!
+        travel_back
         super
       end
 
@@ -81,7 +81,7 @@ module ActiveSupport
       #
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       #   travel_to Time.new(2004, 11, 24, 01, 04, 44) do
-      #     User.create.created_at # => Wed, 24 Nov 2004 01:04:44 EST -05:00
+      #     Time.current # => Wed, 24 Nov 2004 01:04:44 EST -05:00
       #   end
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       def travel_to(date_or_time, &block)
@@ -90,8 +90,19 @@ module ActiveSupport
 
         if block_given?
           block.call
-          simple_stubs.unstub_all!
+          travel_back
         end
+      end
+
+      # Return the current time back to its original state.
+      #
+      #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
+      #   travel_to Time.new(2004, 11, 24, 01, 04, 44)
+      #   Time.current # => Wed, 24 Nov 2004 01:04:44 EST -05:00
+      #   travel_back
+      #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
+      def travel_back
+        simple_stubs.unstub_all!
       end
 
       private

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -41,7 +41,7 @@ module ActiveSupport
 
     # Containing helpers that helps you test passage of time.
     module TimeHelpers
-      # Change current time to the time in the future or in the past by a given time difference by
+      # Changes current time to the time in the future or in the past by a given time difference by
       # stubbing +Time.now+ and +Date.today+.
       #
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
@@ -61,7 +61,7 @@ module ActiveSupport
         travel_to Time.now + duration, &block
       end
 
-      # Change current time to the given time by stubbing +Time.now+ and +Date.today+ to return the
+      # Changes current time to the given time by stubbing +Time.now+ and +Date.today+ to return the
       # time or date passed into this method.
       #
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
@@ -87,7 +87,8 @@ module ActiveSupport
         end
       end
 
-      # Return the current time back to its original state.
+      # Returns the current time back to its original state, by removing the stubs added by
+      # `travel` and `travel_to`.
       #
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       #   travel_to Time.new(2004, 11, 24, 01, 04, 44)

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -41,14 +41,8 @@ module ActiveSupport
 
     # Containing helpers that helps you test passage of time.
     module TimeHelpers
-      def after_teardown #:nodoc:
-        travel_back
-        super
-      end
-
       # Change current time to the time in the future or in the past by a given time difference by
-      # stubbing +Time.now+ and +Date.today+. Note that the stubs are automatically removed
-      # at the end of each test.
+      # stubbing +Time.now+ and +Date.today+.
       #
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       #   travel 1.day
@@ -68,8 +62,7 @@ module ActiveSupport
       end
 
       # Change current time to the given time by stubbing +Time.now+ and +Date.today+ to return the
-      # time or date passed into this method. Note that the stubs are automatically removed
-      # at the end of each test.
+      # time or date passed into this method.
       #
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       #   travel_to Time.new(2004, 11, 24, 01, 04, 44)

--- a/activesupport/test/test_test.rb
+++ b/activesupport/test/test_test.rb
@@ -162,6 +162,10 @@ class TimeHelperTest < ActiveSupport::TestCase
     Time.stubs now: Time.now
   end
 
+  teardown do
+    travel_back
+  end
+
   def test_time_helper_travel
     expected_time = Time.now + 1.day
     travel 1.day

--- a/activesupport/test/test_test.rb
+++ b/activesupport/test/test_test.rb
@@ -201,4 +201,16 @@ class TimeHelperTest < ActiveSupport::TestCase
     assert_not_equal expected_time, Time.now
     assert_not_equal Date.new(2004, 11, 24), Date.today
   end
+
+  def test_time_helper_travel_back
+    expected_time = Time.new(2004, 11, 24, 01, 04, 44)
+
+    travel_to expected_time
+    assert_equal expected_time, Time.now
+    assert_equal Date.new(2004, 11, 24), Date.today
+    travel_back
+
+    assert_not_equal expected_time, Time.now
+    assert_not_equal Date.new(2004, 11, 24), Date.today
+  end
 end

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -97,6 +97,7 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal Date.new(2000, 1, 1), ActiveSupport::TimeZone['Eastern Time (US & Canada)'].today
     travel_to(Time.utc(2000, 1, 2, 5)) # midnight Jan 2 EST
     assert_equal Date.new(2000, 1, 2), ActiveSupport::TimeZone['Eastern Time (US & Canada)'].today
+    travel_back
   end
 
   def test_tomorrow
@@ -108,6 +109,7 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal Date.new(2000, 1, 2), ActiveSupport::TimeZone['Eastern Time (US & Canada)'].tomorrow
     travel_to(Time.utc(2000, 1, 2, 5)) # midnight Jan 2 EST
     assert_equal Date.new(2000, 1, 3), ActiveSupport::TimeZone['Eastern Time (US & Canada)'].tomorrow
+    travel_back
   end
 
   def test_yesterday
@@ -119,6 +121,7 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal Date.new(1999, 12, 31), ActiveSupport::TimeZone['Eastern Time (US & Canada)'].yesterday
     travel_to(Time.utc(2000, 1, 2, 5)) # midnight Jan 2 EST
     assert_equal Date.new(2000, 1, 1), ActiveSupport::TimeZone['Eastern Time (US & Canada)'].yesterday
+    travel_back
   end
 
   def test_local

--- a/guides/source/4_1_release_notes.md
+++ b/guides/source/4_1_release_notes.md
@@ -607,8 +607,9 @@ for detailed changes.
   `Time.now` and
   `Date.today`. ([Pull Request](https://github.com/rails/rails/pull/12824))
 
-* Added `ActiveSupport::Testing::TimeHelpers#travel_back`. This method return
-  the current time to the original state. ([Pull Request](https://github.com/rails/rails/pull/13884))
+* Added `ActiveSupport::Testing::TimeHelpers#travel_back`. This method returns
+  the current time to the original state, by removing the stubs added by `travel`
+  and `travel_to`. ([Pull Request](https://github.com/rails/rails/pull/13884))
 
 * Added `Numeric#in_milliseconds`, like `1.hour.in_milliseconds`, so we can feed
   them to JavaScript functions like

--- a/guides/source/4_1_release_notes.md
+++ b/guides/source/4_1_release_notes.md
@@ -607,6 +607,9 @@ for detailed changes.
   `Time.now` and
   `Date.today`. ([Pull Request](https://github.com/rails/rails/pull/12824))
 
+* Added `ActiveSupport::Testing::TimeHelpers#travel_back`. This method return
+  the current time to the original state. ([Pull Request](https://github.com/rails/rails/pull/13884))
+
 * Added `Numeric#in_milliseconds`, like `1.hour.in_milliseconds`, so we can feed
   them to JavaScript functions like
   `getTime()`. ([Commit](https://github.com/rails/rails/commit/423249504a2b468d7a273cbe6accf4f21cb0e643))


### PR DESCRIPTION
This is a alternative implementation of https://github.com/rails/rails/pull/12966.

The reason is the same plus, I'm removing the auto-rollback after each test case. The reason is this auto-rollback will only work with minitest out of the box and it may confuse the users.

Closes #12966
