### PR TITLE
Add assert_equal_ignore_whitespace helper.

### DIFF
--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -44,7 +44,7 @@ module ActionDispatch
           mount engine => "/blog", :as => "blog"
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "       Prefix Verb URI Pattern              Controller#Action",
           "custom_assets GET  /custom/assets(.:format) custom_assets#show",
           "         blog      /blog                    Blog::Engine",
@@ -67,7 +67,7 @@ module ActionDispatch
           mount engine => "/blog", as: "blog"
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "Prefix Verb URI Pattern Controller#Action",
           "  blog      /blog       Blog::Engine",
           "",
@@ -80,7 +80,7 @@ module ActionDispatch
           get '/cart', :to => 'cart#show'
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "Prefix Verb URI Pattern     Controller#Action",
           "  cart GET  /cart(.:format) cart#show"
         ], output
@@ -91,7 +91,7 @@ module ActionDispatch
           get '/custom/assets', :to => 'custom_assets#show'
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "       Prefix Verb URI Pattern              Controller#Action",
           "custom_assets GET  /custom/assets(.:format) custom_assets#show"
         ], output
@@ -102,7 +102,7 @@ module ActionDispatch
           resources :articles
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "      Prefix Verb   URI Pattern                  Controller#Action",
           "    articles GET    /articles(.:format)          articles#index",
           "             POST   /articles(.:format)          articles#create",
@@ -120,7 +120,7 @@ module ActionDispatch
           root :to => 'pages#main'
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "Prefix Verb URI Pattern Controller#Action",
           "  root GET  /           pages#main"
         ], output
@@ -131,7 +131,7 @@ module ActionDispatch
           get 'api/:action' => 'api'
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "Prefix Verb URI Pattern            Controller#Action",
           "       GET  /api/:action(.:format) api#:action"
         ], output
@@ -142,7 +142,7 @@ module ActionDispatch
           get ':controller/:action'
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "Prefix Verb URI Pattern                    Controller#Action",
           "       GET  /:controller/:action(.:format) :controller#:action"
         ], output
@@ -153,7 +153,7 @@ module ActionDispatch
           get ':controller(/:action(/:id))', :id => /\d+/
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "Prefix Verb URI Pattern                            Controller#Action",
           "       GET  /:controller(/:action(/:id))(.:format) :controller#:action {:id=>/\\d+/}"
         ], output
@@ -164,7 +164,7 @@ module ActionDispatch
           get 'photos/:id' => 'photos#show', :defaults => {:format => 'jpg'}
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "Prefix Verb URI Pattern           Controller#Action",
           %Q[       GET  /photos/:id(.:format) photos#show {:format=>"jpg"}]
         ], output
@@ -175,7 +175,7 @@ module ActionDispatch
           get 'photos/:id' => 'photos#show', :id => /[A-Z]\d{5}/
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "Prefix Verb URI Pattern           Controller#Action",
           "       GET  /photos/:id(.:format) photos#show {:id=>/[A-Z]\\d{5}/}"
         ], output
@@ -193,7 +193,7 @@ module ActionDispatch
           end
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "               Prefix Verb URI Pattern                              Controller#Action",
           "             about_us GET  /about-us(.:format)                      pages#about_us",
           "      our_work_latest GET  /our-work/latest(.:format)               our_work#latest",
@@ -214,7 +214,7 @@ module ActionDispatch
           get 'foo/:id' => RackApp, :id => /[A-Z]\d{5}/
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "Prefix Verb URI Pattern        Controller#Action",
           "       GET  /foo/:id(.:format) #{RackApp.name} {:id=>/[A-Z]\\d{5}/}"
         ], output
@@ -233,7 +233,7 @@ module ActionDispatch
           end
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "Prefix Verb URI Pattern Controller#Action",
           "            /foo        #{RackApp.name} {:constraint=>( my custom constraint )}"
         ], output
@@ -253,7 +253,7 @@ module ActionDispatch
             get '/foo' => 'foo#bar'
           end
         end
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "Prefix Verb URI Pattern              Controller#Action",
           "   foo GET  /sprockets/foo(.:format) foo#bar"
         ], output
@@ -266,7 +266,7 @@ module ActionDispatch
           get "/foobar" => redirect{ "/foo/bar" }
         end
 
-        assert_equal [
+        assert_equal_ignore_whitespace [
           "Prefix Verb URI Pattern       Controller#Action",
           "   foo GET  /foo(.:format)    redirect(301, /foo/bar) {:subdomain=>\"admin\"}",
           "   bar GET  /bar(.:format)    redirect(307, path: /foo/bar)",
@@ -280,7 +280,7 @@ module ActionDispatch
           resources :posts
         end
 
-        assert_equal ["   Prefix Verb   URI Pattern               Controller#Action",
+        assert_equal_ignore_whitespace ["   Prefix Verb   URI Pattern               Controller#Action",
                       "    posts GET    /posts(.:format)          posts#index",
                       "          POST   /posts(.:format)          posts#create",
                       " new_post GET    /posts/new(.:format)      posts#new",
@@ -296,8 +296,22 @@ module ActionDispatch
           get ':controller(/:action)', controller: /api\/[^\/]+/, format: false
         end
 
-        assert_equal ["Prefix Verb URI Pattern            Controller#Action",
+        assert_equal_ignore_whitespace ["Prefix Verb URI Pattern            Controller#Action",
                       "       GET  /:controller(/:action) (?-mix:api\\/[^\\/]+)#:action"], output
+      end
+
+      private
+
+      def assert_equal_ignore_whitespace(expected, actual)
+        if expected.is_a?(Array) && actual.is_a?(Array)
+          expected.zip(actual).each do |e, a|
+            assert_equal e.gsub(/\s+/, ' '), a.gsub(/\s+/, ' ')
+          end
+        elsif expected.is_a?(String) && actual.is_a?(String)
+          assert_equal expected.gsub(/\s+/, ' '), actual.gsub(/\s+/, ' ')
+        else
+          assert_equal expected, actual
+        end
       end
     end
   end


### PR DESCRIPTION
We should be testing the behavior, not the implementation (e.g.
exact formatting of strings) in the unit test.

In the future, even if the format of output changes, we won't
have to match every single space in all test cases.

\cc @senny
