### PR TITLE
[Fixes #15064] Calling number_to_delimited on a ActiveSupport::SafeBuffer results in mangled output

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fixed an issue when using
+    `ActiveSupport::NumberHelper::NumberToDelimitedConverter` to
+    convert a value that is an `ActiveSupport::SafeBuffer` introduced
+    in 2da9d67.
+
+    For more info see #15064.
+
+    *Mark J. Titorenko*
+
 *   `TimeZone#parse` defaults the day of the month to '1' if any other date
     components are specified. This is more consistent with the behavior of
     `Time#parse`.

--- a/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
@@ -13,7 +13,9 @@ module ActiveSupport
 
         def parts
           left, right = number.to_s.split('.')
-          left.gsub!(DELIMITED_REGEX) { "#{$1}#{options[:delimiter]}" }
+          left.gsub!(DELIMITED_REGEX) do |digit_to_delimit|
+            "#{digit_to_delimit}#{options[:delimiter]}"
+          end
           [left, right].compact
         end
     end

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -1,5 +1,6 @@
 require 'abstract_unit'
 require 'active_support/number_helper'
+require 'active_support/core_ext/string/output_safety'
 
 module ActiveSupport
   module NumberHelper
@@ -97,7 +98,7 @@ module ActiveSupport
           assert_equal("123,456,789.78901", number_helper.number_to_delimited(123456789.78901))
           assert_equal("0.78901", number_helper.number_to_delimited(0.78901))
           assert_equal("123,456.78", number_helper.number_to_delimited("123456.78"))
-          assert_equal("123,456.78", number_helper.number_to_delimited(ActiveSupport::SafeBuffer.new("123456.78")))
+          assert_equal("123,456.78", number_helper.number_to_delimited("123456.78".html_safe))
         end
       end
 

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -97,6 +97,7 @@ module ActiveSupport
           assert_equal("123,456,789.78901", number_helper.number_to_delimited(123456789.78901))
           assert_equal("0.78901", number_helper.number_to_delimited(0.78901))
           assert_equal("123,456.78", number_helper.number_to_delimited("123456.78"))
+          assert_equal("123,456.78", number_helper.number_to_delimited(ActiveSupport::SafeBuffer.new("123456.78")))
         end
       end
 


### PR DESCRIPTION
Use block parameter rather than `$1` during `gsub!` so `ActiveSupport::SafeBuffer` values aren't mangled.

Fixes #15064
