### PR TITLE
Only apply DATABASE_URL for Rails.env

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -33,7 +33,7 @@ module ActiveRecord
         def initialize(url)
           raise "Database URL cannot be empty" if url.blank?
           @uri     = URI.parse(url)
-          @adapter = @uri.scheme
+          @adapter = @uri.scheme.gsub('-', '_')
           @adapter = "postgresql" if @adapter == "postgres"
 
           if @uri.opaque

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -220,10 +220,10 @@ module ActiveRecord
           # an environment key or a URL spec, so we have deprecated
           # this ambiguous behaviour and in the future this function
           # can be removed in favor of resolve_url_connection.
-          if configurations.key?(spec)
+          if configurations.key?(spec) || spec !~ /:/
             ActiveSupport::Deprecation.warn "Passing a string to ActiveRecord::Base.establish_connection " \
               "for a configuration lookup is deprecated, please pass a symbol (#{spec.to_sym.inspect}) instead"
-            resolve_connection(configurations[spec])
+            resolve_symbol_connection(spec)
           else
             resolve_url_connection(spec)
           end

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -70,10 +70,13 @@ module ActiveRecord
 
       private
         def config
+          env = DEFAULT_ENV.call.to_s
+
           cfg = Hash.new do |hash, key|
             entry = @raw_config[key]
             env_url = nil
-            if key.to_s == DEFAULT_ENV.call.to_s
+
+            if key.to_s == env
               env_url = ENV["DATABASE_URL"]
             end
             env_url ||= ENV["DATABASE_URL_#{key.upcase}"]
@@ -83,7 +86,7 @@ module ActiveRecord
           end
 
           @raw_config.keys.each {|k| cfg[k] }
-          cfg[DEFAULT_ENV.call.to_s]
+          cfg[env]
 
           cfg
         end

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -78,7 +78,7 @@ module ActiveRecord
             end
             env_url ||= ENV["DATABASE_URL_#{key.upcase}"]
             entry ||= {} if env_url
-            entry.merge!("url" => env_url) { |h, v1, v2| v1 || v2 } if entry.is_a?(Hash)
+            entry.merge!("url" => env_url) { |h, v1, v2| v1 || v2 } if entry.is_a?(Hash) && env_url
             hash[key] = entry if entry
           end
 

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -84,7 +84,7 @@ module ActiveRecord
 
             if env_url
               entry ||= {}
-              entry.merge!("url" => env_url) { |h, v1, v2| v1 || v2 } if entry.is_a?(Hash)
+              entry.merge!("url" => env_url) { |h, v1, v2| v1 || v2 }
             end
 
             hash[key] = entry if entry

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -79,9 +79,14 @@ module ActiveRecord
             if key.to_s == env
               env_url = ENV["DATABASE_URL"]
             end
+
             env_url ||= ENV["DATABASE_URL_#{key.upcase}"]
-            entry ||= {} if env_url
-            entry.merge!("url" => env_url) { |h, v1, v2| v1 || v2 } if entry.is_a?(Hash) && env_url
+
+            if env_url
+              entry ||= {}
+              entry.merge!("url" => env_url) { |h, v1, v2| v1 || v2 } if entry.is_a?(Hash)
+            end
+
             hash[key] = entry if entry
           end
 

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -73,22 +73,8 @@ module ActiveRecord
         def config
           @raw_config.dup.tap do |cfg|
             if url = ENV['DATABASE_URL']
-              if cfg[@env]
-                if cfg[@env]["url"]
-                  # Nothing to do
-                else
-                  ActiveSupport::Deprecation.warn "Overriding database configuration with DATABASE_URL without using an ERB tag in database.yml is deprecated. Please update the entry for #{@env.inspect}:\n\n" \
-                    "  #{@env}:\n    url: <%= ENV['DATABASE_URL'] %>\n\n"\
-                    "This will be required in Rails 4.2"
-                  cfg[@env]["url"] = url
-                end
-              else
-                cfg[@env] = {}
-                ActiveSupport::Deprecation.warn "Supplying DATABASE_URL without a matching entry in database.yml is deprecated. Please add an entry for #{@env.inspect}:\n\n" \
-                  "  #{@env}:\n    url: <%= ENV['DATABASE_URL'] %>\n\n"\
-                  "This will be required in Rails 4.2"
-                cfg[@env]["url"] ||= url
-              end
+              cfg[@env] ||= {}
+              cfg[@env]["url"] ||= url
             end
           end
         end

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -45,6 +45,15 @@ module ActiveRecord
         assert_equal expected, actual
       end
 
