### PR TITLE
Fix `render_to_string` when called via manually instantiated controllers

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -106,7 +106,9 @@ module AbstractController
     def _normalize_render(*args, &block)
       options = _normalize_args(*args, &block)
       #TODO: remove defined? when we restore AP <=> AV dependency
-      options[:variant] = request.variant if defined?(request) && request.variant.present?
+      if defined?(request) && request && request.variant.present?
+        options[:variant] = request.variant
+      end
       _normalize_options(options)
       options
     end


### PR DESCRIPTION
A fix for #14125

This allows for `render_to_string` to be called from manually instantiated controllers. This used to work in older rails versions but is broken in 4.1.rc1.
