### PR TITLE
Dup the changed_attributes otherwise we could lose them

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -350,7 +350,7 @@ module ActiveRecord
       end
       @_start_transaction_state[:level] = (@_start_transaction_state[:level] || 0) + 1
       @_start_transaction_state[:frozen?] = @attributes.frozen?
-      @_start_transaction_state[:changed_attributes] ||= changed_attributes
+      @_start_transaction_state[:changed_attributes] ||= changed_attributes.dup
     end
 
     # Clear the new record state and id of a record.


### PR DESCRIPTION
4-0-stable is falling after https://github.com/rails/rails/commit/8de5d7622df68dd27c12b115da71fc9e94e490e9 because `changed_attributes` is being mutated on the `save` method, and as `@_start_transaction_state` only have a reference to that object, it lose those changes.

master and 4.1 are not falling because commit  https://github.com/rails/rails/commit/9aa1a3d85327fa0a3055b5b757a0be092ce582f7 removes the mutation on `changed_attributes`.

To make sure we keep those changes, we need to `.dup` the `changed_attributes` to hold a new instance of that Hash.

review @rafaelfranca @carlosantoniodasilva @chancancode
