### PR TITLE
begin refactoring add_constraints by moving join keys

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -105,18 +105,9 @@ module ActiveRecord
         chain.each_with_index do |reflection, i|
           table, foreign_table = tables.shift, tables.first
 
-          if reflection.source_macro == :belongs_to
-            if reflection.polymorphic?
-              key = reflection.association_primary_key(assoc_klass)
-            else
-              key = reflection.association_primary_key
-            end
-
-            foreign_key = reflection.foreign_key
-          else
-            key         = reflection.foreign_key
-            foreign_key = reflection.active_record_primary_key
-          end
+          join_keys = reflection.join_keys(assoc_klass)
+          key = join_keys.key
+          foreign_key = join_keys.foreign_key
 
           if reflection == chain.last
             bind_val = bind scope, table.table_name, key.to_s, owner[foreign_key], tracker

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -188,6 +188,23 @@ module ActiveRecord
           active_record == other_aggregation.active_record
       end
 
+      JoinKeys = Struct.new(:key, :foreign_key) # :nodoc:
+
+      def join_keys(assoc_klass)
+        if source_macro == :belongs_to
+          if polymorphic?
+            reflection_key = association_primary_key(assoc_klass)
+          else
+            reflection_key = association_primary_key
+          end
+          reflection_foreign_key = foreign_key
+        else
+          reflection_key = foreign_key
+          reflection_foreign_key = active_record_primary_key
+        end
+        JoinKeys.new(reflection_key, reflection_foreign_key)
+      end
+
       private
         def derive_class_name
           name.to_s.camelize


### PR DESCRIPTION
add_constraints is complicated and difficult to read code. This is the beginning of a long process of refactoring. First step: moved the join keys out of AssociationScope and into Reflection.

We then don't need to call `reflection` because now reflection is `self`.

`foreign_key` must be named something else because reflection already has a `foreign_key` method and when passed into `JoinKeys` it was getting the wrong assignment. `reflection_foreign_key` seemed to be an appropriate name. I also named `key` `reflection_key` to match `reflection_foreign_key`.

cc/ @tenderlove
