### PR TITLE
Use teardown helper method.

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -218,7 +218,7 @@ module ActiveRecord
       @connection = Klass.connection
     end
 
-    def teardown
+    teardown do
       Klass.remove_connection
     end
 

--- a/activerecord/test/cases/adapters/mysql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/active_schema_test.rb
@@ -11,7 +11,7 @@ class ActiveSchemaTest < ActiveRecord::TestCase
     end
   end
 
-  def teardown
+  teardown do
     ActiveRecord::Base.remove_connection
     ActiveRecord::Base.establish_connection(@connection)
   end

--- a/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
@@ -37,7 +37,7 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
       'distinct_select'=>'distinct_id int, select_id int'
   end
 
-  def teardown
+  teardown do
     drop_tables_directly ['group', 'select', 'values', 'distinct', 'distinct_select', 'order']
   end
 

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -11,7 +11,7 @@ class ActiveSchemaTest < ActiveRecord::TestCase
     end
   end
 
-  def teardown
+  teardown do
     ActiveRecord::Base.remove_connection
     ActiveRecord::Base.establish_connection(@connection)
   end

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -37,7 +37,7 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
       'distinct_select'=>'distinct_id int, select_id int'
   end
 
-  def teardown
+  teardown do
     drop_tables_directly ['group', 'select', 'values', 'distinct', 'distinct_select', 'order']
   end
 

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -7,7 +7,7 @@ class PostgresqlActiveSchemaTest < ActiveRecord::TestCase
     end
   end
 
-  def teardown
+  teardown do
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
       remove_method :execute
     end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -19,7 +19,7 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     @column = PgArray.columns.find { |c| c.name == 'tags' }
   end
 
-  def teardown
+  teardown do
     @connection.execute 'drop table if exists pg_arrays'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -23,7 +23,7 @@ class PostgresqlByteaTest < ActiveRecord::TestCase
     assert(@column.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLColumn))
   end
 
-  def teardown
+  teardown do
     @connection.execute 'drop table if exists bytea_data_type'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -25,7 +25,7 @@ class PostgresqlCitextTest < ActiveRecord::TestCase
     @column = Citext.columns_hash['cival']
   end
 
-  def teardown
+  teardown do
     @connection.execute 'DROP TABLE IF EXISTS citexts;'
     @connection.execute 'DROP EXTENSION IF EXISTS citext CASCADE;'
   end

--- a/activerecord/test/cases/adapters/postgresql/composite_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/composite_test.rb
@@ -8,7 +8,7 @@ class PostgresqlCompositeTest < ActiveRecord::TestCase
     self.table_name = "postgresql_composites"
   end
 
-  def teardown
+  teardown do
     @connection.execute 'DROP TABLE IF EXISTS postgresql_composites'
     @connection.execute 'DROP TYPE IF EXISTS full_address'
   end

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -67,7 +67,7 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
     @connection.execute("INSERT INTO postgresql_timestamp_with_zones (id, time) VALUES (1, '2010-01-01 10:00:00-1')")
   end
 
-  def teardown
+  teardown do
     [PostgresqlArray, PostgresqlTsvector, PostgresqlMoney, PostgresqlNumber, PostgresqlTime, PostgresqlNetworkAddress,
      PostgresqlBitString, PostgresqlOid, PostgresqlTimestampWithZone].each(&:delete_all)
   end

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -8,7 +8,7 @@ class PostgresqlEnumTest < ActiveRecord::TestCase
     self.table_name = "postgresql_enums"
   end
 
-  def teardown
+  teardown do
     @connection.execute 'DROP TABLE IF EXISTS postgresql_enums'
     @connection.execute 'DROP TYPE IF EXISTS mood'
   end

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -31,7 +31,7 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     @column = Hstore.columns.find { |c| c.name == 'tags' }
   end
 
-  def teardown
+  teardown do
     @connection.execute 'drop table if exists hstores'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -26,7 +26,7 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
     @column = JsonDataType.columns.find { |c| c.name == 'payload' }
   end
 
-  def teardown
+  teardown do
     @connection.execute 'drop table if exists json_data_type'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/ltree_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/ltree_test.rb
