### PR TITLE
ActiveRecord/ActiveModel '#validate' alias for 'valid?'

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -285,6 +285,8 @@ module ActiveModel
     # Runs all the specified validations and returns +true+ if no errors were
     # added otherwise +false+.
     #
+    # Aliased as validate.
+    #
     #   class Person
     #     include ActiveModel::Validations
     #
@@ -318,6 +320,8 @@ module ActiveModel
     ensure
       self.validation_context = current_context
     end
+
+    alias_method :validate, :valid?
 
     # Performs the opposite of <tt>valid?</tt>. Returns +true+ if errors were
     # added, +false+ otherwise.

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -295,6 +295,15 @@ class ValidationsTest < ActiveModel::TestCase
     assert auto.valid?
   end
 
+  def test_validate
+    auto = Automobile.new
+
+    assert_empty auto.errors
+
+    auto.validate
+    assert_not_empty auto.errors
+  end
+
   def test_strict_validation_in_validates
     Topic.validates :title, strict: true, presence: true
     assert_raises ActiveModel::StrictValidationFailed do

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Introduce `validate` as an alias for `valid?`.
+
+    This is more intuitive when you want to run validations but don't care about the return value.
+
+    *Henrik Nyh*
+
 *   Create indexes inline in CREATE TABLE for MySQL.
 
     This is important, because adding an index on a temporary table after it has been created

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -60,6 +60,8 @@ module ActiveRecord
     # Runs all the validations within the specified context. Returns +true+ if
     # no errors are found, +false+ otherwise.
     #
+    # Aliased as validate.
+    #
     # If the argument is +false+ (default is +nil+), the context is set to <tt>:create</tt> if
     # <tt>new_record?</tt> is +true+, and to <tt>:update</tt> if it is not.
     #
@@ -70,6 +72,8 @@ module ActiveRecord
       output = super(context)
       errors.empty? && output
     end
+
+    alias_method :validate, :valid?
 
   protected
 

--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -52,6 +52,21 @@ class ValidationsTest < ActiveRecord::TestCase
     assert r.save(:context => :special_case)
   end
 
+  def test_validate
+    r = WrongReply.new
+
+    r.validate
+    assert_empty r.errors[:author_name]
+
+    r.validate(:special_case)
+    assert_not_empty r.errors[:author_name]
+
+    r.author_name = "secret"
+
+    r.validate(:special_case)
+    assert_empty r.errors[:author_name]
+  end
+
   def test_invalid_record_exception
     assert_raise(ActiveRecord::RecordInvalid) { WrongReply.create! }
     assert_raise(ActiveRecord::RecordInvalid) { WrongReply.new.save! }


### PR DESCRIPTION
It's unintuitive to call '#valid?' when you want to run validations but don't care about the return value, e.g. in a test:

``` ruby
x.name  = ""
x.valid?
assert_not_empty x.errors_on(:name)
```

Compare that to

``` ruby
x.name  = ""
x.validate
assert_not_empty x.errors_on(:name)
```

The alias in ActiveRecord isn't strictly necessary (the ActiveModel alias is still in effect), but it clarifies.

@dhh was positive when I asked a few months ago: https://twitter.com/henrik/status/390205394305703936

An alternative implementation would be to actually implement `valid?` in terms of `validate`, but I figured an alias would be the simplest thing that works.
