### PR TITLE
Add an interface for type objects to control Ruby => SQL

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -65,6 +65,8 @@ module ActiveRecord
       end
 
       class Type # :nodoc:
+        delegate :type, :type_cast_for_database, to: :@column
+
         def initialize(column)
           @column = column
         end
@@ -75,10 +77,6 @@ module ActiveRecord
           else
             value.unserialized_value
           end
-        end
-
-        def type
-          @column.type
         end
 
         def accessor

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -2,6 +2,8 @@ module ActiveRecord
   module AttributeMethods
     module TimeZoneConversion
       class Type # :nodoc:
+        delegate :type, :type_cast_for_database, to: :@column
+
         def initialize(column)
           @column = column
         end
@@ -9,10 +11,6 @@ module ActiveRecord
         def type_cast(value)
           value = @column.type_cast(value)
           value.acts_like?(:time) ? value.in_time_zone : value
-        end
-
-        def type
-          @column.type
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -47,6 +47,15 @@ module ActiveRecord
           return value.id
         end
 
+        # FIXME: The only case we get an object other than nil or a real column
+        # is `SchemaStatements#add_column` with a PG array that has a non-empty default
+        # value. Is this really the only case? Are we missing tests for other types?
+        # We should have a real column object passed (or nil) here, and check for that
+        # instead
+        if column.respond_to?(:type_cast_for_database)
+          value = column.type_cast_for_database(value)
+        end
+
         case value
         when String, ActiveSupport::Multibyte::Chars
           value = value.to_s

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -18,7 +18,8 @@ module ActiveRecord
 
       alias :encoded? :coder
 
-      delegate :type, :precision, :scale, :limit, :klass, :text?, :number?, :binary?, :type_cast_for_write, to: :cast_type
+      delegate :type, :precision, :scale, :limit, :klass, :text?, :number?, :binary?,
+        :type_cast_for_write, :type_cast_for_database, to: :cast_type
 
       # Instantiates a new column in the table.
       #

--- a/activerecord/lib/active_record/connection_adapters/type/value.rb
+++ b/activerecord/lib/active_record/connection_adapters/type/value.rb
@@ -21,6 +21,10 @@ module ActiveRecord
           value
         end
 
+        def type_cast_for_database(value)
+          type_cast_for_write(value)
+        end
+
         def text?
           false
         end

--- a/activerecord/test/cases/adapters/postgresql/composite_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/composite_test.rb
@@ -122,7 +122,6 @@ class PostgresqlCompositeWithCustomOIDTest < ActiveRecord::TestCase
     assert_equal "Champs-Élysées", composite.address.street
 
     composite.address = FullAddress.new("Paris", "Rue Basse")
-    skip "Saving with custom OID type is currently not supported."
     composite.save!
 
     assert_equal 'Paris', composite.reload.address.city


### PR DESCRIPTION
Adds the ability to save custom types, which type cast to non-primitive
ruby objects.
