### PR TITLE
Rename `stack` to `queue`

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -96,14 +96,14 @@ module ActionDispatch
 
         def non_recursive(cache, options)
           routes = []
-          stack  = [cache]
+          queue  = [cache]
 
-          while stack.any?
-            c = stack.shift
+          while queue.any?
+            c = queue.shift
             routes.concat(c[:___routes]) if c.key?(:___routes)
 
             options.each do |pair|
-              stack << c[pair] if c.key?(pair)
+              queue << c[pair] if c.key?(pair)
             end
           end
 


### PR DESCRIPTION
Because it is used as a queue (FIFO), not as a stack (LIFO).
- http://en.wikipedia.org/wiki/Stack_(abstract_data_type)
- http://en.wikipedia.org/wiki/Queue_(data_structure)
