### PR TITLE
Remove `type_cast_for_schema`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -10,7 +10,7 @@ module ActiveRecord
     module ColumnDumper
       def column_spec(column, types)
         spec = prepare_column_options(column, types)
-        (spec.keys - [:name, :type]).each{ |k| spec[k].insert(0, "#{k.to_s}: ")}
+        spec.except(:name, :type).each{ |k, v| spec[k] = "#{k.to_s}: #{v}"}
         spec
       end
 
@@ -25,13 +25,25 @@ module ActiveRecord
         spec[:precision] = column.precision.inspect if column.precision
         spec[:scale]     = column.scale.inspect if column.scale
         spec[:null]      = 'false' unless column.null
-        spec[:default]   = column.type_cast_for_schema(column.default) if column.has_default?
+        spec[:default]   = default_string(column) if column.has_default?
         spec
       end
 
       # Lists the valid migration options
       def migration_keys
         [:name, :limit, :precision, :scale, :default, :null]
+      end
+
+      private
+
+      def default_string(column)
+        value = column.type_cast_for_database(column.default)
+
+        if value.is_a?(::String)
+          value.inspect
+        else
+          value
+        end
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -18,7 +18,6 @@ module ActiveRecord
       delegate :type, :precision, :scale, :limit, :klass, :accessor,
         :text?, :number?, :binary?, :serialized?, :changed?,
         :type_cast, :type_cast_for_write, :type_cast_for_database,
-        :type_cast_for_schema,
         to: :cast_type
 
       # Instantiates a new column in the table.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       module OID # :nodoc:
         class Bytea < Type::Binary
           def cast_value(value)
-            PGconn.unescape_bytea value
+            PGconn.unescape_bytea(super)
           end
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/cidr.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/cidr.rb
@@ -7,17 +7,6 @@ module ActiveRecord
             :cidr
           end
 
-          def type_cast_for_schema(value)
-            subnet_mask = value.instance_variable_get(:@mask_addr)
-
-            # If the subnet mask is equal to /32, don't output it
-            if subnet_mask == (2**32 - 1)
-              "\"#{value.to_s}\""
-            else
-              "\"#{value.to_s}/#{subnet_mask.to_s(2).count('1')}\""
-            end
-          end
-
           def type_cast_for_database(value)
             if IPAddr === value
               "#{value.to_s}/#{value.instance_variable_get(:@mask_addr).to_s(2).count('1')}"

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
@@ -24,10 +24,6 @@ module ActiveRecord
             value.respond_to?(:infinite?) && value.infinite?
           end
 
-          def type_cast_for_schema(value)
-            value.inspect.gsub('Infinity', '::Float::INFINITY')
-          end
-
           def type_cast_single(value)
             infinity?(value) ? value : @subtype.type_cast(value)
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -43,6 +43,7 @@ module ActiveRecord
   module ConnectionAdapters #:nodoc:
     class SQLite3Binary < Type::Binary # :nodoc:
       def cast_value(value)
+        value = super
         if value.encoding != Encoding::ASCII_8BIT
           value = value.force_encoding(Encoding::ASCII_8BIT)
         end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -245,7 +245,7 @@ module ActiveRecord
       # are the default values suitable for use in `@raw_attriubtes`
       def raw_column_defaults # :nodoc:
         @raw_column_defauts ||= Hash[column_defaults.map { |name, default|
-          [name, columns_hash[name].type_cast_for_write(default)]
+          [name, columns_hash[name].type_cast_for_database(default)]
         }]
       end
 

--- a/activerecord/lib/active_record/type/binary.rb
+++ b/activerecord/lib/active_record/type/binary.rb
@@ -14,7 +14,16 @@ module ActiveRecord
       end
 
       def type_cast_for_database(value)
+        return if value.nil?
         Data.new(super)
+      end
+
+      def cast_value(value)
+        if value.is_a?(Data)
+          value.to_s
+        else
+          super
+        end
       end
 
       class Data

--- a/activerecord/lib/active_record/type/date.rb
+++ b/activerecord/lib/active_record/type/date.rb
@@ -9,10 +9,6 @@ module ActiveRecord
         ::Date
       end
 
