### PR TITLE
Give real privacy to class methods in AR::PredicateBuilder

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Give ActiveRecord::PredicateBuilder private methods the privacy they deserve
+
+    *Hector Satre*
+
 *   When using a custom `join_table` name on a `habtm`, rails was not saving it
     on Reflections. This causes a problem when rails loads fixtures, because it
     uses the reflections to set database with fixtures.

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -113,13 +113,14 @@ module ActiveRecord
     register_handler(Relation, RelationHandler.new)
     register_handler(Array, ArrayHandler.new)
 
-    private
-      def self.build(attribute, value)
-        handler_for(value).call(attribute, value)
-      end
+    def self.build(attribute, value)
+      handler_for(value).call(attribute, value)
+    end
+    private_class_method :build
 
-      def self.handler_for(object)
-        @handlers.detect { |klass, _| klass === object }.last
-      end
+    def self.handler_for(object)
+      @handlers.detect { |klass, _| klass === object }.last
+    end
+    private_class_method :handler_for
   end
 end


### PR DESCRIPTION
For the moment, in the class `ActiveRecord::PredicateBuilder`, the methods `build` and `handler_for` are supposed to be private. But, as they are class method, `private` won't work, we need to explicitly use `private_class_method`.
