### PR TITLE
Remove unneeded `@column_types` instance variable

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -254,7 +254,6 @@ module ActiveRecord
       end
 
       @attributes = self.class.attributes_builder.build_from_database(defaults)
-      @column_types = self.class.column_types
 
       init_internals
       initialize_internals_callback
@@ -280,7 +279,6 @@ module ActiveRecord
     #   post.title # => 'hello world'
     def init_with(coder)
       @attributes = coder['attributes']
-      @column_types = self.class.column_types
 
       init_internals
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -396,8 +396,6 @@ module ActiveRecord
         end
 
       @attributes = fresh_object.instance_variable_get('@attributes')
-
-      @column_types = self.class.column_types
       self
     end
 

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -129,7 +129,7 @@ module ActiveRecord
 
     private
       def store_accessor_for(store_attribute)
-        @column_types[store_attribute.to_s].accessor
+        type_for_attribute(store_attribute.to_s).accessor
       end
 
       class HashAccessor


### PR DESCRIPTION
This was used more previously, but other uses have been removed.
