### PR TITLE
Uncomment description for db:test:prepare so rake -T will list it.

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -351,7 +351,7 @@ db_namespace = namespace :db do
       ActiveRecord::Tasks::DatabaseTasks.purge ActiveRecord::Base.configurations['test']
     end
 
-    # desc 'Check for pending migrations and load the test schema'
+    desc 'Check for pending migrations and load the test schema'
     task :prepare => %w(db:test:deprecated environment load_config) do
       unless ActiveRecord::Base.configurations.blank?
         db_namespace['test:load'].invoke


### PR DESCRIPTION
Uncomment description for db:test:prepare so rake -T will list it.  Many newcomers (and not so newcomers) are confused why their tests don't work without it.
