### PR TITLE
Test the serialized types of virtual columns in XML

### DIFF
--- a/activerecord/lib/active_record/serializers/xml_serializer.rb
+++ b/activerecord/lib/active_record/serializers/xml_serializer.rb
@@ -184,8 +184,6 @@ module ActiveRecord #:nodoc:
                  super
                elsif klass.columns_hash.key?(name)
                  klass.columns_hash[name].type
-               else
-                 NilClass
                end
 
         { :text => :string,

--- a/activerecord/test/cases/xml_serialization_test.rb
+++ b/activerecord/test/cases/xml_serialization_test.rb
@@ -416,8 +416,9 @@ class DatabaseConnectedXmlSerializationTest < ActiveRecord::TestCase
 
   def test_should_support_aliased_attributes
     xml = Author.select("name as firstname").to_xml
-    array = Hash.from_xml(xml)['authors']
-    assert_equal array.size, array.select { |author| author.has_key? 'firstname' }.size
+    Author.all.each do |author|
+      assert xml.include?(%(<firstname>#{author.name}</firstname>)), xml
+    end
   end
 
   def test_array_to_xml_including_has_many_association


### PR DESCRIPTION
The previous tests were passing, because nothing ever looked at the
generated XML. What was previously being generated was
`<firstname type="NilClass">...`, which is not consistent with all other
cases where there is not a known type.
