### PR TITLE
Form full URI as string to be parsed in Rack::Test.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Build full URI as string when processing path in integration tests for
+    performance reasons.
+
+    *Guo Xiang Tan*
+
 *   Fix 'Stack level too deep' when rendering `head :ok` in an action method
     called 'status' in a controller.
 

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -300,13 +300,7 @@ module ActionDispatch
 
           # NOTE: rack-test v0.5 doesn't build a default uri correctly
           # Make sure requested path is always a full uri
-          uri = URI.parse('/')
-          uri.scheme ||= env['rack.url_scheme']
-          uri.host   ||= env['SERVER_NAME']
-          uri.port   ||= env['SERVER_PORT'].try(:to_i)
-          uri += path
-
-          session.request(uri.to_s, env)
+          session.request(build_full_uri(path, env), env)
 
           @request_count += 1
           @request  = ActionDispatch::Request.new(session.last_request.env)
@@ -318,6 +312,10 @@ module ActionDispatch
           @controller = session.last_request.env['action_controller.instance']
 
           return response.status
+        end
+
+        def build_full_uri(path, env)
+          "#{env['rack.url_scheme']}://#{env['SERVER_NAME']}:#{env['SERVER_PORT']}#{path}"
         end
     end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1723,7 +1723,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       get "whatever/:controller(/:action(/:id))"
     end
 
-    get 'whatever/foo/bar'
+    get '/whatever/foo/bar'
     assert_equal 'foo#bar', @response.body
 
     assert_equal 'http://www.example.com/whatever/foo/bar/1',
@@ -1735,10 +1735,10 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       get "whatever/:controller(/:action(/:id))", :id => /\d+/
     end
 
-    get 'whatever/foo/bar/show'
+    get '/whatever/foo/bar/show'
     assert_equal 'foo/bar#show', @response.body
 
-    get 'whatever/foo/bar/show/1'
+    get '/whatever/foo/bar/show/1'
     assert_equal 'foo/bar#show', @response.body
 
     assert_equal 'http://www.example.com/whatever/foo/bar/show',
@@ -2287,12 +2287,12 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       get "(/user/:username)/photos" => "photos#index"
     end
 
-    get 'user/bob/photos'
+    get '/user/bob/photos'
     assert_equal 'photos#index', @response.body
     assert_equal 'http://www.example.com/user/bob/photos',
       url_for(:controller => "photos", :action => "index", :username => "bob")
 
-    get 'photos'
+    get '/photos'
     assert_equal 'photos#index', @response.body
     assert_equal 'http://www.example.com/photos',
       url_for(:controller => "photos", :action => "index", :username => nil)
@@ -3492,7 +3492,7 @@ class TestNamespaceWithControllerOption < ActionDispatch::IntegrationTest
       resources :storage_files, :controller => 'admin/storage_files'
     end
 
-    get 'storage_files'
+    get '/storage_files'
     assert_equal "admin/storage_files#index", @response.body
   end
 


### PR DESCRIPTION
There are performance gains to be made by avoiding URI setter methods.
