### PR TITLE
Add an option to skip installation of Turbolinks

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -50,6 +50,9 @@ module Rails
         class_option :skip_spring,        type: :boolean, default: false,
                                           desc: "Don't install Spring application preloader"
 
+        class_option :skip_turbolinks,    type: :boolean, default: false,
+                                          desc: "Don't install Turbolinks"
+
         class_option :database,           type: :string, aliases: '-d', default: 'sqlite3',
                                           desc: "Preconfigure for selected database (options: #{DATABASES.join('/')})"
 
@@ -287,8 +290,10 @@ module Rails
           gems << GemfileEntry.version("#{options[:javascript]}-rails", nil,
                                  "Use #{options[:javascript]} as the JavaScript library")
 
-          gems << GemfileEntry.version("turbolinks", nil,
-            "Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks")
+          unless options[:skip_turbolinks]
+            gems << GemfileEntry.version("turbolinks", nil,
+              "Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks")
+          end
           gems
         end
       end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -448,6 +448,20 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_skip_turbolinks
+    run_generator [destination_root, "--skip-turbolinks"]
+
+    assert_file "Gemfile" do |content|
+      assert_no_match(/turbolinks/, content)
+    end
+    assert_file "app/views/layouts/application.html.erb" do |content|
+      assert_no_match(/data-turbolinks-track/, content)
+    end
+    assert_file "app/assets/javascripts/application.js" do |content|
+      assert_no_match(/turbolinks/, content)
+    end
+  end
+
   def test_gitignore_when_sqlite3
     run_generator
 


### PR DESCRIPTION
There are already options for disabling Spring, Sprockets, ActiveRecord, Javascript in general, and several other components. This PR adds one for skipping Turbolinks.
