### PR TITLE
Added #upcase_first_char to upcase the first char leaving the rest untouched

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Added `#upcase_first_char` method to ActiveSupport::Multibyte::Chars.
+    This method converts the first character to uppercase leaving the remainder
+    untouched.
+    This is similar to #capitalize but is very useful when a string contains
+    names or acronyms, for example:
+
+        "my name is Aldo and I like BBQ".mb_chars.upcase_first_char.to_s
+        # => "My name is Aldo and I like BBQ"
+        # (#capitalize would return "My name is aldo and i bbq")
+
+    *Aldo "xoen" Giambelluca*
+
 *   `Hash#deep_transform_keys` and `Hash#deep_transform_keys!` now transform hashes
     in nested arrays.  This change also applies to `Hash#deep_stringify_keys`,
     `Hash#deep_stringify_keys!`, `Hash#deep_symbolize_keys` and

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -125,7 +125,7 @@ module ActiveSupport #:nodoc:
   class SafeBuffer < String
     UNSAFE_STRING_METHODS = %w(
       capitalize chomp chop delete downcase gsub lstrip next reverse rstrip
-      slice squeeze strip sub succ swapcase tr tr_s upcase
+      slice squeeze strip sub succ swapcase tr tr_s upcase upcase_first_char
     )
 
     alias_method :original_concat, :concat

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -136,6 +136,14 @@ module ActiveSupport #:nodoc:
         (slice(0) || chars('')).upcase + (slice(1..-1) || chars('')).downcase
       end
 
+      # Converts the first character to uppercase and leaves the remainder untouched.
+      #
+      #  "my name is Aldo and I like BBQ".mb_chars.upcase_first_char.to_s # => "my name is Aldo and I like BBQ"
+      #  "è AJAX?".mb_chars.upcase_first_char.to_s # => "È AJAX?"
+      def upcase_first_char
+        (slice(0) || chars('')).upcase + (slice(1..-1) || chars(''))
+      end
+
       # Capitalizes the first letter of every word, when possible.
       #
       #   "ÉL QUE SE ENTERÓ".mb_chars.titleize    # => "Él Que Se Enteró"
@@ -193,7 +201,7 @@ module ActiveSupport #:nodoc:
         to_s.as_json(options)
       end
 
-      %w(capitalize downcase reverse tidy_bytes upcase).each do |method|
+      %w(capitalize downcase reverse tidy_bytes upcase upcase_first_char).each do |method|
         define_method("#{method}!") do |*args|
           @wrapped_string = send(method, *args).to_s
           self

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -449,6 +449,11 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
     assert_equal 'Abc', 'abc'.mb_chars.capitalize
   end
 
+  def test_upcase_first_char_should_work_on_ascii_characters
+    assert_equal '', ''.mb_chars.upcase_first_char
+    assert_equal 'Abc AJAX', 'abc AJAX'.mb_chars.upcase_first_char
+  end
+
   def test_titleize_should_work_on_ascii_characters
     assert_equal '', ''.mb_chars.titleize
     assert_equal 'Abc Abc', 'abc abc'.mb_chars.titleize
@@ -502,6 +507,15 @@ class MultibyteCharsExtrasTest < ActiveSupport::TestCase
       'АБВГ АБВГ' => 'Абвг абвг',
       '' => '' }.each do |f,t|
         assert_equal t, chars(f).capitalize
+    end
+  end
+
+  def test_upcase_first_char_should_be_unicode_aware
+    { 'аБвг аБвг' => 'АБвг аБвг',
+      'аБвг АБВГ' => 'АБвг АБВГ',
+      'АБВГ АБВГ' => 'АБВГ АБВГ',
+      '' => '' }.each do |f,t|
+        assert_equal t, chars(f).upcase_first_char
     end
   end
 


### PR DESCRIPTION
The #capitalize method has the "side effect" of downcasing all the letters in a
string. This could not be the desired effect when we just want to upcase the
first letter.

This is particularly useful when the string contains acronyms or names and we
don't want to change the case of their letters.

e.g. "my name is Aldo and I like BBQ".capitalize returns
     "My name is aldo and i like bbq" while using #upcase_first_char becames
     "My name is Aldo and I like BBQ" which makes more sense most of the times.
