### PR TITLE
Use Rails::Paths::Path#existent in database_configuration

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Load database configuration from the first
+    database.yml available in paths.
+
+    *Pier-Olivier Thibault*
+
 *   Reading name and email from git for plugin gemspec.
 
     Fixes #9589.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -92,7 +92,7 @@ module Rails
       # Loads and returns the entire raw configuration of database from
       # values stored in `config/database.yml`.
       def database_configuration
-        yaml = Pathname.new(paths["config/database"].first || "")
+        yaml = Pathname.new(paths["config/database"].existent.first || "")
 
         config = if yaml.exist?
           require "yaml"

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -879,5 +879,21 @@ module ApplicationTests
       Rails.application.load_runner
       assert $ran_block
     end
+
+    test "loading the first existing database configuration available" do
+      app_file 'config/environments/development.rb', <<-RUBY
+
+      Rails.application.configure do
+        config.paths.add 'config/database', with: 'config/nonexistant.yml'
+        config.paths['config/database'] << 'config/database.yml'
+        end
+      RUBY
+
+      require "#{app_path}/config/environment"
+
+      db_config =  Rails.application.config.database_configuration
+
+      assert db_config.is_a?(Hash)
+    end
   end
 end


### PR DESCRIPTION
Database configuration was trying to load the first path that
config.paths['config/database'] was returning even if the path didn't
exist in the filesystem.

Because Rails::Paths::Path has the possibility to return more than 1
path (as an array), database_configuration should filter down the paths
to the existing one and then load the first one.

This would make it possible to move the database.yml file and add the
new path to paths['config/database'] and still load the configurations.
