### PR TITLE
Reverse defaults for including password in dbconsole

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `rails dbconsole` includes password from database.yml by default and
+    `-p` argument have reverse effect - when passed asks for password.
+
+    *Łukasz Strzałkowski*
+
 *   Load database configuration from the first
     database.yml available in paths.
 

--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -17,6 +17,7 @@ module Rails
 
     def start
       options = parse_arguments(arguments)
+
       ENV['RAILS_ENV'] = options[:environment] || environment
 
       case config["adapter"]
@@ -37,7 +38,7 @@ module Rails
         if config['password'] && options['include_password']
           args << "--password=#{config['password']}"
         elsif config['password'] && !config['password'].to_s.empty?
-          args << "-p"
+          args << "-a"
         end
 
         args << config['database']
@@ -106,12 +107,12 @@ module Rails
     end
 
     def parse_arguments(arguments)
-      options = {}
+      options = { 'include_password' => true }
 
       OptionParser.new do |opt|
         opt.banner = "Usage: rails dbconsole [environment] [options]"
-        opt.on("-p", "--include-password", "Automatically provide the password from database.yml") do |v|
-          options['include_password'] = true
+        opt.on("-a", "--ask-for-password", "Ask for password explicitly") do |v|
+          options['include_password'] = false
         end
 
         opt.on("--mode [MODE]", ['html', 'list', 'line', 'column'],

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -109,14 +109,14 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   end
 
   def test_mysql_full
-    dbconsole.expects(:find_cmd_and_exec).with(%w[mysql mysql5], '--host=locahost', '--port=1234', '--socket=socket', '--user=user', '--default-character-set=UTF-8', '-p', 'db')
+    dbconsole.expects(:find_cmd_and_exec).with(%w[mysql mysql5], '--host=locahost', '--port=1234', '--socket=socket', '--user=user', '--default-character-set=UTF-8', '--password=qwerty', 'db')
     start(adapter: 'mysql', database: 'db', host: 'locahost', port: 1234, socket: 'socket', username: 'user', password: 'qwerty', encoding: 'UTF-8')
     assert !aborted
   end
 
   def test_mysql_include_password
     dbconsole.expects(:find_cmd_and_exec).with(%w[mysql mysql5], '--user=user', '--password=qwerty', 'db')
-    start({adapter: 'mysql', database: 'db', username: 'user', password: 'qwerty'}, ['-p'])
+    start(adapter: 'mysql', database: 'db', username: 'user', password: 'qwerty')
     assert !aborted
   end
 
@@ -133,12 +133,12 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     assert_equal 'user', ENV['PGUSER']
     assert_equal 'host', ENV['PGHOST']
     assert_equal '5432', ENV['PGPORT']
-    assert_not_equal 'q1w2e3', ENV['PGPASSWORD']
+    assert_equal 'q1w2e3', ENV['PGPASSWORD']
   end
 
   def test_postgresql_include_password
     dbconsole.expects(:find_cmd_and_exec).with('psql', 'db')
-    start({adapter: 'postgresql', database: 'db', username: 'user', password: 'q1w2e3'}, ['-p'])
+    start(adapter: 'postgresql', database: 'db', username: 'user', password: 'q1w2e3')
     assert !aborted
     assert_equal 'user', ENV['PGUSER']
     assert_equal 'q1w2e3', ENV['PGPASSWORD']
@@ -182,14 +182,14 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   end
 
   def test_oracle
-    dbconsole.expects(:find_cmd_and_exec).with('sqlplus', 'user@db')
+    dbconsole.expects(:find_cmd_and_exec).with('sqlplus', 'user/secret@db')
     start(adapter: 'oracle', database: 'db', username: 'user', password: 'secret')
     assert !aborted
   end
 
   def test_oracle_include_password
     dbconsole.expects(:find_cmd_and_exec).with('sqlplus', 'user/secret@db')
-    start({adapter: 'oracle', database: 'db', username: 'user', password: 'secret'}, ['-p'])
+    start(adapter: 'oracle', database: 'db', username: 'user', password: 'secret')
     assert !aborted
   end
 


### PR DESCRIPTION
I think most of the users always run `rails dbconsole` with `-p`. Let's change this and make `-p` default parameter.

Should we deprecate it somehow? Should we change short option (`-p`) into something different to avoid confusion? (same param will have different, reverse, effect now).

/cc @rafaelfranca
