### PR TITLE
PostgreSQL jsonb support

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -69,7 +69,7 @@ module ActiveRecord
       end
 
       private
-        delegate :extract_scale, to: Type
+        delegate :extract_scale, to: :cast_type
 
         def extract_limit(sql_type)
           $1.to_i if sql_type =~ /\((.*)\)/

--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -123,12 +123,6 @@ module ActiveRecord
           end
         end
 
-        # Extracts the scale from PostgreSQL-specific data types.
-        def extract_scale(sql_type)
-          # Money type has a fixed scale of 2.
-          sql_type =~ /^money/ ? 2 : super
-        end
-
         # Extracts the precision from PostgreSQL-specific data types.
         def extract_precision(sql_type)
           if sql_type == 'money'

--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -102,6 +102,9 @@ module ActiveRecord
           # JSON
           when /\A'(.*)'::json\z/
             $1
+          # JSONB
+          when /\A'(.*)'::jsonb\z/
+            $1
           # Object identifier types
           when /\A-?\d+\z/
             $1

--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -91,11 +91,8 @@ module ActiveRecord
           # Hstore
           when /\A'(.*)'::hstore\z/
             $1
-          # JSON
-          when /\A'(.*)'::json\z/
-            $1
-          # JSONB
-          when /\A'(.*)'::jsonb\z/
+          # JSON/JSONB
+          when /\A'(.*)'::jsonb?\z/
             $1
           # Object identifier types
           when /\A-?\d+\z/

--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -94,6 +94,9 @@ module ActiveRecord
           # JSON
           when /\A'(.*)'::json\z/
             $1
+          # JSONB
+          when /\A'(.*)'::jsonb\z/
+            $1
           # Object identifier types
           when /\A-?\d+\z/
             $1

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -39,6 +39,10 @@ module ActiveRecord
         class Money < Type::Decimal
           include Infinity
 
+          def extract_scale(sql_type)
+            2
+          end
+
           def cast_value(value)
             return value unless ::String === value
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -508,6 +508,7 @@ This is not reliable and will be removed in the future.
         register_type 'point', OID::Point.new
         register_type 'hstore', OID::Hstore.new
         register_type 'json', OID::Json.new
+        register_type 'jsonb', OID::Jsonb.new
         register_type 'cidr', OID::Cidr.new
         register_type 'inet', OID::Inet.new
         register_type 'uuid', OID::Uuid.new

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -405,6 +405,7 @@ This is not reliable and will be removed in the future.
         register_type 'point', OID::Point.new
         register_type 'hstore', OID::Hstore.new
         register_type 'json', OID::Json.new
+        register_type 'jsonb', OID::Jsonb.new
         register_type 'cidr', OID::Cidr.new
         register_type 'inet', OID::Inet.new
         register_type 'uuid', OID::Uuid.new

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -274,11 +274,17 @@ This is not reliable and will be removed in the future.
           end
         end
 
+        class Jsonb < Json
+          def type
+            :jsonb
+          end
+        end
+
         class Uuid < Type::Value
           def type
             :uuid
           end
-
+        
           def type_cast(value)
             value.presence
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -325,6 +325,24 @@ This is not reliable and will be removed in the future.
           end
         end
 
+        class Jsonb < Type
+          def type; :jsonb end
+
+          def type_cast_for_write(value)
+            ConnectionAdapters::PostgreSQLColumn.json_to_string value
+          end
+
+          def type_cast(value)
+            return if value.nil?
+
+            ConnectionAdapters::PostgreSQLColumn.string_to_json value
+          end
+
+          def accessor
+            ActiveRecord::Store::StringKeyedHashAccessor
+          end
+        end
+
         class Uuid < Type
           def type; :uuid end
           def type_cast(value)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -30,7 +30,7 @@ module ActiveRecord
           when Array
             case sql_type
             when 'point' then super(PostgreSQLColumn.point_to_string(value))
-            when 'json' then super(PostgreSQLColumn.json_to_string(value))
+            when /^json/ then super(PostgreSQLColumn.json_to_string(value))
             else
               if column.array
                 "'#{PostgreSQLColumn.array_to_string(value, column, self).gsub(/'/, "''")}'"
@@ -41,7 +41,7 @@ module ActiveRecord
           when Hash
             case sql_type
             when 'hstore' then super(PostgreSQLColumn.hstore_to_string(value), column)
-            when 'json' then super(PostgreSQLColumn.json_to_string(value), column)
+            when /^json/ then super(PostgreSQLColumn.json_to_string(value), column)
             else super
             end
           when IPAddr
