### PR TITLE
Fix typo in docs for Array#in_groups_of

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/grouping.rb
+++ b/activesupport/lib/active_support/core_ext/array/grouping.rb
@@ -50,8 +50,8 @@ class Array
   #
   #   %w(1 2 3 4 5 6 7).in_groups(3, false) {|group| p group}
   #   ["1", "2", "3"]
-  #   ["4", "5"]
-  #   ["6", "7"]
+  #   ["4", "5", "6"]
+  #   ["7"]
   def in_groups(number, fill_with = nil)
     # size.div number gives minor group size;
     # size % number gives how many objects need extra accommodation;


### PR DESCRIPTION
P. sure this isn't the proper flow for fixing typos in docs. Such a trivial change, happy to send a PR somewhere else or just let someone else fix directly :-D
