### PR TITLE
Improve error message for guides:generate:kindle

### DIFF
--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -13,8 +13,8 @@ namespace :guides do
 
     desc "Generate .mobi file. The kindlegen executable must be in your PATH. You can get it for free from http://www.amazon.com/kindlepublishing"
     task :kindle do
-      unless `kindlerb -v 2> /dev/null` =~ /kindlerb 0.1.1/  
-        abort "Please `gem install kindlerb`"
+      unless `kindlerb -v 2> /dev/null` =~ /kindlerb 0.1.1/
+        abort "Please `gem install kindlerb` and make sure you have `kindlegen` in your PATH"
       end
       unless `convert` =~ /convert/  
         abort "Please install ImageMagick`"


### PR DESCRIPTION
I was trying to generate Kindle-formatted guides using `rake guides:generate:kindle`.
This was my first contact with this task and with `kindlerb`.
I was not aware it requires Amazon's `kindlegen` in the PATH, which I did not have.

I did however have the correct version of `kindlerb` installed:

``` sh
$ gem list kindlerb

*** LOCAL GEMS ***

kindlerb (0.1.1)
```

In this scenario, `guides:generate:kindle` displays an unhelpful error message:

``` sh
$ rake guides:generate:kindle
Please `gem install kindlerb`
```

I had to look into the Rakefile to learn about `kindlegen` and proceed from there.
### Reason for issue

The rake task calls `kindlerb -v` and if that fails for any reason, aborts with `Please `gem install kindlerb``.
Even if a failure comes from kindlerb itself.
### What I did

I updated the error-checking to follow 1 of 3 possible paths:
1. If `kindlerb -v` succeeds, proceed with generation
2. If `kindlerb -v` aborts with [this error message](https://github.com/danchoi/kindlerb/blob/master/lib/kindlerb.rb#L4), display info about `kindlegen`
3. If `kindlerb -v` fails for any other reason, display the original error message
### Note

Yes if I looked into `rake -D kindle`, I would clearly see this:

``` sh
$ rake -D kindle
rake guides:generate:kindle
    Generate .mobi file. The kindlegen executable must be in your PATH. You can get it for free from http://www.amazon.com/kindlepublishing
```

...but as I'm lazy and don't like reading words, I only did:

``` sh
$ rake -T kindle
rake guides:generate:kindle  # Generate .mobi file
```

I don't know if the added convenience is worth the extra 4 lines.
Perhaps it isn't.
