### PR TITLE
Fixes issue with process method not visible in integration tests

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `process` at `ActionDispatch::Integration::RequestHelpers::Session` is
+    now public to conform to Ruby's 2.0 and onwards `respond_to?` implementation
+    that only checks for public methods by default. This allows `process` to be
+    called again from integration tests for uncommon methods like `options`.
+
+    *Maurício Linhares*
+
 *   Fix regression in functional tests. Responses should have default headers
     assigned.
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -401,6 +401,11 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       response.headers.delete params[:header]
       head :ok, 'c' => '3'
     end
+
+    def options
+      render :text => 'options are cool'
+    end
+
   end
 
   def test_get
@@ -584,6 +589,13 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_options
+    with_test_route_set do
+      process :options, "/specials/options"
+      assert_equal "options are cool", body
+    end
+  end
+
   def test_generate_url_with_controller
     assert_equal 'http://www.example.com/foo', url_for(:controller => "foo")
   end
@@ -670,7 +682,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
 
         set.draw do
           get 'moved' => redirect('/method')
-
+          match 'specials/:action', :to => controller, :via => :options
           match ':action', :to => controller, :via => [:get, :post], :as => :action
           get 'get/:action', :to => controller, :as => :get_action
         end


### PR DESCRIPTION
Since `process` was private in `ActionDispatch::Integration::RequestHelpers::Session`, when you call `process` inside an integration test it would never call `process` at the current session as Ruby 2.0 and onwards only checks for public methods and `process` being private is always a false result when `method_missing` gets called inside `ActionDispatch::Integration::RequestHelpers::Runner`.

Making it public allows it to be called again inside integration tests and fixes rspec/rspec-rails#925.
