### PR TITLE
If a counter_cache exists, use it for #empty?

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -41,6 +41,14 @@ module ActiveRecord
         end
       end
 
+      def empty?
+        if has_cached_counter?
+          size.zero?
+        else
+          super
+        end
+      end
+
       private
 
         # Returns the number of records in this collection.

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -807,6 +807,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_calling_empty_with_counter_cache
+    post = posts(:welcome)
+    assert_queries(0) do
+      assert_not post.comments.empty?
+    end
+  end
+
   def test_custom_named_counter_cache
     topic = topics(:first)
 


### PR DESCRIPTION
When a counter_cache is available, also use it when checking if the collection is empty or not, removing a (redundant) query for both `#empty?` and `#any?`.
