### PR TITLE
No need to decorate columns twice

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -48,7 +48,6 @@ module ActiveRecord
       # how this "single-table" inheritance mapping is implemented.
       def instantiate(attributes, column_types = {})
         klass = discriminate_class_for_record(attributes)
-        column_types = klass.decorate_columns(column_types.dup)
         klass.allocate.init_with(
           'raw_attributes' => attributes,
           'column_types' => column_types,

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -40,7 +40,7 @@ module ActiveRecord
       column_types = {}
 
       if result_set.respond_to? :column_types
-        column_types = result_set.column_types.merge(columns_hash)
+        column_types = result_set.column_types.except(*columns_hash.keys)
       else
         ActiveSupport::Deprecation.warn "the object returned from `select_all` must respond to `column_types`"
       end


### PR DESCRIPTION
We never want result types to override column types, and
`decorate_columns` can only affect column types. No need to go through
the decoration multiple times, we can just exclude the column types from
the result types instead.
