### PR TITLE
Use `columns_hash[]` in place of `columns.find {}` in AR tests.

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/boolean_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/boolean_test.rb
@@ -77,11 +77,11 @@ class Mysql2BooleanTest < ActiveRecord::TestCase
   end
 
   def boolean_column
-    BooleanType.columns.find { |c| c.name == 'archived' }
+    BooleanType.columns_hash['archived']
   end
 
   def string_column
-    BooleanType.columns.find { |c| c.name == 'published' }
+    BooleanType.columns_hash['published']
   end
 
   def emulate_booleans(value)

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -158,13 +158,13 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     k2.table_name = 'posts'
     k2.primary_key = 'title'
 
-    assert k1.columns.find { |c| c.name == 'id' }.primary
-    assert !k1.columns.find { |c| c.name == 'title' }.primary
+    assert k1.columns_hash['id'].primary
+    assert !k1.columns_hash['title'].primary
     assert k1.columns_hash['id'].primary
     assert !k1.columns_hash['title'].primary
 
-    assert !k2.columns.find { |c| c.name == 'id' }.primary
-    assert k2.columns.find { |c| c.name == 'title' }.primary
+    assert !k2.columns_hash['id'].primary
+    assert k2.columns_hash['title'].primary
     assert !k2.columns_hash['id'].primary
     assert k2.columns_hash['title'].primary
   end


### PR DESCRIPTION
\cc @senny
