### PR TITLE
Add unregister_template_handler to prevent leaks.

### DIFF
--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -23,10 +23,6 @@ ActiveSupport::Deprecation.debug = true
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false
 
-# Bogus template processors
-ActionView::Template.register_template_handler :haml, lambda { |template| "Look its HAML!".inspect }
-ActionView::Template.register_template_handler :bak, lambda { |template| "Lame backup".inspect }
-
 FIXTURE_LOAD_PATH = File.expand_path('fixtures', File.dirname(__FILE__))
 ActionMailer::Base.view_paths = FIXTURE_LOAD_PATH
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `ActionView::Template::Handler.unregister_template_handler`.
+    
+    It performs the opposite of `ActionView::Template::Handler.register_template_handler`.
+    
+    *Zuhao Wan*
+
 *   Allow custom `:host` option to be passed to `asset_url` helper that
     overwrites `config.action_controller.asset_host` for particular asset.
 

--- a/actionview/lib/action_view/template/handlers.rb
+++ b/actionview/lib/action_view/template/handlers.rb
@@ -32,6 +32,15 @@ module ActionView #:nodoc:
         @@template_extensions = nil
       end
 
+      # Opposite to register_template_handler.
+      def unregister_template_handler(*extensions)
+        extensions.each do |extension|
+          handler = @@template_handlers.delete extension.to_sym
+          @@default_template_handlers = nil if @@default_template_handlers == handler
+        end
+        @@template_extensions = nil
+      end
+
       def template_handler_extensions
         @@template_handlers.keys.map {|key| key.to_s }.sort
       end

--- a/actionview/test/support/template_handler_helper.rb
+++ b/actionview/test/support/template_handler_helper.rb
@@ -1,0 +1,8 @@
+module TemplateHandlerHelper
+  def with_template_handler(*extensions, handler)
+    ActionView::Template.register_template_handler(*extensions, handler)
+    yield
+  ensure
+    ActionView::Template.unregister_template_handler(*extensions)
+  end
+end

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -31,6 +31,7 @@ class DependencyTrackerTest < ActionView::TestCase
   end
 
   def teardown
+    ActionView::Template.unregister_template_handler :neckbeard
     tracker.remove_tracker(:neckbeard)
   end
 


### PR DESCRIPTION
A few places in the test codebase had `ActionView::Template.register_template_handler`, but the handlers were not removed after the tests.

This patch adds a new method `unregister_template_handler` to `ActionView::Template::Handlers`, and makes sure related tests are cleaned up properly.

cc @senny
