### PR TITLE
Make TimeZone#parse behave more like Time#parse.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `TimeZone#parse` defaults the day of the month to '1' if any other date
+    components are specified. This is more consistent with the behavior of
+    `Time#parse`.
+
+    *Ulysse Carion*
+
 *   `humanize` strips leading underscores, if any.
 
     Before:

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -282,14 +282,25 @@ module ActiveSupport
     #
     #   Time.zone.now               # => Fri, 31 Dec 1999 14:00:00 HST -10:00
     #   Time.zone.parse('22:30:00') # => Fri, 31 Dec 1999 22:30:00 HST -10:00
+    #
+    # However, if the date component is not provided, but any other upper
+    # components are supplied, then the day of the month defaults to 1:
+    #
+    #   Time.zone.parse('Mar 2000') # => Wed, 01 Mar 2000 00:00:00 HST -10:00
     def parse(str, now=now())
       parts = Date._parse(str, false)
       return if parts.empty?
 
+      default_mday = if parts[:year] || parts[:mon]
+        1
+      else
+        now.day
+      end
+
       time = Time.new(
         parts.fetch(:year, now.year),
         parts.fetch(:mon, now.month),
-        parts.fetch(:mday, now.day),
+        parts.fetch(:mday, default_mday),
         parts.fetch(:hour, 0),
         parts.fetch(:min, 0),
         parts.fetch(:sec, 0) + parts.fetch(:sec_fraction, 0),

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -254,6 +254,13 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal Time.utc(1999,12,31,19), twz.time
   end
 
+  def test_parse_with_day_omitted
+    zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
+    zone.stubs(:now).returns zone.local(1999, 12, 31)
+    twz = zone.parse('Feb')
+    assert_equal Time.utc(1999, 2, 1), twz.time
+  end
+
   def test_parse_should_not_black_out_system_timezone_dst_jump
     with_env_tz('EET') do
       zone = ActiveSupport::TimeZone['Pacific Time (US & Canada)']


### PR DESCRIPTION
Namely, if the mday is omitted but any other upper components are provided, then instead of supplying the mday from the current time, it defaults to 1.

Related to #14954. Closes #14543.

@pixeltrix
