### PR TITLE
Basic support for adding and removing foreign keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Support for adding and removing foreign keys. Foreign keys are now
+    a part of `schema.rb`. This is supported by Mysql2Adapter, MysqlAdapter
+    and PostgreSQLAdapter.
+
+    Example:
+
+        # within your migrations:
+        add_foreign_key :articles, :authors
+        remove_foreign_key :articles, :authors
+
+    *Yves Senn*
+
 *   Fix subtle bugs regarding attribute assignment on models with no primary
     key. `'id'` will no longer be part of the attributes hash.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -104,9 +104,14 @@ FOREIGN KEY (#{quote_column_name(o.column)})
 
           def action_sql(action, dependency)
             case dependency
-              when :nullify then "ON #{action} SET NULL"
-              when :cascade  then "ON #{action} CASCADE"
-              when :restrict then "ON #{action} RESTRICT"
+            when :nullify then "ON #{action} SET NULL"
+            when :cascade  then "ON #{action} CASCADE"
+            when :restrict then "ON #{action} RESTRICT"
+            else
+              raise ArgumentError, <<-MSG
+'#{dependency}' is not supported for :on_update or :on_delete.
+Supported values are: :nullify, :cascade, :restrict
+              MSG
             end
           end
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -24,7 +24,8 @@ ADD CONSTRAINT #{quote_column_name(o.name)}
 FOREIGN KEY (#{quote_column_name(o.column)})
   REFERENCES #{quote_table_name(o.to_table)} (#{quote_column_name(o.primary_key)})
           SQL
-          sql << " #{action_sql(o.on_delete)}" if o.on_delete
+          sql << " #{action_sql('DELETE', o.on_delete)}" if o.on_delete
+          sql << " #{action_sql('UPDATE', o.on_update)}" if o.on_update
           sql
         end
 
@@ -101,7 +102,7 @@ FOREIGN KEY (#{quote_column_name(o.column)})
             options.include?(:default) && !(options[:null] == false && options[:default].nil?)
           end
 
-          def action_sql(action = "DELETE", dependency)
+          def action_sql(action, dependency)
             case dependency
               when :nullify then "ON #{action} SET NULL"
               when :cascade  then "ON #{action} CASCADE"

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -30,7 +30,7 @@ FOREIGN KEY (#{quote_column_name(o.column)})
         end
 
         def visit_DropForeignKey(name)
-          "DROP CONSTRAINT #{name}"
+          "DROP CONSTRAINT #{quote_column_name(name)}"
         end
 
         private

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -24,7 +24,7 @@ ADD CONSTRAINT #{quote_column_name(o.name)}
 FOREIGN KEY (#{quote_column_name(o.column)})
   REFERENCES #{quote_table_name(o.to_table)} (#{quote_column_name(o.primary_key)})
           SQL
-          sql << " #{dependency_sql(o.dependent)}" if o.dependent
+          sql << " #{action_sql(o.on_delete)}" if o.on_delete
           sql
         end
 
@@ -101,12 +101,11 @@ FOREIGN KEY (#{quote_column_name(o.column)})
             options.include?(:default) && !(options[:null] == false && options[:default].nil?)
           end
 
-          def dependency_sql(dependency)
+          def action_sql(action = "DELETE", dependency)
             case dependency
-              when :nullify then "ON DELETE SET NULL"
-              when :delete  then "ON DELETE CASCADE"
-              when :restrict then "ON DELETE RESTRICT"
-              else ""
+              when :nullify then "ON #{action} SET NULL"
+              when :cascade  then "ON #{action} CASCADE"
+              when :restrict then "ON #{action} RESTRICT"
             end
           end
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -38,8 +38,8 @@ module ActiveRecord
         options[:primary_key]
       end
 
-      def dependent
-        options[:dependent]
+      def on_delete
+        options[:on_delete]
       end
     end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -35,7 +35,7 @@ module ActiveRecord
       end
 
       def primary_key
-        options[:primary_key]
+        options[:primary_key] || default_primary_key
       end
 
       def on_delete
@@ -44,6 +44,15 @@ module ActiveRecord
 
       def on_update
         options[:on_update]
+      end
+
+      def custom_primary_key?
+        options[:primary_key] != default_primary_key
+      end
+
+      private
+      def default_primary_key
+        "id"
       end
     end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -25,6 +25,20 @@ module ActiveRecord
     class ChangeColumnDefinition < Struct.new(:column, :type, :options) #:nodoc:
     end
 
+    class ForeignKeyDefinition < Struct.new(:from_table, :to_table, :options)
+      def name
+        options[:name]
+      end
+
+      def column
+        options[:column]
+      end
+
+      def primary_key
+        options[:primary_key]
+      end
+    end
+
     # Represents the schema of an SQL table in an abstract way. This class
     # provides methods for manipulating the schema representation.
     #

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -37,6 +37,10 @@ module ActiveRecord
       def primary_key
         options[:primary_key]
       end
+
+      def dependent
+        options[:dependent]
+      end
     end
 
     # Represents the schema of an SQL table in an abstract way. This class

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -41,6 +41,10 @@ module ActiveRecord
       def on_delete
         options[:on_delete]
       end
+
+      def on_update
+        options[:on_update]
+      end
     end
 
     # Represents the schema of an SQL table in an abstract way. This class

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -317,13 +317,25 @@ module ActiveRecord
 
     class AlterTable # :nodoc:
       attr_reader :adds
+      attr_reader :foreign_key_adds
+      attr_reader :foreign_key_drops
 
       def initialize(td)
         @td   = td
         @adds = []
+        @foreign_key_adds = []
+        @foreign_key_drops = []
       end
 
       def name; @td.name; end
+
+      def add_foreign_key(to_table, options)
+        @foreign_key_adds << ForeignKeyDefinition.new(name, to_table, options)
+      end
+
+      def drop_foreign_key(name)
+        @foreign_key_drops << name
+      end
 
       def add_column(name, type, options)
         name = name.to_s

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -661,7 +661,7 @@ module ActiveRecord
         at = create_alter_table from_table
         at.add_foreign_key to_table, options
 
-        execute schema_creation.accept at
+        execute schema_creation.accept(at)
       end
 
       def remove_foreign_key(from_table, options_or_to_table = {})
@@ -675,6 +675,7 @@ module ActiveRecord
 
         fk_name_to_delete = options.fetch(:name) do
           fk_to_delete = foreign_keys(from_table).detect {|fk| fk.column == options[:column] }
+
           if fk_to_delete
             fk_to_delete.name
           else
@@ -685,17 +686,11 @@ module ActiveRecord
         at = create_alter_table from_table
         at.drop_foreign_key fk_name_to_delete
 
-        execute schema_creation.accept at
+        execute schema_creation.accept(at)
       end
 
       def foreign_key_column_for(table_name) # :nodoc:
         "#{table_name.to_s.singularize}_id"
-      end
-
-      def foreign_key_name(table_name, options) # :nodoc:
-        options.fetch(:name) do
-          "fk_rails_#{SecureRandom.hex(5)}"
-        end
       end
 
       def dump_schema_information #:nodoc:
@@ -907,6 +902,12 @@ module ActiveRecord
 
       def create_alter_table(name)
         AlterTable.new create_table_definition(name, false, {})
+      end
+
+      def foreign_key_name(table_name, options) # :nodoc:
+        options.fetch(:name) do
+          "fk_rails_#{SecureRandom.hex(5)}"
+        end
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -647,6 +647,8 @@ module ActiveRecord
       end
 
       def add_foreign_key(from_table, to_table, options = {})
+        return unless supports_foreign_keys?
+
         options[:column] ||= foreign_key_column_for(to_table)
         primary_key = options.fetch(:primary_key, "id")
 
@@ -664,6 +666,8 @@ module ActiveRecord
       end
 
       def remove_foreign_key(from_table, options_or_to_table = {})
+        return unless supports_foreign_keys?
+
         if options_or_to_table.is_a?(Hash)
           options = options_or_to_table
         else

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -647,9 +647,11 @@ module ActiveRecord
       end
 
       def add_foreign_key(from_table, to_table, options = {})
+        primary_key = options.fetch(:primary_key, "id")
+
         options = {
           column: options.fetch(:column),
-          primary_key: "id",
+          primary_key: primary_key,
           name: foreign_key_name(from_table, options)
         }
         at = create_alter_table from_table

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -654,7 +654,7 @@ module ActiveRecord
           column: options[:column],
           primary_key: primary_key,
           name: foreign_key_name(from_table, options),
-          dependent: options.fetch(:dependent, nil)
+          on_delete: options.fetch(:on_delete, nil)
         }
         at = create_alter_table from_table
         at.add_foreign_key to_table, options

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -652,7 +652,8 @@ module ActiveRecord
         options = {
           column: options.fetch(:column),
           primary_key: primary_key,
-          name: foreign_key_name(from_table, options)
+          name: foreign_key_name(from_table, options),
+          dependent: options.fetch(:dependent, nil)
         }
         at = create_alter_table from_table
         at.add_foreign_key to_table, options

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -682,7 +682,11 @@ module ActiveRecord
 
       def foreign_key_name(table_name, options) # :nodoc:
         options.fetch(:name) do
-          "#{table_name}_#{options.fetch(:column)}_fk"
+          identifier = "#{table_name}_#{options.fetch(:column)}_fk"
+          if identifier.length > allowed_index_name_length
+            raise ArgumentError, "Foreign key name '#{identifier}' is too long; the limit is #{allowed_index_name_length} characters"
+          end
+          identifier
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -654,7 +654,8 @@ module ActiveRecord
           column: options[:column],
           primary_key: primary_key,
           name: foreign_key_name(from_table, options),
-          on_delete: options.fetch(:on_delete, nil)
+          on_delete: options[:on_delete],
+          on_update: options[:on_update]
         }
         at = create_alter_table from_table
         at.add_foreign_key to_table, options

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -625,6 +625,13 @@ module ActiveRecord
       end
       alias :add_belongs_to :add_reference
 
+      def foreign_key_name(table_name, options)
+        options.fetch(:name) do
+          column_name = options.fetch(:column)
+          "#{table_name}_#{column_name}_fk"
+        end
+      end
+
       # Removes the reference(s). Also removes a +type+ column if one exists.
       # <tt>remove_reference</tt>, <tt>remove_references</tt> and <tt>remove_belongs_to</tt> are acceptable.
       #

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -233,6 +233,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support creating foreign key constraints?
+      def supports_foreign_keys?
+        false
+      end
+
       # This is meant to be implemented by the adapters that support extensions
       def disable_extension(name)
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -531,8 +531,8 @@ module ActiveRecord
           }
 
           if create_table_info =~ /CONSTRAINT #{quote_column_name(row['name'])} FOREIGN KEY .* REFERENCES .* ON DELETE (CASCADE|SET NULL|RESTRICT)/
-            options[:dependent] = case $1
-              when 'CASCADE'  then :delete
+            options[:on_delete] = case $1
+              when 'CASCADE'  then :cascade
               when 'SET NULL' then :nullify
               end
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -10,6 +10,10 @@ module ActiveRecord
           add_column_position!(super, column_options(o))
         end
 
+        def visit_DropForeignKey(name)
+          "DROP FOREIGN KEY #{name}"
+        end
+
         private
 
         def visit_TableDefinition(o)
@@ -523,26 +527,6 @@ module ActiveRecord
           options = {column: row['column'], name: row['name'], primary_key: row['primary_key']}
           ForeignKeyDefinition.new(table_name, row['to_table'], options)
         end
-      end
-
-      def add_foreign_key(from_table, to_table, options = {})
-        foreign_key_column = options.fetch(:column)
-        referenced_column = "id"
-        foreign_key_name = foreign_key_name(from_table, options)
-        execute <<-SQL
-ALTER TABLE #{quote_table_name(from_table)}
-ADD CONSTRAINT #{foreign_key_name}
-FOREIGN KEY (#{quote_column_name(foreign_key_column)})
-REFERENCES #{quote_table_name(to_table)} (#{quote_column_name(referenced_column)})
-        SQL
-      end
-
-      def remove_foreign_key(from_table, options = {})
-        foreign_key_name = foreign_key_name(from_table, options)
-        execute <<-SQL
-ALTER TABLE #{quote_table_name(from_table)}
-DROP FOREIGN KEY #{foreign_key_name}
-        SQL
       end
 
       # Maps logical Rails types to MySQL-specific data types.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -530,14 +530,19 @@ module ActiveRecord
             primary_key: row['primary_key']
           }
 
-          if create_table_info =~ /CONSTRAINT #{quote_column_name(row['name'])} FOREIGN KEY .* REFERENCES .* ON DELETE (CASCADE|SET NULL|RESTRICT)/
-            options[:on_delete] = case $1
-              when 'CASCADE'  then :cascade
-              when 'SET NULL' then :nullify
-              end
-          end
+          options[:on_update] = extract_foreign_key_action(create_table_info, row['name'], "UPDATE")
+          options[:on_delete] = extract_foreign_key_action(create_table_info, row['name'], "DELETE")
 
           ForeignKeyDefinition.new(table_name, row['to_table'], options)
+        end
+      end
+
+      def extract_foreign_key_action(structure, name, action) # :nodoc:
+        if structure =~ /CONSTRAINT #{quote_column_name(name)} FOREIGN KEY .* REFERENCES .* ON #{action} (CASCADE|SET NULL|RESTRICT)/
+          case $1
+          when 'CASCADE'; :cascade
+          when 'SET NULL'; :nullify
+          end
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -89,6 +89,20 @@ module ActiveRecord
         attr_accessor :array
       end
 
+      class ForeignKeyDefinition < Struct.new(:from_table, :to_table, :options)
+        def name
+          options[:name]
+        end
+
+        def column
+          options[:column]
+        end
+
+        def primary_key
+          options[:primary_key]
+        end
+      end
+
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
         include ColumnMethods
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -89,20 +89,6 @@ module ActiveRecord
         attr_accessor :array
       end
 
-      class ForeignKeyDefinition < Struct.new(:from_table, :to_table, :options)
-        def name
-          options[:name]
-        end
-
-        def column
-          options[:column]
-        end
-
-        def primary_key
-          options[:primary_key]
-        end
-      end
-
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
         include ColumnMethods
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -449,18 +449,18 @@ module ActiveRecord
         end
 
         def foreign_keys(table_name)
-          fk_info = select_all <<-SQL
-SELECT t2.relname AS to_table, a1.attname AS column, a2.attname AS primary_key, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete
-FROM pg_constraint c
-JOIN pg_class t1 ON c.conrelid = t1.oid
-JOIN pg_class t2 ON c.confrelid = t2.oid
-JOIN pg_attribute a1 ON a1.attnum = c.conkey[1] AND a1.attrelid = t1.oid
-JOIN pg_attribute a2 ON a2.attnum = c.confkey[1] AND a2.attrelid = t2.oid
-JOIN pg_namespace t3 ON c.connamespace = t3.oid
-WHERE c.contype = 'f'
-  AND t1.relname = #{quote(table_name)}
-  AND t3.nspname = ANY (current_schemas(false))
-ORDER BY c.conname
+          fk_info = select_all <<-SQL.strip_heredoc
+            SELECT t2.relname AS to_table, a1.attname AS column, a2.attname AS primary_key, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete
+            FROM pg_constraint c
+            JOIN pg_class t1 ON c.conrelid = t1.oid
+            JOIN pg_class t2 ON c.confrelid = t2.oid
+            JOIN pg_attribute a1 ON a1.attnum = c.conkey[1] AND a1.attrelid = t1.oid
+            JOIN pg_attribute a2 ON a2.attnum = c.confkey[1] AND a2.attrelid = t2.oid
+            JOIN pg_namespace t3 ON c.connamespace = t3.oid
+            WHERE c.contype = 'f'
+              AND t1.relname = #{quote(table_name)}
+              AND t3.nspname = ANY (current_schemas(false))
+            ORDER BY c.conname
           SQL
 
           fk_info.map do |row|

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -470,8 +470,8 @@ ORDER BY c.conname
               primary_key: row['primary_key']
             }
 
-            options[:dependent] = case row['dependency']
-              when 'c'; :delete
+            options[:on_delete] = case row['dependency']
+              when 'c'; :cascade
               when 'n'; :nullify
               when 'r'; :restrict
               end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -492,13 +492,6 @@ DROP CONSTRAINT #{foreign_key_name}
           SQL
         end
 
-        def foreign_key_name(table_name, options)
-          options.fetch(:name) do
-            column_name = options.fetch(:column)
-            "#{table_name}_#{column_name}_fk"
-          end
-        end
-
         def index_name_length
           63
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -448,6 +448,30 @@ module ActiveRecord
           execute "ALTER INDEX #{quote_column_name(old_name)} RENAME TO #{quote_table_name(new_name)}"
         end
 
+        def foreign_keys(table_name)
+          fk_info = select_all <<-SQL
+SELECT t2.relname AS to_table, a1.attname AS column, a2.attname AS primary_key, c.conname AS name, c.confdeltype AS dependency
+FROM pg_constraint c
+JOIN pg_class t1 ON c.conrelid = t1.oid
+JOIN pg_class t2 ON c.confrelid = t2.oid
+JOIN pg_attribute a1 ON a1.attnum = c.conkey[1] AND a1.attrelid = t1.oid
+JOIN pg_attribute a2 ON a2.attnum = c.confkey[1] AND a2.attrelid = t2.oid
+JOIN pg_namespace t3 ON c.connamespace = t3.oid
+WHERE c.contype = 'f'
+  AND t1.relname = #{quote(table_name)}
+  AND t3.nspname = ANY (current_schemas(false))
+ORDER BY c.conname
+          SQL
+
+          fk_info.map do |row|
+            options = {
+              column: row['column'],
+              name: row['name'],
+              primary_key: row['primary_key'] }
+            ForeignKeyDefinition.new(table_name, row["to_table"], options)
+          end
+        end
+
         def add_foreign_key(from_table, to_table, options = {})
           foreign_key_column = options.fetch(:column)
           referenced_column = "id"

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -448,6 +448,33 @@ module ActiveRecord
           execute "ALTER INDEX #{quote_column_name(old_name)} RENAME TO #{quote_table_name(new_name)}"
         end
 
+        def add_foreign_key(from_table, to_table, options = {})
+          foreign_key_column = options.fetch(:column)
+          referenced_column = "id"
+          foreign_key_name = foreign_key_name(from_table, options)
+          execute <<-SQL
+ALTER TABLE #{quote_table_name(from_table)}
+ADD CONSTRAINT #{foreign_key_name}
+  FOREIGN KEY (#{quote_column_name(foreign_key_column)})
+  REFERENCES #{quote_table_name(to_table)} (#{quote_column_name(referenced_column)})
+          SQL
+        end
+
+        def remove_foreign_key(from_table, options = {})
+          foreign_key_name = foreign_key_name(from_table, options)
+          execute <<-SQL
+ALTER TABLE #{quote_table_name(from_table)}
+DROP CONSTRAINT #{foreign_key_name}
+          SQL
+        end
+
+        def foreign_key_name(table_name, options)
+          options.fetch(:name) do
+            column_name = options.fetch(:column)
+            "#{table_name}_#{column_name}_fk"
+          end
+        end
+
         def index_name_length
           63
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -472,26 +472,6 @@ ORDER BY c.conname
           end
         end
 
-        def add_foreign_key(from_table, to_table, options = {})
-          foreign_key_column = options.fetch(:column)
-          referenced_column = "id"
-          foreign_key_name = foreign_key_name(from_table, options)
-          execute <<-SQL
-ALTER TABLE #{quote_table_name(from_table)}
-ADD CONSTRAINT #{foreign_key_name}
-  FOREIGN KEY (#{quote_column_name(foreign_key_column)})
-  REFERENCES #{quote_table_name(to_table)} (#{quote_column_name(referenced_column)})
-          SQL
-        end
-
-        def remove_foreign_key(from_table, options = {})
-          foreign_key_name = foreign_key_name(from_table, options)
-          execute <<-SQL
-ALTER TABLE #{quote_table_name(from_table)}
-DROP CONSTRAINT #{foreign_key_name}
-          SQL
-        end
-
         def index_name_length
           63
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -467,7 +467,14 @@ ORDER BY c.conname
             options = {
               column: row['column'],
               name: row['name'],
-              primary_key: row['primary_key'] }
+              primary_key: row['primary_key']
+            }
+
+            options[:dependent] = case row['dependency']
+              when 'c'; :delete
+              when 'n'; :nullify
+              when 'r'; :restrict
+              end
             ForeignKeyDefinition.new(table_name, row["to_table"], options)
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -159,6 +159,10 @@ module ActiveRecord
         true
       end
 
+      def supports_foreign_keys?
+        true
+      end
+
       def index_algorithms
         { concurrently: 'CONCURRENTLY' }
       end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -645,7 +645,9 @@ module ActiveRecord
         unless @connection.respond_to? :revert
           unless arguments.empty? || [:execute, :enable_extension, :disable_extension].include?(method)
             arguments[0] = proper_table_name(arguments.first, table_name_options)
-            arguments[1] = proper_table_name(arguments.second, table_name_options) if method == :rename_table
+            if [:rename_table, :add_foreign_key].include?(method)
+              arguments[1] = proper_table_name(arguments.second, table_name_options)
+            end
           end
         end
         return super unless connection.respond_to?(method)

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -170,13 +170,13 @@ module ActiveRecord
       end
 
       def invert_add_foreign_key(args)
-        from_table, to_table, add_options = *args
+        from_table, to_table, add_options = args
         add_options ||= {}
 
         if add_options[:name]
-          options = {name: add_options[:name]}
+          options = { name: add_options[:name] }
         elsif add_options[:column]
-          options = {column: add_options[:column]}
+          options = { column: add_options[:column] }
         else
           options = to_table
         end

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -74,7 +74,9 @@ module ActiveRecord
         :rename_index, :rename_column, :add_index, :remove_index, :add_timestamps, :remove_timestamps,
         :change_column_default, :add_reference, :remove_reference, :transaction,
         :drop_join_table, :drop_table, :execute_block, :enable_extension,
-        :change_column, :execute, :remove_columns, :change_column_null # irreversible methods need to be here too
+        :change_column, :execute, :remove_columns, :change_column_null,
+        :add_foreign_key, :remove_foreign_key
+       # irreversible methods need to be here too
       ].each do |method|
         class_eval <<-EOV, __FILE__, __LINE__ + 1
           def #{method}(*args, &block)          # def create_table(*args, &block)
@@ -165,6 +167,19 @@ module ActiveRecord
       def invert_change_column_null(args)
         args[2] = !args[2]
         [:change_column_null, args]
+      end
+
+      def invert_add_foreign_key(args)
+        from_table, _to_table, add_options = *args
+        add_options ||= {}
+
+        if add_options[:name]
+          options = {name: add_options[:name]}
+        elsif add_options[:column]
+          options = {column: add_options[:column]}
+        end
+
+        [:remove_foreign_key, [from_table, options]]
       end
 
       # Forwards any missing method call to the \target.

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -170,13 +170,15 @@ module ActiveRecord
       end
 
       def invert_add_foreign_key(args)
-        from_table, _to_table, add_options = *args
+        from_table, to_table, add_options = *args
         add_options ||= {}
 
         if add_options[:name]
           options = {name: add_options[:name]}
         elsif add_options[:column]
           options = {column: add_options[:column]}
+        else
+          options = to_table
         end
 
         [:remove_foreign_key, [from_table, options]]

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -226,7 +226,7 @@ HEADER
                      'primary_key: ' + foreign_key.primary_key.inspect,
                      'name: ' + foreign_key.name.inspect
                     ]
-            parts << ('dependent: ' + foreign_key.dependent.inspect) if foreign_key.dependent
+            parts << ('on_delete: ' + foreign_key.on_delete.inspect) if foreign_key.on_delete
 
             '  ' + parts.join(', ')
           end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -226,6 +226,8 @@ HEADER
                      'primary_key: ' + foreign_key.primary_key.inspect,
                      'name: ' + foreign_key.name.inspect
                     ]
