### PR TITLE
now rake stats is both - engine friendly and backwards compatible

### DIFF
--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -1,23 +1,30 @@
+# while having global constant is not good,
+# many 3rd party tools depend on it, like rspec-rails, cucumber-rails, etc
+# so if will be removed - deprecation warning is needed
+
+# this code produces a warning in case of engine,
+# which is a signal, that this chunk of rake tasks should be rewritten
+STATS_DIRECTORIES = [
+  %w(Controllers        app/controllers),
+  %w(Helpers            app/helpers),
+  %w(Models             app/models),
+  %w(Mailers            app/mailers),
+  %w(Javascripts        app/assets/javascripts),
+  %w(Libraries          lib/),
+  %w(APIs               app/apis),
+  %w(Controller\ tests  test/controllers),
+  %w(Helper\ tests      test/helpers),
+  %w(Model\ tests       test/models),
+  %w(Mailer\ tests      test/mailers),
+  %w(Integration\ tests test/integration),
+  %w(Functional\ tests\ (old)  test/functional),
+  %w(Unit\ tests \ (old)       test/unit)
+].collect do |name, dir| 
+  [ name, "#{defined?(ENGINE_PATH)? ENGINE_PATH : Rails.root}/#{dir}" ]
+end.select { |name, dir| File.directory?(dir) }
+
 desc "Report code statistics (KLOCs, etc) from the application or engine"
 task :stats do
   require 'rails/code_statistics'
-
-  STATS_DIRECTORIES = [
-    %w(Controllers        app/controllers),
-    %w(Helpers            app/helpers),
-    %w(Models             app/models),
-    %w(Mailers            app/mailers),
-    %w(Javascripts        app/assets/javascripts),
-    %w(Libraries          lib/),
-    %w(APIs               app/apis),
-    %w(Controller\ tests  test/controllers),
-    %w(Helper\ tests      test/helpers),
-    %w(Model\ tests       test/models),
-    %w(Mailer\ tests      test/mailers),
-    %w(Integration\ tests test/integration),
-    %w(Functional\ tests\ (old)  test/functional),
-    %w(Unit\ tests \ (old)       test/unit)
-  ].collect { |name, dir| [ name, "#{defined?(ENGINE_PATH)? ENGINE_PATH : Rails.root}/#{dir}" ] }.select { |name, dir| File.directory?(dir) }
-
   CodeStatistics.new(*STATS_DIRECTORIES).to_s
 end


### PR DESCRIPTION
While changes in #15299 were clear, but 3rd party tools are dependent on current global constant, according to #15308

This solution will produce warnings in context of rails engine

Consider merging this/reverting #15299/providing your solution
