### PR TITLE
Removed not used code

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -950,7 +950,6 @@ WARNING
         [@klass.send(:sanitize_sql, other.empty? ? opts : ([opts] + other))]
       when Hash
         opts = PredicateBuilder.resolve_column_aliases(klass, opts)
-        attributes = @klass.send(:expand_hash_conditions_for_aggregates, opts)
 
         bv_len = bind_values.length
         tmp_opts, bind_values = create_binds(opts, bv_len)


### PR DESCRIPTION
Assigned to `attributes` value is not used, and on https://github.com/rails/rails/pull/15257/files#diff-bf6dd6226db3aab589916f09236881c7L959 line it's re-assigned to new value.
