### PR TITLE
Remove double declaration of memcache services on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-services: memcache
 script: 'ci/travis.rb'
 before_install:
   - travis_retry gem install bundler


### PR DESCRIPTION
There is already declaration of `memcached` in [lines 37-38](https://github.com/rails/rails/blob/16cc9146456dfd1f3d5c4d6999a75dafe46bae87/.travis.yml#L37-38)
