### PR TITLE
Require Autoload module properly before using it

### DIFF
--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -1,3 +1,5 @@
+require 'active_support/dependencies/autoload'
+
 module ActiveSupport
   module NumberHelper
     extend ActiveSupport::Autoload


### PR DESCRIPTION
When just using `require 'active_support/number_helper’`, it occurs error like the following

> /path/to/gems/activesupport-4.1.1/lib/active_support/number_helper.rb:3:in `module:NumberHelper': uninitialized constant ActiveSupport::Autoload (NameError)
