### PR TITLE
Expands nested hashs when on data-attributes

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -325,3 +325,9 @@
     *Piotr Sarnacki*, *Łukasz Strzałkowski*
 
 Please check [4-0-stable (ActionPack's CHANGELOG)](https://github.com/rails/rails/blob/4-0-stable/actionpack/CHANGELOG.md) for previous changes.
+
+*   Nested hashes on a data tag now generates one attribute per leaf.
+    So the hash `{ data: one: { { two: 'value2', three: 'value3' } } }`
+    generates the attributes `data-one-two='value2' data-one-three='value3'`
+
+    *Felipe Tanus*

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -142,9 +142,7 @@ module ActionView
           attrs = []
           options.each_pair do |key, value|
             if key.to_s == 'data' && value.is_a?(Hash)
-              value.each_pair do |k, v|
-                attrs << data_tag_option(k, v, escape)
-              end
+              attrs += data_tag_options(key, value, escape)
             elsif BOOLEAN_ATTRIBUTES.include?(key)
               attrs << boolean_tag_option(key) if value
             elsif !value.nil?
@@ -154,12 +152,17 @@ module ActionView
           " #{attrs.sort! * ' '}" unless attrs.empty?
         end
 
-        def data_tag_option(key, value, escape)
-          key   = "data-#{key.to_s.dasherize}"
-          unless value.is_a?(String) || value.is_a?(Symbol) || value.is_a?(BigDecimal)
-            value = value.to_json
+        def data_tag_options(key, value, escape)
+          if value.is_a?(Hash)
+            value.map { |k,v|
+              data_tag_options("#{key.to_s.dasherize}-#{k.to_s.dasherize}", v, escape)
+            }.flatten
+          else
+            unless value.is_a?(String) || value.is_a?(Symbol) || value.is_a?(BigDecimal)
+              value = value.to_json
+            end
+            tag_option(key, value, escape)
           end
-          tag_option(key, value, escape)
         end
 
         def boolean_tag_option(key)

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -127,8 +127,8 @@ class TagHelperTest < ActionView::TestCase
 
   def test_data_attributes
     ['data', :data].each { |data|
-      assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo" />',
-        tag('a', { data => { a_float: 3.14, a_big_decimal: BigDecimal.new("-123.456"), a_number: 1, string: 'hello', symbol: :foo, array: [1, 2, 3], hash: { key: 'value'}, string_with_quotes: 'double"quote"party"' } })
+      assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo" />',
+        tag('a', { data => { a: { float: 3.14, big: { decimal: BigDecimal.new("-123.456") } , number: 1 }, string: 'hello', symbol: :foo, array: [1, 2, 3], string_with_quotes: 'double"quote"party"' } })
     }
   end
 end


### PR DESCRIPTION
On form helpers, currently we can pass a hash for the attribute `data`
and it expands it in many attributes. For example,
`:data => { :value => 3 }` generates the attribute `data-value="3"`.

However, only the first value is  hold true for nested hashes. So the
hash `:data => { :plugin => { :value => 3 } }` generates the attributes
`data-plugin="&quot;value:&quot;:&quot;3&quot;"`.

ouldn't be better in the previous example if it generated the attribute
as `data-plugin-value="3"`? This is exactly the objective of this patch.
