### PR TITLE
Fix Hash#select and #reject on ruby 2.1.1

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -227,6 +227,10 @@ module ActiveSupport
     def deep_symbolize_keys; to_hash.deep_symbolize_keys end
     def to_options!; self end
 
+    def select(*args, &block)
+      dup.select!(*args, &block)
+    end
+
     # Convert to a regular hash with string keys.
     def to_hash
       _new_hash= {}

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -228,7 +228,11 @@ module ActiveSupport
     def to_options!; self end
 
     def select(*args, &block)
-      dup.select!(*args, &block)
+      dup.tap { |hash| hash.select!(*args, &block)}
+    end
+
+    def reject(*args, &block)
+      dup.tap { |hash| hash.reject!(*args, &block)}
     end
 
     # Convert to a regular hash with string keys.

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -228,11 +228,11 @@ module ActiveSupport
     def to_options!; self end
 
     def select(*args, &block)
-      dup.tap { |hash| hash.select!(*args, &block)}
+      dup.tap { |hash| hash.select!(*args, &block) }
     end
 
     def reject(*args, &block)
-      dup.tap { |hash| hash.reject!(*args, &block)}
+      dup.tap { |hash| hash.reject!(*args, &block) }
     end
 
     # Convert to a regular hash with string keys.

--- a/activesupport/lib/active_support/ordered_hash.rb
+++ b/activesupport/lib/active_support/ordered_hash.rb
@@ -28,6 +28,10 @@ module ActiveSupport
       coder.represent_seq '!omap', map { |k,v| { k => v } }
     end
 
+    def reject(*args, &block)
+      dup.tap { |hash| hash.reject!(*args, &block)}
+    end
+
     def nested_under_indifferent_access
       self
     end

--- a/activesupport/lib/active_support/ordered_hash.rb
+++ b/activesupport/lib/active_support/ordered_hash.rb
@@ -28,6 +28,10 @@ module ActiveSupport
       coder.represent_seq '!omap', map { |k,v| { k => v } }
     end
 
+    def select(*args, &block)
+      dup.tap { |hash| hash.select!(*args, &block) }
+    end
+
     def reject(*args, &block)
       dup.tap { |hash| hash.reject!(*args, &block)}
     end

--- a/activesupport/lib/active_support/ordered_hash.rb
+++ b/activesupport/lib/active_support/ordered_hash.rb
@@ -33,7 +33,7 @@ module ActiveSupport
     end
 
     def reject(*args, &block)
-      dup.tap { |hash| hash.reject!(*args, &block)}
+      dup.tap { |hash| hash.reject!(*args, &block) }
     end
 
     def nested_under_indifferent_access

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -480,6 +480,36 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal hash.delete('a'), nil
   end
 
+  def test_indifferent_select
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).select {|k,v| v == 1}
+
+    assert_equal({ 'a' => 1 }, hash)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
+  def test_indifferent_select_bang
+    indifferent_strings = ActiveSupport::HashWithIndifferentAccess.new(@strings)
+    indifferent_strings.select! {|k,v| v == 1}
+
+    assert_equal({ 'a' => 1 }, indifferent_strings)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings
+  end
+
+  def test_indifferent_reject
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).reject {|k,v| v != 1}
+
+    assert_equal({ 'a' => 1 }, hash)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
+  def test_indifferent_reject_bang
+    indifferent_strings = ActiveSupport::HashWithIndifferentAccess.new(@strings)
+    indifferent_strings.reject! {|k,v| v != 1}
+
+    assert_equal({ 'a' => 1 }, indifferent_strings)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings
+  end
+
   def test_indifferent_to_hash
     # Should convert to a Hash with String keys.
     assert_equal @strings, @mixed.with_indifferent_access.to_hash

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -481,7 +481,7 @@ class HashExtTest < ActiveSupport::TestCase
   end
 
   def test_indifferent_select
-    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).select {|k,v| v == 1}
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).select { |_ ,v| v == 1 }
 
     assert_equal({ 'a' => 1 }, hash)
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
@@ -489,14 +489,14 @@ class HashExtTest < ActiveSupport::TestCase
 
   def test_indifferent_select_bang
     indifferent_strings = ActiveSupport::HashWithIndifferentAccess.new(@strings)
-    indifferent_strings.select! {|k,v| v == 1}
+    indifferent_strings.select! { |_, v| v == 1 }
 
     assert_equal({ 'a' => 1 }, indifferent_strings)
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings
   end
 
   def test_indifferent_reject
-    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).reject {|k,v| v != 1}
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).reject { |_, v| v != 1 }
 
     assert_equal({ 'a' => 1 }, hash)
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
@@ -504,7 +504,7 @@ class HashExtTest < ActiveSupport::TestCase
 
   def test_indifferent_reject_bang
     indifferent_strings = ActiveSupport::HashWithIndifferentAccess.new(@strings)
-    indifferent_strings.reject! {|k,v| v != 1}
+    indifferent_strings.reject! { |_, v| v != 1 }
 
     assert_equal({ 'a' => 1 }, indifferent_strings)
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings

--- a/activesupport/test/ordered_hash_test.rb
+++ b/activesupport/test/ordered_hash_test.rb
@@ -120,7 +120,9 @@ class OrderedHashTest < ActiveSupport::TestCase
   end
 
   def test_select
-    assert_equal @keys, @ordered_hash.select { true }.map(&:first)
+    new_ordered_hash = @ordered_hash.select { true }
+    assert_equal @keys, new_ordered_hash.map(&:first)
+    assert_instance_of ActiveSupport::OrderedHash, new_ordered_hash
   end
 
   def test_delete_if
@@ -143,6 +145,7 @@ class OrderedHashTest < ActiveSupport::TestCase
     assert_equal copy, @ordered_hash
     assert !new_ordered_hash.keys.include?('pink')
     assert @ordered_hash.keys.include?('pink')
+    assert_instance_of ActiveSupport::OrderedHash, new_ordered_hash
   end
 
   def test_clear


### PR DESCRIPTION
Backport commit https://github.com/rails/rails/commit/5402b72faafecfa1eda8afce0e0f194fcf385fe3 to fix #14188

After `git bisect` turns out this commit fix ruby 2.1.1.

review @carlosantoniodasilva @tenderlove
