### PR TITLE
Cache key generation doesn't honor ActiveRecord::Relation objects for `Cache::Store#write`

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -510,17 +510,12 @@ module ActiveSupport
         # object responds to +cache_key+. Otherwise, +to_param+ method will be
         # called. If the key is a Hash, then keys will be sorted alphabetically.
         def expanded_key(key) # :nodoc:
-          return key.cache_key.to_s if key.respond_to?(:cache_key)
-
-          case key
-          when Array
-            if key.size > 1
-              key = key.collect{|element| expanded_key(element)}
-            else
-              key = key.first
-            end
-          when Hash
-            key = key.sort_by { |k,_| k.to_s }.collect{|k,v| "#{k}=#{v}"}
+          key = case
+          when key.respond_to?(:cache_key) then key.cache_key
+          when key.is_a?(Array)            then key.map { |element| expanded_key(element) }
+          when key.is_a?(Hash)             then key.sort_by { |k,_| k.to_s }.collect{|k,v| "#{k}=#{v}"}
+          when key.respond_to?(:to_a)      then expanded_key(key.to_a)
+          else key
           end
 
           key.to_param

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -352,6 +352,22 @@ module CacheStoreBehavior
     assert_equal "bar", @cache.read("fu/foo")
   end
 
+  def test_arrayish_as_cache_key
+    obj = Object.new
+    def obj.to_a
+      ["foobar"]
+    end
+
+    @cache.write(obj, "bar")
+    assert_equal "bar", @cache.read("foobar")
+  end
+
+  def test_other_as_cache_key
+    # If it doesn't meet any of the special criteria (Array, Hash, etc.)
+    @cache.write("foo", "bar")
+    assert_equal "bar", @cache.read("foo")
+  end
+
   def test_hash_as_cache_key
     @cache.write({:foo => 1, :fu => 2}, "bar")
     assert_equal "bar", @cache.read("foo=1/fu=2")


### PR DESCRIPTION
[`retrieve_cache_key`](https://github.com/rails/rails/blob/ca20037899e55ddf734b727454a3180bebf82212/activesupport/lib/active_support/cache.rb#L91) handles the `to_a` case, but [`expanded_key`](https://github.com/rails/rails/blob/ca20037899e55ddf734b727454a3180bebf82212/activesupport/lib/active_support/cache.rb#L512) currently doesn't. This means if you pass an ActiveRecord::Relation into Rails.cache.write (at any depth), it doesn't properly extract the cache_key, instead just calling `to_param` on each object, which is (by default) just the ID, and therefore the key-based expiration is broken.

This bug [breaks caching in jbuilder](https://github.com/rails/jbuilder/blob/788981134defbde34e94d32eea0c02178bb772a5/lib/jbuilder/jbuilder_template.rb#L53), among other things.

Is there any reason we can't make a few small modification and just call `ActiveSupport::Cache.expand_cache_key` directly instead of duplicating this logic?

This can be backported to 4.0.x, I'll wait for any feedback before doing that.
