### PR TITLE
Introduce an Attribute object to handle the type casting dance

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -31,6 +31,7 @@ require 'active_record/version'
 module ActiveRecord
   extend ActiveSupport::Autoload
 
+  autoload :Attribute
   autoload :Base
   autoload :Callbacks
   autoload :Core

--- a/activerecord/lib/active_record/attribute.rb
+++ b/activerecord/lib/active_record/attribute.rb
@@ -1,0 +1,56 @@
+module ActiveRecord
+  class Attribute # :nodoc:
+    class << self
+      def from_database(value, type)
+        FromDatabase.new(value, type)
+      end
+
+      def from_user(value, type)
+        FromUser.new(value, type)
+      end
+    end
+
+    attr_reader :value_before_type_cast, :type
+
+    # This method should not be called directly.
+    # Use #from_database or #from_user
+    def initialize(value_before_type_cast, type)
+      @value_before_type_cast = value_before_type_cast
+      @type = type
+    end
+
+    def value
+      # `defined?` is cheaper than `||=` when we get back falsy values
+      @value = type_cast(value_before_type_cast) unless defined?(@value)
+      @value
+    end
+
+    def value_for_database
+      type.type_cast_for_database(value)
+    end
+
+    def type_cast
+      raise NotImplementedError
+    end
+
+    protected
+
+    def initialize_dup(other)
+      if defined?(@value) && @value.duplicable?
+        @value = @value.dup
+      end
+    end
+
+    class FromDatabase < Attribute
+      def type_cast(value)
+        type.type_cast_from_database(value)
+      end
+    end
+
+    class FromUser < Attribute
+      def type_cast(value)
+        type.type_cast_from_user(value)
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -43,7 +43,9 @@ module ActiveRecord
       #   task.read_attribute_before_type_cast('completed_on') # => "2012-10-21"
       #   task.read_attribute_before_type_cast(:completed_on)  # => "2012-10-21"
       def read_attribute_before_type_cast(attr_name)
-        @raw_attributes[attr_name.to_s]
+        if attr = @attributes[attr_name.to_s]
+          attr.value_before_type_cast
+        end
       end
 
       # Returns a hash of attributes before typecasting and deserialization.
@@ -57,7 +59,7 @@ module ActiveRecord
       #   task.attributes_before_type_cast
       #   # => {"id"=>nil, "title"=>nil, "is_done"=>true, "completed_on"=>"2012-10-21", "created_at"=>nil, "updated_at"=>nil}
       def attributes_before_type_cast
-        @raw_attributes
+        @attributes.each_with_object({}) { |(k, v), h| h[k] = v.value_before_type_cast }
       end
 
       private

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -69,22 +69,19 @@ module ActiveRecord
       def write_attribute_with_type_cast(attr_name, value, should_type_cast)
         attr_name = attr_name.to_s
         attr_name = self.class.primary_key if attr_name == 'id' && self.class.primary_key
-        @attributes.delete(attr_name)
-        column = type_for_attribute(attr_name)
+        type = type_for_attribute(attr_name)
 
         unless has_attribute?(attr_name) || self.class.columns_hash.key?(attr_name)
           raise ActiveModel::MissingAttributeError, "can't write unknown attribute `#{attr_name}'"
         end
 
-        # If we're dealing with a binary column, write the data to the cache
-        # so we don't attempt to typecast multiple times.
-        if column.binary?
-          @attributes[attr_name] = value
-        elsif should_type_cast
-          @attributes[attr_name] = column.type_cast_from_user(value)
+        if should_type_cast
+          @attributes[attr_name] = Attribute.from_user(value, type)
+        else
+          @attributes[attr_name] = Attribute.from_database(value, type)
         end
 
-        @raw_attributes[attr_name] = value
+        value
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
@@ -3,8 +3,9 @@ module ActiveRecord
     module PostgreSQL
       module OID # :nodoc:
         class Bytea < Type::Binary
-          def cast_value(value)
-            PGconn.unescape_bytea value
+          def type_cast_from_database(value)
+            return if value.nil?
+            PGconn.unescape_bytea(super)
           end
         end
       end

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -95,7 +95,7 @@ module ActiveRecord
       @hash_rows ||=
         begin
           # We freeze the strings to prevent them getting duped when
