### PR TITLE
SQLite3Adapter now checks for views in table_exists? fixes: 14041

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   SQLite3Adapter now checks for views in `table_exists?`
+
+    Fixes #14041
+
+    *Girish Sonawane*
+
 *   When inverting add_index use the index name if present instead of
     the columns.
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -369,7 +369,7 @@ module ActiveRecord
         sql = <<-SQL
           SELECT name
           FROM sqlite_master
-          WHERE type = 'table' AND NOT name = 'sqlite_sequence'
+          WHERE (type = 'table' OR type = 'view') AND NOT name = 'sqlite_sequence'
         SQL
         sql << " AND name = #{quote_table_name(table_name)}" if table_name
 

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -276,6 +276,16 @@ module ActiveRecord
         assert_equal 0, @conn.select_rows(count_sql).first.first
       end
 
+      def test_views
+        assert_equal %w{ items }, @conn.tables
+
+        @conn.execute <<-eosql
+          CREATE VIEW items_view AS
+            select id from items;
+        eosql
+        assert @conn.table_exists?('items_view')
+      end
+
       def test_tables
         assert_equal %w{ items }, @conn.tables
 


### PR DESCRIPTION
Added check for database views in `table_exists?` in SQLite3Adapter

Fixes #14041
