### PR TITLE
Correctly handle joining scoped associations with table aliases.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   When joining tables with a default scope, ensure the generated table name
+    in the ON conditions from the default scope is correctly aliased .
+
+    Backports #14154.
+
+    *Matt Jones*
+
 *   Fixed has_many association to make it support irregular inflections.
 
     Fixes #8928.

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -106,7 +106,7 @@ module ActiveRecord
               ]
             end
 
-            scope_chain_items += [reflection.klass.send(:build_default_scope)].compact
+            scope_chain_items += [reflection.klass.send(:build_default_scope, ActiveRecord::Relation.new(reflection.klass, table))].compact
 
             scope_chain_items.each do |item|
               unless item.is_a?(Relation)

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -102,15 +102,15 @@ module ActiveRecord
           self.default_scopes += [scope]
         end
 
-        def build_default_scope # :nodoc:
+        def build_default_scope(base_rel = relation) # :nodoc:
           if !Base.is_a?(method(:default_scope).owner)
             # The user has defined their own default scope method, so call that
             evaluate_default_scope { default_scope }
           elsif default_scopes.any?
             evaluate_default_scope do
-              default_scopes.inject(relation) do |default_scope, scope|
+              default_scopes.inject(base_rel) do |default_scope, scope|
                 if !scope.is_a?(Relation) && scope.respond_to?(:call)
-                  default_scope.merge(unscoped { scope.call })
+                  default_scope.merge(base_rel.scoping { scope.call })
                 else
                   default_scope.merge(scope)
                 end

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -117,4 +117,13 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
 
     assert_equal [author], Author.where(id: author).joins(:special_categorizations)
   end
+
+  test "the default scope of the target is correctly aliased when joining associations" do
+    author = Author.create! name: "Jon"
+    author.categories.create! name: 'Not Special'
+    author.special_categories.create! name: 'Special'
+
+    categories = author.categories.includes(:special_categorizations).references(:special_categorizations).to_a
+    assert_equal 2, categories.size
+  end
 end

--- a/activerecord/test/models/category.rb
+++ b/activerecord/test/models/category.rb
@@ -22,6 +22,7 @@ class Category < ActiveRecord::Base
   end
 
   has_many :categorizations
+  has_many :special_categorizations
   has_many :post_comments, :through => :posts, :source => :comments
 
   has_many :authors, :through => :categorizations


### PR DESCRIPTION
Backport of #14154 to 4-0-stable.

/cc @abstractcoder - this fixes #12770 for 4.0.x
/cc @tenderlove
