### PR TITLE
Allow token authentication header with text value.

### DIFF
--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -79,12 +79,12 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     end
   end
 
-  test "authentication request with badly formatted header" do
-    @request.env['HTTP_AUTHORIZATION'] = "Token foobar"
+  test "authentication request with text" do
+    @request.env['HTTP_AUTHORIZATION'] = "Token lifo"
     get :index
 
-    assert_response :unauthorized
-    assert_equal "HTTP Token: Access denied.\n", @response.body, "Authentication header was not properly parsed"
+    assert_response :success
+    assert_equal 'Hello Secret', @response.body
   end
 
   test "authentication request without credential" do


### PR DESCRIPTION
The field content is allowed to be `*TEXT`, and does not have to contain
key value pairs. Update the test to account for this.

See http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2 for the
relevant section of the specification.
