### PR TITLE
Add #model_name instance method to ActiveModel::Naming

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -214,6 +214,12 @@ module ActiveModel
   # is required to pass the Active Model Lint test. So either extending the
   # provided method below, or rolling your own is required.
   module Naming
+    def self.extended(base) #:nodoc:
+      base.class_eval do
+        delegate :model_name, to: :class
+      end
+    end
+
     # Returns an ActiveModel::Name object for module. It can be
     # used to retrieve all kinds of naming-related information
     # (See ActiveModel::Name for more information).

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -272,3 +272,9 @@ class NameWithAnonymousClassTest < ActiveModel::TestCase
     assert_equal "Anonymous", model_name
   end
 end
+
+class NamingMethodDelegationTest < ActiveModel::TestCase
+  def test_model_name
+    assert_equal Blog::Post.model_name, Blog::Post.new.model_name
+  end
+end


### PR DESCRIPTION
This pull request addresses #15428 and [discussion on the Rails Core mailing list](https://groups.google.com/forum/#!topic/rubyonrails-core/ThSaXw9y1F8).
