### PR TITLE
Don't read attributes before type cast when dup'ing

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -254,7 +254,7 @@ module ActiveRecord
 
     ##
     def initialize_dup(other) # :nodoc:
-      cloned_attributes = other.clone_attributes(:read_attribute_before_type_cast)
+      cloned_attributes = other.clone_attributes
       self.class.initialize_attributes(cloned_attributes, :serialized => false)
 
       @attributes = cloned_attributes

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -263,6 +263,36 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
       Hstore.update_all tags: { }
       assert_equal({ }, hstore.reload.tags)
     end
+
+    class TagCollection
+      def initialize(hash); @hash = hash end
+      def to_hash; @hash end
+      def self.load(hash)
+        new(hash)
+      end
+      def self.dump(object); object.to_hash end
+    end
+
+    class HstoreWithSerialize < Hstore
+      serialize :tags, TagCollection
+    end
+
+    def test_hstore_with_serialized_attributes
+      HstoreWithSerialize.create! tags: TagCollection.new({"one" => "two"})
+      record = HstoreWithSerialize.first
+      assert_instance_of TagCollection, record.tags
+      assert_equal({"one" => "two"}, record.tags.to_hash)
+      record.tags = TagCollection.new("three" => "four")
+      record.save!
+      assert_equal({"three" => "four"}, record.tags.to_hash)
+    end
+
+    def test_clone_hstore_with_serialized_attributes
+      HstoreWithSerialize.create! tags: TagCollection.new({"one" => "two"})
+      record = HstoreWithSerialize.first
+      dupe = record.dup
+      assert_equal({"one" => "two"}, dupe.tags.to_hash)
+    end
   end
 
   private


### PR DESCRIPTION
This PR is meant to address issue #14411

Changed the behavior of #dup so that it doesn't clone attributes before type casting. This way, the duplicate copies type casted attributes instead of the raw Postgres data type.

Let me know if there's anything else that needs done.

cc: @senny, @leods92
