### PR TITLE
Raise only when different included blocks are defined

### DIFF
--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -123,7 +123,16 @@ module ActiveSupport
 
     def included(base = nil, &block)
       if base.nil?
-        raise MultipleIncludedBlocks if instance_variable_defined?(:@_included_block)
+        if instance_variable_defined?(:@_included_block)
+          if @_included_block.source_location == block.source_location
+            ActiveSupport::Deprecation.behavior.first.call(
+              "Redefining 'included' block in #{block.source_location.join('#')}",
+              caller
+            )
+          else
+            raise MultipleIncludedBlocks
+          end
+        end
 
         @_included_block = block
       else

--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -101,4 +101,15 @@ class ConcernTest < ActiveSupport::TestCase
       end
     end
   end
+
+  def test_dont_raise_on_same_included_call
+    content = capture(:stderr) {
+      assert_nothing_raised do
+        2.times do
+          load File.expand_path('../fixtures/some_module.rb', __FILE__)
+        end
+      end
+    }
+    assert_match(/Redefining 'included' block/, content)
+  end
 end

--- a/activesupport/test/fixtures/some_module.rb
+++ b/activesupport/test/fixtures/some_module.rb
@@ -1,0 +1,9 @@
+require 'active_support/concern'
+
+module SomeModule
+  extend ActiveSupport::Concern
+
+  included do
+    # shouldn't raise
+  end
+end


### PR DESCRIPTION
Perhaps, raise of error when **same** module gets loaded twice isn't best choice

This happens when module files are loaded first time (e.g. while app reloading) and further required by hand (because some lib don't expect such preloading) - e.g. see ctran/annotate_models#181 for

```
Unable to annotate concerns/promotional.rb:
Cannot define multiple 'included' blocks for a Concern
```

See #10652 and #10650 for initial idea.
Also checked, that Proc#source_location works on jruby & rbx, too
