### PR TITLE
Rename `type_cast` to `type_cast_from_database`

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -57,7 +57,7 @@ module ActiveRecord
       def ids_writer(ids)
         pk_column = reflection.primary_key_column
         ids = Array(ids).reject { |id| id.blank? }
-        ids.map! { |i| pk_column.type_cast(i) }
+        ids.map! { |i| pk_column.type_cast_from_user(i) }
         replace(klass.find(ids).index_by { |r| r.id }.values_at(*ids))
       end
 

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -144,7 +144,7 @@ module ActiveRecord
         column_aliases = aliases.column_aliases join_root
 
         result_set.each { |row_hash|
-          primary_id = type_caster.type_cast row_hash[primary_key]
+          primary_id = type_caster.type_cast_from_database row_hash[primary_key]
           parent = parents[primary_id] ||= join_root.instantiate(row_hash, column_aliases)
           construct(parent, join_root, row_hash, result_set, seen, model_cache, aliases)
         }

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -123,9 +123,9 @@ module ActiveRecord
           }
 
           if self.class.cache_attribute?(name)
-            @attributes[name] = column.type_cast(value)
+            @attributes[name] = column.type_cast_from_database(value)
           else
-            column.type_cast value
+            column.type_cast_from_database value
           end
         }
       end

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module AttributeMethods
     module TimeZoneConversion
       class Type < SimpleDelegator # :nodoc:
-        def type_cast(value)
+        def type_cast_from_database(value)
           convert_time_to_time_zone(super)
         end
 

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
       delegate :type, :precision, :scale, :limit, :klass, :accessor,
         :text?, :number?, :binary?, :serialized?, :changed?,
-        :type_cast, :type_cast_from_user, :type_cast_for_database,
+        :type_cast_from_user, :type_cast_from_database, :type_cast_for_database,
         :type_cast_for_schema,
         to: :cast_type
 
@@ -52,7 +52,7 @@ module ActiveRecord
       end
 
       def default
-        @default ||= type_cast(@original_default)
+        @default ||= type_cast_from_database(@original_default)
       end
 
       def with_type(type)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -108,7 +108,7 @@ module ActiveRecord
             if ::Array === value
               value.map {|item| type_cast_array(oid, item)}
             else
-              oid.type_cast value
+              oid.type_cast_from_database value
             end
           end
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/hstore.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/hstore.rb
@@ -8,15 +8,15 @@ module ActiveRecord
           end
 
           def type_cast_from_user(value)
-            type_cast(type_cast_for_database(value))
+            type_cast_from_database(type_cast_for_database(value))
+          end
+
+          def type_cast_from_database(value)
+            ConnectionAdapters::PostgreSQLColumn.string_to_hstore(value)
           end
 
           def type_cast_for_database(value)
             ConnectionAdapters::PostgreSQLColumn.hstore_to_string(value)
-          end
-
-          def cast_value(value)
-            ConnectionAdapters::PostgreSQLColumn.string_to_hstore value
           end
 
           def accessor

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/json.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/json.rb
@@ -8,15 +8,15 @@ module ActiveRecord
           end
 
           def type_cast_from_user(value)
-            type_cast(type_cast_for_database(value))
+            type_cast_from_database(type_cast_for_database(value))
+          end
+
+          def type_cast_from_database(value)
+            ConnectionAdapters::PostgreSQLColumn.string_to_json(value)
           end
 
           def type_cast_for_database(value)
             ConnectionAdapters::PostgreSQLColumn.json_to_string(value)
-          end
-
-          def cast_value(value)
-            ConnectionAdapters::PostgreSQLColumn.string_to_json value
           end
 
           def accessor

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
@@ -29,7 +29,7 @@ module ActiveRecord
           end
 
           def type_cast_single(value)
-            infinity?(value) ? value : @subtype.type_cast(value)
+            infinity?(value) ? value : @subtype.type_cast_from_database(value)
           end
 
           def cast_value(value)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -348,14 +348,14 @@ module ActiveRecord
         if supports_extensions?
           res = exec_query "SELECT EXISTS(SELECT * FROM pg_available_extensions WHERE name = '#{name}' AND installed_version IS NOT NULL) as enabled",
             'SCHEMA'
-          res.column_types['enabled'].type_cast res.rows.first.first
+          res.column_types['enabled'].type_cast_from_database res.rows.first.first
         end
       end
 
       def extensions
         if supports_extensions?
           res = exec_query "SELECT extname from pg_extension", "SCHEMA"
