### PR TITLE
prevent bad automatic inverse_of association

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -433,7 +433,7 @@ Joining, Preloading and eager loading of these associations is deprecated and wi
         # returns either nil or the inverse association name that it finds.
         def automatic_inverse_of
           if can_find_inverse_of_automatically?(self)
-            inverse_name = ActiveSupport::Inflector.underscore(active_record.name).to_sym
+            inverse_name = ActiveSupport::Inflector.underscore(options[:as] || active_record.name).to_sym
 
             begin
               reflection = klass.reflect_on_association(inverse_name)

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -100,6 +100,17 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     assert_respond_to club_reflection, :has_inverse?
     assert !club_reflection.has_inverse?, "A has_many_through association should not find an inverse automatically"
   end
+
+  def test_polymorphic_relationships_should_still_not_have_inverses_when_non_polymorphic_relationship_has_the_same_name
+    man_reflection = Man.reflect_on_association(:polymorphic_face_without_inverse)
+    face_reflection = Face.reflect_on_association(:man)
+
+    assert_respond_to face_reflection, :has_inverse?
+    assert face_reflection.has_inverse?, "For this test, the non-polymorphic association must have an inverse"
+
+    assert_respond_to man_reflection, :has_inverse?
+    assert !man_reflection.has_inverse?, "The target of a polymorphic association should not find an inverse automatically"
+  end
 end
 
 class InverseAssociationTests < ActiveRecord::TestCase

--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -1,6 +1,7 @@
 class Face < ActiveRecord::Base
   belongs_to :man, :inverse_of => :face
   belongs_to :polymorphic_man, :polymorphic => true, :inverse_of => :polymorphic_face
+  belongs_to :polymorphic_man_without_inverse, :polymorphic => true
   # These is a "broken" inverse_of for the purposes of testing
   belongs_to :horrible_man, :class_name => 'Man', :inverse_of => :horrible_face
   belongs_to :horrible_polymorphic_man, :polymorphic => true, :inverse_of => :horrible_polymorphic_face

--- a/activerecord/test/models/man.rb
+++ b/activerecord/test/models/man.rb
@@ -1,6 +1,7 @@
 class Man < ActiveRecord::Base
   has_one :face, :inverse_of => :man
   has_one :polymorphic_face, :class_name => 'Face', :as => :polymorphic_man, :inverse_of => :polymorphic_man
+  has_one :polymorphic_face_without_inverse, :class_name => 'Face', :as => :polymorphic_man_without_inverse
   has_many :interests, :inverse_of => :man
   has_many :polymorphic_interests, :class_name => 'Interest', :as => :polymorphic_man, :inverse_of => :polymorphic_man
   # These are "broken" inverse_of associations for the purposes of testing

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -774,6 +774,8 @@ ActiveRecord::Schema.define do
     t.integer :man_id
     t.integer :polymorphic_man_id
     t.string  :polymorphic_man_type
+    t.integer :polymorphic_man_without_inverse_id
+    t.string  :polymorphic_man_without_inverse_type
     t.integer :horrible_polymorphic_man_id
     t.string  :horrible_polymorphic_man_type
   end


### PR DESCRIPTION
This should fix #15337.  The problem is that the automatic inverse_of code ignores the "as" option and can accidentally reflect on the wrong assocation and fail to determine that the association is polymorphic.  If the model with a polymorphic belongs_to association also has a non-polymorphic assocation to the same class it will reflect on that association.
