### PR TITLE
Move `extract_precision` onto type objects

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -69,14 +69,10 @@ module ActiveRecord
       end
 
       private
-        delegate :extract_scale, to: :cast_type
+        delegate :extract_scale, :extract_precision, to: :cast_type
 
         def extract_limit(sql_type)
           $1.to_i if sql_type =~ /\((.*)\)/
-        end
-
-        def extract_precision(sql_type)
-          $2.to_i if sql_type =~ /^(numeric|decimal|number)\((\d+)(,\d+)?\)/i
         end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -35,8 +35,6 @@ module ActiveRecord
           require 'active_record/connection_adapters/postgresql/array_parser'
           include PostgreSQL::ArrayParser
         end
-
-        attr_accessor :money_precision
       end
       # :startdoc:
 
@@ -119,17 +117,6 @@ module ActiveRecord
           when /^smallint/i;  2
           when /^timestamp/i; nil
           else super
-          end
-        end
-
-        # Extracts the precision from PostgreSQL-specific data types.
-        def extract_precision(sql_type)
-          if sql_type == 'money'
-            self.class.money_precision
-          elsif sql_type =~ /timestamp/i
-            $1.to_i if sql_type =~ /\((\d+)\)/
-          else
-            super
           end
         end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/money.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/money.rb
@@ -5,6 +5,8 @@ module ActiveRecord
         class Money < Type::Decimal
           include Infinity
 
+          class_attribute :precision
+
           def extract_scale(sql_type)
             2
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -713,7 +713,7 @@ module ActiveRecord
           # Money type has a fixed precision of 10 in PostgreSQL 8.2 and below, and as of
           # PostgreSQL 8.3 it has a fixed precision of 19. PostgreSQLColumn.extract_precision
           # should know about this but can't detect it there, so deal with it here.
-          PostgreSQLColumn.money_precision = (postgresql_version >= 80300) ? 19 : 10
+          OID::Money.precision = (postgresql_version >= 80300) ? 19 : 10
 
           configure_connection
         rescue ::PG::Error => error

--- a/activerecord/lib/active_record/connection_adapters/type/date_time.rb
+++ b/activerecord/lib/active_record/connection_adapters/type/date_time.rb
@@ -8,6 +8,10 @@ module ActiveRecord
           :datetime
         end
 
+        def extract_precision(sql_type)
+          $1.to_i if sql_type =~ /\((\d+)\)/
+        end
+
         private
 
         def cast_value(string)

--- a/activerecord/lib/active_record/connection_adapters/type/numeric.rb
+++ b/activerecord/lib/active_record/connection_adapters/type/numeric.rb
@@ -14,6 +14,10 @@ module ActiveRecord
           else super
           end
         end
+
+        def extract_precision(sql_type)
+          $1.to_i if sql_type =~ /\((\d+)(,\d+)?\)/
+        end
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/type/value.rb
+++ b/activerecord/lib/active_record/connection_adapters/type/value.rb
@@ -3,7 +3,10 @@ module ActiveRecord
     module Type
       class Value # :nodoc:
         def type; end
+
         def extract_scale(sql_type); end
+
+        def extract_precision(sql_type); end
 
         def type_cast(value)
           cast_value(value) unless value.nil?


### PR DESCRIPTION
`money_precision` also felt out of place, so it has been moved onto the money type.
