### PR TITLE
Proper comparison of DateTime#eql? with ActiveSupport::TimeWithZone instance.

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -158,4 +158,17 @@ class DateTime
     end
   end
 
+  # Layers additional behavior on DateTime#eql? so that ActiveSupport::TimeWithZone instances
+  # can be eql? to an equivalent DateTime
+  def eql_with_coercion(other)
+    # if other is an ActiveSupport::TimeWithZone, coerce a Time instance from it so we can do eql? comparison
+    if other.respond_to?(:comparable_time)
+      eql_without_coercion(other.comparable_time)
+    else
+      eql_without_coercion(other)
+    end
+  end
+  alias_method :eql_without_coercion, :eql?
+  alias_method :eql?, :eql_with_coercion
+
 end

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -347,6 +347,12 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal 500000000, DateTime.civil(2000, 1, 1, 0, 0, Rational(1,2)).nsec
   end
 
+  def test_eql?
+    assert_equal true, DateTime.new(2000).eql?( ActiveSupport::TimeWithZone.new(DateTime.new(2000), ActiveSupport::TimeZone['UTC']) )
+    assert_equal true, DateTime.new(2000).eql?( ActiveSupport::TimeWithZone.new(DateTime.new(2000), ActiveSupport::TimeZone["Hawaii"]) )
+    assert_equal false,DateTime.new(2000, 1, 1, 0, 0, 1).eql?( ActiveSupport::TimeWithZone.new(DateTime.new(2000), ActiveSupport::TimeZone['UTC']) )
+  end
+
   protected
     def with_env_tz(new_tz = 'US/Eastern')
       old_tz, ENV['TZ'] = ENV['TZ'], new_tz


### PR DESCRIPTION
fixes #14178

``` ruby
  # Previously:
    n = DateTime.now.in_time_zone # => Fri, 28 Feb 2014 22:00:55 UTC +00:00
    n.eql?(n.dup) # => false
  # Now:
    n = DateTime.now.in_time_zone # => Fri, 28 Feb 2014 22:00:55 UTC +00:00
    n.eql?(n.dup) # => true
```
