### PR TITLE
Array#to now accept negative position also.

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -15,8 +15,10 @@ class Array
   #   %w( a b c d ).to(2)  # => ["a", "b", "c"]
   #   %w( a b c d ).to(10) # => ["a", "b", "c", "d"]
   #   %w().to(0)           # => []
+  #   %w( a b c d ).to(-2) # => ["a", "b", "c"]
+  #   %w( a b c ).to(-10)  # => []
   def to(position)
-    first position + 1
+    self[0..position]
   end
 
   # Equal to <tt>self[1]</tt>.

--- a/activesupport/test/core_ext/array_ext_test.rb
+++ b/activesupport/test/core_ext/array_ext_test.rb
@@ -16,6 +16,8 @@ class ArrayExtAccessTests < ActiveSupport::TestCase
     assert_equal %w( a ), %w( a b c d ).to(0)
     assert_equal %w( a b c ), %w( a b c d ).to(2)
     assert_equal %w( a b c d ), %w( a b c d ).to(10)
+    assert_equal %w( a b c ), %w( a b c d ).to(-2)
+    assert_equal %w(), %w( a b c ).to(-10)
   end
 
   def test_second_through_tenth


### PR DESCRIPTION
revert   96525d63
`Array#to` is working for negative position also.

``` ruby
# Before

%w( a b c d ).to(-2) # => ArgumentError: negative array size

# After

%w( a b c d ).to(-2) # => ["a", "b", "c"]
```

\cc @tenderlove 
