### PR TITLE
Fix warnings in tests

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -156,7 +156,7 @@ _SQL
       assert_equal 0.5..0.7, @first_range.float_range
       assert_equal 0.5...0.7, @second_range.float_range
       assert_equal 0.5...Float::INFINITY, @third_range.float_range
-      assert_equal (-Float::INFINITY...Float::INFINITY), @fourth_range.float_range
+      assert_equal(-Float::INFINITY...Float::INFINITY, @fourth_range.float_range)
       assert_nil @empty_range.float_range
     end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -34,10 +34,10 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_find_with_proc_parameter_and_block
-    e = assert_raises(RuntimeError) do
+    exception = assert_raises(RuntimeError) do
       Topic.all.find(-> { raise "should happen" }) { |e| e.title == "non-existing-title" }
     end
-    assert_equal "should happen", e.message
+    assert_equal "should happen", exception.message
 
     assert_nothing_raised(RuntimeError) do
       Topic.all.find(-> { raise "should not happen" }) { |e| e.title == topics(:first).title }


### PR DESCRIPTION
```
activerecord/test/cases/adapters/postgresql/range_test.rb:159: warning: (...) interpreted as grouped expression
activerecord/test/cases/finder_test.rb:38: warning: shadowing outer local variable - e
activerecord/test/cases/finder_test.rb:43: warning: shadowing outer local variable - e
```
