### PR TITLE
Force routes to be loaded before eager load.

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -283,6 +283,7 @@ module Rails
     # group is :default
     def initialize!(group=:default) #:nodoc:
       raise "Application has been already initialized." if @initialized
+      config.before_eager_load { |app| app.reload_routes! }
       run_initializers(group, self)
       @initialized = true
       self


### PR DESCRIPTION
Routes will now get loaded before any eager_load.

Fixes #14603.

\cc @rafaelfranca
