### PR TITLE
Simplify the code in schema cache

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -12,11 +12,10 @@ module ActiveRecord
         @columns_hash = {}
         @primary_keys = {}
         @tables       = {}
-        prepare_default_proc
       end
 
       def primary_keys(table_name)
-        @primary_keys[table_name]
+        @primary_keys[table_name] ||= table_exists?(table_name) ? connection.primary_key(table_name) : nil
       end
 
       # A cached lookup for table existence.
@@ -29,9 +28,9 @@ module ActiveRecord
       # Add internal cache for table with +table_name+.
       def add(table_name)
         if table_exists?(table_name)
-          @primary_keys[table_name]
-          @columns[table_name]
-          @columns_hash[table_name]
+          primary_keys(table_name)
+          columns(table_name)
+          columns_hash(table_name)
         end
       end
 
@@ -40,14 +39,16 @@ module ActiveRecord
       end
 
       # Get the columns for a table
-      def columns(table)
-        @columns[table]
+      def columns(table_name)
+        @columns[table_name] ||= connection.columns(table_name)
       end
 
       # Get the columns for a table as a hash, key is the column name
       # value is the column object.
-      def columns_hash(table)
-        @columns_hash[table]
+      def columns_hash(table_name)
+        @columns_hash[table_name] ||= Hash[columns(table_name).map { |col|
+          [col.name, col]
+        }]
       end
 
       # Clears out internal caches
@@ -76,32 +77,11 @@ module ActiveRecord
       def marshal_dump
         # if we get current version during initialization, it happens stack over flow.
         @version = ActiveRecord::Migrator.current_version
-        [@version] + [@columns, @columns_hash, @primary_keys, @tables].map { |val|
-          Hash[val]
-        }
+        [@version, @columns, @columns_hash, @primary_keys, @tables]
       end
 
       def marshal_load(array)
         @version, @columns, @columns_hash, @primary_keys, @tables = array
-        prepare_default_proc
-      end
-
-      private
-
-      def prepare_default_proc
-        @columns.default_proc = Proc.new do |h, table_name|
-          h[table_name] = connection.columns(table_name)
-        end
-
-        @columns_hash.default_proc = Proc.new do |h, table_name|
-          h[table_name] = Hash[columns(table_name).map { |col|
-            [col.name, col]
-          }]
-        end
-
-        @primary_keys.default_proc = Proc.new do |h, table_name|
-          h[table_name] = table_exists?(table_name) ? connection.primary_key(table_name) : nil
-        end
       end
     end
   end


### PR DESCRIPTION
The use of default procs was unnessecary, made the code confusing to
follow, and made marshalling needlessly complex.
