### PR TITLE
Unregister Mime::Type in teardown.

### DIFF
--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -32,12 +32,16 @@ end
 class SendFileTest < ActionController::TestCase
   include TestFileUtils
 
-  Mime::Type.register "image/png", :png unless defined? Mime::PNG
-
   def setup
+    @mime_type_defined = defined? Mime::PNG
+    Mime::Type.register "image/png", :png unless @mime_type_defined
     @controller = SendFileController.new
     @request = ActionController::TestRequest.new
     @response = ActionController::TestResponse.new
+  end
+
+  teardown do
+    Mime::Type.unregister :png unless @mime_type_defined
   end
 
   def test_file_nostream


### PR DESCRIPTION
This fixes a potential state leak.

\cc @senny
