### PR TITLE
Ensure we supply Kernel#y for 1.9 too

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -332,6 +332,25 @@ module Rails
       config.helpers_paths
     end
 
+    console do
+      require "pp"
+    end
+
+    console do
+      unless ::Kernel.private_method_defined?(:y)
+        if RUBY_VERSION >= '2.0'
+          require "psych/y"
+        else
+          module ::Kernel
+            def y(*objects)
+              puts ::Psych.dump_stream(*objects)
+            end
+            private :y
+          end
+        end
+      end
+    end
+
   protected
 
     alias :build_middleware_stack :app

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -429,8 +429,6 @@ module Rails
     # Load console and invoke the registered hooks.
     # Check <tt>Rails::Railtie.console</tt> for more info.
     def load_console(app=self)
-      require "pp"
-      require "psych/y"
       require "rails/console/app"
       require "rails/console/helpers"
       run_console_blocks(app)


### PR DESCRIPTION
In 1.9, it doesn't live in its own file, so we'll have to define it ourselves.

Check RUBY_VERSION, instead of rescuing the require, because we want this to break if `psych/y` moves in a future Ruby release.
