### PR TITLE
don't pollute default_connectors hash in the Array#to_sentence

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -68,7 +68,9 @@ class Array
       i18n_connectors = I18n.translate(:'support.array', locale: options[:locale], default: {})
       default_connectors.merge!(i18n_connectors)
     end
-    options = default_connectors.merge!(options)
+
+    options = options.dup
+    options.reverse_merge!(default_connectors)
 
     case length
     when 0


### PR DESCRIPTION
Earlier Array#to_sentence would change the default_connectors but preserves the options provided in the function call but IMHO it should not change the default value.
