### PR TITLE
Truncate day of month in TimeZone#parse.

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -282,14 +282,26 @@ module ActiveSupport
     #
     #   Time.zone.now               # => Fri, 31 Dec 1999 14:00:00 HST -10:00
     #   Time.zone.parse('22:30:00') # => Fri, 31 Dec 1999 22:30:00 HST -10:00
+    #
+    # If no day component is specified but a month component is, and the current
+    # day of the month is greater than the number of days in the specified
+    # month, then the last day of the specified month is used:
+    #
+    #   Time.zone.now               # => Fri, 31 Dec 1999 14:00:00 HST -10:00
+    #   Time.zone.parse('February') # => Sun, 28 Feb 1999 00:00:00 HST -10:00
     def parse(str, now=now())
       parts = Date._parse(str, false)
       return if parts.empty?
 
+      year = parts.fetch(:year, now.year)
+      month = parts.fetch(:mon, now.month)
+
+      day = [Time.days_in_month(month, year), parts.fetch(:mday, now.day)].min
+
       time = Time.new(
-        parts.fetch(:year, now.year),
-        parts.fetch(:mon, now.month),
-        parts.fetch(:mday, now.day),
+        year,
+        month,
+        day,
         parts.fetch(:hour, 0),
         parts.fetch(:min, 0),
         parts.fetch(:sec, 0) + parts.fetch(:sec_fraction, 0),

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -277,6 +277,13 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal Time.utc(2012, 12, 1), twz.time
   end
 
+  def test_parse_with_missing_mday_and_current_day_out_of_range
+    zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
+    zone.stubs(:now).returns zone.local(2000, 1, 31, 12, 59, 59)
+    twz = zone.parse('February 2008')
+    assert_equal Time.utc(2008, 2, 29), twz.time
+  end
+
   def test_parse_with_javascript_date
     zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
     twz = zone.parse("Mon May 28 2012 00:00:00 GMT-0700 (PDT)")


### PR DESCRIPTION
As described in #14543, supplying missing components of a date from TimeZone#now runs into problems when now.day is greater than the number of days in the month. This can cause situations where parsing "February" when it's the 31st of January causes TimeZone#parse to return a day in March.

This problem could be resolved by setting the day of the month to be:

``` ruby
[Time.days_in_month(month, year), parts.fetch(:mday, now.day)].min
```

Which truncates the day of the month, avoiding any date-overflows.

@robin850 What do you think?
