### PR TITLE
Address CVE-2014-4671 (JSONP Flash exploit)

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Prepend a JS comment to JSONP callbacks. Addresses CVE-2014-4671
+    ("Rosetta Flash")
+
+    *Greg Campbell*
+
 *   Generate shallow paths for all children of shallow resources.
 
     Fixes #15783.

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -116,7 +116,7 @@ module ActionController
           self.content_type = Mime::JS
         end
 
-        "#{options[:callback]}(#{json})"
+        "/**/#{options[:callback]}(#{json})"
       else
         self.content_type ||= Mime::JSON
         json

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -520,7 +520,7 @@ class RespondToControllerTest < ActionController::TestCase
   def test_json_with_callback_sets_javascript_content_type
     @request.accept = 'application/json'
     get :json_with_callback
-    assert_equal 'alert(JS)', @response.body
+    assert_equal '/**/alert(JS)', @response.body
     assert_equal 'text/javascript', @response.content_type
   end
 

--- a/actionpack/test/controller/render_json_test.rb
+++ b/actionpack/test/controller/render_json_test.rb
@@ -101,7 +101,7 @@ class RenderJsonTest < ActionController::TestCase
 
   def test_render_json_with_callback
     xhr :get, :render_json_hello_world_with_callback
-    assert_equal 'alert({"hello":"world"})', @response.body
+    assert_equal '/**/alert({"hello":"world"})', @response.body
     assert_equal 'text/javascript', @response.content_type
   end
 


### PR DESCRIPTION
Adds a comment before JSONP callbacks. See
[the reporter's blog post](http://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/) and [the CVE](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-4671) for more information on the vulnerability.
