### PR TITLE
Fixed typo in comment about MAX_ID.

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -549,7 +549,7 @@ module ActiveRecord
     end
 
     # Returns a consistent, platform-independent identifier for +label+.
-    # Identifiers are positive integers less than 2^32.
+    # Identifiers are positive integers less than 2^30.
     def self.identify(label)
       Zlib.crc32(label.to_s) % MAX_ID
     end


### PR DESCRIPTION
[sky@localhost rails]$ grep "MAX_ID = " activerecord/lib/active_record/fixtures.rb
    MAX_ID = 2 *\* 30 - 1
