### PR TITLE
Promote time zone aware attributes to a first class type decorator

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module AttributeMethods
     module TimeZoneConversion
-      class Type < SimpleDelegator # :nodoc:
+      class TimeZoneConverter < SimpleDelegator # :nodoc:
         def type_cast_from_database(value)
           convert_time_to_time_zone(super)
         end
@@ -33,6 +33,11 @@ module ActiveRecord
 
         class_attribute :skip_time_zone_conversion_for_attributes, instance_writer: false
         self.skip_time_zone_conversion_for_attributes = []
+
+        matcher = ->(name, type) { create_time_zone_conversion_attribute?(name, type) }
+        decorate_matching_attribute_types(matcher, :_time_zone_conversion) do |type|
+          TimeZoneConverter.new(type)
+        end
       end
 
       module ClassMethods

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -310,6 +310,8 @@ module ActiveRecord #:nodoc:
     include CounterCache
     include Locking::Optimistic
     include Locking::Pessimistic
+    include Attributes
+    include AttributeDecorators
     include AttributeMethods
     include Callbacks
     include Timestamp
@@ -323,8 +325,6 @@ module ActiveRecord #:nodoc:
     include Reflection
     include Serialization
     include Store
-    include Attributes
-    include AttributeDecorators
   end
 
   ActiveSupport.run_load_hooks(:active_record, Base)

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -220,25 +220,11 @@ module ActiveRecord
       end
 
       def column_types # :nodoc:
-        @column_types ||= decorate_types(build_types_hash)
+        @column_types ||= Hash[columns.map { |column| [column.name, column.cast_type] }]
       end
 
       def type_for_attribute(attr_name) # :nodoc:
         column_types.fetch(attr_name) { Type::Value.new }
-      end
-
-      def decorate_types(types) # :nodoc:
-        return if types.empty?
-
-        @time_zone_column_names ||= self.columns_hash.find_all do |name, col|
-          create_time_zone_conversion_attribute?(name, col)
-        end.map!(&:first)
-
-        @time_zone_column_names.each do |name|
-          types[name] = AttributeMethods::TimeZoneConversion::Type.new(types[name])
-        end
-
-        types
       end
 
       # Returns a hash where the keys are column names and the values are
@@ -334,10 +320,6 @@ module ActiveRecord
           # STI subclasses always use their superclass' table.
           base.table_name
         end
-      end
-
-      def build_types_hash
-        Hash[columns.map { |column| [column.name, column.cast_type] }]
       end
     end
   end

--- a/activerecord/test/cases/attribute_decorators_test.rb
+++ b/activerecord/test/cases/attribute_decorators_test.rb
@@ -110,5 +110,26 @@ module ActiveRecord
 
       assert_equal 'whatever decorated!', column.default
     end
+
+    class Multiplier < SimpleDelegator
+      def type_cast_from_user(value)
+        return if value.nil?
+        value * 2
+      end
+      alias type_cast_from_database type_cast_from_user
+    end
+
+    test "decorating with a proc" do
+      Model.attribute :an_int, Type::Integer.new
+      type_is_integer = proc { |_, type| type.type == :integer }
+      Model.decorate_matching_attribute_types type_is_integer, :multiplier do |type|
+        Multiplier.new(type)
+      end
+
+      model = Model.new(a_string: 'whatever', an_int: 1)
+
+      assert_equal 'whatever', model.a_string
+      assert_equal 2, model.an_int
+    end
   end
 end

--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -12,6 +12,7 @@ module ActiveRecord
         @klass = Class.new do
           def self.superclass; Base; end
           def self.base_class; self; end
+          def self.decorate_matching_attribute_types(*); end
 
           include ActiveRecord::AttributeMethods
 


### PR DESCRIPTION
This refactoring revealed the need for another form of decoration, which
takes a proc to select which it applies to (There's a _lot_ of cases
where this form can be used). To avoid duplication, we can re-implement
the old decoration in terms of the proc-based decoration.

The reason we're `instance_exec`ing the matcher is for cases such as
time zone aware attributes, where a decorator is defined in a parent
class, and a method called in the matcher is overridden by a child
class. The matcher will close over the parent, and evaluate in its
context, which is not the behavior we want.
