### PR TITLE
Add `:all` argument to `count` in `reset_counters`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixed error in `reset_counters` when associations have `select` scope.
+    (Call to `count` generates invalid SQL.)
+
+    *Cade Truitt*
+
 *   PostgreSQL renaming table doesn't attempt to rename non existent sequences.
 
     *Abdelkader Boudih*

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -38,7 +38,7 @@ module ActiveRecord
           counter_name = reflection.counter_cache_column
 
           stmt = unscoped.where(arel_table[primary_key].eq(object.id)).arel.compile_update({
-            arel_table[counter_name] => object.send(counter_association).count
+            arel_table[counter_name] => object.send(counter_association).count(:all)
           }, primary_key)
           connection.update stmt
         end

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -19,6 +19,7 @@ class CounterCacheTest < ActiveRecord::TestCase
 
   class ::SpecialTopic < ::Topic
     has_many :special_replies, :foreign_key => 'parent_id'
+    has_many :lightweight_special_replies, -> { select('topics.id, topics.title') }, :foreign_key => 'parent_id', :class_name => 'SpecialReply'
   end
 
   class ::SpecialReply < ::Reply
@@ -169,5 +170,14 @@ class CounterCacheTest < ActiveRecord::TestCase
       Topic.reset_counters(@topic.id, :undefined_count)
     end
     assert_equal "'Topic' has no association called 'undefined_count'", e.message
+  end
+
+  test "reset counter works with select declared on association" do
+    special = SpecialTopic.create!(:title => 'Special')
+    SpecialTopic.increment_counter(:replies_count, special.id)
+
+    assert_difference 'special.reload.replies_count', -1 do
+      SpecialTopic.reset_counters(special.id, :lightweight_special_replies)
+    end
   end
 end


### PR DESCRIPTION
Prior to this fix, if an association had a scope with a `select`,
calls to `reset_counters` would generate invalid SQL and throw:

ActiveRecord::StatementInvalid: [$DB_ADAPTER]: wrong number of
arguments to function COUNT()

References #10710, #13648
