### PR TITLE
Force change on becomes for STI instances, Fixes #14785

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -189,17 +189,18 @@ module ActiveRecord
     end
 
     # Wrapper around +becomes+ that also changes the instance's sti column value.
-    # This is especially useful if you want to persist the changed class in your
-    # database.
+    # This method also updates the type attribute for this record in the database.
     #
-    # Note: The old instance's sti column value will be changed too, as both objects
+    # Note: The old instance's type attribute (or other inheritance column, if the
+    # inheritance column has been specified) will be changed too, as both objects
     # share the same set of attributes.
     def becomes!(klass)
-      became = becomes(klass)
       sti_type = nil
       if !klass.descends_from_active_record?
         sti_type = klass.sti_name
+        update_attribute(klass.inheritance_column, sti_type)
       end
+      became = becomes(klass)
       became.public_send("#{klass.inheritance_column}=", sti_type)
       became
     end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -319,13 +319,22 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_nothing_raised { minimalistic.save }
   end
 
-  def test_update_sti_type
+  def test_update_sti_superclass_type
     assert_instance_of Reply, topics(:second)
 
     topic = topics(:second).becomes!(Topic)
     assert_instance_of Topic, topic
     topic.save!
     assert_instance_of Topic, Topic.find(topic.id)
+  end
+
+  def test_update_sti_subclass_type
+    assert_instance_of Topic, topics(:first)
+
+    reply = topics(:first).becomes!(Reply)
+    assert_instance_of Reply, reply
+    reply.save!
+    assert_instance_of Reply, Reply.find(reply.id)
   end
 
   def test_preserve_original_sti_type


### PR DESCRIPTION
For STI models, after there is a becomes!, the record becomes
unreachable because it has the wrong type for the class it has
been cast to.

This change updates the type attribute as part of the conversion,
so the model can continue to be reached.
