### PR TITLE
Do not rely on Hash#each_value as it blocks Hash[]= 

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -54,11 +54,11 @@ module ActiveRecord
     # your database connection configuration:
     #
     # * +pool+: number indicating size of connection pool (default 5)
-    # * +checkout _timeout+: number of seconds to block and wait for a 
-    #   connection before giving up and raising a timeout error 
+    # * +checkout _timeout+: number of seconds to block and wait for a
+    #   connection before giving up and raising a timeout error
     #   (default 5 seconds). ('wait_timeout' supported for backwards
     #   compatibility, but conflicts with key used for different purpose
-    #   by mysql2 adapter). 
+    #   by mysql2 adapter).
     class ConnectionPool
       include MonitorMixin
 
@@ -80,9 +80,9 @@ module ActiveRecord
         @reserved_connections = {}
 
         @queue = new_cond
-        # 'wait_timeout', the backward-compatible key, conflicts with spec key 
+        # 'wait_timeout', the backward-compatible key, conflicts with spec key
         # used by mysql2 for something entirely different, checkout_timeout
-        # preferred to avoid conflict and allow independent values. 
+        # preferred to avoid conflict and allow independent values.
         @timeout = spec.config[:checkout_timeout] || spec.config[:wait_timeout] || 5
 
         # default max pool size to 5
@@ -261,7 +261,7 @@ connection.  For example: ActiveRecord::Base.connection.close
             # Sometimes our wait can end because a connection is available,
             # but another thread can snatch it up first. If timeout hasn't
             # passed but no connection is avail, looks like that happened --
-            # loop and wait again, for the time remaining on our timeout. 
+            # loop and wait again, for the time remaining on our timeout.
             before_wait = Time.now
             @queue.wait( [@timeout - waited_time, 0].max )
             waited_time += (Time.now - before_wait)
@@ -269,7 +269,7 @@ connection.  For example: ActiveRecord::Base.connection.close
             # Will go away in Rails 4, when we don't clean up
             # after leaked connections automatically anymore. Right now, clean
             # up after we've returned from a 'wait' if it looks like it's
-            # needed, then loop and try again. 
+            # needed, then loop and try again.
             if(active_connections.size >= @connections.size)
               clear_stale_cached_connections!
             end
@@ -384,21 +384,21 @@ connection.  For example: ActiveRecord::Base.connection.close
 
       # Returns any connections in use by the current thread back to the pool.
       def clear_active_connections!
-        @connection_pools.each_value {|pool| pool.release_connection }
+        @connection_pools.values.each {|pool| pool.release_connection }
       end
 
       # Clears the cache which maps classes.
       def clear_reloadable_connections!
-        @connection_pools.each_value {|pool| pool.clear_reloadable_connections! }
+        @connection_pools.values.each {|pool| pool.clear_reloadable_connections! }
       end
 
       def clear_all_connections!
-        @connection_pools.each_value {|pool| pool.disconnect! }
+        @connection_pools.values.each {|pool| pool.disconnect! }
       end
 
       # Verify active connections.
       def verify_active_connections! #:nodoc:
-        @connection_pools.each_value {|pool| pool.verify_active_connections! }
+        @connection_pools.values.each {|pool| pool.verify_active_connections! }
       end
 
       # Locate the connection of the nearest super class. This can be an


### PR DESCRIPTION
... and causes exceptions in threaded environments.

Attempt to fix #10695 based on how Rails 4 handles it now: https://github.com/rails/rails/blob/4-0-stable/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L501

In my case the problem is between these two methods competing for `@connection_pools`

``` ruby
def establish_connection(name, spec)
  @connection_pools[spec] ||= ConnectionAdapters::ConnectionPool.new(spec)
  @class_to_pool[name] = @connection_pools[spec]
end

def clear_active_connections!
  @connection_pools.values.each {|pool| pool.release_connection }
end
```

Would love some guidance on how to write a proper test for this. I haven't been able to reproduce outside a high concurrent threaded environment. Standalone script here: https://github.com/mhfs/sidekiq-dbcharmer-ar-bug

Tests pass as is.

Involved people:
@mperham @dashbitla @steveklabnik @thedarkone @kovyrin

How I got to the issue:
https://github.com/kovyrin/db-charmer/issues/90
https://github.com/rails/rails/issues/10695

Error and backtrace:

```
RuntimeError: can't add a new key into hash during iteration
/vendor/ruby/2.0.0/gems/activerecord-3.2.17/lib/active_record/connection_adapters/abstract/connection_pool.rb:375 in "[]="
/vendor/ruby/2.0.0/gems/activerecord-3.2.17/lib/active_record/connection_adapters/abstract/connection_pool.rb:375 in "establish_connection"
/vendor/ruby/2.0.0/gems/activerecord-3.2.17/lib/active_record/connection_adapters/abstract/connection_specification.rb:137 in "establish_connection"
/vendor/ruby/2.0.0/gems/db-charmer-1.9.0/lib/db_charmer/active_record/connection_switching.rb:25 in "establish_real_connection_if_exists"
/vendor/ruby/2.0.0/gems/db-charmer-1.9.0/lib/db_charmer/connection_factory.rb:51 in "generate_abstract_class"
/vendor/ruby/2.0.0/gems/db-charmer-1.9.0/lib/db_charmer/connection_factory.rb:35 in "establish_connection"
/vendor/ruby/2.0.0/gems/db-charmer-1.9.0/lib/db_charmer/connection_factory.rb:24 in "connect"
/vendor/ruby/2.0.0/gems/db-charmer-1.9.0/lib/db_charmer/active_record/connection_switching.rb:66 in "coerce_to_connection_proxy"
/vendor/ruby/2.0.0/gems/db-charmer-1.9.0/lib/db_charmer/active_record/connection_switching.rb:82 in "switch_connection_to"
/vendor/ruby/2.0.0/gems/db-charmer-1.9.0/lib/db_charmer/active_record/multi_db_proxy.rb:39 in "on_db"
/vendor/ruby/2.0.0/gems/db-charmer-1.9.0/lib/db_charmer/active_record/multi_db_proxy.rb:19 in "method_missing"
/app/jobs/backfill_stats_job.rb:7 in "perform"
```
