### PR TITLE
remove unnused method from test

### DIFF
--- a/railties/test/rails_info_test.rb
+++ b/railties/test/rails_info_test.rb
@@ -66,16 +66,6 @@ class InfoTest < ActiveSupport::TestCase
   end
 
   protected
-    def svn_info=(info)
-      Rails::Info.module_eval do
-        class << self
-          def svn_info
-            info
-          end
-        end
-      end
-    end
-
     def properties
       Rails::Info.properties
     end


### PR DESCRIPTION
Removes a method that is no longer used in railties/test/rails_info_test.rb
