### PR TITLE
Make the apply_inflections method case-sensitive

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,8 +1,13 @@
+*   Make the `apply_inflections` method case-insensitive when checking
+    whether a word is uncountable or not.
+
+    *Robin Dupret*
+
 *   Make Dependencies pass a name to NameError error.
     *arthurnn*
 
 *   Fixed `ActiveSupport::Cache::FileStore` exploding with long paths.
-    *Adam Panzer / Michael Grosser* 
+    *Adam Panzer / Michael Grosser*
 
 *   Fixed `ActiveSupport::TimeWithZone#-` so precision is not unnecessarily lost
     when working with objects with a nanosecond component.
@@ -27,12 +32,12 @@
 *   Fixed precision error in NumberHelper when using Rationals.
 
     Before:
-        
+
         ActiveSupport::NumberHelper.number_to_rounded Rational(1000, 3), precision: 2
         #=> "330.00"
-    
+
     After:
-    
+
         ActiveSupport::NumberHelper.number_to_rounded Rational(1000, 3), precision: 2
         #=> "333.33"
 

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -160,7 +160,7 @@ module ActiveSupport
       #   uncountable 'money', 'information'
       #   uncountable %w( money information rice )
       def uncountable(*words)
-        (@uncountables << words).flatten!
+        @uncountables += words.flatten.map(&:downcase)
       end
 
       # Specifies a humanized form of a string by a regular expression rule or

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -509,6 +509,14 @@ class InflectorTest < ActiveSupport::TestCase
     end
   end
 
+  def test_inflections_with_uncountable_words
+    ActiveSupport::Inflector.inflections do |inflect|
+      inflect.uncountable "HTTP"
+    end
+
+    assert_equal "HTTP", ActiveSupport::Inflector.pluralize("HTTP")
+  end
+
   # Dups the singleton and yields, restoring the original inflections later.
   # Use this in tests what modify the state of the singleton.
   #


### PR DESCRIPTION
Hello,

Since d3071db1, the apply_inflections method check if the downcased version of a string is contained inside the "whitelist" of uncountable words. However, if the word is composed of capital letters, it won't be
matched in the list while it should.

We can't simply revert to the previous behavior as there is a performance concern (benchmarked over `/usr/share/dict/words`):

|  | user | system | total | real |
| --- | --- | --- | --- | --- |
| Before d3071db1 | 135.610000 | 0.290000 | 135.900000 | (137.807081) |
| Since d3071db1 | 22.170000 | 0.020000 | 22.190000 | ( 22.530005) |
| With the patch | 25.130000 | 0.070000 | 25.200000 | ( 25.611538) |

Benchmarked with http://git.io/aFnWig.

Have a nice day.
