### PR TITLE
Add more exceptions on pluralization for -fe/-ve endings

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -56,7 +56,13 @@ module ActiveSupport
     inflect.irregular('man', 'men')
     inflect.irregular('child', 'children')
     inflect.irregular('sex', 'sexes')
+
+    # Ends with -fe exceptions
     inflect.irregular('move', 'moves')
+    inflect.irregular('olive', 'olives')
+    inflect.irregular('glove', 'gloves')
+    inflect.irregular('safe', 'safes')
+
     inflect.irregular('cow', 'kine')
     inflect.irregular('zombie', 'zombies')
 

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -27,7 +27,7 @@ module InflectorTestCases
     "index"       => "indices",
 
     "wife"        => "wives",
-    "safe"        => "saves",
+    "safe"        => "safes",
     "half"        => "halves",
 
     "move"        => "moves",
@@ -100,6 +100,9 @@ module InflectorTestCases
 
     "rice"        => "rice",
     "shoe"        => "shoes",
+
+    "olive"       => "olives",
+    "glove"       => "gloves",
 
     "horse"       => "horses",
     "prize"       => "prizes",


### PR DESCRIPTION
I'm not sure what's the best way to deal with these pluralization exceptions - if adding in the Rails core or only in the applications, but currently without this commit `'olive'.pluralize => 'olifes'` instead of 'olives'.

I tried to update the plural/singular regular expressions that match 'olive', but I got some conflicts with 'knife', 'wife', 'life' etc.
- wi_fe_ => wi_ves_
- sa_fe_ => sa_fes_
## 
- wi_ves_ => wi_fe_
- oli_ves_ => oli_ve_
