### PR TITLE
Unify the behavior of two `tld_length`.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,42 @@
+*   Unify the behavior of two `tld_length` in
+    `actionpack/lib/action_dispatch/middleware/cookies.rb`
+    and `actionpack/lib/action_dispatch/http/url.rb`
+
+    The two `tld_length` had different behavior before.
+    For example, suppose that we have the domain `sub1.sub2.example.com`.
+    When we set the `tld_length` option of cookies to 2:
+
+        cookies[:name] = { value: 'a yummy cookie', domain: :all, tld_length: 2 }
+
+    or set the option of `cookie_store` to the same value:
+
+        Rails.application.config.session_store :cookie_store, domain: :all, tld_length: 2
+
+    Then the TLD of cookies will be `example.com`.
+
+    On the other hand, when we set the `tld_length` of `config.action_dispatch` to 2:
+
+        Rails.application.configure do
+          config.action_dispatch.tld_length = 2
+        end
+
+    The TLD of URLs will be `sub2.example.com`.
+
+        ActionDispatch::Http::URL.extract_domain("sub1.sub2.example.com")
+        # => "sub2.example.com"
+
+    These different behaviors were confusing. We had to set the two `tld_length` to
+    two different values although which should have the same meaning.
+
+    Now the `tld_length` option of cookies is modified to behave the same way with
+    the other. That means if we set the `tld_length` option of cookies to 2, the
+    TLD of cookies will also be `sub2.example.com` now.
+
+    So if you had set the `tld_length` option of cookies before, you should
+    decrement them by 1.
+
+    *Weihu Chen*
+
 *   Make URL escaping more consistent:
 
     1. Escape '%' characters in URLs - only unescaped data should be passed to URL helpers

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -276,7 +276,7 @@ module ActionDispatch
 
         if options[:domain] == :all
           # if there is a provided tld length then we use it otherwise default domain regexp
-          domain_regexp = options[:tld_length] ? /([^.]+\.?){#{options[:tld_length]}}$/ : DOMAIN_REGEXP
+          domain_regexp = options[:tld_length] ? /([^.]+\.?){#{options[:tld_length] + 1}}$/ : DOMAIN_REGEXP
 
           # if host is not ip and matches domain regexp
           # (ip confirms to domain regexp so we explicitly check for ip)

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -138,12 +138,12 @@ class CookiesTest < ActionController::TestCase
     end
 
     def set_cookie_with_domain_and_tld
-      cookies[:user_name] = {:value => "rizwanreza", :domain => :all, :tld_length => 2}
+      cookies[:user_name] = {:value => "rizwanreza", :domain => :all, :tld_length => 1}
       head :ok
     end
 
     def delete_cookie_with_domain_and_tld
-      cookies.delete(:user_name, :domain => :all, :tld_length => 2)
+      cookies.delete(:user_name, :domain => :all, :tld_length => 1)
       head :ok
     end
 


### PR DESCRIPTION
The `tld_length` in cookie options and the one in ActionDispatch::Http::URL have different behavior.

For example when I set the session_store with:

```
MyApp::Application.config.session_store :cookie_store, domain: :all, tld_length: 2
```

And suppose the url is `sub1.sub2.example.com`.

Then the TLD will be `example.com`.

But when I set the `tld_length` option of action_dispatch to 2:

```
config.action_dispatch.tld_length = 2
```

Then the TLD will be `sub2.example.com`.

These different behavior made me confused.

Maybe it should be unified to the same behavior?
