### PR TITLE
Add PGRange class.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Added a new class that PostgreSQL Ranges will map to. 
+
+    Ruby Ranges are inferior to Postgres Ranges in that they support neither
+    unbounded ranges nor exclusive lower bounds. The new `PGRange` supports
+    the most common Range operations and provides a method to translate to a
+    Ruby Range when it makes sense to. `PGRange` delegates several methods
+    related to iteration and enumeration to this `::Range`.
+
+    Addresses #14010.
+
+    *Jefferson Lai*
+
 *   Fixed serialization for records with an attribute named `format`.
 
     Fixes #15188.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -131,6 +131,8 @@ module ActiveRecord
             else
               super(value, column)
             end
+          when PGRange
+            value
           else
             super(value, column)
           end

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -108,160 +108,133 @@ _SQL
     end
 
     def test_int4range_values
-      assert_equal 1...11, @first_range.int4_range
-      assert_equal 1...10, @second_range.int4_range
-      assert_equal 1...Float::INFINITY, @third_range.int4_range
-      assert_equal(-Float::INFINITY...Float::INFINITY, @fourth_range.int4_range)
+      assert_equal 1...11, @first_range.int4_range.to_range
+      assert_equal 1...10, @second_range.int4_range.to_range
+      assert_equal pgrange(1, nil, :integer, true), @third_range.int4_range
+      assert_equal pgrange(nil, nil, :integer), @fourth_range.int4_range
       assert_nil @empty_range.int4_range
     end
 
     def test_int8range_values
-      assert_equal 10...101, @first_range.int8_range
-      assert_equal 10...100, @second_range.int8_range
-      assert_equal 10...Float::INFINITY, @third_range.int8_range
-      assert_equal(-Float::INFINITY...Float::INFINITY, @fourth_range.int8_range)
+      assert_equal 10...101, @first_range.int8_range.to_range
+      assert_equal 10...100, @second_range.int8_range.to_range
+      assert_equal pgrange(10, nil, :integer), @third_range.int8_range
+      assert_equal pgrange(nil, nil, :integer), @fourth_range.int8_range
       assert_nil @empty_range.int8_range
     end
 
     def test_daterange_values
-      assert_equal Date.new(2012, 1, 2)...Date.new(2012, 1, 5), @first_range.date_range
-      assert_equal Date.new(2012, 1, 2)...Date.new(2012, 1, 4), @second_range.date_range
-      assert_equal Date.new(2012, 1, 2)...Float::INFINITY, @third_range.date_range
-      assert_equal(-Float::INFINITY...Float::INFINITY, @fourth_range.date_range)
+      assert_equal Date.new(2012, 1, 2)...Date.new(2012, 1, 5), @first_range.date_range.to_range
+      assert_equal Date.new(2012, 1, 2)...Date.new(2012, 1, 4), @second_range.date_range.to_range
+      assert_equal pgrange(Date.new(2012, 1, 2), nil, :date, true), @third_range.date_range
+      assert_equal pgrange(nil, nil, :date, true), @fourth_range.date_range
       assert_nil @empty_range.date_range
     end
 
     def test_numrange_values
-      assert_equal BigDecimal.new('0.1')..BigDecimal.new('0.2'), @first_range.num_range
-      assert_equal BigDecimal.new('0.1')...BigDecimal.new('0.2'), @second_range.num_range
-      assert_equal BigDecimal.new('0.1')...BigDecimal.new('Infinity'), @third_range.num_range
-      assert_equal BigDecimal.new('-Infinity')...BigDecimal.new('Infinity'), @fourth_range.num_range
+      assert_equal pgrange(BigDecimal.new('0.1'), BigDecimal.new('0.2'), :decimal), @first_range.num_range
+      assert_equal pgrange(BigDecimal.new('0.1'), BigDecimal.new('0.2'), :decimal, true), @second_range.num_range
+      assert_equal pgrange(BigDecimal.new('0.1'), nil, :decimal, true), @third_range.num_range
+      assert_equal pgrange(nil, nil, :decimal, true), @fourth_range.num_range
       assert_nil @empty_range.num_range
     end
 
     def test_tsrange_values
       tz = ::ActiveRecord::Base.default_timezone
