### PR TITLE
Rename update_record / create_record methods

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -79,11 +79,11 @@ module ActiveRecord
         end
       end
 
-      def update_record(*)
+      def update(*)
         partial_writes? ? super(keys_for_partial_write) : super
       end
 
-      def create_record(*)
+      def create(*)
         partial_writes? ? super(keys_for_partial_write) : super
       end
 

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -302,11 +302,11 @@ module ActiveRecord
       run_callbacks(:save) { super }
     end
 
-    def create_record #:nodoc:
+    def create #:nodoc:
       run_callbacks(:create) { super }
     end
 
-    def update_record(*) #:nodoc:
+    def update(*) #:nodoc:
       run_callbacks(:update) { super }
     end
   end

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -66,7 +66,7 @@ module ActiveRecord
           send(lock_col + '=', previous_lock_value + 1)
         end
 
-        def update_record(attribute_names = @attributes.keys) #:nodoc:
+        def update(attribute_names = @attributes.keys) #:nodoc:
           return super unless locking_enabled?
           return 0 if attribute_names.empty?
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -477,13 +477,13 @@ module ActiveRecord
 
     def create_or_update
       raise ReadOnlyRecord if readonly?
-      result = new_record? ? create_record : update_record
+      result = new_record? ? create : update
       result != false
     end
 
     # Updates the associated record with values matching those of the instance attributes.
     # Returns the number of affected rows.
-    def update_record(attribute_names = @attributes.keys)
+    def update(attribute_names = @attributes.keys)
       attributes_values = arel_attributes_with_values_for_update(attribute_names)
       if attributes_values.empty?
         0
@@ -494,7 +494,7 @@ module ActiveRecord
 
     # Creates a record with values matching those of the instance attributes
     # and returns its id.
-    def create_record(attribute_names = @attributes.keys)
+    def create(attribute_names = @attributes.keys)
       attributes_values = arel_attributes_with_values_for_create(attribute_names)
 
       new_id = self.class.unscoped.insert attributes_values

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -43,7 +43,7 @@ module ActiveRecord
 
   private
 
-    def create_record
+    def create
       if self.record_timestamps
         current_time = current_time_from_proper_timezone
 
@@ -57,7 +57,7 @@ module ActiveRecord
       super
     end
 
-    def update_record(*args)
+    def update(*args)
       if should_record_timestamps?
         current_time = current_time_from_proper_timezone
 


### PR DESCRIPTION
This change renames the `update_record` and `create_record` methods in back to `update` and `create` to avoid conflicts with dynamically generated `create_#{association_name}`/`update_#{association_name}` methods for associations.

Check issue #11645.
