### PR TITLE
Skip individual tests upon Dalli::RingError

### DIFF
--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -49,6 +49,8 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
         assert_response :success
         assert_equal 'foo: "bar"', response.body
       end
+    rescue Dalli::RingError => ex
+      skip ex.message, ex.backtrace
     end
 
     def test_getting_nil_session_value
@@ -57,6 +59,8 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
         assert_response :success
         assert_equal 'foo: nil', response.body
       end
+    rescue Dalli::RingError => ex
+      skip ex.message, ex.backtrace
     end
 
     def test_getting_session_value_after_session_reset
@@ -76,6 +80,8 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
         assert_response :success
         assert_equal 'foo: nil', response.body, "data for this session should have been obliterated from memcached"
       end
+    rescue Dalli::RingError => ex
+      skip ex.message, ex.backtrace
     end
 
     def test_getting_from_nonexistent_session
@@ -85,6 +91,8 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
         assert_equal 'foo: nil', response.body
         assert_nil cookies['_session_id'], "should only create session on write, not read"
       end
+    rescue Dalli::RingError => ex
+      skip ex.message, ex.backtrace
     end
 
     def test_setting_session_value_after_session_reset
@@ -106,6 +114,8 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
         assert_response :success
         assert_not_equal session_id, response.body
       end
+    rescue Dalli::RingError => ex
+      skip ex.message, ex.backtrace
     end
 
     def test_getting_session_id
@@ -119,6 +129,8 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
         assert_response :success
         assert_equal session_id, response.body, "should be able to read session id without accessing the session hash"
       end
+    rescue Dalli::RingError => ex
+      skip ex.message, ex.backtrace
     end
 
     def test_deserializes_unloaded_class
@@ -133,6 +145,8 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
           assert_response :success
         end
       end
+    rescue Dalli::RingError => ex
+      skip ex.message, ex.backtrace
     end
 
     def test_doesnt_write_session_cookie_if_session_id_is_already_exists
@@ -145,6 +159,8 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
         assert_response :success
         assert_equal nil, headers['Set-Cookie'], "should not resend the cookie again if session_id cookie is already exists"
       end
+    rescue Dalli::RingError => ex
+      skip ex.message, ex.backtrace
     end
 
     def test_prevents_session_fixation
@@ -160,6 +176,8 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
         assert_response :success
         assert_not_equal session_id, cookies['_session_id']
       end
+    rescue Dalli::RingError => ex
+      skip ex.message, ex.backtrace
     end
   rescue LoadError, RuntimeError, Dalli::DalliError
     $stderr.puts "Skipping MemCacheStoreTest tests. Start memcached and try again."


### PR DESCRIPTION
Unlike the outer `rescue`, this one is much more precise about what we
want to handle: a connection failure (`Dalli::RingError`) is not
relevant to what we're testing here. But other Dalli errors may well be
indicating an actual problem.
