### PR TITLE
Use `#bytesize` instead of `#size` when checking for cookie overflow

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Use `String#bytesize` instead of `String#size` when checking for cookie
+    overflow.
+
+    *Agis Anastasopoulos*
+   
 *   `render nothing: true` or rendering a `nil` body no longer add a single
     space to the response body.
 

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -468,7 +468,7 @@ module ActionDispatch
           options = { :value => @verifier.generate(serialize(name, options)) }
         end
 
-        raise CookieOverflow if options[:value].size > MAX_COOKIE_SIZE
+        raise CookieOverflow if options[:value].bytesize > MAX_COOKIE_SIZE
         @parent_jar[name] = options
       end
 
@@ -526,7 +526,7 @@ module ActionDispatch
 
         options[:value] = @encryptor.encrypt_and_sign(serialize(name, options[:value]))
 
-        raise CookieOverflow if options[:value].size > MAX_COOKIE_SIZE
+        raise CookieOverflow if options[:value].bytesize > MAX_COOKIE_SIZE
         @parent_jar[name] = options
       end
 


### PR DESCRIPTION
Although the cookie values happens to be ASCII strings because they are
Base64 encoded, it is semantically incorrect to check for the number of the
characters in the cookie, when we actually want to check for the number of the
bytes it consists of.

Furthermore it is unecessary coupling with the current implementation that
uses Base64 for encoding the values.
