### PR TITLE
Only need MINOR version level to test Ruby 2.1.x on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.2
+  - 2.1
   - rbx-2
   - jruby
 env:


### PR DESCRIPTION
cc http://blog.travis-ci.com/2014-04-28-upcoming-build-environment-updates/

See also #15041
