### PR TITLE
Fix ActiveSupport::Callbacks #set_callback docs.

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -566,7 +566,7 @@ module ActiveSupport
       #
       #   set_callback :save, :before, :before_meth
       #   set_callback :save, :after,  :after_meth, if: :condition
-      #   set_callback :save, :around, ->(r, &block) { stuff; result = block.call; stuff }
+      #   set_callback :save, :around, ->(r, block) { stuff; result = block.call; stuff }
       #
       # The second arguments indicates whether the callback is to be run +:before+,
       # +:after+, or +:around+ the event. If omitted, +:before+ is assumed. This


### PR DESCRIPTION
`ActiveSupport::Calbacks.set_callback`now requires an
explicit block to be passed instead of implicit. This commit
amends the method's documentation.

This pull request is a fix for #16041 raised by @wr0ngway.

Documentation change only.
