### PR TITLE
Fixes #15671 reflection strings now work as keys

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1588,7 +1588,7 @@ module ActiveRecord
 
         Builder::HasMany.define_callbacks self, middle_reflection
         Reflection.add_reflection self, middle_reflection.name, middle_reflection
-        middle_reflection.parent_reflection = [name, habtm_reflection]
+        middle_reflection.parent_reflection = [name.to_s, habtm_reflection]
 
         include Module.new {
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
@@ -1609,7 +1609,7 @@ module ActiveRecord
         end
 
         has_many name, scope, hm_options, &extension
-        self._reflections[name].parent_reflection = [name, habtm_reflection]
+        self._reflections[name.to_s].parent_reflection = [name.to_s, habtm_reflection]
       end
     end
   end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -22,11 +22,11 @@ module ActiveRecord
     end
 
     def self.add_reflection(ar, name, reflection)
-      ar._reflections = ar._reflections.merge(name => reflection)
+      ar._reflections = ar._reflections.merge(name.to_s => reflection)
     end
 
     def self.add_aggregate_reflection(ar, name, reflection)
-      ar.aggregate_reflections = ar.aggregate_reflections.merge(name => reflection)
+      ar.aggregate_reflections = ar.aggregate_reflections.merge(name.to_s => reflection)
     end
 
     # \Reflection enables to interrogate Active Record classes and objects
@@ -48,7 +48,7 @@ module ActiveRecord
       #   Account.reflect_on_aggregation(:balance) # => the balance AggregateReflection
       #
       def reflect_on_aggregation(aggregation)
-        aggregate_reflections[aggregation]
+        aggregate_reflections[aggregation.to_s]
       end
 
       # Returns a Hash of name of the reflection as the key and a AssociationReflection as the value.
@@ -92,12 +92,12 @@ module ActiveRecord
       #
       #   @api public
       def reflect_on_association(association)
-        reflections[association]
+        reflections[association.to_s]
       end
 
       #   @api private
       def _reflect_on_association(association) #:nodoc:
-        _reflections[association]
+        _reflections[association.to_s]
       end
 
       # Returns an array of AssociationReflection objects for all associations which have <tt>:autosave</tt> enabled.

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -204,7 +204,7 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_has_and_belongs_to_many_reflection
-    assert_equal :has_and_belongs_to_many, Category.reflections[:posts].macro
+    assert_equal :has_and_belongs_to_many, Category.reflections['posts'].macro
     assert_equal :posts, Category.reflect_on_all_associations(:has_and_belongs_to_many).first.name
   end
 
@@ -404,6 +404,16 @@ class ReflectionTest < ActiveRecord::TestCase
     reflection = AssociationReflection.new(:has_and_belongs_to_many, :products, nil, { :join_table => 'product_categories' }, category)
     reflection.stubs(:klass).returns(product)
     assert_equal 'product_categories', reflection.join_table
+  end
+
+  def test_reflection_keys_can_be_strings
+    hotel = Hotel.create!
+    department = hotel.departments.create!
+    department.chefs.create!
+
+    assert_nothing_raised do
+      assert_equal department.chefs, Hotel.includes(['departments' => 'chefs']).first.chefs
+    end
   end
 
   private


### PR DESCRIPTION
This was fixed on master by #14675 but could not be backported because when the branch was made `_reflect_on_association` didn't exist so grabbing those changes would leave `_reflection_on_association` with the same issue.

This fixes #15671 - where string based keys don't work on nested associations.
