### PR TITLE
[ci skip] Add missing prologue section of upgrading ruby on rails guide.

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -3,6 +3,8 @@ A Guide for Upgrading Ruby on Rails
 
 This guide provides steps to be followed when you upgrade your applications to a newer version of Ruby on Rails. These steps are also available in individual release guides.
 
+--------------------------------------------------------------------------------
+
 General Advice
 --------------
 


### PR DESCRIPTION
Before:

![screenshot 2014-07-01 22 38 25](https://cloud.githubusercontent.com/assets/1000669/3444322/5ff00d98-012d-11e4-80f1-7de096c62944.png)

After:

![screenshot 2014-07-01 22 37 55](https://cloud.githubusercontent.com/assets/1000669/3444312/4ff82efc-012d-11e4-86f1-5f307c081d97.png)
