### PR TITLE
`Rails.threadsafe!` mode is deprecated, Update Docs

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -939,4 +939,4 @@ ActiveRecord::ConnectionTimeoutError - could not obtain a database connection wi
 If you get the above error, you might want to increase the size of connection
 pool by incrementing the `pool` option in `database.yml`
 
-NOTE. If you have enabled `Rails.threadsafe!` mode then there could be a chance that several threads may be accessing multiple connections simultaneously. So depending on your current request load, you could very well have multiple threads contending for a limited amount of connections.
+NOTE. As Rails is multi-threaded by default, there could be a chance that several threads may be accessing multiple connections simultaneously. So depending on your current request load, you could very well have multiple threads contending for a limited amount of connections.


### PR DESCRIPTION
`Rails.threadsafe!` mode is deprecated, update docs to reflect this.
