### PR TITLE
`datetime` and `timestamp` array attributes are saving correctly.

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -32,7 +32,7 @@ module ActiveRecord
           if create_time_zone_conversion_attribute?(attr_name, columns_hash[attr_name])
             method_body, line = <<-EOV, __LINE__ + 1
               def #{attr_name}=(time)
-                time_with_zone = time.respond_to?(:in_time_zone) ? time.in_time_zone : nil
+                time_with_zone = self.class.columns_hash["#{ attr_name }"].time_with_zone(time)
                 previous_time = attribute_changed?("#{attr_name}") ? changed_attributes["#{attr_name}"] : read_attribute(:#{attr_name})
                 write_attribute(:#{attr_name}, time)
                 #{attr_name}_will_change! if previous_time != time_with_zone

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -18,7 +18,7 @@ module ActiveRecord
       delegate :type, :precision, :scale, :limit, :klass, :accessor,
         :text?, :number?, :binary?, :serialized?, :changed?,
         :type_cast, :type_cast_for_write, :type_cast_for_database,
-        :type_cast_for_schema,
+        :type_cast_for_schema, :time_with_zone,
         to: :cast_type
 
       # Instantiates a new column in the table.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       module OID # :nodoc:
         class Array < Type::Value
           attr_reader :subtype
-          delegate :type, to: :subtype
+          delegate :type, :time_with_zone, to: :subtype
 
           def initialize(subtype)
             @subtype = subtype

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/date_time.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/date_time.rb
@@ -19,6 +19,14 @@ module ActiveRecord
               value
             end
           end
+
+          def time_with_zone(value)
+            if value.is_a? ::Array
+              value.map(&method(:time_with_zone))
+            else
+              super
+            end
+          end
         end
       end
     end

--- a/activerecord/lib/active_record/type/date_time.rb
+++ b/activerecord/lib/active_record/type/date_time.rb
@@ -7,6 +7,10 @@ module ActiveRecord
         :datetime
       end
 
+      def time_with_zone(value)
+        value.in_time_zone if value.respond_to?(:in_time_zone)
+      end
+
       private
 
       def cast_value(string)

--- a/activerecord/lib/active_record/type/value.rb
+++ b/activerecord/lib/active_record/type/value.rb
@@ -31,6 +31,10 @@ module ActiveRecord
         value.inspect
       end
 
+      def time_with_zone(value)
+        nil
+      end
+
       def text?
         false
       end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -12,6 +12,8 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
       @connection.create_table('pg_arrays') do |t|
         t.string 'tags', array: true
         t.integer 'ratings', array: true
+        t.datetime :datetimes, array: true, default: []
+        t.timestamp :timestamps, array: true, default: []
       end
     end
     @column = PgArray.columns_hash['tags']
@@ -193,6 +195,24 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     ar = PgArray.create!(tags: tags)
     ar.reload
     assert_equal tags, ar.tags
+  end
+
+  def test_datetime_with_timezone_awareness
+    with_timezone_config aware_attributes: true do
+      PgArray.reset_column_information
+      current_time = [Time.current]
+      record = PgArray.create!(datetimes: current_time)
+      assert_equal current_time, record.datetimes
+    end
+  end
+
+  def test_timestamp_with_timezone_awareness
+    with_timezone_config aware_attributes: true do
+      PgArray.reset_column_information
+      current_time = [Time.current]
+      record = PgArray.create!(timestamps: current_time)
+      assert_equal current_time, record.timestamps
+    end
   end
 
   private


### PR DESCRIPTION
Fixes #13402.
