### PR TITLE
Added irregular inflection for cafe/cafes

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -64,6 +64,7 @@ module ActiveSupport
     inflect.irregular('sex', 'sexes')
     inflect.irregular('move', 'moves')
     inflect.irregular('zombie', 'zombies')
+    inflect.irregular('cafe', 'cafes')
 
     inflect.uncountable(%w(equipment information rice money species series fish sheep jeans police))
   end


### PR DESCRIPTION
Hello,
 While creating an app, I found that the inflector translates 'cafe' to the plural 'caves'.
 I added an irregular exception to fix that.

Cheers,
Sebastian.
