### PR TITLE
Fix cache_digest rake tasks

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Bring `cache_digest` rake tasks up-to-date with the latest API changes
+
+    *Jiri Pospisil*
+
 *   Allow custom `:host` option to be passed to `asset_url` helper that
     overwrites `config.action_controller.asset_host` for particular asset.
 

--- a/actionview/lib/action_view/tasks/dependencies.rake
+++ b/actionview/lib/action_view/tasks/dependencies.rake
@@ -2,16 +2,20 @@ namespace :cache_digests do
   desc 'Lookup nested dependencies for TEMPLATE (like messages/show or comments/_comment.html)'
   task :nested_dependencies => :environment do
     abort 'You must provide TEMPLATE for the task to run' unless ENV['TEMPLATE'].present?
-    template, format = ENV['TEMPLATE'].split(".")
-    format ||= :html
-    puts JSON.pretty_generate ActionView::Digestor.new(template, format, ApplicationController.new.lookup_context).nested_dependencies
+    puts JSON.pretty_generate ActionView::Digestor.new(name: template_name, finder: finder).nested_dependencies
   end
 
   desc 'Lookup first-level dependencies for TEMPLATE (like messages/show or comments/_comment.html)'
   task :dependencies => :environment do
     abort 'You must provide TEMPLATE for the task to run' unless ENV['TEMPLATE'].present?
-    template, format = ENV['TEMPLATE'].split(".")
-    format ||= :html
-    puts JSON.pretty_generate ActionView::Digestor.new(template, format, ApplicationController.new.lookup_context).dependencies
+    puts JSON.pretty_generate ActionView::Digestor.new(name: template_name, finder: finder).dependencies
+  end
+
+  def template_name
+    ENV['TEMPLATE'].split('.', 2).first
+  end
+
+  def finder
+    ApplicationController.new.lookup_context
   end
 end


### PR DESCRIPTION
Bring `cache_digests`:\* rake tasks up-to-date with the API changes introduced in 637bb726cac60aaa1f7e482836458aa73e17fbb7
