### PR TITLE
implement ActiveRecord::Base#pretty_print

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Implemented ActiveRecord::Base#pretty_print to work with PP.
+
+    *Ethan*
+
 *   Keep PostgreSQL `hstore` and `json` attributes as `Hash` in `@attributes`.
     Fixes duplication in combination with `store_accessor`.
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -432,6 +432,29 @@ module ActiveRecord
       "#<#{self.class} #{inspection}>"
     end
 
+    # Takes a PP and prettily prints this record to it, allowing you to get a nice result from `pp record` 
+    # when pp is required.
+    def pretty_print(pp)
+      pp.object_address_group(self) do
+        if defined?(@attributes) && @attributes
+          column_names = self.class.column_names.select { |name| has_attribute?(name) || new_record? }
+          pp.seplist(column_names, proc { pp.text ',' }) do |column_name|
+            column_value = read_attribute(column_name)
+            pp.breakable ' '
+            pp.group(1) do
+              pp.text column_name
+              pp.text ':'
+              pp.breakable
+              pp.pp column_value
+            end
+          end
+        else
+          pp.breakable ' '
+          pp.text 'not initialized'
+        end
+      end
+    end
+
     # Returns a hash of the given methods with their names as keys and returned values as values.
     def slice(*methods)
       Hash[methods.map! { |method| [method, public_send(method)] }].with_indifferent_access

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -1,6 +1,8 @@
 require 'cases/helper'
 require 'models/person'
 require 'models/topic'
+require 'pp'
+require 'active_support/core_ext/string/strip'
 
 class NonExistentTable < ActiveRecord::Base; end
 
@@ -29,5 +31,71 @@ class CoreTest < ActiveRecord::TestCase
 
   def test_inspect_class_without_table
     assert_equal "NonExistentTable(Table doesn't exist)", NonExistentTable.inspect
+  end
+
+  def test_pretty_print_new
+    topic = Topic.new
+    actual = ''
+    PP.pp(topic, StringIO.new(actual))
+    expected = <<-PRETTY.strip_heredoc
+    #<Topic:0xXXXXXX
+     id: nil,
+     title: nil,
+     author_name: nil,
+     author_email_address: "test@test.com",
+     written_on: nil,
+     bonus_time: nil,
+     last_read: nil,
+     content: nil,
+     important: nil,
+     approved: true,
+     replies_count: 0,
+     unique_replies_count: 0,
+     parent_id: nil,
+     parent_title: nil,
+     type: nil,
+     group: nil,
+     created_at: nil,
+     updated_at: nil>
+    PRETTY
+    assert actual.start_with?(expected.split('XXXXXX').first)
+    assert actual.end_with?(expected.split('XXXXXX').last)
+  end
+
+  def test_pretty_print_persisted
+    topic = topics(:first)
+    actual = ''
+    PP.pp(topic, StringIO.new(actual))
+    expected = <<-PRETTY.strip_heredoc
+    #<Topic:0x\\w+
+     id: 1,
+     title: "The First Topic",
+     author_name: "David",
+     author_email_address: "david@loudthinking.com",
+     written_on: 2003-07-16 14:28:11 UTC,
+     bonus_time: 2000-01-01 14:28:00 UTC,
+     last_read: Thu, 15 Apr 2004,
+     content: "Have a nice day",
+     important: nil,
+     approved: false,
+     replies_count: 1,
+     unique_replies_count: 0,
+     parent_id: nil,
+     parent_title: nil,
+     type: nil,
+     group: nil,
+     created_at: [^,]+,
+     updated_at: [^,>]+>
+    PRETTY
+    assert_match(/\A#{expected}\z/, actual)
+  end
+
+  def test_pretty_print_uninitialized
+    topic = Topic.allocate
+    actual = ''
+    PP.pp(topic, StringIO.new(actual))
+    expected = "#<Topic:XXXXXX not initialized>\n"
+    assert actual.start_with?(expected.split('XXXXXX').first)
+    assert actual.end_with?(expected.split('XXXXXX').last)
   end
 end


### PR DESCRIPTION
AR::B has long been lacking pretty print support. I submitted this patch some years ago (pre-github), attempting again. 

before:

```
pp topic

#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "2003-07-16 14:28:11", bonus_time: "2000-01-01 14:28:00", last_read: "2004-04-15", content: "Have a nice day", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "2014-05-18 21:33:26", updated_at: "2014-05-18 21:33:26">
```

(same as #inspect)

now: 

```
pp topic

#<Topic:0x007fb93696bcb0
 id: 1,
 title: "The First Topic",
 author_name: "David",
 author_email_address: "david@loudthinking.com",
 written_on: 2003-07-16 14:28:11 UTC,
 bonus_time: 2000-01-01 14:28:00 UTC,
 last_read: Thu, 15 Apr 2004,
 content: "Have a nice day",
 important: nil,
 approved: false,
 replies_count: 1,
 unique_replies_count: 0,
 parent_id: nil,
 parent_title: nil,
 type: nil,
 group: nil,
 created_at: 2014-05-18 21:31:53 UTC,
 updated_at: 2014-05-18 21:31:53 UTC>
```
