### PR TITLE
Move I18n.locale setting into setup and teardown.

### DIFF
--- a/actionpack/test/controller/localized_templates_test.rb
+++ b/actionpack/test/controller/localized_templates_test.rb
@@ -8,22 +8,24 @@ end
 class LocalizedTemplatesTest < ActionController::TestCase
   tests LocalizedController
 
+  setup do
+    @old_locale = I18n.locale
+  end
+
+  teardown do
+    I18n.locale = @old_locale
+  end
+
   def test_localized_template_is_used
-    old_locale = I18n.locale
     I18n.locale = :de
     get :hello_world
     assert_equal "Gutten Tag", @response.body
-  ensure
-    I18n.locale = old_locale
   end
 
   def test_default_locale_template_is_used_when_locale_is_missing
-    old_locale = I18n.locale
     I18n.locale = :dk
     get :hello_world
     assert_equal "Hello World", @response.body
-  ensure
-    I18n.locale = old_locale
   end
 
   def test_use_fallback_locales
@@ -36,13 +38,9 @@ class LocalizedTemplatesTest < ActionController::TestCase
   end
 
   def test_localized_template_has_correct_header_with_no_format_in_template_name
-    old_locale = I18n.locale
     I18n.locale = :it
-
     get :hello_world
     assert_equal "Ciao Mondo", @response.body
     assert_equal "text/html",  @response.content_type
-  ensure
-    I18n.locale = old_locale
   end
 end


### PR DESCRIPTION
This is not a cosmetic change. Originally, in `test_use_fallback_locales`, I18n.locale was not restored; therefore the state was leaked.

\cc @senny
