### PR TITLE
Remove falsy deprecation note in AS guides [ci skip]

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1106,7 +1106,7 @@ end
 
 A model may find it useful to set `:instance_accessor` to `false` as a way to prevent mass-assignment from setting the attribute.
 
-NOTE: Defined in `active_support/core_ext/module/attribute_accessors.rb`. `active_support/core_ext/class/attribute_accessors.rb` is deprecated and will be removed in Ruby on Rails 4.2.
+NOTE: Defined in `active_support/core_ext/module/attribute_accessors.rb`.
 
 ### Subclasses & Descendants
 


### PR DESCRIPTION
This is no longer true as @jeremy removed the deprecation in 7a5601c.

Although this section talks about the cattr_\* methods in particular, I still kept the note citing their definition at `active_support/core_ext/module/attribute_accessors.rb` (it was changed in 7dfbd91).
