### PR TITLE
active_record: Type cast booleans and durations for string columns.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Avoid type casting boolean and ActiveSupport::Duration values to numeric
+    values for string columns. Otherwise, in some database, the string column
+    values will be coerced to a numeric allowing false or 0.seconds match any
+    string starting with a non-digit.
+
+    Example:
+
+        App.where(apikey: false) # => SELECT * FROM users WHERE apikey = '0'
+
+    *Dylan Thacker-Smith*
+
 *   Add a `:required` option to singular associations, providing a nicer
     API for presence validations on associations.
 

--- a/activerecord/lib/active_record/type/binary.rb
+++ b/activerecord/lib/active_record/type/binary.rb
@@ -24,7 +24,7 @@ module ActiveRecord
 
       class Data # :nodoc:
         def initialize(value)
-          @value = value
+          @value = value.to_s
         end
 
         def to_s

--- a/activerecord/lib/active_record/type/string.rb
+++ b/activerecord/lib/active_record/type/string.rb
@@ -17,8 +17,10 @@ module ActiveRecord
 
       def type_cast_for_database(value)
         case value
-        when ::Numeric then value.to_s
+        when ::Numeric, ActiveSupport::Duration then value.to_s
         when ::String then ::String.new(value)
+        when true then "1"
+        when false then "0"
         else super
         end
       end

--- a/activerecord/test/cases/adapters/mysql2/boolean_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/boolean_test.rb
@@ -47,7 +47,7 @@ class Mysql2BooleanTest < ActiveRecord::TestCase
     assert_equal "1", attributes["published"]
 
     assert_equal 1, @connection.type_cast(true, boolean_column)
-    assert_equal 1, @connection.type_cast(true, string_column)
+    assert_equal "1", @connection.type_cast(true, string_column)
   end
 
   test "test type casting without emulated booleans" do
@@ -60,7 +60,7 @@ class Mysql2BooleanTest < ActiveRecord::TestCase
     assert_equal "1", attributes["published"]
 
     assert_equal 1, @connection.type_cast(true, boolean_column)
-    assert_equal 1, @connection.type_cast(true, string_column)
+    assert_equal "1", @connection.type_cast(true, string_column)
   end
 
   test "with booleans stored as 1 and 0" do

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -6,10 +6,11 @@ require 'models/post'
 require 'models/comment'
 require 'models/edge'
 require 'models/topic'
+require 'models/binary'
 
 module ActiveRecord
   class WhereTest < ActiveRecord::TestCase
-    fixtures :posts, :edges, :authors
+    fixtures :posts, :edges, :authors, :binaries
 
     def test_where_copies_bind_params
       author = authors(:david)
@@ -178,6 +179,36 @@ module ActiveRecord
       [[], {}, nil, ""].each do |blank|
         assert_equal 4, Edge.where(blank).order("sink_id").to_a.size
       end
+    end
+
+    def test_where_with_integer_for_string_column
+      count = Post.where(:title => 0).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_float_for_string_column
+      count = Post.where(:title => 0.0).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_boolean_for_string_column
+      count = Post.where(:title => false).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_decimal_for_string_column
+      count = Post.where(:title => BigDecimal.new(0)).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_duration_for_string_column
+      count = Post.where(:title => 0.seconds).count
+      assert_equal 0, count
+    end
+
+    def test_where_with_integer_for_binary_column
+      count = Binary.where(:data => 0).count
+      assert_equal 0, count
     end
   end
 end


### PR DESCRIPTION
@rafaelfranca, @sgrif, @arthurnn this is a basically a rebase of pull #14894 which was closed without the problem being completely fixed.
## Problem

Pull #16037 partially fixed the problem is described in [Potential Query Manipulation with Common Rails Practises](https://groups.google.com/forum/?hl=en&fromgroups=#!topic/rubyonrails-security/ZOdH5GH5jCU) by quoting Numeric types, however, that pull request missing the need to quote boolean and ActiveSupport::Duration types.

For example:

``` ruby
User.where(:login_token=>params[:token]).first
```

can be exploited by passing in `false` for `params[:token]` through a JSON body causing the query

``` sql
SELECT * FROM `users` WHERE `login_token` = 0 LIMIT 1;
```

to match any login_token that starts with a non-digit character.

Quoting for these additional types was properly handled in mistakenly closed pull request #14894.
## Solution

ActiveRecord::Type::String#type_cast_for_database has been updated to handle these types.  Tests are included for these missed types as well as the numeric types which are already quoted properly to prevent regressions.
