### PR TITLE
Don't reference comments that do not exist

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -26,8 +26,6 @@ module ActiveRecord
         protected
 
         if Module.methods_transplantable?
-          # See define_method_attribute in read.rb for an explanation of
-          # this code.
           def define_method_attribute=(name)
             method = WriterMethodCache[name]
             generated_attribute_methods.module_eval {


### PR DESCRIPTION
The comment in `read.rb` was removed a few years ago. It wasn't terribly helpful, either. :frowning:
