### PR TITLE
Drop the correct index after reverting a migration

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   When inverting add_index use the index name if present instead of
+    the columns.
+
+    If there are two indices with matching columns and one of them is
+    explicitly named then reverting the migration adding the named one
+    would instead drop the unnamed one.
+
+    The inversion of add_index will now drop the index by its name if
+    it is present.
+
+    *Hubert Dąbrowski*
+
 *   Add flag to disable schema dump after migration.
 
     Add a config parameter on Active Record named `dump_schema_after_migration`

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -140,7 +140,12 @@ module ActiveRecord
 
       def invert_add_index(args)
         table, columns, options = *args
-        [:remove_index, [table, (options || {}).merge(column: columns)]]
+        options ||= {}
+
+        index_name = options[:name]
+        options_hash = index_name ? { name: index_name } : { column: columns }
+
+        [:remove_index, [table, options_hash]]
       end
 
       def invert_remove_index(args)

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -174,13 +174,13 @@ module ActiveRecord
       end
 
       def test_invert_add_index
-        remove = @recorder.inverse_of :add_index, [:table, [:one, :two], options: true]
-        assert_equal [:remove_index, [:table, {column: [:one, :two], options: true}]], remove
+        remove = @recorder.inverse_of :add_index, [:table, [:one, :two]]
+        assert_equal [:remove_index, [:table, {column: [:one, :two]}]], remove
       end
 
       def test_invert_add_index_with_name
         remove = @recorder.inverse_of :add_index, [:table, [:one, :two], name: "new_index"]
-        assert_equal [:remove_index, [:table, {column: [:one, :two], name: "new_index"}]], remove
+        assert_equal [:remove_index, [:table, {name: "new_index"}]], remove
       end
 
       def test_invert_add_index_with_no_options


### PR DESCRIPTION
While working with partial indexes I've hit a problem where reverting a migration would drop the invalid index. The reason is that inverting `add_index :table_name, :column_name, name: "named_index"` results in `remove_index :column_name, name: "named_index"` which ends up dropping the index by its columns. 
#8868 made `remove_index :column_name, name: "named_index"` drop the `named_index` only if a corresponding one with matching columns but without the name doesn't exist.

This change makes inverting an `add_index` use the name or the columns explicitly.
