### PR TITLE
Check if variant array contains only symbols

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -70,10 +70,10 @@ module ActionDispatch
       def variant=(variant)
         if variant.is_a?(Symbol)
           @variant = [variant]
-        elsif variant.is_a?(Array)
+        elsif variant.is_a?(Array) && variant.any? && variant.all?{ |v| v.is_a?(Symbol) }
           @variant = variant
         else
-          raise ArgumentError, "request.variant must be set to a Symbol or Array, not a #{variant.class}. " \
+          raise ArgumentError, "request.variant must be set to a Symbol or an Array of Symbols, not a #{variant.class}. " \
             "For security reasons, never directly set the variant to a user-provided value, " \
             "like params[:variant].to_sym. Check user-provided value against a whitelist first, " \
             "then set the variant: request.variant = :tablet if params[:variant] == 'tablet'"

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -852,6 +852,14 @@ class RequestTest < ActiveSupport::TestCase
 
     request.variant = [:phone, :tablet]
     assert_equal [:phone, :tablet], request.variant
+
+    assert_raise ArgumentError do
+      request.variant = [:phone, "tablet"]
+    end
+
+    assert_raise ArgumentError do
+      request.variant = "yolo"
+    end
   end
 
   test "setting variant with non symbol value" do


### PR DESCRIPTION
Improved, more tested and more secure code for variant assignment change from #14043

/cc @carlosantoniodasilva
