### PR TITLE
Update Redcarpet to 3.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'uglifier', '>= 1.3.0', require: false
 
 group :doc do
   gem 'sdoc', '~> 0.4.0'
-  gem 'redcarpet', '~> 3.1.0', platforms: :ruby
+  gem 'redcarpet', '~> 3.1.2', platforms: :ruby
   gem 'w3c_validators'
   gem 'kindlerb'
 end

--- a/guides/rails_guides.rb
+++ b/guides/rails_guides.rb
@@ -24,11 +24,11 @@ begin
   require 'redcarpet'
 rescue LoadError
   # This can happen if doc:guides is executed in an application.
-  $stderr.puts('Generating guides requires Redcarpet 3.1.0+.')
+  $stderr.puts('Generating guides requires Redcarpet 3.1.2+.')
   $stderr.puts(<<ERROR) if bundler?
 Please add
 
-  gem 'redcarpet', '~> 3.1.0'
+  gem 'redcarpet', '~> 3.1.2'
 
 to the Gemfile, run
 

--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -15,7 +15,7 @@ module RailsGuides
 HTML
       end
 
-      def header(text, header_level, anchor)
+      def header(text, header_level)
         # Always increase the heading level by, so we can use h1, h2 heading in the document
         header_level += 1
 


### PR DESCRIPTION
Hello,

This is just a tiny pull request that bumps Redcarpet to 3.1.2 as this version fixes an API breakage between 3.0 and 3.1 ; the header method's arity should not have changed.

Have a nice day.
