### PR TITLE
Removed the single space character for Safari

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   `render nothing: true` or rendering a `nil` body no longer add a single
+    space to the response body.
+
+    The old behavior was added as a workaround for a bug in an early version of
+    Safari, where the HTTP headers are not returned correctly if the response
+    body has a 0-length. This is been fixed since and the workaround is no
+    longer necessary.
+
+    Use `render body: ' '` if the old behavior is desired.
+
+    See #14883 for details.
+
+    *Godfrey Chan*
+
 *   Prepend a JS comment to JSONP callbacks. Addresses CVE-2014-4671
     ("Rosetta Flash")
 

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -67,8 +67,8 @@ module ActionController
         options[:html] = ERB::Util.html_escape(options[:html])
       end
 
-      if options.delete(:nothing) || _any_render_format_is_nil?(options)
-        options[:body] = " "
+      if options.delete(:nothing)
+        options[:body] = nil
       end
 
       if options[:status]
@@ -84,10 +84,6 @@ module ActionController
           options[format] = options[format].to_text
         end
       end
-    end
-
-    def _any_render_format_is_nil?(options)
-      RENDER_FORMATS_IN_PRIORITY.any? { |format| options.key?(format) && options[format].nil? }
     end
 
     # Process controller specific options, as status, content-type and location.

--- a/actionpack/test/controller/new_base/render_body_test.rb
+++ b/actionpack/test/controller/new_base/render_body_test.rb
@@ -111,17 +111,17 @@ module RenderBody
       assert_status 404
     end
 
-    test "rendering body with nil returns an empty body padded for Safari" do
+    test "rendering body with nil returns an empty body" do
       get "/render_body/with_layout/with_nil"
 
-      assert_body " "
+      assert_body ""
       assert_status 200
     end
 
-    test "Rendering body with nil and custom status code returns an empty body padded for Safari and the status" do
+    test "Rendering body with nil and custom status code returns an empty body and the status" do
       get "/render_body/with_layout/with_nil_and_status"
 
-      assert_body " "
+      assert_body ""
       assert_status 403
     end
 

--- a/actionpack/test/controller/new_base/render_html_test.rb
+++ b/actionpack/test/controller/new_base/render_html_test.rb
@@ -114,17 +114,17 @@ module RenderHtml
       assert_status 404
     end
 
-    test "rendering text with nil returns an empty body padded for Safari" do
+    test "rendering text with nil returns an empty body" do
       get "/render_html/with_layout/with_nil"
 
-      assert_body " "
+      assert_body ""
       assert_status 200
     end
 
-    test "Rendering text with nil and custom status code returns an empty body padded for Safari and the status" do
+    test "Rendering text with nil and custom status code returns an empty body and the status" do
       get "/render_html/with_layout/with_nil_and_status"
 
-      assert_body " "
+      assert_body ""
       assert_status 403
     end
 

--- a/actionpack/test/controller/new_base/render_plain_test.rb
+++ b/actionpack/test/controller/new_base/render_plain_test.rb
@@ -106,17 +106,17 @@ module RenderPlain
       assert_status 404
     end
 
-    test "rendering text with nil returns an empty body padded for Safari" do
+    test "rendering text with nil returns an empty body" do
       get "/render_plain/with_layout/with_nil"
 
-      assert_body " "
+      assert_body ""
       assert_status 200
     end
 
-    test "Rendering text with nil and custom status code returns an empty body padded for Safari and the status" do
+    test "Rendering text with nil and custom status code returns an empty body and the status" do
       get "/render_plain/with_layout/with_nil_and_status"
 
-      assert_body " "
+      assert_body ""
       assert_status 403
     end
 

--- a/actionpack/test/controller/new_base/render_text_test.rb
+++ b/actionpack/test/controller/new_base/render_text_test.rb
@@ -106,17 +106,17 @@ module RenderText
       assert_status 404
     end
 
-    test "rendering text with nil returns an empty body padded for Safari" do
+    test "rendering text with nil returns an empty body" do
       get "/render_text/with_layout/with_nil"
 
-      assert_body " "
+      assert_body ""
       assert_status 200
     end
 
-    test "Rendering text with nil and custom status code returns an empty body padded for Safari and the status" do
+    test "Rendering text with nil and custom status code returns an empty body and the status" do
       get "/render_text/with_layout/with_nil_and_status"
 
-      assert_body " "
+      assert_body ""
       assert_status 403
     end
 


### PR DESCRIPTION
~~I'm still cleaning up the tests, but I want to get this out so people can help me test it~~

Once upon a time, a single space character was added to `render nothing: true` (https://github.com/rails/rails/commit/cb0f8fda9652c4d24d04693bdb82cecd3b067e5c, https://github.com/rails/rails/commit/807df4fcf021fc4d15972aa1c17ba7398d43ab0d) to fix a bug in [Safari](https://bugs.webkit.org/show_bug.cgi?id=5924). (Thank you @matthewd for hunting this down.)

Since this bug has been fixed in Safari itself a long time ago (based on the timestamps it should be fixed in Safari 2.x or perhaps 1.x in ~2005), it's probably a good time to remove this.

I wrote a simplified version of the [webkit test case](https://github.com/WebKit/webkit/blob/master/LayoutTests/http/tests/xmlhttprequest/zero-length-response.html) which you can access here:
- xhr async version: http://lit-anchorage-8910.herokuapp.com/async ([source](https://github.com/chancancode/zero-length/blob/master/app/views/blank/async.html))
- xhr sync version: http://lit-anchorage-8910.herokuapp.com/sync ([source](https://github.com/chancancode/zero-length/blob/master/app/views/blank/sync.html))

(The controller doesn't actually use `render nothing`, but it should have the [same effect](https://github.com/chancancode/zero-length/blob/master/app/controllers/blank_controller.rb#L10))

I tested this on a variety of browsers on [browser stack(http://www.browserstack.com/)], including Safari 4.0 and Firefox 3.0 and it seems to work fine.

Ideally, I'd like to see this test case fail on an older version of safari (you might need safari 2.0 or even 1.0). **If you have access to one of those super old browser, please help run the test case and let me know what happens** :smile:

Otherwise, I am fairly confident that this should be okay.

cc @dhh @jeremy @sikachu @matthewd

Fixes #14336
