### PR TITLE
use links in routes view

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_route.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_route.html.erb
@@ -8,7 +8,11 @@
     <%= route[:verb] %>
   </td>
   <td data-route-path='<%= route[:path] %>' data-regexp='<%= route[:regexp] %>'>
-    <%= route[:path] %>
+    <% if route[:linkable] %>
+      <a href="<%= ActionDispatch::Http::URL.url_for(route[:options].merge(only_path: true)) %>"><%= route[:path] %></a>
+    <% else %>
+      <%= route[:path] %>
+    <% end %>
   </td>
   <td data-route-reqs='<%= route[:reqs] %>'>
     <%= route[:reqs] %>

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -126,11 +126,13 @@ module ActionDispatch
         end.collect do |route|
           collect_engine_routes(route)
 
-          { name:   route.name,
-            verb:   route.verb,
-            path:   route.path,
-            reqs:   route.reqs,
-            regexp: route.json_regexp }
+          { name:     route.name,
+            verb:     route.verb,
+            path:     route.path,
+            options:  route.defaults,
+            linkable: route.required_parts.empty? && route.verb == "GET",
+            reqs:     route.reqs,
+            regexp:   route.json_regexp }
         end
       end
 


### PR DESCRIPTION
use links on the 'Routing Error Page' for URL's that down't have required parameters
