### PR TITLE
Fix exception when logging SQL w/ nil binary value. (4-1-stable backport)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Log nil binary column values correctly.
+
+    When an object with a binary column is updated with a nil value
+    in that column, the SQL logger would throw an exception when trying
+    to log that nil value. This only occurs when updating a record
+    that already has a non-nil value in that column since an initial nil
+    value isn't included in the SQL anyway (at least, when dirty checking
+    is enabled.) The column's new value will now be logged as `<NULL binary data>`
+    to parallel the existing `<N bytes of binary data>` for non-nil values.
+
+    *James Coleman*
+
 *   Stringify all variables keys of mysql connection configuration.
 
     When `sql_mode` variable for mysql adapters set in configuration as `String`

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         if column.binary?
           # This specifically deals with the PG adapter that casts bytea columns into a Hash.
           value = value[:value] if value.is_a?(Hash)
-          value = "<#{value.bytesize} bytes of binary data>"
+          value = value.nil? ? "<NULL binary data>" : "<#{value.bytesize} bytes of binary data>"
         end
 
         [column.name, value]

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -125,5 +125,12 @@ class LogSubscriberTest < ActiveRecord::TestCase
       wait
       assert_match(/<16 bytes of binary data>/, @logger.logged(:debug).join)
     end
+
+    def test_nil_binary_data_is_logged
+      binary = Binary.create(data: "")
+      binary.update_attributes(data: nil)
+      wait
+      assert_match(/<NULL binary data>/, @logger.logged(:debug).join)
+    end
   end
 end


### PR DESCRIPTION
When an object with a binary column is updated with a nil value in that column, the SQL logger would throw an exception when trying to log that nil value. This only occurs when updating a record that already has a non-nil value in that column since an initial nil value isn't included in the SQL anyway (at least, when dirty checking is enabled.) The column's new value will now be logged as <NULL binary data> to parallel the existing <N bytes of binary data> for non-nil values.
