### PR TITLE
Load included associations with limit if any

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -118,6 +118,7 @@ module ActiveRecord
 
           scope.select!   preload_values[:select] || values[:select] || table[Arel.star]
           scope.includes! preload_values[:includes] || values[:includes]
+          scope.limit! preload_values[:limit] || values[:limit]
 
           if preload_values.key? :order
             scope.order! preload_values[:order]

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1840,4 +1840,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal false, pirate.valid?(:conference)
     assert_equal "can't be blank", ship.errors[:name].first
   end
+
+  test "included association gets loaded with limit if it was defined" do
+    developer = Developer.create!(name: "Dmitriy")
+    5.times { developer.contracts.create! }
+
+    assert_sql(/LIMIT 3|ROWNUM <= 3/) { Developer.includes(:recent_contracts).load }
+  end
 end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -43,6 +43,7 @@ class Developer < ActiveRecord::Base
 
   has_many :audit_logs
   has_many :contracts
+  has_many :recent_contracts, ->{ limit(3) }, class_name: "Contract"
   has_many :firms, :through => :contracts, :source => :firm
 
   scope :jamises, -> { where(:name => 'Jamis') }


### PR DESCRIPTION
``` ruby
class User < ActiveRecord::Base
  has_many :tweets
  has_many :recent_tweets, ->{ limit(3) }, class_name: "Tweet"
end

class Tweet < ActiveRecord::Base
  belongs_to :user
end

user = User.create!(name: "John Appleseed")
user.tweets.create!(5000.times.map { |num| {text: "tweet-##{num}"} })
```

Loading all users with just recent tweets may be really slow — `User.includes(:recent_tweets).load` produces these queries:
- `SELECT "users".* FROM "users"`
- `SELECT  "tweets".* FROM "tweets"  WHERE "tweets"."user_id" IN (1)`

Pay attention to second query: it doesn't have `LIMIT`. And now imagine if user has gazillion tweets. :)
