### PR TITLE
rename gem bcrypt-ruby to bcrypt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gemspec
 gem 'mocha', '~> 0.14', require: false
 
 gem 'rack-cache', '~> 1.2'
-gem 'bcrypt-ruby', '~> 3.1.2'
+gem 'bcrypt', '~> 3.1.2'
 gem 'jquery-rails', '~> 3.1.0'
 gem 'turbolinks'
 gem 'coffee-rails', '~> 4.0.0'

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -20,9 +20,9 @@ module ActiveModel
       # value to the password_confirmation attribute and the validation
       # will not be triggered.
       #
-      # You need to add bcrypt-ruby (~> 3.1.2) to Gemfile to use #has_secure_password:
+      # You need to add bcrypt (~> 3.1.2) to Gemfile to use #has_secure_password:
       #
-      #   gem 'bcrypt-ruby', '~> 3.1.2'
+      #   gem 'bcrypt', '~> 3.1.2'
       #
       # Example using Active Record (which automatically includes ActiveModel::SecurePassword):
       #

--- a/guides/code/getting_started/Gemfile
+++ b/guides/code/getting_started/Gemfile
@@ -27,7 +27,7 @@ gem 'sdoc', '~> 0.4.0',          group: :doc
 gem 'spring',        group: :development
 
 # Use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.1.2'
+# gem 'bcrypt', '~> 3.1.2'
 
 # Use unicorn as the app server
 # gem 'unicorn'

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -14,7 +14,7 @@ source 'https://rubygems.org'
 <% end -%>
 
 # Use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.1.2'
+# gem 'bcrypt', '~> 3.1.2'
 
 # Use unicorn as the app server
 # gem 'unicorn'


### PR DESCRIPTION
"bcrypt-ruby" changed its gem name to "bcrypt" about two months ago (https://github.com/codahale/bcrypt-ruby/pull/86). Now when I am running a vanilla rails bundle install command, I got following message:

Post-install message from bcrypt-ruby:
###### 

The bcrypt-ruby gem has changed its name to just bcrypt.  Instead of
installing `bcrypt-ruby`, you should install `bcrypt`.  Please update your
dependencies accordingly.
###### 

I think it's better to rename the gem file to the most updated one (i.e. bcrypt) used by bcrypt-ruby project people.
