### PR TITLE
Remove the `text?` predicate from the type objects

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/specialized_string.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/specialized_string.rb
@@ -8,10 +8,6 @@ module ActiveRecord
           def initialize(type)
             @type = type
           end
-
-          def text?
-            false
-          end
         end
       end
     end

--- a/activerecord/lib/active_record/type/string.rb
+++ b/activerecord/lib/active_record/type/string.rb
@@ -5,10 +5,6 @@ module ActiveRecord
         :string
       end
 
-      def text?
-        true
-      end
-
       def changed_in_place?(raw_old_value, new_value)
         if new_value.is_a?(::String)
           raw_old_value != new_value

--- a/activerecord/lib/active_record/type/value.rb
+++ b/activerecord/lib/active_record/type/value.rb
@@ -50,10 +50,6 @@ module ActiveRecord
 
       # These predicates are not documented, as I need to look further into
       # their use, and see if they can be removed entirely.
-      def text? # :nodoc:
-        false
-      end
-
       def number? # :nodoc:
         false
       end

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -61,9 +61,11 @@ module ActiveRecord
 
         column = klass.columns_hash[attribute_name]
         value  = klass.connection.type_cast(value, column)
-        value  = value.to_s[0, column.limit] if value && column.limit && column.text?
+        if value.is_a?(String) && column.limit
+          value = value.to_s[0, column.limit]
+        end
 
-        if !options[:case_sensitive] && value && column.text?
+        if !options[:case_sensitive] && value.is_a?(String)
           # will use SQL LOWER function before comparison, unless it detects a case insensitive collation
           klass.connection.case_insensitive_comparison(table, attribute, column, value)
         else

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -38,7 +38,6 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert_equal :string, @column.type
     assert_equal "character varying", @column.sql_type
     assert @column.array
-    assert_not @column.text?
     assert_not @column.number?
     assert_not @column.binary?
 

--- a/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
@@ -26,7 +26,6 @@ class PostgresqlBitStringTest < ActiveRecord::TestCase
     column = PostgresqlBitString.columns_hash["a_bit"]
     assert_equal :bit, column.type
     assert_equal "bit(8)", column.sql_type
-    assert_not column.text?
     assert_not column.number?
     assert_not column.binary?
     assert_not column.array
@@ -36,7 +35,6 @@ class PostgresqlBitStringTest < ActiveRecord::TestCase
     column = PostgresqlBitString.columns_hash["a_bit_varying"]
     assert_equal :bit_varying, column.type
     assert_equal "bit varying(4)", column.sql_type
-    assert_not column.text?
     assert_not column.number?
     assert_not column.binary?
     assert_not column.array

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -35,7 +35,6 @@ if ActiveRecord::Base.connection.supports_extensions?
       column = Citext.columns_hash['cival']
       assert_equal :citext, column.type
       assert_equal 'citext', column.sql_type
-      assert_not column.text?
       assert_not column.number?
       assert_not column.binary?
       assert_not column.array

--- a/activerecord/test/cases/adapters/postgresql/composite_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/composite_test.rb
@@ -51,7 +51,6 @@ class PostgresqlCompositeTest < ActiveRecord::TestCase
     assert_nil column.type
     assert_equal "full_address", column.sql_type
     assert_not column.number?
-    assert_not column.text?
     assert_not column.binary?
     assert_not column.array
   end
@@ -113,7 +112,6 @@ class PostgresqlCompositeWithCustomOIDTest < ActiveRecord::TestCase
     assert_equal :full_address, column.type
     assert_equal "full_address", column.sql_type
     assert_not column.number?
-    assert_not column.text?
     assert_not column.binary?
     assert_not column.array
   end

--- a/activerecord/test/cases/adapters/postgresql/domain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/domain_test.rb
@@ -30,7 +30,6 @@ class PostgresqlDomainTest < ActiveRecord::TestCase
     assert_equal :decimal, column.type
     assert_equal "custom_money", column.sql_type
     assert column.number?
