### PR TITLE
Fix OrderedHash.select to return self instance.

### DIFF
--- a/activesupport/lib/active_support/ordered_hash.rb
+++ b/activesupport/lib/active_support/ordered_hash.rb
@@ -28,6 +28,10 @@ module ActiveSupport
       coder.represent_seq '!omap', map { |k,v| { k => v } }
     end
 
+    def select(*args, &block)
+      dup.tap { |hash| hash.select!(*args, &block) }
+    end
+
     def reject(*args, &block)
       dup.tap { |hash| hash.reject!(*args, &block) }
     end

--- a/activesupport/test/ordered_hash_test.rb
+++ b/activesupport/test/ordered_hash_test.rb
@@ -120,7 +120,9 @@ class OrderedHashTest < ActiveSupport::TestCase
   end
 
   def test_select
-    assert_equal @keys, @ordered_hash.select { true }.map(&:first)
+    new_ordered_hash = @ordered_hash.select { true }
+    assert_equal @keys, new_ordered_hash.map(&:first)
+    assert_instance_of ActiveSupport::OrderedHash, new_ordered_hash
   end
 
   def test_delete_if
@@ -143,6 +145,7 @@ class OrderedHashTest < ActiveSupport::TestCase
     assert_equal copy, @ordered_hash
     assert !new_ordered_hash.keys.include?('pink')
     assert @ordered_hash.keys.include?('pink')
+    assert_instance_of ActiveSupport::OrderedHash, new_ordered_hash
   end
 
   def test_clear


### PR DESCRIPTION
We need to override the `select` method otherwise `select` wont return a  `OrderedHash` instance, on ruby 2.1.1.

[related to #14198]

cc @zzak @carlosantoniodasilva @rafaelfranca
