### PR TITLE
Allow Rails to load without Rubygems loaded

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -172,10 +172,12 @@ module ActiveRecord
           path_to_adapter = "active_record/connection_adapters/#{spec[:adapter]}_adapter"
           begin
             require path_to_adapter
-          rescue Gem::LoadError => e
-            raise Gem::LoadError, "Specified '#{spec[:adapter]}' for database adapter, but the gem is not loaded. Add `gem '#{e.name}'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord)."
           rescue LoadError => e
-            raise LoadError, "Could not load '#{path_to_adapter}'. Make sure that the adapter in config/database.yml is valid. If you use an adapter other than 'mysql', 'mysql2', 'postgresql' or 'sqlite3' add the necessary adapter gem to the Gemfile.", e.backtrace
+            if defined?(Gem::LoadError) && e.is_a?(Gem::LoadError)
+              raise Gem::LoadError, "Specified '#{spec[:adapter]}' for database adapter, but the gem is not loaded. Add `gem '#{e.name}'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord)."
+            else
+              raise LoadError, "Could not load '#{path_to_adapter}'. Make sure that the adapter in config/database.yml is valid. If you use an adapter other than 'mysql', 'mysql2', 'postgresql' or 'sqlite3' add the necessary adapter gem to the Gemfile.", e.backtrace
+            end
           end
 
           adapter_method = "#{spec[:adapter]}_connection"

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -13,7 +13,7 @@ require 'active_record/connection_adapters/postgresql/database_statements'
 require 'arel/visitors/bind_visitor'
 
 # Make sure we're using pg high enough for PGResult#values
-gem 'pg', '~> 0.11'
+gem 'pg', '~> 0.11' if defined?(Kernel.gem)
 require 'pg'
 
 require 'ipaddr'

--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -11,7 +11,7 @@ module Rails
       add_filter   { |line| line.sub(RENDER_TEMPLATE_PATTERN, '') }
       add_filter   { |line| line.sub('./', '/') } # for tests
 
-      add_gem_filters
+      add_gem_filters if defined?(Gem)
       add_silencer { |line| line !~ APP_DIRS_PATTERN }
     end
 


### PR DESCRIPTION
Rails is a great gem citizen, and doesn't explicitly require Rubygems anywhere. However, while working on a Rails app that doesn't require Rubygems before loading Rails, we've noticed a few places where Rails expects Rubygems to be loaded even though it doesn't require it.

This pull request simply checks for Rubygems before calling Rubygems methods, so that Rails works without Rubygems already being loaded.
