### PR TITLE
Find mail part recursively

### DIFF
--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -403,6 +403,43 @@ module ApplicationTests
       assert_match '<option selected value="?part=text%2Fplain">View as plain-text email</option>', last_response.body
     end
 
+    test "mailers preview worked normally when use attachments" do
+      mailer 'notifier', <<-RUBY
+        class Notifier < ActionMailer::Base
+          default from: "from@example.com"
+
+          def foo
+            attachments['text.csv'] = ''
+            mail to: "to@example.org"
+          end
+        end
+      RUBY
+
+      html_template 'notifier/foo', <<-RUBY
+        <p>Hello, World!</p>
+      RUBY
+
+      text_template 'notifier/foo', <<-RUBY
+        Hello, World!
+      RUBY
+
+      mailer_preview 'notifier', <<-RUBY
+        class NotifierPreview < ActionMailer::Preview
+          def foo
+            Notifier.foo
+          end
+        end
+      RUBY
+
+      app('development')
+
+      get "/rails/mailers/notifier/foo.html"
+      assert_equal 200, last_response.status
+
+      get "/rails/mailers/notifier/foo.txt"
+      assert_equal 200, last_response.status
+    end
+
     private
       def build_app
         super


### PR DESCRIPTION
I'm getting a `NoMethodError in Rails::Mailers#preview` when I try to preview an email view that has a attachment. 

More precisely:

``` ruby
undefined method `mime_type' for #<Array:0x007f6469451cd8>
```

 ActionMailer  generate a `multipart/alternative` email when use `attachments`.  It is necessary to look for mail part recursively.
