### PR TITLE
Override Rack::Request#media_type instead of #content_type

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -26,7 +26,7 @@ module ActionDispatch
         end
       end
 
-      def content_type
+      def media_type
         content_mime_type && content_mime_type.to_s
       end
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -854,7 +854,13 @@ class RequestMimeType < BaseRequestTest
   end
 
   test "content type with charset" do
-    assert_equal Mime::XML, stub_request('CONTENT_TYPE' => 'application/xml; charset=UTF-8').content_mime_type
+    request = stub_request('CONTENT_TYPE' => 'application/xml; charset=UTF-8')
+
+    assert_equal(Mime::XML, request.content_mime_type)
+    assert_equal('application/xml', request.media_type)
+    assert_equal('UTF-8', request.content_charset)
+    assert_equal({ 'charset' => 'UTF-8' }, request.media_type_params)
+    assert_equal('application/xml; charset=UTF-8', request.content_type)
   end
 
   test "user agent" do


### PR DESCRIPTION
`Rack::Request#content_type` is used by a lot of `Rack::Request` methods like `#media_type_params` and `#content_charset`. All these methods expect `#content_type` to be the full `env['CONTENT_TYPE']` header.

Since we are overriding `#content_type` to return only the `Mime::Type.to_s` these methods stop to work since no information about media type parameters are returned on `#content_type`.

These is a subtle change of behaviour here since `#content_type` will return more information than before so I'm not sure we should apply this patch without a proper deprecation path pointing people to use `media_type` when expecting only the media type.

@jeremy @tenderlove let me know what you think about this change of behaviour.
