### PR TITLE
Mail 2.6.1 silences excessive warnings; remove Gemfile hack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem 'coffee-rails', '~> 4.0.0'
 gem 'arel', github: 'rails/arel', branch: 'master'
 gem 'sprockets-rails', github: 'rails/sprockets-rails', branch: 'master'
 gem 'i18n', github: 'svenfuchs/i18n', branch: 'master'
-gem 'mail', '~> 2.5.4'
 
 # require: false so bcrypt is loaded only when has_secure_password is used.
 # This is to avoid ActiveModel (and by extension the entire framework)


### PR DESCRIPTION
Completes https://github.com/rails/rails/pull/15493

Revert "For our build, stick with mail 2.5.x for now"

This reverts commit b8f586a094c104006d29a87fee0d8b48d0af2d14.
