### PR TITLE
Add support for PostgreSQL index operator classes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     # Abstract representation of an index definition on a table. Instances of
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#indexes
-    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using) #:nodoc:
+    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using, :opclass) #:nodoc:
     end
 
     # Abstract representation of a column definition. Instances of this type

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -867,7 +867,7 @@ module ActiveRecord
         column_names = Array(column_name)
         index_name   = index_name(table_name, column: column_names)
 
-        options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :using, :algorithm, :type)
+        options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :using, :algorithm, :type, :opclass)
 
         index_type = options[:unique] ? "UNIQUE" : ""
         index_type = options[:type].to_s if options.key?(:type)
@@ -881,6 +881,7 @@ module ActiveRecord
         end
 
         using = "USING #{options[:using]}" if options[:using].present?
+        opclass = " #{options[:opclass]}" if options[:opclass].present?
 
         if supports_partial_index?
           index_options = options[:where] ? " WHERE #{options[:where]}" : ""
@@ -894,7 +895,7 @@ module ActiveRecord
         end
         index_columns = quoted_columns_for_index(column_names, options).join(", ")
 
-        [index_name, index_type, index_columns, index_options, algorithm, using]
+        [index_name, index_type, index_columns, index_options, algorithm, using, opclass]
       end
 
       protected

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -197,6 +197,7 @@ HEADER
             statement_parts << "order: #{index.orders.inspect}" if index_orders.any?
             statement_parts << "where: #{index.where.inspect}" if index.where
             statement_parts << "using: #{index.using.inspect}" if index.using
+            statement_parts << "opclass: #{index.opclass.inspect}" if index.opclass
             statement_parts << "type: #{index.type.inspect}" if index.type
 
             "  #{statement_parts.join(', ')}"

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -49,6 +49,12 @@ class PostgresqlActiveSchemaTest < ActiveRecord::TestCase
 
     expected = %(CREATE UNIQUE INDEX  "index_people_on_last_name" ON "people" USING gist ("last_name") WHERE state = 'active')
     assert_equal expected, add_index(:people, :last_name, :unique => true, :where => "state = 'active'", :using => :gist)
+
+    expected = %(CREATE  INDEX  "index_people_on_last_name" ON "people"  ("last_name" varchar_pattern_ops))
+    assert_equal expected, add_index(:people, :last_name, opclass: :varchar_pattern_ops)
+
+    expected = %(CREATE  INDEX  "index_people_on_last_name" ON "people" USING gist ("last_name" gist_trgm_ops))
+    assert_equal expected, add_index(:people, :last_name, using: :gist, opclass: :gist_trgm_ops)
   end
 
   private

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -171,6 +171,17 @@ class SchemaDumperTest < ActiveRecord::TestCase
     end
   end
 
+  def test_schema_dumps_index_opclass
+    index_definition = standard_dump.split(/\n/).grep(/add_index.*company_name_index/).first.strip
+    if current_adapter?(:PostgreSQLAdapter)
+      assert_equal 'add_index "companies", ["name"], name: "company_name_index", using: :btree, opclass: :varchar_pattern_ops', index_definition
+    elsif current_adapter?(:MysqlAdapter, :Mysql2Adapter)
+      assert_equal 'add_index "companies", ["name"], name: "company_name_index", using: :btree', index_definition
+    else
+      assert_equal 'add_index "companies", ["name"], name: "company_name_index"', index_definition
+    end
+  end
+
   def test_schema_dumps_partial_indices
     index_definition = standard_dump.split(/\n/).grep(/add_index.*company_partial_index/).first.strip
     if current_adapter?(:PostgreSQLAdapter)

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -214,7 +214,7 @@ ActiveRecord::Schema.define do
 
   add_index :companies, [:firm_id, :type, :rating], name: "company_index"
   add_index :companies, [:firm_id, :type], name: "company_partial_index", where: "rating > 10"
-  add_index :companies, :name, name: 'company_name_index', using: :btree
+  add_index :companies, :name, name: 'company_name_index', using: :btree, opclass: :varchar_pattern_ops
 
   create_table :vegetables, force: true do |t|
     t.string :name


### PR DESCRIPTION
This adds support for setting and dumping the index operator class when using the PostgreSQL adapter.
This is especially useful for search, because it is needed to make use of the operators provided by the pg_trgm extension and also the builtin pattern_ops classes that enable LIKE/REGEX queries on non-C-locale columns.

The current code checks that the operator class is a valid opclass provided by the current database, but it does not yet check wether the combination of index type and operator class is valid. This would be possible by using a slightly more comlicated query for determining the valid opclasses:

``` SQL
SELECT am.amname AS index_method,
       opc.opcname AS opclass_name
    FROM pg_am am, pg_opclass opc
    WHERE opc.opcmethod = am.oid
    ORDER BY index_method, opclass_name;
```

The code is very loosely based on a previous implementation in the postgres_ext 1.0 gem which provided an index_opclass option when working with Rails 3.2.x.

**Usage Examples:**

``` ruby
add_index :people, :last_name, opclass: :varchar_pattern_ops
add_index :people, :last_name, using: :gist, opclass: :gist_trgm_ops
```

[Relevant Postgres Docs: Operator Classes and Operator Families](http://www.postgresql.org/docs/9.3/static/indexes-opclass.html)
