### PR TITLE
Prevent foreign_key_for? from evaluating all attributes

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -232,7 +232,7 @@ module ActiveRecord
 
         # Returns true if record contains the foreign_key
         def foreign_key_for?(record)
-          record.attributes.has_key? reflection.foreign_key
+          record.has_attribute?(reflection.foreign_key)
         end
 
         # This should be implemented to return the values of the relevant key(s) on the owner,


### PR DESCRIPTION
Attributes should be evaluated lazily if possible (this prevents slow type-casting of date/time/timestamp columns when they are not used). `attributes.has_key?` caused all attributes to be evaluated just to set inverse association record instance.
