### PR TITLE
Re-enable foriegn key tests on MySQL

### DIFF
--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -936,7 +936,6 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   end
 end
 
-unless current_adapter?(:MysqlAdapter, :Mysql2Adapter)
 class BelongsToWithForeignKeyTest < ActiveRecord::TestCase
   def test_destroy_linked_models
     address = AuthorAddress.create!
@@ -944,5 +943,4 @@ class BelongsToWithForeignKeyTest < ActiveRecord::TestCase
 
     author.destroy!
   end
-end
 end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -20,7 +20,7 @@ require 'models/toy'
 require 'rexml/document'
 
 class PersistenceTest < ActiveRecord::TestCase
-  fixtures :topics, :companies, :developers, :projects, :computers, :accounts, :minimalistics, 'warehouse-things', :authors, :categorizations, :categories, :posts, :minivans, :pets, :toys
+  fixtures :topics, :companies, :developers, :projects, :computers, :accounts, :minimalistics, 'warehouse-things', :authors, :author_addresses, :categorizations, :categories, :posts, :minivans, :pets, :toys
 
   # Oracle UPDATE does not support ORDER BY
   unless current_adapter?(:OracleAdapter)

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -84,9 +84,7 @@ ActiveRecord::Schema.define do
   create_table :author_addresses, force: true do |t|
   end
 
-  unless current_adapter?(:MysqlAdapter, :Mysql2Adapter)
-    add_foreign_key :authors, :author_addresses
-  end
+  add_foreign_key :authors, :author_addresses
 
   create_table :author_favorites, force: true do |t|
     t.column :author_id, :integer


### PR DESCRIPTION
This reverts commit e84799d, e31104c and e6ca8e2

I tried removing this locally, and nothing fails anymore. If travis passes I think we can re-enable these tests on mater.
