### PR TITLE
Allow procs to be used when permitting parameters

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -79,4 +79,8 @@
 
     *Tony Wooster*
 
+*   Add procs as a way to allow strong parameters related to polymorphic connections
+
+    *Rainer Sai*
+
 Please check [4-1-stable](https://github.com/rails/rails/blob/4-1-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -527,6 +527,21 @@ module ActionController
   #       end
   #   end
   #
+  # When the <tt>accepts_nested_attributes_for</tt> association is of polymorphic type, to accept
+  # varying attributes use procs.
+  #
+  # private
+  # def company_params
+  #   params.require(:company).permit(clients_attributes: ->(attributes) {
+  #     case attributes[:type]
+  #       when "Company"
+  #         [:type, :name, :year_founded]
+  #       when "Person"
+  #         [:type, :first_name, :last_name]
+  #     end
+  #   })
+  # end
+  #
   # See ActionController::Parameters.require and ActionController::Parameters.permit
   # for more information.
   module StrongParameters

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -454,7 +454,7 @@ module ActionController
             params[key] = each_element(value) do |element|
               if element.is_a?(Hash)
                 element = self.class.new(element) unless element.respond_to?(:permit)
-                element.permit(*Array.wrap(filter[key]))
+                element.permit(*Array.wrap(Proc === filter[key] ? filter[key].call(element) : filter[key]))
               end
             end
           end

--- a/actionpack/test/controller/parameters/proc_filter_test.rb
+++ b/actionpack/test/controller/parameters/proc_filter_test.rb
@@ -1,0 +1,48 @@
+require 'abstract_unit'
+require 'action_dispatch/http/upload'
+require 'action_controller/metal/strong_parameters'
+
+class ProcFilterTest < ActiveSupport::TestCase
+
+  def assert_filtered_out(params, key)
+    assert !params.has_key?(key), "key #{key.inspect} has not been filtered out"
+  end
+
+  test 'proc filters' do
+    params = ActionController::Parameters.new(
+      fridge: {
+        height: '180',
+        entities: {
+          :'1' => {
+            type: 'Fish',
+            family: 'Salmonidae',
+            smelly: 'true'
+          },
+          :'0' => {
+            type: 'Juice',
+            taste: 'Orange',
+            dates: {
+              expires_at: '2014-04-04'
+            }
+          }
+        }
+      }
+    )
+
+    permitted = params.permit(
+      fridge: [
+        :height,
+        entities: ->(attributes) {
+          if attributes[:type] == 'Fish'
+            [:type, :family]
+          elsif attributes[:type] == 'Juice'
+            [:type, :taste, { dates: [:expires_at] }]
+          end
+        }
+      ]
+    )
+
+    assert_not_nil permitted[:fridge][:entities][:'0'][:dates][:expires_at]
+    assert_filtered_out permitted[:fridge][:entities][:'1'], :smelly
+  end
+end

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -318,6 +318,27 @@ with a `has_many` association:
 params.require(:book).permit(:title, chapters_attributes: [:title])
 ```
 
+If that `has_many` association is polymorphic, to accept different parameters
+depending on the object received, use procs:
+
+```ruby
+# To whitelist the following data:
+# {"company" => { "name" => "First Company",
+#    "clients_attributes" => {
+#      "1" => { "type" => "Company", "name" => "Second Company", "year_founded" => "2000" },
+#      "2" => { "type" => "Person", "first_name" => "John", "last_name" => "Doe" }}}}
+
+params.require(:company).permit(clients_attributes: ->(attributes) {
+    case attributes[:type]
+      when "Company"
+        [:type, :name, :year_founded]
+      when "Person"
+        [:type, :first_name, :last_name]
+    end
+  }
+)
+```
+
 #### Outside the Scope of Strong Parameters
 
 The strong parameter API was designed with the most common use cases


### PR DESCRIPTION
Allows for a way for users to define parameters permitted for polymorphic relations
