### PR TITLE
Remove unnecessary `Hash#to_a` call

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -80,7 +80,7 @@ module ActionDispatch
           if named_routes.key?(name)
             yield named_routes[name]
           else
-            routes = non_recursive(cache, options.to_a)
+            routes = non_recursive(cache, options)
 
             hash = routes.group_by { |_, r| r.score(options) }
 


### PR DESCRIPTION
Inspired by https://github.com/rails/rails/commit/931ee4186b877856b212b0085cd7bd7f6a4aea67

``` ruby

def stat(num)
  start = GC.stat(:total_allocated_object)
  num.times { yield }
  total_obj_count = GC.stat(:total_allocated_object) - start
  puts "#{total_obj_count / num} allocations per call"
end

h = { 'x' => 'y' }

stat(100) { h.     each { |pair| pair } }
stat(100) { h.to_a.each { |pair| pair } }

__END__
1 allocations per call
2 allocations per call
```
