### PR TITLE
ActionView::LookupContext js/html fallback (#10525 redo)

### DIFF
--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -40,7 +40,7 @@ module ActionView
 
     def prepend_formats(formats)
       formats = Array(formats)
-      return if formats.empty? || @lookup_context.html_fallback_for_js
+      return if formats.empty? || @lookup_context.format_fallback
       @lookup_context.formats = formats | @lookup_context.formats
     end
   end


### PR DESCRIPTION
I made pull request #10525 about a year ago and received comments recently. I messed up that merge from rails/rails master so that pull request somehow has an extra 100 commits or so.

`ActionView::LookupContext` is hardcoded to append the :html format whenever :js is set as the format.  A user may want to extend this behavior to their own custom defined formats (for example a :mobile format could fallback to :html as well).  

This is what it was for:

---

This current behavior is the magic behind allowing you to render an html partial within a javascript response.

``` ruby
# in new.js.erb
# will render the _form.html.erb partial
render partial: 'form', locals: {object: @object}
```

This change allows you to specify your own fallbacks easily.  In somewhere like `config/initializers/mime_types.rb`:

``` ruby
MimeTypes.register_alias "text/html", :mobile
ActionView::LookupContext.format_fallbacks[:mobile] = [:html]
```

Now, if you have a request where the format is :mobile, it will try to render a mobile template first, and fallback to the html template.  Additionally, you could render an html partial within a mobile template.

This behavior is already being tested in `actionpack/test/template/lookup_context_test.rb`.
