### PR TITLE
Skip test_migrate_revert_add_index_with_name for some databases

### DIFF
--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -271,16 +271,19 @@ module ActiveRecord
       ActiveRecord::Base.table_name_prefix = ActiveRecord::Base.table_name_suffix = ''
     end
 
-    def test_migrate_revert_add_index_with_name
-      RevertNamedIndexMigration1.new.migrate(:up)
-      RevertNamedIndexMigration2.new.migrate(:up)
-      RevertNamedIndexMigration2.new.migrate(:down)
+    # MySQL 5.7 and Oracle do not allow to create duplicate indexes on the same columns
+    unless current_adapter?(:MysqlAdapter, :Mysql2Adapter, :OracleAdapter)
+      def test_migrate_revert_add_index_with_name
+        RevertNamedIndexMigration1.new.migrate(:up)
+        RevertNamedIndexMigration2.new.migrate(:up)
+        RevertNamedIndexMigration2.new.migrate(:down)
 
-      connection = ActiveRecord::Base.connection
-      assert connection.index_exists?(:horses, :content),
-             "index on content should exist"
-      assert !connection.index_exists?(:horses, :content, name: "horses_index_named"),
-             "horses_index_named index should not exist"
+        connection = ActiveRecord::Base.connection
+        assert connection.index_exists?(:horses, :content),
+               "index on content should exist"
+        assert !connection.index_exists?(:horses, :content, name: "horses_index_named"),
+              "horses_index_named index should not exist"
+      end
     end
 
   end


### PR DESCRIPTION
This pull request addresses the following errors when tested with the database which 
do not support to create duplicate indexes on the same columns.
- MySQL 5.7.3-m13 server and Oracle database.
  For MySQL it would be probably because of the following change.
  https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-0.html

```
The server now issues a warning if an index is created that duplicates an existing index, or an error in strict SQL mode. (Bug #37520, Bug #11748842)
```

``` ruby
$ for i in mysql mysql2 oracle
> do
> echo $i
> ARCONN=$i ruby -Itest test/cases/invertible_migration_test.rb -n test_migrate_revert_add_index_with_name
> done
mysql
Using mysql
Run options: -n test_migrate_revert_add_index_with_name --seed 42418

# Running:

E

Finished in 0.044939s, 22.2523 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::InvertibleMigrationTest#test_migrate_revert_add_index_with_name:
ActiveRecord::StatementInvalid: Mysql::Error: Duplicate index 'horses_index_named' defined on the table 'activerecord_unittest.horses'. This is deprecated and will be disallowed in a future release.: CREATE  INDEX `horses_index_named`  ON `horses` (`content`)
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:301:in `query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:301:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:373:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:367:in `log'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:301:in `execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:523:in `add_index'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:649:in `block in method_missing'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:621:in `block in say_with_time'
    /home/yahonda/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/benchmark.rb:279:in `measure'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:621:in `say_with_time'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:641:in `method_missing'
    test/cases/invertible_migration_test.rb:121:in `change'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:595:in `exec_migration'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:579:in `block (2 levels) in migrate'
    /home/yahonda/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/benchmark.rb:279:in `measure'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:578:in `block in migrate'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:294:in `with_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:577:in `migrate'
    test/cases/invertible_migration_test.rb:276:in `test_migrate_revert_add_index_with_name'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
mysql2
Using mysql2
Run options: -n test_migrate_revert_add_index_with_name --seed 1515

# Running:

E

Finished in 0.047130s, 21.2179 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::InvertibleMigrationTest#test_migrate_revert_add_index_with_name:
ActiveRecord::StatementInvalid: Mysql2::Error: Duplicate index 'horses_index_named' defined on the table 'activerecord_unittest.horses'. This is deprecated and will be disallowed in a future release.: CREATE  INDEX `horses_index_named`  ON `horses` (`content`)
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:301:in `query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:301:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:373:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:367:in `log'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:301:in `execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb:228:in `execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:523:in `add_index'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:649:in `block in method_missing'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:621:in `block in say_with_time'
    /home/yahonda/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/benchmark.rb:279:in `measure'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:621:in `say_with_time'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:641:in `method_missing'
    test/cases/invertible_migration_test.rb:121:in `change'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:595:in `exec_migration'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:579:in `block (2 levels) in migrate'
    /home/yahonda/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/benchmark.rb:279:in `measure'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:578:in `block in migrate'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:294:in `with_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:577:in `migrate'
    test/cases/invertible_migration_test.rb:276:in `test_migrate_revert_add_index_with_name'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
oracle
Using oracle
Run options: -n test_migrate_revert_add_index_with_name --seed 4670

# Running:

E

Finished in 0.075340s, 13.2732 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::InvertibleMigrationTest#test_migrate_revert_add_index_with_name:
ActiveRecord::StatementInvalid: OCIError: ORA-01408: such column list already indexed: CREATE  INDEX "HORSES_INDEX_NAMED" ON "HORSES" ("CONTENT")
    stmt.c:230:in oci8lib_210.so
    /home/yahonda/.rvm/gems/ruby-2.1.0@railsmaster/gems/ruby-oci8-2.1.7/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/.rvm/gems/ruby-2.1.0@railsmaster/gems/ruby-oci8-2.1.7/lib/oci8/oci8.rb:278:in `exec_internal'
    /home/yahonda/.rvm/gems/ruby-2.1.0@railsmaster/gems/ruby-oci8-2.1.7/lib/oci8/oci8.rb:269:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:429:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:373:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:367:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1500:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:727:in `execute'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:189:in `add_index'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:649:in `block in method_missing'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:621:in `block in say_with_time'
    /home/yahonda/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/benchmark.rb:279:in `measure'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:621:in `say_with_time'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:641:in `method_missing'
    test/cases/invertible_migration_test.rb:121:in `change'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:595:in `exec_migration'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:579:in `block (2 levels) in migrate'
    /home/yahonda/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/benchmark.rb:279:in `measure'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:578:in `block in migrate'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:294:in `with_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:577:in `migrate'
    test/cases/invertible_migration_test.rb:276:in `test_migrate_revert_add_index_with_name'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```
