### PR TITLE
Include ActiveModel::Naming instead of extend

### DIFF
--- a/actionpack/lib/action_controller/model_naming.rb
+++ b/actionpack/lib/action_controller/model_naming.rb
@@ -6,7 +6,7 @@ module ActionController
     end
 
     def model_name_from_record_or_class(record_or_class)
-      (record_or_class.is_a?(Class) ? record_or_class : convert_to_model(record_or_class).class).model_name
+      convert_to_model(record_or_class).model_name
     end
   end
 end

--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -249,9 +249,9 @@ module ActionDispatch
           model = record.to_model
           name = if record.persisted?
                    args << model
-                   model.class.model_name.singular_route_key
+                   model.model_name.singular_route_key
                  else
-                   @key_strategy.call model.class.model_name
+                   @key_strategy.call model.model_name
                  end
 
           named_route = prefix + "#{name}_#{suffix}"
@@ -279,7 +279,7 @@ module ActionDispatch
               parent.model_name.singular_route_key
             else
               args << parent.to_model
-              parent.to_model.class.model_name.singular_route_key
+              parent.to_model.model_name.singular_route_key
             end
           }
 
@@ -292,9 +292,9 @@ module ActionDispatch
           else
             if record.persisted?
               args << record.to_model
-              record.to_model.class.model_name.singular_route_key
+              record.to_model.model_name.singular_route_key
             else
-              @key_strategy.call record.to_model.class.model_name
+              @key_strategy.call record.to_model.model_name
             end
           end
 

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -275,7 +275,7 @@ class ::ApplicationController < ActionController::Base
 end
 
 class Workshop
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
   attr_accessor :id
 

--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -3,7 +3,7 @@ require 'rack/test'
 
 module TestGenerationPrefix
   class Post
-    extend ActiveModel::Naming
+    include ActiveModel::Naming
 
     def to_param
       "1"

--- a/actionpack/test/lib/controller/fake_models.rb
+++ b/actionpack/test/lib/controller/fake_models.rb
@@ -1,7 +1,7 @@
 require "active_model"
 
 class Customer < Struct.new(:name, :id)
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
 
   undef_method :to_json
@@ -40,7 +40,7 @@ end
 
 module Quiz
   class Question < Struct.new(:name, :id)
-    extend ActiveModel::Naming
+    include ActiveModel::Naming
     include ActiveModel::Conversion
 
     def persisted?
@@ -53,7 +53,7 @@ module Quiz
 end
 
 class Post < Struct.new(:title, :author_name, :body, :secret, :persisted, :written_on, :cost)
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
   extend ActiveModel::Translation
 
