### PR TITLE
Changed extract_limit in class Column to return correct mysql float and ...

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Floats with limit >= 25 that get turned into doubles in MySQL no longer have
+    their limit dropped from the schema.
+    
+    Fixes #14135.
+
+    *Aaron Nelson*
+
 *   Fixed a problem where count used with a grouping was not returning a Hash.
 
     Fixes #14721.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -129,6 +129,8 @@ module ActiveRecord
           when /^mediumint/i; 3
           when /^smallint/i;  2
           when /^tinyint/i;   1
+          when /^float/i;     24
+          when /^double/i;    53
           else
             super
           end

--- a/activerecord/test/cases/adapters/mysql/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/schema_test.rb
@@ -17,6 +17,44 @@ module ActiveRecord
           self.table_name = "#{db}.#{table}"
           def self.name; 'Post'; end
         end
+
+        @connection.create_table "mysql_doubles"
+      end
+
+      teardown do
+        @connection.execute "drop table if exists mysql_doubles"
+      end
+
+      class MysqlDouble < ActiveRecord::Base
+        self.table_name = "mysql_doubles"
+      end
+
+      def test_float_limits
+        @connection.add_column :mysql_doubles, :float_no_limit, :float
+        @connection.add_column :mysql_doubles, :float_short, :float, limit: 5
+        @connection.add_column :mysql_doubles, :float_long, :float, limit: 53
+
+        @connection.add_column :mysql_doubles, :float_23, :float, limit: 23
+        @connection.add_column :mysql_doubles, :float_24, :float, limit: 24
+        @connection.add_column :mysql_doubles, :float_25, :float, limit: 25
+        MysqlDouble.reset_column_information
+
+        column_no_limit = MysqlDouble.columns.find { |c| c.name == 'float_no_limit' }
+        column_short = MysqlDouble.columns.find { |c| c.name == 'float_short' }
+        column_long = MysqlDouble.columns.find { |c| c.name == 'float_long' }
+
+        column_23 = MysqlDouble.columns.find { |c| c.name == 'float_23' }
+        column_24 = MysqlDouble.columns.find { |c| c.name == 'float_24' }
+        column_25 = MysqlDouble.columns.find { |c| c.name == 'float_25' }
+
+        # Mysql floats are precision 0..24, Mysql doubles are precision 25..53
+        assert_equal 24, column_no_limit.limit
+        assert_equal 24, column_short.limit
+        assert_equal 53, column_long.limit
+
+        assert_equal 24, column_23.limit
+        assert_equal 24, column_24.limit
+        assert_equal 53, column_25.limit
       end
 
       def test_schema


### PR DESCRIPTION
...double limits

Fixes https://github.com/rails/rails/issues/14135.

When rails uses a float type with a limit in a mysql database, rails converts limits from 25..53 to double types to comply with mysql, but the rails schema still said float with no limit, causing loss of accuracy. This pull request causes floats and doubles to automatically set their limits to the mysql limits for those types (24 and 53, respectively).
