### PR TITLE
content-legth should be eq 0 when render nothing: true

### DIFF
--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -67,7 +67,9 @@ module ActionController
         options[:html] = ERB::Util.html_escape(options[:html])
       end
 
-      if options.delete(:nothing) || _any_render_format_is_nil?(options)
+      if options.delete(:nothing)
+        options[:body] = nil
+      elsif _any_render_format_is_nil?(options)
         options[:body] = " "
       end
 

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -260,6 +260,12 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
     end
   end
 
+  def test_nothing_content_length
+    @controller = Admin::InnerModuleController.new
+    get :index
+    assert_equal 0, response.body.length
+  end
+
   def test_assert_redirect_failure_message_with_protocol_relative_url
     begin
       process :redirect_external_protocol_relative

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -1022,7 +1022,7 @@ class RenderTest < ActionController::TestCase
 
   def test_rendering_nothing_on_layout
     get :rendering_nothing_on_layout
-    assert_equal " ", @response.body
+    assert_equal "", @response.body
   end
 
   def test_render_to_string_doesnt_break_assigns
@@ -1332,4 +1332,3 @@ class RenderTest < ActionController::TestCase
     assert_equal "Before (Anthony)\nInside from partial (Anthony)\nAfter\nBefore (David)\nInside from partial (David)\nAfter\nBefore (Ramm)\nInside from partial (Ramm)\nAfter", @response.body
   end
 end
-


### PR DESCRIPTION
### Problem

When doing `render nothing: true`, it should render a body == ""

This how Rails behaves since 2009, because of a Safari bug.

~~As far as I can see the history, seems like this problem was introduced by this commit https://github.com/rails/rails/commit/53596d091390bda7fb9b78ad838273a9e63fbde1 . Before that change if you only pass a `nothing: true` body would be nil.~~

[fixes #14336]

review @rafaelfranca @carlosantoniodasilva @sikachu

~~I am not sure about the implementation. looks dirty, but I couldnt think a better way. I am opened for suggestions.~~

If it is all good, I can add a CHANGELOG. 
