### PR TITLE
Add .ruby-gemset to .gitignore for rvm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ debug.log
 .Gemfile
 /.bundle
 /.ruby-version
+/.ruby-gemset
 /Gemfile.lock
 pkg
 /dist


### PR DESCRIPTION
Similar to .ruby-version.

For project setup with rvm, you can specify your ruby version and gemset.  Example: 

```
rvm --ruby-version use 2.1.0@rails
```
