### PR TITLE
Refactored ActiveRecord Constants into ActiveRecord_Internals

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -11,6 +11,10 @@ module ActiveRecord
 
       def initialize_relation_delegate_cache # :nodoc:
         @relation_delegate_cache = cache = {}
+        
+        internals = Module.new
+        const_set :CachedActiveRecordInternals, internals
+        
         [
           ActiveRecord::Relation,
           ActiveRecord::Associations::CollectionProxy,
@@ -19,7 +23,7 @@ module ActiveRecord
           delegate = Class.new(klass) {
             include ClassSpecificRelation
           }
-          const_set klass.name.gsub('::', '_'), delegate
+          internals.send :const_set, klass.name.gsub('::', '_'), delegate
           cache[klass] = delegate
         end
       end


### PR DESCRIPTION
Such that if you have an object User < ActiveRecord::Base and look at User.constants(false), rather than displaying all public constants, it yields User::ActiveRecord_Internals, which has those constants inside it
