### PR TITLE
Prevent [response].flatten from recursing infinitely.

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -104,6 +104,16 @@ module ActionDispatch # :nodoc:
       end
     end
 
+    # Used in place of the response when converting to a rack response tuple.
+    # Necessary so that `[response].flatten` doesn't recurse infinitely.
+    class ResponseBody
+      delegate :body, :close, :each, :to_path, :to => :@response
+
+      def initialize(response)
+        @response = response
+      end
+    end
+
     # The underlying body, as a streamable object.
     attr_reader :stream
 
@@ -313,7 +323,7 @@ module ActionDispatch # :nodoc:
         header.delete CONTENT_TYPE
         [status, header, []]
       else
-        [status, header, self]
+        [status, header, ResponseBody.new(self)]
       end
     end
   end

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -217,6 +217,15 @@ class ResponseTest < ActiveSupport::TestCase
     assert_not @response.respond_to?(:method_missing)
     assert @response.respond_to?(:method_missing, true)
   end
+
+  test "can be destructured into status, headers and an enumerable body" do
+    response = ActionDispatch::Response.new(404, { 'Content-Type' => 'text/plain' }, ['Not Found'])
+    status, headers, body = response
+
+    assert_equal 404, status
+    assert_equal({ 'Content-Type' => 'text/plain' }, headers)
+    assert_equal ['Not Found'], body.each.to_a
+  end
 end
 
 class ResponseIntegrationTest < ActionDispatch::IntegrationTest

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -226,6 +226,15 @@ class ResponseTest < ActiveSupport::TestCase
     assert_equal({ 'Content-Type' => 'text/plain' }, headers)
     assert_equal ['Not Found'], body.each.to_a
   end
+
+  test "[response].flatten does not recurse infinitely" do
+    Timeout.timeout(1) do # use a timeout to prevent it stalling indefinitely
+      status, headers, body = [@response].flatten
+      assert_equal @response.status, status
+      assert_equal @response.headers, headers
+      assert_equal @response.body, body.each.to_a.join
+    end
+  end
 end
 
 class ResponseIntegrationTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
This was causing problems for RSpec users (see [this comment](https://github.com/rspec/rspec-rails/issues/601#issuecomment-33885030)) since rspec-expecations has a place where it uses `Array#flatten` on an array containing objects passed to RSpec by users, and if that array contained a rails response, it would recurse infinitely.

It would also be nice to backport this and get it in upcoming patch fixes in whatever other recent versions suffer from this problem.
