### PR TITLE
Tiny doc fix for Strong Parameters

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -502,7 +502,7 @@ module ActionController
   #       end
   #   end
   #
-  # In order to use <tt>accepts_nested_attribute_for</tt> with Strong \Parameters, you
+  # In order to use <tt>accepts_nested_attributes_for</tt> with Strong \Parameters, you
   # will need to specify which nested attributes should be whitelisted.
   #
   #   class Person


### PR DESCRIPTION
Just noticed that attribute needed to be pluralized in the docs.
- accepts_nested_attribute_for -> accepts_nested_attributes_for
