### PR TITLE
Create an ActiveModel::Identity mixin

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Add an `ActiveModel::Identity` mixin for comparisons of objects by ID.
+*   Add an `ActiveModel::Identity` mixin for comparisons of objects by defined key attributes.
 
     *Aidan Feldman*
 

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add an `ActiveModel::Identity` mixin for comparisons of objects by ID.
+
+    *Aidan Feldman*
+
 *   Added `undo_changes` method to `ActiveModel::Dirty` API to restore all the
     changed values to the previous data.
 

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -35,6 +35,7 @@ module ActiveModel
   autoload :Dirty
   autoload :EachValidator, 'active_model/validator'
   autoload :ForbiddenAttributesProtection
+  autoload :Identity
   autoload :Lint
   autoload :Model
   autoload :Name, 'active_model/naming'

--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -25,9 +25,7 @@ module ActiveModel
     included do
       include ActiveModel::Identity
 
-      def key_attributes
-        respond_to?(:id) ? [:id] : []
-      end
+      key_attributes :id
     end
 
     # If your object is already designed to implement all of the Active Model

--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -22,6 +22,14 @@ module ActiveModel
   module Conversion
     extend ActiveSupport::Concern
 
+    included do
+      include ActiveModel::Identity
+
+      def key_attributes
+        respond_to?(:id) ? [:id] : []
+      end
+    end
+
     # If your object is already designed to implement all of the Active Model
     # you can use the default <tt>:to_model</tt> implementation, which simply
     # returns +self+.
@@ -38,21 +46,6 @@ module ActiveModel
     # your object with Active Model compliant methods.
     def to_model
       self
-    end
-
-    # Returns an Array of all key attributes if any is set, regardless if
-    # the object is persisted or not. Returns +nil+ if there are no key attributes.
-    #
-    #   class Person
-    #     include ActiveModel::Conversion
-    #     attr_accessor :id
-    #   end
-    #
-    #   person = Person.create(id: 1)
-    #   person.to_key # => [1]
-    def to_key
-      key = respond_to?(:id) && id
-      key ? [key] : nil
     end
 
     # Returns a +string+ representing the object's key suitable for use in URLs,

--- a/activemodel/lib/active_model/identity.rb
+++ b/activemodel/lib/active_model/identity.rb
@@ -108,7 +108,7 @@ module ActiveModel
       #   person = Person.create(first: 'John', last: 'Smith')
       #   person.to_key # => ['John', 'Smith']
       def key_attributes(*attrs)
-        if attrs.length == 0
+        if attrs.empty?
           self.key_attribute_names
         else
           self.key_attribute_names = attrs

--- a/activemodel/lib/active_model/identity.rb
+++ b/activemodel/lib/active_model/identity.rb
@@ -9,6 +9,7 @@ module ActiveModel
   #     include ActiveModel::Identity
   #
   #     attr_accessor :id
+  #     key_attributes :id
   #   end
   #
   # Two objects without IDs are not equal:

--- a/activemodel/lib/active_model/identity.rb
+++ b/activemodel/lib/active_model/identity.rb
@@ -36,6 +36,38 @@ module ActiveModel
   #
   # The only requirement is that your object responds to +id+.
   module Identity
+    # Returns an Array of Symbols, which correspond to the attribute names used
+    # for identity checking. For example, if your models are unique by first
+    # last name, this method could be overridden:
+    #
+    #   class Person
+    #     include ActiveModel::Identity
+    #     def key_attributes
+    #       [:first, :last]
+    #     end
+    #   end
+    #
+    #   person = Person.create(first: 'John', last: 'Smith')
+    #   person.to_key # => ['John', 'Smith']
+    def key_attributes
+      []
+    end
+
+    # Returns an Array of all key attributes if any is set, regardless if
+    # the object is persisted or not. Returns +nil+ if there are no key attributes.
+    #
+    #   class Person
+    #     include ActiveModel::Identity
+    #     attr_accessor :id
+    #   end
+    #
+    #   person = Person.create(id: 1)
+    #   person.to_key # => [1]
+    def to_key
+      keys = key_attributes.map { |attribute| send(attribute) }
+      keys.any? ? keys : nil
+    end
+
     # Returns true if +comparison_object+ is the same exact object, or +comparison_object+
     # is of the same type and +self+ has an ID and it is equal to +comparison_object.id+.
     #
@@ -48,16 +80,17 @@ module ActiveModel
     def ==(comparison_object)
       super ||
         comparison_object.instance_of?(self.class) &&
-        !id.nil? &&
-        comparison_object.id == id
+        !(key = to_key).nil? &&
+        comparison_object.to_key == key
     end
     alias :eql? :==
 
     # Delegates to id in order to allow two records of the same type and id to work with something like:
     #   [ Person.find(1), Person.find(2), Person.find(3) ] & [ Person.find(1), Person.find(4) ] # => [ Person.find(1) ]
     def hash
