### PR TITLE
Enums need to raise on conflict singular class methods

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -79,6 +79,7 @@ module ActiveRecord
         name        = name.to_sym
 
         # def self.statuses statuses end
+        detect_enum_conflict!(name, name, true)
         detect_enum_conflict!(name, name.to_s.pluralize, true)
         klass.singleton_class.send(:define_method, name.to_s.pluralize) { enum_values }
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -174,6 +174,7 @@ class EnumTest < ActiveRecord::TestCase
       :column,     # generates class method .columns, which conflicts with an AR method
       :logger,     # generates #logger, which conflicts with an AR method
       :attributes, # generates #attributes=, which conflicts with an AR method
+      :all,        # generates class method .all, which conflicts with AR
     ]
 
     conflicts.each_with_index do |name, i|


### PR DESCRIPTION
When writing enum tests for https://github.com/rails/rails/pull/14582, I realized that there was one missing check for enum conflict names.

This should not be allowed:

``` ruby
enum :all => ["value_#{i}"] }
```

review @chancancode @rafaelfranca
