### PR TITLE
Don't leave quiet EventSource request handlers behind

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -209,8 +209,6 @@ module ActionController
       end
     end
 
-    class ClientDisconnect < StandardError; end
-
     def process(name)
       t1 = Thread.current
       locals = t1.keys.map { |key| [key, t1[key]] }
@@ -243,7 +241,7 @@ module ActionController
               log_error(e)
               @_response.stream.close
             end
-          elsif !e.is_a?(ClientDisconnect)
+          else
             error = e
           end
         ensure
@@ -269,7 +267,7 @@ module ActionController
           socket.read_nonblock(1)
         end
       rescue IOError, SystemCallError
-        server_thread.raise(ClientDisconnect)
+        server_thread.raise(IOError)
       end
     end
 

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -277,7 +277,9 @@ module ActionController
         resp.await_commit
       }
 
-      @controller.process :inactive_stream
+      assert_raise IOError do
+        @controller.process :inactive_stream
+      end
 
       assert t.join(3), 'timeout expired before the thread terminated'
     end


### PR DESCRIPTION
This is a fix for: https://github.com/rails/rails/issues/10989

Currently in Rails if you have a quiet AC::Live method and the client disconnects the request handler will be stuck and unable to handle any other requests until the server tries to write to the closed socket.

Not a fan of a few things in this pull request but I figured it would be best to get the conversation started.
1. Having to use rack.hijack to do this, but I don't see another way to do it without changing the rack spec, perhaps someone wiser then myself would have some input? I left the other tests in a broken state, am happy to fix if people are okay with this approach.
2. `thread.raise(ClientDisconnect)` I am not sure if a thread.kill will leak connections from the AR connection pool? If not perhaps a thread.kill and a on_close handler?

A cleaner solution would be to leave the close detection as a responsibility of the web server however I believe this would require a change in the rack spec as rack would need to fire a on_client_close callback and the rack application (in this case rails) would have to take appropriate action. I thought I would open this PR to get the conversation started.
