### PR TITLE
Silence warning emitted in tests

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -216,6 +216,7 @@ module ActiveModel
   module Naming
     def self.extended(base) #:nodoc:
       base.class_eval do
+        remove_possible_method(:model_name)
         delegate :model_name, to: :class
       end
     end


### PR DESCRIPTION
The instance method `model_name` was being defined multiple times,
causing a redefinition warning.
