### PR TITLE
Change `enum` to use String values for `:string`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1793,4 +1793,25 @@
 
     *Slava Markevich*
 
+*   `enum` uses Strings for columns of type `:string`
+
+    An enum on a databse column with type `:string` will store the enumerated values as Strings in the databse,
+    rather than as the ordinal of the value as a string.
+
+    create_table examples do |t|
+      t.column :status, :string, default: 'ok'
+    end
+
+    class Example < ActiveRecord::Base
+      enum status: [:ok, :not_ok]
+    end
+
+    example = Example.new
+    example.status = :ok
+    example.save
+    # => <Example id: 1, status: 'ok'>
+
+    *Peter Marsh*
+    
+
 Please check [4-0-stable](https://github.com/rails/rails/blob/4-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -148,6 +148,11 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal 0, Book.statuses[:proposed]
     assert_equal 1, Book.statuses["written"]
     assert_equal 2, Book.statuses[:published]
+    assert_equal :in_print, Book.print_statuses[:in_print]
+    assert_equal :out_of_print, Book.print_statuses['out_of_print']
+    assert_equal 'A+', Book.review_statuses[:good]
+    assert_equal 'D', Book.review_statuses['bad']
+    assert_equal nil, Book.review_statuses[:not_reviewed]
   end
 
   test "building new objects with enum scopes" do
@@ -162,6 +167,21 @@ class EnumTest < ActiveRecord::TestCase
 
   test "_before_type_cast returns the enum label (required for form fields)" do
     assert_equal "proposed", @book.status_before_type_cast
+  end
+
+  test "assigning string values" do
+    @book.update! print_status: :out_of_print
+    assert @book.out_of_print?
+    assert_equal 'out_of_print', @book.print_status
+    @book.update! review_status: :bad
+    assert @book.bad?
+    assert_equal 'bad', @book.review_status
+  end
+
+  test "string value mapped to nil" do
+    @book.update! review_status: :not_reviewed
+    assert @book.not_reviewed?
+    assert_equal 'not_reviewed', @book.review_status
   end
 
   test "reserved enum names" do

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -10,6 +10,8 @@ class Book < ActiveRecord::Base
   enum status: [:proposed, :written, :published]
   enum read_status: {unread: 0, reading: 2, read: 3}
   enum nullable_status: [:single, :married]
+  enum print_status: [:in_print, :out_of_print]
+  enum review_status: {good: 'A+', bad: 'D', not_reviewed: nil}
 
   def published!
     super

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -98,6 +98,8 @@ ActiveRecord::Schema.define do
     t.column :status, :integer, default: 0
     t.column :read_status, :integer, default: 0
     t.column :nullable_status, :integer
+    t.string :print_status, default: 'in_print'
+    t.string :review_status, default: 'good'
   end
 
   create_table :booleans, force: true do |t|


### PR DESCRIPTION
This changes `enum` to use String values when the underlying databse column has the type `:string`.

For example:

```
create_table examples do |t|
  t.column :status, :string, default: 'ok'
end

class Example < ActiveRecord::Base
  enum status: [:ok, :not_ok]
end

example = Example.new
example.status = :ok
example.save
# => <Example id: 1, status: 'ok'>
```

I'm sure there might be a couple of improvements that could be made to this PR, I would be really grateful for your feedback and glad to make some changes.

One thing I couldn't decide upon while working on this is whether `enum` should inspect the type of the underlying database column or if the user should pass a flag when calling `enum`. I opted for the former, as the latter would require redefining the `enum` method to be something like what follows and I wasn't sure what the policy/procedure for making potentially breaking changes is:

```
def enum(attribute_name, values, use_strings = false) 
  ... 
end
```

EDIT: After the initial failed Travis build I limited this change to only `:string` columns.
