### PR TITLE
[ci skip] Add note about type modifiers that cannot be specified in command line.

### DIFF
--- a/guides/source/migrations.md
+++ b/guides/source/migrations.md
@@ -305,6 +305,8 @@ braces. You can use the following modifiers:
 * `null`         Allows or disallows `NULL` values in the column.
 * `default`      Allows to set a default value on the column. NOTE: If using a dynamic value (such as date), the default will only be calculated the first time (e.g. on the date the migration is applied.)
 
+NOTE: `null` and `default` cannot be specified via command line.
+
 For instance, running:
 
 ```bash


### PR DESCRIPTION
For #15583 and #15571.

`null` and `default` cannot specified using command line, e.g.:

`rails g migration CreateFoo bar:string{null}` won't work.

Closes #15583
