### PR TITLE
Return early on delete and destroy methods

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -244,6 +244,7 @@ module ActiveRecord
       # are actually removed from the database, that depends precisely on
       # +delete_records+. They are in any case removed from the collection.
       def delete(*records)
+        return if records.empty?
         _options = records.extract_options!
         dependent = _options[:dependent] || options[:dependent]
 
@@ -257,6 +258,7 @@ module ActiveRecord
       # Note that this method removes records from the database ignoring the
       # +:dependent+ option.
       def destroy(*records)
+        return if records.empty?
         records = find(records) if records.any? { |record| record.kind_of?(Fixnum) || record.kind_of?(String) }
         delete_or_destroy(records, :destroy)
       end


### PR DESCRIPTION
`destroy` and `delete` don't remove records if `records is empty` for example `category.categorizations.delete` will not delete any records. Add an early return to achieve the same result without running through the code that actually would delete the records if they were provided to the method.

Also fixed an incorrect comment / documentation that said `delete` called callbacks. 
