### PR TITLE
Propagate test messages through assert_routing helper, Fixes #14908

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -38,7 +38,7 @@ module ActionDispatch
       #   # Test a custom route
       #   assert_recognizes({controller: 'items', action: 'show', id: '1'}, 'view/item1')
       def assert_recognizes(expected_options, path, extras={}, msg=nil)
-        request = recognized_request_for(path, extras)
+        request = recognized_request_for(path, extras, msg)
 
         expected_options = expected_options.clone
 
@@ -71,7 +71,7 @@ module ActionDispatch
       #   assert_generates "changesets/12", { controller: 'scm', action: 'show_diff', revision: "12" }
       def assert_generates(expected_path, options, defaults={}, extras = {}, message=nil)
         if expected_path =~ %r{://}
-          fail_on(URI::InvalidURIError) do
+          fail_on(URI::InvalidURIError, message) do
             uri = URI.parse(expected_path)
             expected_path = uri.path.to_s.empty? ? "/" : uri.path
           end
@@ -174,7 +174,7 @@ module ActionDispatch
 
       private
         # Recognizes the route for a given path.
-        def recognized_request_for(path, extras = {})
+        def recognized_request_for(path, extras = {}, msg)
           if path.is_a?(Hash)
             method = path[:method]
             path   = path[:path]
@@ -186,7 +186,7 @@ module ActionDispatch
           request = ActionController::TestRequest.new
 
           if path =~ %r{://}
-            fail_on(URI::InvalidURIError) do
+            fail_on(URI::InvalidURIError, msg) do
               uri = URI.parse(path)
               request.env["rack.url_scheme"] = uri.scheme || "http"
               request.host = uri.host if uri.host
@@ -200,7 +200,7 @@ module ActionDispatch
 
           request.request_method = method if method
 
-          params = fail_on(ActionController::RoutingError) do
+          params = fail_on(ActionController::RoutingError, msg) do
             @routes.recognize_path(path, { :method => method, :extras => extras })
           end
           request.path_parameters = params.with_indifferent_access
@@ -208,10 +208,10 @@ module ActionDispatch
           request
         end
 
-        def fail_on(exception_class)
+        def fail_on(exception_class, msg=nil)
           yield
         rescue exception_class => e
-          raise Minitest::Assertion, e.message
+          raise Minitest::Assertion, msg || e.message
         end
     end
   end

--- a/actionpack/test/dispatch/routing_assertions_test.rb
+++ b/actionpack/test/dispatch/routing_assertions_test.rb
@@ -78,6 +78,14 @@ class RoutingAssertionsTest < ActionController::TestCase
     assert_routing('/articles', :controller => 'articles', :action => 'index')
   end
 
+  def test_assert_routing_raises_message
+    err = assert_raise(Assertion) do
+            assert_routing('/thisIsNotARoute', { :controller => 'articles', :action => 'edit', :id => '1' }, { :id => '1' }, {}, "This is a really bad msg")
+    end
+
+    assert_match err.message, "This is a really bad msg"
+  end
+
   def test_assert_routing_with_defaults
     assert_routing('/articles/1/edit', { :controller => 'articles', :action => 'edit', :id => '1' }, { :id => '1' })
   end


### PR DESCRIPTION
assert_routing was not raising the message passed into the assertion
violation that it raised. This change propagates messages through
the on_fail error.

Fixes #14908

A test case for this issue is located here.
https://github.com/estsauver/test14908

To see that test case fail in the example app, just run
ruby -Itest test/controllers/guests_controller_test.rb