-      assert_equal Time.send(tz, 2010, 1, 1, 14, 30, 0)..Time.send(tz, 2011, 1, 1, 14, 30, 0), @first_range.ts_range
-      assert_equal Time.send(tz, 2010, 1, 1, 14, 30, 0)...Time.send(tz, 2011, 1, 1, 14, 30, 0), @second_range.ts_range
-      assert_equal(-Float::INFINITY...Float::INFINITY, @fourth_range.ts_range)
+      assert_equal Time.send(tz, 2010, 1, 1, 14, 30, 0)..Time.send(tz, 2011, 1, 1, 14, 30, 0), @first_range.ts_range.to_range
+      assert_equal Time.send(tz, 2010, 1, 1, 14, 30, 0)...Time.send(tz, 2011, 1, 1, 14, 30, 0), @second_range.ts_range.to_range
+      assert_equal pgrange(nil, nil, :datetime), @fourth_range.ts_range
       assert_nil @empty_range.ts_range
     end
 
     def test_tstzrange_values
-      assert_equal Time.parse('2010-01-01 09:30:00 UTC')..Time.parse('2011-01-01 17:30:00 UTC'), @first_range.tstz_range
-      assert_equal Time.parse('2010-01-01 09:30:00 UTC')...Time.parse('2011-01-01 17:30:00 UTC'), @second_range.tstz_range
-      assert_equal(-Float::INFINITY...Float::INFINITY, @fourth_range.tstz_range)
+      assert_equal Time.parse('2010-01-01 09:30:00 UTC')..Time.parse('2011-01-01 17:30:00 UTC'), @first_range.tstz_range.to_range
+      assert_equal Time.parse('2010-01-01 09:30:00 UTC')...Time.parse('2011-01-01 17:30:00 UTC'), @second_range.tstz_range.to_range
+      assert_equal pgrange(nil, nil, :datetime, true, true), @fourth_range.tstz_range
       assert_nil @empty_range.tstz_range
     end
 
     def test_custom_range_values
-      assert_equal 0.5..0.7, @first_range.float_range
-      assert_equal 0.5...0.7, @second_range.float_range
-      assert_equal 0.5...Float::INFINITY, @third_range.float_range
-      assert_equal (-Float::INFINITY...Float::INFINITY), @fourth_range.float_range
+      assert_equal pgrange(0.5, 0.7, :float), @first_range.float_range
+      assert_equal pgrange(0.5, 0.7, :float, true), @second_range.float_range
+      assert_equal pgrange(0.5, nil, :float, true), @third_range.float_range
+      assert_equal pgrange(nil, nil, :float, true, true), @fourth_range.float_range
       assert_nil @empty_range.float_range
     end
 
     def test_create_tstzrange
-      tstzrange = Time.parse('2010-01-01 14:30:00 +0100')...Time.parse('2011-02-02 14:30:00 CDT')
+      tstzrange = pgrange(Time.parse('2010-01-01 14:30:00 +0100'), Time.parse('2011-02-02 14:30:00 CDT'), :datetime, true)
       round_trip(@new_range, :tstz_range, tstzrange)
       assert_equal @new_range.tstz_range, tstzrange
