### PR TITLE
Do not type cast twice on attribute assignment

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -140,17 +140,14 @@ module ActiveRecord
         @_enum_methods_module ||= begin
           mod = Module.new do
             private
-              def save_changed_attribute(attr_name, value)
+              def save_changed_attribute(attr_name, old)
                 if (mapping = self.class.defined_enums[attr_name.to_s])
+                  value = read_attribute(attr_name)
                   if attribute_changed?(attr_name)
-                    old = changed_attributes[attr_name]
-
                     if mapping[old] == value
                       changed_attributes.delete(attr_name)
                     end
                   else
-                    old = clone_attribute_value(:read_attribute, attr_name)
-
                     if old != value
                       changed_attributes[attr_name] = mapping.key old
                     end

--- a/activerecord/lib/active_record/type/numeric.rb
+++ b/activerecord/lib/active_record/type/numeric.rb
@@ -15,11 +15,11 @@ module ActiveRecord
         super(value)
       end
 
-      def changed?(old_value, new_value) # :nodoc:
+      def changed?(old_value, _new_value, new_value_before_type_cast) # :nodoc:
         # 0 => 'wibble' should mark as changed so numericality validations run
-        if nil_or_zero?(old_value) && non_numeric_string?(new_value)
+        if nil_or_zero?(old_value) && non_numeric_string?(new_value_before_type_cast)
           # nil => '' should not mark as changed
-          old_value != new_value.presence
+          old_value != new_value_before_type_cast.presence
         else
           super
         end

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -36,10 +36,6 @@ module ActiveRecord
 
       private
 
-      def changed?(old_value, new_value) # :nodoc:
-        old_value != new_value
-      end
-
       def is_default_value?(value)
         value == coder.load(nil)
       end

--- a/activerecord/lib/active_record/type/value.rb
+++ b/activerecord/lib/active_record/type/value.rb
@@ -59,8 +59,8 @@ module ActiveRecord
       # or from assignment, so it could be anything. Types
       # which cannot typecast arbitrary values should override
       # this method.
-      def changed?(old_value, new_value) # :nodoc:
-        old_value != type_cast(new_value)
+      def changed?(old_value, new_value, _new_value_before_type_cast) # :nodoc:
+        old_value != new_value
       end
 
       private


### PR DESCRIPTION
The definition of `write_attribute` in dirty checking ultimately leads
to the columns calling `type_cast` on the value to perform the
comparison. However, this is a potentially expensive computation that we
cache when it occurs in `read_attribute`. The only case that we need the
non-type-cast form is for numeric, so we pass that through as well
(something I'm looking to remove in the future).

This also reduces the number of places that manually access various
stages in an attribute's type casting lifecycle, which will aid in one
of the larger refactorings that I'm working on.
