### PR TITLE
Update tag_helper.rb

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -146,7 +146,11 @@ module ActionView
                 attrs << data_tag_option(k, v, escape)
               end
             elsif BOOLEAN_ATTRIBUTES.include?(key)
-              attrs << boolean_tag_option(key) if value
+              if value.is_a?(String)
+                attrs << tag_option(key, value, escape)
+              elsif value
+                attrs << boolean_tag_option(key)
+              end
             elsif !value.nil?
               attrs << tag_option(key, value, escape)
             end


### PR DESCRIPTION
Allow string value to take precedent for BOOLEAN_ATTRIBUTES in tag_options.

This specifically allows overrides for boolean HTML tags that have behaivior based on inclusion as well as value such as the `async` attribute of the `<script>` tag in Firefox https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script

This specifically works around an issue in Firefox discovered while using `javascript_include_tag "application", async: false` as firefox defaults async to true when async attribute parameter is not included. This patch allows `javascript_include_tag "application", async: "false"` to print the attribute verbatim allowing workarounds for boolean values in tag attributes that default to true on exclusion.
