### PR TITLE
Adds 'snakecase' alias to underscore method

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -118,6 +118,7 @@ class String
   def underscore
     ActiveSupport::Inflector.underscore(self)
   end
+  alias_method :snakecase
 
   # Replaces underscores with dashes in the string.
   #


### PR DESCRIPTION
A companion to 'underscore' as 'camelcase' is to 'camelize'.
