### PR TITLE
Speed-up TimeWithZone to String conversion

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -353,6 +353,14 @@ module ActiveSupport
       initialize(variables[0].utc, ::Time.find_zone(variables[1]), variables[2].utc)
     end
 
+    # respond_to_missing? is not called in some cases, such as when type conversion is
+    # performed with Kernel#String
+    def respond_to?(sym, include_priv = false)
+      # ensure that we're not going to throw and rescue from NoMethodError in method_missing which is slow
+      return false if sym.to_sym == :to_str
+      super
+    end
+
     # Ensure proxy class responds to all methods that underlying time instance
     # responds to.
     def respond_to_missing?(sym, include_priv)


### PR DESCRIPTION
I've noticed that `String(model.created_at)` is performing poorly in comparision
with other fields. The source of the problem is a way `Kernel#String` works: it first
tries to call `to_str` (which causes `NoMethodError` in `method_missing`) and then calls `to_s`.

Performance tests:

```
tz = Time.zone.now
```

Without this code:

```
puts Benchmark.measure { 100_000.times { String(tz) } } # => 10.120000  0.050000   10.170000 ( 10.160466)
```

With this code:

```
puts Benchmark.measure { 100_000.times { String(tz) } } # => 0.780000   0.080000   0.860000  (  0.856519)
```
