### PR TITLE
Use an actual identity type in AR::Result#identity_type

### DIFF
--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -31,7 +31,7 @@ module ActiveRecord
   class Result
     include Enumerable
 
-    IDENTITY_TYPE = Class.new { def type_cast(v); v; end }.new # :nodoc:
+    IDENTITY_TYPE = Type::Value.new # :nodoc:
 
     attr_reader :columns, :rows, :column_types
 


### PR DESCRIPTION
We should be able to rely on this object implenting the full type
interface.
