### PR TITLE
JavaScript and CSS compressors should have default values

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -60,7 +60,7 @@ in `production.rb` - `config.assets.css_compressor` for your CSS and
 
 ```ruby
 config.assets.css_compressor = :yui
-config.assets.js_compressor = :uglify
+config.assets.js_compressor = :uglifier
 ```
 
 NOTE: The `sass-rails` gem is automatically used for CSS compression if included

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -699,10 +699,10 @@ Active Record Observer and Action Controller Sweeper have been extracted to the 
 ### sprockets-rails
 
 * `assets:precompile:primary` and `assets:precompile:all` have been removed. Use `assets:precompile` instead.
-* The `config.assets.compress` option should be changed to `config.assets.js_compressor` like so for instance:
+* The `config.assets.compress` option defaults to `:uglifier` but can be changed like so:
 
 ```ruby
-config.assets.js_compressor = :uglifier
+config.assets.js_compressor = :yui
 ```
 
 ### sass-rails

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -60,8 +60,8 @@ module Rails
         @assets.compile                  = true
         @assets.digest                   = false
         @assets.cache_store              = [ :file_store, "#{root}/tmp/cache/assets/#{Rails.env}/" ]
-        @assets.js_compressor            = nil
-        @assets.css_compressor           = nil
+        @assets.js_compressor            = :uglifier
+        @assets.css_compressor           = :sass
         @assets.logger                   = nil
       end
 


### PR DESCRIPTION
While upgrading several applications from Rails 3.x to Rails 4, something that gets me every time is after getting everything out into production smoothly, we inevitably notice that the assets aren't being compressed. Doh, it's those pesky `js_compressor` and `css_compressor` configuration settings, again. When will I learn?

I think it would be to a lot of people's benefit if these config settings had default values. Here's a few reasons why:
- Most users are already using `uglifier` and `sass` as their compressors of choice. If they aren't, they will get an error and have better feedback to add the gems than just deploying to production and finding out the hard way
- If they are using different compressors, such as `yui` or `closure`, they can easily change the values in their environments for these config options, if they haven't done so already
- Creating a brand new Rails 4 application will have these defaulted to the settings I am suggesting

This would be immensely helpful for those of us upgrading to Rails 4 from previous versions of Rails.
