### PR TITLE
Silence warning in test

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -115,7 +115,7 @@ module ActiveRecord
     end
 
     class MultiparameterAttribute #:nodoc:
-      attr_reader :object, :name, :values, :column
+      attr_reader :object, :name, :values, :cast_type
 
       def initialize(object, name, values)
         @object = object
@@ -126,8 +126,8 @@ module ActiveRecord
       def read_value
         return if values.values.compact.empty?
 
-        @column = object.column_for_attribute(name)
-        klass   = column ? column.klass : nil
+        @cast_type = object.type_for_attribute(name)
+        klass = cast_type.klass
 
         if klass == Time
           read_time
@@ -141,7 +141,7 @@ module ActiveRecord
       private
 
       def instantiate_time_object(set_values)
-        if object.class.send(:create_time_zone_conversion_attribute?, name, column)
+        if object.class.send(:create_time_zone_conversion_attribute?, name, cast_type)
           Time.zone.local(*set_values)
         else
           Time.send(object.class.default_timezone, *set_values)
@@ -151,7 +151,7 @@ module ActiveRecord
       def read_time
         # If column is a :time (and not :date or :datetime) there is no need to validate if
         # there are year/month/day fields
-        if column.type == :time
+        if cast_type.type == :time
           # if the column is a time set the values to their defaults as January 1, 1970, but only if they're nil
           { 1 => 1970, 2 => 1, 3 => 1 }.each do |key,value|
             values[key] ||= value

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -42,10 +42,10 @@ module ActiveRecord
 
       module ClassMethods
         private
-        def create_time_zone_conversion_attribute?(name, column)
+        def create_time_zone_conversion_attribute?(name, cast_type)
           time_zone_aware_attributes &&
             !self.skip_time_zone_conversion_for_attributes.include?(name.to_sym) &&
-            (:datetime == column.type)
+            (:datetime == cast_type.type)
         end
       end
     end


### PR DESCRIPTION
We still had one file using `column_for_attribute` when it could return
nil, causing deprecation warnings in the tests.
