### PR TITLE
Add `force` option to `remove_index` for ignoring a missing index

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added `force` option to `remove_index` for ignoring a missing index.
+
+    *Cody Cutrer*
+
 *   PostgreSQL support default values for enum types. Fixes #7814.
 
     *Yves Senn*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -440,6 +440,14 @@ module ActiveRecord
           execute "CREATE #{index_type} INDEX #{index_algorithm} #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} #{index_using} (#{index_columns})#{index_options}"
         end
 
+        def remove_index(table_name, options)
+          if options.is_a?(Hash) && options[:force]
+            execute "DROP INDEX IF EXISTS #{quote_table_name(index_name(table_name, options))}"
+          else
+            super
+          end
+        end
+
         def remove_index!(table_name, index_name) #:nodoc:
           execute "DROP INDEX #{quote_table_name(index_name)}"
         end

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -47,6 +47,18 @@ module ActiveRecord
         assert_raise(ArgumentError) { connection.remove_index(table_name, "no_such_index") }
       end
 
+      def test_force_remove_nonexistent_index
+        assert_nothing_raised { connection.remove_index(table_name, :name => "no_such_index", :force => true) }
+      end
+
+      def test_force_remove_existing_index
+        connection.add_index(table_name, "foo", name: good_index_name)
+        assert connection.index_name_exists?(table_name, good_index_name, true)
+
+        connection.remove_index(table_name, name: good_index_name, :force => true)
+        assert_not connection.index_name_exists?(table_name, good_index_name, false)
+      end
+
       def test_add_index_works_with_long_index_names
         connection.add_index(table_name, "foo", name: good_index_name)
 


### PR DESCRIPTION
sometimes you don't know if a previous migration ran, so it's useful
to unconditionally drop an index
