### PR TITLE
[postgres] include PgArrayParser directly

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/array_parser.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/array_parser.rb
@@ -9,35 +9,23 @@ module ActiveRecord
         BRACKET_OPEN = '{'
         BRACKET_CLOSE = '}'
 
+        def parse_pg_array(string)
+          local_index = 0
+          array = []
+          while(local_index < string.length)
+            case string[local_index]
+            when BRACKET_OPEN
+              local_index,array = parse_array_contents(array, string, local_index + 1)
+            when BRACKET_CLOSE
+              return array
+            end
+            local_index += 1
+          end
+
+          array
+        end
+
         private
-          # Loads pg_array_parser if available. String parsing can be
-          # performed quicker by a native extension, which will not create
-          # a large amount of Ruby objects that will need to be garbage
-          # collected. pg_array_parser has a C and Java extension
-          begin
-            require 'pg_array_parser'
-            include PgArrayParser
-          rescue LoadError
-            def parse_pg_array(string)
-              parse_data(string)
-            end
-          end
-
-          def parse_data(string)
-            local_index = 0
-            array = []
-            while(local_index < string.length)
-              case string[local_index]
-              when BRACKET_OPEN
-                local_index,array = parse_array_contents(array, string, local_index + 1)
-              when BRACKET_CLOSE
-                return array
-              end
-              local_index += 1
-            end
-
-            array
-          end
 
           def parse_array_contents(array, string, index)
             is_escaping  = false

--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -29,8 +29,20 @@ module ActiveRecord
 
       # :stopdoc:
       class << self
-        include ConnectionAdapters::PostgreSQLColumn::Cast
-        include ConnectionAdapters::PostgreSQLColumn::ArrayParser
+        include PostgreSQLColumn::Cast
+
+        # Loads pg_array_parser if available. String parsing can be
+        # performed quicker by a native extension, which will not create
+        # a large amount of Ruby objects that will need to be garbage
+        # collected. pg_array_parser has a C and Java extension
+        begin
+          require 'pg_array_parser'
+          include PgArrayParser
+        rescue LoadError
+          require 'active_record/connection_adapters/postgresql/array_parser'
+          include PostgreSQLColumn::ArrayParser
+        end
+
         attr_accessor :money_precision
       end
       # :startdoc:


### PR DESCRIPTION
and only load/include ArrayParser if not found

might seem a bit uglier at first sight but Ruby will resolve `parse_pg_array` faster (+ included includes are harder to grasp any-ways without a coffee/mate :), also previously when `PgArrayParser` was being used still all of the ArrayParser's code loaded - never to be used just sitting there in rails-space ...
