### PR TITLE
Fix inconsistent behavior from String#pluralize

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -31,7 +31,7 @@ class String
   def pluralize(count = nil, locale = :en)
     locale = count if count.is_a?(Symbol)
     if count == 1
-      self
+      self.dup
     else
       ActiveSupport::Inflector.pluralize(self, locale)
     end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -58,6 +58,11 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal("blargles", "blargle".pluralize(2))
   end
 
+  test 'pluralize with count = 1 still returns new string' do
+    name = "Kuldeep"
+    assert_not_same name.pluralize(1), name
+  end
+
   def test_singularize
     SingularToPlural.each do |singular, plural|
       assert_equal(singular, plural.singularize)


### PR DESCRIPTION
``` text
# Before:
  When calling String#pluralize with count=1 then it returned same
  string, but with count other than 1, returned new string.

# After:
  String#pluralize always return a new string.

  => Prevent mutation of a string inadvertently.
```

\cc @rafaelfranca 
