### PR TITLE
Active Record joins with default_scope leads to duplicated sql #14351.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -11,6 +11,16 @@
 
     *arthurnn*
 
+*   Active Record joins with default_scope leads to duplicated sql.
+    Prevent generation of multiple where clauses when the 
+    default scope method is defined by the user and
+    contains a condition which would be different on each
+    call to `default_scope`, e.g. `Time.zone.now`
+
+    Fixes #14351.
+
+    *Larry Reid*
+
 *   Add support for `Relation` be passed as parameter on `QueryCache#select_all`.
 
     Fixes #14361.

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -105,7 +105,7 @@ module ActiveRecord
         def build_default_scope # :nodoc:
           if !Base.is_a?(method(:default_scope).owner)
             # The user has defined their own default scope method, so call that
-            evaluate_default_scope { default_scope }
+            evaluate_default_scope { unscoped { default_scope } }
           elsif default_scopes.any?
             evaluate_default_scope do
               default_scopes.inject(relation) do |default_scope, scope|

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -1,4 +1,6 @@
 require 'cases/helper'
+require 'models/unit'
+require 'models/property'
 require 'models/post'
 require 'models/developer'
 
@@ -374,5 +376,17 @@ class DefaultScopingTest < ActiveRecord::TestCase
       assert_equal 1, ThreadsafeDeveloper.all.to_a.count
     end
     threads.each(&:join)
+  end
+
+  def test_with_volatile_default_scope_block
+    query_str = UnitWithBlock.with_active_properties.to_sql
+    assert /(\W|^)scope_field(\W|$)/ =~ query_str, "Found no 'scope_field'."
+    assert ! (/((\W|^)scope_field(\W|$).*){2,}/ =~ query_str), "Found more than one 'scope_field'."
+  end
+
+  def test_with_volatile_default_scope_method
+    query_str = Unit.with_active_properties.to_sql
+    assert /(\W|^)scope_field(\W|$)/ =~ query_str, "Found no 'scope_field'."
+    assert_not (/((\W|^)scope_field(\W|$).*){2,}/ =~ query_str), "Found more than one 'scope_field'."
   end
 end

--- a/activerecord/test/models/property.rb
+++ b/activerecord/test/models/property.rb
@@ -1,0 +1,17 @@
+class Property < ActiveRecord::Base
+  has_many :units
+  @scope_value = 0
+
+  def self.default_scope
+    where('scope_field = :scoper', scoper: @scope_value += 1)
+  end
+end
+
+class PropertyWithBlock < ActiveRecord::Base
+  has_many :units
+  @scope_value = 0
+
+  self.default_scope do
+    where('scope_field = :scoper', scoper: @scope_value += 1)
+  end
+end

--- a/activerecord/test/models/unit.rb
+++ b/activerecord/test/models/unit.rb
@@ -1,0 +1,17 @@
+require 'models/property'
+
+class Unit < ActiveRecord::Base
+  belongs_to :property
+
+  def self.with_active_properties
+    joins(:property)
+  end
+end
+
+class UnitWithBlock < ActiveRecord::Base
+  belongs_to :property, class_name: PropertyWithBlock
+
+  def self.with_active_properties
+    joins(:property)
+  end
+end


### PR DESCRIPTION
A default scope that generates different sql on each call will
generate almost duplicate SQL in the resulting query. For example:

```
def self.default_scope
    where('active_at <= :now AND inactive_at > :now',
        now: Time.zone.now)
end
```

Generates

```
...
(active_at <= '2014-03-11 03:36:13.994068'
AND inactive_at > '2014-03-11 03:36:13.994068')
AND (active_at <= '2014-03-11 03:36:13.967550'
AND inactive_at > '2014-03-11 03:36:13.967550')
```

It only happens when the user defines their own class method for
default_scope, not when using the default_scope method with a block.
