### PR TITLE
Add Content Security Policy(CSP)

### DIFF
--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -38,6 +38,7 @@ module ActionController
     autoload :StrongParameters
     autoload :Testing
     autoload :UrlFor
+    autoload :ContentSecurityPolicy
   end
 
   autoload :TestCase,           'action_controller/test_case'

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -223,6 +223,7 @@ module ActionController
       Flash,
       RequestForgeryProtection,
       ForceSSL,
+      ContentSecurityPolicy,
       Streaming,
       DataStreaming,
       HttpAuthentication::Basic::ControllerMethods,

--- a/actionpack/lib/action_controller/metal/content_security_policy.rb
+++ b/actionpack/lib/action_controller/metal/content_security_policy.rb
@@ -1,0 +1,220 @@
+module ActionController
+  module ContentSecurityPolicy
+    extend ActiveSupport::Concern
+    include AbstractController::Callbacks
+
+    # A good introduction of CSP: http://www.html5rocks.com/en/tutorials/security/content-security-policy/
+    # current CSP draft: http://w3c.github.io/webappsec/specs/content-security-policy/
+    #
+    # USAGE:
+    # content_security_policy.enforce do |csp|
+    #   csp.Directive = Source List
+    # end
+    # or
+    # content_security_policy.enforce.Directive = Source List
+    #
+    # The Source List are all trusted origins that can be load in the browser
+    #
+    # Two modes
+    # enforce: all untrusted resources will not be load in the browser, the policy will be set in HTTP header "Content-Security-Policy"
+    # monitor: all untrusted resources will still be load, but will send the violation report back to server, the policy will be set in HTTP header "Content-Security-Policy-Report-Only"
+    # For csp reporting, see rails/actionpack/lib/action_dispatch/middleware/content_security_policy_reporting.rb
+    #
+    #
+    # Frequently used Directive:
+    # default-src: define the defaults for any directive you leave unspecified.
+    #              For example, if default-src is only set to https://example.com, and you didn't specify a img-src directive, then you can load images from https://example.com, and nowhere else.
+    # connect-src: limits the origins to which you can connect (via XHR, WebSockets, and EventSource).
+    # script-src: list the origins that can serve javascript file
+    # style-src: list the origins that can serve stylesheets file
+    # font-src: specifies the origins that can serve web fonts. Google’s Web Fonts could be enabled via font-src https://themes.googleusercontent.com
+    # frame-src: lists the origins that can be embedded as frames. For example: frame-src https://youtube.com would enable embedding YouTube videos, but no other origins.
+    # img-src: defines the origins from which images can be loaded.
+    # object-src: allows control over Flash and other plugins.
+    #
+    # Four keywords in Source List:
+    # none: Prevents loading resources from any source.
+    # self: Allows loading resources from the same origin (same scheme, host and port).
+    # unsafe-inline: Allows use of inline source elements such as style attribute, onclick. Can be used in both style-src and script-src
+    # unsafe-eval: Allows unsafe dynamic code evaluation such as JavaScript eval(). Can be used in script-src
+    #
+    # All these four keywords must be used in symbol :none, :self, :unsafe_inline, :unsafe_eval. Except these for keywords, other source elements must be enclosed in quote(single-quote or double-quote).
+    # Other Frequently used source elements:
+    # '*' : Wildcard, allows anything
+    # 'data:' : Allows loading resources via the data scheme (eg Base64 encoded images).
+    # 'https:' : Allows loading resources only over HTTPS on any domain
+    #
+    # Supporting adding csp policy in three level: applicationController level, controller level and action level.
+    # Lower level will inherit the policy from topper level, and can change the policy through API like add-, remove-
+    #  1. set a policy using
+    #  class ApplicationController < ActionController::Base
+    #    content_security_policy.enforce.default_src = :self
+    #  end
+    #  2. set a policy in img_src and add a policy in default_src
+    #  class BlogController < ApplicationController
+    #    content_security_policy.enforce do
+    #      csp.img_src = :self, 'data:'
+    #      csp.add_default_src 'https:'
+    #    end
+    #  end
+    #  3. remove a policy
+    #  class BlogController < ApplicationController
+    #    content_security_policy.enforce do
+    #      csp.img_src = :self, 'data:'
+    #      csp.add_default_src 'https:'
+    #    end
+    #
+    #    def show
+    #      content_security_policy.enforce.remove_default_src 'https:'
+    #    end
+    #  end
+    #
+    #
+    # Example:
+    # in ApplicationController, set a loose policy works on entire rails application
+    # content_security_policy.enforce do |csp|
+    #   csp.default_src = :self, 'https:'
+    #   csp.img_src = :self, ':data'
+    #   csp.font_src = :self, ':data'
+    #   csp.object_src = :none
+    #   csp.script_src = :self, :unsafe_inline, 'https:'
+    #   csp.style_src = :self, 'https:', :unsafe_inline
+    # end
+    #
+    # in BlogController, set a policy stricter than the policy in ApplicationController,
+    # For example, you want to load font from the fonts.cdn.example.com, and load image from imgs.cdn.example.com
+    # content_security_policy.enforce do |csp|
+    #   csp.add_img_src 'imgs.cdn.example.com'
+    #   csp.add_font_src 'fonts.cdn.example.com'
+    # end
+    #
+    # in action level of BlogController, set a strictest policy that only works for this action
+    # For example, in show action, you want to provide the google plus button and facebook like button
+    # def show
+    #   content_security_policy.enforce.add_script_src "https://apis.google.com"
+    #   content_security_policy.enforce.add_frame_src "https://plusone.google.com"
+    #   content_security_policy.enforce.add_frame_src "https://facebook.com"
+    # end
+
+    class Builder
+      def initialize(enforce = ContentSecurityPolicyConfig.new, monitor = ContentSecurityPolicyConfig.new)
+        @enforce = enforce
+        @monitor = monitor
+      end
+
+      def enforce
+        @enforce ||= ContentSecurityPolicyConfig.new
+        yield(@enforce) if block_given?
+        @enforce
+      end
+
+      def monitor
+        @monitor ||= ContentSecurityPolicyConfig.new
+        yield(@monitor) if block_given?
+        @monitor
+      end
+
+      def csp_headers
+        csp_header = Hash.new
+        unless @enforce.policy.empty?
+          csp_header.merge!( { 'Content-Security-Policy' => stringify(@enforce.policy)} )
+        end
+
+        unless @monitor.policy.empty?
+          csp_header.merge!( { 'Content-Security-Policy-Report-Only' => stringify(@monitor.policy)} )
+        end
+        csp_header
+      end
+
+      private
+        def stringify(policy)
+          policy.map { |key, value|
+            stringify_symbol([hyphen(key)] + value).join(" ")
+          }.join("; ")
+        end
+
+        def hyphen(str)
+          str.gsub("_","-")
+        end
+
+        def stringify_symbol(value)
+          value.map { |item| item.is_a?(Symbol) ? single_quote_keywords(item) : item }
+        end
+
+        #transit symbol keywords, which are self,none,unsafe-inline,unsafe-eval, into single-quoted string.
+        def single_quote_keywords(symbol)
+          "'#{hyphen(symbol.to_s)}'"
+        end
+    end
+
+    class ContentSecurityPolicyConfig
+      attr_reader :policy
+
+      def initialize(policy = Hash.new)
+        @policy = policy
+      end
+
+      def method_missing(method, *args)
+        method = method.to_s
+        unless  /^(add|remove)_(.+)$/ =~ method
+          directive = tailor_directive(method)
+          @policy[directive] = args.flatten
+        else
+          keywords = method.scan(/^(add|remove)_(.+)$/).flatten
+          action, directive= keywords
+          args = args.flatten
+          case action
+            when 'add'
+              if @policy.has_key?(directive)
+                @policy[directive] += args
+              else
+                @policy[directive] = args
+              end
+            when 'remove'
+              if @policy.has_key?(directive)
+                @policy[directive] -= args
+              end
+          end
+        end
+      end
+
+      private
+        def tailor_directive(directive)
+          directive.sub(/=$/, '')
+        end
+    end
+
+    module ClassMethods
+      def inherited(klass)
+        csp = copy_content_security_policy(content_security_policy)
+        klass.class_eval { @content_security_policy = csp}
+      end
+
+      #copy the policy from applicationController to SubController, or from controller level to action level
+      def copy_content_security_policy(csp)
+        ContentSecurityPolicy::Builder.new(ContentSecurityPolicyConfig.new(csp.enforce.policy.dup), ContentSecurityPolicyConfig.new(csp.monitor.policy.dup))
+      end
+
+      #For both applicationController and sub-controller level
+      def content_security_policy
+        @content_security_policy ||= ContentSecurityPolicy::Builder.new
+      end
+    end
+
+    #For action level
+    def content_security_policy
+      @content_security_policy ||= self.class.copy_content_security_policy(self.class.content_security_policy)
+    end
+
+    def process_action(*args)
+      result = super
+      if content_security_policy.csp_headers.has_key?('Content-Security-Policy')
+        response.headers['Content-Security-Policy'] = content_security_policy.csp_headers['Content-Security-Policy']
+      end
+      if content_security_policy.csp_headers.has_key?('Content-Security-Policy-Report-Only')
+        response.headers['Content-Security-Policy-Report-Only'] = content_security_policy.csp_headers['Content-Security-Policy-Report-Only']
+      end
+      result
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -58,6 +58,7 @@ module ActionDispatch
     autoload :RemoteIp
     autoload :ShowExceptions
     autoload :SSL
