### PR TITLE
Fix count on association relation (calls to empty and size).

### DIFF
--- a/activerecord/lib/active_record/association_relation.rb
+++ b/activerecord/lib/active_record/association_relation.rb
@@ -9,14 +9,6 @@ module ActiveRecord
       @association
     end
 
-    def size
-      @association.size
-    end
-
-    def empty?
-      @association.empty?
-    end
-
     def ==(other)
       other == to_a
     end

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -188,7 +188,7 @@ module ActiveRecord
     private
 
     def has_include?(column_name)
-      eager_loading? || (includes_values.present? && (column_name || references_eager_loaded_tables?))
+      eager_loading? || (includes_values.present? && ((column_name && column_name != :all) || references_eager_loaded_tables?))
     end
 
     def perform_calculation(operation, column_name, options = {})

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -864,6 +864,17 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 9, posts.where(:comments_count => 0).count
   end
 
+  def test_count_on_association_relation
+    author = Author.last
+    another_author = Author.first
+    posts = Post.where(author_id: author.id)
+
+    assert_equal author.posts.where(author_id: author.id).size, posts.count
+
+    assert_equal 0, author.posts.where(author_id: another_author.id).size
+    assert author.posts.where(author_id: another_author.id).empty?
+  end
+
   def test_count_with_distinct
     posts = Post.all
 


### PR DESCRIPTION
Fixes #14744.

More info about this problem: https://github.com/rails/rails/commit/968c581ea34b5236af14805e6a77913b1cb36238#commitcomment-6006135

I just did 2 different commits, each one explaining the reason for these changes.

968c581ea34b5236af14805e6a77913b1cb36238 have introduced this bug #14744
on Association Relation when the method `empty?` or `size` was called.

Example:

``` ruby
# Given an author that does have 3 posts, but none of them with the
# title 'Some Title'
Author.last.posts.where(title: 'Some Title').size
# => 3
```

It was occurring, because the Association Relation had implemented these
methods based on `@association`, this way giving wrong results.

To fix it, was necessary to remove the methods `empty?` and `size` from
Association Relation. It just have to use these methods from Relation.

Example:

``` ruby
# Given an author that does have 3 posts, but none of them with the
# title 'Some Title'
Author.last.posts.where(title: 'Some Title').size
# => 0
# Now it will return the correct value.
```

This fix introduced another bug. The same this commit 70fffaccfc9761498cb50537d8b29c2e5d0585d1 tried to fix.

The problem was when `empty?` or `size` was called on relation. It was
triggering `count(:all)`, which was passing `:all` as the column name to `count`
on Calculations.

On the other hand, the method `calculate` on Calculations was calling
`construct_relation_for_association_calculations` instead of `perform_calculation`,
 because `has_include?` was returning `true` since `column_name` was present.

To prevent calling the wrong method to perform the calculation, we have to check
if the `column_name` is present and if it is different from `:all` (which is now used
to correctly do `count` with `select`).
