### PR TITLE
Extract local cache middleware

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -1,6 +1,5 @@
 require 'active_support/core_ext/object/duplicable'
 require 'active_support/core_ext/string/inflections'
-require 'rack/body_proxy'
 
 module ActiveSupport
   module Cache
@@ -9,6 +8,8 @@ module ActiveSupport
       # duration of a block. Repeated calls to the cache for the same key will hit the
       # in-memory cache for faster access.
       module LocalCache
+        autoload :Middleware, 'active_support/cache/strategy/local_cache_middleware'
+
         # Class for storing and registering the local caches.
         class LocalCacheRegistry # :nodoc:
           extend ActiveSupport::PerThreadRegistry
@@ -64,37 +65,6 @@ module ActiveSupport
         def with_local_cache
           use_temporary_local_cache(LocalStore.new) { yield }
         end
-
-        #--
-        # This class wraps up local storage for middlewares. Only the middleware method should
-        # construct them.
-        class Middleware # :nodoc:
-          attr_reader :name, :local_cache_key
-
-          def initialize(name, local_cache_key)
-            @name             = name
-            @local_cache_key = local_cache_key
-            @app              = nil
-          end
-
-          def new(app)
-            @app = app
-            self
-          end
-
-          def call(env)
-            LocalCacheRegistry.set_cache_for(local_cache_key, LocalStore.new)
-            response = @app.call(env)
-            response[2] = ::Rack::BodyProxy.new(response[2]) do
-              LocalCacheRegistry.set_cache_for(local_cache_key, nil)
-            end
-            response
-          rescue Exception
-            LocalCacheRegistry.set_cache_for(local_cache_key, nil)
-            raise
-          end
-        end
-
         # Middleware class can be inserted as a Rack handler to be local cache for the
         # duration of request.
         def middleware

--- a/activesupport/lib/active_support/cache/strategy/local_cache_middleware.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache_middleware.rb
@@ -1,0 +1,39 @@
+require 'rack/body_proxy'
+module ActiveSupport
+  module Cache
+    module Strategy
+      module LocalCache
+
+        #--
+        # This class wraps up local storage for middlewares. Only the middleware method should
+        # construct them.
+        class Middleware # :nodoc:
+          attr_reader :name, :local_cache_key
+
+          def initialize(name, local_cache_key)
+            @name             = name
+            @local_cache_key = local_cache_key
+            @app              = nil
+          end
+
+          def new(app)
+            @app = app
+            self
+          end
+
+          def call(env)
+            LocalCacheRegistry.set_cache_for(local_cache_key, LocalStore.new)
+            response = @app.call(env)
+            response[2] = ::Rack::BodyProxy.new(response[2]) do
+              LocalCacheRegistry.set_cache_for(local_cache_key, nil)
+            end
+            response
+          rescue Exception
+            LocalCacheRegistry.set_cache_for(local_cache_key, nil)
+            raise
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Problem

When extending `Strategy::LocalCache` in a project we need to have rack added because of https://github.com/rails/rails/commit/e176353b71607f6fd57b327ba3ca12712639ce00 . See here an example of gem that creates a cache strategy without adding rack: https://github.com/Shopify/memcached_store/blob/master/lib/active_support/cache/memcached_store.rb#L46
### Solution

Extract LocalCache Middleware, so it can requires rack dependencies,
without adding rack dependencies to `AS::Cache::Strategy::LocalCache`.

review @tenderlove @guilleiguaran