@@ -19,7 +19,7 @@ class PostgresqlLtreeTest < ActiveRecord::TestCase
     skip "do not test on PG without ltree"
   end
 
-  def teardown
+  teardown do
     @connection.execute 'drop table if exists ltrees'
   end
 

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -8,7 +8,7 @@ if ActiveRecord::Base.connection.supports_ranges?
   end
 
   class PostgresqlRangeTest < ActiveRecord::TestCase
-    def teardown
+    teardown do
       @connection.execute 'DROP TABLE IF EXISTS postgresql_ranges'
       @connection.execute 'DROP TYPE IF EXISTS floatrange'
     end

--- a/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
@@ -27,7 +27,7 @@ class SchemaAuthorizationTest < ActiveRecord::TestCase
     end
   end
 
-  def teardown
+  teardown do
     set_session_auth
     @connection.execute "RESET search_path"
     USERS.each do |u|

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -71,7 +71,7 @@ class SchemaTest < ActiveRecord::TestCase
     @connection.execute "CREATE TABLE #{SCHEMA_NAME}.#{UNMATCHED_PK_TABLE_NAME} (id integer NOT NULL DEFAULT nextval('#{SCHEMA_NAME}.#{UNMATCHED_SEQUENCE_NAME}'::regclass), CONSTRAINT unmatched_pkey PRIMARY KEY (id))"
   end
 
-  def teardown
+  teardown do
     @connection.execute "DROP SCHEMA #{SCHEMA2_NAME} CASCADE"
     @connection.execute "DROP SCHEMA #{SCHEMA_NAME} CASCADE"
   end

--- a/activerecord/test/cases/adapters/postgresql/view_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/view_test.rb
@@ -24,7 +24,7 @@ class ViewTest < ActiveRecord::TestCase
     @connection.execute "CREATE VIEW #{SCHEMA_NAME}.#{VIEW_NAME} AS SELECT id,name,email,moment FROM #{SCHEMA_NAME}.#{TABLE_NAME}"
   end
 
-  def teardown
+  teardown do
     @connection.execute "DROP SCHEMA #{SCHEMA_NAME} CASCADE"
   end
 

--- a/activerecord/test/cases/adapters/postgresql/xml_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/xml_test.rb
@@ -23,7 +23,7 @@ class PostgresqlXMLTest < ActiveRecord::TestCase
     @column = XmlDataType.columns.find { |c| c.name == 'payload' }
   end
 
-  def teardown
+  teardown do
     @connection.execute 'drop table if exists xml_data_type'
   end
 

--- a/activerecord/test/cases/ar_schema_test.rb
+++ b/activerecord/test/cases/ar_schema_test.rb
@@ -10,7 +10,7 @@ if ActiveRecord::Base.connection.supports_migrations?
       ActiveRecord::SchemaMigration.drop_table
     end
 
-    def teardown
+    teardown do
       @connection.drop_table :fruits rescue nil
       @connection.drop_table :nep_fruits rescue nil
       @connection.drop_table :nep_schema_migrations rescue nil

--- a/activerecord/test/cases/associations/eager_load_nested_include_test.rb
+++ b/activerecord/test/cases/associations/eager_load_nested_include_test.rb
@@ -68,7 +68,7 @@ class EagerLoadPolyAssocsTest < ActiveRecord::TestCase
     generate_test_object_graphs
   end
 
-  def teardown
+  teardown do
     [Circle, Square, Triangle, PaintColor, PaintTexture,
      ShapeExpression, NonPolyOne, NonPolyTwo].each do |c|
       c.delete_all
@@ -111,7 +111,7 @@ class EagerLoadNestedIncludeWithMissingDataTest < ActiveRecord::TestCase
     @first_categorization = @davey_mcdave.categorizations.create(:category => Category.first, :post => @first_post)
   end
 
-  def teardown
+  teardown do
     @davey_mcdave.destroy
     @first_post.destroy
     @first_comment.destroy

--- a/activerecord/test/cases/associations/eager_singularization_test.rb
+++ b/activerecord/test/cases/associations/eager_singularization_test.rb
@@ -90,7 +90,7 @@ class EagerSingularizationTest < ActiveRecord::TestCase
     end
   end
 
