### PR TITLE
Generate correct url for docs

### DIFF
--- a/activerecord/test/fixtures/tasks.yml
+++ b/activerecord/test/fixtures/tasks.yml
@@ -1,4 +1,3 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 first_task:
   id: 1
   starting: 2005-03-30t06:30:00.00+01:00

--- a/guides/code/getting_started/test/fixtures/articles.yml
+++ b/guides/code/getting_started/test/fixtures/articles.yml
@@ -1,5 +1,3 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
 one:
   title: MyString
   text: MyText

--- a/guides/code/getting_started/test/fixtures/comments.yml
+++ b/guides/code/getting_started/test/fixtures/comments.yml
@@ -1,5 +1,3 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
 one:
   commenter: MyString
   body: MyText

--- a/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
+++ b/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
@@ -1,4 +1,4 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# Read about fixtures at http://api.rubyonrails.org/v<%= Rails.version %>/classes/ActiveRecord/FixtureSet.html
 <% unless attributes.empty? -%>
 <% %w(one two).each do |name| %>
 <%= name %>:


### PR DESCRIPTION
The correct url for fixtures is http://api.rubyonrails.org/v4.1.1/classes/ActiveRecord/FixtureSet.html though it's currently listed as http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html this commit fixes that issue by injecting the current rails version when the fixture is generated.
