### PR TITLE
Handle missing environment from non empty config

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -93,16 +93,12 @@ module ActiveRecord
         # the connection URL. This hash responds to any string key with
         # resolved connection information.
         def default_url_hash
-          if @raw_config.blank?
-            Hash.new do |hash, key|
-              hash[key] = if key.is_a? String
-                 ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(@url).to_hash
-              else
-                nil
-              end
+          Hash.new do |hash, key|
+            hash[key] = if key.is_a? String
+               ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(@url).to_hash
+            else
+              nil
             end
-          else
-            {}
           end
         end
     end

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -17,6 +17,14 @@ module ActiveRecord
         ENV["DATABASE_URL"] = @previous_database_url
       end
 
+      def test_environment_does_not_exist_in_config_url_does_exist
+        ENV['DATABASE_URL'] = "postgres://localhost/foo"
+        config      = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
+        actual      = klass.new(config).resolve
+        expect_prod = { "adapter"=>"postgresql", "database"=>"foo", "host"=>"localhost" }
+        assert_equal expect_prod, actual["production"]
+      end
+
       def test_string_connection
         config   = { "production" => "postgres://localhost/foo" }
         actual   = klass.new(config).resolve
@@ -67,21 +75,6 @@ module ActiveRecord
         assert_equal nil,      actual[:production]
         assert_equal nil,      actual[:development]
         assert_equal nil,      actual[:test]
-      end
-
-      def test_sting_with_database_url
-        ENV['DATABASE_URL'] = "NOT-POSTGRES://localhost/NOT_FOO"
-
-        config   = { "production" => "postgres://localhost/foo" }
-        actual   = klass.new(config).resolve
-
-        expected = { "production" =>
-                     { "adapter"  => "postgresql",
-                       "database" => "foo",
-                       "host"     => "localhost"
-                      }
-                    }
-        assert_equal expected, actual
       end
 
       def test_url_sub_key_with_database_url


### PR DESCRIPTION
If using a `DATABASE_URL` and a `database.yml`. The connection information in `DATABASE_URL` should be merged into whatever environment we are in. As released in 4.1.0rc1 if someone has a database.yml but is missing a key like production:

``` yml
development:
  host: localhost

# production
```

Then the check for blank config will return false so the information from the `DATABASE_URL` will not be used when attempting to connect to the `production` database and the connection will incorrectly fail.

This commit fixes this problem and adds a test for the behavior.

In addition the ability to specify a connection url in a `database.yml` like this:

```
production: postgres://localhost/foo
```

Was introduced in 4.1.0rc1 though should not be used, instead using a url sub key

```
production:
  url: postgres://localhost/foo
```

This url sub key was also introduced in 4.1.0rc1 though the `production: postgres://localhost/foo` was not removed. As a result we should not test this behavior.
