### PR TITLE
Backport of #15764 and #15902 to 4-0-stable

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,6 @@
+*   Make Dependencies pass a name to NameError error.
+    *arthurnn*, *Yuki Nishijima*
+
 ## Rails 4.0.6 (unreleased) ##
 
 *   `Hash#deep_transform_keys` and `Hash#deep_transform_keys!` now transform hashes

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -446,7 +446,7 @@ module ActiveSupport #:nodoc:
         raise ArgumentError, "A copy of #{from_mod} has been removed from the module tree but is still active!"
       end
 
-      raise NameError, "#{from_mod} is not missing constant #{const_name}!" if from_mod.const_defined?(const_name, false)
+      raise NameError.new("#{from_mod} is not missing constant #{const_name}!", const_name) if from_mod.const_defined?(const_name, false)
 
       qualified_name = qualified_name_for from_mod, const_name
       path_suffix = qualified_name.underscore
@@ -498,9 +498,9 @@ module ActiveSupport #:nodoc:
         end
       end
 
-      raise NameError,
-            "uninitialized constant #{qualified_name}",
-            caller.reject { |l| l.starts_with? __FILE__ }
+      name_error = NameError.new("uninitialized constant #{qualified_name}", const_name)
+      name_error.set_backtrace(caller.reject {|l| l.starts_with? __FILE__ })
+      raise name_error
     end
 
     # Remove the constants that have been autoloaded, and those that have been

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -360,12 +360,14 @@ class DependenciesTest < ActiveSupport::TestCase
         flunk "No raise!!"
       rescue NameError => e
         assert_equal "uninitialized constant A::DoesNotExist", e.message
+        assert_equal :DoesNotExist, e.name
       end
       begin
         A::B::DoesNotExist.nil?
         flunk "No raise!!"
       rescue NameError => e
         assert_equal "uninitialized constant A::B::DoesNotExist", e.message
+        assert_equal :DoesNotExist, e.name
       end
     end
   end
@@ -524,8 +526,9 @@ class DependenciesTest < ActiveSupport::TestCase
     with_autoloading_fixtures do
       require_dependency '././counting_loader'
       assert_equal 1, $counting_loaded_times
-      assert_raise(NameError) { ActiveSupport::Dependencies.load_missing_constant Object, :CountingLoader }
+      e = assert_raise(NameError) { ActiveSupport::Dependencies.load_missing_constant Object, :CountingLoader }
       assert_equal 1, $counting_loaded_times
+      assert_equal :CountingLoader, e.name
     end
   end
 


### PR DESCRIPTION
Backport of #15764 and #15902 to _4-0-stable_ branch. That was a Ruby breaking bug so It should be backported.
