### PR TITLE
Model#save should always set `@destroyed=false`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `@destroyed` should always be set to `false` when an object is duped.
+
+    *Kuldeep Aggarwal*
+
 *   Fixed has_many association to make it support irregular inflections.
 
     Fixes #8928.

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -267,6 +267,7 @@ module ActiveRecord
       @attributes_cache  = {}
 
       @new_record  = true
+      @destroyed   = false
 
       super
     end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -233,6 +233,22 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_nothing_raised { Minimalistic.create!(:id => 2) }
   end
 
+  def test_save_with_duping_of_destroyed_object
+    developer = Developer.create(name: "Kuldeep")
+    developer.destroy
+    new_developer = developer.dup
+    new_developer.save
+    assert new_developer.persisted?
+  end
+
+  def test_dup_of_destroyed_object_is_not_destroyed
+    developer = Developer.create(name: "Kuldeep")
+    developer.destroy
+    new_developer = developer.dup
+    new_developer.save
+    assert_equal new_developer.destroyed?, false
+  end
+
   def test_create_many
     topics = Topic.create([ { "title" => "first" }, { "title" => "second" }])
     assert_equal 2, topics.size


### PR DESCRIPTION
If a new object is saved by duping a destroyed object, then new object should not be destroyed.

\cc @rafaelfranca, @senny 
