### PR TITLE
Don't recurse infinitely when calling non-existent method on super

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -190,8 +190,7 @@ module ActiveRecord
     # If we haven't generated any methods yet, generate them, then
     # see if we've created the method we're looking for.
     def method_missing(method, *args, &block) # :nodoc:
-      self.class.define_attribute_methods
-      if respond_to_without_attributes?(method)
+      if self.class.define_attribute_methods && respond_to_without_attributes?(method)
         # make sure to invoke the correct attribute method, as we might have gotten here via a `super`
         # call in a overwritten attribute method
         if attribute_method = self.class.find_generated_attribute_method(method)

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -58,7 +58,7 @@ module ActiveRecord
       def initialize_generated_modules # :nodoc:
         @generated_attribute_methods = Module.new { extend Mutex_m }
         @attribute_methods_generated = false
-        @thread_registry = {}
+        @thread_registry = ThreadSafe::Cache.new
         include @generated_attribute_methods
       end
 

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -58,6 +58,7 @@ module ActiveRecord
       def initialize_generated_modules # :nodoc:
         @generated_attribute_methods = Module.new { extend Mutex_m }
         @attribute_methods_generated = false
+        @thread_registry = {}
         include @generated_attribute_methods
       end
 
@@ -79,6 +80,16 @@ module ActiveRecord
         generated_attribute_methods.synchronize do
           super if @attribute_methods_generated
           @attribute_methods_generated = false
+          @thread_registry.clear
+        end
+      end
+
+      def current_thread_retried_method_invocation?
+        if @thread_registry[Thread.current.object_id]
+          return true
+        else
+          @thread_registry[Thread.current.object_id] = true
+          return false
         end
       end
 
@@ -190,7 +201,8 @@ module ActiveRecord
     # If we haven't generated any methods yet, generate them, then
     # see if we've created the method we're looking for.
     def method_missing(method, *args, &block) # :nodoc:
-      if self.class.define_attribute_methods && respond_to_without_attributes?(method)
+      self.class.define_attribute_methods
+      if !self.class.current_thread_retried_method_invocation? && respond_to_without_attributes?(method)
         # make sure to invoke the correct attribute method, as we might have gotten here via a `super`
         # call in a overwritten attribute method
         if attribute_method = self.class.find_generated_attribute_method(method)

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -843,6 +843,18 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal !real_topic.title?, klass.find(real_topic.id).title?
   end
 
+  def test_calling_super_when_parent_does_not_define_method_raises_error
+    klass = new_topic_like_ar_class do
+      def some_method_that_is_not_on_super
+        super
+      end
+    end
+
+    assert_raise(NoMethodError) do
+      klass.new.some_method_that_is_not_on_super
+    end
+  end
+
   private
 
   def new_topic_like_ar_class(&block)

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -855,6 +855,40 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_race_condition_does_not_cause_no_method_error
+    klass = new_topic_like_ar_class do
+      def title?
+        super
+      end
+    end
+    klass.generated_attribute_methods.lock
+    topic = klass.new
+    t1 = Thread.new do
+      topic.title?
+    end
+    t2 = Thread.new do
+      topic.title?
+    end
+    t1.run
+    t2.run
+    sleep(0.1) while t1.status == "run" || t2.status == "run"
+    klass.generated_attribute_methods.unlock
+    t1.join
+    t2.join
+  end
+
+  def test_undefine_attribute_method_clears_the_thread_ids_that_know_the_methods_were_defined
+    klass = new_topic_like_ar_class do
+      def title?
+        super
+      end
+    end
+    klass.new.title?
+    assert klass.current_thread_retried_method_invocation?
+    klass.undefine_attribute_methods
+    assert !klass.current_thread_retried_method_invocation?
+  end
+
   private
 
   def new_topic_like_ar_class(&block)


### PR DESCRIPTION
This defect was introduced from this commit:

commit 252539c0366f3c3c222b809444d68f06383ca8ea
Author: Matt Jones al2o3cr@gmail.com
Date:   Thu Oct 24 15:06:53 2013 -0400

```
always check to see if methods exist after calling define_attribute_methods
```

In which the return value from self.class.define_attribute_methods was ignored. That return value indicates whether the methods have been previously defined. I reviewed the history of this method over the last couple years, and the general behavior has been to retry the method call to an attribute method one time, only if the attribute methods were just defined. Otherwise, delegate to super.

The defect generally causes problems in development, as my guard and spork setup fails somewhat quietly when an infinite loop happens. However, some gems expect to receive a NoMethodError in the case of calling super in a method where super does not define that method. Specifically, this expectation exists in the StateMachine gem.

I added a test to show the problem and provided a fix. Thanks.
