### PR TITLE
CollectionProxy uses the arel of its association's scope.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `to_sql` on an association now matches the query that is actually executed, where it
+    could previously have incorrectly accrued additional conditions (e.g. as a result of
+    a previous query). CollectionProxy now always defers to the association scope's
+    `arel` method so the (incorrect) inherited one should be entirely concealed.
+
+    Fixes #14003.
+
+    *Jefferson Lai*
+
 *   The PostgreSQL adapter supports custom domains. Fixes #14305.
 
     *Yves Senn*

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -860,6 +860,10 @@ module ActiveRecord
         !!@association.include?(record)
       end
 
+      def arel
+        scope.arel
+      end
+
       def proxy_association
         @association
       end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -573,6 +573,12 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal expected, actual
   end
 
+  def test_to_sql_on_scoped_proxy
+    auth = Author.first
+    Post.where("1=1").written_by(auth)
+    assert_not auth.posts.to_sql.include?("1=1")
+  end
+
   def test_loading_with_one_association_with_non_preload
     posts = Post.eager_load(:last_comment).order('comments.id DESC')
     post = posts.find { |p| p.id == 1 }

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -149,6 +149,10 @@ class Post < ActiveRecord::Base
     ranked_by_comments.limit_by(limit)
   end
 
+  def self.written_by(author)
+    where(id: author.posts.pluck(:id))
+  end
+
   def self.reset_log
     @log = []
   end


### PR DESCRIPTION
CollectionProxy should be able to reuse the behavior (methods) of its parent class,
but with its own state. This change allows CollectionProxy to use the arel object
corresponding to its association's scope. Fixes #14003.
