### PR TITLE
Documentation: Don't symbolize tainted data.

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -145,7 +145,11 @@ The _setting part_ is easy. You can set the locale in a `before_action` in the `
 before_action :set_locale
 
 def set_locale
-  I18n.locale = params[:locale] || I18n.default_locale
+  if %w[en fr].include?(params[:locale])
+    I18n.locale = params[:locale]
+  else
+    I18n.locale = I18n.default_locale
+  end
 end
 ```
 


### PR DESCRIPTION
[`I18n.locale=` symbolizes its argument](https://github.com/mattetti/i18n/blob/master/lib/i18n/config.rb#L11), so passing it `params[:locale]` allows one to DOS your application by visiting `...?locale=` URLS repeatedly, with unique values, until the never-GCed symbols monopolize the available memory.

This commit updates the example to include a basic whitelist, but doesn't describe its necessity.
