### PR TITLE
Amended json_escape comments

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -78,6 +78,11 @@ class ERB
     # automatically flag the result as HTML safe, since the raw value is unsafe to
     # use inside HTML attributes.
     #
+    # If your JSON is being used downstream for insertion into the DOM, be aware of
+    # whether or not it is being inserted via +html()+. Most JQuery plugins do this.
+    # If that is the case, be sure to +html_escape+ or +sanitize+ any user-generated
+    # content returned by your JSON.
+    #
     # If you need to output JSON elsewhere in your HTML, you can just do something
     # like this, as any unsafe characters (including quotation marks) will be
     # automatically escaped for you:


### PR DESCRIPTION
As it stands, the security of `json_escape` is a bit misleading. Clarifying that user-generated content must still be html_escaped if being inserted into the DOM via JQuery's html() method, since this is such a common use case.

Described here: https://github.com/rails/rails/pull/13073#issuecomment-34820097
