### PR TITLE
Fixed a grammatical error in Booleans section of API documentation guide

### DIFF
--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -172,7 +172,7 @@ def empty?
 end
 ```
 
-The API is careful not to commit to any particular value, the predicate has
+The API is careful not to commit to any particular value, the method has
 predicate semantics, that's enough.
 
 Filenames


### PR DESCRIPTION
from e1e17a5

cc @fxn
