### PR TITLE
In tag helper, honor html_safe on arrays; also make safe_join more similar to Array.join

### DIFF
--- a/actionview/lib/action_view/helpers/output_safety_helper.rb
+++ b/actionview/lib/action_view/helpers/output_safety_helper.rb
@@ -18,9 +18,9 @@ module ActionView #:nodoc:
       end
 
       # This method returns a html safe string similar to what <tt>Array#join</tt>
-      # would return. All items in the array, including the supplied separator, are
-      # html escaped unless they are html safe, and the returned string is marked
-      # as html safe.
+      # would return. The array is flattened, and all items, including
+      # the supplied separator, are html escaped unless they are html
+      # safe, and the returned string is marked as html safe.
       #
       #   safe_join(["<p>foo</p>".html_safe, "<p>bar</p>"], "<br />")
       #   # => "<p>foo</p>&lt;br /&gt;&lt;p&gt;bar&lt;/p&gt;"
@@ -31,7 +31,7 @@ module ActionView #:nodoc:
       def safe_join(array, sep=$,)
         sep = ERB::Util.unwrapped_html_escape(sep)
 
-        array.map { |i| ERB::Util.unwrapped_html_escape(i) }.join(sep).html_safe
+        array.flatten.map! { |i| ERB::Util.unwrapped_html_escape(i) }.join(sep).html_safe
       end
     end
   end

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -173,9 +173,21 @@ module ActionView
         end
 
         def tag_option(key, value, escape)
-          value = value.join(" ") if value.is_a?(Array)
-          value = ERB::Util.unwrapped_html_escape(value) if escape
-          %(#{key}="#{value}")
+          escaped_value = case value
+                          when Array
+                            if escape
+                              safe_join(value, " ")
+                            else
+                              value.join(" ")
+                            end
+                          else
+                            if escape
+                              ERB::Util.unwrapped_html_escape(value)
+                            else
+                              value
+                            end
+                          end
+          %(#{key}="#{escaped_value}")
         end
     end
   end

--- a/actionview/test/template/output_safety_helper_test.rb
+++ b/actionview/test/template/output_safety_helper_test.rb
@@ -25,4 +25,11 @@ class OutputSafetyHelperTest < ActionView::TestCase
     assert_equal "<p>foo</p><br /><p>bar</p>", joined
   end
 
+  test "safe_join should work recursively similarly to Array.join" do
+    joined = safe_join(['a',['b','c']], ':')
+    assert_equal 'a:b:c', joined
+
+    joined = safe_join(['"a"',['<b>','<c>']], ' <br/> ')
+    assert_equal '&quot;a&quot; &lt;br/&gt; &lt;b&gt; &lt;br/&gt; &lt;c&gt;', joined
+  end
 end

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -80,11 +80,27 @@ class TagHelperTest < ActionView::TestCase
 
     str = content_tag('p', "limelight", :class => ["song", "play"])
     assert_equal "<p class=\"song play\">limelight</p>", str
+
+    str = content_tag('p', "limelight", :class => ["song", ["play"]])
+    assert_equal "<p class=\"song play\">limelight</p>", str
   end
 
   def test_content_tag_with_unescaped_array_class
     str = content_tag('p', "limelight", {:class => ["song", "play>"]}, false)
     assert_equal "<p class=\"song play>\">limelight</p>", str
+
+    str = content_tag('p', "limelight", {:class => ["song", ["play>"]]}, false)
+    assert_equal "<p class=\"song play>\">limelight</p>", str
+  end
+
+  def test_content_tag_with_empty_array_class
+    str = content_tag('p', 'limelight', {:class => []})
+    assert_equal '<p class="">limelight</p>', str
+  end
+
+  def test_content_tag_with_unescaped_empty_array_class
+    str = content_tag('p', 'limelight', {:class => []}, false)
+    assert_equal '<p class="">limelight</p>', str
   end
 
   def test_content_tag_with_data_attributes
@@ -113,6 +129,14 @@ class TagHelperTest < ActionView::TestCase
     ['1&amp;2', '1 &lt; 2', '&#8220;test&#8220;'].each do |escaped|
       assert_equal %(<a href="#{escaped}" />), tag('a', :href => escaped.html_safe)
     end
+  end
+
+  def test_tag_honors_html_safe_with_escaped_array_class
+    str = tag('p', :class => ['song>', 'play>'.html_safe])
+    assert_equal '<p class="song&gt; play>" />', str
+
+    str = tag('p', :class => ['song>'.html_safe, 'play>'])
+    assert_equal '<p class="song> play&gt;" />', str
   end
 
   def test_skip_invalid_escaped_attributes


### PR DESCRIPTION
Currently, the tag helper honors the html_safe on its parameter values, so you can do something like `tag('a', href: 'http://example.com?a&amp;b'.html_safe)`.  However, with array values (_e.g._ when supplying multiple classes) the strings are concatenated together with `Array#join` and escaped without regard to the prior `html_safe` status.  This patch resolves the inconsistent behavior, as demonstrated by several tests.  I have also included a test for the empty array, since that's an easy one to break if you do it wrong.

I can't actually see a valid use case for supplying `html_safe` string values; in my opinion people should just supply the raw string and not try to micromanage how Rails escapes strings when using these helpers.  However, as long as we are going to escape values sometimes, we should do it consistently.

**Update:** to get certain tests involving nested array parameters to pass, I had to update `safe_join` to be more similar to `Array.join`, calling `flatten` first.
