### PR TITLE
Refactor the attribute predicate methods

### DIFF
--- a/activerecord/lib/active_record/attribute.rb
+++ b/activerecord/lib/active_record/attribute.rb
@@ -46,16 +46,16 @@ module ActiveRecord
       type.changed_in_place?(old_value, value)
     end
 
+    def value_present?
+      type.value_present?(value)
+    end
+
     def with_value_from_user(value)
       self.class.from_user(name, value, type)
     end
 
     def with_value_from_database(value)
       self.class.from_database(name, value, type)
-    end
-
-    def type_cast
-      raise NotImplementedError
     end
 
     def initialized?
@@ -68,6 +68,10 @@ module ActiveRecord
       if defined?(@value) && @value.duplicable?
         @value = @value.dup
       end
+    end
+
+    def type_cast(*)
+      raise NotImplementedError
     end
 
     class FromDatabase < Attribute # :nodoc:

--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -8,26 +8,7 @@ module ActiveRecord
       end
 
       def query_attribute(attr_name)
-        value = read_attribute(attr_name) { |n| missing_attribute(n, caller) }
-
-        case value
-        when true        then true
-        when false, nil  then false
-        else
-          column = self.class.columns_hash[attr_name]
-          if column.nil?
-            if Numeric === value || value !~ /[^0-9]/
-              !value.to_i.zero?
-            else
-              return false if ActiveRecord::ConnectionAdapters::Column::FALSE_VALUES.include?(value)
-              !value.blank?
-            end
-          elsif column.number?
-            !value.zero?
-          else
-            !value.blank?
-          end
-        end
+        @attributes[attr_name].value_present?
       end
 
       private

--- a/activerecord/lib/active_record/type/numeric.rb
+++ b/activerecord/lib/active_record/type/numeric.rb
@@ -1,10 +1,6 @@
 module ActiveRecord
   module Type
     module Numeric # :nodoc:
-      def number?
-        true
-      end
-
       def type_cast(value)
         value = case value
                 when true then 1
@@ -17,6 +13,10 @@ module ActiveRecord
 
       def changed?(old_value, _new_value, new_value_before_type_cast) # :nodoc:
         super || number_to_non_number?(old_value, new_value_before_type_cast)
+      end
+
+      def value_present?(value)
+        super && !value.zero?
       end
 
       private

--- a/activerecord/lib/active_record/type/numeric_test.rb
+++ b/activerecord/lib/active_record/type/numeric_test.rb
@@ -1,0 +1,26 @@
+require "cases/helper"
+
+module ActiveRecord
+  module Type
+    class NumericTest < ActiveRecord::TestCase
+      test "non-integer zero is not present" do
+        assert_not Type::Float.new.value_present?(0.0)
+        assert_not Type::Decimal.new.value_present?("0.0".to_d)
+      end
+
+      test "integer zero is not present" do
+        assert_not Type::Integer.new.value_present?(0)
+      end
+
+      test "nil is not present" do
+        assert_not Type::Integer.new.value_present?(nil)
+      end
+
+      test "non-zero is present" do
+        assert Type::Integer.new.value_present?(1)
+        assert Type::Float.new.value_present?(0.1)
+        assert Type::Decimal.new.value_present?("0.1".to_d)
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/type/string.rb
+++ b/activerecord/lib/active_record/type/string.rb
@@ -25,6 +25,10 @@ module ActiveRecord
         end
       end
 
+      def value_present?(value)
+        !value.blank?
+      end
+
       private
 
       def cast_value(value)

--- a/activerecord/lib/active_record/type/string_test.rb
+++ b/activerecord/lib/active_record/type/string_test.rb
@@ -1,0 +1,19 @@
+require "cases/helper"
+
+module ActiveRecord
+  module Type
+    class StringTest < ActiveRecord::TestCase
+      test "string 0 is present" do
+        assert String.new.value_present?("0")
+      end
+
+      test "empty strings are not present" do
+        assert_not String.new.value_present?("")
+      end
+
+      test "nil is not present" do
+        assert_not String.new.value_present?(nil)
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/type/value.rb
+++ b/activerecord/lib/active_record/type/value.rb
@@ -48,13 +48,14 @@ module ActiveRecord
         value.inspect
       end
 
+      # Used for the attribute predicate methods
+      def value_present?(value) # :nodoc:
+        !value.blank? && !ConnectionAdapters::Column::FALSE_VALUES.include?(value)
+      end
+
       # These predicates are not documented, as I need to look further into
       # their use, and see if they can be removed entirely.
       def text? # :nodoc:
