### PR TITLE
url_options takes precedence over route defaults

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -17,7 +17,7 @@ module ActionDispatch
           rescue EOFError
             query_parameters.dup
           end
-          params.merge!(path_parameters)
+          params.reverse_merge!(path_parameters)
           params.with_indifferent_access
         end
       end

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -27,7 +27,7 @@ module ActionDispatch
           missing_keys = missing_keys(route, parameterized_parts)
           next unless missing_keys.empty?
           params = options.dup.delete_if do |key, _|
-            parameterized_parts.key?(key) || route.defaults.key?(key)
+            parameterized_parts.key?(key) || route.options.key?(key)
           end
 
           return [route.format(parameterized_parts), params]

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -140,7 +140,7 @@ module ActionDispatch
             match_values = match_data.captures.map { |v| v && Utils.unescape_uri(v) }
             info = Hash[match_names.zip(match_values).find_all { |_, y| y }]
 
-            [match_data, r.defaults.merge(info), r]
+            [match_data, r.defaults.merge(r.options).merge(info), r]
           }
         end
 
@@ -153,6 +153,7 @@ module ActionDispatch
                       r.app,
                       r.path,
                       r.conditions.merge(request_method: "HEAD"),
+                      r.options,
                       r.defaults).tap do |route|
                         route.precedence = r.precedence + precedence
                       end

--- a/actionpack/lib/action_dispatch/journey/routes.rb
+++ b/actionpack/lib/action_dispatch/journey/routes.rb
@@ -54,8 +54,8 @@ module ActionDispatch
       end
 
       # Add a route to the routing table.
-      def add_route(app, path, conditions, defaults, name = nil)
-        route = Route.new(name, app, path, conditions, defaults)
+      def add_route(app, path, conditions, options, defaults, name = nil)
+        route = Route.new(name, app, path, conditions, options, defaults)
 
         route.precedence = routes.length
         routes << route

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -112,7 +112,7 @@ module ActionDispatch
 
       def filter_routes(filter)
         if filter
-          @routes.select { |route| route.defaults[:controller] == filter }
+          @routes.select { |route| route.options[:controller] == filter }
         else
           @routes
         end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -56,21 +56,22 @@ module ActionDispatch
         ANCHOR_CHARACTERS_REGEX = %r{\A(\\A|\^)|(\\Z|\\z|\$)\Z}
         WILDCARD_PATH = %r{\*([^/\)]+)\)?$}
 
-        attr_reader :scope, :path, :options, :requirements, :conditions, :defaults
+        attr_reader :scope, :path, :options, :requirements, :conditions, :defaults, :url_options
 
         def initialize(set, scope, path, options)
           @set, @scope, @path, @options = set, scope, path, options
-          @requirements, @conditions, @defaults = {}, {}, {}
+          @requirements, @conditions, @url_options, @defaults = {}, {}, {}, {}
 
           normalize_options!
           normalize_path!
           normalize_requirements!
           normalize_conditions!
           normalize_defaults!
+          normalize_url_options!
         end
 
         def to_route
-          [ app, conditions, requirements, defaults, options[:as], options[:anchor] ]
+          [app, conditions, requirements, url_options, defaults, options[:as], options[:anchor]]
         end
 
         private
@@ -144,27 +145,30 @@ module ActionDispatch
           end
 
           def normalize_defaults!
-            @defaults.merge!(scope[:defaults]) if scope[:defaults]
             @defaults.merge!(options[:defaults]) if options[:defaults]
+          end
+
+          def normalize_url_options!
+            @url_options.merge!(scope[:defaults]) if scope[:defaults]
 
             options.each do |key, default|
               unless Regexp === default || IGNORE_OPTIONS.include?(key)
-                @defaults[key] = default
+                @url_options[key] = default
               end
             end
 
             if options[:constraints].is_a?(Hash)
               options[:constraints].each do |key, default|
                 if URL_OPTIONS.include?(key) && (String === default || Fixnum === default)
-                  @defaults[key] ||= default
+                  @url_options[key] ||= default
                 end
               end
             end
 
             if Regexp === options[:format]
-              @defaults[:format] = nil
+              @url_options[:format] = nil
             elsif String === options[:format]
-              @defaults[:format] = options[:format]
+              @url_options[:format] = options[:format]
             end
           end
 
@@ -293,7 +297,7 @@ module ActionDispatch
           end
 
           def dispatcher
