### PR TITLE
rake railties:install:migrations respects the order of railties

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -366,7 +366,7 @@ namespace :railties do
     task :migrations => :'db:load_config' do
       to_load = ENV['FROM'].blank? ? :all : ENV['FROM'].split(",").map {|n| n.strip }
       railties = {}
-      Rails.application.railties.each do |railtie|
+      Rails.application.migration_railties.each do |railtie|
         next unless to_load == :all || to_load.include?(railtie.railtie_name)
 
         if railtie.respond_to?(:paths) && (path = railtie.paths['db/migrate'].first)

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -364,6 +364,10 @@ module Rails
       end
     end
 
+    def migration_railties # :nodoc:
+      (ordered_railties & railties_without_main_app).reverse
+    end
+
   protected
 
     alias :build_middleware_stack :app
@@ -392,6 +396,11 @@ module Rails
     def run_console_blocks(app) #:nodoc:
       railties.each { |r| r.run_console_blocks(app) }
       super
+    end
+
+    def railties_without_main_app # :nodoc:
+      @railties_without_main_app ||= Rails::Railtie.subclasses.map(&:instance) +
+        Rails::Engine.subclasses.map(&:instance)
     end
 
     # Returns the ordered railties for this application considering railties_order.

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -112,6 +112,38 @@ module RailtiesTest
       end
     end
 
+    test 'respects the order of railties when installing migrations' do
+      @blog = engine "blog" do |plugin|
+        plugin.write "lib/blog.rb", <<-RUBY
+          module Blog
+            class Engine < ::Rails::Engine
+            end
+          end
+        RUBY
+      end
+
+      @plugin.write "db/migrate/1_create_users.rb", <<-RUBY
+        class CreateUsers < ActiveRecord::Migration
+        end
+      RUBY
+
+      @blog.write "db/migrate/2_create_blogs.rb", <<-RUBY
+        class CreateBlogs < ActiveRecord::Migration
+        end
+      RUBY
+
+      add_to_config("config.railties_order = [Bukkits::Engine, Blog::Engine, :all, :main_app]")
+
+      boot_rails
+
+      Dir.chdir(app_path) do
+        output  = `bundle exec rake railties:install:migrations`.split("\n")
+
+        assert_match(/Copied migration \d+_create_users.bukkits.rb from bukkits/, output.first)
+        assert_match(/Copied migration \d+_create_blogs.blog_engine.rb from blog_engine/, output.last)
+      end
+    end
+
     test "mountable engine should copy migrations within engine_path" do
       @plugin.write "lib/bukkits.rb", <<-RUBY
         module Bukkits


### PR DESCRIPTION
This PR fixes #8930 and some stuff from #8985

I am not sure this is right way to do this but this PR has test cases to see the problem.

As @parndt did in #8985 can make this public and have code in `database.rake` 

cc/ @m1k3
