### PR TITLE
Includes HABTM returns correct size now. Fixes #16032

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Includes HABTM returns correct size now. It's caused by the join dependency
+    only instantiates one HABTM object because the join table hasn't a primary key.
+
+    Fixes #16032.
+
+    Examples:
+
+        before:
+
+        Project.first.salaried_developers.size # => 3
+        Project.includes(:salaried_developers).first.salaried_developers.size # => 1
+
+        after:
+
+        Project.first.salaried_developers.size # => 3
+        Project.includes(:salaried_developers).first.salaried_developers.size # => 3
+
+    *Bigxiang*
+
 *   Fix the SQL generated when a `delete_all` is run on an association to not
     produce an `IN` statements.
 

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -143,7 +143,8 @@ module ActiveRecord
         column_aliases = aliases.column_aliases join_root
 
         result_set.each { |row_hash|
-          parent = parents[row_hash[primary_key]] ||= join_root.instantiate(row_hash, column_aliases)
+          parent_key = primary_key ? row_hash[primary_key] : row_hash.object_id
+          parent = parents[parent_key] ||= join_root.instantiate(row_hash, column_aliases)
           construct(parent, join_root, row_hash, result_set, seen, model_cache, aliases)
         }
 
@@ -224,7 +225,7 @@ module ActiveRecord
       end
 
       def construct(ar_parent, parent, row, rs, seen, model_cache, aliases)
-        primary_id  = ar_parent.id
+        primary_id  = ar_parent.id || ar_parent.object_id
 
         parent.children.each do |node|
           if node.reflection.collection?

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -883,4 +883,23 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     child.special_projects << SpecialProject.new("name" => "Special Project")
     assert child.save, 'child object should be saved'
   end
+
+  def test_included_associations_size
+    assert Project.first.salaried_developers.size,
+      Project.includes(:salaried_developers).first.salaried_developers.size
+
+    assert Project.includes(:salaried_developers).references(:salaried_developers).first.salaried_developers.size,
+      Project.includes(:salaried_developers).first.salaried_developers.size
+
+    # Nested HATBM
+    first_project = Developer.first.projects.first
+    preloaded_first_project =
+      Developer.includes(projects: :salaried_developers).
+        first.
+        projects.
+        detect { |p| p.id == first_project.id }
+
+    assert preloaded_first_project.salaried_developers.loaded?, true
+    assert first_project.salaried_developers.size, preloaded_first_project.salaried_developers.size
+  end
 end


### PR DESCRIPTION
Includes HABTM returns correct size now. It's caused by the join dependency only instantiates one HABTM object because the join table hasn't a primary key.

Fixes #16032.
### Examples:

before:

``` ruby
    Project.first.salaried_developers.size # => 3
    Project.includes(:salaried_developers).first.salaried_developers.size # => 1
```

after:

``` ruby
    Project.first.salaried_developers.size # => 3
    Project.includes(:salaried_developers).first.salaried_developers.size # => 3
```
