### PR TITLE
cache_sql is now thread-safe

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -73,10 +73,11 @@ module ActiveRecord
 
       private
         def cache_sql(sql)
+          value_from_cache = @query_cache[sql]
           result =
-            if @query_cache.has_key?(sql)
+            if value_from_cache
               log_info(sql, "CACHE", 0.0)
-              @query_cache[sql]
+              value_from_cache
             else
               @query_cache[sql] = yield
             end


### PR DESCRIPTION
If a thread execute a SELECT query while an UPDATE query is performed in another thread, the `has_key?` returns `true` and then the `@query_cache[sql]` could be nil if the @query_cache is cleared. (This happen with Capybara. See http://blog.zedroot.org/capybara-and-parallel_test-undefined-method-%60collect-for-nilnilclass/).
