### PR TITLE
Generate shallow paths for all children of shallow resources.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1378,7 +1378,7 @@ module ActionDispatch
           end
 
           with_scope_level(:nested) do
-            if shallow? && shallow_nesting_depth > 1
+            if shallow? && shallow_nesting_depth >= 1
               shallow_scope(parent_resource.nested_scope, nested_options) { yield }
             else
               scope(parent_resource.nested_scope, nested_options) { yield }

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -2219,6 +2219,29 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/api/1.0/users/first.last.xml', api_user_path(:version => '1.0', :id => 'first.last', :format => :xml)
   end
 
+  def test_direct_children_of_shallow_resources
+    draw do
+      resources :blogs do
+        resources :posts, shallow: true do
+          resources :comments
+        end
+      end
+    end
+
+    post '/posts/1/comments'
+    assert_equal 'comments#create', @response.body
+    assert_equal '/posts/1/comments', post_comments_path('1')
+
+    get '/posts/2/comments/new'
+    assert_equal 'comments#new', @response.body
+    assert_equal '/posts/2/comments/new', new_post_comment_path('2')
+
+    get '/posts/1/comments'
+    assert_equal 'comments#index', @response.body
+    assert_equal '/posts/1/comments', post_comments_path('1')
+  end
+
+
   def test_glob_parameter_accepts_regexp
     draw do
       get '/:locale/*file.:format', :to => 'files#show', :file => /path\/to\/existing\/file/


### PR DESCRIPTION
Prior to this commit shallow resources would only generate paths for non-direct children (with a nested depth greater than 1).

Take the following routes file.

```
resources :blogs do
  resources :posts, shallow: true do
    resources :comments do
      resources :tags
    end
  end
end
```

This would generate shallow paths for `tags` nested under `posts`, e.g `/posts/:id/tags/`, however it would not generate shallow paths for `comments` nested under `posts`, e.g `/posts/:id/comments/new`.

This commit changes the behaviour of the route mapper so that it generate paths for direct children of shallow resources, for example if you take the previous routes file, this will now generate shallow paths for `comments` nested under `posts`, .e.g `posts/:id/comments/new`.

This was the behaviour in Rails `4.0.4` however this was broken in @jcoglan's fix for another routes related issue[1].

[1] https://github.com/rails/rails/commit/d0e5963a38f931335926fa30b951cff4e0f3aff4
