### PR TITLE
don't log errors when all is fine

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -870,11 +870,11 @@ module ActiveRecord
       def try_to_load_dependency(file_name)
         require_dependency file_name
       rescue LoadError => e
-        # Let's hope the developer has included it
-        # Let's warn in case this is a subdependency, otherwise
-        # subdependency error messages are totally cryptic
-        if ActiveRecord::Base.logger
-          ActiveRecord::Base.logger.warn("Unable to load #{file_name}, underlying cause #{e.message} \n\n #{e.backtrace.join("\n")}")
+        unless fixture_class_names.key?(file_name.pluralize)
+          if ActiveRecord::Base.logger
+            ActiveRecord::Base.logger.warn("Unable to load #{file_name}, make sure you added it to ActiveSupport::TestCase.set_fixture_class")
+            ActiveRecord::Base.logger.warn("underlying cause #{e.message} \n\n #{e.backtrace.join("\n")}")
+          end
         end
       end
 

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -823,15 +823,20 @@ end
 
 class FixtureLoadingTest < ActiveRecord::TestCase
   def test_logs_message_for_failed_dependency_load
-    ActiveRecord::TestCase.expects(:require_dependency).with(:does_not_exist).raises(LoadError)
-    ActiveRecord::Base.logger.expects(:warn)
-    ActiveRecord::TestCase.try_to_load_dependency(:does_not_exist)
+    ActiveRecord::Base.logger.expects(:warn).twice
+    ActiveRecord::TestCase.try_to_load_dependency('does_not_exist')
+  end
+
+  def test_does_not_logs_message_for_dependency_that_has_been_defined_with_set_fixture_class
+    ActiveRecord::TestCase.set_fixture_class unknown_dead_parrots: DeadParrot
+    ActiveRecord::Base.logger.expects(:warn).never
+    ActiveRecord::TestCase.try_to_load_dependency('unknown_dead_parrot')
   end
 
   def test_does_not_logs_message_for_successful_dependency_load
-    ActiveRecord::TestCase.expects(:require_dependency).with(:works_out_fine)
+    ActiveRecord::TestCase.expects(:require_dependency).with('works_out_fine')
     ActiveRecord::Base.logger.expects(:warn).never
-    ActiveRecord::TestCase.try_to_load_dependency(:works_out_fine)
+    ActiveRecord::TestCase.try_to_load_dependency('works_out_fine')
   end
 end
 


### PR DESCRIPTION
this change prevents rails from logging verbose stack-traces when the exceptional case has already been handled by the developers.

so when your config looks like this

``` ruby
class ActiveSupport::TestCase
  set_fixture_class fixture_class_name: SomeModel, [...]
  fixtures :all
  [...]
```

it does not print a warning containing a possible 100 lines long stack-trace.

the problem only occurs on weird edge-cases where models are inherited+inlined in other model-classes. so something like this

``` ruby
class User < ActiveRecord::Base
  class Admin  < User
  end
end
```

what would be a good way to test this?
