### PR TITLE
Remove order when fetching association ids.

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -391,7 +391,7 @@ module ActiveRecord
       values = @klass.connection.columns_for_distinct(
         "#{quoted_table_name}.#{quoted_primary_key}", relation.order_values)
 
-      relation = relation.except(:select).select(values).distinct!
+      relation = relation.except(:select).select(values).reorder(nil).distinct!
 
       id_rows = @klass.connection.select_all(relation.arel, 'SQL', relation.bind_values)
       id_rows.map {|row| row[primary_key]}


### PR DESCRIPTION
Removes the order from the relation when fetching the association ids. This prevents an exception that database throws when ordering by a column that no longer exists.

Eg. 

```
Author.includes(:posts).
  select('`authors`.*, LOWER(`authors`.`name`) as `lower_name`').
  order('`lower_name`').
  limit(5)
```
