### PR TITLE
Adds support for Postgresql CIDR addresses, fixes #14857

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -110,6 +110,14 @@ module ActiveRecord
           end
         end
 
+        def inet_to_string(object)
+          if IPAddr === object
+            "#{object.to_unmasked_host_string}/#{object.instance_variable_get(:@mask_addr).to_s(2).count('1')}"
+          else
+            object
+          end
+        end
+
         def cidr_to_string(object)
           if IPAddr === object
             "#{object.to_s}/#{object.instance_variable_get(:@mask_addr).to_s(2).count('1')}"

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -46,7 +46,9 @@ module ActiveRecord
             end
           when IPAddr
             case sql_type
-            when 'inet', 'cidr' then super(PostgreSQLColumn.cidr_to_string(value), column)
+            when 'inet' then super(PostgreSQLColumn.inet_to_string(value), column)
+            when 'cidr' then super(PostgreSQLColumn.cidr_to_string(value), column)
+
             else super
             end
           when Float

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -55,7 +55,7 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
     @connection.execute("INSERT INTO postgresql_times (id, time_interval, scaled_time_interval) VALUES (1, '1 year 2 days ago', '3 weeks ago')")
     @first_time = PostgresqlTime.find(1)
 
-    @connection.execute("INSERT INTO postgresql_network_addresses (id, cidr_address, inet_address, mac_address) VALUES(1, '192.168.0/24', '172.16.1.254/32', '01:23:45:67:89:0a')")
+    @connection.execute("INSERT INTO postgresql_network_addresses (id, cidr_address, inet_address, mac_address) VALUES(1, '192.168.0/24', '172.16.1.254/24', '01:23:45:67:89:0a')")
     @first_network_address = PostgresqlNetworkAddress.find(1)
 
     @connection.execute("INSERT INTO postgresql_bit_strings (id, bit_string, bit_string_varying) VALUES (1, B'00010101', X'15')")
@@ -163,7 +163,7 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
 
   def test_network_address_values_ipaddr
     cidr_address = IPAddr.new '192.168.0.0/24'
-    inet_address = IPAddr.new '172.16.1.254'
+    inet_address = IPAddr.new '172.16.1.254/24'
 
     assert_equal cidr_address, @first_network_address.cidr_address
     assert_equal inet_address, @first_network_address.inet_address


### PR DESCRIPTION
The cidr format as specifies requries an unmasked address plus
a mask. Currently, we are reporting a masked address plus a mask.
This change correctly grabs the unmasked addr for a cidr and uses
the masked address for inet types.

This change depends on a change to the ruby lib/ipaddr.rb that is
currently here.

https://github.com/ruby/ruby/pull/599

Thanks to @maciekkolodziej for reporting.
