### PR TITLE
Patch ActionDispatch::Request::LOCALHOST to match any IPv4 127.0.0.0/8 l...

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -23,7 +23,7 @@ module ActionDispatch
     autoload :Session, 'action_dispatch/request/session'
     autoload :Utils,   'action_dispatch/request/utils'
 
-    LOCALHOST   = Regexp.union [/^127\.0\.0\.\d{1,3}$/, /^::1$/, /^0:0:0:0:0:0:0:1(%.*)?$/]
+    LOCALHOST   = Regexp.union [/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, /^::1$/, /^0:0:0:0:0:0:0:1(%.*)?$/]
 
     ENV_METHODS = %w[ AUTH_TYPE GATEWAY_INTERFACE
         PATH_TRANSLATED REMOTE_HOST


### PR DESCRIPTION
...oopback address

The entire 127.0.0.0/8 range is assigned to the loopback address, not only 127.0.0.0/24. This patch allows ActionDispatch::Request::LOCALHOST to match any IPv4 127.0.0.0/8 loopback address.
