### PR TITLE
Breakup complex conditionals on delete

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -194,7 +194,7 @@ module ActiveRecord
                       options[:dependent]
                     end
 
-        delete(:all, dependent: dependent).tap do
+        delete_all_with_dependency(dependent).tap do
           reset
           loaded!
         end
@@ -256,6 +256,14 @@ module ActiveRecord
         else
           records = find(records) if records.any? { |record| record.kind_of?(Fixnum) || record.kind_of?(String) }
           delete_or_destroy(records, dependent)
+        end
+      end
+
+      def delete_all_with_dependency(dependent)
+        if (loaded? || dependent == :destroy) && dependent != :delete_all
+          delete_or_destroy(load_target, dependent)
+        else
+          delete_records(:all, dependent)
         end
       end
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -247,16 +247,8 @@ module ActiveRecord
         _options = records.extract_options!
         dependent = _options[:dependent] || options[:dependent]
 
-        if records.first == :all
-          if (loaded? || dependent == :destroy) && dependent != :delete_all
-            delete_or_destroy(load_target, dependent)
-          else
-            delete_records(:all, dependent)
-          end
-        else
-          records = find(records) if records.any? { |record| record.kind_of?(Fixnum) || record.kind_of?(String) }
-          delete_or_destroy(records, dependent)
-        end
+        records = find(records) if records.any? { |record| record.kind_of?(Fixnum) || record.kind_of?(String) }
+        delete_or_destroy(records, dependent)
       end
 
       def delete_all_with_dependency(dependent)

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -252,10 +252,10 @@ module ActiveRecord
       end
 
       def delete_all_with_dependency(dependent)
-        if (loaded? || dependent == :destroy) && dependent != :delete_all
-          delete_or_destroy(load_target, dependent)
-        else
+        if dependent == :delete_all
           delete_records(:all, dependent)
+        else
+          delete_or_destroy(load_target, dependent)
         end
       end
 


### PR DESCRIPTION
Conditionals in `delete` are complex. We can break them up by calling `delete_all_with_dependency` if `delete_all` is called or if `delete` is called instead not worrrying about `delete_all` in that method. 

Instead of checking for dependency and if the association is loaded we can just check if `dependent == :delete_all` and tidy up everything quite a bit.

This is much easier to read and cleaner code.

cc/ @tenderlove