+    autoload :ContentSecurityPolicyReporting
     autoload :Static
   end
 

--- a/actionpack/lib/action_dispatch/middleware/content_security_policy_reporting.rb
+++ b/actionpack/lib/action_dispatch/middleware/content_security_policy_reporting.rb
@@ -1,0 +1,46 @@
+module ActionDispatch
+  class ContentSecurityPolicyReporting
+    # Content Security Policy Reporting Middleware
+    # In order to let this middleware working, user should do the following two setting:
+    #
+    # 1. set config.content_security_policy_reporting = true, so Rails can load this middleware properly
+    # 2. set report_uri in CSP policy, so browser can send violation report to the server
+    #      content_security_policy.enforce do |csp|
+    #        csp.report_uri = '/csp_reporter'
+    #      end
+    #
+    # This middleware will log the CSP violation reports, and publish an event 'report.content_security_policy'.
+    # So user can subscribe to this event and do whatever they want to do: store at database, send by email, or
+    # send to external applications like New Relic
+    #
+    # The code sample to subscribe to this event:
+    #
+    # ActiveSupport::Notifications.subscribe "report.content_security_policy" do |name, start, finish, id, payload|
+    #    send_to_my_email payload[:report]
+    # end
+    #
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      req = Rack::Request.new(env)
+      if req.content_type == "application/csp-report"
+         report = req.body.read
+         instrument(report)
+         logger(report)
+      end
+      status, headers, body = @app.call(env)
+      [status, headers, body]
+    end
+
+    private
+      def instrument(data)
+        ActiveSupport::Notifications.instrument("report.content_security_policy", report: data)
+      end
+
+      def logger(data)
+        Rails.logger.warn data
+      end
+  end
+end

