### PR TITLE
Specify a time zone when testing TZ aware attributes

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -2,6 +2,8 @@
 require "cases/helper"
 
 class PostgresqlArrayTest < ActiveRecord::TestCase
+  include InTimeZone
+
   class PgArray < ActiveRecord::Base
     self.table_name = 'pg_arrays'
   end
@@ -197,17 +199,20 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
   end
 
   def test_datetime_with_timezone_awareness
-    with_timezone_config aware_attributes: true do
-      PgArray.reset_column_information
-      current_time = [Time.current]
+    tz = "Pacific Time (US & Canada)"
 
-      record = PgArray.new(datetimes: current_time)
-      assert_equal current_time, record.datetimes
+    in_time_zone tz do
+      PgArray.reset_column_information
+      time_string = Time.current.to_s
+      time = Time.zone.parse(time_string)
+
+      record = PgArray.new(datetimes: [time_string])
+      assert_equal [time], record.datetimes
 
       record.save!
       record.reload
 
-      assert_equal current_time, record.datetimes
+      assert_equal [time], record.datetimes
     end
   end
 


### PR DESCRIPTION
Unspecified causes the test to fail on Travis
