### PR TITLE
Add suffix option to store_accessor.

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -34,6 +34,11 @@ module ActiveRecord
   #     store_accessor :settings, :privileges, :servants
   #   end
   #
+  #   #Store accessor accepts an optional suffix to avoid name collisions
+  #   class UserWithAvatar < User
+  #     store_accessor :avatars, :small, :medium, :large, suffix: '_avatar'
+  #   end
+  #
   # The stored attribute names can be retrieved using +stored_attributes+.
   #
   #   User.stored_attributes[:settings] # [:color, :homepage]
@@ -73,6 +78,12 @@ module ActiveRecord
 
       def store_accessor(store_attribute, *keys)
         keys = keys.flatten
+
+        if keys.last.is_a?(Hash)
+          options = keys.pop
+          suffix = options[:suffix]
+          keys = keys.map { |key| "#{key}#{suffix}" }
+        end
 
         _store_accessors_module.module_eval do
           keys.each do |key|

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -6,7 +6,7 @@ class StoreTest < ActiveRecord::TestCase
   fixtures :'admin/users'
 
   setup do
-    @john = Admin::User.create!(:name => 'John Doe', :color => 'black', :remember_login => true, :height => 'tall', :is_a_good_guy => true)
+    @john = Admin::User.create!(:name => 'John Doe', :color => 'black', :remember_login => true, :height => 'tall', :is_a_good_guy => true, :small_avatar => 'small_avatar')
   end
 
   test "reading store attributes through accessors" do
@@ -149,5 +149,22 @@ class StoreTest < ActiveRecord::TestCase
 
   test "all stored attributes are returned" do
     assert_equal [:color, :homepage, :favorite_food], Admin::User.stored_attributes[:settings]
+  end
+
+  test "suffixed store will add suffixed methods" do
+    assert @john.respond_to?(:small_avatar)
+    assert @john.respond_to?(:medium_avatar)
+    assert @john.respond_to?(:large_avatar)
+  end
+
+  test "reading store attributes suffixed through accessors" do
+    assert_equal 'small_avatar', @john.small_avatar
+    assert_nil @john.large_avatar
+  end
+
+  test "writing suffixed store attributes through accessors" do
+    @john.small_avatar = 'big_avatar'
+
+    assert_equal 'big_avatar', @john.small_avatar
   end
 end

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -16,6 +16,8 @@ class Admin::User < ActiveRecord::Base
   belongs_to :account
   store :settings, :accessors => [ :color, :homepage ]
   store_accessor :settings, :favorite_food
+  store :avatars
+  store_accessor :avatars, :small, :medium, :large, :suffix => :_avatar
   store :preferences, :accessors => [ :remember_login ]
   store :json_data, :accessors => [ :height, :weight ], :coder => Coder.new
   store :json_data_empty, :accessors => [ :is_a_good_guy ], :coder => Coder.new

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define do
   create_table :admin_users, :force => true do |t|
     t.string :name
     t.string :settings, :null => true, :limit => 1024
+    t.string :avatars,  :null => true, :limit => 1024
     # MySQL does not allow default values for blobs. Fake it out with a
     # big varchar below.
     t.string :preferences, :null => true, :default => '', :limit => 1024


### PR DESCRIPTION
Adding a suffix to store accessor helps keeping the name inside the store short and clean while exposing methods that have an explicit name.

An example where this is useful is the avatars store.
Having a column that stores the different sizes of an avatar like this `{ small: 'avatar1', medium: 'avatar2' }`.
Having these methods exposed as `user.small` or `user.medium` does not make any sense.
Adding the suffix '_avatar' brings clarity. `user.small_avatar` is explicit enough.

Usage Example:

```
class User < ActiveRecord::Base
  store :avatars
  store_accessor :avatars, :small, :medium, :large, suffix: '_avatar'
end

u = User.new
u.small_avatar = 'Small Avatar'
u.small_avatar # => 'Small Avatar'
```
