### PR TITLE
Always update counter caches in memory when adding records

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -83,6 +83,13 @@ module ActiveRecord
           if has_cached_counter?(reflection)
             counter = cached_counter_attribute_name(reflection)
             owner.class.update_counters(owner.id, counter => difference)
+            update_counter_in_memory(difference, reflection)
+          end
+        end
+
+        def update_counter_in_memory(difference, reflection = reflection())
+          if has_cached_counter?(reflection)
+            counter = cached_counter_attribute_name(reflection)
             owner[counter] += difference
             owner.changed_attributes.delete(counter) # eww
           end
@@ -136,6 +143,25 @@ module ActiveRecord
           else
             false
           end
+        end
+
+        def concat_records(records, *)
+          update_counter_if_success(super, records.length)
+        end
+
+        def _create_record(attributes, *)
+          if attributes.is_a?(Array)
+            super
+          else
+            update_counter_if_success(super, 1)
+          end
+        end
+
+        def update_counter_if_success(saved_successfully, difference)
+          if saved_successfully
+            update_counter_in_memory(difference)
+          end
+          saved_successfully
         end
     end
   end

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -63,7 +63,6 @@ module ActiveRecord
         end
 
         save_through_record(record)
-        update_counter(1)
         record
       end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -772,6 +772,36 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal topic.replies.to_a.size, topic.replies_count
   end
 
+  def test_counter_cache_updates_in_memory_after_concat
+    topic = Topic.create title: "Zoom-zoom-zoom"
+
+    topic.replies << Reply.create(title: "re: zoom", content: "speedy quick!")
+    assert_equal 1, topic.replies_count
+    assert_equal 1, topic.replies.size
+    assert_equal 1, topic.reload.replies.size
+  end
+
+  def test_counter_cache_updates_in_memory_after_create
+    topic = Topic.create title: "Zoom-zoom-zoom"
+
+    topic.replies.create!(title: "re: zoom", content: "speedy quick!")
+    assert_equal 1, topic.replies_count
+    assert_equal 1, topic.replies.size
+    assert_equal 1, topic.reload.replies.size
+  end
+
+  def test_counter_cache_updates_in_memory_after_create_with_array
+    topic = Topic.create title: "Zoom-zoom-zoom"
+
+    topic.replies.create!([
+      { title: "re: zoom", content: "speedy quick!" },
+      { title: "re: zoom 2", content: "OMG lol!" },
+    ])
+    assert_equal 2, topic.replies_count
+    assert_equal 2, topic.replies.size
+    assert_equal 2, topic.reload.replies.size
+  end
+
   def test_pushing_association_updates_counter_cache
     topic = Topic.order("id ASC").first
     reply = Reply.create!


### PR DESCRIPTION
Before, calling `size` would only work if it skipped the cache, and
would return a different result from the cache, but only if:
- The association was previously loaded
- Or you called size previously
- But only if the size was 0 when you called it

This ensures that the counter is appropriately updated in memory.
