### PR TITLE
use any? instead of empty? to make it explicit

### DIFF
--- a/actionpack/lib/action_controller/metal/responder.rb
+++ b/actionpack/lib/action_controller/metal/responder.rb
@@ -267,7 +267,7 @@ module ActionController #:nodoc:
     # Check whether the resource has errors.
     #
     def has_errors?
-      resource.respond_to?(:errors) && !resource.errors.empty?
+      resource.respond_to?(:errors) && resource.errors.any?
     end
 
     # Check whether the necessary Renderer is available


### PR DESCRIPTION
reading through rails source code and found out we can use any? instead of !empty? to make it more explicit.
