### PR TITLE
Restore test deliveries properly in ActionMailer.

### DIFF
--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -20,6 +20,7 @@ module ActionMailer
         class_attribute :_mailer_class
         setup :initialize_test_deliveries
         setup :set_expected_mail
+        teardown :restore_test_deliveries
       end
 
       module ClassMethods
@@ -54,8 +55,15 @@ module ActionMailer
       protected
 
         def initialize_test_deliveries
+          @old_delivery_method = ActionMailer::Base.delivery_method
+          @old_perform_deliveries = ActionMailer::Base.perform_deliveries
           ActionMailer::Base.delivery_method = :test
           ActionMailer::Base.perform_deliveries = true
+        end
+
+        def restore_test_deliveries
+          ActionMailer::Base.delivery_method = @old_delivery_method
+          ActionMailer::Base.perform_deliveries = @old_perform_deliveries
           ActionMailer::Base.deliveries.clear
         end
 


### PR DESCRIPTION
`ActionMailer::Base.delivery_method` and
`ActionMailer::Base.perform_deliveries` have leaked states.

"delivery method can be customized per instance" and "delivery method
can be customized in subclasses not changing the parent" in
delivery_methods_test.rb will fail if test_helper_test.rb (in which
`TestHelperMailerTest` is inherited from `ActionMailer::TestCase`) runs
before it.

cc @senny this is state leak across test suites.
