### PR TITLE
Default config.assets.digests to true in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'jquery-rails', '~> 3.1.0'
 gem 'turbolinks'
 gem 'coffee-rails', '~> 4.0.0'
 gem 'arel', github: 'rails/arel', branch: 'master'
-gem 'sprockets-rails', github: 'rails/sprockets-rails', branch: '2-1-stable'
+gem 'sprockets-rails', github: 'rails/sprockets-rails', branch: 'master'
 gem 'i18n', github: 'svenfuchs/i18n', branch: 'master'
 
 # require: false so bcrypt is loaded only when has_secure_password is used.

--- a/guides/code/getting_started/config/environments/development.rb
+++ b/guides/code/getting_started/config/environments/development.rb
@@ -27,4 +27,12 @@ Rails.application.configure do
 
   # Debug mode disables concatenation and preprocessing of assets.
   config.assets.debug = true
+
+  # Generate digests for assets URLs.
+  config.assets.digest = true
+
+  # Adds additional error checking when serving assets at runtime.
+  # Checks for improperly declared sprockets dependencies.
+  # Raises helpful error messages.
+  config.assets.raise_runtime_errors = true
 end

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -198,12 +198,9 @@ will result in your assets being included more than once.
 
 WARNING: When using asset precompilation, you will need to ensure that your
 controller assets will be precompiled when loading them on a per page basis. By
