### PR TITLE
append link to bad code when error type is SyntaxError

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Append link to bad code to backtrace when exception is SyntaxError.
+
+    *Boris Kuznetsov*
+    
 *   Swapped the parameters of assert_equal in `assert_select` so that the
     proper values were printed correctly 
 

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -32,6 +32,8 @@ module ActionDispatch
     def initialize(env, exception)
       @env = env
       @exception = original_exception(exception)
+
+      expand_backtrace if exception.is_a?(SyntaxError) || exception.try(:original_exception).try(:is_a?, SyntaxError)
     end
 
     def rescue_template
@@ -103,6 +105,12 @@ module ActionDispatch
           Hash[*(start+1..(lines.count+start)).zip(lines).flatten]
         end
       end
+    end
+
+    def expand_backtrace
+      @exception.backtrace.unshift(
+        @exception.to_s.split("\n")
+      ).flatten! 
     end
   end
 end

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -43,6 +43,19 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
         raise ActionController::UrlGenerationError, "No route matches"
       when "/parameter_missing"
         raise ActionController::ParameterMissing, :missing_param_key
+      when "/original_syntax_error"
+        eval 'broke_syntax =' # `eval` need for raise native SyntaxError at runtime
+      when "/syntax_error_into_view"
+        begin
+          eval 'broke_syntax ='
+        rescue Exception => e
+          template = ActionView::Template.new(File.read(__FILE__),
+                                              __FILE__,
+                                              ActionView::Template::Handlers::Raw.new,
+                                              {})
+          raise ActionView::Template::Error.new(template, e)
+        end
+
       else
         raise "puke!"
       end
@@ -241,5 +254,27 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
 
     get "/", {}, env
     assert_operator((output.rewind && output.read).lines.count, :>, 10)
+  end
+
+  test 'display backtrace when error type is SyntaxError' do
+    @app = DevelopmentApp
+
+    get '/original_syntax_error', {}, {'action_dispatch.backtrace_cleaner' => ActiveSupport::BacktraceCleaner.new}
+
+    assert_response 500
+    assert_select '#Application-Trace' do
+      assert_select 'pre code', /\(eval\):1: syntax error, unexpected/
+    end
+  end
+
+  test 'display backtrace when error type is SyntaxError wrapped by ActionView::Template::Error' do
+    @app = DevelopmentApp
+
+    get '/syntax_error_into_view', {}, {'action_dispatch.backtrace_cleaner' => ActiveSupport::BacktraceCleaner.new}
+
+    assert_response 500
+    assert_select '#Application-Trace' do
+      assert_select 'pre code', /\(eval\):1: syntax error, unexpected/
+    end
   end
 end


### PR DESCRIPTION
When we exec bad code and catch the exception then we have access to `backtrace` method of exception. This method return trace of bad code execution.

I found that when error type is SyntaxError — ruby not return link to bad code on `exception.backtrace` but link to bad code contain into exception message.

For test this case just put bad code (like `a =` for example) into your application and see for result.

Here is what you should see ([screen](http://note.io/1dQx6FA)).

After patched the rails wrapper of exception, the application trace will be displayed correctly ([screen](http://note.io/1dQxe80)).
