### PR TITLE
#append_info_to_payload will be called even if exception occured

### DIFF
--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -28,9 +28,12 @@ module ActionController
       ActiveSupport::Notifications.instrument("start_processing.action_controller", raw_payload.dup)
 
       ActiveSupport::Notifications.instrument("process_action.action_controller", raw_payload) do |payload|
-        result = super
-        payload[:status] = response.status
-        append_info_to_payload(payload)
+        result = begin
+          super
+          payload[:status] = response.status
+        ensure
+          append_info_to_payload(payload)
+        end
         result
       end
     end

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -73,6 +73,17 @@ module Another
     def with_action_not_found
       raise AbstractController::ActionNotFound
     end
+
+    def append_info_to_payload(payload)
+      super
+      payload[:test_key] = "test_value"
+      @last_payload = payload
+    end
+
+    def last_payload
+      @last_payload
+    end
+
   end
 end
 
@@ -161,6 +172,16 @@ class ACLogSubscriberTest < ActionController::TestCase
     get :show
     wait
     assert_match(/\(Views: [\d.]+ms\)/, logs[1])
+  end
+
+  def test_append_info_to_payload_is_called_even_with_exception
+    begin
+      get :with_exception
+      wait
+    rescue Exception
+    end
+
+    assert_equal "test_value", @controller.last_payload[:test_key]
   end
 
   def test_process_action_with_filter_parameters


### PR DESCRIPTION
https://github.com/rails/rails/blob/ebfd97124db0cd7550dd197559343e2fda5b79d6/actionpack/lib/action_controller/metal/instrumentation.rb#L33

It should be called because people use it to add information to their logs and they are sad if this info will not be added when exception occured.
