### PR TITLE
Do not clear deliveries in setup.

### DIFF
--- a/actionmailer/test/mail_layout_test.rb
+++ b/actionmailer/test/mail_layout_test.rb
@@ -44,16 +44,6 @@ class ExplicitLayoutMailer < ActionMailer::Base
 end
 
 class LayoutMailerTest < ActiveSupport::TestCase
-  def setup
-    set_delivery_method :test
-    ActionMailer::Base.perform_deliveries = true
-    ActionMailer::Base.deliveries.clear
-  end
-
-  def teardown
-    restore_delivery_method
-  end
-
   def test_should_pickup_default_layout
     mail = AutoLayoutMailer.hello
     assert_equal "Hello from layout Inside", mail.body.to_s.strip


### PR DESCRIPTION
ActionMailer::Base.deliveries is expected to be empty before each test.
If not, we should let the test fail as there must be leaks elsewhere.
