### PR TITLE
AC::Parameters doesn't inherit from Hash

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,15 @@
+*   `ActionController::Parameters` no longer inherits from
+    `HashWithIndifferentAccess`
+
+    Inheriting from `HashWithIndifferentAccess` allowed programmers to call
+    enumerable methods over `AC::Parameters`, losing `@permitted` state, and
+    rendering Strong Parameters a barebones Hash. This changeset reduces
+    `ActionController::Parameters` interface, disallowing such operations.
+
+    *Prem Sichanugrist and Tute Costa*
+
 *   Swapped the parameters of assert_equal in `assert_select` so that the
-    proper values were printed correctly 
+    proper values were printed correctly.
 
     Fixes #14422.
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -377,6 +377,15 @@ module ActionController
     #
     # TODO: Remove this method once we reach 5.0.0
     def is_a?(klass)
+      if klass == Hash || klass == HashWithIndifferentAccess
+        ActiveSupport::Deprecation.warn <<-warning.squish
+          ActionController::Parameters is no longer inherited from `HashWithIndifferentAccess` due to
+          a security concern. Currently, `is_a?` is overridden to return true on `Hash` for backward
+          compatibility. You shouldn't rely on this behavior, as it will be removed in the next
+          version of Rails. We recommend you to do `respond_to?(:to_hash)` instead.
+        warning
+      end
+
       super || @parameters.is_a?(klass)
     end
 
@@ -384,6 +393,15 @@ module ActionController
     #
     # TODO: Remove this method once we reach 5.0.0
     def kind_of?(klass)
+      if klass == Hash || klass == HashWithIndifferentAccess
+        ActiveSupport::Deprecation.warn <<-warning.squish
+          ActionController::Parameters is no longer inherited from `HashWithIndifferentAccess` due to
+          a security concern. Currently, `kind_of?` is overridden to return true on `Hash` for backward
+          compatibility. You shouldn't rely on this behavior, as it will be removed in the next
+          version of Rails. We recommend you to do `respond_to?(:to_hash)` instead.
+        warning
+      end
+
       super || @parameters.kind_of?(klass)
     end
 
@@ -634,7 +652,7 @@ module ActionController
     # is a Hash, this will create an ActionController::Parameters
     # object that has been instantiated with the given +value+ hash.
     def params=(value)
-      @_params = value.is_a?(Hash) ? Parameters.new(value) : value
+      @_params = value.respond_to?(:to_hash) ? Parameters.new(value.to_hash) : value
     end
   end
 end

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -139,13 +139,6 @@ module ActionController
       @permitted = permitted
     end
 
-    # Attribute that keeps track of converted arrays, if any, to avoid double
-    # looping in the common use case permit + mass-assignment. Defined in a
-    # method to instantiate it only if needed.
-    def converted_arrays
-      @converted_arrays ||= Set.new
-    end
-
     # Returns +true+ if the parameter is permitted, +false+ otherwise.
     #
     #   params = ActionController::Parameters.new
@@ -422,6 +415,13 @@ module ActionController
         else
           self.class.new(value)
         end
+      end
+
+      # Attribute that keeps track of converted arrays, if any, to avoid double
+      # looping in the common use case permit + mass-assignment. Defined in a
+      # method to instantiate it only if needed.
+      def converted_arrays
+        @converted_arrays ||= Set.new
       end
 
       def each_element(object)

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -163,7 +163,7 @@ module ActionController
     #   Person.new(params) # => #<Person id: nil, name: "Francesco">
     def permit!
       each_pair do |key, value|
-        value = convert_hashes_to_parameters(key, value)
+        value = convert_and_assign_value(key, value)
         Array.wrap(value).each do |_|
           _.permit! if _.respond_to? :permit!
         end
@@ -285,7 +285,7 @@ module ActionController
     #   params[:person] # => {"name"=>"Francesco"}
     #   params[:none]   # => nil
     def [](key)
-      convert_hashes_to_parameters(key, @parameters[key])
+      convert_and_assign_value(key, @parameters[key])
     end
 
     # Returns a parameter for the given +key+. If the +key+
@@ -300,7 +300,7 @@ module ActionController
     #   params.fetch(:none, 'Francesco')    # => "Francesco"
     #   params.fetch(:none) { 'Francesco' } # => "Francesco"
     def fetch(key, *args, &block)
-      convert_hashes_to_parameters(key, @parameters.fetch(key, *args, &block), false)
+      convert_value_to_parameters(@parameters.fetch(key, *args, &block))
     rescue KeyError
       raise ActionController::ParameterMissing.new(key)
     end
@@ -399,9 +399,9 @@ module ActionController
         self.class.new(parameters, @permitted)
       end
 
-      def convert_hashes_to_parameters(key, value, assign_if_converted=true)
+      def convert_and_assign_value(key, value)
         converted = convert_value_to_parameters(value)
-        self[key] = converted if assign_if_converted && !converted.equal?(value)
+        self[key] = converted unless converted.equal?(value)
         converted
       end
 

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -151,8 +151,8 @@ module ActionDispatch
         case options
         when nil
           _routes.url_for(url_options.symbolize_keys)
-        when Hash
-          _routes.url_for(options.symbolize_keys.reverse_merge!(url_options))
+        when Hash, ActionController::Parameters
+          _routes.url_for(options.to_hash.symbolize_keys.reverse_merge!(url_options))
         when String
           options
         when Array

