### PR TITLE
updated Travis build status image url

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We encourage you to contribute to Ruby on Rails! Please check out the
 
 ## Code Status
 
-* [![Build Status](https://api.travis-ci.org/rails/rails.png)](https://travis-ci.org/rails/rails)
+* [![Build Status](https://travis-ci.org/rails/rails.png?branch=master)](https://travis-ci.org/rails/rails)
 
 ## License
 


### PR DESCRIPTION
Current build status image url is not refreshed. For example right now build 13936 is failing but image in Github is green.

As it can be seen in https://travis-ci.org/rails/rails clicking in the right image it should be this new url.

Cheers.
