### PR TITLE
db:schema:load with migrations in subdirectories

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Insert all the migrations' versions into schema_migrations table when
+    running db:schema:load.
+
+    Load all the migrations' versions from db/migrate directory and its
+    subdirectories to avoid pending migrations errors.
+
+    Fix ActiveRecord::ConnectionAdapters::SchemaStatements
+      .assume_migrated_upto_version method
+
+    Before:
+
+        paths = migrations_paths.map {|p| "#{p}/[0-9]*_*.rb" }
+
+    After:
+
+        paths = migrations_paths.map {|p| "#{p}/**/[0-9]*_*.rb" }
+
+    *Dmitry Gritsay*
+
 *   Revert behavior of `db:schema:load` back to loading the full
     environment. This ensures that initializers are run.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -841,7 +841,7 @@ module ActiveRecord
         sm_table = quote_table_name(ActiveRecord::Migrator.schema_migrations_table_name)
 
         migrated = select_values("SELECT version FROM #{sm_table}").map(&:to_i)
-        paths = migrations_paths.map {|p| "#{p}/[0-9]*_*.rb" }
+        paths = migrations_paths.map {|p| "#{p}/**/[0-9]*_*.rb" }
         versions = Dir[*paths].map do |filename|
           filename.split('/').last.split('_').first.to_i
         end


### PR DESCRIPTION
Getting pending migrations errors after running

```
$ rake db:schema:load
```

when `db/migrate` directory contains any migrations in its subdirectories.

Example directories structure:

```
db/
    migrate/
        archive/
            1_create_people.rb
            2_add_age_to_people.rb
        3_add_phone_number_to_people.rb
```

If the `db/migrate` directory contains any migrations in its subdirectories, their versions are not inserted into `schema_migrations` table.

As for the example above, `ActiveRecord::ConnectionAdapters::SchemaStatements.assume_migrated_upto_version` method inserts only the 3rd version into the `schema_migrations` table.
But `ActiveRecord::Migrator.migrations` method expects the table to include all of the 3 versions. 1 and 2 are perceived as pending and this fact causes the pending migrations error.

The `assume_migrated_upto_version` fetched migrations files using

``` ruby
paths = migrations_paths.map {|p| "#{p}/[0-9]*_*.rb" }
```

So there was no subdirectories support.
The behaviour is fixed by

``` ruby
paths = migrations_paths.map {|p| "#{p}/**/[0-9]*_*.rb" }
```

Added a test case.
