### PR TITLE
active_record: Quote numeric values compared to string columns.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Quote numeric values being compared to non-numeric columns. Otherwise,
+    in some database, the string column values will be coerced to a numeric
+    allowing 0, 0.0 or false to match any string starting with a non-digit.
+
+    Example:
+
+        App.where(apikey: 0) # => SELECT * FROM users WHERE apikey = '0'
+
+    *Dylan Thacker-Smith*
+
 *   When using a custom `join_table` name on a `habtm`, rails was not saving it
     on Reflections. This causes a problem when rails loads fixtures, because it
     uses the reflections to set database with fixtures.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -221,17 +221,6 @@ module ActiveRecord
         true
       end
 
-      def type_cast(value, column)
-        case value
-        when TrueClass
-          1
-        when FalseClass
-          0
-        else
-          super
-        end
-      end
-
       # MySQL 4 technically support transaction isolation, but it is affected by a bug
       # where the transaction level gets persisted for the whole session:
       #
@@ -277,8 +266,6 @@ module ActiveRecord
         if value.kind_of?(String) && column && column.type == :binary
           s = value.unpack("H*")[0]
           "x'#{s}'"
-        elsif value.kind_of?(BigDecimal)
-          value.to_s("F")
         else
           super
         end
@@ -298,6 +285,14 @@ module ActiveRecord
 
       def quoted_false
         QUOTED_FALSE
+      end
+
+      def type_casted_true
+        1
+      end
+
+      def type_casted_false
+        0
       end
 
       # REFERENTIAL INTEGRITY ====================================

--- a/activerecord/test/cases/adapters/mysql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql/quoting_test.rb
@@ -9,15 +9,25 @@ module ActiveRecord
         end
 
         def test_type_cast_true
-          c = Column.new(nil, 1, 'boolean')
           assert_equal 1, @conn.type_cast(true, nil)
-          assert_equal 1, @conn.type_cast(true, c)
+          assert_equal 1, @conn.type_cast(true, boolean_column)
+          assert_equal '1', @conn.type_cast(true, string_column)
         end
 
         def test_type_cast_false
-          c = Column.new(nil, 1, 'boolean')
           assert_equal 0, @conn.type_cast(false, nil)
-          assert_equal 0, @conn.type_cast(false, c)
+          assert_equal 0, @conn.type_cast(false, boolean_column)
+          assert_equal '0', @conn.type_cast(false, string_column)
+        end
+
+        private
+
+        def boolean_column
+          c = Column.new(nil, 1, 'boolean')
+        end
+
+        def string_column
+          c = Column.new(nil, nil, 'text')
         end
       end
     end

--- a/activerecord/test/cases/adapters/mysql2/boolean_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/boolean_test.rb
@@ -47,7 +47,7 @@ class Mysql2BooleanTest < ActiveRecord::TestCase
     assert_equal "1", attributes["published"]
 
     assert_equal 1, @connection.type_cast(true, boolean_column)
-    assert_equal 1, @connection.type_cast(true, string_column)
+    assert_equal "1", @connection.type_cast(true, string_column)
   end
 
   test "test type casting without emulated booleans" do
@@ -60,7 +60,7 @@ class Mysql2BooleanTest < ActiveRecord::TestCase
     assert_equal "1", attributes["published"]
 
     assert_equal 1, @connection.type_cast(true, boolean_column)
-    assert_equal 1, @connection.type_cast(true, string_column)
+    assert_equal "1", @connection.type_cast(true, string_column)
   end
 
   test "with booleans stored as 1 and 0" do

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -112,35 +112,35 @@ module ActiveRecord
       def test_quote_float
         float = 1.2
         assert_equal float.to_s, @quoter.quote(float, nil)
-        assert_equal float.to_s, @quoter.quote(float, Object.new)
+        assert_equal float.to_s, @quoter.quote(float, FakeColumn.new(:float))
       end
 
       def test_quote_fixnum
         fixnum = 1
         assert_equal fixnum.to_s, @quoter.quote(fixnum, nil)
-        assert_equal fixnum.to_s, @quoter.quote(fixnum, Object.new)
+        assert_equal fixnum.to_s, @quoter.quote(fixnum, FakeColumn.new(:integer))
       end
 
       def test_quote_bignum
         bignum = 1 << 100
         assert_equal bignum.to_s, @quoter.quote(bignum, nil)
