### PR TITLE
Remove unnecessary require of Minitest.

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -3,7 +3,6 @@ require 'uri'
 require 'active_support/core_ext/kernel/singleton_class'
 require 'active_support/core_ext/object/try'
 require 'rack/test'
-require 'minitest'
 
 module ActionDispatch
   module Integration #:nodoc:

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -1,5 +1,3 @@
-gem 'minitest' # make sure we get the gem, not stdlib
-require 'minitest'
 require 'active_support/testing/tagged_logging'
 require 'active_support/testing/setup_and_teardown'
 require 'active_support/testing/assertions'

--- a/railties/test/generators/argv_scrubber_test.rb
+++ b/railties/test/generators/argv_scrubber_test.rb
@@ -1,5 +1,5 @@
-require 'active_support/test_case'
 require 'active_support/testing/autorun'
+require 'active_support/test_case'
 require 'rails/generators/rails/app/app_generator'
 require 'tempfile'
 

--- a/railties/test/generators/generator_test.rb
+++ b/railties/test/generators/generator_test.rb
@@ -1,5 +1,5 @@
-require 'active_support/test_case'
 require 'active_support/testing/autorun'
+require 'active_support/test_case'
 require 'rails/generators/app_base'
 
 module Rails


### PR DESCRIPTION
Minitest has already been required when calling Minitest.autorun.
