### PR TITLE
ActiveRecord::Migration.maintain_test_schema! doesn't work with structure.sql

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixed automatic maintaining test schema to properly handle sql structure
+    schema format. Fixes #15394.
+
+    *Wojciech Wnętrzak*
+
 *   PostgreSQL support default values for enum types. Fixes #7814.
 
     *Yves Senn*

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -161,10 +161,12 @@ module ActiveRecord
         when :ruby
           file ||= File.join(db_dir, "schema.rb")
           check_schema_file(file)
+          purge(current_config)
           load(file)
         when :sql
           file ||= File.join(db_dir, "structure.sql")
           check_schema_file(file)
+          purge(current_config)
           structure_load(current_config, file)
         else
           raise ArgumentError, "unknown format #{format.inspect}"

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -21,7 +21,11 @@ module ActiveRecord
 
         FileUtils.rm(file) if File.exist?(file)
       end
-      alias :purge :drop
+
+      def purge
+        drop
+        create
+      end
 
       def charset
         connection.encoding

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -125,12 +125,12 @@ module ApplicationTests
 
       assert_unsuccessful_run "models/user_test.rb", "Migrations are pending"
 
-      app_file 'db/structure.sql', <<-RUBY
+      app_file 'db/structure.sql', <<-SQL
         CREATE TABLE "schema_migrations" ("version" varchar(255) NOT NULL);
         CREATE UNIQUE INDEX "unique_schema_migrations" ON "schema_migrations" ("version");
         CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar(255));
         INSERT INTO schema_migrations (version) VALUES ('#{version}');
-      RUBY
+      SQL
 
       app_file 'config/initializers/disable_maintain_test_schema.rb', <<-RUBY
         Rails.application.config.active_record.maintain_test_schema = false
@@ -139,6 +139,56 @@ module ApplicationTests
       assert_unsuccessful_run "models/user_test.rb", "Could not find table 'users'"
 
       File.delete "#{app_path}/config/initializers/disable_maintain_test_schema.rb"
+
+      assert_successful_test_run('models/user_test.rb')
+    end
+
+    test "sql structure migrations when adding column to existing table" do
+      output_1  = script('generate model user name:string')
+      version_1 = output_1.match(/(\d+)_create_users\.rb/)[1]
+
+      app_file 'test/models/user_test.rb', <<-RUBY
+        require 'test_helper'
+        class UserTest < ActiveSupport::TestCase
+          test "user" do
+            User.create! name: "Jon"
+          end
+        end
+      RUBY
+
+      app_file 'config/initializers/enable_sql_schema_format.rb', <<-RUBY
+        Rails.application.config.active_record.schema_format = :sql
+      RUBY
+
+      app_file 'db/structure.sql', <<-SQL
+        CREATE TABLE "schema_migrations" ("version" varchar(255) NOT NULL);
+        CREATE UNIQUE INDEX "unique_schema_migrations" ON "schema_migrations" ("version");
+        CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar(255));
+        INSERT INTO schema_migrations (version) VALUES ('#{version_1}');
+      SQL
+
+      assert_successful_test_run('models/user_test.rb')
+
+      output_2  = script('generate migration add_email_to_users')
+      version_2 = output_2.match(/(\d+)_add_email_to_users\.rb/)[1]
+
+      app_file 'test/models/user_test.rb', <<-RUBY
+        require 'test_helper'
+
+        class UserTest < ActiveSupport::TestCase
+          test "user" do
+            User.create! name: "Jon", email: "jon@doe.com"
+          end
+        end
+      RUBY
+
+      app_file 'db/structure.sql', <<-SQL
+        CREATE TABLE "schema_migrations" ("version" varchar(255) NOT NULL);
+        CREATE UNIQUE INDEX "unique_schema_migrations" ON "schema_migrations" ("version");
+        CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar(255), "email" varchar(255));
+        INSERT INTO schema_migrations (version) VALUES ('#{version_1}');
+        INSERT INTO schema_migrations (version) VALUES ('#{version_2}');
+      SQL
 
       assert_successful_test_run('models/user_test.rb')
     end

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -67,7 +67,7 @@ module ApplicationTests
       assert_match %r{/app/test/unit/failing_test\.rb}, output
     end
 
-    test "migrations" do
+    test "ruby schema migrations" do
       output  = script('generate model user name:string')
       version = output.match(/(\d+)_create_users\.rb/)[1]
 
@@ -102,6 +102,45 @@ module ApplicationTests
 
       result = assert_successful_test_run('models/user_test.rb')
       assert !result.include?("create_table(:users)")
+    end
+
+    test "sql structure migrations" do
+      output  = script('generate model user name:string')
+      version = output.match(/(\d+)_create_users\.rb/)[1]
+
+      app_file 'test/models/user_test.rb', <<-RUBY
+        require 'test_helper'
+
+        class UserTest < ActiveSupport::TestCase
+          test "user" do
+            User.create! name: "Jon"
+          end
+        end
+      RUBY
+
+      app_file 'db/structure.sql', ''
+      app_file 'config/initializers/enable_sql_schema_format.rb', <<-RUBY
+        Rails.application.config.active_record.schema_format = :sql
+      RUBY
+
+      assert_unsuccessful_run "models/user_test.rb", "Migrations are pending"
+
+      app_file 'db/structure.sql', <<-RUBY
+        CREATE TABLE "schema_migrations" ("version" varchar(255) NOT NULL);
+        CREATE UNIQUE INDEX "unique_schema_migrations" ON "schema_migrations" ("version");
+        CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar(255));
+        INSERT INTO schema_migrations (version) VALUES ('#{version}');
+      RUBY
+
+      app_file 'config/initializers/disable_maintain_test_schema.rb', <<-RUBY
+        Rails.application.config.active_record.maintain_test_schema = false
+      RUBY
+
+      assert_unsuccessful_run "models/user_test.rb", "Could not find table 'users'"
+
+      File.delete "#{app_path}/config/initializers/disable_maintain_test_schema.rb"
+
+      assert_successful_test_run('models/user_test.rb')
     end
 
     private


### PR DESCRIPTION
Introduced in rails 4.1.
Checked using sqlite3 and postgres.

At the end of calling `ActiveRecord::Migration.maintain_test_schema!` this method is called: https://github.com/rails/rails/blob/99873ca1ea98d73c73f8be60dfce0a54224f4ea8/activerecord/lib/active_record/tasks/database_tasks.rb#L159 which later, after choosing database adapter calls method, in example on sqlite3 adapter: https://github.com/rails/rails/blob/99873ca1ea98d73c73f8be60dfce0a54224f4ea8/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb#L35

So at the very end it runs: `sqlite3 db/test.sqlite3 < db/structure.sql`

This however can result in error like:

```
Error: near line 1: table "schema_migrations" already exists
Error: near line 2: index unique_schema_migrations already exists
Error: near line 3: table "users" already exists
Error: near line 4: UNIQUE constraint failed: schema_migrations.version
```

This error can happen when we created migration to add column to existing table.

It looks like it's necessary to always purge database before loading sql file and adding:

```
purge(current_config)
create(current_config)
```

before line https://github.com/rails/rails/blob/99873ca1ea98d73c73f8be60dfce0a54224f4ea8/activerecord/lib/active_record/tasks/database_tasks.rb#L168 fixes the issue.
I'm not sure if that is the best place however.

Similar issue was noted in https://github.com/rails/rails/pull/13528#issuecomment-40718912 by @kevintyll

Please, let me know if the issue is unclear, I can submit example app then.
If you think that's the correct way of fixing it, I can prepare a PR.

Addressing to @jonleighton as he is the author of this feature.
