### PR TITLE
[ci skip] Update GFM link in guides guidelines.

### DIFF
--- a/guides/source/ruby_on_rails_guides_guidelines.md
+++ b/guides/source/ruby_on_rails_guides_guidelines.md
@@ -13,7 +13,7 @@ After reading this guide, you will know:
 Markdown
 -------
 
-Guides are written in [GitHub Flavored Markdown](http://github.github.com/github-flavored-markdown/). There is comprehensive [documentation for Markdown](http://daringfireball.net/projects/markdown/syntax), a [cheatsheet](http://daringfireball.net/projects/markdown/basics), and [additional documentation](http://github.github.com/github-flavored-markdown/) on the differences from traditional Markdown.
+Guides are written in [GitHub Flavored Markdown](https://help.github.com/articles/github-flavored-markdown). There is comprehensive [documentation for Markdown](http://daringfireball.net/projects/markdown/syntax), a [cheatsheet](http://daringfireball.net/projects/markdown/basics).
 
 Prologue
 --------


### PR DESCRIPTION
Also remove a duplicated sentence:

```
, and [additional documentation](http://github.github.com/github-flavored-markdown/) on the differences from traditional Markdown.
```

This already been addressed in [GitHub Flavored Markdown](https://help.github.com/articles/github-flavored-markdown).
