### PR TITLE
Rename options param of #time_ago_in_words to match API change

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -153,8 +153,8 @@ module ActionView
       #
       # Note that you cannot pass a <tt>Numeric</tt> value to <tt>time_ago_in_words</tt>.
       #
-      def time_ago_in_words(from_time, include_seconds_or_options = {})
-        distance_of_time_in_words(from_time, Time.now, include_seconds_or_options)
+      def time_ago_in_words(from_time, options = {})
+        distance_of_time_in_words(from_time, Time.now, options)
       end
 
       alias_method :distance_of_time_in_words_to_now, :time_ago_in_words


### PR DESCRIPTION
Rename `include_seconds_or_options` to `options` to match 6b9356a (which removed the deprecation introduced by #6077).  This has no functional impact because the parameter is passed directly through, but makes it clearer that the parameter no longer supports a boolean as input.
