### PR TITLE
ActiveRecord '#attributes' method improved

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -275,9 +275,12 @@ module ActiveRecord
     #   person = Person.create(name: 'Francesco', age: 22)
     #   person.attributes
     #   # => {"id"=>3, "created_at"=>Sun, 21 Oct 2012 04:53:04, "updated_at"=>Sun, 21 Oct 2012 04:53:04, "name"=>"Francesco", "age"=>22}
-    def attributes
-      attribute_names.each_with_object({}) { |name, attrs|
-        attrs[name] = read_attribute(name)
+    #
+    #   person.attributes("id", "name", "age")
+    #   # => {"id"=>3, "name"=>"Francesco", "age"=>22}
+    def attributes(attr_names = attribute_names)
+      attr_names.each_with_object({}) { |name, attrs|
+        attrs[name.to_s] = read_attribute(name)
       }
     end
 

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -843,6 +843,15 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal !real_topic.title?, klass.find(real_topic.id).title?
   end
 
+  def test_attributes_with_array_given
+    topic = Topic.new do |t|
+      t.title       = "The Story"
+      t.author_name = "Nikolas"
+    end
+
+    assert_equal({"title" => "The Story", "author_name" => "Nikolas"}, topic.attributes([:title, :author_name]))
+  end
+
   private
 
   def new_topic_like_ar_class(&block)


### PR DESCRIPTION
It makes AR more flexible in case when you don't need to fetch all record attributes, and should help to increase performance and let your code be less complicated.
