### PR TITLE
remove Set.new from DetailsKey::get, impacts rendering overhead

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -66,7 +66,7 @@ module ActionView
       def self.get(details)
         if details[:formats]
           details = details.dup
-          syms    = Set.new Mime::SET.symbols
+          syms    = Mime::SET.symbols
           details[:formats] = details[:formats].select { |v|
             syms.include? v
           }


### PR DESCRIPTION
Using ruby-prof, I noticed that Set#add had the largest 'self time'
percentage (5% of the overall time spent rendering) when
benchmarking the rendering of a small cached ERB template that was 3
lines long. It turns out it was from this line. I don't believe the
Set is necessary, either. Removing this line increases the rendering
ips using Benchmark::ips accordingly.
