### PR TITLE
Upgraded jquery-rails gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'mocha', '~> 0.14', require: false
 
 gem 'rack-cache', '~> 1.2'
 gem 'bcrypt-ruby', '~> 3.1.2'
-gem 'jquery-rails', '~> 2.2.0'
+gem 'jquery-rails', '~> 3.1.0'
 gem 'turbolinks'
 gem 'coffee-rails', '~> 4.0.0'
 


### PR DESCRIPTION
Upgrading the jquery-rails gem. To avoid the chrome's jQuery deprecation warning

`event.returnValue is deprecated. Please use the standard event.preventDefault() instead.`
