### PR TITLE
Do not overwrite selected and disabled attributes

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -360,8 +360,8 @@ module ActionView
           html_attributes = option_html_attributes(element)
           text, value = option_text_and_value(element).map { |item| item.to_s }
 
-          html_attributes[:selected] = option_value_selected?(value, selected)
-          html_attributes[:disabled] = disabled && option_value_selected?(value, disabled)
+          html_attributes[:selected] ||= option_value_selected?(value, selected)
+          html_attributes[:disabled] ||= disabled && option_value_selected?(value, disabled)
           html_attributes[:value] = value
 
           content_tag_string(:option, text, html_attributes)

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -119,6 +119,26 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_array_options_for_select_with_custom_defined_selected
+    assert_dom_equal(
+      "<option selected=\"selected\" type=\"Coach\" value=\"1\">Richard Bandler</option>\n<option type=\"Coachee\" value=\"1\">Richard Bandler</option>",
+      options_for_select([
+        ['Richard Bandler', 1, { type: 'Coach', selected: 'selected' }],
+        ['Richard Bandler', 1, { type: 'Coachee' }]
+      ])
+    )
+  end
+
+  def test_array_options_for_select_with_custom_defined_disabled
+    assert_dom_equal(
+      "<option disabled=\"disabled\" type=\"Coach\" value=\"1\">Richard Bandler</option>\n<option type=\"Coachee\" value=\"1\">Richard Bandler</option>",
+      options_for_select([
+        ['Richard Bandler', 1, { type: 'Coach', disabled: 'disabled' }],
+        ['Richard Bandler', 1, { type: 'Coachee' }]
+      ])
+    )
+  end
+
   def test_array_options_for_select_with_selection
     assert_dom_equal(
       "<option value=\"Denmark\">Denmark</option>\n<option value=\"&lt;USA&gt;\" selected=\"selected\">&lt;USA&gt;</option>\n<option value=\"Sweden\">Sweden</option>",
@@ -813,7 +833,7 @@ class FormOptionsHelperTest < ActionView::TestCase
       select("post", "category", %w( one two ), :selected => 'two', :prompt => true)
     )
   end
-  
+
   def test_select_with_disabled_array
     @post = Post.new
     @post.category = "<mus>"


### PR DESCRIPTION
In an application I'm working on, I have the following select:

```
<select id="task_assigned_id" name="task[assigned_id]">
  <option type="Coach" value="1">Joseph O'Connor</option>
  <option type="Coachee" value="1">Joseph O'Connor</option>
</select>
```

To fill it, I'm generating an array of options with its attributes:

```
[
  ['Joseph O'Connor', 1, { type: 'Coach', selected: 'selected' }],
  ['Joseph O'Connor', 1, { type: 'Coachee' }]
]
```

One of these attributes is `selected`, but the `options_for_select` method is ignoring it.
On the other hand I can't use the second argument of the function, cause it is always selecting the last option in the list.

The `disabled` attribute has the same problem.

This PR solves this issue, preventing this two attributes to be overwritten when they are explicitly specified.
