### PR TITLE
Fix PG warnings.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -822,7 +822,7 @@ module ActiveRecord
           # populate range types
           ranges.find_all { |row| type_map.key? row['rngsubtype'].to_i }.each do |row|
             subtype = type_map[row['rngsubtype'].to_i]
-            range = OID::Range.new type_map[row['rngsubtype'].to_i]
+            range = OID::Range.new subtype
             type_map[row['oid'].to_i] = range
           end
         end

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -156,7 +156,7 @@ _SQL
       assert_equal 0.5..0.7, @first_range.float_range
       assert_equal 0.5...0.7, @second_range.float_range
       assert_equal 0.5...Float::INFINITY, @third_range.float_range
-      assert_equal -Float::INFINITY...Float::INFINITY, @fourth_range.float_range
+      assert_equal (-Float::INFINITY...Float::INFINITY), @fourth_range.float_range
       assert_nil @empty_range.float_range
     end
 


### PR DESCRIPTION
Fix warnings due to:
- unused variable in PG Adapter.
- Ambiguous argument warning from range_test for use - to + Infinity range without brackets.
