### PR TITLE
Add `force` option to `remove_column` for ignoring a missing column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added `force` option to `remove_column` for ignoring a missing column.
+
+    *Cody Cutrer*
+
 *   Fixed serialized fields returning serialized data after being updated with
     `update_column`.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -394,6 +394,7 @@ module ActiveRecord
       # to provide these in a migration's +change+ method so it can be reverted.
       # In that case, +type+ and +options+ will be used by add_column.
       def remove_column(table_name, column_name, type = nil, options = {})
+        return if options[:force] && !column_exists?(table_name, column_name)
         execute "ALTER TABLE #{quote_table_name(table_name)} DROP #{quote_column_name(column_name)}"
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -385,6 +385,14 @@ module ActiveRecord
           super
         end
 
+        def remove_column(table_name, column_name, type = nil, options = {})
+          if options[:force]
+            execute "ALTER TABLE #{quote_table_name(table_name)} DROP IF EXISTS #{quote_column_name(column_name)}"
+          else
+            super
+          end
+        end
+
         # Changes the column of a table.
         def change_column(table_name, column_name, type, options = {})
           clear_cache!

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -459,6 +459,7 @@ module ActiveRecord
       end
 
       def remove_column(table_name, column_name, type = nil, options = {}) #:nodoc:
+        return if options[:force] && !column_exists?(table_name, column_name)
         alter_table(table_name) do |definition|
           definition.remove_column column_name
         end

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -126,7 +126,7 @@ module ActiveRecord
       end
 
       def invert_remove_column(args)
-        raise ActiveRecord::IrreversibleMigration, "remove_column is only reversible if given a type." if args.size <= 2
+        raise ActiveRecord::IrreversibleMigration, "remove_column is only reversible if given a type." if args.size <= 2 || args[2].nil?
         super
       end
 

--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -35,6 +35,23 @@ module ActiveRecord
         assert_no_column TestModel, :last_name
       end
 
+      def test_force_remove_nonexistent_column
+        assert_no_column TestModel, :last_name
+
+        assert_nothing_raised { remove_column :test_models, :last_name, :string, :force => true }
+        assert_no_column TestModel, :last_name
+      end
+
+      def test_force_remove_existing_column
+        assert_no_column TestModel, :last_name
+
+        add_column :test_models, :last_name, :string
+        assert_column TestModel, :last_name
+
+        remove_column :test_models, :last_name, :string, :force => true
+        assert_no_column TestModel, :last_name
+      end
+
       def test_add_column_without_limit
         # TODO: limit: nil should work with all adapters.
         skip "MySQL wrongly enforces a limit of 255" if current_adapter?(:MysqlAdapter, :Mysql2Adapter)


### PR DESCRIPTION
sometimes you don't know if a previous migration ran, so it's useful
to unconditionally remove a column
