### PR TITLE
Consolidate testing of update_all type casting

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -192,16 +192,6 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert_equal("[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...]", record.attribute_for_inspect(:ratings))
   end
 
-  def test_update_all
-    pg_array = PgArray.create! tags: ["one", "two", "three"]
-
-    PgArray.update_all tags: ["four", "five"]
-    assert_equal ["four", "five"], pg_array.reload.tags
-
-    PgArray.update_all tags: []
-    assert_equal [], pg_array.reload.tags
-  end
-
   def test_escaping
     unknown = 'foo\\",bar,baz,\\'
     tags = ["hello_#{unknown}"]

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -295,16 +295,6 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
       assert_cycle("a\nb" => "c\nd")
     end
 
-    def test_update_all
-      hstore = Hstore.create! tags: { "one" => "two" }
-
-      Hstore.update_all tags: { "three" => "four" }
-      assert_equal({ "three" => "four" }, hstore.reload.tags)
-
-      Hstore.update_all tags: { }
-      assert_equal({ }, hstore.reload.tags)
-    end
-
     class TagCollection
       def initialize(hash); @hash = hash end
       def to_hash; @hash end

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -155,16 +155,6 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
     assert_equal "320×480", y.resolution
   end
 
-  def test_update_all
-    json = JsonDataType.create! payload: { "one" => "two" }
-
-    JsonDataType.update_all payload: { "three" => "four" }
-    assert_equal({ "three" => "four" }, json.reload.payload)
-
-    JsonDataType.update_all payload: { }
-    assert_equal({ }, json.reload.payload)
-  end
-
   def test_changes_in_place
     json = JsonDataType.new
     assert_not json.changed?

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -235,5 +235,33 @@ module ActiveRecord
       posts_with_special_comments_with_ratings = Post.group("posts.id").joins(:special_comments).merge(special_comments_with_ratings)
       assert_equal 3, authors(:david).posts.merge(posts_with_special_comments_with_ratings).count.length
     end
+
+    class EnsureRoundTripTypeCasting < ActiveRecord::Type::Value
+      def type
+        :string
+      end
+
+      def type_cast_from_database(value)
+        raise value unless value == "type cast for database"
+        "type cast from database"
+      end
+
+      def type_cast_for_database(value)
+        raise value unless value == "value from user"
+        "type cast for database"
+      end
+    end
+
+    class UpdateAllTestModel < ActiveRecord::Base
+      self.table_name = 'posts'
+
+      attribute :body, EnsureRoundTripTypeCasting.new
+    end
+
+    def test_update_all_goes_through_normal_type_casting
+      UpdateAllTestModel.update_all(body: "value from user", type: nil) # No STI
+
+      assert_equal "type cast from database", UpdateAllTestModel.first.body
+    end
   end
 end


### PR DESCRIPTION
We have several test cases on "tricky" types that are essentially
testing that `update_all` goes through the same type casting behavior as
a normal assignment + save. We recently had another case to add this
test for another type in https://github.com/rails/rails/pull/12742.

Rather than testing this separately for every type which is "tricky"
when round tripping, let's instead have a fairly exhaustive test that
ensures we're getting the correct values at every step for `update_all`.
Given the structure of the code now, we can be confident that if the
type is correct, and `update_all` is type casting correctly, we're going
to get the right behavior for all types.
