### PR TITLE
Update data-turbolinks-track to the new syntax

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -6,8 +6,8 @@
   <%%= stylesheet_link_tag    'application', media: 'all' %>
   <%- else -%>
     <%- if gemfile_entries.any? { |m| m.name == 'turbolinks' } -%>
-  <%%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%%= stylesheet_link_tag    'application', media: 'all', data: { turbolinks_track: true } %>
+  <%%= javascript_include_tag 'application', data: { turbolinks_track: true } %>
     <%- else -%>
   <%%= stylesheet_link_tag    'application', media: 'all' %>
   <%%= javascript_include_tag 'application' %>


### PR DESCRIPTION
The Tags of the default projects contained `"data-turbolinks-track" => true` in the new versions. This could now be replaced with `data: { turbolinks_track: true }` which will be translated to the same output.
