### PR TITLE
Fix alias_method_chain for classes which have class methods named 'public', 'protected', or 'private'

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/aliasing.rb
+++ b/activesupport/lib/active_support/core_ext/module/aliasing.rb
@@ -34,11 +34,11 @@ class Module
 
     case
     when public_method_defined?(without_method)
-      public target
+      Class.instance_method(:public).bind(self).call(target)
     when protected_method_defined?(without_method)
-      protected target
+      Class.instance_method(:protected).bind(self).call(target)
     when private_method_defined?(without_method)
-      private target
+      Class.instance_method(:private).bind(self).call(target)
     end
   end
 

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -372,6 +372,47 @@ class MethodAliasingTest < ActiveSupport::TestCase
     assert_equal 'bar', @instance.bar_without_baz
   end
 
+  def test_alias_method_chain_with_overwritten_public_protected_private
+    FooClassWithBarMethod.class_eval do
+      def self.public; end
+      def self.private; end
+      def self.protected; end
+
+      public
+      def bar_public; 'bar_public'; end
+
+      protected
+      def bar_protected; 'bar_protected'; end
+
+      private
+      def bar_private; 'bar_private'; end
+    end
+
+    FooClassWithBarMethod.class_eval do
+      public
+      def bar_public_with_baz
+        bar_public_without_baz << '_with_baz'
+      end
+      alias_method_chain :bar_public, :baz
+
+      protected
+      def bar_protected_with_baz
+        bar_protected_without_baz << '_with_baz'
+      end
+      alias_method_chain :bar_protected, :baz
+
+      private
+      def bar_private_with_baz
+        bar_private_without_baz << '_with_baz'
+      end
+      alias_method_chain :bar_private, :baz
+    end
+
+    assert_equal 'bar_public_with_baz', @instance.public_send(:bar_public)
+    assert_equal 'bar_protected_with_baz', @instance.send(:bar_protected)
+    assert_equal 'bar_private_with_baz', @instance.send(:bar_private)
+  end
+
   def test_alias_method_chain_with_punctuation_method
     FooClassWithBarMethod.class_eval do
       def quux!; 'quux' end


### PR DESCRIPTION
`alias_method_chain` doesn't work on classes that have class methods named "public", "protected", or "private". Not a pretty fix, but the cleanest I could come up with.

The error you would get looks something like this:

```
ArgumentError: wrong number of arguments (1 for 0)
    ../activesupport/lib/active_support/core_ext/module/aliasing.rb:38:in `alias_method_chain'
```

Related to https://github.com/rails/rails/pull/14582

@arthurnn, please review (and maybe ping some people).
