### PR TITLE
Sized enumerator

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,10 @@
-*   `find_in_batches` now returns an `Enumerator` that can calculate its size.
+<<<<<<< HEAD
+*   `find_in_batches`, `find_each` now
+    return an `Enumerator` that can calculate its size.
+=======
+*   `find_in_batches`, `find_each`, `Result#each` now returns an `Enumerator`
+    that can calculate its size.
+>>>>>>> 5863938... Return sized enumerator from Result#each
 
     See also #13938.
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `find_in_batches` now returns an `Enumerator` that can calculate its size.
+
+    See also #13938.
+
+    *Marc-André Lafortune*
+
 *   Make sure transaction state gets reset after a commit operation on the record.
 
     If a new transaction was open inside a callback, the record was loosing track

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,10 +1,5 @@
-<<<<<<< HEAD
-*   `find_in_batches`, `find_each` now
+*   `find_in_batches`, `find_each`, `Result#each` and `Enumerable#index_by` now
     return an `Enumerator` that can calculate its size.
-=======
-*   `find_in_batches`, `find_each`, `Result#each` now returns an `Enumerator`
-    that can calculate its size.
->>>>>>> 5863938... Return sized enumerator from Result#each
 
     See also #13938.
 

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -52,7 +52,9 @@ module ActiveRecord
           records.each { |record| yield record }
         end
       else
-        enum_for :find_each, options
+        enum_for :find_each, options do
+          options[:start] ? where(table[primary_key].gteq(options[:start])).size : size
+        end
       end
     end
 

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -54,7 +54,7 @@ module ActiveRecord
       if block_given?
         hash_rows.each { |row| yield row }
       else
-        hash_rows.to_enum
+        hash_rows.to_enum { @rows.size }
       end
     end
 

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -191,4 +191,14 @@ class EachTest < ActiveRecord::TestCase
       end
     end
   end
+
+  if Enumerator.method_defined? :size
+    def test_find_in_batches_should_return_a_sized_enumerator
+      assert_equal 11, Post.find_in_batches(:batch_size => 1).size
+      assert_equal 6, Post.find_in_batches(:batch_size => 2).size
+      assert_equal 4, Post.find_in_batches(:batch_size => 2, :start => 4).size
+      assert_equal 4, Post.find_in_batches(:batch_size => 3).size
+      assert_equal 1, Post.find_in_batches(:batch_size => 10_000).size
+    end
+  end
 end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -35,6 +35,14 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
+  if Enumerator.method_defined? :size
+    def test_each_should_return_a_sized_enumerator
+      assert_equal 11, Post.find_each(:batch_size => 1).size
+      assert_equal 5, Post.find_each(:batch_size => 2, :start => 7).size
+      assert_equal 11, Post.find_each(:batch_size => 10_000).size
+    end
+  end
+
   def test_each_enumerator_should_execute_one_query_per_batch
     assert_queries(@total + 1) do
       Post.find_each(:batch_size => 1).with_index do |post, index|

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -30,5 +30,11 @@ module ActiveRecord
         assert_kind_of Integer, index
       end
     end
+
+    if Enumerator.method_defined? :size
+      def test_each_without_block_returns_a_sized_enumerator
+        assert_equal 3, result.each.size
+      end
+    end
   end
 end

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -5,14 +5,16 @@ module ActiveRecord
     def result
       Result.new(['col_1', 'col_2'], [
         ['row 1 col 1', 'row 1 col 2'],
-        ['row 2 col 1', 'row 2 col 2']
+        ['row 2 col 1', 'row 2 col 2'],
+        ['row 3 col 1', 'row 3 col 2'],
       ])
     end
 
     def test_to_hash_returns_row_hashes
       assert_equal [
         {'col_1' => 'row 1 col 1', 'col_2' => 'row 1 col 2'},
-        {'col_1' => 'row 2 col 1', 'col_2' => 'row 2 col 2'}
+        {'col_1' => 'row 2 col 1', 'col_2' => 'row 2 col 2'},
+        {'col_1' => 'row 3 col 1', 'col_2' => 'row 3 col 2'},
       ], result.to_hash
     end
 

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -35,7 +35,7 @@ module Enumerable
     if block_given?
       Hash[map { |elem| [yield(elem), elem] }]
     else
-      to_enum :index_by
+      to_enum(:index_by) { size }
     end
   end
 

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -35,7 +35,7 @@ module Enumerable
     if block_given?
       Hash[map { |elem| [yield(elem), elem] }]
     else
-      to_enum(:index_by) { size }
+      to_enum(:index_by) { size if respond_to?(:size) }
     end
   end
 

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -20,26 +20,6 @@ class EnumerableTests < ActiveSupport::TestCase
     end
   end
 
-  def test_group_by
-    names = %w(marcel sam david jeremy)
-    klass = Struct.new(:name)
-    objects = (1..50).map do
-      klass.new names.sample
-    end
-
-    enum = GenericEnumerable.new(objects)
-    grouped = enum.group_by { |object| object.name }
-
-    grouped.each do |name, group|
-      assert group.all? { |person| person.name == name }
-    end
-
-    assert_equal objects.uniq.map(&:name), grouped.keys
-    assert({}.merge(grouped), "Could not convert ActiveSupport::OrderedHash into Hash")
-    assert_equal Enumerator, enum.group_by.class
-    assert_equal grouped, enum.group_by.each(&:name)
-  end
-
   def test_sums
     enum = GenericEnumerable.new([5, 15, 10])
     assert_equal 30, enum.sum

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -73,6 +73,10 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal({ 5 => Payment.new(5), 15 => Payment.new(15), 10 => Payment.new(10) },
                  payments.index_by { |p| p.price })
     assert_equal Enumerator, payments.index_by.class
+    if Enumerator.method_defined? :size
+      assert_equal nil, payments.index_by.size
+      assert_equal 42, (1..42).index_by.size
+    end
     assert_equal({ 5 => Payment.new(5), 15 => Payment.new(15), 10 => Payment.new(10) },
                  payments.index_by.each { |p| p.price })
   end

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -8,7 +8,6 @@ class SummablePayment < Payment
 end
 
 class EnumerableTests < ActiveSupport::TestCase
-  Enumerator = [].each.class
 
   class GenericEnumerable
     include Enumerable


### PR DESCRIPTION
This PR adds a lazy size block to enumerators returned by `Batches#find_each`, `find_in_batches`, `Result#each` and `Enumerable#index_by`.

This allows, for example using my [gem `with_progress`](https://github.com/marcandre/with_progress):

```
Users.where("balance > 0").find_each.with_progress do |u|
  UserMailer.send_invoice(u)
end
```

This will print a progress bar with an estimated time left, etc, while still loading the records in batches.

The PR also has a couple of test cleanup commits at the beginning.

Note: In Ruby 1.9, there is no `Enumerator#size`, so the test is conditional on that. The block given to `to_enum` is ignored in 1.9, so no specific treatment is needed.
