### PR TITLE
[ci skip] Document Rails' shifted semver.

### DIFF
--- a/guides/source/maintenance_policy.md
+++ b/guides/source/maintenance_policy.md
@@ -3,9 +3,28 @@ Maintenance Policy for Ruby on Rails
 
 Support of the Rails framework is divided into four groups: New features, bug
 fixes, security issues, and severe security issues. They are handled as
-follows, all versions in x.y.z format
+follows, all versions in `X.Y.Z` format.
 
 --------------------------------------------------------------------------------
+
+Rails follows a shifted version of [semver](http://semver.org/):
+
+**Patch `Z`**
+
+Only bug fixes, no API changes, no new features.
+Except as necessary for security fixes or deprecations.
+
+**Minor `Y`**
+
+New features, may contain API changes (Serve as major versions of Semver).
+Breaking changes are paired with deprecation notices in patch level release of
+the last minor version level.
+
+**Major `X`**
+
+New features, will likely contain API changes. The difference between Rails'
+minor and major releases is the magnitude of breaking changes, and usually
+reserved for special occasions.
 
 New Features
 ------------
@@ -20,7 +39,7 @@ Only the latest release series will receive bug fixes. When enough bugs are
 fixed and its deemed worthy to release a new gem, this is the branch it happens
 from.
 
-**Currently included series:** 4.1.z, 4.0.z
+**Currently included series:** `4.1.Z`, `4.0.Z`.
 
 Security Issues
 ---------------
@@ -35,7 +54,7 @@ be built from 1.2.2, and then added to the end of 1-2-stable. This means that
 security releases are easy to upgrade to if you're running the latest version
 of Rails.
 
-**Currently included series:** 4.1.z, 4.0.z
+**Currently included series:** `4.1.Z`, `4.0.Z`.
 
 Severe Security Issues
 ----------------------
@@ -44,7 +63,7 @@ For severe security issues we will provide new versions as above, and also the
 last major release series will receive patches and new versions. The
 classification of the security issue is judged by the core team.
 
-**Currently included series:** 4.1.z, 4.0.z, 3.2.z
+**Currently included series:** `4.1.Z`, `4.0.Z`, `3.2.Z`.
 
 Unsupported Release Series
 --------------------------


### PR DESCRIPTION
Since Rails use shifted semver scheme, it's good to document it. 

References: #9979 and #6610.

Please review the content. Thanks.
