### PR TITLE
Make the transactional callbacks act in the same order as all other ones

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Change the order of execution of transactional fixtures so that they are executed in order
+    in which they were defined as opposed to reverse order before. That makes them consistent
+    with all other callbacks.
+
+    This behavior may be switched to the old one with retain_reversed_transactional_callbacks_order
+    option.
+
+    *Piotr Jakubowski*
+
 ## Rails 5.0.0.beta2 (February 01, 2016) ##
 
 *   `ActiveRecord::Relation#reverse_order` throws `ActiveRecord::IrreversibleOrderError`

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -6,6 +6,15 @@ module ActiveRecord
     ACTIONS = [:create, :destroy, :update]
 
     included do
+      ##
+      # :singleton-method:
+      #
+      # Determines whether transactional callbacks should be executed in order of definition
+      # (as all other callbacks) or in reverse order as in Rails 4.
+      #
+      mattr_accessor :retain_reversed_transactional_callbacks_order, instance_writer: false
+      self.retain_reversed_transactional_callbacks_order = false
+
       define_callbacks :commit, :rollback,
                        :before_commit,
                        :before_commit_without_transaction_enrollment,
@@ -289,6 +298,7 @@ module ActiveRecord
       def set_options_for_callbacks!(args, enforced_options = {})
         options = args.extract_options!.merge!(enforced_options)
         args << options
+        options[:prepend] = true unless self.retain_reversed_transactional_callbacks_order
 
         if options[:on]
           fire_on = Array(options[:on])

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -289,11 +289,11 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :after_save,                  :proc   ],
       [ :after_save,                  :object ],
       [ :after_save,                  :block  ],
-      [ :after_commit,                :block  ],
-      [ :after_commit,                :object ],
-      [ :after_commit,                :proc   ],
+      [ :after_commit,                :method ],
       [ :after_commit,                :string ],
-      [ :after_commit,                :method ]
+      [ :after_commit,                :proc   ],
+      [ :after_commit,                :object ],
+      [ :after_commit,                :block  ]
     ], david.history
   end
 
@@ -363,11 +363,11 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :after_save,                  :proc   ],
       [ :after_save,                  :object ],
       [ :after_save,                  :block  ],
-      [ :after_commit,                :block  ],
-      [ :after_commit,                :object ],
-      [ :after_commit,                :proc   ],
+      [ :after_commit,                :method ],
       [ :after_commit,                :string ],
-      [ :after_commit,                :method ]
+      [ :after_commit,                :proc   ],
+      [ :after_commit,                :object ],
+      [ :after_commit,                :block  ]
     ], david.history
   end
 
@@ -419,11 +419,11 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :after_destroy,               :proc   ],
       [ :after_destroy,               :object ],
       [ :after_destroy,               :block  ],
-      [ :after_commit,                :block  ],
-      [ :after_commit,                :object ],
-      [ :after_commit,                :proc   ],
+      [ :after_commit,                :method ],
       [ :after_commit,                :string ],
-      [ :after_commit,                :method ]
+      [ :after_commit,                :proc   ],
+      [ :after_commit,                :object ],
+      [ :after_commit,                :block  ]
     ], david.history
   end
 
@@ -585,11 +585,11 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :before_validation,           :object ],
       [ :before_validation,           :block  ],
       [ :before_validation, :returning_false  ],
-      [ :after_rollback, :block  ],
-      [ :after_rollback, :object ],
-      [ :after_rollback, :proc   ],
-      [ :after_rollback, :string ],
       [ :after_rollback, :method ],
+      [ :after_rollback, :string ],
+      [ :after_rollback, :proc   ],
+      [ :after_rollback, :object ],
+      [ :after_rollback, :block  ]
     ], david.history
   end
 
@@ -613,11 +613,11 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :before_validation, :object ],
       [ :before_validation, :block  ],
       [ :before_validation, :throwing_abort ],
-      [ :after_rollback,    :block  ],
-      [ :after_rollback,    :object ],
-      [ :after_rollback,    :proc   ],
-      [ :after_rollback,    :string ],
       [ :after_rollback,    :method ],
+      [ :after_rollback,    :string ],
+      [ :after_rollback,    :proc   ],
+      [ :after_rollback,    :object ],
+      [ :after_rollback,    :block  ],
     ], david.history
   end
 


### PR DESCRIPTION
All the calllbacks except for transactional are executed in the order they are defined. Transactional callbacks are executed in reverse order. It's because active_model/callbacks#_define_after_model_callback forces options[:prepend] = true. This means that every after_\* callback gets prepend = true by default. Transactional callbacks have their own methods defined in active_record/transaction. Methods for after_commit and after_rollback did not enfore the options[:prepend] = true and that's where the inconsistency comes from.
