### PR TITLE
Add the PostgreSQL guide to the index page [ci skip]

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -118,6 +118,10 @@
       work_in_progress: true
       url: initialization.html
       description: This guide explains the internals of the Rails initialization process as of Rails 4
+    -
+      name: Active Record and PostgreSQL
+      url: active_record_postgresql.html
+      description: This guide covers PostgreSQL specific usage of Active Record
 -
   name: Extending Rails
   documents:


### PR DESCRIPTION
Hello,

This is just a tiny pull request that adds the PostgreSQL guide to the index page of guides.rubyonrails.org. It is currently located under the "Digging deeper" part and not the "Models" one as this is a specific use case but let me know if you find it more logical to move it.

By the way, really awesome work @senny! :heart:

Have a nice day.
