### PR TITLE
Strings gets implicitly converted to a number on arjdbc/sqlite3

### DIFF
--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -558,18 +558,26 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   def test_converted_values_are_returned_after_assignment
     developer = Developer.new(name: 1337, salary: "50000")
 
+    assert_kind_of String, developer.salary_before_type_cast
     assert_equal "50000", developer.salary_before_type_cast
+    assert_kind_of Fixnum, developer.name_before_type_cast
     assert_equal 1337, developer.name_before_type_cast
 
+    assert_kind_of Fixnum, developer.salary
     assert_equal 50000, developer.salary
+    assert_kind_of String, developer.name
     assert_equal "1337", developer.name
 
     developer.save!
 
+    assert_kind_of String, developer.salary_before_type_cast
     assert_equal "50000", developer.salary_before_type_cast
+    assert_kind_of Fixnum, developer.name_before_type_cast
     assert_equal 1337, developer.name_before_type_cast
 
+    assert_kind_of Fixnum, developer.salary
     assert_equal 50000, developer.salary
+    assert_kind_of String, developer.name
     assert_equal "1337", developer.name
   end
 


### PR DESCRIPTION
This test `test_converted_values_are_returned_after_assignment` is passes on CRuby but fails on JRuby with following message:

``` ruby
ruby 1.7.12 (1.9.3p392) 2014-04-15 643e292 on Java HotSpot(TM) 64-Bit Server VM 1.7.0_51-b13 Using jdbcsqlite3
Run options: -n test_converted_values_are_returned_after_assignment --seed 60208

# Running:

F

Finished in 0.198000s, 5.0505 runs/s, 35.3535 assertions/s.

  1) Failure:
AttributeMethodsTest#test_converted_values_are_returned_after_assignment [test/cases/attribute_methods_test.rb:568]:
Expected 1337 to be a kind of String, not Fixnum.

1 runs, 7 assertions, 1 failures, 0 errors, 0 skips
```

so somewhere something similar to `"1337".to_i` is being done. The problem is that if I am expected value from column should be a `String`, it returns a Number. then things can blow up.

Any idea why/how this is happening?
#11700
