### PR TITLE
Remove extraneous variable assignment

### DIFF
--- a/railties/bin/rails
+++ b/railties/bin/rails
@@ -3,7 +3,6 @@
 git_path = File.expand_path('../../../.git', __FILE__)
 
 if File.exist?(git_path)
-  railties_path = File.expand_path('../../lib', __FILE__)
-  $:.unshift(railties_path)
+  $:.unshift(File.expand_path('../../lib', __FILE__))
 end
 require "rails/cli"


### PR DESCRIPTION
Seems a little redundant to assign to a variable that is only used once. Less bytes over the wire...
