### PR TITLE
Add missing require so requiring `active_support/cache` works again.

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/object/duplicable'
 require 'active_support/core_ext/string/inflections'
+require 'active_support/per_thread_registry'
 
 module ActiveSupport
   module Cache


### PR DESCRIPTION
Previously, requiring `active_support/cache` was enough to use any of the cache stores that Active Support provides, but on `4.1.0` you get a `NameError` on the missing `ActiveSupport::PerThreadRegistry` constant.

``` ruby
gem 'activesupport', '4.0.4' # 4.1.0 goes :boom:
require 'active_support/cache'
ActiveSupport::Cache.lookup_store(:null_store)
```

I just added require in the similar way as it is required in other internals of AS (like when requiring `active_support/notifications`).

:smile:
