### PR TITLE
add arel.bind_values for polymorphic joins #15821.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `DatabaseStatements#binds_from_relation` correctly get the binding values 
+    when passing polymorphic relation.
+
+    Fixes #15821.
+
+    *James Yang*
+
 *   `reload` no longer merges with the existing attributes.
     The attribute hash is fully replaced. The record is put into the same state
     as it would be with `Model.find(model.id)`.
@@ -8,7 +15,6 @@
     If this is not the case a `NoMethodError` is raised.
 
     *Sean Griffin*
->>>>>>> master
 
 *   `has_many :through` associations will no longer save the through record
     twice when added in an `after_create` callback defined before the

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   `DatabaseStatements#binds_from_relation` correctly get the binding values 
+    when passing polymorphic relation.
+
+    Fixes #15821.
+
+    *James Yang*
+
+*   `reload` no longer merges with the existing attributes.
+    The attribute hash is fully replaced. The record is put into the same state
+    as it would be with `Model.find(model.id)`.
+
+    *Sean Griffin*
+
 *   `has_many :through` associations will no longer save the through record
     twice when added in an `after_create` callback defined before the
     associations.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `DatabaseStatements#binds_from_relation` correctly get the binding values 
+    when passing polymorphic relation.
+
+    Fixes #15821.
+
+    *James Yang*
+
 *   `has_many :through` associations will no longer save the through record
     twice when added in an `after_create` callback defined before the
     associations.

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -393,8 +393,13 @@ module ActiveRecord
         end
 
         def binds_from_relation(relation, binds)
-          if relation.is_a?(Relation) && binds.empty?
-            relation, binds = relation.arel, relation.bind_values
+          if relation.is_a?(Relation)
+            if relation.arel.bind_values.empty?
+              binds = relation.bind_values
+            else
+              binds = relation.arel.bind_values + relation.bind_values
+            end
+            relation = relation.arel
           end
           [relation, binds]
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -393,7 +393,7 @@ module ActiveRecord
         end
 
         def binds_from_relation(relation, binds)
-          if relation.is_a?(Relation) && binds.empty?
+          if relation.is_a?(Relation)
             if relation.arel.bind_values.empty?
               binds = relation.bind_values
             else

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -394,7 +394,12 @@ module ActiveRecord
 
         def binds_from_relation(relation, binds)
           if relation.is_a?(Relation) && binds.empty?
-            relation, binds = relation.arel, relation.bind_values
+            if relation.arel.bind_values.empty?
+              binds = relation.bind_values
+            else
+              binds = relation.arel.bind_values + relation.bind_values
+            end
+            relation = relation.arel
           end
           [relation, binds]
         end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -304,7 +304,7 @@ module ActiveRecord
         end
       end
 
-      connection.select_value(relation, "#{name} Exists", arel.bind_values + relation.bind_values) ? true : false
+      connection.select_value(relation, "#{name} Exists", relation.bind_values) ? true : false
     end
 
     # This method is called whenever no records are found with either a single

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -304,7 +304,7 @@ module ActiveRecord
         end
       end
 
-      connection.select_value(relation, "#{name} Exists", relation.bind_values) ? true : false
+      connection.select_value(relation, "#{name} Exists", arel.bind_values + relation.bind_values) ? true : false
     end
 
     # This method is called whenever no records are found with either a single

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -89,8 +89,8 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal true, relation.exists?
 
     assert_equal false, relation.exists?(false)
-    assert_equal false, relation.exists?(2)
-    assert_equal false, relation.exists?("2")
+    assert_equal false, relation.exists?(post.id)
+    assert_equal false, relation.exists?(post.id.to_s)
   end
 
   def test_exists_passing_active_record_object_is_deprecated

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -13,6 +13,7 @@ require 'models/customer'
 require 'models/toy'
 require 'models/matey'
 require 'models/dog'
+require 'models/slug'
 
 class FinderTest < ActiveRecord::TestCase
   fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :customers, :categories, :categorizations
@@ -76,6 +77,20 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal false, Topic.exists?(Topic.new.id)
 
     assert_raise(NoMethodError) { Topic.exists?([1,2]) }
