### PR TITLE
Keep  closer to other methods that touch @transaction

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -227,6 +227,10 @@ module ActiveRecord
         end
       end
 
+      def open_transactions
+        @transaction.number
+      end
+
       def current_transaction #:nodoc:
         @transaction
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -325,10 +325,6 @@ module ActiveRecord
         @connection
       end
 
-      def open_transactions
-        @transaction.number
-      end
-
       def create_savepoint(name = nil)
       end
 


### PR DESCRIPTION
Looking at the transaction code to refactor this a bit.

Bringing `open_transactions` method to the right place, so its close to the other methods that touch `@ transaction`

review @chancancode @rafaelfranca
