### PR TITLE
Bump version of bcrypt gem in 4-0-stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,14 @@ gemspec
 
 gem 'mocha', '~> 0.13.0', require: false
 gem 'rack-cache', '~> 1.2'
-gem 'bcrypt-ruby', '~> 3.1.2'
 gem 'jquery-rails', '~> 2.2.0'
 gem 'turbolinks'
 gem 'coffee-rails', '~> 4.0.0', github: 'rails/coffee-rails'
+
+# require: false so bcrypt is loaded only when has_secure_password is used.
+# This is to avoid ActiveModel (and by extension the entire framework)
+# being dependent on a binary library.
+gem 'bcrypt', '~> 3.1.7', require: false
 
 # This needs to be with require false to avoid
 # it being automatically loaded by sprockets

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -18,9 +18,9 @@ module ActiveModel
       # value to the password_confirmation attribute and the the validation
       # will not be triggered.
       #
-      # You need to add bcrypt-ruby (~> 3.1.2) to Gemfile to use #has_secure_password:
+      # You need to add bcrypt (~> 3.1.7) to Gemfile to use #has_secure_password:
       #
-      #   gem 'bcrypt-ruby', '~> 3.1.2'
+      #   gem 'bcrypt', '~> 3.1.7'
       #
       # Example using Active Record (which automatically includes ActiveModel::SecurePassword):
       #
@@ -40,14 +40,14 @@ module ActiveModel
       #   User.find_by(name: 'david').try(:authenticate, 'notright')      # => false
       #   User.find_by(name: 'david').try(:authenticate, 'mUc3m00RsqyRe') # => user
       def has_secure_password(options = {})
-        # Load bcrypt-ruby only when has_secure_password is used.
+        # Load bcrypt gem only when has_secure_password is used.
         # This is to avoid ActiveModel (and by extension the entire framework)
         # being dependent on a binary library.
         begin
           gem 'bcrypt-ruby', '~> 3.1.2'
           require 'bcrypt'
         rescue LoadError
-          $stderr.puts "You don't have bcrypt-ruby installed in your application. Please add it to your Gemfile and run bundle install"
+          $stderr.puts "You don't have bcrypt installed in your application. Please add it to your Gemfile and run bundle install"
           raise
         end
 

--- a/guides/code/getting_started/Gemfile
+++ b/guides/code/getting_started/Gemfile
@@ -31,7 +31,7 @@ end
 gem 'jbuilder', '~> 1.2'
 
 # To use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.1.2'
+# gem 'bcrypt', '~> 3.1.7'
 
 # Use unicorn as the app server
 # gem 'unicorn'

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -16,7 +16,7 @@ group :doc do
 end
 
 # Use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.1.2'
+# gem 'bcrypt', '~> 3.1.7'
 
 # Use unicorn as the app server
 # gem 'unicorn'


### PR DESCRIPTION
@carlosantoniodasilva This is the same as https://github.com/rails/rails/pull/14149, but backported to `4-0-stable` (that original PR was already pulled into `4-1-stable`).

Without the backport, anyone on 4-0-stable will get an annoying post-install message:

```
#######################################################

The `bcrypt-ruby` gem has changed its name to just `bcrypt`. Instead of
installing `bcrypt-ruby`, you should install `bcrypt`. Please update your
dependencies accordingly.

#######################################################
```

No functionality is changed, so it should be safe to backport to save users the trouble.
