### PR TITLE
Fix counter cache when association uses a class_name

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix counter cache when association uses a class_name.
+
+    Fixes #14369.
+
+    *arthurnn*
+
 *   Add support for `Relation` be passed as parameter on `QueryCache#select_all`.
 
     Fixes #14361.

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -815,6 +815,17 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal 0, comments(:greetings).reload.children_count
   end
 
+  def test_belongs_to_with_id_assigning
+    post = posts(:welcome)
+    comment = Comment.create! body: "foo", post: post
+    parent = comments(:greetings)
+    assert_equal 0, parent.reload.children_count
+    comment.parent_id = parent.id
+
+    comment.save!
+    assert_equal 1, parent.reload.children_count
+  end
+
   def test_polymorphic_with_custom_primary_key
     toy = Toy.create!
     sponsor = Sponsor.create!(:sponsorable => toy)


### PR DESCRIPTION
The idea of this commits is from
bf28422cbda9068afb900020fa6911afd01963e1, which fixes this problem, but
only on AR 4.1+.

[fixes #14369]

@rafaelfranca , not sure if changelog is needed.
cc @tenderlove
