### PR TITLE
Make exists? use bound values.

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -292,7 +292,12 @@ module ActiveRecord
       when Array, Hash
         relation = relation.where(conditions)
       else
-        relation = relation.where(table[primary_key].eq(conditions)) if conditions != :none
+        if conditions != :none
+          column = columns_hash[primary_key]
+          substitute = connection.substitute_at(column, bind_values.length)
+          relation = where(table[primary_key].eq(substitute))
+          relation.bind_values += [[column, conditions]]
+        end
       end
 
       connection.select_value(relation, "#{name} Exists", relation.bind_values) ? true : false


### PR DESCRIPTION
When we build a query with an inline value that is a `numeric` (e.g.
because it's out of range for an `int4`) PostgreSQL doesn't use an index
on the column, since it's now comparing `numeric`s and not `int4`s.

This leads to a _very_ slow query.

When we use bound parameters instead of inline values PostgreSQL
raises `numeric_value_out_of_range` since no automatic coercion happens.

This is relevant because otherwise user-supplied input (e.g. `exists?(params[:id])`) can DOS the database.
