### PR TITLE
Completes the work done for #14408 and #11432, which lets you add the --model-name option when generating scaffold controllers.

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
@@ -1,4 +1,4 @@
-<%%= form_for(@<%= singular_table_name %>) do |f| %>
+<%%= form_for(<%= form_resource %>) do |f| %>
   <%% if @<%= singular_table_name %>.errors.any? %>
     <div id="error_explanation">
       <h2><%%= pluralize(@<%= singular_table_name %>.errors.count, "error") %> prohibited this <%= singular_table_name %> from being saved:</h2>

--- a/railties/lib/rails/generators/erb/scaffold/templates/edit.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/edit.html.erb
@@ -2,5 +2,5 @@
 
 <%%= render 'form' %>
 
-<%%= link_to 'Show', @<%= singular_table_name %> %> |
+<%%= link_to 'Show', <%= show_helper %>_path(@<%= singular_table_name %>) %> |
 <%%= link_to 'Back', <%= index_helper %>_path %>

--- a/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
@@ -16,9 +16,9 @@
 <% attributes.reject(&:password_digest?).each do |attribute| -%>
         <td><%%= <%= singular_table_name %>.<%= attribute.name %> %></td>
 <% end -%>
-        <td><%%= link_to 'Show', <%= singular_table_name %> %></td>
-        <td><%%= link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>) %></td>
-        <td><%%= link_to 'Destroy', <%= singular_table_name %>, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%%= link_to 'Show', <%= show_helper %>_path(<%= singular_table_name %>) %></td>
+        <td><%%= link_to 'Edit', edit_<%= show_helper %>_path(<%= singular_table_name %>) %></td>
+        <td><%%= link_to 'Destroy', <%= show_helper %>_path(<%= singular_table_name %>), method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <%% end %>
   </tbody>
@@ -26,4 +26,4 @@
 
 <br>
 
-<%%= link_to 'New <%= human_name %>', new_<%= singular_table_name %>_path %>
+<%%= link_to 'New <%= human_name %>', new_<%= show_helper %>_path %>

--- a/railties/lib/rails/generators/erb/scaffold/templates/show.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/show.html.erb
@@ -7,5 +7,5 @@
 </p>
 
 <% end -%>
-<%%= link_to 'Edit', edit_<%= singular_table_name %>_path(@<%= singular_table_name %>) %> |
+<%%= link_to 'Edit', edit_<%= show_helper %>_path(@<%= singular_table_name %>) %> |
 <%%= link_to 'Back', <%= index_helper %>_path %>

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -121,7 +121,11 @@ module Rails
         end
 
         def index_helper
-          uncountable? ? "#{plural_table_name}_index" : plural_table_name
+          uncountable? ? "#{plural_table_name}_index" : controller_file_path.tr('/', '_')
+        end
+
+        def show_helper
+          index_helper.singularize
         end
 
         def singular_table_name
@@ -137,7 +141,23 @@ module Rails
         end
 
         def route_url
-          @route_url ||= class_path.collect {|dname| "/" + dname }.join + "/" + plural_file_name
+          @route_url ||= "/" + controller_file_path
+        end
+
+        def form_resource
+          route_namespaces = controller_class_path - regular_class_path
+
+          if route_namespaces.count > 0 and 
+            result = "["
+            route_namespaces.each do |route_namespace|
+              result << ":#{route_namespace}, "
+            end
+            result << "@#{singular_table_name}]"
+          else
+            result = "@#{singular_table_name}" 
+          end
+          
+          result
         end
 
         # Tries to retrieve the application name or simple return application.

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -29,7 +29,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
 
     if @<%= orm_instance.save %>
-      redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} was successfully created.'" %>
+      redirect_to <%= show_helper%>_path(@<%= singular_table_name %>), notice: <%= "'#{human_name} was successfully created.'" %>
     else
       render :new
     end
@@ -38,7 +38,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   # PATCH/PUT <%= route_url %>/1
   def update
     if @<%= orm_instance.update("#{singular_table_name}_params") %>
-      redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} was successfully updated.'" %>
+      redirect_to <%= show_helper%>_path(@<%= singular_table_name %>), notice: <%= "'#{human_name} was successfully updated.'" %>
     else
       render :edit
     end

--- a/railties/lib/rails/generators/resource_helpers.rb
+++ b/railties/lib/rails/generators/resource_helpers.rb
@@ -55,6 +55,10 @@ module Rails
           @controller_i18n_scope ||= controller_file_path.tr('/', '.')
         end
 
+        def namespace
+          @namespace ||= Rails::Generators::namespace
+        end
+
         # Loads the ORM::Generators::ActiveModel class. This class is responsible
         # to tell scaffold entities how to generate an specific method for the
         # ORM. Check Rails::Generators::ActiveModel for more information.

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
@@ -22,7 +22,7 @@ class <%= controller_class_name %>ControllerTest < ActionController::TestCase
       post :create, <%= "#{singular_table_name}: { #{attributes_hash} }" %>
     end
 
