### PR TITLE
Don't include inheritance column in the through_scope_attributes

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -93,7 +93,7 @@ module ActiveRecord
         end
 
         def through_scope_attributes
-          scope.where_values_hash(through_association.reflection.name.to_s).except!(through_association.reflection.foreign_key)
+          scope.where_values_hash(through_association.reflection.name.to_s).except!(through_association.reflection.foreign_key, through_association.reflection.klass.inheritance_column)
         end
 
         def save_through_record(record)

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1139,4 +1139,12 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal 2, post.lazy_readers_unscope_skimmers.to_a.size
     assert_equal 2, post.lazy_people_unscope_skimmers.to_a.size
   end
+  
+  def test_has_many_through_add_with_sti_middle_relation
+    club = SuperClub.create!(name: 'Fight Club')
+    member = Member.create!(name: 'Tyler Durden')
+
+    club.members << member
+    assert_equal 1, SuperMembership.where(member_id: member.id, club_id: club.id).count
+  end
 end

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -5,7 +5,7 @@ class Club < ActiveRecord::Base
   has_one :sponsor
   has_one :sponsored_member, :through => :sponsor, :source => :sponsorable, :source_type => "Member"
   belongs_to :category
-
+  
   has_many :favourites, -> { where(memberships: { favourite: true }) }, through: :memberships, source: :member
 
   private
@@ -13,4 +13,11 @@ class Club < ActiveRecord::Base
   def private_method
     "I'm sorry sir, this is a *private* club, not a *pirate* club"
   end
+end
+
+class SuperClub < ActiveRecord::Base
+  self.table_name = "clubs"
+  
+  has_many :memberships, :class_name => "SuperMembership", :foreign_key => "club_id"
+  has_many :members, :through => :memberships
 end


### PR DESCRIPTION
I realize this is probably somewhat a corner case, but the app I work on does have it.

Say you have a model which is an STI subclass, and it contains has_many associations to two other models.  From one of those other models, you want to create an association back to the STI subclass, but _only_ the subclass, not the base class.  Since you really only want the subclass, you name the association after the base class (effectively, the type column becomes a where condition for that association).

You'd also like to get the other objects that are associated through it, so you do a `has_many :through`.  Now you want to add an object to that association.  Unfortunately this breaks, because as of commit ec0928076529e8f0b5a4ad58c95cfa1fe6ed5b60, Rails attempts to include all the where conditions for the association when building the through object, which ends up including the `type` column.  The value of that as returned from `where_values_hash` is an Array, which is fine for querying but not fine for building a new object.

This pull request prevents `through_scope_attributes` from including the inheritance column, which will be set anyway by the association builder.

This affects Rails 4.1.2.rc2, but not 4.1.2.rc1.  I have a failing test case against master here: https://gist.github.com/nbudin/74bba7ceb7f2af7b34bb
