### PR TITLE
Remove needless alias in integer types

### DIFF
--- a/activerecord/lib/active_record/type/integer.rb
+++ b/activerecord/lib/active_record/type/integer.rb
@@ -7,8 +7,6 @@ module ActiveRecord
         :integer
       end
 
-      alias type_cast_for_database type_cast
-
       private
 
       def cast_value(value)


### PR DESCRIPTION
This must have stuck around when we were overriding more in integers,
not sure what it's still doing here.