+            parts << ('dependent: ' + foreign_key.dependent.inspect) if foreign_key.dependent
+
             '  ' + parts.join(', ')
           end
 

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -226,6 +226,7 @@ HEADER
                      'primary_key: ' + foreign_key.primary_key.inspect,
                      'name: ' + foreign_key.name.inspect
                     ]
+            parts << ('on_update: ' + foreign_key.on_update.inspect) if foreign_key.on_update
             parts << ('on_delete: ' + foreign_key.on_delete.inspect) if foreign_key.on_delete
 
             '  ' + parts.join(', ')

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -171,6 +171,8 @@ HEADER
 
           indexes(table, tbl)
 
+          foreign_keys(table, tbl)
+
           tbl.rewind
           stream.print tbl.read
         rescue => e
@@ -208,6 +210,26 @@ HEADER
           end
 
           stream.puts add_index_statements.sort.join("\n")
+          stream.puts
+        end
+      end
+
+      def foreign_keys(table, stream)
+        return unless @connection.supports_foreign_keys?
+
+        if (foreign_keys = @connection.foreign_keys(table)).any?
+          add_foreign_key_statements = foreign_keys.map do |foreign_key|
+            parts = [
+                     'add_foreign_key ' + remove_prefix_and_suffix(foreign_key.from_table).inspect,
+                     remove_prefix_and_suffix(foreign_key.to_table).inspect,
+                     'column: ' + foreign_key.column.inspect,
+                     'primary_key: ' + foreign_key.primary_key.inspect,
+                     'name: ' + foreign_key.name.inspect
+                    ]
+            '  ' + parts.join(', ')
+          end
+
+          stream.puts add_foreign_key_statements.sort.join("\n")
           stream.puts
         end
       end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -226,10 +226,20 @@ HEADER
             parts = [
                      'add_foreign_key ' + remove_prefix_and_suffix(foreign_key.from_table).inspect,
                      remove_prefix_and_suffix(foreign_key.to_table).inspect,
-                     'column: ' + foreign_key.column.inspect,
-                     'primary_key: ' + foreign_key.primary_key.inspect,
-                     'name: ' + foreign_key.name.inspect
                     ]
