### PR TITLE
Fixed problem where `1.day.eql?(1.day)` is false

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,37 @@
+*   Fixed `ActiveSupport::Duration#eql?` so that `1.second.eql?(1.second)` is
+    true.
+
+    This fixes the current situation of:
+
+        1.second.eql?(1.second) #=> false
+
+    `eql?` also requires that the other object is an `ActiveSupport::Duration`.
+    This requirement makes `ActiveSupport::Duration`'s behavior consistent with
+    the behavior of Ruby's numeric types:
+
+        1.eql?(1.0) #=> false
+        1.0.eql?(1) #=> false
+
+        1.second.eql?(1) #=> false (was true)
+        1.eql?(1.second) #=> false
+
+        { 1 => "foo", 1.0 => "bar" }
+        #=> { 1 => "foo", 1.0 => "bar" }
+
+        { 1 => "foo", 1.second => "bar" }
+        # now => { 1 => "foo", 1.second => "bar" }
+        # was => { 1 => "bar" }
+
+    And though the behavior of these hasn't changed, for reference:
+
+        1 == 1.0 #=> true
+        1.0 == 1 #=> true
+
+        1 == 1.second #=> true
+        1.second == 1 #=> true
+
+    *Emily Dobervich*
+
 *   `ActiveSupport::SafeBuffer#prepend` acts like `String#prepend` and modifies
     instance in-place, returning self. `ActiveSupport::SafeBuffer#prepend!` is
     deprecated.

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -49,6 +49,10 @@ module ActiveSupport
       end
     end
 
+    def eql?(other)
+      other.is_a?(Duration) && self == other
+    end
+
     def self.===(other) #:nodoc:
       other.is_a?(Duration)
     rescue ::NoMethodError

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -31,6 +31,13 @@ class DurationTest < ActiveSupport::TestCase
     assert !(1.day == 'foo')
   end
 
+  def test_eql
+    assert 1.minute.eql?(1.minute)
+    assert 2.days.eql?(48.hours)
+    assert !1.second.eql?(1)
+    assert !1.eql?(1.second)
+  end
+
   def test_inspect
     assert_equal '0 seconds',                       0.seconds.inspect
     assert_equal '1 month',                         1.month.inspect


### PR DESCRIPTION
This fixes:
    1.second.eql?(1.second) #=> false

The new `eql?` requires that `other` is an `ActiveSupport::Duration`.
This requirement makes `ActiveSupport::Duration`'s behavior consistent
with other numeric types in Ruby.

```
1.eql?(1.0) #=> false
1.0.eql?(1) #=> false

1.second.eql?(1) #=> false (was true)
1.eql?(1.second) #=> false

{ 1 => "foo", 1.0 => "bar" }
#=> { 1 => "foo", 1.0 => "bar" }

{ 1 => "foo", 1.second => "bar" }
# now => { 1 => "foo", 1.second => "bar" }
# was => { 1 => "bar" }
```

And though the behavior here hasn't changed, for reference:

```
1 == 1.0 #=> true
1.0 == 1 #=> true

1 == 1.second #=> true
1.second == 1 #=> true
```
