### PR TITLE
Remove checks against `column.type` in abstract adapter quoting

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -11,24 +11,11 @@ module ActiveRecord
 
         case value
         when String, ActiveSupport::Multibyte::Chars
-          value = value.to_s
-          return "'#{quote_string(value)}'" unless column
-
-          case column.type
-          when :integer then value.to_i.to_s
-          when :float then value.to_f.to_s
-          else
-            "'#{quote_string(value)}'"
-          end
-
-        when true, false
-          if column && column.type == :integer
-            value ? '1' : '0'
-          else
-            value ? quoted_true : quoted_false
-          end
-          # BigDecimals need to be put in a non-normalized form and quoted.
+          "'#{quote_string(value.to_s)}'"
+        when true       then quoted_true
+        when false      then quoted_false
         when nil        then "NULL"
+        # BigDecimals need to be put in a non-normalized form and quoted.
         when BigDecimal then value.to_s('F')
         when Numeric, ActiveSupport::Duration then value.to_s
         when Date, Time then "'#{quoted_date(value)}'"
@@ -58,24 +45,11 @@ module ActiveRecord
 
         case value
         when String, ActiveSupport::Multibyte::Chars
-          value = value.to_s
-          return value unless column
-
-          case column.type
-          when :integer then value.to_i
-          when :float then value.to_f
-          else
-            value
-          end
-
-        when true, false
-          if column && column.type == :integer
-            value ? 1 : 0
-          else
-            value ? 't' : 'f'
-          end
-          # BigDecimals need to be put in a non-normalized form and quoted.
+          value.to_s
+        when true       then 't'
+        when false      then 'f'
         when nil        then nil
+        # BigDecimals need to be put in a non-normalized form and quoted.
         when BigDecimal then value.to_s('F')
         when Numeric    then value
         when Date, Time then quoted_date(value)

--- a/activerecord/lib/active_record/connection_adapters/type/float.rb
+++ b/activerecord/lib/active_record/connection_adapters/type/float.rb
@@ -12,6 +12,8 @@ module ActiveRecord
           ::Float
         end
 
+        alias type_cast_for_database type_cast
+
         private
 
         def cast_value(value)

--- a/activerecord/lib/active_record/connection_adapters/type/integer.rb
+++ b/activerecord/lib/active_record/connection_adapters/type/integer.rb
@@ -12,6 +12,8 @@ module ActiveRecord
           ::Fixnum
         end
 
+        alias type_cast_for_database type_cast
+
         private
 
         def cast_value(value)

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -15,10 +15,10 @@ module ActiveRecord
 
         def test_type_cast_binary_encoding_without_logger
           @conn.extend(Module.new { def logger; end })
-          column = Struct.new(:type, :name).new(:string, "foo")
+          cast_type = Type::String.new
           binary = SecureRandom.hex
           expected = binary.dup.encode!(Encoding::UTF_8)
-          assert_equal expected, @conn.type_cast(binary, column)
+          assert_equal expected, @conn.type_cast(binary, cast_type)
         end
 
         def test_type_cast_symbol

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -101,12 +101,10 @@ module ActiveRecord
 
       def test_quote_true
         assert_equal @quoter.quoted_true, @quoter.quote(true, nil)
-        assert_equal '1', @quoter.quote(true, Struct.new(:type).new(:integer))
       end
 
       def test_quote_false
         assert_equal @quoter.quoted_false, @quoter.quote(false, nil)
-        assert_equal '0', @quoter.quote(false, Struct.new(:type).new(:integer))
       end
 
       def test_quote_float
@@ -163,16 +161,6 @@ module ActiveRecord
       def test_quote_as_mb_chars_no_column
         string = ActiveSupport::Multibyte::Chars.new('lo\l')
         assert_equal "'lo\\\\l'", @quoter.quote(string, nil)
-      end
-
-      def test_quote_string_int_column
-        assert_equal "1", @quoter.quote('1', FakeColumn.new(:integer))
-        assert_equal "1", @quoter.quote('1.2', FakeColumn.new(:integer))
-      end
-
-      def test_quote_string_float_column
-        assert_equal "1.0", @quoter.quote('1', FakeColumn.new(:float))
-        assert_equal "1.2", @quoter.quote('1.2', FakeColumn.new(:float))
       end
 
       def test_quote_as_mb_chars_binary_column


### PR DESCRIPTION
The intention is to eventually remove `column` from the arguments list
both for `quote` and for `type_cast` entirely. This is the first step
to that end.
