### PR TITLE
Change Gemfile’s double quotation marks in plugin generator

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile
@@ -1,7 +1,7 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 <% if options[:skip_gemspec] -%>
-<%= '# ' if options.dev? || options.edge? -%>gem "rails", "~> <%= Rails::VERSION::STRING %>"
+<%= '# ' if options.dev? || options.edge? -%>gem 'rails', '~> <%= Rails::VERSION::STRING %>'
 <% else -%>
 # Declare your gem's dependencies in <%= name %>.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
@@ -11,7 +11,7 @@ gemspec
 
 <% if options[:skip_gemspec] -%>
 group :development do
-  gem "<%= gem_for_database %>"
+  gem '<%= gem_for_database %>'
 end
 <% else -%>
 # Declare any dependencies that are still in development here instead of in

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -312,7 +312,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_no_file "bukkits.gemspec"
     assert_file "Gemfile" do |contents|
       assert_no_match('gemspec', contents)
-      assert_match(/gem "rails", "~> #{Rails.version}"/, contents)
+      assert_match(/gem 'rails', '~> #{Rails.version}'/, contents)
       assert_match_sqlite3(contents)
       assert_no_match(/# gem "jquery-rails"/, contents)
     end
@@ -323,7 +323,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_no_file "bukkits.gemspec"
     assert_file "Gemfile" do |contents|
       assert_no_match('gemspec', contents)
-      assert_match(/gem "rails", "~> #{Rails.version}"/, contents)
+      assert_match(/gem 'rails', '~> #{Rails.version}'/, contents)
       assert_match_sqlite3(contents)
     end
   end
@@ -416,9 +416,9 @@ protected
 
   def assert_match_sqlite3(contents)
     unless defined?(JRUBY_VERSION)
-      assert_match(/group :development do\n  gem "sqlite3"\nend/, contents)
+      assert_match(/group :development do\n  gem 'sqlite3'\nend/, contents)
     else
-      assert_match(/group :development do\n  gem "activerecord-jdbcsqlite3-adapter"\nend/, contents)
+      assert_match(/group :development do\n  gem 'activerecord-jdbcsqlite3-adapter'\nend/, contents)
     end
   end
 end


### PR DESCRIPTION
Since the generated application’s Gemfile is using single quotation marks, it seems fair to use it on plugin’s Gemfile as well.
