### PR TITLE
Make filter_binds filter out symbols that are equal to strings

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `ActiveRecord::Relation::Merger#filter_binds` now compares equivalent symbols and 
+    strings in column names as equal.
+    
+    This fixes a rare case in which more bind values are passed than there are
+    placeholders for them in the generated SQL statement, which can make PostgreSQL
+    throw a `StatementInvalid` exception.
+    
+    *Nat Budin*
+
 *   `change_column_default` allows `[]` as argument to `change_column_default`.
 
     Fixes #11586.

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -156,7 +156,7 @@ module ActiveRecord
       def filter_binds(lhs_binds, removed_wheres)
         return lhs_binds if removed_wheres.empty?
 
-        set = Set.new removed_wheres.map { |x| x.left.name }
+        set = Set.new removed_wheres.map { |x| x.left.name.to_s }
         lhs_binds.dup.delete_if { |col,_| set.include? col.name }
       end
 

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -108,6 +108,11 @@ class RelationMergingTest < ActiveRecord::TestCase
     merged = left.merge(right)
     assert_equal post, merged.first
   end
+  
+  def test_merging_compares_symbols_and_strings_as_equal
+    post = PostThatLoadsCommentsInAnAfterSaveHook.create!(title: "First Post", body: "Blah blah blah.")
+    assert_equal "First comment!", post.comments.where(body: "First comment!").first_or_create.body
+  end
 end
 
 class MergingDifferentRelationsTest < ActiveRecord::TestCase

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -40,3 +40,11 @@ end
 
 class VerySpecialComment < Comment
 end
+
+class CommentThatAutomaticallyAltersPostBody < Comment
+  belongs_to :post, class_name: "PostThatLoadsCommentsInAnAfterSaveHook", foreign_key: :post_id
+  
+  after_save do |comment|
+    comment.post.update_attributes(body: "Automatically altered")
+  end
+end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -208,3 +208,12 @@ class SpecialPostWithDefaultScope < ActiveRecord::Base
   self.table_name = 'posts'
   default_scope { where(:id => [1, 5,6]) }
 end
+
+class PostThatLoadsCommentsInAnAfterSaveHook < ActiveRecord::Base
+  self.table_name = 'posts'
+  has_many :comments, class_name: "CommentThatAutomaticallyAltersPostBody", foreign_key: :post_id
+  
+  after_save do |post|
+    post.comments.load
+  end
+end


### PR DESCRIPTION
_This comment copied, mostly, from PR #15077.  I've made a new gist for the test case against master._

I ran into this when attempting to upgrade a large, complex, very old Rails application from Rails 3.2 to 4.0, but it appears to also be a problem in 4.1 as well as master.  I've got a small test case for it, but it's possible it could be simplified further: https://gist.github.com/nbudin/24b44fb127df86d46ca7

The problem is that ActiveRecord::Relation::Merger's filter_binds method does not filter out bind variables when one of the attribute nodes has a string name, but the other has a symbol name, even when those names are actually equal.  To trigger this, I used a symbol parameter in `:foreign_key` the `has_many` declaration, which the `Comment` class's `after_save` callback is going to use.  Something earlier in the chain, I suspect the `Post` class's `before_save` callback, will have already put an automatically generated `Association` object into the cached relation here with a string for that bind parameter, so the merger compares them as unequal even though they are actually for the same column.

The end result is that PostgreSQL gets two bind parameters for a SQL query with only one placeholder in it and ActiveRecord raises a `StatementInvalid`.

This patch changes the filter_binds method to make it convert both attribute names to strings before comparing, which makes the test case pass.  (It is entirely possible there's a more performant way to fix this bug.)
