### PR TITLE
Remove duplicated parameter check on #where!

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -573,15 +573,11 @@ WARNING
       end
     end
 
-    def where!(opts = :chain, *rest) # :nodoc:
-      if opts == :chain
-        WhereChain.new(self)
-      else
-        references!(PredicateBuilder.references(opts)) if Hash === opts
+    def where!(opts, *rest) # :nodoc:
+      references!(PredicateBuilder.references(opts)) if Hash === opts
 
-        self.where_values += build_where(opts, rest)
-        self
-      end
+      self.where_values += build_where(opts, rest)
+      self
     end
 
     # Allows you to change a previously set where condition for a given attribute, instead of appending to that condition.

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -99,7 +99,7 @@ module ActiveRecord
       assert_bound_ast value, Post.arel_table[@name], Arel::Nodes::NotEqual
       assert_equal 'ruby on rails', bind.last
     end
-    
+
     def test_rewhere_with_one_condition
       relation = Post.where(title: 'hello').where(title: 'world').rewhere(title: 'alone')
 


### PR DESCRIPTION
It seems that #where! is not designed to be used as a chained where.
See initial implementation at 8c2c60511beaad05a218e73c4918ab89fb1804f0.
So, no need to check twice.
