### PR TITLE
Refactor delete_records method

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -194,7 +194,7 @@ module ActiveRecord
                       options[:dependent]
                     end
 
-        delete_all_records(dependent).tap do
+        delete_or_nullify_all_records(dependent).tap do
           reset
           loaded!
         end

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -194,7 +194,7 @@ module ActiveRecord
                       options[:dependent]
                     end
 
-        delete_records(:all, dependent).tap do
+        delete_all_records(dependent).tap do
           reset
           loaded!
         end

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -105,11 +105,8 @@ module ActiveRecord
           }
         end
 
-        def delete_count(records, method, scope)
-          case method
-          when :destroy
-            records.length
-          when :delete_all
+        def delete_count(method, scope)
+          if method == :delete_all
             scope.delete_all
           else
             scope.update_all(reflection.foreign_key => nil)
@@ -117,23 +114,19 @@ module ActiveRecord
         end
 
         def delete_all_records(method)
-          scope = self.scope
-
-          count = delete_count(:all, method, scope)
-
+          count = delete_count(method, self.scope)
           update_counter(-count)
         end
 
         # Deletes the records according to the <tt>:dependent</tt> option.
         def delete_records(records, method)
-          scope = self.scope.where(reflection.klass.primary_key => records)
-
-          count = delete_count(records, method, scope)
-
           if method == :destroy
+            count = records.length
             records.each(&:destroy!)
             update_counter(-count) unless inverse_updates_counter_cache?
           else
+            scope = self.scope.where(reflection.klass.primary_key => records)
+            count = delete_count(method, scope)
             update_counter(-count)
           end
         end

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -113,7 +113,7 @@ module ActiveRecord
           end
         end
 
-        def delete_all_records(method)
+        def delete_or_nullify_all_records(method)
           count = delete_count(method, self.scope)
           update_counter(-count)
         end

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -121,13 +121,11 @@ module ActiveRecord
         # Deletes the records according to the <tt>:dependent</tt> option.
         def delete_records(records, method)
           if method == :destroy
-            count = records.length
             records.each(&:destroy!)
-            update_counter(-count) unless inverse_updates_counter_cache?
+            update_counter(-records.length) unless inverse_updates_counter_cache?
           else
             scope = self.scope.where(reflection.klass.primary_key => records)
-            count = delete_count(method, scope)
-            update_counter(-count)
+            update_counter(-delete_count(method, scope))
           end
         end
 

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -130,6 +130,10 @@ module ActiveRecord
           end
         end
 
+        def delete_all_records(method)
+          delete_records(:all, method)
+        end
+
         def delete_records(records, method)
           ensure_not_nested
 

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -130,16 +130,12 @@ module ActiveRecord
           end
         end
 
-        def delete_all_records(method)
-          delete_records(:all, method)
+        def delete_or_nullify_all_records(method)
+          delete_records(load_target, method)
         end
 
         def delete_records(records, method)
           ensure_not_nested
-
-          # This is unoptimised; it will load all the target records
-          # even when we just want to delete everything.
-          records = load_target if records == :all
 
           scope = through_association.scope
           scope.where! construct_join_attributes(*records)


### PR DESCRIPTION
`delete_records` had a lot of conditionals and was generally confusing code.

This pulls out anything that deals with just `delete_all` into it's own method `delete_or_nullify_all_records` for any association that has delete_all run on it. 

This uses a new `delete_count` method that takes a method and a scope and is shared between `delete_records` and `delete_or_nullify_all_records`. This handles whether `delete_all` or `update_all` is run on the scope — count being the number `update_counter` is getting passed.

The `delete_or_nullify_all_records` method had to be created in hm:t association as well because of how the methods are chained/coupled. I plan to refactor hm:t `delete_records` eventually as well.

This has allowed for the removal of using :all symbol to check if we are deleting all records further optimizing the code. I was then able to remove the unoptimized `records = load_target if records == :all` in `delete_records`.

The results of delete/delete_all/destroy/destroy_all are the same, this change decouples and improves this part of the code.

cc/ @tenderlove
