### PR TITLE
Deregister csv renderer after test to prevent leak.

### DIFF
--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -6,6 +6,11 @@ module ActionController
     Renderers.add(key, &block)
   end
 
+  # See <tt>Renderers.remove</tt>
+  def self.remove_renderer(key)
+    Renderers.remove(key)
+  end
+
   class MissingRenderer < LoadError
     def initialize(format)
       super "No renderer defined for format: #{format}"
@@ -81,6 +86,17 @@ module ActionController
     def self.add(key, &block)
       define_method("_render_option_#{key}", &block)
       RENDERERS << key.to_sym
+    end
+
+    # This method is the opposite of add method.
+    #
+    # Usage:
+    #
+    #   ActionController::Renderers.remove(:csv)
+    def self.remove(key)
+      RENDERERS.delete(key.to_sym)
+      method = "_render_option_#{key}"
+      remove_method(method) if method_defined?(method)
     end
 
     module All

--- a/actionpack/test/controller/mime/respond_with_test.rb
+++ b/actionpack/test/controller/mime/respond_with_test.rb
@@ -643,6 +643,8 @@ class RespondWithControllerTest < ActionController::TestCase
     get :index, format: 'csv'
     assert_equal Mime::CSV, @response.content_type
     assert_equal "c,s,v", @response.body
+  ensure
+    ActionController::Renderers.remove :csv
   end
 
   def test_raises_missing_renderer_if_an_api_behavior_with_no_renderer
@@ -650,6 +652,23 @@ class RespondWithControllerTest < ActionController::TestCase
     assert_raise ActionController::MissingRenderer do
       get :index, format: 'csv'
     end
+  end
+
+  def test_removing_renderers
+    ActionController::Renderers.add :csv do |obj, options|
+      send_data obj.to_csv, type: Mime::CSV
+    end
+    @controller = CsvRespondWithController.new
+    @request.accept = "text/csv"
+    get :index, format: 'csv'
+    assert_equal Mime::CSV, @response.content_type
+
+    ActionController::Renderers.remove :csv
+    assert_raise ActionController::MissingRenderer do
+      get :index, format: 'csv'
+    end
+  ensure
+    ActionController::Renderers.remove :csv
   end
 
   def test_error_is_raised_if_no_respond_to_is_declared_and_respond_with_is_called


### PR DESCRIPTION
ActionController does not seem to provide an API to remove renderers. Therefore we need to undo the actions in `ActionController::Renderers#add`. Otherwise, it will lead to the failure of `test_raises_missing_renderer_if_an_api_behavior_with_no_renderer` if `test_uses_renderer_if_an_api_behavior` is run first.

cc @senny 
