### PR TITLE
Refactor counter cache create and destroy

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -31,6 +31,14 @@ module ActiveRecord
         @updated
       end
 
+      def decrement_counters
+        with_cache_name { |name| decrement_counter name }
+      end
+
+      def increment_counters
+        with_cache_name { |name| increment_counter name }
+      end
+
       private
 
         def find_target?
@@ -51,13 +59,15 @@ module ActiveRecord
           end
         end
 
-        def decrement_counters
-          with_cache_name { |name| decrement_counter name }
-        end
-
-        def decrement_counter counter_cache_name
+        def decrement_counter(counter_cache_name)
           if foreign_key_present?
             klass.decrement_counter(counter_cache_name, target_id)
+          end
+        end
+
+        def increment_counter(counter_cache_name)
+          if foreign_key_present?
+            klass.increment_counter(counter_cache_name, target_id)
           end
         end
 

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -31,11 +31,11 @@ module ActiveRecord
         @updated
       end
 
-      def decrement_counters
+      def decrement_counters # :nodoc:
         with_cache_name { |name| decrement_counter name }
       end
 
-      def increment_counters
+      def increment_counters # :nodoc:
         with_cache_name { |name| increment_counter name }
       end
 

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -26,16 +26,9 @@ module ActiveRecord::Associations::Builder
     private
 
     def self.add_counter_cache_methods(mixin)
-      return if mixin.method_defined? :belongs_to_counter_cache_after_create
+      return if mixin.method_defined? :belongs_to_counter_cache_after_update
 
       mixin.class_eval do
-        def belongs_to_counter_cache_after_create(reflection)
-          if record = send(reflection.name)
-            cache_column = reflection.counter_cache_column
-            record.class.increment_counter(cache_column, record.id)
-            @_after_create_counter_called = true
-          end
-        end
 
         def belongs_to_counter_cache_after_destroy(reflection)
           foreign_key = reflection.foreign_key.to_sym
@@ -73,10 +66,6 @@ module ActiveRecord::Associations::Builder
 
     def self.add_counter_cache_callbacks(model, reflection)
       cache_column = reflection.counter_cache_column
-
-      model.after_create lambda { |record|
-        record.belongs_to_counter_cache_after_create(reflection)
-      }
 
       model.after_destroy lambda { |record|
         record.belongs_to_counter_cache_after_destroy(reflection)

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -29,7 +29,6 @@ module ActiveRecord::Associations::Builder
       return if mixin.method_defined? :belongs_to_counter_cache_after_update
 
       mixin.class_eval do
-
         def belongs_to_counter_cache_after_update(reflection)
           foreign_key  = reflection.foreign_key
           cache_column = reflection.counter_cache_column

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -30,18 +30,6 @@ module ActiveRecord::Associations::Builder
 
       mixin.class_eval do
 
-        def belongs_to_counter_cache_after_destroy(reflection)
-          foreign_key = reflection.foreign_key.to_sym
-          unless destroyed_by_association && destroyed_by_association.foreign_key.to_sym == foreign_key
-            record = send reflection.name
-            if record && self.actually_destroyed?
-              cache_column = reflection.counter_cache_column
-              record.class.decrement_counter(cache_column, record.id)
-              self.clear_destroy_state
-            end
-          end
-        end
-
         def belongs_to_counter_cache_after_update(reflection)
           foreign_key  = reflection.foreign_key
           cache_column = reflection.counter_cache_column
@@ -66,10 +54,6 @@ module ActiveRecord::Associations::Builder
 
     def self.add_counter_cache_callbacks(model, reflection)
       cache_column = reflection.counter_cache_column
-
-      model.after_destroy lambda { |record|
-        record.belongs_to_counter_cache_after_destroy(reflection)
-      }
 
       model.after_update lambda { |record|
         record.belongs_to_counter_cache_after_update(reflection)

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -134,9 +134,7 @@ module ActiveRecord
       def _create_record(*)
         id = super
 
-        each_counter_cached_associations do |association|
-          association.increment_counters
-        end
+        each_counter_cached_associations(&:increment_counters)
 
         id
       end
@@ -144,7 +142,9 @@ module ActiveRecord
       def destroy_row
         affected_rows = super
 
-        @_actually_destroyed = affected_rows > 0
+        if affected_rows > 0
+          each_counter_cached_associations(&:decrement_counters)
+        end
 
         affected_rows
       end

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -135,7 +135,7 @@ module ActiveRecord
         id = super
 
         each_counter_cached_associations do |association|
-          if record = send(association.reflection.name)
+          if send(association.reflection.name)
             association.increment_counters
             @_after_create_counter_called = true
           end
@@ -148,7 +148,14 @@ module ActiveRecord
         affected_rows = super
 
         if affected_rows > 0
-          each_counter_cached_associations(&:decrement_counters)
+          each_counter_cached_associations do |association|
+            foreign_key = association.reflection.foreign_key.to_sym
+            unless destroyed_by_association && destroyed_by_association.foreign_key.to_sym == foreign_key
+              if send(association.reflection.name)
+                association.decrement_counters
+              end
+            end
+          end
         end
 
         affected_rows

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -131,12 +131,28 @@ module ActiveRecord
 
     private
 
+      def _create_record(*)
+        id = super
+
+        each_counter_cached_associations do |association|
+          association.increment_counters
+        end
+
+        id
+      end
+
       def destroy_row
         affected_rows = super
 
         @_actually_destroyed = affected_rows > 0
 
         affected_rows
+      end
+
+      def each_counter_cached_associations
+        reflections.each do |name, reflection|
+          yield association(name) if reflection.belongs_to? && reflection.counter_cache_column
+        end
       end
 
   end

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -134,7 +134,12 @@ module ActiveRecord
       def _create_record(*)
         id = super
 
-        each_counter_cached_associations(&:increment_counters)
+        each_counter_cached_associations do |association|
+          if record = send(association.reflection.name)
+            association.increment_counters
+            @_after_create_counter_called = true
+          end
+        end
 
         id
       end


### PR DESCRIPTION
Follow up of #14735 

Move destroy and create counter cache callbacks code inside the `CounterCache` model concern.

The rationale is that the `after_destroy` callback need to access the `affected_rows` variable, and it's cleaner to be in the inheritance chain to access it than to leak it as yet another state on the model.

This refactoring do not move the `update` part of counter caches because Its way more complex and I prefer to do it in another PR.

@tenderlove What do you think?

cc @arthurnn
