### PR TITLE
Skip if the association was already loaded.

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -143,6 +143,7 @@ module ActiveRecord
       def grouped_records(association, records)
         h = {}
         records.each do |record|
+          next unless record
           assoc = record.association(association)
           klasses = h[assoc.reflection] ||= {}
           (klasses[assoc.klass] ||= []) << record


### PR DESCRIPTION
This tries to fix #15212 but needs a test.

With this patch I was unable to reproduce the bug.

cc @tenderlove
