### PR TITLE
Change config/secrets.yml template to unset `SECRET_KEY_BASE` after reading it

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/secrets.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/secrets.yml
@@ -19,4 +19,4 @@ test:
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
-  secret_key_base: <%%= ENV["SECRET_KEY_BASE"] %>
+  secret_key_base: <%%= ENV.delete("SECRET_KEY_BASE") %>


### PR DESCRIPTION
This is to prevent the secret from being inherited by spawned child processes, which might potentially leak it.
