### PR TITLE
Convert enum values in ActiveRecord::Base#attributes

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -106,6 +106,19 @@ module ActiveRecord
           klass.send(:detect_enum_conflict!, name, "#{name}_before_type_cast")
           define_method("#{name}_before_type_cast") { enum_values.key self[name] }
 
+          # Convert the enums in the attributes hash
+          define_method(:attributes) do
+            attributes = super()
+
+            DEFINED_ENUMS.each do |name, values|
+              if attributes.has_key? name
+                attributes[name] = values.key(attributes[name])
+              end
+            end
+
+            attributes
+          end
+
           pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
           pairs.each do |value, i|
             enum_values[value] = i

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -222,4 +222,9 @@ class EnumTest < ActiveRecord::TestCase
       end
     end
   end
+
+  test "attributes hash includes enum label" do
+    assert_equal "proposed", @book.attributes["status"]
+  end
+
 end


### PR DESCRIPTION
When calling `#attributes` on a model with enum fields, the resulting hash contains the enum values and not the labels. This PR makes the following change :

```
class Book < ActiveRecord::Base
  enum status: [:proposed, :written, :published]
end

book = Book.new(:status => :written)
book.status # => "written"

# Before
book.attributes # => {"id" => nil, "status" => 1} 

# After
book.attributes # => {"id" => nil, "status" => "written"}
```

Sorry if this is voluntary and not an omission, I didn't see any mention of this in the discussions related to the `ActiveRecord::Enum` feature
