### PR TITLE
Fix app generator test hanging.

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -194,10 +194,6 @@ module Rails
         build(:bin)
       end
 
-      def create_config_files
-        build(:config)
-      end
-
       def update_config_files
         build(:config_when_updating)
       end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -119,7 +119,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true },
                                                                destination_root: app_moved_root, shell: @shell
     generator.send(:app_const)
-    quietly { generator.send(:create_config_files) }
+    quietly { generator.send(:update_config_files) }
     assert_file "myapp_moved/config/environment.rb", /Rails\.application\.initialize!/
     assert_file "myapp_moved/config/initializers/session_store.rb", /_myapp_session/
   end
@@ -134,7 +134,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
     generator.send(:app_const)
-    quietly { generator.send(:create_config_files) }
+    quietly { generator.send(:update_config_files) }
     assert_file "myapp/config/initializers/session_store.rb", /_myapp_session/
   end
 


### PR DESCRIPTION
This fixes an issue (introduced in 8941d5a3) that was preventing `AppGeneratorTest` from running.
