### PR TITLE
Fix #safe_constantize failing for Object scoped missing constants

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -357,6 +357,9 @@ module ActiveSupport
 
       return Regexp.escape(camel_cased_word) if parts.blank?
 
+      # this is done because Object::ABC is essentially same as ABC.
+      parts.delete("Object") if parts.include?("Object")
+
       last  = parts.pop
 
       parts.reverse.inject(last) do |acc, part|

--- a/activesupport/test/constantize_test_cases.rb
+++ b/activesupport/test/constantize_test_cases.rb
@@ -60,6 +60,7 @@ module ConstantizeTestCases
     assert_equal ConstantizeTestCases, yield("::ConstantizeTestCases")
     assert_nil yield("")
     assert_nil yield("::")
+    assert_nil yield("Object::UnknownClass")
     assert_nil yield("UnknownClass")
     assert_nil yield("UnknownClass::Ace")
     assert_nil yield("UnknownClass::Ace::Base")


### PR DESCRIPTION
- Before
  "Object::ABC".safe_constantize # => NameError: uninitialized constant ABC
  The output should be nil.
- After
  "Object::ABC".safe_constantize # => nil
