### PR TITLE
Push limit to type objects

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -13,12 +13,12 @@ module ActiveRecord
         ISO_DATETIME = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(\.\d+)?\z/
       end
 
-      attr_reader :name, :default, :cast_type, :limit, :null, :sql_type, :default_function
+      attr_reader :name, :default, :cast_type, :null, :sql_type, :default_function
       attr_accessor :primary, :coder
 
       alias :encoded? :coder
 
-      delegate :type, :precision, :scale, :klass, :text?, :number?, :binary?, :type_cast_for_write, to: :cast_type
+      delegate :type, :precision, :scale, :limit, :klass, :text?, :number?, :binary?, :type_cast_for_write, to: :cast_type
 
       # Instantiates a new column in the table.
       #
@@ -34,7 +34,6 @@ module ActiveRecord
         @cast_type        = cast_type
         @sql_type         = sql_type
         @null             = null
-        @limit            = extract_limit(sql_type)
         @default          = extract_default(default)
         @default_function = nil
         @primary          = nil
@@ -65,11 +64,6 @@ module ActiveRecord
       def extract_default(default)
         type_cast(default)
       end
-
-      private
-        def extract_limit(sql_type)
-          $1.to_i if sql_type =~ /\((.*)\)/
-        end
     end
   end
   # :startdoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -110,15 +110,6 @@ module ActiveRecord
         def has_default_function?(default_value, default)
           !default_value && (%r{\w+\(.*\)} === default)
         end
-
-        def extract_limit(sql_type)
-          case sql_type
-          when /^bigint/i;    8
-          when /^smallint/i;  2
-          when /^timestamp/i; nil
-          else super
-          end
-        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -569,14 +569,14 @@ module ActiveRecord
         end
 
         def initialize_type_map(m)
-          m.register_type 'int2', OID::Integer.new
+          register_class_with_limit m, 'int2', OID::Integer
           m.alias_type 'int4', 'int2'
           m.alias_type 'int8', 'int2'
           m.alias_type 'oid', 'int2'
           m.register_type 'float4', OID::Float.new
           m.alias_type 'float8', 'float4'
           m.register_type 'text', Type::Text.new
-          m.register_type 'varchar', Type::String.new
+          register_class_with_limit m, 'varchar', Type::String
           m.alias_type 'char', 'varchar'
           m.alias_type 'name', 'varchar'
           m.alias_type 'bpchar', 'varchar'
@@ -627,6 +627,14 @@ module ActiveRecord
           end
 
           load_additional_types(m)
+        end
+
+        def extract_limit(sql_type) # :nodoc:
+          case sql_type
+          when /^bigint/i;    8
+          when /^smallint/i;  2
+          else super
+          end
         end
 
         def load_additional_types(type_map, oids = nil)

--- a/activerecord/lib/active_record/connection_adapters/type/value.rb
+++ b/activerecord/lib/active_record/connection_adapters/type/value.rb
@@ -2,12 +2,13 @@ module ActiveRecord
   module ConnectionAdapters
     module Type
       class Value # :nodoc:
-        attr_reader :precision, :scale
+        attr_reader :precision, :scale, :limit
 
         def initialize(options = {})
-          options.assert_valid_keys(:precision, :scale)
+          options.assert_valid_keys(:precision, :scale, :limit)
           @precision = options[:precision]
           @scale = options[:scale]
+          @limit = options[:limit]
         end
 
         def type; end

--- a/activerecord/test/cases/column_definition_test.rb
+++ b/activerecord/test/cases/column_definition_test.rb
@@ -34,7 +34,7 @@ module ActiveRecord
       # Avoid column definitions in create table statements like:
       # `title` varchar(255) DEFAULT NULL
       def test_should_not_include_default_clause_when_default_is_null
-        column = Column.new("title", nil, Type::String.new, "varchar(20)")
+        column = Column.new("title", nil, Type::String.new(limit: 20))
         column_def = ColumnDefinition.new(
           column.name, "string",
           column.limit, column.precision, column.scale, column.default, column.null)
@@ -42,7 +42,7 @@ module ActiveRecord
       end
 
       def test_should_include_default_clause_when_default_is_present
-        column = Column.new("title", "Hello", Type::String.new, "varchar(20)")
+        column = Column.new("title", "Hello", Type::String.new(limit: 20))
         column_def = ColumnDefinition.new(
           column.name, "string",
           column.limit, column.precision, column.scale, column.default, column.null)
@@ -50,7 +50,7 @@ module ActiveRecord
       end
 
       def test_should_specify_not_null_if_null_option_is_false
-        column = Column.new("title", "Hello", Type::String.new, "varchar(20)", false)
+        column = Column.new("title", "Hello", Type::String.new(limit: 20), "varchar(20)", false)
         column_def = ColumnDefinition.new(
           column.name, "string",
           column.limit, column.precision, column.scale, column.default, column.null)


### PR DESCRIPTION
Columns and injected types no longer have any conditionals based on the
format of SQL type strings! Hooray!
