### PR TITLE
Remove unused variable.

### DIFF
--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -205,7 +205,7 @@ class EnumTest < ActiveRecord::TestCase
 
   test "overriding enum method should not raise" do
     assert_nothing_raised do
-      klass = Class.new(ActiveRecord::Base) do
+      Class.new(ActiveRecord::Base) do
         self.table_name = "books"
 
         def published!


### PR DESCRIPTION
The unused variable `klass` causes a warning to be emitted while running the ActiveRecord test suite. This  patch removes the variable assignment.
