### PR TITLE
do not crash when `config/secrets.yml` is blank.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Do not crash when `config/secrets.yml` is empty.
+
+    *Yves Senn*
+
 *   Set `dump_schema_after_migration` config values in production.
 
     Set `config.active_record.dump_schema_after_migration` as false

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -308,7 +308,8 @@ module Rails
         yaml = config.paths["config/secrets"].first
         if File.exist?(yaml)
           require "erb"
-          env_secrets = YAML.load(ERB.new(IO.read(yaml)).result)[Rails.env]
+          all_secrets = YAML.load(ERB.new(IO.read(yaml)).result) || {}
+          env_secrets = all_secrets[Rails.env]
           secrets.merge!(env_secrets.symbolize_keys) if env_secrets
         end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -336,6 +336,14 @@ module ApplicationTests
       assert_equal 'myamazonsecretaccesskey', app.secrets.aws_secret_access_key
     end
 
+    test "blank config/secrets.yml does not crash the loading process" do
+      app_file 'config/secrets.yml', <<-YAML
+      YAML
+      require "#{app_path}/config/environment"
+
+      assert_nil app.secrets.not_defined
+    end
+
     test "protect from forgery is the default in a new app" do
       make_basic_app
 


### PR DESCRIPTION
While working on an application I was facing the following issue:

Our setup script touches a blank `config/secrets.yml` and then executes tasks that load the environment to populate it. In an initializer there is a condition on the existence of a secret. This currently crashes as the loading process expects the file to be populated:

```
/home/travis/build/4teamwork/geschaeftsverzeichnis/vendor/bundle/ruby/2.0.0/gems/railties-4.1.0.beta1/lib/rails/application.rb:310:in `secrets': undefined method `[]' for false:FalseClass (NoMethodError)
```

The use-case presented above is certainly esoteric and could probably be solved otherwise. However I think we should not crash on a blank `config/secrets.yml` with this cryptic error.

Currently a blank `config/database.yml` yields:

```
/Users/senny/Projects/rails/activerecord/lib/active_record/connection_adapters/connection_specification.rb:231:in `resolve_env_connection': 'development' database is not configured. Available configuration: {} (ActiveRecord::AdapterNotSpecified)
```

After this patch a blank `config/secrets.yml` will result in:

```
[2014-02-12 17:10:16] ERROR RuntimeError: Missing `secret_key_base` for 'development' environment, set this value in `config/secrets.yml`
```
