### PR TITLE
Stop incrementing counter caches on association assignation

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -10,12 +10,10 @@ module ActiveRecord
       def replace(record)
         if record
           raise_on_type_mismatch!(record)
-          update_counters(record)
           replace_keys(record)
           set_inverse_instance(record)
           @updated = true
         else
-          decrement_counters
           remove_keys
         end
 
@@ -35,8 +33,17 @@ module ActiveRecord
         with_cache_name { |name| decrement_counter name }
       end
 
+      def decrement_previous_counters # :nodoc:
+        with_cache_name { |name| decrement_previous_counter name }
+      end
+
       def increment_counters # :nodoc:
         with_cache_name { |name| increment_counter name }
+      end
+
+      # To be overrided by subclasses
+      def changed?
+        owner.attribute_changed?(reflection.foreign_key)
       end
 
       private
@@ -65,10 +72,28 @@ module ActiveRecord
           end
         end
 
+        def decrement_previous_counter(counter_cache_name)
+          if scope = previous_target_scope
+            scope.decrement_counter(counter_cache_name)
+          end
+        end
+
         def increment_counter(counter_cache_name)
           if foreign_key_present?
             klass.increment_counter(counter_cache_name, target_id)
           end
+        end
+
+        def previous_target_scope
+          if klass = previous_klass
+            primary_key = reflection.association_primary_key(klass)
+            klass.where(primary_key => owner.attribute_was(reflection.foreign_key))
+          end
+        end
+
+        # To be overrided by subclasses
+        def previous_klass
+          klass
         end
 
         # Checks whether record is different to the current target, without loading it

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -7,7 +7,16 @@ module ActiveRecord
         type.presence && type.constantize
       end
 
+      def changed?
+        super || owner.attribute_changed?(reflection.foreign_type)
+      end
+
       private
+
+        def previous_klass
+          type = owner.attribute_was(reflection.foreign_type)
+          type.presence && type.constantize
+        end
 
         def replace_keys(record)
           super

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -14,8 +14,7 @@ module ActiveRecord
       private
 
         def previous_klass
-          type = owner.attribute_was(reflection.foreign_type)
-          type.presence && type.constantize
+          owner.attribute_was(reflection.foreign_type).try(:constantize)
         end
 
         def replace_keys(record)

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -18,6 +18,18 @@ module ActiveRecord
       0
     end
 
+    def update_counters(_updates)
+      0
+    end
+
+    def decrement_counter(_name)
+      0
+    end
+
+    def increment_counter(_name)
+      0
+    end
+
     def delete(_id_or_array)
       0
     end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -342,6 +342,25 @@ module ActiveRecord
       @klass.connection.update stmt, 'SQL', bvs
     end
 
+    def update_counters(counters)
+      updates = counters.map do |counter_name, value|
+        operator = value < 0 ? '-' : '+'
+        quoted_column = connection.quote_column_name(counter_name)
+        "#{quoted_column} = COALESCE(#{quoted_column}, 0) #{operator} #{value.abs}"
+      end
+
+      update_all updates.join(', ')
+    end
+
+    def decrement_counter(counter_name)
+      update_counters(counter_name => -1)
+    end
+
+    def increment_counter(counter_name)
+      update_counters(counter_name => 1)
+    end
+
+
     # Updates an object (or multiple objects) and saves it to the database, if validations pass.
     # The resulting object is returned whether the object was saved successfully to the database or not.
     #

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -243,15 +243,19 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_belongs_to_counter_with_assigning_nil
-    post = Post.find(1)
-    comment = Comment.find(1)
 
-    assert_equal post.id, comment.post_id
-    assert_equal 2, Post.find(post.id).comments.size
+    topic = Topic.create("title" => "debate")
+    reply = Reply.create!("title" => "blah!", "content" => "world around!")
+    reply.topic = topic
+    reply.save!
 
-    comment.post = nil
+    assert_equal topic.id, reply.parent_id
+    assert_equal 1, Topic.find(topic.id).replies.size
 
-    assert_equal 1, Post.find(post.id).comments.size
+    reply.topic = nil
+    reply.save
+
+    assert_equal 0, Topic.find(topic.id).replies.size
   end
 
   def test_belongs_to_with_primary_key_counter
@@ -263,11 +267,13 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal 0, debate2.reload.replies_count
 
     reply.topic_with_primary_key = debate2
+    reply.save
 
     assert_equal 0, debate.reload.replies_count
     assert_equal 1, debate2.reload.replies_count
 
     reply.topic_with_primary_key = nil
+    reply.save
 
     assert_equal 0, debate.reload.replies_count
     assert_equal 0, debate2.reload.replies_count
@@ -294,11 +300,13 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, Topic.find(topic2.id).replies.size
 
     reply1.topic = nil
+    reply1.save
 
     assert_equal 0, Topic.find(topic1.id).replies.size
     assert_equal 0, Topic.find(topic2.id).replies.size
 
     reply1.topic = topic1
+    reply1.save
 
     assert_equal 1, Topic.find(topic1.id).replies.size
     assert_equal 0, Topic.find(topic2.id).replies.size
@@ -477,12 +485,13 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
   def test_counter_cache
     topic = Topic.create :title => "Zoom-zoom-zoom"
-    assert_equal 0, topic[:replies_count]
+    assert_equal 0, topic.replies_count
 
     reply = Reply.create(:title => "re: zoom", :content => "speedy quick!")
     reply.topic = topic
+    reply.save!
 
-    assert_equal 1, topic.reload[:replies_count]
+    assert_equal 1, topic.reload.replies_count
     assert_equal 1, topic.replies.size
 
     topic[:replies_count] = 15
@@ -790,6 +799,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_difference lambda { post.reload.tags_count }, -1 do
       assert_difference 'comment.reload.tags_count', +1 do
         tagging.taggable = comment
+        tagging.save!
       end
     end
   end


### PR DESCRIPTION
Followup of #14765 and #14735
Similar in some ways to #9236
Fixes #13304 among others
# Rationale

It's a very bad time to perform the increment because the foreign_key
change is not persisted yet and it happen outside the save transaction,
so if the update fail the increment is not rollbacked.
# Limitation

I can't make `BelongsToAssociationsTest#test_custom_counter_cache` work, because [`Reply`](https://github.com/rails/rails/blob/650585da8ac15742b64965c338110e8e859a3b5e/activerecord/test/models/reply.rb#L4-L5) belongs to `Topic` twice, so ActiveRecord think it's 2 different counters.

I'm not sure what to do with that. I think it just don't make any sense. Maybe we could prevent targeting the same counter from two associations.
# Further work

[The same issue lies in `has_many` association](https://github.com/rails/rails/blob/650585da8ac15742b64965c338110e8e859a3b5e/activerecord/test/cases/associations/has_many_associations_test.rb#L789-L795) the counters are decremented outside any transaction beside no record have been actually deleted. I'll see what I can do about that in a further PR if you don't mind.

@tenderlove @arthurnn @rafaelfranca thoughts?

/cc @jasl 
