### PR TITLE
Backport of #15764 and #15902 to 4-1-stable

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,6 @@
+*   Make Dependencies pass a name to NameError error.
+    *arthurnn*, *Yuki Nishijima*
+
 *   Fixed precision error in NumberHelper when using Rationals.
 
     before:

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -186,7 +186,7 @@ module ActiveSupport #:nodoc:
       # and we assume therefore the user wants to refer to a top-level constant.
       def guess_for_anonymous(const_name)
         if Object.const_defined?(const_name)
-          raise NameError, "#{const_name} cannot be autoloaded from an anonymous class or module"
+          raise NameError.new "#{const_name} cannot be autoloaded from an anonymous class or module", const_name
         else
           Object
         end
@@ -515,9 +515,9 @@ module ActiveSupport #:nodoc:
         end
       end
 
-      raise NameError,
-            "uninitialized constant #{qualified_name}",
-            caller.reject { |l| l.starts_with? __FILE__ }
+      name_error = NameError.new("uninitialized constant #{qualified_name}", const_name)
+      name_error.set_backtrace(caller.reject {|l| l.starts_with? __FILE__ })
+      raise name_error
     end
 
     # Remove the constants that have been autoloaded, and those that have been

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -367,9 +367,11 @@ class DependenciesTest < ActiveSupport::TestCase
     with_autoloading_fixtures do
       e = assert_raise(NameError) { A::DoesNotExist.nil? }
       assert_equal "uninitialized constant A::DoesNotExist", e.message
+      assert_equal :DoesNotExist, e.name
 
       e = assert_raise(NameError) { A::B::DoesNotExist.nil? }
       assert_equal "uninitialized constant A::B::DoesNotExist", e.message
+      assert_equal :DoesNotExist, e.name
     end
   end
 
@@ -537,6 +539,7 @@ class DependenciesTest < ActiveSupport::TestCase
       mod = Module.new
       e = assert_raise(NameError) { mod::E }
       assert_equal 'E cannot be autoloaded from an anonymous class or module', e.message
+      assert_equal :E, e.name
     end
   end
 
@@ -954,7 +957,7 @@ class DependenciesTest < ActiveSupport::TestCase
       assert_kind_of Class, A::B # Necessary to load A::B for the test
       ActiveSupport::Dependencies.mark_for_unload(A::B)
       ActiveSupport::Dependencies.remove_unloadable_constants!
-       
+
       A::B # Make sure no circular dependency error
     end
   end


### PR DESCRIPTION
Backport of #15764 and #15902 to _4-1-stable_ branch. That was a Ruby breaking bug so It should be backported.
