### PR TITLE
Indifferent hash access for inheritable options

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -33,9 +33,9 @@ module ActionMailer
         extend ::AbstractController::Railties::RoutesHelpers.with(app.routes, false)
         include app.routes.mounted_helpers
 
-        register_interceptors(options.delete(:interceptors))
-        register_preview_interceptors(options.delete(:preview_interceptors))
-        register_observers(options.delete(:observers))
+        register_interceptors(options.delete("interceptors"))
+        register_preview_interceptors(options.delete("preview_interceptors"))
+        register_observers(options.delete("observers"))
 
         options.each { |k,v| send("#{k}=", v) }
 

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -25,7 +25,7 @@ module ActionController
       ActionController::Parameters.permit_all_parameters = options.delete(:permit_all_parameters) { false }
       if app.config.action_controller[:always_permitted_parameters]
         ActionController::Parameters.always_permitted_parameters =
-          app.config.action_controller.delete(:always_permitted_parameters)
+          app.config.action_controller.delete("always_permitted_parameters")
       end
       ActionController::Parameters.action_on_unpermitted_parameters = options.delete(:action_on_unpermitted_parameters) do
         (Rails.env.test? || Rails.env.development?) ? :log : false

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -12,7 +12,7 @@ module ActionView
     initializer "action_view.embed_authenticity_token_in_remote_forms" do |app|
       ActiveSupport.on_load(:action_view) do
         ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms =
-          app.config.action_view.delete(:embed_authenticity_token_in_remote_forms)
+          app.config.action_view.delete("embed_authenticity_token_in_remote_forms")
       end
     end
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -79,7 +79,7 @@ module ActiveRecord
     end
 
     initializer "active_record.migration_error" do
-      if config.active_record.delete(:migration_error) == :page_load
+      if config.active_record.delete("migration_error") == :page_load
         config.app_middleware.insert_after "::ActionDispatch::Callbacks",
           "ActiveRecord::Migration::CheckPending"
       end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Parent passed into `InheritableOptions` can now have string keys.
+    before:
+        opts = ActiveSupport::InheritableOptions.new({ 'foo' => 'bar' })
+        opts.foo
+        #=> nil
+    after:
+        opts = ActiveSupport::InheritableOptions.new({ 'foo' => 'bar' })
+        opts.foo
+        #=> 'bar'
+
+    *Alex Williams*
+
 *   Fix rounding errors with #travel_to by resetting the usec on any passed time to zero, so we only travel
     with per-second precision, not anything deeper than that.
     

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -39,9 +39,9 @@ module I18n
 
       app.config.i18n.each do |setting, value|
         case setting
-        when :railties_load_path
+        when "railties_load_path"
           app.config.i18n.load_path.unshift(*value)
-        when :load_path
+        when "load_path"
           I18n.load_path += value
         else
           I18n.send("#{setting}=", value)

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/hash/keys'
+
 module ActiveSupport
   # Usually key value pairs are handled something like this:
   #
@@ -19,11 +21,11 @@ module ActiveSupport
     protected :_get # make it protected
 
     def []=(key, value)
-      super(key.to_sym, value)
+      super(key.to_s, value)
     end
 
     def [](key)
-      super(key.to_sym)
+      super(key.to_s)
     end
 
     def method_missing(name, *args)
@@ -54,7 +56,7 @@ module ActiveSupport
         # use the faster _get when dealing with OrderedOptions
         super() { |h,k| parent._get(k) }
       elsif parent
-        super() { |h,k| parent[k] }
+        super() { |h,k| parent.stringify_keys[k.to_s] }
       else
         super()
       end

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -21,11 +21,11 @@ module ActiveSupport
     protected :_get # make it protected
 
     def []=(key, value)
-      super(key.to_s, value)
+      super(key.to_sym, value)
     end
 
     def [](key)
-      super(key.to_s)
+      super(key.to_sym)
     end
 
     def method_missing(name, *args)
@@ -56,7 +56,7 @@ module ActiveSupport
         # use the faster _get when dealing with OrderedOptions
         super() { |h,k| parent._get(k) }
       elsif parent
-        super() { |h,k| parent.stringify_keys[k.to_s] }
+        super() { |h,k| parent[k] || parent[k.to_s] }
       else
         super()
       end

--- a/activesupport/test/configurable_test.rb
+++ b/activesupport/test/configurable_test.rb
@@ -20,13 +20,13 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
   end
 
   test "adds a configuration hash" do
-    assert_equal({ foo: :bar }, Parent.config)
+    assert_equal({ "foo" => :bar }, Parent.config)
   end
 
   test "adds a configuration hash to a module as well" do
     mixin = Module.new { include ActiveSupport::Configurable }
     mixin.config.foo = :bar
-    assert_equal({ foo: :bar }, mixin.config)
+    assert_equal({ "foo" => :bar }, mixin.config)
   end
 
   test "configuration hash is inheritable" do

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -29,7 +29,7 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     test = [[:allow_concurrency, true], [:else_where, 56]]
 
     a.each_with_index do |(key, value), index|
-      assert_equal test[index].first, key
+      assert_equal test[index].first.to_s, key
       assert_equal test[index].last, value
     end
   end
@@ -58,6 +58,29 @@ class OrderedOptionsTest < ActiveSupport::TestCase
 
     child = ActiveSupport::InheritableOptions.new(parent)
     assert child.foo
+  end
+
+  def test_inheritable_options_is_indifferent_to_parent_keys
+    parent = { 'foo' => true, bar: true }
+
+    child = ActiveSupport::InheritableOptions.new(parent)
+    assert child.foo
+    assert child.bar
+
+    parent['baz'] = 'qux'
+
+    # InheritableOptions retains a reference to the parent
+    assert_equal 'qux', child.baz
+  end
+
+  def test_inheritable_options_wont_change_parent
+    parent = { 'foo' => 'bar' }
+    parent_copy = parent.dup
+
+    child = ActiveSupport::InheritableOptions.new(parent)
+
+    assert_equal 'bar', child.foo
+    assert_equal parent_copy, parent
   end
 
   def test_inheritable_options_can_override_parent

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -373,7 +373,7 @@ module Rails
           require "erb"
           all_secrets = YAML.load(ERB.new(IO.read(yaml)).result) || {}
           env_secrets = all_secrets[Rails.env]
-          secrets.merge!(env_secrets.symbolize_keys) if env_secrets
+          secrets.merge!(env_secrets) if env_secrets
         end
 
         # Fallback to config.secret_key_base if secrets.secret_key_base isn't set


### PR DESCRIPTION
Creating an `ActiveSupport::InheritableOptions` object with a hash that has string keys as the parent does not yield what you would expect.

``` ruby
opts = ActiveSupport::InheritableOptions.new({ 'foo' => 'bar' })
opts.foo
#=> nil
```

This is due to `ActiveSupport::OrderedOptions` overriding `Hash#[]` to convert the hash-lookup to a symbol.
https://github.com/rails/rails/blob/4-1-stable/activesupport/lib/active_support/ordered_options.rb#L26

Without changing the original parent hash, and still maintaining a reference to the original parent, my solution is to call `with_indifferent_access` on the parent when the hash-lookup happens.
