### PR TITLE
Adds the ability to pass options to enum

### DIFF
--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -10,6 +10,12 @@ class Book < ActiveRecord::Base
   enum status: [:proposed, :written, :published]
   enum read_status: {unread: 0, reading: 2, read: 3}
   enum nullable_status: [:single, :married]
+  enum skip_status: [:draft, :live] do |config|
+    config.skip = :scopes, :writer, :reader, :updates, :question_marks
+  end
+  enum prefix_status: [:draft, :live] do |config|
+    config.prefix = true
+  end
 
   def published!
     super

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -107,6 +107,8 @@ ActiveRecord::Schema.define do
     t.column :status, :integer, default: 0
     t.column :read_status, :integer, default: 0
     t.column :nullable_status, :integer
+    t.column :skip_status, :integer, default: 0
+    t.column :prefix_status, :integer, default: 0
   end
 
   create_table :booleans, force: true do |t|


### PR DESCRIPTION
I love Rails flexibility and I thought it would be nice if you could pass some options to enum. You can pass options to enum as a block:

``` ruby
class Conversation < ActiveRecord::Base
  enum status: { active: 0, archived: 1 } do |config|
    config.skip   = :writer, :reader, :accessor, :question_marks, :updates, :scopes
    config.prefix = true
  end
end
```

**skip** will avoid creating methods you don't want, you don't need or want to avoid some collision. If you pass:
- **_:writer**_, this will avoid overriding `conversation.status=`
- **_:reader**_, this will avoid overriding `conversation.status`
- **_:accessor**_, this will avoid overriding `conversation.status=` and `conversation.status`
- **_:question_marks**_, this will avoid defining `conversation.active?` and `conversation.archived?`
- **_:updates**_, this will avoid defining `conversation.active!` and `conversation.archived!`
- **_:scopes**_, this will avoid defining `Conversation.active` and `Conversation.archived`

**prefix** will add the name of the field as a prefix to the new defined methods:

``` ruby
  conversation.status_active! # update method
  conversation.status_active? # question_mark method
  Conversation.status_active  # scope method
```
