### PR TITLE
Make cookie key environment dependent

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: <%= "'_#{app_name}_session'" %>
+Rails.application.config.session_store :cookie_store, key: <%= "\"_#{app_name}_#"+"{Rails.env}_session\"" %>


### PR DESCRIPTION
More than once I've been bitten by cookie issues when testing between staging and production environment. This change will prevent a lot of hair-pulling on new applications.
