### PR TITLE
PostgreSQL automatic type map reload

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   PostgreSQL adapter only warns once for every missing OID per connection.
+
+    Fixes #14275.
+
+    *Matthew Draper*, *Yves Senn*
+
 *   PostgreSQL adapter automatically reloads it's type map when encountering
     unknown OIDs.
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   PostgreSQL adapter automatically reloads it's type map when encountering
+    unknown OIDs.
+
+    Fixes #14678.
+
+    *Matthew Draper*, *Yves Senn*
+
 *   Fix insertion of records via `has_many :through` association with scope.
 
     Fixes #3548.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -142,10 +142,7 @@ module ActiveRecord
           fields.each_with_index do |fname, i|
             ftype = result.ftype i
             fmod  = result.fmod i
-            types[fname] = type_map.fetch(ftype, fmod) { |oid, mod|
-              warn "unknown OID: #{fname}(#{oid}) (#{sql})"
-              OID::Identity.new
-            }
+            types[fname] = get_oid_type(ftype, fmod, fname)
           end
 
           ret = ActiveRecord::Result.new(fields, result.values, types)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -182,9 +182,7 @@ module ActiveRecord
         def columns(table_name)
           # Limit, precision, and scale are all handled by the superclass.
           column_definitions(table_name).map do |column_name, type, default, notnull, oid, fmod|
-            oid = type_map.fetch(oid.to_i, fmod.to_i) {
-              OID::Identity.new
-            }
+            oid = get_oid_type(oid.to_i, fmod.to_i, column_name)
             PostgreSQLColumn.new(column_name, default, oid, type, notnull == 'f')
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -559,6 +559,17 @@ module ActiveRecord
           @type_map
         end
 
+        def get_oid_type(oid, fmod, column_name)
+          if !type_map.key?(oid)
+            initialize_type_map(type_map, [oid])
+          end
+
+          type_map.fetch(oid, fmod) {
+            warn "unknown OID #{oid}: failed to recognize type of #{column_name}"
+            OID::Identity.new
+          }
+        end
+
         def reload_type_map
           type_map.clear
           initialize_type_map(type_map)
@@ -583,19 +594,25 @@ module ActiveRecord
           type_map
         end
 
-        def initialize_type_map(type_map)
+        def initialize_type_map(type_map, oids = nil)
           if supports_ranges?
-            result = execute(<<-SQL, 'SCHEMA')
+            query = <<-SQL
               SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput, r.rngsubtype, t.typtype, t.typbasetype
               FROM pg_type as t
               LEFT JOIN pg_range as r ON oid = rngtypid
             SQL
           else
-            result = execute(<<-SQL, 'SCHEMA')
+            query = <<-SQL
               SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput, t.typtype, t.typbasetype
               FROM pg_type as t
             SQL
           end
+
+          if oids
+            query += "WHERE t.oid::integer IN (%s)" % oids.join(", ")
+          end
+
+          result = execute(query, 'SCHEMA')
           ranges, nodes = result.partition { |row| row['typtype'] == 'r' }
           enums, nodes = nodes.partition { |row| row['typtype'] == 'e' }
           domains, nodes = nodes.partition { |row| row['typtype'] == 'd' }

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -565,8 +565,8 @@ module ActiveRecord
           end
 
           type_map.fetch(oid, fmod) {
-            warn "unknown OID #{oid}: failed to recognize type of #{column_name}"
-            OID::Identity.new
+            warn "unknown OID #{oid}: failed to recognize type of '#{column_name}'. It will be treated as String."
+            type_map[oid] = OID::Identity.new
           }
         end
 

--- a/activerecord/test/cases/adapters/postgresql/domain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/domain_test.rb
@@ -19,9 +19,6 @@ class PostgresqlDomainTest < ActiveRecord::TestCase
         t.column :price, :custom_money
       end
     end
-
-    # reload type map after creating the enum type
-    @connection.send(:reload_type_map)
   end
 
   teardown do

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -21,8 +21,6 @@ class PostgresqlEnumTest < ActiveRecord::TestCase
         t.column :current_mood, :mood
       end
     end
-    # reload type map after creating the enum type
-    @connection.send(:reload_type_map)
   end
 
   teardown do

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1,11 +1,13 @@
 # encoding: utf-8
 require "cases/helper"
 require 'support/ddl_helper'
+require 'support/connection_helper'
 
 module ActiveRecord
   module ConnectionAdapters
     class PostgreSQLAdapterTest < ActiveRecord::TestCase
       include DdlHelper
+      include ConnectionHelper
 
       def setup
         @connection = ActiveRecord::Base.connection
@@ -355,6 +357,32 @@ module ActiveRecord
         assert_raise TypeError do
           @connection.send(:log, nil) { @connection.execute(nil) }
         end
+      end
+
+      def test_reload_type_map_for_newly_defined_types
+        @connection.execute "CREATE TYPE feeling AS ENUM ('good', 'bad')"
+        result = @connection.select_all "SELECT 'good'::feeling"
+        assert_instance_of(PostgreSQLAdapter::OID::Enum,
+                           result.column_types["feeling"])
+      ensure
+        @connection.execute "DROP TYPE IF EXISTS feeling"
+        reset_connection
+      end
+
+      def test_only_reload_type_map_once_for_every_unknown_type
+        silence_warnings do
+          assert_queries 2, ignore_none: true do
+            @connection.select_all "SELECT NULL::anyelement"
+          end
+          assert_queries 1, ignore_none: true do
+            @connection.select_all "SELECT NULL::anyelement"
+          end
+          assert_queries 2, ignore_none: true do
+            @connection.select_all "SELECT NULL::anyarray"
+          end
+        end
+      ensure
+        reset_connection
       end
 
       private

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -385,6 +385,17 @@ module ActiveRecord
         reset_connection
       end
 
+      def test_only_warn_on_first_encounter_of_unknown_oid
+        warning = capture(:stderr) {
+          @connection.select_all "SELECT NULL::anyelement"
+          @connection.select_all "SELECT NULL::anyelement"
+          @connection.select_all "SELECT NULL::anyelement"
+        }
+        assert_match(/\Aunknown OID \d+: failed to recognize type of 'anyelement'. It will be treated as String.\n\z/, warning)
+      ensure
+        reset_connection
+      end
+
       private
       def insert(ctx, data)
         binds   = data.map { |name, value|

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -34,7 +34,6 @@ _SQL
 
           @connection.add_column 'postgresql_ranges', 'float_range', 'floatrange'
         end
-        @connection.send :reload_type_map
         PostgresqlRange.reset_column_information
       rescue ActiveRecord::StatementInvalid
         skip "do not test on PG without range"


### PR DESCRIPTION
This patch contains two fixes:
- PostgreSQL adapter automatically reloads it's type map. 
  - Closes #14678
- PostgreSQL, only warn once per connection per missing OID. 
  - Closes #14275

**PostgreSQL adapter automatically reloads it's type map:**
PostgreSQL caches it's type-map after it's been initialized. When new types are defined, the type map was not updated. This lead to broken behavior and "unknown OID" warnings. This patch reloads the type map a single time when encountering a missing OID. Currently the complete type map is re-initialized. This could be enhanced by looking for the missing OID.

**PostgreSQL, only warn once per connection per missing OID:**
When unknown OIDs are in play, a warning was issued whenever that unknown type is used. This leads to a spam of warning messages on stderr. This patch registers the missing oid with `OID::Identity`. This means the warning is only issued once, per connection, per unkown OID.
