### PR TITLE
Updates the maintenance policy with new Rails versions

### DIFF
--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -2,4 +2,8 @@
 
     *Alex Riabov*
 
+*   Updates the maintenance policy to match the latest versions of Rails
+
+    *Matias Korhonen*
+
 Please check [4-1-stable](https://github.com/rails/rails/blob/4-1-stable/guides/CHANGELOG.md) for previous changes.

--- a/guides/source/maintenance_policy.md
+++ b/guides/source/maintenance_policy.md
@@ -20,7 +20,7 @@ Only the latest release series will receive bug fixes. When enough bugs are
 fixed and its deemed worthy to release a new gem, this is the branch it happens
 from.
 
-**Currently included series:** 4.0.z
+**Currently included series:** 4.1.z, 4.0.z
 
 Security Issues
 ---------------
@@ -35,7 +35,7 @@ be built from 1.2.2, and then added to the end of 1-2-stable. This means that
 security releases are easy to upgrade to if you're running the latest version
 of Rails.
 
-**Currently included series:** 4.0.z, 3.2.z
+**Currently included series:** 4.1.z, 4.0.z
 
 Severe Security Issues
 ----------------------
@@ -44,7 +44,7 @@ For severe security issues we will provide new versions as above, and also the
 last major release series will receive patches and new versions. The
 classification of the security issue is judged by the core team.
 
-**Currently included series:** 4.0.z, 3.2.z
+**Currently included series:** 4.1.z, 4.0.z, 3.2.z
 
 Unsupported Release Series
 --------------------------


### PR DESCRIPTION
I updated the Rails Guides maintenance policy to reflect the release of Rails 4.1.0.

I hope I got the version numbers right, but I'll be happy to amend my pull request if I didn't. For what it's worth, this seemed to be the result that the policy describes, unless I'm very confused.
