### PR TITLE
Make the rails:template rake task load initializers

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Make the `rails:template` rake task load the application's initializers.
+
+    Fixes #12133.
+
+    *Robin Dupret*
+
 *   Introduce `Rails.gem_version` as a convenience method to return
     `Gem::Version.new(Rails.version)`, suggesting a more reliable way to perform
     version comparison.

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -3,7 +3,7 @@ namespace :rails do
   task update: [ "update:configs", "update:bin" ]
 
   desc "Applies the template supplied by LOCATION=(/path/to/template) or URL"
-  task :template do
+  task template: :environment do
     template = ENV["LOCATION"]
     raise "No LOCATION value given. Please set LOCATION either as path to a file or a URL" if template.blank?
     template = File.expand_path(template) if template !~ %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://}

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -271,5 +271,16 @@ module ApplicationTests
         end
       end
     end
+
+    def test_template_load_initializers
+      app_file "config/initializers/dummy.rb", "puts 'Hello, World!'"
+      app_file "template.rb", ""
+
+      output = Dir.chdir(app_path) do
+        `bundle exec rake rails:template LOCATION=template.rb`
+      end
+
+      assert_match(/Hello, World!/, output)
+    end
   end
 end


### PR DESCRIPTION
Hello,

As pointed in #12133, templates could rely on irregular inflections or external libraries for instance so we should load the application's initializers when running the `rails:template` task.

The introducing commit of this feature is f7f11361 ; the initializers have never been loaded invoking this task.

Fixes #12133.

Have a nice day.
