### PR TITLE
Reorder i18n guide

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -92,7 +92,7 @@ Rails adds all `.rb` and `.yml` files from the `config/locales` directory to you
 
 The default `en.yml` locale in this directory contains a sample pair of translation strings:
 
-```ruby
+```yaml
 en:
   hello: "Hello world"
 ```
@@ -369,7 +369,7 @@ NOTE: Rails adds a `t` (`translate`) helper method to your views so that you do 
 
 So let's add the missing translations into the dictionary files (i.e. do the "localization" part):
 
-```ruby
+```yaml
 # config/locales/en.yml
 en:
   hello_world: Hello world!
@@ -421,7 +421,7 @@ OK! Now let's add a timestamp to the view, so we can demo the **date/time locali
 
 And in our pirate translations file let's add a time format (it's already there in Rails' defaults for English):
 
-```ruby
+```yaml
 # config/locales/pirate.yml
 pirate:
   time:
@@ -680,62 +680,13 @@ NOTE: Automatic conversion to HTML safe translate text is only available from th
 
 ![i18n demo html safe](images/i18n/demo_html_safe.png)
 
-How to Store your Custom Translations
--------------------------------------
-
-The Simple backend shipped with Active Support allows you to store translations in both plain Ruby and YAML format.[^2]
-
-For example a Ruby Hash providing translations can look like this:
-
-```ruby
-{
-  pt: {
-    foo: {
-      bar: "baz"
-    }
-  }
-}
-```
-
-The equivalent YAML file would look like this:
-
-```ruby
-pt:
-  foo:
-    bar: baz
-```
-
-As you see, in both cases the top level key is the locale. `:foo` is a namespace key and `:bar` is the key for the translation "baz".
-
-Here is a "real" example from the Active Support `en.yml` translations YAML file:
-
-```ruby
-en:
-  date:
-    formats:
-      default: "%Y-%m-%d"
-      short: "%b %d"
-      long: "%B %d, %Y"
-```
-
-So, all of the following equivalent lookups will return the `:short` date format `"%b %d"`:
-
-```ruby
-I18n.t 'date.formats.short'
-I18n.t 'formats.short', scope: :date
-I18n.t :short, scope: 'date.formats'
-I18n.t :short, scope: [:date, :formats]
-```
-
-Generally we recommend using YAML as a format for storing translations. There are cases, though, where you want to store Ruby lambdas as part of your locale data, e.g. for special date formats.
-
 ### Translations for Active Record Models
 
 You can use the methods `Model.model_name.human` and `Model.human_attribute_name(attribute)` to transparently look up translations for your model and attribute names.
 
 For example when you add the following translations:
 
-```ruby
+```yaml
 en:
   activerecord:
     models:
@@ -750,7 +701,7 @@ Then `User.model_name.human` will return "Dude" and `User.human_attribute_name("
 
 You can also set a plural form for model names, adding as following:
 
-```ruby
+```yaml
 en:
   activerecord:
     models:
@@ -919,6 +870,55 @@ Rails uses fixed strings and other localizations, such as format strings and oth
 #### Active Support Methods
 
 * `Array#to_sentence` uses format settings as given in the [support.array](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/locale/en.yml#L33) scope.
+
+How to Store your Custom Translations
+-------------------------------------
+
+The Simple backend shipped with Active Support allows you to store translations in both plain Ruby and YAML format.[^2]
+
+For example a Ruby Hash providing translations can look like this:
+
+```yaml
+{
+  pt: {
+    foo: {
+      bar: "baz"
+    }
+  }
+}
+```
+
+The equivalent YAML file would look like this:
+
+```yaml
+pt:
+  foo:
+    bar: baz
+```
+
+As you see, in both cases the top level key is the locale. `:foo` is a namespace key and `:bar` is the key for the translation "baz".
+
+Here is a "real" example from the Active Support `en.yml` translations YAML file:
+
+```yaml
+en:
+  date:
+    formats:
+      default: "%Y-%m-%d"
+      short: "%b %d"
+      long: "%B %d, %Y"
+```
+
+So, all of the following equivalent lookups will return the `:short` date format `"%b %d"`:
+
+```ruby
+I18n.t 'date.formats.short'
+I18n.t 'formats.short', scope: :date
+I18n.t :short, scope: 'date.formats'
+I18n.t :short, scope: [:date, :formats]
+```
+
+Generally we recommend using YAML as a format for storing translations. There are cases, though, where you want to store Ruby lambdas as part of your locale data, e.g. for special date formats.
 
 Customize your I18n Setup
 -------------------------


### PR DESCRIPTION
Currently, the section called "How to store your custom translations"
has several subheadings that make no sense, such as "Translations for
ActiveRecord models." These make more sense under the "Overview of the
I18n API Features" section. I moved the "How to store..." section down
to the more appropriate sub-headings "Using Different Backends" and
"Using Different Exception Handlers" and removed the "Customize your
i18n setup" header.
