### PR TITLE
Added another guide to debugging Rails in the references section

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -858,3 +858,4 @@ References
 * [Ryan Bates' stack trace screencast](http://railscasts.com/episodes/24-the-stack-trace)
 * [Ryan Bates' logger screencast](http://railscasts.com/episodes/56-the-logger)
 * [Debugging with ruby-debug](http://bashdb.sourceforge.net/ruby-debug.html)
+* [A Comprehensive Guide To Debugging Rails](http://www.jackkinsella.ie/2014/06/06/a-comprehensive-guide-to-debugging-rails.html)


### PR DESCRIPTION
I compiled about 32 pages of techniques and workflows for debugging Rails, intending for it to be the document I wish existed when I was an intermediate Rails programmer. I'd like to include this as a further reading link in the references section so that others can benefit from my write-up.
