### PR TITLE
In Guides, ErrorsController shouldn't inherit ApplicationController, but ActionController

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1191,7 +1191,7 @@ Create the controller and views.
 * `app/controllers/errors_controller.rb`
 
   ```ruby
-  class ErrorsController < ApplicationController
+  class ErrorsController < ActionController::Base
     layout 'error'
 
     def not_found


### PR DESCRIPTION
This is a followup pull request to https://github.com/rails/rails/pull/15808. Inheriting `ApplicationController` often causes an issue as it always has before/after actions. It should encourage people to use `ActionController::Base` instead.
