### PR TITLE
rename primary key sequence only if it exists

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   PostgreSQL renaming table doesn't attempt to rename non existent sequences
+    
+    *Abdelkader Boudih*
+    
 *   Move 'dependent: :destroy' handling for 'belongs_to'
     from 'before_destroy' to 'after_destroy' callback chain
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -375,8 +375,8 @@ module ActiveRecord
         end
 
         # Renames a table.
-        # Also renames a table's primary key sequence if the sequence name matches the
-        # Active Record default.
+        # Also renames a table's primary key sequence if the sequence name exists and
+        # matches the Active Record default.
         #
         # Example:
         #   rename_table('octopuses', 'octopi')
@@ -384,7 +384,7 @@ module ActiveRecord
           clear_cache!
           execute "ALTER TABLE #{quote_table_name(table_name)} RENAME TO #{quote_table_name(new_name)}"
           pk, seq = pk_and_sequence_for(new_name)
-          if seq.identifier == "#{table_name}_#{pk}_seq"
+          if seq && seq.identifier == "#{table_name}_#{pk}_seq"
             new_seq = "#{new_name}_#{pk}_seq"
             execute "ALTER TABLE #{quote_table_name(seq)} RENAME TO #{quote_table_name(new_seq)}"
           end

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -76,6 +76,16 @@ module ActiveRecord
 
           assert_equal ConnectionAdapters::PostgreSQL::Name.new("public", "octopi_#{pk}_seq"), seq
         end
+
+        def test_renaming_table_doesnt_attempt_to_rename_non_existent_sequences
+          enable_uuid_ossp!(connection)
+          connection.create_table :cats, id: :uuid
+          assert_nothing_raised { rename_table :cats, :felines }
+          assert connection.table_exists? :felines
+        ensure
+          connection.drop_table :cats if connection.table_exists? :cats
+          connection.drop_table :felines if connection.table_exists? :felines
+        end
       end
     end
   end


### PR DESCRIPTION
cc/ @sgrif @rafaelfranca @senny

When a table has  no sequence in the  for primary key (for example :uuid), it was not possible to rename it without using sql. This fix it.
