### PR TITLE
Pluck should work with columns of the same name from different tables

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Pluck now works when selecting columns from different tables with the same
+    name.
+
+    Fixes #15649
+
+    *Sean Griffin*
+
 *   Remove `cache_attributes` and friends. All attributes are cached.
 
     *Sean Griffin*

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -176,9 +176,7 @@ module ActiveRecord
           }
         end
 
-        result = result.map do |attributes|
-          values = attributes.values
-
+        result = result.rows.map do |values|
           columns.zip(values).map { |column, value| column.type_cast_from_database value }
         end
         columns.one? ? result.map!(&:first) : result

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -610,4 +610,11 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal [1,2,3,4,5], taks_relation.pluck(:id)
     assert_equal [false, true, true, true, true], taks_relation.pluck(:approved)
   end
+
+  def test_pluck_columns_with_same_name
+    expected = [["The First Topic", "The Second Topic of the day"], ["The Third Topic of the day", "The Fourth Topic of the day"]]
+    actual = Topic.joins(:replies)
+      .pluck('topics.title', 'replies_topics.title')
+    assert_equal expected, actual
+  end
 end


### PR DESCRIPTION
The column name given by the adapter doesn't include the table
namespace, so going through the hashed version of the result set causes
overridden keys.

Fixes #15649
