### PR TITLE
Allow to pass dynamic conditions for has_sacure_password validations

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/with_options'
+
 module ActiveModel
   module SecurePassword
     extend ActiveSupport::Concern
@@ -56,16 +58,19 @@ module ActiveModel
 
         include InstanceMethodsOnActivation
 
-        if options.fetch(:validations, true)
-          # This ensures the model has a password by checking whether the password_digest
-          # is present, so that this works with both new and existing records. However,
-          # when there is an error, the message is added to the password attribute instead
-          # so that the error message will make sense to the end-user.
-          validate do |record|
-            record.errors.add(:password, :blank) unless record.password_digest.present?
-          end
+        if validation_options = options.fetch(:validations, {})
 
-          validates_confirmation_of :password, if: ->{ password.present? }
+          with_options validation_options do |opt|
+            # This ensures the model has a password by checking whether the password_digest
+            # is present, so that this works with both new and existing records. However,
+            # when there is an error, the message is added to the password attribute instead
+            # so that the error message will make sense to the end-user
+            opt.validate do |record|
+              record.errors.add(:password, :blank) unless record.password_digest.present?
+            end
+
+            opt.validates_confirmation_of :password, if: ->{ password.present? }
+          end
         end
 
         if respond_to?(:attributes_protected_by_default)

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -45,6 +45,12 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_equal ["can't be blank"], @user.errors[:password]
   end
 
+  test "create a new user with validation and a nil password when validation condition is not satisfied"  do
+    @user.password = nil
+    @user.skip_hsp_validations = true
+    assert @user.valid?(:create), 'user should be valid'
+  end
+
   test "create a new user with validation and a blank password confirmation" do
     @user.password = 'password'
     @user.password_confirmation = ''
@@ -65,6 +71,13 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert !@user.valid?(:create), 'user should be invalid'
     assert_equal 1, @user.errors.count
     assert_equal ["doesn't match Password"], @user.errors[:password_confirmation]
+  end
+
+  test "create a new user with validation and an incorrect password confirmation when validation condition is not satisfied" do
+    @user.password = 'password'
+    @user.password_confirmation = 'something else'
+    @user.skip_hsp_validations = true
+    assert @user.valid?(:create), 'user should be valid'
   end
 
   test "create a new user with validation and a correct password confirmation" do

--- a/activemodel/test/models/user.rb
+++ b/activemodel/test/models/user.rb
@@ -5,7 +5,7 @@ class User
   
   define_model_callbacks :create
 
-  has_secure_password
+  has_secure_password validations: { unless: :skip_hsp_validations }
 
-  attr_accessor :password_digest
+  attr_accessor :password_digest, :skip_hsp_validations
 end


### PR DESCRIPTION
In current implementation developer can only disable has_secure_password validations within class definition with `has_secure_password validations: false`. This is not enough in some cases, as those validations may be dependent on a dynamic state of the model.

This pull request adds an option to pass a hash of options with `has_secure_password validations: options`. All the typical validations options like `if: <proc or symbol>` or `unless` are accepted and provides dynamic integration with HSP validation.
