### PR TITLE
Include label value in i18n attribute lookup

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,23 @@
+* Take label values into account when doing I18n lookups for model attributes.
+
+    The following:
+
+        # form.html.erb
+        <%= form_for @post do |f| %>
+          <%= f.label :type, value: "long" %>
+        <% end %>
+
+        # en.yml
+        en:
+          activerecord:
+            attributes:
+              post/long: "Long-form Post"
+
+    Used to simply return "long", but now it will return "Long-form
+    Post".
+
+    *Joshua Cody*
+
 *   Change `asset_path` to use File.join to create proper paths:
 
         https://some.host.com//assets/some.js

--- a/actionview/lib/action_view/helpers/tags/label.rb
+++ b/actionview/lib/action_view/helpers/tags/label.rb
@@ -35,9 +35,9 @@ module ActionView
           if block_given?
             content = @template_object.capture(&block)
           else
+            method_and_value = tag_value.present? ? "#{@method_name}.#{tag_value}" : @method_name
             content = if @content.blank?
                         @object_name.gsub!(/\[(.*)_attributes\]\[\d+\]/, '.\1')
-                        method_and_value = tag_value.present? ? "#{@method_name}.#{tag_value}" : @method_name
 
                         if object.respond_to?(:to_model)
                           key = object.class.model_name.i18n_key
@@ -51,7 +51,7 @@ module ActionView
                       end
 
             content ||= if object && object.class.respond_to?(:human_attribute_name)
-                          object.class.human_attribute_name(@method_name)
+                          object.class.human_attribute_name(method_and_value)
                         end
 
             content ||= @method_name.humanize

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -19,6 +19,9 @@ class FormHelperTest < ActionView::TestCase
         attributes: {
           post: {
             cost: "Total cost"
+          },
+          :"post/language" => {
+            spanish: "Espanol"
           }
         }
       },
@@ -151,6 +154,12 @@ class FormHelperTest < ActionView::TestCase
   def test_label_with_human_attribute_name
     with_locale :label do
       assert_dom_equal('<label for="post_cost">Total cost</label>', label(:post, :cost))
+    end
+  end
+
+  def test_label_with_human_attribute_name_and_options
+    with_locale :label do
+      assert_dom_equal('<label for="post_language_spanish">Espanol</label>', label(:post, :language, value: "spanish"))
     end
   end
 

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -712,6 +712,19 @@ en:
 
 Then `User.model_name.human(count: 2)` will return "Dudes". With `count: 1` or without params will return "Dude".
 
+In the event you need to access nested attributes within a given model, you should nest these under `model/attribute` at the model level of your translation file:
+
+```yaml
+en:
+  activerecord:
+    attributes:
+      user/gender:
+        female: "Female"
+        male: "Male"
+```
+
+Then `User.human_attribute_name("gender.female")` will return "Female".
+
 #### Error Message Scopes
 
 Active Record validation error messages can also be translated easily. Active Record gives you a couple of namespaces where you can place your message translations in order to provide different messages and translation for certain models, attributes, and/or validations. It also transparently takes single table inheritance into account.


### PR DESCRIPTION
Previously, only the object and method name from the label tag were
used when looking up the translation for a label. If a value is
given for the label, this ought to be additionally used. The
following:

```
# form.html.erb
<%= form_for @post do |f| %>
  <%= f.label :type, value: "long" %>
<% end %>

# en.yml
en:
  activerecord:
    attributes:
      post/long: "Long-form Post"
```

Used to simply return "long", but now it will return "Long-form
Post".
