### PR TITLE
Issue/14435 multipart mail preview

### DIFF
--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -1,5 +1,6 @@
 require 'isolation/abstract_unit'
 require 'rack/test'
+
 module ApplicationTests
   class MailerPreviewsTest < ActiveSupport::TestCase
     include ActiveSupport::Testing::Isolation
@@ -426,6 +427,48 @@ module ApplicationTests
       get "/rails/mailers/notifier/foo.txt"
       assert_equal 200, last_response.status
       assert_match '<option selected value="?part=text%2Fplain">View as plain-text email</option>', last_response.body
+    end
+
+    test "encodes inline attachments" do
+      image_content = 'image_content'
+      mailer 'notifier', <<-RUBY
+        class Notifier < ActionMailer::Base
+          default from: "from@example.com"
+
+          def foo
+            attachments.inline['image.png'] = '#{image_content}'
+            mail to: "to@example.org"
+          end
+        end
+      RUBY
+
+      html_template 'notifier/foo', <<-RUBY
+        <p>Hello, World! <%= image_tag attachments['image.png'].url %></p>
+      RUBY
+
+      text_template 'notifier/foo', <<-RUBY
+        Hello, World!
+      RUBY
+
+      mailer_preview 'notifier', <<-RUBY
+        class NotifierPreview < ActionMailer::Preview
+          def foo
+            Notifier.foo
+          end
+        end
+      RUBY
+
+      app('development')
+
+      get "/rails/mailers/notifier/foo.html"
+      assert_equal 200, last_response.status
+
+      get "/rails/mailers/notifier/foo.txt"
+      assert_equal 200, last_response.status
+
+      get "/rails/mailers/notifier/foo?part=text%2Fhtml"
+      assert_equal 200, last_response.status
+      assert_match "<p>Hello, World! <img src=\"data:image/png;base64,#{Base64.encode64(image_content)}\" />", last_response.body
     end
 
     private


### PR DESCRIPTION
MailPreviews with inline attachments error out. They try to render an HTML or
plain text part, but it only sees the attachment part (`image/png` for
example) and a `multipart/relative`, returning an unexpected array when views
expect a `Message::Part`.

If email is of type 'multipart/relative', then we render the `text/html` part
contained in it.

We'd like to render the image using a URL like `http://localhost:3000/rails/mailers/dog_mailer/dog_view?part=image/png`, anyway submitting for review.

Fix for issue: https://github.com/rails/rails/issues/14435.

Pairing with @masonforest. cc @pixeltrix @sikachu.
