### PR TITLE
Add arel_table alias t

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -151,6 +151,8 @@ module ActiveRecord
         @arel_table ||= Arel::Table.new(table_name, arel_engine)
       end
 
+      alias_method :t, :arel_table
+
       # Returns the Arel engine.
       def arel_engine # :nodoc:
         @arel_engine ||=

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -79,6 +79,10 @@ module ActiveRecord
       assert_equal({}, relation.where_values_hash)
     end
 
+    def test_arel_table_alias
+      assert_equal Post.t, Post.arel_table
+    end
+
     def test_table_name_delegates_to_klass
       relation = Relation.new FakeKlass.new('posts'), :b
       assert_equal 'posts', relation.table_name


### PR DESCRIPTION
We use `arel_table` almost like a DSL, so this just quiets the repetitive `arel_table` references in long arel queries.

The following are now the same:

``` ruby
arel_table[:some_column].lt(arel_table[:other_column])
t[:some_column].lt(t[:other_column])
```
