### PR TITLE
Rename all instances of Jadedpixel to Shopify

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1202,11 +1202,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     core = companies(:rails_core)
     assert_equal accounts(:rails_core_account), core.account
-    assert_equal companies(:leetsoft, :jadedpixel), core.companies
+    assert_equal companies(:leetsoft, :shopify), core.companies
     core.destroy
     assert_nil accounts(:rails_core_account).reload.firm_id
     assert_nil companies(:leetsoft).reload.client_of
-    assert_nil companies(:jadedpixel).reload.client_of
+    assert_nil companies(:shopify).reload.client_of
 
     assert_equal num_accounts, Account.count
   end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -309,13 +309,13 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_should_group_by_scoped_field
     c = companies(:rails_core).companies.group(:name).sum(:id)
     assert_equal 7, c['Leetsoft']
-    assert_equal 8, c['Jadedpixel']
+    assert_equal 8, c['Shopify']
   end
 
   def test_should_group_by_summed_field_through_association_and_having
     c = companies(:rails_core).companies.group(:name).having('sum(id) > 7').sum(:id)
     assert_nil      c['Leetsoft']
-    assert_equal 8, c['Jadedpixel']
+    assert_equal 8, c['Shopify']
   end
 
   def test_should_count_selected_field_with_include

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -923,7 +923,7 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_select_values
     assert_equal ["1","2","3","4","5","6","7","8","9", "10", "11"], Company.connection.select_values("SELECT id FROM companies ORDER BY id").map! { |i| i.to_s }
-    assert_equal ["37signals","Summit","Microsoft", "Flamboyant Software", "Ex Nihilo", "RailsCore", "Leetsoft", "Jadedpixel", "Odegy", "Ex Nihilo Part Deux", "Apex"], Company.connection.select_values("SELECT name FROM companies ORDER BY id")
+    assert_equal ["37signals","Summit","Microsoft", "Flamboyant Software", "Ex Nihilo", "RailsCore", "Leetsoft", "Shopify", "Odegy", "Ex Nihilo Part Deux", "Apex"], Company.connection.select_values("SELECT name FROM companies ORDER BY id")
   end
 
   def test_select_rows

--- a/activerecord/test/fixtures/companies.yml
+++ b/activerecord/test/fixtures/companies.yml
@@ -48,9 +48,9 @@ leetsoft:
   name: Leetsoft
   client_of: 6
 
-jadedpixel:
+shopify:
   id: 8
-  name: Jadedpixel
+  name: Shopify
   client_of: 6
 
 odegy:


### PR DESCRIPTION
Just a simple renaming of fixtures referencing Jadedpixel to their more up-to-date Shopify counterpart.

/cc @arthurnn
