### PR TITLE
Drop custom tables after each test.

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1,9 +1,12 @@
 # encoding: utf-8
 require "cases/helper"
+require 'support/ddl_helper'
 
 module ActiveRecord
   module ConnectionAdapters
     class PostgreSQLAdapterTest < ActiveRecord::TestCase
+      include DdlHelper
+
       def setup
         @connection = ActiveRecord::Base.connection
       end
@@ -369,12 +372,8 @@ module ActiveRecord
         ctx.exec_insert(sql, 'SQL', binds)
       end
 
-      def with_example_table(definition = nil)
-        definition ||= 'id serial primary key, number integer, data character varying(255)'
-        @connection.exec_query("create table ex(#{definition})")
-        yield
-      ensure
-        @connection.exec_query('drop table if exists ex')
+      def with_example_table(definition = 'id serial primary key, number integer, data character varying(255)', &block)
+        super(@connection, 'ex', definition, &block)
       end
 
       def connection_without_insert_returning

--- a/activerecord/test/support/ddl_helper.rb
+++ b/activerecord/test/support/ddl_helper.rb
@@ -1,0 +1,8 @@
+module DdlHelper
+  def with_example_table(connection, table_name, definition = nil)
+    connection.exec_query("CREATE TABLE #{table_name}(#{definition})")
+    yield
+  ensure
+    connection.exec_query("DROP TABLE #{table_name}")
+  end
+end


### PR DESCRIPTION
This is a step to prevent side effects when running tests. This will allow us to run them in random order.