--- a/actionpack/test/controller/parameters/parameters_compatibility_test.rb
+++ b/actionpack/test/controller/parameters/parameters_compatibility_test.rb
@@ -1,0 +1,47 @@
+require 'abstract_unit'
+require 'action_dispatch/http/upload'
+require 'action_controller/metal/strong_parameters'
+
+# TODO: These test can be removed once we reach 5.0.0 milestone
+class ParametersCompatibilityTest < ActiveSupport::TestCase
+  def test_calling_undefined_method_proxy_to_hash_with_deprecation
+    assert_deprecated do
+      params = ActionController::Parameters.new('crab' => 'Senjougahara', 'snail' => 'Hachikuji')
+      assert_equal({crab: 'Senjougahara', snail: 'Hachikuji'}, params.symbolize_keys)
+    end
+  end
+
+  def test_calling_defined_method_does_not_show_deprecation
+    assert_not_deprecated do
+      ActionController::Parameters.new.to_h
+    end
+  end
+
+  def test_calling_private_method_on_hash_does_not_work
+    assert_raises NoMethodError do
+      ActionController::Parameters.caller
+    end
+  end
+
+  def test_respond_to_on_non_existance_method_proxy_to_hash_with_deprecation
+    assert_deprecated do
+      params = ActionController::Parameters.new
+      assert params.respond_to?(:symbolize_keys)
+    end
+  end
+
+  def test_respond_to_on_existance_method_does_not_show_deprecation
+    assert_not_deprecated do
+      params = ActionController::Parameters.new
+      assert params.respond_to?(:to_h)
+    end
+  end
+
+  def test_is_a_returns_true_when_passing_hash
+    assert ActionController::Parameters.new.is_a?(Hash)
+  end
+
+  def test_kind_of_returns_true_when_passing_hash
+    assert ActionController::Parameters.new.kind_of?(Hash)
+  end
+end

--- a/actionpack/test/controller/parameters/parameters_compatibility_test.rb
+++ b/actionpack/test/controller/parameters/parameters_compatibility_test.rb
@@ -37,11 +37,26 @@ class ParametersCompatibilityTest < ActiveSupport::TestCase
     end
   end
 
-  def test_is_a_returns_true_when_passing_hash
-    assert ActionController::Parameters.new.is_a?(Hash)
+  def test_is_a_returns_true_and_show_deprecation_warning_when_passing_hash
+    assert_deprecated do
+      assert ActionController::Parameters.new.is_a?(Hash)
+    end
   end
 
-  def test_kind_of_returns_true_when_passing_hash
-    assert ActionController::Parameters.new.kind_of?(Hash)
+  def test_is_a_not_show_deprecation_warning_when_not_passing_hash
+    assert_not_deprecated do
+      ActionController::Parameters.new.is_a?(String)
+    end
+  end
+
+  def test_kind_of_returns_true_and_show_deprecation_warning_when_passing_hash
+    assert_deprecated do
+      assert ActionController::Parameters.new.kind_of?(Hash) end
+  end
+
+  def test_kind_of_not_show_deprecation_warning_when_not_passing_hash
+    assert_not_deprecated do
+      ActionController::Parameters.new.kind_of?(String)
+    end
   end
 end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -39,7 +39,7 @@ class TestCaseTest < ActionController::TestCase
     end
 
     def test_params
-      render :text => params.inspect
+      render :text => params.to_h.inspect
     end
 
     def test_uri

--- a/actionpack/test/controller/webservice_test.rb
+++ b/actionpack/test/controller/webservice_test.rb
@@ -14,7 +14,7 @@ class WebServiceTest < ActionDispatch::IntegrationTest
     def dump_params_keys(hash = params)
       hash.keys.sort.inject("") do |s, k|
         value = hash[k]
-        value = Hash === value ? "(#{dump_params_keys(value)})" : ""
+        value = value.respond_to?(:to_hash) ? "(#{dump_params_keys(value.to_hash)})" : ""
         s << ", " unless s.empty?
         s << "#{k}#{value}"
       end

--- a/actionview/lib/action_view/routing_url_for.rb
+++ b/actionview/lib/action_view/routing_url_for.rb
@@ -77,9 +77,9 @@ module ActionView
       case options
       when String
         options
-      when nil, Hash
+      when nil, Hash, ActionController::Parameters
         options ||= {}
-        options = { :only_path => options[:host].nil? }.merge!(options.symbolize_keys)
+        options = { :only_path => options[:host].nil? }.merge!(options.to_hash.symbolize_keys)
         super
       when :back
         _back_url

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -250,7 +250,7 @@ module ActiveSupport
       end
 
       def convert_value(value, options = {})
-        if value.is_a? Hash
+        if value.respond_to?(:to_hash)
           if options[:for] == :to_hash
             value.to_hash
           else

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -619,7 +619,7 @@ module ApplicationTests
       app_file 'app/controllers/posts_controller.rb', <<-RUBY
       class PostsController < ApplicationController
         def create
-          render text: params[:post].inspect
+          render text: params[:post].to_hash.inspect
         end
       end
       RUBY


### PR DESCRIPTION
Inheriting from HashWithIndifferentAccess allowed programmers to call enumerable methods over `AC::Parameters`, losing `@permitted` state, and rendering Strong Parameters a barebones Hash. This changeset reduces `AC::Parameters` interface, disallowing such operations.
