### PR TITLE
Removed unused `klass` definitions from types

### DIFF
--- a/activerecord/lib/active_record/type/binary.rb
+++ b/activerecord/lib/active_record/type/binary.rb
@@ -9,10 +9,6 @@ module ActiveRecord
         true
       end
 
-      def klass
-        ::String
-      end
-
       def type_cast_for_database(value)
         Data.new(super)
       end

--- a/activerecord/lib/active_record/type/decimal.rb
+++ b/activerecord/lib/active_record/type/decimal.rb
@@ -7,10 +7,6 @@ module ActiveRecord
         :decimal
       end
 
-      def klass
-        ::BigDecimal
-      end
-
       def type_cast_for_schema(value)
         value.to_s
       end

--- a/activerecord/lib/active_record/type/float.rb
+++ b/activerecord/lib/active_record/type/float.rb
@@ -7,10 +7,6 @@ module ActiveRecord
         :float
       end
 
-      def klass
-        ::Float
-      end
-
       alias type_cast_for_database type_cast
 
       private

--- a/activerecord/lib/active_record/type/integer.rb
+++ b/activerecord/lib/active_record/type/integer.rb
@@ -7,10 +7,6 @@ module ActiveRecord
         :integer
       end
 
-      def klass
-        ::Fixnum
-      end
-
       alias type_cast_for_database type_cast
 
       private

--- a/activerecord/lib/active_record/type/string.rb
+++ b/activerecord/lib/active_record/type/string.rb
@@ -9,10 +9,6 @@ module ActiveRecord
         true
       end
 
-      def klass
-        ::String
-      end
-
       private
 
       def cast_value(value)

--- a/activerecord/lib/active_record/type/value.rb
+++ b/activerecord/lib/active_record/type/value.rb
@@ -48,7 +48,6 @@ module ActiveRecord
       end
 
       def klass # :nodoc:
-        ::Object
       end
 
       def type_cast_for_write(value) # :nodoc:


### PR DESCRIPTION
Only `Date` and `Time` are handled.
