### PR TITLE
[ci skip] Document millisecond precision change in ActiveSupport::TimeWithZone#as_json

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -241,6 +241,16 @@ If your application depends on one of these features, you can get them back by
 adding the [`activesupport-json_encoder`](https://github.com/rails/activesupport-json_encoder)
 gem to your Gemfile.
 
+#### JSON representation of Time objects
+
+`#as_json` for objects with time component (`Time`, `DateTime`, `ActiveSupport::TimeWithZone`)
+now returns millisecond precision by default. If you need to keep old behavior with no millisecond
+precision, set the following in an initializer:
+
+```
+ActiveSupport::JSON::Encoding.time_precision = 0
+```
+
 ### Usage of `return` within inline callback blocks
 
 Previously, Rails allowed inline callback blocks to use `return` this way:
@@ -434,8 +444,8 @@ string keys consistently.
 
 ### Explicit block use for `ActiveSupport::Callbacks`
 
-Rails 4.1 now expects an explicit block to be passed when calling 
-`ActiveSupport::Callbacks.set_callback`. This change stems from 
+Rails 4.1 now expects an explicit block to be passed when calling
+`ActiveSupport::Callbacks.set_callback`. This change stems from
 `ActiveSupport::Callbacks` being largely rewritten for the 4.1 release.
 
 ```ruby


### PR DESCRIPTION
Before, `TimeWithZone#as_json` had no millisecond precision, and now it does. Since this may be a breaking change for some apps or API consumers, we should document this in the Upgrade Gudies.
