### PR TITLE
Remove unnecessary branch from quoting in Mysql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -223,8 +223,6 @@ module ActiveRecord
         if value.kind_of?(String) && column && column.type == :binary
           s = value.unpack("H*")[0]
           "x'#{s}'"
-        elsif value.kind_of?(BigDecimal)
-          value.to_s("F")
         else
           super
         end


### PR DESCRIPTION
This is already the behavior for `BigDecimal` in the abstract adapter.
