### PR TITLE
Remove optimization that was required with whiny nils

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -503,14 +503,6 @@ module ActiveRecord
 
         # Extracts the value from a PostgreSQL column default definition.
         def extract_value_from_default(oid, default) # :nodoc:
-          # This is a performance optimization for Ruby 1.9.2 in development.
-          # If the value is nil, we return nil straight away without checking
-          # the regular expressions. If we check each regular expression,
-          # Regexp#=== will call NilClass#to_str, which will trigger
-          # method_missing (defined by whiny nil in ActiveSupport) which
-          # makes this method very very slow.
-          return default unless default
-
           case default
             # Quoted types
             when /\A[\(B]?'(.*)'::/m


### PR DESCRIPTION
Whiny nils is no longer a thing, so we no longer need this optimization
