### PR TITLE
Fix ERB::Util::escape_json to stop it eating quotes

### DIFF
--- a/actionpack/test/template/erb_util_test.rb
+++ b/actionpack/test/template/erb_util_test.rb
@@ -16,6 +16,10 @@ class ErbUtilTest < Test::Unit::TestCase
     end
   end
 
+  def test_json_escape_does_not_remove_quotes
+    assert_equal 'a lovely "', json_escape('a lovely "')
+  end
+
   def test_json_escape_returns_unsafe_strings_when_passed_unsafe_strings
     value = json_escape("asdf")
     assert !value.html_safe?

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -62,7 +62,7 @@ class ERB
     #   <%=j @person.to_json %>
     #
     def json_escape(s)
-      result = s.to_s.gsub(/[&"><]/) { |special| JSON_ESCAPE[special] }
+      result = s.to_s.gsub(/[&><]/) { |special| JSON_ESCAPE[special] }
       s.html_safe? ? result.html_safe : result
     end
 


### PR DESCRIPTION
In 3-2-stable ERB::Util::escape_json silently eats quotes.

This is inconsistent with behavior in Rails 4, and it renders this method fairly useless. Certainly you cannot use it to escape JSON, which is the intended purpose of this method as far as I can tell from reading the method documentation and seeing that it differs in Rails 4.

See #13073 for related info.
