### PR TITLE
Added a strftime :format option for the month name

### DIFF
--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -336,6 +336,15 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, select_month(8, :month_format_string => format_string)
   end
 
+  def test_select_month_with_two_digit_numbers_and_names
+    expected = %(<select id="date_month" name="date[month]">\n)
+    expected << %(<option value="1">01 - January</option>\n<option value="2">02 - February</option>\n<option value="3">03 - March</option>\n<option value="4">04 - April</option>\n<option value="5">05 - May</option>\n<option value="6">06 - June</option>\n<option value="7">07 - July</option>\n<option value="8" selected="selected">08 - August</option>\n<option value="9">09 - September</option>\n<option value="10">10 - October</option>\n<option value="11">11 - November</option>\n<option value="12">12 - December</option>\n)
+    expected << "</select>\n"
+
+    assert_dom_equal expected, select_month(Time.mktime(2003, 8, 16), use_two_digit_numbers: true, add_month_numbers: true)
+    assert_dom_equal expected, select_month(8, add_month_numbers: true, use_two_digit_numbers: true)
+  end
+
   def test_select_month_with_numbers_and_names_with_abbv
     expected = %(<select id="date_month" name="date[month]">\n)
     expected << %(<option value="1">1 - Jan</option>\n<option value="2">2 - Feb</option>\n<option value="3">3 - Mar</option>\n<option value="4">4 - Apr</option>\n<option value="5">5 - May</option>\n<option value="6">6 - Jun</option>\n<option value="7">7 - Jul</option>\n<option value="8" selected="selected">8 - Aug</option>\n<option value="9">9 - Sep</option>\n<option value="10">10 - Oct</option>\n<option value="11">11 - Nov</option>\n<option value="12">12 - Dec</option>\n)


### PR DESCRIPTION
Added a helper `add_format_option(options)` that will help when deprecating those annoying options for `month_name`. Now, you can pass in a `:format` option that is a string that Date.strftime will accept.
http://www.ruby-doc.org/stdlib-2.1.1/libdoc/date/rdoc/Date.html#method-i-strftime

I also deleted some private helpers that were not being used anymore after the refactor.

/cc @senny @matthewd
