### PR TITLE
Update CollectionAssociation.ids_writer to update changed_attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Update changed_attributes when using `<asssociation>_ids=(ids)`.
+
+    *Frank Showalter*
+
 *   Fixed error when specifying a non-empty default value on a PostgreSQL array column.
 
     Fixes #10613.

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -702,6 +702,12 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_equal [projects(:active_record), projects(:action_controller)].map(&:id).sort, developer.project_ids.sort
   end
 
+  def test_assign_ids_updates_changed_attributes
+    developer = Developer.new("name" => "Joe")
+    developer.project_ids = [projects(:active_record).id, nil, projects(:action_controller).id, '']
+    assert developer.changed_attributes.key?("project_ids")
+  end
+
   def test_scoped_find_on_through_association_doesnt_return_read_only_records
     tag = Post.find(1).tags.find_by_name("General")
 


### PR DESCRIPTION
Currently, ActiveRecord implements partial support for dirty attributes. 

``` ruby
post = Post.new(title: "Test Post")
post.changed_attributes # => {"title" => nil }
```

This works great for everything except the common use case of collection lookups.

For example, suppose our app allowed the user to pick from a list of tags. We could use a multi-select or a checkbox array, but the end result would be something like this:

``` ruby
post = Post.new(title: "New Post", tag_ids: ['1','2','3'])
post.changed_attributes # => {"title" => nil }
```

With this pull request, you'd get:

``` ruby
post = Post.new(title: "New Post", tag_ids: ['1','2','3'])
post.changed_attributes # => {"title" => nil, "tag_ids" => [] }
```

This isn't intended to be a be-all-end-all implementation of changed_attributes for associations, just one that covers the common use case of has_many associations that are only associations from a normalization standpoint and thus exclusively make use of the `ids_writer` method to update via the owner.
