### PR TITLE
PredicateBuilder should use in rather than eq for Arel::SelectManager

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -110,6 +110,7 @@ module ActiveRecord
     register_handler(Class, ->(attribute, value) { attribute.eq(value.name) })
     register_handler(Base, ->(attribute, value) { attribute.eq(value.id) })
     register_handler(Range, ->(attribute, value) { attribute.in(value) })
+    register_handler(Arel::SelectManager, ->(attribute, value) { attribute.in(value) })
     register_handler(Relation, RelationHandler.new)
     register_handler(Array, ArrayHandler.new)
 

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -1,5 +1,7 @@
 require "cases/helper"
 require 'models/topic'
+require 'models/author'
+require 'models/book'
 
 module ActiveRecord
   class PredicateBuilderTest < ActiveRecord::TestCase
@@ -9,6 +11,14 @@ module ActiveRecord
       end)
 
       assert_match %r{["`]topics["`].["`]title["`] ~ rails}i, Topic.where(title: /rails/).to_sql
+    end
+
+    def test_selectmanager_handler
+      author = Author.create!(name: 'Steven King')
+      Book.create!(author_id: author.id)
+      Book.create!(author_id: author.id)
+
+      assert_equal author, Author.where(id: Book.arel_table.project(:author_id)).first
     end
   end
 end


### PR DESCRIPTION
When using `where` against an arel subquery, ActiveRecord::Relation::PredicateBuilder matches the subquery to the attribute using `Arel::Predications#eq`, rather than `Arel::Predications#in`. We should be using `in` instead.

The statement

```
Author.where(id: Book.arel_table.project(:author_id))
```

currently generates the sql

```
SELECT \"authors\".* FROM \"authors\" WHERE \"authors\".\"id\" = (SELECT author_id FROM \"books\")
```

which results in a postgres error if the subquery returns more than one row.

It should generate

```
SELECT \"authors\".* FROM \"authors\" WHERE \"authors\".\"id\" IN (SELECT author_id FROM \"books\")
```

instead.
