### PR TITLE
Refactor reflections from sub classes to delegates

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1587,7 +1587,7 @@ module ActiveRecord
           scope   = nil
         end
 
-        habtm_reflection = ActiveRecord::Reflection::HasAndBelongsToManyReflection.new(:has_and_belongs_to_many, name, scope, options, self)
+        habtm_reflection = ActiveRecord::Reflection::HasAndBelongsToManyReflection.new(name, scope, options, self)
 
         builder = Builder::HasAndBelongsToMany.new name, self, options
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -87,7 +87,7 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_reflection_klass_for_nested_class_name
-    reflection = MacroReflection.new(:company, nil, nil, { :class_name => 'MyApplication::Business::Company' }, ActiveRecord::Base)
+    reflection = ActiveRecord::Reflection.create(:has_many, nil, nil, { :class_name => 'MyApplication::Business::Company' }, ActiveRecord::Base)
     assert_nothing_raised do
       assert_equal MyApplication::Business::Company, reflection.klass
     end
@@ -97,21 +97,21 @@ class ReflectionTest < ActiveRecord::TestCase
     ActiveSupport::Inflector.inflections do |inflect|
       inflect.irregular 'plural_irregular', 'plurales_irregulares'
     end
-    reflection = AssociationReflection.new(:has_many, 'plurales_irregulares', nil, {}, ActiveRecord::Base)
+    reflection = ActiveRecord::Reflection.create(:has_many, 'plurales_irregulares', nil, {}, ActiveRecord::Base)
     assert_equal 'PluralIrregular', reflection.class_name
   end
 
   def test_aggregation_reflection
     reflection_for_address = AggregateReflection.new(
-      :composed_of, :address, nil, { :mapping => [ %w(address_street street), %w(address_city city), %w(address_country country) ] }, Customer
+      :address, nil, { :mapping => [ %w(address_street street), %w(address_city city), %w(address_country country) ] }, Customer
     )
 
     reflection_for_balance = AggregateReflection.new(
-      :composed_of, :balance, nil, { :class_name => "Money", :mapping => %w(balance amount) }, Customer
+      :balance, nil, { :class_name => "Money", :mapping => %w(balance amount) }, Customer
     )
 
     reflection_for_gps_location = AggregateReflection.new(
-      :composed_of, :gps_location, nil, { }, Customer
+      :gps_location, nil, { }, Customer
     )
 
     assert Customer.reflect_on_all_aggregations.include?(reflection_for_gps_location)
@@ -135,7 +135,7 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_has_many_reflection
-    reflection_for_clients = AssociationReflection.new(:has_many, :clients, nil, { :order => "id", :dependent => :destroy }, Firm)
+    reflection_for_clients = ActiveRecord::Reflection.create(:has_many, :clients, nil, { :order => "id", :dependent => :destroy }, Firm)
 
     assert_equal reflection_for_clients, Firm.reflect_on_association(:clients)
 
@@ -147,7 +147,7 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_has_one_reflection
-    reflection_for_account = AssociationReflection.new(:has_one, :account, nil, { :foreign_key => "firm_id", :dependent => :destroy }, Firm)
+    reflection_for_account = ActiveRecord::Reflection.create(:has_one, :account, nil, { :foreign_key => "firm_id", :dependent => :destroy }, Firm)
     assert_equal reflection_for_account, Firm.reflect_on_association(:account)
 
     assert_equal Account, Firm.reflect_on_association(:account).klass
@@ -284,12 +284,12 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_association_primary_key_raises_when_missing_primary_key
-    reflection = ActiveRecord::Reflection::AssociationReflection.new(:fuu, :edge, nil, {}, Author)
+    reflection = ActiveRecord::Reflection.create(:has_many, :edge, nil, {}, Author)
     assert_raises(ActiveRecord::UnknownPrimaryKey) { reflection.association_primary_key }
 
     through = Class.new(ActiveRecord::Reflection::ThroughReflection) {
       define_method(:source_reflection) { reflection }
-    }.new(:fuu, :edge, nil, {}, Author)
+    }.new(reflection)
     assert_raises(ActiveRecord::UnknownPrimaryKey) { through.association_primary_key }
   end
 
