### PR TITLE
Consolidate duplicate to_formatted_s method

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -2,8 +2,11 @@ require 'date'
 require 'active_support/inflector/methods'
 require 'active_support/core_ext/date/zones'
 require 'active_support/core_ext/module/remove_method'
+require 'active_support/core_ext/date_and_time/conversions'
 
 class Date
+  include DateAndTime::Conversions
+
   DATE_FORMATS = {
     :short        => '%e %b',
     :long         => '%B %e, %Y',
@@ -24,43 +27,6 @@ class Date
   # component. This removal may generate an issue on FreeBSD, that's why we
   # need to use remove_possible_method here
   remove_possible_method :xmlschema
-
-  # Convert to a formatted string. See DATE_FORMATS for predefined formats.
-  #
-  # This method is aliased to <tt>to_s</tt>.
-  #
-  #   date = Date.new(2007, 11, 10)       # => Sat, 10 Nov 2007
-  #
-  #   date.to_formatted_s(:db)            # => "2007-11-10"
-  #   date.to_s(:db)                      # => "2007-11-10"
-  #
-  #   date.to_formatted_s(:short)         # => "10 Nov"
-  #   date.to_formatted_s(:long)          # => "November 10, 2007"
-  #   date.to_formatted_s(:long_ordinal)  # => "November 10th, 2007"
-  #   date.to_formatted_s(:rfc822)        # => "10 Nov 2007"
-  #   date.to_formatted_s(:iso8601)       # => "2007-11-10"
-  #
-  # == Adding your own date formats to to_formatted_s
-  # You can add your own formats to the Date::DATE_FORMATS hash.
-  # Use the format name as the hash key and either a strftime string
-  # or Proc instance that takes a date argument as the value.
-  #
-  #   # config/initializers/date_formats.rb
-  #   Date::DATE_FORMATS[:month_and_year] = '%B %Y'
-  #   Date::DATE_FORMATS[:short_ordinal] = ->(date) { date.strftime("%B #{date.day.ordinalize}") }
-  def to_formatted_s(format = :default)
-    if formatter = DATE_FORMATS[format]
-      if formatter.respond_to?(:call)
-        formatter.call(self).to_s
-      else
-        strftime(formatter)
-      end
-    else
-      to_default_s
-    end
-  end
-  alias_method :to_default_s, :to_s
-  alias_method :to_s, :to_formatted_s
 
   # Overrides the default inspect method with a human readable one, e.g., "Mon, 21 Feb 2005"
   def readable_inspect

--- a/activesupport/lib/active_support/core_ext/date_and_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/conversions.rb
@@ -1,0 +1,64 @@
+
+module DateAndTime
+  module Conversions
+
+    def self.included(klass)
+      klass.class_eval do
+        alias_method :to_default_s, :to_s if instance_methods(false).include?(:to_s)
+        alias_method :to_s, :to_formatted_s
+      end
+    end
+
+    # Convert to a formatted string.
+    # See Time::DATE_FORMATS and Date::DATE_FORMATS for predefined formats.
+    #
+    # This method is aliased to +to_s+.
+    #
+    #   date = Date.new(2007, 11, 10)       # => Sat, 10 Nov 2007
+    #
+    #   date.to_formatted_s(:db)            # => "2007-11-10"
+    #   date.to_s(:db)                      # => "2007-11-10"
+    #
+    #   date.to_formatted_s(:short)         # => "10 Nov"
+    #   date.to_formatted_s(:long)          # => "November 10, 2007"
+    #   date.to_formatted_s(:long_ordinal)  # => "November 10th, 2007"
+    #   date.to_formatted_s(:rfc822)        # => "10 Nov 2007"
+    #   date.to_formatted_s(:iso8601)       # => "2007-11-10"
+    #
+    #   time = Time.now                    # => Thu Jan 18 06:10:17 CST 2007
+    #
+    #   time.to_formatted_s(:time)         # => "06:10"
+    #   time.to_s(:time)                   # => "06:10"
+    #
+    #   time.to_formatted_s(:db)           # => "2007-01-18 06:10:17"
+    #   time.to_formatted_s(:number)       # => "20070118061017"
+    #   time.to_formatted_s(:short)        # => "18 Jan 06:10"
+    #   time.to_formatted_s(:long)         # => "January 18, 2007 06:10"
+    #   time.to_formatted_s(:long_ordinal) # => "January 18th, 2007 06:10"
+    #   time.to_formatted_s(:rfc822)       # => "Thu, 18 Jan 2007 06:10:17 -0600"
+    #   time.to_formatted_s(:iso8601)      # => "2007-01-18T06:10:17-06:00"
+    #
+    # == Adding your own date formats to +to_formatted_s+
+    # You can add your own formats to the Time::DATE_FORMATS and Date::DATE_FORMATS
+    # hashes. Use the format name as the hash key and either a strftime string or
+    # Proc instance that takes a date argument as the value.
+    #
+    #   # config/initializers/time_and_date_formats.rb
+    #   Date::DATE_FORMATS[:month_and_year] = '%B %Y'
+    #   Date::DATE_FORMATS[:short_ordinal] = ->(date) { date.strftime("%B #{date.day.ordinalize}") }
+    #   Time::DATE_FORMATS[:month_and_year] = '%B %Y'
+    #   Time::DATE_FORMATS[:short_ordinal]  = ->(time) { time.strftime("%B #{time.day.ordinalize}") }
+    def to_formatted_s(format = :default)
+      if formatter = self.class::DATE_FORMATS[format]
+        if formatter.respond_to?(:call)
+          formatter.call(self).to_s
+        else
+          strftime(formatter)
+        end
+      else
+        to_default_s
+      end
+    end
+
+  end
+end

--- a/activesupport/lib/active_support/core_ext/date_and_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/conversions.rb
@@ -14,34 +14,49 @@ module DateAndTime
     #
     # This method is aliased to +to_s+.
     #
-    #   date = Date.new(2007, 11, 10)       # => Sat, 10 Nov 2007
+    #   date = Date.new(2007, 11, 10)           # => Sat, 10 Nov 2007
+    #   time = Time.now                         # => Thu Jan 18 06:10:17 CST 2007
+    #   datetime = DateTime.civil(2007, 11, 10, 0, 0, 0, 0)
+    #                                           # => Sat, 10 Nov 2007 00:00:00 +0000
     #
-    #   date.to_formatted_s(:db)            # => "2007-11-10"
-    #   date.to_s(:db)                      # => "2007-11-10"
+    #   date.to_formatted_s(:db)                # => "2007-11-10"
+    #   date.to_s(:db)                          # => "2007-11-10"
     #
-    #   date.to_formatted_s(:short)         # => "10 Nov"
-    #   date.to_formatted_s(:long)          # => "November 10, 2007"
-    #   date.to_formatted_s(:long_ordinal)  # => "November 10th, 2007"
-    #   date.to_formatted_s(:rfc822)        # => "10 Nov 2007"
-    #   date.to_formatted_s(:iso8601)       # => "2007-11-10"
+    #   time.to_formatted_s(:time)              # => "06:10"
+    #   time.to_s(:time)                        # => "06:10"
     #
-    #   time = Time.now                    # => Thu Jan 18 06:10:17 CST 2007
+    #   datetime.to_formatted_s(:db)            # => "2007-11-10 00:00:00"
+    #   datetime.to_s(:db)                      # => "2007-11-10 00:00:00"
     #
-    #   time.to_formatted_s(:time)         # => "06:10"
-    #   time.to_s(:time)                   # => "06:10"
+    #   date.to_formatted_s(:short)             # => "10 Nov"
+    #   time.to_formatted_s(:short)             # => "18 Jan 06:10"
+    #   datetime.to_formatted_s(:short)         # => "10 Nov 00:00"
     #
-    #   time.to_formatted_s(:db)           # => "2007-01-18 06:10:17"
-    #   time.to_formatted_s(:number)       # => "20070118061017"
-    #   time.to_formatted_s(:short)        # => "18 Jan 06:10"
-    #   time.to_formatted_s(:long)         # => "January 18, 2007 06:10"
-    #   time.to_formatted_s(:long_ordinal) # => "January 18th, 2007 06:10"
-    #   time.to_formatted_s(:rfc822)       # => "Thu, 18 Jan 2007 06:10:17 -0600"
-    #   time.to_formatted_s(:iso8601)      # => "2007-01-18T06:10:17-06:00"
+    #   date.to_formatted_s(:long)              # => "November 10, 2007"
+    #   time.to_formatted_s(:long)              # => "January 18, 2007 06:10"
+    #   datetime.to_formatted_s(:long)          # => "November 10, 2007 00:00"
+    #
+    #   date.to_formatted_s(:long_ordinal)      # => "November 10th, 2007"
+    #   time.to_formatted_s(:long_ordinal)      # => "January 18th, 2007 06:10"
+    #   datetime.to_formatted_s(:long_ordinal)  # => "November 10th, 2007 00:00"
+    #
+    #   date.to_formatted_s(:rfc822)            # => "10 Nov 2007"
+    #   time.to_formatted_s(:rfc822)            # => "Thu, 18 Jan 2007 06:10:17 -0600"
+    #   datetime.to_formatted_s(:rfc822)        # => "Sat, 10 Nov 2007 00:00:00 -0600"
+    #
+    #   date.to_formatted_s(:iso8601)           # => "2007-11-10"
+    #   time.to_formatted_s(:iso8601)           # => "2007-01-18T06:10:17-06:00"
+    #   datetime.to_formatted_s(:iso8601)       # => "2007-11-10T00:00:00-06:00"
+    #
+    #   date.to_formatted_s(:number)            # => "20071110"
+    #   time.to_formatted_s(:number)            # => "20070118061017"
+    #   datetime.to_formatted_s(:number)        # => "20071110000000"
     #
     # == Adding your own date formats to +to_formatted_s+
     # You can add your own formats to the Time::DATE_FORMATS and Date::DATE_FORMATS
-    # hashes. Use the format name as the hash key and either a strftime string or
-    # Proc instance that takes a date argument as the value.
+    # hashes. DateTime formats are shared with Time. Use the format name as the hash
+    # key and either a strftime string or Proc instance that takes a date argument
+    # as the value.
     #
     #   # config/initializers/time_and_date_formats.rb
     #   Date::DATE_FORMATS[:month_and_year] = '%B %Y'

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -2,43 +2,12 @@ require 'date'
 require 'active_support/inflector/methods'
 require 'active_support/core_ext/time/conversions'
 require 'active_support/core_ext/date_time/calculations'
+require 'active_support/core_ext/date_and_time/conversions'
 require 'active_support/values/time_zone'
 
 class DateTime
-  # Convert to a formatted string. See Time::DATE_FORMATS for predefined formats.
-  #
-  # This method is aliased to <tt>to_s</tt>.
-  #
-  # === Examples
-  #   datetime = DateTime.civil(2007, 12, 4, 0, 0, 0, 0)   # => Tue, 04 Dec 2007 00:00:00 +0000
-  #
-  #   datetime.to_formatted_s(:db)            # => "2007-12-04 00:00:00"
-  #   datetime.to_s(:db)                      # => "2007-12-04 00:00:00"
-  #   datetime.to_s(:number)                  # => "20071204000000"
-  #   datetime.to_formatted_s(:short)         # => "04 Dec 00:00"
-  #   datetime.to_formatted_s(:long)          # => "December 04, 2007 00:00"
-  #   datetime.to_formatted_s(:long_ordinal)  # => "December 4th, 2007 00:00"
-  #   datetime.to_formatted_s(:rfc822)        # => "Tue, 04 Dec 2007 00:00:00 +0000"
-  #   datetime.to_formatted_s(:iso8601)       # => "2007-12-04T00:00:00+00:00"
-  #
-  # == Adding your own datetime formats to to_formatted_s
-  # DateTime formats are shared with Time. You can add your own to the
-  # Time::DATE_FORMATS hash. Use the format name as the hash key and
-  # either a strftime string or Proc instance that takes a time or
-  # datetime argument as the value.
-  #
-  #   # config/initializers/time_formats.rb
-  #   Time::DATE_FORMATS[:month_and_year] = '%B %Y'
-  #   Time::DATE_FORMATS[:short_ordinal] = lambda { |time| time.strftime("%B #{time.day.ordinalize}") }
-  def to_formatted_s(format = :default)
-    if formatter = ::Time::DATE_FORMATS[format]
-      formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
-    else
-      to_default_s
-    end
-  end
-  alias_method :to_default_s, :to_s if instance_methods(false).include?(:to_s)
-  alias_method :to_s, :to_formatted_s
+  include DateAndTime::Conversions
+  DATE_FORMATS = ::Time::DATE_FORMATS
 
   #
   #   datetime = DateTime.civil(2000, 1, 1, 0, 0, 0, Rational(-6, 24))

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -1,7 +1,10 @@
 require 'active_support/inflector/methods'
 require 'active_support/values/time_zone'
+require 'active_support/core_ext/date_and_time/conversions'
 
 class Time
+  include DateAndTime::Conversions
+
   DATE_FORMATS = {
     :db           => '%Y-%m-%d %H:%M:%S',
     :number       => '%Y%m%d%H%M%S',
@@ -19,41 +22,6 @@ class Time
     },
     :iso8601      => lambda { |time| time.iso8601 }
   }
