### PR TITLE
Protocol relative URLs missing port in Rails URL helpers

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -129,8 +129,6 @@ module ActionDispatch
           return nil if options[:port].nil? || options[:port] == false
 
           case options[:protocol]
-          when "//"
-            nil
           when "https://"
             options[:port].to_i == 443 ? nil : options[:port]
           else

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -169,6 +169,18 @@ module AbstractController
         )
       end
 
+      def test_without_protocol_and_with_port
+        add_host!
+        add_port!
+
+        assert_equal('//www.basecamphq.com:3000/c/a/i',
+          W.new.url_for(:controller => 'c', :action => 'a', :id => 'i', :protocol => '//')
+        )
+        assert_equal('//www.basecamphq.com:3000/c/a/i',
+          W.new.url_for(:controller => 'c', :action => 'a', :id => 'i', :protocol => false)
+        )
+      end
+
       def test_trailing_slash
         add_host!
         options = {:controller => 'foo', :trailing_slash => true, :action => 'bar', :id => '33'}


### PR DESCRIPTION
I'm trying to generate protocol relative URLs using Rails URL helpers. For this I set the protocol option to false. But whenever I generate a URL, the port part is missing.

```
dashboard (master) > rails c
Loading development environment (Rails 4.0.3)
2.0.0p247 :001 > include Rails.application.routes.url_helpers
 => Object
2.0.0p247 :002 > tunnels_url(host: "0.0.0.0:3000", protocol: false)
 => "//0.0.0.0/tunnels"
```

The thing is: I'd like to generate protocol relative URL but using a custom port.