--- a/actionpack/test/controller/content_security_policy_test.rb
+++ b/actionpack/test/controller/content_security_policy_test.rb
@@ -1,0 +1,339 @@
+require 'abstract_unit'
+
+
+#case 1: Not setting CSP
+class ApplicationController < ActionController::Base
+end
+
+class PostsController < ApplicationController
+
+  def index
+    render :text => "No Content Security Policy setting"
+  end
+end
+
+class PostsControllerTest < ActionController::TestCase
+  tests PostsController
+
+  def setup
+    Rails.application.routes.draw do
+      get 'index' => 'posts#index'
+    end
+    @routes = Rails.application.routes
+    PostsController.send(:include, @routes.url_helpers)
+  end
+
+  def test_no_csp_in_index
+    get :index
+    assert_response 200
+    assert_not response.headers["Content-Security-Policy"]
+    assert_not response.headers["Content-Security-Policy-Report-Only"]
+  end
+end
+
+
+#case 2: Only setting monitor policy in ApplicationController Level
+class ApplicationOneController < ActionController::Base
+  content_security_policy.monitor do |csp|
+    csp.default_src = :self
+    csp.img_src = :self, 'data:'
+    csp.font_src = :self, 'data:'
+    csp.object_src = :none
+    csp.script_src = :self, 'https:', :unsafe_inline
+    csp.style_src = :self, 'https:', :unsafe_inline
+  end
+end
+
+class PostsOneController < ApplicationOneController
+  def index
+    render :text => "Content Security Policy testing"
+  end
+end
+
+class PostsOneControllerTest < ActionController::TestCase
+  tests PostsOneController
+  def setup
+    Rails.application.routes.draw do
+      get 'index' => 'posts_one#index'
+    end
+    @routes = Rails.application.routes
+    PostsOneController.send(:include, @routes.url_helpers)
+  end
+
+  def test_no_enforce_policy_in_index
+    get :index
+    assert_not response.headers["Content-Security-Policy"]
+  end
+
+  def test_monitor_policy_in_index
+    get :index
+    assert_response 200
+    assert_equal "default-src 'self'; img-src 'self' data:; font-src 'self' data:; object-src 'none'; script-src 'self' https: 'unsafe-inline'; style-src 'self' https: 'unsafe-inline'", response.headers["Content-Security-Policy-Report-Only"]
+  end
+end
+
+#case 3: Only setting policy in Controller Level
+# Test Objective: different controllers with different csp setting have different csp policy
+class ApplicationTwoController < ActionController::Base
+end
+
+class PostsTwoController < ApplicationTwoController
+  content_security_policy.monitor do |csp|
+    csp.default_src = :self
+  end
+
+  def index
+    render :text => "Content Security Policy testing"
+  end
+end
+
+class PostsTwoControllerTest < ActionController::TestCase
+  tests PostsTwoController
+  def setup
+    Rails.application.routes.draw do
+      get 'index' => 'posts_two#index'
+    end
+    @routes = Rails.application.routes
+    PostsTwoController.send(:include, @routes.url_helpers)
+  end
+
+  def test_no_enforce_policy_in_index
+    get :index
+    assert_not response.headers["Content-Security-Policy"]
+  end
+
+  def test_monitor_policy_in_index
+    get :index
+    assert_response 200
+    assert_equal "default-src 'self'", response.headers["Content-Security-Policy-Report-Only"]
+  end
+end
+
+class UsersTwoController < ApplicationTwoController
+  def index
+    render :text => "Content Security Policy testing"
+  end
+end
+
+class UsersTwoControllerTest < ActionController::TestCase
+  tests UsersTwoController
+  def setup
+    Rails.application.routes.draw do
+      get 'index' => 'users_two#index'
+    end
+    @routes = Rails.application.routes
+    UsersTwoController.send(:include, @routes.url_helpers)
+  end
+
+  def test_no_policy_in_index
+    get :index
+    assert_not response.headers["Content-Security-Policy"]
+    assert_not response.headers["Content-Security-Policy-Report-Only"]
+  end
+end
+
+class AvatarsController < ApplicationTwoController
+  content_security_policy.enforce.default_src = :self
+  content_security_policy.monitor.default_src = :self
+
+  def index
+    render :text => "Content Security Policy testing"
+  end
+end
+
+class AvatarsControllerTest < ActionController::TestCase
+  tests AvatarsController
+  def setup
+    Rails.application.routes.draw do
+      get 'index' => 'avatars#index'
+    end
+    @routes = Rails.application.routes
+    AvatarsController.send(:include, @routes.url_helpers)
+  end
+
+  def test_enforce_policy_in_index
+    get :index
+    assert_equal "default-src 'self'", response.headers["Content-Security-Policy"]
+  end
+
+  def test_monitor_policy_in_index
+    get :index
+    assert_equal "default-src 'self'", response.headers["Content-Security-Policy-Report-Only"]
+  end
+end
+
+#case 4: Only setting policy in Action Level
+# Test Objective: Two different actions in same controllers with different csp setting have different csp policy
+class ApplicationThreeController < ActionController::Base
+end
+
+class PostsThreeController < ApplicationThreeController
+  def index
+    content_security_policy.enforce do |csp|
+      csp.default_src = :self
+      csp.script_src = "cdn.example.org"
+    end
+    content_security_policy.monitor do |csp|
+      csp.default_src = :self, 'data:'
+      csp.script_src = 'https:'
+    end
+    render :text => "Content Security Policy testing"
+  end
+
+  def new
+    content_security_policy.enforce do |csp|
+      csp.script_src = "js.example.org"
+    end
+    content_security_policy.monitor do |csp|
+      csp.default_src = :self, 'data:'
+      csp.script_src = 'https:',:unsafe_inline,:unsafe_eval
+    end
+    render :text => "Content Security Policy testing"
+  end
+end
+
+class PostsThreeControllerTest < ActionController::TestCase
+  tests PostsThreeController
+  def setup
+    Rails.application.routes.draw do
+      get 'index' => 'posts_three#index'
+      get 'new' => 'posts_three#new'
+    end
+    @routes = Rails.application.routes
+    PostsThreeController.send(:include, @routes.url_helpers)
+  end
+
+  def test_enforce_policy_in_index
+    get :index
+    assert_response 200
+    assert_equal "default-src 'self'; script-src cdn.example.org", response.headers["Content-Security-Policy"]
+  end
+
+  def test_monitor_policy_in_index
+    get :index
+    assert_response 200
+    assert_equal "default-src 'self' data:; script-src https:", response.headers["Content-Security-Policy-Report-Only"]
+  end
+
+  def test_enforce_policy_in_new
+    get :new
+    assert_response 200
+    assert_equal "script-src js.example.org", response.headers["Content-Security-Policy"]
+  end
+
+  def test_monitor_policy_in_new
+    get :new
+    assert_response 200
+    assert_equal "default-src 'self' data:; script-src https: 'unsafe-inline' 'unsafe-eval'", response.headers["Content-Security-Policy-Report-Only"]
+  end
+end
+
+#case 5: Setting policy in all three Level
+# Test Objective: low level copy the policy from the top level and modify the policy through add_, remove_, set_, methods.
+class ApplicationFourController < ActionController::Base
+  content_security_policy.enforce do |csp|
+    csp.default_src = :self
+    csp.img_src = :self, 'data:'
+    csp.font_src = :self, 'data:'
+    csp.object_src = :none
+    csp.script_src = :self, 'https:', :unsafe_inline
+    csp.style_src = :self, 'https:', :unsafe_inline
+  end
+
+  content_security_policy.monitor do |csp|
+    csp.default_src = :self
+    csp.img_src = :self, 'data:'
+    csp.font_src = :self, 'data:'
+    csp.object_src = :none
+    csp.script_src = :self, 'https:', :unsafe_inline
+    csp.style_src = :self, 'https:', :unsafe_inline
+  end
+end
+
+class PostsFourController < ApplicationFourController
+  content_security_policy.enforce do |csp|
+    csp.add_img_src 'imgs.example.org'
+    csp.add_font_src 'fonts.example.org'
+    csp.add_script_src :unsafe_eval
+  end
+
+  def index
+    content_security_policy.enforce do |csp|
+      csp.remove_script_src :unsafe_eval, :unsafe_inline
+      csp.remove_style_src :unsafe_inline
+    end
+    content_security_policy.monitor do |csp|
+      csp.default_src = :self, 'data:'
+      csp.script_src = 'https:'
+    end
+    render :text => "Content Security Policy testing"
+  end
+
+  def new
+    content_security_policy.enforce do |csp|
+      csp.add_script_src "js.example.org"
+    end
+    render :text => "Content Security Policy testing"
+  end
+end
+
+class PostsFourControllerTest < ActionController::TestCase
+  tests PostsFourController
+  def setup
+    Rails.application.routes.draw do
+      get 'index' => 'posts_four#index'
+      get 'new' => 'posts_four#new'
+    end
+    @routes = Rails.application.routes
+    PostsFourController.send(:include, @routes.url_helpers)
+  end
+
+  def test_enforce_policy_in_index
+    get :index
+    assert_response 200
+    assert_equal "default-src 'self'; img-src 'self' data: imgs.example.org; font-src 'self' data: fonts.example.org; object-src 'none'; script-src 'self' https:; style-src 'self' https:", response.headers["Content-Security-Policy"]
+  end
+
+  def test_monitor_policy_in_index
+    get :index
+    assert_response 200
+    assert_equal "default-src 'self' data:; img-src 'self' data:; font-src 'self' data:; object-src 'none'; script-src https:; style-src 'self' https: 'unsafe-inline'", response.headers["Content-Security-Policy-Report-Only"]
+  end
+
+  def test_enforce_policy_in_new
+    get :new
+    assert_response 200
+    assert_equal "default-src 'self'; img-src 'self' data: imgs.example.org; font-src 'self' data: fonts.example.org; object-src 'none'; script-src 'self' https: 'unsafe-inline' 'unsafe-eval' js.example.org; style-src 'self' https: 'unsafe-inline'", response.headers["Content-Security-Policy"]
+  end
+end
+
+#case 6: Test controller inherited from an existed controller
+# Test Objective: The SubController will get all the policy inherited from the SuperController
+class PostsFiveController < PostsFourController
+  content_security_policy.enforce do |csp|
+    csp.remove_img_src 'imgs.example.org'
+    csp.remove_font_src 'fonts.example.org'
+    csp.remove_script_src :unsafe_eval
+  end
+
+  def index
+    render :text => "Content Security Policy testing"
+  end
+end
+
+class PostsFiveControllerTest < ActionController::TestCase
+  tests PostsFiveController
+  def setup
+    Rails.application.routes.draw do
+      get 'index' => 'posts_five#index'
+    end
+    @routes = Rails.application.routes
+    PostsFiveController.send(:include, @routes.url_helpers)
+  end
+
+  def test_enforce_policy_in_index
+    get :index
+    assert_response 200
+    assert_equal "default-src 'self'; img-src 'self' data:; font-src 'self' data:; object-src 'none'; script-src 'self' https: 'unsafe-inline'; style-src 'self' https: 'unsafe-inline'",  response.headers["Content-Security-Policy"]
+  end
+end

