### PR TITLE
Remove PG's definition of `type_cast`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -43,21 +43,6 @@ module ActiveRecord
           end
         end
 
-        def type_cast(value, column)
-          return super unless column
-
-          case value
-          when NilClass
-            if column.array
-              value
-            else
-              super
-            end
-          else
-            super
-          end
-        end
-
         # Quotes strings for use in SQL input.
         def quote_string(s) #:nodoc:
           @connection.escape(s)


### PR DESCRIPTION
All cases except for `nil` in an array have been removed. `nil` in an
array is handled by the Array type object.