-default .coffee and .scss files will not be precompiled on their own. This will
-result in false positives during development as these files will work just fine
-since assets are compiled on the fly in development mode. When running in
-production, however, you will see 500 errors since live compilation is turned
-off by default. See [Precompiling Assets](#precompiling-assets) for more
-information on how precompiling works.
+default .coffee and .scss files will not be precompiled on their own. See
+[Precompiling Assets](#precompiling-assets) for more information on how
+precompiling works.
 
 NOTE: You must have an ExecJS supported runtime in order to use CoffeeScript.
 If you are using Mac OS X or Windows, you have a JavaScript runtime installed in
@@ -581,8 +578,21 @@ runtime. To disable this behavior you can set:
 config.assets.raise_runtime_errors = false
 ```
 
-When this option is true asset pipeline will check if all the assets loaded in your application
-are included in the `config.assets.precompile` list.
+When this option is true, the asset pipeline will check if all the assets loaded
+in your application are included in the `config.assets.precompile` list.
+If `config.assets.digests` is also true, the asset pipeline will require that
+all requests for assets include digests.
+
+### Turning Digests Off
+
+You can turn off digests by updating `config/environments/development.rb` to
+include:
+
+```ruby
+config.assets.digests = false
+```
+
+When this option is true, digests will be generated for asset URLs.
 
 ### Turning Debugging Off
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Default `config.assets.digest` to `true` in development.
+
+    *Dan Kang*
+
 *   Load database configuration from the first
     database.yml available in paths.
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -30,6 +30,9 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
+  # Generate digests for assets URLs.
+  config.assets.digest = true
+
   # Adds additional error checking when serving assets at runtime.
   # Checks for improperly declared sprockets dependencies.
   # Raises helpful error messages.

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -50,6 +50,8 @@ module ApplicationTests
         end
       RUBY
 
+      add_to_env_config "development", "config.assets.digest = false"
+
       require "#{app_path}/config/environment"
 
       get "/assets/demo.js"
@@ -189,7 +191,6 @@ module ApplicationTests
     end
 
     test "asset pipeline should use a Sprockets::Index when config.assets.digest is true" do
-      add_to_config "config.assets.digest = true"
       add_to_config "config.action_controller.perform_caching = false"
 
       ENV["RAILS_ENV"] = "production"
@@ -202,8 +203,6 @@ module ApplicationTests
       app_file "app/assets/images/rails.png", "notactuallyapng"
       app_file "app/assets/stylesheets/application.css.erb", "<%= asset_path('rails.png') %>"
       app_file "app/assets/javascripts/application.js", "alert();"
-      # digest is default in false, we must enable it for test environment
-      add_to_config "config.assets.digest = true"
 
       precompile!
       manifest = Dir["#{app_path}/public/assets/manifest-*.json"].first
@@ -215,8 +214,6 @@ module ApplicationTests
 
     test "the manifest file should be saved by default in the same assets folder" do
       app_file "app/assets/javascripts/application.js", "alert();"
-      # digest is default in false, we must enable it for test environment
-      add_to_config "config.assets.digest = true"
       add_to_config "config.assets.prefix = '/x'"
 
       precompile!
@@ -249,7 +246,6 @@ module ApplicationTests
     test "precompile properly refers files referenced with asset_path and runs in the provided RAILS_ENV" do
       app_file "app/assets/images/rails.png", "notactuallyapng"
       app_file "app/assets/stylesheets/application.css.erb", "<%= asset_path('rails.png') %>"
-      # digest is default in false, we must enable it for test environment
       add_to_env_config "test", "config.assets.digest = true"
 
       precompile!('RAILS_ENV=test')
@@ -281,12 +277,9 @@ module ApplicationTests
     test "precompile appends the md5 hash to files referenced with asset_path and run in production with digest true" do
       app_file "app/assets/images/rails.png", "notactuallyapng"
       app_file "app/assets/stylesheets/application.css.erb", "<%= asset_path('rails.png') %>"
-      add_to_config "config.assets.compile = true"
-      add_to_config "config.assets.digest = true"
 
-      ENV["RAILS_ENV"] = nil
-
-      precompile!('RAILS_GROUPS=assets')
+      ENV["RAILS_ENV"] = "production"
+      precompile!
 
       file = Dir["#{app_path}/public/assets/application-*.css"].first
       assert_match(/\/assets\/rails-([0-z]+)\.png/, File.read(file))
@@ -342,6 +335,8 @@ module ApplicationTests
         end
       RUBY
 
+      add_to_env_config "development", "config.assets.digest = false"
+
       require "#{app_path}/config/environment"
 
       class ::OmgController < ActionController::Base
@@ -365,6 +360,8 @@ module ApplicationTests
       end
 
       app_file "app/assets/javascripts/demo.js", "alert();"
+
+      add_to_env_config "development", "config.assets.digest = false"
 
       require "#{app_path}/config/environment"
 
@@ -395,7 +392,6 @@ module ApplicationTests
       app_file "app/assets/javascripts/application.js", "//= require_tree ."
       app_file "app/assets/javascripts/xmlhr.js.erb", "<%= Post.name %>"
 
-      add_to_config "config.assets.digest = false"
       precompile!
       assert_equal "Post;\n", File.read(Dir["#{app_path}/public/assets/application-*.js"].first)
     end
@@ -415,7 +411,6 @@ module ApplicationTests
     test "digested assets are not mistakenly removed" do
       app_file "app/assets/application.js", "alert();"
       add_to_config "config.assets.compile = true"
-      add_to_config "config.assets.digest = true"
 
       precompile!
 
@@ -438,6 +433,7 @@ module ApplicationTests
     test "asset urls should use the request's protocol by default" do
       app_with_assets_in_view
       add_to_config "config.asset_host = 'example.com'"
+      add_to_env_config "development", "config.assets.digest = false"
       require "#{app_path}/config/environment"
       class ::PostsController < ActionController::Base; end
 
@@ -452,6 +448,7 @@ module ApplicationTests
       app_file "app/assets/javascripts/image_loader.js.erb", "var src='<%= image_path('rails.png') %>';"
       add_to_config "config.assets.precompile = %w{rails.png image_loader.js}"
       add_to_config "config.asset_host = 'example.com'"
+      add_to_env_config "development", "config.assets.digest = false"
       precompile!
 
       assert_match "src='//example.com/assets/rails.png'", File.read(Dir["#{app_path}/public/assets/image_loader-*.js"].first)
@@ -460,9 +457,9 @@ module ApplicationTests
     test "asset paths should use RAILS_RELATIVE_URL_ROOT by default" do
       ENV["RAILS_RELATIVE_URL_ROOT"] = "/sub/uri"
       app_file "app/assets/images/rails.png", "notreallyapng"
-
       app_file "app/assets/javascripts/app.js.erb", "var src='<%= image_path('rails.png') %>';"
       add_to_config "config.assets.precompile = %w{rails.png app.js}"
+      add_to_env_config "development", "config.assets.digest = false"
       precompile!
 
       assert_match "src='/sub/uri/assets/rails.png'", File.read(Dir["#{app_path}/public/assets/app-*.js"].first)

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -34,6 +34,7 @@ module RailtiesTest
 
     test "serving sprocket's assets" do
       @plugin.write "app/assets/javascripts/engine.js.erb", "<%= :alert %>();"
+      add_to_env_config "development", "config.assets.digest = false"
 
       boot_rails
       require 'rack/test'
@@ -1080,6 +1081,7 @@ YAML
       RUBY
 
       add_to_config("config.railties_order = [:all, :main_app, Blog::Engine]")
+      add_to_env_config "development", "config.assets.digest = false"
 
       boot_rails
 


### PR DESCRIPTION
With https://github.com/rails/sprockets-rails/pull/149, assets will only be served if the request has a digest if `config.assets.digest = true` and `config.assets.raise_runtime_errors = true`.

This PR sets `config.assets.digest` to `true` by default and will help users avoid hardcoding paths that work in development but break in production.
