### PR TITLE
Don't include ActiveModel::SecurePassword by default.

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -313,7 +313,6 @@ module ActiveRecord #:nodoc:
     include Timestamp
     include Callbacks
     include Associations
-    include ActiveModel::SecurePassword
     include AutosaveAssociation
     include NestedAttributes
     include Aggregations


### PR DESCRIPTION
In all the Rails applications that I've worked so far, I've only used
this module in one model, specifically the `User` model.

I think is bad to assume that every model needs to handle passwords.
