### PR TITLE
Prevent Rails console log twice

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Prevent Rails console log twice when `config.logger` is set.
+
+    Fixes #11415.
+
+    *Andriel Nuernberg*
+
 *   Do not quote uuid default value on `change_column`.
 
     Fixes #14604.

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -59,8 +59,11 @@ module ActiveRecord
     console do |app|
       require "active_record/railties/console_sandbox" if app.sandbox?
       require "active_record/base"
-      console = ActiveSupport::Logger.new(STDERR)
-      Rails.logger.extend ActiveSupport::Logger.broadcast console
+
+      unless Rails.configuration.logger
+        console = ActiveSupport::Logger.new(STDERR)
+        Rails.logger.extend ActiveSupport::Logger.broadcast console
+      end
     end
 
     runner do


### PR DESCRIPTION
When `config.logger` is set in `development.rb`, for example, the console log is printed twice.

By default, Active Record sets a Logger for the console. Now we check if there is a Logger set in Rails configuration before Active Record instantiate its own.

Fixes #11415.
