### PR TITLE
Replace trivial regexp with string or index, twice as fast

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -96,7 +96,7 @@ module ActionController
       end
 
       def user_name_and_password(request)
-        decode_credentials(request).split(/:/, 2)
+        decode_credentials(request).split(':', 2)
       end
 
       def decode_credentials(request)

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -178,7 +178,7 @@ module Mime
       end
 
       def parse(accept_header)
-        if accept_header !~ /,/
+        if !accept_header.include?(',')
           accept_header = accept_header.split(PARAMETER_SEPARATOR_REGEXP).first
           parse_trailing_star(accept_header) || [Mime::Type.lookup(accept_header)].compact
         else


### PR DESCRIPTION
There are a few places where there are boolean conditionals using a regexp for a single character when a string or index would suffice. Using index(',') instead of =~ /,/ is about twice as fast, and the split usage is about 25% faster.
