### PR TITLE
Add link_to_with_active_class helper

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `link_to_with_active_class` helper which adds a `current-page` or
+    `non-current-page` class to links
+
+    *Matthew Witek*
+
 *   Allow custom `:host` option to be passed to `asset_url` helper that
     overwrites `config.action_controller.asset_host` for particular asset.
 

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -368,6 +368,43 @@ module ActionView
         link_to_unless current_page?(options), name, options, html_options, &block
       end
 
+      # Description
+      # Creates a link tag of the given +name+ using a URL created by the set of
+      # +options+ and will add a class of 'current-page' if the current request URI
+      # is the same as the links, or a class of 'non-current-page' if the current request
+      # URI is not the same as the links.
+
+      # ==== Examples
+      #
+      # for the following examples the current_page is "/"
+      #
+      #   When link path is the current page path, returns a 'current-page' class
+      #   <%= link_to_with_active_class("Root Page", "/") %>
+      #   # => <a class="current-page" href="/">Root Page</a>
+      #
+      #   the 'current-page' class can be modified
+      #   <%= link_to_with_active_class("Root Page", "/", current_page_class: "my-custom-active-class") %>
+      #   # => <a class="my-custom-active-class" href="/">Root Page</a>
+      #
+      #   When the link path is not current page path, returns a 'non-current-page' class
+      #   <%= link_to_with_active_class("Not Root Page", "/not-root-page") %>
+      #   # => <a class="non-current-page" href="/">Not Root Page</a>
+      #
+      #   the 'non-current-page' class can be modified
+      #   <%= link_to_with_active_class("Not Root Page", "/not-root-page", non_current_page_class: "my-custom-non-active-class") %>
+      #   # => <a class="my-custom-non-active-class" href="/">Not Root Page</a>
+      def link_to_with_active_class(name, options = {}, html_options = {}, &block)
+        html_opts = {
+          current_page_class: "current-page",
+          non_current_page_class: "non-current-page"
+        }.merge!(html_options)
+
+        active_page_class = current_page?(options) ? html_opts[:current_page_class] : html_opts[:non_current_page_class]
+        html_opts[:class] = "#{active_page_class} #{html_opts[:class]}".rstrip
+
+        link_to(name, options, html_opts.except(:current_page_class, :non_current_page_class), &block)
+      end
+
       # Creates a link tag of the given +name+ using a URL created by the set of
       # +options+ unless +condition+ is true, in which case only the name is
       # returned. To specialize the default behavior (i.e., show a login link rather

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -480,6 +480,27 @@ class UrlHelperTest < ActiveSupport::TestCase
       link_to_unless_current("Listing", "http://www.example.com/")
   end
 
+  def test_link_to_with_active_class
+    @request = request_for_url("/")
+
+    assert_equal %{<a class="current-page" href="http://www.example.com/">Root Page</a>},
+      link_to_with_active_class("Root Page", "http://www.example.com/")
+
+    assert_equal %{<a class="custom-current" href="http://www.example.com/">Root Page</a>},
+      link_to_with_active_class("Root Page", "http://www.example.com/", current_page_class: "custom-current")
+
+    assert_not_equal %{<a class="active" href="http://www.example.com/">Root Page</a>},
+      link_to_with_active_class("Not Root Page", "http://www.example.com/not-root-path")
+
+    assert_equal %{<a class="non-current-page" href="http://www.example.com/not-root-path">Not Root Page</a>},
+      link_to_with_active_class("Not Root Page", "http://www.example.com/not-root-path")
+
+    assert_equal %{<a class="custom-non-current-page" href="http://www.example.com/not-root-path">Not Root Page</a>},
+      link_to_with_active_class(
+        "Not Root Page", "http://www.example.com/not-root-path", non_current_page_class: "custom-non-current-page"
+      )
+  end
+
   def test_mail_to
     assert_dom_equal %{<a href="mailto:david@loudthinking.com">david@loudthinking.com</a>}, mail_to("david@loudthinking.com")
     assert_dom_equal %{<a href="mailto:david@loudthinking.com">David Heinemeier Hansson</a>}, mail_to("david@loudthinking.com", "David Heinemeier Hansson")


### PR DESCRIPTION
Added a link_to_with_active_class helper which will generate a link tag with
a class of 'current-page' if the link path matches the current request URI.
If the link path does not match, a class of 'non-active-page' will be added
to the link.
