### PR TITLE
Fixed an issue with migrating legacy json cookies.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fixed an issue with migrating legacy json cookies.
+
+    Previously, the `VerifyAndUpgradeLegacySignedMessage` assumes all incoming
+    cookies are marshal-encoded. This is not the case when `secret_token` is
+    used in conjunction with the `:json` or `:hybrid` serializer.
+
+    In those case, when upgrading to use `secret_key_base`, this would cause a
+    `TypeError: incompatible marshal file format` and a 500 error for the user.
+
+    Fixes #14774.
+
+    *Godfrey Chan*
+
 *   Make URL escaping more consistent:
 
     1. Escape '%' characters in URLs - only unescaped data should be passed to URL helpers

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -176,11 +176,11 @@ module ActionDispatch
     module VerifyAndUpgradeLegacySignedMessage
       def initialize(*args)
         super
-        @legacy_verifier = ActiveSupport::MessageVerifier.new(@options[:secret_token])
+        @legacy_verifier = ActiveSupport::MessageVerifier.new(@options[:secret_token], serializer: NullSerializer)
       end
 
       def verify_and_upgrade_legacy_signed_message(name, signed_message)
-        @legacy_verifier.verify(signed_message).tap do |value|
+        deserialize(name, @legacy_verifier.verify(signed_message)).tap do |value|
           self[name] = { value: value }
         end
       rescue ActiveSupport::MessageVerifier::InvalidSignature


### PR DESCRIPTION
Previously, the `VerifyAndUpgradeLegacySignedMessage` assumes all incoming
cookies are marshal-encoded. This is not the case when `secret_token` is
used in conjunction with the `:json` or `:hybrid` serializer.

In those case, when upgrading to use `secret_key_base`, this would cause a
`TypeError: incompatible marshal file format` and a 500 error for the user.

Fixes #14774.

_Godfrey Chan_

cc @rafaelfranca @guilleiguaran

:cry: :gun:
