### PR TITLE
Fix delete all with nil (:nullify) dependency to not produce in statement

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -252,10 +252,10 @@ module ActiveRecord
       end
 
       def delete_all_with_dependency(dependent)
-        if dependent == :delete_all
-          delete_records(:all, dependent)
-        else
+        if dependent == :destroy
           delete_or_destroy(load_target, dependent)
+        else
+          delete_records(:all, dependent)
         end
       end
 

--- a/activerecord/test/cases/associations/callbacks_test.rb
+++ b/activerecord/test/cases/associations/callbacks_test.rb
@@ -150,7 +150,7 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
                   "after_removing#{jamis.id}"], activerecord.developers_log
   end
 
-  def test_has_and_belongs_to_many_remove_callback_on_clear
+  def test_has_and_belongs_to_many_does_not_fire_callbacks_on_clear
     activerecord = projects(:active_record)
     assert activerecord.developers_log.empty?
     if activerecord.developers_with_callbacks.size == 0
@@ -161,7 +161,7 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
     end
     log_array = activerecord.developers_with_callbacks.flat_map {|d| ["before_removing#{d.id}","after_removing#{d.id}"]}.sort
     assert activerecord.developers_with_callbacks.clear
-    assert_equal log_array, activerecord.developers_log.sort
+    assert_predicate activerecord.developers_log, :empty?
   end
 
   def test_has_many_and_belongs_to_many_callbacks_for_save_on_parent

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -131,6 +131,19 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal(expected_sql, loaded_sql)
   end
 
+  def test_delete_all_on_association_with_nil_dependency_is_the_same_as_not_loaded
+    author = authors :david
+    author.posts.create!(:title => "test", :body => "body")
+    author.reload
+    expected_sql = capture_sql { author.posts.delete_all }
+
+    author.posts.create!(:title => "test", :body => "body")
+    author.reload
+    author.posts.to_a
+    loaded_sql = capture_sql { author.posts.delete_all }
+    assert_equal(expected_sql, loaded_sql)
+  end
+
   def test_building_the_associated_object_with_implicit_sti_base_class
     firm = DependentFirm.new
     company = firm.companies.build

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -698,9 +698,6 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       [:added, :before, "Roger"],
       [:added, :after, "Roger"]
     ], log.last(4)
-
-    post.people_with_callbacks.clear
-    assert_equal((%w(Michael David Julian Roger) * 2).sort, log.last(8).collect(&:last).sort)
   end
 
   def test_dynamic_find_should_respect_association_include


### PR DESCRIPTION
When the dependency on a has_many association is not set it defaults to `:nullify` which runs an SQL update query.

When the association is loaded vs not loaded the SQL being produced is different.

Not loaded:

```
category.categorizations.delete_all
UPDATE "categorizations" SET "category_id" = NULL WHERE "categorizations"."category_id" = 1
```

should produce the same SQL as

```
category.categorizations    # IRB automatically calls inspect on category.categorizations
category.categorizations.delete_all
```

But instead produces this update with an IN statement:

```
UPDATE "categorizations" SET "category_id" = NULL WHERE "categorizations"."category_id" = 1 AND "categorizations"."id" IN (1, 2)
```

This pull request makes both examples produce the simpler SQL from the first example:

```
UPDATE "categorizations" SET "category_id" = NULL WHERE "categorizations"."category_id" = 1
```

This pull request also updates some of the tests involving this change. The two tests call `clear` which is the same as `delete_all` and then returns `self`. Clear does not fire callbacks because it is calling `delete_all`, therefore we shouldn't be testing that callbacks are fired.

Callbacks were removed on `delete_all` with any dependency in https://github.com/rails/rails/pull/10604. Previously `:destroy` and `:nullify` fired callbacks, but no longer do.

cc/ @tenderlove 
