### PR TITLE
Skips tests on Windows that create files with illegal characters

### DIFF
--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -136,10 +136,15 @@ module StaticTests
 
     def with_static_file(file)
       path = "#{FIXTURE_LOAD_PATH}/#{public_path}" + file
-      File.open(path, "wb+") { |f| f.write(file) }
+      begin
+        File.open(path, "wb+") { |f| f.write(file) }
+      rescue Errno::EPROTO
+        skip "Couldn't create a file #{path}"
+      end
+
       yield file
     ensure
-      File.delete(path)
+      File.delete(path) if File.exists? path
     end
 end
 


### PR DESCRIPTION
I had problems on running actionpack's tests on a shared folder that was hosted on Windows. The tests were run on Ubuntu so `host_os` check for mswin or mingw wasn't skipping the invalid static file tests.
