### PR TITLE
Adds ActiveModel::Translation.humanize_as_default

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -4,4 +4,8 @@
 
     *Henrik Nyh*
 
+*   Added `ActiveModel::Translation.humanize_as_default` to allow disabling `attribute.humanize` as a default translation value.
+
+    *Fabio Kreusch*
+
 Please check [4-1-stable](https://github.com/rails/rails/blob/4-1-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model/railtie.rb
+++ b/activemodel/lib/active_model/railtie.rb
@@ -8,5 +8,9 @@ module ActiveModel
     initializer "active_model.secure_password" do
       ActiveModel::SecurePassword.min_cost = Rails.env.test?
     end
+
+    initializer "activemodel.configure" do |app|
+      ActiveModel::Translation.humanize_as_default = app.config.active_model.translation_humanize_as_default
+    end
   end
 end

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module/attribute_accessors'
+
 module ActiveModel
 
   # == Active \Model \Translation
@@ -20,6 +22,8 @@ module ActiveModel
   # parent classes.
   module Translation
     include ActiveModel::Naming
+
+    mattr_accessor :humanize_as_default
 
     # Returns the +i18n_scope+ for the class. Overwrite if you want custom lookup.
     def i18n_scope
@@ -60,7 +64,7 @@ module ActiveModel
 
       defaults << :"attributes.#{attribute}"
       defaults << options.delete(:default) if options[:default]
-      defaults << attribute.humanize
+      defaults << attribute.humanize unless ::ActiveModel::Translation.humanize_as_default === false
 
       options[:default] = defaults
       I18n.translate(defaults.shift, options)

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -34,6 +34,13 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     assert_equal 'Name', Person.human_attribute_name('name')
   end
 
+  def test_translated_model_attributes_not_falling_back_to_default_when_disabled
+    original = ActiveModel::Translation.humanize_as_default
+    ActiveModel::Translation.humanize_as_default = false
+    assert_equal 'translation missing: en.activemodel.attributes.person.name', Person.human_attribute_name('name')
+    ActiveModel::Translation.humanize_as_default = original
+  end
+
   def test_translated_model_attributes_using_default_option_as_symbol_and_falling_back_to_default
     assert_equal 'Name', Person.human_attribute_name('name', default: :default_name)
   end


### PR DESCRIPTION
Added `ActiveModel::Translation.humanize_as_default` to allow disabling
`attribute.humanize` as a default translation value.

My use case is that I want it to raise in case it is missing a translation.
