### PR TITLE
Add a test case for save(validate: false) with invalid foreign key.

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -146,7 +146,7 @@ module ActiveRecord
     end
 
     def test_foreign_key_violations_are_translated_to_specific_exception
-      unless @connection.adapter_name == 'SQLite'
+      unless current_adapter?(:SQLite3Adapter)
         assert_raises(ActiveRecord::InvalidForeignKey) do
           # Oracle adapter uses prefetched primary key values from sequence and passes them to connection adapter insert method
           if @connection.prefetch_primary_key?
@@ -155,6 +155,20 @@ module ActiveRecord
           else
             @connection.execute "INSERT INTO fk_test_has_fk (fk_id) VALUES (0)"
           end
+        end
+      end
+    end
+
+    def test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false
+      unless current_adapter?(:SQLite3Adapter)
+        klass_has_fk = Class.new(ActiveRecord::Base) do
+          self.table_name = 'fk_test_has_fk'
+        end
+
+        assert_raises(ActiveRecord::InvalidForeignKey) do
+          has_fk = klass_has_fk.new
+          has_fk.fk_id = 1231231231
+          has_fk.save(validate: false)
         end
       end
     end


### PR DESCRIPTION
This PR adds a test case for the behavior described by #6659. 

Lets suppose I have the following scenario:

``` ruby
class User < ActiveRecord::Base
  has_many :accounts
end

class Account < ActiveRecord::Base
  belongs_to :user
end

account = Account.new
account.user = User.last
account.user_id = 12312312312 # lets suppose that this id does not exist in the database

account.save(validate: false) 
# expected to raise ActiveRecord::InvalidForeignKey 
# if I have a fk constraint in the database
```

This test case is green, so the behavior is correct.
Closes #6659 and #12525
