### PR TITLE
Don't reduce lookup context formats

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -130,6 +130,13 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("multipart/mixed", email.mime_type)
   end
 
+  test "renders attachment in a different format" do
+    email = BaseMailer.rendered_attachment
+    assert_equal(1, email.attachments.length)
+    assert_equal("multipart/mixed", email.mime_type)
+    assert_equal("With rendered attachment\r\n", email.parts[0].body.encoded)
+  end
+
   test "adds the rendered template as part" do
     email = BaseMailer.attachment_with_content
     assert_equal(2, email.parts.length)

--- a/actionmailer/test/fixtures/base_mailer/rendered_attachment.html.erb
+++ b/actionmailer/test/fixtures/base_mailer/rendered_attachment.html.erb
@@ -1,0 +1,1 @@
+With rendered attachment

--- a/actionmailer/test/fixtures/base_mailer/rendered_attachment_attachment.json.erb
+++ b/actionmailer/test/fixtures/base_mailer/rendered_attachment_attachment.json.erb
@@ -1,0 +1,1 @@
+{ note: 'Rendered attachment' }

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -50,6 +50,13 @@ class BaseMailer < ActionMailer::Base
     mail
   end
 
+  def rendered_attachment
+    content = render handlers: [:erb], formats: [:json], template: 'base_mailer/rendered_attachment_attachment', layout: false
+    attachments['invoice.json'] = { mime_type: "application/pdf",
+                                   content: content }
+    mail
+  end
+
   def implicit_multipart(hash = {})
     attachments['invoice.pdf'] = 'This is test File content' if hash.delete(:attachments)
     mail(hash)

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -50,6 +50,13 @@ class BaseMailer < ActionMailer::Base
     mail
   end
 
+  def rendered_attachment
+    content = render handlers: [:erb], formats: [:json], template: 'base_mailer/rendered_attachment_attachment', layout: false
+    attachments['invoice.json'] = { mime_type: "application/json",
+                                   content: content }
+    mail
+  end
+
   def implicit_multipart(hash = {})
     attachments['invoice.pdf'] = 'This is test File content' if hash.delete(:attachments)
     mail(hash)

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Improve routing error page with fuzzy matching search.
+
+    *Winston*
+
 *   Only make deeply nested routes shallow when parent is shallow.
 
     Fixes #14684.

--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -88,13 +88,15 @@
     });
   }
 
-  // takes an array of elements with a data-regexp attribute and
+  // Takes an array of elements with a data-regexp attribute and
   // passes their parent <tr> into the callback function
