### PR TITLE
Fix regression for HashWithIndifferentAccess#dup

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -90,6 +90,13 @@
 
 ## Rails 4.1.0 (April 8, 2014) ##
 
+*   `HashWithIndifferentAccess` better respects `#to_hash` on objects it's
+    given. In particular, `.new`, `#update`, `#merge`, `#replace` all accept
+    objects which respond to `#to_hash`, even if those objects are not Hashes
+    directly.
+
+    *Peter Jaros*
+
 *   Added `Object#presence_in` to simplify value whitelisting.
 
     Before:

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -55,9 +55,9 @@ module ActiveSupport
     end
 
     def initialize(constructor = {})
-      if constructor.is_a?(Hash)
+      if constructor.respond_to?(:to_hash)
         super()
-        update(constructor)
+        update(constructor.to_hash)
       else
         super(constructor)
       end
@@ -72,6 +72,7 @@ module ActiveSupport
     end
 
     def self.new_from_hash_copying_default(hash)
+      hash = hash.to_hash
       new(hash).tap do |new_hash|
         new_hash.default = hash.default
       end
@@ -125,7 +126,7 @@ module ActiveSupport
       if other_hash.is_a? HashWithIndifferentAccess
         super(other_hash)
       else
-        other_hash.each_pair do |key, value|
+        other_hash.to_hash.each_pair do |key, value|
           if block_given? && key?(key)
             value = yield(convert_key(key), self[key], value)
           end

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -72,7 +72,6 @@ module ActiveSupport
     end
 
     def self.new_from_hash_copying_default(hash)
-      hash = hash.to_hash
       new(hash).tap do |new_hash|
         new_hash.default = hash.default
       end
@@ -126,7 +125,7 @@ module ActiveSupport
       if other_hash.is_a? HashWithIndifferentAccess
         super(other_hash)
       else
-        other_hash.to_hash.each_pair do |key, value|
+        other_hash.each_pair do |key, value|
           if block_given? && key?(key)
             value = yield(convert_key(key), self[key], value)
           end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -23,6 +23,16 @@ class HashExtTest < ActiveSupport::TestCase
     end
   end
 
+  class HashByConversion
+    def initialize(hash)
+      @hash = hash
+    end
+
+    def to_hash
+      @hash
+    end
+  end
+
   def setup
     @strings = { 'a' => 1, 'b' => 2 }
     @nested_strings = { 'a' => { 'b' => { 'c' => 3 } } }
@@ -433,6 +443,12 @@ class HashExtTest < ActiveSupport::TestCase
     assert [updated_with_strings, updated_with_symbols, updated_with_mixed].all? { |h| h.keys.size == 2 }
   end
 
+  def test_update_with_to_hash_conversion
+    hash = HashWithIndifferentAccess.new
+    hash.update HashByConversion.new({ :a => 1 })
+    assert_equal hash['a'], 1
+  end
+
   def test_indifferent_merging
     hash = HashWithIndifferentAccess.new
     hash[:a] = 'failure'
@@ -452,11 +468,29 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal 2, hash['b']
   end
 
+  def test_merge_with_to_hash_conversion
+    hash = HashWithIndifferentAccess.new
+    merged = hash.merge HashByConversion.new({ :a => 1 })
+    assert_equal merged['a'], 1
+  end
+
   def test_indifferent_replace
     hash = HashWithIndifferentAccess.new
     hash[:a] = 42
 
     replaced = hash.replace(b: 12)
+
+    assert hash.key?('b')
+    assert !hash.key?(:a)
+    assert_equal 12, hash[:b]
+    assert_same hash, replaced
+  end
+
+  def test_replace_with_to_hash_conversion
+    hash = HashWithIndifferentAccess.new
+    hash[:a] = 42
+
+    replaced = hash.replace(HashByConversion.new(b: 12))
 
     assert hash.key?('b')
     assert !hash.key?(:a)
