### PR TITLE
Baseclass becomes! subclass

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -57,6 +57,15 @@
 
     *Paul B.*
 
+*   Baseclass becomes! subclass.
+
+    Before this change, a record which changed its STI type, could not be found when updated.
+    Setting update_record to the base class, ensures the record can be found.
+
+    Fixes #14785
+
+    *Matthew Draper*, *Earl St Sauver*, *Edo Balvers*
+
 *   Add support for module-level `table_name_suffix` in models.
 
     This makes `table_name_suffix` work the same way as `table_name_prefix` when

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -73,7 +73,14 @@ module ActiveRecord
 
     def _update_record(values, id, id_was) # :nodoc:
       substitutes, binds = substitute_values values
-      um = @klass.unscoped.where(@klass.arel_table[@klass.primary_key].eq(id_was || id)).arel.compile_update(substitutes, @klass.primary_key)
+
+      scope = @klass.unscoped
+
+      if @klass.finder_needs_type_condition?
+        scope.unscope!(where: @klass.inheritance_column)
+      end
+
+      um = scope.where(@klass.arel_table[@klass.primary_key].eq(id_was || id)).arel.compile_update(substitutes, @klass.primary_key)
 
       @klass.connection.update(
         um,

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -333,6 +333,15 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal "Reply", topic.type
   end
 
+  def test_update_sti_subclass_type
+    assert_instance_of Topic, topics(:first)
+
+    reply = topics(:first).becomes!(Reply)
+    assert_instance_of Reply, reply
+    reply.save!
+    assert_instance_of Reply, Reply.find(reply.id)
+  end
+
   def test_update_after_create
     klass = Class.new(Topic) do
       def self.name; 'Topic'; end


### PR DESCRIPTION
Before this change, a record which changed its STI type, could not be found when updated.
Setting update_record to the base class, ensures the record can be found.

The idea was proposed by @matthewd in #14887

Closes #14785
