### PR TITLE
Reorder query in active record query of rails guide 

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -753,13 +753,15 @@ Article.find(10).comments.reorder('name')
 The SQL that would be executed:
 
 ```sql
-SELECT * FROM articles WHERE id = 10 ORDER BY name
+SELECT * FROM articles WHERE id = 10
+SELECT * FROM comments WHERE article_id = 10 ORDER BY name
 ```
 
 In case the `reorder` clause is not used, the SQL executed would be:
 
 ```sql
-SELECT * FROM articles WHERE id = 10 ORDER BY posted_at DESC
+SELECT * FROM articles WHERE id = 10
+SELECT * FROM comments WHERE article_id = 10 ORDER BY posted_at DESC
 ```
 
 ### `reverse_order`


### PR DESCRIPTION
I checked the rails guides recently and found that query in the reorder is not correct. I corrected it and pushed that yesterday and it was merged. But today there was a change i.e to move from post to article and found the same mistake.

In getting the the comments of article reordered by name there must be two things:-

Current Query:-
SELECT \* FROM articles WHERE id = 10 ORDER BY name

Ideally It should be:-
SELECT \* FROM articles WHERE id = 10
SELECT \* FROM comments WHERE article_id = 10 ORDER BY name
1. It hit two queries on database first to load article and then comments but It is showing one.
2. Ordering is done of post but it should be of comments

Same case for default case without any reorder i.e order by posted_at  :-

Current query is:-
SELECT \* FROM articles WHERE id = 10 ORDER BY posted_at DESC

It should be:-

SELECT \* FROM articles WHERE id = 10
SELECT \* FROM comments WHERE article_id = 10 ORDER BY posted_at DESC
