### PR TITLE
Fix performance regression on preloading HABTM associations

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -15,6 +15,7 @@ module ActiveRecord
 
       # Returns the primary key value.
       def id
+        return unless self.class.primary_key
         sync_with_transaction_state
         read_attribute(self.class.primary_key)
       end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -380,7 +380,7 @@ module ActiveRecord
     # Delegates to id in order to allow two records of the same type and id to work with something like:
     #   [ Person.find(1), Person.find(2), Person.find(3) ] & [ Person.find(1), Person.find(4) ] # => [ Person.find(1) ]
     def hash
-      id.hash
+      (id || object_id).hash
     end
 
     # Clone and freeze the attributes hash such that associations are still


### PR DESCRIPTION
We'd spend a lot of time calling `hash` and `eql?` on the join model,
which has no primary key. Calling `id` with no primary key is a really
slow way to get back `nil`, so we can improve the performance there.
However, even with the escape clause, we _still_ weren't getting high
enough performance, as we were checking the primary key too much. `hash`
will always return `nil.hash` for records with no id, and `==` will
always return `false`. We can optimize those cases in the HABTM join
model.

Fixes #15663
