### PR TITLE
simple validation to be able to run migrations with :table_name_with_underscore #15051

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -87,6 +87,7 @@ module ActiveRecord
           when :table_name
             base_name.foreign_key(false)
           when :table_name_with_underscore
+            return nil if base_name.to_s == 'ActiveRecord::SchemaMigration'
             base_name.foreign_key
           else
             if ActiveRecord::Base != self && table_exists?

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -99,6 +99,7 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     ActiveRecord::Base.primary_key_prefix_type = :table_name_with_underscore
     Topic.reset_primary_key
     assert_equal "topic_id", Topic.primary_key
+    assert_equal nil, ActiveRecord::SchemaMigration.primary_key
 
     ActiveRecord::Base.primary_key_prefix_type = nil
     Topic.reset_primary_key


### PR DESCRIPTION
This validation fix the issue with https://github.com/rails/rails/issues/15051 schema_migrations.
I followed @raeno instructions to reproduce it.
Run his repo https://github.com/raeno/rails-4-schema-migration-id
And I created another app with very similar config to run against my local:
https://github.com/joseluistorres/my-test-app
