### PR TITLE
A non-existent table has no columns

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -166,7 +166,7 @@ module ActiveRecord
       #   Person.attribute_method?(:age=)    # => true
       #   Person.attribute_method?(:nothing) # => false
       def attribute_method?(attribute)
-        super || (table_exists? && column_names.include?(attribute.to_s.sub(/=$/, '')))
+        super || column_names.include?(attribute.to_s.remove(/=$/))
       end
 
       # Returns an array of column names as strings if it's not an abstract class and
@@ -178,11 +178,11 @@ module ActiveRecord
       #   Person.attribute_names
       #   # => ["id", "created_at", "updated_at", "name", "age"]
       def attribute_names
-        @attribute_names ||= if !abstract_class? && table_exists?
-            column_names
-          else
-            []
-          end
+        if abstract_class?
+          []
+        else
+          column_names
+        end
       end
 
       # Returns the column object for the named attribute.

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -82,7 +82,7 @@ module ActiveRecord
 
       # Returns an array of column objects for the table associated with this class.
       def columns
-        @columns ||= add_user_provided_columns(connection.schema_cache.columns(table_name))
+        @columns ||= add_user_provided_columns(super)
       end
 
       # Returns a hash of column objects for the table associated with this class.

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -249,6 +249,14 @@ module ActiveRecord
         }]
       end
 
+      def columns # :nodoc:
+        if table_exists?
+          connection.schema_cache.columns(table_name)
+        else
+          []
+        end
+      end
+
       # Returns an array of column names as strings.
       def column_names
         @column_names ||= columns.map { |column| column.name }


### PR DESCRIPTION
Removes the need to check if the table exists from methods that require
columns to be present, makes other column derived methods act
consistently.
