### PR TITLE
Add test case for skip_before_action using :only and if at the same time.

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -25,7 +25,12 @@ module AbstractController
       # If :only or :except are used, convert the options into the
       # :unless and :if options of ActiveSupport::Callbacks.
       # The basic idea is that :only => :index gets converted to
-      # :if => proc {|c| c.action_name == "index" }.
+      # :if => proc { |c| c.action_name == "index" }.
+      # Note that :only have priority over :if, in case they are used together.
+      #
+      # Example:
+      #   only: :index, if: -> { true }
+      #   The option :if will be ignored.
       #
       # ==== Options
       # * <tt>only</tt>   - The callback should be run only for this action

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -225,6 +225,18 @@ class FilterTest < ActionController::TestCase
     skip_before_filter :clean_up_tmp, if: -> { true }
   end
 
+  class SkipFilterUsingOnlyAndConditional < ConditionalFilterController
+    before_filter :clean_up_tmp
+    before_filter :ensure_login
+
+    skip_before_filter :ensure_login, only: :login, if: -> { false }
+    skip_before_filter :clean_up_tmp, only: :login, if: -> { true }
+
+    def login
+      render text: 'ok'
+    end
+  end
+
   class ClassController < ConditionalFilterController
     before_filter ConditionalClassFilter
   end
@@ -612,6 +624,11 @@ class FilterTest < ActionController::TestCase
   def test_running_conditional_skip_options
     test_process(ConditionalOptionsSkipFilter)
     assert_equal %w( ensure_login ), assigns["ran_filter"]
+  end
+
+  def test_if_is_ignored_when_used_with_only
+    test_process(SkipFilterUsingOnlyAndConditional, 'login')
+    assert_nil assigns['ran_filter']
   end
 
   def test_skipping_class_filters


### PR DESCRIPTION
Closes #9703.

Add a test case for `skip_before_action` using the options `:only` and `:if` at the same time. It will ignore the `:if` option and just `:only` will be executed.

Also, updated the documentation.
