### PR TITLE
Silence Downloader's output

### DIFF
--- a/activesupport/test/multibyte_conformance_test.rb
+++ b/activesupport/test/multibyte_conformance_test.rb
@@ -10,7 +10,6 @@ require 'tmpdir'
 class Downloader
   def self.download(from, to)
     unless File.exist?(to)
-      $stderr.puts "Downloading #{from} to #{to}"
       unless File.exist?(File.dirname(to))
         system "mkdir -p #{File.dirname(to)}"
       end


### PR DESCRIPTION
Hello,

This is just a tiny pull request that silences the output of the `Downloader` class when running the `multibyte_conformance_test.rb` file. This output isn't used anywhere for assertions so we can simply remove it. The introducing commit was f238d495. Before:

```
$ rm /tmp/cache/NormalizationTest.txt &>> /dev/null

$ ruby -Itest test/multibyte_conformance_test.rb
Run options: --seed 39629

# Running:

Downloading http://www.unicode.org/Public/6.3.0/ucd/NormalizationTest.txt to /tmp/cache/NormalizationTest.txt
....

Finished in 16.974811s, 0.2356 runs/s, 21652.0826 assertions/s.

4 runs, 367540 assertions, 0 failures, 0 errors, 0 skips
```

After:

```
$ rm /tmp/cache/NormalizationTest.txt &>> /dev/null

$ ruby -Itest test/multibyte_conformance_test.rb
Run options: --seed 48022

# Running:

....

Finished in 16.288564s, 0.2456 runs/s, 22564.2978 assertions/s.

4 runs, 367540 assertions, 0 failures, 0 errors, 0 skips
```

Have a nice day.