-  def teardown
+  teardown do
     connection.drop_table :viri
     connection.drop_table :octopi
     connection.drop_table :passes

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -22,7 +22,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     @target.table_name = 'topics'
   end
 
-  def teardown
+  teardown do
     ActiveRecord::Base.send(:attribute_method_matchers).clear
     ActiveRecord::Base.send(:attribute_method_matchers).concat(@old_matchers)
   end

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -25,7 +25,7 @@ module ActiveRecord
       ActiveSupport::Notifications.subscribe('sql.active_record', @listener)
     end
 
-    def teardown
+    teardown do
       ActiveSupport::Notifications.unsubscribe(@listener)
     end
 

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         @previous_database_url = ENV.delete("DATABASE_URL")
       end
 
-      def teardown
+      teardown do
         ENV["DATABASE_URL"] = @previous_database_url
       end
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -22,8 +22,7 @@ module ActiveRecord
         end
       end
 
-      def teardown
-        super
+      teardown do
         @pool.disconnect!
       end
 

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -206,7 +206,7 @@ if current_adapter?(:PostgreSQLAdapter)
       assert_equal "some text", Default.new.text_col, "Default of text column was not correctly parse after updating default using '::text' since postgreSQL will add parens to the default in db"
     end
 
-    def teardown
+    teardown do
       @connection.schema_search_path = @old_search_path
       Default.reset_column_information
     end

--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -10,7 +10,7 @@ class TestDisconnectedAdapter < ActiveRecord::TestCase
     @connection = ActiveRecord::Base.connection
   end
 
-  def teardown
+  teardown do
     return if in_memory_db?
     spec = ActiveRecord::Base.connection_config
     ActiveRecord::Base.establish_connection(spec)

--- a/activerecord/test/cases/explain_subscriber_test.rb
+++ b/activerecord/test/cases/explain_subscriber_test.rb
@@ -48,7 +48,7 @@ if ActiveRecord::Base.connection.supports_explain?
       assert queries.empty?
     end
 
-    def teardown
+    teardown do
       ActiveRecord::ExplainRegistry.reset
     end
 

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -339,7 +339,7 @@ class InheritanceComputeTypeTest < ActiveRecord::TestCase
     ActiveSupport::Dependencies.log_activity = true
   end
 
-  def teardown
+  teardown do
     ActiveSupport::Dependencies.log_activity = false
     self.class.const_remove :FirmOnTheFly rescue nil
     Firm.const_remove :FirmOnTheFly rescue nil

--- a/activerecord/test/cases/invalid_connection_test.rb
+++ b/activerecord/test/cases/invalid_connection_test.rb
@@ -12,7 +12,7 @@ class TestAdapterWithInvalidConnection < ActiveRecord::TestCase
     Bird.establish_connection adapter: 'mysql', database: 'i_do_not_exist'
   end
 
-  def teardown
+  teardown do
     Bird.remove_connection
   end
 

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -122,7 +122,7 @@ module ActiveRecord
       end
     end
 
-    def teardown
+    teardown do
       %w[horses new_horses].each do |table|
         if ActiveRecord::Base.connection.table_exists?(table)
           ActiveRecord::Base.connection.drop_table(table)

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -11,8 +11,7 @@ module ActiveRecord
         @table_name = :testings
       end
 
-      def teardown
-        super
+      teardown do
         connection.drop_table :testings rescue nil
         ActiveRecord::Base.primary_key_prefix_type = nil
       end

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -8,7 +8,7 @@ module ActiveRecord
         @connection = Minitest::Mock.new
       end
 
-      def teardown
+      teardown do
         assert @connection.verify
       end
 

--- a/activerecord/test/cases/migration/column_positioning_test.rb
+++ b/activerecord/test/cases/migration/column_positioning_test.rb
@@ -18,8 +18,7 @@ module ActiveRecord
         end
       end
 
-      def teardown
-        super
+      teardown do
         connection.drop_table :testings rescue nil
         ActiveRecord::Base.primary_key_prefix_type = nil
       end

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -10,8 +10,7 @@ module ActiveRecord
         @connection = ActiveRecord::Base.connection
       end
 
