### PR TITLE
Remove mocking on save, when not necessary

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -691,14 +691,12 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
 
   def test_should_save_changed_has_one_changed_object_if_child_is_saved
     @pirate.ship.name = "NewName"
-    @pirate.ship.expects(:save).once.returns(true)
-
     assert @pirate.save
+    assert_equal "NewName", @pirate.ship.reload.name
   end
 
   def test_should_not_save_changed_has_one_unchanged_object_if_child_is_saved
     @pirate.ship.expects(:save).never
-
     assert @pirate.save
   end
 


### PR DESCRIPTION
Super small change. However IMO, that `expects(:save)` is not a good idea, as it would mock the default behaviour. As far as I can tell the test is only testing if changed object is saved or not. So we can assert against the name.

Fell free to close this if this doesn't make sense.
@carlosantoniodasilva @rafaelfranca
