### PR TITLE
Fix parsed token value with header `Authorization token=`.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   With authorization header `Authorization: Token token=`, `authenticate` now
+    recognize token as nil, instead of "token".
+
+    Fixes #14846.
+
+    *Larry Lv*
+
 *   Ensure the controller is always notified as soon as the client disconnects
     during live streaming, even when the controller is blocked on a write.
 

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -449,7 +449,7 @@ module ActionController
         authorization_request = request.authorization.to_s
         if authorization_request[TOKEN_REGEX]
           params = token_params_from authorization_request
-          [params.shift.last, Hash[params].with_indifferent_access]
+          [params.shift[1], Hash[params].with_indifferent_access]
         end
       end
 
@@ -464,7 +464,7 @@ module ActionController
 
       # This removes the `"` characters wrapping the value.
       def rewrite_param_values(array_params)
-        array_params.each { |param| param.last.gsub! %r/^"|"$/, '' }
+        array_params.each { |param| (param[1] || "").gsub! %r/^"|"$/, '' }
       end
 
       # This method takes an authorization body and splits up the key-value

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -132,13 +132,30 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     assert_equal(expected, actual)
   end
 
+  test "token_and_options returns empty string with empty token" do
+    token = ''
+    actual = ActionController::HttpAuthentication::Token.token_and_options(sample_request(token)).first
+    expected = token
+    assert_equal(expected, actual)
+  end
+
+  test "token_and_options returns nil with no value after the equal sign" do
+    actual = ActionController::HttpAuthentication::Token.token_and_options(malformed_request).first
+    expected = nil
+    assert_equal(expected, actual)
+  end
+
   private
 
-  def sample_request(token)
-    @sample_request ||= OpenStruct.new authorization: %{Token token="#{token}"}
-  end
+    def sample_request(token)
+      @sample_request ||= OpenStruct.new authorization: %{Token token="#{token}", nonce="def"}
+    end
 
-  def encode_credentials(token, options = {})
-    ActionController::HttpAuthentication::Token.encode_credentials(token, options)
-  end
+    def malformed_request
+      @malformed_request ||= OpenStruct.new authorization: %{Token token=}
+    end
+
+    def encode_credentials(token, options = {})
+      ActionController::HttpAuthentication::Token.encode_credentials(token, options)
+    end
 end


### PR DESCRIPTION
Related issue: #14846

With header `Authorization: Token token=`, we get token value as `nil` instead of `token`.

The current implementation with `params.shift.last` or `param.last` assume `params` or `param` is a two-elements array. But with malformed request, they are not, so instead of `last`, we should use `[1]`

cc @simonbnrd @robin850
