### PR TITLE
streaming should change status of response when exception is caught

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Set stream status to 500 (or 400 on BadRequest) when an error is thrown
+    before commiting.
+
+    Fixes #12552.
+
+    *Kevin Casey*
+
 *   Add new config option `config.action_dispatch.cookies_serializer` for
     specifying a serializer for the signed and encrypted cookie jars.
 

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -205,6 +205,8 @@ module ActionController
         begin
           super(name)
         rescue => e
+          @_response.status = 500 unless @_response.committed?
+          @_response.status = 400 if e.class == ActionController::BadRequest
           begin
             @_response.stream.write(ActionView::Base.streaming_completion_on_exception) if request.format == :html
             @_response.stream.call_on_error

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -156,6 +156,14 @@ module ActionController
         raise 'An exception occurred...'
       end
 
+      def exception_in_controller
+        raise 'Exception in controller'
+      end
+
+      def bad_request_error
+        raise ActionController::BadRequest
+      end
+
       def exception_in_exception_callback
         response.headers['Content-Type'] = 'text/event-stream'
         response.stream.on_error do
@@ -273,6 +281,16 @@ module ActionController
         assert_match 'An exception occurred...', output.rewind && output.read
         assert_stream_closed
       end
+    end
+
+    def test_exception_in_controller_before_streaming
+      response = get :exception_in_controller, format: 'text/event-stream'
+      assert_equal 500, response.status
+    end
+
+    def test_bad_request_in_controller_before_streaming
+      response = get :bad_request_error, format: 'text/event-stream'
+      assert_equal 400, response.status
     end
 
     def test_exceptions_raised_handling_exceptions


### PR DESCRIPTION
This fixes #12552.  #9604 looks like sgrif expected that if streaming and an exception occurs we should just log it and in the view use javascript to display a 500 error while bkudria is saying that we should change the status response (not a 200 for correctly rendering an error message).
