### PR TITLE
Change behavior of query_parameters and request_parameters. Now theay ar...

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -13,7 +13,7 @@ module ActionDispatch
       def parameters
         @env["action_dispatch.request.parameters"] ||= begin
           params = begin
-            request_parameters.merge(query_parameters)
+            request_parameters.deep_merge(query_parameters)
           rescue EOFError
             query_parameters.dup
           end

--- a/actionpack/test/dispatch/request/mixed_params_test.rb
+++ b/actionpack/test/dispatch/request/mixed_params_test.rb
@@ -1,0 +1,39 @@
+require 'abstract_unit'
+
+class MixedParamsTest < ActionDispatch::IntegrationTest
+  class TestController < ActionController::Base
+    class << self
+      attr_accessor :last_params
+    end
+
+    def parse
+      self.class.last_params = params.reject { |key| key == 'action'}
+      head :ok
+    end
+  end
+
+  def teardown
+    TestController.last_params = nil
+  end
+
+  test "mixed url_encoded and query string" do
+    with_test_routing do
+      actual = { "user" => { "name" => "vladson" }, "username" => "vb" }
+      expected = { "user" => { "name" => "vladson", 'role' => 'dev' }, "username" => "vb", 'time' => 'adventure_time' }
+      post '/parse', actual, "QUERY_STRING" => "user[role]=dev&time=adventure_time"
+      assert_equal expected, TestController.last_params
+    end
+  end
+
+  private
+
+  def with_test_routing
+    with_routing do |set|
+      set.draw do
+        post ':action', to: ::MixedParamsTest::TestController
+      end
+      yield
+    end
+  end
+
+end


### PR DESCRIPTION
Change request and query params merge strategy. #10208

In case when your query_params share param key with request params, they replace request_params, now they'll deep_merge and maintain structure.
