### PR TITLE
print generators on failed generate

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -156,7 +156,8 @@ module Rails
         args << "--help" if args.empty? && klass.arguments.any? { |a| a.required? }
         klass.start(args, config)
       else
-        puts "Could not find generator #{namespace}."
+        puts "Could not find generator #{namespace.inspect}."
+        print_generators
       end
     end
 
@@ -199,17 +200,6 @@ module Rails
 
     # Show help message with available generators.
     def self.help(command = 'generate')
-      lookup!
-
-      namespaces = subclasses.map{ |k| k.namespace }
-      namespaces.sort!
-
-      groups = Hash.new { |h,k| h[k] = [] }
-      namespaces.each do |namespace|
-        base = namespace.split(':').first
-        groups[base] << namespace
-      end
-
       puts "Usage: rails #{command} GENERATOR [args] [options]"
       puts
       puts "General options:"
@@ -222,6 +212,20 @@ module Rails
       puts "Please choose a generator below."
       puts
 
+      print_generators
+    end
+
+    def self.print_generators
+      lookup!
+
+      namespaces = subclasses.map{ |k| k.namespace }
+      namespaces.sort!
+
+      groups = Hash.new { |h,k| h[k] = [] }
+      namespaces.each do |namespace|
+        base = namespace.split(':').first
+        groups[base] << namespace
+      end
       # Print Rails defaults first.
       rails = groups.delete("rails")
       rails.map! { |n| n.sub(/^rails:/, '') }


### PR DESCRIPTION
Let's say we just ran:

```
$ rails g migrate add_click_to_issue_assignment
```

We will get an error that looks like: 

```
Could not find generator migrate.
```

This patch adds all existing migrations to the output to make it easier for a developer to find a valid migration. 

```
Could not find generator "migrate". Please select a valid generator:
Rails:
  assets
  controller
  generator
  helper
  integration_test
  mailer
  migration
  model
  resource
  scaffold
  scaffold_controller
  task
```

It would be nice to do some spelling detection and suggest alternatives, but for now this should  help.
