### PR TITLE
Bring SQLite3Adpter init API closer to others

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -187,7 +187,6 @@ module ActiveRecord
         include Arel::Visitors::BindVisitor
       end
 
-      # FIXME: Make the first parameter more similar for the two adapters
       def initialize(connection, logger, connection_options, config)
         super(connection, logger)
         @connection_options, @config = connection_options, config

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -30,7 +30,7 @@ module ActiveRecord
 
       db.busy_timeout(ConnectionAdapters::SQLite3Adapter.type_cast_config_to_integer(config[:timeout])) if config[:timeout]
 
-      ConnectionAdapters::SQLite3Adapter.new(db, logger, config)
+      ConnectionAdapters::SQLite3Adapter.new(db, logger, nil, config)
     rescue Errno::ENOENT => error
       if error.message.include?("No such file or directory")
         raise ActiveRecord::NoDatabaseError.new(error.message, error)
@@ -127,7 +127,7 @@ module ActiveRecord
         include Arel::Visitors::BindVisitor
       end
 
-      def initialize(connection, logger, config)
+      def initialize(connection, logger, connection_options, config)
         super(connection, logger)
 
         @active     = nil


### PR DESCRIPTION
Remove FIXME comment, and make the parameters on all adapters the same.

review @matthewd @rafaelfranca