-      assert_equal @new_range.tstz_range, Time.parse('2010-01-01 13:30:00 UTC')...Time.parse('2011-02-02 19:30:00 UTC')
+      assert_equal @new_range.tstz_range, pgrange(Time.parse('2010-01-01 13:30:00 UTC'), Time.parse('2011-02-02 19:30:00 UTC'), :datetime, true)
     end
 
     def test_update_tstzrange
       assert_equal_round_trip(@first_range, :tstz_range,
-                              Time.parse('2010-01-01 14:30:00 CDT')...Time.parse('2011-02-02 14:30:00 CET'))
+                              pgrange(Time.parse('2010-01-01 14:30:00 CDT'), Time.parse('2011-02-02 14:30:00 CET'), :datetime, true))
       assert_nil_round_trip(@first_range, :tstz_range,
-                            Time.parse('2010-01-01 14:30:00 +0100')...Time.parse('2010-01-01 13:30:00 +0000'))
+                            pgrange(Time.parse('2010-01-01 14:30:00 +0100'), Time.parse('2010-01-01 13:30:00 +0000'), :datetime, true))
     end
 
     def test_create_tsrange
       tz = ::ActiveRecord::Base.default_timezone
       assert_equal_round_trip(@new_range, :ts_range,
-                              Time.send(tz, 2010, 1, 1, 14, 30, 0)...Time.send(tz, 2011, 2, 2, 14, 30, 0))
+                              pgrange(Time.send(tz, 2010, 1, 1, 14, 30, 0), Time.send(tz, 2011, 2, 2, 14, 30, 0), :datetime, true))
     end
 
     def test_update_tsrange
       tz = ::ActiveRecord::Base.default_timezone
       assert_equal_round_trip(@first_range, :ts_range,
-                              Time.send(tz, 2010, 1, 1, 14, 30, 0)...Time.send(tz, 2011, 2, 2, 14, 30, 0))
+                              pgrange(Time.send(tz, 2010, 1, 1, 14, 30, 0), Time.send(tz, 2011, 2, 2, 14, 30, 0), :datetime, true))
       assert_nil_round_trip(@first_range, :ts_range,
-                            Time.send(tz, 2010, 1, 1, 14, 30, 0)...Time.send(tz, 2010, 1, 1, 14, 30, 0))
+                            pgrange(Time.send(tz, 2010, 1, 1, 14, 30, 0), Time.send(tz, 2010, 1, 1, 14, 30, 0), :datetime, true))
     end
 
     def test_create_numrange
       assert_equal_round_trip(@new_range, :num_range,
-                              BigDecimal.new('0.5')...BigDecimal.new('1'))
+                              pgrange(BigDecimal.new('0.5'), BigDecimal.new('1'), :decimal, true))
     end
 
     def test_update_numrange
       assert_equal_round_trip(@first_range, :num_range,
-                              BigDecimal.new('0.5')...BigDecimal.new('1'))
+                              pgrange(BigDecimal.new('0.5'), BigDecimal.new('1'), :decimal, true))
       assert_nil_round_trip(@first_range, :num_range,
-                            BigDecimal.new('0.5')...BigDecimal.new('0.5'))
+                            pgrange(BigDecimal.new('0.5'), BigDecimal.new('0.5'), :decimal, true))
     end
 
     def test_create_daterange
       assert_equal_round_trip(@new_range, :date_range,
-                              Range.new(Date.new(2012, 1, 1), Date.new(2013, 1, 1), true))
+                              pgrange(Date.new(2012, 1, 1), Date.new(2013, 1, 1), :date, true))
     end
 
     def test_update_daterange
       assert_equal_round_trip(@first_range, :date_range,
-                              Date.new(2012, 2, 3)...Date.new(2012, 2, 10))
+                              pgrange(Date.new(2012, 2, 3), Date.new(2012, 2, 10), :date, true))
       assert_nil_round_trip(@first_range, :date_range,
-                            Date.new(2012, 2, 3)...Date.new(2012, 2, 3))
+                            pgrange(Date.new(2012, 2, 3), Date.new(2012, 2, 3), :date, true))
     end
 
     def test_create_int4range
-      assert_equal_round_trip(@new_range, :int4_range, Range.new(3, 50, true))
+      assert_equal_round_trip(@new_range, :int4_range, pgrange(3, 50, :integer, true))
     end
 
     def test_update_int4range
-      assert_equal_round_trip(@first_range, :int4_range, 6...10)
-      assert_nil_round_trip(@first_range, :int4_range, 3...3)
+      assert_equal_round_trip(@first_range, :int4_range, pgrange(6, 10, :integer, true))
+      assert_nil_round_trip(@first_range, :int4_range, pgrange(3, 3, :integer, true))
     end
 
     def test_create_int8range
