### PR TITLE
Localized number input

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -190,11 +190,19 @@ module ActiveRecord
           # in the else clause
           if value.class == BigDecimal
             value
+          elsif value.is_a?(String)
+            parse_localized_decimal(value)
           elsif value.respond_to?(:to_d)
             value.to_d
           else
-            value.to_s.to_d
+            parse_localized_decimal(value.to_s)
           end
+        end
+
+        def parse_localized_decimal(value)
+          separator = I18n.t(:'number.format.separator')
+          delimiter = I18n.t(:'number.format.delimiter')
+          BigDecimal(value.gsub(delimiter, '').gsub(separator, '.'))
         end
 
         protected

--- a/activerecord/test/cases/i18n_test.rb
+++ b/activerecord/test/cases/i18n_test.rb
@@ -2,6 +2,10 @@ require "cases/helper"
 require 'models/topic'
 require 'models/reply'
 
+class NumericData < ActiveRecord::Base
+  self.table_name = 'numeric_data'
+end
+
 class ActiveRecordI18nTests < ActiveRecord::TestCase
 
   def setup
@@ -41,5 +45,32 @@ class ActiveRecordI18nTests < ActiveRecord::TestCase
   def test_translated_model_names_with_sti_fallback
     I18n.backend.store_translations 'en', :activerecord => {:models => {:topic => 'topic model'} }
     assert_equal 'topic model', Reply.model_name.human
+  end
+  
+  def test_default_number_input
+    numeric_data = NumericData.new
+    numeric_data.attributes = { "bank_balance" => "1.234" }
+    numeric_data.save
+    assert_equal(1.234, numeric_data.bank_balance)
+  end
+
+  def test_localized_number_input
+    I18n.backend.store_translations 'de', :number => {:format => {:separator => ',', :delimiter => ''} }
+    numeric_data = NumericData.new
+    I18n.with_locale(:de) do
+      numeric_data.attributes = { "bank_balance" => "1,234" }
+      numeric_data.save
+    end
+    assert_equal(1.234, numeric_data.bank_balance)
+  end
+
+  def test_localized_number_input_with_delimiter
+    I18n.backend.store_translations 'de', :number => {:format => {:separator => ',', :delimiter => '.'} }
+    numeric_data = NumericData.new
+    I18n.with_locale(:de) do
+      numeric_data.attributes = { "bank_balance" => "1.234,5" }
+      numeric_data.save
+    end
+    assert_equal(1234.5, numeric_data.bank_balance)
   end
 end


### PR DESCRIPTION
This will enable a localized input for decimals.
Define your localized number format with number.format.separator
 and number.format.delimiter.
For a German locale this would be:

```
de:
  number:
    format:
      separator: ','
      delimiter: '.'
```

Now you can enter numbers like 1.234,5 and it will be parsed
 correctly according to your locale.
