### PR TITLE
update_column and update_columns also available outside an instance

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   `update_column` and `update_columns` can be called at Class level (Relation level)
+
+    Example:
+
+        # updates `viewed_at` and nothing else.
+        Photo.update_column(1, :viewed_at, Time.now)
+        Photo.update_column([1, 2], :viewed_at, Time.now)
+
+        Photo.update_columns(1 => {:viewed_at => Time.now})
+        Photo.update_columns(1 => {:viewed_at => Time.now},
+                             2 => {:viewed_at => Date.yesterday}
+                             )
+        Photo.update_columns([1, 2] => {:viewed_at => Time.now})
+        
+
+    *James Pinto*
+
 *   `touch` accepts many attributes to be touched at once.
 
     Example:

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     delegate :first_or_create, :first_or_create!, :first_or_initialize, to: :all
     delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, to: :all
     delegate :find_by, :find_by!, to: :all
-    delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, to: :all
+    delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, :update_column, :update_columns, to: :all
     delegate :find_each, :find_in_batches, to: :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly,

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1320,6 +1320,52 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal posts(:welcome),  comments(:greetings).post
   end
 
+  def test_update_column
+    assert_queries(1) do
+      assert_equal 1, Topic.update_column(1, "content = 'no selects!'")
+    end
+    assert_equal "no selects!", Topic.find(1).content
+  end
+
+  def test_update_columns
+    # string
+    assert_queries(2) do
+      assert_equal 2, Topic.update_columns(1 => "content = 'no selects!'", 2 => "content = 'no selects!!'")
+    end
+    assert_equal "no selects!",  Topic.find(1).content
+    assert_equal "no selects!!", Topic.find(2).content
+
+    # array
+    assert_queries(2) do
+      assert_equal 2, Topic.update_columns(1 => ['content = ?', 'no selects again!'], 2 => ['content = ?', 'no selects again!!'])
+    end
+    assert_equal "no selects again!",  Topic.find(1).content
+    assert_equal "no selects again!!", Topic.find(2).content
+
+    # hash
+    assert_queries(2) do
+      assert_equal 2, Topic.update_columns('1' => {:content => 'third is the charm!'}, '2' => {:content => 'third is the charm!!'})
+    end
+    assert_equal "third is the charm!",  Topic.find(1).content
+    assert_equal "third is the charm!!", Topic.find(2).content
+
+    # multiple ids
+    assert_queries(1) do
+      assert_equal 2, Topic.update_columns([1,2] => "content = 'magic!'")
+    end
+    assert_equal "magic!", Topic.find(1).content
+    assert_equal "magic!", Topic.find(2).content
+  end
+
+  def test_update_columns_with_incorrect_arguments
+    # a single argument which is not a hash
+    assert_raises(ArgumentError) { Topic.update_columns('not_a_hash') }
+
+    # an incorrect number of arguments
+    assert_raises(ArgumentError) { Topic.update_columns() }
+    assert_raises(ArgumentError) { Topic.update_columns(1,2,3) }
+  end
+
   def test_distinct
     tag1 = Tag.create(:name => 'Foo')
     tag2 = Tag.create(:name => 'Foo')


### PR DESCRIPTION
Handy and intuitives, update_column and update_columns should also be invokable from the model class.

Photo.update_column(1, :viewed_at, Time.now)
Photo.update_column([1, 2], :viewed_at, Time.now)
Photo.update_columns(1 => {:viewed_at => Time.now})
Photo.update_columns(1 => {:viewed_at => Time.now}, 2 => {:viewed_at => Date.yesterday})
Photo.update_columns([1, 2] => {:viewed_at => Time.now})

This is the fastest way to update attributes because it goes straight to the database,
but remember: **"with great power comes great responsibility"** :+1: 
