### PR TITLE
reuse available belongs_to? method

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -116,7 +116,7 @@ module ActiveRecord
         end
 
         def target_reflection_has_associated_record?
-          !(through_reflection.macro == :belongs_to && owner[through_reflection.foreign_key].blank?)
+          !(through_reflection.belongs_to? && owner[through_reflection.foreign_key].blank?)
         end
 
         def update_through_counter?(method)

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -63,14 +63,13 @@ module ActiveRecord
         # Note: this does not capture all cases, for example it would be crazy to try to
         # properly support stale-checking for nested associations.
         def stale_state
-          if through_reflection.macro == :belongs_to
+          if through_reflection.belongs_to?
             owner[through_reflection.foreign_key] && owner[through_reflection.foreign_key].to_s
           end
         end
 
         def foreign_key_present?
-          through_reflection.macro == :belongs_to &&
-          !owner[through_reflection.foreign_key].nil?
+          through_reflection.belongs_to? && !owner[through_reflection.foreign_key].nil?
         end
 
         def ensure_mutable

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -278,7 +278,7 @@ module ActiveRecord
 
       if group_attrs.first.respond_to?(:to_sym)
         association  = @klass._reflect_on_association(group_attrs.first.to_sym)
-        associated   = group_attrs.size == 1 && association && association.macro == :belongs_to # only count belongs_to associations
+        associated   = group_attrs.size == 1 && association && association.belongs_to? # only count belongs_to associations
         group_fields = Array(associated ? association.foreign_key : group_attrs)
       else
         group_fields = group_attrs


### PR DESCRIPTION
Reflection has a `belongs_to?` method. Instead of checking for
`macro == :belongs_to` throughout the source reuse existing
method.

I also bumped `foreign_key_present?` method onto on line because
the `belongs_to?` makes it shorter than other longer lines in
the same class.