-      if id
-        id.hash
+      key = to_key
+      if key
+        key.hash
       else
         super
       end

--- a/activemodel/lib/active_model/identity.rb
+++ b/activemodel/lib/active_model/identity.rb
@@ -1,0 +1,66 @@
+module ActiveModel
+  # == Active \Model \Identity
+  #
+  # Makes objects of the same type be considered equal if they have the same ID.
+  #
+  # To implement, just include ActiveModel::Identity in your class:
+  #
+  #   class User
+  #     include ActiveModel::Identity
+  #
+  #     attr_accessor :id
+  #   end
+  #
+  # Two objects without IDs are not equal:
+  #
+  #   user1 = User.new
+  #   user2 = User.new
+  #   user2 == user1 # => false
+  #
+  # Two objects with different IDs are not equal:
+  #
+  #   user1.id = 1
+  #   user2.id = 2
+  #   user2 == user1 # => false
+  #
+  # Two objects of different types are not equal:
+  #
+  #   product = Product.new
+  #   product.id = 1
+  #   product == user1 # => false
+  #
+  # Two objects with the same type and ID are considered equal:
+  #
+  #   user2.id = 1
+  #   user2 == user1 # => true
+  #
+  # The only requirement is that your object responds to +id+.
+  module Identity
+    # Returns true if +comparison_object+ is the same exact object, or +comparison_object+
+    # is of the same type and +self+ has an ID and it is equal to +comparison_object.id+.
+    #
+    # Note that new records are different from any other record by definition, unless the
+    # other record is the receiver itself. Besides, if you fetch existing records with
+    # +select+ and leave the ID out, you're on your own, this predicate will return false.
+    #
+    # Note also that destroying a record preserves its ID in the model instance, so deleted
+    # models are still comparable.
+    def ==(comparison_object)
+      super ||
+        comparison_object.instance_of?(self.class) &&
+        !id.nil? &&
+        comparison_object.id == id
+    end
+    alias :eql? :==
+
+    # Delegates to id in order to allow two records of the same type and id to work with something like:
+    #   [ Person.find(1), Person.find(2), Person.find(3) ] & [ Person.find(1), Person.find(4) ] # => [ Person.find(1) ]
+    def hash
+      if id
+        id.hash
+      else
+        super
+      end
+    end
+  end
+end

--- a/activemodel/test/cases/identity_test.rb
+++ b/activemodel/test/cases/identity_test.rb
@@ -1,0 +1,33 @@
+require "cases/helper"
+
+class IdentityTest < ActiveModel::TestCase
+  class IdentityModel
+    include ActiveModel::Identity
+    attr_accessor :id, :attr
+
+    def initialize(options = {})
+      options.each { |name, value| send("#{name}=", value) }
+    end
+  end
+
+  # Note: This is a performance optimization for Array#uniq and Hash#[] with
+  # AR::Base objects. If the future has made this irrelevant, feel free to
+  # delete this.
+  test "records without an id have unique hashes" do
+    assert_not_equal IdentityModel.new.hash, IdentityModel.new.hash
+  end
+
+  test "objects with the same ID are considered equal" do
+    assert_equal IdentityModel.new(id: 1), IdentityModel.new(id: 1)
+  end
+
+  test "objects with blank IDs are considered equal" do
+    one = IdentityModel.new(id: '')
+    two = IdentityModel.new(id: '')
+    assert_equal one, two
+  end
+
+  test "hashes the elements by ID" do
+    assert_equal [ IdentityModel.new(id: 1) ], [ IdentityModel.new(id: 1) ] & [ IdentityModel.new(id: 1) ]
+  end
+end

--- a/activemodel/test/cases/identity_test.rb
+++ b/activemodel/test/cases/identity_test.rb
@@ -10,24 +10,38 @@ class IdentityTest < ActiveModel::TestCase
     end
   end
 
+  class IdentityKeysModel < IdentityModel
+    def key_attributes
+      [:attr]
+    end
+  end
+
+  test "to_key default implementation returns nil for new records" do
+    assert_nil IdentityModel.new.to_key
+  end
+
+  test "to_key default implementation returns the id in an array for persisted records" do
+    assert_equal ['foo'], IdentityKeysModel.new(attr: 'foo').to_key
+  end
+
   # Note: This is a performance optimization for Array#uniq and Hash#[] with
   # AR::Base objects. If the future has made this irrelevant, feel free to
   # delete this.
-  test "records without an id have unique hashes" do
-    assert_not_equal IdentityModel.new.hash, IdentityModel.new.hash
+  test "records without key attributes set have unique hashes" do
+    assert_not_equal IdentityKeysModel.new.hash, IdentityKeysModel.new.hash
   end
 
