### PR TITLE
there could be more than 10 nested records

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix ActionView label translation for more than 10 nested elements.
+
+    *Vladimir Krylov*
+
 *   Added `:plain`, `:html` and `:body` option for `render` method. Please see
     Action Pack's release note for more detail.
 
@@ -320,7 +324,7 @@
 
     *Bryan Ricker*
 
-*   First release, ActionView extracted from ActionPack
+*   First release, ActionView extracted from ActionPack.
 
     *Piotr Sarnacki*, *Łukasz Strzałkowski*
 

--- a/actionview/lib/action_view/helpers/tags/label.rb
+++ b/actionview/lib/action_view/helpers/tags/label.rb
@@ -36,7 +36,7 @@ module ActionView
             content = @template_object.capture(&block)
           else
             content = if @content.blank?
-                        @object_name.gsub!(/\[(.*)_attributes\]\[\d\]/, '.\1')
+                        @object_name.gsub!(/\[(.*)_attributes\]\[\d+\]/, '.\1')
                         method_and_value = tag_value.present? ? "#{@method_name}.#{tag_value}" : @method_name
 
                         if object.respond_to?(:to_model)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2390,6 +2390,20 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_nested_fields_label_translation_with_more_than_10_records
+    with_locale(:locale) do
+      @post.comments = Array.new(11) { |id| Comment.new(id + 1) }
+
+      I18n.expects(:t).with('post.comments.body', default: [:"comment.body", ''], scope: "helpers.label").times(11).returns "Write body here"
+
+      form_for(@post) do |f|
+        f.fields_for(:comments) do |cf|
+          concat cf.label(:body)
+        end
+      end
+    end
+  end
+
   def test_nested_fields_for_with_existing_records_on_a_supplied_nested_attributes_collection_different_from_record_one
     comments = Array.new(2) { |id| Comment.new(id + 1) }
     @post.comments = []


### PR DESCRIPTION
label helper object_name should cut more than 10 sub-elements
