### PR TITLE
ActiveSupport#Cache :race_condition_ttl option handling not optimal

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -641,7 +641,7 @@ module ActiveSupport
       end
         
       def time_since_expired
-        Time.now.to_f - expires_at
+        Time.now.to_f - expires_at if expired?
       end
 
       # Returns the size of the cached value. This could be less than

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -563,8 +563,8 @@ module ActiveSupport
 
         def handle_expired_entry(entry, key, options)
           if entry && entry.expired?
-            race_ttl = options[:race_condition_ttl].try(:to_i)
-            if race_ttl && (Time.now.to_f - entry.expires_at <= race_ttl)
+            race_ttl = options[:race_condition_ttl].to_i
+            if race_ttl > 0 && entry.time_since_expired <= race_ttl
               # When an entry has :race_condition_ttl defined, put the stale entry back into the cache
               # for a brief period while the entry is begin recalculated.
               entry.expires_at = Time.now + race_ttl
@@ -638,6 +638,10 @@ module ActiveSupport
         else
           @expires_in = nil
         end
+      end
+        
+      def time_since_expired
+        Time.now.to_f - expires_at
       end
 
       # Returns the size of the cached value. This could be less than

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -563,7 +563,7 @@ module ActiveSupport
 
         def handle_expired_entry(entry, key, options)
           if entry && entry.expired?
-            race_ttl = options[:race_condition_ttl].to_i
+            race_ttl = options[:race_condition_ttl].try(:to_i)
             if race_ttl && (Time.now.to_f - entry.expires_at <= race_ttl)
               # When an entry has :race_condition_ttl defined, put the stale entry back into the cache
               # for a brief period while the entry is begin recalculated.

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -409,7 +409,7 @@ module CacheStoreBehavior
     end
     assert_equal "baz", result
   end
-
+  
   def test_race_condition_protection_is_limited
     time = Time.now
     @cache.write('foo', 'bar', :expires_in => 60)
@@ -420,7 +420,7 @@ module CacheStoreBehavior
     end
     assert_equal "baz", result
   end
-
+  
   def test_race_condition_protection_is_safe
     time = Time.now
     @cache.write('foo', 'bar', :expires_in => 60)
@@ -435,6 +435,17 @@ module CacheStoreBehavior
     assert_equal "bar", @cache.read('foo')
     Time.stubs(:now).returns(time + 91)
     assert_nil @cache.read('foo')
+  end
+
+  def test_race_condition_protection_is_truly_disarmed_for_nil
+    time = Time.now
+    Time.stubs(:now).returns(time)
+    @cache.write('foo', 'bar', :expires_in => 60)
+    @cache.expects(:delete_entry)
+    Time.stubs(:now).returns(time + 60)
+    @cache.fetch('foo', :race_condition_ttl => nil) do 
+      'baz'
+    end
   end
 
   def test_crazy_key_characters
@@ -1027,6 +1038,17 @@ class CacheEntryTest < ActiveSupport::TestCase
     time = Time.now + 61
     Time.stubs(:now).returns(time)
     assert entry.expired?, 'entry is expired'
+  end
+
+  def test_time_since_expired
+    time = Time.now
+    Time.stubs(:now).returns(time)
+    entry = ActiveSupport::Cache::Entry.new("value", :expires_in => 60)
+    assert_equal nil, entry.time_since_expired
+    Time.stubs(:now).returns(time + 60)
+    assert_equal 0.0, entry.time_since_expired
+    Time.stubs(:now).returns(time + 61)
+    assert_equal 1.0, entry.time_since_expired
   end
 
   def test_compress_values


### PR DESCRIPTION
nil.to_i ==> 0, e.g. second condition is always evaluated here...
