### PR TITLE
Close the meta tag with '/>' instead of '>'

### DIFF
--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
 
 <title><%= yield(:page_title) || 'Ruby on Rails Guides' %></title>
 <link rel="stylesheet" type="text/css" href="stylesheets/style.css" />


### PR DESCRIPTION
This change fixes the 42 instances of `end tag for "meta" omitted, but OMITTAG NO was specified` error message that comes up [when the full railsguides are validated](https://gist.github.com/prakashmurthy/9086679).
