### PR TITLE
Create a predicate to match passwords

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -89,7 +89,20 @@ module ActiveModel
       #   user.authenticate('notright')      # => false
       #   user.authenticate('mUc3m00RsqyRe') # => user
       def authenticate(unencrypted_password)
-        BCrypt::Password.new(password_digest) == unencrypted_password && self
+        authenticated?(unencrypted_password) && self
+      end
+
+      # Returns +true+ if the password matches the digest.
+      #
+      #   class User < ActiveRecord::Base
+      #     has_secure_password validations: false
+      #   end
+      #
+      #   user = User.new(name: 'david', password: 'mUc3m00RsqyRe')
+      #   user.save
+      #   user.authenticated?('mUc3m00RsqyRe')
+      def authenticated?(unencrypted_password)
+        BCrypt::Password.new(password_digest) == unencrypted_password
       end
 
       # Encrypts the password into the +password_digest+ attribute, only if the

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -158,6 +158,13 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert @user.authenticate("secret")
   end
 
+  test "authenticated?" do
+    @user.password = "secret"
+
+    assert_equal false, @user.authenticated?("wrong")
+    assert_equal true, @user.authenticated?("secret")
+  end
+
   test "Password digest cost defaults to bcrypt default cost when min_cost is false" do
     ActiveModel::SecurePassword.min_cost = false
 


### PR DESCRIPTION
This addition is in response to the rejection of a previous pull request because it changed an existing method:
https://github.com/rails/rails/pull/15153

My hope is that since it is additive there won't be as much hesitation to include it since it won't break existing code.

This does add a bit of surface area to the model using has_secure_password. Hopefully this addition seems worth it for the added consistency of the API.
