### PR TITLE
Adds 'snakecase' alias method to 'underscore'

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -118,6 +118,7 @@ class String
   def underscore
     ActiveSupport::Inflector.underscore(self)
   end
+  alias_method :snakecase, :underscore
 
   # Replaces underscores with dashes in the string.
   #


### PR DESCRIPTION
Allows strings to be cast to 'snakecase' instead of 'underscore' to match 'camelcase' for 'camelize'
Fixes syntax error in previous commit.
