### PR TITLE
Reduce notification subscriptions for AC::TemplateAssertions.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   ActionController::TemplateAssertions now sets up subscriptions only once
+    instead of doing it during each test setup.
+
+    *Guo Xiang Tan*
+
 *   JSONP responses are now rendered with the `text/javascript` content type
     when rendering through a `respond_to` block.
 

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -220,23 +220,18 @@ module ActionView
         :@_result,
         :@_routes,
         :@controller,
-        :@_layouts,
-        :@_files,
         :@_rendered_views,
         :@method_name,
         :@output_buffer,
-        :@_partials,
         :@passed,
         :@rendered,
         :@request,
         :@routes,
         :@tagged_logger,
-        :@_templates,
         :@options,
         :@test_passed,
         :@view,
-        :@view_context_class,
-        :@_subscribers
+        :@view_context_class
       ]
 
       def _user_defined_ivars


### PR DESCRIPTION
Instead of subscribing to notifications during tests setup, subscription to notifications is now done only once for all the tests.
