### PR TITLE
Make sure we clean preview_interceptors

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -13,6 +13,7 @@ class BaseTest < ActiveSupport::TestCase
   def teardown
     ActionMailer::Base.asset_host = nil
     ActionMailer::Base.assets_dir = nil
+    ActionMailer::Base.preview_interceptors.clear
   end
 
   test "method call to mail does not raise error" do


### PR DESCRIPTION
Attempt to fix the random failures on mailer base test.

Failing test:

```
  1) Failure:
BaseTest#test_you_can_register_multiple_preview_interceptors_to_the_mail_object_that_both_get_passed_the_mail_object_before_previewing [/home/travis/build/rails/rails/actionmailer/lib/action_mailer/preview.rb:99]:
unexpected invocation: BaseTest::MyInterceptor.previewing_email(#<Mail::Message:0x3c19af0>)
unsatisfied expectations:
- expected exactly once, not yet invoked: BaseTest::MyInterceptor.previewing_email(#<Mail::Message:0x3d57f48>)
- expected exactly once, not yet invoked: BaseTest::MySecondInterceptor.previewing_email(#<Mail::Message:0x3d57f48>)
satisfied expectations:
- allowed any number of times, not yet invoked: BaseTest::BaseMailerPreview.welcome(any_parameters)
```

We should make sure we clean `preview_interceptors` after each test so they dont leak to the next test.

cc @pixeltrix
