### PR TITLE
Remove dead branch when restoring ID within a transaction

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -339,7 +339,7 @@ module ActiveRecord
 
     # Save the new record state and id of a record so it can be restored later if a transaction fails.
     def remember_transaction_record_state #:nodoc:
-      @_start_transaction_state[:id] = id if has_attribute?(self.class.primary_key)
+      @_start_transaction_state[:id] = id
       unless @_start_transaction_state.include?(:new_record)
         @_start_transaction_state[:new_record] = @new_record
       end
@@ -371,12 +371,7 @@ module ActiveRecord
           @raw_attributes = @raw_attributes.dup if @raw_attributes.frozen?
           @new_record = restore_state[:new_record]
           @destroyed  = restore_state[:destroyed]
-          if restore_state.has_key?(:id)
-            write_attribute(self.class.primary_key, restore_state[:id])
-          else
-            @raw_attributes.delete(self.class.primary_key)
-            @attributes.delete(self.class.primary_key)
-          end
+          write_attribute(self.class.primary_key, restore_state[:id])
           @raw_attributes.freeze if was_frozen
         end
       end


### PR DESCRIPTION
There is no way to have an instance of an Active Record model where
`has_attribute?(self.class.primary_key)` returns false. The record is
always initialized in such a way that `@raw_attributes` will have an id
key with nil for the value.

Reduces the number of places outside of attribute methods which care
about the internals of how we store and type cast attributes.
