### PR TITLE
Numeric#in_milliseconds returns an integer instead of a float

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `Numeric#in_milliseconds` preserves millisecond precision.
+
+    *Philippe Creux*
+
 *   Make Dependencies pass a name to NameError error.
     *arthurnn*
 

--- a/activesupport/lib/active_support/core_ext/numeric/time.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/time.rb
@@ -64,6 +64,6 @@ class Numeric
   # Used with the standard time durations, like 1.hour.in_milliseconds --
   # so we can feed them to JavaScript functions like getTime().
   def in_milliseconds
-    self * 1000
+    (self * 1000.0).to_i
   end
 end

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -386,7 +386,12 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_equal '1 Million', BigDecimal("1000010").to_s(:human)
   end
 
-  def test_in_milliseconds
+  def test_in_milliseconds_with_duration
     assert_equal 10_000, 10.seconds.in_milliseconds
+  end
+
+  def test_in_milliseconds_with_numeric
+    assert_equal 10_000, 10.in_milliseconds
+    assert_equal 10_123, 10.123456.in_milliseconds
   end
 end


### PR DESCRIPTION
> `Time` stores the number of nanoseconds since the Epoch.
> `Time#in_milliseconds` should return the number of milliseconds since the
> Epoch with a millisecond accuracy.

**Edit:** I believed that this PR would fix a naïve implementation of `Time.in_milliseconds` while it actually changes the behaviour of `Numeric.in_milliseconds`. `Time#in_milliseconds` could be added via #15890.
