### PR TITLE
Remove extra list item element in engine guide

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -94,7 +94,7 @@ including a skeleton structure that provides the following:
     ```
 
   * A file at `lib/blorgh/engine.rb`, which is identical in function to a
-  * standard Rails application's `config/application.rb` file:
+    standard Rails application's `config/application.rb` file:
 
     ```ruby
     module Blorgh


### PR DESCRIPTION
Cleaning up the list items that detail what an engines `--full` option
generates. Joining a multiline multi list item into a multiline single
list item.

[ci skip]
