### PR TITLE
Fix for public.tsvector

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -233,7 +233,7 @@ module ActiveRecord
           when 'xml'
             :xml
           # tsvector type
-          when 'tsvector'
+          when 'tsvector', 'public.tsvector'
             :tsvector
           # Arrays
           when /^\D+\[\]$/


### PR DESCRIPTION
When dumping the database schema, tsearch index columns are sometimes returned as type 'public.tsvector' and not 'tsvector'. This causes the table to be omitted from the schema.