-          res.rows.map { |r| res.column_types['extname'].type_cast r.first }
+          res.rows.map { |r| res.column_types['extname'].type_cast_from_database r.first }
         else
           super
         end

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -516,7 +516,7 @@ module ActiveRecord
 
     # Determines if a hash contains a truthy _destroy key.
     def has_destroy_flag?(hash)
-      Type::Boolean.new.type_cast(hash['_destroy'])
+      Type::Boolean.new.type_cast_from_user(hash['_destroy'])
     end
 
     # Determines if a new record should be rejected by checking

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -179,7 +179,7 @@ module ActiveRecord
         result = result.map do |attributes|
           values = attributes.values
 
-          columns.zip(values).map { |column, value| column.type_cast value }
+          columns.zip(values).map { |column, value| column.type_cast_from_database value }
         end
         columns.one? ? result.map!(&:first) : result
       end
@@ -379,7 +379,7 @@ module ActiveRecord
     end
 
     def type_cast_using_column(value, column)
-      column ? column.type_cast(value) : value
+      column ? column.type_cast_from_database(value) : value
     end
 
     # TODO: refactor to allow non-string `select_values` (eg. Arel nodes).

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -9,7 +9,7 @@ module ActiveRecord
         super(subtype)
       end
 
-      def type_cast(value)
+      def type_cast_from_database(value)
         if is_default_value?(value)
           value
         else
@@ -18,7 +18,7 @@ module ActiveRecord
       end
 
       def type_cast_from_user(value)
-        type_cast(type_cast_for_database(value))
+        type_cast_from_database(type_cast_for_database(value))
       end
 
       def type_cast_for_database(value)

--- a/activerecord/lib/active_record/type/value.rb
+++ b/activerecord/lib/active_record/type/value.rb
@@ -16,11 +16,8 @@ module ActiveRecord
       # must override this method.
       def type; end
 
-      # Takes an input from the database, or from attribute setters,
-      # and casts it to a type appropriate for this object. This method
-      # should not be overriden by subclasses. Instead, override `cast_value`.
-      def type_cast(value)
-        cast_value(value) unless value.nil?
+      def type_cast_from_database(value)
+        type_cast(value)
       end
 
       def type_cast_from_user(value)
@@ -64,6 +61,12 @@ module ActiveRecord
       end
 
       private
+      # Takes an input from the database, or from attribute setters,
+      # and casts it to a type appropriate for this object. This method
+      # should not be overriden by subclasses. Instead, override `cast_value`.
+      def type_cast(value) # :api: public
+        cast_value(value) unless value.nil?
+      end
 
       # Responsible for casting values from external sources to the appropriate
       # type. Called by `type_cast` for all values except `nil`.

--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -105,7 +105,7 @@ module ActiveRecord
 
           result = @conn.exec_query('SELECT status FROM ex')
 
-          assert_equal 2, result.column_types['status'].type_cast(result.last['status'])
+          assert_equal 2, result.column_types['status'].type_cast_from_database(result.last['status'])
         end
       end
 

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -90,9 +90,9 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
   end
 
   def test_type_cast_array
-    assert_equal(['1', '2', '3'], @column.type_cast('{1,2,3}'))
-    assert_equal([], @column.type_cast('{}'))
-    assert_equal([nil], @column.type_cast('{NULL}'))
+    assert_equal(['1', '2', '3'], @column.type_cast_from_database('{1,2,3}'))
+    assert_equal([], @column.type_cast_from_database('{}'))
+    assert_equal([nil], @column.type_cast_from_database('{NULL}'))
   end
 
   def test_type_cast_integers

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -33,16 +33,16 @@ class PostgresqlByteaTest < ActiveRecord::TestCase
 
     data = "\u001F\x8B"
     assert_equal('UTF-8', data.encoding.name)
-    assert_equal('ASCII-8BIT', @column.type_cast(data).encoding.name)
+    assert_equal('ASCII-8BIT', @column.type_cast_from_database(data).encoding.name)
   end
 
   def test_type_cast_binary_value
     data = "\u001F\x8B".force_encoding("BINARY")
-    assert_equal(data, @column.type_cast(data))
+    assert_equal(data, @column.type_cast_from_database(data))
   end
 
   def test_type_case_nil
