### PR TITLE
Make sure we clean preview_interceptors

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -13,6 +13,7 @@ class BaseTest < ActiveSupport::TestCase
   def teardown
     ActionMailer::Base.asset_host = nil
     ActionMailer::Base.assets_dir = nil
+    ActionMailer::Base.preview_interceptors.clear
   end
 
   test "method call to mail does not raise error" do


### PR DESCRIPTION
backport https://github.com/rails/rails/pull/14318 to 4-1 .

I am 95% that this fixed the mailer issue on travis. 

travis is now failing randomly for another reason:

```
1) Error:
MemCacheStoreTest#test_deserializes_unloaded_class:
ArgumentError: key cannot be blank
```

So we should backport this to 4-1-stable. cc @pixeltrix
