### PR TITLE
Deprecate - Class#superclass_delegating_accessor

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `Class#superclass_delegating_accessor`, use `Class#class_attribute` instead.
+
+    *Akshay Vishnoi*
+
 *   Ensure classes which `include Enumerable` get `#to_json` in addition to
     `#as_json`.
 

--- a/activesupport/lib/active_support/core_ext/class/delegating_attributes.rb
+++ b/activesupport/lib/active_support/core_ext/class/delegating_attributes.rb
@@ -1,5 +1,7 @@
 require 'active_support/core_ext/kernel/singleton_class'
 require 'active_support/core_ext/module/remove_method'
+require 'active_support/core_ext/module/deprecation'
+
 
 class Class
   def superclass_delegating_accessor(name, options = {})
@@ -20,6 +22,8 @@ class Class
       define_method("#{name}?") { !!send("#{name}") }
     end
   end
+
+  deprecate superclass_delegating_accessor: :class_attribute
 
   private
     # Take the object being set and store it in a method. This gives us automatic

--- a/activesupport/test/core_ext/class/delegating_attributes_test.rb
+++ b/activesupport/test/core_ext/class/delegating_attributes_test.rb
@@ -6,14 +6,18 @@ module DelegatingFixtures
   end
 
   class Child < Parent
-    superclass_delegating_accessor :some_attribute
+    ActiveSupport::Deprecation.silence do
+      superclass_delegating_accessor :some_attribute
+    end
   end
 
   class Mokopuna < Child
   end
 
   class PercysMom
-    superclass_delegating_accessor :superpower
+    ActiveSupport::Deprecation.silence do
+      superclass_delegating_accessor :superpower
+    end
   end
 
   class Percy < PercysMom
@@ -29,7 +33,10 @@ class DelegatingAttributesTest < ActiveSupport::TestCase
   end
 
   def test_simple_accessor_declaration
-    single_class.superclass_delegating_accessor :both
+    ActiveSupport::Deprecation.silence do
+      single_class.superclass_delegating_accessor :both
+    end
+
     # Class should have accessor and mutator
     # the instance should have an accessor only
     assert_respond_to single_class, :both
@@ -40,7 +47,11 @@ class DelegatingAttributesTest < ActiveSupport::TestCase
 
   def test_simple_accessor_declaration_with_instance_reader_false
     _instance_methods = single_class.public_instance_methods
-    single_class.superclass_delegating_accessor :no_instance_reader, :instance_reader => false
+
+    ActiveSupport::Deprecation.silence do
+      single_class.superclass_delegating_accessor :no_instance_reader, :instance_reader => false
+    end
+
     assert_respond_to single_class, :no_instance_reader
     assert_respond_to single_class, :no_instance_reader=
     assert !_instance_methods.include?(:no_instance_reader)
@@ -49,7 +60,9 @@ class DelegatingAttributesTest < ActiveSupport::TestCase
   end
 
   def test_working_with_simple_attributes
-    single_class.superclass_delegating_accessor :both
+    ActiveSupport::Deprecation.silence do
+      single_class.superclass_delegating_accessor :both
+    end
 
     single_class.both = "HMMM"
 
@@ -65,7 +78,11 @@ class DelegatingAttributesTest < ActiveSupport::TestCase
 
   def test_child_class_delegates_to_parent_but_can_be_overridden
     parent = Class.new
-    parent.superclass_delegating_accessor :both
+
+    ActiveSupport::Deprecation.silence do
+      parent.superclass_delegating_accessor :both
+    end
+
     child = Class.new(parent)
     parent.both = "1"
     assert_equal "1", child.both
@@ -97,4 +114,9 @@ class DelegatingAttributesTest < ActiveSupport::TestCase
     Child.some_attribute=nil
   end
 
+  def test_deprecation_warning
+    assert_deprecated(/superclass_delegating_accessor is deprecated/) do
+      single_class.superclass_delegating_accessor :test_attribute
+    end
+  end
 end


### PR DESCRIPTION
``` ruby
class TestClass
  superclass_delegating_accessor :test_attribute
end

# Before
TestClass.private_methods.include?(:_test_attribute) # => false
TestClass.private_methods.include?(:_test_attribute=) # => false

# After
TestClass.private_methods.include?(:_test_attribute) # => true
TestClass.private_methods.include?(:_test_attribute=) # => true
```