--- a/actionpack/test/dispatch/csp_test.rb
+++ b/actionpack/test/dispatch/csp_test.rb
@@ -1,0 +1,71 @@
+require 'abstract_unit'
+
+class CSPTest < ActionDispatch::IntegrationTest
+  def default_app
+    lambda { |env|
+      headers = {'Content-Type' => "text/html"}
+      [200, headers, ["OK"]]
+    }
+  end
+
+  def app
+    @app ||= ActionDispatch::CSP.new(default_app)
+  end
+  attr_writer :app
+
+  def enforce_options
+    @enforce_options ={
+        default_src: :none,
+        img_src: [:self, "example.com"],
+        script_src: [:unsafe_eval, :unsafe_inline, "example.com", "cdn.example.org"],
+        style_src: [:unsafe_eval, :unsafe_inline, "cdn.example.org"]
+      }
+  end
+
+  def monitor_options
+    @monitor_options ={
+        default_src: :none,
+        img_src: [:self, "example.com"],
+        script_src: [:unsafe_eval, :unsafe_inline, "example.com", "cdn.example.org"],
+        style_src: [:unsafe_eval, :unsafe_inline, "cdn.example.org"]
+    }
+  end
+
+  def test_without_options
+    get "http://example.org/"
+    assert_not response.headers["Content-Security-Policy"]
+    assert_not response.headers["Content-Security-Policy-Report-Only"]
+  end
+
+  def test_enforce
+    self.app = ActionDispatch::CSP.new(default_app, enforce_options)
+    get "http://example.org/"
+    assert_equal "default-src 'none';img-src 'self' example.com;script-src 'unsafe-eval' 'unsafe-inline' example.com cdn.example.org;style-src 'unsafe-eval' 'unsafe-inline' cdn.example.org;", response.headers["Content-Security-Policy"]
+    assert_not response.headers["Content-Security-Policy-Report-Only"]
+  end
+
+  def test_monitor
+    self.app = ActionDispatch::CSP.new(default_app,{},monitor_options)
+    get "http://example.org/"
+    assert_not response.headers["Content-Security-Policy"]
+    assert_equal "default-src 'none';img-src 'self' example.com;script-src 'unsafe-eval' 'unsafe-inline' example.com cdn.example.org;style-src 'unsafe-eval' 'unsafe-inline' cdn.example.org;", response.headers["Content-Security-Policy-Report-Only"]
+  end
+
+  def test_both_enforce_and_monitor
+    self.app = ActionDispatch::CSP.new(default_app, enforce_options, monitor_options)
+    get "http://example.org/"
+    assert_equal "default-src 'none';img-src 'self' example.com;script-src 'unsafe-eval' 'unsafe-inline' example.com cdn.example.org;style-src 'unsafe-eval' 'unsafe-inline' cdn.example.org;", response.headers["Content-Security-Policy"]
+    assert_equal "default-src 'none';img-src 'self' example.com;script-src 'unsafe-eval' 'unsafe-inline' example.com cdn.example.org;style-src 'unsafe-eval' 'unsafe-inline' cdn.example.org;", response.headers["Content-Security-Policy-Report-Only"]
+  end
+
+  def test_report_uri
+    options = {
+      report_uri: "/csp_reporter"
+    }
+    self.app = ActionDispatch::CSP.new(default_app, options, options)
+    get "http://example.org/"
+    assert response.headers["Content-Security-Policy"].include?("report-uri /csp_reporter;")
+    assert response.headers["Content-Security-Policy-Report-Only"].include?("report-uri /csp_reporter;")
+  end
+
+end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -13,7 +13,7 @@ module Rails
                     :railties_order, :relative_url_root, :secret_key_base, :secret_token,
                     :serve_static_assets, :ssl_options, :static_cache_control, :session_options,
                     :time_zone, :reload_classes_only_on_change,
