### PR TITLE
Use common to_io so users can access the underlying IO object

### DIFF
--- a/actionpack/lib/action_dispatch/http/upload.rb
+++ b/actionpack/lib/action_dispatch/http/upload.rb
@@ -31,6 +31,11 @@ module ActionDispatch
         @headers           = hash[:head]
       end
 
+      # Shortcut for working directly with +tempfile+
+      def to_io
+        @tempfile
+      end
+
       # Shortcut for +tempfile.read+.
       def read(length=nil, buffer=nil)
         @tempfile.read(length, buffer)

--- a/actionpack/test/dispatch/uploaded_file_test.rb
+++ b/actionpack/test/dispatch/uploaded_file_test.rb
@@ -33,6 +33,12 @@ module ActionDispatch
       assert_equal 'foo', uf.tempfile
     end
 
+    def test_delegates_to_io_to_tempfile
+      tf = Object.new
+      uf = Http::UploadedFile.new(:tempfile => tf)
+      assert_equal tf, uf.to_io
+    end
+
     def test_delegates_path_to_tempfile
       tf = Class.new { def path; 'thunderhorse' end }
       uf = Http::UploadedFile.new(:tempfile => tf.new)


### PR DESCRIPTION
No disadvantages to delegating to tempfile. Whitelisting
considered harmful when people expect an HttpUpload to quack like an IO
object eg to_io in my case was expected to be defined.