-    assert_equal(nil, @column.type_cast(nil))
+    assert_equal(nil, @column.type_cast_from_database(nil))
   end
 
   def test_read_value

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -121,7 +121,7 @@ module ActiveRecord
       name = @subscriber.payloads.last[:statement_name]
       assert name
       res = @connection.exec_query("EXPLAIN (FORMAT JSON) EXECUTE #{name}(#{bindval})")
-      plan = res.column_types['QUERY PLAN'].type_cast res.rows.first.first
+      plan = res.column_types['QUERY PLAN'].type_cast_from_database res.rows.first.first
       assert_operator plan.length, :>, 0
     end
 

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -118,11 +118,11 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
       data = "\"1\"=>\"2\""
       hash = @column.class.string_to_hstore data
       assert_equal({'1' => '2'}, hash)
-      assert_equal({'1' => '2'}, @column.type_cast(data))
+      assert_equal({'1' => '2'}, @column.type_cast_from_database(data))
 
-      assert_equal({}, @column.type_cast(""))
-      assert_equal({'key'=>nil}, @column.type_cast('key => NULL'))
-      assert_equal({'c'=>'}','"a"'=>'b "a b'}, @column.type_cast(%q(c=>"}", "\"a\""=>"b \"a b")))
+      assert_equal({}, @column.type_cast_from_database(""))
+      assert_equal({'key'=>nil}, @column.type_cast_from_database('key => NULL'))
+      assert_equal({'c'=>'}','"a"'=>'b "a b'}, @column.type_cast_from_database(%q(c=>"}", "\"a\""=>"b \"a b")))
     end
 
     def test_with_store_accessors
@@ -180,31 +180,31 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     end
 
     def test_parse1
-      assert_equal({'a'=>nil,'b'=>nil,'c'=>'NuLl','null'=>'c'}, @column.type_cast('a=>null,b=>NuLl,c=>"NuLl",null=>c'))
+      assert_equal({'a'=>nil,'b'=>nil,'c'=>'NuLl','null'=>'c'}, @column.type_cast_from_database('a=>null,b=>NuLl,c=>"NuLl",null=>c'))
     end
 
     def test_parse2
-      assert_equal({" " => " "},  @column.type_cast("\\ =>\\ "))
+      assert_equal({" " => " "},  @column.type_cast_from_database("\\ =>\\ "))
     end
 
     def test_parse3
-      assert_equal({"=" => ">"},  @column.type_cast("==>>"))
+      assert_equal({"=" => ">"},  @column.type_cast_from_database("==>>"))
     end
 
     def test_parse4
-      assert_equal({"=a"=>"q=w"},   @column.type_cast('\=a=>q=w'))
+      assert_equal({"=a"=>"q=w"},   @column.type_cast_from_database('\=a=>q=w'))
     end
 
     def test_parse5
-      assert_equal({"=a"=>"q=w"},   @column.type_cast('"=a"=>q\=w'))
+      assert_equal({"=a"=>"q=w"},   @column.type_cast_from_database('"=a"=>q\=w'))
     end
 
     def test_parse6
-      assert_equal({"\"a"=>"q>w"},  @column.type_cast('"\"a"=>q>w'))
+      assert_equal({"\"a"=>"q>w"},  @column.type_cast_from_database('"\"a"=>q>w'))
     end
 
     def test_parse7
-      assert_equal({"\"a"=>"q\"w"}, @column.type_cast('\"a=>q"w'))
+      assert_equal({"\"a"=>"q\"w"}, @column.type_cast_from_database('\"a=>q"w'))
     end
 
     def test_rewrite

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -80,11 +80,11 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
     data = "{\"a_key\":\"a_value\"}"
     hash = column.class.string_to_json data
     assert_equal({'a_key' => 'a_value'}, hash)
-    assert_equal({'a_key' => 'a_value'}, column.type_cast(data))
+    assert_equal({'a_key' => 'a_value'}, column.type_cast_from_database(data))
 
