### PR TITLE
Deprecate `*_path` methods in mailers

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate `*_path` helpers in email views. When used they generate
+    non-working links and are not the intention of most developers. Instead
+    we recommend to use `*_url` helper.
+
+    *Richard Schneeman*
+
 *   Raise an exception when attachments are added after `mail` was called.
     This is a safeguard to prevent invalid emails.
 

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -897,6 +897,11 @@ module ActionMailer
       container.add_part(part)
     end
 
+    # Emails do not support relative path links.
+    def self.supports_path?
+      false
+    end
+
     ActiveSupport.run_load_hooks(:action_mailer, self)
   end
 end

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -30,7 +30,7 @@ module ActionMailer
 
       ActiveSupport.on_load(:action_mailer) do
         include AbstractController::UrlFor
-        extend ::AbstractController::Railties::RoutesHelpers.with(app.routes)
+        extend ::AbstractController::Railties::RoutesHelpers.with(app.routes, false)
         include app.routes.mounted_helpers
 
         register_interceptors(options.delete(:interceptors))

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -164,6 +164,14 @@ module AbstractController
       _find_action_name(action_name).present?
     end
 
+    # Returns true if the given controller is capable of rendering
+    # a path. A subclass of +AbstractController::Base+
+    # may return false. An Email controller for example does not
+    # support paths, only full URLs.
+    def self.supports_path?
+      true
+    end
+
     private
 
       # Returns true if the name can be considered an action because

--- a/actionpack/lib/abstract_controller/railties/routes_helpers.rb
+++ b/actionpack/lib/abstract_controller/railties/routes_helpers.rb
@@ -1,14 +1,14 @@
 module AbstractController
   module Railties
     module RoutesHelpers
-      def self.with(routes)
+      def self.with(routes, include_path_helpers = true)
         Module.new do
           define_method(:inherited) do |klass|
             super(klass)
             if namespace = klass.parents.detect { |m| m.respond_to?(:railtie_routes_url_helpers) }
-              klass.send(:include, namespace.railtie_routes_url_helpers)
+              klass.send(:include, namespace.railtie_routes_url_helpers(include_path_helpers))
             else
-              klass.send(:include, routes.url_helpers)
+              klass.send(:include, routes.url_helpers(include_path_helpers))
             end
           end
         end

--- a/actionpack/test/routing/helper_test.rb
+++ b/actionpack/test/routing/helper_test.rb
@@ -26,6 +26,20 @@ module ActionDispatch
           x.new.pond_duck_path Duck.new
         end
       end
+
+      def test_path_deprecation
+        rs = ::ActionDispatch::Routing::RouteSet.new
+        rs.draw do
+          resources :ducks
+        end
+
+        x = Class.new {
+          include rs.url_helpers(false)
+        }
+        assert_deprecated do
+          assert_equal '/ducks', x.new.ducks_path
+        end
+      end
     end
   end
 end

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -35,12 +35,13 @@ module ActionView
     module ClassMethods
       def view_context_class
         @view_context_class ||= begin
-          routes = respond_to?(:_routes) && _routes
+          include_path_helpers = supports_path?
+          routes  = respond_to?(:_routes)  && _routes
           helpers = respond_to?(:_helpers) && _helpers
 
           Class.new(ActionView::Base) do
             if routes
-              include routes.url_helpers
+              include routes.url_helpers(include_path_helpers)
               include routes.mounted_helpers
             end
 

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -414,6 +414,22 @@ globally in `config/application.rb`:
 config.action_mailer.default_url_options = { host: 'example.com' }
 ```
 
+Because of this behavior you cannot use any of the `*_path` helpers inside of
+an email. Instead you will need to use the associated `*_url` helper. For example
+instead of using
+
+```
+<%= link_to 'welcome', welcome_path %>
+```
+
+You will need to use:
+
+```
+<%= link_to 'welcome', welcome_url %>
+```
+
+By using the full URL, your links will now work in your emails.
+
 #### generating URLs with `url_for`
 
 You need to pass the `only_path: false` option when using `url_for`. This will

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -395,7 +395,7 @@ module Rails
             end
 
             unless mod.respond_to?(:railtie_routes_url_helpers)
-              define_method(:railtie_routes_url_helpers) { railtie.routes.url_helpers }
+              define_method(:railtie_routes_url_helpers) {|include_path_helpers = true| railtie.routes.url_helpers(include_path_helpers) }
             end
           end
         end

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -50,7 +50,7 @@ module ApplicationTests
       assert_equal "test.rails", ActionMailer::Base.default_url_options[:host]
     end
 
-    test "does not include url helpers as action methods" do
+    test "includes url helpers as action methods" do
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
           get "/foo", :to => lambda { |env| [200, {}, []] }, :as => :foo
@@ -66,8 +66,8 @@ module ApplicationTests
 
       require "#{app_path}/config/environment"
       assert Foo.method_defined?(:foo_path)
+      assert Foo.method_defined?(:foo_url)
       assert Foo.method_defined?(:main_app)
-      assert_equal Set.new(["notify"]), Foo.action_methods
     end
 
     test "allows to not load all helpers for controllers" do

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -417,6 +417,58 @@ module ApplicationTests
       assert_match '<option selected value="?part=text%2Fplain">View as plain-text email</option>', last_response.body
     end
 
+    test "*_path helpers emit a deprecation" do
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get 'foo', to: 'foo#index'
+        end
+      RUBY
+
+      mailer 'notifier', <<-RUBY
+        class Notifier < ActionMailer::Base
+          default from: "from@example.com"
+
+          def path_in_view
+            mail to: "to@example.org"
+          end
+
+          def path_in_mailer
+            @url = foo_path
+            mail to: "to@example.org"
+          end
+        end
+      RUBY
+
+      html_template 'notifier/path_in_view', "<%= link_to 'foo', foo_path %>"
+
+      mailer_preview 'notifier', <<-RUBY
+        class NotifierPreview < ActionMailer::Preview
+          def path_in_view
+            Notifier.path_in_view
+          end
+
+          def path_in_mailer
+            Notifier.path_in_mailer
+          end
+        end
+      RUBY
+
+      app('development')
+
+      assert_deprecated do
+        get "/rails/mailers/notifier/path_in_view.html"
+        assert_equal 200, last_response.status
+      end
+
+      html_template 'notifier/path_in_mailer', "No ERB in here"
+
+      assert_deprecated do
+        get "/rails/mailers/notifier/path_in_mailer.html"
+        assert_equal 200, last_response.status
+      end
+    end
+
     private
       def build_app
         super


### PR DESCRIPTION
Email does not support relative links since there is no implicit host. Therefore all links inside of emails must be fully qualified URLs. All path helpers are now deprecated. When removed, the error will give early indication to developers to use `*_url` methods instead.

Currently if a developer uses a `*_path` helper, their tests and `mail_view` will not catch the mistake. The only way to see the error is by sending emails in production. Preventing sending out emails with non-working path's is the desired end goal of this PR.

Currently path helpers are mixed-in to controllers (the ActionMailer::Base acts as a controller). All `*_url` and `*_path` helpers are made available through the same module. This PR separates this behavior into two modules so we can extend the `*_path` methods to add a Deprecation to them. Once deprecated we can use this same area to raise a NoMethodError and add an informative message directing the developer to use `*_url` instead.

The module with warnings is only mixed in when a controller returns false from the newly added `supports_relative_path?`.

Paired @sgrif & @schneems
