### PR TITLE
Backport `Enumerable#to_h` on platforms which do not support it

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Backport `Enumerable#to_h`, `Array#to_h`, `Hash#to_h`, `NilClass#to_h`,
+    `Struct#to_h`, and `ENV.to_h` on versions of ruby which do not support them.
+
+    *Sean Griffin*
+
 *   Add `Hash#transform_values` to simplify a common pattern where the values of a
     hash must change, but the keys are left the same.
 

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/enumerable/to_h'
+
 module Enumerable
   # Calculates a sum from the elements.
   #

--- a/activesupport/lib/active_support/core_ext/enumerable/to_h.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable/to_h.rb
@@ -1,0 +1,53 @@
+unless Enumerable.method_defined?(:to_h)
+  module Enumerable
+    def to_h(*args)
+      result = {}
+      each(*args) do |pair|
+        unless pair.is_a?(Array)
+          raise TypeError.new("wrong element type #{pair.class.name} (expected array)")
+        end
+        unless pair.length == 2
+          raise ArgumentError.new("element has wrong array length (expected 2, was #{pair.length})")
+        end
+        result[pair.first] = pair.last
+      end
+      result
+    end
+  end
+
+  class Array
+    def to_h
+      result = {}
+      each_with_index do |pair, i|
+        unless pair.is_a?(Array)
+          raise TypeError.new("wrong element type #{pair.class.name} at #{i} (expected array)")
+        end
+        unless pair.length == 2
+          raise ArgumentError.new("wrong array length at #{i} (expected 2, was #{pair.length})")
+        end
+        result[pair.first] = pair.last
+      end
+      result
+    end
+  end
+
+  class Hash
+    def to_h
+      if instance_of?(Hash)
+        self
+      else
+        Hash[self]
+      end
+    end
+  end
+
+  class NilClass
+    def to_h
+      {}
+    end
+  end
+
+  def ENV.to_h
+    to_hash
+  end
+end

--- a/activesupport/lib/active_support/core_ext/struct.rb
+++ b/activesupport/lib/active_support/core_ext/struct.rb
@@ -3,4 +3,4 @@ class Struct # :nodoc:
   def to_h
     Hash[members.zip(values)]
   end
-end unless Struct.instance_methods.include?(:to_h)
+end unless Struct.instance_methods(false).include?(:to_h)

--- a/activesupport/test/core_ext/enumerable/to_h_test.rb
+++ b/activesupport/test/core_ext/enumerable/to_h_test.rb
@@ -1,0 +1,131 @@
+require 'abstract_unit'
+require 'active_support/core_ext/hash/indifferent_access'
+require 'active_support/core_ext/enumerable'
+
+class EnumerableToHTest < ActiveSupport::TestCase
+  test "to_h converts an array of tuples to a hash" do
+    assert_equal({ 'a' => 1, 'b' => 2 }, [['a', 1], ['b', 2]].to_h)
+  end
+
+  test "to_h works with any enumerable" do
+    assert_equal({ a: :b, b: :c }, Yielder.to_h([:a, :b], [:b, :c]).to_h)
+  end
+
+  test "to_h on a hash returns self" do
+    hash = { a: :b }
+    assert_same(hash, hash.to_h)
+
+    assert_raises(ArgumentError) do
+      hash.to_h('foo')
+    end
+  end
+
+  test "to_h on a HashWithIndifferentAccess converts to a Hash" do
+    hash = { a: :b }.with_indifferent_access
+
+    assert_not_same(hash, hash.to_h)
+    assert_equal({ 'a' => :b }, hash.to_h)
+    assert_instance_of(Hash, hash.to_h)
+  end
+
+  test "to_h on a random hash subclass converts to a Hash" do
+    klass = Class.new(Hash)
+    hash = klass.new
+
+    assert_not_same(hash, hash.to_h)
+    assert_equal({}, hash.to_h)
+    assert_instance_of(Hash, hash.to_h)
+  end
+
+  test "to_h raises if each yields a non-array" do
+    e = assert_raises(TypeError) do
+      Yielder.to_h(Object.new)
+    end
+    assert_equal("wrong element type Object (expected array)", e.message)
+
+    e = assert_raises(TypeError) do
+      Yielder.to_h("foo")
+    end
+    assert_equal("wrong element type String (expected array)", e.message)
+  end
+
+  test "to_h raises if each yields an array with the wrong number of elements" do
+    e = assert_raises(ArgumentError) do
+      Yielder.to_h([1])
+    end
+    assert_equal("element has wrong array length (expected 2, was 1)", e.message)
+
+    e = assert_raises(ArgumentError) do
+      Yielder.to_h([1, 2, 3])
+    end
+    assert_equal("element has wrong array length (expected 2, was 3)", e.message)
+  end
+
+  test "to_h on nil returns an empty hash" do
+    assert_equal({}, nil.to_h)
+  end
+
+  test "to_h is defined on NilClass, not nil singleton" do
+    assert NilClass.instance_method(:to_h)
+  end
+
+  test "to_h on an array of non-arrays raises" do
+    e = assert_raises(TypeError) do
+      [Object.new].to_h
+    end
+    assert_equal("wrong element type Object at 0 (expected array)", e.message)
+
+    e = assert_raises(TypeError) do
+      [[1, 2], "foo"].to_h
+    end
+    assert_equal("wrong element type String at 1 (expected array)", e.message)
+  end
+
+  test "to_h on an array with a sub-array of the wrong length raises" do
+    e = assert_raises(ArgumentError) do
+      [[1]].to_h
+    end
+    assert_equal("wrong array length at 0 (expected 2, was 1)", e.message)
+
+    e = assert_raises(ArgumentError) do
+      [[1, 2], [1, 2, 3]].to_h
+    end
+    assert_equal("wrong array length at 1 (expected 2, was 3)", e.message)
+  end
+
+  test "to_h on ENV converts to a hash" do
+    assert_equal(ENV.to_hash, ENV.to_h)
+  end
+
+  unless RUBY_VERSION == '1.9.3' || RUBY_VERSION.start_with?('2.0')
+    test "Enumerable#to_h is not overridden" do
+      assert_nil Enumerable.instance_method(:to_h).source_location
+    end
+
+    test "Array#to_h is not overridden" do
+      assert_nil Array.instance_method(:to_h).source_location
+    end
+
+    test "Hash#to_h is not overridden" do
+      assert_nil Hash.instance_method(:to_h).source_location
+    end
+
+    test "NilClass#to_h is not overridden" do
+      assert_nil NilClass.instance_method(:to_h).source_location
+    end
+
+    test "ENV.to_h is not overridden" do
+      assert_nil ENV.method(:to_h).source_location
+    end
+  end
+
+  class Yielder
+    extend Enumerable
+
+    def self.each(*args)
+      args.each do |pair|
+        yield pair
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds `to_h` to all classes that support it in Ruby 2.1. It will not
override Ruby's definition on 2.1 and later.
