### PR TITLE
Fix serialized field returning serialized data after update_column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixed serialized fields returning serialized data after being updated with 
+    `update_column`.
+
+    *Simon Hørup Eskildsen*
+
 *   PostgreSQL and SQLite string columns no longer have a default limit of 255.
 
     Fixes #13435, #9153.

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -131,6 +131,14 @@ module ActiveRecord
           end
         end
 
+        def raw_type_cast_attribute_for_write(column, value)
+          if column && coder = self.class.serialized_attributes[column.name]
+            Attribute.new(coder, value, :serialized)
+          else
+            super
+          end
+        end
+
         def _field_changed?(attr, old, value)
           if self.class.serialized_attributes.include?(attr)
             old != value

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -55,6 +55,27 @@ module ActiveRecord
       # specified +value+. Empty strings for fixnum and float columns are
       # turned into +nil+.
       def write_attribute(attr_name, value)
+        write_attribute_with_type_cast(attr_name, value, :type_cast_attribute_for_write)
+      end
+
+      def raw_write_attribute(attr_name, value)
+        write_attribute_with_type_cast(attr_name, value, :raw_type_cast_attribute_for_write)
+      end
+
+      private
+      # Handle *= for method_missing.
+      def attribute=(attribute_name, value)
+        write_attribute(attribute_name, value)
+      end
+
+      def type_cast_attribute_for_write(column, value)
+        return value unless column
+
+        column.type_cast_for_write value
+      end
+      alias_method :raw_type_cast_attribute_for_write, :type_cast_attribute_for_write
+
+      def write_attribute_with_type_cast(attr_name, value, type_cast_method)
         attr_name = attr_name.to_s
         attr_name = self.class.primary_key if attr_name == 'id' && self.class.primary_key
         @attributes_cache.delete(attr_name)
@@ -67,23 +88,10 @@ module ActiveRecord
         end
 
         if column || @attributes.has_key?(attr_name)
-          @attributes[attr_name] = type_cast_attribute_for_write(column, value)
+          @attributes[attr_name] = send(type_cast_method, column, value)
         else
           raise ActiveModel::MissingAttributeError, "can't write unknown attribute `#{attr_name}'"
         end
-      end
-      alias_method :raw_write_attribute, :write_attribute
-
-      private
-      # Handle *= for method_missing.
-      def attribute=(attribute_name, value)
-        write_attribute(attribute_name, value)
-      end
-
-      def type_cast_attribute_for_write(column, value)
-        return value unless column
-
-        column.type_cast_for_write value
       end
     end
   end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -244,4 +244,20 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     type = Topic.column_types["content"]
     assert !type.instance_variable_get("@column").is_a?(ActiveRecord::AttributeMethods::Serialization::Type)
   end
+
+  def test_serialized_column_should_unserialize_after_update_column
+    t = Topic.create(content: "first")
+    assert_equal("first", t.content)
+
+    t.update_column(:content, Topic.serialized_attributes["content"].dump("second"))
+    assert_equal("second", t.content)
+  end
+
+  def test_serialized_column_should_unserialize_after_update_attribute
+    t = Topic.create(content: "first")
+    assert_equal("first", t.content)
+
+    t.update_attribute(:content, "second")
+    assert_equal("second", t.content)
+  end
 end


### PR DESCRIPTION
Fixes the issue reproduced in the first test in `activerecord/test/cases/serialized_attribute_test.rb`.

This is the way the field already behaves after a reload:

``` ruby
t = Topic.create(content: "first")
t.update_column(:content, "second".to_yaml)
t.content
# => "--- second\n...\n"
t.reload.content
# -> "second"
```

I'm a little unsure of the approach in `activerecord/lib/active_record/attribute_methods/write.rb`, if anyone has a better idea I'd love to hear it.
