### PR TITLE
Fixed the inferred table name of a HABTM auxiliar

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fixed the inferred table name of a HABTM auxiliar table inside a schema.
+
+    Fixes #14824
+
+    *Eric Chahin*
+
 *   Revert the behaviour of `ActiveRecord::Relation#join` changed through 4.0 => 4.1 to 4.0.
 
     In 4.1.0 `Relation#join` is delegated to `Arel#SelectManager`.

--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -11,7 +11,7 @@ module ActiveRecord::Associations::Builder
         end
 
         def join_table
-          @join_table ||= [@lhs_class.table_name, klass.table_name].sort.join("\0").gsub(/^(.*_)(.+)\0\1(.+)/, '\1\2_\3').gsub("\0", "_")
+          @join_table ||= [@lhs_class.table_name, klass.table_name].sort.join("\0").gsub(/^(.*[._])(.+)\0\1(.+)/, '\1\2_\3').gsub("\0", "_")
         end
 
         private


### PR DESCRIPTION
table inside a schema.

Fixes #14824.

This PR relies on https://github.com/rails/rails/pull/14871 being merged in to run.

I would gladly appreciate any feedback on how to properly create a schema for a test case because I don't think what I did follows protocol.
