### PR TITLE
Add RFC 4791 MKCALENDAR method

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -115,4 +115,8 @@
 
     *Tony Wooster*
 
+*   Add MKCALENDAR HTTP method (RFC 4791)
+
+    *Sergey Karpesh*
+
 Please check [4-1-stable](https://github.com/rails/rails/blob/4-1-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -64,6 +64,7 @@ module ActionDispatch
     # Ordered Collections Protocol (WebDAV) (http://www.ietf.org/rfc/rfc3648.txt)
     # Web Distributed Authoring and Versioning (WebDAV) Access Control Protocol (http://www.ietf.org/rfc/rfc3744.txt)
     # Web Distributed Authoring and Versioning (WebDAV) SEARCH (http://www.ietf.org/rfc/rfc5323.txt)
+    # Calendar Extensions to WebDAV (http://www.ietf.org/rfc/rfc4791.txt)
     # PATCH Method for HTTP (http://www.ietf.org/rfc/rfc5789.txt)
     RFC2616 = %w(OPTIONS GET HEAD POST PUT DELETE TRACE CONNECT)
     RFC2518 = %w(PROPFIND PROPPATCH MKCOL COPY MOVE LOCK UNLOCK)
@@ -71,9 +72,10 @@ module ActionDispatch
     RFC3648 = %w(ORDERPATCH)
     RFC3744 = %w(ACL)
     RFC5323 = %w(SEARCH)
+    RFC4791 = %w(MKCALENDAR)
     RFC5789 = %w(PATCH)
 
-    HTTP_METHODS = RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC5789
+    HTTP_METHODS = RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC4791 + RFC5789
 
     HTTP_METHOD_LOOKUP = {}
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3553,6 +3553,7 @@ class TestHttpMethods < ActionDispatch::IntegrationTest
   RFC3648 = %w(ORDERPATCH)
   RFC3744 = %w(ACL)
   RFC5323 = %w(SEARCH)
+  RFC4791 = %w(MKCALENDAR)
   RFC5789 = %w(PATCH)
 
   def simple_app(response)
@@ -3564,13 +3565,13 @@ class TestHttpMethods < ActionDispatch::IntegrationTest
     @app = ActionDispatch::Routing::RouteSet.new
 
     @app.draw do
-      (RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC5789).each do |method|
+      (RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC4791 + RFC5789).each do |method|
         match '/' => s.simple_app(method), :via => method.underscore.to_sym
       end
     end
   end
 
-  (RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC5789).each do |method|
+  (RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC4791 + RFC5789).each do |method|
     test "request method #{method.underscore} can be matched" do
       get '/', nil, 'REQUEST_METHOD' => method
       assert_equal method, @response.body


### PR DESCRIPTION
Without it I get

```
ERROR ActionController::UnknownHttpMethod: MKCALENDAR, accepted HTTP methods are OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT, PROPFIND, PROPPATCH, MKCOL, COPY, MOVE, LOCK, UNLOCK, VERSION-CONTROL, REPORT, CHECKOUT, CHECKIN, UNCHECKOUT, MKWORKSPACE, UPDATE, LABEL, MERGE, BASELINE-CONTROL, MKACTIVITY, ORDERPATCH, ACL, SEARCH, and PATCH
```
