### PR TITLE
Add ChronoModel to the DbConsole adapters list

### DIFF
--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -44,7 +44,7 @@ module Rails
 
         find_cmd_and_exec(['mysql', 'mysql5'], *args)
 
-      when "postgresql", "postgres", "postgis"
+      when "postgresql", "postgres", "postgis", "chronomodel"
         ENV['PGUSER']     = config["username"] if config["username"]
         ENV['PGHOST']     = config["host"] if config["host"]
         ENV['PGPORT']     = config["port"].to_s if config["port"]


### PR DESCRIPTION
ChronoModel http://github.com/ifad/chronomodel implements temporal extensions for ActiveRecord. As it decorates many migration methods, it defines a new adapter inheriting from the PostgreSQLAdapter.

However, as the Rails console command does not need to load any gem, there is no way for CM to hook into the dbconsole config, and adding it to the hardcoded list is necessary.
