### PR TITLE
Fix error when using `with_options` with lambda.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fixed error when using `with_options` with lambda.
+
+    Fixes #9805.
+
+    *Lauro Caetano*
+
 *   Treat blank UUID values as `nil`.
 
     Example:

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -24,6 +24,8 @@ require 'models/minivan'
 require 'models/speedometer'
 require 'models/reference'
 require 'models/job'
+require 'models/college'
+require 'models/student'
 
 class HasManyAssociationsTestForReorderWithJoinDependency < ActiveRecord::TestCase
   fixtures :authors, :posts, :comments
@@ -63,6 +65,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_operator dev.developer_projects.count, :>, 0
     assert_equal named.projects.map(&:id).sort,
                  dev.developer_projects.map(&:project_id).sort
+  end
+
+  def test_has_many_build_with_options
+    college = College.create(name: 'UFMT')
+    student = Student.create(active: true, college_id: college.id, name: 'Sarah')
+
+    assert_equal college.students, Student.where(active: true, college_id: college.id)
   end
 
   def test_create_from_association_should_respect_default_scope

--- a/activerecord/test/models/college.rb
+++ b/activerecord/test/models/college.rb
@@ -1,5 +1,10 @@
 require_dependency 'models/arunit2_model'
+require 'active_support/core_ext/object/with_options'
 
 class College < ARUnit2Model
   has_many :courses
+
+  with_options dependent: :destroy do |assoc|
+    assoc.has_many :students, -> { where(active: true) }
+  end
 end

--- a/activerecord/test/models/student.rb
+++ b/activerecord/test/models/student.rb
@@ -1,3 +1,4 @@
 class Student < ActiveRecord::Base
   has_and_belongs_to_many :lessons
+  belongs_to :college
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -638,6 +638,8 @@ ActiveRecord::Schema.define do
 
   create_table :students, force: true do |t|
     t.string :name
+    t.boolean :active
+    t.integer :college_id
   end
 
   create_table :subscribers, force: true, id: false do |t|

--- a/activesupport/lib/active_support/option_merger.rb
+++ b/activesupport/lib/active_support/option_merger.rb
@@ -12,7 +12,7 @@ module ActiveSupport
 
     private
       def method_missing(method, *arguments, &block)
-        if arguments.last.is_a?(Proc)
+        if arguments.first.is_a?(Proc)
           proc = arguments.pop
           arguments << lambda { |*args| @options.deep_merge(proc.call(*args)) }
         else


### PR DESCRIPTION
It was causing error when using `with_options` passing a lambda as its
last argument.

``` ruby
    class User < ActiveRecord::Base
      with_options dependent: :destroy do |assoc|
        assoc.has_many :profiles, -> { where(active: true) }
      end
    end
```

It was happening because the `option_merger` was taking the last
argument and checking if it was a Hash. This breaks the HasMany usage,
because its last argument can be a Hash or a Proc.

As the behavior described [in this test](https://github.com/rails/rails/blob/master/activesupport/test/option_merger_test.rb#L69), the method will only accept the lambda, this way it will keep the expected behavior. See 9eaa0a34

Fixes #9805
