### PR TITLE
Remove YAML serialization workaround for columns

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         ISO_DATETIME = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(\.\d+)?\z/
       end
 
-      attr_reader :name, :cast_type, :sql_type, :default_function
+      attr_reader :name, :cast_type, :null, :sql_type, :default_function
 
       delegate :type, :precision, :scale, :limit, :klass, :accessor,
         :text?, :number?, :binary?, :serialized?, :changed?,
@@ -34,7 +34,7 @@ module ActiveRecord
         @name             = name
         @cast_type        = cast_type
         @sql_type         = sql_type
-        @nullable         = null
+        @null             = null
         @original_default = default
         @default_function = nil
       end
@@ -60,10 +60,6 @@ module ActiveRecord
           clone.instance_variable_set('@default', nil)
           clone.instance_variable_set('@cast_type', type)
         end
-      end
-
-      def null
-        @nullable
       end
     end
 


### PR DESCRIPTION
We are no longer including column objects in YAML serialization, thanks
to https://github.com/rails/rails/pull/15621
