### PR TITLE
Ensure we always define attribute methods

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -259,6 +259,7 @@ module ActiveRecord
       init_internals
       initialize_internals_callback
 
+      self.class.define_attribute_methods
       # +options+ argument is only needed to make protected_attributes gem easier to hook.
       # Remove it when we drop support to this gem.
       init_attributes(attributes, options) if attributes

--- a/activerecord/test/cases/serialization_test.rb
+++ b/activerecord/test/cases/serialization_test.rb
@@ -69,6 +69,14 @@ class SerializationTest < ActiveRecord::TestCase
     ActiveRecord::Base.include_root_in_json = original_root_in_json
   end
 
+  def test_read_attribute_for_serialization_with_format_without_method_missing
+    klazz = Class.new(ActiveRecord::Base)
+    klazz.table_name = 'books'
+
+    book = klazz.new
+    assert_nil book.read_attribute_for_serialization(:format)
+  end
+
   def test_read_attribute_for_serialization_with_format_after_init
     klazz = Class.new(ActiveRecord::Base)
     klazz.table_name = 'books'


### PR DESCRIPTION
Currently we rely on `method_missing`, which doesn't always get triggered under the right circumstances.
