### PR TITLE
Fix delete all to not produce sql in statement

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -248,7 +248,7 @@ module ActiveRecord
         dependent = _options[:dependent] || options[:dependent]
 
         if records.first == :all
-          if loaded? || dependent == :destroy
+          if (loaded? || dependent == :destroy) && dependent != :delete_all
             delete_or_destroy(load_target, dependent)
           else
             delete_records(:all, dependent)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -22,6 +22,8 @@ require 'models/engine'
 require 'models/categorization'
 require 'models/minivan'
 require 'models/speedometer'
+require 'models/reference'
+require 'models/job'
 
 class HasManyAssociationsTestForReorderWithJoinDependency < ActiveRecord::TestCase
   fixtures :authors, :posts, :comments
@@ -39,7 +41,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :categories, :companies, :developers, :projects,
            :developers_projects, :topics, :authors, :comments,
            :people, :posts, :readers, :taggings, :cars, :essays,
-           :categorizations
+           :categorizations, :jobs
 
   def setup
     Client.destroyed_client_ids.clear
@@ -105,6 +107,19 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     car.funky_bulbs.create!
     assert_nothing_raised { car.reload.funky_bulbs.delete_all }
     assert_equal 0, Bulb.count, "bulbs should have been deleted using :delete_all strategy"
+  end
+
+  def test_delete_all_on_association_is_the_same_as_not_loaded
+    author = authors :david
+    author.thinking_posts.create!(:body => "test")
+    author.reload
+    expected_sql = capture_sql { author.thinking_posts.delete_all }
+
+    author.thinking_posts.create!(:body => "test")
+    author.reload
+    author.thinking_posts.inspect
+    loaded_sql = capture_sql { author.thinking_posts.delete_all }
+    assert_equal(expected_sql, loaded_sql)
   end
 
   def test_building_the_associated_object_with_implicit_sti_base_class

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -19,6 +19,12 @@ module ActiveRecord
       end
     end
 
+    def capture_sql
+      SQLCounter.clear_log
+      yield
+      SQLCounter.log_all.dup
+    end
+
     def assert_sql(*patterns_to_match)
       SQLCounter.clear_log
       yield


### PR DESCRIPTION
When delete_all is run on a CollectionProxy and has a dependency of delete_all the SQL that is produced has an IN statement.

`DELETE FROM `associated_model` where `associated_model`.`parent_id` = 1 AND `associated_model`.`id` IN (1, 2, 3...)`

This is only happening if the association is not loaded — both loaded and non-loaded delete_all should behave the same. This is a problem when it comes to deleting many records because the query becomes very slow. Instead the SQL produced should be:

`DELETE FROM `associated_model` where `associated_model`.`parent_model_id`=1`

I fixed this by making sure the check for loaded and destroy also makes sure that the dependent is not delete_all, so the conditional goes to the else and deletes the records directly without the IN statement.

Thanks to @tenderlove for pairing with me to figure out exactly what was causing this issue.
