### PR TITLE
Emit suggested generator names when not found

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Invalid `bin/rails generate` commands will now show spelling suggestions.
+
+    *Richard Schneeman*
+
 *   Add `bin/setup` script to bootstrap an application.
 
     *Yves Senn*

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -24,7 +24,13 @@ class GeneratorsTest < Rails::Generators::TestCase
     name = :unknown
     output = capture(:stdout){ Rails::Generators.invoke name }
     assert_match "Could not find generator '#{name}'", output
-    assert_match "scaffold", output
+    assert_match "`rails generate --help`", output
+  end
+
+  def test_generator_suggestions
+    name = :migrationz
+    output = capture(:stdout){ Rails::Generators.invoke name }
+    assert_match "Maybe you meant 'migration'", output
   end
 
   def test_help_when_a_generator_with_required_arguments_is_invoked_without_arguments


### PR DESCRIPTION
When someone types in a generator command it currently outputs all generators. Instead we can attempt to find a subtle mis-spelling by running all generator names through a `levenshtein_distance` algorithm provided by rubygems (`Gem::Text`). 

So now a failure looks like this:

``` ruby
$ rails generate migratioooons
Could not find generator 'migratioooons'. Maybe you meant 'migration' or 'integration_test' or 'generator'
Run `rails generate --help` for more options.
```

If the suggestions are bad we leave the user with the hint to run `rails generate --help` to see all commands.
