### PR TITLE
Encapsulate the creation of `Attribute` objects

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -27,12 +27,12 @@ require 'active_model'
 require 'arel'
 
 require 'active_record/version'
+require 'active_record/attribute_set'
 
 module ActiveRecord
   extend ActiveSupport::Autoload
 
   autoload :Attribute
-  autoload :AttributeSet
   autoload :Base
   autoload :Callbacks
   autoload :Core

--- a/activerecord/lib/active_record/attribute.rb
+++ b/activerecord/lib/active_record/attribute.rb
@@ -41,6 +41,14 @@ module ActiveRecord
       type.changed_in_place?(old_value, value)
     end
 
+    def with_value_from_user(value)
+      self.class.from_user(value, type)
+    end
+
+    def with_value_from_database(value)
+      self.class.from_database(value, type)
+    end
+
     def type_cast
       raise NotImplementedError
     end
@@ -69,22 +77,17 @@ module ActiveRecord
       end
     end
 
-    class Null # :nodoc:
-      class << self
-        attr_reader :value, :value_before_type_cast, :value_for_database
+    class NullAttribute < Attribute # :nodoc:
+      def initialize
+        super(nil, Type::Value.new)
+      end
 
-        def changed_from?(*)
-          false
-        end
-        alias changed_in_place_from? changed_from?
-
-        def initialized?
-          true
-        end
+      def value
+        nil
       end
     end
 
-    class Uninitialized < Attribute
+    class Uninitialized < Attribute # :nodoc:
       def initialize(type)
         super(nil, type)
       end
@@ -98,5 +101,8 @@ module ActiveRecord
         false
       end
     end
+    private_constant :FromDatabase, :FromUser, :NullAttribute, :Uninitialized
+
+    Null = NullAttribute.new # :nodoc:
   end
 end

--- a/activerecord/lib/active_record/attribute.rb
+++ b/activerecord/lib/active_record/attribute.rb
@@ -8,6 +8,10 @@ module ActiveRecord
       def from_user(value, type)
         FromUser.new(value, type)
       end
+
+      def uninitialized(type)
+        Uninitialized.new(type)
+      end
     end
 
     attr_reader :value_before_type_cast, :type
@@ -41,6 +45,10 @@ module ActiveRecord
       raise NotImplementedError
     end
 
+    def initialized?
+      true
+    end
+
     protected
 
     def initialize_dup(other)
@@ -69,6 +77,25 @@ module ActiveRecord
           false
         end
         alias changed_in_place_from? changed_from?
+
+        def initialized?
+          true
+        end
+      end
+    end
+
+    class Uninitialized < Attribute
+      def initialize(type)
+        super(nil, type)
+      end
+
+      def value
+        nil
+      end
+      alias value_for_database value
+
+      def initialized?
+        false
       end
     end
   end

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -81,17 +81,10 @@ module ActiveRecord
       # Returns the value of the attribute identified by <tt>attr_name</tt> after
       # it has been typecast (for example, "2004-12-12" in a date column is cast
       # to a date object, like Date.new(2004, 12, 12)).
-      def read_attribute(attr_name)
+      def read_attribute(attr_name, &block)
         name = attr_name.to_s
-        @attributes.fetch(name) {
-          if name == 'id'
-            return read_attribute(self.class.primary_key)
-          elsif block_given? && self.class.columns_hash.key?(name)
-            return yield(name)
-          else
-            return nil
-          end
-        }.value
+        name = self.class.primary_key if name == 'id'
+        @attributes.fetch_value(name, &block)
       end
 
       private

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -69,16 +69,15 @@ module ActiveRecord
       def write_attribute_with_type_cast(attr_name, value, should_type_cast)
         attr_name = attr_name.to_s
         attr_name = self.class.primary_key if attr_name == 'id' && self.class.primary_key
-        type = type_for_attribute(attr_name)
 
         unless has_attribute?(attr_name) || self.class.columns_hash.key?(attr_name)
           raise ActiveModel::MissingAttributeError, "can't write unknown attribute `#{attr_name}'"
         end
 
         if should_type_cast
-          @attributes[attr_name] = Attribute.from_user(value, type)
+          @attributes.write_from_user(attr_name, value)
         else
-          @attributes[attr_name] = Attribute.from_database(value, type)
+          @attributes.write_from_database(attr_name, value)
         end
 
         value

