### PR TITLE
Postgres range type: Fix handling of exclusive lower bound.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -148,7 +148,7 @@ module ActiveRecord
               to   = ConnectionAdapters::Column.string_to_time(extracted[:to])
             when :integer
               from = to_integer(extracted[:from]) rescue value ? 1 : 0
-              from -= 1 if extracted[:exclude_start]
+              from += 1 if extracted[:exclude_start]
               to   = to_integer(extracted[:to]) rescue value ? 1 : 0
             else
               return value

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -203,6 +203,14 @@ if ActiveRecord::Base.connection.supports_ranges?
       assert_nil_round_trip(@first_range, :int8_range, 39999...39999)
     end
 
+    def test_exclude_beginning_for_int_ranges
+      range = PostgresqlRange.create!(int4_range: "(1, 10]")
+      assert_equal 2..10, range.int4_range
+
+      range = PostgresqlRange.create!(int8_range: "(10, 100]")
+      assert_equal 11..100, range.int8_range
+    end
+
     private
       def assert_equal_round_trip(range, attribute, value)
         round_trip(range, attribute, value)


### PR DESCRIPTION
Looks like this has all changed in newer versions of rails, but at least this is correct, and works for my case.