-        false
-      end
-
-      def number? # :nodoc:
         false
       end
 

--- a/activerecord/lib/active_record/type/value_test.rb
+++ b/activerecord/lib/active_record/type/value_test.rb
@@ -1,0 +1,29 @@
+require "cases/helper"
+
+module ActiveRecord
+  module Type
+    class ValueTest < ActiveRecord::TestCase
+      test "true is present" do
+        assert Value.new.value_present?(true)
+      end
+
+      test "false is not present" do
+        assert_not Value.new.value_present?(false)
+      end
+
+      test "nil is not present" do
+        assert_not Value.new.value_present?(nil)
+      end
+
+      test "blank values are not present" do
+        assert_not Value.new.value_present?("")
+      end
+
+      test "'false' values are not present" do
+        ConnectionAdapters::Column::FALSE_VALUES.each do |value|
+          assert_not Value.new.value_present?(value), "#{value.inspect} should not be present"
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -39,13 +39,11 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert_equal "character varying", @column.sql_type
     assert @column.array
     assert_not @column.text?
-    assert_not @column.number?
     assert_not @column.binary?
 
     ratings_column = PgArray.columns_hash['ratings']
     assert_equal :integer, ratings_column.type
     assert ratings_column.array
-    assert_not ratings_column.number?
   end
 
   def test_default

--- a/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
@@ -27,7 +27,6 @@ class PostgresqlBitStringTest < ActiveRecord::TestCase
     assert_equal :bit, column.type
     assert_equal "bit(8)", column.sql_type
     assert_not column.text?
-    assert_not column.number?
     assert_not column.binary?
     assert_not column.array
   end
@@ -37,7 +36,6 @@ class PostgresqlBitStringTest < ActiveRecord::TestCase
     assert_equal :bit_varying, column.type
     assert_equal "bit varying(4)", column.sql_type
     assert_not column.text?
-    assert_not column.number?
     assert_not column.binary?
     assert_not column.array
   end

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -36,7 +36,6 @@ if ActiveRecord::Base.connection.supports_extensions?
       assert_equal :citext, column.type
       assert_equal 'citext', column.sql_type
       assert_not column.text?
-      assert_not column.number?
       assert_not column.binary?
       assert_not column.array
     end

--- a/activerecord/test/cases/adapters/postgresql/composite_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/composite_test.rb
@@ -50,7 +50,6 @@ class PostgresqlCompositeTest < ActiveRecord::TestCase
     column = PostgresqlComposite.columns_hash["address"]
     assert_nil column.type
     assert_equal "full_address", column.sql_type
-    assert_not column.number?
     assert_not column.text?
     assert_not column.binary?
     assert_not column.array
@@ -112,7 +111,6 @@ class PostgresqlCompositeWithCustomOIDTest < ActiveRecord::TestCase
     column = PostgresqlComposite.columns_hash["address"]
     assert_equal :full_address, column.type
     assert_equal "full_address", column.sql_type
-    assert_not column.number?
     assert_not column.text?
     assert_not column.binary?
     assert_not column.array

--- a/activerecord/test/cases/adapters/postgresql/domain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/domain_test.rb
@@ -29,7 +29,6 @@ class PostgresqlDomainTest < ActiveRecord::TestCase
     column = PostgresqlDomain.columns_hash["price"]
     assert_equal :decimal, column.type
     assert_equal "custom_money", column.sql_type
-    assert column.number?
     assert_not column.text?
     assert_not column.binary?
     assert_not column.array

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -33,7 +33,6 @@ class PostgresqlEnumTest < ActiveRecord::TestCase
     column = PostgresqlEnum.columns_hash["current_mood"]
     assert_equal :enum, column.type
     assert_equal "mood", column.sql_type
-    assert_not column.number?
     assert_not column.text?
     assert_not column.binary?
     assert_not column.array

--- a/activerecord/test/cases/adapters/postgresql/full_text_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/full_text_test.rb
@@ -8,7 +8,6 @@ class PostgresqlFullTextTest < ActiveRecord::TestCase
     column = PostgresqlTsvector.columns_hash["text_vector"]
     assert_equal :tsvector, column.type
     assert_equal "tsvector", column.sql_type
-    assert_not column.number?
     assert_not column.text?
     assert_not column.binary?
     assert_not column.array

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -29,7 +29,6 @@ class PostgresqlPointTest < ActiveRecord::TestCase
     assert_equal :point, column.type
     assert_equal "point", column.sql_type
     assert_not column.text?
