### PR TITLE
highlight/excerpt support for regular expressions and blocks.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   The `highlight` helper now accepts a block to be used instead of the `highlighter`
+    option.
+
+    *Lucas Mazza*
+
+*   The `except` and `highlight` helpers now accept regular expressions.
+
+    *Jan Szumiec*
+
 *   Flatten the array parameter in `safe_join`, so it behaves consistently with
     `Array#join`.
 

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -123,7 +123,9 @@ module ActionView
           text
         else
           highlighter = options.fetch(:highlighter, '<mark>\1</mark>')
-          match = Array(phrases).map { |p| Regexp.escape(p) }.join('|')
+          match = Array(phrases).map do |p|
+            Regexp === p ? p.to_s : Regexp.escape(p)
+          end.join('|')
           text.gsub(/(#{match})(?![^<]*?>)/i, highlighter)
         end.html_safe
       end
@@ -156,11 +158,11 @@ module ActionView
         return unless text && phrase
 
         separator = options.fetch(:separator, nil) || ""
-        if Regexp === phrase
+        case phrase
+        when Regexp
           regex = phrase
         else
-          phrase    = Regexp.escape(phrase)
-          regex     = /#{phrase}/i
+          regex = /#{Regexp.escape(phrase)}/i
         end
 
         return unless matches = text.match(regex)

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -155,9 +155,13 @@ module ActionView
       def excerpt(text, phrase, options = {})
         return unless text && phrase
 
-        separator = options[:separator] || ''
-        phrase    = Regexp.escape(phrase)
-        regex     = /#{phrase}/i
+        separator = options.fetch(:separator, nil) || ""
+        if Regexp === phrase
+          regex = phrase
+        else
+          phrase    = Regexp.escape(phrase)
+          regex     = /#{phrase}/i
+        end
 
         return unless matches = text.match(regex)
         phrase = matches[0]

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -103,10 +103,13 @@ module ActionView
       # Highlights one or more +phrases+ everywhere in +text+ by inserting it into
       # a <tt>:highlighter</tt> string. The highlighter can be specialized by passing <tt>:highlighter</tt>
       # as a single-quoted string with <tt>\1</tt> where the phrase is to be inserted (defaults to
-      # '<mark>\1</mark>')
+      # '<mark>\1</mark>') or passing a block that receives each matched term.
       #
       #   highlight('You searched for: rails', 'rails')
       #   # => You searched for: <mark>rails</mark>
+      #
+      #   highlight('You searched for: rails', /for|rails/)
+      #   # => You searched <mark>for</mark>: <mark>rails</mark>
       #
       #   highlight('You searched for: ruby, rails, dhh', 'actionpack')
       #   # => You searched for: ruby, rails, dhh
@@ -116,17 +119,25 @@ module ActionView
       #
       #   highlight('You searched for: rails', 'rails', highlighter: '<a href="search?q=\1">\1</a>')
       #   # => You searched for: <a href="search?q=rails">rails</a>
+      #
+      #   highlight('You searched for: rails', 'rails') { |match| link_to(search_path(q: match, match)) }
+      #   # => You searched for: <a href="search?q=rails">rails</a>
       def highlight(text, phrases, options = {})
         text = sanitize(text) if options.fetch(:sanitize, true)
 
         if text.blank? || phrases.blank?
           text
         else
-          highlighter = options.fetch(:highlighter, '<mark>\1</mark>')
           match = Array(phrases).map do |p|
             Regexp === p ? p.to_s : Regexp.escape(p)
           end.join('|')
-          text.gsub(/(#{match})(?![^<]*?>)/i, highlighter)
+
+          if block_given?
+            text.gsub(/(#{match})(?![^<]*?>)/i) { |found| yield found }
+          else
+            highlighter = options.fetch(:highlighter, '<mark>\1</mark>')
+            text.gsub(/(#{match})(?![^<]*?>)/i, highlighter)
+          end
         end.html_safe
       end
 

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -265,6 +265,13 @@ class TextHelperTest < ActionView::TestCase
     assert_equal options, passed_options
   end
 
+  def test_highlight_with_block
+    assert_equal(
+      "<b>one</b> <b>two</b> <b>three</b>",
+      highlight("one two three", ["one", "two", "three"]) { |word| "<b>#{word}</b>" }
+    )
+  end
+
   def test_excerpt
     assert_equal("...is a beautiful morn...", excerpt("This is a beautiful morning", "beautiful", :radius => 5))
     assert_equal("This is a...", excerpt("This is a beautiful morning", "this", :radius => 5))

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -222,6 +222,11 @@ class TextHelperTest < ActionView::TestCase
     )
   end
 
+  def test_highlight_accepts_regexp
+    assert_equal("This day was challenging for judge <mark>Allen</mark> and his colleagues.",
+                 highlight("This day was challenging for judge Allen and his colleagues.", /\ballen\b/i))
+  end
+
   def test_highlight_with_multiple_phrases_in_one_pass
     assert_equal %(<em>wow</em> <em>em</em>), highlight('wow em', %w(wow em), :highlighter => '<em>\1</em>')
   end
@@ -264,9 +269,12 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("...is a beautiful morn...", excerpt("This is a beautiful morning", "beautiful", :radius => 5))
     assert_equal("This is a...", excerpt("This is a beautiful morning", "this", :radius => 5))
     assert_equal("...iful morning", excerpt("This is a beautiful morning", "morning", :radius => 5))
+    assert_nil excerpt("This is a beautiful morning", "day")
+  end
+
+  def test_excerpt_with_regex
     assert_equal("...udge Allen and...", excerpt("This day was challenging for judge Allen and his colleagues.", /\ballen\b/i, :radius => 5))
     assert_equal("...judge Allen and...", excerpt("This day was challenging for judge Allen and his colleagues.", /\ballen\b/i, :radius => 1, :separator => ' '))
-    assert_nil excerpt("This is a beautiful morning", "day")
   end
 
   def test_excerpt_should_not_be_html_safe

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -264,6 +264,8 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("...is a beautiful morn...", excerpt("This is a beautiful morning", "beautiful", :radius => 5))
     assert_equal("This is a...", excerpt("This is a beautiful morning", "this", :radius => 5))
     assert_equal("...iful morning", excerpt("This is a beautiful morning", "morning", :radius => 5))
+    assert_equal("...udge Allen and...", excerpt("This day was challenging for judge Allen and his colleagues.", /\ballen\b/i, :radius => 5))
+    assert_equal("...judge Allen and...", excerpt("This day was challenging for judge Allen and his colleagues.", /\ballen\b/i, :radius => 1, :separator => ' '))
     assert_nil excerpt("This is a beautiful morning", "day")
   end
 


### PR DESCRIPTION
First, this PR includes the commits from #11793 with the latest review suggestions, plus support for using a block instead of the `highlighter` option on the `highlight` helper.

Closes #11793.
