### PR TITLE
String to date conversions use current century

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,10 @@
+*   `String#to_date` and `String#to_datetime` now default to current century
+    when converting 2 digit years.
+
+    *Kyle Macey*
+
 *   Fixed `ActiveSupport::Cache::FileStore` exploding with long paths.
-    *Adam Panzer / Michael Grosser* 
+    *Adam Panzer / Michael Grosser*
 
 *   Fixed `ActiveSupport::TimeWithZone#-` so precision is not unnecessarily lost
     when working with objects with a nanosecond component.
@@ -24,12 +29,12 @@
 *   Fixed precision error in NumberHelper when using Rationals.
 
     Before:
-        
+
         ActiveSupport::NumberHelper.number_to_rounded Rational(1000, 3), precision: 2
         #=> "330.00"
-    
+
     After:
-    
+
         ActiveSupport::NumberHelper.number_to_rounded Rational(1000, 3), precision: 2
         #=> "333.33"
 

--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -41,7 +41,7 @@ class String
   #   "2012-12-13".to_date # => Thu, 13 Dec 2012
   #   "12/13/2012".to_date # => ArgumentError: invalid date
   def to_date
-    ::Date.parse(self, false) unless blank?
+    ::Date.parse(self) unless blank?
   end
 
   # Converts a string to a DateTime value.
@@ -51,6 +51,6 @@ class String
   #   "2012-12-13 12:50".to_datetime    # => Thu, 13 Dec 2012 12:50:00 +0000
   #   "12/13/2012".to_datetime          # => ArgumentError: invalid date
   def to_datetime
-    ::DateTime.parse(self, false) unless blank?
+    ::DateTime.parse(self) unless blank?
   end
 end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -510,6 +510,7 @@ class StringConversionsTest < ActiveSupport::TestCase
 
   def test_string_to_datetime
     assert_equal DateTime.civil(2039, 2, 27, 23, 50), "2039-02-27 23:50".to_datetime
+    assert_equal DateTime.civil(2039, 2, 27, 23, 50), "39-02-27 23:50".to_datetime
     assert_equal 0, "2039-02-27 23:50".to_datetime.offset # use UTC offset
     assert_equal ::Date::ITALY, "2039-02-27 23:50".to_datetime.start # use Ruby's default start value
     assert_equal DateTime.civil(2039, 2, 27, 23, 50, 19 + Rational(275038, 1000000), "-04:00"), "2039-02-27T23:50:19.275038-04:00".to_datetime
@@ -524,6 +525,7 @@ class StringConversionsTest < ActiveSupport::TestCase
 
   def test_string_to_date
     assert_equal Date.new(2005, 2, 27), "2005-02-27".to_date
+    assert_equal Date.new(2005, 2, 27), "05-02-27".to_date
     assert_nil "".to_date
     assert_equal Date.new(Date.today.year, 2, 3), "Feb 3rd".to_date
   end


### PR DESCRIPTION
Previously, converting a String to Date with a 2 digit year would assume a year
between AD00 and AD99. As most software does not deal with these years, and it
is unlikely that this is considered expected behavior, `String#to_date` and
`String#to_datetime` now use the same defaults as `Date#parse`.
