### PR TITLE
Upgrade Doc: assets:precompile:all was removed on 4

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -567,7 +567,7 @@ Active Record Observer and Action Controller Sweeper have been extracted to the 
 
 ### sprockets-rails
 
-* `assets:precompile:primary` has been removed. Use `assets:precompile` instead.
+* `assets:precompile:primary` and `assets:precompile:all` has been removed. Use `assets:precompile` instead.
 * The `config.assets.compress` option should be changed to
 `config.assets.js_compressor` like so for instance:
 


### PR DESCRIPTION
This is pretty small, but worth mentioning.

rails 4: https://github.com/rails/sprockets-rails/blob/a1b1e5ef632d9aeeaad71351956b1493e48a8643/lib/sprockets/rails/task.rb#L48

rails 3: https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/sprockets/assets.rake#L59

review @rafaelfranca @guilleiguaran
