### PR TITLE
Fixed #get_bind_values to use #map.

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -45,27 +45,22 @@ module ActiveRecord
       end
 
       def self.get_bind_values(owner, chain)
-        bvs = []
-        chain.each_with_index do |reflection, i|
+        chain.map.with_index do |reflection, i|
           if reflection.source_macro == :belongs_to
             foreign_key = reflection.foreign_key
           else
             foreign_key = reflection.active_record_primary_key
           end
 
+          bvs = []
           if reflection == chain.last
             bvs << owner[foreign_key]
-
-            if reflection.type
-              bvs << owner.class.base_class.name
-            end
+            bvs << owner.class.base_class.name if reflection.type
           else
-            if reflection.type
-              bvs << chain[i + 1].klass.base_class.name
-            end
+            bvs << chain[i + 1].klass.base_class.name if reflection.type
           end
-        end
-        bvs
+          bvs
+        end.flatten
       end
 
       private


### PR DESCRIPTION
Quick fix that Aaron wanted me to look into.

/cc @tenderlove

Although this does use #map, I don't believe that this method should use the function, mainly because of the last part where it could add a second element to the list, making it necessary to flatten it after using map.