-                    :beginning_of_week, :filter_redirect
+                    :beginning_of_week, :filter_redirect, :content_security_policy_reporting
 
       attr_writer :log_level
       attr_reader :encoding
@@ -30,6 +30,7 @@ module Rails
         @static_cache_control          = nil
         @force_ssl                     = false
         @ssl_options                   = {}
+        @content_security_policy_reporting = false
         @session_store                 = :cookie_store
         @session_options               = {}
         @time_zone                     = "UTC"

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -15,6 +15,10 @@ module Rails
             middleware.use ::ActionDispatch::SSL, config.ssl_options
           end
 
+          if config.content_security_policy_reporting
+            middleware.use ::ActionDispatch::ContentSecurityPolicyReporting
+          end
+
           middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header
 
           if config.serve_static_assets

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -71,6 +71,38 @@ module Rails
       end
     end
 
+    class ContentSecurityPolicy
+      attr_accessor :enabled
+      def initialize
+        @enabled = false
+      end
+
+      def enforce
+        @enforce ||= ContentSecurityPolicyConfig.new
+        yield(@enforce) if block_given?
+        @enforce
+      end
+
+      def monitor
+        @monitor ||= ContentSecurityPolicyConfig.new
+        yield(@monitor) if block_given?
+        @monitor
+      end
+    end
+
+    class ContentSecurityPolicyConfig
+      attr_reader :policy
+
+      def initialize
+        @policy = Hash.new
+      end
+
+      def method_missing(method, *args)
+        directive = method.to_s.sub(/=$/, '').to_sym
+        @policy[directive] = args[0]
+      end
+    end
+
     class Generators #:nodoc:
       attr_accessor :aliases, :options, :templates, :fallbacks, :colorize_logging
       attr_reader :hidden_namespaces

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -86,6 +86,12 @@ module ApplicationTests
       assert_equal Rails.application.middleware.first.args, [{host: 'example.com'}]
     end
 
