### PR TITLE
Modify the session serializer implementation

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,14 +1,15 @@
 *   Add `:serializer` option for `config.session_store :cookie_store`. This
-    changes default serializer when using `:cookie_store` to
-    `ActionDispatch::Session::MarshalSerializer` which is wrapper on Marshal.
+    changes default serializer when using `:cookie_store`.
 
-    It is also possible to pass:
+    It is possible to pass:
 
-    * `:json_serializer` which is secure wrapper on JSON using `JSON.parse` and
+    * `:json` which is a secure wrapper on JSON using `JSON.parse` and
       `JSON.generate` methods with quirks mode;
-    * any other Symbol or String like `:my_custom_serializer` which will be
-      camelized and constantized in `ActionDispatch::Session` namespace;
-    * serializer object with `load` and `dump` methods defined.
+    * `:marshal` which is a wrapper on Marshal; 
+    * serializer class with `load` and `dump` methods defined.
+
+    For new apps `:json` option is added by default and :marshal is used
+    when no option is specified.
 
     *Łukasz Sarnacki + Matt Aimonetti*
 

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -466,10 +466,12 @@ module ActionDispatch
         end
 
         def serializer
-          serializer = @options[:session_serializer] || :marshal_serializer
+          serializer = @options[:session_serializer] || :marshal
           case serializer
-          when Symbol, String
-            ActionDispatch::Session.const_get(serializer.to_s.camelize)
+          when :marshal
+            ActionDispatch::Session::MarshalSerializer
+          when :json
+            ActionDispatch::Session::JsonSerializer
           else
             serializer
           end

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -379,7 +379,7 @@ class CookiesTest < ActionController::TestCase
     assert_equal 'bar', cookies.encrypted[:foo]
   end
 
-  class ActionDispatch::Session::CustomJsonSerializer
+  class CustomJsonSerializer
     def self.load(value)
       JSON.load(value) + " and loaded"
     end
@@ -389,20 +389,14 @@ class CookiesTest < ActionController::TestCase
     end
   end
 
-  def test_encrypted_cookie_using_custom_json_serializer
-    @request.env["action_dispatch.session_serializer"] = :custom_json_serializer
-    get :set_encrypted_cookie
-    assert_equal 'bar was dumped and loaded', cookies.encrypted[:foo]
-  end
-
   def test_encrypted_cookie_using_serializer_object
-    @request.env["action_dispatch.session_serializer"] = ActionDispatch::Session::CustomJsonSerializer
+    @request.env["action_dispatch.session_serializer"] = CustomJsonSerializer
     get :set_encrypted_cookie
     assert_equal 'bar was dumped and loaded', cookies.encrypted[:foo]
   end
 
   def test_encrypted_cookie_using_json_serializer
-    @request.env["action_dispatch.session_serializer"] = :json_serializer
+    @request.env["action_dispatch.session_serializer"] = :json
     get :set_encrypted_cookie
     cookies = @controller.send :cookies
     assert_not_equal 'bar', cookies[:foo]

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -384,20 +384,14 @@ YourApp::Application.config.session_store :cookie_store, key: '_your_app_session
 You can pass `:serializer` key to specify serializer for serializing session:
 
 ```ruby
-YourApp::Application.config.session_store :cookie_store, key: '_your_app_session', serializer: :json_serializer
+YourApp::Application.config.session_store :cookie_store, key: '_your_app_session', serializer: :json
 ```
 
-Default serializer is `:marshal_serializer`. When Symbol or String is passed it
-will look for appropriate class in `ActionDispatch::Session` namespace, so
-passing `:my_custom_serializer` would load
-`ActionDispatch::Session::MyCustomSerializer`.
+The default serializer for new application is `:json`. For compatibility with
+old applications `:marshal` is used when `serializer` option is not specified.
 
-```ruby
-YourApp::Application.config.session_store :cookie_store, key: '_your_app_session', serializer: :my_custom_serializer
-```
-
-It is also possible to pass serializer object with defined `load` and `dump`
-public methods:
+It is also possible to pass a custom serializer class with `load` and `dump`
+public methods defined:
 
 ```ruby
 YourApp::Application.config.session_store :cookie_store, key: '_your_app_session', serializer: MyCustomSerializer

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: <%= "'_#{app_name}_session'" %>, serializer: :json_serializer
+Rails.application.config.session_store :cookie_store, key: <%= "'_#{app_name}_session'" %>, serializer: :json

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -433,7 +433,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_new_hash_style
     run_generator [destination_root]
     assert_file "config/initializers/session_store.rb" do |file|
-      assert_match(/config.session_store :cookie_store, key: '_.+_session', serializer: :json_serializer/, file)
+      assert_match(/config.session_store :cookie_store, key: '_.+_session', serializer: :json/, file)
     end
   end
 


### PR DESCRIPTION
Rename allowed options to :marshal and :json, for custom serializers
only allow the use of custom classes.
