### PR TITLE
Don't rely on Arel master in bug report template

### DIFF
--- a/guides/bug_report_templates/active_record_master.rb
+++ b/guides/bug_report_templates/active_record_master.rb
@@ -2,7 +2,6 @@ unless File.exist?('Gemfile')
   File.write('Gemfile', <<-GEMFILE)
     source 'https://rubygems.org'
     gem 'rails', github: 'rails/rails'
-    gem 'arel', github: 'rails/arel'
     gem 'sqlite3'
   GEMFILE
 


### PR DESCRIPTION
Hello,

This is just a tiny pull request that removes the dependency on Arel master the bug report template has. We should instead rely on the Arel version supported currently by Active Record.

Closes #14809.

Have a nice day.
