### PR TITLE
Backport to fix wrong nodoc on collection proxy.

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -853,8 +853,6 @@ module ActiveRecord
       def scope
         @association.scope
       end
-
-      # :nodoc:
       alias spawn scope
 
       # Equivalent to <tt>Array#==</tt>. Returns +true+ if the two arrays


### PR DESCRIPTION
Backport 8ddb4fcbd3fe4d7f2b11afe4316cca4f6c6ca2ec to `4-0-stable`.
Closes #14281.
