### PR TITLE
Change create_join_table migration helper to use table prefixes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,31 @@
+*   Change create_join_table migration helper to use table prefixes like
+    it's already done when creating HABTM association.
+
+    Example:
+
+        class Category < ActiveRecord::Base
+          self.table_name = 'catalog_categories'
+          has_and_belongs_to_many :products
+        end
+
+        class Product < ActiveRecord::Base
+          self.table_name = 'catalog_products'
+        end
+
+        ActiveRecord::Schema.define do
+          create_join_table :catalog_categories, :catalog_products
+        end
+
+    It created table `catalog_categories_catalog_products` before, but HABTM
+    association uses `catalog_categories_products` table name:
+
+        `Category.reflections[:products].join_table` #=> "catalog_categories_products"
+
+    Now `create_join_table` creates table `catalog_categories_products`,
+    and it is consistent with what HABTM association does.
+
+    *Piotr Boniecki*
+
 *   Support for Postgres `citext` data type enabling case-insensitive where
     values without needing to wrap in UPPER/LOWER sql functions.
 

--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -11,7 +11,11 @@ module ActiveRecord::Associations::Builder
         end
 
         def join_table
-          @join_table ||= [@lhs_class.table_name, klass.table_name].sort.join("\0").gsub(/^(.*_)(.+)\0\1(.+)/, '\1\2_\3').gsub("\0", "_")
+          @join_table ||= self.class.join_table_name(@lhs_class.table_name, klass.table_name)
+        end
+
+        def self.join_table_name(table_1, table_2)
+          [table_1, table_2].sort.join("\0").gsub(/^(.*_)(.+)\0\1(.+)/, '\1\2_\3').gsub("\0", "_")
         end
 
         private

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -208,6 +208,9 @@ module ActiveRecord
 
       # Creates a new join table with the name created using the lexical order of the first two
       # arguments. These arguments can be a String or a Symbol.
+      # If your tables share a common prefix, it will only appear once at the beginning. For
+      # example, the tables "catalog_categories" and "catalog_products" generate a join table
+      # name of "catalog_categories_products".
       #
       #   # Creates a table called 'assemblies_parts' with no id.
       #   create_join_table(:assemblies, :parts)

--- a/activerecord/lib/active_record/migration/join_table.rb
+++ b/activerecord/lib/active_record/migration/join_table.rb
@@ -1,3 +1,4 @@
+require 'active_record/associations/builder/has_and_belongs_to_many'
 module ActiveRecord
   class Migration
     module JoinTable #:nodoc:
@@ -8,7 +9,7 @@ module ActiveRecord
       end
 
       def join_table_name(table_1, table_2)
-        [table_1.to_s, table_2.to_s].sort.join("_").to_sym
+        ActiveRecord::Associations::Builder::HasAndBelongsToMany::JoinTableResolver::KnownClass.join_table_name(table_1.to_s, table_2.to_s).to_sym
       end
     end
   end

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -12,7 +12,7 @@ module ActiveRecord
 
       def teardown
         super
-        %w(artists_musics musics_videos catalog).each do |table_name|
+        %w(artists_musics musics_videos catalog prefixed_artists prefixed_musics prefixed_artists_musics).each do |table_name|
           connection.drop_table table_name if connection.tables.include?(table_name)
         end
       end
@@ -21,6 +21,12 @@ module ActiveRecord
         connection.create_join_table :artists, :musics
 
         assert_equal %w(artist_id music_id), connection.columns(:artists_musics).map(&:name).sort
+      end
+
+      def test_create_join_table_with_common_prefix
+        connection.create_join_table :prefixed_artists, :prefixed_musics
+
+        assert connection.tables.include?('prefixed_artists_musics')
       end
 
       def test_create_join_table_set_not_null_by_default


### PR DESCRIPTION
Change create_join_table migration helper to use table prefixes like
it's already done when creating HABTM association.

Example:

```
class Category < ActiveRecord::Base
  self.table_name = 'catalog_categories'
  has_and_belongs_to_many :products
end

class Product < ActiveRecord::Base
  self.table_name = 'catalog_products'
end

ActiveRecord::Schema.define do
  create_join_table :catalog_categories, :catalog_products
end
```

It created table `catalog_categories_catalog_products` before, but HABTM
association uses `catalog_categories_products` table name:

```
`Category.reflections[:products].join_table` #=> "catalog_categories_products"
```

Now `create_join_table` creates table `catalog_categories_products`,
and it is consistent with what HABTM association does.
