### PR TITLE
Add test for deprecation warning for passing an AR object to `exists?`.

### DIFF
--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -61,6 +61,12 @@ class FinderTest < ActiveRecord::TestCase
     assert_raise(NoMethodError) { Topic.exists?([1,2]) }
   end
 
+  def test_exists_passing_active_record_object_is_deprecated
+    assert_deprecated do
+      Topic.exists?(Topic.new)
+    end
+  end
+
   def test_exists_fails_when_parameter_has_invalid_type
     if current_adapter?(:PostgreSQLAdapter, :MysqlAdapter)
       assert_raises ActiveRecord::StatementInvalid do


### PR DESCRIPTION
Adding a test case for this commit https://github.com/rails/rails/commit/d92ae6ccca3bcfd73546d612efaea011270bd270
