### PR TITLE
fix interplay of humanize and html_escape

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -117,7 +117,7 @@ module ActiveSupport
       result.gsub!(/([a-z\d]*)/i) { |match|
         "#{inflections.acronyms[match] || match.downcase}"
       }
-      result.gsub!(/^\w/) { $&.upcase } if options.fetch(:capitalize, true)
+      result.gsub!(/^\w/) { |match| match.upcase } if options.fetch(:capitalize, true)
       result
     end
 

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -161,6 +161,10 @@ class StringInflectionsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_humanize_with_html_escape
+    assert_equal 'Hello', ERB::Util.html_escape("hello").humanize
+  end
+
   def test_ord
     assert_equal 97, 'a'.ord
     assert_equal 97, 'abc'.ord


### PR DESCRIPTION
Fix this error when `humanize` is used together with `ERB::Util.html_escape`:

```
[1] pry(main)> ERB::Util.html_escape("hello").humanize
NoMethodError: undefined method `upcase' for nil:NilClass
```

Looks like it was introduced in PR #12789, and is related to #3496.
