### PR TITLE
Don't always mark defaults as dirty for some types

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -54,7 +54,7 @@ module ActiveRecord
         # Intentionally avoid using #column_defaults since overridden defaults (as is done in
         # optimistic locking) won't get written unless they get marked as changed
         self.class.columns.each do |c|
-          attr, orig_value = c.name, c.default
+          attr, orig_value = c.name, c.type_cast(c.default)
           changed_attributes[attr] = orig_value if _field_changed?(attr, orig_value, @raw_attributes[attr])
         end
       end


### PR DESCRIPTION
The contract of `_field_changed?` assumes that the old value is always
type cast. That is not the case for the value in `Column#default` as
things are today. We need to type cast before comparing.
