### PR TITLE
Fix a bug where AS::Dependencies changes the behaivior of NameError#name

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -515,8 +515,9 @@ module ActiveSupport #:nodoc:
         end
       end
 
-      raise NameError,
-            "uninitialized constant #{qualified_name}",
+      name_error = NameError.new("uninitialized constant #{qualified_name}", const_name)
+      raise name_error,
+            name_error.message,
             caller.reject { |l| l.starts_with? __FILE__ }
     end
 

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -367,9 +367,11 @@ class DependenciesTest < ActiveSupport::TestCase
     with_autoloading_fixtures do
       e = assert_raise(NameError) { A::DoesNotExist.nil? }
       assert_equal "uninitialized constant A::DoesNotExist", e.message
+      assert_equal :DoesNotExist, e.name
 
       e = assert_raise(NameError) { A::B::DoesNotExist.nil? }
       assert_equal "uninitialized constant A::B::DoesNotExist", e.message
+      assert_equal :DoesNotExist, e.name
     end
   end
 


### PR DESCRIPTION
I noticed that NameError objects loses a const name after `require 'active_support/dependencies'`. The following example replicates the bug fixed in this commit:

``` ruby
begin
  DoesNotExist
rescue NameError => e
  e.name # => :DoesNotExist
end

class A; end

begin
  A::DoesNotExistNeither
rescue NameError => e
  e.name # => :DoesNotExistNeither
end

require 'active_support/dependencies'

begin
  DoesNotExist
rescue NameError => e
  e.name # => nil
end

begin
  A::DoesNotExistNeither
rescue NameError => e
  e.name # => nil
end
```

This commit changes AS::Dependencies to not just raise NameError but create an object first and raise the object so `NameError#name` will never be `nil`.

I'll send other pull requests if I find this bug in more places in Rails.
