### PR TITLE
Add callbacks documentation for upgrading to 4.1.

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -439,11 +439,11 @@ Rails 4.1 now expects an explicit block to be passed when calling
 `ActiveSupport::Callbacks` being largely rewritten for the 4.1 release.
 
 ```ruby
-# Rails 4.1
-set_callback :save, :around, ->(r, block) { stuff; result = block.call; stuff }
-
-# Rails 4.0
+# Previously in Rails 4.0
 set_callback :save, :around, ->(r, &block) { stuff; result = block.call; stuff }
+
+# Now in Rails 4.1
+set_callback :save, :around, ->(r, block) { stuff; result = block.call; stuff }
 ```
 
 Upgrading from Rails 3.2 to Rails 4.0

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -432,6 +432,20 @@ symbol access is no longer supported. This is also the case for
 `store_accessors` based on top of `json` or `hstore` columns. Make sure to use
 string keys consistently.
 
+### Explicit block use for `ActiveSupport::Callbacks`
+
+Rails 4.1 now expects an explicit block to be passed when calling 
+`ActiveSupport::Callbacks.set_callback`. This change stems from 
+`ActiveSupport::Callbacks` being largely rewritten for the 4.1 release.
+
+```ruby
+# Rails 4.1
+set_callback :save, :around, ->(r, block) { stuff; result = block.call; stuff }
+
+# Rails 4.0
+set_callback :save, :around, ->(r, &block) { stuff; result = block.call; stuff }
+```
+
 Upgrading from Rails 3.2 to Rails 4.0
 -------------------------------------
 


### PR DESCRIPTION
It is now expected in 4.1 to use an explicit block rather than implicit
when setting callbacks through ActiveSupport::Callbacks. This commit
highlights this new expectation as part of the upgrading documentation.

This PR is on request of @chancancode in #16075.

Documentation change only.

Note: I forgot to add [ci skip] to the commit - I will remember for next
time.
