### PR TITLE
Setting an ill-formatted Time-ish String into a TimeZone aware column raises an ArgumentError

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -34,7 +34,7 @@ module ActiveRecord
           if create_time_zone_conversion_attribute?(attr_name, columns_hash[attr_name])
             method_body, line = <<-EOV, __LINE__ + 1
               def #{attr_name}=(time)
-                time_with_zone = time.respond_to?(:in_time_zone) ? time.in_time_zone : nil
+                time_with_zone = time.respond_to?(:in_time_zone) ? time.in_time_zone : nil rescue nil
                 previous_time = attribute_changed?("#{attr_name}") ? changed_attributes["#{attr_name}"] : read_attribute(:#{attr_name})
                 write_attribute(:#{attr_name}, time)
                 #{attr_name}_will_change! if previous_time != time_with_zone

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -668,6 +668,15 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_setting_time_zone_aware_attribute_to_a_broken_time_ish_string_returns_nil
+    in_time_zone "Pacific Time (US & Canada)" do
+      record   = @target.new
+      record.written_on = '2009-08'
+      assert_nil record.written_on
+      assert_nil record[:written_on]
+    end
+  end
+
   def test_setting_time_zone_aware_attribute_interprets_time_zone_unaware_string_in_time_zone
     time_string = 'Tue Jan 01 00:00:00 2008'
     (-11..13).each do |timezone_offset|


### PR DESCRIPTION
Giving a `Date._parse`able but invalid DateTime-ish String value into a TimeZone aware AR column immediately raises since 4.0.x.

This regression was caused by 41ff6a10216f48f43605a1f9cd6094765cab750f which stopped rescuing errors when parsing.

This patch brings back the AR3 behaviour that sets nil in such case instead of raising.
/cc @pixeltrix
