### PR TITLE
Swap Timestamp/Callbacks order in ActiveRecord::Base

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -305,8 +305,8 @@ module ActiveRecord #:nodoc:
     include Locking::Optimistic
     include Locking::Pessimistic
     include AttributeMethods
-    include Callbacks
     include Timestamp
+    include Callbacks
     include Associations
     include ActiveModel::SecurePassword
     include AutosaveAssociation

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -70,6 +70,24 @@ class TimestampTest < ActiveRecord::TestCase
     assert_equal @previously_updated_at, @developer.updated_at
   end
 
+  def test_saving_when_callback_sets_record_timestamps_to_false_doesnt_update_its_timestamp
+    klass = Class.new(Developer) do
+      before_update :cancel_record_timestamps
+      def cancel_record_timestamps
+        self.record_timestamps = false
+        return true
+      end
+    end
+
+    developer = klass.first
+    previously_updated_at = developer.updated_at
+
+    developer.name = "New Name"
+    developer.save!
+
+    assert_equal previously_updated_at, developer.updated_at
+  end
+
   def test_touching_an_attribute_updates_timestamp
     previously_created_at = @developer.created_at
     @developer.touch(:created_at)


### PR DESCRIPTION
### BUG

In Rails 3.2, the lookup order for `ActiveRecord::Base`'s `update`/`create` was found in this `include ...` order:

``` ruby
Callbacks -> Timestamp -> Dirty -> Optimistic -> Persistence
```

In Rails 4 (up thru 4.0.4, and 4.1.0.rc1), the lookup order for the equivalent methods `update_record`/`create_record` became:

``` ruby
Timestamp -> Callbacks -> Dirty -> Optimistic -> Persistence
```

As a result, now in Rails4 you can't do things like alter `record_timestamp`  in callbacks ([example](https://gist.github.com/tiegz/9748836)). Plus, it seems like `Callbacks` should ideally always be called first in the method chain?
### TESTS?

~~I didn't write tests because they pass with-and-without the fix, and not sure if it's worth it?~~ Included.
### REGRESSION

I think this was introduced in [this commit](https://github.com/rails/rails/commit/e030f26ad3de98205edec9d8b59ecca9508cb57d#diff-fdf28ad95ab439f8e95e8a32a59e58a8L61). It made the understandable mistake that `include A, B, C` will include the modules in FIFO order (`A,B,C`), but ruby actually includes them in FILO order (`C,B,A`).

Note that there are a few other modules that were `include`'ed in the reverse order in that commit. ~~I haven't looked into any similar method clashes in those modules though.~~  I couldn't find any clashing methods in those modules.
