### PR TITLE
Dont swallow errors when bad alias_method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Dont swallow errors on compute_type when having a bad alias_method on
+    a class.
+
+    *arthurnn*
+
 *   Assume numeric types have changed if they were assigned to a value that
     would fail numericality validation, regardless of the old value. Previously
     this would only occur if the old value was 0.

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -120,14 +120,8 @@ module ActiveRecord
           candidates << type_name
 
           candidates.each do |candidate|
-            begin
-              constant = ActiveSupport::Dependencies.constantize(candidate)
-              return constant if candidate == constant.to_s
-            # We don't want to swallow NoMethodError < NameError errors
-            rescue NoMethodError
-              raise
-            rescue NameError
-            end
+            constant = ActiveSupport::Dependencies.safe_constantize(candidate)
+            return constant if candidate == constant.to_s
           end
 
           raise NameError.new("uninitialized constant #{candidates.first}", candidates.first)


### PR DESCRIPTION
Given the following models:

``` ruby
class Shop < ActiveRecord::Base
  has_many :customers
end

class Customer < ActiveRecord::Base
  belongs_to :shop
  alias_method :foo, :bar
end
```

This should raise a `undefined method 'bar' for class ..`  and not a `uninitialized constant` error.

A bad `alias_method` raises a `NameError` error, which is the error we were swallowing in that method.

cc @zzak @rafaelfranca @tenderlove
