### PR TITLE
Fix broken Accept header parsing and content negotiation

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -121,11 +121,12 @@ module ActionDispatch
       # matches the order array.
       #
       def negotiate_mime(order)
-        formats.each do |priority|
-          if priority == Mime::ALL
+        formats.each do |accepted_format|
+          # If any format is accepted, return the first defined in the controller
+          if accepted_format == Mime::ALL
             return order.first
-          elsif order.include?(priority)
-            return priority
+          elsif order.include?(accepted_format)
+            return accepted_format
           end
         end
 
@@ -134,11 +135,8 @@ module ActionDispatch
 
       protected
 
-      BROWSER_LIKE_ACCEPTS = /,\s*\*\/\*|\*\/\*\s*,/
-
       def valid_accept_header
-        (xhr? && (accept.present? || content_mime_type)) ||
-          (accept.present? && accept !~ BROWSER_LIKE_ACCEPTS)
+        accept.present? || (xhr? && content_mime_type)
       end
 
       def use_accept_header

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -145,7 +145,7 @@ module Mime
           accept_header.split(/,\s*/)
         end
 
-        accepts.map! { |accept|
+        accepts = accepts.map { |accept|
           # Set default quality
           params = {'q' => 1.0}
 
@@ -177,7 +177,7 @@ module Mime
           end
           [type, params]
         }.reject { |type, subtype, parameters|
-          type.nil?
+          type.blank? || subtype.blank?
         }.each_with_index.map { |(name, parameters), index|
           AcceptItem.new(*name.split("/"), parameters, index)
         }.sort.map { |item|
@@ -187,6 +187,7 @@ module Mime
             Mime::Type.lookup(item.name)
           end
         }.flatten.uniq
+        accepts.empty? ? [Mime::HTML] : accepts
       end
 
 

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -60,86 +60,50 @@ module Mime
 
     # A simple helper class used in parsing the accept header
     class AcceptItem #:nodoc:
-      attr_accessor :index, :name, :q
-      alias :to_s :name
+      attr_accessor :type, :subtype, :parameters, :index
 
-      def initialize(index, name, q = nil)
+      def initialize(type, subtype, parameters, index)
+        @type, @subtype = type, subtype
+        @parameters = parameters
+        parameters['q'] == 0.001 if type == '*' and subtype == '*' # This is for historical reasons, its necessity should be re-evaluated
         @index = index
-        @name = name
-        q ||= 0.0 if @name == Mime::ALL.to_s # default wildcard match to end of list
-        @q = ((q || 1.0).to_f * 100).to_i
       end
 
+      def name
+        type + '/' + subtype
+      end
+      alias_method :to_s, :name
+
       def <=>(item)
-        result = item.q <=> @q
-        result = @index <=> item.index if result == 0
+        result = type_wildcard <=> item.type_wildcard
+        result = subtype_wildcard <=> item.subtype_wildcard if result == 0
+        result = item.parameters['q'] <=> parameters['q'] if result == 0
+        result = item.xml_extension <=> xml_extension if result == 0
+        result = index <=> item.index if result == 0
         result
       end
 
+      # We don't include parameters here yet, the rest of the stack isn't ready for that
       def ==(item)
-        @name == item.to_s
-      end
-    end
-
-    class AcceptList < Array #:nodoc:
-      def assort!
-        sort!
-
-        # Take care of the broken text/xml entry by renaming or deleting it
-        if text_xml_idx && app_xml_idx
-          app_xml.q = [text_xml.q, app_xml.q].max # set the q value to the max of the two
-          exchange_xml_items if app_xml_idx > text_xml_idx  # make sure app_xml is ahead of text_xml in the list
-          delete_at(text_xml_idx)                 # delete text_xml from the list
-        elsif text_xml_idx
-          text_xml.name = Mime::XML.to_s
-        end
-
-        # Look for more specific XML-based types and sort them ahead of app/xml
-        if app_xml_idx
-          idx = app_xml_idx
-
-          while idx < length
-            type = self[idx]
-            break if type.q < app_xml.q
-
-            if type.name.ends_with? '+xml'
-              self[app_xml_idx], self[idx] = self[idx], app_xml
-              @app_xml_idx = idx
-            end
-            idx += 1
-          end
-        end
-
-        map! { |i| Mime::Type.lookup(i.name) }.uniq!
-        to_a
+        name == item.to_s
       end
 
-      private
-        def text_xml_idx
-          @text_xml_idx ||= index('text/xml')
-        end
+      def type_wildcard
+        @type == '*' ? 1 : -1
+      end
 
-        def app_xml_idx
-          @app_xml_idx ||= index(Mime::XML.to_s)
-        end
+      def subtype_wildcard
+        @subtype == '*' ? 1 : -1
+      end
 
-        def text_xml
-          self[text_xml_idx]
-        end
-
-        def app_xml
-          self[app_xml_idx]
-        end
-
-        def exchange_xml_items
-          self[app_xml_idx], self[text_xml_idx] = text_xml, app_xml
-          @app_xml_idx, @text_xml_idx = text_xml_idx, app_xml_idx
-        end
+      def xml_extension
+        @subtype.include?('+xml') ? 1 : -1
+      end
     end
 
     class << self
-      TRAILING_STAR_REGEXP = /(text|application)\/\*/
-      PARAMETER_SEPARATOR_REGEXP = /;\s*\w+="?\w+"?/
+      ACCEPT_HEADER_REGEXP = /(\S+="(?:\\"|.)*?"[^\s,]*|\S+=[^\s,]+|[^\s;,]+[^,]*)/
+      ACCEPT_PARAMETER_REGEXP = /([^\s;=,]+)=("(?:\\"|.)*?"|[^;]+)/
 
       def register_callback(&block)
         @register_callbacks << block
@@ -174,40 +138,57 @@ module Mime
       end
 
       def parse(accept_header)
-        if !accept_header.include?(',')
-          accept_header = accept_header.split(PARAMETER_SEPARATOR_REGEXP).first
-          parse_trailing_star(accept_header) || [Mime::Type.lookup(accept_header)].compact
+        # Only use the complex regexp if the header contains quoted tokens
+        accepts = if accept_header.include?('"')
+          accept_header.scan(ACCEPT_HEADER_REGEXP).map(&:first)
         else
-          list, index = AcceptList.new, 0
-          accept_header.split(',').each do |header|
-            params, q = header.split(PARAMETER_SEPARATOR_REGEXP)
-            if params.present?
-              params.strip!
-
-              params = parse_trailing_star(params) || [params]
-
-              params.each do |m|
-                list << AcceptItem.new(index, m.to_s, q)
-                index += 1
-              end
-            end
-          end
-          list.assort!
+          accept_header.split(/,\s*/)
         end
+
+        accepts.map! { |accept|
+          # Set default quality
+          params = {'q' => 1.0}
+
+          # Split into type and following parameters
+          type, accept_params = accept.split(';', 2)
+
+          # Correct a standard wildcard truncation
+          type = '*/*' if type == '*'
+
+          if accept_params
+            # Only use a complex regexp if the parameters contain quoted tokens
+            accept_params = if accept_params.include?('"')
+              accept_params.scan(ACCEPT_PARAMETER_REGEXP)
+            else
+              accept_params.split(';').map { |a| a.split('=') }
+            end
+
+            accept_params.each { |(key, val)|
+              key.strip!
+              val = if key == 'q'
+                val.to_f
+              elsif val[0] == '"' and val[-1] == '"'
+                val[1..-2].gsub(/\\(.)/, "\\1")
+              else
+                val
+              end
+              params[key] = val
+            }
+          end
+          [type, params]
+        }.reject { |type, subtype, parameters|
+          type.nil?
+        }.each_with_index.map { |(name, parameters), index|
+          AcceptItem.new(*name.split("/"), parameters, index)
+        }.sort.map { |item|
+          if item.type_wildcard != 1 && item.subtype_wildcard == 1
+            Mime::SET.select { |m| m =~ item.type }
+          else
+            Mime::Type.lookup(item.name)
+          end
+        }.flatten.uniq
       end
 
-      def parse_trailing_star(accept_header)
-        parse_data_with_trailing_star($1) if accept_header =~ TRAILING_STAR_REGEXP
-      end
-
-      # For an input of <tt>'text'</tt>, returns <tt>[Mime::JSON, Mime::XML, Mime::ICS,
-      # Mime::HTML, Mime::CSS, Mime::CSV, Mime::JS, Mime::YAML, Mime::TEXT]</tt>.
-      #
-      # For an input of <tt>'application'</tt>, returns <tt>[Mime::HTML, Mime::JS,
-      # Mime::XML, Mime::YAML, Mime::ATOM, Mime::JSON, Mime::RSS, Mime::URL_ENCODED_FORM]</tt>.
-      def parse_data_with_trailing_star(input)
-        Mime::SET.select { |m| m =~ input }
-      end
 
       # This method is opposite of register method.
       #

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -320,16 +320,6 @@ class RespondToControllerTest < ActionController::TestCase
     end
   end
 
-  def test_json_or_yaml_with_leading_star_star
-    @request.accept = "*/*, application/json"
-    get :json_xml_or_html
-    assert_equal 'HTML', @response.body
-
-    @request.accept = "*/* , application/json"
-    get :json_xml_or_html
-    assert_equal 'HTML', @response.body
-  end
-
   def test_json_or_yaml
     xhr :get, :json_or_yaml
     assert_equal 'JSON', @response.body
@@ -493,11 +483,15 @@ class RespondToControllerTest < ActionController::TestCase
   end
 
   def test_browser_check_with_any_any
-    @request.accept = "application/json, application/xml"
+    @request.accept = "application/json, application/xml, */*"
     get :json_xml_or_html
     assert_equal 'JSON', @response.body
 
-    @request.accept = "application/json, application/xml, */*"
+    @request.accept = "application/xml, */*"
+    get :json_xml_or_html
+    assert_equal 'XML', @response.body
+
+    @request.accept = "*/*, text/html"
     get :json_xml_or_html
     assert_equal 'HTML', @response.body
   end

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -75,6 +75,12 @@ class MimeTypeTest < ActiveSupport::TestCase
     assert_equal expect, Mime::Type.parse(accept)
   end
 
+  test "totally broken header defaults to HTML" do
+    accept = "; a=dsf"
+    expect = [Mime::HTML]
+    assert_equal expect, Mime::Type.parse(accept)
+  end
+
   test "parse arbitrary media type parameters" do
     accept = 'multipart/form-data; boundary="simple boundary"'
     expect = [Mime::MULTIPART_FORM]

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -31,7 +31,7 @@ class MimeTypeTest < ActiveSupport::TestCase
 
   test "parse text with trailing star at the beginning" do
     accept = "text/*, text/html, application/json, multipart/form-data"
-    expect = [Mime::HTML, Mime::TEXT, Mime::JS, Mime::CSS, Mime::ICS, Mime::CSV, Mime::VCF, Mime::XML, Mime::YAML, Mime::JSON, Mime::MULTIPART_FORM]
+    expect = [Mime::HTML, Mime::JSON, Mime::MULTIPART_FORM, Mime::TEXT, Mime::JS, Mime::CSS, Mime::ICS, Mime::CSV, Mime::VCF, Mime::XML, Mime::YAML]
     parsed = Mime::Type.parse(accept)
     assert_equal expect, parsed
   end
@@ -84,7 +84,7 @@ class MimeTypeTest < ActiveSupport::TestCase
   # Accept header send with user HTTP_USER_AGENT: Sunrise/0.42j (Windows XP)
   test "parse broken acceptlines" do
     accept = "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/*,,*/*;q=0.5"
-    expect = [Mime::HTML, Mime::XML, "image/*", Mime::TEXT, Mime::ALL]
+    expect = [Mime::HTML, Mime::XML, Mime::TEXT, Mime::SET.select { |m| m.to_s.include?('image') }, Mime::ALL].flatten
     assert_equal expect, Mime::Type.parse(accept).collect { |c| c.to_s }
   end
 

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -79,6 +79,10 @@ class MimeTypeTest < ActiveSupport::TestCase
     accept = "; a=dsf"
     expect = [Mime::HTML]
     assert_equal expect, Mime::Type.parse(accept)
+
+    accept = "text/html; charset=utf-8,*.*, q=0.1"
+    expect = [Mime::HTML, Mime::ALL]
+    assert_equal expect, Mime::Type.parse(accept)
   end
 
   test "parse arbitrary media type parameters" do


### PR DESCRIPTION
This does not completely fix the accept header parsing but is the least disruptive way to make progress and pave the way towards having proper content negotiation in the future. It has a new Mime::Type.parse method which more strictly adheres to rfc2616 allowing multiple token quoted token types and changes the content_negotiation method to use the Accept header priorities over controller-specific priorities unless the wildcard is used in which case it uses the controller-defined formats.

In a future set of patches the parameter information should be pushed back up the stack into the controller so that its readily available without reparsing the header but thats a much more disruptive patch and I think this is a good place to start.

A few of the tests had to be changed because they were technically incorrect.
