### PR TITLE
update LogTailer to tail logs when the request body is closed rather than when the middleware itself returns

### DIFF
--- a/railties/lib/rails/rack/log_tailer.rb
+++ b/railties/lib/rails/rack/log_tailer.rb
@@ -1,3 +1,5 @@
+require 'rack/body_proxy'
+
 module Rails
   module Rack
     class LogTailer
@@ -14,9 +16,8 @@ module Rails
       end
 
       def call(env)
-        response = @app.call(env)
-        tail!
-        response
+        status, headers, body = @app.call(env)
+        [status, headers, ::Rack::BodyProxy.new(body) { tail! }]
       end
 
       def tail!

--- a/railties/test/application/rack/log_tailer_test.rb
+++ b/railties/test/application/rack/log_tailer_test.rb
@@ -1,0 +1,36 @@
+require "isolation/abstract_unit"
+require "rails/rack/log_tailer"
+require "logger"
+require "tempfile"
+
+module ApplicationTests
+  module RackTests
+    class LogTailerTest < ActiveSupport::TestCase
+      include ActiveSupport::Testing::Isolation
+
+      # middleware that logs stuff when the request closes
+      class SomeMiddleware
+        def initialize(app, logger)
+          @app = app
+          @logger = logger
+        end
+
+        def call(env)
+          status, headers, body = @app.call(env)
+          [status, headers, ::Rack::BodyProxy.new(body) { @logger.info "things happened!" }]
+        end
+      end
+
+      test "tails logging that happens when the body is closed" do
+        logfile = Tempfile.new('log_tailer_test').tap { |f| f.sync = true }
+        logger = Logger.new(logfile)
+        stdout = capture(:stdout) do
+          app = Rails::Rack::LogTailer.new(SomeMiddleware.new(proc { |env| [200, {}, []] }, logger), logfile.path)
+          response = app.call({})
+          response.last.close
+        end
+        assert_match 'things happened!', stdout
+      end
+    end
+  end
+end


### PR DESCRIPTION
I encountered log tailing failing to show logs from some middleware in a timely manner (not showing up until the next request), which I found was due to the middleware doing logging when the request closes rather than when the middleware returns. this is not uncommon, e.g. rack's own logger does this (https://github.com/rack/rack/blob/master/lib/rack/commonlogger.rb#L35) 

to fix this I changed the LogTailer to operate when the request body is closed rather than when the middleware itself returns, using Rack::BodyProxy. 
