### PR TITLE
Fixed "fake" nested transactions swallowing manual rollbacks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Fixed "fake" nested transactions swallowing manual rollbacks
+
+    Previously, `ActiveRecord::Rollback` are silently swallowed by all transaction
+    blocks. The intention behind this is that these special "exceptions" are only
+    used to signal a rollback request to Active Record, thus they should be
+    discarded after the rollback request is handled.
+
+    However, this is incorrect for nested transactions. By default, nested
+    transaction blocks are effectively a no-op – they simply become part of the
+    parent transaction†. To achieve this, the correct behaviour is to "bubble up"
+    the `ActiveRecord::Rollback` "exception", which allow the first parent
+    transaction block with a real database transaction to correctly handle the
+    rollback.
+
+    The documentation has been changed to reflect this. This effectively rolls
+    back 53bbbcc.
+
+    Fixes #3455, #14698.
+
+    † The reason that nested transactions defaults to no-op is that savepoints are
+      not supported in all databases.
+
+    *Godfrey Chan*
+
 *   Return a non zero status when running `rake db:migrate:status` and migration table does
     not exist.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -206,10 +206,15 @@ module ActiveRecord
 
           yield
         else
-          within_new_transaction(options) { yield }
+          begin
+            within_new_transaction(options) { yield }
+          rescue ActiveRecord::Rollback
+            # `ActiveRecord::Rollback` is a special exception that's used to
+            # manually rollback transactions. Once the rollback is handled,
+            # the "exception" can be safely discarded since it's not a real
+            # error.
+          end
         end
-      rescue ActiveRecord::Rollback
-        # rollbacks are silently swallowed
       end
 
       def within_new_transaction(options = {}) #:nodoc:

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -315,7 +315,6 @@ class TransactionTest < ActiveRecord::TestCase
     assert !@first.reload.approved
   end
 
-
   def test_force_savepoint_in_nested_transaction
     Topic.transaction do
       @first.approved = true


### PR DESCRIPTION
Previously, `ActiveRecord::Rollback` are silently swallowed by all transaction
blocks. The intention behind this is that these special "exceptions" are only
used to signal a rollback request to Active Record, thus they should be
discarded after the rollback request is handled.

However, this is incorrect for nested transactions. By default, nested
transaction blocks are effectively a no-op – they simply become part of the
parent transaction†. To achieve this, the correct behaviour is to "bubble up"
the `ActiveRecord::Rollback` "exception", which allow the first parent
transaction block with a real database transaction to correctly handle the
rollback.

The documentation has been changed to reflect this. This effectively rolls
back 53bbbcc.

Fixes #3455, #14698.

† The reason that nested transactions defaults to no-op is that savepoints are
  not supported in all databases.

_Godfrey Chan_

---

This "bug" was around since forever, so this is definitely a change in behaviour. I doubt that anyone is relying on the current behaviour though.

cc @tenderlove @jeremy @fxn @arthurnn @senny 