+
+            if foreign_key.column != @connection.foreign_key_column_for(foreign_key.to_table)
+              parts << ('column: ' + foreign_key.column.inspect)
+            end
+
+            if foreign_key.custom_primary_key?
+              parts << ('primary_key: ' + foreign_key.primary_key.inspect)
+            end
+
+            if foreign_key.name !~ /^fk_rails_[0-9a-f]{10}$/
+              parts << ('name: ' + foreign_key.name.inspect)
+            end
+
             parts << ('on_update: ' + foreign_key.on_update.inspect) if foreign_key.on_update
             parts << ('on_delete: ' + foreign_key.on_delete.inspect) if foreign_key.on_delete
 

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -271,6 +271,11 @@ module ActiveRecord
         assert_equal [:enable_extension, ['uuid-ossp'], nil], enable
       end
 
+      def test_invert_add_foreign_key
+        enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people]
+        assert_equal [:remove_foreign_key, [:dogs, :people]], enable
+      end
+
       def test_invert_add_foreign_key_with_column
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people, column: "owner_id"]
         assert_equal [:remove_foreign_key, [:dogs, column: "owner_id"]], enable

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -270,6 +270,26 @@ module ActiveRecord
         enable = @recorder.inverse_of :disable_extension, ['uuid-ossp']
         assert_equal [:enable_extension, ['uuid-ossp'], nil], enable
       end
