### PR TITLE
Provide `prepend_order` and `append_order` relation methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Provide `order.append` and `order.prepend` relation methods, to
+    control how multiple orders are combined. Calling `order` on an
+    already-ordered relation is now deprecated, so we can eventually
+    make `order` an alias for `order.prepend`.
+
+    *Matthew Draper*
+
 *   When calling `update_columns` on a record that is not persisted, the error
     message now reflects whether that object is a new record or has been
     destroyed.

--- a/activerecord/lib/active_record/associations/preloader/has_one.rb
+++ b/activerecord/lib/active_record/associations/preloader/has_one.rb
@@ -14,7 +14,7 @@ module ActiveRecord
         private
 
         def build_scope
-          super.order(preload_scope.values[:order] || reflection_scope.values[:order])
+          super.append_order(preload_scope.values[:order] || reflection_scope.values[:order])
         end
 
       end

--- a/activerecord/lib/active_record/associations/preloader/has_one.rb
+++ b/activerecord/lib/active_record/associations/preloader/has_one.rb
@@ -14,7 +14,7 @@ module ActiveRecord
         private
 
         def build_scope
-          super.append_order(preload_scope.values[:order] || reflection_scope.values[:order])
+          super.order.append(preload_scope.values[:order] || reflection_scope.values[:order])
         end
 
       end

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -9,7 +9,8 @@ module ActiveRecord
     delegate :find_each, :find_in_batches, to: :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly,
-             :having, :create_with, :uniq, :distinct, :references, :none, :unscope, to: :all
+             :having, :create_with, :uniq, :distinct, :references, :none, :unscope,
+             :append_order, :prepend_order, to: :all
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, to: :all
     delegate :pluck, :ids, to: :all
 

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -9,8 +9,7 @@ module ActiveRecord
     delegate :find_each, :find_in_batches, to: :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly,
-             :having, :create_with, :uniq, :distinct, :references, :none, :unscope,
-             :append_order, :prepend_order, to: :all
+             :having, :create_with, :uniq, :distinct, :references, :none, :unscope, to: :all
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, to: :all
     delegate :pluck, :ids, to: :all
 

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -138,7 +138,7 @@ module ActiveRecord
           relation.reorder! values[:order]
         elsif values[:order]
           # merge in order_values from relation
-          relation.order! values[:order]
+          relation.append_order! values[:order]
         end
 
         relation.extend(*values[:extending]) unless values[:extending].blank?

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -544,8 +544,16 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_find_should_append_to_association_order
-    ordered_developers = projects(:active_record).developers.order('projects.id')
+    assert_deprecated do
+      ordered_developers = projects(:active_record).developers.order('projects.id')
+      assert_equal ['developers.name desc, developers.id desc', 'projects.id'], ordered_developers.order_values
+    end
+
+    ordered_developers = projects(:active_record).developers.append_order('projects.id')
     assert_equal ['developers.name desc, developers.id desc', 'projects.id'], ordered_developers.order_values
+
+    ordered_developers = projects(:active_record).developers.prepend_order('projects.id')
+    assert_equal ['projects.id', 'developers.name desc, developers.id desc'], ordered_developers.order_values
   end
 
   def test_dynamic_find_all_should_respect_readonly_access

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -549,10 +549,10 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
       assert_equal ['developers.name desc, developers.id desc', 'projects.id'], ordered_developers.order_values
     end
 
-    ordered_developers = projects(:active_record).developers.append_order('projects.id')
+    ordered_developers = projects(:active_record).developers.order.append('projects.id')
     assert_equal ['developers.name desc, developers.id desc', 'projects.id'], ordered_developers.order_values
 
-    ordered_developers = projects(:active_record).developers.prepend_order('projects.id')
+    ordered_developers = projects(:active_record).developers.order.prepend('projects.id')
     assert_equal ['projects.id', 'developers.name desc, developers.id desc'], ordered_developers.order_values
   end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -353,10 +353,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
       assert_equal ['id DESC', 'companies.id'], ordered_clients.order_values
     end
 
-    ordered_clients =  companies(:first_firm).clients_sorted_desc.append_order('companies.id')
+    ordered_clients =  companies(:first_firm).clients_sorted_desc.order.append('companies.id')
     assert_equal ['id DESC', 'companies.id'], ordered_clients.order_values
 
