### PR TITLE
Use connection-specific bytea escaping

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -4,14 +4,14 @@ module ActiveRecord
       module Quoting
         # Escapes binary strings for bytea input to the database.
         def escape_bytea(value)
-          PGconn.escape_bytea(value) if value
+          @connection.escape_bytea(value) if value
         end
 
         # Unescapes bytea output from a database to the binary string it represents.
         # NOTE: This is NOT an inverse of escape_bytea! This is only to be used
         # on escaped binary output from database drive.
         def unescape_bytea(value)
-          PGconn.unescape_bytea(value) if value
+          @connection.unescape_bytea(value) if value
         end
 
         # Quotes PostgreSQL-specific data types for SQL input.


### PR DESCRIPTION
In our normal usage, it's rare for this to make a difference... but is more technically correct:

> PQescapeBytea can only be used safely in client programs that use a single PostgreSQL connection at a time (in this case it can find out what it needs to know "behind the scenes"). It **might give the wrong results** if used in programs that use multiple database connections

(emphasis in [original](http://www.postgresql.org/docs/9.3/interactive/libpq-exec.html))

Per discussion on #7589.

The same concerns don't apply to `unescape_bytea`, but as `pg` provides it, we might as well use it for symmetry.

@senny
