### PR TITLE
Add in-memory traversal for :through associations

### DIFF
--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -11,6 +11,19 @@ module ActiveRecord
 
       private
 
+        def get_records
+          if proxy_assoc = get_through_proxy_assoc_if_loaded_and_not_stale
+            through_proxy = proxy_assoc.target
+            if !through_proxy || ((target_assoc = association_if_loaded_and_not_stale(through_proxy, source_reflection.name)) &&
+                                  # if either no record or record is of the wrong polymorphic type
+                                  (!(record = target_assoc.target) || !throught_proxy_target_source_type_matches?(record)))
+              []
+            elsif record
+              [record]
+            end
+          end || super
+        end
+
         def create_through_record(record)
           ensure_not_nested
 

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -83,6 +83,20 @@ module ActiveRecord
             raise HasManyThroughNestedAssociationsAreReadonly.new(owner, reflection)
           end
         end
+
+        def association_if_loaded_and_not_stale(source, association_name)
+          if (association = source.association(association_name)).loaded? && !association.stale_target?
+            association
+          end
+        end
+
+        def get_through_proxy_assoc_if_loaded_and_not_stale
+          !reflection.scope && association_if_loaded_and_not_stale(owner, through_reflection.name)
+        end
+
+        def throught_proxy_target_source_type_matches?(proxy_target)
+          !(source_type = options[:source_type]) || source_type == proxy_target.class.base_class.name
+        end
     end
   end
 end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -19,6 +19,7 @@ class Author < ActiveRecord::Base
   has_many :comments_containing_the_letter_e, :through => :posts, :source => :comments
   has_many :comments_with_order_and_conditions, -> { order('comments.body').where("comments.body like 'Thank%'") }, :through => :posts, :source => :comments
   has_many :comments_with_include, -> { includes(:post) }, :through => :posts, :source => :comments
+  has_many :post_comments, :through => :post, :source => :comments
 
   has_many :first_posts
   has_many :comments_on_first_posts, -> { order('posts.id desc, comments.id asc') }, :through => :first_posts, :source => :comments

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -8,6 +8,7 @@ class Member < ActiveRecord::Base
   has_one :hairy_club, -> { where :clubs => {:name => "Moustache and Eyebrow Fancier Club"} }, :through => :membership, :source => :club
   has_one :sponsor, :as => :sponsorable
   has_one :sponsor_club, :through => :sponsor
+  has_one :inverseable_sponsor_club, :through => :sponsor
   has_one :member_detail, :inverse_of => false
   has_one :organization, :through => :member_detail
   belongs_to :member_type

--- a/activerecord/test/models/organization.rb
+++ b/activerecord/test/models/organization.rb
@@ -8,5 +8,7 @@ class Organization < ActiveRecord::Base
   has_one :author, :primary_key => :name
   has_one :author_owned_essay_category, :through => :author, :source => :owned_essay_category
 
+  has_one :sponsor, :as => :sponsorable
+
   scope :clubs, -> { from('clubs') }
 end

--- a/activerecord/test/models/sponsor.rb
+++ b/activerecord/test/models/sponsor.rb
@@ -1,5 +1,6 @@
 class Sponsor < ActiveRecord::Base
   belongs_to :sponsor_club, :class_name => "Club", :foreign_key => "club_id"
+  belongs_to :inverseable_sponsor_club, :class_name => "Club", :foreign_key => "club_id", :inverse_of => :sponsor
   belongs_to :sponsorable, :polymorphic => true
   belongs_to :thing, :polymorphic => true, :foreign_type => :sponsorable_type, :foreign_key => :sponsorable_id
   belongs_to :sponsorable_with_conditions, -> { where :name => 'Ernie'}, :polymorphic => true,


### PR DESCRIPTION
If the :through association is loaded and its :source association
is also loaded, AR can retrieve has_one/has_many :through records
without querying DB.

``` ruby
class Author
  has_many :posts
  has_many :comments, :through => :posts
end

class Post
  belongs_to :author
  has_many :comments
end

class Comment
  belongs_to :post
end

author = Author.includes(:posts => :comments).first
# previously `author.comments.to_a` would issue an additional
# redundant SQL query (to load comments again), now instead
# since both `author.posts` and `author.posts.comments` are
# loaded, AR is smart enough to traverse in memory object graph
# to avoid hitting DB. Essentially it will now do
# `author.posts.map(&:comments).compact`.
author.comments.to_a # this will now not issue an SQL query
```

I'm not that comfortable around this part of AR code a thorough review
by AR-association masters is in order :bowtie:. 
