### PR TITLE
Convert StrongParameters cache to a hash. This fixes an unbounded memory leak

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -130,7 +130,7 @@ module ActionController
     # looping in the common use case permit + mass-assignment. Defined in a
     # method to instantiate it only if needed.
     def converted_arrays
-      @converted_arrays ||= Set.new
+      @converted_arrays ||= {}
     end
 
     # Returns +true+ if the parameter is permitted, +false+ otherwise.
@@ -333,15 +333,15 @@ module ActionController
 
     private
       def convert_hashes_to_parameters(key, value, assign_if_converted=true)
-        converted = convert_value_to_parameters(value)
+        converted = convert_value_to_parameters(key, value)
         self[key] = converted if assign_if_converted && !converted.equal?(value)
         converted
       end
 
-      def convert_value_to_parameters(value)
-        if value.is_a?(Array) && !converted_arrays.member?(value)
-          converted = value.map { |_| convert_value_to_parameters(_) }
-          converted_arrays << converted
+      def convert_value_to_parameters(key, value)
+        if value.is_a?(Array) && !converted_arrays.member?(key)
+          converted = value.map { |v| convert_value_to_parameters(nil, v) }
+          converted_arrays[key] = converted if key
           converted
         elsif value.is_a?(Parameters) || !value.is_a?(Hash)
           value

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -169,7 +169,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
 
   test 'arrays are converted at most once' do
     params = ActionController::Parameters.new(foo: [{}])
-    assert params[:foo].equal?(params[:foo])
+    assert_same params[:foo], params[:foo]
   end
 
   test "fetch doesnt raise ParameterMissing exception if there is a default" do


### PR DESCRIPTION
demonstrated on @tenderlove's latest blog post:

http://tenderlovemaking.com/2014/06/02/yagni-methods-are-killing-me.html
