### PR TITLE
Fix symbol at guides getting_started.md

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -89,7 +89,7 @@ Open up a command line prompt. On Mac OS X open Terminal.app, on Windows choose
 dollar sign `$` should be run in the command line. Verify that you have a
 current version of Ruby installed:
 
-TIP. A number of tools exist to help you quickly install Ruby and Ruby
+TIP: A number of tools exist to help you quickly install Ruby and Ruby
 on Rails on your system. Windows users can use [Rails Installer](http://railsinstaller.org),
 while Mac OS X users can use [Tokaido](https://github.com/tokaido/tokaidoapp).
 


### PR DESCRIPTION
A colon was used in other parts.
I repaired it because it became a period here.
