### PR TITLE
adding the exception RecordNotFound to UUID find #11957

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb
@@ -12,6 +12,8 @@ module ActiveRecord
                              [a-fA-F0-9]{4}-?
                              [a-fA-F0-9]{4}-?\}?\z}x
 
+          alias_method :type_cast_for_database, :type_cast_from_database
+
           def type
             :uuid
           end

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -252,5 +252,19 @@ class PostgresqlUUIDTestInverseOf < ActiveRecord::TestCase
       comment = post.uuid_comments.create!
       assert post.uuid_comments.find(comment.id)
     end
+
+    def test_find_with_uuid
+      UuidPost.create!
+      assert_raise ActiveRecord::RecordNotFound do
+        UuidPost.find(123456)
+      end
+
+    end
+
+    def test_find_by_with_uuid
+      UuidPost.create!
+      assert_nil UuidPost.find_by(id: 789)
+    end
   end
+
 end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -117,7 +117,7 @@ end
 
 def enable_uuid_ossp!(connection)
   return false unless connection.supports_extensions?
-  return true if connection.extension_enabled?('uuid-ossp')
+  return connection.reconnect! if connection.extension_enabled?('uuid-ossp')
 
   connection.enable_extension 'uuid-ossp'
   connection.commit_db_transaction


### PR DESCRIPTION
Basic change to handle UUIDS exception to fix https://github.com/rails/rails/issues/11957 and those related.
Ex. 
User.find(some-non-uuid)
will trigger a RecordNotFound instead of PG::InvalidTextRepresentation
I created an app to test this as well:
https://github.com/joseluistorres/my-test-app

Please provide feedback, thanks!
