### PR TITLE
Issue debug statement about "unknown OID" for PostgreSQL custom types.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -143,7 +143,7 @@ module ActiveRecord
             ftype = result.ftype i
             fmod  = result.fmod i
             types[fname] = type_map.fetch(ftype, fmod) { |oid, mod|
-              warn "unknown OID: #{fname}(#{oid}) (#{sql})"
+              ActiveRecord::Base.logger.debug "unknown OID: #{fname}(#{oid}) (#{sql})"
               OID::Identity.new
             }
           end


### PR DESCRIPTION
Changed from a warning.

I dunno if this can be put in 4.1 or earlier releases, but it would be really nice. I can't imagine it causing any problems.
