### PR TITLE
Remove `require 'active_support'` from individual modules

### DIFF
--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -1,4 +1,3 @@
-require "active_support"
 require "active_support/file_update_checker"
 require "active_support/core_ext/array/wrap"
 

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -1,4 +1,3 @@
-require "active_support"
 require "active_support/i18n_railtie"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/time.rb
+++ b/activesupport/lib/active_support/time.rb
@@ -1,5 +1,3 @@
-require 'active_support'
-
 module ActiveSupport
   autoload :Duration, 'active_support/duration'
   autoload :TimeWithZone, 'active_support/time_with_zone'


### PR DESCRIPTION
Let users require `active_support` before loading any ActiveSupport modules.
http://guides.rubyonrails.org/active_support_core_extensions.html

refs #15167

FYI, the remains

```
$ git grep "require ['|\"]active_support['|\"]" activesupport/
activesupport/bin/generate_tables:  require 'active_support'
activesupport/lib/active_support/all.rb:require 'active_support'
activesupport/test/abstract_unit.rb:require 'active_support'
```
