### PR TITLE
Fix reference to sanitize helper test suite

### DIFF
--- a/actionview/test/template/sanitize_helper_test.rb
+++ b/actionview/test/template/sanitize_helper_test.rb
@@ -1,6 +1,6 @@
 require 'abstract_unit'
 
-# The exhaustive tests are in test/controller/html/sanitizer_test.rb.
+# The exhaustive tests are in  test/template/html-scanner/sanitizer_test.rb
 # This tests the that the helpers hook up correctly to the sanitizer classes.
 class SanitizeHelperTest < ActionView::TestCase
   tests ActionView::Helpers::SanitizeHelper


### PR DESCRIPTION
The sanitize helper tests comment points to a directory that does (no longer?) exist. Changed this to refer to the directory i found.