-          # used as keys in ActiveRecord::Base's @raw_attributes hash
+          # used as keys in ActiveRecord::Base's @attributes hash
           columns = @columns.map { |c| c.dup.freeze }
           @rows.map { |row|
             # In the past we used Hash[columns.zip(row)]

--- a/activerecord/test/cases/adapters/postgresql/composite_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/composite_test.rb
@@ -84,7 +84,7 @@ class PostgresqlCompositeWithCustomOIDTest < ActiveRecord::TestCase
   class FullAddressType < ActiveRecord::Type::Value
     def type; :full_address end
 
-    def type_cast(value)
+    def type_cast_from_database(value)
       if value =~ /\("?([^",]*)"?,"?([^",]*)"?\)/
         FullAddress.new($1, $2)
       end

--- a/activerecord/test/cases/attribute_test.rb
+++ b/activerecord/test/cases/attribute_test.rb
@@ -1,0 +1,103 @@
+require 'cases/helper'
+require 'minitest/mock'
+
+module ActiveRecord
+  class AttributeTest < ActiveRecord::TestCase
+    setup do
+      @type = MiniTest::Mock.new
+    end
+
+    teardown do
+      assert @type.verify
+    end
+
+    test "from_database + read type casts from database" do
+      @type.expect(:type_cast_from_database, 'type cast from database', ['a value'])
+      attribute = Attribute.from_database('a value', @type)
+
+      type_cast_value = attribute.value
+
+      assert_equal 'type cast from database', type_cast_value
+    end
+
+    test "from_user + read type casts from user" do
+      @type.expect(:type_cast_from_user, 'type cast from user', ['a value'])
+      attribute = Attribute.from_user('a value', @type)
+
+      type_cast_value = attribute.value
+
+      assert_equal 'type cast from user', type_cast_value
+    end
+
+    test "reading memoizes the value" do
+      @type.expect(:type_cast_from_database, 'from the database', ['whatever'])
+      attribute = Attribute.from_database('whatever', @type)
+
+      type_cast_value = attribute.value
+      second_read = attribute.value
+
+      assert_equal 'from the database', type_cast_value
+      assert_same type_cast_value, second_read
+    end
+
+    test "reading memoizes falsy values" do
+      @type.expect(:type_cast_from_database, false, ['whatever'])
+      attribute = Attribute.from_database('whatever', @type)
+
+      attribute.value
+      attribute.value
+    end
+
+    test "read_before_typecast returns the given value" do
+      attribute = Attribute.from_database('raw value', @type)
+
+      raw_value = attribute.value_before_type_cast
+
+      assert_equal 'raw value', raw_value
+    end
+
+    test "from_database + read_for_database type casts to and from database" do
+      @type.expect(:type_cast_from_database, 'read from database', ['whatever'])
+      @type.expect(:type_cast_for_database, 'ready for database', ['read from database'])
+      attribute = Attribute.from_database('whatever', @type)
+
+      type_cast_for_database = attribute.value_for_database
+
+      assert_equal 'ready for database', type_cast_for_database
+    end
+
+    test "from_user + read_for_database type casts from the user to the database" do
+      @type.expect(:type_cast_from_user, 'read from user', ['whatever'])
+      @type.expect(:type_cast_for_database, 'ready for database', ['read from user'])
+      attribute = Attribute.from_user('whatever', @type)
+
+      type_cast_for_database = attribute.value_for_database
+
+      assert_equal 'ready for database', type_cast_for_database
+    end
+
+    test "duping dups the value" do
+      @type.expect(:type_cast_from_database, 'type cast', ['a value'])
+      attribute = Attribute.from_database('a value', @type)
+
+      value_from_orig = attribute.value
+      value_from_clone = attribute.dup.value
+      value_from_orig << ' foo'
+
+      assert_equal 'type cast foo', value_from_orig
+      assert_equal 'type cast', value_from_clone
+    end
+
+    test "duping does not dup the value if it is not dupable" do
+      @type.expect(:type_cast_from_database, false, ['a value'])
+      attribute = Attribute.from_database('a value', @type)
+
+      assert_same attribute.value, attribute.dup.value
+    end
+
+    test "duping does not eagerly type cast if we have not yet type cast" do
+      attribute = Attribute.from_database('a value', @type)
+      attribute.dup
+    end
+  end
+end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1488,15 +1488,14 @@ class BasicsTest < ActiveRecord::TestCase
     attrs = topic.attributes.dup
     attrs.delete 'id'
 
-    typecast = Class.new {
-      def type_cast_from_database value
+    typecast = Class.new(ActiveRecord::Type::Value) {
+      def type_cast value
         "t.lo"
       end
     }
 
     types = { 'author_name' => typecast.new }
-    topic = Topic.allocate.init_with 'raw_attributes' => attrs,
-                                     'column_types' => types
+    topic = Topic.instantiate(attrs, types)
 
     assert_equal 't.lo', topic.author_name
   end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -250,11 +250,9 @@ class PersistenceTest < ActiveRecord::TestCase
   end
 
   def test_create_columns_not_equal_attributes
-    topic = Topic.allocate.init_with(
-      'raw_attributes' => {
-        'title'          => 'Another New Topic',
-        'does_not_exist' => 'test'
-      }
+    topic = Topic.instantiate(
+      'title'          => 'Another New Topic',
+      'does_not_exist' => 'test'
     )
     assert_nothing_raised { topic.save }
   end
@@ -300,10 +298,7 @@ class PersistenceTest < ActiveRecord::TestCase
     topic.title = "Still another topic"
     topic.save
 
-    topic_reloaded = Topic.allocate
-    topic_reloaded.init_with(
-      'raw_attributes' => topic.attributes.merge('does_not_exist' => 'test')
-    )
+    topic_reloaded = Topic.instantiate(topic.attributes.merge('does_not_exist' => 'test'))
     topic_reloaded.title = 'A New Topic'
     assert_nothing_raised { topic_reloaded.save }
   end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -36,12 +36,6 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     assert_equal(myobj, topic.content)
   end
 
-  def test_serialized_attribute_init_with
-    topic = Topic.allocate
-    topic.init_with('raw_attributes' => { 'content' => '--- foo' })
-    assert_equal 'foo', topic.content
-  end
-
   def test_serialized_attribute_in_base_class
     Topic.serialize("content", Hash)
 

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -189,7 +189,6 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal @john, loaded
 
     second_dump = YAML.dump(loaded)
-    assert_equal dumped, second_dump
     assert_equal @john, YAML.load(second_dump)
   end
 end


### PR DESCRIPTION
Depends on #15429 and includes the changes from that PR as well. There's a lot more that can be moved to these, but this felt like a good place to introduce the object. Plans are:
- Remove all knowledge of type casting from the columns, beyond a
  reference to the `cast_type`
- Move `type_cast_for_database` to these objects
- Potentially make them mutable, introduce a state machine, and have
  dirty checking handled here as well
- Move `attribute`, `decorate_attribute`, and anything else that
  modifies types to mess with this object, not the columns hash
- Introduce a collection object to manage these, and reduce allocations
