### PR TITLE
Add ability to extend `rails server` command options parser

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -9,7 +9,17 @@ module Rails
       def parse!(args)
         args, options = args.dup, {}
 
-        opt_parser = OptionParser.new do |opts|
+        option_parser(options).parse! args
+
+        options[:log_stdout] = options[:daemonize].blank? && (options[:environment] || Rails.env) == "development"
+        options[:server]     = args.shift
+        options
+      end
+
+      private
+
+      def option_parser(options)
+        OptionParser.new do |opts|
           opts.banner = "Usage: rails server [mongrel, thin, etc] [options]"
           opts.on("-p", "--port=port", Integer,
                   "Runs Rails on the specified port.", "Default: 3000") { |v| options[:Port] = v }
@@ -37,12 +47,6 @@ module Rails
 
           opts.on("-h", "--help", "Show this help message.") { puts opts; exit }
         end
-
-        opt_parser.parse! args
-
-        options[:log_stdout] = options[:daemonize].blank? && (options[:environment] || Rails.env) == "development"
-        options[:server]     = args.shift
-        options
       end
     end
 


### PR DESCRIPTION
With this change it will be possible to add additional options to the `option_parser` like this:

```
require 'rails/commands/server'
module Rails
  class Server < ::Rack::Server
    class Options
      def option_parser_with_open(options)
        parser = option_parser_without_open options
        parser.on('-o', '--open', 'Open in default browser') { options[:open] = true }
        parser
      end
      alias_method_chain :option_parser, :open
    end

    def start_with_open
      start_without_open do
        `open http://localhost:3000` if options[:open]
      end
    end
    alias_method_chain :start, :open
  end
end
```
