### PR TITLE
Mismatch branch name between text and code example

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -527,7 +527,7 @@ been updated.
 
 ### Older Versions of Ruby on Rails
 
-If you want to add a fix to older versions of Ruby on Rails, you'll need to set up and switch to your own local tracking branch. Here is an example to switch to the 3-0-stable branch:
+If you want to add a fix to older versions of Ruby on Rails, you'll need to set up and switch to your own local tracking branch. Here is an example to switch to the 4-0-stable branch:
 
 ```bash
 $ git branch --track 4-0-stable origin/4-0-stable


### PR DESCRIPTION
There is a mismatch between the text and code example in the "Contributing to Ruby on Rails". The text says `Here is an example to switch to the 3-0-stable branch:` but the code example uses the **4-0-stable** branch.
