### PR TITLE
ActionController::Parameters#require now accepts FalseClass values

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   ActionController::Parameters#require now accepts FalseClass values
+
+    Fixes #15685.
+
+    *Sergio Romano*
+
 *   With authorization header `Authorization: Token token=`, `authenticate` now
     recognize token as nil, instead of "token".
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -184,6 +184,7 @@ module ActionController
     #   ActionController::Parameters.new(person: {}).require(:person)
     #   # => ActionController::ParameterMissing: param not found: person
     def require(key)
+      return false if self[key].is_a? FalseClass
       self[key].presence || raise(ParameterMissing.new(key))
     end
 

--- a/actionpack/test/controller/required_params_test.rb
+++ b/actionpack/test/controller/required_params_test.rb
@@ -24,10 +24,26 @@ class ActionControllerRequiredParamsTest < ActionController::TestCase
     post :create, { book: { name: "Mjallo!" } }
     assert_response :ok
   end
+
+  test "required parameters with false value will not raise" do
+    post :create, { book: { name: false } }
+    assert_response :ok
+  end
 end
 
 class ParametersRequireTest < ActiveSupport::TestCase
-  test "required parameters must be present not merely not nil" do
+
+  test "required parameters should accept and return false value" do
+    assert(!ActionController::Parameters.new(person: false).require(:person))
+  end
+
+  test "required parameters must not be nil" do
+    assert_raises(ActionController::ParameterMissing) do
+      ActionController::Parameters.new(person: nil).require(:person)
+    end
+  end
+
+  test "required parameters must not be empty" do
     assert_raises(ActionController::ParameterMissing) do
       ActionController::Parameters.new(person: {}).require(:person)
     end


### PR DESCRIPTION
Fixes #15685.