-    ordered_clients =  companies(:first_firm).clients_sorted_desc.prepend_order('companies.id')
+    ordered_clients =  companies(:first_firm).clients_sorted_desc.order.prepend('companies.id')
     assert_equal ['companies.id', 'id DESC'], ordered_clients.order_values
   end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -347,9 +347,17 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 3, companies(:first_firm).limited_clients.limit(nil).to_a.size
   end
 
-  def test_find_should_append_to_association_order
-    ordered_clients =  companies(:first_firm).clients_sorted_desc.order('companies.id')
+  def test_find_should_manipulate_association_order
+    assert_deprecated do
+      ordered_clients =  companies(:first_firm).clients_sorted_desc.order('companies.id')
+      assert_equal ['id DESC', 'companies.id'], ordered_clients.order_values
+    end
+
+    ordered_clients =  companies(:first_firm).clients_sorted_desc.append_order('companies.id')
     assert_equal ['id DESC', 'companies.id'], ordered_clients.order_values
+
+    ordered_clients =  companies(:first_firm).clients_sorted_desc.prepend_order('companies.id')
+    assert_equal ['companies.id', 'id DESC'], ordered_clients.order_values
   end
 
   def test_dynamic_find_should_respect_association_order

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -79,7 +79,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   # Through: has_many through
   def test_has_many_through_has_many_through_with_has_many_source_reflection
     luke, david = subscribers(:first), subscribers(:second)
-    assert_equal [luke, david, david], authors(:david).subscribers.order('subscribers.nick')
+    assert_equal [luke, david, david], authors(:david).subscribers
   end
 
   def test_has_many_through_has_many_through_with_has_many_source_reflection_preload
@@ -404,7 +404,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   def test_distinct_has_many_through_a_has_many_through_association_on_through_reflection
     author = authors(:david)
     assert_equal [subscribers(:first), subscribers(:second)],
-                 author.distinct_subscribers.order('subscribers.nick')
+                 author.distinct_subscribers
   end
 
   def test_nested_has_many_through_with_a_table_referenced_multiple_times

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -235,11 +235,11 @@ class RelationTest < ActiveRecord::TestCase
       assert_equal topics(:fourth).title, topics.first.title
     end
 
-    topics = Topic.order('author_name').append_order('title')
+    topics = Topic.order('author_name').order.append('title')
     assert_equal 5, topics.to_a.size
     assert_equal topics(:fourth).title, topics.first.title
 
-    topics = Topic.order('title').prepend_order('author_name')
+    topics = Topic.order('title').order.prepend('author_name')
     assert_equal 5, topics.to_a.size
     assert_equal topics(:fourth).title, topics.first.title
   end
@@ -263,7 +263,7 @@ class RelationTest < ActiveRecord::TestCase
       assert_equal ['The First Topic', 'The Second Topic of the day', 'The Third Topic of the day', 'The Fourth Topic of the day', 'The Fifth Topic of the day'], topics_titles
     end
 
-    topics = Topic.order('author_name').append_order('title').reorder('id').to_a
+    topics = Topic.order('author_name').order.append('title').reorder('id').to_a
     topics_titles = topics.map{ |t| t.title }
     assert_equal ['The First Topic', 'The Second Topic of the day', 'The Third Topic of the day', 'The Fourth Topic of the day', 'The Fifth Topic of the day'], topics_titles
   end
@@ -1370,7 +1370,7 @@ class RelationTest < ActiveRecord::TestCase
       assert_equal 'zyke', car1.name
     end
 
-    car2 = FastCar.append_order('id DESC').scoping do
+    car2 = FastCar.order.append('id DESC').scoping do
       FastCar.all.merge!(order: 'id asc').first
     end
     assert_equal 'zyke', car2.name

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -229,7 +229,17 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_finding_with_order_concatenated
-    topics = Topic.order('author_name').order('title')
+    assert_deprecated do
+      topics = Topic.order('author_name').order('title')
+      assert_equal 5, topics.to_a.size
+      assert_equal topics(:fourth).title, topics.first.title
+    end
+
+    topics = Topic.order('author_name').append_order('title')
+    assert_equal 5, topics.to_a.size
+    assert_equal topics(:fourth).title, topics.first.title
+
+    topics = Topic.order('title').prepend_order('author_name')
     assert_equal 5, topics.to_a.size
     assert_equal topics(:fourth).title, topics.first.title
   end
