### PR TITLE
Add Object#tie method

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `Object#tie`.
+
+    *Alexandr Avoyants*
+
 *   `ActiveSupport::SafeBuffer#prepend` acts like `String#prepend` and modifies
     instance in-place, returning self. `ActiveSupport::SafeBuffer#prepend!` is
     deprecated.

--- a/activesupport/lib/active_support/core_ext/object/tie.rb
+++ b/activesupport/lib/active_support/core_ext/object/tie.rb
@@ -1,0 +1,47 @@
+class Object
+  # If receives some arguments:
+  # invokes the public method whose name goes as first argument just like
+  # +public_send+ does,
+  # except if first argument is nil it returns receiver itself.
+  #
+  # Also can be called with block only (and no arguments).
+  # In this case method returns result of block call (whith receiver as block argument)
+  # or receiver itself (if block returns nil or false).
+  #
+  # Method is intended for creating conditional method chains, e.g.:
+  #
+  #   "test".reverse.next.concat("45").tie((:upcase if do_upcase?))
+  #
+  # or
+  #
+  #   "test".reverse.next.concat("45").tie {|s| s.upcase if do_upcase? }
+  #
+  # instead of
+  #
+  #   if do_upcase?
+  #     "test".reverse.next.concat("45").upcase
+  #   else
+  #     "test".reverse.next.concat("45")
+  #   end
+  #
+  # or
+  #
+  #   s = "test".reverse.next.concat("45")
+  #   s = s.upcase if do_upcase?
+  #   s
+  #
+  # Raises ArgumentError if called without any arguments and without block.
+  def tie(*args, &block)
+    if args.size > 0
+      if args.first.nil?
+        self
+      else
+        self.public_send(*args, &block)
+      end
+    elsif block_given?
+      yield(self) || self
+    else
+      raise ArgumentError, "#{self.class}#tie method requires any arguments or block"
+    end
+  end
+end

--- a/activesupport/test/core_ext/object/tie_test.rb
+++ b/activesupport/test/core_ext/object/tie_test.rb
@@ -1,0 +1,73 @@
+require 'abstract_unit'
+require 'active_support/core_ext/object/tie'
+
+class TieTest < ActiveSupport::TestCase
+  def test_nil_argument
+    assert_equal subject.tie(nil), subject
+  end
+
+  def test_nil_and_one_more_argument
+    assert_equal subject.tie(nil, 'arg1'), subject
+  end
+
+  def test_nil_and_two_more_arguments
+    assert_equal subject.tie(nil, 'arg1', 'arg2'), subject
+  end
+
+  def test_nil_argument_with_block
+    assert_equal subject.tie(nil, &:do_something), subject
+  end
+
+  def test_nil_and_two_arguments_with_block
+    assert_equal subject.tie(nil, 'arg1', 'arg2', &:do_something), subject
+  end
+
+  def test_method_name_argument
+    assert_equal subject.tie(:foo), subject.foo
+  end
+
+  def test_method_name_and_one_more_argument
+    assert_equal subject.tie(:foo, 'arg1'), subject.foo('arg1')
+  end
+
+  def test_method_name_and_two_more_arguments
+    assert_equal subject.tie(:foo, 'arg1', 'arg2'), subject.foo('arg1', 'arg2')
+  end
+
+  def test_method_name_with_block
+    assert_equal subject.tie(:foo, &p), subject.foo(&p)
+  end
+
+  def test_method_name_and_two_more_arguments_with_block
+    assert_equal subject.tie(:foo, 'arg1', 'arg2', &p), subject.foo('arg1', 'arg2', &p)
+  end
+
+  def test_yields_self_and_returns_result_if_it_is_not_nil
+    assert_equal subject.tie(&:object_id), subject.object_id
+  end
+
+  def test_yields_self_and_returns_self_if_result_of_yielding_is_nil
+    assert_equal subject.tie{|o| nil }, subject
+  end
+
+  def test_yields_self_and_returns_self_if_result_of_yielding_is_false
+    assert_equal subject.tie{|o| false }, subject
+  end
+
+  def test_no_arguments_and_no_block_given
+    assert_raise(ArgumentError) { subject.tie }
+  end
+
+private
+  def subject
+    @subject ||= Object.new.tap do |s|
+      def s.foo(*args, &block)
+        "Object: #{self} Args: #{args} Block: #{block}"
+      end
+    end
+  end
+
+  def p
+    @p ||= proc {}
+  end
+end


### PR DESCRIPTION
If receives some arguments:
invokes the public method whose name goes as first argument just like
+public_send+ does,
except if first argument is nil it returns receiver itself.

Also can be called with block only (and no arguments).
In this case method returns result of block call (whith receiver as block argument)
or receiver itself (if block returns nil or false).

Method is intended for creating conditional method chains, e.g.:

   `"test".reverse.next.concat("45").tie((:upcase if do_upcase?))`

 or

   `"test".reverse.next.concat("45").tie {|s| s.upcase if do_upcase? }`

 instead of

   `if do_upcase?`
     `"test".reverse.next.concat("45").upcase`
   `else`
     `"test".reverse.next.concat("45")`
   `end`

 or

   `s = "test".reverse.next.concat("45")`
   `s = s.upcase if do_upcase?`
   `s`

 Raises ArgumentError if called without any arguments and without block.
