### PR TITLE
Fix for external generators extend Erb::Generators

### DIFF
--- a/railties/lib/rails/generators/erb.rb
+++ b/railties/lib/rails/generators/erb.rb
@@ -17,8 +17,8 @@ module Erb # :nodoc:
         :erb
       end
 
-      def filename_with_extensions(name, format_override=self.format)
-        [name, format_override, handler].compact.join(".")
+      def filename_with_extensions(name, format = self.format)
+        [name, format, handler].compact.join(".")
       end
     end
   end

--- a/railties/lib/rails/generators/erb.rb
+++ b/railties/lib/rails/generators/erb.rb
@@ -17,8 +17,8 @@ module Erb # :nodoc:
         :erb
       end
 
-      def filename_with_extensions(name, format)
-        [name, format, handler].compact.join(".")
+      def filename_with_extensions(name, format_override=nil)
+        [name, format_override || self.format, handler].compact.join(".")
       end
     end
   end

--- a/railties/lib/rails/generators/erb.rb
+++ b/railties/lib/rails/generators/erb.rb
@@ -17,8 +17,8 @@ module Erb # :nodoc:
         :erb
       end
 
-      def filename_with_extensions(name, format_override=nil)
-        [name, format_override || self.format, handler].compact.join(".")
+      def filename_with_extensions(name, format_override=self.format)
+        [name, format_override, handler].compact.join(".")
       end
     end
   end

--- a/railties/lib/rails/generators/erb.rb
+++ b/railties/lib/rails/generators/erb.rb
@@ -17,7 +17,7 @@ module Erb # :nodoc:
         :erb
       end
 
-      def filename_with_extensions(name, format = self.format)
+      def filename_with_extensions(name, format=self.format)
         [name, format, handler].compact.join(".")
       end
     end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -350,4 +350,8 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert_match(/password_digest: <%= BCrypt::Password.create\('secret'\) %>/, content)
     end
   end
+
+  def test_generator_filename_with_extensions_default
+    assert_equal Erb::Generators::Base.new.filename_with_extensions("show"), "show.html.erb"
+  end
 end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -350,8 +350,4 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert_match(/password_digest: <%= BCrypt::Password.create\('secret'\) %>/, content)
     end
   end
-
-  def test_generator_filename_with_extensions_default
-    assert_equal Erb::Generators::Base.new.filename_with_extensions("show"), "show.html.erb"
-  end
 end


### PR DESCRIPTION
HAML and probably other generators extend this class and invoke filename_with_extensions with the old signature (without format). This makes the second argument optional and defaults it to the #format method which could be overridden as well.
