### PR TITLE
Result sets never override a model's column type

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -40,7 +40,7 @@ module ActiveRecord
       column_types = {}
 
       if result_set.respond_to? :column_types
-        column_types = result_set.column_types
+        column_types = result_set.column_types.merge(columns_hash)
       else
         ActiveSupport::Deprecation.warn "the object returned from `select_all` must respond to `column_types`"
       end

--- a/activerecord/test/cases/adapters/mysql/consistency_test.rb
+++ b/activerecord/test/cases/adapters/mysql/consistency_test.rb
@@ -1,0 +1,48 @@
+require "cases/helper"
+
+class MysqlConsistencyTest < ActiveRecord::TestCase
+  self.use_transactional_fixtures = false
+
+  class Consistency < ActiveRecord::Base
+    self.table_name = "mysql_consistency"
+  end
+
+  setup do
+    @old_emulate_booleans = ActiveRecord::ConnectionAdapters::MysqlAdapter.emulate_booleans
+    ActiveRecord::ConnectionAdapters::MysqlAdapter.emulate_booleans = false
+
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table("mysql_consistency") do |t|
+      t.boolean "a_bool"
+      t.string "a_string"
+    end
+    Consistency.reset_column_information
+    Consistency.create!
+  end
+
+  teardown do
+    ActiveRecord::ConnectionAdapters::MysqlAdapter.emulate_booleans = @old_emulate_booleans
+    @connection.drop_table "mysql_consistency"
+  end
+
+  test "boolean columns with random value type cast to 0 when emulate_booleans is false" do
+    with_new = Consistency.new
+    with_last = Consistency.last
+    with_new.a_bool = 'wibble'
+    with_last.a_bool = 'wibble'
+
+    assert_equal 0, with_new.a_bool
+    assert_equal 0, with_last.a_bool
+  end
+
+  test "string columns call #to_s" do
+    with_new = Consistency.new
+    with_last = Consistency.last
+    thing = Object.new
+    with_new.a_string = thing
+    with_last.a_string = thing
+
+    assert_equal thing.to_s, with_new.a_string
+    assert_equal thing.to_s, with_last.a_string
+  end
+end

--- a/activerecord/test/cases/custom_properties_test.rb
+++ b/activerecord/test/cases/custom_properties_test.rb
@@ -37,7 +37,9 @@ module ActiveRecord
       data.reload
 
       assert_equal 2, data.overloaded_float
+      assert_kind_of Fixnum, OverloadedType.last.overloaded_float
       assert_equal 2.0, UnoverloadedType.last.overloaded_float
+      assert_kind_of Float, UnoverloadedType.last.overloaded_float
     end
 
     def test_properties_assigned_in_constructor


### PR DESCRIPTION
MySQL and PostgreSQL provide a column type override in order to properly
type cast computed columns included in a result set. This should never
override the known types of full fledged columns. In addition to messing
up computed properties, this would have led to inconsistent behavior
between a record created with `new`, and a record created with `last` on
the mysql adapter in the following cases:
- `tinyint(1)` with `emulate_booleans` set to `false`
- `text`, `string`, `binary`, and `decimal` columns
