### PR TITLE
Deprecate Marshal serialization

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -49,6 +49,10 @@ module ActiveSupport
       @cipher = options[:cipher] || 'aes-256-cbc'
       @verifier = MessageVerifier.new(@sign_secret || @secret, :serializer => NullSerializer)
       @serializer = options[:serializer] || Marshal
+      if @serializer == Marshal
+        deprecator = ::ActiveSupport::Deprecation.instance
+        deprecator.warn("Marshal serializer for MessageEncryptor is deprecated");
+      end
     end
 
     # Encrypt and sign a message. We need to sign the message in order to avoid

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -30,6 +30,10 @@ module ActiveSupport
       @secret = secret
       @digest = options[:digest] || 'SHA1'
       @serializer = options[:serializer] || Marshal
+      if @serializer == Marshal
+        deprecator = ::ActiveSupport::Deprecation.instance
+        deprecator.warn("Marshal serializer for MessageVerifier is deprecated")
+      end
     end
 
     def verify(signed_message)

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -77,6 +77,13 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     assert_not_verified([iv,  message] * bad_encoding_characters)
   end
 
+  def test_deprecated_serializer_warning
+    assert_deprecated(/Marshal serializer for MessageEncryptor is deprecated/) do
+      @verifier = ActiveSupport::MessageEncryptor.new("Hey, I'm a secret!")
+    end
+  end
+
+
   private
 
   def assert_not_decrypted(value)

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -69,6 +69,12 @@ class MessageVerifierTest < ActiveSupport::TestCase
                     "undefined class/module MessageVerifierTest::AutoloadClass"], exception.message
   end
 
+  def test_deprecated_serializer_warning
+    assert_deprecated(/Marshal serializer for MessageVerifier is deprecated/) do
+      @verifier = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!")
+    end
+  end
+
   def assert_not_verified(message)
     assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
       @verifier.verify(message)


### PR DESCRIPTION
Marshal serialization should not be used as default
