### PR TITLE
Fix general singularization rule for words ending in "aves"

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix general singularization rule for words ending in "aves"
+
+    For example "waves" => "wave", "caves" => "cave", "slaves" => "slave".
+
+    *Tom Wey*
+
 *   Fix `to_param` behavior when there are nested empty hashes.
 
     Before:

--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -31,6 +31,7 @@ module ActiveSupport
     inflect.singular(/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$/i, '\1sis')
     inflect.singular(/(^analy)(sis|ses)$/i, '\1sis')
     inflect.singular(/([^f])ves$/i, '\1fe')
+    inflect.singular(/([^s]ave)s$/i, '\1')
     inflect.singular(/(hive)s$/i, '\1')
     inflect.singular(/(tive)s$/i, '\1')
     inflect.singular(/([lr])ves$/i, '\1f')

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -30,6 +30,10 @@ module InflectorTestCases
     "safe"        => "saves",
     "half"        => "halves",
 
+    "wave"        => "waves",
+    "cave"        => "caves",
+    "slave"       => "slaves",
+
     "move"        => "moves",
 
     "salesperson" => "salespeople",


### PR DESCRIPTION
For example:
- "waves" => "wave" (instead of "wafe")
- "caves" => "cave" (instead of "cafe")
- "slaves" => "slave" (instead of "slafe")

There's an existing test for an exception to this rule: "safe" => "saves". I'm a little unsure about that inflection (I would have thought "save" => "saves" and "safe" => "safes") but I've left this functionality in place.

Related to this, the following rule exists for singularizing:

`inflect.singular(/([^f])ves$/i, '\1fe')`

I'm not sure what the purpose of the `[^f]` is here. I can't find any words which end "fves" and
`$ ack "fves$" /usr/share/dict/words`
returns nothing.

Still, doesn't mean there isn't one! It would be great to add a test case for the scenario this is here to cover if anyone knows?

Thanks!
