### PR TITLE
Replace x.sort_by!.select! with x.select!.sort_by!

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -105,7 +105,8 @@ module ActionDispatch
             routes.concat get_routes_as_head(routes)
           end
 
-          routes.sort_by!(&:precedence).select! { |r| r.matches?(req) }
+          routes.select! { |r| r.matches?(req) }
+          routes.sort_by!(&:precedence)
 
           routes.map! { |r|
             match_data  = r.path.match(req.path_info)


### PR DESCRIPTION
The latter has the same speed as the former in the worst case
and faster in general, because it is always better to sort less items.

Unfortunately, `routes.select!{...}.sort_by!{...}` is not possible here
because `select!` returns `nil`, so select! and sort! must be done
in two steps.
