### PR TITLE
`bin/setup` script to bootstrap applications.

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -163,7 +163,7 @@ of the files and folders that Rails created by default:
 | File/Folder | Purpose |
 | ----------- | ------- |
 |app/|Contains the controllers, models, views, helpers, mailers and assets for your application. You'll focus on this folder for the remainder of this guide.|
-|bin/|Contains the rails script that starts your app and can contain other scripts you use to deploy or run your application.|
+|bin/|Contains the rails script that starts your app and can contain other scripts you use to setup, deploy or run your application.|
 |config/|Configure your application's routes, database, and more. This is covered in more detail in [Configuring Rails Applications](configuring.html).|
 |config.ru|Rack configuration for Rack based servers used to start the application.|
 |db/|Contains your current database schema, as well as the database migrations.|

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `bin/setup` script to bootstrap an application.
+
+    *Yves Senn*
+
 *   Replace double quotes with single quotes while adding an entry into Gemfile.
 
     *Alexander Belaev*

--- a/railties/lib/rails/generators/rails/app/templates/bin/setup
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup
@@ -1,0 +1,28 @@
+require 'pathname'
+
+# path to your application root.
+APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
+
+Dir.chdir APP_ROOT do
+  # This script is a starting point to setup your application.
+  # Add necessary setup steps to this file:
+
+  puts "== Installing dependencies =="
+  system "gem install bundler --conservative"
+  system "bundle install"
+
+  # puts "\n== Copying sample files =="
+  # unless File.exists?("config/database.yml")
+  #   system "cp config/database.yml.sample config/database.yml"
+  # end
+
+  puts "\n== Preparing database =="
+  system "bin/rake db:setup"
+
+  puts "\n== Removing old logs and tempfiles =="
+  system "rm -f log/*"
+  system "rm -rf tmp/cache"
+
+  puts "\n== Restarting application server =="
+  system "touch tmp/restart.txt"
+end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -21,6 +21,7 @@ DEFAULT_APP_FILES = %w(
   bin/bundle
   bin/rails
   bin/rake
+  bin/setup
   config/environments
   config/initializers
   config/locales


### PR DESCRIPTION
This is a first draft to collect feedback.
### About

While this script does not perform much work out of the box, the idea is to have a starting point to add your own setup code. Having an automated way to bootstrap your application saves not only time but also serves as verifiable documentation. By default the script does:
- `bundle install`
- `bin/rake db:setup`

To encourage users to modify it, I included some suggestions what you might want to do.
### Example

[This Gist](https://gist.github.com/senny/0b7e5959341554c9a50b) shows the output of the script for a newly generated application. Database setup fails because there is no schema present.
### Work
- [ ] document, where should this convention be documented?
