### PR TITLE
Removed variable shawdowing warning in actionpack url.rb

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -92,8 +92,8 @@ module ActionDispatch
           end
 
           result << host
-          normalize_port(port, protocol) { |port|
-            result << ":#{port}"
+          normalize_port(port, protocol) { |normalized_port|
+            result << ":#{normalized_port}"
           }
 
           result


### PR DESCRIPTION
Introduced in a64914d.

Before:

/Users/Juan/dev/rails/actionpack/lib/action_dispatch/http/url.rb:95: warning: shadowing outer local variable - port

After:

No warning
