### PR TITLE
Modify assert condition not to be affected by bind variable naming conventions

### DIFF
--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -18,7 +18,7 @@ class RelationMergingTest < ActiveRecord::TestCase
 
   def test_relation_to_sql
     sql = Post.first.comments.to_sql
-    assert_no_match(/\?/, sql)
+    assert_match(/.?post_id.? = 1\Z/i, sql)
   end
 
   def test_relation_merging_with_arel_equalities_keeps_last_equality


### PR DESCRIPTION
This pull request updates `test_relation_to_sql` assert_no_match conditions to make this test works as expected. Because of these following reasons:
- Oracle enhanced adapter does not support this feature yet, `to_sql` shows bind variables, which should not. But this test has been passed because of bind value naming convention differences.
- Each database has their own bind parameter naming convention. SQLite and MySQL use `?`, PostgreSQL uses `$` , then Oracle uses `:a1`. In case for future regressions this test has been modified to use literal value.

Here are details.
# oracle
- Actual SQL statement executed at Oracle when `Post.first.comments` executed

`````` sql
  Comment Load (5.9ms)  SELECT "COMMENTS".* FROM "COMMENTS" WHERE "COMMENTS"."POST_ID" = :a1  [["post_id", 1]]```
``````
- `Post.first.comments.to_sql` with oracle enhanced adapter

``` ruby
(rdb:1)  Post.first.comments.to_sql
"SELECT \"COMMENTS\".* FROM \"COMMENTS\" WHERE \"COMMENTS\".\"POST_ID\" = :a1"
```
# sqlite3
- Actual SQL statement executed at sqlite3 when `Post.first.comments` executed

``` sql
  Comment Load (0.3ms)  SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?  [["post_id", 1]]
```
- `Post.first.comments.to_sql` with sqlite3 adapter 

``` ruby
(rdb:1) Post.first.comments.to_sql
"SELECT \"comments\".* FROM \"comments\" WHERE \"comments\".\"post_id\" = 1"
```
# mysql
- Actual SQL statement executed

``` sql
  Comment Load (0.6ms)  SELECT `comments`.* FROM `comments` WHERE `comments`.`post_id` = ?  [["post_id", 1]]
```
- `Post.first.comments.to_sql` with mysql adapter

``` ruby
(rdb:1)  Post.first.comments.to_sql
"SELECT `comments`.* FROM `comments` WHERE `comments`.`post_id` = 1"
```
# mysql2
- Actual SQL statement executed

``` sql
  Comment Load (0.4ms)  SELECT `comments`.* FROM `comments` WHERE `comments`.`post_id` = 1
```
- `Post.first.comments.to_sql` with mysql2 adapter 

``` ruby
(rdb:1) Post.first.comments.to_sql
"SELECT `comments`.* FROM `comments` WHERE `comments`.`post_id` = 1"
```
# postgresql
- Actual SQL statement executed

``` sql
  Comment Load (0.5ms)  SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = $1  [["post_id", 1]]
```
- `Post.first.comments.to_sql` with postgresql adapter 

``` ruby
(rdb:1) Post.first.comments.to_sql
"SELECT \"comments\".* FROM \"comments\" WHERE \"comments\".\"post_id\" = 1"
```