-  // if the regexp matches a given path
-  function eachElemsForPath(elems, path, func) {
+  // if the user input fuzzy matches a route or if the regexp matches a given path
+  function eachElemsForPath(elems, value, func) {
+    var path = sanitizePath(value);
     each(elems, function(e){
-      var reg = e.getAttribute("data-regexp");
-      if (path.match(RegExp(reg))) {
+      var route  = e.getAttribute("data-route-path"),
+          regexp = e.getAttribute("data-regexp");
+      if (route.match(RegExp(value)) || path.match(RegExp(regexp))) {
         func(e.parentNode.cloneNode(true));
       }
     })
@@ -121,14 +123,14 @@
 
     // On key press perform a search for matching paths
     pathElem.onkeyup = function(e){
-      var path        = sanitizePath(pathElem.value),
-          defaultText = '<tr><th colspan="4">Paths Matching (' + path + '):</th></tr>';
+      var userInput   = pathElem.value,
+          defaultText = '<tr><th colspan="4">Paths Matching (' + userInput +'):</th></tr>';
 
       // Clear out results section
       selectedSection.innerHTML= defaultText;
 
       // Display matches if they exist
-      eachElemsForPath(regexpElems, path, function(e){
+      eachElemsForPath(regexpElems, userInput, function(e){
         selectedSection.appendChild(e);
       });
 

--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -25,12 +25,14 @@
     background: #f2f2f2;
   }
 
-  #route_table tbody.matched_paths {
+  #route_table tbody.exact_matches,
+  #route_table tbody.fuzzy_matches {
     background-color: LightGoldenRodYellow;
     border-bottom: solid 2px SlateGrey;
   }
 
-  #route_table tbody.matched_paths tr {
+  #route_table tbody.exact_matches tr,
+  #route_table tbody.fuzzy_matches tr {
     background: none;
     border-bottom: none;
   }
@@ -63,13 +65,15 @@
       <th><%# HTTP Verb %>
       </th>
       <th><%# Path %>
-        <%= search_field(:path, nil, id: 'path_search', placeholder: "Path Match") %>
+        <%= search_field(:path, nil, id: 'search', placeholder: "Path Match") %>
       </th>
       <th><%# Controller#action %>
       </th>
     </tr>
   </thead>
-  <tbody class='matched_paths' id='matched_paths'>
+  <tbody class='exact_matches' id='exact_matches'>
+  </tbody>
+  <tbody class='fuzzy_matches' id='fuzzy_matches'>
   </tbody>
   <tbody>
     <%= yield %>
@@ -77,6 +81,7 @@
 </table>
 
 <script type='text/javascript'>
+  // Iterates each element through a function
   function each(elems, func) {
     if (!elems instanceof Array) { elems = [elems]; }
     for (var i = 0, len = elems.length; i < len; i++) {
@@ -84,79 +89,110 @@
     }
   }
 
-  function setValOn(elems, val) {
-    each(elems, function(elem) {
-      elem.innerHTML = val;
-    });
-  }
-
-  function onClick(elems, func) {
-    each(elems, function(elem) {
-      elem.onclick = func;
-    });
-  }
-
-  // Enables functionality to toggle between `_path` and `_url` helper suffixes
-  function setupRouteToggleHelperLinks() {
-    var toggleLinks = document.querySelectorAll('#route_table [data-route-helper]');
-    onClick(toggleLinks, function(){
-      var helperTxt   = this.getAttribute("data-route-helper"),
-          helperElems = document.querySelectorAll('[data-route-name] span.helper');
-      setValOn(helperElems, helperTxt);
-    });
-  }
-
-  // Takes an array of elements with a data-regexp attribute and
-  // passes their parent <tr> into the callback function
-  // if the user input fuzzy matches a route or if the regexp matches a given path
-  function eachElemsForPath(elems, value, func) {
-    var path = sanitizePath(value);
-    each(elems, function(e){
-      var route  = e.getAttribute("data-route-path"),
-          regexp = e.getAttribute("data-regexp");
-      if (route.match(RegExp(value)) || path.match(RegExp(regexp))) {
-        func(e.parentNode.cloneNode(true));
-      }
-    })
-  }
-
-  // Ensure path always starts with a slash "/" and remove params or fragments
-  function sanitizePath(path) {
-    var path = path.charAt(0) == '/' ? path : "/" + path;
-    return path.replace(/\#.*|\?.*/, '');
+  // Sets innerHTML for an element
+  function setContent(elem, text) {
+    elem.innerHTML = text;
   }
 
   // Enables path search functionality
   function setupMatchPaths() {
+    // Check if the user input (sanitized as a path) matches the regexp data attribute
+    function checkExactMatch(section, elem, value) {
+      var string = sanitizePath(value),
+          regexp = elem.getAttribute("data-regexp");
+
+      showMatch(string, regexp, section, elem);
+    }
+
+    // Check if the route path data attribute contains the user input
+    function checkFuzzyMatch(section, elem, value) {
+      var string = elem.getAttribute("data-route-path"),
+          regexp = value;
+
+      showMatch(string, regexp, section, elem);
+    }
+
+    // Display the parent <tr> element in the appropriate section when there's a match
+    function showMatch(string, regexp, section, elem) {
+      if(string.match(RegExp(regexp))) {
+        section.appendChild(elem.parentNode.cloneNode(true));
+      }
+    }
+
+    // Check if there are any matched results in a section
+    function checkNoMatch(section, defaultText, noMatchText) {
+      if (section.innerHTML === defaultText) {
+        setContent(section, defaultText + noMatchText);
+      }
+    }
+
+    // Ensure path always starts with a slash "/" and remove params or fragments
+    function sanitizePath(path) {
+      var path = path.charAt(0) == '/' ? path : "/" + path;
+      return path.replace(/\#.*|\?.*/, '');
+    }
+
     var regexpElems     = document.querySelectorAll('#route_table [data-regexp]'),
-        pathElem        = document.querySelector('#path_search'),
-        selectedSection = document.querySelector('#matched_paths'),
-        noMatchText     = '<tr><th colspan="4">None</th></tr>';
+        searchElem      = document.querySelector('#search'),
+        exactMatches    = document.querySelector('#exact_matches'),
+        fuzzyMatches    = document.querySelector('#fuzzy_matches');
 
-
-    // Remove matches if no path is present
-    pathElem.onblur = function(e) {
-      if (pathElem.value === "") selectedSection.innerHTML = "";
+    // Remove matches when no search value is present
+    searchElem.onblur = function(e) {
+      if (searchElem.value === "") {
+        setContent(exactMatches, "");
+        setContent(fuzzyMatches, "");
+      }
     }
 
     // On key press perform a search for matching paths
-    pathElem.onkeyup = function(e){
-      var userInput   = pathElem.value,
-          defaultText = '<tr><th colspan="4">Paths Matching (' + userInput +'):</th></tr>';
+    searchElem.onkeyup = function(e){
+      var userInput         = searchElem.value,
+          defaultExactMatch = '<tr><th colspan="4">Paths Matching (' + sanitizePath(userInput) +'):</th></tr>',
+          defaultFuzzyMatch = '<tr><th colspan="4">Paths Containing (' + userInput +'):</th></tr>',
+          noExactMatch      = '<tr><th colspan="4">No Exact Matches Found</th></tr>',
+          noFuzzyMatch      = '<tr><th colspan="4">No Fuzzy Matches Found</th></tr>';
 
       // Clear out results section
-      selectedSection.innerHTML= defaultText;
+      setContent(exactMatches, defaultExactMatch);
+      setContent(fuzzyMatches, defaultFuzzyMatch);
 
-      // Display matches if they exist
-      eachElemsForPath(regexpElems, userInput, function(e){
-        selectedSection.appendChild(e);
-      });
+      // Display exact matches and fuzzy matches
+      each(regexpElems, function(elem) {
+        checkExactMatch(exactMatches, elem, userInput);
+        checkFuzzyMatch(fuzzyMatches, elem, userInput);
+      })
 
-      // If no match present, tell the user
-      if (selectedSection.innerHTML === defaultText) {
-        selectedSection.innerHTML = selectedSection.innerHTML + noMatchText;
-      }
+      // Display 'No Matches' message when no matches are found
+      checkNoMatch(exactMatches, defaultExactMatch, noExactMatch);
+      checkNoMatch(fuzzyMatches, defaultFuzzyMatch, noFuzzyMatch);
     }
+  }
+
+  // Enables functionality to toggle between `_path` and `_url` helper suffixes
+  function setupRouteToggleHelperLinks() {
+
+    // Sets content for each element
+    function setValOn(elems, val) {
+      each(elems, function(elem) {
+        setContent(elem, val);
+      });
+    }
+
+    // Sets onClick event for each element
+    function onClick(elems, func) {
+      each(elems, function(elem) {
+        elem.onclick = func;
+      });
+    }
+
+    var toggleLinks = document.querySelectorAll('#route_table [data-route-helper]');
+    onClick(toggleLinks, function(){
+      var helperTxt   = this.getAttribute("data-route-helper"),
+          helperElems = document.querySelectorAll('[data-route-name] span.helper');
+
+      setValOn(helperElems, helperTxt);
+    });
   }
 
   setupMatchPaths();

--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -4,21 +4,39 @@
     border-collapse: collapse;
   }
 
-  #route_table td {
-    padding: 0 30px;
+  #route_table thead tr {
+    border-bottom: 2px solid #ddd;
   }
 
-  #route_table tr.bottom th {
-    padding-bottom: 10px;
+  #route_table thead tr.bottom {
+    border-bottom: none;
+  }
+
+  #route_table thead tr.bottom th {
+    padding: 10px 0;
     line-height: 15px;
   }
 
-  #route_table .matched_paths {
-    background-color: LightGoldenRodYellow;
+  #route_table tbody tr {
+    border-bottom: 1px solid #ddd;
   }
 
-  #route_table .matched_paths {
-    border-bottom: solid 3px SlateGrey;
+  #route_table tbody tr:nth-child(odd) {
+    background: #f2f2f2;
+  }
+
+  #route_table tbody.matched_paths {
+    background-color: LightGoldenRodYellow;
+    border-bottom: solid 2px SlateGrey;
+  }
+
+  #route_table tbody.matched_paths tr {
+    background: none;
+    border-bottom: none;
+  }
+
+  #route_table td {
+    padding: 4px 30px;
   }
 
   #path_search {

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Don't reduce lookup context formats upon render so renders of a different format can be
+    made within one request.
+
+    *Noel Peden*
+
 *   `date_select` helper with option `with_css_classes: true` does not overwrite other classes.
 
     *Izumi Wong-Horiuchi*

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -102,7 +102,7 @@ module ActionView
       # Assign the rendered format to lookup context.
       def _process_format(format, options = {}) #:nodoc:
         super
