### PR TITLE
Update Minitest references in Testing Guide

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -175,10 +175,10 @@ class ArticleTest < ActiveSupport::TestCase
 
 The `ArticleTest` class defines a _test case_ because it inherits from `ActiveSupport::TestCase`. `ArticleTest` thus has all the methods available from `ActiveSupport::TestCase`. You'll see those methods a little later in this guide.
 
-Any method defined within a class inherited from `MiniTest::Unit::TestCase`
-(which is the superclass of `ActiveSupport::TestCase`) that begins with `test` (case sensitive) is simply called a test. So, `test_password`, `test_valid_password` and `testValidPassword` all are legal test names and are run automatically when the test case is run.
+Any method defined within a class inherited from `Minitest::Test`
+(which is the superclass of `ActiveSupport::TestCase`) that begins with `test_` (case sensitive) is simply called a test. So, `test_password` and `test_valid_password` are legal test names and are run automatically when the test case is run.
 
-Rails adds a `test` method that takes a test name and a block. It generates a normal `MiniTest::Unit` test with method names prefixed with `test_`. So,
+Rails adds a `test` method that takes a test name and a block. It generates a normal `Minitest::Unit` test with method names prefixed with `test_`. So,
 
 ```ruby
 test "the truth" do
@@ -393,7 +393,7 @@ NOTE: Creating your own assertions is an advanced topic that we won't cover in t
 
 ### Rails Specific Assertions
 
-Rails adds some custom assertions of its own to the `test/unit` framework:
+Rails adds some custom assertions of its own to the `minitest` framework:
 
 | Assertion                                                                         | Purpose |
 | --------------------------------------------------------------------------------- | ------- |
@@ -788,16 +788,12 @@ when you initiate a Rails project.
 | `rake test:all:db`      | Runs all tests quickly by merging all types and resetting db |
 
 
-Brief Note About `MiniTest`
+Brief Note About `Minitest`
 -----------------------------
 
-Ruby ships with a vast Standard Library for all common use-cases including testing. Ruby 1.8 provided `Test::Unit`, a framework for unit testing in Ruby. All the basic assertions discussed above are actually defined in `Test::Unit::Assertions`. The class `ActiveSupport::TestCase` which we have been using in our unit and functional tests extends `Test::Unit::TestCase`, allowing
-us to use all of the basic assertions in our tests.
+Ruby ships with a vast Standard Library for all common use-cases including testing. Since version 1.9, Ruby provides `Minitest`, a framework for testing. All the basic assertions such as `assert_equal` discussed above are actually defined in `Minitest::Assertions`. The classes `ActiveSupport::TestCase`, `ActionController::TestCase`, `ActionMailer::TestCase`, `ActionView::TestCase` and `ActionDispatch::IntegrationTest` - which we have been inheriting in our test classes - include `Minitest::Assertions`, allowing us to use all of the basic assertions in our tests.
 
-Ruby 1.9 introduced `MiniTest`, an updated version of `Test::Unit` which provides a backwards compatible API for `Test::Unit`. You could also use `MiniTest` in Ruby 1.8 by installing the `minitest` gem.
-
-NOTE: For more information on `Test::Unit`, refer to [test/unit Documentation](http://ruby-doc.org/stdlib/libdoc/test/unit/rdoc/)
-For more information on `MiniTest`, refer to [Minitest](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/minitest/unit/rdoc/)
+NOTE: For more information on `Minitest`, refer to [Minitest](http://ruby-doc.org/stdlib-2.1.0/libdoc/minitest/rdoc/MiniTest.html)
 
 Setup and Teardown
 ------------------
@@ -1041,7 +1037,7 @@ access to Rails' helper methods such as `link_to` or `pluralize`.
 Other Testing Approaches
 ------------------------
 
-The built-in `test/unit` based testing is not the only way to test Rails applications. Rails developers have come up with a wide variety of other approaches and aids for testing, including:
+The built-in `minitest` based testing is not the only way to test Rails applications. Rails developers have come up with a wide variety of other approaches and aids for testing, including:
 
 * [NullDB](http://avdi.org/projects/nulldb/), a way to speed up testing by avoiding database use.
 * [Factory Girl](https://github.com/thoughtbot/factory_girl/tree/master), a replacement for fixtures.


### PR DESCRIPTION
The Guide references `test/unit`, which has been replaced by `Minitest` in
all versions of Ruby supported by Rails. The following updates were
performed:
- The superclass of `ActiveSupport::TestCase` is no longer
  `MiniTest::Unit::TestCase`, but `Minitest::Test` [1](https://github.com/rails/rails/blob/6c2b569660c9216595d02ce6412e3bdcc7293317/activesupport/lib/active_support/test_case.rb#L18).
- The preferred spelling is `Minitest`, not `MiniTest` [2](https://github.com/seattlerb/minitest/blob/d5d43cef9a3fd4a0eea972dde125ed5ba1ddb821/lib/minitest.rb#L9).
- For a method to be a test in Minitest, its name must start with `test_`,
  not only `test` [3](https://github.com/seattlerb/minitest/blob/d5d43cef9a3fd4a0eea972dde125ed5ba1ddb821/lib/minitest/test.rb#L62).
- Explanations about `test/unit` in Ruby 1.8 were removed in favor of more
  up-to-date information on `Minitest`.