-    assert_not column.number?
     assert_not column.binary?
     assert_not column.array
   end

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -55,7 +55,6 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
     def test_column
       assert_equal :hstore, @column.type
       assert_equal "hstore", @column.sql_type
-      assert_not @column.number?
       assert_not @column.text?
       assert_not @column.binary?
       assert_not @column.array

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -34,7 +34,6 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
     column = JsonDataType.columns_hash["payload"]
     assert_equal :json, column.type
     assert_equal "json", column.sql_type
-    assert_not column.number?
     assert_not column.text?
     assert_not column.binary?
     assert_not column.array

--- a/activerecord/test/cases/adapters/postgresql/ltree_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/ltree_test.rb
@@ -30,7 +30,6 @@ class PostgresqlLtreeTest < ActiveRecord::TestCase
     column = Ltree.columns_hash['path']
     assert_equal :ltree, column.type
     assert_equal "ltree", column.sql_type
-    assert_not column.number?
     assert_not column.text?
     assert_not column.binary?
     assert_not column.array

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -25,7 +25,6 @@ class PostgresqlMoneyTest < ActiveRecord::TestCase
     assert_equal :money, column.type
     assert_equal "money", column.sql_type
     assert_equal 2, column.scale
-    assert column.number?
     assert_not column.text?
     assert_not column.binary?
     assert_not column.array

--- a/activerecord/test/cases/adapters/postgresql/network_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/network_test.rb
@@ -9,7 +9,6 @@ class PostgresqlNetworkTest < ActiveRecord::TestCase
     column = PostgresqlNetworkAddress.columns_hash["cidr_address"]
     assert_equal :cidr, column.type
     assert_equal "cidr", column.sql_type
-    assert_not column.number?
     assert_not column.text?
     assert_not column.binary?
     assert_not column.array
@@ -19,7 +18,6 @@ class PostgresqlNetworkTest < ActiveRecord::TestCase
     column = PostgresqlNetworkAddress.columns_hash["inet_address"]
     assert_equal :inet, column.type
     assert_equal "inet", column.sql_type
-    assert_not column.number?
     assert_not column.text?
     assert_not column.binary?
     assert_not column.array
@@ -29,7 +27,6 @@ class PostgresqlNetworkTest < ActiveRecord::TestCase
     column = PostgresqlNetworkAddress.columns_hash["mac_address"]
     assert_equal :macaddr, column.type
     assert_equal "macaddr", column.sql_type
-    assert_not column.number?
     assert_not column.text?
     assert_not column.binary?
     assert_not column.array

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -50,7 +50,6 @@ class PostgresqlUUIDTest < ActiveRecord::TestCase
     column = UUIDType.columns_hash["guid"]
     assert_equal :uuid, column.type
     assert_equal "uuid", column.sql_type
-    assert_not column.number?
     assert_not column.text?
     assert_not column.binary?
     assert_not column.array

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -388,6 +388,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     end
 
     assert_equal true, Topic.new(:author_name => "Name").author_name?
+    assert_equal true, Topic.new(:author_name => "0").author_name?
   end
 
   def test_query_attribute_number

--- a/activerecord/test/cases/attribute_test.rb
+++ b/activerecord/test/cases/attribute_test.rb
@@ -138,5 +138,16 @@ module ActiveRecord
     test "uninitialized attributes have no value" do
       assert_nil Attribute.uninitialized(:foo, nil).value
     end
+
+    test "value_present? passes the cast value to the type" do
+      type = Object.new
+      def type.type_cast_from_database(value); value.to_s; end
+      def type.value_present?(value); value == "1"; end
+      present_attribute = Attribute.from_database(nil, 1, type)
+      blank_attribute = Attribute.from_database(nil, 2, type)
+
+      assert present_attribute.value_present?
+      assert_not blank_attribute.value_present?
+    end
   end
 end

--- a/activerecord/test/cases/type/value_test.rb
+++ b/activerecord/test/cases/type/value_test.rb
@@ -1,0 +1,9 @@
+require "cases/helper"
+
+module ActiveRecord
+  module Type
+    class ValueTest < ActiveRecord::TestCase
+
+    end
+  end
+end


### PR DESCRIPTION
For all types other than string based types, this calculation ultimately
came down to whether or not we consider the value to be "false", and if
it's blank. For string types alone, "0" should be considered present.
This also allows us to remove the `number?` predicate from the type
objects.
