### PR TITLE
Allow postgresql enum_test to be run in random order.

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/domain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/domain_test.rb
@@ -1,18 +1,17 @@
 # -*- coding: utf-8 -*-
 require "cases/helper"
+require 'support/postgresql_helper'
 require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlDomainTest < ActiveRecord::TestCase
+  include PostgresqlHelper
+
   class PostgresqlDomain < ActiveRecord::Base
     self.table_name = "postgresql_domains"
   end
 
   def setup
-    # reset connection to bust all cached statement plans
-    connection_spec = ActiveRecord::Base.remove_connection
-    ActiveRecord::Base.establish_connection(connection_spec)
-
     @connection = ActiveRecord::Base.connection
     @connection.transaction do
       @connection.execute "CREATE DOMAIN custom_money as numeric(8,2)"
@@ -28,6 +27,7 @@ class PostgresqlDomainTest < ActiveRecord::TestCase
   teardown do
     @connection.execute 'DROP TABLE IF EXISTS postgresql_domains'
     @connection.execute 'DROP DOMAIN IF EXISTS custom_money'
+    reset_pg_session
   end
 
   def test_column

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
 require "cases/helper"
+require 'support/postgresql_helper'
 require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
 
 class PostgresqlEnumTest < ActiveRecord::TestCase
+  include PostgresqlHelper
+
   class PostgresqlEnum < ActiveRecord::Base
     self.table_name = "postgresql_enums"
-  end
-
-  teardown do
-    @connection.execute 'DROP TABLE IF EXISTS postgresql_enums'
-    @connection.execute 'DROP TYPE IF EXISTS mood'
   end
 
   def setup
@@ -25,6 +23,12 @@ class PostgresqlEnumTest < ActiveRecord::TestCase
     end
     # reload type map after creating the enum type
     @connection.send(:reload_type_map)
+  end
+
+  teardown do
+    @connection.execute 'DROP TABLE IF EXISTS postgresql_enums'
+    @connection.execute 'DROP TYPE IF EXISTS mood'
+    reset_pg_session
   end
 
   def test_column

--- a/activerecord/test/support/postgresql_helper.rb
+++ b/activerecord/test/support/postgresql_helper.rb
@@ -1,0 +1,8 @@
+module PostgresqlHelper
+  # Make sure to drop all cached query plans to prevent invalid reference errors like:
+  #  cache lookup failed for type XYZ
+  def reset_pg_session
+    original_connection = ActiveRecord::Base.remove_connection
+    ActiveRecord::Base.establish_connection(original_connection)
+  end
+end


### PR DESCRIPTION
Creating and dropping similar tables within the same connection causes postgresql to look up old values in the cache of tables which have already been dropped.
