### PR TITLE
Change the JSON renderer to enforce the 'JS' Content Type

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   JSONP responses are now rendered with the `text/javascript` content type
+    when rendering through a `respond_to` block.
+
+    Fixes #15081.
+
+    *Lucas Mazza*
+
 *   Add `config.action_controller.always_permitted_parameters` to configure which
     parameters are permitted globally. The default value of this configuration is
     `['controller', 'action']`.

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -112,7 +112,10 @@ module ActionController
       json = json.to_json(options) unless json.kind_of?(String)
 
       if options[:callback].present?
-        self.content_type ||= Mime::JS
+        if self.content_type.nil? || self.content_type == Mime::JSON
+          self.content_type = Mime::JS
+        end
+
         "#{options[:callback]}(#{json})"
       else
         self.content_type ||= Mime::JSON

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -128,6 +128,12 @@ class RespondToController < ActionController::Base
     end
   end
 
+  def json_with_callback
+    respond_to do |type|
+      type.json { render :json => 'JS', :callback => 'alert' }
+    end
+  end
+
   def iphone_with_html_response_type
     request.format = :iphone if request.env["HTTP_ACCEPT"] == "text/iphone"
 
@@ -509,6 +515,13 @@ class RespondToControllerTest < ActionController::TestCase
     @request.accept = "text/html"
     get :all_types_with_layout
     assert_equal '<html><div id="html">HTML for all_types_with_layout</div></html>', @response.body
+  end
+
+  def test_json_with_callback_sets_javascript_content_type
+    @request.accept = 'application/json'
+    get :json_with_callback
+    assert_equal 'alert(JS)', @response.body
+    assert_equal 'text/javascript', @response.content_type
   end
 
   def test_xhr


### PR DESCRIPTION
The controller can set the response format as 'JSON' before the renderer code be evaluated, so we must replace it when necessary.

Fixes #15081

/cc @rafaelfranca @josevalim
