### PR TITLE
Add controller and action name to the fragment caching instrumentation payload

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Instrument fragment cache metrics.
+
+    Adds `:controller`: and `:action` keys to the instrumentation payload
+    for the `*_fragment.action_controller` notifications. This allows tracking
+    e.g. the fragment cache hit rates for each controller action.
+
+    *Daniel Schierbeck*
+
 *   Properly treat the entire IPv6 User Local Address space as private for
     purposes of remote IP detection. Also handle uppercase private IPv6
     addresses.

--- a/actionpack/lib/action_controller/caching/fragments.rb
+++ b/actionpack/lib/action_controller/caching/fragments.rb
@@ -90,7 +90,13 @@ module ActionController
       end
 
       def instrument_fragment_cache(name, key) # :nodoc:
-        ActiveSupport::Notifications.instrument("#{name}.action_controller", :key => key){ yield }
+        payload = {
+          :controller => controller_name,
+          :action => action_name,
+          :key => key
+        }
+
+        ActiveSupport::Notifications.instrument("#{name}.action_controller", payload){ yield }
       end
     end
   end

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -227,6 +227,22 @@ CACHED
       @store.read("views/test.host/functional_caching/inline_fragment_cached/#{template_digest("functional_caching/inline_fragment_cached")}"))
   end
 
+  def test_fragment_cache_instrumentation
+    payload = nil
+
+    subscriber = proc do |*args|
+      event = ActiveSupport::Notifications::Event.new(*args)
+      payload = event.payload
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, "read_fragment.action_controller") do
+      get :inline_fragment_cached
+    end
+
+    assert_equal "functional_caching", payload[:controller]
+    assert_equal "inline_fragment_cached", payload[:action]
+  end
+
   def test_html_formatted_fragment_caching
     get :formatted_fragment_cached, :format => "html"
     assert_response :success


### PR DESCRIPTION
This allows tracking the cache activity and performance separately for each controller action. For instance, it would be possible to calculate the cache hit rate for a specific action on a specific controller.

I'd like to add the virtual path of the template to the payload, but it doesn't appear to be accessible from within the module – and I'd rather not pass it explicitly from Action View. If you have any ideas, it would be much appreciated.
