### PR TITLE
Remove LookupContext#with_layout_format

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -238,21 +238,5 @@ module ActionView
 
       super(@skip_default_locale ? I18n.locale : default_locale)
     end
-
-    # Uses the first format in the formats array for layout lookup.
-    def with_layout_format
-      if formats.size == 1
-        yield
-      else
-        old_formats = formats
-        _set_detail(:formats, formats[0,1])
-
-        begin
-          yield
-        ensure
-          _set_detail(:formats, old_formats)
-        end
-      end
-    end
   end
 end

--- a/actionview/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionview/lib/action_view/renderer/streaming_template_renderer.rb
@@ -47,7 +47,7 @@ module ActionView
       return [super] unless layout_name && template.supports_streaming?
 
       locals ||= {}
-      layout   = layout_name && find_layout(layout_name, locals.keys)
+      layout   = layout_name && find_layout(layout_name, locals.keys, [formats.first])
 
       Body.new do |buffer|
         delayed_render(buffer, template, layout, @view, locals)

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -95,8 +95,6 @@ module ActionView
         end
       when Proc
         resolve_layout(layout.call, keys, formats)
-      when FalseClass
-        nil
       else
         layout
       end

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -58,7 +58,7 @@ module ActionView
     end
 
     def render_with_layout(path, locals) #:nodoc:
-      layout  = path && find_layout(path, locals.keys)
+      layout  = path && find_layout(path, locals.keys, [formats.first])
       content = yield(layout)
 
       if layout
@@ -73,25 +73,28 @@ module ActionView
     # This is the method which actually finds the layout using details in the lookup
     # context object. If no layout is found, it checks if at least a layout with
     # the given name exists across all details before raising the error.
-    def find_layout(layout, keys)
-      with_layout_format { resolve_layout(layout, keys) }
+    def find_layout(layout, keys, formats)
+      resolve_layout(layout, keys, formats)
     end
 
-    def resolve_layout(layout, keys)
+    def resolve_layout(layout, keys, formats)
+      details = @details.dup
+      details[:formats] = formats
+
       case layout
       when String
         begin
           if layout =~ /^\//
-            with_fallbacks { find_template(layout, nil, false, keys, @details) }
+            with_fallbacks { find_template(layout, nil, false, keys, details) }
           else
-            find_template(layout, nil, false, keys, @details)
+            find_template(layout, nil, false, keys, details)
           end
         rescue ActionView::MissingTemplate
           all_details = @details.merge(:formats => @lookup_context.default_formats)
           raise unless template_exists?(layout, nil, false, keys, all_details)
         end
       when Proc
-        resolve_layout(layout.call, keys)
+        resolve_layout(layout.call, keys, formats)
       when FalseClass
         nil
       else


### PR DESCRIPTION
# Summary

This PR removes `LookupContext#with_layout_format` by simply passing formats explicitely.
# Implementation

By passing layout formats explicitly to the respective stakeholder methods, we can remove `#with_layout_format` which is a horrible implementation, as it relies on a modal interface and (temporarily) changes global data.
