### PR TITLE
Fix MailerPreview broken tests

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -594,7 +594,7 @@ class BaseTest < ActiveSupport::TestCase
   test "you can register a preview interceptor to the mail object that gets passed the mail object before previewing" do
     ActionMailer::Base.register_preview_interceptor(MyInterceptor)
     mail = BaseMailer.welcome
-    BaseMailerPreview.stubs(:welcome).returns(mail)
+    BaseMailerPreview.any_instance.stubs(:welcome).returns(mail)
     MyInterceptor.expects(:previewing_email).with(mail)
     BaseMailerPreview.call(:welcome)
   end
@@ -602,7 +602,7 @@ class BaseTest < ActiveSupport::TestCase
   test "you can register a preview interceptor using its stringified name to the mail object that gets passed the mail object before previewing" do
     ActionMailer::Base.register_preview_interceptor("BaseTest::MyInterceptor")
     mail = BaseMailer.welcome
-    BaseMailerPreview.stubs(:welcome).returns(mail)
+    BaseMailerPreview.any_instance.stubs(:welcome).returns(mail)
     MyInterceptor.expects(:previewing_email).with(mail)
     BaseMailerPreview.call(:welcome)
   end
@@ -610,7 +610,7 @@ class BaseTest < ActiveSupport::TestCase
   test "you can register an interceptor using its symbolized underscored name to the mail object that gets passed the mail object before previewing" do
     ActionMailer::Base.register_preview_interceptor(:"base_test/my_interceptor")
     mail = BaseMailer.welcome
-    BaseMailerPreview.stubs(:welcome).returns(mail)
+    BaseMailerPreview.any_instance.stubs(:welcome).returns(mail)
     MyInterceptor.expects(:previewing_email).with(mail)
     BaseMailerPreview.call(:welcome)
   end
@@ -618,7 +618,7 @@ class BaseTest < ActiveSupport::TestCase
   test "you can register multiple preview interceptors to the mail object that both get passed the mail object before previewing" do
     ActionMailer::Base.register_preview_interceptors("BaseTest::MyInterceptor", MySecondInterceptor)
     mail = BaseMailer.welcome
-    BaseMailerPreview.stubs(:welcome).returns(mail)
+    BaseMailerPreview.any_instance.stubs(:welcome).returns(mail)
     MyInterceptor.expects(:previewing_email).with(mail)
     MySecondInterceptor.expects(:previewing_email).with(mail)
     BaseMailerPreview.call(:welcome)


### PR DESCRIPTION
### Problem

`actionmailer  base_test` fails randomly on travis ATM.
### Why/Solution

`BaseMailerPreview.welcome` is an instance method, so we need to stub the
method on a instance level and not on Class. The stub is important, to make
sure the Message object is the same in the other expectations.
This was working randomly because Mocha uses == to compare two objects
on the `with()` expectation and even if the Mail::Message objects were
not the same object, they are equal, but thats not the case in 100% of
the runs. So we need to make sure we use `.any_instance` method and have
the right message object.

review @rafaelfranca @jeremy @pixeltrix

:heart: :heart: :heart: :heart: thanks to @robin850 for given me ssh access to his machine that we were able to simulate the issue.
