### PR TITLE
LOCALHOST definition should match any 127.0.0.0/8 address

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -23,7 +23,7 @@ module ActionDispatch
     autoload :Session, 'action_dispatch/request/session'
     autoload :Utils,   'action_dispatch/request/utils'
 
-    LOCALHOST   = Regexp.union [/^127\.0\.0\.\d{1,3}$/, /^::1$/, /^0:0:0:0:0:0:0:1(%.*)?$/]
+    LOCALHOST   = Regexp.union [/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, /^::1$/, /^0:0:0:0:0:0:0:1(%.*)?$/]
 
     ENV_METHODS = %w[ AUTH_TYPE GATEWAY_INTERFACE
         PATH_TRANSLATED REMOTE_HOST

--- a/actionpack/test/controller/show_exceptions_test.rb
+++ b/actionpack/test/controller/show_exceptions_test.rb
@@ -32,7 +32,7 @@ module ShowExceptions
 
     test 'show diagnostics from a local ip if show_detailed_exceptions? is set to request.local?' do
       @app = ShowExceptionsController.action(:boom)
-      ['127.0.0.1', '127.0.0.127', '::1', '0:0:0:0:0:0:0:1', '0:0:0:0:0:0:0:1%0'].each do |ip_address|
+      ['127.0.0.1', '127.0.0.127', '127.12.1.1', '::1', '0:0:0:0:0:0:0:1', '0:0:0:0:0:0:0:1%0'].each do |ip_address|
         self.remote_addr = ip_address
         get '/'
         assert_match(/boom/, body)

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -525,6 +525,13 @@ class RequestCGI < BaseRequestTest
   end
 end
 
+class LocalhostTest < BaseRequestTest
+  test "IPs that match localhost" do
+    request = stub_request("REMOTE_IP" => "127.1.1.1", "REMOTE_ADDR" => "127.1.1.1")
+    assert_equal !!request.local?, true 
+  end
+end
+
 class RequestCookie < BaseRequestTest
   test "cookie syntax resilience" do
     request = stub_request("HTTP_COOKIE" => "_session_id=c84ace84796670c052c6ceb2451fb0f2; is_admin=yes")


### PR DESCRIPTION
(I saw the PR for https://github.com/rails/rails/pull/14743 hadn't been updated in two weeks,
so I added a couple test cases. ) 

The entire 127.0.0.0/8 range is assigned to the loopback address, not
only 127.0.0.0/24. This patch allows ActionDispatch::Request::LOCALHOST
to match any IPv4 127.0.0.0/8 loopback address.

The only place that the #local? method was previously under test was
in the show_expectations_test.rb file. I don't particularly like that
that's implicitly where this code is under test, and I feel like I
should move some of that testing code into the
test/dispatch/request_test.rb file, but I wanted some feedback first.

Credit goes to @sriedel for discovering the issue and adding the
patch.
