### PR TITLE
Stop swallowing errors on transaction after callbacks.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -350,6 +350,12 @@
 
     *Yves Senn*
 
+*   Stop swallowing standard errors on `after_commit` and `after_rollback`.
+
+    Fixes #13460.
+
+    *arthurnn* *Vipul A M*
+
 *   PostgreSQL `Column#type` is now determined through the corresponding OID.
     The column types stay the same except for enum columns. They no longer have
     `nil` as type but `enum`.

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -222,7 +222,7 @@ module ActiveRecord
         begin
           commit_transaction unless error
         rescue Exception
-          rollback_transaction
+          rollback_transaction unless @transaction.state.completed?
           raise
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -135,26 +135,43 @@ module ActiveRecord
 
       def rollback_records
         @state.set_state(:rolledback)
+        error = nil
         records.uniq.each do |record|
           begin
-            record.rolledback!(parent.closed?)
+            record.rolledback! unless error
           rescue => e
-            raise if :raise == ActiveRecord::Base.errors_in_transactional_callbacks
-            record.logger.error(e) if record.respond_to?(:logger) && record.logger
+            if :raise == ActiveRecord::Base.errors_in_transactional_callbacks
+              error = e
+            else
+              record.logger.error(e) if record.respond_to?(:logger) && record.logger
+            end
+          ensure
+            record.restore_transaction_record_state(parent.closed?)
+            record.clear_transaction_record_state
           end
         end
+
+        raise error if error
       end
 
       def commit_records
         @state.set_state(:committed)
+        error = nil
         records.uniq.each do |record|
           begin
-            record.committed!
+            record.committed! unless error
           rescue => e
-            raise if :raise == ActiveRecord::Base.errors_in_transactional_callbacks
-            record.logger.error(e) if record.respond_to?(:logger) && record.logger
+            if :raise == ActiveRecord::Base.errors_in_transactional_callbacks
+              error = e
+            else
+              record.logger.error(e) if record.respond_to?(:logger) && record.logger
+            end
+          ensure
+            record.force_clear_transaction_record_state
           end
         end
+
+        raise error if error
       end
 
       def closed?

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -35,6 +35,10 @@ module ActiveRecord
         @state == :rolledback
       end
 
+      def completed?
+        committed? || rolledback?
+      end
+
       def set_state(state)
         if !VALID_STATES.include?(state)
           raise ArgumentError, "Invalid transaction state: #{state}"
@@ -132,22 +136,14 @@ module ActiveRecord
       def rollback_records
         @state.set_state(:rolledback)
         records.uniq.each do |record|
-          begin
-            record.rolledback!(parent.closed?)
-          rescue => e
-            record.logger.error(e) if record.respond_to?(:logger) && record.logger
-          end
+          record.rolledback!(parent.closed?)
         end
       end
 
       def commit_records
         @state.set_state(:committed)
         records.uniq.each do |record|
-          begin
-            record.committed!
-          rescue => e
-            record.logger.error(e) if record.respond_to?(:logger) && record.logger
-          end
+          record.committed!
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -136,14 +136,24 @@ module ActiveRecord
       def rollback_records
         @state.set_state(:rolledback)
         records.uniq.each do |record|
-          record.rolledback!(parent.closed?)
+          begin
+            record.rolledback!(parent.closed?)
+          rescue => e
+            raise if :raise == ActiveRecord::Base.errors_in_transactional_callbacks
+            record.logger.error(e) if record.respond_to?(:logger) && record.logger
+          end
         end
       end
 
       def commit_records
         @state.set_state(:committed)
         records.uniq.each do |record|
-          record.committed!
+          begin
+            record.committed!
+          rescue => e
+            raise if :raise == ActiveRecord::Base.errors_in_transactional_callbacks
+            record.logger.error(e) if record.respond_to?(:logger) && record.logger
+          end
         end
       end
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -105,6 +105,17 @@ module ActiveRecord
     end
 
     initializer "active_record.set_configs" do |app|
