### PR TITLE
Association scope should work when a nil value is returned.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Association scope should work when a nil value is returned.
+
+    *arthurnn*
+
 *   Dynamically register PostgreSQL enum OIDs. This prevents "unknown OID"
     warnings on enum columns.
 

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -109,7 +109,7 @@ module ActiveRecord
           # Exclude the scope of the association itself, because that
           # was already merged in the #scope method.
           scope_chain[i].each do |scope_chain_item|
-            item  = eval_scope(klass, scope_chain_item, owner)
+            item  = eval_scope(klass, scope_chain_item, owner) || klass.unscoped
 
             if scope_chain_item == refl.scope
               scope.merge! item.except(:where, :includes, :bind)

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -43,6 +43,12 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_equal Firm.all.merge!(:includes => :account_with_select).find(1).account_with_select.attributes.size, 2
   end
 
+  def test_select_with_nil_scope
+    firm = Firm.find(1)
+    firm.firm_name = "foo"
+    assert_equal firm.account_with_select.attributes.size, 4
+  end
+
   def test_finding_using_primary_key
     firm = companies(:first_firm)
     assert_equal Account.find_by_firm_id(firm.id), firm.account

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -65,7 +65,9 @@ class Firm < Company
 
   has_one :account, :foreign_key => "firm_id", :dependent => :destroy, :validate => true
   has_one :unvalidated_account, :foreign_key => "firm_id", :class_name => 'Account', :validate => false
-  has_one :account_with_select, -> { select("id, firm_id") }, :foreign_key => "firm_id", :class_name=>'Account'
+  has_one :account_with_select, lambda { |record|
+    select("id, firm_id") unless record.try(:firm_name)
+  }, :foreign_key => "firm_id", :class_name=>'Account'
   has_one :readonly_account, -> { readonly }, :foreign_key => "firm_id", :class_name => "Account"
   # added order by id as in fixtures there are two accounts for Rails Core
   # Oracle tests were failing because of that as the second fixture was selected


### PR DESCRIPTION
### Problem

We have some associations that need to associate 2 fks, when the record exists.

``` ruby
  has_one :transfer, -> (record) {
      where(shop_id: record.shop_id)  if record
  }, foreign_key: 'transfer_id', primary_key: 'transfer_id'
```

So when the `record` is nil, we will return a nil object to the proc. We should be able to deal with that easily just short-circuiting it.

review @carlosantoniodasilva @tenderlove
