### PR TITLE
Ensure time zones don't change after round trip with array columns

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -10,7 +10,17 @@ module ActiveRecord
 
         def type_cast(value)
           value = @column.type_cast(value)
-          value.acts_like?(:time) ? value.in_time_zone : value
+          convert_value_to_time_zone(value)
+        end
+
+        def convert_value_to_time_zone(value)
+          if value.is_a?(Array)
+            value.map { |v| convert_value_to_time_zone(v) }
+          elsif value.acts_like?(:time)
+            value.in_time_zone
+          else
+            value
+          end
         end
       end
 

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -208,11 +208,13 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
 
       record = PgArray.new(datetimes: [time_string])
       assert_equal [time], record.datetimes
+      assert_equal ActiveSupport::TimeZone[tz], record.datetimes.first.time_zone
 
       record.save!
       record.reload
 
       assert_equal [time], record.datetimes
+      assert_equal ActiveSupport::TimeZone[tz], record.datetimes.first.time_zone
     end
   end
 


### PR DESCRIPTION
The times would be equivalent, even if they were in different time zones. E.g. 12:00 UTC == 5:00 PDT. This brings the behavior (and test case) in line with non-array date times when using time zone aware attributes.