-            Routing::RouteSet::Dispatcher.new(:defaults => defaults)
+            Routing::RouteSet::Dispatcher.new(:defaults => @url_options)
           end
 
           def to
@@ -1464,8 +1468,8 @@ module ActionDispatch
           end
 
           mapping = Mapping.new(@set, @scope, URI.parser.escape(path), options)
-          app, conditions, requirements, defaults, as, anchor = mapping.to_route
-          @set.add_route(app, conditions, requirements, defaults, as, anchor)
+          app, conditions, requirements, url_options, defaults, as, anchor = mapping.to_route
+          @set.add_route(app, conditions, requirements, url_options, defaults, as, anchor)
         end
 
         def root(path, options={})

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -274,9 +274,9 @@ module ActionDispatch
 
         def define_named_route_methods(name, route)
           define_url_helper route, :"#{name}_path",
-            route.defaults.merge(:use_route => name, :only_path => true)
+            route.options.merge(:use_route => name, :only_path => true)
           define_url_helper route, :"#{name}_url",
-            route.defaults.merge(:use_route => name, :only_path => false)
+            route.options.merge(:use_route => name, :only_path => false)
         end
       end
 
@@ -421,7 +421,7 @@ module ActionDispatch
         routes.empty?
       end
 
-      def add_route(app, conditions = {}, requirements = {}, defaults = {}, name = nil, anchor = true)
+      def add_route(app, conditions = {}, requirements = {}, options = {}, defaults = {}, name = nil, anchor = true)
         raise ArgumentError, "Invalid route name: '#{name}'" unless name.blank? || name.to_s.match(/^[_a-z]\w*$/i)
 
         if name && named_routes[name]
@@ -435,7 +435,7 @@ module ActionDispatch
         path = build_path(conditions.delete(:path_info), requirements, SEPARATORS, anchor)
         conditions = build_conditions(conditions, path.names.map { |x| x.to_sym })
 
-        route = @set.add_route(app, path, conditions, defaults, name)
+        route = @set.add_route(app, path, conditions, options, defaults, name)
         named_routes[name] = route if name
         route
       end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -398,6 +398,15 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_url_options_precedence_over_route_defaults
+    with_test_route_set do
+      get '/get_with_params?bar=foobar'
+      assert_equal 'foobar', request.parameters['bar']
+
+      assert_equal 200, status
+    end
+  end
+
   def test_get_with_query_string
     with_test_route_set do
       get '/get_with_params?foo=bar'
@@ -511,7 +520,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
         end
 
         set.draw do
-          match ':action', :to => controller, :via => [:get, :post], :as => :action
+          match ':action', :to => controller, :via => [:get, :post], :as => :action, :defaults => { :bar => 'foo' }
           get 'get/:action', :to => controller, :as => :get_action
         end
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1682,7 +1682,7 @@ class RouteSetTest < ActiveSupport::TestCase
       get ':controller/:action/:id'
     end
 
-    assert_equal '/ibocorp', url_for(set, { :controller => 'ibocorp', :action => "show", :page => 1 })
+    assert_equal '/ibocorp/1', url_for(set, { :controller => 'ibocorp', :action => "show", :page => 1 })
   end
 
   def test_generate_with_optional_params_recalls_last_request

--- a/actionpack/test/journey/route_test.rb
+++ b/actionpack/test/journey/route_test.rb
@@ -6,19 +6,19 @@ module ActionDispatch
       def test_initialize
         app      = Object.new
         path     = Path::Pattern.new '/:controller(/:action(/:id(.:format)))'
-        defaults = {}
-        route    = Route.new("name", app, path, {}, defaults)
+        options  = {}
+        route    = Route.new("name", app, path, {}, options)
 
         assert_equal app, route.app
         assert_equal path, route.path
-        assert_same  defaults, route.defaults
+        assert_same  options, route.options
       end
 
       def test_route_adds_itself_as_memo
         app      = Object.new
         path     = Path::Pattern.new '/:controller(/:action(/:id(.:format)))'
-        defaults = {}
-        route    = Route.new("name", app, path, {}, defaults)
+        options  = {}
+        route    = Route.new("name", app, path, {}, options)
 
         route.ast.grep(Nodes::Terminal).each do |node|
           assert_equal route, node.memo
