### PR TITLE
Use SVG version of travis build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We encourage you to contribute to Ruby on Rails! Please check out the
 
 ## Code Status
 
-* [![Build Status](https://travis-ci.org/rails/rails.png?branch=master)](https://travis-ci.org/rails/rails)
+* [![Build Status](https://travis-ci.org/rails/rails.svg?branch=master)](https://travis-ci.org/rails/rails)
 
 ## License
 


### PR DESCRIPTION
SVG advantages:
- Smaller file sizes
- Scales to any size without losing clarity (except very tiny)
- Looks great on retina displays
