### PR TITLE
Changed change_column in PG schema_statements.rb to make sure that the u...

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -182,6 +182,15 @@ module ActiveRecord
           end
           result
         end
+
+        # Does not quote function default values for UUID columns
+        def quote_default_value(value, column) #:nodoc:
+          if column.type == :uuid && value =~ /\(\)/
+            value
+          else 
+            quote(value)
+          end
+        end
       end
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -40,6 +40,19 @@ class PostgresqlUUIDTest < ActiveRecord::TestCase
     drop_table "uuid_data_type"
   end
 
+  def test_change_column_default
+    @connection.add_column :uuid_data_type, :thingy, :uuid, null: false, default: "uuid_generate_v1()"
+    UUIDType.reset_column_information
+    column = UUIDType.columns.find { |c| c.name == 'thingy' }
+    assert_equal "uuid_generate_v1()", column.default_function
+    
+    @connection.change_column :uuid_data_type, :thingy, :uuid, null: false, default: "uuid_generate_v4()"
+    
+    UUIDType.reset_column_information
+    column = UUIDType.columns.find { |c| c.name == 'thingy' }
+    assert_equal "uuid_generate_v4()", column.default_function
+  end
+
   def test_data_type_of_uuid_types
     column = UUIDType.columns_hash["guid"]
     assert_equal :uuid, column.type


### PR DESCRIPTION
...uid_generate function was not being quoted.

This is a bug fix for https://github.com/rails/rails/issues/14604.

Two previous pull requests that had discussion: https://github.com/rails/rails/pull/14723 and https://github.com/rails/rails/pull/14749.
