### PR TITLE
Add configuration to enable mail previews

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `config.action_mailer.preview_enabled` configuration option.
+
+    This config option can be used to enable the mail preview in environments
+    other than development (such as staging).
+
+    Defaults to `true` in development and false elsewhere.
+
+    *Leonard Garvey*
+
 *   Allow preview interceptors to be registered through
     `config.action_mailer.preview_interceptors`.
 

--- a/actionmailer/lib/action_mailer/preview.rb
+++ b/actionmailer/lib/action_mailer/preview.rb
@@ -11,6 +11,14 @@ module ActionMailer
       #
       mattr_accessor :preview_path, instance_writer: false
 
+      # Enable or disable mailer previews through app configuration:
+      #
+      #     config.action_mailer.preview_enabled = true
+      #
+      # Defaults to true for development environment
+      #
+      mattr_accessor :preview_enabled, instance_writer: false
+
       # :nodoc:
       mattr_accessor :preview_interceptors, instance_writer: false
       self.preview_interceptors = []
@@ -92,6 +100,10 @@ module ActionMailer
 
         def preview_path #:nodoc:
           Base.preview_path
+        end
+
+        def preview_enabled #:nodoc:
+          Base.preview_enabled
         end
 
         def inform_preview_interceptors(message) #:nodoc:

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -18,8 +18,9 @@ module ActionMailer
       options.assets_dir      ||= paths["public"].first
       options.javascripts_dir ||= paths["public/javascripts"].first
       options.stylesheets_dir ||= paths["public/stylesheets"].first
+      options.preview_enabled = Rails.env.development? if options.preview_enabled.nil?
 
-      if Rails.env.development?
+      if options.preview_enabled
         options.preview_path  ||= defined?(Rails.root) ? "#{Rails.root}/test/mailers/previews" : nil
       end
 
@@ -37,6 +38,13 @@ module ActionMailer
         register_observers(options.delete(:observers))
 
         options.each { |k,v| send("#{k}=", v) }
+
+        if options.preview_enabled
+          app.routes.append do
+            get '/rails/mailers'         => "rails/mailers#index"
+            get '/rails/mailers/*path'   => "rails/mailers#preview"
+          end
+        end
       end
     end
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -453,6 +453,18 @@ There are a number of settings available on `config.action_mailer`:
     config.action_mailer.interceptors = ["MailInterceptor"]
     ```
 
+* `config.action_mailer.preview_path` specifies the location of mailer previews.
+
+    ```ruby
+    config.action_mailer.preview_path = "#{Rails.root}/lib/mailer_previews"
+    ```
+
+* `config.action_mailer.preview_enabled` enable or disable mailer previews. By default this is `true` in development.
+
+    ```ruby
+    config.action_mailer.preview_enabled = false
+    ```
+
 ### Configuring Active Support
 
 There are a few configuration options available in Active Support:

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -22,8 +22,6 @@ module Rails
       initializer :add_builtin_route do |app|
         if Rails.env.development?
           app.routes.append do
-            get '/rails/mailers'         => "rails/mailers#index"
-            get '/rails/mailers/*path'   => "rails/mailers#preview"
             get '/rails/info/properties' => "rails/info#properties"
             get '/rails/info/routes'     => "rails/info#routes"
             get '/rails/info'            => "rails/info#index"

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -965,5 +965,29 @@ module ApplicationTests
 
       assert db_config.is_a?(Hash)
     end
+
+    test 'config.mail_preview_enabled defaults to true in development' do
+      Rails.env = "development"
+      require "#{app_path}/config/environment"
+
+      assert Rails.application.config.action_mailer.preview_enabled
+    end
+
+    test 'config.mail_preview_enabled defaults to false in production' do
+      Rails.env = "production"
+      require "#{app_path}/config/environment"
+
+      assert_equal Rails.application.config.action_mailer.preview_enabled, false
+    end
+
+    test 'config.mail_preview_enabled can be set in the configuration file' do
+      Rails.env = "production"
+      add_to_config <<-RUBY
+        config.action_mailer.preview_enabled = true
+      RUBY
+      require "#{app_path}/config/environment"
+
+      assert_equal Rails.application.config.action_mailer.preview_enabled, true
+    end
   end
 end

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -26,6 +26,20 @@ module ApplicationTests
       assert_equal 404, last_response.status
     end
 
+    test "/rails/mailers is accessible with correct configuraiton" do
+      add_to_config "config.action_mailer.preview_enabled = true"
+      app("production")
+      get "/rails/mailers"
+      assert_equal 200, last_response.status
+    end
+
+    test "/rails/mailers is not accessible with preview_enabled = false" do
+      add_to_config "config.action_mailer.preview_enabled = false"
+      app("development")
+      get "/rails/mailers"
+      assert_equal 404, last_response.status
+    end
+
     test "mailer previews are loaded from the default preview_path" do
       mailer 'notifier', <<-RUBY
         class Notifier < ActionMailer::Base


### PR DESCRIPTION
Adds `config.action_mailer.preview_enabled`

This allows mail previewing to be enabled easily in non-development
environments such as staging. The default is set to true for development
so no changes should be required to existing Rails applications.

The mail preview path can still be configured using the existing
`config.action_mailer.preview_path` configuration option.

Adding this prevents devs from having to do stuff like:

``` ruby
  config.action_mailer.preview_path ||= defined?(Rails.root) ? "#{Rails.root}/test/mailers/previews" : nil

  routes.append do
    get '/rails/mailers'         => "rails/mailers#index"
    get '/rails/mailers/*path'   => "rails/mailers#preview"
  end
```

in order to enable mail previewing on staging.
