### PR TITLE
Fix html-scanner crash in SanitizeHelper#sanitize for empty protocols

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix html-scanner crash when passing `<a href=":">` to `sanitize`.
+
+    Fixes #8126.
+    
+    *Lukas Fittl*
+
 *   `number_to_percentage` does not crash with `Float::NAN` or `Float::INFINITY`
     as input.
 

--- a/actionview/lib/action_view/vendor/html-scanner/html/sanitizer.rb
+++ b/actionview/lib/action_view/vendor/html-scanner/html/sanitizer.rb
@@ -182,7 +182,7 @@ module HTML
 
     def contains_bad_protocols?(attr_name, value)
       uri_attributes.include?(attr_name) &&
-      (value =~ /(^[^\/:]*):|(&#0*58)|(&#x70)|(&#x0*3a)|(%|&#37;)3A/i && !allowed_protocols.include?(value.split(protocol_separator).first.downcase.strip))
+      (value =~ /(^[^\/:]+):|(&#0*58)|(&#x70)|(&#x0*3a)|(%|&#37;)3A/i && !allowed_protocols.include?(value.split(protocol_separator).first.downcase.strip))
     end
   end
 end

--- a/actionview/test/template/html-scanner/sanitizer_test.rb
+++ b/actionview/test/template/html-scanner/sanitizer_test.rb
@@ -313,6 +313,10 @@ class SanitizerTest < ActionController::TestCase
     assert_sanitized %(<a href="javascript&#x003A;alert('XSS');">), "<a>"
     assert_sanitized %(<a href="http&#x3A;//legit">), %(<a href="http://legit">)
   end
+  
+  def test_empty_protocol
+    assert_sanitized "<a href=\":\">test</a>", "<a href=\":\">test</a>"
+  end
 
 protected
   def assert_sanitized(input, expected = nil)


### PR DESCRIPTION
As detailed in issue #8126 there is a bug in the vendored html-scanner gem that makes WhiteListSanitizer#contains_bad_protocols? crash when `<a href=":"></a>` is passed to it.

This bugfix is a simple fix in the regular expression of #contains_bad_protocols? in order to only match protocols with at least one character - so that the code does not throw "undefined method `downcase' for nil:NilClass".

We have encountered this kind of HTML in user-generated content, and even though I agree its pretty weird to pass something like that in, there is no other way to avoid this problem for us whilst still sanitizing other tags in the same input.
