### PR TITLE
Add documentation/tests around interpolated values in ActiveModel::Errors

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -290,9 +290,10 @@ module ActiveModel
     #
     #   person.errors.messages # => {}
     #
-    # If the +message+ being added makes use of an interpolated <tt>count</tt>,
-    # a <tt>:count</tt> option must be specified. Failure to do so will
-    # result in an I18n::MissingInterpolationArgument exception.
+    # If the +message+ being added makes use of an interpolated value
+    # (e.g., +count+), this value must be specified as an option. Failure
+    # to do so will result in an +I18n::MissingInterpolationArgument+
+    # exception.
     #
     #   person.errors.add(:name, :too_short)
     #   # => I18n::MissingInterpolationArgument
@@ -341,11 +342,12 @@ module ActiveModel
     #   person.errors.add :name, :blank
     #   person.errors.added? :name, :blank # => true
     #
-    # When used to check for a +message+ that includes an interpolated <tt>count</tt>, it 
-    # requires a <tt>:count</tt> option. This interpolated value is used
-    # in the check for the message's presence. A <tt>:count</tt> that does not
-    # match the <tt>:count</tt> provided in +add+ for an attribute-message pair
-    # will result in a +false+ return value.
+    # When used to check for a +message+ that includes an interpolated value
+    # (e.g., +count+), it requires that we specify this value as an option.
+    # This interpolated value is used in the check for the message's presence.
+    # For instance, providing a ++:count++ that does not match the ++:count++
+    # provided in +add+ for an attribute-message pair will result in a +false+
+    # return value.
     #
     #   person.errors.add(:name, :too_long, count: 22)
     #   person.errors.added?(:name, :too_long) # => I18n::MissingInterpolationArgument

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -345,7 +345,7 @@ module ActiveModel
     # When used to check for a +message+ that includes an interpolated value
     # (e.g., +count+), it requires that we specify this value as an option.
     # This interpolated value is used in the check for the message's presence.
-    # For instance, providing a ++:count++ that does not match the ++:count++
+    # For instance, providing a +:count+ that does not match the +:count+
     # provided in +add+ for an attribute-message pair will result in a +false+
     # return value.
     #

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -289,6 +289,15 @@ module ActiveModel
     #   # => NameIsInvalid: name is invalid
     #
     #   person.errors.messages # => {}
+    #
+    # If the +message+ being added makes use of an interpolated <tt>count</tt>,
+    # a <tt>:count</tt> option must be specified. Failure to do so will
+    # result in an I18n::MissingInterpolationArgument exception.
+    #
+    #   person.errors.add(:name, :too_short)
+    #   # => I18n::MissingInterpolationArgument
+    #   person.errors.add(:name, :too_short, count: 7)
+    #   # => ["is too short (minimum is 7 characters)"]
     def add(attribute, message = :invalid, options = {})
       message = normalize_message(attribute, message, options)
       if exception = options[:strict]
@@ -331,6 +340,17 @@ module ActiveModel
     #
     #   person.errors.add :name, :blank
     #   person.errors.added? :name, :blank # => true
+    #
+    # When used to check for a +message+ that includes an interpolated <tt>count</tt>, it 
+    # requires a <tt>:count</tt> option. This interpolated value is used
+    # in the check for the message's presence. A <tt>:count</tt> that does not
+    # match the <tt>:count</tt> provided in +add+ for an attribute-message pair
+    # will result in a +false+ return value.
+    #
+    #   person.errors.add(:name, :too_long, count: 22)
+    #   person.errors.added?(:name, :too_long) # => I18n::MissingInterpolationArgument
+    #   person.errors.added?(:name, :too_long, count: 33) # => false
+    #   person.errors.added?(:name, :too_long, count: 22) # => true
     def added?(attribute, message = :invalid, options = {})
       message = normalize_message(attribute, message, options)
       self[attribute].include? message

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -132,6 +132,13 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal [message], person.errors[:name]
   end
 
+  test "add an error message that includes an interpolated count" do
+    person = Person.new
+    person.errors.add(:name, :wrong_length, count: 1)
+    message = person.errors.generate_message(:name, :wrong_length, count: 1)
+    assert_equal [message], person.errors[:name]
+  end
+
   test "add an error with a proc" do
     person = Person.new
     message = Proc.new { "cannot be blank" }
@@ -180,6 +187,23 @@ class ErrorsTest < ActiveModel::TestCase
     person = Person.new
     person.errors.add(:name, "is invalid")
     assert !person.errors.added?(:name, "cannot be blank")
+  end
+
+  test "added? returns true when checking for an existing error message that includes an interpolated count" do
+    person = Person.new
+    person.errors.add(:age, :greater_than_or_equal_to, count: 1)
+    assert person.errors.added?(:age, :greater_than_or_equal_to, count: 1)
+  end
+
+  test "added? returns false when checking for a nonexisting error message that includes an interpolated count" do
+    person = Person.new
+    assert !person.errors.added?(:name, :too_short, count: 1)
+  end
+
+  test "added? returns false when checking for an existing error message and providing a non-matching interpolated count" do
+    person = Person.new
+    person.errors.add(:name, :too_long, count: 1)
+    assert !person.errors.added?(:name, :too_long, count: 2)
   end
 
   test "size calculates the number of error messages" do


### PR DESCRIPTION
Document and test :count option in #add and #added? methods. The purpose of this documentation is to make it clear that the #add and #added? methods should be invoked with the :count option for messages that make use of an interpolated count (by default). Failure to do so will result in an I18n::MissingInterpolationArgument exception.
