### PR TITLE
`collection_check_boxes` respects `:index` option for the hidden filed name

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `collection_check_boxes` respects `:index` option for the hidden filed name.
+
+    Fixes #14147.
+
+    *Vasiliy Ermolovich*
+
 *   `date_select` helper with option `with_css_classes: true` does not overwrite other classes.
 
     *Izumi Wong-Horiuchi*

--- a/actionview/lib/action_view/helpers/tags/collection_check_boxes.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_check_boxes.rb
@@ -28,10 +28,7 @@ module ActionView
           # Append a hidden field to make sure something will be sent back to the
           # server if all check boxes are unchecked.
           if @options.fetch(:include_hidden, true)
-            hidden_name = @html_options[:name] || "#{tag_name}[]"
-            hidden = @template_object.hidden_field_tag(hidden_name, "", :id => nil)
-
-            rendered_collection + hidden
+            rendered_collection + hidden_field
           else
             rendered_collection
           end
@@ -41,6 +38,18 @@ module ActionView
 
         def render_component(builder)
           builder.check_box + builder.label
+        end
+
+        def hidden_field
+          hidden_name = @html_options[:name]
+
+          hidden_name ||= if @options.has_key?(:index)
+            "#{tag_name_with_index(@options[:index])}[]"
+          else
+            "#{tag_name}[]"
+          end
+
+          @template_object.hidden_field_tag(hidden_name, "", id: nil)
         end
       end
     end

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -221,6 +221,13 @@ class FormCollectionsHelperTest < ActionView::TestCase
     assert_select "input[type=hidden][name='user[other_category_ids][]'][value=]", :count => 1
   end
 
+  test 'collection check boxes generates a hidden field with index if it was provided' do
+    collection = [Category.new(1, 'Category 1'), Category.new(2, 'Category 2')]
+    with_collection_check_boxes :user, :category_ids, collection, :id, :name, { index: 322 }
+
+    assert_select "input[type=hidden][name='user[322][category_ids][]'][value=]", count: 1
+  end
+
   test 'collection check boxes does not generate a hidden field if include_hidden option is false' do
     collection = [Category.new(1, 'Category 1'), Category.new(2, 'Category 2')]
     with_collection_check_boxes :user, :category_ids, collection, :id, :name, include_hidden: false


### PR DESCRIPTION
closes #14147
