### PR TITLE
Updated Named Scope STI

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -28,6 +28,17 @@
 
     *Brock Trappitt*
 
+*   Changed scoped blocks to be executed with `instance_eval`
+
+    Named scopes (i.e. using STI) were previously cached according to
+    base class so scoped queries made by classes with a common ancestor would
+    leak. Changed the way scope blocks were called so inheritance rules are
+    followed during the call and scopes are cached correctly.
+
+    Fixes #13466.
+
+    *Jefferson Lai*
+
 *   Fixed the inferred table name of a has_and_belongs_to_many auxiliar
     table inside a schema.
 

--- a/activerecord/lib/active_record/scoping.rb
+++ b/activerecord/lib/active_record/scoping.rb
@@ -11,11 +11,11 @@ module ActiveRecord
 
     module ClassMethods
       def current_scope #:nodoc:
-        ScopeRegistry.value_for(:current_scope, base_class.to_s)
+        ScopeRegistry.value_for(:current_scope, self.to_s)
       end
 
       def current_scope=(scope) #:nodoc:
-        ScopeRegistry.set_value_for(:current_scope, base_class.to_s, scope)
+        ScopeRegistry.set_value_for(:current_scope, self.to_s, scope)
       end
     end
 

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -148,9 +148,13 @@ module ActiveRecord
           extension = Module.new(&block) if block
 
           singleton_class.send(:define_method, name) do |*args|
-            scope = all.scoping { body.call(*args) }
+            if body.respond_to?(:to_proc)
+              scope = all.scoping { instance_exec(*args, &body) }
+            else
+              # Body is given as an object instead of a block, so invoke call()
+              scope = all.scoping { body.call(*args) }
+            end
             scope = scope.extending(extension) if extension
-
             scope || all
           end
         end

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -2,12 +2,13 @@ require "cases/helper"
 require 'models/post'
 require 'models/topic'
 require 'models/comment'
+require 'models/rating'
 require 'models/reply'
 require 'models/author'
 require 'models/developer'
 
 class NamedScopingTest < ActiveRecord::TestCase
-  fixtures :posts, :authors, :topics, :comments, :author_addresses
+  fixtures :posts, :authors, :topics, :comments, :author_addresses, :ratings
 
   def test_implements_enumerable
     assert !Topic.all.empty?
@@ -113,6 +114,10 @@ class NamedScopingTest < ActiveRecord::TestCase
   def test_scope_with_STI
     assert_equal 3,Post.containing_the_letter_a.count
     assert_equal 1,SpecialPost.containing_the_letter_a.count
+  end
+
+  def test_scope_subquery_with_STI
+    assert_nothing_raised { VerySpecialComment.special_parent(SpecialRating.first).count }
   end
 
   def test_has_many_through_associations_have_access_to_scopes

--- a/activerecord/test/fixtures/ratings.yml
+++ b/activerecord/test/fixtures/ratings.yml
@@ -2,13 +2,23 @@ normal_comment_rating:
   id: 1
   comment_id: 8
   value: 1
+  type: Rating
 
 special_comment_rating:
   id: 2
   comment_id: 6
   value: 1
+  type: Rating
 
 sub_special_comment_rating:
   id: 3
   comment_id: 12
   value: 1
+  type: Rating
+
+special_rating:
+  id: 4
+  comment_id: 10
+  value: 1
+  type: SpecialRating
+  special_comment_id: 3

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -42,6 +42,7 @@ class SubSpecialComment < SpecialComment
 end
 
 class VerySpecialComment < Comment
+  scope :special_parent, lambda { |special_rating| where parent_id: special_rating.special_comment.id }
 end
 
 class CommentThatAutomaticallyAltersPostBody < Comment

--- a/activerecord/test/models/rating.rb
+++ b/activerecord/test/models/rating.rb
@@ -2,3 +2,7 @@ class Rating < ActiveRecord::Base
   belongs_to :comment
   has_many :taggings, :as => :taggable
 end
+
+class SpecialRating < Rating
+  belongs_to :special_comment
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -599,7 +599,9 @@ ActiveRecord::Schema.define do
 
   create_table :ratings, force: true do |t|
     t.integer :comment_id
+    t.integer :special_comment_id
     t.integer :value
+    t.string :type
   end
 
   create_table :readers, force: true do |t|


### PR DESCRIPTION
Updated #14544 to work with `activerecord-deprecated_finders`. Required change to older style of lambda definitions. Fixes issue #13466
