### PR TITLE
Habtm relation size calculation fix for 4.0 branch

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fixed HABTM's CollectionAssociation size calculation.
+
+    HABTM should not include new records as part of #count_records as new
+    records are already counted.
+
+    Fixes #14914.
+
+    *Fred Wu*
+
 *   Keep track of dirty attributes after transaction is rollback.
 
     Related #13166.

--- a/activerecord/lib/active_record/associations/has_and_belongs_to_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_and_belongs_to_many_association.rb
@@ -35,7 +35,7 @@ module ActiveRecord
       private
 
         def count_records
-          load_target.size
+          load_target.reject { |r| r.new_record? }.size
         end
 
         def delete_records(records, method)

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -228,6 +228,14 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_equal developers(:poor_jamis, :jamis, :david), projects(:active_record).developers
   end
 
+  def test_habtm_collection_size_from_build
+    devel = Developer.create("name" => "Fred Wu")
+    devel.projects << Project.create("name" => "Grimetime")
+    devel.projects.build
+
+    assert_equal 2, devel.projects.size
+  end
+
   def test_build
     devel = Developer.find(1)
     proj = assert_no_queries { devel.projects.build("name" => "Projekt") }


### PR DESCRIPTION
HABTM should not include new records as part of #count_records as new records are already counted.

This addresses #14914 for the 4-0-stable branch, and is a different approach to #14969 which addresses the same issue.

cc @rafaelfranca @bigxiang

P.S. A different fix for master which can be backported to 4-1-stable: #14992.