+
+      def test_invert_add_foreign_key_with_column
+        enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people, column: "owner_id"]
+        assert_equal [:remove_foreign_key, [:dogs, column: "owner_id"]], enable
+      end
+
+      def test_invert_add_foreign_key_with_column_and_name
+        enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people, column: "owner_id", name: "fk"]
+        assert_equal [:remove_foreign_key, [:dogs, name: "fk"]], enable
+      end
+
+      def test_remove_foreign_key_is_irreversible
+        assert_raises ActiveRecord::IrreversibleMigration do
+          @recorder.inverse_of :remove_foreign_key, [:dogs, column: "owner_id"]
+        end
+
+        assert_raises ActiveRecord::IrreversibleMigration do
+          @recorder.inverse_of :remove_foreign_key, [:dogs, name: "fk"]
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -126,6 +126,16 @@ module ActiveRecord
         assert_equal :nullify, fk.on_delete
       end
 
+      def test_add_foreign_key_with_on_update
+        @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", on_update: :nullify
+
+        foreign_keys = @connection.foreign_keys("astronauts")
+        assert_equal 1, foreign_keys.size
+
+        fk = foreign_keys.first
+        assert_equal :nullify, fk.on_update
+      end
+
       def test_remove_foreign_key_inferes_column
         @connection.add_foreign_key :astronauts, :rockets
 
