### PR TITLE
Refactored AssociationScope#get_bind_values

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -47,15 +47,8 @@ module ActiveRecord
       def self.get_bind_values(owner, chain)
         bvs = []
         chain.each_with_index do |reflection, i|
-          if reflection.source_macro == :belongs_to
-            foreign_key = reflection.foreign_key
-          else
-            foreign_key = reflection.active_record_primary_key
-          end
-
           if reflection == chain.last
-            bvs << owner[foreign_key]
-
+            bvs << reflection.join_id_for(owner)
             if reflection.type
               bvs << owner.class.base_class.name
             end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -278,6 +278,11 @@ module ActiveRecord
         end
       end
 
+      def join_id_for(owner) #:nodoc:
+        key = (source_macro == :belongs_to) ? foreign_key : active_record_primary_key
+        owner[key]
+      end
+
       def through_reflection
         nil
       end


### PR DESCRIPTION
@tenderlove asked me to add a method `join_id_for(owner)` to reflection to avoid accessing the source_macro because we only accessed `foreign key` at line L57.
