### PR TITLE
Do not load rails without loading bundler

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb
@@ -1,4 +1,3 @@
-# Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' # Set up gems listed in the Gemfile.


### PR DESCRIPTION
This if File.exist seems like a bad idea / let's people run into weird issues when the Gemfile is missing (deploy messed up / deleted by accident / BUNDLE_GEMFILE pointed to invalid file etc).
Users that do not want bundler can just remove the require.

@josevalim @rafaelfranca
