### PR TITLE
Ensure we always use instances of the adapter specific column class

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -363,6 +363,10 @@ module ActiveRecord
         end
       end
 
+      def new_column(name, default, cast_type, sql_type = nil, null = true)
+        Column.new(name, default, cast_type, sql_type, null)
+      end
+
       protected
 
       def lookup_cast_type(sql_type) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -206,8 +206,7 @@ module ActiveRecord
         raise NotImplementedError
       end
 
-      def new_column(field, default, sql_type, null, collation, extra = "") # :nodoc:
-        cast_type = lookup_cast_type(sql_type)
+      def new_column(field, default, cast_type, sql_type = nil, null = true, collation = "", extra = "") # :nodoc:
         Column.new(field, default, cast_type, sql_type, null, collation, strict_mode?, extra)
       end
 
@@ -425,7 +424,9 @@ module ActiveRecord
         execute_and_free(sql, 'SCHEMA') do |result|
           each_hash(result).map do |field|
             field_name = set_field_encoding(field[:Field])
-            new_column(field_name, field[:Default], field[:Type], field[:Null] == "YES", field[:Collation], field[:Extra])
+            sql_type = field[:Type]
+            cast_type = lookup_cast_type(sql_type)
+            new_column(field_name, field[:Default], cast_type, sql_type, field[:Null] == "YES", field[:Collation], field[:Extra])
           end
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -181,8 +181,12 @@ module ActiveRecord
             oid = get_oid_type(oid.to_i, fmod.to_i, column_name, type)
             default_value = extract_value_from_default(default)
             default_function = extract_default_function(default_value, default)
-            PostgreSQLColumn.new(column_name, default_value, oid, type, notnull == 'f', default_function)
+            new_column(column_name, default_value, oid, type, notnull == 'f', default_function)
           end
+        end
+
+        def new_column(name, default, cast_type, sql_type = nil, null = true, default_function = nil) # :nodoc:
+          PostgreSQLColumn.new(name, default, cast_type, sql_type, null, default_function)
         end
 
         # Returns the current database name.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -393,7 +393,7 @@ module ActiveRecord
 
           sql_type = field['type']
           cast_type = lookup_cast_type(sql_type)
-          Column.new(field['name'], field['dflt_value'], cast_type, sql_type, field['notnull'].to_i == 0)
+          new_column(field['name'], field['dflt_value'], cast_type, sql_type, field['notnull'].to_i == 0)
         end
       end
 

--- a/activerecord/lib/active_record/properties.rb
+++ b/activerecord/lib/active_record/properties.rb
@@ -65,7 +65,7 @@ module ActiveRecord
       def property(name, cast_type)
         name = name.to_s
         # Assign a new hash to ensure that subclasses do not share a hash
-        self.user_provided_columns = user_provided_columns.merge(name => ConnectionAdapters::Column.new(name, nil, cast_type))
+        self.user_provided_columns = user_provided_columns.merge(name => connection.new_column(name, nil, cast_type))
       end
 
       # Returns an array of column objects for the table associated with this class.


### PR DESCRIPTION
- Create a consistent API across adapters for building new columns
- Use it for custom properties so we don't get `UndefinedMethodError`s
  in stuff I'm implementing elsewhere.
