### PR TITLE
Include fixtures to prevent foreign key violation.

### DIFF
--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -937,6 +937,8 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 end
 
 class BelongsToWithForeignKeyTest < ActiveRecord::TestCase
+  fixtures :authors, :author_addresses
+
   def test_destroy_linked_models
     address = AuthorAddress.create!
     author = Author.create! name: "Author", author_address_id: address.id


### PR DESCRIPTION
When some other tests use `:authors` fixtures, the authors table in db has the following content:

``` bash
+----+-------+-------------------+-------------------------+-----------------+-------------------+
| id | name  | author_address_id | author_address_extra_id | organization_id | owned_essay_id    |
+----+-------+-------------------+-------------------------+-----------------+-------------------+
|  1 | David |                 1 |                       2 | No Such Agency  | A Modest Proposal |
|  2 | Mary  |              NULL |                    NULL | NULL            | NULL              |
|  3 | Bob   |              NULL |                    NULL | NULL            | NULL              |
+----+-------+-------------------+-------------------------+-----------------+-------------------+
```

Destroying address in this test case would therefore result in foreign key violation error. With these two fixtures loaded before the test, we can prevent the error.

cc @senny
