### PR TITLE
Simplify Finding Default Layout

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecate `ActionView::Layouts#action_has_layout?` and `ActionView::Layouts#action_has_layout=`.
+    Use `:only` or `:except` when configuring with `::layout` or pass `layout: false` to `#render`.
+
+    *Nick Sutterer*
+
 *   Allow custom `:host` option to be passed to `asset_url` helper that
     overwrites `config.action_controller.asset_host` for particular asset.
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,5 +1,5 @@
 *   Deprecate `ActionView::Layouts#action_has_layout?` and `ActionView::Layouts#action_has_layout=`.
-    Use `:only` or `:except` when configuring with `::layout` or pass `layout: false` to `#render`.
+    Use `:only` or `:except` when configuring with `Controller.layout` or pass `layout: false` to `#render`.
 
     *Nick Sutterer*
 

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -333,10 +333,9 @@ module ActionView
       private
       def invoke_for(controller, proc)
         layout = controller.send(proc)
-        return if layout.nil?
 
         raise ArgumentError, "Your layout method :#{proc} returned #{layout}. It " \
-          "should have returned a String, false, or nil" unless layout.is_a?(String) || layout === false
+          "should have returned a String, false, or nil" unless layout.is_a?(String) || !layout
 
         layout
       end

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -366,7 +366,7 @@ module ActionView
     end
 
     def action_has_layout=(value)
-      ActiveSupport::Deprecation.warn("Controller#action_has_layout= is deprecated and will be removed in 4.2. Please use `layout: false`.")
+      ActiveSupport::Deprecation.warn("Controller#action_has_layout= is deprecated and will be removed in 4.3. Please use `layout: false`.")
       @_action_has_layout = value
     end
 
@@ -376,7 +376,7 @@ module ActionView
     # either override this method in your controller to return false
     # for that action or set the <tt>action_has_layout</tt> attribute
     # to false before rendering.
-    def action_has_layout? # TODO: remove in 4.2.
+    def action_has_layout? # TODO: remove in 4.3.
       return if instance_variable_defined?(:@_action_has_layout) && @_action_has_layout === false
       true
     end
@@ -389,8 +389,7 @@ module ActionView
     #
     # ==== Parameters
     # * <tt>name</tt> - The name of the template
-    def _layout_for_option(name)
-      # called when render call contains :layout. where is this evaluated?
+    def _layout_for_option(name) # :nodoc:
       case name
       when String     then _normalize_layout(name)
       when Proc       then name

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -269,7 +269,8 @@ module ActionView
       # * :only   - A list of actions to apply this layout to.
       # * :except - Apply this layout to all actions but this one.
       def layout(layout, conditions = {})
-        raise ArgumentError, "Layouts must be specified as a String, Symbol, Proc, false, or nil" unless layout == false || layout.nil? || layout.is_a?(Proc) || layout.is_a?(String) || layout.is_a?(Symbol)
+        is_valid = (layout == false || layout.nil? || layout.is_a?(Proc) || layout.is_a?(String) || layout.is_a?(Symbol))
+        raise ArgumentError, "Layouts must be specified as a String, Symbol, Proc, false, or nil" unless is_valid
 
         extend LayoutConditions unless conditions.empty?
 

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -365,7 +365,7 @@ module ActionView
       end
     end
 
-    def action_has_layout=(value) # TODO: remove in 4.2.
+    def action_has_layout=(value)
       ActiveSupport::Deprecation.warn("Controller#action_has_layout= is deprecated and will be removed in 4.2. Please use `layout: false`.")
       @_action_has_layout = value
     end
@@ -376,7 +376,6 @@ module ActionView
     # either override this method in your controller to return false
     # for that action or set the <tt>action_has_layout</tt> attribute
     # to false before rendering.
-    # DISCUSS: how do we tell user overriding this method is deprecated?
     def action_has_layout? # TODO: remove in 4.2.
       return if instance_variable_defined?(:@_action_has_layout) && @_action_has_layout === false
       true

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -251,8 +251,6 @@ module ActionView
         end
       end
 
-      private
-
       # Specify the layout to use for this class.
       #
       # If the specified layout is a:
@@ -279,6 +277,8 @@ module ActionView
 
         self._layout_proc = layout
       end
+
+      private
 
       def _conditional_layout?(*)
         true
@@ -346,7 +346,7 @@ module ActionView
     end
 
     # Creates a _layout method to be called by _default_layout .
-    module LayoutMethod
+    module LayoutMethod # :nodoc:
       private
       def _layout # reader, called in #_default_layout.
         self.class._layout_for(action_name, lookup_context, self)

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -377,7 +377,7 @@ module ActionView
     # for that action or set the <tt>action_has_layout</tt> attribute
     # to false before rendering.
     def action_has_layout? # TODO: remove in 4.3.
-      return if instance_variable_defined?(:@_action_has_layout) && @_action_has_layout === false
+      return if instance_variable_defined?(:@_action_has_layout) && @_action_has_layout == false
       true
     end
 

