### PR TITLE
Fix railties asset tests: precompile the image we're referencing

### DIFF
--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -450,7 +450,7 @@ module ApplicationTests
     test "asset urls should be protocol-relative if no request is in scope" do
       app_file "app/assets/images/rails.png", "notreallyapng"
       app_file "app/assets/javascripts/image_loader.js.erb", "var src='<%= image_path('rails.png') %>';"
-      add_to_config "config.assets.precompile = %w{image_loader.js}"
+      add_to_config "config.assets.precompile = %w{rails.png image_loader.js}"
       add_to_config "config.asset_host = 'example.com'"
       precompile!
 
@@ -462,7 +462,7 @@ module ApplicationTests
       app_file "app/assets/images/rails.png", "notreallyapng"
 
       app_file "app/assets/javascripts/app.js.erb", "var src='<%= image_path('rails.png') %>';"
-      add_to_config "config.assets.precompile = %w{app.js}"
+      add_to_config "config.assets.precompile = %w{rails.png app.js}"
       precompile!
 
       assert_match "src='/sub/uri/assets/rails.png'", File.read(Dir["#{app_path}/public/assets/app-*.js"].first)


### PR DESCRIPTION
You can't compile a file that references a non-compiled asset's path.

.. unless you turn off asset runtime errors.

Outside of a test case like this, `config.assets.precompile` would normally retain its default entry, which precompiles all images (and other non-JS/CSS files) that are in `app/assets`.
