### PR TITLE
Maintain column order when overriding existing columns

### DIFF
--- a/activerecord/lib/active_record/properties.rb
+++ b/activerecord/lib/active_record/properties.rb
@@ -88,9 +88,14 @@ module ActiveRecord
       private
 
       def add_user_provided_columns(schema_columns)
-        schema_columns.reject { |column|
-          user_provided_columns.key? column.name
-        } + user_provided_columns.values
+        existing_columns = schema_columns.map do |column|
+          user_provided_columns[column.name] || column
+        end
+
+        existing_column_names = existing_columns.map(&:name)
+        new_columns = user_provided_columns.except(*existing_column_names).values
+
+        existing_columns + new_columns
       end
     end
   end

--- a/activerecord/test/cases/custom_properties_test.rb
+++ b/activerecord/test/cases/custom_properties_test.rb
@@ -79,5 +79,10 @@ module ActiveRecord
 
       assert_equal 4.4, data.overloaded_float
     end
+
+    def test_overloading_properties_does_not_change_column_order
+      column_names = OverloadedType.column_names
+      assert_equal %w(id overloaded_float unoverloaded_float overloaded_string_with_limit non_existent_decimal), column_names
+    end
   end
 end


### PR DESCRIPTION
Working towards re-implementing serialized attributes to use the
properties API exposed the need for this, as serializing a column
shouldn't change the order of the columns.
