### PR TITLE
[ci skip] Remove Duration#=== when we drop support for 2.0.0-p353

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -105,8 +105,7 @@ module ActiveSupport
 
       # We define it as a workaround to Ruby 2.0.0-p353 bug.
       # For more information, check rails/rails#13055.
-      # It should be dropped once a new Ruby patch-level
-      # release after 2.0.0-p353 happens.
+      # Remove it when we drop support for 2.0.0-p353.
       def ===(other) #:nodoc:
         value === other
       end


### PR DESCRIPTION
refer - #13055
