### PR TITLE
Remove unused `array_member` from PG quoting for HStore columns

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
@@ -2,10 +2,9 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module Cast # :nodoc:
-        def hstore_to_string(object, array_member = false) # :nodoc:
+        def hstore_to_string(object) # :nodoc:
           if Hash === object
             string = object.map { |k, v| "#{escape_hstore(k)}=>#{escape_hstore(v)}" }.join(', ')
-            string = escape_hstore(string) if array_member
             string
           else
             object

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -65,33 +65,31 @@ module ActiveRecord
           end
         end
 
-        def type_cast(value, column, array_member = false)
-          return super(value, column) unless column
+        def type_cast(value, column)
+          return super unless column
 
           case value
           when Range
             if /range$/ =~ column.sql_type
               PostgreSQLColumn.range_to_string(value)
             else
-              super(value, column)
+              super
             end
           when NilClass
-            if column.array && array_member
-              'NULL'
-            elsif column.array
+            if column.array
               value
             else
-              super(value, column)
+              super
             end
           when Array
             super(value, array_column(column))
           when Hash
             case column.sql_type
-            when 'hstore' then PostgreSQLColumn.hstore_to_string(value, array_member)
-            else super(value, column)
+            when 'hstore' then PostgreSQLColumn.hstore_to_string(value)
+            else super
             end
           else
-            super(value, column)
+            super
           end
         end
 


### PR DESCRIPTION
Hstore no longer needs additional quoting to be used in an array, the
array type handles it sufficiently.
