### PR TITLE
Made calls to 'blank?' and 'present?' easier to reason about

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -27,7 +27,7 @@ module ActionController
         status = ActionDispatch::ExceptionWrapper.status_code_for_exception(exception_class_name)
       end
       message = "Completed #{status} #{Rack::Utils::HTTP_STATUS_CODES[status]} in #{event.duration.round}ms"
-      message << " (#{additions.join(" | ")})" unless additions.blank?
+      message << " (#{additions.join(" | ")})" if additions.present?
 
       info(message)
     end

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -23,7 +23,7 @@ module ActionController
         if @only.present?
           @only.include?(action)
         elsif @except.present?
-          !@except.include?(action)
+          @except.exclude?(action)
         else
           true
         end

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -419,7 +419,7 @@ module ActionController
 
       def authenticate(controller, &login_procedure)
         token, options = token_and_options(controller.request)
-        unless token.blank?
+        if token.present?
           login_procedure.call(token, options)
         end
       end

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -23,7 +23,7 @@ module Mime
 
   SET              = Mimes.new
   EXTENSION_LOOKUP = {}
-  LOOKUP           = Hash.new { |h, k| h[k] = Type.new(k) unless k.blank? }
+  LOOKUP           = Hash.new { |h, k| h[k] = Type.new(k) if k.present? }
 
   class << self
     def [](type)

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
@@ -1,4 +1,4 @@
-<% unless @exception.blamed_files.blank? %>
+<% if @exception.blamed_files.present? %>
   <% if (hide = @exception.blamed_files.length > 8) %>
     <a href="#" onclick="return toggleTrace()">Toggle blamed files</a>
   <% end %>

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -541,7 +541,7 @@ module ActionView
       #   # => <fieldset class="format"><p><input id="name" name="name" type="text" /></p></fieldset>
       def field_set_tag(legend = nil, options = nil, &block)
         output = tag(:fieldset, options, true)
-        output.safe_concat(content_tag(:legend, legend)) unless legend.blank?
+        output.safe_concat(content_tag(:legend, legend)) if legend.present?
         output.concat(capture(&block)) if block_given?
         output.safe_concat("</fieldset>")
       end

--- a/actionview/lib/action_view/testing/resolvers.rb
+++ b/actionview/lib/action_view/testing/resolvers.rb
@@ -39,7 +39,7 @@ module ActionView #:nodoc:
         )
       end
 
