### PR TITLE
Deprecate type casting of boolean values on integer columns

### DIFF
--- a/activerecord/lib/active_record/type/integer.rb
+++ b/activerecord/lib/active_record/type/integer.rb
@@ -17,8 +17,13 @@ module ActiveRecord
 
       def cast_value(value)
         case value
-        when true then 1
-        when false then 0
+        when true, false
+          ActiveSupport::Deprecation.warn(<<-WARNING.strip_heredoc)
+            Typecasting of booleans on integer columns is deprecated, and will be removed in a
+            future version of rails. If your database does not support boolean columns, check
+            your adapter's documentation for boolean emulation.
+          WARNING
+          value ? 1 : 0
         else value.to_i rescue nil
         end
       end

--- a/activerecord/test/cases/adapters/mysql2/boolean_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/boolean_test.rb
@@ -51,16 +51,18 @@ class Mysql2BooleanTest < ActiveRecord::TestCase
   end
 
   test "test type casting without emulated booleans" do
-    emulate_booleans false
+    assert_deprecated do
+      emulate_booleans false
 
-    boolean = BooleanType.create!(archived: true, published: true)
-    attributes = boolean.reload.attributes_before_type_cast
+      boolean = BooleanType.create!(archived: true, published: true)
+      attributes = boolean.reload.attributes_before_type_cast
 
-    assert_equal 1, attributes["archived"]
-    assert_equal "1", attributes["published"]
+      assert_equal 1, attributes["archived"]
+      assert_equal "1", attributes["published"]
 
-    assert_equal 1, @connection.type_cast(true, boolean_column)
-    assert_equal 1, @connection.type_cast(true, string_column)
+      assert_equal 1, @connection.type_cast(true, boolean_column)
+      assert_equal 1, @connection.type_cast(true, string_column)
+    end
   end
 
   test "with booleans stored as 1 and 0" do

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -47,15 +47,21 @@ module ActiveRecord
         end
 
         def test_type_cast_true
-          c = Column.new(nil, 1, Type::Integer.new)
           assert_equal 't', @conn.type_cast(true, nil)
-          assert_equal 1, @conn.type_cast(true, c)
+
+          assert_deprecated do
+            c = Column.new(nil, 1, Type::Integer.new)
+            assert_equal 1, @conn.type_cast(true, c)
+          end
         end
 
         def test_type_cast_false
-          c = Column.new(nil, 1, Type::Integer.new)
           assert_equal 'f', @conn.type_cast(false, nil)
-          assert_equal 0, @conn.type_cast(false, c)
+
+          assert_deprecated do
+            c = Column.new(nil, 1, Type::Integer.new)
+            assert_equal 0, @conn.type_cast(false, c)
+          end
         end
 
         def test_type_cast_string

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -93,12 +93,16 @@ module ActiveRecord
 
       def test_quote_true
         assert_equal @quoter.quoted_true, @quoter.quote(true, nil)
-        assert_equal '1', @quoter.quote(true, Type::Integer.new)
+        assert_deprecated do
+          assert_equal '1', @quoter.quote(true, Type::Integer.new)
+        end
       end
 
       def test_quote_false
         assert_equal @quoter.quoted_false, @quoter.quote(false, nil)
-        assert_equal '0', @quoter.quote(false, Type::Integer.new)
+        assert_deprecated do
+          assert_equal '0', @quoter.quote(false, Type::Integer.new)
+        end
       end
 
       def test_quote_float

--- a/activerecord/test/cases/types_test.rb
+++ b/activerecord/test/cases/types_test.rb
@@ -50,8 +50,10 @@ module ActiveRecord
         assert_equal 0, type.type_cast('bad1')
         assert_equal 0, type.type_cast('bad')
         assert_equal 1, type.type_cast(1.7)
-        assert_equal 0, type.type_cast(false)
-        assert_equal 1, type.type_cast(true)
+        assert_deprecated do
+          assert_equal 0, type.type_cast(false)
+          assert_equal 1, type.type_cast(true)
+        end
         assert_nil type.type_cast(nil)
       end
 


### PR DESCRIPTION
For adapters like MySQL which do not have a native boolean type, this
behavior has long been handled elsewhere.
