### PR TITLE
Dup options hash to prevent modifications

### DIFF
--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -34,6 +34,8 @@ module ActionView
       # naming convention helps to identify translations that include HTML tags so that
       # you know what kind of output to expect when you call translate in a template.
       def translate(key, options = {})
+        options = options.dup
+        
         options[:default] = wrap_translate_defaults(options[:default]) if options[:default]
 
         # If the user has specified rescue_format then pass it all through, otherwise use

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -151,4 +151,10 @@ class TranslationHelperTest < ActiveSupport::TestCase
     translation = translate(:'translations.missing', default: ['A Generic String', 'Second generic string'])
     assert_equal 'A Generic String', translation
   end
+
+  def test_translate_doesnt_change_options
+    options = {}
+    translate(:'translations.missing', options)
+    assert_equal options, {}
+  end
 end


### PR DESCRIPTION
`options[:default]` and `options[:raise]` can be mistakenly added to the `options` hash. This can be a problem if you're reusing the same object.
