### PR TITLE
Replace map.flatten(1) with flat_map

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -121,9 +121,9 @@ module ActionDispatch
         def possibles(cache, options, depth = 0)
           cache.fetch(:___routes) { [] } + options.find_all { |pair|
             cache.key?(pair)
-          }.map { |pair|
+          }.flat_map { |pair|
             possibles(cache[pair], options, depth + 1)
-          }.flatten(1)
+          }
         end
 
         # Returns +true+ if no missing keys are present, otherwise +false+.

--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -120,11 +120,11 @@ module ActionDispatch
         end
 
         def transitions
-          @string_states.map { |from, hash|
+          @string_states.flat_map { |from, hash|
             hash.map { |s, to| [from, s, to] }
-          }.flatten(1) + @regexp_states.map { |from, hash|
+          } + @regexp_states.flat_map { |from, hash|
             hash.map { |s, to| [from, s, to] }
-          }.flatten(1)
+          }
         end
 
         private


### PR DESCRIPTION
Using `flat_map` is equivalent `map.flatten(1)` but simpler and an order of magnitude faster.

``` ruby
require 'benchmark/ips'

ARRAY = 100.times.map { (0..9).to_a }

def slow
  ARRAY.map { |x| x }.flatten(1)
end

def fast
  ARRAY.flat_map { |x| x }
end

Benchmark.ips do |x|
  x.report('slow') { slow }
  x.report('fast') { fast }
end
```

```
slow 12348.2 (±9.0%) i/s -  61450 in 5.017159s
fast 56647.8 (±7.2%) i/s - 282152 in 5.006973s
```

There are many other instances of `map.flatten` (without the `1` argument) in this codebase, that may or may not be safe to replace with `flat_map`, since `flat_map` isn’t recursive like `flatten`. I can work on a separate pull request that replaces those cases but this seemed like a quick and low-risk win. :smile_cat:
