### PR TITLE
Remove unecessary require

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -1,5 +1,3 @@
-require 'thread'
-
 module ActiveRecord
   # See ActiveRecord::Transactions::ClassMethods for documentation.
   module Transactions


### PR DESCRIPTION
Was reading the first transaction code, and realized this require was added there and never removed.
https://github.com/rails/rails/blob/db045dbb/activerecord/lib/active_record/transactions.rb

@rafaelfranca @chancancode
