### PR TITLE
Make CORS requests considered as Ajax requests

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Make CORS requests considered as Ajax requests.
+
+    This fixes a problem where HTML page was returned instead of JSON
+    response because the CORS request was not considered as Ajax.
+
+    *Yvan Barthélemy*
+
 *   The method `shallow?` returns false if the parent resource is a singleton so
     we need to check if we're not inside a nested scope before copying the :path
     and :as options to their shallow equivalents.

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -196,12 +196,22 @@ module ActionDispatch
     end
 
     # Returns true if the "X-Requested-With" header contains "XMLHttpRequest"
-    # (case-insensitive). All major JavaScript libraries send this header with
-    # every Ajax request.
+    # (case-insensitive) or if HTTP_ORIGIN is present. All major JavaScript 
+    # libraries send X-Requested-With header with every Ajax request except
+    # jQuery for CORS requests. That is why we assume CORS requests are
+    # Ajax requests too.
+
     def xml_http_request?
-      @env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i
+      @env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i || cors?
     end
     alias :xhr? :xml_http_request?
+
+    def cors?
+      return false unless @env['HTTP_ORIGIN']
+
+      uri = URI.parse @env['HTTP_ORIGIN']
+      uri.host != @env['HTTP_HOST'] || uri.scheme != @env['rack.url_scheme'] || uri.port != @env['HTTP_PORT'].to_i
+    end
 
     def ip
       @ip ||= super

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -605,6 +605,22 @@ class RequestProtocol < BaseRequestTest
     assert request.xhr?
   end
 
+  test "cross-origin resourse sharing request" do
+    request = stub_request
+    assert !request.cors?
+
+    request = stub_request 'HTTP_HOST' => 'test.dev', 'HTTP_PORT' => '80', 'rack.url_scheme' => 'http', 'HTTP_ORIGIN' => 'http://test.dev'
+    assert !request.cors?
+
+    request = stub_request 'HTTP_HOST' => 'test.dev', 'HTTP_PORT' => '80', 'rack.url_scheme' => 'http', 'HTTP_ORIGIN' => 'https://test.dev'
+    assert request.cors?
+    assert request.xhr?
+
+    request = stub_request 'HTTP_HOST' => 'test.dev', 'HTTP_PORT' => '80', 'rack.url_scheme' => 'http', 'HTTP_ORIGIN' => 'http://otherdomain.dev'
+    assert request.cors?
+    assert request.xhr?
+  end
+
   test "reports ssl" do
     assert !stub_request.ssl?
     assert stub_request('HTTPS' => 'on').ssl?


### PR DESCRIPTION
jQuery does not send the usual HTTP_X_REQUESTED_BY header that is
used by Rails to detect Ajax Request when using CORS. To overcome
this, a new cors? method was added to request, and this is used in
xhr? to determine wether the request is Ajax.

This fixes a problem where HTML page was returned instead of JSON
response because the CORS request was not considered as Ajax.
