### PR TITLE
Replace two slashes with just one in Journey::Format#evaluate.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix Journey::Format#evaluate when argument has a leading slash.
+
+    Fixes #10963.
+
+    *Larry Lv*
+
 *   Fix env['PATH_INFO'] missing leading slash when a rack app mounted at '/'.
 
     Fixes #15511.

--- a/actionpack/lib/action_dispatch/journey/visitors.rb
+++ b/actionpack/lib/action_dispatch/journey/visitors.rb
@@ -45,7 +45,7 @@ module ActionDispatch
 
         @children.each { |index| parts[index] = parts[index].evaluate(hash) }
 
-        parts.join
+        parts.join.gsub(%r|//|, '/')
       end
     end
 

--- a/actionpack/test/controller/url_rewriter_test.rb
+++ b/actionpack/test/controller/url_rewriter_test.rb
@@ -22,6 +22,7 @@ class UrlRewriterTests < ActiveSupport::TestCase
     @routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
       r.draw do
         get ':controller(/:action(/:id))'
+        get '*path' => "pages#show"
       end
     end
   end
@@ -85,6 +86,11 @@ class UrlRewriterTests < ActiveSupport::TestCase
     assert_equal '/foo/bar/3/', @rewriter.rewrite(@routes, options)
     options.update({:query => 'string'})
     assert_equal '/foo/bar/3/?query=string', @rewriter.rewrite(@routes, options)
+  end
+
+  def test_splat
+    options = {:controller => 'pages', :action => 'show', :path => '/test', :only_path => true}
+    assert_equal '/test', @rewriter.rewrite(@routes, options)
   end
 end
 


### PR DESCRIPTION
Fixes issue #10963.

This is a try for fixing the issue above. I think it's better to replace consecutive slashes in the end of `evaluate` method.

What do you think? cc @senny  @pixeltrix 
