### PR TITLE
change methods name to be more suitable

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -105,7 +105,7 @@ module ActiveRecord::Associations::Builder
     end
 
     def self.define_readers(mixin, name)
-      mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
+      mixin.module_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}(*args)
           association(:#{name}).reader(*args)
         end
@@ -113,7 +113,7 @@ module ActiveRecord::Associations::Builder
     end
 
     def self.define_writers(mixin, name)
-      mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
+      mixin.module_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}=(value)
           association(:#{name}).writer(value)
         end

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -28,7 +28,7 @@ module ActiveRecord::Associations::Builder
     def self.add_counter_cache_methods(mixin)
       return if mixin.method_defined? :belongs_to_counter_cache_after_update
 
-      mixin.class_eval do
+      mixin.module_eval do
         def belongs_to_counter_cache_after_update(reflection)
           foreign_key  = reflection.foreign_key
           cache_column = reflection.counter_cache_column

--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -61,7 +61,7 @@ module ActiveRecord::Associations::Builder
     def self.define_readers(mixin, name)
       super
 
-      mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
+      mixin.module_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name.to_s.singularize}_ids
           association(:#{name}).ids_reader
         end
@@ -71,7 +71,7 @@ module ActiveRecord::Associations::Builder
     def self.define_writers(mixin, name)
       super
 
-      mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
+      mixin.module_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name.to_s.singularize}_ids=(ids)
           association(:#{name}).ids_writer(ids)
         end

--- a/activerecord/lib/active_record/associations/builder/singular_association.rb
+++ b/activerecord/lib/active_record/associations/builder/singular_association.rb
@@ -13,7 +13,7 @@ module ActiveRecord::Associations::Builder
 
     # Defines the (build|create)_association methods for belongs_to or has_one association
     def self.define_constructors(mixin, name)
-      mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
+      mixin.module_eval <<-CODE, __FILE__, __LINE__ + 1
         def build_#{name}(*args, &block)
           association(:#{name}).build(*args, &block)
         end


### PR DESCRIPTION
While not big problem

In my changing
this mixin instances using class_eval is created by generated_association_methods that return module
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/core.rb#L181
so mixin is module

then I think module should be used module_eval and that is more suitable than class_eval
