### PR TITLE
Use #model_name on instances instead of classes

### DIFF
--- a/actionpack/lib/action_controller/model_naming.rb
+++ b/actionpack/lib/action_controller/model_naming.rb
@@ -6,7 +6,7 @@ module ActionController
     end
 
     def model_name_from_record_or_class(record_or_class)
-      (record_or_class.is_a?(Class) ? record_or_class : convert_to_model(record_or_class).class).model_name
+      convert_to_model(record_or_class).model_name
     end
   end
 end

--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -249,9 +249,9 @@ module ActionDispatch
           model = record.to_model
           name = if record.persisted?
                    args << model
-                   model.class.model_name.singular_route_key
+                   model.model_name.singular_route_key
                  else
-                   @key_strategy.call model.class.model_name
+                   @key_strategy.call model.model_name
                  end
 
           named_route = prefix + "#{name}_#{suffix}"
@@ -279,7 +279,7 @@ module ActionDispatch
               parent.model_name.singular_route_key
             else
               args << parent.to_model
-              parent.to_model.class.model_name.singular_route_key
+              parent.to_model.model_name.singular_route_key
             end
           }
 
@@ -292,9 +292,9 @@ module ActionDispatch
           else
             if record.persisted?
               args << record.to_model
-              record.to_model.class.model_name.singular_route_key
+              record.to_model.model_name.singular_route_key
             else
-              @key_strategy.call record.to_model.class.model_name
+              @key_strategy.call record.to_model.model_name
             end
           end
 

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1815,8 +1815,8 @@ module ActionView
           object = convert_to_model(@object)
           key    = object ? (object.persisted? ? :update : :create) : :submit
 
-          model = if object.class.respond_to?(:model_name)
-            object.class.model_name.human
+          model = if object.respond_to?(:model_name)
+            object.model_name.human
           else
             @object_name.to_s.humanize
           end

--- a/actionview/lib/action_view/helpers/tags/label.rb
+++ b/actionview/lib/action_view/helpers/tags/label.rb
@@ -40,7 +40,7 @@ module ActionView
                         @object_name.gsub!(/\[(.*)_attributes\]\[\d+\]/, '.\1')
 
                         if object.respond_to?(:to_model)
-                          key = object.class.model_name.i18n_key
+                          key = object.model_name.i18n_key
                           i18n_default = ["#{key}.#{method_and_value}".to_sym, ""]
                         end
 

--- a/actionview/lib/action_view/model_naming.rb
+++ b/actionview/lib/action_view/model_naming.rb
@@ -6,7 +6,7 @@ module ActionView
     end
 
     def model_name_from_record_or_class(record_or_class)
-      (record_or_class.is_a?(Class) ? record_or_class : convert_to_model(record_or_class).class).model_name
+      convert_to_model(record_or_class).model_name
     end
   end
 end

--- a/actionview/test/activerecord/polymorphic_routes_test.rb
+++ b/actionview/test/activerecord/polymorphic_routes_test.rb
@@ -34,8 +34,8 @@ class ModelDelegator < ActiveRecord::Base
 end
 
 class ModelDelegate
-  def self.model_name
-    ActiveModel::Name.new(self)
+  def model_name
+    ActiveModel::Name.new(self.class)
   end
 
   def to_param

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -434,7 +434,7 @@ module ActiveModel
 
       options = {
         default: defaults,
-        model: @base.class.model_name.human,
+        model: @base.model_name.human,
         attribute: @base.class.human_attribute_name(attribute),
         value: value
       }.merge!(options)

--- a/activemodel/lib/active_model/lint.rb
+++ b/activemodel/lib/active_model/lint.rb
@@ -73,16 +73,19 @@ module ActiveModel
 
       # == \Naming
       #
