### PR TITLE
Make OrderedOptions inherit from ::Hash instead of Hash.

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -14,7 +14,7 @@ module ActiveSupport
   #   h.girl = 'Mary'
   #   h.boy  # => 'John'
   #   h.girl # => 'Mary'
-  class OrderedOptions < Hash
+  class OrderedOptions < ::Hash
     alias_method :_get, :[] # preserve the original #[] method
     protected :_get # make it protected
 


### PR DESCRIPTION
Inherit from ::Hash should be better, and we already do this in activesupport/lib/active_support/ordered_hash.rb.
