### PR TITLE
databases.rake refactoring

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -189,11 +189,7 @@ db_namespace = namespace :db do
     task :load => [:environment, :load_config] do
       require 'active_record/fixtures'
 
-      base_dir = if ENV['FIXTURES_PATH']
-        ActiveRecord::Tasks::DatabaseTasks.root.join(ENV['FIXTURES_PATH'])
-      else
-        ActiveRecord::Tasks::DatabaseTasks.fixtures_path
-      end
+      base_dir = ActiveRecord::Tasks::DatabaseTasks.fixtures_path
 
       fixtures_dir = File.join [base_dir, ENV['FIXTURES_DIR']].compact
 
@@ -211,12 +207,7 @@ db_namespace = namespace :db do
 
       puts %Q(The fixture ID for "#{label}" is #{ActiveRecord::FixtureSet.identify(label)}.) if label
 
-      base_dir = if ENV['FIXTURES_PATH']
-        ActiveRecord::Tasks::DatabaseTasks.root.join(ENV['FIXTURES_PATH'])
-      else
-        ActiveRecord::Tasks::DatabaseTasks.fixtures_path
-      end
-
+      base_dir = ActiveRecord::Tasks::DatabaseTasks.fixtures_path
 
       Dir["#{base_dir}/**/*.yml"].each do |file|
         if data = YAML::load(ERB.new(IO.read(file)).result)

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -96,8 +96,7 @@ db_namespace = namespace :db do
       unless ActiveRecord::Base.connection.table_exists?(ActiveRecord::Migrator.schema_migrations_table_name)
         abort 'Schema migrations table does not exist yet.'
       end
-      db_list = ActiveRecord::SchemaMigration.pluck(:version)
-      db_list.map! { |version| ActiveRecord::SchemaMigration.normalize_migration_number(version) }
+      db_list = ActiveRecord::SchemaMigration.normalized_versions
 
       file_list =
           ActiveRecord::Migrator.migrations_paths.flat_map do |path|

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -200,7 +200,7 @@ db_namespace = namespace :db do
       fixture_files = if ENV['FIXTURES']
                         ENV['FIXTURES'].split(',')
                       else
-                        Dir["#{fixtures_dir}/**/*.yml"].map {|f| f[(fixtures_dir.size + 1)..-5] }
+                        Pathname.glob("#{fixtures_dir}/**/*.yml").map {|f| f.basename.sub_ext('').to_s }
                       end
 
       ActiveRecord::FixtureSet.create_fixtures(fixtures_dir, fixture_files)

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -191,7 +191,11 @@ db_namespace = namespace :db do
 
       base_dir = ActiveRecord::Tasks::DatabaseTasks.fixtures_path
 
-      fixtures_dir = File.join [base_dir, ENV['FIXTURES_DIR']].compact
+      fixtures_dir = if ENV['FIXTURES_DIR']
+                       File.join base_dir, ENV['FIXTURES_DIR']
+                     else
+                       base_dir
+                     end
 
       (ENV['FIXTURES'] ? ENV['FIXTURES'].split(',') : Dir["#{fixtures_dir}/**/*.yml"].map {|f| f[(fixtures_dir.size + 1)..-5] }).each do |fixture_file|
         ActiveRecord::FixtureSet.create_fixtures(fixtures_dir, fixture_file)

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -96,7 +96,7 @@ db_namespace = namespace :db do
       unless ActiveRecord::Base.connection.table_exists?(ActiveRecord::Migrator.schema_migrations_table_name)
         abort 'Schema migrations table does not exist yet.'
       end
-      db_list = ActiveRecord::Base.connection.select_values("SELECT version FROM #{ActiveRecord::Migrator.schema_migrations_table_name}")
+      db_list = ActiveRecord::SchemaMigration.pluck(:version)
       db_list.map! { |version| ActiveRecord::SchemaMigration.normalize_migration_number(version) }
 
       file_list =

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -190,7 +190,7 @@ db_namespace = namespace :db do
       require 'active_record/fixtures'
 
       base_dir = if ENV['FIXTURES_PATH']
-        File.join [Rails.root, ENV['FIXTURES_PATH'] || %w{test fixtures}].flatten
+        Rails.root.join(ENV['FIXTURES_PATH'])
       else
         ActiveRecord::Tasks::DatabaseTasks.fixtures_path
       end
@@ -212,7 +212,7 @@ db_namespace = namespace :db do
       puts %Q(The fixture ID for "#{label}" is #{ActiveRecord::FixtureSet.identify(label)}.) if label
 
       base_dir = if ENV['FIXTURES_PATH']
-        File.join [Rails.root, ENV['FIXTURES_PATH'] || %w{test fixtures}].flatten
+        Rails.root.join(ENV['FIXTURES_PATH'])
       else
         ActiveRecord::Tasks::DatabaseTasks.fixtures_path
       end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -116,8 +116,8 @@ db_namespace = namespace :db do
       puts "\ndatabase: #{ActiveRecord::Base.connection_config[:database]}\n\n"
       puts "#{'Status'.center(8)}  #{'Migration ID'.ljust(14)}  Migration Name"
       puts "-" * 50
-      (db_list + file_list).sort_by {|migration| migration[1]}.each do |migration|
-        puts "#{migration[0].center(8)}  #{migration[1].ljust(14)}  #{migration[2]}"
+      (db_list + file_list).sort_by { |_, version, _| version }.each do |status, version, name|
+        puts "#{status.center(8)}  #{version.ljust(14)}  #{name}"
       end
       puts
     end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -203,9 +203,7 @@ db_namespace = namespace :db do
                         Dir["#{fixtures_dir}/**/*.yml"].map {|f| f[(fixtures_dir.size + 1)..-5] }
                       end
 
-      fixture_files.each do |fixture_file|
-        ActiveRecord::FixtureSet.create_fixtures(fixtures_dir, fixture_file)
-      end
+      ActiveRecord::FixtureSet.create_fixtures(fixtures_dir, fixture_files)
     end
 
     # desc "Search for a fixture given a LABEL or ID. Specify an alternative path (eg. spec/fixtures) using FIXTURES_PATH=spec/fixtures."

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -197,7 +197,13 @@ db_namespace = namespace :db do
                        base_dir
                      end
 
-      (ENV['FIXTURES'] ? ENV['FIXTURES'].split(',') : Dir["#{fixtures_dir}/**/*.yml"].map {|f| f[(fixtures_dir.size + 1)..-5] }).each do |fixture_file|
+      fixture_files = if ENV['FIXTURES']
+                        ENV['FIXTURES'].split(',')
+                      else
+                        Dir["#{fixtures_dir}/**/*.yml"].map {|f| f[(fixtures_dir.size + 1)..-5] }
+                      end
+
+      fixture_files.each do |fixture_file|
         ActiveRecord::FixtureSet.create_fixtures(fixtures_dir, fixture_file)
       end
     end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -190,7 +190,7 @@ db_namespace = namespace :db do
       require 'active_record/fixtures'
 
       base_dir = if ENV['FIXTURES_PATH']
-        Rails.root.join(ENV['FIXTURES_PATH'])
+        ActiveRecord::Tasks::DatabaseTasks.root.join(ENV['FIXTURES_PATH'])
       else
         ActiveRecord::Tasks::DatabaseTasks.fixtures_path
       end
@@ -212,7 +212,7 @@ db_namespace = namespace :db do
       puts %Q(The fixture ID for "#{label}" is #{ActiveRecord::FixtureSet.identify(label)}.) if label
 
       base_dir = if ENV['FIXTURES_PATH']
-        Rails.root.join(ENV['FIXTURES_PATH'])
+        ActiveRecord::Tasks::DatabaseTasks.root.join(ENV['FIXTURES_PATH'])
       else
         ActiveRecord::Tasks::DatabaseTasks.fixtures_path
       end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -93,7 +93,7 @@ db_namespace = namespace :db do
 
     desc 'Display status of migrations'
     task :status => [:environment, :load_config] do
-      unless ActiveRecord::Base.connection.table_exists?(ActiveRecord::Migrator.schema_migrations_table_name)
+      unless ActiveRecord::SchemaMigration.table_exists?
         abort 'Schema migrations table does not exist yet.'
       end
       db_list = ActiveRecord::SchemaMigration.normalized_versions

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -43,6 +43,10 @@ module ActiveRecord
       def normalize_migration_number(number)
         "%.3d" % number.to_i
       end
+
+      def normalized_versions
+        pluck(:version).map { |v| normalize_migration_number v }
+      end
     end
 
     def version

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -58,7 +58,11 @@ module ActiveRecord
       end
 
       def fixtures_path
-        @fixtures_path ||= File.join(root, 'test', 'fixtures')
+        @fixtures_path ||= if ENV['FIXTURES_PATH']
+                             File.join(root, ENV['FIXTURES_PATH'])
+                           else
+                             File.join(root, 'test', 'fixtures')
+                           end
       end
 
       def root

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -184,6 +184,21 @@ module ApplicationTests
           assert_match(/create_table "books"/, structure_dump)
         end
       end
+
+      test 'test migration status migrated file is deleted' do
+        Dir.chdir(app_path) do
+          `rails generate model user username:string password:string;
+           rails generate migration add_email_to_users email:string;
+           rake db:migrate
+           rm db/migrate/*email*.rb`
+
+          output = `rake db:migrate:status`
+          File.write('test.txt', output)
+
+          assert_match(/up\s+\d{14}\s+Create users/, output)
+          assert_match(/up\s+\d{14}\s+\** NO FILE \**/, output)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
`databases.rake` is not the best ruby code. This pull request contains some improvements, making the code more functional and using things like `Pathname#sub_ext` and `Array#grep` instead of crazy regular expressions and loops with temporary variables and nested conditionals.

I'm not sure if having so many commits in one PR is a good thing. I tried to make them granular and self-descriptive. If it is not ok, I can squash them together or send them via separate pull requests.
