### PR TITLE
Moved 'params[request_forgery_protection_token]' into its own method and...

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Moved `params[request_forgery_protection_token]` into its own method
+    and improved tests.
+
+    Fixes #11316.
+
+    *Tom Kadwill*
+
 *   Added verification of route constraints given as a Proc or an object responding
     to `:matches?`. Previously, when given an non-complying object, it would just
     silently fail to enforce the constraint. It will now raise an `ArgumentError`

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -247,7 +247,7 @@ module ActionController #:nodoc:
       # * Does the X-CSRF-Token header match the form_authenticity_token
       def verified_request?
         !protect_against_forgery? || request.get? || request.head? ||
-          form_authenticity_token == params[request_forgery_protection_token] ||
+          form_authenticity_token == form_authenticity_param ||
           form_authenticity_token == request.headers['X-CSRF-Token']
       end
 


### PR DESCRIPTION
... improved tests.

Fixes https://github.com/rails/rails/pull/11316 and improves tests, as describes in https://github.com/rails/rails/pull/14933.
