### PR TITLE
MySQL 5.6  Fractional Seconds

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support for Mysql 5.6 Fractional Seconds.
+
+    *arthurnn*, *Tatsuhiko Miyagawa*
+
 *   Support for Postgres `citext` data type enabling case-insensitive where
     values without needing to wrap in UPPER/LOWER sql functions.
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -83,6 +83,14 @@ module ActiveRecord
         @connection.escape(string)
       end
 
+      def quoted_date(value)
+        if value.acts_like?(:time) && value.respond_to?(:usec)
+          "#{super}.#{sprintf("%06d", value.usec)}"
+        else
+          super
+        end
+      end
+
       # CONNECTION MANAGEMENT ====================================
 
       def active?

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -212,7 +212,7 @@ class BasicsTest < ActiveRecord::TestCase
     )
 
     # For adapters which support microsecond resolution.
-    if current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter)
+    if current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter) || mysql_56?
       assert_equal 11, Topic.find(1).written_on.sec
       assert_equal 223300, Topic.find(1).written_on.usec
       assert_equal 9900, Topic.find(2).written_on.usec

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -41,6 +41,11 @@ def in_memory_db?
   ActiveRecord::Base.connection_pool.spec.config[:database] == ":memory:"
 end
 
+def mysql_56?
+  current_adapter?(:Mysql2Adapter) &&
+    ActiveRecord::Base.connection.send(:version).join(".") >= "5.6.0"
+end
+
 def supports_savepoints?
   ActiveRecord::Base.connection.supports_savepoints?
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -674,7 +674,11 @@ ActiveRecord::Schema.define do
     t.string   :title
     t.string   :author_name
     t.string   :author_email_address
-    t.datetime :written_on
+    if mysql_56?
+      t.datetime :written_on, limit: 6
+    else
+      t.datetime :written_on
+    end
     t.time     :bonus_time
     t.date     :last_read
     # use VARCHAR2(4000) instead of CLOB datatype as CLOB data type has many limitations in


### PR DESCRIPTION
Adding microseconds support for mysql 5.6
This should not affect mysql 5.5 so IMO we dont need a version check.

this is PR #8240 + tests and Changelog entry.

review @rafaelfranca @jeremy @tenderlove
