### PR TITLE
Backport #14154 to 4-1-stable

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -54,7 +54,7 @@ module ActiveRecord
             end
             scope_chain_index += 1
 
-            scope_chain_items.concat [klass.send(:build_default_scope)].compact
+            scope_chain_items.concat [klass.send(:build_default_scope, ActiveRecord::Relation.create(klass, table))].compact
 
             rel = scope_chain_items.inject(scope_chain_items.shift) do |left, right|
               left.merge right

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -93,14 +93,14 @@ module ActiveRecord
           self.default_scopes += [scope]
         end
 
-        def build_default_scope # :nodoc:
+        def build_default_scope(base_rel = relation) # :nodoc:
           if !Base.is_a?(method(:default_scope).owner)
             # The user has defined their own default scope method, so call that
             evaluate_default_scope { default_scope }
           elsif default_scopes.any?
             evaluate_default_scope do
-              default_scopes.inject(relation) do |default_scope, scope|
-                default_scope.merge(unscoped { scope.call })
+              default_scopes.inject(base_rel) do |default_scope, scope|
+                default_scope.merge(base_rel.scoping { scope.call })
               end
             end
           end

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -117,4 +117,13 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
 
     assert_equal [author], Author.where(id: author).joins(:special_categorizations)
   end
+
+  test "the default scope of the target is correctly aliased when joining associations" do
+    author = Author.create! name: "Jon"
+    author.categories.create! name: 'Not Special'
+    author.special_categories.create! name: 'Special'
+
+    categories = author.categories.includes(:special_categorizations).references(:special_categorizations).to_a
+    assert_equal 2, categories.size
+  end
 end

--- a/activerecord/test/models/category.rb
+++ b/activerecord/test/models/category.rb
@@ -22,6 +22,7 @@ class Category < ActiveRecord::Base
   end
 
   has_many :categorizations
+  has_many :special_categorizations
   has_many :post_comments, :through => :posts, :source => :comments
 
   has_many :authors, :through => :categorizations


### PR DESCRIPTION
This allows the default scope to be built using the current table alias.
Resolves #12770

/cc @tenderlove
