### PR TITLE
fix bug in email with name example code

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -309,7 +309,7 @@ email address in the format `"Full Name <email>"`.
 ```ruby
 def welcome_email(user)
   @user = user
-  email_with_name = "#{@user.name} <#{@user.email}>"
+  email_with_name = %("#{@user.name}" <#{@user.email}>)
   mail(to: email_with_name, subject: 'Welcome to My Awesome Site')
 end
 ```


### PR DESCRIPTION
The display name in the email "to" field needs to be quoted otherwise
your email-sending service will fail when trying to deliver mail to
user's with commas in their name (i.e. John Smith, M.D.).
