### PR TITLE
 raise `ArgumentError` if `validates` has duplicated attributes.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   raise `ArgumentExcpetion` if `validates` has duplicated attributes. 
+
+    Example:
+
+        class Person
+           include ActiveModel::Validations
+
+           attr :name
+           validates_presence_of :name, :name
+         end
+
+         person = Person.new
+
+         # Before 
+         person.valid?
+         person.errors.size #=> 2
+         
+         # Now
+         person.valid? #=> `ArgumentError Exception`
+
+    *Angelo Capilleri*
+
 *   `#to_param` returns `nil` if `#to_key` returns `nil`. Fixes #11399.
 
     *Yves Senn*

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -105,6 +105,7 @@ module ActiveModel
 
         raise ArgumentError, "You need to supply at least one attribute" if attributes.empty?
         raise ArgumentError, "You need to supply at least one validation" if validations.empty?
+        raise ArgumentError, "You need to supply attributes only once for validation" if attributes.uniq!
 
         defaults[:attributes] = attributes
 

--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -125,6 +125,10 @@ class ValidatesTest < ActiveModel::TestCase
     assert_raise(ArgumentError) { Person.validates :karma, unknown: true }
   end
 
+  def test_validates_with_duplicated_attributes
+    assert_raise(ArgumentError) { Person.validates :karma, :karma, presence: true }
+  end
+
   def test_validates_with_included_validator
     PersonWithValidator.validates :title, presence: true
     person = PersonWithValidator.new


### PR DESCRIPTION
Currently you can pass duplicated attributes as argument to `valitates` methods.

Example:

```
Person.validates_presence_of :name, :name
person = Person.new

# before
person.valid?
person.errors.size #=> 2

# with this pr
person.valid? #=> `ArgumentError Exception`
```
