### PR TITLE
Add more tests for mysql 5.6 microseconds + Fix tests

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -97,6 +97,13 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     @connection.execute "DROP TABLE `bar_baz`"
   end
 
+  if mysql_56?
+    def test_quote_time_usec
+      assert_equal "'1970-01-01 00:00:00.000000'", @connection.quote(Time.at(0))
+      assert_equal "'1970-01-01 00:00:00.000000'", @connection.quote(Time.at(0).to_datetime)
+    end
+  end
+
   private
 
   def run_without_connection

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -452,7 +452,7 @@ class PersistenceTest < ActiveRecord::TestCase
 
   def test_update_attribute_for_updated_at_on
     developer = Developer.find(1)
-    prev_month = Time.now.prev_month
+    prev_month = Time.now.prev_month.change(usec: 0)
 
     developer.update_attribute(:updated_at, prev_month)
     assert_equal prev_month, developer.updated_at
@@ -523,7 +523,7 @@ class PersistenceTest < ActiveRecord::TestCase
 
   def test_update_column_should_not_modify_updated_at
     developer = Developer.find(1)
-    prev_month = Time.now.prev_month
+    prev_month = Time.now.prev_month.change(usec: 0)
 
     developer.update_column(:updated_at, prev_month)
     assert_equal prev_month, developer.updated_at
@@ -620,7 +620,7 @@ class PersistenceTest < ActiveRecord::TestCase
 
   def test_update_columns_should_not_modify_updated_at
     developer = Developer.find(1)
-    prev_month = Time.now.prev_month
+    prev_month = Time.now.prev_month.change(usec: 0)
 
     developer.update_columns(updated_at: prev_month)
     assert_equal prev_month, developer.updated_at


### PR DESCRIPTION
Two separate things in this PR:

First commit, is to add a unit test to make sure the `quote` method is working as expected.

Second:
When running `persistence_test`, multiple times, 2 tests were failing randomly, after nailing down the issue seems like the problem was happening because we were comparing `prev_month.to_i` , which has a `usec`, and if the DB didnt save that `usec` we could have round issues. I am not sure if thats the proper fix or not. please let me know what you guys think.

review @rafaelfranca 
