### PR TITLE
Ensure that .process return the method return

### DIFF
--- a/actionview/test/actionpack/abstract/render_test.rb
+++ b/actionview/test/actionpack/abstract/render_test.rb
@@ -60,42 +60,42 @@ module AbstractController
       end
 
       def test_render_template
-        @controller.process(:template)
+        assert_equal "With Template", @controller.process(:template)
         assert_equal "With Template", @controller.response_body
       end
 
       def test_render_file
-        @controller.process(:file)
+        assert_equal "With File", @controller.process(:file)
         assert_equal "With File", @controller.response_body
       end
 
       def test_render_inline
-        @controller.process(:inline)
+        assert_equal "With Inline", @controller.process(:inline)
         assert_equal "With Inline", @controller.response_body
       end
 
       def test_render_text
-        @controller.process(:text)
+        assert_equal "With Text", @controller.process(:text)
         assert_equal "With Text", @controller.response_body
       end
 
       def test_render_default
-        @controller.process(:default)
+        assert_equal "With Default", @controller.process(:default)
         assert_equal "With Default", @controller.response_body
       end
 
       def test_render_string
-        @controller.process(:string)
+        assert_equal "With String", @controller.process(:string)
         assert_equal "With String", @controller.response_body
       end
 
       def test_render_symbol
-        @controller.process(:symbol)
+        assert_equal "With Symbol", @controller.process(:symbol)
         assert_equal "With Symbol", @controller.response_body
       end
 
       def test_render_string_with_path
-        @controller.process(:string_with_path)
+        assert_equal "With String With Path", @controller.process(:string_with_path)
         assert_equal "With String With Path", @controller.response_body
       end
     end

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -720,6 +720,11 @@ class RenderTest < ActionController::TestCase
     assert_equal "Elastica", @response.body
   end
 
+  def test_render_process
+    get :render_action_hello_world_as_string
+    assert_equal ["Hello world!"], @controller.process(:render_action_hello_world_as_string)
+  end
+
   # :ported:
   def test_render_from_variable
     get :render_hello_world_from_variable
@@ -1332,4 +1337,3 @@ class RenderTest < ActionController::TestCase
     assert_equal "Before (Anthony)\nInside from partial (Anthony)\nAfter\nBefore (David)\nInside from partial (David)\nAfter\nBefore (Ramm)\nInside from partial (Ramm)\nAfter", @response.body
   end
 end
-


### PR DESCRIPTION
Add tests to ensure we dont swallow the returning value on `process` method.

review @matthewd @rafaelfranca

related #14903
