### PR TITLE
Fix confusing exception in ActiveSupport delegation

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fixed confusing `DelegationError` in `Module#delegate`.
+
+    See #15186.
+
+    *Vladimir Yarotsky*
+
 *   Fixed `ActiveSupport::Subscriber` so that no duplicate subscriber is created
     when a subscriber method is redefined.
 

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -72,7 +72,7 @@ Product = Struct.new(:name) do
 
   def type
     @type ||= begin
-      nil.type_name
+      :thing_without_same_method_name_as_delegated.name
     end
   end
 end


### PR DESCRIPTION
Follow-up on #15186. I decided to change the existing test, as it did intend to cover this case, but failed to do so.
