### PR TITLE
Enhance readability of ActionView DateHelper#distance_of_time_in_words

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -19,6 +19,10 @@ module ActionView
     #   the <tt>select_month</tt> method would use simply "date" (which can be overwritten using <tt>:prefix</tt>) instead
     #   of \date[month].
     module DateHelper
+      MINUTES_IN_YEAR = 525600
+      MINUTES_IN_QUARTER_YEAR = 131400
+      MINUTES_IN_THREE_QUARTERS_YEAR = 394200
+
       # Reports the approximate distance in time between two Time, Date or DateTime objects or integers as seconds.
       # Pass <tt>include_seconds: true</tt> if you want more detailed approximations when distance < 1 min, 29 secs.
       # Distances are reported based on the following table:
@@ -120,11 +124,11 @@ module ActionView
               else
                 minutes_with_offset = distance_in_minutes
               end
-              remainder                   = (minutes_with_offset % 525600)
-              distance_in_years           = (minutes_with_offset.div 525600)
-              if remainder < 131400
+              remainder                   = (minutes_with_offset % MINUTES_IN_YEAR)
+              distance_in_years           = (minutes_with_offset.div MINUTES_IN_YEAR)
+              if remainder < MINUTES_IN_QUARTER_YEAR
                 locale.t(:about_x_years,  :count => distance_in_years)
-              elsif remainder < 394200
+              elsif remainder < MINUTES_IN_THREE_QUARTERS_YEAR
                 locale.t(:over_x_years,   :count => distance_in_years)
               else
                 locale.t(:almost_x_years, :count => distance_in_years + 1)


### PR DESCRIPTION
Refactor numerical constants to module constants which give the numbers
a contextual meaning. This commit aims to provide quicker understanding
for part of the implementation of the
`DateHelper#distance_of_time_in_words` method.
