### PR TITLE
update the recommended ruby version.

### DIFF
--- a/railties/lib/rails/ruby_version_check.rb
+++ b/railties/lib/rails/ruby_version_check.rb
@@ -2,7 +2,7 @@ if RUBY_VERSION < '1.9.3'
   desc = defined?(RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : "ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE})"
   abort <<-end_message
 
-    Rails 4 prefers to run on Ruby 2.0.
+    Rails 4 prefers to run on Ruby 2.1 or newer.
 
     You're running
       #{desc}


### PR DESCRIPTION
I changed the message since this file hasn't been updated for more than one year and it sounded like as if we should stick to Ruby 2.0. It appears Rails 4 initially had a problem with Ruby 2.1, but by [March, 2014](http://web.archive.org/web/20140330023208/http://rubyonrails.org/download) (when Rails 4.1 wasn't released yet) the official site started recommending Ruby 2.1. 