@@ -247,7 +257,13 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_finding_with_reorder
-    topics = Topic.order('author_name').order('title').reorder('id').to_a
+    assert_deprecated do
+      topics = Topic.order('author_name').order('title').reorder('id').to_a
+      topics_titles = topics.map{ |t| t.title }
+      assert_equal ['The First Topic', 'The Second Topic of the day', 'The Third Topic of the day', 'The Fourth Topic of the day', 'The Fifth Topic of the day'], topics_titles
+    end
+
+    topics = Topic.order('author_name').append_order('title').reorder('id').to_a
     topics_titles = topics.map{ |t| t.title }
     assert_equal ['The First Topic', 'The Second Topic of the day', 'The Third Topic of the day', 'The Fourth Topic of the day', 'The Fifth Topic of the day'], topics_titles
   end
@@ -1336,17 +1352,25 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_default_scope_order_with_scope_order
-    assert_equal 'zyke', CoolCar.order_using_new_style.limit(1).first.name
-    assert_equal 'zyke', FastCar.order_using_new_style.limit(1).first.name
+    assert_deprecated do
+      assert_equal 'zyke', CoolCar.order_using_new_style.limit(1).first.name
+      assert_equal 'zyke', FastCar.order_using_new_style.limit(1).first.name
+    end
+
+    assert_equal 'zyke', CoolCar.order_using_append.limit(1).first.name
+
+    assert_equal 'zyke', CoolCar.order_using_prepend.last.name
   end
 
   def test_order_using_scoping
-    car1 = CoolCar.order('id DESC').scoping do
-      CoolCar.all.merge!(order: 'id asc').first
+    assert_deprecated do
+      car1 = CoolCar.order('id DESC').scoping do
+        CoolCar.all.merge!(order: 'id asc').first
+      end
+      assert_equal 'zyke', car1.name
     end
-    assert_equal 'zyke', car1.name
 
-    car2 = FastCar.order('id DESC').scoping do
+    car2 = FastCar.append_order('id DESC').scoping do
       FastCar.all.merge!(order: 'id asc').first
     end
     assert_equal 'zyke', car2.name

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -109,7 +109,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
       assert_equal expected, received
     end
 
-    received = Developer.order('name ASC').reorder('name DESC').append_order('id DESC').collect { |dev| [dev.name, dev.id] }
+    received = Developer.order('name ASC').reorder('name DESC').order.append('id DESC').collect { |dev| [dev.name, dev.id] }
     assert_equal expected, received
   end
 
@@ -193,7 +193,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
       assert !(scope.to_sql =~ /order/i)
     end
 
