### PR TITLE
Add `force` option to `drop_table` for ignoring a missing table

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added `force` option to `drop_table` for ignoring a missing table.
+
+    *Cody Cutrer*
+
 *   Fixed serialized fields returning serialized data after being updated with
     `update_column`.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -360,11 +360,18 @@ module ActiveRecord
 
       # Drops a table from the database.
       #
-      # Although this command ignores +options+ and the block if one is given, it can be helpful
-      # to provide these in a migration's +change+ method so it can be reverted.
+      # [<tt>:force<tt>]
+      #   Set this to true to ignore a non-existent table.
+      #
+      #   Defaults to false.
+      #
+      # Although this command ignores most +options+ and the block if one is given,
+      # it can be helpful to provide these in a migration's +change+ method so it
+      # can be reverted.
       # In that case, +options+ and the block will be used by create_table.
       def drop_table(table_name, options = {})
-        execute "DROP TABLE #{quote_table_name(table_name)}"
+        return if options[:force] && !table_exists?(table_name)
+        execute "DROP TABLE #{options[:drop_options]} #{quote_table_name(table_name)}"
       end
 
       # Adds a new column to the named table.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -496,7 +496,8 @@ module ActiveRecord
       end
 
       def drop_table(table_name, options = {})
-        execute "DROP#{' TEMPORARY' if options[:temporary]} TABLE #{quote_table_name(table_name)}"
+        options = options.merge(:drop_options => "TEMPORARY") if options[:temporary]
+        super(table_name, options)
       end
 
       def rename_index(table_name, old_name, new_name)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -378,6 +378,15 @@ module ActiveRecord
           rename_table_indexes(table_name, new_name)
         end
 
+        def drop_table(table_name, options)
+          if options[:force]
+            options = options.dup
+            options[:drop_options] = "IF EXISTS"
+            options.delete(:force)
+          end
+          super
+        end
+
         # Adds a new column to the named table.
         # See TableDefinition#column for details of the options you can use.
         def add_column(table_name, column_name, type, options = {})

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -384,6 +384,17 @@ module ActiveRecord
         end
       end
 
+      def test_force_drop_nonexistent_table
+        assert_nothing_raised { connection.drop_table(:nonexistent, :force => true) }
+      end
+
+      def test_force_drop_existing_table
+        connection.create_table :testings
+        assert connection.table_exists?(:testings)
+        connection.drop_table(:testings, :force => true)
+        assert_not connection.table_exists?(:testings)
+      end
+
       private
       def testing_table_with_only_foo_attribute
         connection.create_table :testings, :id => false do |t|


### PR DESCRIPTION
sometimes you don't know if a previous migration ran, so it's useful
to unconditionally drop a table
