### PR TITLE
Allow both keys to be symbols or strings in reflection

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -68,7 +68,7 @@ module ActiveRecord
             ref[name] = reflection
           end
         end
-        ref
+        ref.with_indifferent_access
       end
 
       # Returns an array of AssociationReflection objects for all the

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -426,6 +426,46 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal 'product_categories', reflection.join_table
   end
 
+  def test_reflection_association_accepts_symbols_as_keys
+    hotel = Hotel.create!
+    department = hotel.departments.create!
+    department.chefs.create!
+
+    assert_nothing_raised do
+      assert_equal department.chefs, Hotel.includes([departments: :chefs]).first.chefs
+    end
+  end
+
+  def test_reflection_association_accepts_strings_as_keys
+    hotel = Hotel.create!
+    department = hotel.departments.create!
+    department.chefs.create!
+
+    assert_nothing_raised do
+      assert_equal department.chefs, Hotel.includes(['departments' => 'chefs']).first.chefs
+    end
+  end
+
+  def test_has_many_reflection_accepts_symbols_as_keys
+    assert_equal :has_many, Firm.reflections[:clients].macro
+  end
+
+  def test_has_many_reflection_accepts_strings_as_keys
+    assert_equal :has_many, Firm.reflections['clients'].macro
+  end
+  def test_belongs_to_reflection_accepts_symbols_as_keys
+    assert_equal :belongs_to, Client.reflections[:firm].macro
+  end
+
+  def test_belongs_to_reflection_accepts_strings_as_keys
+    assert_equal :belongs_to, Client.reflections['firm'].macro
+  end
+
+  def test_some_more_shit
+    reflection_for_clients = AssociationReflection.new(:has_many, :clients, nil, { :order => "id", :dependent => :destroy }, Firm)
+    assert_equal reflection_for_clients, Firm.reflect_on_association('clients')
+  end
+
   private
     def assert_reflection(klass, association, options)
       assert reflection = klass.reflect_on_association(association)


### PR DESCRIPTION
This fixes an issue where when #14675 was implemented or shortly we nuked the ability to accept symbols as strings. There were no failing tests because they were changed to accept strings instead of symbols.

I added some regression tests that test both associations and the reflections cache accept both string and symbols as keys. :smile_cat: 

This caused tests that used symbols to fail (of course). After a lot of trial and error I found that `with_indifferent_access` seemed to be our only course of action. I know this is not ideal and it's not generally preferred. I'm open to other ideas.

If accepted I have a branch ready for 4-1-stable as well to fix #15671 (additional work needed to be done and a simple backport wasn't going to work).
