### PR TITLE
Make CSRF failure logging optional/configurable.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -2,5 +2,10 @@
     `default_url_options` methods.
 
     *Tony Wooster*
+*   Make logging of CSRF failures optional (but on by default) with the
+    `log_warning_on_csrf_failure` configuration setting in
+    ActionController::RequestForgeryProtection
+
+    *John Barton*
 
 Please check [4-1-stable](https://github.com/rails/rails/blob/4-1-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -68,6 +68,10 @@ module ActionController #:nodoc:
       config_accessor :allow_forgery_protection
       self.allow_forgery_protection = true if allow_forgery_protection.nil?
 
+      # Controls whether a CSRF failure logs a warning. On by default.
+      config_accessor :log_warning_on_csrf_failure
+      self.log_warning_on_csrf_failure = true
+
       helper_method :form_authenticity_token
       helper_method :protect_against_forgery?
     end
@@ -193,7 +197,9 @@ module ActionController #:nodoc:
         mark_for_same_origin_verification!
 
         if !verified_request?
-          logger.warn "Can't verify CSRF token authenticity" if logger
+          if logger && log_warning_on_csrf_failure
+            logger.warn "Can't verify CSRF token authenticity"
+          end
           handle_unverified_request
         end
       end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -289,6 +289,22 @@ module RequestForgeryProtectionTests
     end
   end
 
+  def test_should_not_warn_if_csrf_logging_disabled
+    old_logger = ActionController::Base.logger
+    logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
+    ActionController::Base.logger = logger
+    ActionController::Base.log_warning_on_csrf_failure = false
+
+    begin
+      assert_blocked { post :index }
+
+      assert_equal 0, logger.logged(:warn).size
+    ensure
+      ActionController::Base.logger = old_logger
+      ActionController::Base.log_warning_on_csrf_failure = true
+    end
+  end
+
   def test_should_only_allow_same_origin_js_get_with_xhr_header
     assert_cross_origin_blocked { get :same_origin_js }
     assert_cross_origin_blocked { get :same_origin_js, format: 'js' }


### PR DESCRIPTION
Added the log_warning_on_csrf_failure option to ActionController::RequestForgeryProtection
which is on by default.

My reasoning being that I'm using papertrailapp on an app that is maybe 80% API and I'm explicitly using null_session to ignore CSRF problems on my API endpoints safely, but am getting a lot of log noise which isn't very helpful. I thought about overriding `verify_authenticity_token` in my app code, but the comments suggest that is a **bad** idea and I agree, but as the logging happens in there rather than in any of the protection method classes, I can't override the behaviour the preferred way.

The other implementation options I've thought of:
- push all the logging down into the classes in ProtectionMethods and then I re-implement NullSession in my own app code as QuietNullSession
- add a QuietNullSession to ProtectionMethods

I prefer it to be a config option because that way I don't have to worry about keeping my CSRF stuff in sync with rails over time, because honestly I'm unlikely to, and then _security_ will happen to me.