@@ -924,6 +958,12 @@ class HashExtTest < ActiveSupport::TestCase
     h = hash_with_only_nil_values.dup
     assert_equal({}, h.compact!)
     assert_equal({}, h)
+  end
+
+  def test_new_with_to_hash_conversion
+    hash = HashWithIndifferentAccess.new(HashByConversion.new(a: 1))
+    assert hash.key?('a')
+    assert_equal 1, hash[:a]
   end
 end
 

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1456,6 +1456,15 @@ class HashToXmlTest < ActiveSupport::TestCase
     assert_not_same hash_wia, hash_wia.with_indifferent_access
   end
 
+   def test_dup_should_only_modify_the_copy
+    hash = ActiveSupport::HashWithIndifferentAccess.new({ a: { b: 'b' } })
+    dup  = hash.dup
+    dup[:a][:c] = 'c'
+
+    assert_nil hash[:a][:c]
+    assert_equal dup[:a][:c], "c"
+  end
+
   def test_should_copy_the_default_value_when_converting_to_hash_with_indifferent_access
     hash = Hash.new(3)
     hash_wia = hash.with_indifferent_access

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -23,16 +23,6 @@ class HashExtTest < ActiveSupport::TestCase
     end
   end
 
-  class HashByConversion
-    def initialize(hash)
-      @hash = hash
-    end
-
-    def to_hash
-      @hash
-    end
-  end
-
   def setup
     @strings = { 'a' => 1, 'b' => 2 }
     @nested_strings = { 'a' => { 'b' => { 'c' => 3 } } }
@@ -443,12 +433,6 @@ class HashExtTest < ActiveSupport::TestCase
     assert [updated_with_strings, updated_with_symbols, updated_with_mixed].all? { |h| h.keys.size == 2 }
   end
 
-  def test_update_with_to_hash_conversion
-    hash = HashWithIndifferentAccess.new
-    hash.update HashByConversion.new({ :a => 1 })
-    assert_equal hash['a'], 1
-  end
-
   def test_indifferent_merging
     hash = HashWithIndifferentAccess.new
     hash[:a] = 'failure'
@@ -468,29 +452,11 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal 2, hash['b']
   end
 
-  def test_merge_with_to_hash_conversion
-    hash = HashWithIndifferentAccess.new
-    merged = hash.merge HashByConversion.new({ :a => 1 })
-    assert_equal merged['a'], 1
-  end
-
   def test_indifferent_replace
     hash = HashWithIndifferentAccess.new
     hash[:a] = 42
 
     replaced = hash.replace(b: 12)
-
-    assert hash.key?('b')
-    assert !hash.key?(:a)
-    assert_equal 12, hash[:b]
-    assert_same hash, replaced
-  end
-
-  def test_replace_with_to_hash_conversion
-    hash = HashWithIndifferentAccess.new
-    hash[:a] = 42
-
-    replaced = hash.replace(HashByConversion.new(b: 12))
 
     assert hash.key?('b')
     assert !hash.key?(:a)


### PR DESCRIPTION
The PR #14518 just added the following regression to `HashWithIndifferentAccess#dup`:

``` ruby
hash = ActiveSupport::HashWithIndifferentAccess.new({ a: { b: 'b' } })
dup  = hash.dup
dup[:a][:c] = 'c'

hash[:a][:c] #=> "c"
# it was modifying the original hash too
dup[:a][:c]  #=> "c"
```

Just reverting #14518 and backporting 03f35a27dc88335550ca0ab1d21e46948c9f5093 solves the problem.

It now behaves as expected:

``` ruby
hash = ActiveSupport::HashWithIndifferentAccess.new({ a: { b: 'b' } })
dup  = hash.dup
dup[:a][:c] = 'c'

hash[:a][:c] #=> nil
# does not modify the original hash
dup[:a][:c]  #=> "c"
```

Also I added a regression test (that shall be cherry-picked to master, maybe?).

cc @rafaelfranca @robin850