-      templates.sort_by {|t| -t.identifier.match(/^#{query}$/).captures.reject(&:blank?).size }
+      templates.sort_by {|t| -t.identifier.match(/^#{query}$/).captures.select(&:present?).size }
     end
   end
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -56,7 +56,7 @@ module ActiveRecord
       # Implements the ids writer method, e.g. foo.item_ids= for Foo.has_many :items
       def ids_writer(ids)
         pk_column = reflection.primary_key_column
-        ids = Array(ids).reject { |id| id.blank? }
+        ids = Array(ids).select(&:present?)
         ids.map! { |i| pk_column.type_cast(i) }
         replace(klass.find(ids).index_by { |r| r.id }.values_at(*ids))
       end

--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -20,12 +20,12 @@ module ActiveRecord
               !value.to_i.zero?
             else
               return false if ActiveRecord::ConnectionAdapters::Column::FALSE_VALUES.include?(value)
-              !value.blank?
+              value.present?
             end
           elsif column.number?
             !value.zero?
           else
-            !value.blank?
+            value.present?
           end
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -45,7 +45,7 @@ module ActiveRecord
 
         # Converts the given URL to a full connection hash.
         def to_hash
-          config = raw_config.reject { |_,value| value.blank? }
+          config = raw_config.select { |_,value| value.present? }
           config.map { |key,value| config[key] = uri_parser.unescape(value) if value.is_a? String }
           config
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -188,7 +188,7 @@ module ActiveRecord
         end
 
         def column_for(table_name, column_name) #:nodoc:
-          columns(table_name).detect { |c| c.name == column_name.to_s } 
+          columns(table_name).detect { |c| c.name == column_name.to_s }
         end
 
         # Returns the current database name.
@@ -486,12 +486,12 @@ module ActiveRecord
         # PostgreSQL requires the ORDER BY columns in the select list for distinct queries, and
         # requires that the ORDER BY include the distinct column.
         def columns_for_distinct(columns, orders) #:nodoc:
-          order_columns = orders.reject(&:blank?).map{ |s|
+          order_columns = orders.select(&:present?).map{ |s|
               # Convert Arel node to string
               s = s.to_sql unless s.is_a?(String)
               # Remove any ASC/DESC modifiers
               s.gsub(/\s+(ASC|DESC)\s*(NULLS\s+(FIRST|LAST)\s*)?/i, '')
-            }.reject(&:blank?).map.with_index { |column, i| "#{column} AS alias_#{i}" }
+            }.select(&:present?).map.with_index { |column, i| "#{column} AS alias_#{i}" }
 
           [super, *order_columns].join(', ')
         end

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -379,7 +379,7 @@ module ActiveRecord
       attributes = attributes.with_indifferent_access
       existing_record = send(association_name)
 
-      if (options[:update_only] || !attributes['id'].blank?) && existing_record &&
+      if (options[:update_only] || attributes['id'].present?) && existing_record &&
           (options[:update_only] || existing_record.id.to_s == attributes['id'].to_s)
         assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy]) unless call_reject_if(association_name, attributes)
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -354,7 +354,7 @@ db_namespace = namespace :db do
 
     # desc 'Check for pending migrations and load the test schema'
     task :prepare => %w(db:test:deprecated environment load_config) do
-      unless ActiveRecord::Base.configurations.blank?
+      if ActiveRecord::Base.configurations.present?
         db_namespace['test:load'].invoke
       end
     end

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -133,14 +133,14 @@ module ActiveRecord
           relation.order! values[:order]
         end
 
-        relation.extend(*values[:extending]) unless values[:extending].blank?
+        relation.extend(*values[:extending]) if values[:extending].present?
       end
 
       def merge_single_values
         relation.from_value          = values[:from] unless relation.from_value
         relation.lock_value          = values[:lock] unless relation.lock_value
 
-        unless values[:create_with].blank?
+        if values[:create_with].present?
           relation.create_with_value = (relation.create_with_value || {}).merge(values[:create_with])
         end
       end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -131,7 +131,7 @@ module ActiveRecord
     end
 
     def includes!(*args) # :nodoc:
-      args.reject!(&:blank?)
+      args.select!(&:present?)
       args.flatten!
 
       self.includes_values |= args
@@ -826,7 +826,7 @@ module ActiveRecord
 
     def reverse_order! # :nodoc:
       orders = order_values.uniq
-      orders.reject!(&:blank?)
+      orders.select!(&:present?)
       self.order_values = reverse_sql_order(orders)
       self
     end
@@ -845,12 +845,12 @@ module ActiveRecord
 
       collapse_wheres(arel, (where_values - ['']).uniq)
 
-      arel.having(*having_values.uniq.reject(&:blank?)) unless having_values.empty?
+      arel.having(*having_values.uniq.select(&:present?)) unless having_values.empty?
 
       arel.take(connection.sanitize_limit(limit_value)) if limit_value
       arel.skip(offset_value.to_i) if offset_value
 
-      arel.group(*group_values.uniq.reject(&:blank?)) unless group_values.empty?
+      arel.group(*group_values.uniq.select(&:present?)) unless group_values.empty?
 
       build_order(arel)
 
@@ -896,7 +896,7 @@ module ActiveRecord
     end
 
     def custom_join_ast(table, joins)
-      joins = joins.reject(&:blank?)
+      joins = joins.select(&:present?)
 
       return [] if joins.empty?
 
@@ -1031,7 +1031,7 @@ module ActiveRecord
 
     def build_order(arel)
       orders = order_values.uniq
-      orders.reject!(&:blank?)
+      orders.select!(&:present?)
 
       arel.order(*orders) unless orders.empty?
     end

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -41,7 +41,7 @@ module ActiveRecord
     def define(info, &block) # :nodoc:
       instance_eval(&block)
 
-      unless info[:version].blank?
+      if info[:version].present?
         initialize_schema_migrations_table
         connection.assume_migrated_upto_version(info[:version], migrations_paths)
       end

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -47,7 +47,7 @@ module ActiveRecord
       def structure_dump(filename)
         set_psql_env
         search_path = configuration['schema_search_path']
-        unless search_path.blank?
+        if search_path.present?
           search_path = search_path.split(",").map{|search_path_part| "--schema=#{Shellwords.escape(search_path_part.strip)}" }.join(" ")
         end
 

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -29,7 +29,7 @@ module ActiveSupport
       end
 
       def push_tags(*tags)
-        tags.flatten.reject(&:blank?).tap do |new_tags|
+        tags.flatten.select(&:present?).tap do |new_tags|
           current_tags.concat new_tags
         end
       end


### PR DESCRIPTION
Made calls to `blank?` and `present?` easier to reason about by changing code that did not need to be negative or double negative. It's just easier to think about code that's written in a positive way than negative code.
- Replaced `unless blank?` with `if present?`
- Replaced `reject(&:blank?)` with `select(&:present?)`
- Replaced `!blank?` with `present?`
- Replaced `!include?` with `exclude?`
