### PR TITLE
Disable autolink in example code blocks in guides.

### DIFF
--- a/guides/assets/javascripts/guides.js
+++ b/guides/assets/javascripts/guides.js
@@ -51,3 +51,9 @@ var guidesIndex = {
     window.location = url;
   }
 };
+
+// Disable autolink inside example code blocks of guides.
+$(document).ready(function() {
+  SyntaxHighlighter.defaults['auto-links'] = false;
+  SyntaxHighlighter.all();
+});


### PR DESCRIPTION
/cc @chancancode @robin850

configuration reference: http://alexgorbatchev.com/SyntaxHighlighter/manual/configuration/

Related issues:
- https://github.com/vmg/redcarpet/issues/334
- https://github.com/docrails-tw/guides/issues/62
