### PR TITLE
Remove deprecated file

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_json.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_json.rb
@@ -1,5 +1,0 @@
-ActiveSupport::Deprecation.warn 'You have required `active_support/core_ext/object/to_json`. ' \
-  'This file will be removed in Rails 4.2. You should require `active_support/core_ext/object/json` ' \
-  'instead.'
-
-require 'active_support/core_ext/object/json'

--- a/activesupport/test/core_ext/object/json_test.rb
+++ b/activesupport/test/core_ext/object/json_test.rb
@@ -1,9 +1,0 @@
-require 'abstract_unit'
-
-class JsonTest < ActiveSupport::TestCase
-  # See activesupport/test/json/encoding_test.rb for JSON encoding tests
-
-  def test_deprecated_require_to_json_rb
-    assert_deprecated { require 'active_support/core_ext/object/to_json' }
-  end
-end


### PR DESCRIPTION
Remove `active_support/core_ext/object/to_json.rb` and deprecation test cases as it needs to be removed in rails 4.2.
