### PR TITLE
Remove warning from MySQL test run.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -161,6 +161,7 @@ module ActiveRecord
       end
 
       def error_number(exception) # :nodoc:
+        return if exception.respond_to?(:error) && exception.error == "query: not connected"
         exception.errno if exception.respond_to?(:errno)
       end
 


### PR DESCRIPTION
Short circuit the Mysql::ConnectionAdapter#error_number to return early if the error is
one in which there is no connection. This removes a warning from the test suite run.
