### PR TITLE
Use the join_table calculated by the association in Reflections

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1577,8 +1577,6 @@ module ActiveRecord
           scope   = nil
         end
 
-        habtm_reflection = ActiveRecord::Reflection::HasAndBelongsToManyReflection.new(:has_and_belongs_to_many, name, scope, options, self)
-
         builder = Builder::HasAndBelongsToMany.new name, self, options
 
         join_model = builder.through_model
@@ -1592,7 +1590,6 @@ module ActiveRecord
 
         Builder::HasMany.define_callbacks self, middle_reflection
         Reflection.add_reflection self, middle_reflection.name, middle_reflection
-        middle_reflection.parent_reflection = [name.to_s, habtm_reflection]
 
         include Module.new {
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
@@ -1613,7 +1610,12 @@ module ActiveRecord
         end
 
         has_many name, scope, hm_options, &extension
-        self._reflections[name.to_s].parent_reflection = [name.to_s, habtm_reflection]
+
+        hm_reflection = _reflect_on_association(name)
+        habtm_reflection = ActiveRecord::Reflection::HasAndBelongsToManyReflection.new(:has_and_belongs_to_many, name, scope, options, self)
+
+        hm_reflection.parent_reflection = [name.to_s, habtm_reflection]
+        middle_reflection.parent_reflection = [name.to_s, habtm_reflection]
       end
     end
   end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -266,7 +266,7 @@ module ActiveRecord
       end
 
       def join_table
-        @join_table ||= options[:join_table] || derive_join_table
+        active_record._reflect_on_association(name).join_table
       end
 
       def foreign_key
@@ -533,10 +533,6 @@ Joining, Preloading and eager loading of these associations is deprecated and wi
           end
         end
 
-        def derive_join_table
-          [active_record.table_name, klass.table_name].sort.join("\0").gsub(/^(.*_)(.+)\0\1(.+)/, '\1\2_\3').gsub("\0", "_")
-        end
-
         def primary_key(klass)
           klass.primary_key || raise(UnknownPrimaryKey.new(klass))
         end
@@ -756,6 +752,15 @@ directive on your declaration like:
 
         check_validity_of_inverse!
       end
+
+      def join_table
+         @join_table ||= options[:join_table] || derive_join_table
+      end
+
+      def derive_join_table
+        through_reflection.klass.table_name
+      end
+
 
       protected
 


### PR DESCRIPTION
For some reason, AssociationReflection just copied the [code from the Associations::Builder](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb#L14) to return the `join_table` name.

Calling the actual table_name of the reflection's class gives us the table name of the join_table.

This breaks [3 tests in reflection_tests.rb](https://github.com/rails/rails/blob/master/activerecord/test/cases/reflection_test.rb#L352-L389) which used a Struct to emulate a subset of ActiveRecord, but never actually defined any associations, so through_reflection here is nil making the test fail. I updated the tests to use real AR models. Let me know if this is a Bad Idea :)
