### PR TITLE
File.exist? instead of File.exists? in bin/setup

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup
@@ -12,7 +12,7 @@ Dir.chdir APP_ROOT do
   system "bundle check || bundle install"
 
   # puts "\n== Copying sample files =="
-  # unless File.exists?("config/database.yml")
+  # unless File.exist?("config/database.yml")
   #   system "cp config/database.yml.sample config/database.yml"
   # end
 


### PR DESCRIPTION
File.exists? is deprecated in Ruby 2.1+

https://github.com/ruby/ruby/blob/v2_1_2/file.c#L1413
