### PR TITLE
Replace double quotes with single quotes while adding an entry into Gemfile

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Replace double quotes with single quotes while adding an entry into Gemfile.
+
+    *Alexander Belaev*
+
 *   Default `config.assets.digest` to `true` in development.
 
     *Dan Kang*

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -20,9 +20,9 @@ module Rails
 
         # Set the message to be shown in logs. Uses the git repo if one is given,
         # otherwise use name (version).
-        parts, message = [ name.inspect ], name
+        parts, message = [ quote(name) ], name
         if version ||= options.delete(:version)
-          parts   << version.inspect
+          parts   << quote(version)
           message << " (#{version})"
         end
         message = options[:git] if options[:git]
@@ -30,7 +30,7 @@ module Rails
         log :gemfile, message
 
         options.each do |option, value|
-          parts << "#{option}: #{value.inspect}"
+          parts << "#{option}: #{quote(value)}"
         end
 
         in_root do
@@ -68,7 +68,7 @@ module Rails
         log :source, source
 
         in_root do
-          prepend_file "Gemfile", "source #{source.inspect}\n", verbose: false
+          prepend_file "Gemfile", "source #{quote(source)}\n", verbose: false
         end
       end
 
@@ -252,6 +252,16 @@ module Rails
             "#{name}.bat"
           else
             name
+          end
+        end
+
+        # Surround string with single quotes if there is no quotes.
+        # Otherwise fall back to double quotes
+        def quote(str)
+          if str.class == String && str.scan("'").size > 0
+            str.inspect
+          else
+            "'#{str}'"
           end
         end
 

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -41,13 +41,13 @@ class ActionsTest < Rails::Generators::TestCase
   def test_add_source_adds_source_to_gemfile
     run_generator
     action :add_source, 'http://gems.github.com'
-    assert_file 'Gemfile', /source "http:\/\/gems\.github\.com"/
+    assert_file 'Gemfile', /source 'http:\/\/gems\.github\.com'/
   end
 
   def test_gem_should_put_gem_dependency_in_gemfile
     run_generator
     action :gem, 'will-paginate'
-    assert_file 'Gemfile', /gem "will\-paginate"/
+    assert_file 'Gemfile', /gem 'will\-paginate'/
   end
 
   def test_gem_with_version_should_include_version_in_gemfile
@@ -55,7 +55,7 @@ class ActionsTest < Rails::Generators::TestCase
 
     action :gem, 'rspec', '>=2.0.0.a5'
 
-    assert_file 'Gemfile', /gem "rspec", ">=2.0.0.a5"/
+    assert_file 'Gemfile', /gem 'rspec', '>=2.0.0.a5'/
   end
 
   def test_gem_should_insert_on_separate_lines
@@ -66,8 +66,8 @@ class ActionsTest < Rails::Generators::TestCase
     action :gem, 'rspec'
     action :gem, 'rspec-rails'
 
-    assert_file 'Gemfile', /^gem "rspec"$/
-    assert_file 'Gemfile', /^gem "rspec-rails"$/
+    assert_file 'Gemfile', /^gem 'rspec'$/
+    assert_file 'Gemfile', /^gem 'rspec-rails'$/
   end
 
   def test_gem_should_include_options
@@ -75,7 +75,7 @@ class ActionsTest < Rails::Generators::TestCase
 
     action :gem, 'rspec', github: 'dchelimsky/rspec', tag: '1.2.9.rc1'
 
-    assert_file 'Gemfile', /gem "rspec", github: "dchelimsky\/rspec", tag: "1\.2\.9\.rc1"/
+    assert_file 'Gemfile', /gem 'rspec', github: 'dchelimsky\/rspec', tag: '1\.2\.9\.rc1'/
   end
 
   def test_gem_group_should_wrap_gems_in_a_group
@@ -89,7 +89,7 @@ class ActionsTest < Rails::Generators::TestCase
       gem 'fakeweb'
     end
 
-    assert_file 'Gemfile', /\ngroup :development, :test do\n  gem "rspec-rails"\nend\n\ngroup :test do\n  gem "fakeweb"\nend/
+    assert_file 'Gemfile', /\ngroup :development, :test do\n  gem 'rspec-rails'\nend\n\ngroup :test do\n  gem 'fakeweb'\nend/
   end
 
   def test_environment_should_include_data_in_environment_initializer_block


### PR DESCRIPTION
The purpose of this commit is to make the quotes consistent in Gemfile.
New Gemfile in rails root directory uses single quotes, but if user uses a template(--template) option to add more gems into Gemfile, then it generates rows with double quotes.
An example of inconsistent Gemfile:

``` ruby
source 'https://rubygems.org'

# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
gem 'rails', '4.1.1'
# Use postgresql as the database for Active Record
gem 'pg'
# Use SCSS for stylesheets
gem 'sass-rails', '~> 4.0.3'


group :test do
  gem "technoweenie-restful-authentication", lib: "restful-authentication", source: "http://gems.github.com/"
  gem "rails", "3.0", git: "git://github.com/rails/rails"
end
```

``` ruby
# template.rb
gem_group :test do
  gem 'technoweenie-restful-authentication', lib: 'restful-authentication', source: 'http://gems.github.com/'
  gem 'rails', '3.0', git: 'git://github.com/rails/rails'
end
```
