### PR TITLE
Consistency fix to the Getting Started with Rails guide

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -701,7 +701,7 @@ Let's add links to the other views as well, starting with adding this "New Post"
 This link will allow you to bring up the form that lets you create a new post. You should also add a link to this template — `app/views/posts/new.html.erb` — to go back to the `index` action. Do this by adding this underneath the form in this template:
 
 ```erb
-<%= form_for :post do |f| %>
+<%= form_for :post, url: posts_path do |f| %>
   ...
 <% end %>
 


### PR DESCRIPTION
This corrects the code snippet taken from the app/views/posts/new.html.erb
file on line 704.  Earlier in the guide on lines 395-398 the guide user is 
instructed to change the form_for line in the new.html.erb file to use the 
posts_path helper.  This fix updates the code snippet to be consistent with that 
earlier change.
