### PR TITLE
Replace nil checks in Quoting with a NullColumn.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -6,13 +6,13 @@ module ActiveRecord
       # Quotes the column value to help prevent
       # {SQL injection attacks}[http://en.wikipedia.org/wiki/SQL_injection].
       def quote(value, column = nil)
+        column ||= NullColumn.new
         # records are quoted as their primary key
         return value.quoted_id if value.respond_to?(:quoted_id)
 
         case value
         when String, ActiveSupport::Multibyte::Chars
           value = value.to_s
-          return "'#{quote_string(value)}'" unless column
 
           case column.type
           when :integer then value.to_i.to_s

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -12,6 +12,7 @@ module ActiveRecord
     extend ActiveSupport::Autoload
 
     autoload :Column
+    autoload :NullColumn
     autoload :ConnectionSpecification
 
     autoload_at 'active_record/connection_adapters/abstract/schema_definitions' do

--- a/activerecord/lib/active_record/connection_adapters/null_column.rb
+++ b/activerecord/lib/active_record/connection_adapters/null_column.rb
@@ -1,0 +1,26 @@
+module ActiveRecord
+  module ConnectionAdapters # :nodoc:
+    # NullColumn is an implementation of the NullObject pattern that
+    # allows the quoting modules in the ConnectionAdapters to avoid
+    # checking whether a column was passed in or not. It implements
+    # just enough functionality to allow the default behavior of
+    # quoting to occur.
+    class NullColumn # :nodoc:
+      def type
+        :null
+      end
+
+      def limit
+        nil
+      end
+
+      def precision
+        nil
+      end
+
+      def scale
+        nil
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -16,8 +16,7 @@ module ActiveRecord
 
         # Quotes PostgreSQL-specific data types for SQL input.
         def quote(value, column = nil) #:nodoc:
-          return super unless column
-
+          column ||= ActiveRecord::ConnectionAdapters::NullColumn.new
           sql_type = type_to_sql(column.type, column.limit, column.precision, column.scale)
 
           case value

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -226,7 +226,8 @@ module ActiveRecord
       # QUOTING ==================================================
 
       def quote(value, column = nil)
-        if value.kind_of?(String) && column && column.type == :binary
+        column ||= ActiveRecord::ConnectionAdapters::NullColumn.new
+        if value.kind_of?(String) && column.type == :binary
           s = value.unpack("H*")[0]
           "x'#{s}'"
         else


### PR DESCRIPTION
This commit takes the nil check in the Connection adapters and replaces it with an
implementation of the NullObject pattern to avoid uncessary code branching. I would
have preferred to inject the NullColumn object directly, instead of using a nilguard,
but was unable to locate the code that passes a nil argument into the quote method.

Even without that injection, this eliminates three code branches that weren't necessary.
