### PR TITLE
Enhance readability of NestedAttributes and its test suite

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -305,7 +305,8 @@ module ActiveRecord
         options[:reject_if] = REJECT_ALL_BLANK_PROC if options[:reject_if] == :all_blank
 
         attr_names.each do |association_name|
-          if reflection = reflect_on_association(association_name)
+          reflection = reflect_on_association(association_name)
+          if reflection
             reflection.autosave = true
             add_autosave_association_callbacks(reflection)
 


### PR DESCRIPTION
The following assignment and condition checking in one go does not
communicate its intent immediately:

```
if reflection = reflect_on_association(association_name)
```

and thus it is splitted.

Some tests state that a new record should not be built when the
:reject_if proc evaluates to false and vice versa. That's not the
case though, because a new record will be rejected if the respective
proc evaluates to true.

Besides its main purpose, a test suite can provide a general outline
of what to expect when we look directly at the implementation so
I've added a few tests to help achieve this.
