### PR TITLE
Don't sort ActiveSupport::Ordered hash with `to_param` or `to_query`

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_param.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_param.rb
@@ -54,9 +54,15 @@ class Hash
     if empty?
       namespace ? nil.to_query(namespace) : ''
     else
-      collect do |key, value|
+      params = collect do |key, value|
         value.to_query(namespace ? "#{namespace}[#{key}]" : key)
-      end.sort! * '&'
+      end
+
+      if !defined?(ActiveSupport::OrderedHash) || !is_a?(ActiveSupport::OrderedHash)
+        params.sort!
+      end
+
+      params * '&'
     end
   end
 end

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -20,6 +20,14 @@ class ToQueryTest < ActiveSupport::TestCase
     assert_query_equal 'a=%5B10%5D', 'a' => '[10]'.html_safe
   end
 
+  def test_ordered_hash
+    hash = ActiveSupport::OrderedHash.new
+    hash['b'] = 1
+    hash['a'] = 2
+
+    assert_equal hash.to_query, 'b=1&a=2'
+  end
+
   def test_nil_parameter_value
     empty = Object.new
     def empty.to_param; nil end


### PR DESCRIPTION
ActiveSupport::Ordered is supposed to be ordered by default. Why do we need to apply `sort` for it?
