### PR TITLE
Allow string hash values on AR order method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Allow passing string values to AR order method:
+
+    Example:
+
+        Model.order(id: 'asc').to_sql == Model.order(id: :asc).to_sql
+
+    Fixes #10732
+
+    *Marcelo Casiraghi*
+
 *   Default scopes are no longer overriden by chained conditions.
 
     Before this change when you defined a `default_scope` in a model

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1031,9 +1031,11 @@ module ActiveRecord
     end
 
     def validate_order_args(args)
-      args.grep(Hash) do |h|
-        unless (h.values - [:asc, :desc]).empty?
-          raise ArgumentError, 'Direction should be :asc or :desc'
+      args.grep(Hash) do |hash|
+        hash.values.each do |arg|
+          unless arg.to_s.casecmp('asc').zero? || arg.to_s.casecmp('desc').zero?
+            raise ArgumentError, 'Direction should be asc or desc'
+          end
         end
       end
     end
@@ -1055,7 +1057,7 @@ module ActiveRecord
         when Hash
           arg.map { |field, dir|
             field = klass.attribute_alias(field) if klass.attribute_alias?(field)
-            table[field].send(dir)
+            table[field].send(dir.to_s.downcase)
           }
         else
           arg

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -171,7 +171,6 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal topics(:first).title, topics.first.title
   end
 
-
   def test_finding_with_arel_order
     topics = Topic.order(Topic.arel_table[:id].asc)
     assert_equal 5, topics.to_a.size
@@ -194,8 +193,45 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal Topic.order(:id).to_sql, Topic.order(:id => :asc).to_sql
   end
 
+  def test_finding_with_desc_order_with_string
+    topics = Topic.order(id: "desc")
+    assert_equal 5, topics.to_a.size
+    expected_order = [topics(:fifth), topics(:fourth), topics(:third), topics(:second), topics(:first)]
+    assert_equal expected_order, topics.to_a
+  end
+
+  def test_finding_with_asc_order_with_string
+    topics = Topic.order(id: 'asc')
+    assert_equal 5, topics.to_a.size
+    expected_order = [topics(:first), topics(:second), topics(:third), topics(:fourth), topics(:fifth)]
+    assert_equal expected_order, topics.to_a
+  end
+
+  def test_nothing_raises_on_upcase_desc_arg
+    assert_nothing_raised { Topic.order(id: "DESC") }
+  end
+
+  def test_nothing_raises_on_downcase_desc_arg
+    assert_nothing_raised { Topic.order(id: "desc") }
+  end
+
+  def test_nothing_raises_on_upcase_asc_arg
+    assert_nothing_raised { Topic.order(id: "ASC") }
+  end
+
+  def test_nothing_raises_on_downcase_asc_arg
+    assert_nothing_raised { Topic.order(id: "asc") }
+  end
+
+  def test_nothing_raises_on_case_insensitive_args
+    assert_nothing_raised { Topic.order(id: "DeSc") }
+    assert_nothing_raised { Topic.order(id: :DeSc)  }
+    assert_nothing_raised { Topic.order(id: "aSc")  }
+    assert_nothing_raised { Topic.order(id: :aSc)   }
+  end
+
   def test_raising_exception_on_invalid_hash_params
-    assert_raise(ArgumentError) { Topic.order(:name, "id DESC", :id => :DeSc) }
+    assert_raise(ArgumentError) { Topic.order(:name, "id DESC", id: :asfsdf) }
   end
 
   def test_finding_last_with_arel_order


### PR DESCRIPTION
Rebased code for #10732

Closes  #10732

/cc @senny
