### PR TITLE
Greppable prefixed delegation

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -142,6 +142,16 @@ class Module
   #
   def delegate(*methods)
     options = methods.pop
+
+    if options.is_a?(Hash) && prefix_name = options[:prefixing_with]
+      if options[:to]
+        raise ArgumentError, "It doesn't make sense to use both the :to and :prefixing_with options together. Use one or the other."
+      end
+      options[:to]      = prefix_name
+      methods.map! { |method| method.to_s.gsub("#{prefix_name}_", "").to_sym }
+      options[:prefix]  = true
+    end
+
     unless options.is_a?(Hash) && to = options[:to]
       raise ArgumentError, 'Delegation needs a target. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter).'
     end

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -43,7 +43,8 @@ class Someone < Struct.new(:name, :place)
 end
 
 Invoice   = Struct.new(:client) do
-  delegate :street, :city, :name, :to => :client, :prefix => true
+  delegate :street, :city, :to => :client, :prefix => true
+  delegate :client_name, :prefixing_with => :client
   delegate :street, :city, :name, :to => :client, :prefix => :customer
 end
 


### PR DESCRIPTION
Add an additional option `:prefixing_with` for delegate that allows prefixed delegations to be declared but ensures they are greppable/searchable using the name of the method they are defining i.e:

``` ruby
delegate :foo_bar, :prefixing_with => :foo
```

I don't really mind what the option is called, so let me know if you would like it changed.
