### PR TITLE
Fixed a regression introduced in 84cf156

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -108,6 +108,11 @@ module ActiveRecord
     end
 
     module ClassMethods
+      def allocate
+        define_attribute_methods
+        super
+      end
+
       def initialize_find_by_cache
         self.find_by_statement_cache = {}.extend(Mutex_m)
       end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -143,7 +143,11 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   # Syck calls respond_to? before actually calling initialize
   def test_respond_to_with_allocated_object
-    topic = Topic.allocate
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = 'topics'
+    end
+
+    topic = klass.allocate
     assert !topic.respond_to?("nothingness")
     assert !topic.respond_to?(:nothingness)
     assert_respond_to topic, "title"


### PR DESCRIPTION
84cf156 (PR #15694) introduced a subtle regression. There are actually three
distinct entry points to creating an AR object – via .new (i.e. #initialize),
via #init_with (e.g. from YAML or database queries) and via .allocate.

With the patch in 84cf156, attribute methods and respond_to? will not work
correctly when objects are allocated directly, without going through either

The reason this test case didn't catch the regression was that the `Topic`
class is shared between test cases, so by the time this test case is ran the
attribute methods are very likely to be defined.

Switching to use a fresh anonymous class in the test to ensure we surface this
problem in the future.
