### PR TITLE
remove deprecation warning

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove deprecated string based terminators for `ActiveSupport::Callbacks`.
+
+    *Eileen M. Uchitelle*
+
 *   Fixed an issue when using
     `ActiveSupport::NumberHelper::NumberToDelimitedConverter` to
     convert a value that is an `ActiveSupport::SafeBuffer` introduced

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -724,12 +724,6 @@ module ActiveSupport
       #   would call <tt>Audit#save</tt>.
       def define_callbacks(*names)
         options = names.extract_options!
-        if options.key?(:terminator) && String === options[:terminator]
-          ActiveSupport::Deprecation.warn "String based terminators are deprecated, please use a lambda"
-          value = options[:terminator]
-          line = class_eval "lambda { |result| #{value} }", __FILE__, __LINE__
-          options[:terminator] = lambda { |target, result| target.instance_exec(result, &line) }
-        end
 
         names.each do |name|
           class_attribute "_#{name}_callbacks"


### PR DESCRIPTION
This deprecation was released in 4.1.0 and can be removed for 4.2.0,
deprecation message / handling is no longer necessary.