+      def test_resolver_with_environment_database_uri_and_global_database_uri_and_current_env_symbol_key
+        ENV['DATABASE_URL'] = "postgres://localhost/foo"
+        ENV['DATABASE_URL_DEFAULT_ENV'] = "mysql://host/foo_bar"
+        config   = { "default_env" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
+        actual   = resolve(:default_env, config)
+        expected = { "adapter"=>"postgresql", "database"=>"foo", "host"=>"localhost" }
+        assert_equal expected, actual
+      end
+
       def test_resolver_with_database_uri_and_and_current_env_string_key
         ENV['DATABASE_URL'] = "postgres://localhost/foo"
         config   = { "default_env" => {  "adapter" => "not_postgres", "database" => "not_foo" } }

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -70,6 +70,14 @@ module ActiveRecord
         assert_equal expected, actual
       end
 
+      def test_resolver_with_custom_database_uri_and_no_matching_config
+        ENV['DATABASE_URL_PRODUCTION'] = "postgres://localhost/foo"
+        config   = {}
+        actual   = resolve(:production, config)
+        expected = { "adapter"=>"postgresql", "database"=>"foo", "host"=>"localhost" }
+        assert_equal expected, actual
+      end
+
       def test_resolver_with_custom_database_uri_and_custom_key
         ENV['DATABASE_URL_PRODUCTION'] = "postgres://localhost/foo"
         config   = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
@@ -116,6 +124,19 @@ module ActiveRecord
         actual      = klass.new(config).resolve
         expect_prod = { "adapter"=>"postgresql", "database"=>"foo", "host"=>"localhost" }
         assert_equal expect_prod, actual["default_env"]
+      end
+
+      def test_environment_key_available_immediately
+        ENV['DATABASE_URL_PRODUCTION'] = "postgres://localhost/foo"
+        config   = {}
+        actual   = klass.new(config).resolve
+        expected = { "production" =>
+                     { "adapter"  => "postgresql",
+                       "database" => "foo",
+                       "host"     => "localhost"
+                     }
+                   }
+        assert_equal expected, actual
       end
 
       def test_string_connection

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -89,6 +89,14 @@ module ActiveRecord
         assert_equal expect_prod, actual["default_env"]
       end
 
+      def test_url_with_hyphenated_scheme
+        ENV['DATABASE_URL'] = "ibm-db://localhost/foo"
+        config   = { "default_env" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
+        actual   = resolve(:default_env, config)
+        expected = { "adapter"=>"ibm_db", "database"=>"foo", "host"=>"localhost" }
+        assert_equal expected, actual
+      end
+
       def test_string_connection
         config   = { "default_env" => "postgres://localhost/foo" }
         actual   = klass.new(config).resolve

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -89,8 +89,10 @@ module ActiveRecord
       def test_resolver_with_database_uri_and_unknown_string_key
         ENV['DATABASE_URL'] = "postgres://localhost/foo"
         config   = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
-        assert_raises AdapterNotSpecified do
-          spec("production", config)
+        assert_deprecated do
+          assert_raises AdapterNotSpecified do
+            spec("production", config)
+          end
         end
       end
 

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -28,7 +28,7 @@ module ActiveRecord
       def test_resolver_with_database_uri_and_current_env_symbol_key
         ENV['DATABASE_URL'] = "postgres://localhost/foo"
         config   = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
-        actual   = assert_deprecated { resolve(:default_env, config) }
+        actual   = resolve(:default_env, config)
         expected = { "adapter"=>"postgresql", "database"=>"foo", "host"=>"localhost" }
         assert_equal expected, actual
       end
@@ -44,7 +44,7 @@ module ActiveRecord
       def test_resolver_with_database_uri_and_known_key
         ENV['DATABASE_URL'] = "postgres://localhost/foo"
         config   = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
-        actual   = assert_deprecated { resolve(:production, config) }
+        actual   = resolve(:production, config)
         expected = { "adapter"=>"not_postgres", "database"=>"not_foo", "host"=>"localhost" }
         assert_equal expected, actual
       end
@@ -52,10 +52,8 @@ module ActiveRecord
       def test_resolver_with_database_uri_and_unknown_symbol_key
         ENV['DATABASE_URL'] = "postgres://localhost/foo"
         config   = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
-        assert_deprecated do
-          assert_raises AdapterNotSpecified do
-            resolve(:production, config)
-          end
+        assert_raises AdapterNotSpecified do
+          resolve(:production, config)
         end
       end
 
@@ -72,7 +70,7 @@ module ActiveRecord
       def test_resolver_with_database_uri_and_supplied_url
         ENV['DATABASE_URL'] = "not-postgres://not-localhost/not_foo"
         config   = { "production" => {  "adapter" => "also_not_postgres", "database" => "also_not_foo" } }
-        actual   = assert_deprecated { resolve("postgres://localhost/foo", config) }
+        actual   = resolve("postgres://localhost/foo", config)
         expected = { "adapter"=>"postgresql", "database"=>"foo", "host"=>"localhost" }
         assert_equal expected, actual
       end
@@ -86,7 +84,7 @@ module ActiveRecord
       def test_environment_does_not_exist_in_config_url_does_exist
         ENV['DATABASE_URL'] = "postgres://localhost/foo"
         config      = { "not_default_env" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
-        actual      = assert_deprecated { klass.new(config).resolve }
+        actual      = klass.new(config).resolve
         expect_prod = { "adapter"=>"postgresql", "database"=>"foo", "host"=>"localhost" }
         assert_equal expect_prod, actual["default_env"]
       end
@@ -131,7 +129,7 @@ module ActiveRecord
         ENV['DATABASE_URL'] = "postgres://localhost/foo"
 
         config   = {}
-        actual   = assert_deprecated { klass.new(config).resolve }
+        actual   = klass.new(config).resolve
         expected = { "adapter"  => "postgresql",
                      "database" => "foo",
                      "host"     => "localhost" }
@@ -162,7 +160,7 @@ module ActiveRecord
         ENV['DATABASE_URL'] = "postgres://localhost/foo"
 
         config   = {"default_env" => { "pool" => "5" } }
-        actual   = assert_deprecated { klass.new(config).resolve }
+        actual   = klass.new(config).resolve
         expected = { "default_env" =>
                      { "adapter"  => "postgresql",
                        "database" => "foo",
@@ -177,7 +175,7 @@ module ActiveRecord
         ENV['DATABASE_URL'] = "postgres://localhost/foo"
 
         config   = {"default_env" => { "adapter" => "NOT-POSTGRES", "database" => "NOT-FOO", "pool" => "5" } }
-        actual   = assert_deprecated { klass.new(config).resolve }
+        actual   = klass.new(config).resolve
         expected = { "default_env" =>
                      { "adapter"  => "postgresql",
                        "database" => "foo",

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/frontbase.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/frontbase.yml
@@ -23,7 +23,27 @@ test:
   <<: *default
   database: <%= app_name %>_test
 
-# Do not keep production credentials in the repository,
-# instead read the configuration from the environment.
+# As with config/secrets.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="frontbase://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%%= ENV['DATABASE_URL'] %>
+#
 production:
-  url: <%%= ENV["DATABASE_URL"] %>
+  <<: *default
+  database: <%= app_name %>_production
+  username: <%= app_name %>
+  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
@@ -61,7 +61,27 @@ test:
   <<: *default
   database: <%= app_name[0,4] %>_tst
 
-# Do not keep production credentials in the repository,
-# instead read the configuration from the environment.
+# As with config/secrets.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="ibm-db://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%%= ENV['DATABASE_URL'] %>
+#
 production:
-  url: <%%= ENV["DATABASE_URL"] %>
+  <<: *default
+  database: <%= app_name %>_production
+  username: <%= app_name %>
+  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
@@ -53,7 +53,16 @@ test:
   <<: *default
   url: jdbc:db://localhost/<%= app_name %>_test
 
-# Do not keep production credentials in the repository,
-# instead read the configuration from the environment.
+# As with config/secrets.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
 production:
-  url: <%%= ENV["DATABASE_URL"] %>
+  url: jdbc:db://localhost/<%= app_name %>_production
+  username: <%= app_name %>
+  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
@@ -26,6 +26,27 @@ test:
   <<: *default
   database: <%= app_name %>_test
 
-# Do not keep production credentials in the repository,
-# instead read the configuration from the environment.
-production: <%%= ENV["DATABASE_URL"] %>
+# As with config/secrets.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="mysql://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%%= ENV['DATABASE_URL'] %>
+#
+production:
+  <<: *default
+  database: <%= app_name %>_production
+  username: <%= app_name %>
+  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
@@ -42,7 +42,27 @@ test:
   <<: *default
   database: <%= app_name %>_test
 
-# Do not keep production credentials in the repository,
-# instead read the configuration from the environment.
+# As with config/secrets.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%%= ENV['DATABASE_URL'] %>
+#
 production:
-  url: <%%= ENV["DATABASE_URL"] %>
+  <<: *default
+  database: <%= app_name %>_production
+  username: <%= app_name %>
+  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
@@ -18,7 +18,6 @@ test:
   <<: *default
   database: db/test.sqlite3
 
-# Do not keep production credentials in the repository,
-# instead read the configuration from the environment.
 production:
-  url: <%%= ENV["DATABASE_URL"] %>
+  <<: *default
+  database: db/production.sqlite3

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
@@ -32,11 +32,27 @@ test:
   <<: *default
   database: <%= app_name %>_test
 
-# Avoid production credentials in the repository,
-# instead read the configuration from the environment.
+# As with config/secrets.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
 #
-# Example:
-#   mysql2://myuser:mypass@localhost/somedatabase
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="mysql2://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%%= ENV['DATABASE_URL'] %>
 #
 production:
-  url: <%%= ENV["DATABASE_URL"] %>
+  <<: *default
+  database: <%= app_name %>_production
+  username: <%= app_name %>
+  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
@@ -32,7 +32,27 @@ test:
   <<: *default
   database: <%= app_name %>_test
 
-# Do not keep production credentials in the repository,
-# instead read the configuration from the environment.
+# As with config/secrets.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="oracle://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%%= ENV['DATABASE_URL'] %>
+#
 production:
-  url: <%%= ENV["DATABASE_URL"] %>
+  <<: *default
+  database: <%= app_name %>_production
+  username: <%= app_name %>
+  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
@@ -59,11 +59,27 @@ test:
   <<: *default
   database: <%= app_name %>_test
 
-# Do not keep production credentials in the repository,
-# instead read the configuration from the environment.
+# As with config/secrets.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
 #
-# Example:
-#   postgres://myuser:mypass@localhost/somedatabase
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%%= ENV['DATABASE_URL'] %>
 #
 production:
-  url: <%%= ENV["DATABASE_URL"] %>
+  <<: *default
+  database: <%= app_name %>_production
+  username: <%= app_name %>
+  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml
@@ -20,13 +20,6 @@ test:
   <<: *default
   database: db/test.sqlite3
 
-# Do not keep production credentials in the repository,
-# instead read the configuration from the environment.
-#
-# Examples:
-#   sqlite3::memory:
-#   sqlite3:db/production.sqlite3
-#   sqlite3:/full/path/to/database.sqlite3
-#
 production:
-  url: <%%= ENV["DATABASE_URL"] %>
+  <<: *default
+  database: db/production.sqlite3

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
@@ -42,7 +42,27 @@ test:
   <<: *default
   database: <%= app_name %>_test
 
-# Do not keep production credentials in the repository,
-# instead read the configuration from the environment.
+# As with config/secrets.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="sqlserver://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%%= ENV['DATABASE_URL'] %>
+#
 production:
-  url: <%%= ENV["DATABASE_URL"] %>
+  <<: *default
+  database: <%= app_name %>_production
+  username: <%= app_name %>
+  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
As we like ENV vars, also support DATABASE_URL_#{env}, for more obscure use cases.

This needs more tests:
- There's nothing about the 'DATABASE_URL_FOO' handling
- And nothing showing that a normally-configured "foo" is unaffected by the DATABASE_URL (unless our current env is called 'foo')

Also, the `config` method could probably look substantially less awful.
#14616 // @rafaelfranca
