### PR TITLE
Move pg array database type casting to the Array type

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -38,21 +38,6 @@ module ActiveRecord
           end
         end
 
-        def array_to_string(value, column, adapter) # :nodoc:
-          casted_values = value.map do |val|
-            if String === val
-              if val == "NULL"
-                "\"#{val}\""
-              else
-                quote_and_escape(adapter.type_cast(val, column, true))
-              end
-            else
-              adapter.type_cast(val, column, true)
-            end
-          end
-          "{#{casted_values.join(',')}}"
-        end
-
         def range_to_string(object) # :nodoc:
           from = object.begin.respond_to?(:infinite?) && object.begin.infinite? ? '' : object.begin
           to   = object.end.respond_to?(:infinite?) && object.end.infinite? ? '' : object.end
@@ -84,19 +69,6 @@ module ActiveRecord
               else
                 '"%s"' % value.to_s.gsub(/(["\\])/, '\\\\\1')
               end
-            end
-          end
-
-          ARRAY_ESCAPE = "\\" * 2 * 2 # escape the backslash twice for PG arrays
-
-          def quote_and_escape(value)
-            case value
-            when "NULL", Numeric
-              value
-            else
-              value = value.gsub(/\\/, ARRAY_ESCAPE)
-              value.gsub!(/"/,"\\\"")
-              "\"#{value}\""
             end
           end
       end

--- a/activerecord/lib/active_record/type/date_time.rb
+++ b/activerecord/lib/active_record/type/date_time.rb
@@ -7,6 +7,16 @@ module ActiveRecord
         :datetime
       end
 
+      def type_cast_for_database(value)
+        zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
+
+        if value.acts_like?(:time)
+          value.send(zone_conversion_method)
+        else
+          super
+        end
+      end
+
       private
 
       def cast_value(string)


### PR DESCRIPTION
The case where we have a column object, but don't have a type cast method involves type casting the default value when changing the schema. We get one of the column definition structs instead. That is a case that I'm trying to remove overall, but in the short term, we can achieve the same behavior without needing to pass the adapter to the array type by creating a fake type that proxies to the adapter.
