### PR TITLE
ActionController::Parameters#require should accept false boolean values

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -184,7 +184,9 @@ module ActionController
     #   ActionController::Parameters.new(person: {}).require(:person)
     #   # => ActionController::ParameterMissing: param not found: person
     def require(key)
-      self[key].presence || raise(ParameterMissing.new(key))
+      value = self[key]
+      raise ParameterMissing.new(key) if value.respond_to?(:empty?) ? value.empty? : value.nil?
+      value
     end
 
     # Alias of #require.

--- a/actionpack/test/controller/required_params_test.rb
+++ b/actionpack/test/controller/required_params_test.rb
@@ -24,10 +24,22 @@ class ActionControllerRequiredParamsTest < ActionController::TestCase
     post :create, { book: { name: "Mjallo!" } }
     assert_response :ok
   end
+
+  test "required parameters with false value will not raise" do
+    post :create, { book: { name: false } }
+    assert_response :ok
+  end
 end
 
 class ParametersRequireTest < ActiveSupport::TestCase
-  test "required parameters must be present not merely not nil" do
+
+  test "required parameters must not be nil" do
+    assert_raises(ActionController::ParameterMissing) do
+      ActionController::Parameters.new(person: nil).require(:person)
+    end
+  end
+
+  test "required parameters must not be empty" do
     assert_raises(ActionController::ParameterMissing) do
       ActionController::Parameters.new(person: {}).require(:person)
     end


### PR DESCRIPTION
as reported in https://github.com/rails/rails/issues/15685#issuecomment-46009045
