### PR TITLE
If our connection is explicitly non-strict, tell MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -793,8 +793,8 @@ module ActiveRecord
         # Make MySQL reject illegal values rather than truncating or blanking them, see
         # http://dev.mysql.com/doc/refman/5.0/en/server-sql-mode.html#sqlmode_strict_all_tables
         # If the user has provided another value for sql_mode, don't replace it.
-        if strict_mode? && !variables.has_key?('sql_mode')
-          variables['sql_mode'] = 'STRICT_ALL_TABLES'
+        unless variables.has_key?('sql_mode')
+          variables['sql_mode'] = strict_mode? ? 'STRICT_ALL_TABLES' : ''
         end
 
         # NAMES does not have an equals sign, see


### PR DESCRIPTION
We default to making the connection strict, but have historically relied on the MySQL default when we want it to be non-strict. On some (recent?) versions of MySQL, new connections default to being strict, so if we've been told 'strict:false', we're obliged to pass that on.

This fixes a test failure that we've seen turn up on relatively-new development machines, so we do already have a test covering it.

Specifically, a bunch of the OpenAcademy students were seeing this, and we just told them to ignore it at the time. :neutral_face: 

... and I was also seeing it, but I rarely run MySQL tests locally. :neutral_face:  :neutral_face: 
