### PR TITLE
[Guides] Do not gsub non ASCII characters in header anchor.

### DIFF
--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -47,8 +47,7 @@ module RailsGuides
       end
 
       def dom_id_text(text)
-        text.downcase.gsub(/\?/, '-questionmark').gsub(/!/, '-bang').gsub(/[^a-z0-9]+/, ' ')
-          .strip.gsub(/\s+/, '-')
+        text.downcase.gsub(/\?/, '-questionmark').gsub(/!/, '-bang').gsub(/\s+/, '-')
       end
 
       def engine


### PR DESCRIPTION
My Chinese translation will fail to generate proper anchor with `.gsub(/[^a-z0-9]+/, ' ')`. Remove this the anchor still works in English Guides (also works in Chinese translation). Is there any particular reason to remove all non ASCII characters? Thanks.
