### PR TITLE
Relax mail gem constraint from ~> 2.5.4 to ~> 2.5, >= 2.5.4

### DIFF
--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('actionpack',  version)
-  s.add_dependency('mail',        '~> 2.5.4')
+  s.add_dependency 'mail', ['~> 2.5', '>= 2.5.4']
 end


### PR DESCRIPTION
This allows Rails users to install mail 2.6 which relaxes the mime-types
dependency, which is a big win for a lot of people.

Previously, the mail gem restricted mime-types to ~> 1.16 but now it has
expanded to [">= 1.16", "< 3"]

And the mime-types maintainer will also be checking that 2.x releases don't
break mail.

See https://github.com/mikel/mail/pull/713 
https://rubygems.org/gems/mail/versions/2.6.0

Related to https://github.com/rails/rails/pull/15493