-      # Model.model_name must return a string with some convenience methods:
-      # <tt>:human</tt>, <tt>:singular</tt> and <tt>:plural</tt>. Check
-      # ActiveModel::Naming for more information.
+      # Model.model_name and Model#model_name must return a string with some
+      # convenience methods: # <tt>:human</tt>, <tt>:singular</tt> and
+      # <tt>:plural</tt>. Check ActiveModel::Naming for more information.
       def test_model_naming
-        assert model.class.respond_to?(:model_name), "The model should respond to model_name"
+        assert model.class.respond_to?(:model_name), "The model class should respond to model_name"
         model_name = model.class.model_name
         assert model_name.respond_to?(:to_str)
         assert model_name.human.respond_to?(:to_str)
         assert model_name.singular.respond_to?(:to_str)
         assert model_name.plural.respond_to?(:to_str)
+
+        assert model.respond_to?(:model_name), "The model instance should respond to model_name"
+        assert_equal model.model_name, model.class.model_name
       end
 
       # == \Errors Testing

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -308,7 +308,7 @@ module ActiveModel
       if record_or_class.respond_to?(:model_name)
         record_or_class.model_name
       elsif record_or_class.respond_to?(:to_model)
-        record_or_class.to_model.class.model_name
+        record_or_class.to_model.model_name
       else
         record_or_class.class.model_name
       end

--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -93,7 +93,7 @@ module ActiveModel
         end
 
         if root
-          root = self.class.model_name.element if root == true
+          root = model_name.element if root == true
           { root => serializable_hash(options) }
         else
           serializable_hash(options)

--- a/activemodel/lib/active_model/serializers/xml.rb
+++ b/activemodel/lib/active_model/serializers/xml.rb
@@ -84,7 +84,7 @@ module ActiveModel
           @builder = options[:builder]
           @builder.instruct! unless options[:skip_instruct]
 
-          root = (options[:root] || @serializable.class.model_name.element).to_s
+          root = (options[:root] || @serializable.model_name.element).to_s
           root = ActiveSupport::XmlMini.rename_key(root, options)
 
           args = [root]

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -39,6 +39,7 @@ module ActiveModel
     extend ActiveSupport::Concern
 
     included do
+      extend ActiveModel::Naming
       extend ActiveModel::Callbacks
       extend ActiveModel::Translation
 

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -55,16 +55,16 @@ module ActiveRecord
     def cache_key(*timestamp_names)
       case
       when new_record?
-        "#{self.class.model_name.cache_key}/new"
+        "#{model_name.cache_key}/new"
       when timestamp_names.any?
         timestamp = max_updated_column_timestamp(timestamp_names)
         timestamp = timestamp.utc.to_s(cache_timestamp_format)
-        "#{self.class.model_name.cache_key}/#{id}-#{timestamp}"
+        "#{model_name.cache_key}/#{id}-#{timestamp}"
       when timestamp = max_updated_column_timestamp
         timestamp = timestamp.utc.to_s(cache_timestamp_format)
-        "#{self.class.model_name.cache_key}/#{id}-#{timestamp}"
+        "#{model_name.cache_key}/#{id}-#{timestamp}"
       else
-        "#{self.class.model_name.cache_key}/#{id}"
+        "#{model_name.cache_key}/#{id}"
       end
     end
 


### PR DESCRIPTION
This allows rails code to be more confident when asking for a model name, instead of having to ask for the class.

I am looking for feedback on the sections labeled `REVIEW`. I will remove and rebase.

Addresses #15428.

See rails-core discussion at https://groups.google.com/forum/#!topic/rubyonrails-core/ThSaXw9y1F8

Also see #15871, which adds the instance change to ActiveModel, but doesn't use it in the rest of rails.
The most useful thing about this change, IMO, is the fact that rails can start calling `model_name` without first getting the objects class.
- ActiveModel::Naming delegates instance `#model_name`. There are a few
  different ways we could handle this (see discussion at #15871), I'm open to suggestions.
- Normally, we would use include instead of extend if a module needs
  to add instance methods. However, that would be a HUGE breaking change.
- I think I found all of the instances of `x.class.model_name` and converted
  them, and all tests pass.
