### PR TITLE
[Regression 4.0 -> 4.1] Put back Relation#join method as a delegate to Array

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Revert the behaviour of AR::Relation#join changed through 4.0 => 4.1 to 4.0
+
+    In 4.1.0 Relation#join is delegated to Arel#SelectManager.
+    In 4.0 series it is delegated to Array#join
+
+    *Bogdan Gusiev*
+
 *   Log nil binary column values correctly.
 
     When an object with a binary column is updated with a nil value

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -43,7 +43,7 @@ module ActiveRecord
       :keep_if, :pop, :shift, :delete_at, :compact, :select!
     ].to_set # :nodoc:
 
-    delegate :to_xml, :to_yaml, :length, :collect, :map, :each, :all?, :include?, :to_ary, to: :to_a
+    delegate :to_xml, :to_yaml, :length, :collect, :map, :each, :all?, :include?, :to_ary, :join, to: :to_a
 
     delegate :table_name, :quoted_table_name, :primary_key, :quoted_primary_key,
              :connection, :columns_hash, :to => :klass

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -32,7 +32,7 @@ module ActiveRecord
       :exclude?, :find_all, :flat_map, :group_by, :include?, :length,
       :map, :none?, :one?, :partition, :reject, :reverse,
       :sample, :second, :sort, :sort_by, :third,
-      :to_ary, :to_set, :to_xml, :to_yaml
+      :to_ary, :to_set, :to_xml, :to_yaml, :join
     ]
 
     ARRAY_DELEGATES.each do |method|

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1677,4 +1677,8 @@ class RelationTest < ActiveRecord::TestCase
     merged = left.merge(right)
     assert_equal post, merged.first
   end
+
+  def test_relation_join_method
+    assert_equal 'Thank you for the welcome,Thank you again for the welcome', Post.first.comments.join(",")
+  end
 end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -26,6 +26,10 @@ class Comment < ActiveRecord::Base
     all
   end
   scope :all_as_scope, -> { all }
+
+  def to_s
+    body
+  end
 end
 
 class SpecialComment < Comment


### PR DESCRIPTION
This is a regression 4.0 -> 4.1 fix.
In 4.1.0 `Relation#join` is delegated to `Arel::SelectManager`.
In 4.0 series it is delegated to `Array#join`

This patch puts back the behaviour of 4.0
