### PR TITLE
Move cleanup into teardown, delete obsolete code.

### DIFF
--- a/actionview/test/template/compiled_templates_test.rb
+++ b/actionview/test/template/compiled_templates_test.rb
@@ -1,15 +1,8 @@
 require 'abstract_unit'
 
 class CompiledTemplatesTest < ActiveSupport::TestCase
-  def setup
-    # Clean up any details key cached to expose failures
-    # that otherwise would appear just on isolated tests
+  teardown do
     ActionView::LookupContext::DetailsKey.clear
-
-    @compiled_templates = ActionView::CompiledTemplates
-    @compiled_templates.instance_methods.each do |m|
-      @compiled_templates.send(:remove_method, m) if m =~ /^_render_template_/
-    end
   end
 
   def test_template_gets_recompiled_when_using_different_keys_in_local_assigns


### PR DESCRIPTION
cc @senny