@@ -76,7 +76,7 @@ class Post < Struct.new(:title, :author_name, :body, :secret, :persisted, :writt
 end
 
 class Comment
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
 
   attr_reader :id
@@ -102,7 +102,7 @@ module Blog
   end
 
   class Post < Struct.new(:title, :id)
-    extend ActiveModel::Naming
+    include ActiveModel::Naming
     include ActiveModel::Conversion
 
     def persisted?

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1815,8 +1815,8 @@ module ActionView
           object = convert_to_model(@object)
           key    = object ? (object.persisted? ? :update : :create) : :submit
 
-          model = if object.class.respond_to?(:model_name)
-            object.class.model_name.human
+          model = if object.respond_to?(:model_name)
+            object.model_name.human
           else
             @object_name.to_s.humanize
           end

--- a/actionview/lib/action_view/helpers/tags/label.rb
+++ b/actionview/lib/action_view/helpers/tags/label.rb
@@ -40,7 +40,7 @@ module ActionView
                         @object_name.gsub!(/\[(.*)_attributes\]\[\d+\]/, '.\1')
 
                         if object.respond_to?(:to_model)
-                          key = object.class.model_name.i18n_key
+                          key = object.model_name.i18n_key
                           i18n_default = ["#{key}.#{method_and_value}".to_sym, ""]
                         end
 

--- a/actionview/lib/action_view/model_naming.rb
+++ b/actionview/lib/action_view/model_naming.rb
@@ -6,7 +6,7 @@ module ActionView
     end
 
     def model_name_from_record_or_class(record_or_class)
-      (record_or_class.is_a?(Class) ? record_or_class : convert_to_model(record_or_class).class).model_name
+      convert_to_model(record_or_class).model_name
     end
   end
 end

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -302,7 +302,7 @@ module ActionView
 end
 
 class Workshop
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
   attr_accessor :id
 

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
 end
 
 class Customer < Struct.new(:name, :id)
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
 
   undef_method :to_json
@@ -36,7 +36,7 @@ end
 module Quiz
   #Models
   class Question < Struct.new(:name, :id)
-    extend ActiveModel::Naming
+    include ActiveModel::Naming
     include ActiveModel::Conversion
 
     def persisted?

--- a/actionview/test/activerecord/polymorphic_routes_test.rb
+++ b/actionview/test/activerecord/polymorphic_routes_test.rb
@@ -34,8 +34,8 @@ class ModelDelegator < ActiveRecord::Base
 end
 
 class ModelDelegate
-  def self.model_name
-    ActiveModel::Name.new(self)
+  def model_name
+    ActiveModel::Name.new(self.class)
   end
 
   def to_param

--- a/actionview/test/activerecord/render_partial_with_record_identification_test.rb
+++ b/actionview/test/activerecord/render_partial_with_record_identification_test.rb
@@ -94,7 +94,7 @@ class RenderPartialWithRecordIdentificationTest < ActiveRecordTestCase
 end
 
 class Game < Struct.new(:name, :id)
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
   def to_param
     id.to_s

--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -1,7 +1,7 @@
 require "active_model"
 
 class Customer < Struct.new(:name, :id)
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
 
   undef_method :to_json
@@ -32,7 +32,7 @@ class GoodCustomer < Customer
 end
 
 class Post < Struct.new(:title, :author_name, :body, :secret, :persisted, :written_on, :cost)
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
   extend ActiveModel::Translation
 
@@ -55,7 +55,7 @@ class Post < Struct.new(:title, :author_name, :body, :secret, :persisted, :writt
 end
 
 class Comment
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
 
   attr_reader :id
@@ -76,7 +76,7 @@ class Comment
 end
 
 class Tag
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
 
   attr_reader :id
@@ -96,7 +96,7 @@ class Tag
 end
 
 class CommentRelevance
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
 
   attr_reader :id
@@ -112,7 +112,7 @@ class CommentRelevance
 end
 
 class Sheep
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
 
   attr_reader :id
@@ -125,7 +125,7 @@ class Sheep
 end
 
 class TagRelevance
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
 
   attr_reader :id
@@ -146,7 +146,7 @@ class Author < Comment
 end
 
 class HashBackedAuthor < Hash
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
 
   def persisted?; false; end
@@ -162,7 +162,7 @@ module Blog
   end
 
   class Post < Struct.new(:title, :id)
-    extend ActiveModel::Naming
+    include ActiveModel::Naming
     include ActiveModel::Conversion
 
     def persisted?

--- a/actionview/test/template/atom_feed_helper_test.rb
+++ b/actionview/test/template/atom_feed_helper_test.rb
@@ -1,7 +1,7 @@
 require 'abstract_unit'
 
 class Scroll < Struct.new(:id, :to_param, :title, :body, :updated_at, :created_at)
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
 
   def persisted?

--- a/actionview/test/template/record_tag_helper_test.rb
+++ b/actionview/test/template/record_tag_helper_test.rb
@@ -1,7 +1,7 @@
 require 'abstract_unit'
 
 class RecordTagPost
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
   attr_accessor :id, :body
 

--- a/actionview/test/template/test_test.rb
+++ b/actionview/test/template/test_test.rb
@@ -38,7 +38,7 @@ class PeopleHelperTest < ActionView::TestCase
   def test_link_to_person
     with_test_route_set do
       person = Struct.new(:name) {
-        extend ActiveModel::Naming
+        include ActiveModel::Naming
         def to_model; self; end
         def persisted?; true; end
         def self.name; 'Mocha::Mock'; end

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -712,7 +712,7 @@ class LinkToUnlessCurrentWithControllerTest < ActionController::TestCase
 end
 
 class Session
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
   attr_accessor :id, :workshop_id
 

--- a/activemodel/README.rdoc
+++ b/activemodel/README.rdoc
@@ -144,11 +144,11 @@ behavior out of the box:
 * Model name introspection
 
     class NamedPerson
-      extend ActiveModel::Naming
+      include ActiveModel::Naming
     end
 
-    NamedPerson.model_name.name   # => "NamedPerson"
-    NamedPerson.model_name.human  # => "Named person"
+    NamedPerson.new.model_name.name   # => "NamedPerson"
+    NamedPerson.new.model_name.human  # => "Named person"
 
   {Learn more}[link:classes/ActiveModel/Naming.html]
 

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -434,7 +434,7 @@ module ActiveModel
 
       options = {
         default: defaults,
-        model: @base.class.model_name.human,
+        model: @base.model_name.human,
         attribute: @base.class.human_attribute_name(attribute),
         value: value
       }.merge!(options)

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -13,7 +13,7 @@ module ActiveModel
   #
   #   class Person
   #     # Required dependency for ActiveModel::Errors
-  #     extend ActiveModel::Naming
+  #     include ActiveModel::Naming
   #
   #     def initialize
   #       @errors = ActiveModel::Errors.new(self)

--- a/activemodel/lib/active_model/lint.rb
+++ b/activemodel/lib/active_model/lint.rb
@@ -73,16 +73,19 @@ module ActiveModel
 
       # == \Naming
       #
-      # Model.model_name must return a string with some convenience methods:
-      # <tt>:human</tt>, <tt>:singular</tt> and <tt>:plural</tt>. Check
-      # ActiveModel::Naming for more information.
+      # Model.model_name and Model#model_name must return a string with some
+      # convenience methods: # <tt>:human</tt>, <tt>:singular</tt> and
+      # <tt>:plural</tt>. Check ActiveModel::Naming for more information.
       def test_model_naming
-        assert model.class.respond_to?(:model_name), "The model should respond to model_name"
+        assert model.class.respond_to?(:model_name), "The model class should respond to model_name"
         model_name = model.class.model_name
         assert model_name.respond_to?(:to_str)
         assert model_name.human.respond_to?(:to_str)
         assert model_name.singular.respond_to?(:to_str)
         assert model_name.plural.respond_to?(:to_str)
+
+        assert model.respond_to?(:model_name), "The model instance should respond to model_name"
+        assert_equal model.model_name, model.class.model_name
       end
 
       # == \Errors Testing

--- a/activemodel/lib/active_model/lint.rb
+++ b/activemodel/lib/active_model/lint.rb
@@ -73,19 +73,16 @@ module ActiveModel
 
       # == \Naming
       #
-      # Model.model_name and Model#model_name must return a string with some
-      # convenience methods: # <tt>:human</tt>, <tt>:singular</tt> and
-      # <tt>:plural</tt>. Check ActiveModel::Naming for more information.
+      # Model#model_name must return a string with some convenience methods:
+      # <tt>:human</tt>, <tt>:singular</tt> and <tt>:plural</tt>.
+      # Check ActiveModel::Naming for more information.
       def test_model_naming
-        assert model.class.respond_to?(:model_name), "The model class should respond to model_name"
-        model_name = model.class.model_name
+        assert model.respond_to?(:model_name), "The model should respond to model_name"
+        model_name = model.model_name
         assert model_name.respond_to?(:to_str)
         assert model_name.human.respond_to?(:to_str)
         assert model_name.singular.respond_to?(:to_str)
         assert model_name.plural.respond_to?(:to_str)
-
-        assert model.respond_to?(:model_name), "The model instance should respond to model_name"
-        assert_equal model.model_name, model.class.model_name
       end
 
       # == \Errors Testing

--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -58,7 +58,7 @@ module ActiveModel
   module Model
     def self.included(base) #:nodoc:
       base.class_eval do
-        extend  ActiveModel::Naming
+        include ActiveModel::Naming
         extend  ActiveModel::Translation
         include ActiveModel::Validations
         include ActiveModel::Conversion

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -308,7 +308,7 @@ module ActiveModel
       if record_or_class.respond_to?(:model_name)
         record_or_class.model_name
       elsif record_or_class.respond_to?(:to_model)
-        record_or_class.to_model.class.model_name
+        record_or_class.to_model.model_name
       else
         record_or_class.class.model_name
       end

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -218,26 +218,34 @@ module ActiveModel
 
     def self.extended(base) # :nodoc:
       ActiveSupport::Deprecation.warn(
-        "extending ActiveModel::Naming is deprecated. Please use include instead"
+        "extending ActiveModel::Naming is deprecated. Please use include instead."
       )
 
       base.send(:include, self)
     end
 
-    # Returns an ActiveModel::Name object for module. It can be
-    # used to retrieve all kinds of naming-related information
-    # (See ActiveModel::Name for more information).
-    #
-    #   class Person
-    #     include ActiveModel::Model
-    #   end
-    #
-    #   Person.model_name.name     # => "Person"
-    #   Person.model_name.class    # => ActiveModel::Name
-    #   Person.model_name.singular # => "person"
-    #   Person.model_name.plural   # => "people"
-    def model_name
-      self.class.model_name
+    # FIXME: Remove the InstanceMethods module after the deprecation cycle
+    # for extending ActiveSupport::Naming ends.
+    included do
+      include InstanceMethods
+    end
+
+    module InstanceMethods
+      # Returns an ActiveModel::Name object for module. It can be
+      # used to retrieve all kinds of naming-related information
+      # (See ActiveModel::Name for more information).
+      #
+      #   class Person
+      #     include ActiveModel::Model
+      #   end
+      #
+      #   Person.model_name.name     # => "Person"
+      #   Person.model_name.class    # => ActiveModel::Name
+      #   Person.model_name.singular # => "person"
+      #   Person.model_name.plural   # => "people"
+      def model_name
+        self.class.model_name
+      end
     end
 
     module ClassMethods

--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -93,7 +93,7 @@ module ActiveModel
         end
 
         if root
-          root = self.class.model_name.element if root == true
+          root = model_name.element if root == true
           { root => serializable_hash(options) }
         else
           serializable_hash(options)

--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -8,7 +8,7 @@ module ActiveModel
       include ActiveModel::Serialization
 
       included do
-        extend ActiveModel::Naming
+        include ActiveModel::Naming
 
         class_attribute :include_root_in_json
         self.include_root_in_json = false

--- a/activemodel/lib/active_model/serializers/xml.rb
+++ b/activemodel/lib/active_model/serializers/xml.rb
@@ -84,7 +84,7 @@ module ActiveModel
           @builder = options[:builder]
           @builder.instruct! unless options[:skip_instruct]
 
-          root = (options[:root] || @serializable.class.model_name.element).to_s
+          root = (options[:root] || @serializable.model_name.element).to_s
           root = ActiveSupport::XmlMini.rename_key(root, options)
 
           args = [root]

--- a/activemodel/lib/active_model/serializers/xml.rb
+++ b/activemodel/lib/active_model/serializers/xml.rb
@@ -12,7 +12,7 @@ module ActiveModel
       include ActiveModel::Serialization
 
       included do
-        extend ActiveModel::Naming
+        include ActiveModel::Naming
       end
 
       class Serializer #:nodoc:

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -19,7 +19,10 @@ module ActiveModel
   # class based +i18n_scope+ and +lookup_ancestors+ to find translations in
   # parent classes.
   module Translation
-    include ActiveModel::Naming
+
+    def self.extended(base) # :nodoc:
+      base.send(:include, ActiveModel::Naming)
+    end
 
     # Returns the +i18n_scope+ for the class. Overwrite if you want custom lookup.
     def i18n_scope

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -39,6 +39,7 @@ module ActiveModel
     extend ActiveSupport::Concern
 
     included do
+      extend ActiveModel::Naming
       extend ActiveModel::Callbacks
       extend ActiveModel::Translation
 

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -39,7 +39,7 @@ module ActiveModel
     extend ActiveSupport::Concern
 
     included do
-      extend ActiveModel::Naming
+      include ActiveModel::Naming
       extend ActiveModel::Callbacks
       extend ActiveModel::Translation
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 
 class ErrorsTest < ActiveModel::TestCase
   class Person
-    extend ActiveModel::Naming
+    include ActiveModel::Naming
     def initialize
       @errors = ActiveModel::Errors.new(self)
     end

--- a/activemodel/test/cases/lint_test.rb
+++ b/activemodel/test/cases/lint_test.rb
@@ -4,7 +4,7 @@ class LintTest < ActiveModel::TestCase
   include ActiveModel::Lint::Tests
 
   class CompliantModel
-    extend ActiveModel::Naming
+    include ActiveModel::Naming
     include ActiveModel::Conversion
 
     def persisted?() false end

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -273,8 +273,22 @@ class NameWithAnonymousClassTest < ActiveModel::TestCase
   end
 end
 
-class NamingMethodDelegationTest < ActiveModel::TestCase
-  def test_model_name
-    assert_equal Blog::Post.model_name, Blog::Post.new.model_name
+class NamingUsage < ActiveModel::TestCase
+  class MyModel; end
+
+  def test_extend_naming_is_a_warning
+    assert_deprecated do
+      MyModel.extend ActiveModel::Naming
+    end
+  end
+
+  def test_include_naming_defines_instance_accessor
+    MyModel.send(:include, ActiveModel::Naming)
+    assert_equal MyModel.new.model_name, ActiveModel::Name.new(MyModel)
+  end
+
+  def test_include_naming_defines_class_accessor
+    MyModel.send(:include, ActiveModel::Naming)
+    assert_equal MyModel.model_name, ActiveModel::Name.new(MyModel)
   end
 end

--- a/activemodel/test/models/blog_post.rb
+++ b/activemodel/test/models/blog_post.rb
@@ -4,6 +4,6 @@ module Blog
   end
 
   class Post
-    extend ActiveModel::Naming
+    include ActiveModel::Naming
   end
 end

--- a/activemodel/test/models/contact.rb
+++ b/activemodel/test/models/contact.rb
@@ -1,5 +1,5 @@
 class Contact
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
   include ActiveModel::Conversion
 
   attr_accessor :id, :name, :age, :created_at, :awesome, :preferences

--- a/activemodel/test/models/sheep.rb
+++ b/activemodel/test/models/sheep.rb
@@ -1,3 +1,3 @@
 class Sheep
-  extend ActiveModel::Naming
+  include ActiveModel::Naming
 end

--- a/activemodel/test/models/track_back.rb
+++ b/activemodel/test/models/track_back.rb
@@ -6,6 +6,6 @@ class Post
   end
 
   class NamedTrackBack
-    extend ActiveModel::Naming
+    include ActiveModel::Naming
   end
 end

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -282,7 +282,7 @@ module ActiveRecord #:nodoc:
   # So it's possible to assign a logger to the class through <tt>Base.logger=</tt> which will then be used by all
   # instances in the current object space.
   class Base
-    extend ActiveModel::Naming
+    include ActiveModel::Naming
 
     extend ActiveSupport::Benchmarkable
     extend ActiveSupport::DescendantsTracker

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -55,16 +55,16 @@ module ActiveRecord
     def cache_key(*timestamp_names)
       case
       when new_record?
-        "#{self.class.model_name.cache_key}/new"
+        "#{model_name.cache_key}/new"
       when timestamp_names.any?
         timestamp = max_updated_column_timestamp(timestamp_names)
         timestamp = timestamp.utc.to_s(cache_timestamp_format)
-        "#{self.class.model_name.cache_key}/#{id}-#{timestamp}"
+        "#{model_name.cache_key}/#{id}-#{timestamp}"
       when timestamp = max_updated_column_timestamp
         timestamp = timestamp.utc.to_s(cache_timestamp_format)
-        "#{self.class.model_name.cache_key}/#{id}-#{timestamp}"
+        "#{model_name.cache_key}/#{id}-#{timestamp}"
       else
-        "#{self.class.model_name.cache_key}/#{id}"
+        "#{model_name.cache_key}/#{id}"
       end
     end
 


### PR DESCRIPTION
This is basically #15889, but incorporating the feedback from @rafaelfranca.
