### PR TITLE
Make reflection and aggregate_reflection caches work with string keys.

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -617,11 +617,11 @@ module ActiveRecord
       #   # => [:tag, :tags]
       #
       def source_reflection_names
-        (options[:source] ? [options[:source]] : [name.to_s.singularize, name]).collect { |n| n.to_sym }.uniq
+        (options[:source] ? [options[:source]] : [name.to_s.singularize, name]).collect { |n| n }.uniq
       end
 
       def source_reflection_name # :nodoc:
-        return @source_reflection_name.to_sym if @source_reflection_name
+        return @source_reflection_name if @source_reflection_name
 
         names = [name.to_s.singularize, name].collect { |n| n.to_sym }.uniq
         names = names.find_all { |n|

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -22,7 +22,7 @@ module ActiveRecord
     end
 
     def self.add_reflection(ar, name, reflection)
-      ar.reflections = ar.reflections.merge(name => reflection)
+      ar.reflections = ar.reflections.merge(name.to_s => reflection)
     end
 
     def self.add_aggregate_reflection(ar, name, reflection)
@@ -72,7 +72,7 @@ module ActiveRecord
       #   Invoice.reflect_on_association(:line_items).macro  # returns :has_many
       #
       def reflect_on_association(association)
-        reflections[association]
+        reflections[association.to_s]
       end
 
       # Returns an array of AssociationReflection objects for all associations which have <tt>:autosave</tt> enabled.

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -26,7 +26,7 @@ module ActiveRecord
     end
 
     def self.add_aggregate_reflection(ar, name, reflection)
-      ar.aggregate_reflections = ar.aggregate_reflections.merge(name => reflection)
+      ar.aggregate_reflections = ar.aggregate_reflections.merge(name.to_s => reflection)
     end
 
     # \Reflection enables to interrogate Active Record classes and objects
@@ -48,7 +48,7 @@ module ActiveRecord
       #   Account.reflect_on_aggregation(:balance) # => the balance AggregateReflection
       #
       def reflect_on_aggregation(aggregation)
-        aggregate_reflections[aggregation]
+        aggregate_reflections[aggregation.to_s]
       end
 
       # Returns an array of AssociationReflection objects for all the

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -192,7 +192,7 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_reflection_should_not_raise_error_when_compared_to_other_object
-    assert_nothing_raised { Firm.reflections[:clients] == Object.new }
+    assert_nothing_raised { Firm.reflections['clients'] == Object.new }
   end
 
   def test_has_many_through_reflection


### PR DESCRIPTION
Following @tenderlove's suggestion on https://github.com/rails/rails/pull/14668#issuecomment-39997563, now the `reflection` and the `aggregate_reflection` caches use String as keys. This is needed to avoid `to_sym` in some cases, such as did in https://github.com/rails/rails/pull/14668.

I think we won't have problems changing these caches, since they are only used in `reflection.rb` file.

Another point is the test. I think it is wrong, it should not use the `reflection` Hash, right?

cc/ @tenderlove
