### PR TITLE
Adding support to utf8mb4 on mysql2 for schema_migrations table

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -419,10 +419,8 @@ module ActiveRecord
 
       # Should not be called normally, but this operation is non-destructive.
       # The migrations module handles this automatically.
-      MAX_INDEX_LENGTH_FOR_UTF8MB4 = 191
       def initialize_schema_migrations_table
         sm_table = ActiveRecord::Migrator.schema_migrations_table_name
-        connection_config = ActiveRecord::Base.connection_config
 
         unless table_exists?(sm_table)
           create_table(sm_table, :id => false) do |schema_migrations_table|
@@ -433,8 +431,8 @@ module ActiveRecord
             :unique => true, 
             :name => "#{Base.table_name_prefix}unique_schema_migrations#{Base.table_name_suffix}"
           }
-
-          index_options[:length] = MAX_INDEX_LENGTH_FOR_UTF8MB4 if 'mysql2' == connection_config[:adapter] && 'utf8mb4' == connection_config[:encoding]
+          
+          index_options[:length] = Base.connection.max_index_length if Base.connection.max_index_length
 
           add_index sm_table, :version, index_options
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -93,6 +93,12 @@ module ActiveRecord
         'Abstract'
       end
 
+      # Returns the max limit of chars supported by an index, according to the
+      # especified encoding.
+      def max_index_length
+        nil
+      end
+
       # Does this adapter support migrations? Backend specific, as the
       # abstract adapter always returns +false+.
       def supports_migrations?

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -29,6 +29,8 @@ module ActiveRecord
       end
 
       ADAPTER_NAME = 'Mysql2'
+      
+      MAX_INDEX_LENGTH_FOR_UTF8MB4 = 191
 
       def initialize(connection, logger, connection_options, config)
         super
@@ -39,6 +41,10 @@ module ActiveRecord
       def supports_explain?
         true
       end
+      
+      def max_index_length
+        MAX_INDEX_LENGTH_FOR_UTF8MB4 if 'utf8mb4' == @config[:encoding]
+      end      
 
       # HELPER METHODS ===========================================
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -50,8 +50,10 @@ if ActiveRecord::Base.connection.supports_migrations?
       config = @conn.instance_variable_get(:@config)
       original_encoding = config[:encoding]
       config[:encoding] = 'utf8mb4'
-      assert_nothing_raised { @conn.initialize_schema_migrations_table }
-      assert_equal @conn.max_index_length, ActiveRecord::ConnectionAdapters::Mysql2Adapter::MAX_INDEX_LENGTH_FOR_UTF8MB4
+      if current_adapter?(:Mysql2Adapter)
+        assert_nothing_raised { @conn.initialize_schema_migrations_table }
+        assert_equal @conn.max_index_length, ActiveRecord::ConnectionAdapters::Mysql2Adapter::MAX_INDEX_LENGTH_FOR_UTF8MB4
+      end
     ensure
       config[:encoding] = original_encoding
     end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -29,21 +29,31 @@ if ActiveRecord::Base.connection.supports_migrations?
   end
 
   class MigrationTableAndIndexTest < ActiveRecord::TestCase
-    def test_add_schema_info_respects_prefix_and_suffix
-      conn = ActiveRecord::Base.connection
+    def setup
+      @conn = ActiveRecord::Base.connection
+      @conn.drop_table(ActiveRecord::Migrator.schema_migrations_table_name) if @conn.table_exists?(ActiveRecord::Migrator.schema_migrations_table_name)
+    end
 
-      conn.drop_table(ActiveRecord::Migrator.schema_migrations_table_name) if conn.table_exists?(ActiveRecord::Migrator.schema_migrations_table_name)
+    def test_add_schema_info_respects_prefix_and_suffix
       # Use shorter prefix and suffix as in Oracle database identifier cannot be larger than 30 characters
       ActiveRecord::Base.table_name_prefix = 'p_'
       ActiveRecord::Base.table_name_suffix = '_s'
-      conn.drop_table(ActiveRecord::Migrator.schema_migrations_table_name) if conn.table_exists?(ActiveRecord::Migrator.schema_migrations_table_name)
-
-      conn.initialize_schema_migrations_table
-
-      assert_equal "p_unique_schema_migrations_s", conn.indexes(ActiveRecord::Migrator.schema_migrations_table_name)[0][:name]
+      @conn.drop_table(ActiveRecord::Migrator.schema_migrations_table_name) if @conn.table_exists?(ActiveRecord::Migrator.schema_migrations_table_name)
+      @conn.initialize_schema_migrations_table
+      assert_equal "p_unique_schema_migrations_s", @conn.indexes(ActiveRecord::Migrator.schema_migrations_table_name)[0][:name]
     ensure
       ActiveRecord::Base.table_name_prefix = ""
       ActiveRecord::Base.table_name_suffix = ""
+    end
+
+    def test_initialize_schema_migrations_for_utf8mb4
+      config = @conn.instance_variable_get(:@config)
+      original_encoding = config[:encoding]
+      config[:encoding] = 'utf8mb4'
+      assert_nothing_raised { @conn.initialize_schema_migrations_table }
+      assert_equal @conn.max_index_length, ActiveRecord::ConnectionAdapters::Mysql2Adapter::MAX_INDEX_LENGTH_FOR_UTF8MB4
+    ensure
+      config[:encoding] = original_encoding
     end
   end
 


### PR DESCRIPTION
Given the following database.yml:

``` yaml
development: 
  adapter: mysql2
  encoding: utf8mb4
  collation: utf8mb4_unicode_ci
```

This error is thrown when I try to create a database:

``` shell
ActiveRecord::StatementInvalid: Mysql2::Error: Specified key was too long; max key length is 767 bytes: CREATE UNIQUE INDEX `unique_schema_migrations` ON `schema_migrations` (`version`)
```

That's because of a limitation created by utf8mb4: indexes can be at most 191 chars and schema_migrations is a varchar(255).
