### PR TITLE
refactor and clean up delete_all method

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -194,7 +194,7 @@ module ActiveRecord
                       options[:dependent]
                     end
 
-        delete_all_with_dependency(dependent).tap do
+        delete_records(:all, dependent).tap do
           reset
           loaded!
         end
@@ -249,14 +249,6 @@ module ActiveRecord
 
         records = find(records) if records.any? { |record| record.kind_of?(Fixnum) || record.kind_of?(String) }
         delete_or_destroy(records, dependent)
-      end
-
-      def delete_all_with_dependency(dependent)
-        if dependent == :destroy
-          delete_or_destroy(load_target, dependent)
-        else
-          delete_records(:all, dependent)
-        end
       end
 
       # Deletes the +records+ and removes them from this association calling


### PR DESCRIPTION
Now that `delete_all` with a `destroy` and `delete_all` dependency behave the same we no longer need this conditional. This means we can remove the `delete_all_with_dependency` method I added and go straight to delete_records from delete_all, passing `:all` and the `dependent` directly.

cc/ @tenderlove
