### PR TITLE
Associations now raises `ArgumentError` on name conflicts.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Associations now raise `ArgumentError` on name conflicts.
+
+    Dangerous association names conflicts include instance or class methods already
+    defined by `ActiveRecord::Base`.
+
+    Example:
+
+        class Car < ActiveRecord::Base
+          has_many :errors
+        end
+        # Will raise ArgumentError.
+
+    Fixes #13217.
+
+    *Lauro Caetano*
+
 *   Fix regressions on `select_*` methods.
     When `select_*` methods receive a `Relation` object, they should be able to get the arel/binds from it.
     Also fix regressions on select_rows that was ignoring the binds.

--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -26,6 +26,12 @@ module ActiveRecord::Associations::Builder
     attr_reader :name, :scope, :options
 
     def self.build(model, name, scope, options, &block)
+      if model.dangerous_attribute_method?(name)
+        raise ArgumentError, "You tried to define an association named #{name} on the model #{model.name}, but " \
+                             "this will conflict with a method #{name} already defined by Active Record. " \
+                             "Please choose a different association name."
+      end
+
       builder = create_builder model, name, scope, options, &block
       reflection = builder.build(model)
       define_accessors model, reflection

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -853,4 +853,14 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert post.save
     assert_equal post.author_id, author2.id
   end
+
+  test 'dangerous association name raises ArgumentError' do
+    [:errors, 'errors', :save, 'save'].each do |name|
+      assert_raises(ArgumentError, "Association #{name} should not be allowed") do
+        Class.new(ActiveRecord::Base) do
+          belongs_to name
+        end
+      end
+    end
+  end
 end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1820,4 +1820,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
       topic.approved_replies.create!
     end
   end
+
+  test 'dangerous association name raises ArgumentError' do
+    [:errors, 'errors', :save, 'save'].each do |name|
+      assert_raises(ArgumentError, "Association #{name} should not be allowed") do
+        Class.new(ActiveRecord::Base) do
+          has_many name
+        end
+      end
+    end
+  end
 end

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -564,4 +564,14 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
       end
     end
   end
+
+  test 'dangerous association name raises ArgumentError' do
+    [:errors, 'errors', :save, 'save'].each do |name|
+      assert_raises(ArgumentError, "Association #{name} should not be allowed") do
+        Class.new(ActiveRecord::Base) do
+          has_one name
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
It's an attempt to fix #13217.

In order to avoid unexpected behavior, dangerous association names should raise `ArgumentError`.

This way, models like this:

``` ruby
class Project < ActiveRecord::Base
  has_many :errors
end
# It was deleting all the errors when saving, 
# because the valid? method calls errors.clear. 
# see https://github.com/rails/rails/blob/master/activemodel/lib/active_model/validations.rb#L312-L314
```

Will raise `ArgumentError`, saying that the association name will generate an instance method which is already defined by `ActiveRecord::Base`.
