### PR TITLE
add tests for to_key implementation in ActiveRecord::Base

### DIFF
--- a/activerecord/test/cases/attribute_methods/primary_key_test.rb
+++ b/activerecord/test/cases/attribute_methods/primary_key_test.rb
@@ -1,0 +1,18 @@
+require 'cases/helper'
+require 'models/subscriber'
+
+module ActiveRecord
+  module AttributeMethods
+    module PrimaryKey
+      class PrimaryKeyTest < ActiveModel::TestCase
+        test "to_key implementation for new ActiveRecord::Base inherited class object" do
+          assert_equal ['Aditya'], Subscriber.new(nick: 'Aditya').to_key
+        end
+
+        test "to_key implementation for ActiveRecord::Base persisted class object" do
+          assert_equal ['Aditya'], Subscriber.create(nick: 'Aditya').to_key
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an amendment for the PR https://github.com/rails/rails/pull/15163 where the tests need to be moved to activerecord/test instead of activemodel/test directory
