### PR TITLE
Push scale to type objects

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -13,12 +13,12 @@ module ActiveRecord
         ISO_DATETIME = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(\.\d+)?\z/
       end
 
-      attr_reader :name, :default, :cast_type, :limit, :null, :sql_type, :precision, :scale, :default_function
+      attr_reader :name, :default, :cast_type, :limit, :null, :sql_type, :precision, :default_function
       attr_accessor :primary, :coder
 
       alias :encoded? :coder
 
-      delegate :type, :klass, :text?, :number?, :binary?, :type_cast_for_write, to: :cast_type
+      delegate :type, :scale, :klass, :text?, :number?, :binary?, :type_cast_for_write, to: :cast_type
 
       # Instantiates a new column in the table.
       #
@@ -36,7 +36,6 @@ module ActiveRecord
         @null             = null
         @limit            = extract_limit(sql_type)
         @precision        = extract_precision(sql_type)
-        @scale            = extract_scale(sql_type)
         @default          = extract_default(default)
         @default_function = nil
         @primary          = nil
@@ -69,7 +68,7 @@ module ActiveRecord
       end
 
       private
-        delegate :extract_scale, :extract_precision, to: :cast_type
+        delegate :extract_precision, to: :cast_type
 
         def extract_limit(sql_type)
           $1.to_i if sql_type =~ /\((.*)\)/

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/money.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/money.rb
@@ -7,7 +7,7 @@ module ActiveRecord
 
           class_attribute :precision
 
-          def extract_scale(sql_type)
+          def scale
             2
           end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -571,7 +571,6 @@ module ActiveRecord
           m.alias_type 'int4', 'int2'
           m.alias_type 'int8', 'int2'
           m.alias_type 'oid', 'int2'
-          m.register_type 'numeric', OID::Decimal.new
           m.register_type 'float4', OID::Float.new
           m.alias_type 'float8', 'float4'
           m.register_type 'text', Type::Text.new
@@ -609,6 +608,11 @@ module ActiveRecord
           m.alias_type 'circle', 'varchar'
           m.alias_type 'lseg', 'varchar'
           m.alias_type 'box', 'varchar'
+
+          m.register_type 'numeric' do |_, sql_type|
+            scale = extract_scale(sql_type)
+            OID::Decimal.new(scale: scale)
+          end
 
           load_additional_types(m)
         end

--- a/activerecord/lib/active_record/connection_adapters/type.rb
+++ b/activerecord/lib/active_record/connection_adapters/type.rb
@@ -19,14 +19,6 @@ require 'active_record/connection_adapters/type/hash_lookup_type_map'
 module ActiveRecord
   module ConnectionAdapters
     module Type # :nodoc:
-      class << self
-        def extract_scale(sql_type)
-          case sql_type
-            when /\((\d+)\)/ then 0
-            when /\((\d+)(,(\d+))\)/ then $3.to_i
-          end
-        end
-      end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/type/decimal.rb
+++ b/activerecord/lib/active_record/connection_adapters/type/decimal.rb
@@ -4,8 +4,6 @@ module ActiveRecord
       class Decimal < Value # :nodoc:
         include Numeric
 
-        delegate :extract_scale, to: Type
-
         def type
           :decimal
         end

--- a/activerecord/lib/active_record/connection_adapters/type/value.rb
+++ b/activerecord/lib/active_record/connection_adapters/type/value.rb
@@ -2,9 +2,14 @@ module ActiveRecord
   module ConnectionAdapters
     module Type
       class Value # :nodoc:
-        def type; end
+        attr_reader :scale
 
-        def extract_scale(sql_type); end
+        def initialize(options = {})
+          options.assert_valid_keys(:scale)
+          @scale = options[:scale]
+        end
+
+        def type; end
 
         def extract_precision(sql_type); end
 


### PR DESCRIPTION
Ideally types will be usable without having to specify a sql type
string, so we should keep the information related to parsing them on the
adapter or another object.