--- a/actionview/test/actionpack/abstract/layouts_test.rb
+++ b/actionview/test/actionpack/abstract/layouts_test.rb
@@ -295,7 +295,7 @@ module AbstractControllerTests
       end
 
       test "when the layout is specified as a symbol and the method doesn't exist, raise an exception" do
-        assert_raises(NameError) { WithSymbolAndNoMethod.new.process(:index) }
+        assert_raises(NoMethodError) { WithSymbolAndNoMethod.new.process(:index) }
       end
 
       test "when the layout is specified as a symbol and the method returns something besides a string/false/nil, raise an exception" do

--- a/actionview/test/actionpack/abstract/layouts_test.rb
+++ b/actionview/test/actionpack/abstract/layouts_test.rb
@@ -39,8 +39,9 @@ module AbstractControllerTests
         render :template => ActionView::Template::Text.new("Hello string!")
       end
 
+      # TODO: use this for deprecation test
       def action_has_layout_false
-        self.action_has_layout = false
+        # self.action_has_layout = false
         render :template => ActionView::Template::Text.new("Hello string!")
       end
 
@@ -358,16 +359,16 @@ module AbstractControllerTests
       end
 
       test "when a grandchild has nil layout specified, the child has an implied layout, and the " \
-        "parent has specified a layout, use the child controller layout" do
+        "parent has specified a layout, use the grand child controller layout" do
           controller = WithGrandChildOfImplied.new
           controller.process(:index)
           assert_equal "With Grand Child Hello string!", controller.response_body
       end
 
       test "a child inherits layout from abstract controller" do
-          controller = AbstractWithStringChild.new
-          controller.process(:index)
-          assert_equal "With String Hello abstract child!", controller.response_body
+        controller = AbstractWithStringChild.new
+        controller.process(:index)
+        assert_equal "With String Hello abstract child!", controller.response_body
       end
 
       test "raises an exception when specifying layout true" do
@@ -416,8 +417,24 @@ module AbstractControllerTests
         assert_equal "With String index", controller.response_body
       end
 
-      test "when layout is disabled with action_has_layout=false, render no layout" do
+      test "when layout is disabled with #action_has_layout? returning false, render no layout" do
         controller = WithString.new
+        controller.instance_eval do
+          def action_has_layout?
+            false
+          end
+        end
+        controller.process(:action_has_layout_false)
+        assert_equal "Hello string!", controller.response_body
+      end
+
+      test "deprecation warning when #action_has_layout= is used" do
+        controller = Class.new(WithString).new
+
+        assert_deprecated do
+          controller.action_has_layout = false # this still works
+        end
+
         controller.process(:action_has_layout_false)
         assert_equal "Hello string!", controller.response_body
       end

--- a/actionview/test/actionpack/abstract/layouts_test.rb
+++ b/actionview/test/actionpack/abstract/layouts_test.rb
@@ -91,6 +91,14 @@ module AbstractControllerTests
       end
     end
 
+    class AbstractWithStringChildDefaultsToInherited < AbstractWithString
+      layout nil
+
+      def index
+        render :template => ActionView::Template::Text.new("Hello abstract child!")
+      end
+    end
+
     class WithProc < Base
       layout proc { "overwrite" }
 
@@ -214,6 +222,14 @@ module AbstractControllerTests
       end
     end
 
+    class WithOnlyConditionalFlipped < WithOnlyConditional
+      layout "hello_override", :only => :index
+    end
+
+    class WithOnlyConditionalFlippedAndInheriting < WithOnlyConditional
+      layout nil, :only => :index
+    end
+
     class WithExceptConditional < WithStringImpliedChild
       layout "overwrite", :except => :show
 
@@ -224,6 +240,26 @@ module AbstractControllerTests
       def show
         render :template => ActionView::Template::Text.new("Hello show!")
       end
+    end
+
+    class WithConditionalOverride < WithString
+      layout "overwrite", :only => :overwritten
+
+      def non_overwritten
+        render :template => ActionView::Template::Text.new("Hello non overwritten!")
+      end
+
+      def overwritten
+        render :template => ActionView::Template::Text.new("Hello overwritten!")
+      end
+    end
+
+    class WithConditionalOverrideFlipped < WithConditionalOverride
+      layout "hello_override", :only => :non_overwritten
+    end
+
+    class WithConditionalOverrideFlippedAndInheriting < WithConditionalOverride
+      layout nil, :only => :non_overwritten
     end
 
     class TestBase < ActiveSupport::TestCase
@@ -371,6 +407,12 @@ module AbstractControllerTests
         assert_equal "With String Hello abstract child!", controller.response_body
       end
 
+      test "a child inherits layout from abstract controller2" do
+        controller = AbstractWithStringChildDefaultsToInherited.new
+        controller.process(:index)
+        assert_equal "With String Hello abstract child!", controller.response_body
+      end
+
       test "raises an exception when specifying layout true" do
         assert_raises ArgumentError do
           Object.class_eval do
