### PR TITLE
Typo fix for unscope [ci skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -46,7 +46,7 @@
 
         class User < ActiveRecord::Base
           default_scope { where state: 'pending' }
-          scope :active, -> { unescope(where: :state).where(state: 'active') }
+          scope :active, -> { unscope(where: :state).where(state: 'active') }
           scope :inactive, -> { rewhere state: 'inactive' }
         end
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -315,7 +315,7 @@ To get the previous behavior it is needed to explicitly remove the
 ```ruby
 class User < ActiveRecord::Base
   default_scope { where state: 'pending' }
-  scope :active, -> { unescope(where: :state).where(state: 'active') }
+  scope :active, -> { unscope(where: :state).where(state: 'active') }
   scope :inactive, -> { rewhere state: 'inactive' }
 end
 


### PR DESCRIPTION
Typo fix for `unscope`
