### PR TITLE
The correct status to test should be :switching_protocols.

### DIFF
--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -81,8 +81,8 @@ module BareMetalTest
       assert_nil headers['Content-Length']
     end
 
-    test "head :continue (101) does not return a content-type header" do
-      headers = HeadController.action(:continue).call(Rack::MockRequest.env_for("/")).second
+    test "head :switching_protocols (101) does not return a content-type header" do
+      headers = HeadController.action(:switching_protocols).call(Rack::MockRequest.env_for("/")).second
       assert_nil headers['Content-Type']
       assert_nil headers['Content-Length']
     end


### PR DESCRIPTION
The test is identical to https://github.com/rails/rails/blob/master/actionpack/test/controller/new_base/bare_metal_test.rb#L78-L82 except the description.

I think the intention was to test for status `:switiching_protocols` (101).

cc @senny.
