### PR TITLE
Fixed automatic inverse_of for models nested in module

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fixed automatic inverse_of for models nested in module.
+
+    *Andrew McCloud*
+
 *   Deprecate `serialized_attributes` without replacement. You can access its
     behavior by going through the column's type object.
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -487,7 +487,7 @@ Joining, Preloading and eager loading of these associations is deprecated and wi
         # returns either nil or the inverse association name that it finds.
         def automatic_inverse_of
           if can_find_inverse_of_automatically?(self)
-            inverse_name = ActiveSupport::Inflector.underscore(options[:as] || active_record.name).to_sym
+            inverse_name = ActiveSupport::Inflector.underscore(options[:as] || active_record.name.demodulize).to_sym
 
             begin
               reflection = klass._reflect_on_association(inverse_name)

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -10,6 +10,9 @@ require 'models/comment'
 require 'models/car'
 require 'models/bulb'
 require 'models/mixed_case_monkey'
+require 'models/admin'
+require 'models/admin/account'
+require 'models/admin/user'
 
 class AutomaticInverseFindingTests < ActiveRecord::TestCase
   fixtures :ratings, :comments, :cars
@@ -25,6 +28,15 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     assert_respond_to man_reflection, :has_inverse?
     assert man_reflection.has_inverse?, "The man reflection should have an inverse"
     assert_equal monkey_reflection, man_reflection.inverse_of, "The man reflection's inverse should be the monkey reflection"
+  end
+
+  def test_has_many_and_belongs_to_should_find_inverse_automatically_for_model_in_module
+    account_reflection = Admin::Account.reflect_on_association(:users)
+    user_reflection = Admin::User.reflect_on_association(:account)
+
+    assert_respond_to account_reflection, :has_inverse?
+    assert account_reflection.has_inverse?, "The Admin::Account reflection should have an inverse"
+    assert_equal user_reflection, account_reflection.inverse_of, "The Admin::Account reflection's inverse should be the Admin::User reflection"
   end
 
   def test_has_one_and_belongs_to_should_find_inverse_automatically


### PR DESCRIPTION
First contribution to Rails. I was not entirely sure if I should re-use existing test models or create new ones for this specific example.
