### PR TITLE
Add a failing test for a URL helper that was broken by a6b9ea2.

### DIFF
--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1994,6 +1994,24 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal 'cards#destroy', @response.body
   end
 
+  def test_shallow_deeply_nested_resources
+    draw do
+      resources :blogs do
+        resources :posts do
+          resources :comments, shallow: true
+        end
+      end
+    end
+
+    get '/comments/1'
+    assert_equal 'comments#show', @response.body
+
+    assert_equal '/comments/1', comment_path('1')
+    assert_equal '/blogs/new', new_blog_path
+    assert_equal '/blogs/1/posts/new', new_blog_post_path(:blog_id => 1)
+    assert_equal '/blogs/1/posts/2/comments/new', new_blog_post_comment_path(:blog_id => 1, :post_id => 2)
+  end
+
   def test_shallow_nested_resources_within_scope
     draw do
       scope '/hello' do


### PR DESCRIPTION
Between Rails 4.0.3 and 4.0.4 (and into 4.1.0), the routes in this test stopped producing the URL helper `comment_path` -- it became `blog_comment_path` instead. This was fixed in a6b9ea2 but the patch breaks the expected `new_blog_post_comment_path` helper, which was working until that patch landed.
