### PR TITLE
Reaper has access to threadsafe active? call

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -393,7 +393,7 @@ module ActiveRecord
         synchronize do
           stale = Time.now - @dead_connection_timeout
           connections.dup.each do |conn|
-            if conn.in_use? && stale > conn.last_use && !conn.active?
+            if conn.in_use? && stale > conn.last_use && !conn.active_threadsafe?
               remove conn
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -262,6 +262,12 @@ module ActiveRecord
       def active?
       end
 
+      # Adapter should redefine this if it needs a threadsafe way to approximate
+      # if the connection is active
+      def active_threadsafe?
+        active?
+      end
+
       # Disconnects from the database if already connected, and establishes a
       # new connection with the database. Implementors should call super if they
       # override the default implementation.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -586,9 +586,14 @@ module ActiveRecord
 
       # Is this connection alive and ready for queries?
       def active?
-        @connection.connect_poll != PG::PGRES_POLLING_FAILED
+        @connection.query 'SELECT 1'
+        true
       rescue PGError
         false
+      end
+
+      def active_threadsafe?
+        @connection.connect_poll != PG::PGRES_POLLING_FAILED
       end
 
       # Close then reopen the connection.

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -142,7 +142,7 @@ module ActiveRecord
 
         connections = @pool.connections.dup
         connections.each do |conn|
-          conn.extend(Module.new { def active?; false; end; })
+          conn.extend(Module.new { def active_threadsafe?; false; end; })
         end
 
         @pool.reap

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -69,7 +69,7 @@ module ActiveRecord
         conn = pool.checkout
         count = pool.connections.length
 
-        conn.extend(Module.new { def active?; false; end; })
+        conn.extend(Module.new { def active_threadsafe?; false; end; })
 
         while count == pool.connections.length
           Thread.pass


### PR DESCRIPTION
This should be the simplest way resolve #12867, reverts breakage caused by 34c7e73c1def1312e59ef1f334586ff2f668246e
