### PR TITLE
Require yaml explicitly on #database_configuration

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -95,6 +95,7 @@ module Rails
         yaml = Pathname.new(paths["config/database"].first || "")
 
         config = if yaml.exist?
+          require "yaml"
           require "erb"
           YAML.load(ERB.new(yaml.read).result) || {}
         elsif ENV['DATABASE_URL']


### PR DESCRIPTION
This is something I've found while bootstrapping a new app with rails 4.1.0.rc2 and sequel-rails. Although `#database_configuration` is intended to be used by AR (which already [requires yaml](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/base.rb#L1)), it would be a good idea to let other orm adapters to use it (sequel-rails already [uses it](https://github.com/TalentBox/sequel-rails/blob/master/lib/sequel_rails/railtie.rb#L67)). So IMHO I think it's responsibility of this method to require the necessary dependencies.

It seems that sequel-rails works fine until 4.1.0.beta2, from rc1 it raises `uninitialized constant Rails::Application::Configuration::Psych (NameError)`. After a couple of hours comparing the [changes between beta2 and rc1](https://gist.github.com/planas/9858812) I haven't found the specific commit that makes it fail, but I guess that was another gem requiring yaml at some point (probably i18n).