--- a/activerecord/lib/active_record/attribute_set.rb
+++ b/activerecord/lib/active_record/attribute_set.rb
@@ -2,7 +2,7 @@ require 'active_record/attribute_set/builder'
 
 module ActiveRecord
   class AttributeSet # :nodoc:
-    delegate :[], :[]=, :each_with_object, to: :attributes
+    delegate :[], :each_with_object, to: :attributes
     delegate :keys, to: :initialized_attributes
 
     def initialize(attributes)
@@ -25,6 +25,14 @@ module ActiveRecord
       else
         yield name
       end
+    end
+
+    def write_from_database(name, value)
+      attributes[name] = self[name].with_value_from_database(value)
+    end
+
+    def write_from_user(name, value)
+      attributes[name] = self[name].with_value_from_user(value)
     end
 
     def freeze

--- a/activerecord/lib/active_record/attribute_set/builder.rb
+++ b/activerecord/lib/active_record/attribute_set/builder.rb
@@ -7,7 +7,7 @@ module ActiveRecord
         @types = types
       end
 
-      def build_from_database(values, additional_types = {})
+      def build_from_database(values = {}, additional_types = {})
         attributes = build_attributes_from_values(values, additional_types)
         add_uninitialized_attributes(attributes)
         AttributeSet.new(attributes)

--- a/activerecord/lib/active_record/attribute_set/builder.rb
+++ b/activerecord/lib/active_record/attribute_set/builder.rb
@@ -1,0 +1,33 @@
+module ActiveRecord
+  class AttributeSet # :nodoc:
+    class Builder # :nodoc:
+      attr_reader :types
+
+      def initialize(types)
+        @types = types
+      end
+
+      def build_from_database(values, additional_types = {})
+        attributes = build_attributes_from_values(values, additional_types)
+        add_uninitialized_attributes(attributes)
+        AttributeSet.new(attributes)
+      end
+
+      private
+
+      def build_attributes_from_values(values, additional_types)
+        attributes = Hash.new(Attribute::Null)
+        values.each_with_object(attributes) do |(name, value), hash|
+          type = additional_types.fetch(name, types[name])
+          hash[name] = Attribute.from_database(value, type)
+        end
+      end
+
+      def add_uninitialized_attributes(attributes)
+        types.except(*attributes.keys).each do |name, type|
+          attributes[name] = Attribute.uninitialized(type)
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -322,7 +322,7 @@ module ActiveRecord
     def initialize_dup(other) # :nodoc:
       pk = self.class.primary_key
       @attributes = @attributes.dup
-      @attributes[pk] = Attribute.from_database(nil, type_for_attribute(pk))
+      @attributes.write_from_database(pk, nil)
 
       run_callbacks(:initialize) unless _initialize_callbacks.empty?
 
@@ -522,7 +522,7 @@ module ActiveRecord
     def init_internals
       pk = self.class.primary_key
       unless @attributes.include?(pk)
-        @attributes[pk] = Attribute.from_database(nil, type_for_attribute(pk))
+        @attributes.write_from_database(pk, nil)
       end
 
       @aggregation_cache        = {}

--- a/activerecord/test/cases/attribute_set_test.rb
+++ b/activerecord/test/cases/attribute_set_test.rb
@@ -61,5 +61,61 @@ module ActiveRecord
       assert_equal({ foo: 1, bar: 2.2 }, attributes.to_hash)
       assert_equal({ foo: 1, bar: 2.2 }, attributes.to_h)
     end
