### PR TITLE
Add a '--skip-routes' flag for the Controller generator.

### DIFF
--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -2,6 +2,8 @@ module Rails
   module Generators
     class ControllerGenerator < NamedBase # :nodoc:
       argument :actions, type: :array, default: [], banner: "action action"
+      class_option :skip_routes, type: :boolean, desc: "Dont' add routes to config/routes.rb."
+
       check_class_collision suffix: "Controller"
 
       def create_controller_files
@@ -9,8 +11,10 @@ module Rails
       end
 
       def add_routes
-        actions.reverse.each do |action|
-          route generate_routing_code(action)
+        unless options[:skip_routes]
+          actions.reverse.each do |action|
+            route generate_routing_code(action)
+          end
         end
       end
 

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -70,6 +70,13 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
     assert_file "config/routes.rb", /get 'account\/foo'/, /get 'account\/bar'/
   end
 
+  def test_skip_routes
+    run_generator ["account", "foo", "--skip-routes"]
+    assert_file "config/routes.rb" do |routes|
+      assert_no_match /get 'account\/foo'/, routes
+    end
+  end
+
   def test_invokes_default_template_engine_even_with_no_action
     run_generator ["account"]
     assert_file "app/views/account"


### PR DESCRIPTION
This way it is possible to skip the addition of the 'get "foo/bar"' routes when generating a controller.
