### PR TITLE
Fixed problem with through association with STI. #14046

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -57,6 +57,10 @@ module ActiveRecord
           }
         end
 
+        def use_where_reflection_scope?
+          reflection.scope.present? && reflection_scope.where_values.present?
+        end
+
         private
 
         def reset_association(owners, association_name)
@@ -78,7 +82,9 @@ module ActiveRecord
           if options[:source_type]
             scope.where! reflection.foreign_type => options[:source_type]
           else
-            unless reflection_scope.where_values.empty?
+            # This is for cover case with STI on through association. AR should not use where
+            # values if reflection.scope is blank.
+            if use_where_reflection_scope?
               scope.includes_values = Array(reflection_scope.values[:includes] || options[:source])
               scope.where_values    = reflection_scope.values[:where]
             end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -23,12 +23,16 @@ require 'models/membership'
 require 'models/club'
 require 'models/categorization'
 require 'models/sponsor'
+require 'models/member_log'
+require 'models/log'
+require 'models/error_log'
 
 class EagerAssociationTest < ActiveRecord::TestCase
   fixtures :posts, :comments, :authors, :essays, :author_addresses, :categories, :categories_posts,
             :companies, :accounts, :tags, :taggings, :people, :readers, :categorizations,
             :owners, :pets, :author_favorites, :jobs, :references, :subscribers, :subscriptions, :books,
-            :developers, :projects, :developers_projects, :members, :memberships, :clubs, :sponsors
+            :developers, :projects, :developers_projects, :members, :memberships, :clubs, :sponsors,
+            :member_logs, :error_logs
 
   def test_eager_with_has_one_through_join_model_with_conditions_on_the_through
     member = Member.all.merge!(:includes => :favourite_club).find(members(:some_other_guy).id)
@@ -77,6 +81,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_has_many_through_with_order
     authors = Author.includes(:favorite_authors).to_a
     assert_no_queries { authors.map(&:favorite_authors) }
+  end
+
+  def test_eager_with_has_many_through_join_model_with_STI_on_the_through
+    assert Member.all.merge!(:includes => :error_logs).find(members(:groucho).id)
   end
 
   def test_with_two_tables_in_from_without_getting_double_quoted

--- a/activerecord/test/fixtures/error_logs.yml
+++ b/activerecord/test/fixtures/error_logs.yml
@@ -1,0 +1,4 @@
+permission_denied:
+  id: 1
+  name: Permission Denied
+  type: ErrorLog

--- a/activerecord/test/fixtures/member_logs.yml
+++ b/activerecord/test/fixtures/member_logs.yml
@@ -1,0 +1,3 @@
+member_log_of_permission_denied:
+  error_log: permission_denied
+  member_id: 1

--- a/activerecord/test/models/error_log.rb
+++ b/activerecord/test/models/error_log.rb
@@ -1,0 +1,2 @@
+class ErrorLog < Log
+end

--- a/activerecord/test/models/log.rb
+++ b/activerecord/test/models/log.rb
@@ -1,0 +1,2 @@
+class Log < ActiveRecord::Base
+end

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -27,6 +27,9 @@ class Member < ActiveRecord::Base
   has_many :clubs, :through => :current_memberships
 
   has_one :club_through_many, :through => :current_memberships, :source => :club
+
+  has_one :member_logs, :class_name => "MemberLog"
+  has_one :error_logs, :through => :member_logs
 end
 
 class SelfMember < ActiveRecord::Base

--- a/activerecord/test/models/member_log.rb
+++ b/activerecord/test/models/member_log.rb
@@ -1,0 +1,4 @@
+class MemberLog < ActiveRecord::Base
+  belongs_to :member
+  belongs_to :error_log
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -393,6 +393,16 @@ ActiveRecord::Schema.define do
     t.integer :friend_id
   end
 
+  create_table :member_logs, force: true do |t|
+    t.integer :member_id
+    t.integer :error_log_id
+  end
+
+  create_table :logs, force: true do |t|
+    t.string :name
+    t.string :type
+  end
+
   create_table :memberships, force: true do |t|
     t.datetime :joined_on
     t.integer :club_id, :member_id


### PR DESCRIPTION
There were a problem with through association with STI  #14046

The problem was caused by `Foo.unscoped`. If model `Foo` was create via STI `Foo.unscoped.valuse[:where]` returns where condition to handle the STI logic.

But on through association on the first place we don't want to put this were clause to join table. I simply added check for `reflection.scope`. And if it is blank than simply skip this.
