### PR TITLE
Fix 10.3 invite_email.body assert_match documentation example.

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -996,7 +996,7 @@ class UserControllerTest < ActionController::TestCase
 
     assert_equal "You have been invited by me@example.com", invite_email.subject
     assert_equal 'friend@example.com', invite_email.to[0]
-    assert_match(/Hi friend@example.com/, invite_email.body)
+    assert_match(/Hi friend@example.com/, invite_email.body.to_s)
   end
 end
 ```


### PR DESCRIPTION
Currently there is no implicit conversion for `Mail::Body` to string
therefore `.to_s` must be applied. This is exampled in 10.2.2.

This pull request is to fix #15986 raised by @heidar.

Documentation change only.
