### PR TITLE
Quote range strings when quoting PG ranges

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -24,7 +24,7 @@ module ActiveRecord
           when Range
             if /range$/ =~ sql_type
               escaped = quote_string(PostgreSQLColumn.range_to_string(value))
-              "#{escaped}::#{sql_type}"
+              "'#{escaped}'::#{sql_type}"
             else
               super
             end

--- a/activerecord/test/cases/adapters/postgresql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/quoting_test.rb
@@ -61,7 +61,7 @@ module ActiveRecord
         def test_quote_range
           range = "1,2]'; SELECT * FROM users; --".."a"
           c = PostgreSQLColumn.new(nil, nil, OID::Range.new(Type::Integer.new, :int8range))
-          assert_equal "[1,2]''; SELECT * FROM users; --,a]::int8range", @conn.quote(range, c)
+          assert_equal "'[1,2]''; SELECT * FROM users; --,a]'::int8range", @conn.quote(range, c)
         end
 
         def test_quote_bit_string

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -262,6 +262,23 @@ _SQL
       assert_raises(ArgumentError) { PostgresqlRange.create!(float_range: "(0.5, 0.7]") }
     end
 
+    def test_update_all_with_ranges
+      PostgresqlRange.create!
+
+      PostgresqlRange.update_all(int8_range: 1..100)
+
+      assert_equal 1...101, PostgresqlRange.first.int8_range
+    end
+
+    def test_ranges_correctly_escape_input
+      e = assert_raises(ActiveRecord::StatementInvalid) do
+        range = "1,2]'; SELECT * FROM users; --".."a"
+        PostgresqlRange.update_all(int8_range: range)
+      end
+
+      assert e.message.starts_with?("PG::InvalidTextRepresentation")
+    end
+
     private
       def assert_equal_round_trip(range, attribute, value)
         round_trip(range, attribute, value)


### PR DESCRIPTION
The test case for CVE-2014-3483 doesn't actually send the generated SQL
to the database. The generated SQL is actually invalid for real inputs.
