### PR TITLE
Recognizing a given path whose route uses request.env within constraint  

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -174,6 +174,6 @@
     `request.env`. This allows using `request.env` keys within `route`
     constraints.
 
-    *Tony Wooster*
+    *Lucas Souza*
 
 Please check [4-1-stable](https://github.com/rails/rails/blob/4-1-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -170,5 +170,10 @@
 
     *Tony Wooster*
 
+*   Allowing `recognize_path` uses the given environment which can be
+    `request.env`. This allows using `request.env` keys within `route`
+    constraints.
+
+    *Tony Wooster*
 
 Please check [4-1-stable](https://github.com/rails/rails/blob/4-1-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -677,12 +677,11 @@ module ActionDispatch
       end
 
       def recognize_path(path, environment = {})
-        method = (environment[:method] || "GET").to_s.upcase
         path = Journey::Router::Utils.normalize_path(path) unless path =~ %r{://}
         extras = environment[:extras] || {}
 
         begin
-          env = Rack::MockRequest.env_for(path, {:method => method})
+          env = Rack::MockRequest.env_for(path, environment)
         rescue URI::InvalidURIError => e
           raise ActionController::RoutingError, e.message
         end

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -361,6 +361,22 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     assert_raise(ActionController::RoutingError) { rs.recognize_path("/admin/products") }
   end
 
+  def test_route_with_rack_environment
+    rs.draw do
+      post   "/people"     => "people#create"
+      get    "/people/:id" => "people#show"
+      put    "/people/:id" => "people#update"
+      patch  "/people/:id" => "people#update"
+      delete "/people/:id" => "people#destroy"
+    end
+
+    assert_equal({controller: "people", action: "create"}, rs.recognize_path("/people", Rack::MockRequest.env_for("/people", method: :post)))
+    assert_equal({controller: "people", action: "show", id: "5"}, rs.recognize_path("/people/5", Rack::MockRequest.env_for("/people/5", method: :get)))
+    assert_equal({controller: "people", action: "update", id: "5"}, rs.recognize_path("/people/5", Rack::MockRequest.env_for("/people/5", method: :put)))
+    assert_equal({controller: "people", action: "update", id: "5"}, rs.recognize_path("/people/5", Rack::MockRequest.env_for("/people/5", method: :patch)))
+    assert_equal({controller: "people", action: "destroy", id: "5"}, rs.recognize_path("/people/5", Rack::MockRequest.env_for("/people/5", method: :delete)))
+  end
+
   def test_route_with_regexp_and_dot
     rs.draw do
       get ':controller/:action/:file',


### PR DESCRIPTION
Now you can call `Rails.application.routes.recognize_path` passing `request.env` as the second parameter. 

It prevents a possible `NoMethodError for nil` when you are using `request.env[‘some_custom_key’].some_method` within route constraint. For example:

```
match "/some_path", to: "some_controller#some_action", 
            constraint: ->(req) { req['warden'].user }
```
