### PR TITLE
Add test for using ActionView::Helpers::FormHelper.label with block and html

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -746,6 +746,7 @@ module ActionView
       #   label(:post, :terms) do
       #     'Accept <a href="/terms">Terms</a>.'.html_safe
       #   end
+      #   # => <label for="post_terms">Accept <a href="/terms">Terms</a>.</label>
       def label(object_name, method, content_or_options = nil, options = nil, &block)
         Tags::Label.new(object_name, method, self, content_or_options, options).render(&block)
       end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -265,6 +265,13 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_label_with_block_and_html
+    assert_dom_equal(
+      '<label for="post_terms">Accept <a href="/terms">Terms</a>.</label>',
+      label(:post, :terms) { 'Accept <a href="/terms">Terms</a>.'.html_safe }
+    )
+  end
+
   def test_label_with_block_and_options
     assert_dom_equal(
       '<label for="my_for">The title, please:</label>',


### PR DESCRIPTION
This example didn't have an output, so I wrote a test to confirm and added it to the documentation.
