### PR TITLE
Remove unused `initialize_attributes` method

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -252,7 +252,7 @@ module ActiveRecord
       defaults = self.class.column_defaults.dup
       defaults.each { |k, v| defaults[k] = v.dup if v.duplicable? }
 
-      @raw_attributes = self.class.initialize_attributes(defaults)
+      @raw_attributes = defaults
       @column_types_override = nil
       @column_types = self.class.column_types
 
@@ -278,7 +278,7 @@ module ActiveRecord
     #   post.init_with('attributes' => { 'title' => 'hello world' })
     #   post.title # => 'hello world'
     def init_with(coder)
-      @raw_attributes = self.class.initialize_attributes(coder['attributes'])
+      @raw_attributes = coder['attributes']
       @column_types_override = coder['column_types']
       @column_types = self.class.column_types
 
@@ -323,7 +323,6 @@ module ActiveRecord
     ##
     def initialize_dup(other) # :nodoc:
       cloned_attributes = other.clone_attributes(:read_attribute_before_type_cast)
-      self.class.initialize_attributes(cloned_attributes, :serialized => false)
 
       @raw_attributes = cloned_attributes
       @raw_attributes[self.class.primary_key] = nil

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -295,13 +295,6 @@ module ActiveRecord
         @cached_time_zone        = nil
       end
 
-      # This is a hook for use by modules that need to do extra stuff to
-      # attributes when they are initialized. (e.g. attribute
-      # serialization)
-      def initialize_attributes(attributes, options = {}) #:nodoc:
-        attributes
-      end
-
       private
 
       # Guesses the table name, but does not decorate it with prefix and suffix information.

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -177,7 +177,7 @@ module ActiveRecord
         end
 
         result = result.map do |attributes|
-          values = klass.initialize_attributes(attributes).values
+          values = attributes.values
 
           columns.zip(values).map { |column, value| column.type_cast value }
         end


### PR DESCRIPTION
This was previously a hook for a special case related to `serialize`,
which has since been removed.
