### PR TITLE
Removed missleading comment [ci skip]

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -155,7 +155,7 @@ module ActiveSupport
     #
     # Singular names are not handled correctly:
     #
-    #   'business'.classify     # => "Business"
+    #   'calculus'.classify     # => "Calculu"
     def classify(table_name)
       # strip out any leading schema name
       camelize(singularize(table_name.to_s.sub(/.*\./, '')))


### PR DESCRIPTION
After this 21dbe6f39b57f52967e92716dbd5e2b894e7a64c

```
2.1.1 :001 > 'business'.classify
 => "Business"
```

This comment is miss-leading.

"Singular names are not handled correctly:" 

We can change example or remove this comment.
