### PR TITLE
[Docs] Fix typo in accepts_nested_attributes_for docs

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -145,7 +145,7 @@ module ActiveRecord
     #     accepts_nested_attributes_for :posts, reject_if: :reject_posts
     #
     #     def reject_posts(attributed)
-    #       attributed['title'].blank?
+    #       attributes['title'].blank?
     #     end
     #   end
     #


### PR DESCRIPTION
Very simple one letter typo as noticed on this docs page: http://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html