-        lookup_context.formats = [format.to_sym]
+        lookup_context.formats.unshift format.to_sym
         lookup_context.rendered_format = lookup_context.formats.first
       end
 

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -102,7 +102,7 @@ module ActionView
       # Assign the rendered format to lookup context.
       def _process_format(format, options = {}) #:nodoc:
         super
-        lookup_context.formats = [format.to_sym]
+        lookup_context.formats.unshift(format.to_sym).uniq!
         lookup_context.rendered_format = lookup_context.formats.first
       end
 

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -102,7 +102,7 @@ module ActionView
       # Assign the rendered format to lookup context.
       def _process_format(format, options = {}) #:nodoc:
         super
-        lookup_context.formats.unshift format.to_sym
+        lookup_context.formats.unshift(format.to_sym).uniq!
         lookup_context.rendered_format = lookup_context.formats.first
       end
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   PostgreSQL adapter only warns once for every missing OID per connection.
+
+    Fixes #14275.
+
+    *Matthew Draper*, *Yves Senn*
+
 *   PostgreSQL adapter automatically reloads it's type map when encountering
     unknown OIDs.
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   PostgreSQL adapter automatically reloads it's type map when encountering
+    unknown OIDs.
+
+    Fixes #14678.
+
+    *Matthew Draper*, *Yves Senn*
+
 *   Fix insertion of records via `has_many :through` association with scope.
 
     Fixes #3548.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -142,10 +142,7 @@ module ActiveRecord
           fields.each_with_index do |fname, i|
             ftype = result.ftype i
             fmod  = result.fmod i
