### PR TITLE
Reorder conditional logic in link_to_if and link_to_unless

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -389,15 +389,7 @@ module ActionView
       #   # If not...
       #   # => <a href="/accounts/signup">Reply</a>
       def link_to_unless(condition, name, options = {}, html_options = {}, &block)
-        if condition
-          if block_given?
-            block.arity <= 1 ? capture(name, &block) : capture(name, options, html_options, &block)
-          else
-            ERB::Util.html_escape(name)
-          end
-        else
-          link_to(name, options, html_options)
-        end
+        link_to_if !condition, name, options, html_options, &block
       end
 
       # Creates a link tag of the given +name+ using a URL created by the set of
@@ -421,7 +413,15 @@ module ActionView
       #   # If they are logged in...
       #   # => <a href="/accounts/show/3">my_username</a>
       def link_to_if(condition, name, options = {}, html_options = {}, &block)
-        link_to_unless !condition, name, options, html_options, &block
+        if condition
+          link_to(name, options, html_options)
+        else
+          if block_given?
+            block.arity <= 1 ? capture(name, &block) : capture(name, options, html_options, &block)
+          else
+            ERB::Util.html_escape(name)
+          end
+        end
       end
 
       # Creates a mailto link tag to the specified +email_address+, which is


### PR DESCRIPTION
According to the best practice that "unless not" and "unless else" are hard to follow logically link_to_unless and link_to_if were reversed.

This simply reorders the conditionals into a more readable form.
