### PR TITLE
Add missing test case for quoting behavior

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -518,6 +518,10 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal Topic.find('1-meowmeow'), Topic.find(1)
   end
 
+  def test_find_by_slug_with_array
+    assert_equal Topic.find(['1-meowmeow', '2-hello']), Topic.find([1, 2])
+  end
+
   def test_equality_of_new_records
     assert_not_equal Topic.new, Topic.new
     assert_equal false, Topic.new == Topic.new

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -750,6 +750,13 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal [], relation.to_a
   end
 
+  def test_typecasting_where_with_array
+    ids = Author.pluck(:id)
+    slugs = ids.map { |id| "#{id}-as-a-slug" }
+
+    assert_equal Author.all.to_a, Author.where(id: slugs).to_a
+  end
+
   def test_find_all_using_where_with_relation
     david = authors(:david)
     # switching the lines below would succeed in current rails


### PR DESCRIPTION
It appears that the only time that `quote` is called with a column,
but without first calling `type_cast` is when where is called with an
array. My previous pull request broke this behavior, without failing
tests. This adds a test for the only case I can think of that exercises
the `if column.type == :integer` branch of `quote` effectively.
