### PR TITLE
Fix AS::NumberHelper results with rationals

### DIFF
--- a/actionview/test/template/number_helper_test.rb
+++ b/actionview/test/template/number_helper_test.rb
@@ -48,6 +48,7 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal "-111.235", number_with_precision(-111.2346)
     assert_equal "111.00", number_with_precision(111, precision: 2)
     assert_equal "0.00100", number_with_precision(0.001, precision: 5)
+    assert_equal "3.33", number_with_precision(Rational(10, 3), precision: 2)
   end
 
   def test_number_to_human_size

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fixed precision error in NumberHelper when using Rationals.
+
+    before:
+        ActiveSupport::NumberHelper.number_to_rounded Rational(1000, 3), precision: 2
+        #=> "330.00"
+    after:
+        ActiveSupport::NumberHelper.number_to_rounded Rational(1000, 3), precision: 2
+        #=> "333.33"
+
+    See #15379.
+
+    *Juanjo Bazán*
+
 *   Removed deprecated `Numeric#ago` and friends
 
     Replacements:

--- a/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
@@ -12,11 +12,7 @@ module ActiveSupport
         when Float, String
           @number = BigDecimal(number.to_s)
         when Rational
-          if significant
-            @number = BigDecimal(number, digit_count(number.to_i) + precision)
-          else
-            @number = BigDecimal(number, precision)
-          end
+          @number = BigDecimal(number, digit_count(number.to_i) + precision)
         else
           @number = number.to_d
         end

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -134,6 +134,7 @@ module ActiveSupport
           assert_equal("111.23460000000000000000", number_helper.number_to_rounded('111.2346', :precision => 20))
           assert_equal("111.23460000000000000000", number_helper.number_to_rounded(BigDecimal(111.2346, Float::DIG), :precision => 20))
           assert_equal("111.2346" + "0"*96, number_helper.number_to_rounded('111.2346', :precision => 100))
+          assert_equal("111.2346", number_helper.number_to_rounded(Rational(1112346, 10000), :precision => 4))
         end
       end
 
@@ -174,6 +175,7 @@ module ActiveSupport
           assert_equal "9775.0000000000000000", number_helper.number_to_rounded(BigDecimal(9775), :precision => 20, :significant => true )
           assert_equal "9775.0000000000000000", number_helper.number_to_rounded("9775", :precision => 20, :significant => true )
           assert_equal "9775." + "0"*96, number_helper.number_to_rounded("9775", :precision => 100, :significant => true )
+          assert_equal("97.7", number_helper.number_to_rounded(Rational(9772, 100), :precision => 3, :significant => true))
         end
       end
 


### PR DESCRIPTION
[This change](https://github.com/rails/rails/commit/9e997e9039435617b6a844158f5437e97f6bc107) introduced a bug where Rational numbers are rounded always as if the `:significant` option is true, so `:precision` is incorrectly being applied.

Both tests in actionview and activesupport included in this PR would fail with the current code. 

before:

``` ruby
ActiveSupport::NumberHelper.number_to_rounded Rational(10, 3), precision: 2  
=> "3.3"
```

after:

``` ruby
ActiveSupport::NumberHelper.number_to_rounded Rational(10, 3), precision: 2  
=> "3.33"
```

Not sure if I should modify the changelog.
