### PR TITLE
Managing cookies in custom exception route is possible.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Change middlewares stack order so that managing cookies in custome exception
+    is possible.
+
+    Fixes #11679.
+
+    *Larry Lv*
+
 *   Invalid `bin/rails generate` commands will now show spelling suggestions.
 
     *Richard Schneeman*

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -33,8 +33,6 @@ module Rails
 
           # Must come after Rack::MethodOverride to properly log overridden methods
           middleware.use ::Rails::Rack::Logger, config.log_tags
-          middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
-          middleware.use ::ActionDispatch::DebugExceptions, app
           middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
 
           unless config.cache_classes
@@ -51,6 +49,9 @@ module Rails
             middleware.use config.session_store, config.session_options
             middleware.use ::ActionDispatch::Flash
           end
+
+          middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
+          middleware.use ::ActionDispatch::DebugExceptions, app
 
           middleware.use ::ActionDispatch::ParamsParser
           middleware.use ::Rack::Head

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -107,5 +107,45 @@ module ApplicationTests
       assert_match(/boooom/, last_response.body)
       assert_match(/測試テスト시험/, last_response.body)
     end
+
+    test "can manage cookies in custom exception route" do
+      FileUtils.rm_rf "#{app_path}/config/environments"
+
+      app_file 'config/routes.rb', <<-ROUTES
+        Rails.application.routes.draw do
+          get 'ok', to: 'application#ok'
+          get '404', to: 'application#not_found'
+        end
+      ROUTES
+
+      controller :application, <<-RUBY
+        class ApplicationController < ActionController::Base
+          def ok
+            render text: cookies[:foo]
+          end
+
+          def not_found
+            cookies[:foo] = 'foo'
+            render text: '404 Not Found', status: 404
+          end
+        end
+      RUBY
+
+      add_to_config <<-RUBY
+        config.action_dispatch.show_exceptions = true
+        config.exceptions_app = self.routes
+        config.consider_all_requests_local = false
+      RUBY
+
+      require "#{app_path}/config/environment"
+
+      get '/not_fould'
+      assert_equal last_response.status, 404
+      assert_equal last_response.body, '404 Not Found'
+
+      get '/ok'
+      assert_equal last_request.cookies['foo'], 'foo'
+      assert_equal last_response.body, 'foo'
+    end
   end
 end


### PR DESCRIPTION
Related issue: #11679

Change default middleware stack order, move ShowExceptions middleware
under Cookies and Flash middleware, so that cookies and flash are
manageable in custom exception route.

This is extracted from @yonbergman 's old commit.

I'm not sure this is a good change, but it is a real problem. What do you guys think?
