### PR TITLE
Honor public/private in ActionView::Helpers::Tags::Base#value

### DIFF
--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -25,7 +25,7 @@ module ActionView
         private
 
         def value(object)
-          object.send @method_name if object
+          object.public_send @method_name if object
         end
 
         def value_before_type_cast(object)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -124,6 +124,12 @@ class FormHelperTest < ActionView::TestCase
     assert_raise(NotImplementedError) { FooTag.new.render }
   end
 
+  def test_tags_base_value_honors_public_private
+    test_object = Class.new { private def my_method ; end }.new
+    tag = ActionView::Helpers::Tags::Base.new 'test_object', :my_method, nil
+    assert_raise(NoMethodError) { tag.send :value, test_object }
+  end
+
   def test_label
     assert_dom_equal('<label for="post_title">Title</label>', label("post", "title"))
     assert_dom_equal(

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -125,7 +125,10 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_tags_base_value_honors_public_private
-    test_object = Class.new { private def my_method ; end }.new
+    test_object = Class.new do
+      def my_method ; end
+      private :my_method
+    end.new
     tag = ActionView::Helpers::Tags::Base.new 'test_object', :my_method, nil
     assert_raise(NoMethodError) { tag.send :value, test_object }
   end


### PR DESCRIPTION
- use public_send instead of send to avoid calling private methods in form helpers

I do not know if this feature is wanted, but it was simple enough to implement so I just went ahead and did it.

I discovered this together with a bug in MRI/simple_delegator.
E.g. When you have an object using `SimpleDelegator` that has an `open` method which you try to call with `send` it ends up calling an `open` method somewhere in Ruby that wants 1..3 arguments in Ruby 2.0. Too bad if you have an attribute named open.
( see [this gist](https://gist.github.com/PragTob/9189371) for a sample)

That does not happen with public_send. However that is a bug somewhere else. So writing a test for it seemed too hard so I wrote a simple honor public/private test. Any suggestions for a better testing of this?

I do think that in general it'd be good to honor public/private in this case. What do you think?

Cheers,
Tobi
