### PR TITLE
Added 'all' environment to secrets.yml

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added 'all' environment to secrets.yml
+
+    *Ian Mitchell*
+
 *   Load database configuration from the first
     database.yml available in paths.
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -322,7 +322,8 @@ module Rails
         if File.exist?(yaml)
           require "erb"
           all_secrets = YAML.load(ERB.new(IO.read(yaml)).result) || {}
-          env_secrets = all_secrets[Rails.env]
+          env_secrets = all_secrets['all'] || {}
+          env_secrets.merge!(all_secrets[Rails.env]) if all_secrets[Rails.env]
           secrets.merge!(env_secrets.symbolize_keys) if env_secrets
         end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -344,6 +344,35 @@ module ApplicationTests
       assert_nil app.secrets.not_defined
     end
 
+    test "generic environment secrets present in all environments" do
+      app_file 'config/secrets.yml', <<-YAML
+        development:
+          secret_key_base: 3b7cd727ee24e8444053437c36cc66c3
+          aws_access_key_id: myamazonaccesskeyid
+
+        all:
+          aws_secret_access_key: myamazonsecretaccesskey
+      YAML
+
+      require "#{app_path}/config/environment"
+      assert_equal 'myamazonaccesskeyid', app.secrets.aws_access_key_id
+      assert_equal 'myamazonsecretaccesskey', app.secrets.aws_secret_access_key
+    end
+
+    test "environment specific secrets overrides generic secrets" do
+      app_file 'config/secrets.yml', <<-YAML
+        development:
+          secret_key_base: 3b7cd727ee24e8444053437c36cc66c3
+          aws_secret_access_key: myamazonsecretaccesskey
+
+        all:
+          aws_secret_access_key: notmyamazonsecretaccesskey
+      YAML
+
+      require "#{app_path}/config/environment"
+      assert_equal 'myamazonsecretaccesskey', app.secrets.aws_secret_access_key
+    end
+
     test "protect from forgery is the default in a new app" do
       make_basic_app
 


### PR DESCRIPTION
Instead of making the user define a `key: value` in `secrets.yml` for all three environments, they can now set it in the `all` environment. This `key: value` will be present in production, test, and development. You can override the key by defining it for a specific environment

For instance, with the `secrets.yml` file:

```
development:
  my_key: my_val

all:
  my_key: not_my_val
```

It would use `not_my_val` for test and production, and `my_val` in development.

This is my first contribution -- if I've screwed up, just let me know! Not sure if this change is something everyone wants, but I thought it'd be nice for defining application critical API keys. I chose `all`
over `global` because I felt it fit better, but it's a quick change if anyone disagrees!
