### PR TITLE
Expand explanation of how to set secrets.yml.

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -79,12 +79,15 @@ secrets, you need to:
       secret_key_base:
 
     production:
-      secret_key_base:
+      secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
     ```
 
-2. Copy the existing `secret_key_base` from the `secret_token.rb` initializer to
-   `secrets.yml` under the `production` section.
-
+2. Use your existing `secret_key_base` from the `secret_token.rb` initializer to
+   set the SECRET_KEY_BASE environment variable for whichever users run the Rails
+   app in production mode. Alternately, you can simply copy the existing 
+   `secret_key_base` from the `secret_token.rb` initializer to `secrets.yml` 
+   under the `production` section, replacing '<%= ENV["SECRET_KEY_BASE"] %>'.
+   
 3. Remove the `secret_token.rb` initializer.
 
 4. Use `rake secret` to generate new keys for the `development` and `test` sections.


### PR DESCRIPTION
The guide for upgrading to Rails 4.1.0 suggests copying the existing secret_key_base from the secret_token.rb initializer to secrets.yml under the production section. This is considered insecure by default in Rails 4.1.0, which generates a secrets.yml containing <%= ENV["SECRET_KEY_BASE"] %> for production mode:

```
production:
  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
```

This expanded explanation shows both ways of setting secret_key for production mode.
