### PR TITLE
Further simplify `changed?` conditional for numeric types

### DIFF
--- a/activerecord/lib/active_record/type/numeric.rb
+++ b/activerecord/lib/active_record/type/numeric.rb
@@ -16,26 +16,20 @@ module ActiveRecord
       end
 
       def changed?(old_value, _new_value, new_value_before_type_cast) # :nodoc:
-        # 0 => 'wibble' should mark as changed so numericality validations run
-        if nil_or_zero?(old_value) && non_numeric_string?(new_value_before_type_cast)
-          # nil => '' should not mark as changed
-          old_value != new_value_before_type_cast.presence
-        else
-          super
-        end
+        super || zero_to_non_number?(old_value, new_value_before_type_cast)
       end
 
       private
+
+      def zero_to_non_number?(old_value, new_value_before_type_cast)
+        old_value == 0 && non_numeric_string?(new_value_before_type_cast)
+      end
 
       def non_numeric_string?(value)
         # 'wibble'.to_i will give zero, we want to make sure
         # that we aren't marking int zero to string zero as
         # changed.
-        value !~ /\A\d+\.?\d*\z/
-      end
-
-      def nil_or_zero?(value)
-        value.nil? || value == 0
+        value.to_s !~ /\A\d+\.?\d*\z/
       end
     end
   end


### PR DESCRIPTION
`Type::Integer.new.type_cast('') # => nil`, we do not need a special
case to handle this, `nil => ''` already returns false. The only case we
need to handle is `0 => 'wibble'` should be changed, while `0 => '0'`
should not.