@@ -155,11 +165,11 @@ module ActiveRecord
         assert_match %r{\s+add_foreign_key "fk_test_has_fk", "fk_test_has_pk", column: "fk_id", primary_key: "id", name: "fk_name"$}, output
       end
 
-      def test_schema_dumping_on_delete_option
-        @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", on_delete: :nullify
+      def test_schema_dumping_on_delete_and_on_update_options
+        @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", on_delete: :nullify, on_update: :cascade
 
         output = dump_table_schema "astronauts"
-        assert_match %r{\s+add_foreign_key "astronauts",.+on_delete: :nullify$}, output
+        assert_match %r{\s+add_foreign_key "astronauts",.+on_update: :cascade,.+on_delete: :nullify$}, output
       end
 
       class CreateCitiesAndHousesMigration < ActiveRecord::Migration

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -42,7 +42,7 @@ module ActiveRecord
         assert_equal "fk_test_has_fk", fk.from_table
         assert_equal "fk_test_has_pk", fk.to_table
         assert_equal "fk_id", fk.column
-        assert_equal "id", fk.primary_key
+        assert_equal "pk_id", fk.primary_key
         assert_equal "fk_name", fk.name
       end
 
@@ -57,7 +57,7 @@ module ActiveRecord
         assert_equal "rockets", fk.to_table
         assert_equal "rocket_id", fk.column
         assert_equal "id", fk.primary_key
-        assert_equal "astronauts_rocket_id_fk", fk.name
+        assert_match(/^fk_rails_.{10}$/, fk.name)
       end
 
       def test_add_foreign_key_with_column
@@ -71,7 +71,7 @@ module ActiveRecord
         assert_equal "rockets", fk.to_table
         assert_equal "rocket_id", fk.column
         assert_equal "id", fk.primary_key
-        assert_equal "astronauts_rocket_id_fk", fk.name
+        assert_match(/^fk_rails_.{10}$/, fk.name)
       end
 
       def test_add_foreign_key_with_non_standard_primary_key
@@ -146,15 +146,6 @@ module ActiveRecord
         assert_equal :nullify, fk.on_update
       end
 
-      def test_add_foreign_key_with_too_long_identifier
-        with_example_table @connection, "long_table_name_will_result_in_a_long_foreign_key_name", "rocket_id integer" do
-          e = assert_raises(ArgumentError) do
-            @connection.add_foreign_key "long_table_name_will_result_in_a_long_foreign_key_name", "rockets"
-          end
-          assert_match(/^Foreign key name 'long_table_name_will_result_in_a_long_foreign_key_name_rocket_id_fk' is too long;/, e.message)
-        end
-      end
-
       def test_remove_foreign_key_inferes_column
         @connection.add_foreign_key :astronauts, :rockets
 
@@ -179,9 +170,21 @@ module ActiveRecord
         assert_equal [], @connection.foreign_keys("astronauts")
       end
 
+      def test_remove_foreign_non_existing_foreign_key_raises
+        assert_raises ArgumentError do
+          @connection.remove_foreign_key :astronauts, :rockets
+        end
+      end
+
       def test_schema_dumping
