### PR TITLE
Extend fixture label replacement to allow string interpolation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Extend Fixture $LABEL replacement to allow string interpolation
+    Example:
+
+        martin:
+          email: $LABEL@email.com
+
+        users(:martin).email # => martin@email.com
+
+    *Eric Steele*
+    
 *   Add support for `Relation` be passed as parameter on `QueryCache#select_all`.
 
     Fixes #14361.

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -361,6 +361,7 @@ module ActiveRecord
   #   geeksomnia:
   #     name: Geeksomnia's Account
   #     subdomain: $LABEL
+  #     email: $LABEL@email.com
   #
   # Also, sometimes (like when porting older join table fixtures) you'll need
   # to be able to get a hold of the identifier for a given label. ERB
@@ -627,7 +628,7 @@ module ActiveRecord
 
           # interpolate the fixture label
           row.each do |key, value|
-            row[key] = label if "$LABEL" == value
+            row[key] = value.gsub("$LABEL", label) if value.is_a?(String)
           end
 
           # generate a primary key if necessary

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -782,6 +782,10 @@ class FoxyFixturesTest < ActiveRecord::TestCase
     assert_equal("frederick", parrots(:frederick).name)
   end
 
+  def test_supports_label_string_interpolation
+    assert_equal("X marks the spot!", pirates(:mark).catchphrase)
+  end
+
   def test_supports_polymorphic_belongs_to
     assert_equal(pirates(:redbeard), treasures(:sapphire).looter)
     assert_equal(parrots(:louis), treasures(:ruby).looter)

--- a/activerecord/test/fixtures/pirates.yml
+++ b/activerecord/test/fixtures/pirates.yml
@@ -7,3 +7,6 @@ redbeard:
   parrot: louis
   created_on: "<%= 2.weeks.ago.to_s(:db) %>"
   updated_on: "<%= 2.weeks.ago.to_s(:db) %>"
+
+mark:
+  catchphrase: "X $LABELs the spot!"


### PR DESCRIPTION
Allows fixtures to use their $LABEL as part of a string instead of limiting use to the entire value.

```
mark:
  first_name: $LABEL
  username: $LABEL1973
  email: $LABEL@$LABELmail.com

users(:mark).first_name # => mark
users(:mark).username   # => mark1973
users(:mark).email      # => mark@markmail.com
```
