### PR TITLE
HTTP::Headers#key? correctly converts

### DIFF
--- a/actionpack/lib/action_dispatch/http/headers.rb
+++ b/actionpack/lib/action_dispatch/http/headers.rb
@@ -26,7 +26,9 @@ module ActionDispatch
         @env[env_name(key)] = value
       end
 
-      def key?(key); @env.key? key; end
+      def key?(key)
+        @env.key? env_name(key)
+      end
       alias :include? :key?
 
       def fetch(key, *args, &block)

--- a/actionpack/test/dispatch/header_test.rb
+++ b/actionpack/test/dispatch/header_test.rb
@@ -55,6 +55,8 @@ class HeaderTest < ActiveSupport::TestCase
   test "key?" do
     assert @headers.key?("CONTENT_TYPE")
     assert @headers.include?("CONTENT_TYPE")
+    assert @headers.key?("Content-Type")
+    assert @headers.include?("Content-Type")
   end
 
   test "fetch with block" do


### PR DESCRIPTION
Previously if you were looking for a given key, the header may incorrectly tell you that it did not exist even though it would return a valid value:

``` ruby
env     = { "CONTENT_TYPE" => "text/plain" }
headers = ActionDispatch::Http::Headers.new(env)
headers["Content-Type"] 
# => "text/plain"

headers.key?("Content-Type")
# => false
```

This PR fixes that behavior by converting the key before checking for presence
