### PR TITLE
Adding assertion for @original_wd in generator

### DIFF
--- a/railties/test/generators/generator_test.rb
+++ b/railties/test/generators/generator_test.rb
@@ -80,6 +80,12 @@ module Rails
         }
         assert_equal gems.drop(2), generator.gemfile_entries
       end
+
+      def test_sets_original_wd_instance_variable
+        klass = make_builder_class
+        klass.start(['new', 'blah'])
+        assert_not_nil klass.instance_variable_get("@original_wd")
+      end
     end
   end
 end


### PR DESCRIPTION
Given the documentation for `$ rails new` and `$ rails plugin new`,
and how the `--template` option is used, those building templates
may rely on the `@original_wd` instance variable to determine where
the generator is creating the files.

In our case we are doing something analogous to the following:

``` ruby
inside(File.join(@original_wd, name)) do
  Rake::FileList.each("**/*") do |filename|
    apply_boilerplate(filename)
  end

  run "mv path/to/specific_file path/to/new_location"
end
```

If there are better ways to do the above, its not immediately obvious.
