### PR TITLE
Backport #11912 fix to 4-0-stable

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -169,7 +169,7 @@ module ActionDispatch # :nodoc:
     end
     alias_method :status_message, :message
 
-    def respond_to?(method)
+    def respond_to?(method, include_private = false)
       if method.to_s == 'to_path'
         stream.respond_to?(:to_path)
       else

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -214,6 +214,11 @@ class ResponseTest < ActiveSupport::TestCase
       ActionDispatch::Response.default_headers = nil
     end
   end
+
+  test "respond_to? accepts include_private" do
+    assert_not @response.respond_to?(:method_missing)
+    assert @response.respond_to?(:method_missing, true)
+  end
 end
 
 class ResponseIntegrationTest < ActionDispatch::IntegrationTest

--- a/railties/lib/rails/railtie/configuration.rb
+++ b/railties/lib/rails/railtie/configuration.rb
@@ -80,7 +80,7 @@ module Rails
         to_prepare_blocks << blk if blk
       end
 
-      def respond_to?(name)
+      def respond_to?(name, include_private = false)
         super || @@options.key?(name.to_sym)
       end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -679,5 +679,12 @@ module ApplicationTests
       end
       assert_equal Logger::INFO, Rails.logger.level
     end
+
+    test "respond_to? accepts include_private" do
+      make_basic_app
+
+      assert_not Rails.configuration.respond_to?(:method_missing)
+      assert Rails.configuration.respond_to?(:method_missing, true)
+    end
   end
 end


### PR DESCRIPTION
This should be backported to 4-0-stable IMO, but I guess it is to late to 4.0.6 , and as this is not a new regression I would not include it in 4.0.6 , We can merge in 4-0-stable and release this with 4.0.7 .

[fixes #15896]

review @rafaelfranca
