### PR TITLE
Change double quotes to single quotes in guide

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1873,7 +1873,7 @@ Then you make the `app/views/articles/show.html.erb` look like the following:
 <%= render @article.comments %>
 
 <h2>Add a comment:</h2>
-<%= render "comments/form" %>
+<%= render 'comments/form' %>
 
 <%= link_to 'Edit Article', edit_article_path(@article) %> |
 <%= link_to 'Back to Articles', articles_path %>


### PR DESCRIPTION
I was going through the getting started guide today and this bugged me... I like consistency! :P

There are also double-quotes in the authentication demo, but this is the one that bothered me the most, especially because 'render' is called elsewhere with single quotes.
