### PR TITLE
Fix serialized attributes always being saved

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -55,8 +55,12 @@ module ActiveRecord
         # optimistic locking) won't get written unless they get marked as changed
         self.class.columns.each do |c|
           attr, orig_value = c.name, c.default
-          changed_attributes[attr] = orig_value if _field_changed?(attr, orig_value, @attributes[attr])
+          init_changed_attribute(attr, orig_value) if _field_changed?(attr, orig_value, @attributes[attr])
         end
+      end
+
+      def init_changed_attribute(attr, orig_value)
+        changed_attributes[attr] = orig_value
       end
 
       # Wrap write_attribute to remember original attribute value.

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -145,7 +145,7 @@ module ActiveRecord
         end
 
         def changed_attributes
-          super.reverse_merge!(changed_serialized_attributes)
+          super.except!(*self.class.serialized_attributes.keys).merge!(changed_serialized_attributes)
         end
 
         def read_attribute_before_type_cast(attr_name)
@@ -198,6 +198,14 @@ module ActiveRecord
         def changes_applied
           super
           reset_original_serialized_attributes
+        end
+
+        def init_changed_attribute(attr, orig_value)
+          if serialized_attribute?(attr)
+            original_serialized_attributes[attr] = orig_value
+          else
+            super
+          end
         end
 
         def changed_serialized_attributes

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -132,7 +132,7 @@ module ActiveRecord
         end
 
         def _field_changed?(attr, old, value)
-          if self.class.serialized_attributes.include?(attr)
+          if serialized_attribute?(attr)
             old != value
           else
             super
@@ -140,7 +140,7 @@ module ActiveRecord
         end
 
         def read_attribute_before_type_cast(attr_name)
-          if self.class.serialized_attributes.include?(attr_name)
+          if serialized_attribute?(attr_name)
             super.unserialized_value
           else
             super
@@ -158,7 +158,7 @@ module ActiveRecord
         end
 
         def typecasted_attribute_value(name)
-          if self.class.serialized_attributes.include?(name)
+          if serialized_attribute?(name)
             @attributes[name].serialized_value
           else
             super
@@ -167,12 +167,18 @@ module ActiveRecord
 
         def attributes_for_coder
           attribute_names.each_with_object({}) do |name, attrs|
-            attrs[name] = if self.class.serialized_attributes.include?(name)
+            attrs[name] = if serialized_attribute?(name)
                             @attributes[name].serialized_value
                           else
                             read_attribute(name)
                           end
           end
+        end
+
+        private
+
+        def serialized_attribute?(attr_name)
+          self.class.serialized_attributes.include?(attr_name)
         end
       end
     end

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -115,14 +115,6 @@ module ActiveRecord
           end
         end
 
-        def should_record_timestamps?
-          super || (self.record_timestamps && (attributes.keys & self.class.serialized_attributes.keys).present?)
-        end
-
-        def keys_for_partial_write
-          super | (attributes.keys & self.class.serialized_attributes.keys)
-        end
-
         def type_cast_attribute_for_write(column, value)
           if column && coder = self.class.serialized_attributes[column.name]
             Attribute.new(coder, value, :unserialized)

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -477,17 +477,22 @@ class DirtyTest < ActiveRecord::TestCase
     end
   end
 
-  def test_save_always_should_update_timestamps_when_serialized_attributes_are_present
+  def test_save_should_update_timestamps_with_partial_writes_only_when_serialized_attributes_change
     with_partial_writes(Topic) do
       topic = Topic.create!(:content => {:a => "a"})
       topic.save!
 
-      updated_at = topic.updated_at
+      updated_at = 1.month.ago
+      topic.update_column(:updated_at, updated_at)
       topic.content[:hello] = 'world'
       topic.save!
 
       assert_not_equal updated_at, topic.updated_at
       assert_equal 'world', topic.content[:hello]
+
+      topic.update_column(:updated_at, updated_at)
+      topic.save!
+      assert_equal updated_at, topic.updated_at
     end
   end
 

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -461,15 +461,16 @@ class DirtyTest < ActiveRecord::TestCase
       topic.content = {a: "a"}
       assert topic.changed?
       topic.content[:b] = "b"
-      assert topic.changed?
+      assert topic.content_changed?
       topic.save!
       assert_equal "b", topic.content[:b]
       assert !topic.changed?
       topic.reload
       assert_equal "b", topic.content[:b]
-      assert !topic.changed?
+      assert !topic.content_changed?
       topic.content['b'] = "c"
       assert topic.changed?
+      assert_nil topic.content_was #one downside of using .hash for comparator is no way to track original value
       topic.save
       original_content = topic.content.dup
       assert !topic.changed?

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -471,9 +471,12 @@ class DirtyTest < ActiveRecord::TestCase
       topic.content['b'] = "c"
       assert topic.changed?
       topic.save
+      original_content = topic.content.dup
       assert !topic.changed?
       topic.content = nil
       assert topic.changed?
+      topic.content = original_content
+      assert !topic.changed?
     end
   end
 

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -446,11 +446,34 @@ class DirtyTest < ActiveRecord::TestCase
     with_partial_writes(Topic) do
       topic = Topic.create!(:content => {:a => "a"})
       topic.content[:b] = "b"
-      #assert topic.changed? # Known bug, will fail
+      assert topic.changed?
       topic.save!
       assert_equal "b", topic.content[:b]
       topic.reload
       assert_equal "b", topic.content[:b]
+    end
+  end
+
+  def test_changed_should_check_serialized_attributes
+    with_partial_writes(Topic) do
+      topic = Topic.create!
+      assert !topic.changed?
+      topic.content = {a: "a"}
+      assert topic.changed?
+      topic.content[:b] = "b"
+      assert topic.changed?
+      topic.save!
+      assert_equal "b", topic.content[:b]
+      assert !topic.changed?
+      topic.reload
+      assert_equal "b", topic.content[:b]
+      assert !topic.changed?
+      topic.content['b'] = "c"
+      assert topic.changed?
+      topic.save
+      assert !topic.changed?
+      topic.content = nil
+      assert topic.changed?
     end
   end
 

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -48,7 +48,7 @@ class StoreTest < ActiveRecord::TestCase
 
   test "updating the store populates the changed array correctly" do
     @john.color = 'red'
-    assert_equal 'black', @john.settings_change[0]['color']
+    assert_nil @john.settings_change[0], "original value of stored attributes should be nil"
     assert_equal 'red', @john.settings_change[1]['color']
   end
 


### PR DESCRIPTION
Fixes #8328.  Models with serialized attributes will only be saved if the record has changed.

Uses #hash to compare original serialize attribute value to current value.  Similar to #13428

Chose to use #hash for comparison for performance reasons.  The downside of using #hash rather than #deep_dup is that serialized_attribute_was will not be stored, and will return nil.  
