### PR TITLE
Fix regression on eager loading association based on SQL query rather than existing column.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix regression on eager loading association based on SQL query rather than
+    existing column.
+
+    Fixes #15480.
+
+    *Lauro Caetano*, *Carlos Antonio da Silva*
+
 *   Preserve type when dumping PostgreSQL point, bit, bit varying and money
     columns.
 

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -104,11 +104,13 @@ module ActiveRecord
         end
 
         def association_key_type
-          @klass.column_types[association_key_name.to_s].type
+          column = @klass.column_types[association_key_name.to_s]
+          column && column.type
         end
 
         def owner_key_type
-          @model.column_types[owner_key_name.to_s].type
+          column = @model.column_types[owner_key_name.to_s]
+          column && column.type
         end
 
         def load_slices(slices)

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1239,6 +1239,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
     }
   end
 
+  test "including association based on sql condition and no database column" do
+    assert_equal pets(:parrot), Owner.including_last_pet.first.last_pet
+  end
+
   test "include instance dependent associations is deprecated" do
     message = "association scope 'posts_with_signature' is"
     assert_deprecated message do

--- a/activerecord/test/models/owner.rb
+++ b/activerecord/test/models/owner.rb
@@ -3,6 +3,18 @@ class Owner < ActiveRecord::Base
   has_many :pets, -> { order 'pets.name desc' }
   has_many :toys, :through => :pets
 
+  belongs_to :last_pet, class_name: 'Pet'
+  scope :including_last_pet, -> {
+    select(%q[
+      owners.*, (
+        select p.pet_id from pets p
+        where p.owner_id = owners.owner_id
+        order by p.name desc
+        limit 1
+      ) as last_pet_id
+    ]).includes(:last_pet)
+  }
+
   after_commit :execute_blocks
 
   def blocks


### PR DESCRIPTION
It is a regression added by #14855 (yeah, that's my fault :angry:)

Basically it checks if the column exists before trying to get its type.

Fixes #15480.
