### PR TITLE
Have AR::Base#[] act consistently for non-existent attributes

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -380,6 +380,8 @@ module ActiveRecord
       # This all happens inside a transaction, _if_ the Transactions module is included into
       # ActiveRecord::Base after the AutosaveAssociation module, which it does by default.
       def save_has_one_association(reflection)
+        return if reflection.through_reflection
+
         association = association_instance_get(reflection.name)
         record      = association && association.load_target
 
@@ -392,9 +394,7 @@ module ActiveRecord
             key = reflection.options[:primary_key] ? send(reflection.options[:primary_key]) : id
 
             if (autosave && record.changed_for_autosave?) || new_record? || record_changed?(reflection, record, key)
-              unless reflection.through_reflection
-                record[reflection.foreign_key] = key
-              end
+              record[reflection.foreign_key] = key
 
               saved = record.save(:validate => !autosave)
               raise ActiveRecord::Rollback if !saved && autosave

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -51,6 +51,8 @@ module ActiveRecord
       self.pluralize_table_names = true
 
       self.inheritance_column = 'type'
+
+      delegate :type_for_attribute, to: :class
     end
 
     module ClassMethods
@@ -219,6 +221,10 @@ module ActiveRecord
 
       def column_types # :nodoc:
         @column_types ||= decorate_columns(columns_hash.dup)
+      end
+
+      def type_for_attribute(attr_name) # :nodoc:
+        column_types.fetch(attr_name) { column_for_attribute(attr_name) }
       end
 
       def decorate_columns(columns_hash) # :nodoc:

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -99,7 +99,7 @@ module ActiveRecord
     end
 
     def max_updated_column_timestamp(timestamp_names = timestamp_attributes_for_update)
-      if (timestamps = timestamp_names.map { |attr| self[attr] }.compact).present?
+      if (timestamps = timestamp_names.map { |attr| read_attribute(attr) }.compact).present?
         timestamps.map { |ts| ts.to_time }.max
       end
     end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -996,7 +996,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
     assert post.author_addresses.include?(address)
     post.author_addresses.delete(address)
-    assert post[:author_count].nil?
+    assert_raises(ActiveModel::MissingAttributeError) { post[:author_count] }
   end
 
   def test_primary_key_option_on_source

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -43,6 +43,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal clubs(:moustache_club), new_member.club
     assert new_member.save
     assert_equal clubs(:moustache_club), new_member.club
+    assert new_member.current_membership.id
   end
 
   def test_replace_target_record

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -299,6 +299,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     computer = Computer.select('id').first
     assert_raises(ActiveModel::MissingAttributeError) { computer[:developer] }
     assert_raises(ActiveModel::MissingAttributeError) { computer[:extendedWarranty] }
+    assert_raises(ActiveModel::MissingAttributeError) { computer[:no_column_exists] }
     assert_raises(ActiveModel::MissingAttributeError) { computer[:no_column_exists] = 'Hello!' }
     assert_nothing_raised { computer[:developer] = 'Hello!' }
   end


### PR DESCRIPTION
Currently we have an inconcistency between calling `[]` for columns that
exist but were not included in the query, and accessing columns which do
not exist.

```
class Author < ActiveRecord::Base
  connection.create_table(:authors, force: true) do |t|
    t.string :name
  end
end

author = Author.select('id').first

# Before:
author[:name] # => Raises ActiveModel::MissingAttributeError
author[:non_existent] # => nil

# After:
author[:name] # => Raises ActiveModel::MissingAttributeError
author[:non_existent] # => Raises ActiveModel::MissingAttributeError
```

Personally, I think it'd make more sense for `[]` to return nil in all
cases, but the documentation states that "It raises
`ActiveModel::MissingAttributeError` if the identified attribute is
missing." so we cannot do that at this time.
