### PR TITLE
[ci skip] Fix router option reference in 4.2 release notes.

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -88,7 +88,7 @@ for detailed changes.
 
 ### Deprecations
 
-* Deprecated support for setting the `to:` option of a router to a symbol or a
+* Deprecated support for setting the `:to` option of a router to a symbol or a
   string that does not contain a `#` character:
 
       get '/posts', to: MyRackApp    => (No change necessary)


### PR DESCRIPTION
Found this while updating my translation.
