### PR TITLE
use File.exist? instead of File.exists?

### DIFF
--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -144,7 +144,7 @@ module StaticTests
 
       yield file
     ensure
-      File.delete(path) if File.exists? path
+      File.delete(path) if File.exist? path
     end
 end
 


### PR DESCRIPTION
Ruby 2.1 and 2.2 with -w option warned to use File.exists?. I fixed it.
