### PR TITLE
Use new when we need a new object

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -183,7 +183,7 @@ module ActiveRecord
       def subclass_from_attributes(attrs)
         subclass_name = attrs.with_indifferent_access[inheritance_column]
 
-        if subclass_name.present? && subclass_name != self.name
+        if subclass_name.present? && subclass_name != self.sti_name
           subclass = subclass_name.safe_constantize
 
           unless descendants.include?(subclass)

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -48,10 +48,10 @@ module ActiveRecord
       # how this "single-table" inheritance mapping is implemented.
       def instantiate(attributes, column_types = {})
         klass = discriminate_class_for_record(attributes)
-        klass.allocate.init_with(
-          'raw_attributes' => attributes,
-          'column_types' => column_types,
-          'new_record' => false,
+        klass.new(
+          attributes,
+          column_types: column_types,
+          existing_record: true,
         )
       end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1290,18 +1290,6 @@ class BasicsTest < ActiveRecord::TestCase
     assert !SubStiPost.descends_from_active_record?
   end
 
-  def test_find_on_abstract_base_class_doesnt_use_type_condition
-    old_class = LooseDescendant
-    Object.send :remove_const, :LooseDescendant
-
-    descendant = old_class.create! :first_name => 'bob'
-    assert_not_nil LoosePerson.find(descendant.id), "Should have found instance of LooseDescendant when finding abstract LoosePerson: #{descendant.inspect}"
-  ensure
-    unless Object.const_defined?(:LooseDescendant)
-      Object.const_set :LooseDescendant, old_class
-    end
-  end
-
   def test_assert_queries
     query = lambda { ActiveRecord::Base.connection.execute 'select count(*) from developers' }
     assert_queries(2) { 2.times { query.call } }
@@ -1495,8 +1483,7 @@ class BasicsTest < ActiveRecord::TestCase
     }
 
     types = { 'author_name' => typecast.new }
-    topic = Topic.allocate.init_with 'raw_attributes' => attrs,
-                                     'column_types' => types
+    topic = Topic.instantiate(attrs, types)
 
     assert_equal 't.lo', topic.author_name
   end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -250,11 +250,9 @@ class PersistenceTest < ActiveRecord::TestCase
   end
 
   def test_create_columns_not_equal_attributes
-    topic = Topic.allocate.init_with(
-      'raw_attributes' => {
-        'title'          => 'Another New Topic',
-        'does_not_exist' => 'test'
-      }
+    topic = Topic.instantiate(
+      'title'          => 'Another New Topic',
+      'does_not_exist' => 'test'
     )
     assert_nothing_raised { topic.save }
   end
@@ -300,9 +298,8 @@ class PersistenceTest < ActiveRecord::TestCase
     topic.title = "Still another topic"
     topic.save
 
-    topic_reloaded = Topic.allocate
-    topic_reloaded.init_with(
-      'raw_attributes' => topic.attributes.merge('does_not_exist' => 'test')
+    topic_reloaded = Topic.instantiate(
+      topic.attributes.merge('does_not_exist' => 'test')
     )
     topic_reloaded.title = 'A New Topic'
     assert_nothing_raised { topic_reloaded.save }

--- a/activerecord/test/cases/serialization_test.rb
+++ b/activerecord/test/cases/serialization_test.rb
@@ -73,6 +73,9 @@ class SerializationTest < ActiveRecord::TestCase
     klazz = Class.new(ActiveRecord::Base)
     klazz.table_name = 'books'
 
+    book = klazz.new
+    assert_nil book.read_attribute_for_serialization(:format)
+
     book = klazz.new(format: 'paperback')
     assert_equal 'paperback', book.read_attribute_for_serialization(:format)
   end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -37,8 +37,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_serialized_attribute_init_with
-    topic = Topic.allocate
-    topic.init_with('raw_attributes' => { 'content' => '--- foo' })
+    topic = Topic.instantiate('content' => '--- foo')
     assert_equal 'foo', topic.content
   end
 

--- a/activerecord/test/cases/xml_serialization_test.rb
+++ b/activerecord/test/cases/xml_serialization_test.rb
@@ -296,7 +296,7 @@ class DatabaseConnectedXmlSerializationTest < ActiveRecord::TestCase
     xml = authors(:david).to_xml :include=>:hello_posts, :indent => 0
     assert_match %r{<hello-posts type="array">}, xml
     assert_match %r{<hello-post type="Post">}, xml
-    assert_match %r{<hello-post type="StiPost">}, xml
+    assert_match %r{<hello-post type="SubStiPost">}, xml
   end
 
   def test_included_associations_should_skip_types
@@ -398,12 +398,12 @@ class DatabaseConnectedXmlSerializationTest < ActiveRecord::TestCase
     assert Hash.from_xml(xml)
     assert_match %r{^  <posts-with-comments type="array">}, xml
     assert_match %r{^    <posts-with-comment type="Post">}, xml
-    assert_match %r{^    <posts-with-comment type="StiPost">}, xml
+    assert_match %r{^    <posts-with-comment type="SubStiPost">}, xml
 
     types = Hash.from_xml(xml)['author']['posts_with_comments'].collect {|t| t['type'] }
     assert types.include?('SpecialPost')
     assert types.include?('Post')
-    assert types.include?('StiPost')
+    assert types.include?('SubStiPost')
   end
 
   def test_should_produce_xml_for_methods_returning_array

--- a/activerecord/test/fixtures/posts.yml
+++ b/activerecord/test/fixtures/posts.yml
@@ -37,7 +37,7 @@ sti_post_and_comments:
   author_id: 1
   title: sti me
   body: hello
-  type: StiPost
+  type: SubStiPost
 
 sti_habtm:
   id: 6

--- a/activerecord/test/models/bulb.rb
+++ b/activerecord/test/models/bulb.rb
@@ -18,12 +18,12 @@ class Bulb < ActiveRecord::Base
     self[:color] = color.upcase + "!"
   end
 
-  def self.new(attributes = {}, &block)
+  def self.new(attributes = {}, options = {}, &block)
     bulb_type = (attributes || {}).delete(:bulb_type)
 
     if bulb_type.present?
       bulb_class = "#{bulb_type.to_s.camelize}Bulb".constantize
-      bulb_class.new(attributes, &block)
+      bulb_class.new(attributes, options, &block)
     else
       super
     end


### PR DESCRIPTION
YAML loading and finding a record are not the same thing. `new` with
user params vs finding a record are much closer. This also means that a
user would be able to override `initialize` and have the same behavior
as they would get from an `after_initialize` callback.

We had a few cases where data existed in tests that wouldn't be possible
in the real world, and appear to have just acquired some cruft from
unrelated changes. (How would an abstract class get into the DB? You
wouldn't be able to create it?)
