### PR TITLE
Handle tab in token authentication header.

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -385,7 +385,7 @@ module ActionController
     #
     #   RewriteRule ^(.*)$ dispatch.fcgi [E=X-HTTP_AUTHORIZATION:%{HTTP:Authorization},QSA,L]
     module Token
-      TOKEN_REGEX = /^Token /
+      TOKEN_REGEX = /^Token\s+/
       AUTHN_PAIR_DELIMITERS = /(?:,|;|\t+)/
       extend self
 

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -87,6 +87,14 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     assert_equal "HTTP Token: Access denied.\n", @response.body, "Authentication header was not properly parsed"
   end
 
+  test "authentication request with tab in header" do
+    @request.env['HTTP_AUTHORIZATION'] = "Token\ttoken=\"lifo\""
+    get :index
+
+    assert_response :success
+    assert_equal 'Hello Secret', @response.body
+  end
+
   test "authentication request without credential" do
     get :display
 


### PR DESCRIPTION
The HTTP spec allows for `LWS` to precede the header content, which
could include multiple `SP` and `HT` characters. Update the regex used to
match the Token authorization header to account for this, instead of
matching on a single `SP`.

See http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html and
http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2 for the relevant
sections of the specification.
