### PR TITLE
Remove redundant code.

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
@@ -32,9 +32,8 @@ module ActionDispatch
     end
 
     def render_html(status)
-      found = false
-      path = "#{public_path}/#{status}.#{I18n.locale}.html" if I18n.locale
-      path = "#{public_path}/#{status}.html" unless path && (found = File.exist?(path))
+      path = "#{public_path}/#{status}.#{I18n.locale}.html"
+      path = "#{public_path}/#{status}.html" unless (found = File.exist?(path))
 
       if found || File.exist?(path)
         render_format(status, 'text/html', File.read(path))


### PR DESCRIPTION
Unless I am missing something, we shouldn't have to check `if I18n.locale` exists.

![screenshot from 2014-05-20 18 34 55](https://cloud.githubusercontent.com/assets/4335742/3035240/20d47402-e088-11e3-91c6-f91b0c090611.png)
