### PR TITLE
Fix test session fetch

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   ActionController::TestSession now accepts a default value as well as
+    a block for generating a default value based off the key provided.
+
+    This fixes calls to session#fetch in ApplicationController instances that
+    take more two arguments or a block from raising `ArgumentError: wrong
+    number of arguments (2 for 1)` when performing controller tests.
+
+    *Matthew Gerrior*
+
 *   Fix `ActionController::Parameters#fetch` overwriting `KeyError` returned by
     default block.
 

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -171,6 +171,10 @@ module ActionController
       clear
     end
 
+    def fetch(*args, &block)
+      @data.fetch(*args, &block)
+    end
+
     private
 
       def load!

--- a/actionpack/test/dispatch/session/test_session_test.rb
+++ b/actionpack/test/dispatch/session/test_session_test.rb
@@ -40,4 +40,14 @@ class ActionController::TestSessionTest < ActiveSupport::TestCase
     assert_equal %w(one two), session.keys
     assert_equal %w(1 2), session.values
   end
+
+  def test_fetch_returns_default
+    session = ActionController::TestSession.new(one: '1')
+    assert_equal('2', session.fetch(:two, '2'))
+  end
+
+  def test_fetch_returns_block_value
+    session = ActionController::TestSession.new(one: '1')
+    assert_equal(2, session.fetch('2') { |key| key.to_i })
+  end
 end


### PR DESCRIPTION
This pull request fixes an issue when passing two arguments or a block to `session#fetch` in an application controller. The `ActionController::TestSession` currently extends `Rack::Session::Abstract::SessionHash` which aliases `#fetch` to `#[]` which only takes one argument. This causes an `ArgumentError: wrong number of arguments (2 for 1)` error to be raised when testing a controller that executes code such as

``` ruby
class HomeController < ApplicationController
  def index
    @title = session.fetch(:title, 'Hello, world!')
  end
end
```

I've subsequently created a simple rails application that produces the error at https://github.com/MGerrior/SessionTestApp/ . Please let me know if any changes are necessary to move this forward.
