### PR TITLE
Removed unnecessary test in actionpack/test/controller/request_forgery_protection_test.rb

### DIFF
--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -115,12 +115,6 @@ class FreeCookieController < RequestForgeryProtectionControllerUsingResetSession
   end
 end
 
-class CustomAuthenticityParamController < RequestForgeryProtectionControllerUsingResetSession
-  def form_authenticity_param
-    'foobar'
-  end
-end
-
 # common test methods
 module RequestForgeryProtectionTests
   def setup
@@ -456,22 +450,5 @@ class FreeCookieControllerTest < ActionController::TestCase
   test 'should not emit a csrf-token meta tag' do
     get :meta
     assert @response.body.blank?
-  end
-end
-
-class CustomAuthenticityParamControllerTest < ActionController::TestCase
-  def setup
-    super
-    ActionController::Base.request_forgery_protection_token = :custom_token_name
-  end
-
-  def teardown
-    ActionController::Base.request_forgery_protection_token = :authenticity_token
-    super
-  end
-
-  def test_should_allow_custom_token
-    post :index, :custom_token_name => 'foobar'
-    assert_response :ok
   end
 end


### PR DESCRIPTION
While working on https://github.com/rails/rails/pull/11316 I've been digging around https://github.com/rails/rails/blob/master/actionpack/test/controller/request_forgery_protection_test.rb

There is a test which I believe was written for `form_authenticity_param`. However, when I remove `form_authenticity_param`, all of the tests still pass.

This is my first Rails commit so I may be missing something obvious :)
