### PR TITLE
Avoid hard-coded value in test setup/teardown.

### DIFF
--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -805,6 +805,7 @@ class RequestFormat < BaseRequestTest
   end
 
   test "ignore_accept_header" do
+    old_ignore_accept_header = ActionDispatch::Request.ignore_accept_header
     ActionDispatch::Request.ignore_accept_header = true
 
     begin
@@ -834,7 +835,7 @@ class RequestFormat < BaseRequestTest
       request.expects(:parameters).at_least_once.returns({:format => :json})
       assert_equal [ Mime::JSON ], request.formats
     ensure
-      ActionDispatch::Request.ignore_accept_header = false
+      ActionDispatch::Request.ignore_accept_header = old_ignore_accept_header
     end
   end
 end


### PR DESCRIPTION
Although `ignore_accept_header` is currently set to false by default, I guess it's better to stick to the principle that we should avoid hard-coded values in a test's setup and teardown, in order to prevent state leaks.

However, the cost of doing so is that we might miss the opportunity to catch a state leak from somewhere else.

@senny what do you think?
