### PR TITLE
make zones_map private

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -377,13 +377,6 @@ module ActiveSupport
         @zones ||= zones_map.values.sort
       end
 
-      def zones_map
-        @zones_map ||= begin
-          MAPPING.each_key {|place| self[place]} # load all the zones
-          @lazy_zones_map
-        end
-      end
-
       # Locate a specific time zone object. If the argument is a string, it
       # is interpreted to mean the name of the timezone to locate. If it is a
       # numeric value it is either the hour offset, or the second offset, of the
@@ -409,6 +402,14 @@ module ActiveSupport
       # for time zones in the USA.
       def us_zones
         @us_zones ||= all.find_all { |z| z.name =~ /US|Arizona|Indiana|Hawaii|Alaska/ }
+      end
+
+      private
+      def zones_map
+        @zones_map ||= begin
+          MAPPING.each_key {|place| self[place]} # load all the zones
+          @lazy_zones_map
+        end
       end
     end
 

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -395,8 +395,7 @@ class TimeZoneTest < ActiveSupport::TestCase
   end
 
   def test_unknown_zones_dont_store_mapping_keys
-    ActiveSupport::TimeZone["bogus"]
-    assert !ActiveSupport::TimeZone.zones_map.key?("bogus")
+    assert_nil ActiveSupport::TimeZone["bogus"]
   end
 
   def test_new


### PR DESCRIPTION
I noticed there is no documentation for ActiveSupport::TimeZone.zones_map. I was using this method before to get an array of all the names of time zones:

```
ActiveSupport::TimeZones.zones_map(&:name)
```

Now zones_map seems to return a ThreadSafe::Cache instead of something I can map and call name on. So I switched to using .all:

```
ActiveSupport::TimeZones.all.map(&:name)
```

It seems like maybe zones_map wasn't something intended to be used in the public interface at all, or at least not anymore. If it is, can we write some documentation for it?
