### PR TITLE
Prevent relation builder from generating NULL for array of ranges

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -5,7 +5,18 @@ module ActiveRecord
         values = value.map { |x| x.is_a?(Base) ? x.id : x }
         ranges, values = values.partition { |v| v.is_a?(Range) }
 
-        values_predicate = if values.include?(nil)
+        array_predicates = ranges.map { |range| attribute.in(range) }
+        if values.present?
+          array_predicates << values_predicate(attribute, values)
+        end
+
+        array_predicates.inject { |composite, predicate| composite.or(predicate) }
+      end
+
+      private
+
+      def values_predicate(attribute, values)
+        if values.include?(nil)
           values = values.compact
 
           case values.length
@@ -19,10 +30,6 @@ module ActiveRecord
         else
           attribute.in(values)
         end
-
-        array_predicates = ranges.map { |range| attribute.in(range) }
-        array_predicates << values_predicate
-        array_predicates.inject { |composite, predicate| composite.or(predicate) }
       end
     end
   end


### PR DESCRIPTION
It's updated version of pull-request #9179 and partial fix of issue #9171. Additionally I've added test coverage of the array handler.