-    assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
+    assert_redirected_to <%= show_helper %>_path(assigns(:<%= singular_table_name %>))
   end
 
   test "should show <%= singular_table_name %>" do
@@ -37,7 +37,7 @@ class <%= controller_class_name %>ControllerTest < ActionController::TestCase
 
   test "should update <%= singular_table_name %>" do
     patch :update, id: <%= "@#{singular_table_name}" %>, <%= "#{singular_table_name}: { #{attributes_hash} }" %>
-    assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
+    assert_redirected_to <%= show_helper %>_path(assigns(:<%= singular_table_name %>))
   end
 
   test "should destroy <%= singular_table_name %>" do

--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -27,6 +27,9 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, 'line_items', :plural_name
     assert_name g, 'line_item',  :i18n_scope
     assert_name g, 'line_items', :table_name
+    assert_name g, 'line_item',  :show_helper
+    assert_name g, '/line_items', :route_url
+    assert_name g, '@line_item',  :form_resource
   end
 
   def test_named_generator_attributes
@@ -41,6 +44,9 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, 'foos',       :plural_name
     assert_name g, 'admin.foo',  :i18n_scope
     assert_name g, 'admin_foos', :table_name
+    assert_name g, 'admin_foo',  :show_helper
+    assert_name g, '/admin/foos', :route_url
+    assert_name g, '@admin_foo',  :form_resource
   end
 
   def test_named_generator_attributes_as_ruby
@@ -55,6 +61,9 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, 'foos',       :plural_name
     assert_name g, 'admin.foo',  :i18n_scope
     assert_name g, 'admin_foos', :table_name
+    assert_name g, 'admin_foo',  :show_helper
+    assert_name g, '/admin/foos', :route_url
+    assert_name g, '@admin_foo',  :form_resource
   end
 
   def test_named_generator_attributes_without_pluralized
@@ -73,6 +82,9 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, 'admin/foos',  :controller_file_path
     assert_name g, 'foos',        :controller_file_name
     assert_name g, 'admin.foos',  :controller_i18n_scope
+    assert_name g, 'admin_foo',   :show_helper
+    assert_name g, '/admin/foos', :route_url
+    assert_name g, '@admin_foo',  :form_resource
   end
 
   def test_scaffold_plural_names_as_ruby
@@ -83,6 +95,9 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, 'admin/foos',  :controller_file_path
     assert_name g, 'foos',        :controller_file_name
     assert_name g, 'admin.foos',  :controller_i18n_scope
+    assert_name g, 'admin_foo',   :show_helper
+    assert_name g, '/admin/foos', :route_url
+    assert_name g, '@admin_foo',  :form_resource
   end
 
   def test_application_name
@@ -98,6 +113,11 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, 'posts', :index_helper
   end
 
+  def test_index_helper_with_underscore
+    g = generator ['line_item']
+    assert_name g, 'line_items', :index_helper
+  end
+
   def test_index_helper_to_pluralize_once
     g = generator ['Stadium']
     assert_name g, 'stadia', :index_helper
@@ -108,7 +128,17 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, 'sheep_index', :index_helper
   end
 
-  def test_hide_namespace
+  def test_index_helper_with_namespace
+    g = generator ['User::Tweet']
+    assert_name g, 'user_tweets', :index_helper
+  end
+
+  def test_index_helper_with_with_model_name_option
+    g = generator ['Admin::User'], model_name: 'User'
+    assert_name g, 'admin_users', :index_helper
+  end
+
+  def test_hide_namespace_
     g = generator ['Hidden']
     g.class.stubs(:namespace).returns('hidden')
 
@@ -118,7 +148,7 @@ class NamedBaseTest < Rails::Generators::TestCase
   end
 
   def test_scaffold_plural_names_with_model_name_option
-    g = generator ['Admin::Foo'], model_name: 'User'
+    g = generator ['Admin::Users'], model_name: 'User'
     assert_name g, 'user',        :singular_name
     assert_name g, 'User',        :name
     assert_name g, 'user',        :file_path
@@ -128,12 +158,15 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, 'users',       :plural_name
     assert_name g, 'user',        :i18n_scope
     assert_name g, 'users',       :table_name
-    assert_name g, 'Admin::Foos', :controller_name
+    assert_name g, 'Admin::Users', :controller_name
     assert_name g, %w(admin),     :controller_class_path
-    assert_name g, 'Admin::Foos', :controller_class_name
-    assert_name g, 'admin/foos',  :controller_file_path
-    assert_name g, 'foos',        :controller_file_name
-    assert_name g, 'admin.foos',  :controller_i18n_scope
+    assert_name g, 'Admin::Users', :controller_class_name
+    assert_name g, 'admin/users',  :controller_file_path
+    assert_name g, 'users',        :controller_file_name
+    assert_name g, 'admin.users',  :controller_i18n_scope
+    assert_name g, 'admin_user',   :show_helper
+    assert_name g, '/admin/users', :route_url
+    assert_name g, '[:admin, @user]',  :form_resource
   end
 
   protected


### PR DESCRIPTION
Follow up to #11432.

See commit messages for details.