@@ -83,13 +83,14 @@ module ActionDispatch
 
       def test_score
         constraints = {:required_defaults => [:controller, :action]}
-        defaults = {:controller=>"pages", :action=>"show"}
+        options = { :controller => "pages", :action => "show" }
+        defaults = {}
 
         path = Path::Pattern.new "/page/:id(/:action)(.:format)"
-        specific = Route.new "name", nil, path, constraints, defaults
+        specific = Route.new "name", nil, path, constraints, options, defaults
 
         path = Path::Pattern.new "/:controller(/:action(/:id))(.:format)"
-        generic = Route.new "name", nil, path, constraints
+        generic = Route.new "name", nil, path, constraints, options, defaults
 
         knowledge = {:id=>20, :controller=>"pages", :action=>"show"}
 

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -196,7 +196,7 @@ module ActionDispatch
         route_name = "gorby_thunderhorse"
         pattern = Router::Strexp.new("/foo/:id", { :id => /\d+/ }, ['/', '.', '?'], false)
         path = Path::Pattern.new pattern
-        @router.routes.add_route nil, path, {}, {}, route_name
+        @router.routes.add_route nil, path, {}, {}, {}, route_name
 
         error = assert_raises(ActionController::UrlGenerationError) do
           @formatter.generate(:path_info, route_name, { }, { })
@@ -482,7 +482,7 @@ module ActionDispatch
       def test_recognize_literal
         path   = Path::Pattern.new "/books(/:action(.:format))"
         app    = Object.new
-        route  = @router.routes.add_route(app, path, {}, {:controller => 'books'})
+        route  = @router.routes.add_route(app, path, {}, {:controller => 'books'}, {})
 
         env    = rails_env 'PATH_INFO' => '/books/list.rss'
         expected = { :controller => 'books', :action => 'list', :format => 'rss' }
@@ -502,7 +502,7 @@ module ActionDispatch
         conditions = {
           :request_method => 'GET'
         }
-        @router.routes.add_route(app, path, conditions, {})
+        @router.routes.add_route(app, path, conditions, {}, {})
 
         env = rails_env 'PATH_INFO' => '/books/list.rss',
                         "REQUEST_METHOD"    => "HEAD"
@@ -521,12 +521,12 @@ module ActionDispatch
         conditions = {
           :request_method => 'GET'
         }
-        @router.routes.add_route(app, path, conditions, {})
+        @router.routes.add_route(app, path, conditions, {}, {})
 
         conditions = conditions.dup
         conditions[:request_method] = 'POST'
 
-        post = @router.routes.add_route(app, path, conditions, {})
+        post = @router.routes.add_route(app, path, conditions, {}, {})
 
         env = rails_env 'PATH_INFO' => '/books/list.rss',
                         "REQUEST_METHOD"    => "POST"

--- a/actionpack/test/journey/routes_test.rb
+++ b/actionpack/test/journey/routes_test.rb
@@ -43,8 +43,8 @@ module ActionDispatch
         one   = Path::Pattern.new '/hello'
         two   = Path::Pattern.new '/aaron'
 
-        routes.add_route nil, one, {}, {}, 'aaron'
-        routes.add_route nil, two, {}, {}, 'aaron'
+        routes.add_route nil, one, {}, {}, {}, 'aaron'
+        routes.add_route nil, two, {}, {}, {}, 'aaron'
 
         assert_equal '/hello', routes.named_routes['aaron'].path.spec.to_s
       end


### PR DESCRIPTION
It fixes https://github.com/rails/rails/issues/7144.

We are fixing two related things here: the query string parameter precedence over the route defaults parameters, and the proper url rendering with these default parameters.

Use case:

``` ruby
# routes.rb
get 'test' => 'welcome#index', defaults: { foo: 'foo_default' }
```

Without the fix:

``` ruby
url_for(foo: 'new_foo') # /test

# GET /test?foo=new_foo
params # {"foo"=>"foo_default", "action"=>"index", "controller"=>"welcome"}
```

With the fix:

``` ruby
url_for(foo: 'new_foo') # /test?foo=new_foo

# GET /test?foo=new_foo
params # {"foo"=>"new_foo", "action"=>"index", "controller"=>"welcome"}
```

What we did was distinguish what are the route options and what are the route defaults, thus the provided attribute isn't removed from `url_options` anymore.

Many thanks to @fabioyamate for pairing with me to solve this.
