### PR TITLE
Don't use `Column` for type casting in Relation calculations

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -53,11 +53,6 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_nil NumericData.average(:bank_balance)
   end
 
-  def test_type_cast_calculated_value_should_convert_db_averages_of_fixnum_class_to_decimal
-    assert_equal 0, NumericData.all.send(:type_cast_calculated_value, 0, nil, 'avg')
-    assert_equal 53.0, NumericData.all.send(:type_cast_calculated_value, 53, nil, 'avg')
-  end
-
   def test_should_get_maximum_of_field
     assert_equal 60, Account.maximum(:credit_limit)
   end


### PR DESCRIPTION
Working towards removing type casting behavior from `Column` entirely.
