### PR TITLE
Pass AR::Relation instead of Array to find_in_batches block

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -99,7 +99,6 @@ module ActiveRecord
     def find_in_batches(options = {})
       options.assert_valid_keys(:start, :batch_size)
 
-      relation = self
       start = options[:start]
       batch_size = options[:batch_size] || 1000
 
@@ -114,19 +113,20 @@ module ActiveRecord
         logger.warn("Scoped order and limit are ignored, it's forced to be batch order and batch size")
       end
 
-      relation = relation.reorder(batch_order).limit(batch_size)
-      records = start ? relation.where(table[primary_key].gteq(start)).to_a : relation.to_a
+      relation = reorder(batch_order).limit(batch_size)
+      relation = relation.where(table[primary_key].gteq(start)) if start
+      relation.load
 
-      while records.any?
-        records_size = records.size
-        primary_key_offset = records.last.id
+      while relation.any?
+
+        primary_key_offset = relation.last.id
         raise "Primary key not included in the custom select clause" unless primary_key_offset
 
-        yield records
+        yield relation
 
-        break if records_size < batch_size
+        break if relation.size < batch_size
 
-        records = relation.where(table[primary_key].gt(primary_key_offset)).to_a
+        relation = relation.where(table[primary_key].gt(primary_key_offset)).load
       end
     end
 

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -91,7 +91,7 @@ class EachTest < ActiveRecord::TestCase
   def test_find_in_batches_should_return_batches
     assert_queries(@total + 1) do
       Post.find_in_batches(:batch_size => 1) do |batch|
-        assert_kind_of Array, batch
+        assert_kind_of ActiveRecord::Relation, batch
         assert_kind_of Post, batch.first
       end
     end
@@ -100,7 +100,7 @@ class EachTest < ActiveRecord::TestCase
   def test_find_in_batches_should_start_from_the_start_option
     assert_queries(@total) do
       Post.find_in_batches(:batch_size => 1, :start => 2) do |batch|
-        assert_kind_of Array, batch
+        assert_kind_of ActiveRecord::Relation, batch
         assert_kind_of Post, batch.first
       end
     end
@@ -108,11 +108,11 @@ class EachTest < ActiveRecord::TestCase
 
   def test_find_in_batches_shouldnt_execute_query_unless_needed
     assert_queries(2) do
-      Post.find_in_batches(:batch_size => @total) {|batch| assert_kind_of Array, batch }
+      Post.find_in_batches(:batch_size => @total) {|batch| assert_kind_of ActiveRecord::Relation, batch }
     end
 
     assert_queries(1) do
-      Post.find_in_batches(:batch_size => @total + 1) {|batch| assert_kind_of Array, batch }
+      Post.find_in_batches(:batch_size => @total + 1) {|batch| assert_kind_of ActiveRecord::Relation, batch }
     end
   end
 
@@ -120,7 +120,7 @@ class EachTest < ActiveRecord::TestCase
     c = Post.connection
     assert_sql(/ORDER BY #{c.quote_table_name('posts')}.#{c.quote_column_name('id')}/) do
       Post.find_in_batches(:batch_size => 1) do |batch|
-        assert_kind_of Array, batch
+        assert_kind_of ActiveRecord::Relation, batch
         assert_kind_of Post, batch.first
       end
     end
@@ -132,10 +132,10 @@ class EachTest < ActiveRecord::TestCase
 
     assert_nothing_raised do
       Post.find_in_batches(:batch_size => 1) do |batch|
-        assert_kind_of Array, batch
+        assert_kind_of ActiveRecord::Relation, batch
         assert_kind_of Post, batch.first
 
-        batch.map! { not_a_post }
+        batch.map { not_a_post }
       end
     end
   end


### PR DESCRIPTION
This patch allows to operate a relation inside of `find_in_batches` that allows to have some additional flexibility.

Example:

`User.where(condition).update_all` will lock table for writing in MySQL if there are too many records (> 100k). But the following will be possible after this patch:

``` ruby
User.where(condition).find_in_batches do |relation|
  relation.update_all("disabled = true")
end
```
