### PR TITLE
Time columns should support time zone aware attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   `time` columns can now affected by `time_zone_aware_attributes`. If you have
+    set `config.time_zone` to a value other than `'UTC'`, they will be treated
+    as in that time zone by default in Rails 5.0. If this is not the desired
+    behavior, you can set
+
+        ActiveRecord::Base.time_zone_aware_types = [:datetime]
+
+    A deprecation warning will be emitted if you have a `:time` column, and have
+    not explicitly opted out.
+
+    Fixes #3145
+
+    *Sean Griffin*
+
 *   `nil` as a value for a binary column in a query no longer logs as
     "<NULL binary data>", and instead logs as just "nil".
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -18,7 +18,7 @@ module ActiveRecord
           end
 
           attr_reader :subtype, :delimiter
-          delegate :type, to: :subtype
+          delegate :type, :user_input_in_time_zone, to: :subtype
 
           def initialize(subtype, delimiter = ',')
             @subtype = subtype

--- a/activerecord/lib/active_record/type/time.rb
+++ b/activerecord/lib/active_record/type/time.rb
@@ -7,6 +7,19 @@ module ActiveRecord
         :time
       end
 
+      def user_input_in_time_zone(value)
+        return unless value.present?
+
+        case value
+        when ::String
+          value = "2000-01-01 #{value}"
+        when ::Time
+          value = value.change(year: 2000, day: 1, month: 1)
+        end
+
+        super(value)
+      end
+
       private
 
       def cast_value(value)

--- a/activerecord/lib/active_record/type/time_value.rb
+++ b/activerecord/lib/active_record/type/time_value.rb
@@ -9,6 +9,10 @@ module ActiveRecord
         "'#{value.to_s(:db)}'"
       end
 
+      def user_input_in_time_zone(value)
+        value.in_time_zone
+      end
+
       private
 
       def new_time(year, mon, mday, hour, min, sec, microsec, offset = nil)

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -30,6 +30,9 @@ ARTest.connect
 # Quote "type" if it's a reserved word for the current connection.
 QUOTED_TYPE = ActiveRecord::Base.connection.quote_column_name('type')
 
+# FIXME: Remove this when the deprecation cycle on TZ aware types by default ends.
+ActiveRecord::Base.time_zone_aware_types << :time
+
 def current_adapter?(*types)
   types.any? do |type|
     ActiveRecord::ConnectionAdapters.const_defined?(type) &&

--- a/activerecord/test/cases/multiparameter_attributes_test.rb
+++ b/activerecord/test/cases/multiparameter_attributes_test.rb
@@ -250,8 +250,8 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
         }
         topic = Topic.find(1)
         topic.attributes = attributes
-        assert_equal Time.utc(2000, 1, 1, 16, 24, 0), topic.bonus_time
-        assert topic.bonus_time.utc?
+        assert_equal Time.zone.local(2000, 1, 1, 16, 24, 0), topic.bonus_time
+        assert_not topic.bonus_time.utc?
       end
     end
   end


### PR DESCRIPTION
The types that are affected by `time_zone_aware_attributes` (which is on by default) have been made configurable, in case this not the desired behavior for existing applications.

Fixes #3145
