### PR TITLE
Make sure transaction state resets after commit

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -295,7 +295,7 @@ module ActiveRecord
     def committed! #:nodoc:
       run_callbacks :commit if destroyed? || persisted?
     ensure
-      clear_transaction_record_state
+      @_start_transaction_state.clear
     end
 
     # Call the +after_rollback+ callbacks. The +force_restore_state+ argument indicates if the record


### PR DESCRIPTION
### Problem

If we open a transaction inside a `after_*` callback, it will increase the level on `@_start_transaction_state`, and the `committed!` method only resets one level. So when that happen that `@_start_transaction_state` would leaky to the next `save` method call.
### Solution

On `committed!` clear the entire state as after that method we wont need to restore the state anymore.

review @rafaelfranca @tenderlove @carlosantoniodasilva

[fixes #12566]
