### PR TITLE
remove unnecessary gsub for space in ActionView::Helpers#debug

### DIFF
--- a/actionview/lib/action_view/helpers/debug_helper.rb
+++ b/actionview/lib/action_view/helpers/debug_helper.rb
@@ -16,15 +16,15 @@ module ActionView
       #   # =>
       #   <pre class='debug_dump'>--- !ruby/object:User
       #   attributes:
-      #   &nbsp; updated_at:
-      #   &nbsp; username: testing
-      #   &nbsp; age: 42
-      #   &nbsp; password: xyz
-      #   &nbsp; created_at:
+      #     updated_at:
+      #     username: testing
+      #     age: 42
+      #     password: xyz
+      #     created_at:
       #   </pre>
       def debug(object)
         Marshal::dump(object)
-        object = ERB::Util.html_escape(object.to_yaml).gsub("  ", "&nbsp; ").html_safe
+        object = ERB::Util.html_escape(object.to_yaml)
         content_tag(:pre, object, :class => "debug_dump")
       rescue Exception  # errors from Marshal or YAML
         # Object couldn't be dumped, perhaps because of singleton methods -- this is the fallback

--- a/actionview/test/template/debug_helper_test.rb
+++ b/actionview/test/template/debug_helper_test.rb
@@ -3,6 +3,6 @@ require 'active_record_unit'
 class DebugHelperTest < ActionView::TestCase
   def test_debug
     company = Company.new(name: "firebase")
-    assert_match "&nbsp; name: firebase", debug(company)
+    assert_match "name: firebase", debug(company)
   end
 end


### PR DESCRIPTION
Remove unnecessary substitution for spaces in favor nbsp when we are using html_safe and that too in a "pre" tag. I think it is not needed.
