### PR TITLE
Add changelog entry for my previous pull requests [ci skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Refactor the typecasting behavior of columns to an API built around
+    dependency injection and composition, rather than case statements on the SQL
+    type string. Testing the columns becomes much easier, as does adding new
+    types or overriding behavior in the future.
+
+    *Sean Griffin*
+
 *   Fixed serialized fields returning serialized data after being updated with
     `update_column`.
 


### PR DESCRIPTION
Since the original PR was broken up, none of the pull requests justified a change log entry on their own. Now that the bulk of the refactoring has been merged in, a change log entry is warranted.
