### PR TITLE
FilterParameters is referenced at the class level from the Request

### DIFF
--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -74,7 +74,6 @@ module ActionDispatch
     autoload :MimeNegotiation
     autoload :Parameters
     autoload :ParameterFilter
-    autoload :FilterParameters
     autoload :Upload
     autoload :UploadedFile, 'action_dispatch/http/upload'
     autoload :URL


### PR DESCRIPTION
Since it's already required in the file, we don't need to use autoload
too. This commit is symmetrical change to 0b10180 for Response.

cc @tenderlove
