### PR TITLE
Fix problem with helper_method for ruby less than 2.1

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -65,6 +65,7 @@ module AbstractController
         self._helper_methods += meths
 
         meths.each do |meth|
+          raise TypeError.new("value cannot be nil") if meth.nil?
           _helpers.class_eval <<-ruby_eval, __FILE__, __LINE__ + 1
             def #{meth}(*args, &blk)                               # def current_user(*args, &blk)
               controller.send(%(#{meth}), *args, &blk)             #   controller.send(:current_user, *args, &blk)


### PR DESCRIPTION
In ruby 2.1 `def` returns symbol, not nil. If I run my code with ruby 2.0 I got very strange error:

```
syntax error, unexpected *
def (*args, &blk)
      ^
(irb):1: syntax error, unexpected &
def (*args, &blk)
             ^
        from /usr/bin/irb:11:in `<main>'
```

My code is something like that:

```
helper_method def abc
    // CODE
end
```
