### PR TITLE
Remove AD::Journey::Formatter#verify_required_parts!

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -132,11 +132,6 @@ module ActionDispatch
           }
         end
 
-        # Returns +true+ if no missing keys are present, otherwise +false+.
-        def verify_required_parts!(route, parts)
-          missing_keys(route, parts).empty?
-        end
-
         def build_cache
           root = { ___routes: [] }
           routes.each_with_index do |route, i|


### PR DESCRIPTION
Nobody uses this private method, maybe it is a leftover from some old
refactoring. Let's delete it.
