### PR TITLE
add has_one? method and reuse instead of checking macro

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -179,7 +179,7 @@ module ActiveRecord
         def creation_attributes
           attributes = {}
 
-          if (reflection.macro == :has_one || reflection.macro == :has_many) && !options[:through]
+          if (reflection.has_one? || reflection.macro == :has_many) && !options[:through]
             attributes[reflection.foreign_key] = owner[reflection.active_record_primary_key]
 
             if reflection.options[:as]

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -92,7 +92,7 @@ module ActiveRecord
         # has_one associations.
         def invertible_for?(record)
           inverse = inverse_reflection_for(record)
-          inverse && inverse.macro == :has_one
+          inverse && inverse.has_one?
         end
 
         def target_id

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -107,7 +107,7 @@ module ActiveRecord
           if inverse
             if inverse.macro == :has_many
               record.send(inverse.name) << build_through_record(record)
-            elsif inverse.macro == :has_one
+            elsif inverse.has_one?
               record.send("#{inverse.name}=", build_through_record(record))
             end
           end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -187,7 +187,7 @@ module ActiveRecord
             # Doesn't use after_save as that would save associations added in after_create/after_update twice
             after_create save_method
             after_update save_method
-          elsif reflection.macro == :has_one
+          elsif reflection.has_one?
             define_method(save_method) { save_has_one_association(reflection) } unless method_defined?(save_method)
             # Configures two callbacks instead of a single after_save so that
             # the model may rely on their execution order relative to its

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -400,6 +400,10 @@ Joining, Preloading and eager loading of these associations is deprecated and wi
         macro == :belongs_to
       end
 
+      def has_one?
+        macro == :has_one
+      end
+
       def association_class
         case macro
         when :belongs_to
@@ -739,7 +743,7 @@ directive on your declaration like:
           raise HasManyThroughAssociationPolymorphicSourceError.new(active_record.name, self, source_reflection)
         end
 
-        if macro == :has_one && through_reflection.collection?
+        if has_one? && through_reflection.collection?
           raise HasOneThroughCantAssociateThroughCollection.new(active_record.name, self, through_reflection)
         end
 


### PR DESCRIPTION
Instead of checking for `macro == :has_one` throughout the codebase create a `has_one?` method to match the `belongs_to?`, `polymorphic?` and other methods.
