### PR TITLE
Correct ActiveModel::Conversion#to_key implementation

### DIFF
--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -49,7 +49,8 @@ module ActiveModel
     #   person = Person.create
     #   person.to_key # => [1]
     def to_key
-      key = respond_to?(:id) && id
+      defined_key = (self.class.try(:primary_key) || 'id')
+      key = respond_to?(defined_key) && public_send(defined_key)
       key ? [key] : nil
     end
 

--- a/activemodel/test/cases/conversion_with_persistance_test.rb
+++ b/activemodel/test/cases/conversion_with_persistance_test.rb
@@ -1,0 +1,27 @@
+require 'cases/helper'
+require 'active_record'
+
+class ConversionWithPersistanceTest < ActiveModel::TestCase
+  setup do
+    @klass = Class.new(ActiveRecord::Base) do
+      ActiveRecord::Base.establish_connection({ adapter: "sqlite3", database: "testing" })
+      ActiveRecord::Base.connection.create_table(:conversion_with_persistances) do |t|
+        t.string :name
+      end
+      self.table_name  = "conversion_with_persistances"
+      self.primary_key = "name"
+    end
+  end
+
+  teardown do
+    ActiveRecord::Base.connection.drop_table :conversion_with_persistances
+  end
+
+  test "to_key implementation for new ActiveRecord::Base inherited class object" do
+    assert_equal ['Aditya'], @klass.new(name: 'Aditya').to_key
+  end
+
+  test "to_key implementation for ActiveRecord::Base persisted class object" do
+    assert_equal ['Aditya'], @klass.create(name: 'Aditya').to_key
+  end
+end


### PR DESCRIPTION
The ActiveModel::Conversion#to_key should first check for the primary_key defined on the class of the object before opting for the hard-coded :id attribute.
