### PR TITLE
use YAML.load_file in database tasks example

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -28,7 +28,7 @@ module ActiveRecord
     # Example usage of +DatabaseTasks+ outside Rails could look as such:
     #
     #   include ActiveRecord::Tasks
-    #   DatabaseTasks.database_configuration = YAML.load(File.read('my_database_config.yml'))
+    #   DatabaseTasks.database_configuration = YAML.load_file('my_database_config.yml')
     #   DatabaseTasks.db_dir = 'db'
     #   # other settings...
     #


### PR DESCRIPTION
rather than YAML.load(File.read(path)). YAML.load_file is also used in guides/rails_guides/helper.rb since 2011, the only other precedent I could find.
