### PR TITLE
Do not make N+1 queries with "pluck" if collection is loaded

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -110,6 +110,18 @@ module ActiveRecord
         @association.select(*fields, &block)
       end
 
+      def pluck(*column_names)
+        if loaded? && !column_names.find { |column_name| column_name.is_a?(String) }
+          stringified_column_names = column_names.map(&:to_s)
+          load_target.map do |record|
+            values = record.attributes.slice(*stringified_column_names).values
+            values.one? ? values.first : values
+          end
+        else
+          @association.scope.pluck(*column_names)
+        end
+      end
+
       # Finds an object in the collection responding to the +id+. Uses the same
       # rules as <tt>ActiveRecord::Base.find</tt>. Returns <tt>ActiveRecord::RecordNotFound</tt>
       # error if the object cannot be found.


### PR DESCRIPTION
To fix #14917 (and maybe #5990) I'm suggesting to use loaded records if it's possible
