### PR TITLE
Fix rails dbconsole for jdbcmysql adapter

### DIFF
--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -20,7 +20,7 @@ module Rails
       ENV['RAILS_ENV'] = options[:environment] || environment
 
       case config["adapter"]
-      when /^mysql/
+      when /^(jdbc)?mysql/
         args = {
           'host'      => '--host',
           'port'      => '--port',


### PR DESCRIPTION
Without this patch, if you have `adapter: jdbcmysql` in `config/database.yml`, and you try to run `rails dbconsole`, you will get:

```
Unknown command-line client for foo_staging. Submit a Rails patch to add support!
```

Therefore, I am submitting a rails patch. @ggilder
