### PR TITLE
Change default to_time of distance_of_time_in_words to Time.now

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -68,7 +68,7 @@ module ActionView
       #   distance_of_time_in_words(from_time, to_time, include_seconds: true)                        # => about 6 years
       #   distance_of_time_in_words(to_time, from_time, include_seconds: true)                        # => about 6 years
       #   distance_of_time_in_words(Time.now, Time.now)                                               # => less than a minute
-      def distance_of_time_in_words(from_time, to_time = 0, options = {})
+      def distance_of_time_in_words(from_time, to_time = Time.now, options = {})
         options = {
           scope: :'datetime.distance_in_words'
         }.merge!(options)


### PR DESCRIPTION
Note : If someone from the core team is okay with this, I'll then make a Changelog entry and tests.

Most of the time you use `distance_of_time_in_words`, you deal with `Time.now`

Naively I tried to do :

``` ruby
distance_of_time_in_words(2.hours.from_now)
=> "More than 44 years"
```

Not very intuitive right ?

EDIT : Using Rails 3.2.x
