### PR TITLE
Add Time#in_milliseconds

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -62,4 +62,9 @@ class Time
   def formatted_offset(colon = true, alternate_utc_string = nil)
     utc? && alternate_utc_string || ActiveSupport::TimeZone.seconds_to_utc_offset(utc_offset, colon)
   end
+
+  # Converts +self+ to an integer number of milliseconds since the Unix epoch.
+  def in_milliseconds
+    (self.to_f * 1000).to_i
+  end
 end

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -695,6 +695,11 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_in_milliseconds
+    assert_equal 86_400_000, Time.utc(1970, 1, 2, 0, 0, 0).in_milliseconds
+    assert_equal 86_400_123, Time.utc(1970, 1, 2, 0, 0, 0.123456).in_milliseconds
+  end
+
   def test_compare_with_time
     assert_equal  1, Time.utc(2000) <=> Time.utc(1999, 12, 31, 23, 59, 59, 999)
     assert_equal  0, Time.utc(2000) <=> Time.utc(2000, 1, 1, 0, 0, 0)


### PR DESCRIPTION
This method is implemented on the [Numeric's time extension](https://github.com/rails/rails/blob/f1eddea1e3f6faf93581c43651348f48b2b7d8bb/activesupport/lib/active_support/core_ext/numeric/time.rb), I believe that it should be available on `Time` as well.
