### PR TITLE
Making belongs_to: touch behaviour be consistent with save updating updated_at

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Change belongs_to touch to be consistent with timestamp updates
+
+    If a model is set up with a belongs_to: touch relatinoship the parent
+    record will only be touched if the record was modified. This makes it
+    consistent with timestamp updating on the record itself.
+
+    *Brock Trappitt*
+
 *   Fixed the inferred table name of a HABTM auxiliar table inside a schema.
 
     Fixes #14824

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -103,7 +103,7 @@ module ActiveRecord::Associations::Builder
         BelongsTo.touch_record(record, foreign_key, n, touch)
       }
 
-      model.after_save    callback
+      model.after_save    callback, if: :changed?
       model.after_touch   callback
       model.after_destroy callback
     end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -369,6 +369,13 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_queries(2) { line_item.update amount: 10 }
   end
 
+  def test_belongs_to_with_touch_option_on_empty_update
+    line_item = LineItem.create!
+    Invoice.create!(line_items: [line_item])
+
+    assert_queries(0) { line_item.save }
+  end
+
   def test_belongs_to_with_touch_option_on_destroy
     line_item = LineItem.create!
     Invoice.create!(line_items: [line_item])


### PR DESCRIPTION
If no attributes have been changed and save is called on a record the updated_at timestamp isn't updated. However if there is a belongs_to: touch enabled it propagates up the tree, and thus busts any cache keys despite nothing having changed.

That is how I hit the problem. I have an application that just calls save while processing records, regardless of if the records had changed. It was slowing down due to the increased number of queries in addition to busting all the cache keys.

Main question is do I need to change the UPGRADE notes or similar since it does break backwards compat if this was being relied upon?

Then a couple of super minor things:
- Is the test name fine?
- Should I use an entirely separate callback instead of passing the if?
- The callbacks are otherwise in increasing line length, should I move mine to the end?