@@ -102,7 +102,7 @@ module ActiveRecord
           when Array
             case column.sql_type
             when 'point' then PostgreSQLColumn.point_to_string(value)
-            when 'json' then PostgreSQLColumn.json_to_string(value)
+            when /^json/ then PostgreSQLColumn.json_to_string(value)
             else
               if column.array
                 PostgreSQLColumn.array_to_string(value, column, self)
@@ -122,7 +122,7 @@ module ActiveRecord
           when Hash
             case column.sql_type
             when 'hstore' then PostgreSQLColumn.hstore_to_string(value, array_member)
-            when 'json' then PostgreSQLColumn.json_to_string(value)
+            when /^json/ then PostgreSQLColumn.json_to_string(value)
             else super(value, column)
             end
           when IPAddr

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -30,7 +30,7 @@ module ActiveRecord
           when Array
             case sql_type
             when 'point' then super(PostgreSQLColumn.point_to_string(value))
-            when /^json/ then super(PostgreSQLColumn.json_to_string(value))
+            when /^jsonb?/ then super(PostgreSQLColumn.json_to_string(value))
             else
               if column.array
                 "'#{PostgreSQLColumn.array_to_string(value, column, self).gsub(/'/, "''")}'"
@@ -41,7 +41,7 @@ module ActiveRecord
           when Hash
             case sql_type
             when 'hstore' then super(PostgreSQLColumn.hstore_to_string(value), column)
-            when /^json/ then super(PostgreSQLColumn.json_to_string(value), column)
+            when /^jsonb?/ then super(PostgreSQLColumn.json_to_string(value), column)
             else super
             end
           when IPAddr
@@ -102,7 +102,7 @@ module ActiveRecord
           when Array
             case column.sql_type
             when 'point' then PostgreSQLColumn.point_to_string(value)
-            when /^json/ then PostgreSQLColumn.json_to_string(value)
+            when /^jsonb?/ then PostgreSQLColumn.json_to_string(value)
             else
               if column.array
                 PostgreSQLColumn.array_to_string(value, column, self)
@@ -122,7 +122,7 @@ module ActiveRecord
           when Hash
             case column.sql_type
             when 'hstore' then PostgreSQLColumn.hstore_to_string(value, array_member)
-            when /^json/ then PostgreSQLColumn.json_to_string(value)
+            when /^jsonb?/ then PostgreSQLColumn.json_to_string(value)
             else super(value, column)
             end
           when IPAddr

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -139,6 +139,10 @@ module ActiveRecord
           column(name, 'json', options)
         end
 
+        def jsonb(name, options = {})
+          column(name, 'jsonb', options)
+        end
+
         def citext(name, options = {})
           column(name, 'citext', options)
         end
@@ -234,6 +238,7 @@ module ActiveRecord
         macaddr:     { name: "macaddr" },
         uuid:        { name: "uuid" },
         json:        { name: "json" },
+        jsonb:       { name: "jsonb" },
         ltree:       { name: "ltree" },
         citext:      { name: "citext" }
       }

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -140,6 +140,10 @@ module ActiveRecord
           column(name, 'json', options)
         end
 
+        def jsonb(name, options = {})
+          column(name, 'jsonb', options)
+        end
+
         def citext(name, options = {})
           column(name, 'citext', options)
         end
@@ -234,6 +238,7 @@ module ActiveRecord
         macaddr:     { name: "macaddr" },
         uuid:        { name: "uuid" },
         json:        { name: "json" },
+        jsonb:       { name: "jsonb" },
         ltree:       { name: "ltree" },
         citext:      { name: "citext" }
       }

--- a/activerecord/lib/active_record/connection_adapters/type/value.rb
+++ b/activerecord/lib/active_record/connection_adapters/type/value.rb
@@ -4,6 +4,10 @@ module ActiveRecord
       class Value # :nodoc:
         def type; end
 
+        def extract_scale(sql_type)
+          Type.extract_scale(sql_type)
+        end
+
         def type_cast(value)
           cast_value(value) unless value.nil?
         end

