### PR TITLE
remove calls to sql_type on pg columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fixed error when specifying a non-empty default value on a PostgreSQL array column.
+
+    Fixes #10613.
+
+    *Luke Steensen*
+
 *   Make possible to change `record_timestamps` inside Callbacks.
 
     *Tieg Zaharia*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -64,7 +64,7 @@ module ActiveRecord
           end
 
           def add_column_options!(sql, options)
-            sql << " DEFAULT #{@conn.quote(options[:default], options[:column])}" if options_include_default?(options)
+            sql << " DEFAULT #{quote_value(options[:default], options[:column])}" if options_include_default?(options)
             # must explicitly check for :null to allow change_column to work on migrations
             if options[:null] == false
               sql << " NOT NULL"
@@ -73,6 +73,12 @@ module ActiveRecord
               sql << " AUTO_INCREMENT"
             end
             sql
+          end
+
+          def quote_value(value, column)
+            column.sql_type ||= type_to_sql(column.type, column.limit, column.precision, column.scale)
+
+            @conn.quote(value, column)
           end
 
           def options_include_default?(options)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -15,7 +15,7 @@ module ActiveRecord
     # are typically created by methods in TableDefinition, and added to the
     # +columns+ attribute of said TableDefinition object, in order to be used
     # for generating a number of table creation or table changing SQL statements.
-    class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :primary_key) #:nodoc:
+    class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :primary_key, :sql_type) #:nodoc:
 
       def primary_key?
         primary_key || type.to_sym == :primary_key

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -30,7 +30,7 @@ module ActiveRecord
           options = o.options
           sql_type = type_to_sql(o.type, options[:limit], options[:precision], options[:scale])
           change_column_sql = "CHANGE #{quote_column_name(column.name)} #{quote_column_name(options[:name])} #{sql_type}"
-          add_column_options!(change_column_sql, options)
+          add_column_options!(change_column_sql, options.merge(column: column))
           add_column_position!(change_column_sql, options)
         end
 

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -48,6 +48,17 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     PgArray.reset_column_information
   end
 
+  def test_default_strings
+    @connection.add_column 'pg_arrays', 'names', :string, array: true, default: ["foo", "bar"]
+    PgArray.reset_column_information
+    column = PgArray.columns_hash["names"]
+
+    assert_equal(["foo", "bar"], column.default)
+    assert_equal(["foo", "bar"], PgArray.new.names)
+  ensure
+    PgArray.reset_column_information
+  end
+
   def test_change_column_with_array
     @connection.add_column :pg_arrays, :snippets, :string, array: true, default: []
     @connection.change_column :pg_arrays, :snippets, :text, array: true, default: "{}"


### PR DESCRIPTION
This fixes #10613 (for me at least).

I've never dug into this code before, but what I ended up with looks very similar to @tenderlove's commit 4b4c8bdc776e2d42cd070d9cb1b3cc22f82469b1, which makes me think I'm on the right track.

If there's anything else I should be doing, please let me know. I'm really looking forward to getting this bug fixed. Thanks!
