### PR TITLE
Stop converting non-numeric values to 0 when column integer or float

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Stop converting non-numeric values to 0 when column type is
+    integer or float
+
+    Previously, non-numeric values were converted to 0 and 0.0 when
+    column type is integer and float respectively.
+
+    This behavior is inconsistent because with UUID id, invalid string
+    values are passed to database without converting to 0.
+
+    This commit differentiates between invalid values passed as
+    integer/float and normal integers/floats.
+
+    Before:
+
+        Model1.find_by(id: "lol")
+        => SELECT "model1".* FROM "model1" WHERE "model1"."id" = 0 LIMIT 1
+
+    After:
+
+        Model1.find_by(id: "lol")
+        => SELECT "model1".* FROM "model1" WHERE "model1"."id" = 'lol' LIMIT 1
+
+    Fixes #12793.
+
+    *Anup Nivargi*, *Prathamesh Sonpatki*, *Vipul Amler*
+
 *   PostgreSQL implementation of SchemaStatements#index_name_exists?
 
     The database agnostic implementation does not detect with indexes that are

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -168,11 +168,13 @@ module ActiveRecord
       def test_quote_string_int_column
         assert_equal "1", @quoter.quote('1', FakeColumn.new(:integer))
         assert_equal "1", @quoter.quote('1.2', FakeColumn.new(:integer))
+        assert_equal "'lol'", @quoter.quote('lol', FakeColumn.new(:integer))
       end
 
       def test_quote_string_float_column
         assert_equal "1.0", @quoter.quote('1', FakeColumn.new(:float))
         assert_equal "1.2", @quoter.quote('1.2', FakeColumn.new(:float))
+        assert_equal "'lol'", @quoter.quote('lol', FakeColumn.new(:float))
       end
 
       def test_quote_as_mb_chars_binary_column


### PR DESCRIPTION
- Previously, non-numeric values were converted to 0 and 0.0 when column
  type  is integer and float respectively.
- This behavior is inconsistent because with UUID id, invalid string
  values are passed to database without converting to 0.
-  This commit differentiates between invalid values passed as
  integer/float and normal integers/floats.
-  Before:

``` ruby
   Model1.find_by(id: "lol")
    SELECT "model1".* FROM "model1" WHERE "model1"."id" = 0 LIMIT 1
```
-  After:

``` ruby
    Model1.find_by(id: "lol")
    SELECT "model1".* FROM "model1" WHERE "model1"."id" = 'lol' LIMIT 1
```
