### PR TITLE
Fix guide. sample code syntax error.[ci skip]

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -871,7 +871,7 @@ should happen, an `Array` can be used. Moreover, you can apply both `:if` and
 ```ruby
 class Computer < ActiveRecord::Base
   validates :mouse, presence: true,
-                    if: ["market.retail?", :desktop?]
+                    if: ["market.retail?", :desktop?],
                     unless: Proc.new { |c| c.trackpad.present? }
 end
 ```


### PR DESCRIPTION
I read Active Record Validations' guide page. 
I execute sample code.
It raises syntax error.

``` bash
SyntaxError: %sample_path%/computer.rb:4: syntax error, unexpected ':'
                    unless: Proc.new { |c| c.trackpad.present? }
```

There is no comma at tail of if-symbol line.
