### PR TITLE
Remove duplicate require added by 47860b6

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -1,7 +1,6 @@
 require 'active_support/concern'
 require 'active_support/core_ext/class/attribute'
 require 'action_view'
-require 'action_view/view_paths'
 require 'set'
 
 module AbstractController


### PR DESCRIPTION
Since 47860b6 we're requiring `action_view` already, so I think we don't need to also require `action_view/view_paths`