+
+    test "known columns are built with uninitialized attributes" do
+      attributes = attributes_with_uninitialized_key
+      assert attributes[:foo].initialized?
+      assert_not attributes[:bar].initialized?
+    end
+
+    test "uninitialized attributes are not included in the attributes hash" do
+      attributes = attributes_with_uninitialized_key
+      assert_equal({ foo: 1 }, attributes.to_hash)
+    end
+
+    test "uninitialized attributes are not included in keys" do
+      attributes = attributes_with_uninitialized_key
+      assert_equal [:foo], attributes.keys
+    end
+
+    test "uninitialized attributes return false for include?" do
+      attributes = attributes_with_uninitialized_key
+      assert attributes.include?(:foo)
+      assert_not attributes.include?(:bar)
+    end
+
+    test "unknown attributes return false for include?" do
+      attributes = attributes_with_uninitialized_key
+      assert_not attributes.include?(:wibble)
+    end
+
+    test "fetch_value returns the value for the given attribute" do
+      builder = AttributeSet::Builder.new(foo: Type::Integer.new, bar: Type::Float.new)
+      attributes = builder.build_from_database(foo: '1.1', bar: '2.2')
+
+      assert_equal 1, attributes.fetch_value(:foo)
+      assert_equal 2.2, attributes.fetch_value(:bar)
+    end
+
+    test "fetch_value returns nil for unknown attributes" do
+      attributes = attributes_with_uninitialized_key
+      assert_nil attributes.fetch_value(:wibble)
+    end
+
+    test "fetch_value uses the given block for uninitialized attributes" do
+      attributes = attributes_with_uninitialized_key
+      value = attributes.fetch_value(:bar) { |n| n.to_s + '!' }
+      assert_equal 'bar!', value
+    end
+
+    test "fetch_value returns nil for uninitialized attributes if no block is given" do
+      attributes = attributes_with_uninitialized_key
+      assert_nil attributes.fetch_value(:bar)
+    end
+
+    def attributes_with_uninitialized_key
+      builder = AttributeSet::Builder.new(foo: Type::Integer.new, bar: Type::Float.new)
+      builder.build_from_database(foo: '1.1')
+    end
   end
 end

--- a/activerecord/test/cases/attribute_set_test.rb
+++ b/activerecord/test/cases/attribute_set_test.rb
@@ -35,7 +35,7 @@ module ActiveRecord
       attributes[:bar].value
 
       duped = attributes.dup
-      duped[:foo] = Attribute.from_database(2, Type::Integer.new)
+      duped.write_from_database(:foo, 2)
       duped[:bar].value << 'bar'
 
       assert_equal 1, attributes[:foo].value
@@ -111,6 +111,40 @@ module ActiveRecord
     test "fetch_value returns nil for uninitialized attributes if no block is given" do
       attributes = attributes_with_uninitialized_key
       assert_nil attributes.fetch_value(:bar)
+    end
+
+    class MyType
+      def type_cast_from_user(value)
+        return if value.nil?
+        value + " from user"
+      end
+
+      def type_cast_from_database(value)
+        return if value.nil?
+        value + " from database"
+      end
+    end
+
+    test "write_from_database sets the attribute with database typecasting" do
+      builder = AttributeSet::Builder.new(foo: MyType.new)
+      attributes = builder.build_from_database
+
+      assert_nil attributes.fetch_value(:foo)
+
+      attributes.write_from_database(:foo, "value")
+
+      assert_equal "value from database", attributes.fetch_value(:foo)
+    end
+
+    test "write_from_user sets the attribute with user typecasting" do
+      builder = AttributeSet::Builder.new(foo: MyType.new)
+      attributes = builder.build_from_database
+
+      assert_nil attributes.fetch_value(:foo)
+
+      attributes.write_from_user(:foo, "value")
+
+      assert_equal "value from user", attributes.fetch_value(:foo)
     end
 
     def attributes_with_uninitialized_key

--- a/activerecord/test/cases/attribute_test.rb
+++ b/activerecord/test/cases/attribute_test.rb
@@ -99,5 +99,31 @@ module ActiveRecord
       attribute = Attribute.from_database('a value', @type)
       attribute.dup
     end
+
+    class MyType
+      def type_cast_from_user(value)
+        value + " from user"
+      end
+
+      def type_cast_from_database(value)
+        value + " from database"
+      end
+    end
+
+    test "with_value_from_user returns a new attribute with the value from the user" do
+      old = Attribute.from_database("old", MyType.new)
+      new = old.with_value_from_user("new")
+
+      assert_equal "old from database", old.value
+      assert_equal "new from user", new.value
+    end
+
+    test "with_value_from_database returns a new attribute with the value from the database" do
+      old = Attribute.from_user("old", MyType.new)
+      new = old.with_value_from_database("new")
+
+      assert_equal "old from user", old.value
+      assert_equal "new from database", new.value
+    end
   end
 end


### PR DESCRIPTION
Depends on #15868

This will make it less painful to add additional properties, which should persist across writes, such as `name`.
