### PR TITLE
Replace additional instances of map{}.flatten with flat_map

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/builder.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/builder.rb
@@ -27,7 +27,7 @@ module ActionDispatch
             marked[s] = true # mark s
 
             s.group_by { |state| symbol(state) }.each do |sym, ps|
-              u = ps.map { |l| followpos(l) }.flatten
+              u = ps.flat_map { |l| followpos(l) }
               next if u.empty?
 
               if u.uniq == [DUMMY]
@@ -90,7 +90,7 @@ module ActionDispatch
               firstpos(node.left)
             end
           when Nodes::Or
-            node.children.map { |c| firstpos(c) }.flatten.uniq
+            node.children.flat_map { |c| firstpos(c) }.uniq
           when Nodes::Unary
             firstpos(node.left)
           when Nodes::Terminal
@@ -105,7 +105,7 @@ module ActionDispatch
           when Nodes::Star
             firstpos(node.left)
           when Nodes::Or
-            node.children.map { |c| lastpos(c) }.flatten.uniq
+            node.children.flat_map { |c| lastpos(c) }.uniq
           when Nodes::Cat
             if nullable?(node.right)
               lastpos(node.left) | lastpos(node.right)

--- a/actionpack/lib/action_dispatch/journey/gtg/simulator.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/simulator.rb
@@ -31,7 +31,7 @@ module ActionDispatch
 
           return if acceptance_states.empty?
 
-          memos = acceptance_states.map { |x| tt.memo(x) }.flatten.compact
+          memos = acceptance_states.flat_map { |x| tt.memo(x) }.compact
 
           MatchData.new(memos)
         end

--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -114,8 +114,8 @@ module ActionDispatch
         end
 
         def states
-          ss = @string_states.keys + @string_states.values.map(&:values).flatten
-          rs = @regexp_states.keys + @regexp_states.values.map(&:values).flatten
+          ss = @string_states.keys + @string_states.values.flat_map(&:values)
+          rs = @regexp_states.keys + @regexp_states.values.flat_map(&:values)
           (ss + rs).uniq
         end
 
@@ -143,11 +143,11 @@ module ActionDispatch
           def move_regexp(t, a)
             return [] if t.empty?
 
-            t.map { |s|
+            t.flat_map { |s|
               if states = @regexp_states[s]
                 states.map { |re, v| re === a ? v : nil }
               end
-            }.flatten.compact.uniq
+            }.compact.uniq
           end
 
           def move_string(t, a)

--- a/actionpack/lib/action_dispatch/journey/nfa/dot.rb
+++ b/actionpack/lib/action_dispatch/journey/nfa/dot.rb
@@ -16,9 +16,9 @@ module ActionDispatch
           #  end
           #  "  #{n.object_id} [label=\"#{label}\", shape=box];"
           #}
-          #memo_edges = memos.map { |k, memos|
+          #memo_edges = memos.flat_map { |k, memos|
           #  (memos || []).map { |v| "  #{k} -> #{v.object_id};" }
