### PR TITLE
Attaching a file with quotes in the name doesn't work

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -100,6 +100,13 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal('This is test File content', email.attachments['invoice.pdf'].decoded)
   end
 
+  test "attachment with content and a filename with quotes" do
+    email = BaseMailer.attachment_with_quotes_in_filename
+    assert_equal(1, email.attachments.length)
+    assert_equal('invoice "for you".pdf', email.attachments[0].filename)
+    assert_equal('This is test File content', email.attachments['invoice "for you".pdf'].decoded)
+  end
+
   test "attachment gets content type from filename" do
     email = BaseMailer.attachment_with_content
     assert_equal('invoice.pdf', email.attachments[0].filename)

--- a/actionmailer/test/fixtures/base_mailer/attachment_with_quotes_in_filename.erb
+++ b/actionmailer/test/fixtures/base_mailer/attachment_with_quotes_in_filename.erb
@@ -1,0 +1,1 @@
+Attachment with quotes in its filename

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -37,6 +37,11 @@ class BaseMailer < ActionMailer::Base
     mail(hash)
   end
 
+  def attachment_with_quotes_in_filename(hash = {})
+    attachments['invoice "for you".pdf'] = 'This is test File content'
+    mail(hash)
+  end
+
   def attachment_with_hash
     attachments['invoice.jpg'] = { data: ::Base64.encode64("\312\213\254\232)b"),
                                    mime_type: "image/x-jpg",


### PR DESCRIPTION
Here's a failing spec that demonstrates this case.

Expected behavior: Either the file is attached with the quotes properly escaped in the Content-Disposition, or an exception is thrown.
Actual behavior: The attachment is not added to the attachments list.

I'm not sure how best to fix this, but this test case should at least isolate the problem.

Thanks!
