### PR TITLE
Simplify _prefixes

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Deprecate `AbstractController::Base::parent_prefixes`. Override `AbstractController::Base::_prefixes` or `AbstractController::Base::local_prefixes` when you want to change where to find views.
+* Deprecate `AbstractController::Base::parent_prefixes`. Override `AbstractController::Base::local_prefixes` when you want to change where to find views.
 
     *Nick Sutterer*
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Deprecate `AbstractController::Base::parent_prefixes`. Override `AbstractController::Base::_prefixes` or `AbstractController::Base::local_prefixes` when you want to change where to find views.
+
+    *Nick Sutterer*
+
 * Take label values into account when doing I18n lookups for model attributes.
 
     The following:

--- a/actionview/lib/action_view/view_paths.rb
+++ b/actionview/lib/action_view/view_paths.rb
@@ -14,28 +14,23 @@ module ActionView
              :locale, :locale=, :to => :lookup_context
 
     module ClassMethods
-      def parent_prefixes
-        @parent_prefixes ||= begin
-          parent_controller = superclass
-          prefixes = []
-
-          until parent_controller.abstract?
-            prefixes << parent_controller.controller_path
-            parent_controller = parent_controller.superclass
-          end
-
-          prefixes
+      def _prefixes
+        @_prefixes ||= begin
+          return _local_prefixes if superclass.abstract?
+          _local_prefixes + superclass._prefixes
         end
+      end
+
+      def _local_prefixes
+        [controller_path]
       end
     end
 
     # The prefixes used in render "foo" shortcuts.
     def _prefixes
-      @_prefixes ||= begin
-        parent_prefixes = self.class.parent_prefixes
-        parent_prefixes.dup.unshift(controller_path)
-      end
+      self.class._prefixes
     end
+
 
     # LookupContext is the object responsible to hold all information required to lookup
     # templates, i.e. view paths and details. Check ActionView::LookupContext for more

--- a/actionview/lib/action_view/view_paths.rb
+++ b/actionview/lib/action_view/view_paths.rb
@@ -16,6 +16,8 @@ module ActionView
     module ClassMethods
       def _prefixes
         @_prefixes ||= begin
+          deprecated_prefixes = handle_deprecated_parent_prefixes and return deprecated_prefixes
+
           return _local_prefixes if superclass.abstract?
           _local_prefixes + superclass._prefixes
         end
@@ -23,6 +25,12 @@ module ActionView
 
       def _local_prefixes
         [controller_path]
+      end
+
+      def handle_deprecated_parent_prefixes # TODO: remove in 4.3/5.0.
+        return unless respond_to?(:parent_prefixes)
+        ActiveSupport::Deprecation.warn "Overriding ActionController::Base::parent_prefixes is deprecated, override ::local_prefixes or ::_prefixes instead."
+        _local_prefixes + parent_prefixes
       end
     end
 

--- a/actionview/lib/action_view/view_paths.rb
+++ b/actionview/lib/action_view/view_paths.rb
@@ -23,10 +23,10 @@ module ActionView
         end
       end
 
+      private
+
       # Override this method in your controller if you want to change paths prefixes for finding views.
-      # Prefixes defined here will still be added to parents' prefixes.
-      #
-      # Override <tt>::_prefixes</tt> if you don't want to inherit from superclasses.
+      # Prefixes defined here will still be added to parents' <tt>::_prefixes</tt>.
       def local_prefixes
         [controller_path]
       end

--- a/actionview/lib/action_view/view_paths.rb
+++ b/actionview/lib/action_view/view_paths.rb
@@ -18,19 +18,23 @@ module ActionView
         @_prefixes ||= begin
           deprecated_prefixes = handle_deprecated_parent_prefixes and return deprecated_prefixes
 
-          return _local_prefixes if superclass.abstract?
-          _local_prefixes + superclass._prefixes
+          return local_prefixes if superclass.abstract?
+          local_prefixes + superclass._prefixes
         end
       end
 
