### PR TITLE
Require "active_support/dependencies/autoload"

### DIFF
--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -1,3 +1,5 @@
+require "active_support/dependencies/autoload"
+
 module ActiveSupport
   module NumberHelper
     extend ActiveSupport::Autoload


### PR DESCRIPTION
If I do not want to require the entire ActiveSupport in my project, but only Number Helper, I get an error:

```
irb(main):001:0> require 'active_support/number_helper'
NameError: uninitialized constant ActiveSupport::Autoload
    from ...//gems/activesupport-4.1.1/lib/active_support/number_helper.rb:3:in `<module:NumberHelper>'
```

I’m not sure whether this is somehow _intended_ by the Rails team, to force people to either load **the entire ActiveSupport** or nothing at all. It seems to me like it would make sense to be able to just require a single file.
