### PR TITLE
Bundle tzinfo-data on :x64_mingw (64-bit Ruby on Windows).

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -33,5 +33,5 @@ source 'https://rubygems.org'
 
 <% if RUBY_PLATFORM.match(/bccwin|cygwin|emx|mingw|mswin|wince/) -%>
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin]
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 <% end -%>


### PR DESCRIPTION
On Windows, the default Rails 4.1.0 `Gemfile` includes the following line:

``` ruby
# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
gem 'tzinfo-data', platforms: [:mingw, :mswin]
```

However, this doesn't match 64-bit Windows MinGW builds of Ruby (such as the x64 RubyInstaller build). Users on this platform will encounter a `TZInfo::DataSourceNotFound` exception starting Rails unless they manually alter their `Gemfile`.

This pull request adds `:x64_mingw` to the platforms, so that tzinfo-data is also used on 64-bit MinGW Ruby builds.
