### PR TITLE
Fixed sanitize_sql_like to escape parentheses

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Fixed `sanitize_sql_like` helper method to escape parentheses in a SQL
+    LIKE statement.
+
+    Example:
+
+        class Article
+          def self.search(term)
+            where("title LIKE ?", sanitize_sql_like(term))
+          end
+        end
+
+        Article.search("(20% _reduction_")
+        # => Query looks like "... title LIKE '\(20\% \_reduction\_' ..."
+
+    *Maxim Petrunin*
+
 *   Fixed has_many association to make it support irregular inflections.
 
     Fixes #8928.

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -108,9 +108,9 @@ module ActiveRecord
       end
 
       # Sanitizes a +string+ so that it is safe to use within a sql
-      # LIKE statement. This method uses +escape_character+ to escape all occurrences of "\", "_" and "%"
+      # LIKE statement. This method uses +escape_character+ to escape all occurrences of "\", "_", ")", "(" and "%"
       def sanitize_sql_like(string, escape_character = "\\")
-        pattern = Regexp.union(escape_character, "%", "_")
+        pattern = Regexp.union(escape_character, "%", "_", ")", "(")
         string.gsub(pattern) { |x| [escape_character, x].join }
       end
 

--- a/activerecord/test/cases/sanitize_test.rb
+++ b/activerecord/test/cases/sanitize_test.rb
@@ -57,6 +57,7 @@ class SanitizeTest < ActiveRecord::TestCase
     assert_equal 'snake\_cased\_string', Binary.send(:sanitize_sql_like, 'snake_cased_string')
     assert_equal 'C:\\\\Programs\\\\MsPaint', Binary.send(:sanitize_sql_like, 'C:\\Programs\\MsPaint')
     assert_equal 'normal string 42', Binary.send(:sanitize_sql_like, 'normal string 42')
+    assert_equal ':-\) and :-\(', Binary.send(:sanitize_sql_like, ':-) and :-(')
   end
 
   def test_sanitize_sql_like_with_custom_escape_character
@@ -65,6 +66,7 @@ class SanitizeTest < ActiveRecord::TestCase
     assert_equal 'great!!', Binary.send(:sanitize_sql_like, 'great!', '!')
     assert_equal 'C:\\Programs\\MsPaint', Binary.send(:sanitize_sql_like, 'C:\\Programs\\MsPaint', '!')
     assert_equal 'normal string 42', Binary.send(:sanitize_sql_like, 'normal string 42', '!')
+    assert_equal ':-!) and :-!(', Binary.send(:sanitize_sql_like, ':-) and :-(', '!')
   end
 
   def test_sanitize_sql_like_example_use_case


### PR DESCRIPTION
There is a problem with sanitising `LIKE` statement If there is a parentheses in it it can cause error like this in real Rails app:

```
Street Load (3.5ms)  SELECT `streets`.* FROM `streets` WHERE (name LIKE '%(%')
Completed 500 Internal Server Error in 18ms

RegexpError (end pattern with unmatched parenthesis: /(/):
```

See corresponding [SO question](http://stackoverflow.com/questions/23158150/proper-escape-like-conditions#23158150).

Pull request adding parentheses to list of escaping symbols and fix that problem.

Example:

```
class Street
  def self.search(term)
    where("title LIKE ?", sanitize_sql_like(term))
  end
end

Street.search("(20% _reduction_)")
# => Query looks like "... title LIKE '\(20\% \_reduction\_\)' ..."
```
