### PR TITLE
Updates application layout template with JavaScript at bottom of page.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -7,10 +7,8 @@
   <%- else -%>
     <%- if gemfile_entries.any? { |m| m.name == 'turbolinks' } -%>
   <%%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%- else -%>
   <%%= stylesheet_link_tag    'application', media: 'all' %>
-  <%%= javascript_include_tag 'application' %>
     <%- end -%>
   <%- end -%>
   <%%= csrf_meta_tags %>
@@ -19,5 +17,12 @@
 
 <%%= yield %>
 
+<%- if !options[:skip_javascript] -%>
+  <%- if gemfile_entries.any? { |m| m.name == 'turbolinks' } -%>
+<%%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%- else -%>
+<%%= javascript_include_tag 'application' %>
+  <%- end -%>
+<%- end -%>
 </body>
 </html>


### PR DESCRIPTION
Prevailing wisdom in front end performance states that CSS should be
loaded at the top of a page and JavaScript at the bottom. This updates
the generated application layout to follow that convention.

The application layout will now look like this by default:

``` erb
<!DOCTYPE html>
<html>
<head>
  <title>ApplicationName</title>
  <%= stylesheet_link_tag 'application', media: 'all',
        'data-turbolinks-track' => true %>
  <%= csrf_meta_tags %>
</head>
<body>

<%= yield %>

<%= javascript_include_tag 'application',
      'data-turbolinks-track' => true %>
</body>
</html>
```

This seems to me to be a more sensible default than the existing template as most people are likely to move the JavaScript tags from the head to the bottom of the body anyway. Please let me know what you think.
