### PR TITLE
Detect in-place changes on mutable attributes on Active Model

### DIFF
--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -176,4 +176,20 @@ class DirtyTest < ActiveModel::TestCase
     assert_equal ActiveSupport::HashWithIndifferentAccess.new, @model.previous_changes
     assert_equal ActiveSupport::HashWithIndifferentAccess.new, @model.changed_attributes
   end
+
+  test "mutable attributes changed in place are detected" do
+    @model.name = 'Sean'
+    @model.save
+
+    assert_not @model.changed?
+
+    @model.name << ' Griffin'
+
+    assert @model.changed?
+    assert @model.name_changed?
+    assert_equal ['name'], @model.changed
+    # We cannot detect the values changed to/from
+    assert_equal [nil, 'Sean Griffin'], @model.changes['name']
+    assert_not @model.name_changed?(from: 'Sean')
+  end
 end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   ActiveModel::Dirty now detects in-place changes to mutable values.
+    Serialized attributes on ActiveRecord models will no longer save
+    when unchanged. Fixes #8328.
+
+    *Sean Griffin*
+
 *   Make timezone aware attributes work with PostgreSQL array columns.
 
     Fixes #13402.

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -50,8 +50,6 @@ module ActiveRecord
         #     serialize :preferences, Hash
         #   end
         def serialize(attr_name, class_name_or_coder = Object)
-          include Behavior
-
           coder = if [:load, :dump].all? { |x| class_name_or_coder.respond_to?(x) }
                     class_name_or_coder
                   else
@@ -65,21 +63,6 @@ module ActiveRecord
           # merge new serialized attribute and create new hash to ensure that each class in inheritance hierarchy
           # has its own hash of own serialized attributes
           self.serialized_attributes = serialized_attributes.merge(attr_name.to_s => coder)
-        end
-      end
-
-
-      # This is only added to the model when serialize is called, which
-      # ensures we do not make things slower when serialization is not used.
-      module Behavior # :nodoc:
-        extend ActiveSupport::Concern
-
-        def should_record_timestamps?
-          super || (self.record_timestamps && (attributes.keys & self.class.serialized_attributes.keys).present?)
-        end
-
-        def keys_for_partial_write
-          super | (attributes.keys & self.class.serialized_attributes.keys)
         end
       end
     end

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -143,7 +143,7 @@ module ActiveRecord
               def save_changed_attribute(attr_name, old)
                 if (mapping = self.class.defined_enums[attr_name.to_s])
                   value = read_attribute(attr_name)
-                  if attribute_changed?(attr_name)
+                  if changed_attributes.key?(attr_name)
                     if mapping[old] == value
                       changed_attributes.delete(attr_name)
                     end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -186,6 +186,7 @@ module ActiveRecord
       became.instance_variable_set("@raw_attributes", @raw_attributes)
       became.instance_variable_set("@attributes", @attributes)
       became.instance_variable_set("@changed_attributes", @changed_attributes) if defined?(@changed_attributes)
+      became.instance_variable_set("@original_attribute_hashes", @original_attribute_hashes) if defined?(@original_attribute_hashes)
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became.instance_variable_set("@errors", errors)

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -329,6 +329,13 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
       dupe = record.dup
       assert_equal({"one" => "two"}, dupe.tags.to_hash)
     end
+
+    def test_changes_in_place
+      json = Hstore.create!(tags: { 'a' => 'a' })
+      assert_not json.tags_changed?
+      json.tags['b'] = 'b'
+      assert json.tags_changed?
+    end
   end
 
   private

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -164,4 +164,11 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
     JsonDataType.update_all payload: { }
     assert_equal({ }, json.reload.payload)
   end
+
+  def test_changes_in_place
+    json = JsonDataType.create!(payload: { 'a' => 'a' })
+    assert_not json.payload_changed?
+    json.payload['b'] = 'b'
+    assert json.payload_changed?
+  end
 end


### PR DESCRIPTION
We have several mutable types on Active Record now. (Serialized, JSON,
HStore). We need to be able to detect if these have been modified in
place. By storing the hashed value of the original attribute, we can
achieve this without significantly increasing memory usage or time for
dirty checking per-record.

fixes #8328
