### PR TITLE
`includes` uses SQL parsing when String joins are involved.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `includes` is able to detect the right preloading strategy when string
+    joins are involved.
+
+    Fixes #14109.
+
+    *Aaron Patterson*, *Yves Senn*
+
 *   Fixed error with validation with enum fields for records where the
     value for any enum attribute is always evaluated as 0 during
     uniqueness validation.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -617,7 +617,9 @@ module ActiveRecord
 
     def references_eager_loaded_tables?
       joined_tables = arel.join_sources.map do |join|
-        unless join.is_a?(Arel::Nodes::StringJoin)
+        if join.is_a?(Arel::Nodes::StringJoin)
+          tables_in_string(join.left)
+        else
           [join.left.table_name, join.left.table_alias]
         end
       end
@@ -628,6 +630,13 @@ module ActiveRecord
       joined_tables = joined_tables.flatten.compact.map { |t| t.downcase }.uniq
 
       (references_values - joined_tables).any?
+    end
+
+    def tables_in_string(string)
+      return [] if string.blank?
+      # always convert table names to downcase as in Oracle quoted table names are in uppercase
+      # ignore raw_sql_ that is used by Oracle adapter as alias for limit/offset subqueries
+      string.scan(/([a-zA-Z_][.\w]+).?\./).flatten.map{ |s| s.downcase }.uniq - ['raw_sql_']
     end
   end
 end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1194,4 +1194,13 @@ class EagerAssociationTest < ActiveRecord::TestCase
       authors(:david).essays.includes(:writer).any?
     end
   end
+
+  test "preloading associations with string joins and order references" do
+    author = assert_queries(2) {
+      Author.includes(:posts).joins("LEFT JOIN posts ON posts.author_id = authors.id").order("posts.title DESC").first
+    }
+    assert_no_queries {
+      assert_equal 5, author.posts.size
+    }
+  end
 end


### PR DESCRIPTION
Closes #14109

This is a partial revert of 22b3481ba2aa55fad1f9a5db94072312b345fb55.
The current implementation of `references_eager_loaded_tables?` needs to know
every table involved in the query. With the current API this is not possible
without SQL parsing.

While a2dab46cae35a06fd5c5500037177492a047c252 deprecated SQL parsing for `includes`.
It did not issue deprecation warnings when String joins are involved. This resulted
in a breaking change after the deprecated behavior was removed (22b3481ba2aa55fad1f9a5db94072312b345fb55).

We will need to rethink the usage of `includes`, `preload` and `eager_load` but for now,
this brings back the old _working_ behavior.
