### PR TITLE
Fix performance regression on preloading HABTM associations

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -75,6 +75,15 @@ module ActiveRecord::Associations::Builder
           self.right_reflection = _reflect_on_association(rhs_name)
         end
 
+        def hash
+          object_id.hash
+        end
+
+        def ==(other)
+          equal?(other)
+        end
+        alias :eql? :==
+
       }
 
       join_model.name                = "HABTM_#{association_name.to_s.camelize}"

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -15,6 +15,7 @@ module ActiveRecord
 
       # Returns the primary key value.
       def id
+        return unless self.class.primary_key
         sync_with_transaction_state
         read_attribute(self.class.primary_key)
       end


### PR DESCRIPTION
We'd spend a lot of time calling `hash` and `eql?` on the join model,
which has no primary key. Calling `id` with no primary key is a really
slow way to get back `nil`, so we can improve the performance there.
However, even with the escape clause, we _still_ weren't getting high
enough performance, as we were checking the primary key too much. `hash`
will always return `nil.hash` for records with no id, and `==` will
always return `false`. We can optimize those cases in the HABTM join
model.
