### PR TITLE
Correctly dump `:bigserial` primary keys on PG

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Correctly dump `:bigserial` primary keys on PostgreSQL. Previously if a
+    table was created with `create_table :foo, id: :bigserial`, that information
+    would be lost in `schema.rb`.
+
+    Fixes #15968.
+
+    *Sean Griffin*
+
 *   PostgreSQL renaming table doesn't attempt to rename non existent sequences.
 
     *Abdelkader Boudih*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -33,6 +33,10 @@ module ActiveRecord
         [:name, :limit, :precision, :scale, :default, :null]
       end
 
+      def print_primary_key_type(column, printer)
+        # :noop
+      end
+
       private
 
       def schema_default(column)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -1,6 +1,7 @@
 require 'active_record/connection_adapters/postgresql/oid/infinity'
 
 require 'active_record/connection_adapters/postgresql/oid/array'
+require 'active_record/connection_adapters/postgresql/oid/big_integer'
 require 'active_record/connection_adapters/postgresql/oid/bit'
 require 'active_record/connection_adapters/postgresql/oid/bit_varying'
 require 'active_record/connection_adapters/postgresql/oid/bytea'

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/big_integer.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/big_integer.rb
@@ -1,0 +1,19 @@
+require 'active_record/connection_adapters/postgresql/oid/integer'
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID # :nodoc:
+        class BigInteger < Integer # :nodoc:
+          def type
+            :big_integer
+          end
+
+          def limit
+            8
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -83,6 +83,10 @@ module ActiveRecord
         def money(name, options)
           column(name, :money, options)
         end
+
+        def big_integer(name, options)
+          column(name, :big_integer, options)
+        end
       end
 
       class ColumnDefinition < ActiveRecord::ConnectionAdapters::ColumnDefinition

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -1,0 +1,21 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module SchemaDumper # :nodoc:
+        def print_primary_key_type(column, printer)
+          case column.type
+          when :uuid
+            printer.print(", id: :uuid")
+            if column.default_function
+              printer.print(%Q(, default: "#{column.default_function}"))
+            end
+          when :big_integer
+            printer.print(", id: :bigserial")
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -7,6 +7,7 @@ require 'active_record/connection_adapters/postgresql/oid'
 require 'active_record/connection_adapters/postgresql/quoting'
 require 'active_record/connection_adapters/postgresql/referential_integrity'
 require 'active_record/connection_adapters/postgresql/schema_definitions'
+require 'active_record/connection_adapters/postgresql/schema_dumper'
 require 'active_record/connection_adapters/postgresql/schema_statements'
 require 'active_record/connection_adapters/postgresql/database_statements'
 
@@ -81,6 +82,7 @@ module ActiveRecord
         string:      { name: "character varying" },
         text:        { name: "text" },
         integer:     { name: "integer" },
+        big_integer: { name: "bigint" },
         float:       { name: "float" },
         decimal:     { name: "decimal" },
         datetime:    { name: "timestamp" },
@@ -115,6 +117,7 @@ module ActiveRecord
       include PostgreSQL::Quoting
       include PostgreSQL::ReferentialIntegrity
       include PostgreSQL::SchemaStatements
+      include PostgreSQL::SchemaDumper
       include PostgreSQL::DatabaseStatements
       include Savepoints
 
@@ -425,7 +428,7 @@ module ActiveRecord
         def initialize_type_map(m) # :nodoc:
           register_class_with_limit m, 'int2', OID::Integer
           m.alias_type 'int4', 'int2'
-          m.alias_type 'int8', 'int2'
+          m.register_type 'int8', OID::BigInteger.new
           m.alias_type 'oid', 'int2'
           m.register_type 'float4', OID::Float.new
           m.alias_type 'float8', 'float4'
@@ -494,7 +497,6 @@ module ActiveRecord
 
         def extract_limit(sql_type) # :nodoc:
           case sql_type
