### PR TITLE
update rack-ssl to mitigate CVE-2014-2538.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Rails 3.2.18 () ##
+
+*   Update `rack-ssl` to 1.4.0 to avert CVE-2014-2538.
+    *Weston Platter*
+
+## Rails 3.2.17 (Feb 18, 2014) ##
+
+## Rails 3.2.16 (Dec 3, 2013) ##
+
 ## Rails 3.2.15 (Oct 16, 2013) ##
 
 * No changes.

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.rdoc_options << '--exclude' << '.'
 
   s.add_dependency('rake',          '>= 0.8.7')
-  s.add_dependency('rack-ssl',      '~> 1.3.2')
+  s.add_dependency('rack-ssl',      '~> 1.4.0')
 
   # The current API of the Thor gem (0.14) will remain stable at least until Thor 2.0. Because
   # Thor is so heavily used by other gems, we will accept Thor's semver guarantee to reduce


### PR DESCRIPTION
More info on the CVE, https://bugzilla.redhat.com/show_bug.cgi?id=1078612

Should I also bump the patch level version to account for this change?
