### PR TITLE
Fixed serialization for records with an attribute named `format`.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fixed serialization for records with an attribute named `format`.
+
+    Fixes #15188.
+
+    *Godfrey Chan*
+
 *   When a `group` is set, `sum`, `size`, `average`, `minimum` and `maximum`
     on a NullRelation should return a Hash.
 

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -66,6 +66,7 @@ module ActiveRecord
       # Generates all the attribute related methods for columns in the database
       # accessors, mutators and query methods.
       def define_attribute_methods # :nodoc:
+        return false if @attribute_methods_generated
         # Use a mutex; we don't want two thread simultaneously trying to define
         # attribute methods.
         generated_attribute_methods.synchronize do

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -286,6 +286,8 @@ module ActiveRecord
 
       @new_record = false
 
+      self.class.define_attribute_methods
+
       run_callbacks :find
       run_callbacks :initialize
 

--- a/activerecord/test/cases/serialization_test.rb
+++ b/activerecord/test/cases/serialization_test.rb
@@ -1,8 +1,11 @@
 require "cases/helper"
 require 'models/contact'
 require 'models/topic'
+require 'models/book'
 
 class SerializationTest < ActiveRecord::TestCase
+  fixtures :books
+
   FORMATS = [ :xml, :json ]
 
   def setup
@@ -64,5 +67,21 @@ class SerializationTest < ActiveRecord::TestCase
     assert !klazz.new.include_root_in_json
   ensure
     ActiveRecord::Base.include_root_in_json = original_root_in_json
+  end
+
+  def test_read_attribute_for_serialization_with_format_after_init
+    klazz = Class.new(ActiveRecord::Base)
+    klazz.table_name = 'books'
+
+    book = klazz.new(format: 'paperback')
+    assert_equal 'paperback', book.read_attribute_for_serialization(:format)
+  end
+
+  def test_read_attribute_for_serialization_with_format_after_find
+    klazz = Class.new(ActiveRecord::Base)
+    klazz.table_name = 'books'
+
+    book = klazz.find(books(:awdr).id)
+    assert_equal 'paperback', book.read_attribute_for_serialization(:format)
   end
 end

--- a/activerecord/test/fixtures/books.yml
+++ b/activerecord/test/fixtures/books.yml
@@ -2,8 +2,10 @@ awdr:
   author_id: 1
   id: 1
   name: "Agile Web Development with Rails"
+  format: "paperback"
 
 rfr:
   author_id: 1
   id: 2
   name: "Ruby for Rails"
+  format: "ebook"

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define do
 
   create_table :books, force: true do |t|
     t.integer :author_id
+    t.string :format
     t.column :name, :string
     t.column :status, :integer, default: 0
     t.column :read_status, :integer, default: 0


### PR DESCRIPTION
``` irb
>> book.method(:format)
=> #<Method: BookFormat(Kernel)#format>
>> skip_backtrace { book.send(:format) }
=> "#<ArgumentError: too few arguments>"
>> book.format
=> "paperback"
>> book.method(:format)
=> #<Method: BookFormat(#<Module:0x007fe16d195a90>)#__temp__66f627d61647>
>> skip_backtrace { book.send(:format) }
=> "paperback"
```

---

This bug can be triggered when serializing record `R` (the instance) of type `C` (the class), provided that the following conditions are met:
1. The name of one or more columns/attributes on `C`/`R` matches an existing private method on C (e.g. those defined by `Kernel`, such as `format`).
2. The attribute methods have not yet been generated on `C`.

In this case, the matching private methods will be called by the serialization code (with no arguments) and their return values will be serialized instead. If the method requires one or more arguments, it will result in an `ArgumentError`.

This regression is introduced in d1316bb.

---

Attribute methods (e.g. `#name` and `#format`, assuming the class has columns named `name` and `format` in its database table) are lazily defined. Instead of defining them when a the class is defined (e.g. in [the `inherited` hook](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/attribute_methods.rb#L55-L58) on `ActiveRecord::Base`), this operation is deferred until they are first accessed.

The reason behind this is that is defining those methods requires knowing what columns are defined on the database table, which usually requires a round-trip to the database. Deferring their definition until the last-possible moment helps reducing unnecessary work, especially in development mode where classes are redefined and throw away between requests.

Typically, when an attribute is first accessed (e.g. `a_book.format`), it will fire the [`method_missing` hook](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/attribute_methods.rb#L195) on the class, which triggers the definition of the attribute methods. This even works for methods like `format`, because calling a private method with an explicit receiver will also trigger that hook.

Unfortunately, `read_attribute_for_serialization` is simply [an alias to `send`](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/serialization.rb#L141), which does not respect method visibility. As a result, when serializing a record with those conflicting attributes, the `method_missing` is not fired, and as a result the attribute methods are not defined one would expect.

Before d1316bb, this is negated by the fact that calling the `run_callbacks` method will also trigger a call to `respond_to?`, which is [another trigger point](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/attribute_methods.rb#L228) for the class to define its attribute methods. Therefore, when Active Record [tries to run the `after_find`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/core.rb#L289) callbacks, it will also define all the attribute methods thus masking the problem.

---

The proper fix for this problem is probably to restrict `read_attribute_for_serialization` to call public methods only (i.e. alias `read_attribute_for_serialization` to `public_send` instead of `send`). This however would be quite risky to change in a patch release and would probably require a full deprecation cycle.

Another approach would be to override `read_attribute_for_serialization` inside Active Record to force the definition of attribute methods:

``` ruby
   def read_attribute_for_serialization(attribute)
     self.class.define_attribute_methods
     send(attribute)
   end
```

Unfortunately, this is quite likely going to cause a performance degradation.

This patch therefore restores the behaviour from the 4-0-stable branch by explicitly forcing the class to define its attribute methods in a similar spot (when records are initialized). This should not cause any extra roundtrips to the database because the `@columns` should already be cached on the class.

Fixes #15188.

---

For the record, I _hate_ this patch, so if you have better ideas I'd love to hear them.
