### PR TITLE
Allow proc and symbol as values for `only_integer` of `NumericalityValidator`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow proc and symbol as values for `only_integer` of `NumericalityValidator`
+
+    *Robin Mehner*
+
 *   `has_secure_password` now verifies that the given password is less than 72
     characters if validations are enabled.
 

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -30,7 +30,7 @@ module ActiveModel
           return
         end
 
-        if options[:only_integer]
+        if allow_only_integer?(record)
           unless value = parse_raw_value_as_an_integer(raw_value)
             record.errors.add(attr_name, :not_an_integer, filtered_options(raw_value))
             return
@@ -74,6 +74,17 @@ module ActiveModel
         filtered = options.except(*RESERVED_OPTIONS)
         filtered[:value] = value
         filtered
+      end
+
+      def allow_only_integer?(record)
+        case options[:only_integer]
+        when Symbol
+          record.send(options[:only_integer])
+        when Proc
+          options[:only_integer].call(record)
+        else
+          options[:only_integer]
+        end
       end
     end
 
@@ -121,6 +132,7 @@ module ActiveModel
       # * <tt>:equal_to</tt>
       # * <tt>:less_than</tt>
       # * <tt>:less_than_or_equal_to</tt>
+      # * <tt>:only_integer</tt>
       #
       # For example:
       #

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -50,6 +50,21 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!(NIL + INTEGERS)
   end
 
+  def test_validates_numericality_of_with_integer_only_and_symbol_as_value
+    Topic.validates_numericality_of :approved, only_integer: :condition_is_true_but_its_not
+
+    invalid!(NIL + BLANK + JUNK)
+    valid!(FLOATS + INTEGERS + BIGDECIMAL + INFINITY)
+  end
+
+  def test_validates_numericality_of_with_integer_only_and_proc_as_value
+    Topic.send(:define_method, :allow_only_integers?, lambda { false })
+    Topic.validates_numericality_of :approved, only_integer: Proc.new {|topic| topic.allow_only_integers? }
+
+    invalid!(NIL + BLANK + JUNK)
+    valid!(FLOATS + INTEGERS + BIGDECIMAL + INFINITY)
+  end
+
   def test_validates_numericality_with_greater_than
     Topic.validates_numericality_of :approved, greater_than: 10
 


### PR DESCRIPTION
We have to dynamically decide of the value should be validated as float or as integer. This PR adds the possibility of defining a symbol or a Proc as value for the `only_integer` option, while preserving the old behaviour of just setting a boolean.

I see one difference in behaviour to the existing version: If you provided a symbol instead of a boolean before, it was always handled as truthness (the same as `only_integer: true`). With this PR applied it would raise an `NoMethodError`, because it tries to call the method on the object. Should I handle that to keep full backwards compatibility?

Thank you Rails team for your hard work! Happy to get any feedback :)
