### PR TITLE
Just call read_attribute, no need to use send.

### DIFF
--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -233,13 +233,13 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
   def test_belongs_to_counter
     debate = Topic.create("title" => "debate")
-    assert_equal 0, debate.send(:read_attribute, "replies_count"), "No replies yet"
+    assert_equal 0, debate.read_attribute("replies_count"), "No replies yet"
 
     trash = debate.replies.create("title" => "blah!", "content" => "world around!")
-    assert_equal 1, Topic.find(debate.id).send(:read_attribute, "replies_count"), "First reply created"
+    assert_equal 1, Topic.find(debate.id).read_attribute("replies_count"), "First reply created"
 
     trash.destroy
-    assert_equal 0, Topic.find(debate.id).send(:read_attribute, "replies_count"), "First reply deleted"
+    assert_equal 0, Topic.find(debate.id).read_attribute("replies_count"), "First reply deleted"
   end
 
   def test_belongs_to_counter_with_assigning_nil

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -288,10 +288,10 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   def test_read_attribute
     topic = Topic.new
     topic.title = "Don't change the topic"
-    assert_equal "Don't change the topic", topic.send(:read_attribute, "title")
+    assert_equal "Don't change the topic", topic.read_attribute("title")
     assert_equal "Don't change the topic", topic["title"]
 
-    assert_equal "Don't change the topic", topic.send(:read_attribute, :title)
+    assert_equal "Don't change the topic", topic.read_attribute(:title)
     assert_equal "Don't change the topic", topic[:title]
   end
 
@@ -358,10 +358,10 @@ class AttributeMethodsTest < ActiveRecord::TestCase
       super(attr_name).upcase
     end
 
-    assert_equal "STOP CHANGING THE TOPIC", topic.send(:read_attribute, "title")
+    assert_equal "STOP CHANGING THE TOPIC", topic.read_attribute("title")
     assert_equal "STOP CHANGING THE TOPIC", topic["title"]
 
-    assert_equal "STOP CHANGING THE TOPIC", topic.send(:read_attribute, :title)
+    assert_equal "STOP CHANGING THE TOPIC", topic.read_attribute(:title)
     assert_equal "STOP CHANGING THE TOPIC", topic[:title]
   end
 


### PR DESCRIPTION
Follow up to af549a1ad6692d7e2c756750651f0e1b293f5185
