### PR TITLE
Use sqlite3 adapter in examples

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -18,14 +18,15 @@ module ActiveRecord
     # Example for SQLite database:
     #
     #   ActiveRecord::Base.establish_connection(
-    #     adapter:  "sqlite",
+    
+    #     adapter:  "sqlite3",
     #     database: "path/to/dbfile"
     #   )
     #
     # Also accepts keys as strings (for parsing from YAML for example):
     #
     #   ActiveRecord::Base.establish_connection(
-    #     "adapter"  => "sqlite",
+    #     "adapter"  => "sqlite3",
     #     "database" => "path/to/dbfile"
     #   )
     #


### PR DESCRIPTION
Two bits of example code use sqlite as an adapter, which doesn't exist. Using the code verbatim will raise a LoadError exception. Considering this is code a lot of people new to Rails might be running, it's especially confusing.

```
orangejulius@orangejulius ~/Documents/test_sqlite_adapter $ rails c
Loading development environment (Rails 4.1.0.rc1)
2.0.0-p353 :001 > ActiveRecord::Base.establish_connection(
2.0.0-p353 :002 >     "adapter" => "sqlite",
2.0.0-p353 :003 >     "database" => "db.sqlite"
2.0.0-p353 :004?>   )
LoadError: Could not load 'active_record/connection_adapters/sqlite_adapter'. Make sure that    the adapter in config/database.yml is valid. If you use an adapter other than 'mysql', 'mysql2', 'postgresql' or 'sqlite3' add the necessary adapter gem to the Gemfile.
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:247:in `require'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:247:in `block in require'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:232:in `load_dependency'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:247:in `require'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/activerecord-4.1.0.rc1/lib/active_record/connection_adapters/connection_specification.rb:161:in `spec'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/activerecord-4.1.0.rc1/lib/active_record/connection_handling.rb:50:in `establish_connection'
from (irb):1
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/railties-4.1.0.rc1/lib/rails/commands/console.rb:90:in `start'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/railties-4.1.0.rc1/lib/rails/commands/console.rb:9:in `start'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/railties-4.1.0.rc1/lib/rails/commands/commands_tasks.rb:69:in `console'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/railties-4.1.0.rc1/lib/rails/commands/commands_tasks.rb:40:in `run_command!'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/railties-4.1.0.rc1/lib/rails/commands.rb:17:in `<top (required)>'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:247:in `require'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:247:in `block in require'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:232:in `load_dependency'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:247:in `require'
from /Users/orangejulius/Documents/test_sqlite_adapter/bin/rails:8:in `<top (required)>'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:241:in `load'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:241:in `block in load'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:232:in `load_dependency'
from /Users/orangejulius/.rvm/gems/ruby-2.0.0-p353/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:241:in `load'
from /Users/orangejulius/.rvm/rubies/ruby-2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
from /Users/orangejulius/.rvm/rubies/ruby-2.0.0-p353/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
from -e:1:in `<main>'2.0.0-p353 :005 >
```
