### PR TITLE
Update AC::Metal documentation example

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -70,7 +70,8 @@ module ActionController
   # can do the following:
   #
   #   class HelloController < ActionController::Metal
-  #     include ActionController::Rendering
+  #     include AbstractController::Rendering
+  #     include ActionView::Layouts
   #     append_view_path "#{Rails.root}/app/views"
   #
   #     def index


### PR DESCRIPTION
Include proper modules since AV was extracted form AP as mentioned in #14659.
