### PR TITLE
Make `NilClass` quack like `to_s` formattable objects

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -3,6 +3,13 @@ require 'active_support/inflector/methods'
 require 'active_support/core_ext/date/zones'
 require 'active_support/core_ext/module/remove_method'
 
+class NilClass
+  # Returns +""+.
+  def to_s(*args)
+    ""  
+  end
+end
+
 class Date
   DATE_FORMATS = {
     :short        => '%e %b',

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -26,6 +26,7 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     assert_equal "2005-02-21",          date.to_s(:db)
     assert_equal "21 Feb 2005",         date.to_s(:rfc822)
     assert_equal "2005-02-21",          date.to_s(:iso8601)
+    assert_equal "",                    nil.to_s(:short)
   end
 
   def test_readable_inspect
@@ -384,4 +385,3 @@ class DateExtBehaviorTest < ActiveSupport::TestCase
     end
   end
 end
-


### PR DESCRIPTION
`nil` would ignore arguments for `to_s` in order to quack like Date objects (and other objects whose `to_s` accepts a format).

``` ruby
date = nil
date.to_s              #=> ""
date.to_s(:short)      #=> ""
date.to_s(:long)       #=> ""
```
