### PR TITLE
raise ArgumentError when :uniq or :unique is used with add_column/change...

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -17,6 +17,12 @@ module ActiveRecord
     # for generating a number of table creation or table changing SQL statements.
     class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :primary_key) #:nodoc:
 
+      def self.check_invalid_options!(options)
+        [:uniq, :unique].each do |key|
+          raise ArgumentError, "option '#{key}' is not supported, add an index" if options[key]
+        end
+      end
+
       def primary_key?
         primary_key || type.to_sym == :primary_key
       end
@@ -264,6 +270,8 @@ module ActiveRecord
       alias :belongs_to :references
 
       def new_column_definition(name, type, options) # :nodoc:
+        ColumnDefinition.check_invalid_options!(options)
+
         column = create_column_definition name, type
         limit = options.fetch(:limit) do
           native[type][:limit] if native[type].is_a?(Hash)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -510,6 +510,7 @@ module ActiveRecord
       end
 
       def change_column(table_name, column_name, type, options = {}) #:nodoc:
+        ColumnDefinition.check_invalid_options!(options)
         execute("ALTER TABLE #{quote_table_name(table_name)} #{change_column_sql(table_name, column_name, type, options)}")
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -396,6 +396,7 @@ module ActiveRecord
 
         # Changes the column of a table.
         def change_column(table_name, column_name, type, options = {})
+          ColumnDefinition.check_invalid_options!(options)
           clear_cache!
           quoted_table_name = quote_table_name(table_name)
           sql_type = type_to_sql(type, options[:limit], options[:precision], options[:scale])

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -481,6 +481,7 @@ module ActiveRecord
       end
 
       def change_column(table_name, column_name, type, options = {}) #:nodoc:
+        ColumnDefinition.check_invalid_options!(options)
         alter_table(table_name) do |definition|
           include_default = options_include_default?(options)
           definition[column_name].instance_eval do

--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -95,6 +95,24 @@ module ActiveRecord
         assert_equal 7, wealth_column.scale
       end
 
+      def test_add_column_with_uniq_option
+        assert_raise(ArgumentError) { add_column 'test_models', 'unique_field', :string, :uniq => true }
+      end
+
+      def test_change_column_with_uniq_option
+        add_column 'test_models', 'unique_field', :string
+        assert_raise(ArgumentError) { change_column 'test_models', 'unique_field', :string, :uniq => true }
+      end
+
+      def test_add_column_with_unique_option
+        assert_raise(ArgumentError) { add_column 'test_models', 'unique_field', :string, :unique => true }
+      end
+
+      def test_change_column_with_unique_option
+        add_column 'test_models', 'unique_field', :string
+        assert_raise(ArgumentError) { change_column 'test_models', 'unique_field', :string, :unique => true }
+      end
+
       if current_adapter?(:SQLite3Adapter)
         def test_change_column_preserve_other_column_precision_and_scale
           connection.add_column 'test_models', 'last_name', :string


### PR DESCRIPTION
I was watching an old play by play by @tenderlove and he added a `:uniq` option to `add_column`, which of course doesn't do anything (you have to add an index). This happened to me (and my coworkers) too, and none of us noticed it until some time later when we wrote more specs. Not sure why but it's just easy to assume that it works, perhaps because you remember the option does exist, you just forget that the option is for add_index and not add_column.

So I made add_column/change_column raise an exception if you provide uniq/unique as an option, so it does not just silently ignore it.
