### PR TITLE
Remove unused `Column#coder`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -14,12 +14,9 @@ module ActiveRecord
       end
 
       attr_reader :name, :default, :cast_type, :null, :sql_type, :default_function
-      attr_accessor :coder
-
-      alias :encoded? :coder
 
       delegate :type, :precision, :scale, :limit, :klass, :text?, :number?, :binary?,
-        :type_cast_for_write, :type_cast_for_database, to: :cast_type
+        :type_cast, :type_cast_for_write, :type_cast_for_database, to: :cast_type
 
       # Instantiates a new column in the table.
       #
@@ -37,20 +34,10 @@ module ActiveRecord
         @null             = null
         @default          = extract_default(default)
         @default_function = nil
-        @coder            = nil
       end
 
       def has_default?
         !default.nil?
-      end
-
-      # Casts value to an appropriate instance.
-      def type_cast(value)
-        if encoded?
-          coder.load(value)
-        else
-          cast_type.type_cast(value)
-        end
       end
 
       # Returns the human name of the column name.

--- a/activerecord/test/cases/column_definition_test.rb
+++ b/activerecord/test/cases/column_definition_test.rb
@@ -11,26 +11,6 @@ module ActiveRecord
         @viz = @adapter.schema_creation
       end
 
-      def test_can_set_coder
-        column = Column.new("title", nil, Type::String.new, "varchar(20)")
-        column.coder = YAML
-        assert_equal YAML, column.coder
-      end
-
-      def test_encoded?
-        column = Column.new("title", nil, Type::String.new, "varchar(20)")
-        assert !column.encoded?
-
-        column.coder = YAML
-        assert column.encoded?
-      end
-
-      def test_type_case_coded_column
-        column = Column.new("title", nil, Type::String.new, "varchar(20)")
-        column.coder = YAML
-        assert_equal "hello", column.type_cast("--- hello")
-      end
-
       # Avoid column definitions in create table statements like:
       # `title` varchar(255) DEFAULT NULL
       def test_should_not_include_default_clause_when_default_is_null


### PR DESCRIPTION
It appears this property was added, but never actually used. It would be
broken if it were, as it only type casts one way.
