### PR TITLE
Remove surplus period from assertion messages

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/selector.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/selector.rb
@@ -267,7 +267,7 @@ module ActionDispatch
             text.strip! unless NO_STRIP.include?(match.name)
             text.sub!(/\A\n/, '') if match.name == "textarea"
             unless match_with.is_a?(Regexp) ? (text =~ match_with) : (text == match_with.to_s)
-              content_mismatch ||= sprintf("<%s> expected but was\n<%s>.", match_with, text)
+              content_mismatch ||= sprintf("<%s> expected but was\n<%s>", match_with, text)
               true
             end
           end
@@ -276,7 +276,7 @@ module ActionDispatch
             html = match.children.map(&:to_s).join
             html.strip! unless NO_STRIP.include?(match.name)
             unless match_with.is_a?(Regexp) ? (html =~ match_with) : (html == match_with.to_s)
-              content_mismatch ||= sprintf("<%s> expected but was\n<%s>.", match_with, html)
+              content_mismatch ||= sprintf("<%s> expected but was\n<%s>", match_with, html)
               true
             end
           end
@@ -289,7 +289,7 @@ module ActionDispatch
 
         # FIXME: minitest provides messaging when we use assert_operator,
         # so is this custom message really needed?
-        message = message || %(Expected #{count_description(min, max, count)} matching "#{selector.to_s}", found #{matches.size}.)
+        message = message || %(Expected #{count_description(min, max, count)} matching "#{selector.to_s}", found #{matches.size})
         if count
           assert_equal count, matches.size, message
         else

--- a/actionpack/test/controller/assert_select_test.rb
+++ b/actionpack/test/controller/assert_select_test.rb
@@ -79,13 +79,13 @@ class AssertSelectTest < ActionController::TestCase
   def test_assert_select
     render_html %Q{<div id="1"></div><div id="2"></div>}
     assert_select "div", 2
-    assert_failure(/Expected at least 1 element matching \"p\", found 0/) { assert_select "p" }
+    assert_failure(/\AExpected at least 1 element matching \"p\", found 0\.$/) { assert_select "p" }
   end
 
   def test_equality_integer
     render_html %Q{<div id="1"></div><div id="2"></div>}
-    assert_failure(/Expected exactly 3 elements matching \"div\", found 2/) { assert_select "div", 3 }
-    assert_failure(/Expected exactly 0 elements matching \"div\", found 2/) { assert_select "div", 0 }
+    assert_failure(/\AExpected exactly 3 elements matching \"div\", found 2\.$/) { assert_select "div", 3 }
+    assert_failure(/\AExpected exactly 0 elements matching \"div\", found 2\.$/) { assert_select "div", 0 }
   end
 
   def test_equality_true_false
@@ -100,13 +100,14 @@ class AssertSelectTest < ActionController::TestCase
 
   def test_equality_false_message
     render_html %Q{<div id="1"></div><div id="2"></div>}
-    assert_failure(/Expected exactly 0 elements matching \"div\", found 2/) { assert_select "div", false }
+    assert_failure(/\AExpected exactly 0 elements matching \"div\", found 2\.$/) { assert_select "div", false }
   end
 
   def test_equality_string_and_regexp
     render_html %Q{<div id="1">foo</div><div id="2">foo</div>}
     assert_nothing_raised    { assert_select "div", "foo" }
     assert_raise(Assertion) { assert_select "div", "bar" }
+    assert_failure(/\A<bar> expected but was\n<foo>\.$/) { assert_select "div", "bar" }
     assert_nothing_raised    { assert_select "div", :text=>"foo" }
     assert_raise(Assertion) { assert_select "div", :text=>"bar" }
     assert_nothing_raised    { assert_select "div", /(foo|bar)/ }
@@ -124,6 +125,7 @@ class AssertSelectTest < ActionController::TestCase
     assert_raise(Assertion) { assert_select "p", html }
     assert_nothing_raised    { assert_select "p", :html=>html }
     assert_raise(Assertion) { assert_select "p", :html=>text }
+    assert_failure(/\A<#{text}> expected but was\n<#{html}>\.$/) { assert_select "p", :html=>text }
     # No stripping for pre.
     render_html %Q{<pre>\n<em>"This is <strong>not</strong> a big problem,"</em> he said.\n</pre>}
     text = "\n\"This is not a big problem,\" he said.\n"
@@ -144,29 +146,29 @@ class AssertSelectTest < ActionController::TestCase
   def test_counts
     render_html %Q{<div id="1">foo</div><div id="2">foo</div>}
     assert_nothing_raised               { assert_select "div", 2 }
-    assert_failure(/Expected exactly 3 elements matching \"div\", found 2/) do
+    assert_failure(/\AExpected exactly 3 elements matching \"div\", found 2\.$/) do
       assert_select "div", 3
     end
     assert_nothing_raised               { assert_select "div", 1..2 }
-    assert_failure(/Expected between 3 and 4 elements matching \"div\", found 2/) do
+    assert_failure(/\AExpected between 3 and 4 elements matching \"div\", found 2\.$/) do
       assert_select "div", 3..4
     end
     assert_nothing_raised               { assert_select "div", :count=>2 }
-    assert_failure(/Expected exactly 3 elements matching \"div\", found 2/) do
+    assert_failure(/\AExpected exactly 3 elements matching \"div\", found 2\.$/) do
       assert_select "div", :count=>3
     end
     assert_nothing_raised               { assert_select "div", :minimum=>1 }
     assert_nothing_raised               { assert_select "div", :minimum=>2 }
-    assert_failure(/Expected at least 3 elements matching \"div\", found 2/) do
+    assert_failure(/\AExpected at least 3 elements matching \"div\", found 2\.$/) do
       assert_select "div", :minimum=>3
     end
     assert_nothing_raised               { assert_select "div", :maximum=>2 }
     assert_nothing_raised               { assert_select "div", :maximum=>3 }
-    assert_failure(/Expected at most 1 element matching \"div\", found 2/) do
+    assert_failure(/\AExpected at most 1 element matching \"div\", found 2\.$/) do
       assert_select "div", :maximum=>1
     end
     assert_nothing_raised               { assert_select "div", :minimum=>1, :maximum=>2 }
-    assert_failure(/Expected between 3 and 4 elements matching \"div\", found 2/) do
+    assert_failure(/\AExpected between 3 and 4 elements matching \"div\", found 2\.$/) do
       assert_select "div", :minimum=>3, :maximum=>4
     end
   end
@@ -204,7 +206,7 @@ class AssertSelectTest < ActionController::TestCase
       end
     end
 
-    assert_failure(/Expected at least 1 element matching \"#4\", found 0\./) do
+    assert_failure(/\AExpected at least 1 element matching \"#4\", found 0\.$/) do
       assert_select "div" do
         assert_select "#4"
       end


### PR DESCRIPTION
MiniTest already adds a period to the provided message.
