### PR TITLE
Fix path shown in mailer's templates

### DIFF
--- a/railties/lib/rails/generators/erb/mailer/templates/view.html.erb
+++ b/railties/lib/rails/generators/erb/mailer/templates/view.html.erb
@@ -1,5 +1,5 @@
 <h1><%= class_name %>#<%= @action %></h1>
 
 <p>
-  <%%= @greeting %>, find me in app/views/<%= @path %>
+  <%%= @greeting %>, find me in <%= @path %>
 </p>

--- a/railties/lib/rails/generators/erb/mailer/templates/view.text.erb
+++ b/railties/lib/rails/generators/erb/mailer/templates/view.text.erb
@@ -1,3 +1,3 @@
 <%= class_name %>#<%= @action %>
 
-<%%= @greeting %>, find me in app/views/<%= @path %>
+<%%= @greeting %>, find me in <%= @path %>

--- a/railties/test/generators/mailer_generator_test.rb
+++ b/railties/test/generators/mailer_generator_test.rb
@@ -69,12 +69,12 @@ class MailerGeneratorTest < Rails::Generators::TestCase
   def test_invokes_default_text_template_engine
     run_generator
     assert_file "app/views/notifier/foo.text.erb" do |view|
-      assert_match(%r(app/views/notifier/foo\.text\.erb), view)
+      assert_match(%r(\sapp/views/notifier/foo\.text\.erb), view)
       assert_match(/<%= @greeting %>/, view)
     end
 
     assert_file "app/views/notifier/bar.text.erb" do |view|
-      assert_match(%r(app/views/notifier/bar\.text\.erb), view)
+      assert_match(%r(\sapp/views/notifier/bar\.text\.erb), view)
       assert_match(/<%= @greeting %>/, view)
     end
   end
@@ -82,12 +82,12 @@ class MailerGeneratorTest < Rails::Generators::TestCase
   def test_invokes_default_html_template_engine
     run_generator
     assert_file "app/views/notifier/foo.html.erb" do |view|
-      assert_match(%r(app/views/notifier/foo\.html\.erb), view)
+      assert_match(%r(\sapp/views/notifier/foo\.html\.erb), view)
       assert_match(/<%= @greeting %>/, view)
     end
 
     assert_file "app/views/notifier/bar.html.erb" do |view|
-      assert_match(%r(app/views/notifier/bar\.html\.erb), view)
+      assert_match(%r(\sapp/views/notifier/bar\.html\.erb), view)
       assert_match(/<%= @greeting %>/, view)
     end
   end


### PR DESCRIPTION
The mailer's templates was showing the wrong path to the files, was with `app/views/app/views/...`

related with: 02c814c99202e42ebeb10b89af1392b594c727e9

Thank's @rubys for show me this.
