### PR TITLE
Don't encourage usage of `columns_hash`

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -202,11 +202,16 @@ module ActiveRecord
         if column.nil?
           ActiveSupport::Deprecation.warn(<<-MESSAGE.strip_heredoc)
             `column_for_attribute` will return a null object for non-existent columns
-            in Rails 5.0. If you would like to continue to receive `nil`, you should
-            instead call `model.class.columns_hash[name]`
+            in Rails 5.0. Use `attribute_exists?` if you need to check for an
+            attribute's existence.
           MESSAGE
         end
         column
+      end
+
+      # Returns whether or not an attribute exists with the given name.
+      def attribute_exists?(name)
+        @attributes.include?(name)
       end
     end
 


### PR DESCRIPTION
As discussed in https://github.com/plataformatec/simple_form/pull/1094,
we should not encourage usage of `columns_hash`, and instead provide an
alternate method to determine whether or not an attribute exists.

The language `attribute` was chosen over `column` since these are in the
`AttributeMethods` module.
