### PR TITLE
Add hint to error message of task db:migrate:down

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -75,7 +75,7 @@ db_namespace = namespace :db do
     # desc 'Runs the "down" for a given migration VERSION.'
     task :down => [:environment, :load_config] do
       version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
-      raise 'VERSION is required' unless version
+      raise 'VERSION is required - To go down one migration, run db:rollback' unless version
       ActiveRecord::Migrator.run(:down, ActiveRecord::Migrator.migrations_paths, version)
       db_namespace['_dump'].invoke
     end


### PR DESCRIPTION
When I run `rake db:migrate:down` with no VERSION, I expect it to run the last migration down. Let's add a hint to help developers use the right task.

```
$> rake db:migrate:down
VERSION is required - To go down one migration, run db:rollback
```
