### PR TITLE
DateTime#to_f preserves fractional seconds

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Changed `DateTime#to_f` to include fractional seconds instead of always rounding to .0
+
+    *John Paul Ashenfelter*
+
 *   Add `Hash#transform_values` to simplify a common pattern where the values of a
     hash must change, but the keys are left the same.
 

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -71,9 +71,9 @@ class DateTime
     civil(year, month, day, hour, min, sec, offset)
   end
 
-  # Converts +self+ to a floating-point number of seconds since the Unix epoch.
+  # Converts +self+ to a floating-point number of seconds, including fractional microseconds, since the Unix epoch.
   def to_f
-    seconds_since_unix_epoch.to_f
+    seconds_since_unix_epoch.to_f + sec_fraction
   end
 
   # Converts +self+ to an integer number of seconds since the Unix epoch.

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -338,6 +338,7 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   def test_to_f
     assert_equal 946684800.0, DateTime.civil(2000).to_f
     assert_equal 946684800.0, DateTime.civil(1999,12,31,19,0,0,Rational(-5,24)).to_f
+    assert_equal 946684800.5, DateTime.civil(1999,12,31,19,0,0.5,Rational(-5,24)).to_f
   end
 
   def test_to_i


### PR DESCRIPTION
In Issue GH#15994, @xjlu points out that the to_f method strips the fractional seconds from the DateTime and always returns .0. [https://github.com/rails/rails/issues/15994]

Since @jeremy asked for a pull request with tests, here is the fix with tests.

I am wondering about a flag to preserve the current behavior. It would seem weird someone would count on the fractional value always being .0, but could do something like

to_f(preserve_usec=false) and then switch the implementation, but that seems like overkill to me
