### PR TITLE
Disable `source_type` scope when `through` already scoped

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add condition to disable `source_type` scope when `through` association already has scope
+
+    Add a condition to disable the `source_type` automatic class scoping when the 
+    `through_reflection` already has a scope.
+
+    Fixes #13920
+
+    *Sergio Campamá*
+
 *   Add support for module-level `table_name_suffix` in models.
 
     This makes `table_name_suffix` work the same way as `table_name_prefix` when

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -590,7 +590,7 @@ module ActiveRecord
 
           through_scope_chain = through_reflection.scope_chain.map(&:dup)
 
-          if options[:source_type]
+          if options[:source_type] && !through_reflection.scope
             through_scope_chain.first <<
               through_reflection.klass.where(foreign_type => options[:source_type])
           end

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -17,6 +17,7 @@ require 'models/member_detail'
 require 'models/member_type'
 require 'models/sponsor'
 require 'models/club'
+require 'models/hotel'
 require 'models/organization'
 require 'models/category'
 require 'models/categorization'
@@ -564,6 +565,17 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
     assert !c.post_taggings.empty?
     c.save
     assert !c.post_taggings.empty?
+  end
+
+  def test_polymorphic_join_table_used_multiple_times_in_query
+    club = clubs(:moustache_club)
+    author = authors(:david)
+    hotel = Hotel.create
+    club.sponsored_authors << author
+    club.sponsored_hotels << hotel
+
+    assert_equal 1, Club.with_sponsored_author_and_hotel(author, hotel).count
+    assert_equal 1, author.sponsor_clubs.with_sponsored_hotel(hotel).count
   end
 
   private

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -140,6 +140,9 @@ class Author < ActiveRecord::Base
   has_many :posts_with_default_include, :class_name => 'PostWithDefaultInclude'
   has_many :comments_on_posts_with_default_include, :through => :posts_with_default_include, :source => :comments
 
+  has_many :sponsors, -> { where(sponsorable_type: "Author") }, as: :sponsorable
+  has_many :sponsor_clubs, through: :sponsors, source: :sponsor_club, class_name: "Club"
+
   scope :relation_include_posts, -> { includes(:posts) }
   scope :relation_include_tags,  -> { includes(:tags) }
 

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -3,10 +3,25 @@ class Club < ActiveRecord::Base
   has_many :memberships, :inverse_of => false
   has_many :members, :through => :memberships
   has_one :sponsor
+  has_many :author_sponsorables, -> { where(sponsorable_type: "Author") }, class_name: "Sponsor"
+  has_many :sponsored_authors, through: :author_sponsorables, source: :sponsorable, source_type: "Author", class_name: "Author"
+  has_many :hotel_sponsorables, -> { where(sponsorable_type: "Hotel") }, class_name: "Sponsor"
+  has_many :sponsored_hotels, through: :hotel_sponsorables, source: :sponsorable, source_type: "Hotel", class_name: "Hotel"
   has_one :sponsored_member, :through => :sponsor, :source => :sponsorable, :source_type => "Member"
   belongs_to :category
 
   has_many :favourites, -> { where(memberships: { favourite: true }) }, through: :memberships, source: :member
+  scope :with_sponsored_hotel, ->(hotel) {
+    joins(:sponsored_hotels).where(hotels: {id: hotel.id})
+  }
+ 
+  scope :with_sponsored_author, ->(author) {
+    joins(:sponsored_authors).where(authors: {id: author.id})
+  }
+ 
+  scope :with_sponsored_author_and_hotel, ->(author, hotel) {
+    joins(:sponsored_authors).joins(:sponsored_hotels).where(authors: {id: author.id}, hotels: {id: hotel.id})
+  }
 
   private
 


### PR DESCRIPTION
Add a condition to disable the `source_type` automatic class scoping
when the `through_reflection` already has a scope.

Fixes #13920
