### PR TITLE
Don't save through records twice (4-1-stable)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `has_many :through` associations will no longer save the through record
+    twice when added in an `after_create` callback defined before the
+    associations.
+
+    *Sean Griffin*
+
 *   Fixed automatic maintaining test schema to properly handle sql structure
     schema format.
 

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -363,6 +363,7 @@ module ActiveRecord
 
               raise ActiveRecord::Rollback unless saved
             end
+            @new_record_before_save = false
           end
 
           # reconstruct the scope now that we know the owner's id

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1142,4 +1142,23 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal 2, post.lazy_readers_unscope_skimmers.to_a.size
     assert_equal 2, post.lazy_people_unscope_skimmers.to_a.size
   end
+
+  class ClubWithCallbacks < ActiveRecord::Base
+    self.table_name = 'clubs'
+    after_create :add_a_member
+
+    has_many :memberships, inverse_of: :club, foreign_key: :club_id
+    has_many :members, through: :memberships
+
+    def add_a_member
+      members << Member.last
+    end
+  end
+
+  def test_has_many_with_callback_before_association
+    Member.create!
+    club = ClubWithCallbacks.create!
+
+    assert_equal 1, club.reload.memberships.count
+  end
 end


### PR DESCRIPTION
If the through record gets created in an after_create hook that is
defined before the association is defined (therefore after its
after_create hook) get saved twice. This ensures that the through
records are created only once, regardless of the order of the hooks.

Backports the fix for #3798 to 4.1. Slightly more conservative on the callback order since it's a patch version.
