### PR TITLE
refactor assert_sql query to reuse capture_sql

### DIFF
--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -26,9 +26,7 @@ module ActiveRecord
     end
 
     def assert_sql(*patterns_to_match)
-      SQLCounter.clear_log
-      yield
-      SQLCounter.log_all
+      capture_sql { yield }
     ensure
       failed_patterns = []
       patterns_to_match.each do |pattern|


### PR DESCRIPTION
Sets assert_sql to reuse the capture_sql method instead of repeating code. 

This PR fixes the refactoring discussed in #14546.
