### PR TITLE
Move conditionals about freezing closer to the definition of `freeze`

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -546,5 +546,11 @@ module ActiveRecord
     def init_attributes(attributes, options)
       assign_attributes(attributes)
     end
+
+    def thaw
+      if frozen?
+        @raw_attributes = @raw_attributes.dup
+      end
+    end
   end
 end

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -347,7 +347,7 @@ module ActiveRecord
         @_start_transaction_state[:destroyed] = @destroyed
       end
       @_start_transaction_state[:level] = (@_start_transaction_state[:level] || 0) + 1
-      @_start_transaction_state[:frozen?] = @raw_attributes.frozen?
+      @_start_transaction_state[:frozen?] = frozen?
     end
 
     # Clear the new record state and id of a record.
@@ -367,8 +367,7 @@ module ActiveRecord
         transaction_level = (@_start_transaction_state[:level] || 0) - 1
         if transaction_level < 1 || force
           restore_state = @_start_transaction_state
-          was_frozen = restore_state[:frozen?]
-          @raw_attributes = @raw_attributes.dup if @raw_attributes.frozen?
+          thaw unless restore_state[:frozen?]
           @new_record = restore_state[:new_record]
           @destroyed  = restore_state[:destroyed]
           if restore_state.has_key?(:id)
@@ -377,7 +376,6 @@ module ActiveRecord
             @raw_attributes.delete(self.class.primary_key)
             @attributes.delete(self.class.primary_key)
           end
-          @raw_attributes.freeze if was_frozen
         end
       end
     end


### PR DESCRIPTION
Reduces the number of places that care about the internals of how we
store and type cast attributes. We do not need to go through the
dup/freeze dance, as you couldn't have saved a frozen new record anyway,
and that is the only time we would end up modifying the frozen hash.