+  end
+
+  def test_exists_with_polymorphic_relation
+    post = SlugPost.create!(title: 'slugs', body: "default", slug: Slug.new(name: 'the-slug'))
+    relation = SlugPost.find_slug('the-slug')
+    query = "slugs"
+
+    assert_equal true, relation.exists?(title: ["slugs"])
+    assert_equal true, relation.exists?(['title LIKE ?', "#{query}%"])
+    assert_equal true, relation.exists?
+    assert_equal true, relation.exists?(post.id)
+    assert_equal true, relation.exists?(post.id.to_s)
+
+    assert_equal false, relation.exists?(false)
   end
 
   def test_exists_passing_active_record_object_is_deprecated

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -87,10 +87,10 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal true, relation.exists?(title: ["slugs"])
     assert_equal true, relation.exists?(['title LIKE ?', "#{query}%"])
     assert_equal true, relation.exists?
+    assert_equal true, relation.exists?(post.id)
+    assert_equal true, relation.exists?(post.id.to_s)
 
     assert_equal false, relation.exists?(false)
-    assert_equal false, relation.exists?(post.id)
-    assert_equal false, relation.exists?(post.id.to_s)
   end
 
   def test_exists_passing_active_record_object_is_deprecated

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -13,6 +13,7 @@ require 'models/customer'
 require 'models/toy'
 require 'models/matey'
 require 'models/dog'
+require 'models/slug'
 
 class FinderTest < ActiveRecord::TestCase
   fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :customers, :categories, :categorizations
@@ -76,6 +77,20 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal false, Topic.exists?(Topic.new.id)
 
     assert_raise(NoMethodError) { Topic.exists?([1,2]) }
+  end
+
+  def test_exists_with_polymorphic_relation
+    post = SlugPost.create!(title: 'slugs', body: "default", slug: Slug.new(name: 'the-slug'))
+    relation = SlugPost.find_slug('the-slug')
+    query = "slugs"
+
+    assert_equal true, relation.exists?(title: ["slugs"])
+    assert_equal true, relation.exists?(['title LIKE ?', "#{query}%"])
+    assert_equal true, relation.exists?
+
+    assert_equal false, relation.exists?(false)
+    assert_equal false, relation.exists?(2)
+    assert_equal false, relation.exists?("2")
   end
 
   def test_exists_passing_active_record_object_is_deprecated

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -217,3 +217,9 @@ class PostThatLoadsCommentsInAnAfterSaveHook < ActiveRecord::Base
     post.comments.load
   end
 end
+
+class SlugPost < ActiveRecord::Base
+  self.table_name = 'posts'
+  has_one :slug, as: :sluggable
+  scope :find_slug, ->(slug) { joins(:slug).where(slugs: { name: slug }) }
+end

--- a/activerecord/test/models/slug.rb
+++ b/activerecord/test/models/slug.rb
@@ -1,0 +1,3 @@
+class Slug < ActiveRecord::Base
+
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -644,6 +644,12 @@ ActiveRecord::Schema.define do
     t.integer :ship_id
   end
 
+  create_table :slugs, force: true do |t|
+    t.string :name
+    t.integer :sluggable_id
+    t.string :sluggable_type
+  end
+
   create_table :speedometers, force: true, id: false do |t|
     t.string :speedometer_id
     t.string :name


### PR DESCRIPTION
It seems `arel` gem changes its behavior which puts sql's dynamic parameter‘s value to `arel.bind_values` rather than directly assign values to sql statement:

``` ruby
# rails 4.1.2.rc2 
# arel 5.0.0
Post Load (0.1ms)  SELECT "posts".* FROM "posts" INNER JOIN "slugs" ON
 "slugs"."sluggable_id" = "posts"."id" AND "slugs"."sluggable_type" = 'Post' 
WHERE "slugs"."name" = 'the-slug'

# rails master
# arel 6.0.0
Post Load (0.1ms)  SELECT "posts".* FROM "posts" INNER JOIN "slugs" ON 
"slugs"."sluggable_id" = "posts"."id" AND "slugs"."sluggable_type" = ? 
WHERE "slugs"."name" = 'the-slug'  [[nil, "Post"]]

# /activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
require 'arel/collectors/bind'
require 'arel/collectors/sql_string'
```

Instead of passing binding values from `exists?`'s, we may prepend `arel.bind_values` to `relation.bind_values` which pass the test cases provide by [issue_15821](https://github.com/rails/rails/issues/15821). It this change is feasible. I will include test case in further commit.
