### PR TITLE
Return false when trying to save destroyed record

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Saving destroyed or deleted record now return false or raise
+    `ActiveRecord::RecordNotSaved` instead of silently pass and return `true`
+    without saving record back to the database.
+
+    *Prem Sichanugrist*
+
 *   `@destroyed` should always be set to `false` when an object is duped.
 
     *Kuldeep Aggarwal*

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -483,9 +483,14 @@ module ActiveRecord
     end
 
     def create_or_update
-      raise ReadOnlyRecord if readonly?
-      result = new_record? ? _create_record : _update_record
-      result != false
+      if readonly?
+        raise ReadOnlyRecord
+      elsif destroyed?
+        false
+      else
+        result = new_record? ? _create_record : _update_record
+        result != false
+      end
     end
 
     # Updates the associated record with values matching those of the instance attributes.

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -836,4 +836,23 @@ class PersistenceTest < ActiveRecord::TestCase
     end
   end
 
+  def test_save_deleted_record
+    client = Client.find(3)
+    client.delete
+    clients_count = Client.count
+
+    assert_equal false, client.save
+    assert_raise(ActiveRecord::RecordNotSaved) { client.save! }
+    assert_equal clients_count, Client.count
+  end
+
+  def test_save_destroyed_record
+    client = Client.find(3)
+    client.destroy
+    clients_count = Client.count
+
+    assert_equal false, client.save
+    assert_raise(ActiveRecord::RecordNotSaved) { client.save! }
+    assert_equal clients_count, Client.count
+  end
 end


### PR DESCRIPTION
Saving destroyed record weren't adding the record back to the database anyway, so we should return the proper result, which is `false`.

Originally I thought that we should just mark the record as read-only. However, that breaks the compatibility as we won't be able to call `destroy` twice anymore. So, just checking if the record was destroyed is actually cleaner.