-    scope = DeveloperOrderedBySalary.append_order('salary DESC, name ASC').reverse_order.unscope(:order)
+    scope = DeveloperOrderedBySalary.order.append('salary DESC, name ASC').reverse_order.unscope(:order)
     assert !(scope.to_sql =~ /order/i)
   end
 

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -24,8 +24,8 @@ class RelationScopingTest < ActiveRecord::TestCase
       assert_equal Developer.order("id DESC").order("name DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).order(Developer.arel_table[:name].desc).reverse_order
     end
 
-    assert_equal Developer.order("id DESC").append_order("name DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).append_order(Developer.arel_table[:name].desc).reverse_order
-    assert_equal Developer.order("id DESC").prepend_order("name DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).prepend_order(Developer.arel_table[:name].desc).reverse_order
+    assert_equal Developer.order("id DESC").order.append("name DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).order.append(Developer.arel_table[:name].desc).reverse_order
+    assert_equal Developer.order("id DESC").order.prepend("name DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).order.prepend(Developer.arel_table[:name].desc).reverse_order
   end
 
   def test_reverse_order_with_arel_nodes_and_strings
@@ -33,8 +33,8 @@ class RelationScopingTest < ActiveRecord::TestCase
       assert_equal Developer.order("id DESC").order("name DESC").to_a.reverse, Developer.order("id DESC").order(Developer.arel_table[:name].desc).reverse_order
     end
 
-    assert_equal Developer.order("id DESC").append_order("name DESC").to_a.reverse, Developer.order("id DESC").append_order(Developer.arel_table[:name].desc).reverse_order
-    assert_equal Developer.order("id DESC").prepend_order("name DESC").to_a.reverse, Developer.order("id DESC").prepend_order(Developer.arel_table[:name].desc).reverse_order
+    assert_equal Developer.order("id DESC").order.append("name DESC").to_a.reverse, Developer.order("id DESC").order.append(Developer.arel_table[:name].desc).reverse_order
+    assert_equal Developer.order("id DESC").order.prepend("name DESC").to_a.reverse, Developer.order("id DESC").order.prepend(Developer.arel_table[:name].desc).reverse_order
   end
 
   def test_double_reverse_order_produces_original_order

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -20,11 +20,21 @@ class RelationScopingTest < ActiveRecord::TestCase
   end
 
   def test_reverse_order_with_multiple_arel_nodes
-    assert_equal Developer.order("id DESC").order("name DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).order(Developer.arel_table[:name].desc).reverse_order
+    assert_deprecated do
+      assert_equal Developer.order("id DESC").order("name DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).order(Developer.arel_table[:name].desc).reverse_order
+    end
+
+    assert_equal Developer.order("id DESC").append_order("name DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).append_order(Developer.arel_table[:name].desc).reverse_order
+    assert_equal Developer.order("id DESC").prepend_order("name DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).prepend_order(Developer.arel_table[:name].desc).reverse_order
   end
 
   def test_reverse_order_with_arel_nodes_and_strings
-    assert_equal Developer.order("id DESC").order("name DESC").to_a.reverse, Developer.order("id DESC").order(Developer.arel_table[:name].desc).reverse_order
+    assert_deprecated do
+      assert_equal Developer.order("id DESC").order("name DESC").to_a.reverse, Developer.order("id DESC").order(Developer.arel_table[:name].desc).reverse_order
+    end
+
+    assert_equal Developer.order("id DESC").append_order("name DESC").to_a.reverse, Developer.order("id DESC").append_order(Developer.arel_table[:name].desc).reverse_order
+    assert_equal Developer.order("id DESC").prepend_order("name DESC").to_a.reverse, Developer.order("id DESC").prepend_order(Developer.arel_table[:name].desc).reverse_order
   end
 
   def test_double_reverse_order_produces_original_order

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -15,6 +15,8 @@ class Car < ActiveRecord::Base
   scope :incl_engines, -> { includes(:engines) }
 
   scope :order_using_new_style,  -> { order('name asc') }
+  scope :order_using_append,  -> { append_order('name asc') }
+  scope :order_using_prepend,  -> { prepend_order('name asc') }
 end
 
 class CoolCar < Car

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -15,8 +15,8 @@ class Car < ActiveRecord::Base
   scope :incl_engines, -> { includes(:engines) }
 
   scope :order_using_new_style,  -> { order('name asc') }
-  scope :order_using_append,  -> { append_order('name asc') }
-  scope :order_using_prepend,  -> { prepend_order('name asc') }
+  scope :order_using_append,  -> { order.append('name asc') }
+  scope :order_using_prepend,  -> { order.prepend('name asc') }
 end
 
 class CoolCar < Car

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -111,6 +111,7 @@ class DeveloperOrderedBySalary < ActiveRecord::Base
   default_scope { order('salary DESC') }
 
   scope :by_name, -> { order('name DESC') }
+  scope :by_name_prepended, -> { prepend_order('name DESC') }
 end
 
 class DeveloperCalledDavid < ActiveRecord::Base

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -111,7 +111,7 @@ class DeveloperOrderedBySalary < ActiveRecord::Base
   default_scope { order('salary DESC') }
 
   scope :by_name, -> { order('name DESC') }
-  scope :by_name_prepended, -> { prepend_order('name DESC') }
+  scope :by_name_prepended, -> { order.prepend('name DESC') }
 end
 
 class DeveloperCalledDavid < ActiveRecord::Base


### PR DESCRIPTION
The multiple-ordering behaviour that was briefly present in 4.0.0 (before it was reverted in 92c5a2244ec3e58fd5e70e7dd2d7882b80183c80) is far more likely to be what people intend: regardless of what it looked like before, immediately after you call `order(:foo)`, the relation will be ordered primarily by `foo`.

But we can't just flip it, because that would create a hidden danger for anyone upgrading. Instead, we'll ask people to be explicit about which behaviour they want, when ordering an already-ordered relation.

I wouldn't be at all surprised if this lead people to existing bugs in their code, where they were subtly assuming `prepend_order` behaviour / unaware that under some conditions their relation was already carrying an order that trumped the one they intended to apply.

Anyway, calling `order` on an already-ordered relation is now deprecated, so we can eventually make `order` an alias for `prepend_order`.

/cc @rafaelfranca
