### PR TITLE
add row_format option for mysql tables

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -455,7 +455,9 @@ module ActiveRecord
       end
 
       def create_table(table_name, options = {}) #:nodoc:
-        super(table_name, options.reverse_merge(:options => "ENGINE=InnoDB"))
+        table_options = "ENGINE=InnoDB"
+        table_options += " ROW_FORMAT=#{options[:row_format].upcase}" if options[:row_format]
+        super(table_name, options.reverse_merge(options: table_options))
       end
 
       def bulk_change_table(table_name, operations) #:nodoc:


### PR DESCRIPTION
This allows MySQL 5.6.x users to better support utf8mb4 (a.k.a. real
UTF-8) by using DYNAMIC row format tables that allow longer indexes.

You would put this in your database.yml in that case:
`row_format: dynamic`

I'm happy to add a test or two for this if anyone can suggest the right place to put it.
