### PR TITLE
Incorrect values being printed by assert_select.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Swapped the parameters of assert_equal in `assert_select` so that the
+    proper values were printed correctly 
+
+    Fixes #14422.
+
+    *Vishal Lal*
+
 *   The method `shallow?` returns false if the parent resource is a singleton so
     we need to check if we're not inside a nested scope before copying the :path
     and :as options to their shallow equivalents.

--- a/actionpack/lib/action_dispatch/testing/assertions/selector.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/selector.rb
@@ -291,7 +291,7 @@ module ActionDispatch
         # so is this custom message really needed?
         message = message || %(Expected #{count_description(min, max, count)} matching "#{selector.to_s}", found #{matches.size}.)
         if count
-          assert_equal matches.size, count, message
+          assert_equal count, matches.size, message
         else
           assert_operator matches.size, :>=, min, message if min
           assert_operator matches.size, :<=, max, message if max


### PR DESCRIPTION
Swapped the values so that the correct values are printed
-          assert_equal matches.size, count, message
-          assert_equal count, matches.size, message
