### PR TITLE
Always instrument ActiveSupport::Cache

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -8,6 +8,7 @@ require 'active_support/core_ext/numeric/bytes'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/object/to_param'
 require 'active_support/core_ext/string/inflections'
+require 'active_support/deprecation'
 
 module ActiveSupport
   # See ActiveSupport::Cache::Store for documentation.
@@ -178,14 +179,16 @@ module ActiveSupport
         @silence = previous_silence
       end
 
-      # Set to +true+ if cache stores should be instrumented.
-      # Default is +false+.
+      # :deprecated:
       def self.instrument=(boolean)
-        Thread.current[:instrument_cache_store] = boolean
+        ActiveSupport::Deprecation.warn "ActiveSupport::Cache.instrument is deprecated and will be removed in Rails 5. Instrumentation is now always on so you can safely stop using it."
+        true
       end
 
+      # :deprecated:
       def self.instrument
-        Thread.current[:instrument_cache_store] || false
+        ActiveSupport::Deprecation.warn "ActiveSupport::Cache.instrument is deprecated and will be removed in Rails 5. Instrumentation is now always on so you can safely stop using it."
+        true
       end
 
       # Fetches data from the cache, using the given key. If there is data in
@@ -539,13 +542,9 @@ module ActiveSupport
         def instrument(operation, key, options = nil)
           log(operation, key, options)
 
-          if self.class.instrument
-            payload = { :key => key }
-            payload.merge!(options) if options.is_a?(Hash)
-            ActiveSupport::Notifications.instrument("cache_#{operation}.active_support", payload){ yield(payload) }
-          else
-            yield(nil)
-          end
+          payload = { :key => key }
+          payload.merge!(options) if options.is_a?(Hash)
+          ActiveSupport::Notifications.instrument("cache_#{operation}.active_support", payload){ yield(payload) }
         end
 
         def log(operation, key, options = nil)


### PR DESCRIPTION
The current approach is broken because it uses a thread local value which
means on multi-threaded environments it has to be turned on per thread.
Secondly, ActiveSupport::Notifications does not instrument items when there
are not subscribers so this flag is unnecessary.
