### PR TITLE
Don't save unchanged parent in has_one through

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -419,7 +419,7 @@ module ActiveRecord
       # If the record is new or it has changed, returns true.
       def record_changed?(reflection, record, key)
         record.new_record? ||
-          (record.has_attribute?(reflection.foreign_key) && record[reflection.foreign_key] != key) ||
+          (!reflection.through_reflection && record.has_attribute?(reflection.foreign_key) && record[reflection.foreign_key] != key) ||
           record.attribute_changed?(reflection.foreign_key)
       end
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -21,6 +21,9 @@ require 'models/treasure'
 require 'models/eye'
 require 'models/electron'
 require 'models/molecule'
+require 'models/minivan'
+require 'models/speedometer'
+require 'models/dashboard'
 require 'models/member'
 require 'models/member_detail'
 require 'models/organization'
@@ -80,6 +83,18 @@ class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
     model.instance_variables.grep(/_callbacks$/).flat_map do |ivar|
       model.instance_variable_get(ivar)
     end
+  end
+end
+
+class TestDefaultAutosaveAssociationonAHasOneThroughAssociation < ActiveRecord::TestCase
+  fixtures :minivans, :speedometers, :dashboards
+
+  def test_parent_not_resaved_when_unchanged
+    minivan = minivans(:cool_first)
+    minivan.dashboard.expects(:save).never
+
+    minivan.name += '-changed'
+    assert_nothing_raised { minivan.save! }
   end
 end
 


### PR DESCRIPTION
When the `AutosaveAssociation#save_has_one_association` is called for a `has_one :user, through: :post` association, the following code [on line 408 in `autosave_association.rb`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/autosave_association.rb#L408) is always true:

`record[reflection.foreign_key] != key`

This because `reflection.foreign_key` would return the `Post`s' foreign key `"user_id"`, while `record` is a `User` object. Obviously a `user[:user_id]` is always nil and never equal to the `id` of the object the association is set on.

The symptom is that a parent object is always saved, and callbacks always run, even though there might not be any changes, which according to the call to `record_changed?` is undesirable behaviour.

Fixes #13360