+    test "ActionDispatch::ContentSecurityPolicyReporting is present when config.content_security_policy_reporting is set to true" do
+      add_to_config "config.content_security_policy_reporting = true"
+      boot!
+      assert middleware.include?("ActionDispatch::ContentSecurityPolicyReporting")
+    end
+
     test "removing Active Record omits its middleware" do
       use_frameworks []
       boot!


### PR DESCRIPTION
This middleware is going to add support for Content Security Policy(CSP) for Rails. CSP helps to detect and mitigate XSS attacks and data injection attacks by setting the content-security-policy HTTP header.

The value of content-security-policy header is made up of one or more directives and each directive come with a source whitelists to specify the trusted resources that can be load by the browser. Any resources that are not specified in the source whitelists will be blocked by the browser.

For more information about the directives and source whitelists, check out here http://content-security-policy.com/

The middleware provides convenient API to set the CSP:

```
config.csp = {
  :enforce => true,
  :default_src => 'self',
  :script_src => 'unsafe-inline unsafe-eval https://api.google.com"
}
```

will set the content-security-policy header like below:

```
Content-Security-Policy:default-src 'self';script-src 'unsafe-inline' 'unsafe-eval' https://api.google.com;
```

The option :enforce is used to indicate if the browser will block the untrusted resources. By default, the option is set to false. So the browser will only report violations of the policy rather than blocking untrusted resource. 

Here is also a good introduction, http://www.html5rocks.com/en/tutorials/security/content-security-policy/

cc @rafaelfranca @chancancode
