### PR TITLE
Fix habtm reflection

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Rails 4.1.2 (unreleased) ##
 
+*   Fix has_and_belongs_to_many public reflection.
+    When defining a has_and_belongs_to_many, internally we convert that to two has_many.
+    But as `reflections` is a public API, people expect to see the right macro.
+
+    Fixes #14682.
+
+    *arthurnn*
+
 *   Fixed serialization for records with an attribute named `format`.
 
     Fixes #15188.

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -151,7 +151,7 @@ module ActiveRecord
       association = association_instance_get(name)
 
       if association.nil?
-        raise AssociationNotFoundError.new(self, name) unless reflection = self.class.reflect_on_association(name)
+        raise AssociationNotFoundError.new(self, name) unless reflection = self.class._reflect_on_association(name)
         association = reflection.association_class.new(self, reflection)
         association_instance_set(name, association)
       end

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -50,7 +50,7 @@ module ActiveRecord
     def initialize(reflection)
       through_reflection      = reflection.through_reflection
       source_reflection_names = reflection.source_reflection_names
-      source_associations     = reflection.through_reflection.klass.reflections.keys.map(&:to_s)
+      source_associations     = reflection.through_reflection.klass._reflections.keys
       super("Could not find the source association(s) #{source_reflection_names.collect{ |a| a.inspect }.to_sentence(:two_words_connector => ' or ', :last_word_connector => ', or ', :locale => :en)} in model #{through_reflection.klass}. Try 'has_many #{reflection.name.inspect}, :through => #{through_reflection.name.inspect}, :source => <name>'. Is it one of #{source_associations.to_sentence(:two_words_connector => ' or ', :last_word_connector => ', or ', :locale => :en)}?")
     end
   end

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -50,7 +50,7 @@ module ActiveRecord
     def initialize(reflection)
       through_reflection      = reflection.through_reflection
       source_reflection_names = reflection.source_reflection_names
-      source_associations     = reflection.through_reflection.klass.reflect_on_all_associations.collect { |a| a.name.inspect }
+      source_associations     = reflection.through_reflection.klass.reflections.keys.map(&:to_s)
       super("Could not find the source association(s) #{source_reflection_names.collect{ |a| a.inspect }.to_sentence(:two_words_connector => ' or ', :last_word_connector => ', or ', :locale => :en)} in model #{through_reflection.klass}. Try 'has_many #{reflection.name.inspect}, :through => #{through_reflection.name.inspect}, :source => <name>'. Is it one of #{source_associations.to_sentence(:two_words_connector => ' or ', :last_word_connector => ', or ', :locale => :en)}?")
     end
   end

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1606,6 +1606,9 @@ module ActiveRecord
         end
 
         has_many name, scope, hm_options, &extension
+
+        reflection = ActiveRecord::Reflection::AssociationReflection.new(:has_and_belongs_to_many, name, scope, options, self)
+        self.reflections = self.reflections.except(middle_reflection.name).merge!(name => reflection)
       end
     end
   end

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -160,7 +160,7 @@ module ActiveRecord
       def marshal_load(data)
         reflection_name, ivars = data
         ivars.each { |name, val| instance_variable_set(name, val) }
-        @reflection = @owner.class.reflect_on_association(reflection_name)
+        @reflection = @owner.class._reflect_on_association(reflection_name)
       end
 
       def initialize_attributes(record) #:nodoc:

--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -66,13 +66,13 @@ module ActiveRecord::Associations::Builder
 
         def self.add_left_association(name, options)
           belongs_to name, options
-          self.left_reflection = reflect_on_association(name)
+          self.left_reflection = _reflect_on_association(name)
         end
 
         def self.add_right_association(name, options)
           rhs_name = name.to_s.singularize.to_sym
           belongs_to rhs_name, options
-          self.right_reflection = reflect_on_association(rhs_name)
+          self.right_reflection = _reflect_on_association(rhs_name)
         end
 
       }

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -100,7 +100,8 @@ module ActiveRecord
         # Hence this method.
         def inverse_updates_counter_cache?(reflection = reflection())
           counter_name = cached_counter_attribute_name(reflection)
