### PR TITLE
Create indexes inline in CREATE TABLE for MySQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Create indexes inline in CREATE TABLE for MySQL
+
+    This is important, because adding an index on a temporary table after it has been created
+    would commit the transaction.
+    It also allows creating and dropping indexed tables with fewer queries and fewer permissions required.
+
+    Example:
+
+        create_table :temp, temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query" do |t|
+          t.index :zip
+        end
+        # => CREATE TEMPORARY TABLE temp (INDEX (zip)) AS SELECT id, name, zip FROM a_really_complicated_query
+
+    *Cody Cutrer*, *Steve Rice*
+
 *   Save `has_one` association even if the record doesn't changed.
 
     Fixes #14407.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -795,7 +795,7 @@ module ActiveRecord
           if index_name.length > max_index_length
             raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' is too long; the limit is #{max_index_length} characters"
           end
-          if index_name_exists?(table_name, index_name, false)
+          if table_exists?(table_name) && index_name_exists?(table_name, index_name, false)
             raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' already exists"
           end
           index_columns = quoted_columns_for_index(column_names, options).join(", ")

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -217,6 +217,12 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support creating indexes in the same statement as
+      # creating the table? As of this writing, only mysql does.
+      def supports_indexes_in_create?
+        false
+      end
+
       # This is meant to be implemented by the adapters that support extensions
       def disable_extension(name)
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -12,7 +12,7 @@ module ActiveRecord
           statements = []
           statements.concat(o.columns.map { |c| accept c })
           statements.concat(o.indexes.map { |(column_name, options)| index_in_create(o.name, column_name, options) })
-          create_sql << "(#{statements.join(', ')}) "
+          create_sql << "(#{statements.join(', ')}) " if statements.present?
           create_sql << "#{o.options}"
           create_sql << " AS #{@conn.to_sql(o.as)}" if o.as
           create_sql

--- a/activerecord/test/cases/adapters/mysql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/active_schema_test.rb
@@ -116,6 +116,17 @@ class ActiveSchemaTest < ActiveRecord::TestCase
     end
   end
 
+  def test_indexes_in_create
+    begin
+      ActiveRecord::Base.connection.stubs(:index_name_exists?).returns(false)
+      expected = "CREATE TEMPORARY TABLE `temp` (INDEX `index_temp_on_zip` (`zip`)) ENGINE=InnoDB AS SELECT id, name, zip FROM a_really_complicated_query"
+      actual = ActiveRecord::Base.connection.create_table(:temp, temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query") do |t|
+        t.index :zip
+      end
+      assert_equal expected, actual
+    end
+  end
+
   private
     def with_real_execute
       ActiveRecord::Base.connection.singleton_class.class_eval do

--- a/activerecord/test/cases/adapters/mysql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/active_schema_test.rb
@@ -17,7 +17,8 @@ class ActiveSchemaTest < ActiveRecord::TestCase
   end
 
   def test_add_index
-    # add_index calls index_name_exists? which can't work since execute is stubbed
+    # add_index calls table_exists? and index_name_exists? which can't work since execute is stubbed
+    def (ActiveRecord::Base.connection).table_exists?(*); true; end
     def (ActiveRecord::Base.connection).index_name_exists?(*); false; end
 
     expected = "CREATE  INDEX `index_people_on_last_name`  ON `people` (`last_name`) "
@@ -118,7 +119,8 @@ class ActiveSchemaTest < ActiveRecord::TestCase
 
   def test_indexes_in_create
     begin
-      ActiveRecord::Base.connection.stubs(:index_name_exists?).returns(false)
+      ActiveRecord::Base.connection.stubs(:table_exists?).with(:temp).returns(false)
+      ActiveRecord::Base.connection.stubs(:index_name_exists?).with(:index_temp_on_zip).returns(false)
       expected = "CREATE TEMPORARY TABLE `temp` (INDEX `index_temp_on_zip` (`zip`)) ENGINE=InnoDB AS SELECT id, name, zip FROM a_really_complicated_query"
       actual = ActiveRecord::Base.connection.create_table(:temp, temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query") do |t|
         t.index :zip

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -116,6 +116,17 @@ class ActiveSchemaTest < ActiveRecord::TestCase
     end
   end
 
+  def test_indexes_in_create
+    begin
+      ActiveRecord::Base.connection.stubs(:index_name_exists?).returns(false)
+      expected = "CREATE TEMPORARY TABLE `temp` (INDEX `index_temp_on_zip` (`zip`)) ENGINE=InnoDB AS SELECT id, name, zip FROM a_really_complicated_query"
+      actual = ActiveRecord::Base.connection.create_table(:temp, temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query") do |t|
+        t.index :zip
+      end
+      assert_equal expected, actual
+    end
+  end
+
   private
     def with_real_execute
       ActiveRecord::Base.connection.singleton_class.class_eval do

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -17,7 +17,8 @@ class ActiveSchemaTest < ActiveRecord::TestCase
   end
 
   def test_add_index
-    # add_index calls index_name_exists? which can't work since execute is stubbed
+    # add_index calls table_exists? and index_name_exists? which can't work since execute is stubbed
+    def (ActiveRecord::Base.connection).table_exists?(*); true; end
     def (ActiveRecord::Base.connection).index_name_exists?(*); false; end
 
     expected = "CREATE  INDEX `index_people_on_last_name`  ON `people` (`last_name`) "
@@ -118,7 +119,8 @@ class ActiveSchemaTest < ActiveRecord::TestCase
 
   def test_indexes_in_create
     begin
-      ActiveRecord::Base.connection.stubs(:index_name_exists?).returns(false)
+      ActiveRecord::Base.connection.stubs(:table_exists?).with(:temp).returns(false)
+      ActiveRecord::Base.connection.stubs(:index_name_exists?).with(:index_temp_on_zip).returns(false)
       expected = "CREATE TEMPORARY TABLE `temp` (INDEX `index_temp_on_zip` (`zip`)) ENGINE=InnoDB AS SELECT id, name, zip FROM a_really_complicated_query"
       actual = ActiveRecord::Base.connection.create_table(:temp, temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query") do |t|
         t.index :zip


### PR DESCRIPTION
When using `mysql` or `mysql2` adapters, fold index creation into `CREATE TABLE` statements. This has a few benefits:
- requires fewer SQL statements to create a table
- can reverse a table-creating migration with a single `DROP TABLE` statement, instead of unnecessarily removing all indexes and then dropping (big performance penalty for large tables)
- requires having only `CREATE` permissions on a database, instead of `CREATE` + `INDEX` permissions
- prevents early committing of transactions when adding indexes to temporary tables

This is intended as a replacement for @ccutrer's #13787. It fixes some bugs and test failures with that PR and updates tests.

I am happy to squash the commits together, however I left as-is to avoid crushing @ccutrer's authorship.
