### PR TITLE
Fix BC year handling in postgres

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/date_time.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/date_time.rb
@@ -11,7 +11,8 @@ module ActiveRecord
               when 'infinity' then ::Float::INFINITY
               when '-infinity' then -::Float::INFINITY
               when / BC$/
-                super("-" + value.sub(/ BC$/, ""))
+                astronomical_year = format("%04d", -value[/^\d+/].to_i + 1)
+                super(value.sub(/ BC$/, "").sub(/^\d+/, astronomical_year))
               else
                 super
               end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -149,8 +149,9 @@ module ActiveRecord
             result = "#{result}.#{sprintf("%06d", value.usec)}"
           end
 
-          if value.year < 0
-            result = result.sub(/^-/, "") + " BC"
+          if value.year <= 0
+            bce_year = format("%04d", -value.year + 1)
+            result = result.sub(/^-?\d+/, bce_year) + " BC"
           end
           result
         end

--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -123,6 +123,18 @@ class TimestampTest < ActiveRecord::TestCase
     assert_equal date, Developer.find_by_name("aaron").updated_at
   end
 
+  def test_bc_timestamp_leap_year
+    date = Time.utc(-4, 2, 29)
+    Developer.create!(:name => "taihou", :updated_at => date)
+    assert_equal date, Developer.find_by_name("taihou").updated_at
+  end
+
+  def test_bc_timestamp_year_zero
+    date = Time.utc(0, 4, 7)
+    Developer.create!(:name => "yahagi", :updated_at => date)
+    assert_equal date, Developer.find_by_name("yahagi").updated_at
+  end
+
   private
 
   def pg_datetime_precision(table_name, column_name)


### PR DESCRIPTION
Current method is broken: it simply converts astronomical year (what ruby uses) to BC era year (what postgres uses) even though they're off by one, starts from 1, and year 0 AD does not exist which causes postgres to return error.
- `0000-01-01` => `0001-01-01 BC`
- `0000-02-29` => `0001-02-29 BC`

For example, just try searching any model's `created_at` with `Date.new(0)` (0001-01-01 BC) or `Date.new(-4,2,29)` (0005-02-29 BC).
