### PR TITLE
Clean up deliveries after each test.

### DIFF
--- a/actionmailer/test/delivery_methods_test.rb
+++ b/actionmailer/test/delivery_methods_test.rb
@@ -47,12 +47,12 @@ class DefaultsDeliveryMethodsTest < ActiveSupport::TestCase
 end
 
 class CustomDeliveryMethodsTest < ActiveSupport::TestCase
-  def setup
+  setup do
     @old_delivery_method = ActionMailer::Base.delivery_method
     ActionMailer::Base.add_delivery_method :custom, MyCustomDelivery
   end
 
-  def teardown
+  teardown do
     ActionMailer::Base.delivery_method = @old_delivery_method
     new = ActionMailer::Base.delivery_methods.dup
     new.delete(:custom)
@@ -93,18 +93,16 @@ class MailDeliveryTest < ActiveSupport::TestCase
     end
   end
 
-  def setup
-    ActionMailer::Base.delivery_method = :smtp
+  setup do
+    @old_delivery_method = DeliveryMailer.delivery_method
   end
 
-  def teardown
-    DeliveryMailer.delivery_method = :smtp
-    DeliveryMailer.perform_deliveries = true
-    DeliveryMailer.raise_delivery_errors = true
+  teardown do
+    DeliveryMailer.delivery_method = @old_delivery_method
+    DeliveryMailer.deliveries.clear
   end
 
   test "ActionMailer should be told when Mail gets delivered" do
-    DeliveryMailer.deliveries.clear
     DeliveryMailer.expects(:deliver_mail).once
     DeliveryMailer.welcome.deliver
   end
@@ -176,22 +174,29 @@ class MailDeliveryTest < ActiveSupport::TestCase
   end
 
   test "does not perform deliveries if requested" do
-    DeliveryMailer.perform_deliveries = false
-    DeliveryMailer.deliveries.clear
-    Mail::Message.any_instance.expects(:deliver!).never
-    DeliveryMailer.welcome.deliver
+    old_perform_deliveries = DeliveryMailer.perform_deliveries
+    begin
+      DeliveryMailer.perform_deliveries = false
+      Mail::Message.any_instance.expects(:deliver!).never
+      DeliveryMailer.welcome.deliver
+    ensure
+      DeliveryMailer.perform_deliveries = old_perform_deliveries
+    end
   end
 
   test "does not append the deliveries collection if told not to perform the delivery" do
-    DeliveryMailer.perform_deliveries = false
-    DeliveryMailer.deliveries.clear
-    DeliveryMailer.welcome.deliver
-    assert_equal(0, DeliveryMailer.deliveries.length)
+    old_perform_deliveries = DeliveryMailer.perform_deliveries
+    begin
+      DeliveryMailer.perform_deliveries = false
+      DeliveryMailer.welcome.deliver
+      assert_equal [], DeliveryMailer.deliveries
+    ensure
+      DeliveryMailer.perform_deliveries = old_perform_deliveries
+    end
   end
 
   test "raise errors on bogus deliveries" do
     DeliveryMailer.delivery_method = BogusDelivery
-    DeliveryMailer.deliveries.clear
     assert_raise RuntimeError do
       DeliveryMailer.welcome.deliver
     end
@@ -199,27 +204,34 @@ class MailDeliveryTest < ActiveSupport::TestCase
 
   test "does not increment the deliveries collection on error" do
     DeliveryMailer.delivery_method = BogusDelivery
-    DeliveryMailer.deliveries.clear
     assert_raise RuntimeError do
       DeliveryMailer.welcome.deliver
     end
-    assert_equal(0, DeliveryMailer.deliveries.length)
+    assert_equal [], DeliveryMailer.deliveries
   end
 
   test "does not raise errors on bogus deliveries if set" do
-    DeliveryMailer.delivery_method = BogusDelivery
-    DeliveryMailer.raise_delivery_errors = false
-    assert_nothing_raised do
-      DeliveryMailer.welcome.deliver
+    old_raise_delivery_errors = DeliveryMailer.raise_delivery_errors
+    begin
+      DeliveryMailer.delivery_method = BogusDelivery
+      DeliveryMailer.raise_delivery_errors = false
+      assert_nothing_raised do
+        DeliveryMailer.welcome.deliver
+      end
+    ensure
+      DeliveryMailer.raise_delivery_errors = old_raise_delivery_errors
     end
   end
 
   test "does not increment the deliveries collection on bogus deliveries" do
-    DeliveryMailer.delivery_method = BogusDelivery
-    DeliveryMailer.raise_delivery_errors = false
-    DeliveryMailer.deliveries.clear
-    DeliveryMailer.welcome.deliver
-    assert_equal(0, DeliveryMailer.deliveries.length)
+    old_raise_delivery_errors = DeliveryMailer.raise_delivery_errors
+    begin
+      DeliveryMailer.delivery_method = BogusDelivery
+      DeliveryMailer.raise_delivery_errors = false
+      DeliveryMailer.welcome.deliver
+      assert_equal [], DeliveryMailer.deliveries
+    ensure
+      DeliveryMailer.raise_delivery_errors = old_raise_delivery_errors
+    end
   end
-
 end


### PR DESCRIPTION
Whenever `DeliveryMailer.welcome.deliver` is called, `DeliveryMailer.deliveries` should be cleaned up afterwards to prevent state leaks from one test to another.

@senny please review.
