### PR TITLE
Fix *_ids method for has_many with primary_key

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -43,13 +43,7 @@ module ActiveRecord
 
       # Implements the ids reader method, e.g. foo.item_ids for Foo.has_many :items
       def ids_reader
-        source_reflection = reflection.source_reflection
-        if source_reflection.collection?
-          pk_column_name = source_reflection.primary_key_column.name
-        else
-          pk_column_name = source_reflection.association_primary_key
-        end
-
+        pk_column_name = reflection.source_reflection_pk_column_name
         if loaded?
           load_target.map do |record|
             record.send(pk_column_name)

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -43,12 +43,13 @@ module ActiveRecord
 
       # Implements the ids reader method, e.g. foo.item_ids for Foo.has_many :items
       def ids_reader
+        pk_column = reflection.primary_key_column
         if loaded?
           load_target.map do |record|
-            record.send(reflection.association_primary_key)
+            record.send(pk_column.name)
           end
         else
-          column  = "#{reflection.quoted_table_name}.#{reflection.association_primary_key}"
+          column  = "#{reflection.quoted_table_name}.#{pk_column.name}"
           scope.pluck(column)
         end
       end

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -43,13 +43,13 @@ module ActiveRecord
 
       # Implements the ids reader method, e.g. foo.item_ids for Foo.has_many :items
       def ids_reader
-        pk_column = reflection.primary_key_column
+        pk_column_name = reflection.primary_key_column.name
         if loaded?
           load_target.map do |record|
-            record.send(pk_column.name)
+            record.send(pk_column_name)
           end
         else
-          column  = "#{reflection.quoted_table_name}.#{pk_column.name}"
+          column  = "#{reflection.quoted_table_name}.#{pk_column_name}"
           scope.pluck(column)
         end
       end

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -43,7 +43,13 @@ module ActiveRecord
 
       # Implements the ids reader method, e.g. foo.item_ids for Foo.has_many :items
       def ids_reader
-        pk_column_name = reflection.primary_key_column.name
+        source_reflection = reflection.source_reflection
+        if source_reflection.collection?
+          pk_column_name = source_reflection.primary_key_column.name
+        else
+          pk_column_name = source_reflection.association_primary_key
+        end
+
         if loaded?
           load_target.map do |record|
             record.send(pk_column_name)

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -305,6 +305,14 @@ Joining, Preloading and eager loading of these associations is deprecated and wi
         self
       end
 
+      def source_reflection_pk_column_name
+        if source_reflection.collection?
+          pk_column_name = source_reflection.primary_key_column.name
+        else
+          pk_column_name = source_reflection.association_primary_key
+        end
+      end
+
       # A chain of reflections from this one back to the owner. For more see the explanation in
       # ThroughReflection.
       def chain

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1509,10 +1509,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_has_many_custom_primary_key
     david = authors(:david)
-    expected_essays = Essay.where(writer_id: "David")
-    assert_equal expected_essays.map(&:id), david.essay_ids
-    assert_equal expected_essays, david.essays
-    assert_equal expected_essays.map(&:id), david.essay_ids
+    assert_equal Essay.where(writer_id: "David"), david.essays
+  end
+
+  def test_ids_on_unloaded_association_with_custom_primary_key
+    david = authors(:david)
+    assert_equal Essay.where(writer_id: "David").pluck(:id), david.essay_ids
+  end
+
+  def test_ids_on_loaded_association_with_custom_primary_key
+    david = authors(:david)
+    david.essays
+    assert_equal Essay.where(writer_id: "David").pluck(:id), david.essay_ids
   end
 
   def test_has_many_assignment_with_custom_primary_key

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1519,7 +1519,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_ids_on_loaded_association_with_custom_primary_key
     david = authors(:david)
-    david.essays
+    david.essays.to_a
     assert_equal Essay.where(writer_id: "David").pluck(:id), david.essay_ids
   end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1509,7 +1509,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_has_many_custom_primary_key
     david = authors(:david)
-    assert_equal david.essays, Essay.where(writer_id: "David")
+    expected_essays = Essay.where(writer_id: "David")
+    assert_equal expected_essays.map(&:id), david.essay_ids
+    assert_equal expected_essays, david.essays
+    assert_equal expected_essays.map(&:id), david.essay_ids
   end
 
   def test_has_many_assignment_with_custom_primary_key


### PR DESCRIPTION
A `has_many` association with a custom `primary_key` was using the wrong primary key field name to find the list of associated IDs.

See https://github.com/rails/rails/issues/14439 for details.