+        @connection.add_foreign_key :astronauts, :rockets
+        output = dump_table_schema "astronauts"
+        assert_match %r{\s+add_foreign_key "astronauts", "rockets"$}, output
+      end
+
+      def test_schema_dumping_with_options
         output = dump_table_schema "fk_test_has_fk"
-        assert_match %r{\s+add_foreign_key "fk_test_has_fk", "fk_test_has_pk", column: "fk_id", primary_key: "id", name: "fk_name"$}, output
+        assert_match %r{\s+add_foreign_key "fk_test_has_fk", "fk_test_has_pk", column: "fk_id", primary_key: "pk_id", name: "fk_name"$}, output
       end
 
       def test_schema_dumping_on_delete_and_on_update_options
@@ -205,7 +208,7 @@ module ActiveRecord
       def test_add_foreign_key_is_reversible
         migration = CreateCitiesAndHousesMigration.new
         silence_stream($stdout) { migration.migrate(:up) }
-        assert_equal ["houses_city_id_fk"], @connection.foreign_keys("houses").map(&:name)
+        assert_equal 1, @connection.foreign_keys("houses").size
       ensure
         silence_stream($stdout) { migration.migrate(:down) }
       end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -1,0 +1,49 @@
+require 'cases/helper'
+
+if ActiveRecord::Base.connection.supports_foreign_keys?
+module ActiveRecord
+  class Migration
+    class ForeignKeyTest < ActiveRecord::TestCase
+      class Rocket < ActiveRecord::Base
+      end
+
+      class Astronaut < ActiveRecord::Base
+      end
+
+      setup do
+        @connection = ActiveRecord::Base.connection
+        @connection.create_table "rockets" do |t|
+          t.string :name
+        end
+
+        @connection.create_table "astronauts" do |t|
+          t.string :name
+          t.references :rocket
+        end
+      end
+
+      def test_add_foreign_key
+        @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id"
+
+        assert_raises ActiveRecord::InvalidForeignKey do
+          Astronaut.create rocket_id: 33
+        end
+      end
+
+      def test_remove_foreign_key
+        @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id"
+        @connection.remove_foreign_key :astronauts, column: "rocket_id"
+
+        Astronaut.create rocket_id: 33
+      end
+
+      def test_remove_foreign_key_by_name
+        @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", name: "fancy_named_fk"
+        @connection.remove_foreign_key :astronauts, name: "fancy_named_fk"
+
+        Astronaut.create rocket_id: 33
+      end
+    end
+  end
+end
+end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -202,4 +202,28 @@ module ActiveRecord
     end
   end
 end
+else
+module ActiveRecord
+  class Migration
+    class NoForeignKeySupportTest < ActiveRecord::TestCase
+      setup do
+        @connection = ActiveRecord::Base.connection
+      end
+
+      def test_add_foreign_key_should_be_noop
+        @connection.add_foreign_key :clubs, :categories
+      end
+
+      def test_remove_foreign_key_should_be_noop
+        @connection.remove_foreign_key :clubs, :categories
+      end
+
+      def test_foreign_keys_should_raise_not_implemented
+        assert_raises NotImplementedError do
+          @connection.foreign_keys("clubs")
+        end
+      end
+    end
+  end
+end
 end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -23,8 +23,10 @@ module ActiveRecord
       end
 
       teardown do
-        @connection.execute "DROP TABLE IF EXISTS astronauts"
-        @connection.execute "DROP TABLE IF EXISTS rockets"
+        if defined?(@connection)
+          @connection.execute "DROP TABLE IF EXISTS astronauts"
+          @connection.execute "DROP TABLE IF EXISTS rockets"
+        end
       end
 
       def test_foreign_keys

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -126,6 +126,16 @@ module ActiveRecord
         assert_equal :nullify, fk.on_delete
       end
 
+      def test_on_update_and_on_delete_raises_with_invalid_values
+        assert_raises ArgumentError do
+          @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", on_delete: :invalid
+        end
+
+        assert_raises ArgumentError do
+          @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", on_update: :invalid
+        end
+      end
+
       def test_add_foreign_key_with_on_update
         @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", on_update: :nullify
 

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -139,6 +139,25 @@ module ActiveRecord
         output = dump_table_schema "astronauts"
         assert_match %r{\s+add_foreign_key "astronauts",.+dependent: :nullify$}, output
       end
+
+      class CreateCitiesAndHousesMigration < ActiveRecord::Migration
+        def change
+          create_table("cities") { |t| }
+
+          create_table("houses") do |t|
+            t.column :city_id, :integer
+          end
+          add_foreign_key :houses, :cities, column: "city_id"
+        end
+      end
+
+      def test_add_foreign_key_is_reversible
+        migration = CreateCitiesAndHousesMigration.new
+        silence_stream($stdout) { migration.migrate(:up) }
+        assert_equal ["houses_city_id_fk"], @connection.foreign_keys("houses").map(&:name)
+      ensure
+        silence_stream($stdout) { migration.migrate(:down) }
+      end
     end
   end
 end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -91,8 +91,8 @@ module ActiveRecord
         end
       end
 
-      def test_add_dependent_restrict_foreign_key
-        @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", dependent: :restrict
+      def test_add_on_delete_restrict_foreign_key
+        @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", on_delete: :restrict
 
         foreign_keys = @connection.foreign_keys("astronauts")
         assert_equal 1, foreign_keys.size
@@ -100,30 +100,30 @@ module ActiveRecord
         fk = foreign_keys.first
         if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
           # ON DELETE RESTRICT is the default on MySQL
-          assert_equal nil, fk.dependent
+          assert_equal nil, fk.on_delete
         else
-          assert_equal :restrict, fk.dependent
+          assert_equal :restrict, fk.on_delete
         end
       end
 
-      def test_add_dependent_delete_foreign_key
-        @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", dependent: :delete
+      def test_add_on_delete_cascade_foreign_key
+        @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", on_delete: :cascade
 
         foreign_keys = @connection.foreign_keys("astronauts")
         assert_equal 1, foreign_keys.size
 
         fk = foreign_keys.first
-        assert_equal :delete, fk.dependent
+        assert_equal :cascade, fk.on_delete
       end
 
-      def test_add_dependent_nullify_foreign_key
-        @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", dependent: :nullify
+      def test_add_on_delete_nullify_foreign_key
+        @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", on_delete: :nullify
 
         foreign_keys = @connection.foreign_keys("astronauts")
         assert_equal 1, foreign_keys.size
 
         fk = foreign_keys.first
-        assert_equal :nullify, fk.dependent
+        assert_equal :nullify, fk.on_delete
       end
 
       def test_remove_foreign_key_inferes_column
