### PR TITLE
Update test data which doesn't reflect expected usage

### DIFF
--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -514,14 +514,14 @@ class PersistenceTest < ActiveRecord::TestCase
 
   def test_update_column_should_not_leave_the_object_dirty
     topic = Topic.find(1)
-    topic.update_column("content", "Have a nice day")
+    topic.update_column("content", "--- Have a nice day\n...\n")
 
     topic.reload
-    topic.update_column(:content, "You too")
+    topic.update_column(:content, "--- You too\n...\n")
     assert_equal [], topic.changed
 
     topic.reload
-    topic.update_column("content", "Have a nice day")
+    topic.update_column("content", "--- Have a nice day\n...\n")
     assert_equal [], topic.changed
   end
 
@@ -605,14 +605,14 @@ class PersistenceTest < ActiveRecord::TestCase
 
   def test_update_columns_should_not_leave_the_object_dirty
     topic = Topic.find(1)
-    topic.update({ "content" => "Have a nice day", :author_name => "Jose" })
+    topic.update({ "content" => "--- Have a nice day\n...\n", :author_name => "Jose" })
 
     topic.reload
-    topic.update_columns({ content: "You too", "author_name" => "Sebastian" })
+    topic.update_columns({ content: "--- You too\n...\n", "author_name" => "Sebastian" })
     assert_equal [], topic.changed
 
     topic.reload
-    topic.update_columns({ content: "Have a nice day", author_name: "Jose" })
+    topic.update_columns({ content: "--- Have a nice day\n...\n", author_name: "Jose" })
     assert_equal [], topic.changed
   end
 

--- a/activerecord/test/fixtures/topics.yml
+++ b/activerecord/test/fixtures/topics.yml
@@ -6,7 +6,7 @@ first:
   written_on: 2003-07-16t15:28:11.2233+01:00
   last_read: 2004-04-15
   bonus_time: 2005-01-30t15:28:00.00+01:00
-  content: Have a nice day
+  content: "--- Have a nice day\n...\n"
   approved: false
   replies_count: 1
 
@@ -15,7 +15,7 @@ second:
   title: The Second Topic of the day
   author_name: Mary
   written_on: 2004-07-15t15:28:00.0099+01:00
-  content: Have a nice day
+  content: "--- Have a nice day\n...\n"
   approved: true
   replies_count: 0
   parent_id: 1
@@ -26,7 +26,7 @@ third:
   title: The Third Topic of the day
   author_name: Carl
   written_on: 2012-08-12t20:24:22.129346+00:00
-  content: I'm a troll
+  content: "--- I'm a troll\n...\n"
   approved: true
   replies_count: 1
 
@@ -35,7 +35,7 @@ fourth:
   title: The Fourth Topic of the day
   author_name: Carl
   written_on: 2006-07-15t15:28:00.0099+01:00
-  content: Why not?
+  content: "--- Why not?\n...\n"
   approved: true
   type: Reply
   parent_id: 3
@@ -45,5 +45,5 @@ fifth:
   title: The Fifth Topic of the day
   author_name: Jason
   written_on: 2013-07-13t12:11:00.0099+01:00
-  content: Omakase
+  content: "--- Omakase\n...\n"
   approved: true


### PR DESCRIPTION
Topics call `serialize :content`, which means that the values in the
database should be YAML encoded, and we would only expect to receive
YAML strings to `update_column` and `update_columns`.
