### PR TITLE
Improve store attributes feature

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -92,26 +92,7 @@ module ActiveRecord
         return nil if value.nil?
         return coder.load(value) if encoded?
 
-        klass = self.class
-
-        case type
-        when :string, :text
-          case value
-          when TrueClass; "1"
-          when FalseClass; "0"
-          else
-            value.to_s
-          end
-        when :integer              then klass.value_to_integer(value)
-        when :float                then value.to_f
-        when :decimal              then klass.value_to_decimal(value)
-        when :datetime, :timestamp then klass.string_to_time(value)
-        when :time                 then klass.string_to_dummy_time(value)
-        when :date                 then klass.value_to_date(value)
-        when :binary               then klass.binary_to_string(value)
-        when :boolean              then klass.value_to_boolean(value)
-        else value
-        end
+        self.class.type_cast(value, type)
       end
 
       # Returns the human name of the column name.
@@ -127,6 +108,28 @@ module ActiveRecord
       end
 
       class << self
+        # Casts value to an appropriate instance.
+        def type_cast(value, type)
+          case type
+          when :string, :text
+            case value
+            when TrueClass; "1"
+            when FalseClass; "0"
+            else
+              value.to_s
+            end
+          when :integer              then value_to_integer(value)
+          when :float                then value.to_f
+          when :decimal              then value_to_decimal(value)
+          when :datetime, :timestamp then string_to_time(value)
+          when :time                 then string_to_dummy_time(value)
+          when :date                 then value_to_date(value)
+          when :binary               then binary_to_string(value)
+          when :boolean              then value_to_boolean(value)
+          else value
+          end
+        end
+
         # Used to convert from BLOBs to Strings
         def binary_to_string(value)
           value

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -252,9 +252,10 @@ EOS
       end
 
       def read(record, key)
-        store = get_config(key, record)[:store]
-        accessor = get_accessor(store, record)
-        accessor.read(record, store, key)
+        config = get_config(key, record)
+        accessor = get_accessor(config[:store], record)
+        value = accessor.read(record, config[:store], key)
+        value.nil? ? config[:default] : value
       end
 
       def write(record, key, value)

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -199,4 +199,11 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal 4, user.years
     assert_equal true, user.available
   end
+
+  test "return default value if serialized attribute is unset" do
+    user = Admin::User.new
+
+    assert_equal 0, user.years
+    assert_equal false, user.available
+  end
 end

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -148,7 +148,8 @@ class StoreTest < ActiveRecord::TestCase
   end
 
   test "all stored attributes are returned" do
-    assert_equal [:color, :homepage, :favorite_food], Admin::User.stored_attributes[:settings]
+    assert_equal [:color, :homepage, :favorite_food,
+      :company, :years, :available], Admin::User.stored_attributes[:settings]
   end
 
   test "stored_attributes are tracked per class" do
@@ -189,5 +190,13 @@ class StoreTest < ActiveRecord::TestCase
     second_dump = YAML.dump(loaded)
     assert_equal dumped, second_dump
     assert_equal @john, YAML.load(second_dump)
+  end
+
+  test "value is casted to specified type" do
+    user = Admin::User.new(company: :Ruby, years: '4', available: 'true')
+
+    assert_equal "Ruby", user.company
+    assert_equal 4, user.years
+    assert_equal true, user.available
   end
 end

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -17,7 +17,10 @@ class Admin::User < ActiveRecord::Base
   store :params, accessors: [ :token ], coder: YAML
   store :settings, :accessors => [ :color, :homepage ]
   store_accessor :settings, :favorite_food
-  store_accessor :settings, :company => :string, :years => :integer, :available => :boolean
+  store_accessor :settings,
+    :company => :string,
+    :years => { :type => :integer, :default => 0 },
+    :available => { :type => :boolean, :default => false }
   store :preferences, :accessors => [ :remember_login ]
   store :json_data, :accessors => [ :height, :weight ], :coder => Coder.new
   store :json_data_empty, :accessors => [ :is_a_good_guy ], :coder => Coder.new

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -17,6 +17,7 @@ class Admin::User < ActiveRecord::Base
   store :params, accessors: [ :token ], coder: YAML
   store :settings, :accessors => [ :color, :homepage ]
   store_accessor :settings, :favorite_food
+  store_accessor :settings, :company => :string, :years => :integer, :available => :boolean
   store :preferences, :accessors => [ :remember_login ]
   store :json_data, :accessors => [ :height, :weight ], :coder => Coder.new
   store :json_data_empty, :accessors => [ :is_a_good_guy ], :coder => Coder.new


### PR DESCRIPTION
There are 2 changes in store attributes feature:
- cast value of a serialized attribute to a specified type

``` ruby
class User < ActiveRecord::Base
  store :profile
  store_accessor :profile, :name, :age, :use_gravatar

  def age=(value)
     value = ActiveRecord::ConnectionAdapters::Column.value_to_integer(value)
     super
  end

  def use_gravatar=(value)
     value = ActiveRecord::ConnectionAdapters::Column.value_to_boolean(value)
     super
  end
end

# replaced by

class User < ActiveRecord::Base
   store :profile
   store_accessor :profile, :name, :age => :integer, :use_gravatar => :boolean
end
```
- default value

``` ruby
class Car < ActiveRecord::Base
   store :settings
   store_accessor :settings, :color

  def color
     super || 'red'
  end
end

# replaced by 
class Car < ActiveRecord::Base
  store :settings
  store_accessor :settings, :color => { :default => 'red' }
end
```

2 features together

``` ruby
class User < ActiveRecord::Base
  store :profile
  store_accessor :profile, :age => { :type => :integer, :default => 18 }
end
```

Also, `read_stored_attribute` and `write_stored_attribute` were changed. They don't need to specify store_attribute if it was specified in `store_accessor`.
