### PR TITLE
PG arrays should type cast user input

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -12,10 +12,14 @@ module ActiveRecord
 
           def type_cast_from_database(value)
             if value.is_a?(::String)
-              type_cast_array(parse_pg_array(value))
+              type_cast_array(parse_pg_array(value), :type_cast_from_database)
             else
               super
             end
+          end
+
+          def type_cast_from_user(value)
+            type_cast_array(value, :type_cast_from_user)
           end
 
           # Loads pg_array_parser if available. String parsing can be
@@ -32,11 +36,11 @@ module ActiveRecord
 
           private
 
-          def type_cast_array(value)
+          def type_cast_array(value, method)
             if value.is_a?(::Array)
-              value.map { |item| type_cast_array(item) }
+              value.map { |item| type_cast_array(item, method) }
             else
-              @subtype.type_cast_from_database(value)
+              @subtype.public_send(method, value)
             end
           end
         end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -97,8 +97,13 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
 
   def test_type_cast_integers
     x = PgArray.new(ratings: ['1', '2'])
-    assert x.save!
-    assert_equal(['1', '2'], x.ratings)
+
+    assert_equal([1, 2], x.ratings)
+
+    x.save!
+    x.reload
+
+    assert_equal([1, 2], x.ratings)
   end
 
   def test_select_with_strings


### PR DESCRIPTION
We guarantee that `model.value` does not change after
`model.save && model.reload`. This requires type casting user input for
non-string types.
