### PR TITLE
Allow multiple trusted networks with differing proxy header behavior (raises IpSpoofAttackError)

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -419,7 +419,7 @@ module ActionController
     #   params.fetch(:none)                 # => ActionController::ParameterMissing: param is missing or the value is empty: none
     #   params.fetch(:none, 'Francesco')    # => "Francesco"
     #   params.fetch(:none) { 'Francesco' } # => "Francesco"
-    def fetch(key, *args, &block)
+    def fetch(key, *args)
       convert_value_to_parameters(
         @parameters.fetch(key) {
           if block_given?
@@ -514,7 +514,7 @@ module ActionController
     # to key. If the key is not found, returns the default value. If the
     # optional code block is given and the key is not found, pass in the key
     # and return the result of block.
-    def delete(key, &block)
+    def delete(key)
       convert_value_to_parameters(@parameters.delete(key))
     end
 

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -138,7 +138,7 @@ module ActionDispatch
         end
 
         # If every single IP option is in the trusted list, just return REMOTE_ADDR
-        [forwarded_ips, client_ips, remote_addr].flatten.compact.first
+        forwarded_ips.first || client_ips.first || remote_addr
       end
 
       # Memoizes the value returned by #calculate_ip and returns it for

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -160,7 +160,7 @@ module ActionDispatch
         end
 
         # If every single IP option is in the trusted list, just return REMOTE_ADDR
-        [forwarded_ips, client_ips, remote_addr].flatten.compact.first
+        forwarded_ips.first || client_ips.first || remote_addr
       end
 
       # Memoizes the value returned by #calculate_ip and returns it for

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -127,7 +127,9 @@ class RequestIP < BaseRequestTest
                            'REMOTE_ADDR'          => '1.1.1.1',
                            'HTTP_X_BLUECOAT_VIA'  => 'de462e07a2db325e'
     assert_equal '1.1.1.1', request.remote_ip
+  end
 
+  test "remote ip spoof protection ignores differing private addresses" do
     request = stub_request 'HTTP_X_FORWARDED_FOR' => '10.1.1.232',
                            'HTTP_CLIENT_IP'       => '192.168.1.103',
                            'REMOTE_ADDR'          => '1.1.1.1'

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -127,6 +127,11 @@ class RequestIP < BaseRequestTest
                            'REMOTE_ADDR'          => '1.1.1.1',
                            'HTTP_X_BLUECOAT_VIA'  => 'de462e07a2db325e'
     assert_equal '1.1.1.1', request.remote_ip
+
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => '192.168.1.103',
+                           'HTTP_CLIENT_IP'       => '10.1.1.232',
+                           'REMOTE_ADDR'          => '1.1.1.1'
+    assert_equal '1.1.1.1', request.remote_ip
   end
 
   test "remote ip spoof protection ignores the case where different header conventions yield the same IP" do

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -128,8 +128,8 @@ class RequestIP < BaseRequestTest
                            'HTTP_X_BLUECOAT_VIA'  => 'de462e07a2db325e'
     assert_equal '1.1.1.1', request.remote_ip
 
-    request = stub_request 'HTTP_X_FORWARDED_FOR' => '192.168.1.103',
-                           'HTTP_CLIENT_IP'       => '10.1.1.232',
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => '10.1.1.232',
+                           'HTTP_CLIENT_IP'       => '192.168.1.103',
                            'REMOTE_ADDR'          => '1.1.1.1'
     assert_equal '1.1.1.1', request.remote_ip
   end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -124,8 +124,8 @@ class RequestIP < BaseRequestTest
                            'HTTP_X_BLUECOAT_VIA'  => 'de462e07a2db325e'
     assert_equal '1.1.1.1', request.remote_ip
 
-    request = stub_request 'HTTP_X_FORWARDED_FOR' => '192.168.1.103',
-                           'HTTP_CLIENT_IP'       => '10.1.1.232',
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => '10.1.1.232',
+                           'HTTP_CLIENT_IP'       => '192.168.1.103',
                            'REMOTE_ADDR'          => '1.1.1.1'
     assert_equal '1.1.1.1', request.remote_ip
   end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -123,6 +123,11 @@ class RequestIP < BaseRequestTest
                            'REMOTE_ADDR'          => '1.1.1.1',
                            'HTTP_X_BLUECOAT_VIA'  => 'de462e07a2db325e'
     assert_equal '1.1.1.1', request.remote_ip
+
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => '192.168.1.103',
+                           'HTTP_CLIENT_IP'       => '10.1.1.232',
+                           'REMOTE_ADDR'          => '1.1.1.1'
+    assert_equal '1.1.1.1', request.remote_ip
   end
 
   test "remote ip spoof protection ignores the case where different header conventions yield the same IP" do

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -125,6 +125,25 @@ class RequestIP < BaseRequestTest
     assert_equal '1.1.1.1', request.remote_ip
   end
 
+  test "remote ip spoof protection ignores the case where different header conventions yield the same IP" do
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => '10.3.2.1, 4.4.4.4, 192.168.1.3',
+                           'HTTP_CLIENT_IP'       => '4.4.4.4',
+                           'REMOTE_ADDR'          => '1.1.1.1'
+    assert_equal '4.4.4.4', request.remote_ip
+  end
+
+  test "remote ip spoof protection ignores internal (private/trusted) proxies" do
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => '10.1.2.3, 192.168.1.1',
+                           'HTTP_CLIENT_IP'       => '2.2.2.2',
+                           'REMOTE_ADDR'          => '1.1.1.1'
+    assert_equal '2.2.2.2', request.remote_ip
+
+    request = stub_request 'HTTP_X_FORWARDED_FOR' => '3.3.3.3, 192.168.1.2',
+                           'HTTP_CLIENT_IP'       => '172.18.0.1',
+                           'REMOTE_ADDR'          => '1.1.1.1'
+    assert_equal '3.3.3.3', request.remote_ip
+  end
+
   test "remote ip v6" do
     request = stub_request 'REMOTE_ADDR' => '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
     assert_equal '2001:0db8:85a3:0000:0000:8a2e:0370:7334', request.remote_ip

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -123,7 +123,9 @@ class RequestIP < BaseRequestTest
                            'REMOTE_ADDR'          => '1.1.1.1',
                            'HTTP_X_BLUECOAT_VIA'  => 'de462e07a2db325e'
     assert_equal '1.1.1.1', request.remote_ip
+  end
 
+  test "remote ip spoof protection ignores differing private addresses" do
     request = stub_request 'HTTP_X_FORWARDED_FOR' => '10.1.1.232',
                            'HTTP_CLIENT_IP'       => '192.168.1.103',
                            'REMOTE_ADDR'          => '1.1.1.1'


### PR DESCRIPTION
request.remote_ip() should not raise ActionDispatch::RemoteIp::IpSpoofAttackError when a request has passed through proxies for two or more private (or otherwise trusted) networks, where one proxy has set the nonstandard HTTP_CLIENT_IP header, and another has set the nonstandard HTTP_X_FORWARDED_FOR header.

As it stands, e.g.:
1. A request originates at 192.168.1.103, and passes through a proxy which sets HTTP_CLIENT_IP to that address.
2. The first proxy then sends the request out from 10.1.1.232, to a second proxy
3. The second proxy prepends this new address to HTTP_X_FORWARDED_FOR, and then sends the request to a Rails server
4. The Rails server sees that both HTTP_CLIENT_IP and HTTP_X_FORWARDED_FOR have been set, so it compares the two addresses in the two headers.
5. Since the addresses are different, Rails raises an ActionDispatch::RemoteIp::IpSpoofAttackError

The fix is to filter trusted IPs before making this comparison (tests included).
