### PR TITLE
Keep the types of virtual columns after yaml serialization

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         ISO_DATETIME = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(\.\d+)?\z/
       end
 
-      attr_reader :name, :cast_type, :null, :sql_type, :default_function
+      attr_reader :name, :cast_type, :sql_type, :default_function
 
       delegate :type, :precision, :scale, :limit, :klass, :accessor,
         :text?, :number?, :binary?, :serialized?, :changed?,
@@ -34,7 +34,7 @@ module ActiveRecord
         @name             = name
         @cast_type        = cast_type
         @sql_type         = sql_type
-        @null             = null
+        @nullable         = null
         @original_default = default
         @default_function = nil
       end
@@ -60,6 +60,10 @@ module ActiveRecord
           clone.instance_variable_set('@default', nil)
           clone.instance_variable_set('@cast_type', type)
         end
+      end
+
+      def null
+        @nullable
       end
     end
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -356,6 +356,7 @@ module ActiveRecord
     def encode_with(coder)
       coder['raw_attributes'] = @raw_attributes
       coder['attributes'] = @attributes
+      coder['column_types'] = @column_types_override
       coder['new_record'] = new_record?
     end
 

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -36,6 +36,17 @@ module ActiveRecord
         ActiveRecord::Store::IndifferentHashAccessor
       end
 
+      def init_with(coder)
+        @subtype = coder['subtype']
+        @coder = coder['coder']
+        __setobj__(@subtype)
+      end
+
+      def encode_with(coder)
+        coder['subtype'] = @subtype
+        coder['coder'] = @coder
+      end
+
       private
 
       def is_default_value?(value)


### PR DESCRIPTION
On MySQL and PostgreSQL, the adapter does not type cast virtual columns
for us.