+      if app.config.active_record.errors_in_transactional_callbacks.nil?
+        ActiveSupport::Deprecation.warn <<-EOF
+You haven't set the errors_in_transactional_callbacks option. By default the value will be :log, but in next versions it will use :raise.
+
+Here`s what they mean:
+`:log`   : after_commit/after_rollback callbacks would only log if there is an error raised in the callback.
+`:raise` : If any error should occur in after_commit/after_rollback callbacks, it will not be swallowed.
+
+EOF
+      end
+
       ActiveSupport.on_load(:active_record) do
         app.config.active_record.each do |k,v|
           send "#{k}=", v

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -297,17 +297,11 @@ module ActiveRecord
     # but call it after the commit of a destroyed object.
     def committed! #:nodoc:
       run_callbacks :commit if destroyed? || persisted?
-    ensure
-      force_clear_transaction_record_state
     end
 
-    # Call the +after_rollback+ callbacks. The +force_restore_state+ argument indicates if the record
-    # state should be rolled back to the beginning or just to the last savepoint.
-    def rolledback!(force_restore_state = false) #:nodoc:
+    # Call the +after_rollback+ callbacks.
+    def rolledback! #:nodoc:
       run_callbacks :rollback
-    ensure
-      restore_transaction_record_state(force_restore_state)
-      clear_transaction_record_state
     end
 
     # Add the record to the current transaction so that the +after_rollback+ and +after_commit+ callbacks
@@ -367,6 +361,8 @@ module ActiveRecord
     end
 
     # Restore the new record state and id of a record that was previously saved by a call to save_record_state.
+    # The +force+ argument indicates if the record state should be rolled back to the beginning
+    # or just to the last savepoint.
     def restore_transaction_record_state(force = false) #:nodoc:
       unless @_start_transaction_state.empty?
         transaction_level = (@_start_transaction_state[:level] || 0) - 1

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -334,21 +334,6 @@ module ActiveRecord
       status
     end
 
-    protected
-
-    # Save the new record state and id of a record so it can be restored later if a transaction fails.
-    def remember_transaction_record_state #:nodoc:
-      @_start_transaction_state[:id] = id if has_attribute?(self.class.primary_key)
-      unless @_start_transaction_state.include?(:new_record)
-        @_start_transaction_state[:new_record] = @new_record
-      end
-      unless @_start_transaction_state.include?(:destroyed)
-        @_start_transaction_state[:destroyed] = @destroyed
-      end
-      @_start_transaction_state[:level] = (@_start_transaction_state[:level] || 0) + 1
-      @_start_transaction_state[:frozen?] = @attributes.frozen?
-    end
-
     # Clear the new record state and id of a record.
     def clear_transaction_record_state #:nodoc:
       @_start_transaction_state[:level] = (@_start_transaction_state[:level] || 0) - 1
@@ -381,6 +366,21 @@ module ActiveRecord
           @attributes.freeze if was_frozen
         end
       end
+    end
+
+    protected
+
+    # Save the new record state and id of a record so it can be restored later if a transaction fails.
+    def remember_transaction_record_state #:nodoc:
+      @_start_transaction_state[:id] = id if has_attribute?(self.class.primary_key)
+      unless @_start_transaction_state.include?(:new_record)
+        @_start_transaction_state[:new_record] = @new_record
+      end
+      unless @_start_transaction_state.include?(:destroyed)
+        @_start_transaction_state[:destroyed] = @destroyed
+      end
+      @_start_transaction_state[:level] = (@_start_transaction_state[:level] || 0) + 1
+      @_start_transaction_state[:frozen?] = @attributes.frozen?
     end
 
     # Determine if a record was created or destroyed in a transaction. State should be one of :new_record or :destroyed.

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -10,6 +10,9 @@ module ActiveRecord
       define_callbacks :commit, :rollback,
                        terminator: ->(_, result) { result == false },
                        scope: [:kind, :name]
+
+      mattr_accessor :errors_in_transactional_callbacks, instance_writer: false
+      self.errors_in_transactional_callbacks = :log
     end
 
     # = Active Record Transactions


### PR DESCRIPTION
### Problem

When raising a standard error on `after_commit` /  `after_rollback`, they are logged but swallowed afterwards. IMO, this is dangerous behaviour as people can just ignore the logs and never see those errors.
### Solution

After re-work of the transaction model on rails 4+ this change is a trivial change. We just need to make sure we dont rollback the transaction after its is completed.
### Drawbacks

When people upgrade rails to use the version with this commit(probably 4.2), they will probably start seeing lots of errors on tests, as before they were probably being swallowed, TBH I see this more as a advantage than a drawback.
Apps that use `after_commit` and need to ensure its behaviour even if the others records after_commits fail, could find trouble with this new behaviour. If thats a concern, we could add a new after_commit DSL, `after_commit(:ensure)` maybe.

[fixes #13460]

Would like to get most feedback as possible on this, as this changes rails behaviour.
review @rafaelfranca @tenderlove @dhh @chancancode @senny
cc @vipulnsward @fw42
