### PR TITLE
proof of concept going back in time is diffrent then offsets

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -96,30 +96,19 @@ class Time
   # takes a hash with any of these keys: <tt>:years</tt>, <tt>:months</tt>,
   # <tt>:weeks</tt>, <tt>:days</tt>, <tt>:hours</tt>, <tt>:minutes</tt>,
   # <tt>:seconds</tt>.
-  def advance(options)
-    unless options[:weeks].nil?
-      options[:weeks], partial_weeks = options[:weeks].divmod(1)
-      options[:days] = options.fetch(:days, 0) + 7 * partial_weeks
-    end
+  def advance(date_hash)
+    return self if date_hash.empty?
 
-    unless options[:days].nil?
-      options[:days], partial_days = options[:days].divmod(1)
-      options[:hours] = options.fetch(:hours, 0) + 24 * partial_days
-    end
+    time_in_seconds = 0
+    time_in_seconds += date_hash.fetch(:years, 0) * 1.year
+    time_in_seconds += date_hash.fetch(:months, 0) * 1.month
+    time_in_seconds += date_hash.fetch(:weeks, 0) * 1.week
+    time_in_seconds += date_hash.fetch(:days, 0) * 1.day
+    time_in_seconds += date_hash.fetch(:hours, 0) * 1.hour
+    time_in_seconds += date_hash.fetch(:minutes, 0) * 1.minute
+    time_in_seconds += date_hash.fetch(:seconds, 0)
 
-    d = to_date.advance(options)
-    d = d.gregorian if d.julian?
-    time_advanced_by_date = change(:year => d.year, :month => d.month, :day => d.day)
-    seconds_to_advance = \
-      options.fetch(:seconds, 0) +
-      options.fetch(:minutes, 0) * 60 +
-      options.fetch(:hours, 0) * 3600
-
-    if seconds_to_advance.zero?
-      time_advanced_by_date
-    else
-      time_advanced_by_date.since(seconds_to_advance)
-    end
+    since time_in_seconds
   end
 
   # Returns a new Time representing the time a number of seconds ago, this is basically a wrapper around the Numeric extension

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -406,25 +406,25 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_advance
-    assert_equal Time.local(2006,2,28,15,15,10), Time.local(2005,2,28,15,15,10).advance(:years => 1)
-    assert_equal Time.local(2005,6,28,15,15,10), Time.local(2005,2,28,15,15,10).advance(:months => 4)
+    assert_equal Time.local(2006,2,28,21,15,10), Time.local(2005,2,28,15,15,10).advance(:years => 1)
+    assert_equal Time.local(2005,6,28,16,15,10), Time.local(2005,2,28,15,15,10).advance(:months => 4)
     assert_equal Time.local(2005,3,21,15,15,10), Time.local(2005,2,28,15,15,10).advance(:weeks => 3)
     assert_equal Time.local(2005,3,25,3,15,10), Time.local(2005,2,28,15,15,10).advance(:weeks => 3.5)
     assert_in_delta Time.local(2005,3,26,12,51,10), Time.local(2005,2,28,15,15,10).advance(:weeks => 3.7), 1
     assert_equal Time.local(2005,3,5,15,15,10), Time.local(2005,2,28,15,15,10).advance(:days => 5)
     assert_equal Time.local(2005,3,6,3,15,10), Time.local(2005,2,28,15,15,10).advance(:days => 5.5)
     assert_in_delta Time.local(2005,3,6,8,3,10), Time.local(2005,2,28,15,15,10).advance(:days => 5.7), 1
-    assert_equal Time.local(2012,9,28,15,15,10), Time.local(2005,2,28,15,15,10).advance(:years => 7, :months => 7)
-    assert_equal Time.local(2013,10,3,15,15,10), Time.local(2005,2,28,15,15,10).advance(:years => 7, :months => 19, :days => 5)
-    assert_equal Time.local(2013,10,17,15,15,10), Time.local(2005,2,28,15,15,10).advance(:years => 7, :months => 19, :weeks => 2, :days => 5)
-    assert_equal Time.local(2001,12,27,15,15,10), Time.local(2005,2,28,15,15,10).advance(:years => -3, :months => -2, :days => -1)
-    assert_equal Time.local(2005,2,28,15,15,10), Time.local(2004,2,29,15,15,10).advance(:years => 1) #leap day plus one year
+    assert_equal Time.local(2012,9,26,10,15,10), Time.local(2005,2,28,15,15,10).advance(:years => 7, :months => 7)
+    assert_equal Time.local(2013,9,26,10,15,10), Time.local(2005,2,28,15,15,10).advance(:years => 7, :months => 19, :days => 5)
+    assert_equal Time.local(2013,10,10,10,15,10), Time.local(2005,2,28,15,15,10).advance(:years => 7, :months => 19, :weeks => 2, :days => 5)
+    assert_equal Time.local(2001,12,29,21,15,10), Time.local(2005,2,28,15,15,10).advance(:years => -3, :months => -2, :days => -1)
+    assert_equal Time.local(2005,2,28,21,15,10), Time.local(2004,2,29,15,15,10).advance(:years => 1) #leap day plus one year
     assert_equal Time.local(2005,2,28,20,15,10), Time.local(2005,2,28,15,15,10).advance(:hours => 5)
     assert_equal Time.local(2005,2,28,15,22,10), Time.local(2005,2,28,15,15,10).advance(:minutes => 7)
     assert_equal Time.local(2005,2,28,15,15,19), Time.local(2005,2,28,15,15,10).advance(:seconds => 9)
     assert_equal Time.local(2005,2,28,20,22,19), Time.local(2005,2,28,15,15,10).advance(:hours => 5, :minutes => 7, :seconds => 9)
     assert_equal Time.local(2005,2,28,10,8,1), Time.local(2005,2,28,15,15,10).advance(:hours => -5, :minutes => -7, :seconds => -9)
-    assert_equal Time.local(2013,10,17,20,22,19), Time.local(2005,2,28,15,15,10).advance(:years => 7, :months => 19, :weeks => 2, :days => 5, :hours => 5, :minutes => 7, :seconds => 9)
+    assert_equal Time.local(2013,10,10,15,22,19), Time.local(2005,2,28,15,15,10).advance(:years => 7, :months => 19, :weeks => 2, :days => 5, :hours => 5, :minutes => 7, :seconds => 9)
   end
 
   def test_utc_advance


### PR DESCRIPTION
I have a questions about time and dates.  I wrote a proof of concept and wanted to see if I my concern is valid.  
With Active Support going forward or back in time seems to not go back a specified amount of time but go back a semantic amount to time.
example.
Time.new(2006,2,28,15,15,10).forward_one_year => 2006 to 2007
not
Time.new(2006,2,28,15,15,10).forward_one_year => + 31557600 sec

This does not account for leap years, or any variations in time.
Should using this library mean going forward 7 years mean a change in the current year by 7 or adding the equivalent of 7 years?

There are gaps in the code where going forward or back wads a year means different things I think.
First off is there a convention I am missing regarding time?  I have not used many other libraries regarding time but the ones I have used mostly add seconds.

Some help understanding this would be great.  I am willing to work on a pull request I just wanted to make sure I am on the right track.
