### PR TITLE
Fix the warning while building an engine gemspec

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix the warning of dependency version checking while building plugin gemspec
+
+    *Pan Gaoyong*
+
 *   Reading name and email from git for plugin gemspec.
 
     Fixes #9589.

--- a/railties/lib/rails/gem_version.rb
+++ b/railties/lib/rails/gem_version.rb
@@ -11,5 +11,6 @@ module Rails
     PRE   = "alpha"
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+    BASE = [MAJOR, MINOR].compact.join(".")
   end
 end

--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
@@ -19,9 +19,10 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 <% end -%>
 
-  <%= '# ' if options.dev? || options.edge? -%>s.add_dependency "rails", "~> <%= Rails::VERSION::STRING %>"
+  <%= '# ' if options.dev? || options.edge? -%>
+s.add_dependency "rails", "~> <%= Rails.base_version %>", ">= <%= Rails.version %>"
 <% unless options[:skip_active_record] -%>
 
-  s.add_development_dependency "<%= gem_for_database %>"
+  s.add_development_dependency "<%= gem_for_database %>", "~> 0"
 <% end -%>
 end

--- a/railties/lib/rails/version.rb
+++ b/railties/lib/rails/version.rb
@@ -5,4 +5,9 @@ module Rails
   def self.version
     VERSION::STRING
   end
+
+  # Returns the base version of the currently loaded Rails as a string
+  def self.base_version
+    VERSION::BASE
+  end
 end

--- a/railties/test/version_test.rb
+++ b/railties/test/version_test.rb
@@ -9,4 +9,10 @@ class VersionTest < ActiveSupport::TestCase
     assert Rails.gem_version.is_a? Gem::Version
     assert_equal Rails.version, Rails.gem_version.to_s
   end
+
+  def test_rails_base_version
+    base = Rails.version.split('.')[0..1].join('.')
+    assert_equal base, Rails::VERSION::BASE 
+    assert_equal base, Rails.base_version
+  end
 end


### PR DESCRIPTION
After a new plugin is created, if you try to build it with the default generated engine gemspec, the gem(2.2.2) will warn you like this,

``` shell
$ gem build engine.gemspec
WARNING:  pessimistic dependency on rails (~> 4.1.0) may be overly strict
  if rails is semantically versioned, use:
    add_runtime_dependency 'rails', '~> 4.1', '>= 4.1.0'
WARNING:  open-ended dependency on sqlite3 (>= 0, development) is not recommended
  if sqlite3 is semantically versioned, use:
    add_development_dependency 'sqlite3', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```

This fix makes the default engine gemspec follow the recommended
semantical version string for dependency to avoid warnings.
