### PR TITLE
Ignore database config by default

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore database config.
+/config/database.yml
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal


### PR DESCRIPTION
Once database.yml is checked into the repository, credential information could be leaked and a bad habit of checking configurations into the code repository is practiced.

One re-occuring pattern for Rails newbies is to execute "rails new" and "git add ." to commit every thing on the trust of the default .gitignore file. Even though he later realized the database.yml is under track and put database.yml in the .gitignore file this would not be not be sufficient, he must also manually git-rm the file, otherwise he would then need to run git-filter-branch to eradicate database.yml, which would cause a lot of hassle.

Therefore I suggest we put this line defaultly into a newly-generated rails project.
