### PR TITLE
`reload` should fully reload attributes

### DIFF
--- a/activerecord/lib/active_record/attribute_set.rb
+++ b/activerecord/lib/active_record/attribute_set.rb
@@ -6,10 +6,6 @@ module ActiveRecord
       @attributes = attributes
     end
 
-    def update(other)
-      attributes.update(other.attributes)
-    end
-
     def to_hash
       attributes.each_with_object({}) { |(k, v), h| h[k] = v.value }
     end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -395,7 +395,7 @@ module ActiveRecord
           self.class.unscoped { self.class.find(id) }
         end
 
-      @attributes.update(fresh_object.instance_variable_get('@attributes'))
+      @attributes = fresh_object.instance_variable_get('@attributes')
 
       @column_types = self.class.column_types
       self

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -858,4 +858,11 @@ class PersistenceTest < ActiveRecord::TestCase
       post.body
     end
   end
+
+  def test_reload_removes_custom_selects
+    post = Post.select('posts.*, 1 as wibble').last!
+
+    assert_equal 1, post[:wibble]
+    assert_nil post.reload[:wibble]
+  end
 end


### PR DESCRIPTION
`reload` is meant to put a record in the same state it would be if you
were to do `Post.find(post.id)`. This means we should fully replace the
attributes hash.
