### PR TITLE
always use File.join in asset_path

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Change `asset_path` to use File.join to create proper paths (#14932):
+
+        https://some.host.com//assets/some.js
+
+    becomes
+
+        https://some.host.com/assets/some.js
+
+    *Peter Schröder*
+
 *   Change `favicon_link_tag` default mimetype from `image/vnd.microsoft.icon` to
     `image/x-icon`.
 

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -134,11 +134,11 @@ module ActionView
 
         relative_url_root = defined?(config.relative_url_root) && config.relative_url_root
         if relative_url_root
-          source = "#{relative_url_root}#{source}" unless source.starts_with?("#{relative_url_root}/")
+          source = File.join(relative_url_root, source) unless source.starts_with?("#{relative_url_root}/")
         end
 
         if host = compute_asset_host(source, options)
-          source = "#{host}#{source}"
+          source = File.join(host, source)
         end
 
         "#{source}#{tail}"

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -309,6 +309,14 @@ class AssetTagHelperTest < ActionView::TestCase
     AssetPathToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
 
+  def test_asset_path_tag_to_not_create_duplicate_slashes
+    @controller.config.asset_host = "host/"
+    assert_dom_equal('http://host/foo', asset_path("foo"))
+
+    @controller.config.relative_url_root = '/some/root/'
+    assert_dom_equal('http://host/some/root/foo', asset_path("foo"))
+  end
+
   def test_compute_asset_public_path
     assert_equal "/robots.txt", compute_asset_path("robots.txt")
     assert_equal "/robots.txt", compute_asset_path("/robots.txt")


### PR DESCRIPTION
this makes sure that there are no duplicate slashes in asset urls.

we ran into a problem where our app was generating asset urls like `https://some.host.com//assets/some.js`

/cc @fw42 @arthurnn 
