### PR TITLE
Changes the test methods' declaration

### DIFF
--- a/activemodel/test/cases/model_test.rb
+++ b/activemodel/test/cases/model_test.rb
@@ -35,17 +35,17 @@ class ModelTest < ActiveModel::TestCase
     @model = BasicModel.new
   end
 
-  def test_initialize_with_params
+  test "initialize with params" do
     object = BasicModel.new(attr: "value")
     assert_equal "value", object.attr
   end
 
-  def test_initialize_with_params_and_mixins_reversed
+  test "initialize with params and mixins reversed" do
     object = BasicModelWithReversedMixins.new(attr: "value")
     assert_equal "value", object.attr
   end
 
-  def test_initialize_with_nil_or_empty_hash_params_does_not_explode
+  test "initialize with nil or empty hash params does not explode" do
     assert_nothing_raised do
       BasicModel.new()
       BasicModel.new(nil)
@@ -54,22 +54,22 @@ class ModelTest < ActiveModel::TestCase
     end
   end
 
-  def test_persisted_is_always_false
+  test "persisted is always false" do
     object = BasicModel.new(attr: "value")
     assert object.persisted? == false
   end
 
-  def test_mixin_inclusion_chain
+  test "mixin inclusion chain" do
     object = BasicModel.new
     assert_equal 'default value', object.attr
   end
 
-  def test_mixin_initializer_when_args_exist
+  test "mixin initializer when args exist" do
     object = BasicModel.new(hello: 'world')
     assert_equal 'world', object.hello
   end
 
-  def test_mixin_initializer_when_args_dont_exist
+  test "mixin initializer when args dont exist" do
     assert_raises(NoMethodError) { SimpleModel.new(hello: 'world') }
   end
 end

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -115,7 +115,7 @@ class SerializationTest < ActiveModel::TestCase
     end
   end
 
-  def test_include_option_with_ary
+  test "include option with ary" do
     @user.friends = FriendList.new(@user.friends)
     expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
                 "friends"=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
@@ -123,7 +123,7 @@ class SerializationTest < ActiveModel::TestCase
     assert_equal expected, @user.serializable_hash(include: :friends)
   end
 
-  def test_multiple_includes
+  test "multiple includes" do
     expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
                 "address"=>{"street"=>"123 Lane", "city"=>"Springfield", "state"=>"CA", "zip"=>11111},
                 "friends"=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
@@ -131,13 +131,13 @@ class SerializationTest < ActiveModel::TestCase
     assert_equal expected, @user.serializable_hash(include: [:address, :friends])
   end
 
-  def test_include_with_options
+  test "include with options" do
     expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
                 "address"=>{"street"=>"123 Lane"}}
     assert_equal expected, @user.serializable_hash(include: { address: { only: "street" } })
   end
 
-  def test_nested_include
+  test "nested include" do
     @user.friends.first.friends = [@user]
     expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
                 "friends"=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male',
@@ -146,19 +146,19 @@ class SerializationTest < ActiveModel::TestCase
     assert_equal expected, @user.serializable_hash(include: { friends: { include: :friends } })
   end
 
-  def test_only_include
+  test "only include" do
     expected = {"name"=>"David", "friends" => [{"name" => "Joe"}, {"name" => "Sue"}]}
     assert_equal expected, @user.serializable_hash(only: :name, include: { friends: { only: :name } })
   end
 
-  def test_except_include
+  test "except include" do
     expected = {"name"=>"David", "email"=>"david@example.com",
                 "friends"=> [{"name" => 'Joe', "email" => 'joe@example.com'},
                              {"name" => "Sue", "email" => 'sue@example.com'}]}
     assert_equal expected, @user.serializable_hash(except: :gender, include: { friends: { except: :gender } })
   end
 
-  def test_multiple_includes_with_options
+  test "multiple includes with options" do
     expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
                 "address"=>{"street"=>"123 Lane"},
                 "friends"=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -11,49 +11,49 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     I18n.backend.reload!
   end
 
-  def test_translated_model_attributes
+  test "translated model attributes" do
     I18n.backend.store_translations 'en', activemodel: { attributes: { person: { name: 'person name attribute' } } }
     assert_equal 'person name attribute', Person.human_attribute_name('name')
   end
 
-  def test_translated_model_attributes_with_default
+  test "translated model attributes with default" do
     I18n.backend.store_translations 'en', attributes: { name: 'name default attribute' }
     assert_equal 'name default attribute', Person.human_attribute_name('name')
   end
 
-  def test_translated_model_attributes_using_default_option
+  test "translated model attributes using default option" do
     assert_equal 'name default attribute', Person.human_attribute_name('name', default: "name default attribute")
   end
 