-            types[fname] = type_map.fetch(ftype, fmod) { |oid, mod|
-              warn "unknown OID: #{fname}(#{oid}) (#{sql})"
-              OID::Identity.new
-            }
+            types[fname] = get_oid_type(ftype, fmod, fname)
           end
 
           ret = ActiveRecord::Result.new(fields, result.values, types)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -182,9 +182,7 @@ module ActiveRecord
         def columns(table_name)
           # Limit, precision, and scale are all handled by the superclass.
           column_definitions(table_name).map do |column_name, type, default, notnull, oid, fmod|
-            oid = type_map.fetch(oid.to_i, fmod.to_i) {
-              OID::Identity.new
-            }
+            oid = get_oid_type(oid.to_i, fmod.to_i, column_name)
             PostgreSQLColumn.new(column_name, default, oid, type, notnull == 'f')
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -559,6 +559,17 @@ module ActiveRecord
           @type_map
         end
 
+        def get_oid_type(oid, fmod, column_name)
+          if !type_map.key?(oid)
+            initialize_type_map(type_map, [oid])
+          end
+
+          type_map.fetch(oid, fmod) {
+            warn "unknown OID #{oid}: failed to recognize type of #{column_name}"
+            OID::Identity.new
+          }
+        end
+
         def reload_type_map
           type_map.clear
           initialize_type_map(type_map)