-      def _local_prefixes
+      # Override this method in your controller if you want to change paths prefixes for finding views.
+      # Prefixes defined here will still be added to parents' prefixes.
+      #
+      # Override <tt>::_prefixes</tt> if you don't want to inherit from superclasses.
+      def local_prefixes
         [controller_path]
       end
 
       def handle_deprecated_parent_prefixes # TODO: remove in 4.3/5.0.
         return unless respond_to?(:parent_prefixes)
         ActiveSupport::Deprecation.warn "Overriding ActionController::Base::parent_prefixes is deprecated, override ::local_prefixes or ::_prefixes instead."
-        _local_prefixes + parent_prefixes
+        local_prefixes + parent_prefixes
       end
     end
 

--- a/actionview/test/actionpack/abstract/abstract_controller_test.rb
+++ b/actionview/test/actionpack/abstract/abstract_controller_test.rb
@@ -150,7 +150,7 @@ module AbstractController
       end
     end
 
-    class DeprecatedParentPrefixes < AbstractController::Base
+    class OverridingLocalPrefixes < AbstractController::Base
       include AbstractController::Rendering
       include ActionView::Rendering
       append_view_path File.expand_path(File.join(File.dirname(__FILE__), "views"))
@@ -160,6 +160,30 @@ module AbstractController
         render
       end
 
+      def self.local_prefixes
+        # this would usually return "abstract_controller/testing/overriding_local_prefixes"
+        super + ["abstract_controller/testing/me3"]
+      end
+
+      class Inheriting < self
+      end
+    end
+
+    class OverridingLocalPrefixesTest < ActiveSupport::TestCase # TODO: remove me in 5.0/4.3.
+      test "overriding ::local_prefixes adds prefix" do
+        @controller = OverridingLocalPrefixes.new
+        @controller.process(:index)
+        assert_equal "Hello from me3/index.erb", @controller.response_body
+      end
+
+      test "::local_prefixes is inherited" do
+        @controller = OverridingLocalPrefixes::Inheriting.new
+        @controller.process(:index)
+        assert_equal "Hello from me3/index.erb", @controller.response_body
+      end
+    end
+
+    class DeprecatedParentPrefixes < OverridingLocalPrefixes
       def self.parent_prefixes
         ["abstract_controller/testing/me3"]
       end
@@ -174,8 +198,6 @@ module AbstractController
         assert_equal "Hello from me3/index.erb", @controller.response_body
       end
     end
-
-
 
     # Test rendering with layouts
     # ====

--- a/actionview/test/actionpack/abstract/abstract_controller_test.rb
+++ b/actionview/test/actionpack/abstract/abstract_controller_test.rb
@@ -150,6 +150,33 @@ module AbstractController
       end
     end
 
+    class DeprecatedParentPrefixes < AbstractController::Base
+      include AbstractController::Rendering
+      include ActionView::Rendering
+      append_view_path File.expand_path(File.join(File.dirname(__FILE__), "views"))
+
+
+      def index
+        render
+      end
+
+      def self.parent_prefixes
+        ["abstract_controller/testing/me3"]
+      end
+    end
+
+    class DeprecatedParentPrefixesTest < ActiveSupport::TestCase # TODO: remove me in 5.0/4.3.
+      test "overriding ::parent_prefixes is deprecated" do
+        @controller = DeprecatedParentPrefixes.new
+        assert_deprecated do
+          @controller.process(:index)
+        end
+        assert_equal "Hello from me3/index.erb", @controller.response_body
+      end
+    end
+
+
+
     # Test rendering with layouts
     # ====
     # self._layout is used when defined


### PR DESCRIPTION
# Summary

This simplifies the logic to compile the `_prefixes` array used for view inheritance. The change allows overriding `::_local_prefixes` which didn't work before.
# Implementation

It is now implemented with a proper recursion travelling up the inheritance chain instead of doing all the work locally in the concrete controller. Controllers in the chain can now define their local `_prefixes` by overriding `_local_prefixes` (we can rename that). This didn't work before.

We use this extensively in Cells for the new Trailblazer file layout. I thought it might be helpful to push that back to the core.
