### PR TITLE
Update documentation for setting asset_host to a Proc

### DIFF
--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -88,9 +88,12 @@ module ActionView
     # still sending assets for plain HTTP requests from asset hosts. If you don't
     # have SSL certificates for each of the asset hosts this technique allows you
     # to avoid warnings in the client about mixed media.
+    # Note that the request parameter might not be supplied, e.g. when the assets
+    # are precompiled via a Rake task. Make sure to use a Proc instead of a lambda,
+    # since a Proc allows missing parameters and sets them to nil.
     #
     #   config.action_controller.asset_host = Proc.new { |source, request|
-    #     if request.ssl?
+    #     if request && request.ssl?
     #       "#{request.protocol}#{request.host_with_port}"
     #     else
     #       "#{request.protocol}assets.example.com"


### PR DESCRIPTION
mention that the request parameter might not be supplied
Relevant test: https://github.com/rails/rails/blob/3051356a8005518392f3414184daf933f5597092/actionmailer/test/asset_host_test.rb#L45
