### PR TITLE
Add warning section for `rescue_from Exception` in Guides

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1164,6 +1164,8 @@ class ClientsController < ApplicationController
 end
 ```
 
+WARNING: You shouldn't do `rescue_from Exception` or `rescue_from StandardError` unless you have a particular reason as it will cause serious side-effects (e.g. you won't be able to see exception details and tracebacks during development). If you would like to dynamically generate error pages, see [Custom errors page](#custom-errors-page).
+
 NOTE: Certain exceptions are only rescuable from the `ApplicationController` class, as they are raised before the controller gets initialized and the action gets executed. See Pratik Naik's [article](http://m.onkey.org/2008/7/20/rescue-from-dispatching) on the subject for more information.
 
 


### PR DESCRIPTION
Now that we have Custom error page in Guides, we should add this warning as well. I've seen `rescue_from Exception` or `rescue_from StandardError` a lot of times. In any case, it's for custom error pages.
As documented, it causes serious side-effects such as:
- You won't be able to see exception details and tracebacks during development.
- Rack middleware that expects exceptions to hit it(e.g. airbrake) will stop working.

I also think that we should at least output a warning when `rescue_from` is given `Exception` / `StandardError` or we shouldn't allow to do so as I've never seen any proper use case for it. What do you think?
