### PR TITLE
Move behavior of `read_attribute` to `AttributeSet`

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -27,12 +27,12 @@ require 'active_model'
 require 'arel'
 
 require 'active_record/version'
+require 'active_record/attribute_set'
 
 module ActiveRecord
   extend ActiveSupport::Autoload
 
   autoload :Attribute
-  autoload :AttributeSet
   autoload :Base
   autoload :Callbacks
   autoload :Core

--- a/activerecord/lib/active_record/attribute.rb
+++ b/activerecord/lib/active_record/attribute.rb
@@ -8,6 +8,10 @@ module ActiveRecord
       def from_user(value, type)
         FromUser.new(value, type)
       end
+
+      def uninitialized(type)
+        Uninitialized.new(type)
+      end
     end
 
     attr_reader :value_before_type_cast, :type
@@ -41,6 +45,10 @@ module ActiveRecord
       raise NotImplementedError
     end
 
+    def initialized?
+      true
+    end
+
     protected
 
     def initialize_dup(other)
@@ -69,6 +77,25 @@ module ActiveRecord
           false
         end
         alias changed_in_place_from? changed_from?
+
+        def initialized?
+          true
+        end
+      end
+    end
+
+    class Uninitialized < Attribute # :nodoc:
+      def initialize(type)
+        super(nil, type)
+      end
+
+      def value
+        nil
+      end
+      alias value_for_database value
+
+      def initialized?
+        false
       end
     end
   end

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -81,17 +81,10 @@ module ActiveRecord
       # Returns the value of the attribute identified by <tt>attr_name</tt> after
       # it has been typecast (for example, "2004-12-12" in a date column is cast
       # to a date object, like Date.new(2004, 12, 12)).
-      def read_attribute(attr_name)
+      def read_attribute(attr_name, &block)
         name = attr_name.to_s
-        @attributes.fetch(name) {
-          if name == 'id'
-            return read_attribute(self.class.primary_key)
-          elsif block_given? && self.class.columns_hash.key?(name)
-            return yield(name)
-          else
-            return nil
-          end
-        }.value
+        name = self.class.primary_key if name == 'id'
+        @attributes.fetch_value(name, &block)
       end
 
       private

--- a/activerecord/lib/active_record/attribute_set/builder.rb
+++ b/activerecord/lib/active_record/attribute_set/builder.rb
@@ -1,0 +1,33 @@
+module ActiveRecord
+  class AttributeSet # :nodoc:
+    class Builder # :nodoc:
+      attr_reader :types
+
+      def initialize(types)
+        @types = types
+      end
+
+      def build_from_database(values, additional_types = {})
+        attributes = build_attributes_from_values(values, additional_types)
+        add_uninitialized_attributes(attributes)
+        AttributeSet.new(attributes)
+      end
+
+      private
+
+      def build_attributes_from_values(values, additional_types)
+        attributes = Hash.new(Attribute::Null)
+        values.each_with_object(attributes) do |(name, value), hash|
+          type = additional_types.fetch(name, types[name])
+          hash[name] = Attribute.from_database(value, type)
+        end
+      end
+
+      def add_uninitialized_attributes(attributes)
+        types.except(*attributes.keys).each do |name, type|
+          attributes[name] = Attribute.uninitialized(type)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Moved `Builder` to its own file, as it started looking very weird once I
added private methods to the `AttributeSet` class and the `Builder`
class started to grow.

Would like to refactor `fetch_value` to change to

``` ruby
self[name].value(&block)
```

But that requires the attributes to know about their name, which they
currently do not.
