### PR TITLE
Remove wrapping div with inline styles for hidden form fields.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Remove wrapping div with inline styles for hidden form fields.
+
+    We are dropping HTML 4.01 and XHTML strict compliance since input tags directly
+    inside a form are valid HTML5, and the absense of inline styles help in validating
+    for Content Security Policy.
+
+    *Joost Baaij*
+
 *   `date_select` helper with option `with_css_classes: true` does not overwrite other classes.
 
     *Izumi Wong-Horiuchi*

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -726,9 +726,11 @@ module ActionView
               method_tag(method) + token_tag(authenticity_token)
           end
 
-          enforce_utf8 = html_options.delete("enforce_utf8") { true }
-          tags = (enforce_utf8 ? utf8_enforcer_tag : ''.html_safe) << method_tag
-          content_tag(:div, tags, :style => 'display:none')
+          if html_options.delete("enforce_utf8") { true }
+            utf8_enforcer_tag + method_tag
+          else
+            method_tag
+          end
         end
 
         def form_tag_html(html_options)

--- a/actionview/test/activerecord/form_helper_activerecord_test.rb
+++ b/actionview/test/activerecord/form_helper_activerecord_test.rb
@@ -59,12 +59,13 @@ class FormHelperActiveRecordTest < ActionView::TestCase
   protected
 
   def hidden_fields(method = nil)
-    txt =  %{<div style="display:none">}
-    txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
+    txt = %{<input name="utf8" type="hidden" value="&#x2713;" />}
+
     if method && !%w(get post).include?(method.to_s)
       txt << %{<input name="_method" type="hidden" value="#{method}" />}
     end
-    txt << %{</div>}
+
+    txt
   end
 
   def form_text(action = "/", id = nil, html_class = nil, remote = nil, multipart = nil, method = nil)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -3020,12 +3020,13 @@ class FormHelperTest < ActionView::TestCase
   protected
 
   def hidden_fields(method = nil)
-    txt =  %{<div style="display:none">}
-    txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
+    txt = %{<input name="utf8" type="hidden" value="&#x2713;" />}
+
     if method && !%w(get post).include?(method.to_s)
       txt << %{<input name="_method" type="hidden" value="#{method}" />}
     end
-    txt << %{</div>}
+
+    txt
   end
 
   def form_text(action = "/", id = nil, html_class = nil, remote = nil, multipart = nil, method = nil)

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -14,12 +14,15 @@ class FormTagHelperTest < ActionView::TestCase
     method = options[:method]
     enforce_utf8 = options.fetch(:enforce_utf8, true)
 
-    txt =  %{<div style="display:none">}
-    txt << %{<input name="utf8" type="hidden" value="&#x2713;" />} if enforce_utf8
-    if method && !%w(get post).include?(method.to_s)
-      txt << %{<input name="_method" type="hidden" value="#{method}" />}
+    ''.tap do |txt|
+      if enforce_utf8
+        txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
+      end
+
+      if method && !%w(get post).include?(method.to_s)
+        txt << %{<input name="_method" type="hidden" value="#{method}" />}
+      end
     end
-    txt << %{</div>}
   end
 
   def form_text(action = "http://www.example.com", options = {})


### PR DESCRIPTION
We are dropping HTML 4.01 and XHTML strict compliance since input tags directly inside a form are valid HTML5, and the absense of inline styles help in validating for Content Security Policy.
