### PR TITLE
Revert "Fixed plugin_generator test"

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -185,7 +185,6 @@ task default: :test
       end
 
       public_task :set_default_accessors!
-      public_task :apply_rails_template
       public_task :create_root
 
       def create_root_files
@@ -242,6 +241,7 @@ task default: :test
         build(:leftovers)
       end
 
+      public_task :apply_rails_template, :run_bundle
 
       def name
         @name ||= begin
@@ -254,9 +254,6 @@ task default: :test
           underscored
         end
       end
-
-      public_task :run_bundle
-      public_task :replay_template
 
     protected
 


### PR DESCRIPTION
This reverts commit fefa8ae9a172835fb6b8aef7d1dd46d58eecd49f.

As this commit  22a1a5ac8c4631f29cfeac451c361e8da1dd2261 has reverted all changes so this plugin generator also needs to fix.

This should give a green build.
