### PR TITLE
HTTP Authentication header could include unquoted values

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -459,7 +459,7 @@ module ActionController
       # pairs by the standardized `:`, `;`, or `\t` delimiters defined in
       # `AUTHN_PAIR_DELIMITERS`.
       def raw_params(auth)
-        auth.sub(TOKEN_REGEX, '').split(/"\s*#{AUTHN_PAIR_DELIMITERS}\s*/)
+        auth.sub(TOKEN_REGEX, '').split(/"?\s*#{AUTHN_PAIR_DELIMITERS}\s*/)
       end
 
       # Encodes the given token and options into an Authorization header value.

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -60,6 +60,13 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
       assert_response :success
       assert_equal 'Only for loooooong credentials', @response.body, "Authentication failed for request header #{header} and long credentials"
     end
+    test "successful authentication with #{header.downcase} including unquoted values" do
+      @request.env[header] = %{Token token=lifo, algorithm=test}
+      get :index
+
+      assert_response :success
+      assert_equal 'Hello Secret', @response.body, "Authentication failed for request header #{header}"
+    end
   end
 
   AUTH_HEADERS.each do |header|


### PR DESCRIPTION
Since f71cca9e1007bd928ec6fe27e3b3147ec59afac7 (which was included in 4.0), AC HttpAuthentication stopped accepting unquoted values in the header string.
This patch fixes the incompatibility.
