### PR TITLE
Transactions refactor

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       end
     end
 
-    class TransactionState
+    class TransactionState #:nodoc:
       attr_accessor :parent
 
       VALID_STATES = Set.new([:committed, :rolledback, nil])


### PR DESCRIPTION
This is part one of my transaction refactor, I have a slightly bigger piece coming but I'd like to get some feedback on this first.

The main motivation is that I'd like to :scissors: the awkward flow control in https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L215-L228. When I was getting back into this part of the code yesterday, I find the conditional dance here very disorienting.

After some fiddling I understood why that was necessary evil (more details in the commit notes, basically the evil `return` inside the yield necessitates the `ensure` dance). This is a best-effort refactor given those constraints. IMO it is still better than what we have, but I'd like some feedback, esp from eyes that haven't looked at this for a while.

The diff is not that great, so here is before/after:

``` ruby
      def within_new_transaction(options = {}) #:nodoc:
        transaction = begin_transaction(options)
        yield
      rescue Exception => error
        rollback_transaction if transaction
        raise
      ensure
        begin
          commit_transaction unless error
        rescue Exception
          rollback_transaction
          raise
        end
      end
```

``` ruby
      def within_transaction(transaction) #:nodoc:
        yield
      rescue Exception => error
        rollback_transaction
        raise
      ensure
        finalize_transaction unless error
      end

      def finalize_transaction #:nodoc:
        commit_transaction
      rescue Exception
        rollback_transaction
        raise
      end
```
