### PR TITLE
Use `break` instead of `next` in AD::Journey::Formatter#match_route

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -85,7 +85,7 @@ module ActionDispatch
             hash = routes.group_by { |_, r| r.score(options) }
 
             hash.keys.sort.reverse_each do |score|
-              next if score < 0
+              break if score < 0
 
               hash[score].sort_by { |i, _| i }.each do |_, route|
                 yield route


### PR DESCRIPTION
The array is sorted in descending order, so there is no point in
iterating further if we met a negative item - all the rest will be
negative too.
