### PR TITLE
Make 'sqlite3:' URL paths relative again

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Treat the path component of SQLite3 database URLs as relative again.
+
+    Use an extra (fourth!) slash for an absolute path:
+
+        sqlite3:////some/full/path
+
+    *Matthew Draper*
+
 *   Enable support for materialized views on PostgreSQL >= 9.3.
 
     *Dave Lee*

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -74,22 +74,8 @@ module ActiveRecord
             "username" => uri.user,
             "password" => uri.password,
             "port"     => uri.port,
-            "database" => database,
+            "database" => uri.path.sub(%r{^/},""),
             "host"     => uri.host })
-        end
-
-        # Returns name of the database.
-        # Sqlite3 expects this to be a full path or `:memory:`.
-        def database
-          if @adapter == 'sqlite3'
-            if '/:memory:' == uri.path
-              ':memory:'
-            else
-              uri.path
-            end
-          else
-            uri.path.sub(%r{^/},"")
-          end
         end
       end
 

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -31,7 +31,7 @@ module ActiveRecord
         def test_connect_with_url
           original_connection = ActiveRecord::Base.remove_connection
           tf = Tempfile.open 'whatever'
-          url = "sqlite3://#{tf.path}"
+          url = "sqlite3:///#{tf.path}"
           ActiveRecord::Base.establish_connection(url)
           assert ActiveRecord::Base.connection
         ensure

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -82,13 +82,18 @@ module ActiveRecord
           assert_equal password, spec["password"]
         end
 
-        def test_url_host_db_for_sqlite3
-          spec = resolve 'sqlite3://foo:bar@dburl:9000/foo_test'
+        def test_url_absolute_db_for_sqlite3
+          spec = resolve 'sqlite3:////foo_test'
           assert_equal('/foo_test', spec["database"])
         end
 
-        def test_url_host_memory_db_for_sqlite3
-          spec = resolve 'sqlite3://foo:bar@dburl:9000/:memory:'
+        def test_url_relative_db_for_sqlite3
+          spec = resolve 'sqlite3:///foo_test'
+          assert_equal('foo_test', spec["database"])
+        end
+
+        def test_url_memory_db_for_sqlite3
+          spec = resolve 'sqlite3:///:memory:'
           assert_equal(':memory:', spec["database"])
         end
       end

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml
@@ -24,7 +24,9 @@ test:
 # instead read the configuration from the environment.
 #
 # Example:
-#   sqlite3://myuser:mypass@localhost/full/path/to/somedatabase
+#   sqlite3:///db/production.sqlite3
+# or
+#   sqlite3:////full/path/to/database.sqlite3
 #
 production:
   url: <%%= ENV["DATABASE_URL"] %>

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -216,7 +216,7 @@ module ApplicationTests
         require "#{app_path}/config/environment"
         orig_database_url = ENV.delete("DATABASE_URL")
         orig_rails_env, Rails.env = Rails.env, 'development'
-        database_url_db_name = File.join(app_path, "db/database_url_db.sqlite3")
+        database_url_db_name = "db/database_url_db.sqlite3"
         ENV["DATABASE_URL"] = "sqlite3://:@localhost/#{database_url_db_name}"
         ActiveRecord::Base.establish_connection
         assert ActiveRecord::Base.connection

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -17,11 +17,11 @@ module ApplicationTests
       end
 
       def database_url_db_name
-        File.join(app_path, "db/database_url_db.sqlite3")
+        "db/database_url_db.sqlite3"
       end
 
       def set_database_url
-        ENV['DATABASE_URL'] = File.join("sqlite3://:@localhost", database_url_db_name)
+        ENV['DATABASE_URL'] = "sqlite3://:@localhost/#{database_url_db_name}"
         # ensure it's using the DATABASE_URL
         FileUtils.rm_rf("#{app_path}/config/database.yml")
       end


### PR DESCRIPTION
This returns to the behaviour from 4.0.

Use an extra (fourth!) slash for an absolute path:

```
sqlite3:////some/full/path
```

Reverts fbb79b517f3127ba620fedd01849f9628b78d6ce and dd93a5f4598b420710fb4a9a2628abfd98799fb6; fixes #14495.
