### PR TITLE
'Where' (.not) with polymorphic association in AR::Relation bug fix

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -2,8 +2,11 @@ module ActiveRecord
   class PredicateBuilder # :nodoc:
     @handlers = []
 
+    PolymorphicAssociation = Struct.new(:reflection, :base_class, :table, :value)
+
     autoload :RelationHandler, 'active_record/relation/predicate_builder/relation_handler'
     autoload :ArrayHandler, 'active_record/relation/predicate_builder/array_handler'
+    autoload :PolymorphicHandler, 'active_record/relation/predicate_builder/polymorphic_handler'
 
     def self.resolve_column_aliases(klass, hash)
       hash = hash.dup
@@ -57,9 +60,9 @@ module ActiveRecord
       # PriceEstimate.where(estimate_of: treasure)
       if klass && reflection = klass.reflect_on_association(column.to_sym)
         if reflection.polymorphic? && base_class = polymorphic_base_class_from_value(value)
-          queries << build(table[reflection.foreign_type], base_class)
+          value = PolymorphicAssociation.new(reflection, base_class, table, value)
         end
-
+        
         column = reflection.foreign_key
       end
 
@@ -112,6 +115,7 @@ module ActiveRecord
     register_handler(Range, ->(attribute, value) { attribute.in(value) })
     register_handler(Relation, RelationHandler.new)
     register_handler(Array, ArrayHandler.new)
+    register_handler(PolymorphicAssociation, PolymorphicHandler.new)
 
     private
       def self.build(attribute, value)

--- a/activerecord/lib/active_record/relation/predicate_builder/polymorphic_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/polymorphic_handler.rb
@@ -1,0 +1,21 @@
+module ActiveRecord
+  class PredicateBuilder
+    class PolymorphicHandler # :nodoc:
+      def call(attribute, values)
+        reflection, base_class, table, value = values.to_a
+
+        type_predictate = table[reflection.foreign_type].eq(base_class.name)
+        key_predictate  = case value
+        when Array
+          attribute.in value.map(&:id)
+        when Base
+          attribute.eq value.id
+        when Relation
+          RelationHandler.new.call(attribute, value)
+        end
+
+        type_predictate.and(key_predictate)
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -120,9 +120,11 @@ unless ENV['FIXTURE_DEBUG']
 end
 
 require "cases/validations_repair_helper"
+require "cases/where_polymorphic_expectations_helper"
 class ActiveSupport::TestCase
   include ActiveRecord::TestFixtures
   include ActiveRecord::ValidationsRepairHelper
+  include ActiveRecord::WherePolymorphicExpectationsHelper
 
   self.fixture_path = FIXTURES_ROOT
   self.use_instantiated_fixtures  = false

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -1,6 +1,8 @@
 require 'cases/helper'
 require 'models/post'
 require 'models/comment'
+require 'models/price_estimate'
+require 'models/treasure'
 
 module ActiveRecord
   class WhereChainTest < ActiveRecord::TestCase
@@ -39,6 +41,19 @@ module ActiveRecord
       expected = Arel::Nodes::NotEqual.new(Comment.arel_table[@name], 'hello')
       relation = Post.joins(:comments).where.not(comments: {title: 'hello'})
       assert_equal(expected.to_sql, relation.where_values.first.to_sql)
+    end
+
+    def test_polymorphic_nested_relation_not_eq
+      treasure = Treasure.new(id: 1)
+      table    = PriceEstimate.arel_table
+      relation = PriceEstimate.where.not(estimate_of: treasure)
+
+      expected = Arel::Nodes::Not.new(
+        Arel::Nodes::Equality.new(table[:estimate_of_type], 'Treasure').and(
+        Arel::Nodes::Equality.new(table[:estimate_of_id], 1))
+      ).to_sql      
+
+      assert_equal(expected, relation.where_values.first.to_sql)
     end
 
     def test_not_eq_with_preceding_where

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -67,26 +67,26 @@ module ActiveRecord
       expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: 1)
       actual   = PriceEstimate.where(estimate_of: treasure)
 
-      assert_equal expected.to_sql, actual.to_sql
+      assert_equal wrap_polymorphic(expected.to_sql), actual.to_sql
     end
 
     def test_polymorphic_nested_array_where