--- a/activerecord/test/cases/adapters/postgresql/jsonb_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/jsonb_test.rb
@@ -1,0 +1,151 @@
+# encoding: utf-8
+
+require "cases/helper"
+require 'active_record/base'
+require 'active_record/connection_adapters/postgresql_adapter'
+
+class PostgresqlJSONBTest < ActiveRecord::TestCase
+  class JsonbDataType < ActiveRecord::Base
+    self.table_name = 'jsonb_data_type'
+
+    store_accessor :settings, :resolution
+  end
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+    begin
+      @connection.transaction do
+        @connection.create_table('jsonb_data_type') do |t|
+          t.jsonb 'payload', :default => {}
+          t.jsonb 'settings'
+        end
+      end
+    rescue ActiveRecord::StatementInvalid
+      skip "do not test on PG without jsonb"
+    end
+    @column = JsonbDataType.columns_hash['payload']
+  end
+
+  teardown do
+    @connection.execute 'drop table if exists jsonb_data_type'
+  end
+
+  def test_column
+    column = JsonbDataType.columns_hash["payload"]
+    assert_equal :jsonb, column.type
+    assert_equal "jsonb", column.sql_type
+    assert_not column.number?
+    assert_not column.text?
+    assert_not column.binary?
+    assert_not column.array
+  end
+
+  def test_default
+    @connection.add_column 'jsonb_data_type', 'permissions', :jsonb, default: '{"users": "read", "posts": ["read", "write"]}'
+    JsonbDataType.reset_column_information
+    column = JsonbDataType.columns_hash["permissions"]
+
+    assert_equal({"users"=>"read", "posts"=>["read", "write"]}, column.default)
+    assert_equal({"users"=>"read", "posts"=>["read", "write"]}, JsonbDataType.new.permissions)
+  ensure
+    JsonbDataType.reset_column_information
+  end
+
+  def test_change_table_supports_jsonb
+    @connection.transaction do
+      @connection.change_table('jsonb_data_type') do |t|
+        t.jsonb 'users', default: '{}'
+      end
+      JsonbDataType.reset_column_information
+      column = JsonbDataType.columns_hash['users']
+      assert_equal :jsonb, column.type
+
+      raise ActiveRecord::Rollback # reset the schema change
+    end
+  ensure
+    JsonbDataType.reset_column_information
+  end
+
+  def test_cast_value_on_write
+    x = JsonbDataType.new payload: {"string" => "foo", :symbol => :bar}
+    assert_equal({"string" => "foo", "symbol" => "bar"}, x.payload)
+    x.save
+    assert_equal({"string" => "foo", "symbol" => "bar"}, x.reload.payload)
+  end
+
+  def test_type_cast_jsonb
+    column = JsonbDataType.columns_hash["payload"]
+
+    data = "{\"a_key\":\"a_value\"}"
+    hash = column.class.string_to_json data
+    assert_equal({'a_key' => 'a_value'}, hash)
+    assert_equal({'a_key' => 'a_value'}, column.type_cast(data))
+
+    assert_equal({}, column.type_cast("{}"))
+    assert_equal({'key'=>nil}, column.type_cast('{"key": null}'))
+    assert_equal({'c'=>'}','"a"'=>'b "a b'}, column.type_cast(%q({"c":"}", "\"a\"":"b \"a b"})))
+  end
+
+  def test_rewrite
+    @connection.execute "insert into jsonb_data_type (payload) VALUES ('{\"k\":\"v\"}')"
+    x = JsonbDataType.first
+    x.payload = { '"a\'' => 'b' }
+    assert x.save!
+  end
+
+  def test_select
+    @connection.execute "insert into jsonb_data_type (payload) VALUES ('{\"k\":\"v\"}')"
+    x = JsonbDataType.first
+    assert_equal({'k' => 'v'}, x.payload)
+  end
+
+  def test_select_multikey
+    @connection.execute %q|insert into jsonb_data_type (payload) VALUES ('{"k1":"v1", "k2":"v2", "k3":[1,2,3]}')|
+    x = JsonbDataType.first
+    assert_equal({'k1' => 'v1', 'k2' => 'v2', 'k3' => [1,2,3]}, x.payload)
+  end
+
+  def test_null_jsonb
+    @connection.execute %q|insert into jsonb_data_type (payload) VALUES(null)|
+    x = JsonbDataType.first
+    assert_equal(nil, x.payload)
+  end
+
+  def test_select_array_jsonb_value
+    @connection.execute %q|insert into jsonb_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
+    x = JsonbDataType.first
+    assert_equal(['v0', {'k1' => 'v1'}], x.payload)
+  end
+
+  def test_rewrite_array_jsonb_value
+    @connection.execute %q|insert into jsonb_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
+    x = JsonbDataType.first
+    x.payload = ['v1', {'k2' => 'v2'}, 'v3']
+    assert x.save!
+  end
+
+  def test_with_store_accessors
+    x = JsonbDataType.new(resolution: "320×480")
+    assert_equal "320×480", x.resolution
+
+    x.save!
+    x = JsonbDataType.first
+    assert_equal "320×480", x.resolution
+
+    x.resolution = "640×1136"
+    x.save!
+
+    x = JsonbDataType.first
+    assert_equal "640×1136", x.resolution
+  end
+
+  def test_update_all
+    jsonb = JsonbDataType.create! payload: { "one" => "two" }
+
+    JsonbDataType.update_all payload: { "three" => "four" }
+    assert_equal({ "three" => "four" }, jsonb.reload.payload)
+
+    JsonbDataType.update_all payload: { }
+    assert_equal({ }, jsonb.reload.payload)
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/jsonb_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/jsonb_test.rb
@@ -148,4 +148,10 @@ class PostgresqlJSONBTest < ActiveRecord::TestCase
     JsonbDataType.update_all payload: { }
     assert_equal({ }, jsonb.reload.payload)
   end
