### PR TITLE
Add foreign_key_type option to add_reference

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   It is possible to pass `foreign_key_type` option to `add_reference`
+
+    Integer was hardcoded type for reference foreign key field. Now it
+    is possible to set any foreign key type:
+
+    ```ruby
+    add_reference :products, :supplier, foreign_key_type: :uuid
+    ```
+
+    *Łukasz Sarnacki*
+
 *   Active Record objects can now be correctly dumped, loaded and dumped again without issues.
 
     Previously, if you did `YAML.dump`, `YAML.load` and then `YAML.dump` again

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -312,6 +312,12 @@ module ActiveRecord
       #
       # Creates a <tt>company_id(integer)</tt> column.
       #
+      # ====== Add a foreign key column with specified type
+      #
+      #  change_table(:suppliers) do |t|
+      #    t.references :company, foreign_key_type: :uuid
+      #  end
+      #
       # ====== Add a polymorphic foreign key column
       #
       #  change_table(:suppliers) do |t|
@@ -616,10 +622,15 @@ module ActiveRecord
       #
       #   add_reference(:products, :supplier, polymorphic: true, index: true)
       #
+      # ====== Create a supplier_id with given type
+      #
+      #   add_reference(:products, :supplier, foreign_key_type: :uuid)
+      #
       def add_reference(table_name, ref_name, options = {})
         polymorphic = options.delete(:polymorphic)
         index_options = options.delete(:index)
-        add_column(table_name, "#{ref_name}_id", :integer, options)
+        foreign_key_type = options.delete(:foreign_key_type) || :integer
+        add_column(table_name, "#{ref_name}_id", foreign_key_type, options)
         add_column(table_name, "#{ref_name}_type", :string, polymorphic.is_a?(Hash) ? polymorphic : options) if polymorphic
         add_index(table_name, polymorphic ? %w[id type].map{ |t| "#{ref_name}_#{t}" } : "#{ref_name}_id", index_options.is_a?(Hash) ? index_options : {}) if index_options
       end

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -23,6 +23,13 @@ module ActiveRecord
         end
       end
 
+      def test_references_column_type_with_foreign_key_type_set_to_uuid
+        with_change_table do |t|
+          @connection.expect :add_reference, nil, [:delete_me, :customer, foreign_key_type: :uuid]
+          t.references :customer, foreign_key_type: :uuid
+        end
+      end
+
       def test_remove_references_column_type_removes_id
         with_change_table do |t|
           @connection.expect :remove_reference, nil, [:delete_me, :customer, {}]
@@ -55,6 +62,13 @@ module ActiveRecord
         with_change_table do |t|
           @connection.expect :remove_reference, nil, [:delete_me, :taggable, polymorphic: true]
           t.remove_references :taggable, polymorphic: true
+        end
+      end
+
+      def test_references_column_type_with_polymorphic_and_options_null_is_false_adds_table_flag
+        with_change_table do |t|
+          @connection.expect :add_reference, nil, [:delete_me, :taggable, polymorphic: true, null: false]
+          t.references :taggable, polymorphic: true, null: false
         end
       end
 

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -20,6 +20,11 @@ module ActiveRecord
         assert column_exists?(table_name, :user_id, :integer)
       end
 
+      def test_creates_reference_id_column_with_given_foreign_key_type
+        add_reference table_name, :user, foreign_key_type: :string
+        assert column_exists?(table_name, :user_id, :string)
+      end
+
       def test_does_not_create_reference_type_column
         add_reference table_name, :taggable
         assert_not column_exists?(table_name, :taggable_type, :string)


### PR DESCRIPTION
When adding reference using add_reference method, integer is hardcoded type for foreign_key. This PR makes it possible to set any foreign key type (this is useful when using i.e. `uuid`).

Let me know if there is something to add here or if you want to have this option in `add_reference` method at all.