-      treasure = Treasure.new
+      treasure = Treasure.new id: 1
       treasure.id = 1
-      hidden = HiddenTreasure.new
+      hidden = HiddenTreasure.new id: 2
       hidden.id = 2
 
       expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: [treasure, hidden])
       actual   = PriceEstimate.where(estimate_of: [treasure, hidden])
 
-      assert_equal expected.to_sql, actual.to_sql
+      assert_equal wrap_polymorphic(expected.to_sql), actual.to_sql
     end
 
     def test_polymorphic_nested_relation_where
       expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: Treasure.where(id: [1,2]))
       actual   = PriceEstimate.where(estimate_of: Treasure.where(id: [1,2]))
 
-      assert_equal expected.to_sql, actual.to_sql
+      assert_equal wrap_polymorphic(expected.to_sql), actual.to_sql
     end
 
     def test_polymorphic_sti_shallow_where
@@ -96,7 +96,7 @@ module ActiveRecord
       expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: 1)
       actual   = PriceEstimate.where(estimate_of: treasure)
 
-      assert_equal expected.to_sql, actual.to_sql
+      assert_equal wrap_polymorphic(expected.to_sql), actual.to_sql
     end
 
     def test_polymorphic_nested_where
@@ -106,7 +106,7 @@ module ActiveRecord
       expected = Treasure.where(price_estimates: { thing_type: 'Post', thing_id: 1 }).joins(:price_estimates)
       actual   = Treasure.where(price_estimates: { thing: thing }).joins(:price_estimates)
 
-      assert_equal expected.to_sql, actual.to_sql
+      assert_equal wrap_polymorphic(expected.to_sql), actual.to_sql
     end
 
     def test_polymorphic_sti_nested_where
@@ -116,7 +116,7 @@ module ActiveRecord
       expected = Treasure.where(price_estimates: { estimate_of_type: 'Treasure', estimate_of_id: 1 }).joins(:price_estimates)
       actual   = Treasure.where(price_estimates: { estimate_of: treasure }).joins(:price_estimates)
 
-      assert_equal expected.to_sql, actual.to_sql
+      assert_equal wrap_polymorphic(expected.to_sql), actual.to_sql
     end
 
     def test_decorated_polymorphic_where
@@ -141,7 +141,7 @@ module ActiveRecord
       expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: 1)
       actual   = PriceEstimate.where(estimate_of: decorated_treasure)
 
-      assert_equal expected.to_sql, actual.to_sql
+      assert_equal wrap_polymorphic(expected.to_sql), actual.to_sql
     end
 
     def test_aliased_attribute

--- a/activerecord/test/cases/where_polymorphic_expectations_helper.rb
+++ b/activerecord/test/cases/where_polymorphic_expectations_helper.rb
@@ -1,0 +1,9 @@
+module ActiveRecord
+  module WherePolymorphicExpectationsHelper
+
+    # Wraps polymorphic conditions in parentheses
+    def wrap_polymorphic(statement)
+      statement.gsub(/WHERE\s(.+)\Z/) { "WHERE (#{$1})" }
+    end
+  end
+end


### PR DESCRIPTION
Hi!

While working on a Rails 4 app I ran into a nasty bug that builds wrong queries for polymorphic associations.

Here's an example:

``` ruby
class Like < ActiveRecord::Base
  belongs_to :likeable, polymorphic: true
end
```

In current versions of Rails it works this way:

``` ruby
Like.where.not(likeable: Post.first).to_sql 
=> "... where (likes.likeable_type != 'Post') and (likes.likeable_id != 1)"
```

This query finds all likes whose likeables are not a 'Post' and their ids are not 1. This behavior is wrong.

The idea is to use parentheses around both polymorphic conditions to treat them as a unified expression.

Here's how it works in this PR:

``` ruby
Like.where(likeable: Post.first).to_sql
=> "... where (likes.likeable_type = 'Post' and likes.likeable_id = 1)"

Like.where.not(likeable: Post.first).to_sql
=> "... where (not (likes.likeable_type = 'Post' and likes.likeable_id = 1))"
```
