### PR TITLE
Move extract_scale to decimal type

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/type.rb
+++ b/activerecord/lib/active_record/connection_adapters/type.rb
@@ -22,8 +22,8 @@ module ActiveRecord
       class << self
         def extract_scale(sql_type)
           case sql_type
-            when /^(numeric|decimal|number)\((\d+)\)/i then 0
-            when /^(numeric|decimal|number)\((\d+)(,(\d+))\)/i then $4.to_i
+            when /\((\d+)\)/ then 0
+            when /\((\d+)(,(\d+))\)/ then $3.to_i
           end
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/type/decimal.rb
+++ b/activerecord/lib/active_record/connection_adapters/type/decimal.rb
@@ -4,6 +4,8 @@ module ActiveRecord
       class Decimal < Value # :nodoc:
         include Numeric
 
+        delegate :extract_scale, to: Type
+
         def type
           :decimal
         end

--- a/activerecord/lib/active_record/connection_adapters/type/value.rb
+++ b/activerecord/lib/active_record/connection_adapters/type/value.rb
@@ -3,10 +3,7 @@ module ActiveRecord
     module Type
       class Value # :nodoc:
         def type; end
-
-        def extract_scale(sql_type)
-          Type.extract_scale(sql_type)
-        end
+        def extract_scale(sql_type); end
 
         def type_cast(value)
           cast_value(value) unless value.nil?

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -353,9 +353,9 @@ class SchemaDumperTest < ActiveRecord::TestCase
     output = standard_dump
     # Oracle supports precision up to 38 and it identifies decimals with scale 0 as integers
     if current_adapter?(:OracleAdapter)
-      assert_match %r{t.integer\s+"atoms_in_universe",\s+precision: 38,\s+scale: 0}, output
+      assert_match %r{t.integer\s+"atoms_in_universe",\s+precision: 38}, output
     else
-      assert_match %r{t.decimal\s+"atoms_in_universe",\s+precision: 55,\s+scale: 0}, output
+      assert_match %r{t.decimal\s+"atoms_in_universe",\s+precision: 55}, output
     end
   end
 


### PR DESCRIPTION
The only type that has a scale is decimal. There's a special case where
decimal columns with 0 scale are type cast to integers if the scale is
not specified. Appears to only affect schema dumping. Would prefer to
see the scale not be specified, and modify the test instead, but wanted
some feedback on the two choices.