@@ -299,7 +299,7 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_active_record_primary_key_raises_when_missing_primary_key
-    reflection = ActiveRecord::Reflection::AssociationReflection.new(:fuu, :author, nil, {}, Edge)
+    reflection = ActiveRecord::Reflection.create(:has_many, :author, nil, {}, Edge)
     assert_raises(ActiveRecord::UnknownPrimaryKey) { reflection.active_record_primary_key }
   end
 
@@ -317,32 +317,28 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_default_association_validation
-    assert AssociationReflection.new(:has_many, :clients, nil, {}, Firm).validate?
+    assert ActiveRecord::Reflection.create(:has_many, :clients, nil, {}, Firm).validate?
 
-    assert !AssociationReflection.new(:has_one, :client, nil, {}, Firm).validate?
-    assert !AssociationReflection.new(:belongs_to, :client, nil, {}, Firm).validate?
-    assert !AssociationReflection.new(:has_and_belongs_to_many, :clients, nil, {}, Firm).validate?
+    assert !ActiveRecord::Reflection.create(:has_one, :client, nil, {}, Firm).validate?
+    assert !ActiveRecord::Reflection.create(:belongs_to, :client, nil, {}, Firm).validate?
   end
 
   def test_always_validate_association_if_explicit
-    assert AssociationReflection.new(:has_one, :client, nil, { :validate => true }, Firm).validate?
-    assert AssociationReflection.new(:belongs_to, :client, nil, { :validate => true }, Firm).validate?
-    assert AssociationReflection.new(:has_many, :clients, nil, { :validate => true }, Firm).validate?
-    assert AssociationReflection.new(:has_and_belongs_to_many, :clients, nil, { :validate => true }, Firm).validate?
+    assert ActiveRecord::Reflection.create(:has_one, :client, nil, { :validate => true }, Firm).validate?
+    assert ActiveRecord::Reflection.create(:belongs_to, :client, nil, { :validate => true }, Firm).validate?
+    assert ActiveRecord::Reflection.create(:has_many, :clients, nil, { :validate => true }, Firm).validate?
   end
 
   def test_validate_association_if_autosave
-    assert AssociationReflection.new(:has_one, :client, nil, { :autosave => true }, Firm).validate?
-    assert AssociationReflection.new(:belongs_to, :client, nil, { :autosave => true }, Firm).validate?
-    assert AssociationReflection.new(:has_many, :clients, nil, { :autosave => true }, Firm).validate?
-    assert AssociationReflection.new(:has_and_belongs_to_many, :clients, nil, { :autosave => true }, Firm).validate?
+    assert ActiveRecord::Reflection.create(:has_one, :client, nil, { :autosave => true }, Firm).validate?
+    assert ActiveRecord::Reflection.create(:belongs_to, :client, nil, { :autosave => true }, Firm).validate?
+    assert ActiveRecord::Reflection.create(:has_many, :clients, nil, { :autosave => true }, Firm).validate?
   end
 
   def test_never_validate_association_if_explicit
-    assert !AssociationReflection.new(:has_one, :client, nil, { :autosave => true, :validate => false }, Firm).validate?
-    assert !AssociationReflection.new(:belongs_to, :client, nil, { :autosave => true, :validate => false }, Firm).validate?
-    assert !AssociationReflection.new(:has_many, :clients, nil, { :autosave => true, :validate => false }, Firm).validate?
-    assert !AssociationReflection.new(:has_and_belongs_to_many, :clients, nil, { :autosave => true, :validate => false }, Firm).validate?
+    assert !ActiveRecord::Reflection.create(:has_one, :client, nil, { :autosave => true, :validate => false }, Firm).validate?
+    assert !ActiveRecord::Reflection.create(:belongs_to, :client, nil, { :autosave => true, :validate => false }, Firm).validate?
+    assert !ActiveRecord::Reflection.create(:has_many, :clients, nil, { :autosave => true, :validate => false }, Firm).validate?
   end
 
   def test_foreign_key
@@ -364,11 +360,11 @@ class ReflectionTest < ActiveRecord::TestCase
     category = Struct.new(:table_name, :pluralize_table_names).new('categories', true)
     product = Struct.new(:table_name, :pluralize_table_names).new('products', true)
 
-    reflection = AssociationReflection.new(:has_and_belongs_to_many, :categories, nil, {}, product)
+    reflection = ActiveRecord::Reflection.create(:has_many, :categories, nil, {}, product)
     reflection.stubs(:klass).returns(category)
     assert_equal 'categories_products', reflection.join_table
 
