### PR TITLE
Avoid namespacing routes inside engines

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,1 +1,10 @@
+*   Avoid namespacing routes inside engines.
+
+    Mountable engines are namespaced by default so the generated routes
+    were too while they should not.
+
+    Fixes #14079.
+
+    *Yves Senn*, *Carlos Antonio da Silva*, *Robin Dupret*
+
 Please check [4-1-stable](https://github.com/rails/rails/blob/4-1-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -27,11 +27,11 @@ module Rails
         #   end
         # end
         def generate_routing_code(action)
-          depth = class_path.length
+          depth = regular_class_path.length
           # Create 'namespace' ladder
           # namespace :foo do
           #   namespace :bar do
-          namespace_ladder = class_path.each_with_index.map do |ns, i|
+          namespace_ladder = regular_class_path.each_with_index.map do |ns, i|
             indent("namespace :#{ns} do\n", i * 2)
           end.join
 

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -355,6 +355,18 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     FileUtils.rm gemfile_path
   end
 
+  def test_generating_controller_inside_mountable_engine
+    run_generator [destination_root, "--mountable"]
+
+    capture(:stdout) do
+      `#{destination_root}/bin/rails g controller admin/dashboard foo`
+    end
+
+    assert_file "config/routes.rb" do |contents|
+      assert_match(/namespace :admin/, contents)
+      assert_no_match(/namespace :bukkit/, contents)
+    end
+  end
 
 protected
   def action(*args, &block)


### PR DESCRIPTION
Hello,

Since #11544, invoking the controller generator, any generated route is namespaced according to the class_path method. Since a mountable plugin is namespaced, creating a controller inside would generate a namespaced route based on the engine's name.

The controller generator now relies on regular_class_path which does not contain the class hierarchy but the given path.

cc @rafaelfranca @carlosantoniodasilva

Fixes #14079.

Have a nice day.
