### PR TITLE
Add test for deprecation warning for passing an AR object to `find`.

### DIFF
--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -33,6 +33,12 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal(topics(:first).title, Topic.find(1).title)
   end
 
+  def test_find_passing_active_record_object_is_deprecated
+    assert_deprecated do
+      Topic.find(Topic.last)
+    end
+  end
+
   def test_symbols_table_ref
     Post.first # warm up
     x = Symbol.all_symbols.count


### PR DESCRIPTION
Test case for https://github.com/rails/rails/commit/d35f0033c7dec2b8d8b52058fb8db495d49596f7