-  test "objects with the same ID are considered equal" do
-    assert_equal IdentityModel.new(id: 1), IdentityModel.new(id: 1)
+  test "objects with the same key attribute values are considered equal" do
+    assert_equal IdentityKeysModel.new(attr: 1), IdentityKeysModel.new(attr: 1)
   end
 
-  test "objects with blank IDs are considered equal" do
-    one = IdentityModel.new(id: '')
-    two = IdentityModel.new(id: '')
+  test "objects with blank key attributes are considered equal" do
+    one = IdentityKeysModel.new(attr: '')
+    two = IdentityKeysModel.new(attr: '')
     assert_equal one, two
   end
 
-  test "hashes the elements by ID" do
-    assert_equal [ IdentityModel.new(id: 1) ], [ IdentityModel.new(id: 1) ] & [ IdentityModel.new(id: 1) ]
+  test "hashes the elements by key attributes" do
+    assert_equal [ IdentityKeysModel.new(attr: 1) ], [ IdentityKeysModel.new(attr: 1) ] & [ IdentityKeysModel.new(attr: 1) ]
   end
 end

--- a/activemodel/test/cases/identity_test.rb
+++ b/activemodel/test/cases/identity_test.rb
@@ -11,9 +11,7 @@ class IdentityTest < ActiveModel::TestCase
   end
 
   class IdentityKeysModel < IdentityModel
-    def key_attributes
-      [:attr]
-    end
+    key_attributes :attr
   end
 
   test "to_key default implementation returns nil for new records" do

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -7,6 +7,8 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     included do
+      include ActiveModel::Identity
+
       ##
       # :singleton-method:
       #
@@ -346,33 +348,6 @@ module ActiveRecord
       coder['raw_attributes'] = attributes_before_type_cast
       coder['attributes'] = @attributes
       coder['new_record'] = new_record?
-    end
-
-    # Returns true if +comparison_object+ is the same exact object, or +comparison_object+
-    # is of the same type and +self+ has an ID and it is equal to +comparison_object.id+.
-    #
-    # Note that new records are different from any other record by definition, unless the
-    # other record is the receiver itself. Besides, if you fetch existing records with
-    # +select+ and leave the ID out, you're on your own, this predicate will return false.
-    #
-    # Note also that destroying a record preserves its ID in the model instance, so deleted
-    # models are still comparable.
-    def ==(comparison_object)
-      super ||
-        comparison_object.instance_of?(self.class) &&
-        !id.nil? &&
-        comparison_object.id == id
-    end
-    alias :eql? :==
-
-    # Delegates to id in order to allow two records of the same type and id to work with something like:
-    #   [ Person.find(1), Person.find(2), Person.find(3) ] & [ Person.find(1), Person.find(4) ] # => [ Person.find(1) ]
-    def hash
-      if id
-        id.hash
-      else
-        super
-      end
     end
 
     # Clone and freeze the attributes hash such that associations are still

--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -173,6 +173,51 @@ person.first_name_change # => [nil, "First Name"]
 person.last_name_change # => nil
 ```
 
+### Identity
+
+The Identity module makes objects of the same type be considered equal if they have the same ID. To implement, just include `ActiveModel::Identity` in your class:
+
+```ruby
+class User
+  include ActiveModel::Identity
+
+  attr_accessor :id
+end
+```
+
+Two objects without IDs are not equal:
+
+```ruby
+user1 = User.new
+user2 = User.new
+user2 == user1 # => false
+```
+
+Two objects with different IDs are not equal:
+
+```ruby
+user1.id = 1
+user2.id = 2
+user2 == user1 # => false
+```
+
+Two objects of different types are not equal:
+
+```ruby
+product = Product.new
+product.id = 1
+product == user1 # => false
+```
+
+Two objects with the same type and ID are considered equal:
+
+```ruby
+user2.id = 1
+user2 == user1 # => true
+```
+
+The only requirement is that your object responds to `#id`.
+
 ### Validations
 
 Validations module adds the ability to class objects to validate them in Active Record style.

--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -182,6 +182,7 @@ class User
   include ActiveModel::Identity
 
   attr_accessor :id
+  key_attributes :id
 end
 ```
 
@@ -247,7 +248,7 @@ person.valid?                        # => raises ActiveModel::StrictValidationFa
 ### ActiveModel::Naming
 
 Naming adds a number of class methods which make the naming and routing
-easier to manage. The module defines the `model_name` class method which 
+easier to manage. The module defines the `model_name` class method which
 will define a number of accessors using some `ActiveSupport::Inflector` methods.
 
 ```ruby


### PR DESCRIPTION
This commit moves ActiveRecord::Core#== and #hash into a module in ActiveModel.  Any class can now include this mixin to have two instances be considered equal based on their `id`.

I considered making the attribute used for comparison configurable, but it seemed like a lot of complication for little gain.  Sound reasonable?
