### PR TITLE
Use null column for association key types

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -104,13 +104,11 @@ module ActiveRecord
         end
 
         def association_key_type
-          column = @klass.column_types[association_key_name.to_s]
-          column && column.type
+          @klass.column_for_attribute(association_key_name).type
         end
 
         def owner_key_type
-          column = @model.column_types[owner_key_name.to_s]
-          column && column.type
+          @model.column_for_attribute(owner_key_name).type
         end
 
         def load_slices(slices)


### PR DESCRIPTION
Refactoring of #15482 with new behavior available only on master.
