### PR TITLE
In ActionDispatch::Session::DestroyableSession: instead of setting it to nil, assign the newly generated session-ID to the Rack::Session::Abstract::SessionHash after destroying it.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   In `ActionDispatch::Session::DestroyableSession`: instead of setting it to nil, assign the newly generated session-ID to the `Rack::Session::Abstract::SessionHash` after destroying it.
+
+    *Michael Berg*
+
 *   Fix regression when using `ActionView::Helpers::TranslationHelper#translate` with
     `options[:raise]`.
 

--- a/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
@@ -14,8 +14,7 @@ module ActionDispatch
         clear
         options = @env[Rack::Session::Abstract::ENV_SESSION_OPTIONS_KEY] if @env
         options ||= {}
-        @by.send(:destroy_session, @env, options[:id], options) if @by
-        options[:id] = nil
+        options[:id] = @by.send(:destroy_session, @env, options[:id], options) if @by
         @loaded = false
       end
     end

--- a/actionpack/test/dispatch/session/cache_store_test.rb
+++ b/actionpack/test/dispatch/session/cache_store_test.rb
@@ -24,6 +24,11 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
       render :text => "#{request.session_options[:id]}"
     end
 
+    def get_session_id_after_reset_session
+      reset_session
+      render :text => "#{request.session_options[:id]}"
+    end
+
     def call_reset_session
       session[:bar]
       reset_session
@@ -70,6 +75,15 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
       get '/get_session_value'
       assert_response :success
       assert_equal 'foo: nil', response.body, "data for this session should have been obliterated from cache"
+    end
+  end
+
+  def test_getting_session_id_after_session_reset
+    with_test_route_set do
+      get "/get_session_id_after_reset_session"
+
+      assert_response :success
+      assert_not_equal "", response.body, "session_id hasn't been set after reset_session"
     end
   end
 

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -30,6 +30,11 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
       render :text => "id: #{request.session_options[:id]}"
     end
 
+    def get_session_id_after_reset_session
+      reset_session
+      render :text => "id: #{request.session_options[:id]}"
+    end
+
     def call_session_clear
       session.clear
       head :ok
@@ -247,6 +252,15 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
 
       get "/change_session_id"
       assert_not_equal sid, response.body
+    end
+  end
+
+  def test_getting_session_id_after_session_reset
+    with_test_route_set do
+      get "/get_session_id_after_reset_session"
+
+      assert_response :success
+      assert_not_equal "", response.body, "session_id hasn't been set after reset_session"
     end
   end
 

--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -32,6 +32,11 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
       head :ok
     end
 
+    def get_session_id_after_reset_session
+      reset_session
+      render :text => "#{request.session_options[:id]}"
+    end
+
     def rescue_action(e) raise end
   end
 
@@ -76,6 +81,15 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
         get '/get_session_value'
         assert_response :success
         assert_equal 'foo: nil', response.body, "data for this session should have been obliterated from memcached"
+      end
+    end
+
+    def test_getting_session_id_after_session_reset
+      with_test_route_set do
+        get '/get_session_id_after_reset_session'
+
+        assert_response :success
+        assert_not_equal "", response.body, "session_id hasn't been set after reset_session"
       end
     end
 


### PR DESCRIPTION
In Rails 3.2, the `ActionDispatch::Session::CookieStore` inherits from `Rack::Session::Cookie`. 

The other stores, like `CacheStore`, `MemCacheStore` or even `RedisSessionStore` ([link](https://github.com/roidrage/redis-session-store)) inherit from `ActionDispatch::Session::AbstractStore`.

However, there's a small piece where `ActionDispatch::Session::AbstractStore` does not behave like `Rack::Session::Cookie`: When destroying the Session via `destroy`, Racks implementation (and thus the CookieStore) [assigns a newly generated session-ID back to the SessionHash](https://github.com/rack/rack/blob/rack-1.5/lib/rack/session/abstract/id.rb#L85), while the implementation in Rails' `AbstractStore` always [assigns nil](https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb#L18).

Due to the fact that most people use CookieStore (i suppose), this may not have been noticed by now.

Newer versions of Rails (4+) don't patch Racks `Rack::Session::Abstract::ID` anymore with the [nil assignment](https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb#L18), so they don't have this Issue.

This patch assigns the newly generated ID back to the session-hash in `ActionDispatch::Session::AbstractStore`. 
This enables us to use the (new) session-ID after destroying it when not using the CookieStore.
