### PR TITLE
Fix inverse associations test

### DIFF
--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -333,7 +333,7 @@ class InverseHasManyTests < ActiveRecord::TestCase
 
   def test_parent_instance_should_be_shared_within_create_block_of_new_child
     man = Man.first
-    interest = man.interests.build do |i|
+    interest = man.interests.create do |i|
       assert i.man.equal?(man), "Man of child should be the same instance as a parent"
     end
     assert interest.man.equal?(man), "Man of the child should still be the same instance as a parent"


### PR DESCRIPTION
`InverseHasManyTests#test_parent_instance_should_be_shared_within_create_block_of_new_child`
was mistakenly the same as
`InverseHasManyTests#test_parent_instance_should_be_shared_within_build_block_of_new_child`.
