### PR TITLE
Fix documentation

### DIFF
--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -48,7 +48,7 @@ module ActionView
       # Change allowed default attributes
       #
       #   class Application < Rails::Application
-      #     config.action_view.sanitized_allowed_attributes = 'id', 'class', 'style'
+      #     config.action_view.sanitized_allowed_attributes = ['id', 'class', 'style']
       #   end
       #
       # Please note that sanitizing user-provided text does not guarantee that the
@@ -204,7 +204,7 @@ module ActionView
         # Adds to the Set of allowed HTML attributes for the +sanitize+ helper.
         #
         #   class Application < Rails::Application
-        #     config.action_view.sanitized_allowed_attributes = 'onclick', 'longdesc'
+        #     config.action_view.sanitized_allowed_attributes = ['onclick', 'longdesc']
         #   end
         #
         def sanitized_allowed_attributes=(attributes)


### PR DESCRIPTION
To prevent `ArgumentError`, `config.action_view.sanitized_allowed_attributes` should be assigned by an array instead of a list.

```
/Users/tonytonyjan/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/set.rb:98:in `do_with_enum': value must be enumerable (ArgumentError)
    from /Users/tonytonyjan/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/set.rb:355:in `merge'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/actionview-4.1.1/lib/action_view/helpers/sanitize_helper.rb:211:in `sanitized_allowed_attributes='
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/actionview-4.1.1/lib/action_view/railtie.rb:26:in `block (3 levels) in <class:Railtie>'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/actionview-4.1.1/lib/action_view/railtie.rb:25:in `each'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/actionview-4.1.1/lib/action_view/railtie.rb:25:in `block (2 levels) in <class:Railtie>'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.1/lib/active_support/lazy_load_hooks.rb:38:in `instance_eval'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.1/lib/active_support/lazy_load_hooks.rb:38:in `execute_hook'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.1/lib/active_support/lazy_load_hooks.rb:28:in `block in on_load'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.1/lib/active_support/lazy_load_hooks.rb:27:in `each'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.1/lib/active_support/lazy_load_hooks.rb:27:in `on_load'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/actionview-4.1.1/lib/action_view/railtie.rb:24:in `block in <class:Railtie>'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/railties-4.1.1/lib/rails/initializable.rb:30:in `instance_exec'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/railties-4.1.1/lib/rails/initializable.rb:30:in `run'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/railties-4.1.1/lib/rails/initializable.rb:55:in `block in run_initializers'
    from /Users/tonytonyjan/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/tsort.rb:226:in `block in tsort_each'
    from /Users/tonytonyjan/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/tsort.rb:348:in `block (2 levels) in each_strongly_connected_component'
    from /Users/tonytonyjan/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/tsort.rb:427:in `each_strongly_connected_component_from'
    from /Users/tonytonyjan/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/tsort.rb:347:in `block in each_strongly_connected_component'
    from /Users/tonytonyjan/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/tsort.rb:345:in `each'
    from /Users/tonytonyjan/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/tsort.rb:345:in `call'
    from /Users/tonytonyjan/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/tsort.rb:345:in `each_strongly_connected_component'
    from /Users/tonytonyjan/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/tsort.rb:224:in `tsort_each'
    from /Users/tonytonyjan/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/tsort.rb:205:in `tsort_each'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/railties-4.1.1/lib/rails/initializable.rb:54:in `run_initializers'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/railties-4.1.1/lib/rails/application.rb:288:in `initialize!'
    from /Users/tonytonyjan/Dropbox/home/codes/penta_ruby/config/environment.rb:5:in `<top (required)>'
    from /Users/tonytonyjan/Dropbox/home/codes/penta_ruby/config.ru:3:in `require'
    from /Users/tonytonyjan/Dropbox/home/codes/penta_ruby/config.ru:3:in `block in <main>'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/rack-1.5.2/lib/rack/builder.rb:55:in `instance_eval'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/rack-1.5.2/lib/rack/builder.rb:55:in `initialize'
    from /Users/tonytonyjan/Dropbox/home/codes/penta_ruby/config.ru:in `new'
    from /Users/tonytonyjan/Dropbox/home/codes/penta_ruby/config.ru:in `<main>'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/rack-1.5.2/lib/rack/builder.rb:49:in `eval'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/rack-1.5.2/lib/rack/builder.rb:49:in `new_from_string'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/rack-1.5.2/lib/rack/builder.rb:40:in `parse_file'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/rack-1.5.2/lib/rack/server.rb:277:in `build_app_and_options_from_config'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/rack-1.5.2/lib/rack/server.rb:199:in `app'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/railties-4.1.1/lib/rails/commands/server.rb:50:in `app'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/rack-1.5.2/lib/rack/server.rb:314:in `wrapped_app'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/railties-4.1.1/lib/rails/commands/server.rb:130:in `log_to_stdout'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/railties-4.1.1/lib/rails/commands/server.rb:67:in `start'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/railties-4.1.1/lib/rails/commands/commands_tasks.rb:81:in `block in server'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/railties-4.1.1/lib/rails/commands/commands_tasks.rb:76:in `tap'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/railties-4.1.1/lib/rails/commands/commands_tasks.rb:76:in `server'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/railties-4.1.1/lib/rails/commands/commands_tasks.rb:40:in `run_command!'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/railties-4.1.1/lib/rails/commands.rb:17:in `<top (required)>'
    from /Users/tonytonyjan/Dropbox/home/codes/penta_ruby/bin/rails:8:in `require'
    from /Users/tonytonyjan/Dropbox/home/codes/penta_ruby/bin/rails:8:in `<top (required)>'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/spring-1.1.3/lib/spring/client/rails.rb:27:in `load'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/spring-1.1.3/lib/spring/client/rails.rb:27:in `call'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/spring-1.1.3/lib/spring/client/command.rb:7:in `call'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/spring-1.1.3/lib/spring/client.rb:26:in `run'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/spring-1.1.3/bin/spring:48:in `<top (required)>'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/spring-1.1.3/lib/spring/binstub.rb:11:in `load'
    from /Users/tonytonyjan/.rvm/gems/ruby-2.1.2/gems/spring-1.1.3/lib/spring/binstub.rb:11:in `<top (required)>'
    from /Users/tonytonyjan/Dropbox/home/codes/penta_ruby/bin/spring:16:in `require'
    from /Users/tonytonyjan/Dropbox/home/codes/penta_ruby/bin/spring:16:in `<top (required)>'
    from bin/rails:3:in `load'
    from bin/rails:3:in `<main>'
```