-    reflection = AssociationReflection.new(:has_and_belongs_to_many, :products, nil, {}, category)
+    reflection = ActiveRecord::Reflection.create(:has_many, :products, nil, {}, category)
     reflection.stubs(:klass).returns(product)
     assert_equal 'categories_products', reflection.join_table
   end
@@ -377,11 +373,11 @@ class ReflectionTest < ActiveRecord::TestCase
     category = Struct.new(:table_name, :pluralize_table_names).new('catalog_categories', true)
     product = Struct.new(:table_name, :pluralize_table_names).new('catalog_products', true)
 
-    reflection = AssociationReflection.new(:has_and_belongs_to_many, :categories, nil, {}, product)
+    reflection = ActiveRecord::Reflection.create(:has_many, :categories, nil, {}, product)
     reflection.stubs(:klass).returns(category)
     assert_equal 'catalog_categories_products', reflection.join_table
 
-    reflection = AssociationReflection.new(:has_and_belongs_to_many, :products, nil, {}, category)
+    reflection = ActiveRecord::Reflection.create(:has_many, :products, nil, {}, category)
     reflection.stubs(:klass).returns(product)
     assert_equal 'catalog_categories_products', reflection.join_table
   end
@@ -390,11 +386,11 @@ class ReflectionTest < ActiveRecord::TestCase
     category = Struct.new(:table_name, :pluralize_table_names).new('catalog_categories', true)
     page = Struct.new(:table_name, :pluralize_table_names).new('content_pages', true)
 
-    reflection = AssociationReflection.new(:has_and_belongs_to_many, :categories, nil, {}, page)
+    reflection = ActiveRecord::Reflection.create(:has_many, :categories, nil, {}, page)
     reflection.stubs(:klass).returns(category)
     assert_equal 'catalog_categories_content_pages', reflection.join_table
 
-    reflection = AssociationReflection.new(:has_and_belongs_to_many, :pages, nil, {}, category)
+    reflection = ActiveRecord::Reflection.create(:has_many, :pages, nil, {}, category)
     reflection.stubs(:klass).returns(page)
     assert_equal 'catalog_categories_content_pages', reflection.join_table
   end
@@ -403,11 +399,11 @@ class ReflectionTest < ActiveRecord::TestCase
     category = Struct.new(:table_name, :pluralize_table_names).new('categories', true)
     product = Struct.new(:table_name, :pluralize_table_names).new('products', true)
 
-    reflection = AssociationReflection.new(:has_and_belongs_to_many, :categories, nil, { :join_table => 'product_categories' }, product)
+    reflection = ActiveRecord::Reflection.create(:has_many, :categories, nil, { :join_table => 'product_categories' }, product)
     reflection.stubs(:klass).returns(category)
     assert_equal 'product_categories', reflection.join_table
 
-    reflection = AssociationReflection.new(:has_and_belongs_to_many, :products, nil, { :join_table => 'product_categories' }, category)
+    reflection = ActiveRecord::Reflection.create(:has_many, :products, nil, { :join_table => 'product_categories' }, category)
     reflection.stubs(:klass).returns(product)
     assert_equal 'product_categories', reflection.join_table
   end


### PR DESCRIPTION
This change is the beginning of a larger refactoring to move reflections from sub classes to delegates. Instead of forcing all associations be an `AssociationReflection` and checking the type on the `@macro` instance var we can now have named reflections; `HasManyReflection`, `HasOneReflection`, `BelongsToReflection`, and `HasAndBelongsToManyReflection`. :sweat_smile: 

The refactoring also removes the `@collection` instance variable by explicitly setting `collection?` to `false` by default and then setting it to `true` in both HM and HABTM.

Methods shared between `ThroughReflection`, `AssociationReflection`, and `MacroReflection` have been moved to a new `ReflectionMethods` class.

Reflection tests in `activerecord/test/cases/reflection_test.rb` had to be somewhat changed and rewritten since we no longer accept unknown macro types, HABTM isn't used internally, and we now construct the Reflections a little differently.

This does not remove the `@macro` instance var just yet but we are working towards that. 

cc/ @tenderlove

(p.s. I can squash just don't like to do it before review :smile_cat:) 
