### PR TITLE
Don't use column object for type casting in `quoting`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -14,8 +14,8 @@ module ActiveRecord
         # value. Is this really the only case? Are we missing tests for other types?
         # We should have a real column object passed (or nil) here, and check for that
         # instead
-        if column.respond_to?(:type_cast_for_database)
-          value = column.type_cast_for_database(value)
+        if column.respond_to?(:cast_type)
+          value = column.cast_type.type_cast_for_database(value)
         end
 
         _quote(value)
@@ -34,8 +34,8 @@ module ActiveRecord
         # value. Is this really the only case? Are we missing tests for other types?
         # We should have a real column object passed (or nil) here, and check for that
         # instead
-        if column.respond_to?(:type_cast_for_database)
-          value = column.type_cast_for_database(value)
+        if column.respond_to?(:cast_type)
+          value = column.cast_type.type_cast_for_database(value)
         end
 
         _type_cast(value)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -179,8 +179,8 @@ module ActiveRecord
         end
 
         def array_column(column)
-          if column.array && !column.respond_to?(:type_cast_for_database)
-            OID::Array.new(AdapterProxyType.new(column, self))
+          if column.array && !column.respond_to?(:cast_type)
+            Column.new('', nil, OID::Array.new(AdapterProxyType.new(column, self)))
           else
             column
           end

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -93,12 +93,10 @@ module ActiveRecord
 
       def test_quote_true
         assert_equal @quoter.quoted_true, @quoter.quote(true, nil)
-        assert_equal '1', @quoter.quote(true, Type::Integer.new)
       end
 
       def test_quote_false
         assert_equal @quoter.quoted_false, @quoter.quote(false, nil)
-        assert_equal '0', @quoter.quote(false, Type::Integer.new)
       end
 
       def test_quote_float
@@ -157,35 +155,12 @@ module ActiveRecord
         assert_equal "'lo\\\\l'", @quoter.quote(string, nil)
       end
 
-      def test_quote_string_int_column
-        assert_equal "1", @quoter.quote('1', Type::Integer.new)
-        assert_equal "1", @quoter.quote('1.2', Type::Integer.new)
-      end
-
-      def test_quote_string_float_column
-        assert_equal "1.0", @quoter.quote('1', Type::Float.new)
-        assert_equal "1.2", @quoter.quote('1.2', Type::Float.new)
-      end
-
-      def test_quote_as_mb_chars_binary_column
-        string = ActiveSupport::Multibyte::Chars.new('lo\l')
-        assert_equal "'lo\\\\l'", @quoter.quote(string, Type::Binary.new)
-      end
-
-      def test_quote_binary_without_string_to_binary
-        assert_equal "'lo\\\\l'", @quoter.quote('lo\l', Type::Binary.new)
-      end
-
       def test_string_with_crazy_column
         assert_equal "'lo\\\\l'", @quoter.quote('lo\l')
       end
 
       def test_quote_duration
         assert_equal "1800", @quoter.quote(30.minutes)
-      end
-
-      def test_quote_duration_int_column
-        assert_equal "7200", @quoter.quote(2.hours, Type::Integer.new)
       end
     end
   end


### PR DESCRIPTION
We're never going to be able to use the attribute object here, however,
so let's just accept the ugly demeter violation here for now.

Remove test cases which were either redundant with other tests in the
file, or were actually testing the type objects (which are tested
elsewhere)
