### PR TITLE
The :source option for has_many => through should accept String values.

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -621,7 +621,7 @@ module ActiveRecord
       end
 
       def source_reflection_name # :nodoc:
-        return @source_reflection_name if @source_reflection_name
+        return @source_reflection_name.to_sym if @source_reflection_name
 
         names = [name.to_s.singularize, name].collect { |n| n.to_sym }.uniq
         names = names.find_all { |n|

--- a/activerecord/test/models/tag.rb
+++ b/activerecord/test/models/tag.rb
@@ -3,5 +3,5 @@ class Tag < ActiveRecord::Base
   has_many :taggables, :through => :taggings
   has_one  :tagging
 
-  has_many :tagged_posts, :through => :taggings, :source => :taggable, :source_type => 'Post'
+  has_many :tagged_posts, :through => :taggings, :source => 'taggable', :source_type => 'Post'
 end


### PR DESCRIPTION
With the changes introduced by 16b70fddd4dc7e7fb7be108add88bae6e3c2509b it was expecting the value to be a Symbol, while it could also be a String value.

The solution was call `to_sym` on the given `:source`.

Fixes https://github.com/rails/rails/issues/14651

This PR should only be backported to `4-1-stable`
