### PR TITLE
Restore I18n.locale to default after test.

### DIFF
--- a/actionmailer/test/i18n_with_controller_test.rb
+++ b/actionmailer/test/i18n_with_controller_test.rb
@@ -32,6 +32,10 @@ class ActionMailerI18nWithControllerTest < ActionDispatch::IntegrationTest
     Routes
   end
 
+  teardown do
+    I18n.locale = I18n.default_locale
+  end
+
   def test_send_mail
     with_translation 'de', email_subject: '[Anmeldung] Willkommen' do
       get '/test/send_mail'


### PR DESCRIPTION
If i18n_with_controller_test.rb were to run first, the `I18n.locale` will
be changed to `:de`, and the following tests in base_test.rb will fail:

"subject gets default from I18n"
“default subject can have interpolations”
"translations are scoped properly"
"implicit multipart with default locale"

cc @senny
