### PR TITLE
Sungularize ActionController::UnpermittedParameters error in case when only 1 parameter is unpermitted.

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -50,7 +50,7 @@ module ActionController
 
     def unpermitted_parameters(event)
       unpermitted_keys = event.payload[:keys]
-      debug("Unpermitted parameters: #{unpermitted_keys.join(", ")}")
+      debug("Unpermitted parameter#{'s' if unpermitted_keys.size > 1}: #{unpermitted_keys.join(", ")}")
     end
 
     def deep_munge(event)

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -32,7 +32,7 @@ module ActionController
 
     def initialize(params) # :nodoc:
       @params = params
-      super("found unpermitted parameters: #{params.join(", ")}")
+      super("found unpermitted parameter#{'s' if params.size > 1 }: #{params.join(", ")}")
     end
   end
 

--- a/actionpack/test/controller/parameters/log_on_unpermitted_params_test.rb
+++ b/actionpack/test/controller/parameters/log_on_unpermitted_params_test.rb
@@ -10,23 +10,45 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
     ActionController::Parameters.action_on_unpermitted_parameters = false
   end
 
-  test "logs on unexpected params" do
+  test "logs on unexpected param" do
     params = ActionController::Parameters.new({
       book: { pages: 65 },
       fishing: "Turnips"
     })
 
-    assert_logged("Unpermitted parameters: fishing") do
+    assert_logged("Unpermitted parameter: fishing") do
+      params.permit(book: [:pages])
+    end
+  end
+
+  test "logs on unexpected params" do
+    params = ActionController::Parameters.new({
+      book: { pages: 65 },
+      fishing: "Turnips",
+      car: "Mersedes"
+    })
+
+    assert_logged("Unpermitted parameters: fishing, car") do
+      params.permit(book: [:pages])
+    end
+  end
+
+  test "logs on unexpected nested param" do
+    params = ActionController::Parameters.new({
+      book: { pages: 65, title: "Green Cats and where to find then." }
+    })
+
+    assert_logged("Unpermitted parameter: title") do
       params.permit(book: [:pages])
     end
   end
 
   test "logs on unexpected nested params" do
     params = ActionController::Parameters.new({
-      book: { pages: 65, title: "Green Cats and where to find then." }
+      book: { pages: 65, title: "Green Cats and where to find then.", author: "G. A. Dog" }
     })
 
-    assert_logged("Unpermitted parameters: title") do
+    assert_logged("Unpermitted parameters: title, author") do
       params.permit(book: [:pages])
     end
   end


### PR DESCRIPTION
Old behaviour of Strong params had grammar error in case single attribute was unpermitted:

`ActionController::UnpermittedParameters (found unpermitted parameters: cellphone)`

This pull-request fixed it, so new error will have singular form:

`ActionController::UnpermittedParameters (found unpermitted parameter: cellphone)`

Of course, if there are 2 or more unpermitted parameter then error will be pluralized:

`ActionController::UnpermittedParameters (found unpermitted parameters: cellphone, town)`
