### PR TITLE
Avoid suggesting dangerous code in i18n guide

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -179,7 +179,7 @@ end
 # in your /etc/hosts file to try this out locally
 def extract_locale_from_tld
   parsed_locale = request.host.split('.').last
-  I18n.available_locales.include?(parsed_locale.to_sym) ? parsed_locale : nil
+  I18n.available_locales.map(&:to_s).include?(parsed_locale) ? parsed_locale : nil
 end
 ```
 
@@ -192,7 +192,7 @@ We can also set the locale from the _subdomain_ in a very similar way:
 # in your /etc/hosts file to try this out locally
 def extract_locale_from_subdomain
   parsed_locale = request.subdomains.first
-  I18n.available_locales.include?(parsed_locale.to_sym) ? parsed_locale : nil
+  I18n.available_locales.map(&:to_s).include?(parsed_locale) ? parsed_locale : nil
 end
 ```
 


### PR DESCRIPTION
Calling `to_sym` on user input opens apps up to Denial of Service attacks, via the symbol table being expanded to consume vast swathes of memory.

It is a fairly common configuration to have DNS configured such that all subdomains route to your Rails app, in which case an attacker visits `www1.foo.com`, `www2.foo.com`, and so on until something gives.

It is far less likely to have this problem with TLDs, so that change was only for consistency.
