### PR TITLE
add test for destroy! in persistence tests

### DIFF
--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -365,6 +365,14 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(topic.id) }
   end
 
+  def test_destroy_with_failing_callback!
+    topic = Topic.find(1)
+    topic.class_eval do
+      before_destroy { false }
+    end
+    assert_raise(ActiveRecord::RecordNotDestroyed) { topic.destroy! }
+  end
+
   def test_record_not_found_exception
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(99999) }
   end


### PR DESCRIPTION
from looking at the code at [persistence.rb](https://github.com/rails/rails/blob/475c96589ca65282e1a61350271c2f83f0d4044f/activerecord/lib/active_record/persistence.rb#L151-L157) it looked like the `destroy!` method would not raise an exception... i still did not fully understand the defails, but i think it's black callback magic :sparkles: 

i see that there are already some tests for `destroy!` in `callbacks_test.rb` and `has_many_associations.rb`. nevertheless i think that this test should be in here as well.