-          when /^bigint/i;    8
           when /^smallint/i;  2
           else super
           end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -129,9 +129,8 @@ HEADER
           if pkcol
             if pk != 'id'
               tbl.print %Q(, primary_key: "#{pk}")
-            elsif pkcol.sql_type == 'uuid'
-              tbl.print ", id: :uuid"
-              tbl.print %Q(, default: "#{pkcol.default_function}") if pkcol.default_function
+            else
+              @connection.print_primary_key_type(pkcol, tbl)
             end
           else
             tbl.print ", id: false"

--- a/activerecord/test/cases/adapters/postgresql/big_serial_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/big_serial_test.rb
@@ -1,0 +1,40 @@
+require "cases/helper"
+require "support/schema_dumping_helper"
+
+class PostgresqlBigSerialTest < ActiveRecord::TestCase
+  include SchemaDumpingHelper
+
+  class PostgresqlBigSerial < ActiveRecord::Base; end
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table(:postgresql_big_serials, force: true, id: :bigserial) do |t|
+    end
+  end
+
+  teardown do
+    if @connection
+      @connection.execute('DROP TABLE IF EXISTS postgresql_big_serials')
+    end
+  end
+
+  test "bigserial columns have a biginteger type" do
+    assert_equal :big_integer, PostgresqlBigSerial.type_for_attribute('id').type
+  end
+
+  test "bigserial columns have a limit of 8" do
+    assert_equal 8, PostgresqlBigSerial.type_for_attribute('id').limit
+  end
+
+  test "bigserial primary keys are dumped correctly" do
+    output = dump_table_schema("postgresql_big_serials")
+    assert_match %r(create_table "postgresql_big_serials",.*\sid: :bigserial), output
+    assert_no_match %r(create_table "postgresql_big_serials",.*default), output
+  end
+
+  test "bigserial primary keys work as normal" do
+    assert_equal "id", PostgresqlBigSerial.primary_key
+
+    assert_not_nil PostgresqlBigSerial.create!.id
+  end
+end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -198,29 +198,3 @@ if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
     end
   end
 end
-
-if current_adapter?(:PostgreSQLAdapter)
-  class PrimaryKeyBigSerialTest < ActiveRecord::TestCase
-    self.use_transactional_fixtures = false
-
-    class Widget < ActiveRecord::Base
-    end
-
-    setup do
-      @connection = ActiveRecord::Base.connection
-      @connection.create_table(:widgets, id: :bigserial) { |t| }
-    end
-
-    teardown do
-      @connection.drop_table :widgets
-    end
-
-    def test_bigserial_primary_key
-      assert_equal "id", Widget.primary_key
-      assert_equal :integer, Widget.columns_hash[Widget.primary_key].type
-
-      widget = Widget.create!
-      assert_not_nil widget.id
-    end
-  end
-end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -63,7 +63,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
       next if column_set.empty?
 
       lengths = column_set.map do |column|
-        if match = column.match(/t\.(?:integer|decimal|float|datetime|timestamp|time|date|text|binary|string|boolean|uuid|point)\s+"/)
+        if match = column.match(/t\.(?:integer|decimal|float|datetime|timestamp|time|date|text|binary|string|boolean|uuid|point|big_integer)\s+"/)
           match[0].length
         end
       end
@@ -251,7 +251,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
   if current_adapter?(:PostgreSQLAdapter)
     def test_schema_dump_includes_bigint_default
       output = standard_dump
-      assert_match %r{t.integer\s+"bigint_default",\s+limit: 8,\s+default: 0}, output
+      assert_match %r{t.big_integer\s+"bigint_default",\s+limit: 8,\s+default: 0}, output
     end
 
     if ActiveRecord::Base.connection.supports_extensions?


### PR DESCRIPTION
Opted for polymorphism on the connection adapter, rather than the type
objects, as putting it there would require adding methods to all types
that ultimately only affects a small number of types and only on
PostgreSQL. I've got some ideas for separating schema concerns into
another object, this will be refactored onto those once I flesh that
out.

Fixes #15968.