-    assert_equal({}, column.type_cast("{}"))
-    assert_equal({'key'=>nil}, column.type_cast('{"key": null}'))
-    assert_equal({'c'=>'}','"a"'=>'b "a b'}, column.type_cast(%q({"c":"}", "\"a\"":"b \"a b"})))
+    assert_equal({}, column.type_cast_from_database("{}"))
+    assert_equal({'key'=>nil}, column.type_cast_from_database('{"key": null}'))
+    assert_equal({'c'=>'}','"a"'=>'b "a b'}, column.type_cast_from_database(%q({"c":"}", "\"a\"":"b \"a b"})))
   end
 
   def test_rewrite

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -49,10 +49,10 @@ class PostgresqlMoneyTest < ActiveRecord::TestCase
 
   def test_money_type_cast
     column = PostgresqlMoney.columns_hash['wealth']
-    assert_equal(12345678.12, column.type_cast("$12,345,678.12"))
-    assert_equal(12345678.12, column.type_cast("$12.345.678,12"))
-    assert_equal(-1.15, column.type_cast("-$1.15"))
-    assert_equal(-2.25, column.type_cast("($2.25)"))
+    assert_equal(12345678.12, column.type_cast_from_user("$12,345,678.12"))
+    assert_equal(12345678.12, column.type_cast_from_user("$12.345.678,12"))
+    assert_equal(-1.15, column.type_cast_from_user("-$1.15"))
+    assert_equal(-2.25, column.type_cast_from_user("($2.25)"))
   end
 
   def test_schema_dumping

--- a/activerecord/test/cases/attribute_decorators_test.rb
+++ b/activerecord/test/cases/attribute_decorators_test.rb
@@ -12,11 +12,11 @@ module ActiveRecord
         super(delegate)
       end
 
-      def type_cast(value)
+      def type_cast_from_user(value)
         "#{super} #{@decoration}"
       end
 
-      alias type_cast_from_user type_cast
+      alias type_cast_from_database type_cast_from_user
     end
 
     setup do

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1489,7 +1489,7 @@ class BasicsTest < ActiveRecord::TestCase
     attrs.delete 'id'
 
     typecast = Class.new {
-      def type_cast value
+      def type_cast_from_database value
         "t.lo"
       end
     }

--- a/activerecord/test/cases/connection_adapters/type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/type_lookup_test.rb
@@ -85,7 +85,7 @@ module ActiveRecord
           cast_type = @connection.type_map.lookup(type)
 
           assert_equal :decimal, cast_type.type
-          assert_equal 2, cast_type.type_cast(2.1)
+          assert_equal 2, cast_type.type_cast_from_user(2.1)
         end
       end
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -95,7 +95,7 @@ class ReflectionTest < ActiveRecord::TestCase
     column = @first.column_for_attribute("attribute_that_doesnt_exist")
     object = Object.new
 
-    assert_equal object, column.type_cast(object)
+    assert_equal object, column.type_cast_from_database(object)
     assert_equal object, column.type_cast_from_user(object)
     assert_equal object, column.type_cast_for_database(object)
   end

--- a/activerecord/test/cases/types_test.rb
+++ b/activerecord/test/cases/types_test.rb
@@ -6,141 +6,141 @@ module ActiveRecord
     class TypesTest < ActiveRecord::TestCase
       def test_type_cast_boolean
         type = Type::Boolean.new
-        assert type.type_cast('').nil?
-        assert type.type_cast(nil).nil?
+        assert type.type_cast_from_user('').nil?
+        assert type.type_cast_from_user(nil).nil?
 
-        assert type.type_cast(true)
-        assert type.type_cast(1)
-        assert type.type_cast('1')
-        assert type.type_cast('t')
-        assert type.type_cast('T')
-        assert type.type_cast('true')
-        assert type.type_cast('TRUE')
-        assert type.type_cast('on')
-        assert type.type_cast('ON')
+        assert type.type_cast_from_user(true)
+        assert type.type_cast_from_user(1)
+        assert type.type_cast_from_user('1')
+        assert type.type_cast_from_user('t')
+        assert type.type_cast_from_user('T')
+        assert type.type_cast_from_user('true')
+        assert type.type_cast_from_user('TRUE')
+        assert type.type_cast_from_user('on')
+        assert type.type_cast_from_user('ON')
 
         # explicitly check for false vs nil
