### PR TITLE
	modified:   activesupport/Rakefile

### DIFF
--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -1,14 +1,16 @@
 require 'rake/testtask'
 require 'rubygems/package_task'
 
+desc "Default Task"
 task :default => :test
+
+# Run the unit tests
 Rake::TestTask.new do |t|
   t.libs << 'test'
   t.pattern = 'test/**/*_test.rb'
   t.warning = true
   t.verbose = true
 end
-
 
 namespace :test do
   task :isolated do


### PR DESCRIPTION
The Rakefile for activesupport should be consistent with the Rakefiles of actionmailer, actionpack. So added a desc to the default task, added a comment of Run the unit tests and deleted an extra line of space where it was unnecessary
