### PR TITLE
[ci skip] Fixed the documentation of xml_http_request? (aka xhr?)

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -209,8 +209,8 @@ module ActionDispatch
     end
 
     # Returns true if the "X-Requested-With" header contains "XMLHttpRequest"
-    # (case-insensitive). All major JavaScript libraries send this header with
-    # every Ajax request.
+    # (case-insensitive), which may need to be manually added depending on the
+    # choice of JavaScript libraries and frameworks.
     def xml_http_request?
       @env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i
     end


### PR DESCRIPTION
>  All major JavaScript libraries send this header with every Ajax request.

I think the current description could potentially be misleading, since it may have users take `X-Requested-With` in the headers for granted (at least, that was the case with me, I totally swallowed [the doc](http://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-xml_http_request-3F)).

This part was brought by 0aa66f04e4b4698718023cacb18612e04a4c5eb1 on Sep 2010, from talking about Prototype.js in particular to JavaScript **_libraries_** in general. About four years later, however, we're now using so called JavaScript **_frameworks_** as well, some of them have their own implementations of ajax requests. So no need to limitedly talking about **_libraries_** anymore (even though the two terms are sometimes used loosely). 

On the library side of things, [jQuery](http://bugs.jquery.com/ticket/4601) and [YUI](https://github.com/yui/yui3/blob/0bbfdc715ec7d7b5f08f4e96861bcc4d1c340f10/build/io-base/io-base.js#L122) have already stopped adding the header when it was a cross domain request ([Prototype](https://github.com/sstephenson/prototype/blob/master/src/prototype/ajax/request.js#L233) and [Dojo](https://github.com/dojo/dojo/blob/1bc1d7ab85bea12cc8945fde3981ecc9162959ef/request/xhr.js#L221) seem to be safe though).

On the framework side of things, some of them such as [Backbone.js](https://github.com/jashkenas/backbone/blob/master/backbone.js#L1272) use jQuery as a proxy to send ajax request, and [AngularJS](https://github.com/angular/angular.js/pull/1454) even did completely remove it from the default headers.

So while I'm a bit uncertain the amount of exceptions are sufficient (or shall I check all the popular js projects?) , I think it's better to change the documentation to let users ensure that `X-Requested-With` is _really_ included in the headers by themselves.
