### PR TITLE
Fixes #14891 database connection pool performance regression

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Fixes database connection pool performance regression as of Rails 4.0 in
+    highly concurrent environments running on JRuby.
+
+    Replaces the new Rails 4 connection pool with an old, tried and tested
+    connection pool called GenePool, yet maintains backward compatibility.
+
+    Addresses significant slow down when multiple threads attempt to checkout
+    connections at the same time. Would take as much as 3 seconds to get an
+    existing database connection with 100 concurrent threads.
+
+    Adds new database connection pool configuration option +checkout_warning+
+    which logs a warning when it takes longer than supplied number of seconds to
+    return a connection from the pool
+
+    Fixes #14891.
+
+    *Reid Morrison*
+
 *   When using a custom `join_table` name on a `habtm`, rails was not saving it
     on Reflections. This causes a problem when rails loads fixtures, because it
     uses the reflections to set database with fixtures.

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', version
   s.add_dependency 'activemodel',   version
 
-  s.add_dependency 'arel', '~> 5.0.0'
+  s.add_dependency 'arel',      '~> 5.0.0'
+  s.add_dependency 'gene_pool', '>= 1.4.1'
 end

--- a/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
+++ b/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
@@ -3,15 +3,6 @@ require "cases/helper"
 module ActiveRecord
   module ConnectionAdapters
     class AdapterLeasingTest < ActiveRecord::TestCase
-      class Pool < ConnectionPool
-        def insert_connection_for_test!(c)
-          synchronize do
-            @connections << c
-            @available.add c
-          end
-        end
-      end
-
       def setup
         @adapter = AbstractAdapter.new nil, nil
       end
@@ -35,12 +26,10 @@ module ActiveRecord
       end
 
       def test_close
-        pool = Pool.new(ConnectionSpecification.new({}, nil))
-        pool.insert_connection_for_test! @adapter
-        @adapter.pool = pool
+        pool = ConnectionPool.new ActiveRecord::Base.connection_pool.spec
 
         # Make sure the pool marks the connection in use
-        assert_equal @adapter, pool.connection
+        assert @adapter = pool.connection
         assert @adapter.in_use?
 
         # Close should put the adapter back in the pool

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -218,6 +218,7 @@ module ActiveRecord
       # correct in this case.
       def test_checkout_fairness
         @pool.instance_variable_set(:@size, 10)
+        @pool.instance_variable_get(:@pool).pool_size = 10
         expected = (1..@pool.size).to_a.freeze
         # check out all connections so our threads start out waiting
         conns = expected.map { @pool.checkout }
@@ -256,6 +257,7 @@ module ActiveRecord
       # threads acquired a connection is enforced.
       def test_checkout_fairness_by_group
         @pool.instance_variable_set(:@size, 10)
+        @pool.instance_variable_get(:@pool).pool_size = 10
         # take all the connections
         conns = (1..10).map { @pool.checkout }
         mutex = Mutex.new


### PR DESCRIPTION
Replaces the new Rails 4 connection pool with an old, tried and tested
connection pool called GenePool, yet maintains backward compatibility.

Addresses significant slow down when multiple threads attempt to checkout
connections at the same time. Would take as much as 3 seconds to get an
existing database connection with 100 concurrent threads.

Adds new database connection pool configuration option +checkout_warning+
which logs a warning when it takes longer than the supplied number of
seconds to return a connection from the pool.
