### PR TITLE
Add support for Arel Nodes + Attributes as column_name arguments in ActiveRecord::Calculations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -4,6 +4,14 @@
 
     *Godfrey Chan*
 
+*   Add support for arel attributes and nodes in `ActiveRecord::Calculations`
+
+    The `select` method on an ActiveRecord::Relation allowed for Arel nodes
+    whilst methods from `calculations` such as pluck did not. Now they are 
+    also valid arguments in place of any column name.
+
+    *Brock Trappitt*
+
 *   When a `group` is set, `sum`, `size`, `average`, `minimum` and `maximum`
     on a NullRelation should return a Hash.
 
@@ -22,7 +30,7 @@
 
 *   Change belongs_to touch to be consistent with timestamp updates
 
-    If a model is set up with a belongs_to: touch relatinoship the parent
+    If a model is set up with a belongs_to: touch relationship the parent
     record will only be touched if the record was modified. This makes it
     consistent with timestamp updating on the record itself.
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -111,8 +111,6 @@ module ActiveRecord
       # activerecord-deprecated_finders.
       if column_name.is_a?(Symbol) && attribute_alias?(column_name)
         column_name = attribute_alias(column_name)
-#      elsif column_name.is_a?(Arel::Attributes::Attribute) || column_name.class <= Arel::Nodes::Node
-#        column_name = visitor.compile(column_name)
       end
 
       if has_include?(column_name)
@@ -232,8 +230,8 @@ module ActiveRecord
     def aggregate_column(column_name)
       if @klass.column_names.include?(column_name.to_s)
         Arel::Attribute.new(@klass.unscoped.table, column_name)
-#      elsif column_name.is_a?(Arel::Attributes::Attribute) || column_name.class <= Arel::Nodes::Node
-#        visitor.compile(column_name)
+      elsif column_name.is_a?(Arel::Attributes::Attribute) || column_name.class <= Arel::Nodes::Node
+        column_name
       else
         Arel.sql(column_name == :all ? "*" : column_name.to_s)
       end

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -111,6 +111,8 @@ module ActiveRecord
       # activerecord-deprecated_finders.
       if column_name.is_a?(Symbol) && attribute_alias?(column_name)
         column_name = attribute_alias(column_name)
+#      elsif column_name.is_a?(Arel::Attributes::Attribute) || column_name.class <= Arel::Nodes::Node
+#        column_name = visitor.compile(column_name)
       end
 
       if has_include?(column_name)
@@ -230,6 +232,8 @@ module ActiveRecord
     def aggregate_column(column_name)
       if @klass.column_names.include?(column_name.to_s)
         Arel::Attribute.new(@klass.unscoped.table, column_name)
+#      elsif column_name.is_a?(Arel::Attributes::Attribute) || column_name.class <= Arel::Nodes::Node
+#        visitor.compile(column_name)
       else
         Arel.sql(column_name == :all ? "*" : column_name.to_s)
       end

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -157,6 +157,8 @@ module ActiveRecord
       column_names.map! do |column_name|
         if column_name.is_a?(Symbol) && attribute_alias?(column_name)
           attribute_alias(column_name)
+        elsif column_name.is_a?(Arel::Attributes::Attribute) || column_name.class <= Arel::Nodes::Node
+          visitor.compile(column_name)
         else
           column_name.to_s
         end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -33,6 +33,16 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 318, Account.sum(:available_credit)
   end
 
+  def test_should_calculate_arel_attribute
+    node = Account.arel_table[:available_credit]
+    assert_equal 318, Account.sum(node)
+  end
+
+  def test_should_calculate_arel_node
+    node = Account.arel_table[:available_credit] * 2
+    assert_equal 636, Account.sum(node)
+  end
+
   def test_should_return_decimal_average_of_integer_field
     value = Account.average(:id)
     assert_equal 3.5, value

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -34,12 +34,12 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_calculate_arel_attribute
-    node = Account.arel_table[:available_credit]
+    node = Account.arel_table[:credit_limit]
     assert_equal 318, Account.sum(node)
   end
 
   def test_should_calculate_arel_node
-    node = Account.arel_table[:available_credit] * 2
+    node = Account.arel_table[:credit_limit] * 2
     assert_equal 636, Account.sum(node)
   end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -606,4 +606,30 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal [1,2,3,4,5], taks_relation.pluck(:id)
     assert_equal [false, true, true, true, true], taks_relation.pluck(:approved)
   end
+
+  def test_pluck_can_take_an_arel_attribute
+    node = Topic.arel_table[:id]
+    assert_equal [1,2,3,4,5], Topic.order(:id).pluck(node)
+  end
+
+  def test_pluck_can_take_multiple_arel_attributes
+    id_node = Topic.arel_table[:id]
+    title_node = Topic.arel_table[:title]
+    assert_equal [
+      [1, "The First Topic"], [2, "The Second Topic of the day"],
+      [3, "The Third Topic of the day"], [4, "The Fourth Topic of the day"],
+      [5, "The Fifth Topic of the day"]
+    ], Topic.order(:id).pluck(id_node, title_node)
+  end
+
+  def test_pluck_can_take_computed_arel_node
+    node = Topic.arel_table[:id]
+    node = node + 6
+    assert_equal [7,8,9,10,11], Topic.order(:id).pluck(node)
+  end
+
+  def test_pluck_can_take_arel_function_nodes
+    node = Topic.arel_table[:id].count
+    assert_equal [5], Topic.pluck(node)
+  end
 end


### PR DESCRIPTION
The `select` method on an ActiveRecord::Relation allowed for Arel nodes whilst methods from calculations such as pluck did not. Now they are also valid arguments in place of any column name in ActiveRecord::Calculations.

I dislike how I'm checking for subclasses of Arel::Nodes::Node and the code duplication.  I should note that it is possible to pass in Arel::Nodes::Node subclasses that just don't make sense, but I just considered that the API users responsibility.

In general I'm more happy with the pluck half of it than the calculations, hence the separate commits.

If whole thing seems fine then I'll squash and rebase. The other CHANGELOG I updated was one of my own.