+
+  def test_where
+    jsonb = JsonbDataType.create! payload: { "one" => "two" }
+    x = JsonbDataType.where("payload->>'one' = 'two'").first
+    assert_equal({ "one" => "two" }, x.payload)
+  end
 end

--- a/activerecord/test/cases/adapters/postgresql/jsonb_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/jsonb_test.rb
@@ -150,7 +150,7 @@ class PostgresqlJSONBTest < ActiveRecord::TestCase
   end
 
   def test_where
-    jsonb = JsonbDataType.create! payload: { "one" => "two" }
+    JsonbDataType.create! payload: { "one" => "two" }
     x = JsonbDataType.where("payload->>'one' = 'two'").first
     assert_equal({ "one" => "two" }, x.payload)
   end

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -1,0 +1,54 @@
+# encoding: utf-8
+
+require "cases/helper"
+require 'active_record/base'
+require 'active_record/connection_adapters/postgresql_adapter'
+
+class PostgresqlByteaTest < ActiveRecord::TestCase
+  class PostgresqlMoney < ActiveRecord::Base; end
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.execute("set lc_monetary = 'C'")
+  end
+
+  def test_column
+    column = PostgresqlMoney.columns_hash["wealth"]
+    assert_equal :decimal, column.type
+    assert_equal "money", column.sql_type
+    assert_equal 2, column.scale
+    assert column.number?
+    assert_not column.text?
+    assert_not column.binary?
+    assert_not column.array
+  end
+
+  def test_money_values
+    @connection.execute("INSERT INTO postgresql_moneys (id, wealth) VALUES (1, '567.89'::money)")
+    @connection.execute("INSERT INTO postgresql_moneys (id, wealth) VALUES (2, '-567.89'::money)")
+
+    first_money = PostgresqlMoney.find(1)
+    second_money = PostgresqlMoney.find(2)
+    assert_equal 567.89, first_money.wealth
+    assert_equal(-567.89, second_money.wealth)
+  end
+
+  def test_money_type_cast
+    column = PostgresqlMoney.columns_hash['wealth']
+    assert_equal(12345678.12, column.type_cast("$12,345,678.12"))
+    assert_equal(12345678.12, column.type_cast("$12.345.678,12"))
+    assert_equal(-1.15, column.type_cast("-$1.15"))
+    assert_equal(-2.25, column.type_cast("($2.25)"))
+  end
+
+  def test_create_and_update_money
+    money = PostgresqlMoney.create(wealth: "987.65")
+    assert_equal 987.65, money.wealth
+
+    new_value = BigDecimal.new('123.45')
+    money.wealth = new_value
+    money.save!
+    money.reload
+    assert_equal new_value, money.wealth
+  end
+end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -42,7 +42,7 @@ class SubSpecialComment < SpecialComment
 end
 
 class VerySpecialComment < Comment
-  scope :special_parent, -> (special_rating) { where parent_id: special_rating.special_comment.id }
+  scope :special_parent, ->(special_rating) { where parent_id: special_rating.special_comment.id }
 end
 
 class CommentThatAutomaticallyAltersPostBody < Comment


### PR DESCRIPTION
Adding support to ActiveRecord for jsonb column type when using Postgresql 9.4+

For details about Json vs Jsonb implementations:

http://www.postgresql.org/docs/9.4/static/datatype-json.html   

For ease of testing, I've setup a Vagrant box with PostgreSQL 9.4 Beta 1 & a Ruby 2.1 environment ready to go if that's your thing:

vagrant init chris-teague/centos-postgresql94-ruby21   
