### PR TITLE
ActiveSupport::SafeBuffer#prepend inconsistency

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `ActiveSupport::SafeBuffer#prepend` acts like `String#prepend` and modifies
+    instance in-place, returning self. `ActiveSupport::SafeBuffer#prepend!` is
+    deprecated.
+
+    *Pavel Pravosud*
+
 *   `HashWithIndifferentAccess` better respects `#to_hash` on objects it's
     given. In particular, `.new`, `#update`, `#merge`, `#replace` all accept
     objects which respond to `#to_hash`, even if those objects are not Hashes

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -171,11 +171,7 @@ module ActiveSupport #:nodoc:
 
     %w[concat prepend].each do |method_name|
       define_method method_name do |value|
-        if !html_safe? || value.html_safe?
-          super(value)
-        else
-          super(ERB::Util.h(value))
-        end
+        super(html_escape_interpolated_argument(value))
       end
     end
     alias << concat

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -124,7 +124,7 @@ module ActiveSupport #:nodoc:
   class SafeBuffer < String
     UNSAFE_STRING_METHODS = %w(
       capitalize chomp chop delete downcase gsub lstrip next reverse rstrip
-      slice squeeze strip sub succ swapcase tr tr_s upcase prepend
+      slice squeeze strip sub succ swapcase tr tr_s upcase
     )
 
     alias_method :original_concat, :concat
@@ -169,14 +169,21 @@ module ActiveSupport #:nodoc:
       self[0, 0]
     end
 
-    def concat(value)
-      if !html_safe? || value.html_safe?
-        super(value)
-      else
-        super(ERB::Util.h(value))
+    %w[concat prepend].each do |method_name|
+      define_method method_name do |value|
+        if !html_safe? || value.html_safe?
+          super(value)
+        else
+          super(ERB::Util.h(value))
+        end
       end
     end
     alias << concat
+
+    def prepend!(value)
+      ActiveSupport::Deprecation.deprecation_warning "ActiveSupport::SafeBuffer#prepend!", :prepend
+      prepend value
+    end
 
     def +(other)
       dup.concat(other)

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -4,6 +4,7 @@ require 'abstract_unit'
 require 'inflector_test_cases'
 require 'constantize_test_cases'
 
+require 'active_support/deprecation/reporting'
 require 'active_support/inflector'
 require 'active_support/core_ext/string'
 require 'active_support/time'
@@ -606,6 +607,27 @@ class OutputSafetyTest < ActiveSupport::TestCase
 
     assert @combination.html_safe?
     assert !@other_combination.html_safe?
+  end
+
+  test "Prepending safe onto unsafe yields unsafe" do
+    @string.prepend "other".html_safe
+    assert !@string.html_safe?
+    assert_equal @string, "otherhello"
+  end
+
+  test "Prepending unsafe onto safe yields escaped safe" do
+    other = "other".html_safe
+    other.prepend "<foo>"
+    assert other.html_safe?
+    assert_equal other, "&lt;foo&gt;other"
+  end
+
+  test "Deprecated #prepend! method is still present" do
+    ActiveSupport::Deprecation.silence do
+      other = "other".html_safe
+      other.prepend! "<foo>"
+      assert_equal other, "&lt;foo&gt;other"
+    end
   end
 
   test "Concatting safe onto unsafe yields unsafe" do


### PR DESCRIPTION
Native ruby `String#prepend` modifies instance in-place, while `ActiveSupport::SafeBuffer` returns modified version, but the initial object remains unchanged.

``` ruby
a = "bar"           # => "bar"
a.prepend "foo"     # => "foobar"
a                   # => "foobar"
b = "bar".html_safe # => "bar"
b.class             # => ActiveSupport::SafeBuffer
b.prepend "foo"     # => "foobar"
b                   # => "bar", expected "foobar"
```
