### PR TITLE
Use singular routes when plural routes do not exist

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -210,6 +210,7 @@ module ActionDispatch
           def call(t, args)
             controller_options = t.url_options
             options = controller_options.merge @options
+            ensure_no_model_for_format(args)
             hash = handle_positional_args(controller_options, args, options, @segment_keys)
             t._routes.url_for(hash)
           end
@@ -228,6 +229,14 @@ module ActionDispatch
             end
 
             result.merge!(inner_options)
+          end
+
+          def ensure_no_model_for_format(args)
+            if format_index = @segment_keys.index(:format)
+              if args[format_index].respond_to?(:to_model)
+                args.delete_at(format_index)
+              end
+            end
           end
         end
 

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -275,6 +275,23 @@ class RedirectTest < ActionController::TestCase
     end
   end
 
+  def test_redirect_to_singular_record
+    with_routing do |set|
+      set.draw do
+        resource :workshop
+        get ':controller/:action'
+      end
+
+      get :redirect_to_existing_record
+      assert_equal "http://test.host/workshop", redirect_to_url
+      assert_redirected_to Workshop.new(5)
+
+      get :redirect_to_new_record
+      assert_equal "http://test.host/workshop", redirect_to_url
+      assert_redirected_to Workshop.new(nil)
+    end
+  end
+
   def test_redirect_to_nil
     assert_raise(ActionController::ActionControllerError) do
       get :redirect_to_nil

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -95,6 +95,8 @@ class FormHelperTest < ActionView::TestCase
       resources :comments
     end
 
+    resource :comment
+
     namespace :admin do
       resources :posts do
         resources :comments
@@ -3020,6 +3022,18 @@ class FormHelperTest < ActionView::TestCase
   def test_fields_for_returns_block_result
     output = fields_for(Post.new) { |f| "fields" }
     assert_equal "fields", output
+  end
+
+  def test_form_for_with_new_singular_resource
+    form_for(Comment.new) {}
+    expected = whole_form('/comment', 'new_comment', 'new_comment')
+    assert_equal expected, output_buffer
+  end
+
+  def test_form_for_with_persisted_singular_resource
+    form_for(Comment.new(123)) {}
+    expected = whole_form('/comment', 'edit_comment_123', 'edit_comment', method: :patch)
+    assert_equal expected, output_buffer
   end
 
   def test_form_for_only_instantiates_builder_once


### PR DESCRIPTION
We have two distinct problems here. For new records, it's much simpler -- The detected index route will not exist, so we can simply check `respond_to`.

With show actions, the detected helper method will exist, but take one fewer argument than we think. The method itself is splatting args, so it's difficult to make a determination based on the arity of the function. It seems the simplest thing to do here is check if a model was passed as the format argument.

Fixes #1769
