### PR TITLE
fixed ActiveModel documentation [ci skip]

### DIFF
--- a/activemodel/README.rdoc
+++ b/activemodel/README.rdoc
@@ -147,7 +147,7 @@ behavior out of the box:
       extend ActiveModel::Naming
     end
 
-    NamedPerson.model_name        # => "NamedPerson"
+    NamedPerson.model_name.name   # => "NamedPerson"
     NamedPerson.model_name.human  # => "Named person"
 
   {Learn more}[link:classes/ActiveModel/Naming.html]

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -204,7 +204,7 @@ module ActiveModel
   #     extend ActiveModel::Naming
   #   end
   #
-  #   BookCover.model_name        # => "BookCover"
+  #   BookCover.model_name.name   # => "BookCover"
   #   BookCover.model_name.human  # => "Book cover"
   #
   #   BookCover.model_name.i18n_key              # => :book_cover


### PR DESCRIPTION
`model_name` returns [an instance of `ActiveModel::Name`](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/naming.rb#L233), not `String`.
