### PR TITLE
The comparison between `Relation` and `CollectionProxy` should be consistent.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   The comparison between `Relation` and `CollectionProxy` should be consistent.
+
+    Example:
+
+        author.posts == Post.where(author_id: author.id)
+        # => true
+        Post.where(author_id: author.id) == author.posts
+        # => true
+
+    Fixes #13506.
+
+    *Lauro Caetano*
+
 *   Fixed error for aggregate methods (`empty?`, `any?`, `count`) with `select`
     which created invalid SQL.
 

--- a/activerecord/lib/active_record/association_relation.rb
+++ b/activerecord/lib/active_record/association_relation.rb
@@ -17,6 +17,10 @@ module ActiveRecord
       @association.empty?
     end
 
+    def ==(other)
+      other == to_a
+    end
+
     private
 
     def exec_queries

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -569,6 +569,8 @@ module ActiveRecord
     # Compares two relations for equality.
     def ==(other)
       case other
+      when Associations::CollectionProxy
+        self == other.to_a
       when Relation
         other.to_sql == to_sql
       when Array

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -569,7 +569,7 @@ module ActiveRecord
     # Compares two relations for equality.
     def ==(other)
       case other
-      when Associations::CollectionProxy
+      when Associations::CollectionProxy, AssociationRelation
         self == other.to_a
       when Relation
         other.to_sql == to_sql

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -577,6 +577,15 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal car.bulbs.includes(:car), Bulb.where(car_id: car.id), 'AssociationRelation should be comparable with Relation'
   end
 
+  def test_equality_of_collection_proxy_and_association_relation
+    car = Car.create!
+    car.bulbs.build
+    car.save
+
+    assert_equal car.bulbs, car.bulbs.includes(:car), 'CollectionProxy should be comparable with AssociationRelation'
+    assert_equal car.bulbs.includes(:car), car.bulbs, 'AssociationRelation should be comparable with CollectionProxy'
+  end
+
   def test_hashing
     assert_equal [ Topic.find(1) ], [ Topic.find(2).topic ] & [ Topic.find(1) ]
   end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -551,6 +551,23 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal one, two
   end
 
+  def test_equality_of_relation_and_collection_proxy
+    car = Car.create!
+    car.bulbs.build
+    car.save
+
+    assert car.bulbs == Bulb.where(car_id: car.id), 'CollectionProxy should be comparable with Relation'
+    assert Bulb.where(car_id: car.id) == car.bulbs, 'Relation should be comparable with CollectionProxy'
+  end
+
+  def test_equality_of_relation_and_array
+    car = Car.create!
+    car.bulbs.build
+    car.save
+
+    assert Bulb.where(car_id: car.id) == car.bulbs.to_a, 'Relation should be comparable with Array'
+  end
+
   def test_hashing
     assert_equal [ Topic.find(1) ], [ Topic.find(2).topic ] & [ Topic.find(1) ]
   end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -568,6 +568,15 @@ class BasicsTest < ActiveRecord::TestCase
     assert Bulb.where(car_id: car.id) == car.bulbs.to_a, 'Relation should be comparable with Array'
   end
 
+  def test_equality_of_relation_and_association_relation
+    car = Car.create!
+    car.bulbs.build
+    car.save
+
+    assert_equal Bulb.where(car_id: car.id), car.bulbs.includes(:car), 'Relation should be comparable with AssociationRelation'
+    assert_equal car.bulbs.includes(:car), Bulb.where(car_id: car.id), 'AssociationRelation should be comparable with Relation'
+  end
+
   def test_hashing
     assert_equal [ Topic.find(1) ], [ Topic.find(2).topic ] & [ Topic.find(1) ]
   end


### PR DESCRIPTION
Before this patch, it was behaving this way:

``` ruby
author.posts == Post.where(author_id: author.id)
# => true
Post.where(author_id: author.id) == author.posts
# => false
```

This patch checks if the object given to `Relation#==` is a `CollectionProxy` and then call `to_a` on it to do the comparison.

Fixes #13506
