### PR TITLE
MySQL doesn't work with foreign keys

### DIFF
--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -83,7 +83,10 @@ ActiveRecord::Schema.define do
 
   create_table :author_addresses, force: true do |t|
   end
-  add_foreign_key :authors, :author_addresses
+
+  unless current_adapter?(:MysqlAdapter, :Mysql2Adapter)
+    add_foreign_key :authors, :author_addresses
+  end
 
   create_table :author_favorites, force: true do |t|
     t.column :author_id, :integer


### PR DESCRIPTION
This was previously fixed in e84799d but broken in 3f596f8. This commit
reintroduced the conditional that prevents the foreign keys from being
added to MySQL databases.
