### PR TITLE
Generate shallow paths for all children of shallow resources.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -177,5 +177,10 @@
 
     *Tony Wooster*
 
+*   Generate shallow paths for all children of shallow resources.
+
+    Fixes #15783.
+
+    *Seb Jacobs*
 
 Please check [4-1-stable](https://github.com/rails/rails/blob/4-1-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1434,7 +1434,7 @@ module ActionDispatch
           end
 
           with_scope_level(:nested) do
-            if shallow? && shallow_nesting_depth > 1
+            if shallow? && shallow_nesting_depth >= 1
               shallow_scope(parent_resource.nested_scope, nested_options) { yield }
             else
               scope(parent_resource.nested_scope, nested_options) { yield }

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -2022,6 +2022,28 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/blogs/1/posts/2/comments/new', new_blog_post_comment_path(:blog_id => 1, :post_id => 2)
   end
 
+  def test_direct_children_of_shallow_resources
+    draw do
+      resources :blogs do
+        resources :posts, shallow: true do
+          resources :comments
+        end
+      end
+    end
+
+    post '/posts/1/comments'
+    assert_equal 'comments#create', @response.body
+    assert_equal '/posts/1/comments', post_comments_path('1')
+
+    get '/posts/2/comments/new'
+    assert_equal 'comments#new', @response.body
+    assert_equal '/posts/2/comments/new', new_post_comment_path('2')
+
+    get '/posts/1/comments'
+    assert_equal 'comments#index', @response.body
+    assert_equal '/posts/1/comments', post_comments_path('1')
+  end
+
   def test_shallow_nested_resources_within_scope
     draw do
       scope '/hello' do


### PR DESCRIPTION
Prior to this commit shallow resources would only generate paths for
non-direct children (with a nested depth greater than 1).

Take the following routes file.

```
resources :blogs do
  resources :posts, shallow: true do
    resources :comments do
      resources :tags
    end
  end
end
```

This would generate shallow paths for `tags` nested under `posts`,
e.g `/posts/:id/tags/`, however it would not generate shallow paths
for `comments` nested under `posts`, e.g `/posts/:id/comments/new`.

This commit changes the behaviour of the route mapper so that it
generate paths for direct children of shallow resources, for example
if you take the previous routes file, this will now generate
shallow paths for `comments` nested under `posts`, .e.g
`posts/:id/comments/new`.

This was the behaviour in Rails `4.0.4` however this was broken in
@jcoglan's fix for another routes related issue[1].

This also fixes an issue[2] reported by @smdern.

_Note_ This is a follow up to an existing pull request[3].

[1] https://github.com/rails/rails/commit/d0e5963a38f931335926fa30b951cff4e0f3aff4
[2] https://github.com/rails/rails/issues/15783
[3] https://github.com/rails/rails/pull/16014
