### PR TITLE
Avoid unnecessary conditional block

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
@@ -21,13 +21,8 @@
     <%%= f.label :password_confirmation %><br>
     <%%= f.password_field :password_confirmation %>
 <% else -%>
-  <%- if attribute.reference? -%>
     <%%= f.label :<%= attribute.column_name %> %><br>
     <%%= f.<%= attribute.field_type %> :<%= attribute.column_name %> %>
-  <%- else -%>
-    <%%= f.label :<%= attribute.name %> %><br>
-    <%%= f.<%= attribute.field_type %> :<%= attribute.name %> %>
-  <%- end -%>
 <% end -%>
   </div>
 <% end -%>


### PR DESCRIPTION
[`GeneratedAttribute#column_name`](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/generated_attribute.rb#L113-L115) checks already for `reference?` on the attribute returning the right name to use as symbol for label and field.

See also https://github.com/rails/rails/commit/b017562382e1c43655eec3456d2a78c1d4407952 where this code was introduced.