-        assert_equal bignum.to_s, @quoter.quote(bignum, Object.new)
+        assert_equal bignum.to_s, @quoter.quote(bignum, FakeColumn.new(:integer))
       end
 
       def test_quote_bigdecimal
         bigdec = BigDecimal.new((1 << 100).to_s)
         assert_equal bigdec.to_s('F'), @quoter.quote(bigdec, nil)
-        assert_equal bigdec.to_s('F'), @quoter.quote(bigdec, Object.new)
+        assert_equal bigdec.to_s('F'), @quoter.quote(bigdec, FakeColumn.new(:decimal))
       end
 
       def test_dates_and_times
         @quoter.extend(Module.new { def quoted_date(value) 'lol' end })
         assert_equal "'lol'", @quoter.quote(Date.today, nil)
-        assert_equal "'lol'", @quoter.quote(Date.today, Object.new)
+        assert_equal "'lol'", @quoter.quote(Date.today, FakeColumn.new(:date))
         assert_equal "'lol'", @quoter.quote(Time.now, nil)
-        assert_equal "'lol'", @quoter.quote(Time.now, Object.new)
+        assert_equal "'lol'", @quoter.quote(Time.now, FakeColumn.new(:time))
         assert_equal "'lol'", @quoter.quote(DateTime.now, nil)
-        assert_equal "'lol'", @quoter.quote(DateTime.now, Object.new)
+        assert_equal "'lol'", @quoter.quote(DateTime.now, FakeColumn.new(:datetime))
       end
 
       def test_crazy_object

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -179,5 +179,30 @@ module ActiveRecord
         assert_equal 4, Edge.where(blank).order("sink_id").to_a.size
       end
     end
+
+    def test_where_with_integer_for_string_column
+      count = Post.where(:title => 0).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_float_for_string_column
+      count = Post.where(:title => 0.0).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_boolean_for_string_column
+      count = Post.where(:title => false).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_decimal_for_string_column
+      count = Post.where(:title => BigDecimal.new(0)).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_duration_for_string_column
+      count = Post.where(:title => 0.seconds).count
+      assert_equal 0, count
+    end
   end
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -567,6 +567,8 @@ ActiveRecord::Schema.define do
   create_table :price_estimates, force: true do |t|
     t.string :estimate_of_type
     t.integer :estimate_of_id
+    t.string :thing_type
+    t.integer :thing_id
     t.integer :price
   end
 


### PR DESCRIPTION
Previously attempted in pull #9207, but that needed pull https://github.com/rails/arel/pull/162 to be merged to implement it properly.  Now arel is fixed, and that pull request got merged with a test for the desired behaviour in arel.
## Problem

Same as pull #9207:

> The problem is described in [Potential Query Manipulation with Common Rails Practises](https://groups.google.com/forum/?hl=en&fromgroups=#!topic/rubyonrails-security/ZOdH5GH5jCU), which notes that "it is not possible for ActiveRecord to automatically protect against all instances of this attack".  However, it is possible to handle the case where the column type is known.
> 
> For example:
> 
> ``` ruby
> User.where(:login_token=>params[:token]).first
> ```
> 
> performs the query
> 
> ``` sql
> SELECT * FROM `users` WHERE `login_token` = 0 LIMIT 1;
> ```
> 
> where it will match any login_token that starts with a non-digit character.  But since active record can determine that login_token is a string type column, it can quote the integer it is being compared with as follows.
> 
> ``` sql
> SELECT * FROM `users` WHERE `login_token` = '0' LIMIT 1;
> ```
> 
> which will have the desired affect of only matching the exact string '0'.
## Solution

Coerce the numeric values to string values in ActiveRecord::ConnectionAdapters::Quoting's `type_cast` and `quote` methods when a string type column is provided.  The `type_cast` method needed to be changed for connection adapters using prepared_statements, and the `quote` method needed to be changed when prepared statements aren't used.

Boolean values are represented as the integers 0 or 1 for some databases, so booleans also need coerced to string when comparing against a string type column.
## Limitations

From pull #9207

> SQL fragments with quoted values have no information about the column type, so the following is still unsafe.
> 
> ``` ruby
> User.where("login_token = ?", params[:token])
> ```
> 
> The parameters to the SQL fragment should still be converted to the correct type before passing it to active record as follows.
> 
> ``` ruby
> User.where("login_token = ?", params[:token].to_s)
> ```
