### PR TITLE
Update Travis settings for Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
-  - rbx
+  - rbx-2
   - jruby
 env:
   - "GEM=railties"
@@ -17,7 +17,7 @@ env:
   - "GEM=ar:postgresql"
 matrix:
   allow_failures:
-    - rvm: rbx
+    - rvm: rbx-2
     - rvm: jruby
   fast_finish: true
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -76,11 +76,6 @@ platforms :jruby do
   end
 end
 
-platforms :rbx do
-  gem 'psych', '~> 2.0'
-  gem 'rubysl', '~> 2.0'
-end
-
 # gems that are necessary for ActiveRecord tests with Oracle database
 if ENV['ORACLE_ENHANCED']
   platforms :ruby do


### PR DESCRIPTION
Specific `rbx-2` to limit testing on Rubinius 2.x (since there will be other versions of Rubinius > 2.x soon).

Also, as of Rubinius 2.2.5, it is no longer necessary to bundle the `rubysl` gem.