-    assert_not column.text?
     assert_not column.binary?
     assert_not column.array
   end

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -34,7 +34,6 @@ class PostgresqlEnumTest < ActiveRecord::TestCase
     assert_equal :enum, column.type
     assert_equal "mood", column.sql_type
     assert_not column.number?
-    assert_not column.text?
     assert_not column.binary?
     assert_not column.array
   end

--- a/activerecord/test/cases/adapters/postgresql/full_text_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/full_text_test.rb
@@ -9,7 +9,6 @@ class PostgresqlFullTextTest < ActiveRecord::TestCase
     assert_equal :tsvector, column.type
     assert_equal "tsvector", column.sql_type
     assert_not column.number?
-    assert_not column.text?
     assert_not column.binary?
     assert_not column.array
   end

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -28,7 +28,6 @@ class PostgresqlPointTest < ActiveRecord::TestCase
     column = PostgresqlPoint.columns_hash["x"]
     assert_equal :point, column.type
     assert_equal "point", column.sql_type
-    assert_not column.text?
     assert_not column.number?
     assert_not column.binary?
     assert_not column.array

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -56,7 +56,6 @@ class PostgresqlHstoreTest < ActiveRecord::TestCase
       assert_equal :hstore, @column.type
       assert_equal "hstore", @column.sql_type
       assert_not @column.number?
-      assert_not @column.text?
       assert_not @column.binary?
       assert_not @column.array
     end

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -35,7 +35,6 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
     assert_equal :json, column.type
     assert_equal "json", column.sql_type
     assert_not column.number?
-    assert_not column.text?
     assert_not column.binary?
     assert_not column.array
   end

--- a/activerecord/test/cases/adapters/postgresql/ltree_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/ltree_test.rb
@@ -31,7 +31,6 @@ class PostgresqlLtreeTest < ActiveRecord::TestCase
     assert_equal :ltree, column.type
     assert_equal "ltree", column.sql_type
     assert_not column.number?
-    assert_not column.text?
     assert_not column.binary?
     assert_not column.array
   end

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -26,7 +26,6 @@ class PostgresqlMoneyTest < ActiveRecord::TestCase
     assert_equal "money", column.sql_type
     assert_equal 2, column.scale
     assert column.number?
-    assert_not column.text?
     assert_not column.binary?
     assert_not column.array
   end

--- a/activerecord/test/cases/adapters/postgresql/network_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/network_test.rb
@@ -10,7 +10,6 @@ class PostgresqlNetworkTest < ActiveRecord::TestCase
     assert_equal :cidr, column.type
     assert_equal "cidr", column.sql_type
     assert_not column.number?
-    assert_not column.text?
     assert_not column.binary?
     assert_not column.array
   end
@@ -20,7 +19,6 @@ class PostgresqlNetworkTest < ActiveRecord::TestCase
     assert_equal :inet, column.type
     assert_equal "inet", column.sql_type
     assert_not column.number?
-    assert_not column.text?
     assert_not column.binary?
     assert_not column.array
   end
@@ -30,7 +28,6 @@ class PostgresqlNetworkTest < ActiveRecord::TestCase
     assert_equal :macaddr, column.type
     assert_equal "macaddr", column.sql_type
     assert_not column.number?
-    assert_not column.text?
     assert_not column.binary?
     assert_not column.array
   end

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -51,7 +51,6 @@ class PostgresqlUUIDTest < ActiveRecord::TestCase
     assert_equal :uuid, column.type
     assert_equal "uuid", column.sql_type
     assert_not column.number?
-    assert_not column.text?
     assert_not column.binary?
     assert_not column.array
   end


### PR DESCRIPTION
This was only used for uniqueness validations. The first usage was in
conjunction with `limit`. Types which cast to string, but are not
considered text cannot have a limit. The second case was only with an
explicit `:case_sensitive => true` option given by the user.
