### PR TITLE
Do not set integer columns to nil when assigning random values

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -51,6 +51,8 @@ module ActiveRecord
         else
           cast_type.type_cast(value)
         end
+      rescue UnableToTypeCast => e
+        raise UnableToTypeCast.new(e.message, name)
       end
 
       # Returns the human name of the column name.

--- a/activerecord/lib/active_record/connection_adapters/type/integer.rb
+++ b/activerecord/lib/active_record/connection_adapters/type/integer.rb
@@ -20,8 +20,10 @@ module ActiveRecord
           case value
           when true then 1
           when false then 0
-          else value.to_i rescue nil
+          else value.to_i
           end
+        rescue
+          raise UnableToTypeCast.new("Unable to cast #{value.inspect} to integer.")
         end
       end
     end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -219,4 +219,13 @@ module ActiveRecord
 
   class TransactionIsolationError < ActiveRecordError
   end
+
+  class UnableToTypeCast < ActiveRecordError
+    attr_reader :column_name
+
+    def initialize(message, column_name = nil)
+      @column_name = column_name
+      super(message)
+    end
+  end
 end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -74,13 +74,6 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal apple.id, citibank.firm_id
   end
 
-  def test_id_assignment
-    apple = Firm.create("name" => "Apple")
-    citibank = Account.create("credit_limit" => 10)
-    citibank.firm_id = apple
-    assert_nil citibank.firm_id
-  end
-
   def test_natural_assignment_with_primary_key
     apple = Firm.create("name" => "Apple")
     citibank = Client.create("name" => "Primary key client")

--- a/activerecord/test/cases/types_test.rb
+++ b/activerecord/test/cases/types_test.rb
@@ -57,26 +57,22 @@ module ActiveRecord
 
       def test_type_cast_non_integer_to_integer
         type = Type::Integer.new
-        assert_nil type.type_cast([1,2])
-        assert_nil type.type_cast({1 => 2})
-        assert_nil type.type_cast((1..2))
+        assert_raises(UnableToTypeCast) { type.type_cast([1,2]) }
+        assert_raises(UnableToTypeCast) { type.type_cast({1 => 2}) }
+        assert_raises(UnableToTypeCast) { type.type_cast((1..2)) }
       end
 
-      def test_type_cast_activerecord_to_integer
-        type = Type::Integer.new
-        firm = Firm.create(:name => 'Apple')
-        assert_nil type.type_cast(firm)
-      end
+      def test_columns_add_column_name_to_exception
+        column = Column.new('my_column', nil, Type::Integer.new)
+        raised = nil
 
-      def test_type_cast_object_without_to_i_to_integer
-        type = Type::Integer.new
-        assert_nil type.type_cast(Object.new)
-      end
+        begin
+          column.type_cast([1, 2])
+        rescue UnableToTypeCast => e
+          raised = e
+        end
 
-      def test_type_cast_nan_and_infinity_to_integer
-        type = Type::Integer.new
-        assert_nil type.type_cast(Float::NAN)
-        assert_nil type.type_cast(1.0/0.0)
+        assert_equal 'my_column', raised.column_name
       end
 
       def test_type_cast_float


### PR DESCRIPTION
This behavior was originally added to allow the following to work:

```
Post.where(category_id: [1, 2]).new
```

This case will still continue to work as it did before, since this form
is likely used for things like access control. However, assigning types
which do not respond to `#to_i` to an integer column will now raise an
exception for the general case.
