### PR TITLE
strip trailing whitespace from structure dump file

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -55,6 +55,12 @@ module ActiveRecord
         raise 'Error dumping database' unless Kernel.system(command)
 
         File.open(filename, "a") { |f| f << "SET search_path TO #{ActiveRecord::Base.connection.schema_search_path};\n\n" }
+
+        # remove trailing whitespace
+        structure_temp_file = Tempfile.new('structure')
+        File.open(filename, 'r') { |f| f.each_line{|line| structure_temp_file.puts line.rstrip } }
+        structure_temp_file.close
+        FileUtils.mv(structure_temp_file.path, filename)
       end
 
       def structure_load(filename)


### PR DESCRIPTION
Hey,

this is really annoying to me :)
almost everybody strips trailing whitespace in their editor automatically.
it is tedious the review changes in the structure.sql when they contain changes due to trailing whitespace

what do you think?

ben
