### PR TITLE
options for Relation.explain

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   `Relation#explain` delegates all additional arguments to the underlying adapter.
+    This adds support for MySQL's EXTENDED explain and PostgreSQL specific explain flags.
+
+      Examples:
+
+        # PostgreSQL
+        User.where(username: "jane").explain(analyze: true)
+
+        # MySQL
+        User.where(username: "jack").explain(extended: true)
+
+    *Max Melentiev*
+
 *   Honor overridden `rack.test` in Rack environment for the connection
     management middlware.
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -106,8 +106,10 @@ module ActiveRecord
 
       # DATABASE STATEMENTS ======================================
 
-      def explain(arel, binds = [])
-        sql     = "EXPLAIN #{to_sql(arel, binds.dup)}"
+      def explain(arel, binds = [], options = {})
+        sql = 'EXPLAIN '
+        sql << 'EXTENDED ' if options[:extended]
+        sql << to_sql(arel, binds.dup)
         start   = Time.now
         result  = exec_query(sql, 'EXPLAIN', binds)
         elapsed = Time.now - start

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -272,7 +272,7 @@ module ActiveRecord
 
       # DATABASE STATEMENTS ======================================
 
-      def explain(arel, binds = [])
+      def explain(arel, binds = [], *)
         sql = "EXPLAIN QUERY PLAN #{to_sql(arel, binds)}"
         ExplainPrettyPrinter.new.pp(exec_query(sql, 'EXPLAIN', []))
       end

--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -15,7 +15,7 @@ module ActiveRecord
 
     # Makes the adapter execute EXPLAIN for the tuples of queries and bindings.
     # Returns a formatted string ready to be logged.
-    def exec_explain(queries) # :nodoc:
+    def exec_explain(queries, *args) # :nodoc:
       str = queries.map do |sql, bind|
         [].tap do |msg|
           msg << "EXPLAIN for: #{sql}"
@@ -23,7 +23,7 @@ module ActiveRecord
             bind_msg = bind.map {|col, val| [col.name, val]}.inspect
             msg.last << " #{bind_msg}"
           end
-          msg << connection.explain(sql, bind)
+          msg << connection.explain(sql, bind, *args)
         end.join("\n")
       end.join("\n")
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -231,9 +231,9 @@ module ActiveRecord
     #
     # Please see further details in the
     # {Active Record Query Interface guide}[http://guides.rubyonrails.org/active_record_querying.html#running-explain].
-    def explain
+    def explain(*args)
       #TODO: Fix for binds.
-      exec_explain(collecting_queries_for_explain { exec_queries })
+      exec_explain(collecting_queries_for_explain { exec_queries }, *args)
     end
 
     # Converts relation objects to Array.

--- a/activerecord/test/cases/adapters/mysql2/explain_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/explain_test.rb
@@ -20,6 +20,12 @@ module ActiveRecord
           assert_match %(EXPLAIN for: SELECT `audit_logs`.* FROM `audit_logs` WHERE `audit_logs`.`developer_id` IN (1)), explain
           assert_match %r(audit_logs |.* ALL), explain
         end
+
+        def test_extended_explain_for_one_query
+          explain = Developer.where(id: 1).explain(extended: true)
+          assert_match %(EXPLAIN for: SELECT `developers`.* FROM `developers` WHERE `developers`.`id` = 1), explain
+          assert_match %r(filtered), explain
+        end
       end
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/explain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/explain_test.rb
@@ -19,6 +19,20 @@ module ActiveRecord
           assert_match %(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = $1), explain
           assert_match %(EXPLAIN for: SELECT "audit_logs".* FROM "audit_logs" WHERE "audit_logs"."developer_id" IN (1)), explain
         end
+
+        def test_explain_for_one_query_with_modifiers
+          explain = Developer.where(id: 1).explain(analyze: true)
+          assert_match %(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = $1), explain
+          assert_match %(QUERY PLAN), explain
+          assert_match %(Index Scan using developers_pkey on developers), explain
+          assert_match %(Total runtime), explain
+        end
+
+        def test_explain_for_one_query_with_json_format
+          explain = Developer.where(id: 1).explain(format: :json)
+          json = JSON.parse(explain.lines.to_a[1..-1].join)
+          assert json.first.key?('Plan')
+        end
       end
     end
   end

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -64,6 +64,18 @@ if ActiveRecord::Base.connection.supports_explain?
       assert_equal expected, base.exec_explain(queries)
     end
 
+    def test_exec_explain_with_options
+      sqls    = %w(foo bar)
+      binds   = [[], []]
+      queries = sqls.zip(binds)
+      options = {modifier: :value}
+
+      connection.expects(:explain).with('bar', [], options).returns('query plan bar')
+      connection.expects(:explain).with('foo', [], options).returns('query plan foo')
+      expected = sqls.map {|sql| "EXPLAIN for: #{sql}\nquery plan #{sql}"}.join("\n")
+      assert_equal expected, base.exec_explain(queries, options)
+    end
+
     def test_unsupported_connection_adapter
       connection.stubs(:supports_explain?).returns(false)
 


### PR DESCRIPTION
Also support for postgre's ANALYZE & BUFFERS options

It adds ability to pass custom options to `Relation.analyze`.
I've implemented support for postgre's options. Mysql's `EXPLAIN EXTENDED` can be implemented later.