-      assert_equal_round_trip(@new_range, :int8_range, Range.new(30, 50, true))
+      assert_equal_round_trip(@new_range, :int8_range, pgrange(30, 50, :integer, true))
     end
 
     def test_update_int8range
-      assert_equal_round_trip(@first_range, :int8_range, 60000...10000000)
-      assert_nil_round_trip(@first_range, :int8_range, 39999...39999)
+      assert_equal_round_trip(@first_range, :int8_range, pgrange(60000, 10000000, :integer, true))
+      assert_nil_round_trip(@first_range, :int8_range, pgrange(39999, 39999, :integer, true))
     end
 
-    def test_exclude_beginning_for_subtypes_with_succ_method_is_deprecated
-      tz = ::ActiveRecord::Base.default_timezone
-
-      silence_warnings {
-        assert_deprecated {
-          range = PostgresqlRange.create!(date_range: "(''2012-01-02'', ''2012-01-04'']")
-          assert_equal Date.new(2012, 1, 3)..Date.new(2012, 1, 4), range.date_range
-        }
-        assert_deprecated {
-          range = PostgresqlRange.create!(ts_range: "(''2010-01-01 14:30'', ''2011-01-01 14:30'']")
-          assert_equal Time.send(tz, 2010, 1, 1, 14, 30, 1)..Time.send(tz, 2011, 1, 1, 14, 30, 0), range.ts_range
-        }
-        assert_deprecated {
-          range = PostgresqlRange.create!(tstz_range: "(''2010-01-01 14:30:00+05'', ''2011-01-01 14:30:00-03'']")
-          assert_equal Time.parse('2010-01-01 09:30:01 UTC')..Time.parse('2011-01-01 17:30:00 UTC'), range.tstz_range
-        }
-        assert_deprecated {
-          range = PostgresqlRange.create!(int4_range: "(1, 10]")
-          assert_equal 2..10, range.int4_range
-        }
-        assert_deprecated {
-          range = PostgresqlRange.create!(int8_range: "(10, 100]")
-          assert_equal 11..100, range.int8_range
-        }
-      }
-    end
-
-    def test_exclude_beginning_for_subtypes_without_succ_method_is_not_supported
-      assert_raises(ArgumentError) { PostgresqlRange.create!(num_range: "(0.1, 0.2]") }
-      assert_raises(ArgumentError) { PostgresqlRange.create!(float_range: "(0.5, 0.7]") }
+    def test_cast_range_to_pgrange
+      round_trip(@first_range, :int4_range, 30...40)
+      assert_equal(@first_range.int4_range, pgrange(30, 40, :integer, true))
     end
 
     private
@@ -303,6 +276,10 @@ _SQL
             '#{values[:float_range]}'
           )
         SQL
+      end
+
+      def pgrange(from, to, subtype, excl_end=false, excl_start=false)
+        ActiveRecord::ConnectionAdapters::PostgreSQL::PGRange.new(from, to, subtype, :exclude_end => excl_end, :exclude_start => excl_start)
       end
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -107,6 +107,10 @@ _SQL
       assert_equal :int8range, @first_range.column_for_attribute(:int8_range).type
     end
 
+    def test_transformed_discrete_range
+      assert_equal pgrange(1, 10, :integer), @first_range.int4_range
+    end
+
     def test_int4range_values
       assert_equal 1...11, @first_range.int4_range.to_range
       assert_equal 1...10, @second_range.int4_range.to_range


### PR DESCRIPTION
Addresses #14010.

Adding a new class `PGRange` that PostgreSQL Ranges will map to instead of Ruby Ranges. The new PGRange class addresses the shortcomings when attempting to directly translate the Postgres Range to Ruby Range. Namely, Ruby ranges do not support unbound beginnings and ends, nor do they support exclusive beginnings.
