### PR TITLE
Some Validation::HelperMethods no longer callable on model instance in 4.1.rc1

### DIFF
--- a/activemodel/lib/active_model/validations/with.rb
+++ b/activemodel/lib/active_model/validations/with.rb
@@ -139,6 +139,8 @@ module ActiveModel
     # class version of this method for more information.
     def validates_with(*args, &block)
       options = args.extract_options!
+      options[:class] = self.class
+
       args.each do |klass|
         validator = klass.new(options, &block)
         validator.validate(self)

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -284,10 +284,11 @@ class ValidationsTest < ActiveModel::TestCase
     auto = Automobile.new
 
     assert          auto.invalid?
-    assert_equal 2, auto.errors.size
+    assert_equal 3, auto.errors.size
 
     auto.make  = 'Toyota'
     auto.model = 'Corolla'
+    auto.approved = '1'
 
     assert auto.valid?
   end

--- a/activemodel/test/models/automobile.rb
+++ b/activemodel/test/models/automobile.rb
@@ -3,10 +3,11 @@ class Automobile
 
   validate :validations
 
-  attr_accessor :make, :model
+  attr_accessor :make, :model, :approved
 
   def validations
     validates_presence_of :make
     validates_length_of   :model, within: 2..10
+    validates_acceptance_of :approved, allow_nil: false
   end
 end


### PR DESCRIPTION
`validates_acceptance_of` helper method no longer working when called on model instance due to validator setup method being called from initializer. Failing test case attached.

After some digging, the code in commit https://github.com/rails/rails/commit/7d84c3a2f7ede0e8d04540e9c0640de7378e9b3a now calls the validator setup for both class level and instance level validates_with methods. Previously, the setup method was only called when using class level validators as described in these comments for `ActiveModel::Validator`:

```
# This setup method is only called when used with validation macros or the
# class level <tt>validates_with</tt> method.
```

In the example of `validates_acceptance_of`, the setup method relies on a class method `attribute_method?` which fails when called in the context of the instance level validator.

sorry @apotonick, I made the previous pull request against the wrong branch and had to close and open new issue. Let me know if this makes sense or if I'm missing something.
