### PR TITLE
Don't assume that Hstore columns have always changed

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -8,7 +8,7 @@ module ActiveRecord
 
         def hstore_to_string(object, array_member = false) # :nodoc:
           if Hash === object
-            string = object.map { |k, v| "#{escape_hstore(k)}=>#{escape_hstore(v)}" }.join(',')
+            string = object.map { |k, v| "#{escape_hstore(k)}=>#{escape_hstore(v)}" }.join(', ')
             string = escape_hstore(string) if array_member
             string
           else

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -170,6 +170,7 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
       hstore.reload
 
       assert_equal 'four', hstore.settings['three']
+      assert_not hstore.changed?
     end
 
     def test_gen1

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -183,6 +183,7 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
     json.save!
     json.reload
 
-    assert json.payload['three'] = 'four'
+    assert_equal({ 'one' => 'two', 'three' => 'four' }, json.payload)
+    assert_not json.changed?
   end
 end


### PR DESCRIPTION
HStore columns come back from the database separated by a comma and a
space, not just a comma. We need to mirror that behavior since we
compare the two values.

Also adds a regression test against JSON to ensure we don't have the
same bug there.
