### PR TITLE
Partial insert should not skip "not null" columns that have null values

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -90,7 +90,11 @@ module ActiveRecord
       # Serialized attributes should always be written in case they've been
       # changed in place.
       def keys_for_partial_write
-        changed
+        changed | keys_for_not_null_columns_having_null_value
+      end
+
+      def keys_for_not_null_columns_having_null_value
+        self.class.columns.reject(&:null).map(&:name).select {|c| self[c].nil?}
       end
 
       def _field_changed?(attr, old, value)


### PR DESCRIPTION
Since AR 4.0, MySQL adapter is configured to be "strict" by default, and to bring AR 3.2 behaviour back, `strict: false` option was introduced.
However, this `strict: false` mode is not actually compatible with AR 3.2 concerning "not null" constraint treatment when combined with the "partial insert" feature.

When "not null" column was omitted from insert statement in MySQL non-strict mode, MySQL silently puts some value instead of raising an error,
for example, `0` for an integer column, `''` for a varchar column, `0000-00-00` for a date column.

This fix brings AR 3.2 behaviour back, so as to raise null constraint error when nil was given to a "not null" column.
