### PR TITLE
PostgreSQL Timestamps always map to `:datetime`.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   PostgreSQL should internally use `:datetime` consistently for TimeStamp. Assures
+    different spellings of timestamps are treated the same.
+
+    Example:
+
+        mytimestamp.simplified_type('timestamp without time zone')
+        # => :datetime
+        mytimestamp.simplified_type('timestamp(6) without time zone')
+        # => also :datetime (previously would be :timestamp)
+
+    See #14513.
+
+    *Jefferson Lai*
+
 *   `ActiveRecord::Base.no_touching` no longer triggers callbacks or start empty transactions.
 
     Fixes #14841.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -209,12 +209,7 @@ This is not reliable and will be removed in the future.
         class Timestamp < Type
           def type; :timestamp; end
           def simplified_type(sql_type)
-            case sql_type
-            when /^timestamp with(?:out)? time zone$/
-              :datetime
-            else
-              :timestamp
-            end
+            :datetime
           end
 
           def type_cast(value)


### PR DESCRIPTION
The PG Adapter should use `:datetime` consistently instead of mapping
mispellings to `:timestamp`.

See #14513 
