### PR TITLE
Prevent time field converting zones in changes 'was'

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -58,8 +58,6 @@ module ActiveRecord
           @changed_attributes.delete(attr) unless _field_changed?(attr, old, value)
         else
           old = clone_attribute_value(:read_attribute, attr)
-          # Save Time objects as TimeWithZone if time_zone_aware_attributes == true
-          old = old.in_time_zone if clone_with_time_zone_conversion_attribute?(attr, old)
           @changed_attributes[attr] = old if _field_changed?(attr, old, value)
         end
 
@@ -90,9 +88,6 @@ module ActiveRecord
         old != value
       end
 
-      def clone_with_time_zone_conversion_attribute?(attr, old)
-        old.class.name == "Time" && time_zone_aware_attributes && !self.skip_time_zone_conversion_for_attributes.include?(attr.to_sym)
-      end
 
       def changes_from_nil_to_empty_string?(column, old, value)
         # For nullable numeric columns, NULL gets stored in database for blank (i.e. '') values.

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -121,7 +121,7 @@ class DirtyTest < ActiveRecord::TestCase
     end
   end
 
-  def test_time_attributes_changes_without_time_zone
+  def test_datetime_attributes_changes_without_time_zone
 
     target = Class.new(ActiveRecord::Base)
     target.table_name = 'pirates'

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -565,6 +565,19 @@ class DirtyTest < ActiveRecord::TestCase
     end
   end
 
+  def test_time_attributes_do_not_convert_zone
+    in_time_zone 'Paris' do
+      topic = Topic.new(:bonus_time => Time.now)
+      original_bonus_time = topic.bonus_time
+      topic.save!
+
+      topic.bonus_time = Time.now + 1.day
+      assert topic.bonus_time_changed?
+      assert_equal original_bonus_time, topic.bonus_time_was
+      assert_equal original_bonus_time.zone, topic.bonus_time_was.zone
+    end
+  end
+
   private
     def with_partial_updates(klass, on = true)
       old = klass.partial_updates?


### PR DESCRIPTION
When changing "Time" attributes the old '_was' value (e.g. bonus_time_was) will be converted based on zone.  However, in all other cases "Time" attributes do not convert zones.

The expected behaviour is to NOT convert zones due to variations across dates, even within a single zone -- see more discussion here: https://github.com/rails/rails/issues/3145#issuecomment-5400841 

Original commit added here: https://github.com/rails/rails/commit/36129f21b86db4bd69e932e586129e246c2a5ca8

```
Dirty datetime attributes should be aware of time zone info
```

Then later removed in commit slated for rails 4.(?) https://github.com/rails/rails/commit/cb400b0c654e62c99dca1faf052c9389c58d692c 

```
remove unnecessary code
it was added in 36129f2
but isn't useful anymore as corresponding tests pass without it
```

I've made the PR to rails 3-2-stable since rails 4+ seems to have rearranged the dirty.rb file considerably.
