### PR TITLE
Correctly dump big serial primary keys (4-1-stable)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Correctly dump `:bigserial` primary keys on PostgreSQL. Previously if a
+    table was created with `create_table :foo, id: :bigserial`, that information
+    would be lost in `schema.rb`.
+
+    Fixes #15968.
+
+    *Sean Griffin*
+
 *   `has_many :through` associations will no longer save the through record
     twice when added in an `after_create` callback defined before the
     associations.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -41,6 +41,10 @@ module ActiveRecord
         [:name, :limit, :precision, :scale, :default, :null]
       end
 
+      def print_primary_key_type(column, printer)
+        # :noop
+      end
+
       private
 
         def default_string(value)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -1,0 +1,21 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module SchemaDumper # :nodoc:
+        def print_primary_key_type(column, printer)
+          case column.sql_type
+          when 'uuid'
+            printer.print(", id: :uuid")
+            if column.default_function
+              printer.print(%Q(, default: "#{column.default_function}"))
+            end
+          when 'bigint', 'int8'
+            printer.print(", id: :bigserial")
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -4,6 +4,7 @@ require 'active_record/connection_adapters/postgresql/oid'
 require 'active_record/connection_adapters/postgresql/cast'
 require 'active_record/connection_adapters/postgresql/array_parser'
 require 'active_record/connection_adapters/postgresql/quoting'
+require 'active_record/connection_adapters/postgresql/schema_dumper'
 require 'active_record/connection_adapters/postgresql/schema_statements'
 require 'active_record/connection_adapters/postgresql/database_statements'
 require 'active_record/connection_adapters/postgresql/referential_integrity'
@@ -448,6 +449,7 @@ module ActiveRecord
       include ReferentialIntegrity
       include SchemaStatements
       include DatabaseStatements
+      include PostgreSQL::SchemaDumper
       include Savepoints
 
       # Returns 'PostgreSQL' as adapter name for identification purposes.

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -121,9 +121,8 @@ HEADER
           if pkcol
             if pk != 'id'
               tbl.print %Q(, primary_key: "#{pk}")
-            elsif pkcol.sql_type == 'uuid'
-              tbl.print ", id: :uuid"
-              tbl.print %Q(, default: "#{pkcol.default_function}") if pkcol.default_function
+            else
+              @connection.print_primary_key_type(pkcol, tbl)
             end
           else
             tbl.print ", id: false"

--- a/activerecord/test/cases/adapters/postgresql/big_serial_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/big_serial_test.rb
@@ -1,0 +1,30 @@
+require "cases/helper"
+require "support/schema_dumping_helper"
+
+class PostgresqlBigSerialTest < ActiveRecord::TestCase
+  include SchemaDumpingHelper
+
+  class PostgresqlBigSerial < ActiveRecord::Base; end
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table(:postgresql_big_serials, force: true, id: :bigserial) do |t|
+    end
+  end
+
+  teardown do
+    if @connection
+      @connection.execute('DROP TABLE IF EXISTS postgresql_big_serials')
+    end
+  end
+
+  test "bigserial columns have a limit of 8" do
+    assert_equal 8, PostgresqlBigSerial.columns_hash['id'].limit
+  end
+
+  test "bigserial primary keys are dumped correctly" do
+    output = dump_table_schema("postgresql_big_serials")
+    assert_match %r(create_table "postgresql_big_serials",.*\sid: :bigserial), output
+    assert_no_match %r(create_table "postgresql_big_serials",.*default), output
+  end
+end

--- a/activerecord/test/support/schema_dumping_helper.rb
+++ b/activerecord/test/support/schema_dumping_helper.rb
@@ -1,0 +1,11 @@
+module SchemaDumpingHelper
+  def dump_table_schema(table, connection = ActiveRecord::Base.connection)
+    old_ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
+    ActiveRecord::SchemaDumper.ignore_tables = connection.tables - [table]
+    stream = StringIO.new
+    ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
+    stream.string
+  ensure
+    ActiveRecord::SchemaDumper.ignore_tables = old_ignore_tables
+  end
+end


### PR DESCRIPTION
Backport of #15973 for 4.1
