### PR TITLE
Deprecate `serialized_attributes` without replacement

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecate `serialized_attributes` without replacement. You can access its
+    behavior by going through the column's type object.
+
+    *Sean Griffin*
+
 *   Correctly extract IPv6 addresses from `DATABASE_URI`: the square brackets
     are part of the URI structure, not the actual host.
 

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -22,7 +22,9 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_list_of_serialized_attributes
-    assert_equal %w(content), Topic.serialized_attributes.keys
+    assert_deprecated do
+      assert_equal %w(content), Topic.serialized_attributes.keys
+    end
   end
 
   def test_serialized_attribute
@@ -207,7 +209,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     t = Topic.create(content: "first")
     assert_equal("first", t.content)
 
-    t.update_column(:content, Topic.serialized_attributes["content"].dump("second"))
+    t.update_column(:content, Topic.type_for_attribute('content').type_cast_for_database("second"))
     assert_equal("second", t.content)
   end
 


### PR DESCRIPTION
We've stopped using it internally, in favor of polymorphism. So should
you!
