### PR TITLE
Dump PostgreSQL primary key with custom function as a default.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix the schema dump generated for tables without constraints and with
+    primary key with default value of custom PostgreSQL function result.
+
+    Fixes #16111
+
+    *Andrey Novikov*
+
 *   Fix the SQL generated when a `delete_all` is run on an association to not
     produce an `IN` statements.
 

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -120,7 +120,8 @@ HEADER
           # first dump primary key column
           if @connection.respond_to?(:pk_and_sequence_for)
             pk, _ = @connection.pk_and_sequence_for(table)
-          elsif @connection.respond_to?(:primary_key)
+          end
+          if !pk && @connection.respond_to?(:primary_key)
             pk = @connection.primary_key(table)
           end
 


### PR DESCRIPTION
Fixes #16111. See it for more information.

For example, if I use pgcrypto extension in PostgreSQL 9.4 beta 1, where uuid-ossp extension isn't available for moment of writing, and thus required to use a gen_random_uuid() method as a primary key default.

In this case schema dumper wasn't able to correctly reconstruct create_table statement and lost primary key constraint on schema load.

If I create migration in PostgreSQL 9.4 beta 1 as:

``` ruby
enable_extension 'pgcrypto'
create_table "pg_uuids", id: :uuid, default: "gen_random_uuid()", force: true do |t|
  t.string "name"
  t.uuid   "other_uuid", default: "gen_random_uuid()"
end
```

Schema dumper currently dumps it as this:

``` ruby
create_table "pg_uuids", id: false, force: true do |t|
  t.uuid   "id",         default: "gen_random_uuid()", null: false
  t.string "name"
  t.uuid   "other_uuid", default: "gen_random_uuid()"
end
```

Instead of this:

``` ruby
create_table "pg_uuids", id: :uuid, default: "gen_random_uuid()", force: true do |t|
  t.string "name"
  t.uuid   "other_uuid", default: "gen_random_uuid()"
end
```

What about to also backport it to 4-1-stable?