@@ -393,6 +435,30 @@ module AbstractControllerTests
         assert_equal "With Implied Hello index!", controller.response_body
       end
 
+      test "when specify an :only option which match current action name and is opposite from parent controller" do
+        controller = WithOnlyConditionalFlipped.new
+        controller.process(:show)
+        assert_equal "With Implied Hello show!", controller.response_body
+      end
+
+      test "when specify an :only option which does not match current action name and is opposite from parent controller" do
+        controller = WithOnlyConditionalFlipped.new
+        controller.process(:index)
+        assert_equal "With Override Hello index!", controller.response_body
+      end
+
+      test "when specify to inherit and an :only option which match current action name and is opposite from parent controller" do
+        controller = WithOnlyConditionalFlippedAndInheriting.new
+        controller.process(:show)
+        assert_equal "With Implied Hello show!", controller.response_body
+      end
+
+      test "when specify to inherit and an :only option which does not match current action name and is opposite from parent controller" do
+        controller = WithOnlyConditionalFlippedAndInheriting.new
+        controller.process(:index)
+        assert_equal "Overwrite Hello index!", controller.response_body
+      end
+
       test "when specify an :except option which match current action name" do
         controller = WithExceptConditional.new
         controller.process(:show)
@@ -403,6 +469,42 @@ module AbstractControllerTests
         controller = WithExceptConditional.new
         controller.process(:index)
         assert_equal "Overwrite Hello index!", controller.response_body
+      end
+
+      test "when specify overwrite as an :only option which match current action name" do
+        controller = WithConditionalOverride.new
+        controller.process(:overwritten)
+        assert_equal "Overwrite Hello overwritten!", controller.response_body
+      end
+
+      test "when specify overwrite as an :only option which does not match current action name" do
+        controller = WithConditionalOverride.new
+        controller.process(:non_overwritten)
+        assert_equal "Hello non overwritten!", controller.response_body
+      end
+
+      test "when specify overwrite as an :only option which match current action name and is opposite from parent controller" do
+        controller = WithConditionalOverrideFlipped.new
+        controller.process(:overwritten)
+        assert_equal "Hello overwritten!", controller.response_body
+      end
+
+      test "when specify overwrite as an :only option which does not match current action name and is opposite from parent controller" do
+        controller = WithConditionalOverrideFlipped.new
+        controller.process(:non_overwritten)
+        assert_equal "With Override Hello non overwritten!", controller.response_body
+      end
+
+      test "when specify to inherit and overwrite as an :only option which match current action name and is opposite from parent controller" do
+        controller = WithConditionalOverrideFlippedAndInheriting.new
+        controller.process(:overwritten)
+        assert_equal "Hello overwritten!", controller.response_body
+      end
+
+      test "when specify to inherit and overwrite as an :only option which does not match current action name and is opposite from parent controller" do
+        controller = WithConditionalOverrideFlippedAndInheriting.new
+        controller.process(:non_overwritten)
+        assert_equal "Overwrite Hello non overwritten!", controller.response_body
       end
 
       test "layout for anonymous controller" do

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -641,7 +641,7 @@ class TestController < ApplicationController
              "accessing_params_in_template_with_layout",
              "render_with_explicit_template",
              "render_with_explicit_string_template",
-             "update_page", "update_page_with_instance_variables"
+             "update_page", "update_page_with_instance_variables", "render_action_hello_world"
 
           "layouts/standard"
         when "action_talk_to_layout", "layout_overriding_layout"
@@ -738,9 +738,8 @@ class RenderTest < ActionController::TestCase
   end
 
   def test_render_action_upcased
-    assert_raise ActionView::MissingTemplate do
-      get :render_action_upcased_hello_world
-    end
+    get :render_action_upcased_hello_world
+    assert_equal "Hello world!", @response.body
   end
 
   # :ported:

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -738,8 +738,9 @@ class RenderTest < ActionController::TestCase
   end
 
   def test_render_action_upcased
-    get :render_action_upcased_hello_world
-    assert_equal "Hello world!", @response.body
+    assert_raise ActionView::MissingTemplate do
+      get :render_action_upcased_hello_world
+    end
   end
 
   # :ported:


### PR DESCRIPTION
# Summary

This PR simlifies the logic for finding default layouts in controllers when rendering.

Note: The code here is still changing, this PR was opened to have a discussion forum and to check general acceptance of this refactoring. All tests pass on my system :grimacing: 
# Implementation

While the former implementation was really hard to read and understand, the new `DefaultLayout` class cleanly provides encapsulation, and, more important, removes dozens of line of string evals, `super` calls where it was hard to know what `super` is and removes the need to hook into `inherited`.

Instead, it implements a recursion that travels up the controller inheritance chain to figure out the default layout.

Bottom line: No dynamic method defintions, no string eval, no `inherited`, and 47% less code.
