### PR TITLE
more appropriate doc for active_record .instantiate method 

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -37,7 +37,7 @@ module ActiveRecord
       end
 
       # Given an attributes hash, +instantiate+ returns a new instance of
-      # the appropriate class.
+      # the appropriate class. Accepts only keys as strings.
       #
       # For example, +Post.all+ may return Comments, Messages, and Emails
       # by storing the record's subclass in a +type+ attribute. By calling


### PR DESCRIPTION
Now it specifies that all Hash keys should be strings, because symbols are not supported. 

fixes #15107
