### PR TITLE
`Attribute` should know about its name

### DIFF
--- a/activerecord/lib/active_record/attribute_set.rb
+++ b/activerecord/lib/active_record/attribute_set.rb
@@ -2,11 +2,14 @@ require 'active_record/attribute_set/builder'
 
 module ActiveRecord
   class AttributeSet # :nodoc:
-    delegate :[], to: :attributes
     delegate :keys, to: :initialized_attributes
 
     def initialize(attributes)
       @attributes = attributes
+    end
+
+    def [](name)
+      attributes[name] || Attribute.null(name)
     end
 
     def values_before_type_cast
@@ -22,13 +25,8 @@ module ActiveRecord
       attributes.include?(name) && self[name].initialized?
     end
 
-    def fetch_value(name)
-      attribute = self[name]
-      if attribute.initialized? || !block_given?
-        attribute.value
-      else
-        yield name
-      end
+    def fetch_value(name, &block)
+      self[name].value(&block)
     end
 
     def write_from_database(name, value)

--- a/activerecord/lib/active_record/attribute_set/builder.rb
+++ b/activerecord/lib/active_record/attribute_set/builder.rb
@@ -16,16 +16,15 @@ module ActiveRecord
       private
 
       def build_attributes_from_values(values, additional_types)
-        attributes = Hash.new(Attribute::Null)
-        values.each_with_object(attributes) do |(name, value), hash|
+        values.each_with_object({}) do |(name, value), hash|
           type = additional_types.fetch(name, types[name])
-          hash[name] = Attribute.from_database(value, type)
+          hash[name] = Attribute.from_database(name, value, type)
         end
       end
 
       def add_uninitialized_attributes(attributes)
         types.except(*attributes.keys).each do |name, type|
-          attributes[name] = Attribute.uninitialized(type)
+          attributes[name] = Attribute.uninitialized(name, type)
         end
       end
     end

--- a/activerecord/test/cases/attribute_set_test.rb
+++ b/activerecord/test/cases/attribute_set_test.rb
@@ -8,6 +8,8 @@ module ActiveRecord
 
       assert_equal 1, attributes[:foo].value
       assert_equal 2.2, attributes[:bar].value
+      assert_equal :foo, attributes[:foo].name
+      assert_equal :bar, attributes[:bar].name
     end
 
     test "building with custom types" do
@@ -24,6 +26,7 @@ module ActiveRecord
 
       assert_equal '3.3', attributes[:foo].value_before_type_cast
       assert_equal nil, attributes[:bar].value_before_type_cast
+      assert_equal :bar, attributes[:bar].name
     end
 
     test "duping creates a new hash and dups each attribute" do

--- a/activerecord/test/cases/attribute_test.rb
+++ b/activerecord/test/cases/attribute_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
 
     test "from_database + read type casts from database" do
       @type.expect(:type_cast_from_database, 'type cast from database', ['a value'])
-      attribute = Attribute.from_database('a value', @type)
+      attribute = Attribute.from_database(nil, 'a value', @type)
 
       type_cast_value = attribute.value
 
@@ -22,7 +22,7 @@ module ActiveRecord
 
     test "from_user + read type casts from user" do
       @type.expect(:type_cast_from_user, 'type cast from user', ['a value'])
-      attribute = Attribute.from_user('a value', @type)
+      attribute = Attribute.from_user(nil, 'a value', @type)
 
       type_cast_value = attribute.value
 
@@ -31,7 +31,7 @@ module ActiveRecord
 
     test "reading memoizes the value" do
       @type.expect(:type_cast_from_database, 'from the database', ['whatever'])
-      attribute = Attribute.from_database('whatever', @type)
+      attribute = Attribute.from_database(nil, 'whatever', @type)
 
       type_cast_value = attribute.value
       second_read = attribute.value
@@ -42,14 +42,14 @@ module ActiveRecord
 
     test "reading memoizes falsy values" do
       @type.expect(:type_cast_from_database, false, ['whatever'])
-      attribute = Attribute.from_database('whatever', @type)
+      attribute = Attribute.from_database(nil, 'whatever', @type)
 
       attribute.value
       attribute.value
     end
 
     test "read_before_typecast returns the given value" do
-      attribute = Attribute.from_database('raw value', @type)
+      attribute = Attribute.from_database(nil, 'raw value', @type)
 
       raw_value = attribute.value_before_type_cast
 
@@ -59,7 +59,7 @@ module ActiveRecord
     test "from_database + read_for_database type casts to and from database" do
       @type.expect(:type_cast_from_database, 'read from database', ['whatever'])
       @type.expect(:type_cast_for_database, 'ready for database', ['read from database'])
-      attribute = Attribute.from_database('whatever', @type)
+      attribute = Attribute.from_database(nil, 'whatever', @type)
 
       type_cast_for_database = attribute.value_for_database
 
@@ -69,7 +69,7 @@ module ActiveRecord
     test "from_user + read_for_database type casts from the user to the database" do
       @type.expect(:type_cast_from_user, 'read from user', ['whatever'])
       @type.expect(:type_cast_for_database, 'ready for database', ['read from user'])
-      attribute = Attribute.from_user('whatever', @type)
+      attribute = Attribute.from_user(nil, 'whatever', @type)
 
       type_cast_for_database = attribute.value_for_database
 
@@ -78,7 +78,7 @@ module ActiveRecord
 
     test "duping dups the value" do
       @type.expect(:type_cast_from_database, 'type cast', ['a value'])
-      attribute = Attribute.from_database('a value', @type)
+      attribute = Attribute.from_database(nil, 'a value', @type)
 
       value_from_orig = attribute.value
       value_from_clone = attribute.dup.value
@@ -90,13 +90,13 @@ module ActiveRecord
 
     test "duping does not dup the value if it is not dupable" do
       @type.expect(:type_cast_from_database, false, ['a value'])
-      attribute = Attribute.from_database('a value', @type)
+      attribute = Attribute.from_database(nil, 'a value', @type)
 
       assert_same attribute.value, attribute.dup.value
     end
 
     test "duping does not eagerly type cast if we have not yet type cast" do
-      attribute = Attribute.from_database('a value', @type)
+      attribute = Attribute.from_database(nil, 'a value', @type)
       attribute.dup
     end
 
@@ -111,7 +111,7 @@ module ActiveRecord
     end
 
     test "with_value_from_user returns a new attribute with the value from the user" do
-      old = Attribute.from_database("old", MyType.new)
+      old = Attribute.from_database(nil, "old", MyType.new)
       new = old.with_value_from_user("new")
 
       assert_equal "old from database", old.value
@@ -119,11 +119,24 @@ module ActiveRecord
     end
 
     test "with_value_from_database returns a new attribute with the value from the database" do
-      old = Attribute.from_user("old", MyType.new)
+      old = Attribute.from_user(nil, "old", MyType.new)
       new = old.with_value_from_database("new")
 
       assert_equal "old from user", old.value
       assert_equal "new from database", new.value
+    end
+
+    test "uninitialized attributes yield their name if a block is given to value" do
+      block = proc { |name| name.to_s + "!" }
+      foo = Attribute.uninitialized(:foo, nil)
+      bar = Attribute.uninitialized(:bar, nil)
+
+      assert_equal "foo!", foo.value(&block)
+      assert_equal "bar!", bar.value(&block)
+    end
+
+    test "uninitialized attributes have no value" do
+      assert_nil Attribute.uninitialized(:foo, nil).value
     end
   end
 end


### PR DESCRIPTION
Depends on #15869

This allows using polymorphism for the uninitialized attributes raising
an exception behavior.
