### PR TITLE
Revert part of "[ci skip] doc Http::Headers methods"

### DIFF
--- a/actionpack/lib/action_dispatch/http/headers.rb
+++ b/actionpack/lib/action_dispatch/http/headers.rb
@@ -19,7 +19,7 @@ module ActionDispatch
       include Enumerable
       attr_reader :env
 
-      def initialize(env = {}) # :nodoc:
+      def initialize(env = {})
         @env = env
       end
 


### PR DESCRIPTION
This reverts part of commit aabbf07.

`:nodoc:` should be discussed via PR, and not committed directly to
docrails.

cc @fxn @schneems
