### PR TITLE
Deep merge query params onto request params

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -13,7 +13,7 @@ module ActionDispatch
       def parameters
         @env["action_dispatch.request.parameters"] ||= begin
           params = begin
-            request_parameters.merge(query_parameters)
+            request_parameters.deep_merge(query_parameters)
           rescue EOFError
             query_parameters.dup
           end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -892,6 +892,14 @@ class RequestParameters < BaseRequestTest
     assert_equal({"bar" => 2}, request.query_parameters)
   end
 
+  test "deep merge query parameters onto request parameters" do
+    request = stub_request
+    request.expects(:request_parameters).at_least_once.returns("baz" => { "foo" => 1, "bar" => 3 })
+    request.expects(:query_parameters).at_least_once.returns("baz" => { "bar" => 2 })
+
+    assert_equal({"baz" => {"foo" => 1, "bar" => 2}}, request.parameters)
+  end
+
   test "parameters still accessible after rack parse error" do
     request = stub_request("QUERY_STRING" => "x[y]=1&x[y][][w]=2")
 


### PR DESCRIPTION
I ran the following request the other day:

```
POST /user?profession[name]="Software Writer"
profession[level]="señor"
```

Here is the `params` hash I got:

``` ruby
profession: { name: "Software Writer" }
```

It seemed rather inadequate that the query parameters were not **deep** merged onto the request parameters.

This PR fixes this. The `params` hash is now:

``` ruby
profession: { name: "Software Engineer", level: "señor" }
```
