### PR TITLE
Add always permitted parameters as a configurable option.

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -105,11 +105,10 @@ module ActionController
     # params are present. The default includes both 'controller' and 'action'
     # because they are added by Rails and should be of no concern. One way
     # to change these is to specify `always_permitted_parameters` in your
-    # config, e.g.
-    # `config.always_permitted_parameters = %w( controller action format )`
-
+    # config. For instance:
+    #
+    #    config.always_permitted_parameters = %w( controller action format )
     cattr_accessor :always_permitted_parameters
-
     self.always_permitted_parameters = %w( controller action )
 
     def self.const_missing(const_name)

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -22,6 +22,10 @@ module ActionController
       options = app.config.action_controller
 
       ActionController::Parameters.permit_all_parameters = options.delete(:permit_all_parameters) { false }
+      if app.config.action_controller[:always_permitted_parameters]
+        ActionController::Parameters.always_permitted_parameters =
+          app.config.action_controller.delete(:always_permitted_parameters)
+      end
       ActionController::Parameters.action_on_unpermitted_parameters = options.delete(:action_on_unpermitted_parameters) do
         (Rails.env.test? || Rails.env.development?) ? :log : false
       end

--- a/actionpack/test/controller/parameters/always_permitted_parameters_test.rb
+++ b/actionpack/test/controller/parameters/always_permitted_parameters_test.rb
@@ -1,0 +1,29 @@
+require 'abstract_unit'
+require 'action_controller/metal/strong_parameters'
+
+class AlwaysPermittedParametersTest < ActiveSupport::TestCase
+  def setup
+    ActionController::Parameters.action_on_unpermitted_parameters = :raise
+    ActionController::Parameters.always_permitted_parameters = %w( controller action format )
+  end
+
+  def teardown
+    ActionController::Parameters.action_on_unpermitted_parameters = false
+    ActionController::Parameters.always_permitted_parameters = %w( controller action )
+  end
+
+  test "shows deprecations warning on NEVER_UNPERMITTED_PARAMS" do
+    assert_deprecated do
+       ActionController::Parameters::NEVER_UNPERMITTED_PARAMS
+    end
+  end
+
+  test "permits parameters that are whitelisted" do
+    params = ActionController::Parameters.new({
+      book: { pages: 65 },
+      format: "json"
+    })
+    permitted = params.permit book: [:pages]
+    assert permitted.permitted?
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -311,6 +311,8 @@ The schema dumper adds one additional configuration option:
 
 * `config.action_controller.action_on_unpermitted_parameters` enables logging or raising an exception if parameters that are not explicitly permitted are found. Set to `:log` or `:raise` to enable. The default value is `:log` in development and test environments, and `false` in all other environments.
 
+* `config.action_controller.always_permitted_parameters` sets a list of whitelisted parameters that are permitted by default. The default values are `['controller', 'action']`.
+
 ### Configuring Action Dispatch
 
 * `config.action_dispatch.session_store` sets the name of the store for session data. The default is `:cookie_store`; other valid options include `:active_record_store`, `:mem_cache_store` or the name of your own custom class.
@@ -773,7 +775,7 @@ error similar to given below will be thrown.
 ActiveRecord::ConnectionTimeoutError - could not obtain a database connection within 5 seconds. The max pool size is currently 5; consider increasing it:
 ```
 
-If you get the above error, you might want to increase the size of connection 
+If you get the above error, you might want to increase the size of connection
 pool by incrementing the `pool` option in `database.yml`
 
 NOTE. If you have enabled `Rails.threadsafe!` mode then there could be a chance that several threads may be accessing multiple connections simultaneously. So depending on your current request load, you could very well have multiple threads contending for a limited amount of connections.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -592,6 +592,19 @@ module ApplicationTests
       assert_match "We're sorry, but something went wrong", last_response.body
     end
 
+    test "config.action_controller.always_permitted_parameters are: controller, action by default" do
+      require "#{app_path}/config/environment"
+      assert_equal %w(controller action), ActionController::Parameters.always_permitted_parameters
+    end
+
+    test "config.action_controller.always_permitted_parameters = ['controller', 'action', 'format']" do
+      add_to_config <<-RUBY
+        config.action_controller.always_permitted_parameters = %w( controller action format )
+      RUBY
+      require "#{app_path}/config/environment"
+      assert_equal %w( controller action format ), ActionController::Parameters.always_permitted_parameters
+    end
+
     test "config.action_controller.action_on_unpermitted_parameters is :log by default on development" do
       ENV["RAILS_ENV"] = "development"
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -605,6 +605,31 @@ module ApplicationTests
       assert_equal %w( controller action format ), ActionController::Parameters.always_permitted_parameters
     end
 
+    test "config.action_controller.always_permitted_parameters = ['controller','action','format'] does not raise exeception" do
+      app_file 'app/controllers/posts_controller.rb', <<-RUBY
+      class PostsController < ActionController::Base
+        def create
+          render text: params.permit(post: [:title])
+        end
+      end
+      RUBY
+
+      add_to_config <<-RUBY
+        routes.prepend do
+          resources :posts
+        end
+        config.action_controller.always_permitted_parameters = %w( controller action format )
+        config.action_controller.action_on_unpermitted_parameters = :raise
+      RUBY
+
+      require "#{app_path}/config/environment"
+
+      assert_equal :raise, ActionController::Parameters.action_on_unpermitted_parameters
+
+      post "/posts", {post: {"title" =>"zomg"}, format: "json"}
+      assert_equal 200, last_response.status
+    end
+
     test "config.action_controller.action_on_unpermitted_parameters is :log by default on development" do
       ENV["RAILS_ENV"] = "development"
 


### PR DESCRIPTION
- This commit adds back the always_permitted_parameters configuration option to strong parameters.
- The initial pull requests where this feature was added are the following:
  - https://github.com/rails/rails/pull/12682
  - https://github.com/rails/strong_parameters/pull/174
