### PR TITLE
force_ssl doesn't respect the format of the original request (3-2-stable)

### DIFF
--- a/actionpack/lib/action_controller/metal/force_ssl.rb
+++ b/actionpack/lib/action_controller/metal/force_ssl.rb
@@ -27,12 +27,13 @@ module ActionController
         host = options.delete(:host)
         before_filter(options) do
           if !request.ssl? && !Rails.env.development?
-            redirect_options = {:protocol => 'https://', :status => :moved_permanently}
-            redirect_options.merge!(:host => host) if host
-            redirect_options.merge!(:params => request.query_parameters)
-            redirect_options.merge!(:format => request.params[:format]) if request.format.present?
+            secure_url = ActionDispatch::Http::URL.url_for({
+              :protocol => 'https://',
+              :path     => request.fullpath,
+              :host     => host || request.host
+            })
 
-            redirect_to redirect_options
+            redirect_to secure_url, :status => :moved_permanently
           end
         end
       end

--- a/actionpack/lib/action_controller/metal/force_ssl.rb
+++ b/actionpack/lib/action_controller/metal/force_ssl.rb
@@ -30,6 +30,8 @@ module ActionController
             redirect_options = {:protocol => 'https://', :status => :moved_permanently}
             redirect_options.merge!(:host => host) if host
             redirect_options.merge!(:params => request.query_parameters)
+            redirect_options.merge!(:format => request.params[:format]) if request.format.present?
+
             redirect_to redirect_options
           end
         end

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -41,6 +41,12 @@ class ForceSSLControllerLevelTest < ActionController::TestCase
     assert_equal "https://test.host/force_ssl_controller_level/banana?token=secret", redirect_to_url
   end
 
+  def test_banana_redirects_to_https_with_json
+    get :banana, :format => "json"
+    assert_response 301
+    assert_equal "https://test.host/force_ssl_controller_level/banana.json", redirect_to_url
+  end
+
   def test_cheeseburger_redirects_to_https
     get :cheeseburger
     assert_response 301
@@ -56,7 +62,7 @@ class ForceSSLCustomDomainTest < ActionController::TestCase
     assert_response 301
     assert_equal "https://secure.test.host/force_ssl_custom_domain/banana", redirect_to_url
   end
-  
+
   def test_cheeseburger_redirects_to_https_with_custom_host
     get :cheeseburger
     assert_response 301


### PR DESCRIPTION
`force_ssl` won't take the format of the original request into account, as a result redirecting to a format-less URL.

This patch is almost exact as #9061 on the 4-2-stable branch, but I think this is a critical issue and should be fixed in the older supported versions as well.

There's a fix with a test as well as a separate commit refactoring how redirect URL is constructed.