-          reflection.klass.reflect_on_all_associations(:belongs_to).any? { |inverse_reflection|
+          reflection.klass._reflections.values.any? { |inverse_reflection|
+            :belongs_to == inverse_reflection.macro &&
             inverse_reflection.counter_cache_column == counter_name
           }
         end

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -207,7 +207,7 @@ module ActiveRecord
       end
 
       def find_reflection(klass, name)
-        klass.reflect_on_association(name) or
+        klass._reflect_on_association(name) or
           raise ConfigurationError, "Association named '#{ name }' was not found on #{ klass.name }; perhaps you misspelled it?"
       end
 

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -273,9 +273,11 @@ module ActiveRecord
       # go through nested autosave associations that are loaded in memory (without loading
       # any new ones), and return true if is changed for autosave
       def nested_records_changed_for_autosave?
-        self.class.reflect_on_all_autosave_associations.any? do |reflection|
-          association = association_instance_get(reflection.name)
-          association && Array.wrap(association.target).any? { |a| a.changed_for_autosave? }
+        self.class._reflections.values.any? do |reflection|
+          if reflection.options[:autosave]
+            association = association_instance_get(reflection.name)
+            association && Array.wrap(association.target).any? { |a| a.changed_for_autosave? }
+          end
         end
       end
 

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -20,7 +20,7 @@ module ActiveRecord
       def reset_counters(id, *counters)
         object = find(id)
         counters.each do |association|
-          has_many_association = reflect_on_association(association.to_sym)
+          has_many_association = _reflect_on_association(association.to_sym)
           raise ArgumentError, "'#{self.name}' has no association called '#{association}'" unless has_many_association
 
           if has_many_association.is_a? ActiveRecord::Reflection::ThroughReflection

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -29,8 +29,7 @@ module ActiveRecord
 
           foreign_key  = has_many_association.foreign_key.to_s
           child_class  = has_many_association.klass
-          belongs_to   = child_class.reflect_on_all_associations(:belongs_to)
-          reflection   = belongs_to.find { |e| e.foreign_key.to_s == foreign_key && e.options[:counter_cache].present? }
+          reflection   = child_class._reflections.values.find { |e| :belongs_to == e.macro && e.foreign_key.to_s == foreign_key && e.options[:counter_cache].present? }
           counter_name = reflection.counter_cache_column
 
           stmt = unscoped.where(arel_table[primary_key].eq(object.id)).arel.compile_update({

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -643,7 +643,7 @@ module ActiveRecord
               model_class
             end
 
-          reflection_class.reflect_on_all_associations.each do |association|
+          reflection_class._reflections.values.each do |association|
             case association.macro
             when :belongs_to
               # Do not replace association name with association foreign key if they are named the same

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -305,8 +305,9 @@ module ActiveRecord
         options[:reject_if] = REJECT_ALL_BLANK_PROC if options[:reject_if] == :all_blank
 
         attr_names.each do |association_name|
-          if reflection = reflect_on_association(association_name)
+          if reflection = _reflect_on_association(association_name)
             reflection.autosave = true
+            reflect_on_association(association_name).autosave = true
             add_autosave_association_callbacks(reflection)
 
             nested_attributes_options = self.nested_attributes_options.dup
@@ -542,7 +543,7 @@ module ActiveRecord
     end
 
     def raise_nested_attributes_record_not_found!(association_name, record_id)
-      raise RecordNotFound, "Couldn't find #{self.class.reflect_on_association(association_name).klass.name} with ID=#{record_id} for #{self.class.name} with ID=#{id}"
+      raise RecordNotFound, "Couldn't find #{self.class._reflect_on_association(association_name).klass.name} with ID=#{record_id} for #{self.class.name} with ID=#{id}"
     end
   end
 end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -4,8 +4,10 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     included do
+      class_attribute :_reflections
       class_attribute :reflections
       class_attribute :aggregate_reflections
+      self._reflections = {}
       self.reflections = {}
       self.aggregate_reflections = {}
     end
@@ -22,6 +24,7 @@ module ActiveRecord
     end
 
     def self.add_reflection(ar, name, reflection)
+      ar._reflections = ar._reflections.merge(name => reflection)
       ar.reflections = ar.reflections.merge(name => reflection)
     end
 
@@ -62,7 +65,7 @@ module ActiveRecord
       #   Account.reflect_on_all_associations(:has_many)  # returns an array of all has_many associations
       #
       def reflect_on_all_associations(macro = nil)
-        association_reflections = reflections.values
+        association_reflections = :has_and_belongs_to_many == macro ? reflections.values : _reflections.values
         macro ? association_reflections.select { |reflection| reflection.macro == macro } : association_reflections
       end
 
@@ -77,7 +80,7 @@ module ActiveRecord
 
       # Returns an array of AssociationReflection objects for all associations which have <tt>:autosave</tt> enabled.
       def reflect_on_all_autosave_associations
-        reflections.values.select { |reflection| reflection.options[:autosave] }
+        _reflections.values.select { |reflection| reflection.options[:autosave] }
       end
     end
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -5,6 +5,7 @@ module ActiveRecord
 
     included do
       class_attribute :_reflections
+      # @api public
       class_attribute :reflections
       class_attribute :aggregate_reflections
       self._reflections = {}

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -65,7 +65,7 @@ module ActiveRecord
       #   Account.reflect_on_all_associations(:has_many)  # returns an array of all has_many associations
       #
       def reflect_on_all_associations(macro = nil)
-        association_reflections = :has_and_belongs_to_many == macro ? reflections.values : _reflections.values
+        association_reflections = reflections.values
         macro ? association_reflections.select { |reflection| reflection.macro == macro } : association_reflections
       end
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -273,7 +273,7 @@ module ActiveRecord
       group_attrs = group_values
 
       if group_attrs.first.respond_to?(:to_sym)
-        association  = @klass.reflect_on_association(group_attrs.first.to_sym)
+        association  = @klass._reflect_on_association(group_attrs.first.to_sym)
         associated   = group_attrs.size == 1 && association && association.macro == :belongs_to # only count belongs_to associations
         group_fields = Array(associated ? association.foreign_key : group_attrs)
       else

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -26,7 +26,7 @@ module ActiveRecord
             queries << '1=0'
           else
             table       = Arel::Table.new(column, default_table.engine)
-            association = klass.reflect_on_association(column.to_sym)
+            association = klass._reflect_on_association(column.to_sym)
 
             value.each do |k, v|
               queries.concat expand(association && association.klass, table, k, v)
@@ -55,7 +55,7 @@ module ActiveRecord
       #
       # For polymorphic relationships, find the foreign key and type:
       # PriceEstimate.where(estimate_of: treasure)
-      if klass && reflection = klass.reflect_on_association(column.to_sym)
+      if klass && reflection = klass._reflect_on_association(column.to_sym)
         if reflection.polymorphic? && base_class = polymorphic_base_class_from_value(value)
           queries << build(table[reflection.foreign_type], base_class)
         end

--- a/activerecord/lib/active_record/validations/presence.rb
+++ b/activerecord/lib/active_record/validations/presence.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       def validate(record)
         super
         attributes.each do |attribute|
-          next unless record.class.reflect_on_association(attribute)
+          next unless record.class._reflect_on_association(attribute)
           associated_records = Array.wrap(record.send(attribute))
 
           # Superclass validates presence. Ensure present records aren't about to be destroyed.

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -47,7 +47,7 @@ module ActiveRecord
       end
 
       def build_relation(klass, table, attribute, value) #:nodoc:
-        if reflection = klass.reflect_on_association(attribute)
+        if reflection = klass._reflect_on_association(attribute)
           attribute = reflection.foreign_key
           value = value.attributes[reflection.primary_key_column.name] unless value.nil?
         end
@@ -75,7 +75,7 @@ module ActiveRecord
 
       def scope_relation(record, table, relation)
         Array(options[:scope]).each do |scope_item|
-          if reflection = record.class.reflect_on_association(scope_item)
+          if reflection = record.class._reflect_on_association(scope_item)
             scope_value = record.send(reflection.foreign_key)
             scope_item  = reflection.foreign_key
           else

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -200,7 +200,12 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_reflection_should_not_raise_error_when_compared_to_other_object
-    assert_nothing_raised { Firm.reflections[:clients] == Object.new }
+    assert_nothing_raised { Firm._reflections[:clients] == Object.new }
+  end
+
+  def test_has_and_belongs_to_many_reflection
+    assert_equal :has_and_belongs_to_many, Category.reflections[:posts].macro
+    assert_equal :posts, Category.reflect_on_all_associations(:has_and_belongs_to_many).first.name
   end
 
   def test_has_many_through_reflection

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -200,7 +200,7 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_reflection_should_not_raise_error_when_compared_to_other_object
-    assert_nothing_raised { Firm._reflections[:clients] == Object.new }
+    assert_not_equal Object.new, Firm._reflections[:clients]
   end
 
   def test_has_and_belongs_to_many_reflection


### PR DESCRIPTION
This adds back `has_and_belongs_to_many` reflection to the reflections
hash. Even thought we are not using that internally, as
`Model.reflections` is a public method we need to keep the hash of
reflections coherent.

ad7b5ef is the commit that made
`has_and_belongs_to_many became` a `has_many :through` and a `has_many`.

review @tenderlove @rafaelfranca @matthewd

I am still not 100% convinced we need to do this, but I guess thats what was proposed on the issue.

[fixes #14682]
