### PR TITLE
PostgreSQL, remove varchar limit.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   PostgreSQL and SQLite string columns no longer have a default limit of 255.
+
+    Fixes #13435, #9153.
+
+    *Vladimir Sazhin*, *Toms Mikoss*, *Yves Senn*
+
 *   Block a few default Class methods as scope name.
 
     For instance, this will raise:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -209,7 +209,7 @@ module ActiveRecord
 
       NATIVE_DATABASE_TYPES = {
         primary_key: "serial primary key",
-        string:      { name: "character varying", limit: 255 },
+        string:      { name: "character varying" },
         text:        { name: "text" },
         integer:     { name: "integer" },
         float:       { name: "float" },

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -63,7 +63,7 @@ module ActiveRecord
 
       NATIVE_DATABASE_TYPES = {
         primary_key:  'INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL',
-        string:       { name: "varchar", limit: 255 },
+        string:       { name: "varchar" },
         text:         { name: "text" },
         integer:      { name: "integer" },
         float:        { name: "float" },

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -25,7 +25,7 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
 
   def test_column
     assert_equal :string, @column.type
-    assert_equal "character varying(255)", @column.sql_type
+    assert_equal "character varying", @column.sql_type
     assert @column.array
     assert_not @column.text?
     assert_not @column.number?

--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -35,6 +35,14 @@ module ActiveRecord
         assert_no_column TestModel, :last_name
       end
 
+      def test_add_column_without_limit
+        # TODO: limit: nil should work with all adapters.
+        skip "MySQL wrongly enforces a limit of 255" if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
+        add_column :test_models, :description, :string, limit: nil
+        TestModel.reset_column_information
+        assert_nil TestModel.columns_hash["description"].limit
+      end
+
       if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
         def test_unabstracted_database_dependent_types
           add_column :test_models, :intelligence_quotient, :tinyint

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -63,7 +63,7 @@ class ReflectionTest < ActiveRecord::TestCase
 
   def test_column_string_type_and_limit
     assert_equal :string, @first.column_for_attribute("title").type
-    assert_equal 255, @first.column_for_attribute("title").limit
+    assert_equal 250, @first.column_for_attribute("title").limit
   end
 
   def test_column_null_not_null

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -673,7 +673,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :topics, force: true do |t|
-    t.string   :title
+    t.string   :title, limit: 250
     t.string   :author_name
     t.string   :author_email_address
     if mysql_56?


### PR DESCRIPTION
Closes #13435
Closes #9153

There is no reason for the PG adapter to have a default limit of 255 on :string
columns. See this snippet from the PG docs:

```
Tip: There is no performance difference among these three types, apart
from increased storage space when using the blank-padded type, and a
few extra CPU cycles to check the length when storing into a
length-constrained column. While character(n) has performance
advantages in some other database systems, there is no such advantage
in PostgreSQL; in fact character(n) is usually the slowest of the
three because of its additional storage costs. In most situations text
or character varying should be used instead.
```