@@ -155,11 +155,11 @@ module ActiveRecord
         assert_match %r{\s+add_foreign_key "fk_test_has_fk", "fk_test_has_pk", column: "fk_id", primary_key: "id", name: "fk_name"$}, output
       end
 
-      def test_schema_dumping_dependent_option
-        @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", dependent: :nullify
+      def test_schema_dumping_on_delete_option
+        @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", on_delete: :nullify
 
         output = dump_table_schema "astronauts"
-        assert_match %r{\s+add_foreign_key "astronauts",.+dependent: :nullify$}, output
+        assert_match %r{\s+add_foreign_key "astronauts",.+on_delete: :nullify$}, output
       end
 
       class CreateCitiesAndHousesMigration < ActiveRecord::Migration

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -22,26 +22,46 @@ module ActiveRecord
         end
       end
 
+      def test_foreign_keys
+        foreign_keys = @connection.foreign_keys("fk_test_has_fk")
+        assert_equal 1, foreign_keys.size
+
+        fk = foreign_keys.first
+        assert_equal "fk_test_has_fk", fk.from_table
+        assert_equal "fk_test_has_pk", fk.to_table
+        assert_equal "fk_id", fk.column
+        assert_equal "id", fk.primary_key
+        assert_equal "fk_name", fk.name
+      end
+
       def test_add_foreign_key
         @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id"
 
-        assert_raises ActiveRecord::InvalidForeignKey do
-          Astronaut.create rocket_id: 33
-        end
+        foreign_keys = @connection.foreign_keys("astronauts")
+        assert_equal 1, foreign_keys.size
+
+        fk = foreign_keys.first
+        assert_equal "astronauts", fk.from_table
+        assert_equal "rockets", fk.to_table
+        assert_equal "rocket_id", fk.column
+        assert_equal "id", fk.primary_key
+        assert_equal "astronauts_rocket_id_fk", fk.name
       end
 
       def test_remove_foreign_key
         @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id"
-        @connection.remove_foreign_key :astronauts, column: "rocket_id"
 
-        Astronaut.create rocket_id: 33
+        assert_equal 1, @connection.foreign_keys("astronauts").size
+        @connection.remove_foreign_key :astronauts, column: "rocket_id"
+        assert_equal [], @connection.foreign_keys("astronauts")
       end
 
       def test_remove_foreign_key_by_name
         @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", name: "fancy_named_fk"
-        @connection.remove_foreign_key :astronauts, name: "fancy_named_fk"
 
-        Astronaut.create rocket_id: 33
+        assert_equal 1, @connection.foreign_keys("astronauts").size
+        @connection.remove_foreign_key :astronauts, name: "fancy_named_fk"
+        assert_equal [], @connection.foreign_keys("astronauts")
       end
     end
   end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -1,11 +1,13 @@
 require 'cases/helper'
 require 'support/ddl_helper'
+require 'support/schema_dumping_helper'
 
 if ActiveRecord::Base.connection.supports_foreign_keys?
 module ActiveRecord
   class Migration
     class ForeignKeyTest < ActiveRecord::TestCase
       include DdlHelper
+      include SchemaDumpingHelper
 
       class Rocket < ActiveRecord::Base
       end
@@ -89,6 +91,11 @@ module ActiveRecord
         assert_equal 1, @connection.foreign_keys("astronauts").size
         @connection.remove_foreign_key :astronauts, name: "fancy_named_fk"
         assert_equal [], @connection.foreign_keys("astronauts")
+      end
+
+      def test_schema_dumping
+        output = dump_table_schema "fk_test_has_fk"
+        assert_match %r{\s+add_foreign_key "fk_test_has_fk", "fk_test_has_pk", column: "fk_id", primary_key: "id", name: "fk_name"$}, output
       end
     end
   end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -136,6 +136,15 @@ module ActiveRecord
         assert_equal :nullify, fk.on_update
       end
 
+      def test_add_foreign_key_with_too_long_identifier
+        with_example_table @connection, "long_table_name_will_result_in_a_long_foreign_key_name", "rocket_id integer" do
+          e = assert_raises(ArgumentError) do
+            @connection.add_foreign_key "long_table_name_will_result_in_a_long_foreign_key_name", "rockets"
+          end
+          assert_match(/^Foreign key name 'long_table_name_will_result_in_a_long_foreign_key_name_rocket_id_fk' is too long;/, e.message)
+        end
+      end
+
       def test_remove_foreign_key_inferes_column
         @connection.add_foreign_key :astronauts, :rockets
 

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -46,7 +46,21 @@ module ActiveRecord
         assert_equal "fk_name", fk.name
       end
 
-      def test_add_foreign_key
+      def test_add_foreign_key_inferes_column
+        @connection.add_foreign_key :astronauts, :rockets
+
+        foreign_keys = @connection.foreign_keys("astronauts")
+        assert_equal 1, foreign_keys.size
+
+        fk = foreign_keys.first
+        assert_equal "astronauts", fk.from_table
+        assert_equal "rockets", fk.to_table
+        assert_equal "rocket_id", fk.column
+        assert_equal "id", fk.primary_key
+        assert_equal "astronauts_rocket_id_fk", fk.name
+      end
+
+      def test_add_foreign_key_with_column
         @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id"
 
         foreign_keys = @connection.foreign_keys("astronauts")
@@ -112,7 +126,15 @@ module ActiveRecord
         assert_equal :nullify, fk.dependent
       end
 
-      def test_remove_foreign_key
+      def test_remove_foreign_key_inferes_column
+        @connection.add_foreign_key :astronauts, :rockets
+
+        assert_equal 1, @connection.foreign_keys("astronauts").size
+        @connection.remove_foreign_key :astronauts, :rockets
+        assert_equal [], @connection.foreign_keys("astronauts")
+      end
+
+      def test_remove_foreign_key_by_column
         @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id"
 
         assert_equal 1, @connection.foreign_keys("astronauts").size

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -22,6 +22,11 @@ module ActiveRecord
         end
       end
 
+      teardown do
+        @connection.execute "DROP TABLE IF EXISTS astronauts"
+        @connection.execute "DROP TABLE IF EXISTS rockets"
+      end
+
       def test_foreign_keys
         foreign_keys = @connection.foreign_keys("fk_test_has_fk")
         assert_equal 1, foreign_keys.size

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -372,6 +372,13 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_match %r{create_table "subscribers", id: false}, output
   end
 
