### PR TITLE
Fix signature of AS::OrderedOptions#respond_to?

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -37,7 +37,7 @@ module ActiveSupport #:nodoc:
       end
     end
 
-    def respond_to?(name)
+    def respond_to?(*)
       true
     end
   end


### PR DESCRIPTION
[`Object#respond_to?`](http://ruby-doc.org/core-2.0/Object.html#method-i-respond_to-3F) takes an optional second argument, and `AS::OrderedOptions#respond_to?` should take it too. Where I burnt myself was when stubbing a method on it using RSpec. RSpec would call something like `object.respond_to?(name, true)`, which would cause a "wrong number of arguments" error.

It's fixed in Rails 4, because there I didn't get an error.
