### PR TITLE
Do not force postgresql to prepare statements when there are no binds.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1160,7 +1160,7 @@ module ActiveRecord
         FEATURE_NOT_SUPPORTED = "0A000" # :nodoc:
 
         def exec_no_cache(sql, binds)
-          @connection.async_exec(sql, [])
+          @connection.async_exec(sql)
         end
 
         def exec_cache(sql, binds)


### PR DESCRIPTION
Fixes regression from 1f2192e46d78ee0ba2b06373f2c24caf8440ff5b.

Now, in 3.2.19, AR always passes an empty array to PG::Connection#async_exec, causing a prepared statement even when there are no binds.  I suspect this was an unintentional change as it is not relevant to the multiline bit string fix. (and, it is uncouth to begin forcing prepared statements here where people do not expect it)

```
# from irb
ActiveRecord::Base.connection.raw_connection.async_exec("select 1”)
# from pg query logs
2014-07-09 19:28:53 UTC LOG:  duration: 0.039 ms  statement: select 1

# from irb
ActiveRecord::Base.connection.raw_connection.async_exec("select 1", [])
# from pg query logs
2014-07-09 19:31:41 UTC LOG:  duration: 0.127 ms  parse <unnamed>: select 1
2014-07-09 19:31:41 UTC LOG:  duration: 0.021 ms  bind <unnamed>: select 1
2014-07-09 19:31:41 UTC LOG:  duration: 0.008 ms  execute <unnamed>: select 1
```
