### PR TITLE
Mail 2.6.1 silences excessive warnings; remove Gemfile hack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,6 @@ gem 'rack-cache', '~> 1.2'
 gem 'jquery-rails', '~> 2.2.0'
 gem 'turbolinks'
 
-gem 'mail', '~> 2.5.4'
-
 # require: false so bcrypt is loaded only when has_secure_password is used.
 # This is to avoid ActiveModel (and by extension the entire framework)
 # being dependent on a binary library.


### PR DESCRIPTION
Completes https://github.com/rails/rails/pull/15493

Revert "For our build, stick with mail 2.5.x for now"

This reverts commit bea0d10222567d2c930f2a5005d32354b70ac415.
