### PR TITLE
Add support for module-level table_suffix in models

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add support for module-level `table_name_suffix` in models.
+
+    This makes `table_name_suffix` work the same way as `table_name_prefix` when
+    using namespaced models.
+
+    *Jenner LaFave*
+
 *   Revert the behaviour of `ActiveRecord::Relation#join` changed through 4.0 => 4.1 to 4.0.
 
     In 4.1.0 `Relation#join` is delegated to `Arel#SelectManager`.

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -29,6 +29,10 @@ module ActiveRecord
       # :singleton-method:
       # Works like +table_name_prefix+, but appends instead of prepends (set to "_basecamp" gives "projects_basecamp",
       # "people_basecamp"). By default, the suffix is the empty string.
+      #
+      # If you are organising your models within modules, you can add a suffix to the models within
+      # a namespace by defining a singleton method in the parent module called table_name_suffix which
+      # returns your chosen suffix.
       class_attribute :table_name_suffix, instance_writer: false
       self.table_name_suffix = ""
 
@@ -151,6 +155,10 @@ module ActiveRecord
 
       def full_table_name_prefix #:nodoc:
         (parents.detect{ |p| p.respond_to?(:table_name_prefix) } || self).table_name_prefix
+      end
+
+      def full_table_name_suffix #:nodoc:
+        (parents.detect {|p| p.respond_to?(:table_name_suffix) } || self).table_name_suffix
       end
 
       # Defines the name of the table column which will store the class name on single-table
@@ -337,7 +345,8 @@ module ActiveRecord
             contained = contained.singularize if parent.pluralize_table_names
             contained += '_'
           end
-          "#{full_table_name_prefix}#{contained}#{undecorated_table_name(name)}#{table_name_suffix}"
+
+          "#{full_table_name_prefix}#{contained}#{undecorated_table_name(name)}#{full_table_name_suffix}"
         else
           # STI subclasses always use their superclass' table.
           base.table_name

--- a/activerecord/test/cases/modules_test.rb
+++ b/activerecord/test/cases/modules_test.rb
@@ -112,6 +112,34 @@ class ModulesTest < ActiveRecord::TestCase
     classes.each(&:reset_table_name)
   end
 
+  def test_module_table_name_suffix
+    assert_equal 'companies_suffixed', MyApplication::Business::Suffixed::Company.table_name, 'inferred table_name for ActiveRecord model in module with table_name_suffix'
+    assert_equal 'companies_suffixed', MyApplication::Business::Suffixed::Nested::Company.table_name, 'table_name for ActiveRecord model in nested module with a parent table_name_suffix'
+    assert_equal 'companies', MyApplication::Business::Suffixed::Firm.table_name, 'explicit table_name for ActiveRecord model in module with table_name_suffix should not be suffixed'
+  end
+
+  def test_module_table_name_suffix_with_global_suffix
+    classes = [ MyApplication::Business::Company,
+                MyApplication::Business::Firm,
+                MyApplication::Business::Client,
+                MyApplication::Business::Client::Contact,
+                MyApplication::Business::Developer,
+                MyApplication::Business::Project,
+                MyApplication::Business::Suffixed::Company,
+                MyApplication::Business::Suffixed::Nested::Company,
+                MyApplication::Billing::Account ]
+
+    ActiveRecord::Base.table_name_suffix = '_global'
+    classes.each(&:reset_table_name)
+    assert_equal 'companies_global', MyApplication::Business::Company.table_name, 'inferred table_name for ActiveRecord model in module without table_name_suffix'
+    assert_equal 'companies_suffixed', MyApplication::Business::Suffixed::Company.table_name, 'inferred table_name for ActiveRecord model in module with table_name_suffix'
+    assert_equal 'companies_suffixed', MyApplication::Business::Suffixed::Nested::Company.table_name, 'table_name for ActiveRecord model in nested module with a parent table_name_suffix'
+    assert_equal 'companies', MyApplication::Business::Suffixed::Firm.table_name, 'explicit table_name for ActiveRecord model in module with table_name_suffix should not be suffixed'
+  ensure
+    ActiveRecord::Base.table_name_suffix = ''
+    classes.each(&:reset_table_name)
+  end
+
   def test_compute_type_can_infer_class_name_of_sibling_inside_module
     old = ActiveRecord::Base.store_full_sti_class
     ActiveRecord::Base.store_full_sti_class = true

--- a/activerecord/test/models/company_in_module.rb
+++ b/activerecord/test/models/company_in_module.rb
@@ -46,6 +46,24 @@ module MyApplication
         end
       end
     end
+
+    module Suffixed
+      def self.table_name_suffix
+        '_suffixed'
+      end
+
+      class Company < ActiveRecord::Base
+      end
+
+      class Firm < Company
+        self.table_name = 'companies'
+      end
+
+      module Nested
+        class Company < ActiveRecord::Base
+        end
+      end
+    end
   end
 
   module Billing


### PR DESCRIPTION
This makes table_name_suffix work the same as table_name_prefix when
using namespaced models. Pretty much the same as 67d1cec.

![fwoomp](https://cloud.githubusercontent.com/assets/172474/2867252/abaf1ae0-d233-11e3-833f-5085e905b4ab.gif)
