### PR TITLE
Require ActiveSupport::Autoload explicitly

### DIFF
--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -1,3 +1,5 @@
+require 'active_support/dependencies/autoload'
+
 module ActiveSupport
   module NumberHelper
     extend ActiveSupport::Autoload


### PR DESCRIPTION
Since d3b93e403b3d0c11607e037770ad91c062b2e897, we cannot require
active_support/number_helper and several files which require it (e.g.
active_support/core_ext/numeric).
