### PR TITLE
Add Rack::Deflater middleware to production environment template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -1,3 +1,5 @@
+require 'rack/deflater'
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -84,4 +86,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
   <%- end -%>
+
+  # Serve gzipped content
+  config.middleware.insert_before Rack::ETag, Rack::Deflater
 end


### PR DESCRIPTION
Some proxy servers, like nginx (recent versions) won't keep the ETag header if the gzip compression is enabled in the proxy-side as it would change the content. Also nginx doesn't support weak ETag yet.

In some cases, serving a full application directly with Puma, for instance, may be good enough for some applications with no need for load balancing and enabling gzip compression by default in production environments is a good default to support.

In other servers set-ups there may be a cluster of servers and the suggested approach in the guides of serving the assets directly from the proxy server by local assets location require them to be accessible in the same filesystem as the proxy server which may be a bit of burden in the deployment process. Another approach is to configure the proxy-server to cache those requests after the first access to the proxied url with the application serving the assets for the first access (not cached by nginx yet). But this approach doesn't work well in nginx if nginx is also responsible for gzipping the assets. Applying gzip compression directly in the backend avoid having to configure a new proxy in the path just to compress the content before it gets cached.
