### PR TITLE
Fix tidy_bytes for JRuby

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix the implementation of Multibyte::Unicode.tidy_bytes for JRuby
+
+    The existing implementation caused JRuby to raise the error:
+    `Encoding::ConverterNotFoundError: code converter not found (UTF-8 to UTF8-MAC)`
+
+    *Justin Coyne*
+
 *   Fix `to_param` behavior when there are nested empty hashes.
 
     Before:

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -233,16 +233,16 @@ module ActiveSupport
           # We're going to 'transcode' bytes from UTF-8 when possible, then fall back to
           # CP1252 when we get errors. The final string will be 'converted' back to UTF-8
           # before returning.
-          reader = Encoding::Converter.new(Encoding::UTF_8, Encoding::UTF_8_MAC)
+          reader = Encoding::Converter.new(Encoding::UTF_8, Encoding::UTF_16LE)
 
           source = string.dup
-          out = ''.force_encoding(Encoding::UTF_8_MAC)
+          out = ''.force_encoding(Encoding::UTF_16LE)
 
           loop do
             reader.primitive_convert(source, out)
             _, _, _, error_bytes, _ = reader.primitive_errinfo
             break if error_bytes.nil?
-            out << error_bytes.encode(Encoding::UTF_8_MAC, Encoding::Windows_1252, invalid: :replace, undef: :replace)
+            out << error_bytes.encode(Encoding::UTF_16LE, Encoding::Windows_1252, invalid: :replace, undef: :replace)
           end
 
           reader.finish


### PR DESCRIPTION
The previous implementation was broken because JRuby (1.7.10) doesn't
have a code converter for UTF-8 to UTF8-MAC.
