### PR TITLE
automatically include ActiveModel::Validations when include ActiveModel::SecurePassword

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -1,6 +1,7 @@
 module ActiveModel
   module SecurePassword
     extend ActiveSupport::Concern
+    include ActiveModel::Validations
 
     # BCrypt hash function can handle maximum 72 characters, and if we pass
     # password of length more than 72 characters it ignores extra characters.

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -20,6 +20,11 @@ class SecurePasswordTest < ActiveModel::TestCase
     ActiveModel::SecurePassword.min_cost = @original_min_cost
   end
 
+  test "user object should respond to valid?" do
+    assert_respond_to @visitor, :valid?
+    assert_respond_to @user, :valid?
+  end
+
   test "create/update without validations" do
     assert @visitor.valid?(:create), 'visitor should be valid'
     assert @visitor.valid?(:update), 'visitor should be valid'

--- a/activemodel/test/models/user.rb
+++ b/activemodel/test/models/user.rb
@@ -1,6 +1,5 @@
 class User
   extend ActiveModel::Callbacks
-  include ActiveModel::Validations
   include ActiveModel::SecurePassword
   
   define_model_callbacks :create

--- a/activemodel/test/models/visitor.rb
+++ b/activemodel/test/models/visitor.rb
@@ -1,6 +1,5 @@
 class Visitor
   extend ActiveModel::Callbacks
-  include ActiveModel::Validations
   include ActiveModel::SecurePassword
 
   define_model_callbacks :create


### PR DESCRIPTION
Since `ActiveModel::SecurePassword` enforces its own validations, it must include `ActiveModel::Validations`.
As asked in #15841
