### PR TITLE
Run ActiveModel test suites in random order.

### DIFF
--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -147,7 +147,7 @@ class SecurePasswordTest < ActiveModel::TestCase
   test "setting a nil password should clear an existing password" do
     @existing_user.password = nil
     assert_equal nil, @existing_user.password_digest
-  end  
+  end
 
   test "authenticate" do
     @user.password = "secret"
@@ -157,24 +157,42 @@ class SecurePasswordTest < ActiveModel::TestCase
   end
 
   test "Password digest cost defaults to bcrypt default cost when min_cost is false" do
+    original_min_cost = ActiveModel::SecurePassword.min_cost
     ActiveModel::SecurePassword.min_cost = false
 
-    @user.password = "secret"
-    assert_equal BCrypt::Engine::DEFAULT_COST, @user.password_digest.cost
+    begin
+      @user.password = "secret"
+      assert_equal BCrypt::Engine::DEFAULT_COST, @user.password_digest.cost
+    ensure
+      ActiveModel::SecurePassword.min_cost = original_min_cost
+    end
   end
 
   test "Password digest cost honors bcrypt cost attribute when min_cost is false" do
+    original_min_cost = ActiveModel::SecurePassword.min_cost
+    original_cost = BCrypt::Engine.cost
+
     ActiveModel::SecurePassword.min_cost = false
     BCrypt::Engine.cost = 5
 
-    @user.password = "secret"
-    assert_equal BCrypt::Engine.cost, @user.password_digest.cost
+    begin
+      @user.password = "secret"
+      assert_equal BCrypt::Engine.cost, @user.password_digest.cost
+    ensure
+      ActiveModel::SecurePassword.min_cost = original_min_cost
+      BCrypt::Engine.cost = original_cost
+    end
   end
 
   test "Password digest cost can be set to bcrypt min cost to speed up tests" do
+    original_min_cost = ActiveModel::SecurePassword.min_cost
     ActiveModel::SecurePassword.min_cost = true
 
-    @user.password = "secret"
-    assert_equal BCrypt::Engine::MIN_COST, @user.password_digest.cost
+    begin
+      @user.password = "secret"
+      assert_equal BCrypt::Engine::MIN_COST, @user.password_digest.cost
+    ensure
+      ActiveModel::SecurePassword.min_cost = original_min_cost
+    end
   end
 end

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -7,6 +7,10 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     I18n.backend = I18n::Backend::Simple.new
   end
 
+  def teardown
+    I18n.backend.reload!
+  end
+
   def test_translated_model_attributes
     I18n.backend.store_translations 'en', activemodel: { attributes: { person: { name: 'person name attribute' } } }
     assert_equal 'person name attribute', Person.human_attribute_name('name')

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -63,12 +63,15 @@ class ConfirmationValidationTest < ActiveModel::TestCase
 
     Topic.validates_confirmation_of(:title)
 
-    t = Topic.new("title" => "We should be confirmed","title_confirmation" => "")
-    assert t.invalid?
-    assert_equal ["doesn't match Test Title"], t.errors[:title_confirmation]
-
-    I18n.load_path.replace @old_load_path
-    I18n.backend = @old_backend
+    begin
+      t = Topic.new("title" => "We should be confirmed","title_confirmation" => "")
+      assert t.invalid?
+      assert_equal ["doesn't match Test Title"], t.errors[:title_confirmation]
+    ensure
+      I18n.load_path.replace @old_load_path
+      I18n.backend = @old_backend
+      I18n.backend.reload!
+    end
   end
 
   test "does not override confirmation reader if present" do

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -19,6 +19,7 @@ class I18nValidationTest < ActiveModel::TestCase
     Person.clear_validators!
     I18n.load_path.replace @old_load_path
     I18n.backend = @old_backend
+    I18n.backend.reload!
   end
 
   def test_full_message_encoding


### PR DESCRIPTION
This gets the whole ActiveModel test suites working even if
`self.i_suck_and_my_tests_are_order_dependent!` is disabled
in `ActiveSupport::TestCase`.

`BCrypt::Engine.cost` needs to be reset to nil or default,
otherwise changes to cost made in other tests will be carried
over and result in failure when expecting `Bcrypt::Engine::DEFAULT`.
