### PR TITLE
Optimize dependent destroy on a has many

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -781,4 +781,8 @@
 
     *Yves Senn*
 
+*   Optimize dependent destroy on a has many to be smarter by not individually destroying each associated objects if there are no destroy callbacks
+
+    *Rahul Kapadia*
+
 Please check [4-1-stable](https://github.com/rails/rails/blob/4-1-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -128,6 +128,10 @@ module ActiveRecord
 
         # Deletes the records according to the <tt>:dependent</tt> option.
         def delete_records(records, method)
+          if method == :destroy && reflection.klass._destroy_callbacks.empty?
+            method = :delete_all
+          end
+
           if method == :destroy
             records.each(&:destroy!)
             update_counter(-records.length) unless inverse_updates_counter_cache?

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -28,6 +28,8 @@ require 'models/college'
 require 'models/student'
 require 'models/pirate'
 require 'models/ship'
+require 'models/dog'
+require 'models/dog_lover'
 
 class HasManyAssociationsTestForReorderWithJoinDependency < ActiveRecord::TestCase
   fixtures :authors, :posts, :comments
@@ -124,6 +126,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     car.funky_bulbs.create!
     assert_nothing_raised { car.reload.funky_bulbs.delete_all }
     assert_equal 0, Bulb.count, "bulbs should have been deleted using :delete_all strategy"
+  end
+
+  def test_depndent_destroy_does_not_individually_destroy_when_no_destroy_callbacks
+    dog_lover = DogLover.create!
+    dog_lover.trained_dogs.create!()
+    Dog.any_instance.expects(:destroy).never
+    dog_lover.destroy
+    assert_equal 0, Dog.count, "all associates dog objects should be deleted"
   end
 
   def test_delete_all_on_association_is_the_same_as_not_loaded


### PR DESCRIPTION
https://gist.github.com/rahulk1000/10a67737f231a14fb9fa

See the gist above for reference:
When the car object gets destroyed, each of its 10,000 parts will get destroyed individually which is quite cumbersome. This change makes the dependent destroy smarter so that it deletes them with SQL instead when the associated object has no destroy callbacks on it. It does not make sense to call destroy on each object is it has no destroy call backs. 
