### PR TITLE
Improve ActiveSupport JSON::Encoding Initialize

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -25,8 +25,8 @@ module ActiveSupport
       class JSONGemEncoder #:nodoc:
         attr_reader :options
 
-        def initialize(options = nil)
-          @options = options || {}
+        def initialize(options = {})
+          @options = options
         end
 
         # Encode the given object into a JSON string


### PR DESCRIPTION
Rather than initialize with passed in parameter or nil and then checking
for nil to return an empty hash, simply initialize with a default value
of an empty hash
