### PR TITLE
Habtm relation size calculation fix

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fixed HABTM's CollectionAssociation size calculation.
+
+    HABTM should fall back to using the normal CollectionAssociation's size
+    calculation if the collection is not cached or loaded.
+
+    Fixes #14913 and #14914.
+
+    *Fred Wu*
+
 *   Return a non zero status when running `rake db:migrate:status` and migration table does
     not exist.
 

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -23,7 +23,7 @@ module ActiveRecord
         elsif loaded?
           target.size
         else
-          count
+          super
         end
       end
 

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -217,6 +217,24 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_equal developers(:poor_jamis, :jamis, :david), projects(:active_record).developers
   end
 
+  def test_habtm_collection_size_from_build
+    devel = Developer.create("name" => "Fred Wu")
+    devel.projects << Project.create("name" => "Grimetime")
+    devel.projects.build
+
+    assert_equal 2, devel.projects.size
+  end
+
+  def test_habtm_collection_size_from_params
+    devel = Developer.new({
+      projects_attributes: {
+        '0' => {}
+      }
+    })
+
+    assert_equal 1, devel.projects.size
+  end
+
   def test_build
     devel = Developer.find(1)
     proj = assert_no_queries { devel.projects.build("name" => "Projekt") }

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -13,6 +13,8 @@ class Developer < ActiveRecord::Base
     end
   end
 
+  accepts_nested_attributes_for :projects
+
   has_and_belongs_to_many :projects_extended_by_name,
       -> { extending(DeveloperProjectsAssociationExtension) },
       :class_name => "Project",


### PR DESCRIPTION
HABTM should fall back to using the normal CollectionAssociation's size calculation if the collection is not cached or loaded.

This addresses both #14913 and #14914 for master.

If I didn't break anything and if everyone's happy with the change, I will backport this to 4.1.

cc @tenderlove @rafaelfranca @carlosantoniodasilva @senny

P.S. This fix was done independently to #14969. A different fix for 4-0-stable: #14995.
