### PR TITLE
Fix a bug where NameError#name returns a qualified name in string

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -187,7 +187,7 @@ module ActiveSupport #:nodoc:
       # top-level constant.
       def guess_for_anonymous(const_name)
         if Object.const_defined?(const_name)
-          raise NameError.new "#{const_name} cannot be autoloaded from an anonymous class or module", const_name.to_s
+          raise NameError.new "#{const_name} cannot be autoloaded from an anonymous class or module", const_name
         else
           Object
         end
@@ -516,7 +516,7 @@ module ActiveSupport #:nodoc:
         end
       end
 
-      name_error = NameError.new("uninitialized constant #{qualified_name}", qualified_name)
+      name_error = NameError.new("uninitialized constant #{qualified_name}", const_name)
       name_error.set_backtrace(caller.reject {|l| l.starts_with? __FILE__ })
       raise name_error
     end

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -367,11 +367,11 @@ class DependenciesTest < ActiveSupport::TestCase
     with_autoloading_fixtures do
       e = assert_raise(NameError) { A::DoesNotExist.nil? }
       assert_equal "uninitialized constant A::DoesNotExist", e.message
-      assert_equal "A::DoesNotExist", e.name
+      assert_equal :DoesNotExist, e.name
 
       e = assert_raise(NameError) { A::B::DoesNotExist.nil? }
       assert_equal "uninitialized constant A::B::DoesNotExist", e.message
-      assert_equal "A::B::DoesNotExist", e.name
+      assert_equal :DoesNotExist, e.name
     end
   end
 
@@ -539,7 +539,7 @@ class DependenciesTest < ActiveSupport::TestCase
       mod = Module.new
       e = assert_raise(NameError) { mod::E }
       assert_equal 'E cannot be autoloaded from an anonymous class or module', e.message
-      assert_equal 'E', e.name
+      assert_equal :E, e.name
     end
   end
 


### PR DESCRIPTION
Following up to #15764. AS::Dependencies is still breaking Ruby's original behaviour, which is:
- It only returns a const name, not a qualified aname
- It returns a symbol, not a string

``` ruby
$ irb
> begin
>   DoesNotExist
> rescue NameError => e
>   e.name # => :DoesNotExist
> end
>
> class A; end
>
> begin
>   A::DoesNotExistNeither
> rescue NameError => e
>   e.name # => :DoesNotExistNeither
> end
```

cc @arthurnn
