### PR TITLE
[Fixes #14948] Hash#to_query: right serialization for  empty hash and array

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Fixed backward compatibility isues introduced in 326e652
+
+    Empty Hash or Array should not present in serialization result
+
+        {a: []}.to_query # => ""
+        {a: {}}.to_query # => ""
+
+    For more info see #14948.
+
+    *Bogdan Gusiev*
+
 *   Add `SecureRandom::uuid_v3` and `SecureRandom::uuid_v5` to support stable
     UUID fixtures on PostgreSQL.
 

--- a/activesupport/lib/active_support/core_ext/object/to_param.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_param.rb
@@ -51,12 +51,12 @@ class Hash
   #
   # This method is also aliased as +to_query+.
   def to_param(namespace = nil)
-    if empty?
-      namespace ? nil.to_query(namespace) : ''
-    else
-      collect do |key, value|
+    collect do |key, value|
+      unless (value.is_a?(Hash) || value.is_a?(Array)) && value.empty?
         value.to_query(namespace ? "#{namespace}[#{key}]" : key)
-      end.sort! * '&'
-    end
+      else
+        nil
+      end
+    end.compact.sort! * '&'
   end
 end

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -49,13 +49,15 @@ class ToQueryTest < ActiveSupport::TestCase
   def test_nested_empty_hash
     assert_equal '',
       {}.to_query
-    assert_query_equal 'a=1&b%5Bc%5D=3&b%5Bd%5D=',
+    assert_query_equal 'a=1&b%5Bc%5D=3',
       { a: 1, b: { c: 3, d: {} } }
+    assert_query_equal '',
+      { a: {b: {c: {}}} }
     assert_query_equal 'b%5Bc%5D=false&b%5Be%5D=&b%5Bf%5D=&p=12',
       { p: 12, b: { c: false, e: nil, f: '' } }
-    assert_query_equal 'b%5Bc%5D=3&b%5Bf%5D=&b%5Bk%5D=',
+    assert_query_equal 'b%5Bc%5D=3&b%5Bf%5D=',
       { b: { c: 3, k: {}, f: '' } }
-    assert_query_equal 'a%5B%5D=&b=3',
+    assert_query_equal 'b=3',
       {a: [], b: 3}
   end
 


### PR DESCRIPTION
Empty Hash or Array should not present in serialization result

``` ruby
{a: []}.to_query # => ""
{a: {}}.to_query # => ""
```

For more info see #14948.
