### PR TITLE
Hide bundler output for `rails new` if quiet option is specified.

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -412,7 +412,8 @@ module Rails
 
         require 'bundler'
         Bundler.with_clean_env do
-          print `"#{Gem.ruby}" "#{_bundle_command}" #{command}`
+          output = `"#{Gem.ruby}" "#{_bundle_command}" #{command}`
+          print output unless options[:quiet]
         end
       end
 


### PR DESCRIPTION
I noticed that even if you run `rails new` with `--quiet`, Bundler output is still printed to the terminal.

I'm not sure how to write a unit test for this, though, since it's using backticks and actually running the Bundler command was pretty slow.
