### PR TITLE
Ensure we are returning either `true` or `false` for `#==`

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -299,7 +299,7 @@ module ActiveRecord
     def ==(comparison_object)
       super ||
         comparison_object.instance_of?(self.class) &&
-        id &&
+        !id.nil? &&
         comparison_object.id == id
     end
     alias :eql? :==

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -151,7 +151,7 @@ module ActiveRecord
         super ||
           other_aggregation.kind_of?(self.class) &&
           name == other_aggregation.name &&
-          other_aggregation.options &&
+          !other_aggregation.options.nil? &&
           active_record == other_aggregation.active_record
       end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -533,6 +533,7 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_equality_of_new_records
     assert_not_equal Topic.new, Topic.new
+    assert_equal false, Topic.new == Topic.new
   end
 
   def test_equality_of_destroyed_records
@@ -542,6 +543,12 @@ class BasicsTest < ActiveRecord::TestCase
     topic_1.destroy
     assert_equal topic_1, topic_2
     assert_equal topic_2, topic_1
+  end
+
+  def test_equality_with_blank_ids
+    one = Subscriber.new(:id => '')
+    two = Subscriber.new(:id => '')
+    assert_equal one, two
   end
 
   def test_hashing
@@ -576,12 +583,6 @@ class BasicsTest < ActiveRecord::TestCase
     end
 
     assert_equal nil, Topic.find_by_id(topic.id)
-  end
-
-  def test_blank_ids
-    one = Subscriber.new(:id => '')
-    two = Subscriber.new(:id => '')
-    assert_equal one, two
   end
 
   def test_comparison_with_different_objects


### PR DESCRIPTION
460eb83d cused `ActiveRecord::Base#==` to sometimes return `nil` in some cases,
this ensures we always return a boolean value.

This broke a test on discourse when testing against 4.1.0.rc2, see https://github.com/chancancode/discourse/issues/1.

I also fixed a similar problem in AR reflections. That condition doesn't seem to be currently tested, and I'm not sure if it's worth adding a specific test for this, but the change seems safe. If we want to make sure that's tested, I can investigate and add that.

I checked other definitions of `#==` within the codebase for similar problem by inspecting the code and from our existing test suite (see https://travis-ci.org/rails/rails/builds/21779437). I believe these should be the only two instances of the same problem.

cc @fxn @tenderlove
