### PR TITLE
Fix macro name on reflections on habtm

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1212,6 +1212,9 @@ module ActiveRecord
       #   has_many :subscribers, through: :subscriptions, source: :user
       def has_many(name, scope = nil, options = {}, &extension)
         reflection = Builder::HasMany.build(self, name, scope, options, &extension)
+        if options.fetch(:habtm, false)
+          reflection.macro = :has_and_belongs_to_many
+        end
         Reflection.add_reflection self, name, reflection
       end
 
@@ -1594,6 +1597,7 @@ module ActiveRecord
         hm_options = {}
         hm_options[:through] = middle_reflection.name
         hm_options[:source] = join_model.right_reflection.name
+        hm_options[:habtm] = true
 
         [:before_add, :after_add, :before_remove, :after_remove, :autosave, :validate, :join_table].each do |k|
           hm_options[k] = options[k] if options.key? k

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -179,7 +179,7 @@ module ActiveRecord
         def creation_attributes
           attributes = {}
 
-          if (reflection.macro == :has_one || reflection.macro == :has_many) && !options[:through]
+          if [:has_one, :has_many, :has_and_belongs_to_many].include?(reflection.macro) && !options[:through]
             attributes[reflection.foreign_key] = owner[reflection.active_record_primary_key]
 
             if reflection.options[:as]

--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -1,4 +1,4 @@
-# This class is inherited by the has_many and has_many_and_belongs_to_many association classes
+# This class is inherited by the has_many and has_and_belongs_to_many association classes
 
 require 'active_record/associations'
 

--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -5,7 +5,7 @@ module ActiveRecord::Associations::Builder
     end
 
     def valid_options
-      super + [:primary_key, :dependent, :as, :through, :source, :source_type, :inverse_of, :counter_cache, :join_table]
+      super + [:primary_key, :dependent, :as, :through, :source, :source_type, :inverse_of, :counter_cache, :join_table, :habtm]
     end
 
     def self.valid_dependent_options

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -106,7 +106,7 @@ module ActiveRecord
 
           inverse = source_reflection.inverse_of
           if inverse
-            if inverse.macro == :has_many
+            if [:has_many, :has_and_belongs_to_many].include?(inverse.macro)
               record.send(inverse.name) << build_through_record(record)
             elsif inverse.macro == :has_one
               record.send("#{inverse.name}=", build_through_record(record))
@@ -171,7 +171,7 @@ module ActiveRecord
             klass.decrement_counter counter, records.map(&:id)
           end
 
-          if through_reflection.macro == :has_many && update_through_counter?(method)
+          if [:has_many, :has_and_belongs_to_many].include?(through_reflection.macro) && update_through_counter?(method)
             update_counter(-count, through_reflection)
           end
 
@@ -188,7 +188,7 @@ module ActiveRecord
           records.each do |record|
             through_records = through_records_for(record)
 
-            if through_reflection.macro == :has_many
+            if [:has_many, :has_and_belongs_to_many].include?(through_reflection.macro)
               through_records.each { |r| through_association.target.delete(r) }
             else
               if through_records.include?(through_association.target)

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -177,7 +177,7 @@ module ActiveRecord
         end
 
         case reflection.macro
-        when :has_many
+        when :has_many, :has_and_belongs_to_many
           reflection.options[:through] ? HasManyThrough : HasMany
         when :has_one
           reflection.options[:through] ? HasOneThrough : HasOne

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -664,7 +664,7 @@ module ActiveRecord
                 fk_type = association.active_record.columns_hash[association.foreign_key].type
                 row[fk_name] = ActiveRecord::FixtureSet.identify(value, fk_type)
               end
-            when :has_many
+            when :has_many, :has_and_belongs_to_many
               if association.options[:through]
                 add_join_records(rows, row, HasManyThroughProxy.new(association))
               end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
     def self.create(macro, name, scope, options, ar)
       case macro
-      when :has_many, :belongs_to, :has_one
+      when :has_many, :has_and_belongs_to_many, :belongs_to, :has_one
         klass = options[:through] ? ThroughReflection : AssociationReflection
       when :composed_of
         klass = AggregateReflection
@@ -101,7 +101,7 @@ module ActiveRecord
       #
       # <tt>composed_of :balance, class_name: 'Money'</tt> returns <tt>:composed_of</tt>
       # <tt>has_many :clients</tt> returns <tt>:has_many</tt>
-      attr_reader :macro
+      attr_accessor :macro
 
       attr_reader :scope
 
@@ -196,7 +196,7 @@ module ActiveRecord
 
       def initialize(macro, name, scope, options, active_record)
         super
-        @collection = :has_many == macro
+        @collection = [:has_many, :has_and_belongs_to_many].include?(macro)
         @automatic_inverse_of = nil
         @type         = options[:as] && "#{options[:as]}_type"
         @foreign_type = options[:foreign_type] || "#{name}_type"
@@ -357,7 +357,7 @@ module ActiveRecord
           else
             Associations::BelongsToAssociation
           end
-        when :has_many
+        when :has_many, :has_and_belongs_to_many
           if options[:through]
             Associations::HasManyThroughAssociation
           else
@@ -376,7 +376,7 @@ module ActiveRecord
         options.key? :polymorphic
       end
 
-      VALID_AUTOMATIC_INVERSE_MACROS = [:has_many, :has_one, :belongs_to]
+      VALID_AUTOMATIC_INVERSE_MACROS = [:has_many, :has_and_belongs_to_many, :has_one, :belongs_to]
       INVALID_AUTOMATIC_INVERSE_OPTIONS = [:conditions, :through, :polymorphic, :foreign_key]
 
       protected

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -824,4 +824,9 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   def test_custom_join_table
     assert_equal 'edges', Vertex.reflect_on_association(:sources).join_table
   end
+
+  def test_habtm_reflection_macro_name
+    reflection = Developer.reflect_on_association(:special_projects)
+    assert_equal :has_and_belongs_to_many, reflection.macro
+  end
 end


### PR DESCRIPTION
Since 4.1, when rails starts a use `has_many through` to do `habtm`,
`habtm` reflections was using `has_many` macro. This commit bring back
`has_and_belongs_to_many` macro in `habtm` associations' reflections.

fixes #14682
