### PR TITLE
Allow custom asset host to be passed in asset_url

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -87,5 +87,9 @@
 
     *Piotr Chmolowski, Łukasz Strzałkowski*
 
+*   Allow custom `:host` option to be passed to `asset_url` helper that
+    overwrites `config.action_controller.asset_host` for particular asset.
+
+    *Hubert Łępicki*
 
 Please check [4-1-stable](https://github.com/rails/rails/blob/4-1-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -147,7 +147,14 @@ module ActionView
 
       # Computes the full URL to an asset in the public directory. This
       # will use +asset_path+ internally, so most of their behaviors
-      # will be the same.
+      # will be the same. If :host options is set, it overwrites global
+      # +config.action_controller.asset_host+ setting.
+      #
+      # All other options provided are forwarded to +asset_path+ call.
+      #
+      #   asset_url "application.js"                                 # => http://example.com/application.js
+      #   asset_url "application.js", host: "http://cdn.example.com" # => http://cdn.example.com/javascripts/application.js
+      #
       def asset_url(source, options = {})
         path_to_asset(source, options.merge(:protocol => :request))
       end

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -191,7 +191,8 @@ module ActionView
       # (proc or otherwise).
       def compute_asset_host(source = "", options = {})
         request = self.request if respond_to?(:request)
-        host = config.asset_host if defined? config.asset_host
+        host = options[:host]
+        host ||= config.asset_host if defined? config.asset_host
         host ||= request.base_url if request && options[:protocol] == :request
 
         if host.respond_to?(:call)

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -596,6 +596,10 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
     assert_equal "gopher://www.example.com", compute_asset_host("foo", :protocol => :request)
   end
 
+  def test_should_return_custom_host_if_passed_in_options
+    assert_equal "http://custom.example.com", compute_asset_host("foo", :host => "http://custom.example.com")
+  end
+
   def test_should_ignore_relative_root_path_on_complete_url
     assert_dom_equal(%(http://www.example.com/images/xml.png), image_path("http://www.example.com/images/xml.png"))
   end
@@ -758,5 +762,16 @@ class AssetUrlHelperEmptyModuleTest < ActionView::TestCase
 
     assert @module.config.asset_host
     assert_equal "http://www.example.com/foo", @module.asset_url("foo")
+  end
+
+  def test_asset_url_with_custom_asset_host
+    @module.instance_eval do
+      def config
+        Struct.new(:asset_host).new("http://www.example.com")
+      end
+    end
+
+    assert @module.config.asset_host
+    assert_equal "http://custom.example.com/foo", @module.asset_url("foo", :host => "http://custom.example.com")
   end
 end

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -913,6 +913,14 @@ that it plays nicely with the pipeline. You may find quirks related to your
 specific set up, you may not. The defaults nginx uses, for example, should give
 you no problems when used as an HTTP cache.
 
+If you want to serve only some assets from your CDN, you can use custom
+`:host` option of  `asset_url` helper, which overwrites value set in
+`config.action_controller.asset_host`.
+
+```ruby
+asset_url 'image.png', :host => 'http://cdn.example.com'
+```
+
 Customizing the Pipeline
 ------------------------
 


### PR DESCRIPTION
Hey,

my use case scenario is as follows: I serve most of the assets from CDN. My CDN does not, however, support CORS. This means, I am more than fine with JavaScript and CSS, however, when I try to load AngularJS templates I get security error in browser.

I have solved the problem by overwritting compute_asset_host method in my project, to allow me to pass :host option to asset_url helpers. This way, I can load Angular templates from the same host as the main application loads from, and the rest of assets are loaded from CDN.

If this would be useful for someone else, please merge :)

Thanks,
Hubert Łępicki