-          #}.flatten.uniq
+          #}.uniq
 
         <<-eodot
 digraph nfa {

--- a/actionpack/lib/action_dispatch/journey/nfa/simulator.rb
+++ b/actionpack/lib/action_dispatch/journey/nfa/simulator.rb
@@ -34,7 +34,7 @@ module ActionDispatch
 
           return if acceptance_states.empty?
 
-          memos = acceptance_states.map { |x| tt.memo(x) }.flatten.compact
+          memos = acceptance_states.flat_map { |x| tt.memo(x) }.compact
 
           MatchData.new(memos)
         end

--- a/actionpack/lib/action_dispatch/journey/nfa/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/nfa/transition_table.rb
@@ -42,7 +42,7 @@ module ActionDispatch
         end
 
         def states
-          (@table.keys + @table.values.map(&:keys).flatten).uniq
+          (@table.keys + @table.values.flat_map(&:keys)).uniq
         end
 
         # Returns a generalized transition graph with reduced states. The states
@@ -93,7 +93,7 @@ module ActionDispatch
         # Returns set of NFA states to which there is a transition on ast symbol
         # +a+ from some state +s+ in +t+.
         def following_states(t, a)
-          Array(t).map { |s| inverted[s][a] }.flatten.uniq
+          Array(t).flat_map { |s| inverted[s][a] }.uniq
         end
 
         # Returns set of NFA states to which there is a transition on ast symbol
@@ -107,7 +107,7 @@ module ActionDispatch
         end
 
         def alphabet
-          inverted.values.map(&:keys).flatten.compact.uniq.sort_by { |x| x.to_s }
+          inverted.values.flat_map(&:keys).compact.uniq.sort_by { |x| x.to_s }
         end
 
         # Returns a set of NFA states reachable from some NFA state +s+ in set
@@ -131,9 +131,9 @@ module ActionDispatch
         end
 
         def transitions
-          @table.map { |to, hash|
+          @table.flat_map { |to, hash|
             hash.map { |from, sym| [from, sym, to] }
-          }.flatten(1)
+          }
         end
 
         private

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -53,9 +53,9 @@ module ActionDispatch
         end
 
         def optional_names
-          @optional_names ||= spec.grep(Nodes::Group).map { |group|
+          @optional_names ||= spec.grep(Nodes::Group).flat_map { |group|
             group.grep(Nodes::Symbol)
-          }.flatten.map { |n| n.name }.uniq
+          }.map { |n| n.name }.uniq
         end
 
         class RegexpOffsets < Journey::Visitors::Visitor # :nodoc:

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -530,8 +530,8 @@ module ActiveRecord
     #   end
     #
     #   @firm = Firm.first
-    #   @firm.clients.collect { |c| c.invoices }.flatten # select all invoices for all clients of the firm
-    #   @firm.invoices                                   # selects all invoices by going through the Client join model
+    #   @firm.clients.flat_map { |c| c.invoices } # select all invoices for all clients of the firm
+    #   @firm.invoices                            # selects all invoices by going through the Client join model
     #
     # Similarly you can go through a +has_one+ association on the join model:
     #

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -23,7 +23,7 @@ module ActiveRecord
 
           reset_association owners, through_reflection.name
 
-          middle_records = through_records.map { |(_,rec)| rec }.flatten
+          middle_records = through_records.flat_map { |(_,rec)| rec }
 
           preloaders = preloader.preload(middle_records,
                                          source_reflection.name,

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -459,7 +459,7 @@ module ActiveRecord
       end
 
       def bulk_change_table(table_name, operations) #:nodoc:
-        sqls = operations.map do |command, args|
+        sqls = operations.flat_map do |command, args|
           table, arguments = args.shift, args
           method = :"#{command}_sql"
 
@@ -468,7 +468,7 @@ module ActiveRecord
           else
             raise "Unknown method called : #{method}(#{arguments.inspect})"
           end
-        end.flatten.join(", ")
+        end.join(", ")
 
         execute("ALTER TABLE #{quote_table_name(table_name)} #{sqls}")
       end

--- a/activerecord/test/cases/associations/callbacks_test.rb
+++ b/activerecord/test/cases/associations/callbacks_test.rb
@@ -159,7 +159,7 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
       activerecord.reload
       assert activerecord.developers_with_callbacks.size == 2
     end
-    log_array = activerecord.developers_with_callbacks.collect {|d| ["before_removing#{d.id}","after_removing#{d.id}"]}.flatten.sort
+    log_array = activerecord.developers_with_callbacks.flat_map {|d| ["before_removing#{d.id}","after_removing#{d.id}"]}.sort
     assert activerecord.developers_with_callbacks.clear
     assert_equal log_array, activerecord.developers_log.sort
   end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -76,9 +76,9 @@ class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
   end
 
   def callbacks_for_model(model)
-    model.instance_variables.grep(/_callbacks$/).map do |ivar|
+    model.instance_variables.grep(/_callbacks$/).flat_map do |ivar|
       model.instance_variable_get(ivar)
-    end.flatten
+    end
   end
 end
 

--- a/railties/lib/rails/commands/plugin.rb
+++ b/railties/lib/rails/commands/plugin.rb
@@ -11,7 +11,7 @@ else
               end
     if File.exist?(railsrc)
       extra_args_string = File.read(railsrc)
-      extra_args = extra_args_string.split(/\n+/).map {|l| l.split}.flatten
+      extra_args = extra_args_string.split(/\n+/).flat_map {|l| l.split}
       puts "Using #{extra_args.join(" ")} from #{railsrc}"
       ARGV.insert(1, *extra_args)
     end

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -188,7 +188,7 @@ module Rails
       #   generate(:authenticated, "user session")
       def generate(what, *args)
         log :generate, what
-        argument = args.map {|arg| arg.to_s }.flatten.join(" ")
+        argument = args.flat_map {|arg| arg.to_s }.join(" ")
 
         in_root { run_ruby_script("bin/rails generate #{what} #{argument}", verbose: false) }
       end

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -101,7 +101,7 @@ module Rails
       def filter_by(&block)
         all_paths.find_all(&block).flat_map { |path|
           paths = path.existent
-          paths - path.children.map { |p| yield(p) ? [] : p.existent }.flatten
+          paths - path.children.flat_map { |p| yield(p) ? [] : p.existent }
         }.uniq
       end
     end

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -115,7 +115,7 @@ class SourceAnnotationExtractor
   # Prints the mapping from filenames to annotations in +results+ ordered by filename.
   # The +options+ hash is passed to each annotation's +to_s+.
   def display(results, options={})
-    options[:indent] = results.map { |f, a| a.map(&:line) }.flatten.max.to_s.size
+    options[:indent] = results.flat_map { |f, a| a.map(&:line) }.max.to_s.size
     results.keys.sort.each do |file|
       puts "#{file}:"
       results[file].each do |note|


### PR DESCRIPTION
This is a follow-up to https://github.com/rails/rails/pull/14240. As noted in that issue, using `flat_map` is significantly faster than `map.flatten`.

``` ruby
require 'benchmark/ips'

ARRAY = 100.times.map { (0..9).to_a }

def slow
  ARRAY.map { |x| x }.flatten(1)
end

def fast
  ARRAY.flat_map { |x| x }
end

Benchmark.ips do |x|
  x.report('slow') { slow }
  x.report('fast') { fast }
end
```

```
slow 12348.2 (±9.0%) i/s -  61450 in 5.017159s
fast 56647.8 (±7.2%) i/s - 282152 in 5.006973s
```
