### PR TITLE
reuse available collection? check instead of macro

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -179,7 +179,7 @@ module ActiveRecord
         def creation_attributes
           attributes = {}
 
-          if (reflection.has_one? || reflection.macro == :has_many) && !options[:through]
+          if (reflection.has_one? || reflection.collection?) && !options[:through]
             attributes[reflection.foreign_key] = owner[reflection.active_record_primary_key]
 
             if reflection.options[:as]

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -105,7 +105,7 @@ module ActiveRecord
 
           inverse = source_reflection.inverse_of
           if inverse
-            if inverse.macro == :has_many
+            if inverse.collection?
               record.send(inverse.name) << build_through_record(record)
             elsif inverse.has_one?
               record.send("#{inverse.name}=", build_through_record(record))
@@ -170,7 +170,7 @@ module ActiveRecord
             klass.decrement_counter counter, records.map(&:id)
           end
 
-          if through_reflection.macro == :has_many && update_through_counter?(method)
+          if through_reflection.collection? && update_through_counter?(method)
             update_counter(-count, through_reflection)
           end
 
@@ -187,7 +187,7 @@ module ActiveRecord
           records.each do |record|
             through_records = through_records_for(record)
 
-            if through_reflection.macro == :has_many
+            if through_reflection.collection?
               through_records.each { |r| through_association.target.delete(r) }
             else
               if through_records.include?(through_association.target)

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -392,7 +392,7 @@ Joining, Preloading and eager loading of these associations is deprecated and wi
       # * you use autosave; <tt>autosave: true</tt>
       # * the association is a +has_many+ association
       def validate?
-        !options[:validate].nil? ? options[:validate] : (options[:autosave] == true || macro == :has_many)
+        !options[:validate].nil? ? options[:validate] : (options[:autosave] == true || collection?)
       end
 
       # Returns +true+ if +self+ is a +belongs_to+ reflection.


### PR DESCRIPTION
Reflection has an available method that is used to check if the reflection is a `collection?`. Any :has_many macro is considered a collection and `collection?` should be reused instead of `macro == :has_many`.

Rebased with master to fix conflicts with #15596 :smile_cat: 
