### PR TITLE
Remove cruft now that strong_parameters is default

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -68,6 +68,7 @@ module ActiveModel
           validates_confirmation_of :password, if: ->{ password.present? }
         end
 
+        # This code is necessary as long as the protected_attributes gem is supported.
         if respond_to?(:attributes_protected_by_default)
           def self.attributes_protected_by_default #:nodoc:
             super + ['password_digest']


### PR DESCRIPTION
attributes_protected_by_default looks like it got remove when strong_parameters got introduced
so there doesn't seem to be a need for this.
