### PR TITLE
String inflections should use I18n.locale if locale is not specified

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -15,7 +15,7 @@ class String
   #
   # If the optional parameter +locale+ is specified,
   # the word will be pluralized as a word of that language.
-  # By default, this parameter is set to <tt>:en</tt>.
+  # By default, this parameter is set to <tt>I18n.locale</tt>.
   # You must define your own inflection rules for languages other than English.
   #
   #   'post'.pluralize             # => "posts"
@@ -28,7 +28,7 @@ class String
   #   'apple'.pluralize(2)         # => "apples"
   #   'ley'.pluralize(:es)         # => "leyes"
   #   'ley'.pluralize(1, :es)      # => "ley"
-  def pluralize(count = nil, locale = :en)
+  def pluralize(count = nil, locale = I18n.locale)
     locale = count if count.is_a?(Symbol)
     if count == 1
       self
@@ -41,7 +41,7 @@ class String
   #
   # If the optional parameter +locale+ is specified,
   # the word will be singularized as a word of that language.
-  # By default, this parameter is set to <tt>:en</tt>.
+  # By default, this parameter is set to <tt>I18n.locale</tt>.
   # You must define your own inflection rules for languages other than English.
   #
   #   'posts'.singularize            # => "post"
@@ -51,7 +51,7 @@ class String
   #   'the blue mailmen'.singularize # => "the blue mailman"
   #   'CamelOctopi'.singularize      # => "CamelOctopus"
   #   'leyes'.singularize(:es)       # => "ley"
-  def singularize(locale = :en)
+  def singularize(locale = I18n.locale)
     ActiveSupport::Inflector.singularize(self, locale)
   end
 

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -399,6 +399,37 @@ class InflectorTest < ActiveSupport::TestCase
     assert !ActiveSupport::Inflector.inflections.singulars.empty?
   end
 
+  def test_inflector_locality_with_locale
+    original_locale = I18n.locale
+
+    ActiveSupport::Inflector.inflections(:es) do |inflect|
+      inflect.plural(/$/, 's')
+      inflect.plural(/z$/i, 'ces')
+
+      inflect.singular(/s$/, '')
+      inflect.singular(/es$/, '')
+
+      inflect.irregular('el', 'los')
+    end
+
+    I18n.locale = :es
+    assert_equal     'hijos',       'hijo'.pluralize
+    assert_equal     'luces',        'luz'.pluralize
+    assert_equal      'luzs',        'luz'.pluralize(:en)
+    assert_equal       'los',         'el'.pluralize
+    assert_equal       'els',         'el'.pluralize(:en)
+    assert_equal  'sociedad', 'sociedades'.singularize
+    assert_equal 'sociedade', 'sociedades'.singularize(:en)
+
+    ActiveSupport::Inflector.inflections(:es) { |inflect| inflect.clear }
+
+    I18n.locale = :en
+    assert_equal 'users',  'user'.pluralize
+    assert_equal  'user', 'users'.singularize
+
+    I18n.locale = original_locale
+  end
+
   def test_clear_all
     with_dup do
       ActiveSupport::Inflector.inflections do |inflect|


### PR DESCRIPTION
When we set languages other than English (`:en`), we expect every word to be translated to the language we set. However, `String#pluralize` and `String#singularize` still use `:en` when locale is not specified. This means we always need to specify locale every time we use one of these methods.

To avoid that mess, let `String#pluralize` and `String#singularize` use `I18n.locale` by default so everything will be translated properly without specifying locale.