-        assert_equal false, type.type_cast(false)
-        assert_equal false, type.type_cast(0)
-        assert_equal false, type.type_cast('0')
-        assert_equal false, type.type_cast('f')
-        assert_equal false, type.type_cast('F')
-        assert_equal false, type.type_cast('false')
-        assert_equal false, type.type_cast('FALSE')
-        assert_equal false, type.type_cast('off')
-        assert_equal false, type.type_cast('OFF')
-        assert_equal false, type.type_cast(' ')
-        assert_equal false, type.type_cast("\u3000\r\n")
-        assert_equal false, type.type_cast("\u0000")
-        assert_equal false, type.type_cast('SOMETHING RANDOM')
+        assert_equal false, type.type_cast_from_user(false)
+        assert_equal false, type.type_cast_from_user(0)
+        assert_equal false, type.type_cast_from_user('0')
+        assert_equal false, type.type_cast_from_user('f')
+        assert_equal false, type.type_cast_from_user('F')
+        assert_equal false, type.type_cast_from_user('false')
+        assert_equal false, type.type_cast_from_user('FALSE')
+        assert_equal false, type.type_cast_from_user('off')
+        assert_equal false, type.type_cast_from_user('OFF')
+        assert_equal false, type.type_cast_from_user(' ')
+        assert_equal false, type.type_cast_from_user("\u3000\r\n")
+        assert_equal false, type.type_cast_from_user("\u0000")
+        assert_equal false, type.type_cast_from_user('SOMETHING RANDOM')
       end
 
       def test_type_cast_string
         type = Type::String.new
-        assert_equal "1", type.type_cast(true)
-        assert_equal "0", type.type_cast(false)
-        assert_equal "123", type.type_cast(123)
+        assert_equal "1", type.type_cast_from_user(true)
+        assert_equal "0", type.type_cast_from_user(false)
+        assert_equal "123", type.type_cast_from_user(123)
       end
 
       def test_type_cast_integer
         type = Type::Integer.new
-        assert_equal 1, type.type_cast(1)
-        assert_equal 1, type.type_cast('1')
-        assert_equal 1, type.type_cast('1ignore')
-        assert_equal 0, type.type_cast('bad1')
-        assert_equal 0, type.type_cast('bad')
-        assert_equal 1, type.type_cast(1.7)
-        assert_equal 0, type.type_cast(false)
-        assert_equal 1, type.type_cast(true)
-        assert_nil type.type_cast(nil)
+        assert_equal 1, type.type_cast_from_user(1)
+        assert_equal 1, type.type_cast_from_user('1')
+        assert_equal 1, type.type_cast_from_user('1ignore')
+        assert_equal 0, type.type_cast_from_user('bad1')
+        assert_equal 0, type.type_cast_from_user('bad')
+        assert_equal 1, type.type_cast_from_user(1.7)
+        assert_equal 0, type.type_cast_from_user(false)
+        assert_equal 1, type.type_cast_from_user(true)
+        assert_nil type.type_cast_from_user(nil)
       end
 
       def test_type_cast_non_integer_to_integer
         type = Type::Integer.new
-        assert_nil type.type_cast([1,2])
-        assert_nil type.type_cast({1 => 2})
-        assert_nil type.type_cast((1..2))
+        assert_nil type.type_cast_from_user([1,2])
+        assert_nil type.type_cast_from_user({1 => 2})
+        assert_nil type.type_cast_from_user((1..2))
       end
 
       def test_type_cast_activerecord_to_integer
         type = Type::Integer.new
         firm = Firm.create(:name => 'Apple')
-        assert_nil type.type_cast(firm)
+        assert_nil type.type_cast_from_user(firm)
       end
 
       def test_type_cast_object_without_to_i_to_integer
         type = Type::Integer.new
-        assert_nil type.type_cast(Object.new)
+        assert_nil type.type_cast_from_user(Object.new)
       end
 
       def test_type_cast_nan_and_infinity_to_integer
         type = Type::Integer.new
-        assert_nil type.type_cast(Float::NAN)
-        assert_nil type.type_cast(1.0/0.0)
+        assert_nil type.type_cast_from_user(Float::NAN)
+        assert_nil type.type_cast_from_user(1.0/0.0)
       end
 
       def test_type_cast_float
         type = Type::Float.new
-        assert_equal 1.0, type.type_cast("1")
+        assert_equal 1.0, type.type_cast_from_user("1")
       end
 
       def test_type_cast_decimal
         type = Type::Decimal.new
