### PR TITLE
Nested error messages from associations

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -354,7 +354,9 @@ module ActiveModel
     #   person.errors.full_messages
     #   # => ["Name is too short (minimum is 5 characters)", "Name can't be blank", "Email can't be blank"]
     def full_messages
-      map { |attribute, message| full_message(attribute, message) }
+      each_with_object([]) do |(attribute, message), messages|
+        messages << full_message(attribute, message) if message.is_a?(String)
+      end
     end
 
     # Returns all the full error messages for a given attribute in an array.

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -308,6 +308,13 @@ module ActiveRecord
         validation_context = self.validation_context unless [:create, :update].include?(self.validation_context)
         unless valid = record.valid?(validation_context)
           if reflection.options[:autosave]
+            if reflection.collection?
+              errors.messages[reflection.name] ||= []
+              errors.messages[reflection.name] << record.errors.messages
+            else
+              errors.messages[reflection.name] = record.errors.messages
+            end
+
             record.errors.each do |attribute, message|
               attribute = "#{reflection.name}.#{attribute}"
               errors[attribute] << message

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1230,19 +1230,21 @@ module AutosaveAssociationOnACollectionAssociationTests
   end
 
   def test_should_automatically_validate_the_associated_models
-    @pirate.send(@association_name).each { |child| child.name = '' }
+    association = @pirate.send(@association_name)
+    association.each { |child| child.name = '' }
 
     assert !@pirate.valid?
     assert_equal ["can't be blank"], @pirate.errors["#{@association_name}.name"]
-    assert @pirate.errors[@association_name].empty?
+    assert_equal association.map(&:errors).map(&:messages), @pirate.errors[@association_name]
   end
 
   def test_should_not_use_default_invalid_error_on_associated_models
-    @pirate.send(@association_name).build(:name => '')
+    association = @pirate.send(@association_name)
+    association.build(:name => '')
 
     assert !@pirate.valid?
     assert_equal ["can't be blank"], @pirate.errors["#{@association_name}.name"]
-    assert @pirate.errors[@association_name].empty?
+    assert_equal association.map(&:errors).map(&:messages).select(&:present?), @pirate.errors[@association_name]
   end
 
   def test_should_default_invalid_error_from_i18n
@@ -1250,12 +1252,13 @@ module AutosaveAssociationOnACollectionAssociationTests
       { @associated_model_name.to_s.to_sym => { blank: "cannot be blank" } }
     }})
 
-    @pirate.send(@association_name).build(name: '')
+    association = @pirate.send(@association_name)
+    association.build(name: '')
 
     assert !@pirate.valid?
     assert_equal ["cannot be blank"], @pirate.errors["#{@association_name}.name"]
     assert_equal ["#{@association_name.to_s.humanize} name cannot be blank"], @pirate.errors.full_messages
-    assert @pirate.errors[@association_name].empty?
+    assert_equal association.map(&:errors).map(&:messages).select(&:present?), @pirate.errors[@association_name]
   ensure
     I18n.backend = I18n::Backend::Simple.new
   end


### PR DESCRIPTION
Now when a nested model has an error, it will be nested in the base
model's error messages hash in addition to the nested model's error
messages hash.

For example, if a user has two posts that are invalid (the first one
lacks a title and the other lacks a body), we get:

``` ruby
    {
      :"posts.title" => ["can't be blank"],
      :"posts.body" => ["can't be blank"],
      :posts => [
        { title: ["can't be blank"] },
        { body: ["can't be blank"] }
      ]
    }
```

Instead of just:

``` ruby
    {
      :"posts.title" => ["can't be blank"],
      :"posts.body" => ["can't be blank"]
    }
```

This makes it much easier to render errors on a fat client app when dealing with nested models.
