### PR TITLE
Remove a long gone :order option from has_one's valid_options

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_one.rb
+++ b/activerecord/lib/active_record/associations/builder/has_one.rb
@@ -5,7 +5,7 @@ module ActiveRecord::Associations::Builder
     end
 
     def valid_options
-      valid = super + [:order, :as]
+      valid = super + [:as]
       valid += [:through, :source, :source_type] if options[:through]
       valid
     end


### PR DESCRIPTION
It was somehow left behind when migrating to the new scope based API.