-
-  # Converts to a formatted string. See DATE_FORMATS for built-in formats.
-  #
-  # This method is aliased to <tt>to_s</tt>.
-  #
-  #   time = Time.now                    # => Thu Jan 18 06:10:17 CST 2007
-  #
-  #   time.to_formatted_s(:time)         # => "06:10"
-  #   time.to_s(:time)                   # => "06:10"
-  #
-  #   time.to_formatted_s(:db)           # => "2007-01-18 06:10:17"
-  #   time.to_formatted_s(:number)       # => "20070118061017"
-  #   time.to_formatted_s(:short)        # => "18 Jan 06:10"
-  #   time.to_formatted_s(:long)         # => "January 18, 2007 06:10"
-  #   time.to_formatted_s(:long_ordinal) # => "January 18th, 2007 06:10"
-  #   time.to_formatted_s(:rfc822)       # => "Thu, 18 Jan 2007 06:10:17 -0600"
-  #   time.to_formatted_s(:iso8601)      # => "2007-01-18T06:10:17-06:00"
-  #
-  # == Adding your own time formats to +to_formatted_s+
-  # You can add your own formats to the Time::DATE_FORMATS hash.
-  # Use the format name as the hash key and either a strftime string
-  # or Proc instance that takes a time argument as the value.
-  #
-  #   # config/initializers/time_formats.rb
-  #   Time::DATE_FORMATS[:month_and_year] = '%B %Y'
-  #   Time::DATE_FORMATS[:short_ordinal]  = ->(time) { time.strftime("%B #{time.day.ordinalize}") }
-  def to_formatted_s(format = :default)
-    if formatter = DATE_FORMATS[format]
-      formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
-    else
-      to_default_s
-    end
-  end
-  alias_method :to_default_s, :to_s
-  alias_method :to_s, :to_formatted_s
 
   # Returns the UTC offset as an +HH:MM formatted string.
   #


### PR DESCRIPTION
I found some duplicate code in the Date and Time core extensions and thought it would be easy enough to consolidate.  I followed the convention already used for common Date and Time methods in the core extensions by putting the module in the date_and_time folder/namespace.

I'm not so sure how I feel about the end result, though, and welcome any feedback and suggestions.
