### PR TITLE
Change Http::Cache::SPECIAL_KEYS from Array to Set

### DIFF
--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -92,7 +92,7 @@ module ActionDispatch
         LAST_MODIFIED = "Last-Modified".freeze
         ETAG          = "ETag".freeze
         CACHE_CONTROL = "Cache-Control".freeze
-        SPECIAL_KEYS  = %w[extras no-cache max-age public must-revalidate]
+        SPECIAL_KEYS  = Set.new(%w[extras no-cache max-age public must-revalidate])
 
         def cache_control_segments
           if cache_control = self[CACHE_CONTROL]


### PR DESCRIPTION
Slightly improves performance, for example, a simple benchmark:

``` ruby
require 'benchmark/ips'
require 'set'

SPECIAL_KEYS = %w[extras no-cache max-age public must-revalidate]
SPECIAL_KEYS_SET = Set.new(SPECIAL_KEYS).freeze
directive = 'must-revalidate'

Benchmark.ips do |x|
  x.report('array') { SPECIAL_KEYS.include?(directive) }
  x.report('set') { SPECIAL_KEYS_SET.include?(directive) }
end
```

Output:

```
-------------------------------------
   array     67926 i/100ms
     set     74054 i/100ms
-------------------------------------
   array  2318423.4 (±2.8%) i/s -   11615346 in   5.014899s
     set  3387981.8 (±4.7%) i/s -   16958366 in   5.019355s
```
