### PR TITLE
Add ability to test router redirects

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -72,8 +72,17 @@ module ActionDispatch
         def normalize_argument_to_redirection(fragment)
           if Regexp === fragment
             fragment
-          else
+          elsif @controller
             @controller._compute_redirect_to_location(fragment)
+          else
+            case fragment
+            when /\A([a-z][a-z\d\-+\.]*:|\/\/).*/i
+              fragment
+            when String
+              request.protocol + request.host_with_port + fragment
+            else
+              url_for(fragment)
+            end
           end
         end
     end

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -638,3 +638,40 @@ class ActionPackHeaderTest < ActionController::TestCase
     assert_equal 'application/rss+xml; charset=utf-8', @response.headers['Content-Type']
   end
 end
+
+class ActionPackAssertionsIntegrationTest < ActionDispatch::IntegrationTest
+  def test_assert_redirected_to_router_redirect_success
+    with_routing do |set|
+      set.draw do
+        get 'route_one', :to => redirect('/route_two')
+        get 'route_two', :to => 'action_pack_assertions#nothing'
+      end
+
+      get '/route_one'
+
+      assert_redirected_to '/route_two'
+      assert_redirected_to 'http://www.example.com/route_two'
+      assert_redirected_to %r(route_two)
+      assert_redirected_to controller: 'action_pack_assertions', action: 'nothing'
+    end
+  end
+
+  def test_assert_redirected_to_router_redirect_failure
+    with_routing do |set|
+      set.draw do
+        get 'route_one', :to => redirect('/route_two')
+        get 'route_two', :to => 'action_pack_assertions#nothing'
+      end
+
+      get '/route_one'
+      assert_raises(ActiveSupport::TestCase::Assertion) do
+        assert_redirected_to '/route_one'
+      end
+
+      get '/route_two'
+      assert_raises(ActiveSupport::TestCase::Assertion) do
+        assert_redirected_to '/route_two'
+      end
+    end
+  end
+end


### PR DESCRIPTION
So far `assert_redirected_to` could only test redirects that happen on the controller level.

``` ruby
# app/controllers/some_controller.rb
class SomeController < ApplicationController
  def index
    redirect_to "/some_path"
  end
end
```

``` ruby
# test/controllers/some_controller_test.rb
class SomeControllerTest < ActionController::TestCase
  def test_index_redirects
    get :index
    assert_redirected_to "/some_path"
  end
end
```

However, when wanting to test redirects that happen on the router level (in integration tests), this matcher doesn't work.

``` ruby
# config/routes.rb
Blog::Application.routes.draw do
  get "/foo", to: redirect("/bar")
  get "/bar", to: "..."
end
```

``` ruby
# test/integration/redirect_test.rb
class RedirectTest < ActionDispatch::IntegrationTest
  def test_redirects
    get "/foo"
    assert_redirected_to "/bar"
  end
end
```

```
NoMethodError: undefined method `_compute_redirect_to_location' for nil:NilClass
```

That's because this matcher expects `@controller` to be assigned, which is not the case with router redirects. This commit extends `assert_redirected_to` with the ability to test the router level redirects.
