### PR TITLE
[ci skip] Fixed link to strong params in Getting Started section 5.6.

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -749,8 +749,7 @@ to create an article. Try it! You should get an error that looks like this:
 (images/getting_started/forbidden_attributes_for_new_article.png)
 
 Rails has several security features that help you write secure applications,
-and you're running into one of them now. This one is called `[strong_parameters]
-(http://guides.rubyonrails.org/action_controller_overview.html#strong-parameters)`,
+and you're running into one of them now. This one is called [strong parameters](http://guides.rubyonrails.org/action_controller_overview.html#strong-parameters),
 which requires us to tell Rails exactly which parameters are allowed into our
 controller actions.
 


### PR DESCRIPTION
In Section 5.6 of Getting Started, the link to the section on strong parameters was broken. I fixed it.
