### PR TITLE
fix polymorphic relation call exists? #15821.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `DatabaseStatements#binds_from_relation` correctly get the binding values 
+    when polymorphic relation call `exists?`.
+
+    Fixes #15821.
+
+    *James Yang*
+
 *   `reload` no longer merges with the existing attributes.
     The attribute hash is fully replaced. The record is put into the same state
     as it would be with `Model.find(model.id)`.

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -393,8 +393,13 @@ module ActiveRecord
         end
 
         def binds_from_relation(relation, binds)
-          if relation.is_a?(Relation) && binds.empty?
-            relation, binds = relation.arel, relation.bind_values
+          if relation.is_a?(Relation)
+            if relation.arel.bind_values.empty?
+              binds = relation.bind_values
+            else
+              binds = relation.arel.bind_values + relation.bind_values
+            end
+            relation = relation.arel
           end
           [relation, binds]
         end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -13,7 +13,7 @@ require 'models/customer'
 require 'models/toy'
 require 'models/matey'
 require 'models/dog'
-require 'models/slug'
+require 'models/tagging'
 
 class FinderTest < ActiveRecord::TestCase
   fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :customers, :categories, :categorizations
@@ -80,11 +80,11 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_exists_with_polymorphic_relation
-    post = SlugPost.create!(title: 'slugs', body: "default", slug: Slug.new(name: 'the-slug'))
-    relation = SlugPost.find_slug('the-slug')
-    query = "slugs"
+    post = TagPost.create!(title: 'TagPost', body: "default", taggings: [Tagging.new(comment: 'tagging comment')])
+    relation = TagPost.find_tagging('tagging comment')
+    query = "TagPost"
 
-    assert_equal true, relation.exists?(title: ["slugs"])
+    assert_equal true, relation.exists?(title: ["TagPost"])
     assert_equal true, relation.exists?(['title LIKE ?', "#{query}%"])
     assert_equal true, relation.exists?
     assert_equal true, relation.exists?(post.id)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -13,6 +13,7 @@ require 'models/customer'
 require 'models/toy'
 require 'models/matey'
 require 'models/dog'
+require 'models/slug'
 
 class FinderTest < ActiveRecord::TestCase
   fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :customers, :categories, :categorizations
@@ -76,6 +77,20 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal false, Topic.exists?(Topic.new.id)
 
     assert_raise(NoMethodError) { Topic.exists?([1,2]) }
+  end
+
+  def test_exists_with_polymorphic_relation
+    post = SlugPost.create!(title: 'slugs', body: "default", slug: Slug.new(name: 'the-slug'))
+    relation = SlugPost.find_slug('the-slug')
+    query = "slugs"
+
+    assert_equal true, relation.exists?(title: ["slugs"])
+    assert_equal true, relation.exists?(['title LIKE ?', "#{query}%"])
+    assert_equal true, relation.exists?
+    assert_equal true, relation.exists?(post.id)
+    assert_equal true, relation.exists?(post.id.to_s)
+
+    assert_equal false, relation.exists?(false)
   end
 
   def test_exists_passing_active_record_object_is_deprecated

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -218,8 +218,9 @@ class PostThatLoadsCommentsInAnAfterSaveHook < ActiveRecord::Base
   end
 end
 
-class SlugPost < ActiveRecord::Base
+class TagPost < ActiveRecord::Base
   self.table_name = 'posts'
-  has_one :slug, as: :sluggable
-  scope :find_slug, ->(slug) { joins(:slug).where(slugs: { name: slug }) }
+  has_many :taggings, :as => :taggable
+
+  scope :find_tagging, ->(comment) { joins(:taggings).where(taggings: { comment: comment }) }
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -217,3 +217,9 @@ class PostThatLoadsCommentsInAnAfterSaveHook < ActiveRecord::Base
     post.comments.load
   end
 end
+
+class SlugPost < ActiveRecord::Base
+  self.table_name = 'posts'
+  has_one :slug, as: :sluggable
+  scope :find_slug, ->(slug) { joins(:slug).where(slugs: { name: slug }) }
+end

--- a/activerecord/test/models/slug.rb
+++ b/activerecord/test/models/slug.rb
@@ -1,0 +1,3 @@
+class Slug < ActiveRecord::Base
+
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -644,6 +644,12 @@ ActiveRecord::Schema.define do
     t.integer :ship_id
   end
 
+  create_table :slugs, force: true do |t|
+    t.string :name
+    t.integer :sluggable_id
+    t.string :sluggable_type
+  end
+
   create_table :speedometers, force: true, id: false do |t|
     t.string :speedometer_id
     t.string :name


### PR DESCRIPTION
After explore the differences for `JoinAssociation#join_constraints` between rails 4.2.0 alpha and 4.1.2.rc2, I find the method returns `JoinInformation` structure which carry a `bind_values` array and does not directly substitute the dynamic parameter holders `(?)` of sql statement anymore.

``` ruby
# rails 4.1.2.rc2
# /active_record/associations/join_dependency/join_association.rb
def join_constraints(foreign_table, foreign_klass, node, join_type, tables, scope_chain, chain)
  #...
  if reflection.type
    constraint = constraint.and table[reflection.type].eq foreign_klass.base_class.name
  end

  joins
end

# Query
Post Load (0.1ms)  SELECT "posts".* FROM "posts" INNER JOIN "slugs" ON
 "slugs"."sluggable_id" = "posts"."id" AND "slugs"."sluggable_type" = 'Post' 
WHERE "slugs"."name" = 'the-slug'

# rails 4.2.0 alpha
# /active_record/associations/join_dependency/join_association.rb
def join_constraints(foreign_table, foreign_klass, node, join_type, tables, scope_chain, chain)
  #...
  if reflection.type
    # ...
    substitute = klass.connection.substitute_at(column, bind_values.length)
    bind_values.push [column, value]
    constraint = constraint.and table[reflection.type].eq substitute
  end

  JoinInformation.new joins, bind_values
end

# Query
Post Load (0.1ms)  SELECT "posts".* FROM "posts" INNER JOIN "slugs" ON 
"slugs"."sluggable_id" = "posts"."id" AND "slugs"."sluggable_type" = ? 
WHERE "slugs"."name" = 'the-slug'  [[nil, "Post"]]
```

It turns out to fix [issue_15821](https://github.com/rails/rails/issues/15821) in a general way is to prepend `relation.arel.bind_values` to `binds` from `DatabaseStatements#binds_from_relation`. 

``` ruby
# /active_record/relation/finder_methods.rb
def exists?(conditions = :none)
  connection.select_value(relation, "#{name} Exists", relation.bind_values) ? true : false
end

# /active_record/connection_adapters/abstract/database_statements.rb
def select_value(arel, name = nil, binds = [])
  # select_one method then call binds_from_relation
  if result = select_one(arel, name, binds)
    result.values.first
  end
end  

def binds_from_relation(relation, binds)
  if relation.is_a?(Relation) && binds.blank?
    # should prepend relation.arel.bind_values to binds
    relation, binds = relation.arel, relation.bind_values
  end
  [relation, binds]
end
```

I try to solve this few days ago, the first commit in [pull request 15861](https://github.com/rails/rails/pull/15861) only fix `FinderMethods#exists?`. Eventually I think put the modification on `DatabaseStatements#binds_from_relation` will better. This help lower level methods  `#select_values` and `#select_all` to transform the `ActiveRecord::Relation` to `Arel` with correct binds. 
