### PR TITLE
ActiveSupport Message verifier now given an option to user to chooseto generate  url safe data

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*  Add new options for ActiveSupport::MessageVerifier to generate url safe data
+   
+   If user wants url safe data then  it will encode using urlsafe_encode64 and decode using urlsafe_decoe64.
+
+   Before:
+       data = ::Base64.strict_encode64(Marshal.dump(90366))
+        => "BAhpA/5gAQ=="
+   
+   After
+       data = ::Base64.strict_encode64(Marshal.dump(90366),  url_safe: true)
+        => "BAhpA_5gAQ==" 
+
+    *Rajarshi Das* 
+
 *   Fix the implementation of Multibyte::Unicode.tidy_bytes for JRuby
 
     The existing implementation caused JRuby to raise the error:

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -74,6 +74,12 @@ class MessageVerifierTest < ActiveSupport::TestCase
       @verifier.verify(message)
     end
   end
+
+  def test_url_safe
+    verifier = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!", :url_safe => true)  
+    message = verifier.generate(Marshal.dump(90366))
+    assert_not message.include?("/")
+  end  
 end
 
 end


### PR DESCRIPTION
https://github.com/rails/rails/issues/14070

Fix this issue
We're using `ActiveSupport::MessageVerifier` to generate an auto-unsubscribe link. Something that we found awkward is that some tokens contains slash ('/') , this cause that unsubscribe route needs a globbing to work.

```
  u.unsubscription_token
  => "BAhpA/5gAQ==--ebb79a495452ba2bdc0335d45b921c238a19eccc"

   # http://.../unsubscribe/BAhpA/5gAQ==--ebb79a495452ba2bdc0335d45b921c238a19eccc

   # routes.rb
   get '/newsletter/unsubscribe/*signature' => 'newsletters#unsubscribe'
```

the slash is generated in message_verifier.rb#L47

```
    data = ::Base64.strict_encode64(Marshal.dump(90366))
      => "BAhpA/5gAQ=="
```

_now after fixing_

```
        data = ::Base64.strict_encode64(Marshal.dump(90366), url_safe: true)
      => ""BAhpA_5gAQ==""
```

so we are wondering shouldn't `ActiveSupport::MessageVerifier.new(secret_token).generate(user.id)` generate a token without slash? is ok if we add something to filter slash symbol in message_verifier.rb#L47 ???

cc @rafaelfranca  @NZKoz 
