### PR TITLE
Return self from model.readonly!

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Return self from model.readonly!
+
+    *David Rueck*
+
 *   PostgreSQL renaming table doesn't attempt to rename non existent sequences.
 
     *Abdelkader Boudih*

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -403,9 +403,10 @@ module ActiveRecord
       @readonly
     end
 
-    # Marks this record as read only.
+    # Marks this record as read only and returns it
     def readonly!
       @readonly = true
+      self
     end
 
     def connection_handler

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -10,6 +10,12 @@ require 'models/person'
 class ReadOnlyTest < ActiveRecord::TestCase
   fixtures :authors, :posts, :comments, :developers, :projects, :developers_projects, :people, :readers
 
+  def test_readonly_bang
+    dev = Developer.new.readonly!
+    assert_instance_of(Developer, dev)
+    assert dev.readonly?
+  end
+
   def test_cant_save_readonly_record
     dev = Developer.find(1)
     assert !dev.readonly?


### PR DESCRIPTION
Currently the result of calling `readonly!` on an ActiveRecord model is always `true` rather than `self`, so it can't be used for a fluent interface or returned directly. As a result, to create and return a read only instance of a model you would need something like:

``` ruby
model = Model.new(attrs)
model.readonly!
model
```

or more concisely, but still a little awkward:

``` ruby
Model.new(attrs).tap(&:readonly!)
```

It would be nice to be able to just return the value directly like:

``` ruby
Model.new(attrs).readonly!
```

I wasn't sure if it was a conscious decision not to do this, perhaps command query separation? but there is some precedent in methods such as the bang methods on `String` or the semi-analogous `Object#freeze` that each return `self` (if successful).

Thanks for the consideration/feedback!
