### PR TITLE
Cache key should be different when is Array.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Cache key should add a trailing slash when the key is an array,
+    so `cache.fetch('foo')` and `cache.fetch(['foo'])` wont conflict.
+
+    *arthurnn*
+
 *   Change the signature of `fetch_multi` to return a hash rather than an
     array. This makes it consistent with the output of `read_multi`.
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -511,7 +511,7 @@ module ActiveSupport
         # called. If the key is a Hash, then keys will be sorted alphabetically.
         def expanded_key(key) # :nodoc:
           return key.cache_key.to_s if key.respond_to?(:cache_key)
-
+          trailing_slash = false
           case key
           when Array
             if key.size > 1
@@ -519,11 +519,12 @@ module ActiveSupport
             else
               key = key.first
             end
+            trailing_slash = true
           when Hash
             key = key.sort_by { |k,_| k.to_s }.collect{|k,v| "#{k}=#{v}"}
           end
-
-          key.to_param
+          key = key.to_param
+          trailing_slash ? "#{key}/" : key
         end
 
         # Prefix a key with the namespace. Namespace and key will be delimited

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -257,6 +257,10 @@ module CacheStoreBehavior
     assert_nil @cache.fetch('foo') { 'baz' }
   end
 
+  def test_fetch_with_array_and_without
+    assert_not_equal @cache.fetch('foo') { 'barz' }, @cache.fetch(['foo']) { 'barr' }
+  end
+
   def test_should_read_and_write_hash
     assert @cache.write('foo', {:a => "b"})
     assert_equal({:a => "b"}, @cache.read('foo'))
@@ -349,7 +353,7 @@ module CacheStoreBehavior
 
   def test_array_as_cache_key
     @cache.write([:fu, "foo"], "bar")
-    assert_equal "bar", @cache.read("fu/foo")
+    assert_equal "bar", @cache.read("fu/foo/")
   end
 
   def test_hash_as_cache_key


### PR DESCRIPTION
`cache.fetch(['foo'])` and `cache.fetch('foo')` should generate
different cache keys as they are not equivalents.

[related #8615]
[related #8614]

review @guilleiguaran @spastorino @carlosantoniodasilva
