### PR TITLE
Correctly handle hash orders when limiting reflections [4-0-stable]

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -245,7 +245,7 @@ module ActiveRecord
     end
 
     def construct_limited_ids_condition(relation)
-      orders = relation.order_values.map { |val| val.presence }.compact
+      orders = relation.arel.orders
       values = @klass.connection.columns_for_distinct("#{quoted_table_name}.#{quoted_primary_key}", orders)
 
       relation = relation.dup.select(values).distinct!

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -679,6 +679,12 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_eager_with_has_many_and_hash_order
+    posts = Post.includes(:comments).references(:comments).order(title: :asc).limit(1).to_a
+
+    assert_equal 1, posts.length
+  end
+
   def test_eager_association_loading_with_habtm
     posts = Post.all.merge!(:includes => :categories, :order => "posts.id").to_a
     assert_equal 2, posts[0].categories.size


### PR DESCRIPTION
NOTE: PR against 4-0-stable.

Fixes #15405. The behavior in that issue occurs on any version prior to f83c9b10b4c92b0d8deacb30d6fdfa2b1252d6dd, so 4.1.0 and up are not affected.
