### PR TITLE
Require action_view to fix missing constant ENCODING_FLAG

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Properly require `action_view` in `AbstractController::Rendering` to prevent
+    uninitialized constant error for `ENCODING_FLAG`.
+
+    *Philipe Fatio*
+
 *   Do not discard query parameters that form a hash with the same root key as
     the `wrapper_key` for a request using `wrap_parameters`.
 

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -1,5 +1,6 @@
 require 'active_support/concern'
 require 'active_support/core_ext/class/attribute'
+require 'action_view'
 require 'action_view/view_paths'
 require 'set'
 


### PR DESCRIPTION
Requiring `action_view/view_paths` instead of `action_view` may cause an uninitialized
constant error for ENCODING_FLAG, which is defined in `action_view`.

The error was the following:

```
/home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionview/lib/action_view/template/handlers/erb.rb:90:in `<class:ERB>': uninitialized constant ActionView::Template::Handlers::ERB::ENCODING_FLAG (NameError)
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionview/lib/action_view/template/handlers/erb.rb:76:in `<module:Handlers>'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionview/lib/action_view/template/handlers/erb.rb:5:in `<class:Template>'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionview/lib/action_view/template/handlers/erb.rb:4:in `<module:ActionView>'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionview/lib/action_view/template/handlers/erb.rb:3:in `<top (required)>'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionview/lib/action_view/template/handlers.rb:10:in `extended'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionview/lib/action_view/template.rb:97:in `extend'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionview/lib/action_view/template.rb:97:in `<class:Template>'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionview/lib/action_view/template.rb:7:in `<module:ActionView>'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionview/lib/action_view/template.rb:5:in `<top (required)>'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionview/lib/action_view/base.rb:7:in `require'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionview/lib/action_view/base.rb:7:in `<top (required)>'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionview/lib/action_view/view_paths.rb:1:in `require'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionview/lib/action_view/view_paths.rb:1:in `<top (required)>'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionpack/lib/abstract_controller/rendering.rb:3:in `require'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionpack/lib/abstract_controller/rendering.rb:3:in `<top (required)>'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionmailer/lib/action_mailer/base.rb:368:in `<class:Base>'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionmailer/lib/action_mailer/base.rb:363:in `<module:ActionMailer>'
    from /home/travis/build/fphilipe/premailer-rails/vendor/bundle/ruby/1.9.1/bundler/gems/rails-1713e8fe1617/actionmailer/lib/action_mailer/base.rb:9:in `<top (required)>'
    from /home/travis/build/fphilipe/premailer-rails/lib/premailer/rails.rb:22:in `<top (required)>'
```

This error occurs when using standalone ActionMailer. The line that triggers the above error is something along the following:

``` ruby
ActionMailer::Base.register_interceptor(object)
```
