### PR TITLE
Remove composed_of special case from multi-parameter attributes

### DIFF
--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -244,6 +244,10 @@ module ActiveRecord
         def writer_method(name, class_name, mapping, allow_nil, converter)
           define_method("#{name}=") do |part|
             klass = class_name.constantize
+            if part.is_a?(Hash)
+              part = klass.new(*part.values)
+            end
+
             unless part.is_a?(klass) || converter.nil? || part.nil?
               part = converter.respond_to?(:call) ? converter.call(part) : klass.send(converter, part)
             end

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -126,8 +126,8 @@ module ActiveRecord
       def read_value
         return if values.values.compact.empty?
 
-        @column = object.class.reflect_on_aggregation(name.to_sym) || object.column_for_attribute(name)
-        klass   = column.klass
+        @column = object.column_for_attribute(name)
+        klass   = column ? column.klass : nil
 
         if klass == Time
           read_time
@@ -186,8 +186,7 @@ module ActiveRecord
         positions    = (1..max_position)
         validate_required_parameters!(positions)
 
-        set_values = values.values_at(*positions)
-        klass.new(*set_values)
+        values.slice(*positions)
       end
 
       # Checks whether some blank date parameter exists. Note that this is different


### PR DESCRIPTION
As we move towards removing the `klass` method from `column`, the else
clause as it stands right now will become the only case.
