### PR TITLE
Add indefinite article methods to Inflector

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add indefinite_article and with_indefinite_article methods to the
+    inflector
+
+    *Reuben Sutton*
+
 *   Change the signature of `fetch_multi` to return a hash rather than an
     array. This makes it consistent with the output of `read_multi`.
 

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -211,4 +211,20 @@ class String
   def foreign_key(separate_class_name_and_id_with_underscore = true)
     ActiveSupport::Inflector.foreign_key(self, separate_class_name_and_id_with_underscore)
   end
+  
+  # Returns the indefinite article for a string
+  # 
+  #   "cat".indefinite_article      # => "a"
+  #   "elephant".indefinite_article # => "an"
+  def indefinite_article
+    ActiveSupport::Inflector.indefinite_article(self)
+  end
+  
+  # Returns the current string with it's indefinite article prepended
+  #
+  #   "cat".with_indefinite_article      # => "a cat"
+  #   "elephant".with_indefinite_article # => "an elephant"
+  def with_indefinite_article
+    ActiveSupport::Inflector.with_indefinite_article(self)
+  end
 end

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -323,6 +323,54 @@ module ActiveSupport
     def ordinalize(number)
       "#{number}#{ordinal(number)}"
     end
+    
+    # Return the indefinite article for a phrase
+    #
+    #   indefinite_article("cat") # => "a"
+    def indefinite_article(phrase)
+      word = phrase.match(/\w+/).to_s
+      return if word.blank?
+      
+      lowercase_word = word.downcase
+      
+      return "an" if lowercase_word.start_with?(*%w(hono heir honest))
+      
+      return "an" if lowercase_word.start_with? "hour" && !lowercase_word.start_with? "houri"
+      
+      an_letters = %w(a e h i l m n o r s x)
+      if word.length == 1 && word.start_with?(*an_letters)
+        return "an"
+      elsif word.length == 1
+        return "a"
+      end
+      
+      return "an" if /(?!FJO|[HLMNS]Y.|RY[EO]|SQU|(F[LR]?|[HL]|MN?|N|RH?|S[CHKLMNPTVW]?|X(YL)?)[AEIOU])[FHLMNRSX][A-Z]/ =~ word
+      
+      [/^e[uw]/, /^onc?e\b/, /^uni([^nmd]|mo)/, /^u[bcfhjkqrst][aeiou]/].each do |regex|
+        return "a" if regex =~ lowercase_word
+      end
+      
+      return "a" if /^U[NK][AIEO]/ =~ word
+      
+      if word == word.upcase && lowercase_word.start_with?(*an_letters)
+        return "an"
+      elsif word == word.upcase
+        return "a"
+      end
+      
+      return "an" if lowercase_word.start_with?(*%w(a e i o u))
+     
+      return"an" if /^y(b[lor]|cl[ea]|fere|gg|p[ios]|rou|tt)/ =~ lowercase_word
+     
+      "a"
+    end
+    
+    # Return the phrase with it's indefinite article included
+    #
+    #   with_indefinite_article("cat") # => "a cat"
+    def with_indefinite_article(phrase)
+      "#{indefinite_article(phrase)} #{phrase}"
+    end
 
     private
 

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -335,7 +335,7 @@ module ActiveSupport
       
       return "an" if lowercase_word.start_with?(*%w(hono heir honest))
       
-      return "an" if lowercase_word.start_with? "hour" && !lowercase_word.start_with? "houri"
+      return "an" if lowercase_word.start_with?("hour") && !lowercase_word.start_with?("houri")
       
       an_letters = %w(a e h i l m n o r s x)
       if word.length == 1 && word.start_with?(*an_letters)

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -247,6 +247,14 @@ class StringInflectionsTest < ActiveSupport::TestCase
       string.safe_constantize
     end
   end
+  
+  def test_indefinite_article
+    assert_equal "a", "cat".indefinite_article
+  end
+  
+  def test_with_indefinite_article
+    assert_equal "a cat", "cat".with_indefinite_article
+  end
 end
 
 class StringAccessTest < ActiveSupport::TestCase

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -520,4 +520,13 @@ class InflectorTest < ActiveSupport::TestCase
   ensure
     ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, original)
   end
+  
+  
+  def test_indefinite_article
+    assert_equal "an", ActiveSupport::Inflector.indefinite_article("elephant")
+    assert_equal "an elephant", ActiveSupport::Inflector.with_indefinite_article("elephant")
+    assert_equal "a", ActiveSupport::Inflector.indefinite_article("cat")
+    assert_equal "a cat", ActiveSupport::Inflector.with_indefinite_article("cat")
+    assert_equal "an", ActiveSupport::Inflector.indefinite_article("x-ray")
+  end
 end


### PR DESCRIPTION
I have added indefinite_article and with_indefinite_article
to ActiveSupport::Inflector and wrapper methods to core_ext for String

This allows the following:

```
"elephant".indefinite_article
# => "an"
"x-ray".with_indefinite_article
# => "an x-ray"
"cat".with_indefinite_article
# => "a cat"
```

The logic is a port of the Lingua::EN::Inflect perl module