-  def test_translated_model_attributes_using_default_option_as_symbol
+  test "translated model attributes using default option as symbol" do
     I18n.backend.store_translations 'en', default_name: 'name default attribute'
     assert_equal 'name default attribute', Person.human_attribute_name('name', default: :default_name)
   end
 
-  def test_translated_model_attributes_falling_back_to_default
+  test "translated model attributes falling back to default" do
     assert_equal 'Name', Person.human_attribute_name('name')
   end
 
-  def test_translated_model_attributes_using_default_option_as_symbol_and_falling_back_to_default
+  test "translated model attributes using default option as symbol and falling back to default" do
     assert_equal 'Name', Person.human_attribute_name('name', default: :default_name)
   end
 
-  def test_translated_model_attributes_with_symbols
+  test "translated model attributes with symbols" do
     I18n.backend.store_translations 'en', activemodel: { attributes: { person: { name: 'person name attribute'} } }
     assert_equal 'person name attribute', Person.human_attribute_name(:name)
   end
 
-  def test_translated_model_attributes_with_ancestor
+  test "translated model attributes with ancestor" do
     I18n.backend.store_translations 'en', activemodel: { attributes: { child: { name: 'child name attribute'} } }
     assert_equal 'child name attribute', Child.human_attribute_name('name')
   end
 
-  def test_translated_model_attributes_with_ancestors_fallback
+  test "translated model attributes with ancestors fallback" do
     I18n.backend.store_translations 'en', activemodel: { attributes: { person: { name: 'person name attribute'} } }
     assert_equal 'person name attribute', Child.human_attribute_name('name')
   end
 
-  def test_translated_model_attributes_with_attribute_matching_namespaced_model_name
+  test "translated model attributes with attribute matching namespaced model name" do
     I18n.backend.store_translations 'en', activemodel: { attributes: {
       person: { gender: 'person gender'},
       :"person/gender" => { attribute: 'person gender attribute' }
@@ -63,43 +63,43 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     assert_equal 'person gender attribute', Person::Gender.human_attribute_name('attribute')
   end
 
-  def test_translated_deeply_nested_model_attributes
+  test "translated deeply nested model attributes" do
     I18n.backend.store_translations 'en', activemodel: { attributes: { :"person/contacts/addresses" => { street: 'Deeply Nested Address Street' } } }
     assert_equal 'Deeply Nested Address Street', Person.human_attribute_name('contacts.addresses.street')
   end
 
-  def test_translated_nested_model_attributes
+  test "translated nested model attributes" do
     I18n.backend.store_translations 'en', activemodel: { attributes: { :"person/addresses" => { street: 'Person Address Street' } } }
     assert_equal 'Person Address Street', Person.human_attribute_name('addresses.street')
   end
 
-  def test_translated_nested_model_attributes_with_namespace_fallback
+  test "translated nested model attributes with namespace fallback" do
     I18n.backend.store_translations 'en', activemodel: { attributes: { addresses: { street: 'Cool Address Street' } } }
     assert_equal 'Cool Address Street', Person.human_attribute_name('addresses.street')
   end
 
-  def test_translated_model_names
+  test "translated model names" do
     I18n.backend.store_translations 'en', activemodel: { models: { person: 'person model' } }
     assert_equal 'person model', Person.model_name.human
   end
 
-  def test_translated_model_names_with_sti
+  test "translated model names with sti" do
     I18n.backend.store_translations 'en', activemodel: { models: { child: 'child model' } }
     assert_equal 'child model', Child.model_name.human
   end
 
-  def test_translated_model_names_with_ancestors_fallback
+  test "translated model names with ancestors fallback" do
     I18n.backend.store_translations 'en', activemodel: { models: { person: 'person model' } }
     assert_equal 'person model', Child.model_name.human
   end
 
-  def test_human_does_not_modify_options
+  test "human does not modify options" do
     options = { default: 'person model' }
     Person.model_name.human(options)
     assert_equal({ default: 'person model' }, options)
   end
 
-  def test_human_attribute_name_does_not_modify_options
+  test "human attribute name does not modify options" do
     options = { default: 'Cool gender' }
     Person.human_attribute_name('gender', options)
     assert_equal({ default: 'Cool gender' }, options)


### PR DESCRIPTION
I don't know if it's important but i believe it's at least interesting. How about have a pattern for test methods' declaration? These past days i'm reading and studying about tests in Rails applications, and looking at the tests created here in Rails' repository, despite a pattern has not been implemented, the declaration 

``` ruby
test "some test declaration" do
 assert true
end
```

is more frequent that

``` ruby
def test_some_test_declaration
 assert true
end
```

Like a said, i don't know if it's important, but could be interesting.

i changed

``` ruby
def test_some_test_declaration
  assert true
end
```

to

``` ruby
test "some test declaration" do
  assert true
end
```
