### PR TITLE
Partition routes during setup.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Partitioning of routes is now done when the routes are being drawn. This
+    helps to decrease the time spent filtering the routes during the first request.
+
+    *Guo Xiang Tan*
+
 *   Fix regression in functional tests. Responses should have default headers
     assigned.
 

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -88,7 +88,7 @@ module ActionDispatch
         end
 
         def custom_routes
-          partitioned_routes.last
+          routes.custom_routes
         end
 
         def filter_routes(path)

--- a/actionpack/test/journey/routes_test.rb
+++ b/actionpack/test/journey/routes_test.rb
@@ -3,6 +3,10 @@ require 'abstract_unit'
 module ActionDispatch
   module Journey
     class TestRoutes < ActiveSupport::TestCase
+      setup do
+        @routes = Routes.new
+      end
+
       def test_clear
         routes = Routes.new
         exp    = Router::Strexp.build '/foo(/:id)', {}, ['/.?']
@@ -34,6 +38,23 @@ module ActionDispatch
         sim = routes.simulator
         routes.add_route nil, path, {}, {}, {}
         assert_not_equal sim, routes.simulator
+      end
+
+      def test_partition_route
+        path   = Path::Pattern.from_string '/hello'
+
+        anchored_route = @routes.add_route nil, path, {}, {}, {}
+        assert_equal [anchored_route], @routes.anchored_routes
+        assert_equal [], @routes.custom_routes
+
+        strexp = Router::Strexp.build(
+          "/hello/:who", { who: /\d/ }, ['/', '.', '?']
+        )
+        path  = Path::Pattern.new strexp
+
+        custom_route = @routes.add_route nil, path, {}, {}, {}
+        assert_equal [custom_route], @routes.custom_routes
+        assert_equal [anchored_route], @routes.anchored_routes
       end
 
       def test_first_name_wins


### PR DESCRIPTION
Partitioning of all the routes is currently being done during the first request. Since there is no need to clear the cache for `partitioned_routes` when adding a new route. We can move the partitioning of the routes during setup time.
