### PR TITLE
Fixes STI when 2+ levels deep.

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -105,9 +105,9 @@ module ActiveRecord
           super
         else
           # If B < A and A defines its own attribute method, then we don't want to overwrite that.
-          defined = method_defined_within?(method_name, superclass) &&
-            superclass.instance_method(method_name).owner != superclass.generated_attribute_methods
-          defined || super
+          defined = method_defined_within?(method_name, superclass, superclass.generated_attribute_methods)
+          base_defined = Base.method_defined?(method_name) || Base.private_method_defined?(method_name)
+          defined && !base_defined || super
         end
       end
 

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -746,6 +746,19 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert "unknown attribute: hello", error.message
   end
 
+  def test_methods_override_in_multi_level_subclass
+    klass = Class.new(Developer) do
+      def name
+        "dev:#{read_attribute(:name)}"
+      end
+    end
+
+    2.times { klass = Class.new klass }
+    dev = klass.new(name: 'arthurnn')
+    dev.save!
+    assert_equal 'dev:arthurnn', dev.reload.name
+  end
+
   def test_global_methods_are_overwritten
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = 'computers'


### PR DESCRIPTION
PR #14052 Added a regression where it was only looking for methods in one
level up, So when the method was defined in a 2+ levels up the
inheritance chain, the method was not found as defined.

This is a bit hard to explain, but the regression test added illustrate the issue pretty well.

review @chancancode @rafaelfranca 

This needs to go to master, 4-1 and 4-0

I dont think I should add a CHANGELOG as this is fixing regression. But lemme know if I am wrong.
