### PR TITLE
Fix request's path_info when a rack app mounted at '/'.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix env['PATH_INFO'] missing leading slash when a rack app mounted at '/'.
+
+    Fixes #15511.
+
+    *Larry Lv*
+
 *   ActionController::Parameters#require now accepts `false` values.
 
     Fixes #15685.

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -35,6 +35,7 @@ module ActionDispatch
           unless route.path.anchored
             req.script_name = (script_name.to_s + match.to_s).chomp('/')
             req.path_info = match.post_match
+            req.path_info = "/" + req.path_info unless req.path_info.start_with? "/"
           end
 
           req.path_parameters = set_params.merge parameters

--- a/actionpack/test/dispatch/mount_test.rb
+++ b/actionpack/test/dispatch/mount_test.rb
@@ -31,6 +31,8 @@ class TestRoutingMount < ActionDispatch::IntegrationTest
     resources :users do
       mount FakeEngine, :at => "/fakeengine", :as => :fake_mounted_at_resource
     end
+
+    mount SprocketsApp, :at => "/", :via => :get
   end
 
   def app
@@ -42,6 +44,11 @@ class TestRoutingMount < ActionDispatch::IntegrationTest
           "A mounted helper should be defined with a parent's prefix"
     assert Router.named_routes.routes[:user_fake_mounted_at_resource],
           "A named route should be defined with a parent's prefix"
+  end
+
+  def test_mounting_at_root_path
+    get "/omg"
+    assert_equal " -- /omg", response.body
   end
 
   def test_mounting_sets_script_name


### PR DESCRIPTION
When a rack app is mounted at '/', and we visit '/omg', the env['PATH_INFO'] will be 'omg' and be passed to the rack app. Then the rack app won't find the match path for 'omg'.

Tests with https://gist.github.com/Peeja/de5ce3ea12b264aaf792 has passed.

Fixes issue #15511.

cc @Peeja
