### PR TITLE
/config/secrets.yml in gitignore file by default  [ci skip] 

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -14,3 +14,6 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+
+# Ignore secrets file.
+/config/secrets.yml


### PR DESCRIPTION
when create a new Rails application (rails new command)
I should be written config/secrets.yml in gitignore file 