+  if ActiveRecord::Base.connection.supports_foreign_keys?
+    def test_foreign_keys_are_dumped_at_the_bottom_to_circumvent_dependency_issues
+      output = standard_dump
+      assert_match(/^\s+add_foreign_key "fk_test_has_fk"[^\n]+\n\s+add_foreign_key "lessons_students"/, output)
+    end
+  end
+
   class CreateDogMigration < ActiveRecord::Migration
     def up
       create_table("dog_owners") do |t|

--- a/activerecord/test/fixtures/fk_test_has_pk.yml
+++ b/activerecord/test/fixtures/fk_test_has_pk.yml
@@ -1,2 +1,2 @@
 first:
-  id: 1
+  pk_id: 1

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -855,10 +855,10 @@ ActiveRecord::Schema.define do
       t.integer :fk_id, null: false
     end
 
-    create_table :fk_test_has_pk, force: true do |t|
+    create_table :fk_test_has_pk, force: true, primary_key: "pk_id" do |t|
     end
 
-    execute "ALTER TABLE fk_test_has_fk ADD CONSTRAINT fk_name FOREIGN KEY (#{quote_column_name 'fk_id'}) REFERENCES #{quote_table_name 'fk_test_has_pk'} (#{quote_column_name 'id'})"
+    execute "ALTER TABLE fk_test_has_fk ADD CONSTRAINT fk_name FOREIGN KEY (#{quote_column_name 'fk_id'}) REFERENCES #{quote_table_name 'fk_test_has_pk'} (#{quote_column_name 'pk_id'})"
 
     execute "ALTER TABLE lessons_students ADD CONSTRAINT student_id_fk FOREIGN KEY (#{quote_column_name 'student_id'}) REFERENCES #{quote_table_name 'students'} (#{quote_column_name 'id'})"
   end

--- a/activerecord/test/schema/sqlite_specific_schema.rb
+++ b/activerecord/test/schema/sqlite_specific_schema.rb
@@ -7,7 +7,7 @@ ActiveRecord::Schema.define do
   execute "DROP TABLE fk_test_has_pk" rescue nil
   execute <<_SQL
   CREATE TABLE 'fk_test_has_pk' (
-    'id' INTEGER NOT NULL PRIMARY KEY
+    'pk_id' INTEGER NOT NULL PRIMARY KEY
   );
 _SQL
 
@@ -16,7 +16,7 @@ _SQL
     'id'    INTEGER NOT NULL PRIMARY KEY,
     'fk_id' INTEGER NOT NULL,
 
-    FOREIGN KEY ('fk_id') REFERENCES 'fk_test_has_pk'('id')
+    FOREIGN KEY ('fk_id') REFERENCES 'fk_test_has_pk'('pk_id')
   );
 _SQL
 end

--- a/activerecord/test/support/ddl_helper.rb
+++ b/activerecord/test/support/ddl_helper.rb
@@ -1,8 +1,8 @@
 module DdlHelper
   def with_example_table(connection, table_name, definition = nil)
-    connection.exec_query("CREATE TABLE #{table_name}(#{definition})")
+    connection.execute("CREATE TABLE #{table_name}(#{definition})")
     yield
   ensure
-    connection.exec_query("DROP TABLE #{table_name}")
+    connection.execute("DROP TABLE #{table_name}")
   end
 end

--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -25,6 +25,31 @@ guide.
 Major Features
 --------------
 
+### Foreign key support
+
+The migration DSL now supports adding and removing foreign keys. They are dumped
+to `schema.rb` as well. At this time, only the `mysql`, `mysql2` and `postgresql`
+adapters support foreign keys.
+
+```ruby
+# add a foreign key to `articles.author_id` referencing `authors.id`
+add_foreign_key :articles, :authors
+
+# add a foreign key to `articles.author_id` referencing `users.lng_id`
+add_foreign_key :articles, :users, column: :author_id, primary_key: "lng_id"
+
+# remove the foreign key on `accounts.branch_id`
+remove_foreign_key :accounts, :branches
+
+# remove the foreign key on `accounts.owner_id`
+remove_foreign_key :accounts, column: :owner_id
+```
+
+See the API documentation on
+[add_foreign_key](http://api.rubyonrails.org/v4.2.0/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_foreign_key)
+and
+[remove_foreign_key](http://api.rubyonrails.org/v4.2.0/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-remove_foreign_key)
+for a full description.
 
 
 Railties


### PR DESCRIPTION
We had this as a GSoC idea but there was no accepted student to work on it. Because I was really looking forward to see this in `rails/rails` I made a first draft.

This patch adds basic support for adding and removing foreign keys using the migration DSL:

``` ruby
add_foreign_key :from, :to # will add the key to `to_id`
add_foreign_key :from, :to, column: "fk_id" # with specific column

add_foreign_key :from, :to, on_delete: :restrict # to specify ON DELETE RESTRICT
add_foreign_key :from, :to, on_delete: :cascade # to specify ON DELETE CASCADE
add_foreign_key :from, :to, on_delete: :nullify # to specify ON DELETE SET NULL

add_foreign_key :from, :to, on_update: :cascade # to specify ON UPDATE CASCADE
add_foreign_key :from, :to, on_update: :nullify # to specify ON UPDATE SET NULL

add_foreign_key :from, :to, name: "my_fk" # with specific name
add_foreign_key :from, :to, primary_key: "special_pk" # will reference `special_pk` from `:to`
```

Removing a foreign key works mostly the same:

``` ruby
remove_foreign_key :from, :to # will remove foreign key on `to_id`
remove_foreign_key :from, column: "fk_id" # will remove foreign key on `fk_id`
remove_foreign_key :from, name: "my_fk" # will remove foreign key named `my_fk`
```

Foreign keys are dumped after the indexes to `schema.rb`. The options `name` and `column` are always dumped. `dependent` only when set.

`add_foreign_key` is reversible, `remove_foreign_key` is not.

There is a `connection#supports_foreign_keys?` method to determine wether the adapter does support the API.
### TODO:
- [x] Write documentation
- [x] Decide wether `add-/remove_foreign_key` should be no-op when `supports_foreign_keys?` is `false`
- [x] Make sure it works with automatic test schema maintenance (#15394)
- [x] Schema dumping must ensure the tables are created in the right order
- [x] Handle long identifiers.
- [x] rename dependent to `on_delete` and introduce `on_update`
- [x] rename when a table / column is renamed. (because of digest names, this is no longer needed)
### Future Work (not this PR):
- Support foreign keys when creating a table (This would allow SQLite to use FK's as well)

This patch was hugely inspired by `foreigner`. Credits to @matthuhiggins :heart:
