### PR TITLE
Explicitly load Kernel#y when starting a console

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -430,6 +430,7 @@ module Rails
     # Check <tt>Rails::Railtie.console</tt> for more info.
     def load_console(app=self)
       require "pp"
+      require "psych/y"
       require "rails/console/app"
       require "rails/console/helpers"
       run_console_blocks(app)


### PR DESCRIPTION
Previously, we relied on the IRB-detection in Psych itself. But that
doesn't work when we're running under spring: the application boots (and
thus psych is required) before we switch to console mode and load IRB.

I can't see any test to do with `pp`, so I followed that precedent. :wink:

Fixes #14587.
