### PR TITLE
Change order of scope subsections in Active Record Querying guide

### DIFF
--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,1 +1,5 @@
+*   Switched the order of `Applying a default scope` and `Merging of scopes` subsections so default scopes are introduced first.
+
+    *Alex Riabov*
+
 Please check [4-1-stable](https://github.com/rails/rails/blob/4-1-stable/guides/CHANGELOG.md) for previous changes.

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1231,6 +1231,35 @@ Using a class method is the preferred way to accept arguments for scopes. These 
 category.posts.created_before(time)
 ```
 
+### Applying a default scope
+
+If we wish for a scope to be applied across all queries to the model we can use the
+`default_scope` method within the model itself.
+
+```ruby
+class Client < ActiveRecord::Base
+  default_scope { where("removed_at IS NULL") }
+end
+```
+
+When queries are executed on this model, the SQL query will now look something like
+this:
+
+```sql
+SELECT * FROM clients WHERE removed_at IS NULL
+```
+
+If you need to do more complex things with a default scope, you can alternatively
+define it as a class method:
+
+```ruby
+class Client < ActiveRecord::Base
+  def self.default_scope
+    # Should return an ActiveRecord::Relation.
+  end
+end
+```
+
 ### Merging of scopes
 
 Just like `where` clauses scopes are merged using `AND` conditions.
@@ -1283,36 +1312,6 @@ User.where(state: 'inactive')
 
 As you can see above the `default_scope` is being merged in both
 `scope` and `where` conditions.
-
-
-### Applying a default scope
-
-If we wish for a scope to be applied across all queries to the model we can use the
-`default_scope` method within the model itself.
-
-```ruby
-class Client < ActiveRecord::Base
-  default_scope { where("removed_at IS NULL") }
-end
-```
-
-When queries are executed on this model, the SQL query will now look something like
-this:
-
-```sql
-SELECT * FROM clients WHERE removed_at IS NULL
-```
-
-If you need to do more complex things with a default scope, you can alternatively
-define it as a class method:
-
-```ruby
-class Client < ActiveRecord::Base
-  def self.default_scope
-    # Should return an ActiveRecord::Relation.
-  end
-end
-```
 
 ### Removing All Scoping
 


### PR DESCRIPTION
In Active Record Querying guide, currently `Merging of scopes` section uses a concept of default scope in its example before it is introduced in the following section titled `Applying a default scope`.

It makes more sense to switch the ordering to introduce default scopes (`Applying a default scope`) first and then go into `Merging of scopes` section where it is used.
