### PR TITLE
Return hash with_indifferent_access on Session::JsonSerializer

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/json_serializer.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/json_serializer.rb
@@ -2,7 +2,12 @@ module ActionDispatch
   module Session
     class JsonSerializer
       def self.load(value)
-        JSON.parse(value, quirks_mode: true)
+        case result = JSON.parse(value, quirks_mode: true)
+        when Hash
+          result.with_indifferent_access
+        else
+          result
+        end
       end
 
       def self.dump(value)

--- a/actionpack/test/controller/flash_hash_test.rb
+++ b/actionpack/test/controller/flash_hash_test.rb
@@ -67,6 +67,16 @@ module ActionDispatch
       assert_equal({'flashes' => {'message' => 'Hello'}, 'discard' => %w[message]}, hash.to_session_value)
     end
 
+    def test_from_session_value_on_json_serializer
+      decrypted_data = "{ \"session_id\":\"d98bdf6d129618fc2548c354c161cfb5\", \"flash\":{\"discard\":[], \"flashes\":{\"message\":\"hey you\"}} }"
+      session = ActionDispatch::Session::JsonSerializer.load(decrypted_data)
+      hash = Flash::FlashHash.from_session_value(session['flash'])
+
+      assert_equal({'discard' => %w[message], 'flashes' => { 'message' => 'hey you'}}, hash.to_session_value)
+      assert_equal "hey you", hash[:message]
+      assert_equal "hey you", hash["message"]
+    end
+
     def test_empty?
       assert @hash.empty?
       @hash['zomg'] = 'bears'


### PR DESCRIPTION
We need to be able to access data, flash messages example, as both
flash[:success] and flash["success"].

Hey guys I've been trying to write a regression test for this to prove my point but couldn't so far. I'm doing something like this in dispatch/cookies_test.rb

``` ruby
  def test_flash_message_using_json_serializer
    @request.env["action_dispatch.session_serializer"] = :json
    get :set_flash_message
    assert_equal 'beer!', flash[:success]
    assert_equal 'beer!', flash["success"]
  end
```

I've been running spree build on rails edge and realized a bunch of tests failing were related to missing flash message content on the view. It took me a while to see that rails generate a session_store with `serializer: :json` and successfully reproduce that on a spree app itself.

This is related to https://github.com/rails/rails/commit/b23ffd0 and https://github.com/rails/rails/commit/fd48786. Let me know if doesn't make any sense. I can't access `flash[:success]` on views unless I add that call in JsonSerializer.

// @lukesarnacki @guilleiguaran was this working properly for you guys?
