### PR TITLE
Use literal array of symbols for default protected instance variables

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -54,11 +54,11 @@ module AbstractController
       Mime::TEXT
     end
 
-    DEFAULT_PROTECTED_INSTANCE_VARIABLES = Set.new %w(
+    DEFAULT_PROTECTED_INSTANCE_VARIABLES = Set.new %i(
       @_action_name @_response_body @_formats @_prefixes @_config
       @_view_context_class @_view_renderer @_lookup_context
       @_routes @_db_runtime
-    ).map(&:to_sym)
+    )
 
     # This method should return a hash with assigns.
     # You can overwrite this configuration per controller.


### PR DESCRIPTION
It is faster :rocket:

``` ruby
require 'benchmark'

n = 50000
Benchmark.bm do |x|
  x.report do
    n.times do
      %w(@_action_name @_response_body @_formats @_prefixes @_config
          @_view_context_class @_view_renderer @_lookup_context
          @_routes @_db_runtime
        ).map(&:to_sym)
    end
  end
  x.report do
    n.times do
      %i(@_action_name @_response_body @_formats @_prefixes @_config
          @_view_context_class @_view_renderer @_lookup_context
          @_routes @_db_runtime
        )
    end
  end
```

```
user     system      total        real
   0.170000   0.000000   0.170000 (  0.172828)
   0.010000   0.000000   0.010000 (  0.014453)
```
