### PR TITLE
Correctly alias table names when joining more than once

### DIFF
--- a/activerecord/lib/active_record/associations/alias_tracker.rb
+++ b/activerecord/lib/active_record/associations/alias_tracker.rb
@@ -32,8 +32,18 @@ module ActiveRecord
             join.left.downcase.scan(
               /join(?:\s+\w+)?\s+(\S+\s+)?#{quoted_name}\son/
             ).size
-          else
+          elsif join.respond_to? :left
             join.left.table_name == name ? 1 : 0
+          else
+            # this branch is reached by two tests:
+            #
+            # activerecord/test/cases/associations/cascaded_eager_loading_test.rb:37
+            #   with :posts
+            #
+            # activerecord/test/cases/associations/eager_test.rb:1133
+            #   with :comments
+            #
+            0
           end
         end
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -336,7 +336,16 @@ module ActiveRecord
     end
 
     def find_with_associations
-      join_dependency = construct_join_dependency
+      # NOTE: the JoinDependency constructed here needs to know about
+      #       any joins already present in `self`, so pass them in
+      #
+      # failing to do so means that in cases like activerecord/test/cases/associations/inner_join_association_test.rb:136
+      # incorrect SQL is generated. In that case, the join dependency for
+      # SpecialCategorizations is constructed without knowledge of the
+      # preexisting join in joins_values to categorizations (by way of
+      # the `has_many :through` for categories).
+      #
+      join_dependency = construct_join_dependency(joins_values)
 
       aliases  = join_dependency.aliases
       relation = select aliases.columns

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -126,4 +126,14 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     categories = author.categories.includes(:special_categorizations).references(:special_categorizations).to_a
     assert_equal 2, categories.size
   end
+
+  test "the correct records are loaded when including an aliased association" do
+    author = Author.create! name: "Jon"
+    author.categories.create! name: 'Not Special'
+    author.special_categories.create! name: 'Special'
+
+    categories = author.categories.eager_load(:special_categorizations).order(:name).to_a
+    assert_equal 0, categories.first.special_categorizations.size
+    assert_equal 1, categories.second.special_categorizations.size
+  end
 end


### PR DESCRIPTION
See #14155 for a longer description. 

The attached commit has some notes; I'd appreciate some feedback, as the change to `AliasTracker` seems particularly hackish to me. All the tests pass, but the also all passed _before_ I added the one in this commit :) so I'm uncertain if this is a well-covered area of functionality.

/cc @tenderlove
