### PR TITLE
Generate link with block from link_to_if and link_to_unless

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -414,7 +414,7 @@ module ActionView
       #   # => <a href="/accounts/show/3">my_username</a>
       def link_to_if(condition, name, options = {}, html_options = {}, &block)
         if condition
-          link_to(name, options, html_options)
+          link_to(name, options, html_options, &block)
         else
           if block_given?
             block.arity <= 1 ? capture(name, &block) : capture(name, options, html_options, &block)

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -380,6 +380,17 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_dom_equal %{<a href="/">Listing</a>}, link_to_if(true, "Listing", url_hash)
   end
 
+  def test_link_to_if_with_block
+    assert_dom_equal '<a href="/"><div>Banner</div></a>',
+                     link_to_if(true, url_hash) { content_tag(:div, 'Banner') }
+  end
+
+  def test_link_to_unless_with_block
+    assert_dom_equal '<a href="/"><div>Banner</div></a>',
+                     link_to_unless(false, url_hash) { content_tag(:div, 'Banner') }
+  end
+
+
   def request_for_url(url, opts = {})
     env = Rack::MockRequest.env_for("http://www.example.com#{url}", opts)
     ActionDispatch::Request.new(env)


### PR DESCRIPTION
@kidwm propose to use block for generating default behaviour as link content, like it is for `name` param.

Closes #14830
