### PR TITLE
Fix 2 wrong behaviors for has_and_belongs_to_many association in Rails 4.0

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -2977,4 +2977,40 @@
 
     *Aaron Patterson*
 
+*   Fix wrong size result after built has_and_belongs_to_many association and
+    kept the assciation unloaded. GH#14914
+
+        class User < ActiveRecord::Base
+            has_and_belongs_to_many :comments
+        end
+
+        class Comment < ActiveRecord::Base
+            has_and_belongs_to_many :users
+        end
+
+        user = User.create
+        user.comments.build
+
+        user.comments.size                  # should be 1
+
+    *Xiang Li*
+
+*   Fix wrong `clear` behavior when has_and_belongs_to_many association has 
+    scopes and hasn't been loaded.
+
+        class User < ActiveRecord::Base
+            has_and_belongs_to_many :comments
+            has_and_belongs_to_many :scoped_comments, 
+              -> { where(attr: 'attr') }
+        end
+
+        class Comment < ActiveRecord::Base
+            has_and_belongs_to_many :users
+        end
+
+        User.first.scoped_comments.clear    # should delete scoped comments only
+
+    *Xiang Li*
+
+
 Please check [3-2-stable](https://github.com/rails/rails/blob/3-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -271,6 +271,16 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_equal Developer.find_by_name("Marcel").projects.last, proj2  # prove join table is updated
   end
 
+  def test_size_after_build_and_unloaded
+    devel = Developer.create(name: "no name")
+    proj = devel.projects.build("name" => "Projekt")
+    assert !devel.projects.loaded?
+
+    assert_equal 1, devel.projects.size
+    assert_equal devel.projects.last, proj
+    assert devel.projects.loaded?
+  end
+
   def test_create
     devel = Developer.find(1)
     proj = devel.projects.create("name" => "Projekt")
@@ -491,6 +501,12 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_equal developers(:david), projects(:active_record).developers_named_david_with_hash_conditions.find(developers(:david).id)
     assert_equal developers(:david), projects(:active_record).salaried_developers.find(developers(:david).id)
 
+    projects(:active_record).developers_named_david.clear
+    assert_equal 2, projects(:active_record, :reload).developers.size
+  end
+
+  def test_unloaded_associations_with_conditions
+    assert !projects(:active_record).developers_named_david.loaded?
     projects(:active_record).developers_named_david.clear
     assert_equal 2, projects(:active_record, :reload).developers.size
   end


### PR DESCRIPTION
**Fix wrong `size` result after built `has_and_belongs_to_many` association and kept the assciation unloaded.**

It was reported in #14914

``` ruby
    class User < ActiveRecord::Base
      has_and_belongs_to_many :comments
    end

    class Comment < ActiveRecord::Base
      has_and_belongs_to_many :users
    end

    user = User.create
    user.comments.build

    user.comments.size #should be 1, but be 2
```

The reason is that `count_records` method in `has_and_belongs_to_many_association.rb` just loads the association and fetches the size again, it repeatly calculates the unloaded new objects, but `has_many_association.rb` doesn't. So I just copied the method from `has_many_association.rb` and removed `counter_cache` statement.

**Fix wrong `clear` behavior when `has_and_belongs_to_many` association has scopes and hasn't been loaded.**

``` ruby
    class User < ActiveRecord::Base
      has_and_belongs_to_many :comments
      has_and_belongs_to_many :scoped_comments,
        -> { where(attr: 'attr') }
    end

    class Comment < ActiveRecord::Base
      has_and_belongs_to_many :users
    end

    # should delete scoped comments only,
    # but it deletes all records
    User.first.scoped_comments.clear
```

The reason is that `delete_records` method in `has_and_belongs_to_many_association.rb` doesn't calculate scopes. The old test case uses `size` method first, it loads the association and can't present this problem. The new test case uses `clear` method directly to indicate the problem. I added a block of code in `delete_records` in order to make sure that scopes are calculated correctly.
