### PR TITLE
Autoload ActiveModel::StrictValidationFailed

### DIFF
--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -48,6 +48,7 @@ module ActiveModel
 
   eager_autoload do
     autoload :Errors
+    autoload :StrictValidationFailed, 'active_model/errors'
   end
 
   module Serializers


### PR DESCRIPTION
Currently, if environment doesn’t eager load the code, invoking this constant before calling `#valid?` on a model instance results in a `NameError`.

I ran into this while testing a model with strict validation using `assert_raise`, which happens to require one to invoke the constant first. You could also reproduce this by simply invoking the class in console.
