### PR TITLE
Additional attributes when update an enum with declaration.

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -114,9 +114,9 @@ module ActiveRecord
             klass.send(:detect_enum_conflict!, name, "#{value}?")
             define_method("#{value}?") { self[name] == i }
 
-            # def active!() update! status: :active end
+            # def active!(other_attrs={}) update! other_attrs.merge status: :active end
             klass.send(:detect_enum_conflict!, name, "#{value}!")
-            define_method("#{value}!") { update! name => value }
+            define_method("#{value}!") { |other_attrs={}| update! other_attrs.merge name => value }
 
             # scope :active, -> { where status: 0 }
             klass.send(:detect_enum_conflict!, name, value, true)

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -31,6 +31,12 @@ class EnumTest < ActiveRecord::TestCase
     assert @book.written?
   end
 
+  test "update by declaration with additional attributes" do
+    @book.written! name: "Agile Web Development with Rails II"
+    assert @book.written?
+    assert_equal @book.name, "Agile Web Development with Rails II"
+  end
+
   test "update by setter" do
     @book.update! status: :written
     assert @book.written?


### PR DESCRIPTION
Updated the declaration way for updating an enum to take in additional values, examples below:

``` ruby

# migration
def change
  create_table :conversations do |t|
    t.integer :status
    t.string  :handled_by

    t.timestamps
  end
end

class Conversation < ActiveRecord::Base
  enum status: [ :active, :archived ]
end

# conversation.update! status: 0
conversation.active!
conversation.active? # => true
conversation.status  # => "active"

# conversation.update! status: 0, handled_by: "admin1"
conversation.archived! handled_by: "admin1"
conversation.archived? # => true
conversation.status  # => "archived"
conversation.handled_by # => "admin1"
```
