### PR TITLE
Remove old deprecation warning

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -37,14 +37,7 @@ module ActiveRecord
     #   Post.find_by_sql ["SELECT body FROM comments WHERE author = :user_id OR approved_by = :user_id", { :user_id => user_id }]
     def find_by_sql(sql, binds = [])
       result_set = connection.select_all(sanitize_sql(sql), "#{name} Load", binds)
-      column_types = {}
-
-      if result_set.respond_to? :column_types
-        column_types = result_set.column_types.except(*columns_hash.keys)
-      else
-        ActiveSupport::Deprecation.warn "the object returned from `select_all` must respond to `column_types`"
-      end
-
+      column_types = result_set.column_types.except(*columns_hash.keys)
       result_set.map { |record| instantiate(record, column_types) }
     end
 


### PR DESCRIPTION
This has been around for a couple of versions now, a `NoMethodError`
should suffice at this point.
