### PR TITLE
Fix search for create_table_migration template override

### DIFF
--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -18,7 +18,18 @@ module ActiveRecord
       def create_migration_file
         return unless options[:migration] && options[:parent].nil?
         attributes.each { |a| a.attr_options.delete(:index) if a.reference? && !a.has_index? } if options[:indexes] == false
-        migration_template "../../migration/templates/create_table_migration.rb", "db/migrate/create_#{table_name}.rb"
+        ensure_migration_source_paths
+        migration_template "create_table_migration.rb", "db/migrate/create_#{table_name}.rb"
+      end
+
+      def ensure_migration_source_paths
+        return if @migration_source_paths_added
+        Rails::Generators.templates_path.each do |path|
+          source_paths << File.join(path, self.class.base_name, "migration")
+        end
+        path = File.expand_path(File.join(self.class.base_name, "migration", "templates"), self.class.base_root)
+        source_paths << path
+        @migration_source_paths_added = true
       end
 
       def create_model_file


### PR DESCRIPTION
A developer should be able to customize the template used by the model or migration generator, by adding a file to their source tree in a predictable location.

This functionality was likely broken for _create table migrations_ by:
https://github.com/rails/rails/commit/20e041579f5fe9df51bdc40048cc1ef78915e116

After that change, you could now generate a migration:

`rails g migration CreateFoo`

and it would look for a custom template at `<myproject>/lib/templates/active_record/migration/create_table_migration.rb`

However, if you generated the migration by generating a model:

`rails g model Bar`

it would look for a template at the unpredictable and awkward path `<myproject>/lib/templates/migration/templates/create_table_migration.rb`

This change adds the migration generator's template paths to the model generator's search paths. When you generate a model, it will now look for templates in order:

```
<myproject>/lib/templates/active_record/model/create_table_migration.rb
<activerecord gem>/lib/rails/generators/active_record/model/templates/create_table_migration.rb
<myproject>/lib/templates/active_record/migration/create_table_migration.rb
<activerecord gem>/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
```

This has the side-effect of allowing you to have different templates for creating a table, depending on whether you generated a model or the migration directly. That was not the motivation, but its likely more helpful than harmful.
- [ ] Seeking  feedback on how to properly modify the `source_paths` for `ModelGenerator`. I'm not very familiar with generator or Thor `Action` internals, so I had to blindly stab until I found something that worked. I particularly do not like the awkwardness of the `ensure_migration_source_paths` method - ideally that would be handled by some sort of initializer.
- [ ] Confirm we want to retain the functionality introduced by https://github.com/rails/rails/commit/20e041579f5fe9df51bdc40048cc1ef78915e116. It may be preferable to revert that commit. It introduced an awkward coupling between the ModelGenerator and MigrationGenerator that is exposed by this fix.
- [ ] Add or modify tests around this functionality so it doesn't break again. Can someone point me to existing tests?
