### PR TITLE
setting content_type by hash[:content_type]

### DIFF
--- a/actionpack/lib/action_dispatch/http/upload.rb
+++ b/actionpack/lib/action_dispatch/http/upload.rb
@@ -27,7 +27,7 @@ module ActionDispatch
         raise(ArgumentError, ':tempfile is required') unless @tempfile
 
         @original_filename = encode_filename(hash[:filename])
-        @content_type      = hash[:type]
+        @content_type      = hash[:type] || hash[:content_type]
         @headers           = hash[:head]
       end
 


### PR DESCRIPTION
Why we need to use hash[:type] instead hash[:content_type]? This is a simple alias to use hash[:content_type]