-      def teardown
-        super
+      teardown do
         %w(artists_musics musics_videos catalog).each do |table_name|
           connection.drop_table table_name if connection.tables.include?(table_name)
         end

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -21,8 +21,7 @@ module ActiveRecord
         end
       end
 
-      def teardown
-        super
+      teardown do
         connection.drop_table :testings rescue nil
         ActiveRecord::Base.primary_key_prefix_type = nil
       end

--- a/activerecord/test/cases/migration/logger_test.rb
+++ b/activerecord/test/cases/migration/logger_test.rb
@@ -19,8 +19,7 @@ module ActiveRecord
         ActiveRecord::SchemaMigration.delete_all
       end
 
-      def teardown
-        super
+      teardown do
         ActiveRecord::SchemaMigration.drop_table
       end
 

--- a/activerecord/test/cases/migration/references_index_test.rb
+++ b/activerecord/test/cases/migration/references_index_test.rb
@@ -11,8 +11,7 @@ module ActiveRecord
         @table_name = :testings
       end
 
-      def teardown
-        super
+      teardown do
         connection.drop_table :testings rescue nil
       end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -33,7 +33,7 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Base.connection.schema_cache.clear!
   end
 
-  def teardown
+  teardown do
     ActiveRecord::Base.table_name_prefix = ""
     ActiveRecord::Base.table_name_suffix = ""
 
@@ -585,7 +585,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       Person.reset_sequence_name
     end
 
-    def teardown
+    teardown do
       Person.connection.drop_table(:delete_me) rescue nil
     end
 

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -26,8 +26,7 @@ module ActiveRecord
       ActiveRecord::SchemaMigration.delete_all rescue nil
     end
 
-    def teardown
-      super
+    teardown do
       ActiveRecord::SchemaMigration.delete_all rescue nil
       ActiveRecord::Migration.verbose = true
     end

--- a/activerecord/test/cases/modules_test.rb
+++ b/activerecord/test/cases/modules_test.rb
@@ -18,7 +18,7 @@ class ModulesTest < ActiveRecord::TestCase
     ActiveRecord::Base.store_full_sti_class = false
   end
 
-  def teardown
+  teardown do
     # reinstate the constants that we undefined in the setup
     @undefined_consts.each do |constant, value|
       Object.send :const_set, constant, value unless value.nil?

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -28,7 +28,7 @@ end
 class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   include AssertRaiseWithMessage
 
-  def teardown
+  teardown do
     Pirate.accepts_nested_attributes_for :ship, :allow_destroy => true, :reject_if => proc { |attributes| attributes.empty? }
   end
 

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -10,7 +10,7 @@ class PooledConnectionsTest < ActiveRecord::TestCase
     @connection = ActiveRecord::Base.remove_connection
   end
 
-  def teardown
+  teardown do
     ActiveRecord::Base.clear_all_connections!
     ActiveRecord::Base.establish_connection(@connection)
     @per_test_teardown.each {|td| td.call }

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -10,8 +10,7 @@ module ActiveRecord
         @pool = ConnectionPool.new ActiveRecord::Base.connection_pool.spec
       end
 
-      def teardown
-        super
+      teardown do
         @pool.connections.each(&:close)
       end
 

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -10,8 +10,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
 
   MyObject = Struct.new :attribute1, :attribute2
 
-  def teardown
-    super
+  teardown do
     Topic.serialize("content")
   end
 

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -11,7 +11,7 @@ class TestUnconnectedAdapter < ActiveRecord::TestCase
     @specification = ActiveRecord::Base.remove_connection
   end
 
-  def teardown
+  teardown do
     @underlying = nil
     ActiveRecord::Base.establish_connection(@specification)
     load_schema if in_memory_db?

--- a/activerecord/test/cases/validations/i18n_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_validation_test.rb
@@ -14,7 +14,7 @@ class I18nValidationTest < ActiveRecord::TestCase
     I18n.backend.store_translations('en', :errors => {:messages => {:custom => nil}})
   end
 
-  def teardown
+  teardown do
     I18n.load_path.replace @old_load_path
     I18n.backend = @old_backend
   end


### PR DESCRIPTION
Follow-Up to #14348 

Ensure that SQLCounter.clear_log is called after each test.

This is a step to prevent side effects when running tests. This will allow us to run them in random order.
