### PR TITLE
Rename method and stop passing unused arguements.

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -85,13 +85,13 @@ module ActiveSupport
 
         def increment(name, amount = 1, options = nil) # :nodoc:
           value = bypass_local_cache{super}
-          increment_or_decrement(value, name, amount, options)
+          set_cache_value(value, name, amount, options)
           value
         end
 
         def decrement(name, amount = 1, options = nil) # :nodoc:
           value = bypass_local_cache{super}
-          increment_or_decrement(value, name, amount, options)
+          set_cache_value(value, name, amount, options)
           value
         end
 
@@ -119,8 +119,7 @@ module ActiveSupport
             super
           end
 
-        private
-          def increment_or_decrement(value, name, amount, options)
+          def set_cache_value(value, name, amount, options)
             if local_cache
               local_cache.mute do
                 if value
@@ -131,6 +130,8 @@ module ActiveSupport
               end
             end
           end
+
+        private
 
           def local_cache_key
             @local_cache_key ||= "#{self.class.name.underscore}_local_cache_#{object_id}".gsub(/[\/-]/, '_').to_sym


### PR DESCRIPTION
- Renamed `increment_or_decrement` to an apt `set_cache_value` since it actually doesn't increment/decrement in localstore.
- Stopped passing unused increment amount value to it.
