### PR TITLE
an API to allow changing of the connection pool implementation used

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -492,6 +492,26 @@ module ActiveRecord
         end
       end
 
+      @@connection_pool_class = ConnectionAdapters::ConnectionPool
+
+      # Returns the connection pool class used when establishing a connection.
+      def self.connection_pool_class 
+        @@connection_pool_class
+      end
+
+      # Allows for changing the connection pool implementation e.g. in a initializer
+      #
+      #   ActiveRecord::ConnectionAdapters::ConnectionHandler.connection_pool_class = MyPool
+      #
+      def self.connection_pool_class=(klass) 
+        @@connection_pool_class = klass
+      end
+
+      # Returns the connection pool class used when establishing a connection.
+      def connection_pool_class
+        @@connection_pool_class
+      end
+
       def connection_pool_list
         owner_to_pool.values.compact
       end
@@ -507,8 +527,9 @@ module ActiveRecord
       def establish_connection(owner, spec)
         @class_to_pool.clear
         raise RuntimeError, "Anonymous class is not allowed." unless owner.name
-        owner_to_pool[owner.name] = ConnectionAdapters::ConnectionPool.new(spec)
+        owner_to_pool[owner.name] = connection_pool_class.new(spec)
       end
+
 
       # Returns true if there are any active connections among the connection
       # pools that the ConnectionHandler is managing.


### PR DESCRIPTION
I would like to propose a standard way of changing the pool used (e.g. in an initializer) ... sample : 

```
ActiveRecord::ConnectionAdapters::ConnectionHandler.connection_pool_class = Custom::Pool
```

... no fancy `config.connection_pool_class` API or anything (for now) as I understand this is not something most users will do. the motivation for this is mostly JRuby, there are "highly-concurrent" possibilities that exists (e.g. in Java) to implement a pool in a mostly non-blocking way ... which is very different than AR's default pool guts. we can leverage existing libraries on JRuby to do that. also usually when deploying with JRuby on existing servers there's connection pooling already provided (and configured else-where), the current approach to double "configure" pooling is far from ideal (there's probably more that we'd like to propose in the future in terms of allowing configuring custom pool properties or the class from database.yml but for now I'd like to hear core team's opinions on whether it's approached right). allowing to change the class used would allow (e.g. in AR-JDBC) to setup a custom "false" pool where most of the connection pooling gets delegated to the underlying data source.

I'm open to suggestions (also am not sure about the naming due `ConnectionHandler`'s existing methods)
