### PR TITLE
SQL Like Escaping as a method on String

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -109,8 +109,8 @@ module ActiveRecord
 
       # Sanitizes a string so that it is safe to use within a sql
       # like statement.
-      def sanitize_sql_like
-        gsub(/[\\_%\|]/) { |x| "\\#{x}" }
+      def sanitize_sql_like(statement)
+        statement.gsub(/[\\_%\|]/) { |x| "\\#{x}" }
       end
 
       # Accepts an array of conditions. The array has each value

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -107,6 +107,12 @@ module ActiveRecord
         end.join(', ')
       end
 
+      # Sanitizes a string so that it is safe to use within a sql
+      # like statement.
+      def sanitize_sql_like
+        gsub(/[\\_%\|]/) { |x| "\\#{x}" }
+      end
+
       # Accepts an array of conditions. The array has each value
       # sanitized and interpolated into the SQL statement.
       #   ["name='%s' and group_id='%s'", "foo'bar", 4]  returns  "name='foo''bar' and group_id='4'"

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -236,7 +236,4 @@ class String
   def html_safe
     ActiveSupport::SafeBuffer.new(self)
   end
-  def escape_like
-    gsub(/[\\_%\|]/) { |x| "\\#{x}" }
-  end
 end

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -236,4 +236,7 @@ class String
   def html_safe
     ActiveSupport::SafeBuffer.new(self)
   end
+  def escape_like
+    gsub(/[\\_%\|]/) { |x| "\\#{x}" }
+  end
 end


### PR DESCRIPTION
This would add the patch from #6104 (amended to include the \ escape character and || operator) to all Strings.

This does not have the backwards compatibility issues brought up in #6104 because it is a new helper method with no previous implementation to break.

IMO this should be a part of Rails so that the Rails team can iterate on a single sql injection protection implementation for like statements that covers edge cases that might not be immediately obvious.

The other option (the current option) is for developers such as myself to implement a potentially flawed DIY solution. Those edge cases (ex. db-specific special characters) are not going to be obvious at first but with many eyes they will be spotted.
