### PR TITLE
Always escape string passed to url helper.

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -29,7 +29,7 @@ module ActionDispatch
           # Symbol captures can generate multiple path segments, so include /.
           reserved_segment  = '/'
           reserved_fragment = '/?'
-          reserved_pchar    = ':@&=+$,;%'
+          reserved_pchar    = ':@&=+$,;'
 
           safe_pchar    = "#{URI::REGEXP::PATTERN::UNRESERVED}#{reserved_pchar}"
           safe_segment  = "#{safe_pchar}#{reserved_segment}"

--- a/actionpack/test/journey/router/utils_test.rb
+++ b/actionpack/test/journey/router/utils_test.rb
@@ -5,11 +5,11 @@ module ActionDispatch
     class Router
       class TestUtils < ActiveSupport::TestCase
         def test_path_escape
-          assert_equal "a/b%20c+d", Utils.escape_path("a/b c+d")
+          assert_equal "a/b%20c+d%25", Utils.escape_path("a/b c+d%")
         end
 
         def test_fragment_escape
-          assert_equal "a/b%20c+d?e", Utils.escape_fragment("a/b c+d?e")
+          assert_equal "a/b%20c+d%25?e", Utils.escape_fragment("a/b c+d%?e")
         end
 
         def test_uri_unescape


### PR DESCRIPTION
Makes it clear that anything passed with the helper must not be percent encoded.

Fixes previous behavior which tricks people into believing passing non-percent-encoded will generate a proper percent-encoded path while in reality it won't ('%' isn't escaped).

The intention is nice but the heuristic is broken. As of current implementation, passing a string for `:id` or anything part of path requires either `id.gsub('%', '%25')` or `URI.encode(id)` otherwise the generated url might be broken.

I can think of three possible solutions:
1. this one
2. assume everything is percent-encoded
3. try decoding the string and encode if decoding fails

Sorry for reporting this at bad timing.

Current state:

```
irb(main):004:0> paste_id = "100% testing"
=> "100% testing"

# broken
irb(main):005:0> Rails.application.routes.url_helpers.paste_path(paste_id)
=> "/100%%20testing"

# slightly redundant encode here since the helper will do another encode
# (except the percent part, of course)
irb(main):006:0> Rails.application.routes.url_helpers.paste_path(URI.encode paste_id)
=> "/100%25%20testing"

# ugly, confusing thanks to seemingly random gsub
irb(main):007:0> Rails.application.routes.url_helpers.paste_path(paste_id.gsub '%', '%25')
=> "/100%25%20testing"
```
