### PR TITLE
PostgreSQL timestamps should always be datetimes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -204,11 +204,8 @@ This is not reliable and will be removed in the future.
           end
         end
 
-        class Timestamp < Type
-          def type; :timestamp; end
-          def simplified_type(sql_type)
-            :datetime
-          end
+        class DateTime < Type
+          def type; :datetime; end
 
           def type_cast(value)
             return if value.nil?
@@ -483,7 +480,7 @@ This is not reliable and will be removed in the future.
         register_type 'bool', OID::Boolean.new
         register_type 'bit', OID::Bit.new
         alias_type 'varbit', 'bit'
-        register_type 'timestamp', OID::Timestamp.new
+        register_type 'timestamp', OID::DateTime.new
         alias_type 'timestamptz', 'timestamp'
         register_type 'date', OID::Date.new
         register_type 'time', OID::Time.new


### PR DESCRIPTION
The current behavior is that they are treated as `datetime` normally,
but if they are part of an array, they are treated as `timestamp`. The
only place that seems to be impacted by this is schema dumping, which
shouldn't matter since `t.datetime` and `t.timestamp` are equivalent in
the `PostgreSQL` adapter, anyway.
