### PR TITLE
Update json gem version to 1.8.1

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Update JSON gem version to 1.8.1
+     
+    *Rajarshi Das*
+
 *   Deprecate `Class#superclass_delegating_accessor`, use `Class#class_attribute` instead.
 
     *Akshay Vishnoi*

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rdoc_options.concat ['--encoding',  'UTF-8']
 
   s.add_dependency 'i18n',       '~> 0.6', '>= 0.6.9'
-  s.add_dependency 'json',       '~> 1.7', '>= 1.7.7'
+  s.add_dependency 'json',       '~> 1.8', '>= 1.8.1'
   s.add_dependency 'tzinfo',     '~> 1.1'
   s.add_dependency 'minitest',   '~> 5.1'
   s.add_dependency 'thread_safe','~> 0.1'


### PR DESCRIPTION
Update json gem version to 1.8.1

Changes of Json 
- Fix regex encoding problem on ruby-head, ouch
- Remove Rubinius exception since transcoding should be working now.
- Try to convert first with to_hash, then to_h rb_convert_type doesn't return if conversion fails, so use rb_check_convert_type and the raise vi rb_convert_type. Make sure, that this behaviour is consisten across all generator implementations.
- also ruby 2.0 and some more
