### PR TITLE
Fix regression on `assert_redirected_to`.

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -73,7 +73,13 @@ module ActionDispatch
           if Regexp === fragment
             fragment
           else
-            @controller._compute_redirect_to_location(fragment)
+            handle = @controller || Class.new(ActionController::Metal) do
+              include ActionController::Redirecting
+              def initialize(request)
+                @_request = request
+              end
+            end.new(@request)
+            handle._compute_redirect_to_location(fragment)
           end
         end
     end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -374,6 +374,10 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       follow_redirect!
       assert_response :success
       assert_equal "/get", path
+
+      get '/moved'
+      assert_response :redirect
+      assert_redirected_to '/method'
     end
   end
 
@@ -511,6 +515,8 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
         end
 
         set.draw do
+          get 'moved' => redirect('/method')
+
           match ':action', :to => controller, :via => [:get, :post], :as => :action
           get 'get/:action', :to => controller, :as => :get_action
         end


### PR DESCRIPTION
`assert_redirected_to` would fail if there is no controller set on
a `ActionDispatch::IntegrationTest`, as _compute_redirect_to_location
would be called on the controller to build the url.

This regression was introduced after 1dacfbabf3bb1e0a9057dd2a016b1804e7fa38c0.

[fixes #14691]

review @rafaelfranca @pixeltrix
