### PR TITLE
Add raise to around callbacks

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -297,14 +297,14 @@ module ActiveSupport
             target = env.target
             value  = env.value
 
-            unless env.halted
+            if env.halted
+              next_callback.call env
+            else
               user_callback.call(target, value) {
                 env = next_callback.call env
                 env.value
               }
               env
-            else
-              next_callback.call env
             end
           }
         end

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -304,6 +304,7 @@ module ActiveSupport
                 env = next_callback.call env
                 env.value
               }
+              raise ArgumentError, "no block given (yield)" unless env.value
               env
             end
           }


### PR DESCRIPTION
First I flipped the conditional to use if/else instead of unless/else since it's frowned upon to use an else with an unless. if/else is cleaner.

I added a raise if the `env.value` is `nil` because if `around_destroy` is called with `destroy` and the developer fails to add a `yield` to their callback an error will be thrown that records were not destroyed. This is confusing and a raise the explains that a yield is missing is more user friendly. 

I wasn't sure which error to throw, other callbacks were throwing an `ArgumentError` so I went with that. Let me know if that's incorrect and I'll fix it right up.
