### PR TITLE
Quote range strings when quoting PG ranges (4-0-stable)

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -24,7 +24,7 @@ module ActiveRecord
           when Range
             if /range$/ =~ sql_type
               escaped = quote_string(PostgreSQLColumn.range_to_string(value))
-              "#{escaped}::#{sql_type}"
+              "'#{escaped}'::#{sql_type}"
             else
               super
             end

--- a/activerecord/test/cases/adapters/postgresql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/quoting_test.rb
@@ -56,7 +56,7 @@ module ActiveRecord
         def test_quote_range
           range = "1,2]'; SELECT * FROM users; --".."a"
           c = PostgreSQLColumn.new(nil, nil, OID::Range.new(:integer), 'int8range')
-          assert_equal "[1,2]''; SELECT * FROM users; --,a]::int8range", @conn.quote(range, c)
+          assert_equal "'[1,2]''; SELECT * FROM users; --,a]'::int8range", @conn.quote(range, c)
         end
       end
     end

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -1,0 +1,26 @@
+require "cases/helper"
+
+if ActiveRecord::Base.connection.supports_ranges?
+  class PostgresqlRange < ActiveRecord::Base
+    self.table_name = "postgresql_ranges"
+  end
+
+  class PostgresqlRangeTest < ActiveRecord::TestCase
+    test "update_all with ranges" do
+      PostgresqlRange.create!
+
+      PostgresqlRange.update_all(int8_range: 1..100)
+
+      assert_equal 1...101, PostgresqlRange.first.int8_range
+    end
+
+    test "ranges correctly escape input" do
+      e = assert_raises(ActiveRecord::StatementInvalid) do
+        range = "1,2]'; SELECT * FROM users; --".."a"
+        PostgresqlRange.update_all(int8_range: range)
+      end
+
+      assert e.message.starts_with?("PG::InvalidTextRepresentation")
+    end
+  end
+end


### PR DESCRIPTION
The test case for CVE-2014-3483 doesn't actually send the generated SQL
to the database. The generated SQL is actually invalid for all inputs. 
