### PR TITLE
Fix underscore inflector handling of namespaced and adjacent acronyms

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -91,7 +91,7 @@ module ActiveSupport
     def underscore(camel_cased_word)
       return camel_cased_word unless camel_cased_word =~ /[A-Z-]|::/
       word = camel_cased_word.to_s.gsub('::', '/')
-      word.gsub!(/(?:([A-Za-z\d])|\b)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1}#{$1 && '_'}#{$2.downcase}" }
+      word.gsub!(/(?<=[A-Za-z\d\/]|^)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{'_' unless $`.empty? or $`[-1] == '/'}#{$1.downcase}" }
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
       word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
       word.tr!("-", "_")

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -125,6 +125,9 @@ class InflectorTest < ActiveSupport::TestCase
       ["PhDRequired",       "phd_required",       "PhD required",       "PhD Required"],
       ["IRoRU",             "i_ror_u",            "I RoR u",            "I RoR U"],
       ["RESTfulHTTPAPI",    "restful_http_api",   "RESTful HTTP API",   "RESTful HTTP API"],
+      ["HTTP::RESTful",     "http/restful",       "HTTP/RESTful",       "HTTP/RESTful"],
+      ["HTTP::RESTfulAPI",  "http/restful_api",   "HTTP/RESTful API",   "HTTP/RESTful API"],
+      ["APIRESTful",        "api_restful",        "API RESTful",        "API RESTful"],
 
       # misdirection
       ["Capistrano",        "capistrano",         "Capistrano",       "Capistrano"],


### PR DESCRIPTION
The underscore inflector regular expression was not working correctly
for namespaced acronyms that were not entirely uppercased
(e.g. HTTP::RESTful) or adjacent acronyms (e.g. APIRESTful).

I suspect that positive lookbehind would have been used in the
original implementation had it been available in supported Ruby
versions at the time. Now that Rails requires Ruby 1.9.2 or above,
this is no longer an issue.

Thanks to Pawel Kozlowski (khozlov) for highlighting the namespace
issue in #8571.
