### PR TITLE
Always preload included polymorphic associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Always preload included polymorphic associations, you can now include polymorphic associations
+    while using `eager_load` or `references` scope
+
+      Example:
+
+        Tag.includes(taggings: :taggable).where(taggings: {id: 1}).references(:taggings)
+        # Will no more raise an ActiveRecord::EagerLoadPolymorphicError
+
+    *Recca*
+
 *   PostgreSQL implementation of SchemaStatements#index_name_exists?
 
     The database agnostic implementation does not detect with indexes that are

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -352,7 +352,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     end
 
     assert_raise ActiveRecord::EagerLoadPolymorphicError do
-      tags(:general).taggings.includes(:taggable).where('bogus_table.column = 1').references(:bogus_table).to_a
+      tags(:general).taggings.eager_load(:taggable).to_a
     end
   end
 
@@ -682,6 +682,14 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     assert_equal posts.length, posts_with_taggings.length
     posts.length.times do |i|
       assert_equal posts[i].taggings.length, assert_no_queries { posts_with_taggings[i].taggings.length }
+    end
+  end
+
+  def test_always_preload_polymorphic_associations
+    assert_queries(2) do
+      tags = Tag.all.merge!(:includes => {:taggings => [:taggable, :super_tag]}, :where => ['taggings.super_tag_id != ?', 1]).references(:taggings).to_a
+      tags.first.taggings.first.taggable
+      tags.first.taggings.first.super_tag
     end
   end
 


### PR DESCRIPTION
Always preload included polymorphic associations while using `eager_load` or `references`

Before:

``` ruby
Tagging.includes(:taggable, :tag).references(:tag).where(tags: {id: 1})
#This raise ActiveRecord::EagerLoadPolymorphicError: Can not eagerly load the polymorphic association :taggable
```

After:

``` ruby
Tagging.includes(:taggable, :tag).references(:tag).where(tags: {id: 1})
##load tag with taggings
#SELECT "taggings"."id" AS t0_r0, "taggings"."tag_id" AS t0_r1, "taggings"."super_tag_id" AS t0_r2, "taggings"."taggable_id" AS t0_r3, "taggings"."taggable_type", "tags"."id" AS t1_r0, "tags"."name" AS t1_r FROM "taggings" LEFT OUTER JOIN "tags" ON "tags"."id" = "taggings"."tag_id" WHERE "tags"."id" = 1
##load the polymorphic :
#Post Load (x ms)  SELECT "posts".* FROM "posts" WHERE "posts"."id" IN (1, 2)
#FakeModel Load (x ms)  SELECT "fake_models".* FROM "fake_models" WHERE "fake_models"."id" IN (1)
#Item Load (x ms)  SELECT "items".* FROM "items" WHERE "items"."id" IN (1)
```
