### PR TITLE
Fixes error in parsing parameters passed to a model with associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   When creating a new record of a model that has_many of another model, 
+    the second model wasn't parsed and gave an error. This error is now
+    fixed and the second model is parsed correctly.
+
+    Fixes #14249.
+
+    *Ahmed AbouElhamayed*
+
 *   `includes` is able to detect the right preloading strategy when string
     joins are involved.
 

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -207,14 +207,21 @@ module ActiveRecord
           false
         end
 
+        def handle_hashes(record)
+          klass.new(record)
+        end
+
         # Raises ActiveRecord::AssociationTypeMismatch unless +record+ is of
         # the kind of the class of the associated objects. Meant to be used as
         # a sanity check when you are about to assign an associated record.
         def raise_on_type_mismatch!(record)
           unless record.is_a?(reflection.klass) || record.is_a?(reflection.class_name.constantize)
+            record = handle_hashes(record) if record.is_a?(Hash)
+            return record if reflection.klass && record.is_a?(reflection.klass)
             message = "#{reflection.class_name}(##{reflection.klass.object_id}) expected, got #{record.class}(##{record.class.object_id})"
             raise ActiveRecord::AssociationTypeMismatch, message
           end
+          record
         end
 
         # Can be redefined by subclasses, notably polymorphic belongs_to

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -353,7 +353,7 @@ module ActiveRecord
       # Replace this collection with +other_array+. This will perform a diff
       # and delete/add only records that have changed.
       def replace(other_array)
-        other_array.each { |val| raise_on_type_mismatch!(val) }
+        other_array.map! { |val| val = raise_on_type_mismatch!(val) }
         original_target = load_target.dup
 
         if owner.new_record?

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -335,6 +335,14 @@ class OverridingAssociationsTest < ActiveRecord::TestCase
       end
     end
   end
+
+  def test_hash_parsing_in_associations
+    molecule = Molecule.create(:name => "molecule_1")
+    molecule.electrons.create(:name => "electron_1")
+    json_molecule = molecule.to_json(:include => :electrons)
+    molecule2 = Molecule.new(JSON.parse(json_molecule))
+    assert molecule2.electrons.count == 1
+  end
 end
 
 class GeneratedMethodsTest < ActiveRecord::TestCase


### PR DESCRIPTION
When trying to create a record of a model that has_many of another
model and passing the parameters of the second model record as a
hash, it used to raise an exception. This fixes that behaviour and
allows passing of a second model record parameters to the parameters
used to create the first model.
This fixes #14249 

[Ahmed AbouElhamayed]
