### PR TITLE
Fixes issue with parsing whitespace content back from database - fixes #13907

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Parsing PostgreSQL arrays with empty strings now works correctly.
+
+    Previously, if you tried to parse `{"1","","2","","3"}` the result
+    would be `["1","2","3"]`, removing the empty strings from the array,
+    which would be incorrect. Now it will correctly produce `["1","","2","","3"]`
+    as the result of parsing the above PostgreSQL array.
+
+    Fixes #13907.
+
+    *Maurício Linhares*
+
 *   Associations now raise `ArgumentError` on name conflicts.
 
     Dangerous association names conflicts include instance or class methods already

--- a/activerecord/lib/active_record/connection_adapters/postgresql/array_parser.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/array_parser.rb
@@ -91,8 +91,9 @@ module ActiveRecord
           end
 
           def add_item_to_array(array, current_item, quoted)
-            if current_item.length == 0
-            elsif !quoted && current_item == 'NULL'
+            return if !quoted && current_item.length == 0
+
+            if !quoted && current_item == 'NULL'
               array.push nil
             else
               array.push current_item

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -93,6 +93,18 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert_cycle(:tags, [[['1'], ['2']], [['2'], ['3']]])
   end
 
+  def test_with_empty_strings
+    assert_cycle(:tags, [ '1', '2', '', '4', '', '5' ])
+  end
+
+  def test_with_multi_dimensional_empty_strings
+    assert_cycle(:tags, [[['1', '2'], ['', '4'], ['', '5']]])
+  end
+
+  def test_with_arbitrary_whitespace
+    assert_cycle(:tags, [[['1', '2'], ['    ', '4'], ['    ', '5']]])
+  end
+
   def test_multi_dimensional_with_integers
     assert_cycle(:ratings, [[[1], [7]], [[8], [10]]])
   end


### PR DESCRIPTION
That's actually funny, I wrote the original code that served as a base for this parser [here](https://github.com/dockyard/pg_array_parser/commit/b163938bfd26fa9bde4af9db3814d00ea89bbcee#diff-a94e566f3af5e6328b83bf26177a003b) and it also had the same issue with whitespace that was fixed by [this change](https://github.com/dockyard/pg_array_parser/commit/f5b1ab979555dd9787373e5e6fd031fe3c9a7427), so, here it goes again, hehehe, fixing my own code a second time :D

Included two more tests to make sure this fix stays now. This fixes #13907.
