### PR TITLE
Replace `type_cast` case statement with delegation

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -249,10 +249,9 @@ module ActiveRecord
         raise NotImplementedError
       end
 
-      # Overridden by the adapters to instantiate their specific Column type.
       def new_column(field, default, sql_type, null, collation, extra = "") # :nodoc:
         cast_type = lookup_cast_type(sql_type)
-        Column.new(field, default, cast_type, sql_type, null, collation, extra)
+        Column.new(field, default, cast_type, sql_type, null, collation, strict_mode?, extra)
       end
 
       # Must return the Mysql error number from the exception, if the exception has an

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -94,28 +94,10 @@ module ActiveRecord
 
       # Casts value to an appropriate instance.
       def type_cast(value)
-        return nil if value.nil?
-        return coder.load(value) if encoded?
-
-        klass = self.class
-
-        case type
-        when :string, :text
-          case value
-          when TrueClass; "1"
-          when FalseClass; "0"
-          else
-            value.to_s
-          end
-        when :integer              then klass.value_to_integer(value)
-        when :float                then value.to_f
-        when :decimal              then klass.value_to_decimal(value)
-        when :datetime             then klass.string_to_time(value)
-        when :time                 then klass.string_to_dummy_time(value)
-        when :date                 then klass.value_to_date(value)
-        when :binary               then klass.binary_to_string(value)
-        when :boolean              then klass.value_to_boolean(value)
-        else value
+        if encoded?
+          coder.load(value)
+        else
+          cast_type.type_cast(value)
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -29,13 +29,6 @@ module ActiveRecord
 
   module ConnectionAdapters
     class Mysql2Adapter < AbstractMysqlAdapter
-
-      class Column < AbstractMysqlAdapter::Column # :nodoc:
-        def adapter
-          Mysql2Adapter
-        end
-      end
-
       ADAPTER_NAME = 'Mysql2'
 
       def initialize(connection, logger, connection_options, config)
@@ -67,11 +60,6 @@ module ActiveRecord
         else
           to_enum(:each_hash, result)
         end
-      end
-
-      def new_column(field, default, sql_type, null, collation, extra = "") # :nodoc:
-        cast_type = lookup_cast_type(sql_type)
-        Column.new(field, default, cast_type, sql_type, null, collation, strict_mode?, extra)
       end
 
       def error_number(exception)

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -66,21 +66,6 @@ module ActiveRecord
     # * <tt>:sslcipher</tt> - Necessary to use MySQL with an SSL connection.
     #
     class MysqlAdapter < AbstractMysqlAdapter
-
-      class Column < AbstractMysqlAdapter::Column #:nodoc:
-        def type_cast(value)
-          if encoded?
-            super
-          else
-            cast_type.type_cast(value)
-          end
-        end
-
-        def adapter
-          MysqlAdapter
-        end
-      end
-
       ADAPTER_NAME = 'MySQL'
 
       class StatementPool < ConnectionAdapters::StatementPool
@@ -140,11 +125,6 @@ module ActiveRecord
         else
           to_enum(:each_hash, result)
         end
-      end
-
-      def new_column(field, default, sql_type, null, collation, extra = "") # :nodoc:
-        cast_type = lookup_cast_type(sql_type)
-        Column.new(field, default, cast_type, sql_type, null, collation, strict_mode?, extra)
       end
 
       def error_number(exception) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -123,13 +123,6 @@ module ActiveRecord
         end
       end
 
-      def type_cast(value)
-        return if value.nil?
-        return super if encoded?
-
-        @oid_type.type_cast value
-      end
-
       def accessor
         @oid_type.accessor
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -41,16 +41,6 @@ module ActiveRecord
   end
 
   module ConnectionAdapters #:nodoc:
-    class SQLite3Column < Column #:nodoc:
-      def type_cast(value)
-        if encoded?
-          super
-        else
-          cast_type.type_cast(value)
-        end
-      end
-    end
-
     class SQLite3Binary < Type::Binary # :nodoc:
       def cast_value(value)
         if value.encoding != Encoding::ASCII_8BIT
@@ -403,7 +393,7 @@ module ActiveRecord
 
           sql_type = field['type']
           cast_type = lookup_cast_type(sql_type)
-          SQLite3Column.new(field['name'], field['dflt_value'], cast_type, sql_type, field['notnull'].to_i == 0)
+          Column.new(field['name'], field['dflt_value'], cast_type, sql_type, field['notnull'].to_i == 0)
         end
       end
 

--- a/activerecord/test/cases/column_test.rb
+++ b/activerecord/test/cases/column_test.rb
@@ -146,7 +146,7 @@ module ActiveRecord
 
       if current_adapter?(:SQLite3Adapter)
         def test_binary_encoding
-          column = SQLite3Column.new("field", nil, SQLite3Binary.new)
+          column = Column.new("field", nil, SQLite3Binary.new)
           utf8_string = "a string".encode(Encoding::UTF_8)
           type_cast = column.type_cast(utf8_string)
 


### PR DESCRIPTION
All subclasses of column were now delegating `type_cast` to their
injected type object. We can remove the overriding methods, and
generalize it on the `Column` class itself. This also enabled us to
remove several column classes completely, as they no longer had any
meaningful behavior of their own.

/cc @senny
