### PR TITLE
Drop Relation::Calculation +options+ arguments

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -19,48 +19,37 @@ module ActiveRecord
     #
     #   Person.group(:city).count
     #   # => { 'Rome' => 5, 'Paris' => 3 }
-    def count(column_name = nil, options = {})
-      # TODO: Remove options argument as soon we remove support to
-      # activerecord-deprecated_finders.
-      column_name, options = nil, column_name if column_name.is_a?(Hash)
-      calculate(:count, column_name, options)
+    def count(column_name = nil)
+      column_name = nil if column_name.is_a?(Hash)
+      calculate(:count, column_name)
     end
 
     # Calculates the average value on a given column. Returns +nil+ if there's
-    # no row. See +calculate+ for examples with options.
+    # no row.
     #
     #   Person.average(:age) # => 35.8
-    def average(column_name, options = {})
-      # TODO: Remove options argument as soon we remove support to
-      # activerecord-deprecated_finders.
-      calculate(:average, column_name, options)
+    def average(column_name)
+      calculate(:average, column_name)
     end
 
     # Calculates the minimum value on a given column. The value is returned
-    # with the same data type of the column, or +nil+ if there's no row. See
-    # +calculate+ for examples with options.
+    # with the same data type of the column, or +nil+ if there's no row.
     #
     #   Person.minimum(:age) # => 7
-    def minimum(column_name, options = {})
-      # TODO: Remove options argument as soon we remove support to
-      # activerecord-deprecated_finders.
-      calculate(:minimum, column_name, options)
+    def minimum(column_name)
+      calculate(:minimum, column_name)
     end
 
     # Calculates the maximum value on a given column. The value is returned
-    # with the same data type of the column, or +nil+ if there's no row. See
-    # +calculate+ for examples with options.
+    # with the same data type of the column, or +nil+ if there's no row.
     #
     #   Person.maximum(:age) # => 93
-    def maximum(column_name, options = {})
-      # TODO: Remove options argument as soon we remove support to
-      # activerecord-deprecated_finders.
-      calculate(:maximum, column_name, options)
+    def maximum(column_name)
+      calculate(:maximum, column_name)
     end
 
     # Calculates the sum of values on a given column. The value is returned
-    # with the same data type of the column, 0 if there's no row. See
-    # +calculate+ for examples with options.
+    # with the same data type of the column, 0 if there's no row.
     #
     #   Person.sum(:age) # => 4562
     def sum(*args)
@@ -98,17 +87,15 @@ module ActiveRecord
     #   Person.group(:last_name).having("min(age) > 17").minimum(:age)
     #
     #   Person.sum("2 * age")
-    def calculate(operation, column_name, options = {})
-      # TODO: Remove options argument as soon we remove support to
-      # activerecord-deprecated_finders.
+    def calculate(operation, column_name)
       if column_name.is_a?(Symbol) && attribute_alias?(column_name)
         column_name = attribute_alias(column_name)
       end
 
       if has_include?(column_name)
-        construct_relation_for_association_calculations.calculate(operation, column_name, options)
+        construct_relation_for_association_calculations.calculate(operation, column_name)
       else
-        perform_calculation(operation, column_name, options)
+        perform_calculation(operation, column_name)
       end
     end
 
@@ -191,9 +178,7 @@ module ActiveRecord
       eager_loading? || (includes_values.present? && (column_name || references_eager_loaded_tables?))
     end
 
-    def perform_calculation(operation, column_name, options = {})
-      # TODO: Remove options argument as soon we remove support to
-      # activerecord-deprecated_finders.
+    def perform_calculation(operation, column_name)
       operation = operation.to_s.downcase
 
       # If #count is used with #distinct / #uniq it is considered distinct. (eg. relation.distinct.count)


### PR DESCRIPTION
Clean up TODOs now that support for AR deprecated_finders have been
removed

Notice this while looking into a change of behaviour on Relation#maximum probably caused by https://github.com/rails/rails/pull/10561, see https://github.com/huoxito/spree/commit/84262b3d3f3739e43fcb48d819d9e93ec309c53f for details, which I believe is fine. CHANGELOG tells me that deprecated_finders support has been removed so I figured removing those TODOs would be fine too hopefully.
