### PR TITLE
Ensure `OID::Array#type_cast_for_database` matches PG's quoting behavior

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
@@ -40,7 +40,7 @@ module ActiveRecord
 
           def register_array_type(row)
             if subtype = @store.lookup(row['typelem'].to_i)
-              register row['oid'], OID::Array.new(subtype)
+              register row['oid'], OID::Array.new(subtype, row['typdelim'])
             end
           end
 

--- a/activerecord/test/cases/adapters/postgresql/type_lookup_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/type_lookup_test.rb
@@ -1,0 +1,15 @@
+require 'cases/helper'
+
+class PostgresqlTypeLookupTest < ActiveRecord::TestCase
+  setup do
+    @connection = ActiveRecord::Base.connection
+  end
+
+  test "array delimiters are looked up correctly" do
+    box_array = @connection.type_map.lookup(1020)
+    int_array = @connection.type_map.lookup(1007)
+
+    assert_equal ';', box_array.delimiter
+    assert_equal ',', int_array.delimiter
+  end
+end


### PR DESCRIPTION
Also takes a step towards supporting types which use a character other
than ',' for the delimiter (`box` is the only built in type for which
this is the case)
