### PR TITLE
Adding a documentation example and a test to button_to with path

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -232,6 +232,11 @@ module ActionView
       #   #      <div><input value="New" type="submit" /></div>
       #   #    </form>"
       #
+      #   <%= button_to "New", new_articles_path %>
+      #   # => "<form method="post" action="/articles/new" class="button_to">
+      #   #      <div><input value="New" type="submit" /></div>
+      #   #    </form>"
+      #
       #   <%= button_to [:make_happy, @user] do %>
       #     Make happy <strong><%= @user.name %></strong>
       #   <% end %>

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -56,6 +56,13 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_dom_equal %{<form method="post" action="http://www.example.com" class="button_to"><div><input type="submit" value="Hello" /></div></form>}, button_to("Hello", "http://www.example.com")
   end
 
+  def test_button_to_with_path
+    assert_dom_equal(
+      %{<form method="post" action="/article/Hello" class="button_to"><div><input type="submit" value="Hello" /></div></form>},
+      button_to("Hello", article_path("Hello".html_safe))
+    )
+  end
+
   def test_button_to_with_straight_url_and_request_forgery
     self.request_forgery = true
 


### PR DESCRIPTION
I did not see in the docs that `button_to` supports not only URLs but paths as well. I documented this functionality with a unit tests and added an example to the docs as well.
