### PR TITLE
fixes in active record query for reorder in rails guides

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -753,13 +753,13 @@ Post.find(10).comments.reorder('name')
 The SQL that would be executed:
 
 ```sql
-SELECT * FROM posts WHERE id = 10 ORDER BY name
+SELECT * FROM comments WHERE post_id = 10 ORDER BY name
 ```
 
 In case the `reorder` clause is not used, the SQL executed would be:
 
 ```sql
-SELECT * FROM posts WHERE id = 10 ORDER BY posted_at DESC
+SELECT * FROM comments WHERE post_id = 10 ORDER BY posted_at DESC
 ```
 
 ### `reverse_order`


### PR DESCRIPTION
I found a issue in rails guides in Active record Query.

In the reorder option it is showing select comments of a post and reorder them according to name column but the query for that is :-
SELECT \* FROM posts WHERE id = 10 ORDER BY name

Ideally It should be :-
 SELECT \* FROM comments WHERE post_id = 10 ORDER BY name

and same is the issue with without reorder:-
SELECT \* FROM posts WHERE id = 10 ORDER BY posted_at DESC

It should be:-
SELECT \* FROM comments WHERE post_id = 10 ORDER BY posted_at DESC
