### PR TITLE
Digestor: pass the missing "keys" param to LookupContext

### DIFF
--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -164,6 +164,14 @@ class FunctionalCachingController < CachingController
     end
   end
 
+  def formatted_fragment_cached_with_variant
+    request.variant = params[:variant].to_sym if params[:variant].present?
+
+    respond_to do |format|
+      format.html.phone
+    end
+  end
+
   def fragment_cached_without_digest
   end
 end
@@ -240,6 +248,17 @@ CACHED
 
     assert_equal "  <p>Builder</p>\n",
       @store.read("views/test.host/functional_caching/formatted_fragment_cached/#{template_digest("functional_caching/formatted_fragment_cached", "xml")}")
+  end
+
+  def test_fragment_caching_with_variant
+    get :formatted_fragment_cached_with_variant, :format => "html", :variant => :phone
+    assert_response :success
+    expected_body = "<body>\n<p>PHONE</p>\n</body>\n"
+
+    assert_equal expected_body, @response.body
+
+    assert_equal "<p>PHONE</p>",
+      @store.read("views/test.host/functional_caching/formatted_fragment_cached/#{template_digest("functional_caching/formatted_fragment_cached_with_variant", :html, :phone)}")
   end
 
   private

--- a/actionpack/test/fixtures/functional_caching/formatted_fragment_cached_with_variant.html+phone.erb
+++ b/actionpack/test/fixtures/functional_caching/formatted_fragment_cached_with_variant.html+phone.erb
@@ -1,0 +1,3 @@
+<body>
+<%= cache do %><p>PHONE</p><% end %>
+</body>

--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -126,7 +126,7 @@ module ActionView
       end
 
       def template
-        @template ||= finder.find(logical_name, [], partial?, formats: [ format ], variants: [ variant ])
+        @template ||= finder.find(logical_name, [], partial?, [], formats: [ format ], variants: [ variant ])
       end
 
       def source

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -165,9 +165,11 @@ module ActionView
 
       def fragment_name_with_digest(name) #:nodoc:
         if @virtual_path
+          variant = request.variant.is_a?(Array) ? request.variant.first : request.variant
+
           [
             *Array(name.is_a?(Hash) ? controller.url_for(name).split("://").last : name),
-            Digestor.digest(name: @virtual_path, format: formats.last.to_sym, variant: request.variant, finder: lookup_context, dependencies: view_cache_dependencies)
+            Digestor.digest(name: @virtual_path, format: formats.last.to_sym, variant: variant, finder: lookup_context, dependencies: view_cache_dependencies)
           ]
         else
           name

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -25,7 +25,7 @@ class FixtureFinder
     details.hash
   end
 
-  def find(logical_name, keys, partial, options)
+  def find(logical_name, prefixes = [], partial = false, keys = [], options = {})
     partial_name = partial ? logical_name.gsub(%r|/([^/]+)$|, '/_\1') : logical_name
     format = options[:formats].first.to_s
     format += "+#{options[:variants].first}" if options[:variants].any?


### PR DESCRIPTION
Related to #14243 & #14242

Took me a while to debug this. The problem was that Digestor didn't pass the `keys` param to `LookupContext` (actually passing `options` as `keys`), so variants were lost in between.

I don't consider it ready, because I haven't figured out a way to test it properly.

Also, there's one catch: if `show.html+phone.erb` exists, it will be rendered, but if doesn't, lookup will fall back to `show.html.erb`. I'm not sure if that's a desirable behavior.

/cc @dhh @strzalek @jeremy