@@ -583,19 +594,25 @@ module ActiveRecord
           type_map
         end
 
-        def initialize_type_map(type_map)
+        def initialize_type_map(type_map, oids = nil)
           if supports_ranges?
-            result = execute(<<-SQL, 'SCHEMA')
+            query = <<-SQL
               SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput, r.rngsubtype, t.typtype, t.typbasetype
               FROM pg_type as t
               LEFT JOIN pg_range as r ON oid = rngtypid
             SQL
           else
-            result = execute(<<-SQL, 'SCHEMA')
+            query = <<-SQL
               SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput, t.typtype, t.typbasetype
               FROM pg_type as t
             SQL
           end
+
+          if oids
+            query += "WHERE t.oid::integer IN (%s)" % oids.join(", ")
+          end
+
+          result = execute(query, 'SCHEMA')
           ranges, nodes = result.partition { |row| row['typtype'] == 'r' }
           enums, nodes = nodes.partition { |row| row['typtype'] == 'e' }
           domains, nodes = nodes.partition { |row| row['typtype'] == 'd' }

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -565,8 +565,8 @@ module ActiveRecord
           end
 
           type_map.fetch(oid, fmod) {
-            warn "unknown OID #{oid}: failed to recognize type of #{column_name}"
-            OID::Identity.new
+            warn "unknown OID #{oid}: failed to recognize type of '#{column_name}'. It will be treated as String."
+            type_map[oid] = OID::Identity.new
           }
         end
 

--- a/activerecord/test/cases/adapters/postgresql/domain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/domain_test.rb
@@ -19,9 +19,6 @@ class PostgresqlDomainTest < ActiveRecord::TestCase
         t.column :price, :custom_money
       end
     end
-
-    # reload type map after creating the enum type
-    @connection.send(:reload_type_map)
   end
 
   teardown do

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -21,8 +21,6 @@ class PostgresqlEnumTest < ActiveRecord::TestCase
         t.column :current_mood, :mood
       end
     end
-    # reload type map after creating the enum type
-    @connection.send(:reload_type_map)
   end
 
   teardown do

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1,11 +1,13 @@
 # encoding: utf-8
 require "cases/helper"
 require 'support/ddl_helper'
+require 'support/connection_helper'
 
 module ActiveRecord
   module ConnectionAdapters
     class PostgreSQLAdapterTest < ActiveRecord::TestCase
       include DdlHelper
+      include ConnectionHelper
 
       def setup
         @connection = ActiveRecord::Base.connection
@@ -355,6 +357,32 @@ module ActiveRecord
         assert_raise TypeError do
           @connection.send(:log, nil) { @connection.execute(nil) }
         end
+      end
+
+      def test_reload_type_map_for_newly_defined_types
+        @connection.execute "CREATE TYPE feeling AS ENUM ('good', 'bad')"
+        result = @connection.select_all "SELECT 'good'::feeling"
+        assert_instance_of(PostgreSQLAdapter::OID::Enum,
+                           result.column_types["feeling"])
+      ensure
+        @connection.execute "DROP TYPE IF EXISTS feeling"
+        reset_connection
+      end
+
+      def test_only_reload_type_map_once_for_every_unknown_type
+        silence_warnings do
+          assert_queries 2, ignore_none: true do
+            @connection.select_all "SELECT NULL::anyelement"
+          end
+          assert_queries 1, ignore_none: true do
+            @connection.select_all "SELECT NULL::anyelement"
+          end
+          assert_queries 2, ignore_none: true do
+            @connection.select_all "SELECT NULL::anyarray"
+          end
+        end
+      ensure
+        reset_connection
       end
 
       private

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -385,6 +385,17 @@ module ActiveRecord
         reset_connection
       end
 
