### PR TITLE
Generate proper SQL when table-prefixed hash key is used in order

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `order` accepts `'table_name.column_name' => :asc` as an argument.
+
+    *Nikolay Shebanov*
+
 *   `touch` accepts many attributes to be touched at once.
 
     Example:

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -193,6 +193,12 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal Topic.order(:id).to_sql, Topic.order(:id => :asc).to_sql
   end
 
+  def test_order_with_table_prefixed_hash_keys
+    assert_equal Author.joins(:comments).order('comments.id' => :asc).to_sql,
+                 Author.joins(:comments).order(Comment.arel_table[:id].asc).to_sql
+    assert_raise(ArgumentError) { Author.joins(:comments).order('something_else.id' => :asc) }
+  end
+
   def test_finding_with_desc_order_with_string
     topics = Topic.order(id: "desc")
     assert_equal 5, topics.to_a.size


### PR DESCRIPTION
`where` method accepts several notation formats, such as `foo: :bar`, `'foo = bar'`, `'foo' => 'bar'` and also `'foo_items.foo' => 'bar'`. Each of them is widely used in RoR apps, and it seems normal to use the same approach in `order`, which in turn supports all except the last one.

Here's what we have now:

```
Topic.order('topics.id' => 'asc').to_sql
# => "SELECT \"topics\".* FROM \"topics\"   ORDER BY \"topics\".\"topics.id\" ASC"
```

So this PR is my attempt to implement the desired behavior. Likely this can be done more efficiently.
