### PR TITLE
Move `NoTouching` down the inheritance chain on AR::Base

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `ActiveRecord::Base.no_touching` no longer triggers callbacks or start empty transactions.
+
+    Fixes #14841.
+
+    *Lucas Mazza*
+
 *   Fix name collision with `Array#select!` with `Relation#select!`.
 
     Fixes #14752.

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -296,7 +296,6 @@ module ActiveRecord #:nodoc:
 
     include Core
     include Persistence
-    include NoTouching
     include ReadonlyAttributes
     include ModelSchema
     include Inheritance
@@ -318,6 +317,7 @@ module ActiveRecord #:nodoc:
     include NestedAttributes
     include Aggregations
     include Transactions
+    include NoTouching
     include Reflection
     include Serialization
     include Store

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -112,7 +112,7 @@ class TimestampTest < ActiveRecord::TestCase
     previous_starting = task.starting
     previous_ending = task.ending
     task.touch(:starting, :ending)
-    
+
     assert_not_equal previous_starting, task.starting
     assert_not_equal previous_ending, task.ending
     assert_in_delta Time.now, task.starting, 1
@@ -168,6 +168,25 @@ class TimestampTest < ActiveRecord::TestCase
     end
 
     assert !@developer.no_touching?
+  end
+
+  def test_no_touching_with_callbacks
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "developers"
+
+      attr_accessor :after_touch_called
+
+      after_touch do |user|
+        user.after_touch_called = true
+      end
+    end
+
+    developer = klass.first
+
+    klass.no_touching do
+      developer.touch
+      assert_not developer.after_touch_called
+    end
   end
 
   def test_saving_a_record_with_a_belongs_to_that_specifies_touching_the_parent_should_update_the_parent_updated_at


### PR DESCRIPTION
This way the `no_touching` blocks won't trigger any `touch` related callbacks and won't create empty transactions (since it is included after the `Transactions` module).

Fixes #14841.