+      def test_only_warn_on_first_encounter_of_unknown_oid
+        warning = capture(:stderr) {
+          @connection.select_all "SELECT NULL::anyelement"
+          @connection.select_all "SELECT NULL::anyelement"
+          @connection.select_all "SELECT NULL::anyelement"
+        }
+        assert_match(/\Aunknown OID \d+: failed to recognize type of 'anyelement'. It will be treated as String.\n\z/, warning)
+      ensure
+        reset_connection
+      end
+
       private
       def insert(ctx, data)
         binds   = data.map { |name, value|

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -34,7 +34,6 @@ _SQL
 
           @connection.add_column 'postgresql_ranges', 'float_range', 'floatrange'
         end
-        @connection.send :reload_type_map
         PostgresqlRange.reset_column_information
       rescue ActiveRecord::StatementInvalid
         skip "do not test on PG without range"

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -130,6 +130,8 @@ class String
   #
   #   'ActiveRecord::CoreExtensions::String::Inflections'.demodulize # => "Inflections"
   #   'Inflections'.demodulize                                       # => "Inflections"
+  #   '::Inflections'.demodulize                                     # => "Inflections"
+  #   ''.demodulize                                                  # => ''
   #
   # See also +deconstantize+.
   def demodulize

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -172,6 +172,8 @@ module ActiveSupport
     #
     #   'ActiveRecord::CoreExtensions::String::Inflections'.demodulize # => "Inflections"
     #   'Inflections'.demodulize                                       # => "Inflections"
+    #   '::Inflections'.demodulize                                     # => "Inflections"
+    #   ''.demodulize                                                  # => ''
     #
     # See also +deconstantize+.
     def demodulize(path)

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -200,6 +200,7 @@ class InflectorTest < ActiveSupport::TestCase
   def test_demodulize
     assert_equal "Account", ActiveSupport::Inflector.demodulize("MyApplication::Billing::Account")
     assert_equal "Account", ActiveSupport::Inflector.demodulize("Account")
+    assert_equal "Account", ActiveSupport::Inflector.demodulize("::Account")
     assert_equal "", ActiveSupport::Inflector.demodulize("")
   end
 

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1631,6 +1631,9 @@ Given a string with a qualified constant name, `demodulize` returns the very con
 "Product".demodulize                        # => "Product"
 "Backoffice::UsersController".demodulize    # => "UsersController"
 "Admin::Hotel::ReservationUtils".demodulize # => "ReservationUtils"
+"::Inflections".demodulize                  # => "Inflections"
+"".demodulize                               # => ""
+
 ```
 
 Active Record for example uses this method to compute the name of a counter cache column:


### PR DESCRIPTION
In Rails 3 or 4.0 the you could render an attachment inside a mailer:

``` ruby
class Notifier < ActionMailer::Base
  def instructions(user)
    xlsx = render handlers: [:axlsx], template: 'users/mailers/instructions', layout: false
    attachments["user.xlsx"] = {mime_type: Mime::XLSX, content: xlsx}

    mail :to => user.email, :subject => 'Instructions'
  end
end
```

With 4.1 the lookup context reduces the formats list to `:xlsx` and the following template lookup tries to find `instructions.xlsx.erb` instead of `instructions.html.erb`.

This fixes the problem. I assume `lookup_context.formats = [format.to_sym]` was to increase lookup efficiency thereafter. There may be a better way.

All actionview, actionpack, actionmailer, actionsupport tests pass. I'm still getting familiar with the Rails test suite. If someone can suggest where to place templates / test code I'll write one up. 
