### PR TITLE
URLs can't contain utf-8 characters

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -53,7 +53,7 @@ module ActionDispatch
           end
 
           def unescape_uri(uri)
-            uri.gsub(ESCAPED) { [$&[1, 2].hex].pack('C') }.force_encoding(uri.encoding)
+            uri.gsub(ESCAPED) { [$&[1, 2].hex].pack('C') }.force_encoding(ENCODING)
           end
 
           protected

--- a/actionpack/test/journey/router/utils_test.rb
+++ b/actionpack/test/journey/router/utils_test.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'abstract_unit'
 
 module ActionDispatch
@@ -26,6 +27,10 @@ module ActionDispatch
 
         def test_normalize_path_uppercase
           assert_equal "/foo%AAbar%AAbaz", Utils.normalize_path("/foo%aabar%aabaz")
+        end
+
+        def test_us_ascii_to_utf_8_ruby_1_9_3
+          assert_equal "/person/Šašinková", Utils.normalize_path("/person/Šašinková")
         end
       end
     end


### PR DESCRIPTION
- URI::Parser:: unescape is monkey patched in active support to force the encoding to utf-8 if it isn't by default. Lets set unescape to use ASCII-8BIT

Possible fix for https://github.com/rails/rails/issues/16104
