### PR TITLE
Db migration status

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -83,8 +83,7 @@ db_namespace = namespace :db do
     desc 'Display status of migrations'
     task :status => [:environment, :load_config] do
       unless ActiveRecord::Base.connection.table_exists?(ActiveRecord::Migrator.schema_migrations_table_name)
-        puts 'Schema migrations table does not exist yet.'
-        next  # means "return" for rake task
+        abort 'Schema migrations table does not exist yet.'
       end
       db_list = ActiveRecord::Base.connection.select_values("SELECT version FROM #{ActiveRecord::Migrator.schema_migrations_table_name}")
       db_list.map! { |version| "%.3d" % version }

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -58,7 +58,7 @@ module ApplicationTests
       end
 
       test 'migration status when schema migrations table is not present' do
-        output = Dir.chdir(app_path){ `rake db:migrate:status` }
+        output = Dir.chdir(app_path){ `rake db:migrate:status 2>&1` }
         assert_equal "Schema migrations table does not exist yet.\n", output
       end
 


### PR DESCRIPTION
## Context

With the following setup:
- An app database created but never setup from rails rake task
- Running the `db:migrate:status` rake task will return `Schema migrations table does not exist yet.`  in the `STDOUT`.

**Rails has no method to detect programmatically if a database exists and if it has already been setup by the `db:setup` rake task**
## To discuss

I propose then to abort the `db:migrate:status` task with a non zero error code so that the message is sent to `STDERR`. 
This will give an easy way to detect wether **the database has been setup or not**.

_E.g. in a cookbook:_

``` ruby
execute 'bundle exec rake db:setup' do
  not_if 'bundle exec rake db:migrate:status'
end
```