-      def type_cast_for_schema(value)
-        "'#{value.to_s(:db)}'"
-      end
-
       private
 
       def cast_value(value)

--- a/activerecord/lib/active_record/type/decimal.rb
+++ b/activerecord/lib/active_record/type/decimal.rb
@@ -11,10 +11,6 @@ module ActiveRecord
         ::BigDecimal
       end
 
-      def type_cast_for_schema(value)
-        value.to_s
-      end
-
       private
 
       def cast_value(value)

--- a/activerecord/lib/active_record/type/time_value.rb
+++ b/activerecord/lib/active_record/type/time_value.rb
@@ -5,10 +5,6 @@ module ActiveRecord
         ::Time
       end
 
-      def type_cast_for_schema(value)
-        "'#{value.to_s(:db)}'"
-      end
-
       private
 
       def new_time(year, mon, mday, hour, min, sec, microsec, offset = nil)

--- a/activerecord/lib/active_record/type/value.rb
+++ b/activerecord/lib/active_record/type/value.rb
@@ -27,10 +27,6 @@ module ActiveRecord
         type_cast_for_write(value)
       end
 
-      def type_cast_for_schema(value)
-        value.inspect
-      end
-
       def text?
         false
       end

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -64,9 +64,7 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     def test_default
       @connection.add_column 'hstores', 'permissions', :hstore, default: '"users"=>"read", "articles"=>"write"'
       Hstore.reset_column_information
-      column = Hstore.columns_hash["permissions"]
 
-      assert_equal({"users"=>"read", "articles"=>"write"}, column.default)
       assert_equal({"users"=>"read", "articles"=>"write"}, Hstore.new.permissions)
     ensure
       Hstore.reset_column_information

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -43,9 +43,7 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
   def test_default
     @connection.add_column 'json_data_type', 'permissions', :json, default: '{"users": "read", "posts": ["read", "write"]}'
     JsonDataType.reset_column_information
-    column = JsonDataType.columns_hash["permissions"]
 
-    assert_equal({"users"=>"read", "posts"=>["read", "write"]}, column.default)
     assert_equal({"users"=>"read", "posts"=>["read", "write"]}, JsonDataType.new.permissions)
   ensure
     JsonDataType.reset_column_information

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -208,6 +208,11 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_match %r{t\.boolean\s+"has_fun",.+default: false}, output
   end
 
+  def test_schema_dump_should_quote_strings
+    output = standard_dump
+    assert_match %r{t\.string\s+"name",.+default: "Boeing 747"}, output
+  end
+
   if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
     def test_schema_dump_should_not_add_default_value_for_mysql_text_field
       output = standard_dump
@@ -279,14 +284,14 @@ class SchemaDumperTest < ActiveRecord::TestCase
     def test_schema_dump_includes_json_shorthand_definition
       output = standard_dump
       if %r{create_table "postgresql_json_data_type"} =~ output
-        assert_match %r|t.json "json_data", default: {}|, output
+        assert_match %r|t.json "json_data", default: "{}"|, output
       end
     end
 
     def test_schema_dump_includes_inet_shorthand_definition
       output = standard_dump
       if %r{create_table "postgresql_network_addresses"} =~ output
-        assert_match %r{t.inet\s+"inet_address",\s+default: "192.168.1.1"}, output
+        assert_match %r{t.inet\s+"inet_address",\s+default: "192.168.1.1/32"}, output
       end
     end
 
@@ -314,7 +319,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     def test_schema_dump_includes_hstores_shorthand_definition
       output = standard_dump
       if %r{create_table "postgresql_hstores"} =~ output
-        assert_match %r[t.hstore "hash_store", default: {}], output
+        assert_match %r[t.hstore "hash_store", default: ""], output
       end
     end
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :aircraft, force: true do |t|
-    t.string :name
+    t.string :name, default: "Boeing 747"
   end
 
   create_table :articles, force: true do |t|


### PR DESCRIPTION
We already store the default value for a column in a database readable
format. If the value returned from that is good enough for the database
normally, it should be good enough for the database in this case as
well. With that in mind, the only special case remaining is the need for
quotes to be added to strings, which doesn't justify the method's
existence.