-        assert_equal BigDecimal.new("0"), type.type_cast(BigDecimal.new("0"))
-        assert_equal BigDecimal.new("123"), type.type_cast(123.0)
-        assert_equal BigDecimal.new("1"), type.type_cast(:"1")
+        assert_equal BigDecimal.new("0"), type.type_cast_from_user(BigDecimal.new("0"))
+        assert_equal BigDecimal.new("123"), type.type_cast_from_user(123.0)
+        assert_equal BigDecimal.new("1"), type.type_cast_from_user(:"1")
       end
 
       def test_type_cast_binary
         type = Type::Binary.new
-        assert_equal nil, type.type_cast(nil)
-        assert_equal "1", type.type_cast("1")
-        assert_equal 1, type.type_cast(1)
+        assert_equal nil, type.type_cast_from_user(nil)
+        assert_equal "1", type.type_cast_from_user("1")
+        assert_equal 1, type.type_cast_from_user(1)
       end
 
       def test_type_cast_time
         type = Type::Time.new
-        assert_equal nil, type.type_cast(nil)
-        assert_equal nil, type.type_cast('')
-        assert_equal nil, type.type_cast('ABC')
+        assert_equal nil, type.type_cast_from_user(nil)
+        assert_equal nil, type.type_cast_from_user('')
+        assert_equal nil, type.type_cast_from_user('ABC')
 
         time_string = Time.now.utc.strftime("%T")
-        assert_equal time_string, type.type_cast(time_string).strftime("%T")
+        assert_equal time_string, type.type_cast_from_user(time_string).strftime("%T")
       end
 
       def test_type_cast_datetime_and_timestamp
         type = Type::DateTime.new
-        assert_equal nil, type.type_cast(nil)
-        assert_equal nil, type.type_cast('')
-        assert_equal nil, type.type_cast('  ')
-        assert_equal nil, type.type_cast('ABC')
+        assert_equal nil, type.type_cast_from_user(nil)
+        assert_equal nil, type.type_cast_from_user('')
+        assert_equal nil, type.type_cast_from_user('  ')
+        assert_equal nil, type.type_cast_from_user('ABC')
 
         datetime_string = Time.now.utc.strftime("%FT%T")
-        assert_equal datetime_string, type.type_cast(datetime_string).strftime("%FT%T")
+        assert_equal datetime_string, type.type_cast_from_user(datetime_string).strftime("%FT%T")
       end
 
       def test_type_cast_date
         type = Type::Date.new
-        assert_equal nil, type.type_cast(nil)
-        assert_equal nil, type.type_cast('')
-        assert_equal nil, type.type_cast(' ')
-        assert_equal nil, type.type_cast('ABC')
+        assert_equal nil, type.type_cast_from_user(nil)
+        assert_equal nil, type.type_cast_from_user('')
+        assert_equal nil, type.type_cast_from_user(' ')
+        assert_equal nil, type.type_cast_from_user('ABC')
 
         date_string = Time.now.utc.strftime("%F")
-        assert_equal date_string, type.type_cast(date_string).strftime("%F")
+        assert_equal date_string, type.type_cast_from_user(date_string).strftime("%F")
       end
 
       def test_type_cast_duration_to_integer
         type = Type::Integer.new
-        assert_equal 1800, type.type_cast(30.minutes)
-        assert_equal 7200, type.type_cast(2.hours)
+        assert_equal 1800, type.type_cast_from_user(30.minutes)
+        assert_equal 7200, type.type_cast_from_user(2.hours)
       end
 
       def test_string_to_time_with_timezone
         [:utc, :local].each do |zone|
           with_timezone_config default: zone do
             type = Type::DateTime.new
-            assert_equal Time.utc(2013, 9, 4, 0, 0, 0), type.type_cast("Wed, 04 Sep 2013 03:00:00 EAT")
+            assert_equal Time.utc(2013, 9, 4, 0, 0, 0), type.type_cast_from_user("Wed, 04 Sep 2013 03:00:00 EAT")
           end
         end
       end
@@ -149,7 +149,7 @@ module ActiveRecord
         def test_binary_encoding
           type = SQLite3Binary.new
           utf8_string = "a string".encode(Encoding::UTF_8)
-          type_cast = type.type_cast(utf8_string)
+          type_cast = type.type_cast_from_user(utf8_string)
 
           assert_equal Encoding::ASCII_8BIT, type_cast.encoding
         end


### PR DESCRIPTION
In some cases there is a difference between the two, we should always
be doing one or the other. For convenience, `type_cast` is still a
private method on type, so new types that do not need different behavior
don't need to implement two methods, but it has been moved to private so
it cannot be used accidentally.
