### PR TITLE
Fall back to filter_parameters when filter_redirect is not set for redirect log lines

### DIFF
--- a/actionpack/lib/action_dispatch/http/filter_redirect.rb
+++ b/actionpack/lib/action_dispatch/http/filter_redirect.rb
@@ -3,13 +3,14 @@ module ActionDispatch
     module FilterRedirect
 
       FILTERED = '[FILTERED]'.freeze # :nodoc:
+      NULL_PARAM_FILTER = ParameterFilter.new # :nodoc:
 
       def filtered_location
         filters = location_filter
         if !filters.empty? && location_filter_match?(filters)
           FILTERED
         else
-          location
+          parameter_filtered_location
         end
       end
 
@@ -30,6 +31,21 @@ module ActionDispatch
           elsif Regexp === filter
             location.match(filter)
           end
+        end
+      end
+
+
+      def parameter_filter
+        ParameterFilter.new request.env.fetch("action_dispatch.parameter_filter") {
+          return NULL_PARAM_FILTER
+        }
+      end
+
+      KV_RE   = '[^&;=]+'
+      PAIR_RE = %r{(#{KV_RE})=(#{KV_RE})}
+      def parameter_filtered_location
+        location.gsub(PAIR_RE) do |_|
+          parameter_filter.filter([[$1, $2]]).first.join("=")
         end
       end
 


### PR DESCRIPTION
See also https://github.com/rails/rails/pull/8404 and https://github.com/rails/rails/commit/86e3aaab939a67536f007d1633ec19521dba15e9

I noticed that log lines for redirects were not filtered as I expected. I did a bit of searching and I see that we have a newish config option related to this that I wasn't aware of. It's a great option, but I propose that we fallback to params filtering when this new option is not used. 

I worked up a crude implementation (steals code from `filter_parameters` and doesn't include tests) to illustrate the point. I collected some example log lines that show the current/expected behavior. 

I'm happy to improve this PR if there's consensus that this is generally a good idea. 

Thanks!

-- Current behavior --

Rails.application.config.filter_parameters += [:password]

Started GET "/" for 127.0.0.1 at 2014-02-13 19:58:50 -0600
Processing by ApplicationController#one as HTML
Redirected to http://localhost:3000/two?password=secret
Completed 302 Found in 15ms (ActiveRecord: 0.0ms)

Started GET "/two?password=[FILTERED]" for 127.0.0.1 at 2014-02-13 19:58:50 -0600
Processing by ApplicationController#two as HTML
  Parameters: {"password"=>"[FILTERED]"}
Completed 200 OK in 0ms (ActiveRecord: 0.0ms)

I expected the log line "Redirected to http://localhost:3000/two?password=secret" to be filtered.

-- Expected behavior --

Started GET "/" for 127.0.0.1 at 2014-02-13 19:58:50 -0600
Processing by ApplicationController#one as HTML
Redirected to http://localhost:3000/two?password=[FILTERED]
Completed 302 Found in 20ms (ActiveRecord: 0.0ms)

I expected the log line to read: "Redirected to http://localhost:3000/two?password=[FILTERED]"

-- Behavior with the newly introduced redirect filter --

Rails.application.config.filter_redirect << 'password'

Started GET "/" for 127.0.0.1 at 2014-02-13 19:58:50 -0600
Processing by ApplicationController#one as HTML
Redirected to [FILTERED]
Completed 302 Found in 20ms (ActiveRecord: 0.0ms)

With the new redirect filter option in use, the entire URL is filtered: "Redirected to [FILTERED]"

/cc @freegenie -- would love your feedback!
