### PR TITLE
Still touch associations when theres no timestamp

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -452,6 +452,8 @@ module ActiveRecord
         changed_attributes.except!(*changes.keys)
         primary_key = self.class.primary_key
         self.class.unscoped.where(primary_key => self[primary_key]).update_all(changes) == 1
+      else
+        true
       end
     end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -340,6 +340,17 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_queries(1) { line_item.touch }
   end
 
+  def test_belongs_to_with_touch_option_on_touch_without_updated_at_attributes
+    assert !LineItem.column_names.include?("updated_at")
+
+    line_item = LineItem.create!
+    invoice = Invoice.create!(line_items: [line_item])
+    initial = invoice.updated_at
+    line_item.touch
+
+    refute_equal initial, invoice.reload.updated_at
+  end
+
   def test_belongs_to_with_touch_option_on_touch_and_removed_parent
     line_item = LineItem.create!
     Invoice.create!(line_items: [line_item])


### PR DESCRIPTION
Prior to Rails 4.0.4 when touching a object which doesn't have timestamp
attributes (updated_at / updated_on) rails would still touch all
associations. After 73ba2c14cd7d7dfb2d132b18c47ade995401736f it updates
associations but rollsback because `touch` would return nil since
there's no timestamp attribute.

This sounds a bit insane (touching an object without timestamps) but I came through it today while upgrading and just felt like reporting anyway due to being a change of behaviour between minor releases.

The following would pass on 4.0.3 but fails on 4.0.4

``` ruby
unless File.exist?('Gemfile')
  File.write('Gemfile', <<-GEMFILE)
    source 'https://rubygems.org'
    gem 'rails', path: '../rails'
    gem 'sqlite3'
  GEMFILE

  system 'bundle'
end

require 'bundler'
Bundler.setup(:default)

require 'active_record'
require 'minitest/autorun'
require 'logger'

ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :products do |t|
    t.timestamps
  end

  create_table :assets do |t|
    t.integer :product_id
  end
end

class Product < ActiveRecord::Base
  has_many :assets
end

class Asset < ActiveRecord::Base
  belongs_to :product, touch: true
end

class BugTest < MiniTest::Unit::TestCase
  def test_association_stuff
    product = Product.create!
    image = Asset.create! product: product
    initial = product.reload.updated_at
    image.touch

    refute_equal initial, product.reload.updated_at
  end
end
```
