### PR TITLE
ActiveRecord::FinderMethods.find doesn't pass proc parameter to array #1...

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `ActiveRecord::FinderMethods.find` with block can handle proc parameter as `Enumerable#find` does.
+
+    Fixes #15382.
+
+    *James Yang*
+
 *   Make timezone aware attributes work with PostgreSQL array columns.
 
     Fixes #13402.

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -65,7 +65,7 @@ module ActiveRecord
     #   # returns an Array of the required fields, available since Rails 3.1.
     def find(*args)
       if block_given?
-        to_a.find { |*block_args| yield(*block_args) }
+        to_a.find(*args) { |*block_args| yield(*block_args) }
       else
         find_with_ids(*args)
       end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -38,7 +38,7 @@ class FinderTest < ActiveRecord::TestCase
       Topic.all.find(lambda { raise ActiveRecord::RecordNotFound }, &->(e){ e.title == Topic.new.title })
     end
 
-    assert_nothing_raises(ActiveRecord::RecordNotFound) do
+    assert_nothing_raised(ActiveRecord::RecordNotFound) do
       Topic.all.find(lambda { raise ActiveRecord::RecordNotFound }, &->(e){ e.title == topics(:first).title })
     end
   end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -33,6 +33,16 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal(topics(:first).title, Topic.find(1).title)
   end
 
+  def test_find_with_proc_parameter_and_block
+    assert_raises(ActiveRecord::RecordNotFound) do
+      Topic.all.find(lambda { raise ActiveRecord::RecordNotFound }, &->(e){ e.title == Topic.new.title })
+    end
+
+    assert_nothing_raises(ActiveRecord::RecordNotFound) do
+      Topic.all.find(lambda { raise ActiveRecord::RecordNotFound }, &->(e){ e.title == topics(:first).title })
+    end
+  end
+
   def test_find_passing_active_record_object_is_deprecated
     assert_deprecated do
       Topic.find(Topic.last)


### PR DESCRIPTION
push arguments to `to_a.find`'s arguments, so proc parameter now works.

Closes #15382
