### PR TITLE
Initialize `@raw_attributes` as `HashWithIndifferentAccess`

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -280,7 +280,7 @@ module ActiveRecord
     #   person.has_attribute?('age')    # => true
     #   person.has_attribute?(:nothing) # => false
     def has_attribute?(attr_name)
-      @raw_attributes.has_key?(attr_name.to_s)
+      @raw_attributes.has_key?(attr_name)
     end
 
     # Returns an array of names for the attributes available on this object.

--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -43,7 +43,7 @@ module ActiveRecord
       #   task.read_attribute_before_type_cast('completed_on') # => "2012-10-21"
       #   task.read_attribute_before_type_cast(:completed_on)  # => "2012-10-21"
       def read_attribute_before_type_cast(attr_name)
-        @raw_attributes[attr_name.to_s]
+        @raw_attributes[attr_name]
       end
 
       # Returns a hash of attributes before typecasting and deserialization.

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -252,7 +252,7 @@ module ActiveRecord
       defaults = self.class.raw_column_defaults.dup
       defaults.each { |k, v| defaults[k] = v.dup if v.duplicable? }
 
-      @raw_attributes = defaults
+      @raw_attributes = defaults.with_indifferent_access
       @column_types_override = nil
       @column_types = self.class.column_types
 
@@ -278,7 +278,7 @@ module ActiveRecord
     #   post.init_with('attributes' => { 'title' => 'hello world' })
     #   post.title # => 'hello world'
     def init_with(coder)
-      @raw_attributes = coder['raw_attributes']
+      @raw_attributes = coder['raw_attributes'].with_indifferent_access
       @column_types_override = coder['column_types']
       @column_types = self.class.column_types
 
@@ -325,7 +325,7 @@ module ActiveRecord
     def initialize_dup(other) # :nodoc:
       cloned_attributes = other.clone_attributes(:read_attribute_before_type_cast)
 
-      @raw_attributes = cloned_attributes
+      @raw_attributes = cloned_attributes.with_indifferent_access
       @raw_attributes[self.class.primary_key] = nil
       @attributes = other.clone_attributes(:read_attribute)
       @attributes[self.class.primary_key] = nil

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -68,7 +68,7 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
 
   def test_cast_value_on_write
     x = JsonDataType.new payload: {"string" => "foo", :symbol => :bar}
-    assert_equal({"string" => "foo", :symbol => :bar}, x.payload_before_type_cast)
+    assert_equal({"string" => "foo", "symbol" => :bar}, x.payload_before_type_cast)
     assert_equal({"string" => "foo", "symbol" => "bar"}, x.payload)
     x.save
     assert_equal({"string" => "foo", "symbol" => "bar"}, x.reload.payload)


### PR DESCRIPTION
- save `to_s` call on each `read_attribute_before_type_cast` call
