### PR TITLE
Remove pointless `||= nil`

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -398,9 +398,9 @@ module ActionDispatch
       end
 
       private
-        def integration_session
-          @integration_session ||= nil
-        end
+
+        attr_reader :integration_session
+
     end
   end
 


### PR DESCRIPTION
`@ivars` start as `nil` already, unless someone wanted to turn `false` into `nil` doing `||= nil` seems quite pointless.
