### PR TITLE
Handle offset on update_all.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Handle `offset` on `update_all`. The offset will not be handled by MySQL,
+    because it does not have support for it on `update`.
+
+    Fixes #10849.
+
+    *Lauro Caetano*
+
 *   When using a custom `join_table` name on a `habtm`, rails was not saving it
     on Reflections. This causes a problem when rails loads fixtures, because it
     uses the reflections to set database with fixtures.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -289,10 +289,11 @@ module ActiveRecord
       klass.current_scope = previous
     end
 
-    # Updates all records with details given if they match a set of conditions supplied, limits and order can
-    # also be supplied. This method constructs a single SQL UPDATE statement and sends it straight to the
-    # database. It does not instantiate the involved models and it does not trigger Active Record callbacks
-    # or validations.
+    # Updates all records with details given if they match a set of conditions
+    # supplied, limits, offset (except for MySQL) and order can also be supplied. This method
+    # constructs a single SQL UPDATE statement and sends it straight to the
+    # database. It does not instantiate the involved models and it does not
+    # trigger Active Record callbacks or validations.
     #
     # ==== Parameters
     #
@@ -308,6 +309,11 @@ module ActiveRecord
     #
     #   # Update all books that match conditions, but limit it to 5 ordered by date
     #   Book.where('title LIKE ?', '%Rails%').order(:created_at).limit(5).update_all(author: 'David')
+    #
+    #   # Update all books that match conditions, but offset it to 5 ordered by date
+    #   Book.where('title LIKE ?', '%Rails%').order(:created_at).offset(5).update_all(author: 'David')
+    #
+    #   Note that the offset is not supported by MySQL update.
     def update_all(updates)
       raise ArgumentError, "Empty list of attributes to change" if updates.blank?
 
@@ -322,6 +328,7 @@ module ActiveRecord
       else
         stmt.take(arel.limit)
         stmt.order(*arel.orders)
+        stmt.skip(offset_value.to_i) if offset_value
         stmt.wheres = arel.constraints
       end
 


### PR DESCRIPTION
Handle the `offset` on `update_all`.

Note that it will not work for MySQL, because it does not support the offset clause and subselect (which is the approach for the other adapters) on update.

Fixes #10849.

Dependent on this PR on Arel: https://github.com/rails/arel/pull/262.
