### PR TITLE
Abstract away use of HABTM macro

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1577,7 +1577,7 @@ module ActiveRecord
           scope   = nil
         end
 
-        habtm_reflection = ActiveRecord::Reflection::AssociationReflection.new(:has_and_belongs_to_many, name, scope, options, self)
+        habtm_reflection = ActiveRecord::Reflection::HABTMReflection.new(:has_and_belongs_to_many, name, scope, options, self)
 
         builder = Builder::HasAndBelongsToMany.new name, self, options
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -228,7 +228,7 @@ module ActiveRecord
 
       def initialize(macro, name, scope, options, active_record)
         super
-        @collection = [:has_many, :has_and_belongs_to_many].include?(macro)
+        @collection = macro == :has_many
         @automatic_inverse_of = nil
         @type         = options[:as] && "#{options[:as]}_type"
         @foreign_type = options[:foreign_type] || "#{name}_type"
@@ -536,6 +536,13 @@ Joining, Preloading and eager loading of these associations is deprecated and wi
         def primary_key(klass)
           klass.primary_key || raise(UnknownPrimaryKey.new(klass))
         end
+    end
+
+    class HABTMReflection < AssociationReflection #:nodoc:
+      def initialize(macro, name, scope, options, active_record)
+        super
+        @collection = true
+      end
     end
 
     # Holds all the meta-data about a :through association as it was specified


### PR DESCRIPTION
By having the `:has_and_belongs_to_many` macro in the `@collection`
we are punishing `:has_many` associations because it has to allocate
the array and check the macro.

@collection is returned to `macro == :has_many` and a new reflection
class `HABTMReflection` is created to handle this case instead.

cc/ @tenderlove
