### PR TITLE
Bring the missing parameters back.

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -48,7 +48,11 @@ module ActiveRecord
       end
 
       private
-      def method_body; raise NotImplementedError; end
+
+      # Override this method in the subclasses for method body.
+      def method_body(method_name, const_name)
+        raise NotImplementedError, "Subclasses must implement a method_body(method_name, const_name) method."
+      end
     end
 
     module ClassMethods


### PR DESCRIPTION
Methods that will be overriding in the subclasses should take the parameters too.

The method `method_body` will be overriding in the `ActiveRecord::AttributeMethods::Read::ReaderMethodCache` and `ActiveRecord::AttributeMethods::Write::WriterMethodCache`
