### PR TITLE
Deprecate decimal columns being automatically treated as integers

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -396,6 +396,7 @@ module ActiveRecord
           precision = extract_precision(sql_type)
 
           if scale == 0
+            # FIXME: Remove this class as well
             Type::DecimalWithoutScale.new(precision: precision)
           else
             Type::Decimal.new(precision: precision, scale: scale)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -478,6 +478,8 @@ module ActiveRecord
             # places after decimal  = fmod - 4 & 0xffff
             # places before decimal = (fmod - 4) >> 16 & 0xffff
             if fmod && (fmod - 4 & 0xffff).zero?
+              # FIXME: Remove this class, and the second argument to
+              # lookups on PG
               Type::DecimalWithoutScale.new(precision: precision)
             else
               OID::Decimal.new(precision: precision, scale: scale)

--- a/activerecord/lib/active_record/properties.rb
+++ b/activerecord/lib/active_record/properties.rb
@@ -64,7 +64,19 @@ module ActiveRecord
 
       # Returns an array of column objects for the table associated with this class.
       def columns
-        @columns ||= add_user_provided_columns(connection.schema_cache.columns(table_name))
+        @columns ||= add_user_provided_columns(connection.schema_cache.columns(table_name)).each do |column|
+          if Type::DecimalWithoutScale === column.cast_type
+            ActiveSupport::Deprecation.warn <<-MESSAGE.strip_heredoc
+              Decimal columns with 0 scale being automatically treated as integers
+              is deprecated, and will be removed in a future version of Rails. If
+              you'd like to keep this behavior, add
+
+                property :#{column.name}, Type::Integer.new
+
+              to your #{name} model.
+            MESSAGE
+          end
+        end
       end
 
       # Returns a hash of column objects for the table associated with this class.

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -984,6 +984,10 @@ class BasicsTest < ActiveRecord::TestCase
 
   class NumericData < ActiveRecord::Base
     self.table_name = 'numeric_data'
+
+    property :world_population, Type::Integer.new
+    property :my_house_population, Type::Integer.new
+    property :atoms_in_universe, Type::Integer.new
   end
 
   def test_big_decimal_conditions

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -15,6 +15,10 @@ Company.has_many :accounts
 
 class NumericData < ActiveRecord::Base
   self.table_name = 'numeric_data'
+
+  property :world_population, Type::Integer.new
+  property :my_house_population, Type::Integer.new
+  property :atoms_in_universe, Type::Integer.new
 end
 
 class CalculationsTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -9,6 +9,7 @@ require 'active_record'
 require 'cases/test_case'
 require 'active_support/dependencies'
 require 'active_support/logger'
+require 'active_support/core_ext/string/strip'
 
 require 'support/config'
 require 'support/connection'

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -11,7 +11,10 @@ require MIGRATIONS_ROOT + "/rename/1_we_need_things"
 require MIGRATIONS_ROOT + "/rename/2_rename_things"
 require MIGRATIONS_ROOT + "/decimal/1_give_me_big_numbers"
 
-class BigNumber < ActiveRecord::Base; end
+class BigNumber < ActiveRecord::Base
+  property :world_population, Type::Integer.new
+  property :my_house_population, Type::Integer.new
+end
 
 class Reminder < ActiveRecord::Base; end
 


### PR DESCRIPTION
With `ActiveRecord::Properties`, we now have a reasonable path for users
to continue to keep this behavior if they want it. This is an edge case
that has added a lot of complexity to the code base.
