### PR TITLE
Reverts dirty track restore on transactions rollback

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -12,12 +12,6 @@
 
     *Paul B.*
 
-*   Keep track of dirty attributes after transaction is rollback.
-
-    Related #13166.
-
-    *Bogdan Gusiev* *arthurnn*
-
 *   Add support for module-level `table_name_suffix` in models.
 
     This makes `table_name_suffix` work the same way as `table_name_prefix` when

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -350,7 +350,6 @@ module ActiveRecord
       end
       @_start_transaction_state[:level] = (@_start_transaction_state[:level] || 0) + 1
       @_start_transaction_state[:frozen?] = @attributes.frozen?
-      @_start_transaction_state[:changed_attributes] ||= changed_attributes.dup
     end
 
     # Clear the new record state and id of a record.
@@ -369,9 +368,6 @@ module ActiveRecord
           @attributes = @attributes.dup if @attributes.frozen?
           @new_record = restore_state[:new_record]
           @destroyed  = restore_state[:destroyed]
-          changed_attributes.replace(restore_state[:changed_attributes]).delete_if do |attribute, old_value|
-            old_value == @attributes[attribute]
-          end
           if restore_state.has_key?(:id)
             write_attribute(self.class.primary_key, restore_state[:id])
           else

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -274,48 +274,6 @@ class TransactionTest < ActiveRecord::TestCase
     end
   end
 
-  def test_rollback_when_changing_inside_transaction
-    assert !@first.approved?
-    Topic.transaction do
-      @first.approved = true
-      @first.save!
-      raise ActiveRecord::Rollback
-    end
-    assert @first.approved
-    assert @first.changes["approved"]
-    @first.save!
-    assert @first.reload.approved
-  end
-
-  def test_rollback_when_changing_outside_transaction
-    assert !@first.approved?
-    @first.approved = true
-    Topic.transaction do
-      @first.save!
-      raise ActiveRecord::Rollback
-    end
-    assert @first.changes["approved"]
-    assert @first.approved
-    @first.save!
-    assert @first.reload.approved
-  end
-
-  def test_rollback_when_changing_back_to_prev_stage
-    assert !@first.approved?
-    Topic.transaction do
-      @first.approved = true
-      @first.save!
-      @first.approved = false
-      @first.save!
-      raise ActiveRecord::Rollback
-    end
-    assert !@first.approved
-    assert !@first.changes["approved"]
-    @first.save!
-    assert !@first.reload.approved
-  end
-
-
   def test_force_savepoint_in_nested_transaction
     Topic.transaction do
       @first.approved = true


### PR DESCRIPTION
We are reverting these commits, because there are other caveats related
to dirty attributes not being restored when a transaction is rollback.
For instance, nested transactions cannot proper restore the dirty
attributes state after a rollback.

At the moment, the dirty attributes are scoped by the transaction.
When we call `.save` on a record, the dirty attributes will be reset even
if the transaction gets rollback.

[related #13166]
[related #15018]
[related #15016]
[closes #15019]

This reverts commits
- bab48f0a3d53a08bc23ea0887219e8deb963c3d9
  - b0fa7cf3ff8432cc2eef3682b34763b7f8c93cc8.
- 73fb39b6faa9de593ae75ad4e3b8e065ea0e53af
  - 37c238927fbed059de3f26a90d8923fb377568a5.
  - 8d8d4f1560264cd1c74364d67fa0501f6dd2c4fa

Revert "Merge pull request #13166 from bogdan/transaction-magic"

@rafaelfranca @chancancode

This revert needs to happen on 4-1-stable and 4-0-stable
