### PR TITLE
4-1-stable allow string based keys for nested associations

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1588,7 +1588,7 @@ module ActiveRecord
 
         Builder::HasMany.define_callbacks self, middle_reflection
         Reflection.add_reflection self, middle_reflection.name, middle_reflection
-        middle_reflection.parent_reflection = [name, habtm_reflection]
+        middle_reflection.parent_reflection = [name.to_sym, habtm_reflection]
 
         include Module.new {
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
@@ -1609,7 +1609,7 @@ module ActiveRecord
         end
 
         has_many name, scope, hm_options, &extension
-        self._reflections[name].parent_reflection = [name, habtm_reflection]
+        self._reflections[name.to_sym].parent_reflection = [name.to_sym, habtm_reflection]
       end
     end
   end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -22,11 +22,11 @@ module ActiveRecord
     end
 
     def self.add_reflection(ar, name, reflection)
-      ar._reflections = ar._reflections.merge(name => reflection)
+      ar._reflections = ar._reflections.merge(name.to_sym => reflection)
     end
 
     def self.add_aggregate_reflection(ar, name, reflection)
-      ar.aggregate_reflections = ar.aggregate_reflections.merge(name => reflection)
+      ar.aggregate_reflections = ar.aggregate_reflections.merge(name.to_sym => reflection)
     end
 
     # \Reflection enables to interrogate Active Record classes and objects
@@ -48,7 +48,7 @@ module ActiveRecord
       #   Account.reflect_on_aggregation(:balance) # => the balance AggregateReflection
       #
       def reflect_on_aggregation(aggregation)
-        aggregate_reflections[aggregation]
+        aggregate_reflections[aggregation.to_sym]
       end
 
       # Returns a Hash of name of the reflection as the key and a AssociationReflection as the value.
@@ -92,12 +92,12 @@ module ActiveRecord
       #
       #   @api public
       def reflect_on_association(association)
-        reflections[association]
+        reflections[association.to_sym]
       end
 
       #   @api private
       def _reflect_on_association(association) #:nodoc:
-        _reflections[association]
+        _reflections[association.to_sym]
       end
 
       # Returns an array of AssociationReflection objects for all associations which have <tt>:autosave</tt> enabled.

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -406,6 +406,26 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal 'product_categories', reflection.join_table
   end
 
+  def test_reflection_association_accepts_symbols_as_keys
+    hotel = Hotel.create!
+    department = hotel.departments.create!
+    department.chefs.create!
+
+    assert_nothing_raised do
+      assert_equal department.chefs, Hotel.includes([departments: :chefs]).first.chefs
+    end
+  end
+
+  def test_reflection_association_accepts_strings_as_keys
+    hotel = Hotel.create!
+    department = hotel.departments.create!
+    department.chefs.create!
+
+    assert_nothing_raised do
+      assert_equal department.chefs, Hotel.includes(['departments' => 'chefs']).first.chefs
+    end
+  end
+
   private
     def assert_reflection(klass, association, options)
       assert reflection = klass.reflect_on_association(association)


### PR DESCRIPTION
Fixes issue #15671

This allows both strings and symbols to be accepted as keys in a nested association by adding `to_sym` to where strings were being rejected.

Originally we attempted to fix this issue the same as it was "fixed" on master, but that led to other issues of backwards compatibility. We decided to fix this problem on 4-1-stable by using symbols and not strings.

@senny and @matthewd this fixes only the issue mentioned above on 4-1-stable. I haven't started working out how to fix master yet, I've been quite busy. 

I also added 2 tests that ensure that both strings and symbols work in nested associations.

Thanks!
