### PR TITLE
Sti class name

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Change `subclass_from_attributes` to use `find_sti_class`. This allows
+    a user to overwrite `find_sti_class` to customize what classes should be
+    used for a given value in the database. This change also moves
+    `find_sti_class` from `private` to `protected`
+
+    *Eric Roberts*
+    
 *   Fix the SQL generated when a `delete_all` is run on an association to not
     produce an `IN` statements.
 

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -137,6 +137,20 @@ module ActiveRecord
 
       protected
 
+      def find_sti_class(type_name)
+        if store_full_sti_class
+          ActiveSupport::Dependencies.constantize(type_name)
+        else
+          compute_type(type_name)
+        end
+      rescue NameError
+        raise SubclassNotFound,
+          "The single-table inheritance mechanism failed to locate the subclass: '#{type_name}'. " +
+          "This error is raised because the column '#{inheritance_column}' is reserved for storing the class in case of inheritance. " +
+          "Please rename this column if you didn't intend it to be used for storing the inheritance class " +
+          "or overwrite #{name}.inheritance_column to use another column for that information."
+      end
+
       # Returns the class type of the record using the current module as a prefix. So descendants of
       # MyApp::Business::Account would appear as MyApp::Business::AccountSubclass.
       def compute_type(type_name)
@@ -180,20 +194,6 @@ module ActiveRecord
 
       def using_single_table_inheritance?(record)
         record[inheritance_column].present? && columns_hash.include?(inheritance_column)
-      end
-
-      def find_sti_class(type_name)
-        if store_full_sti_class
-          ActiveSupport::Dependencies.constantize(type_name)
-        else
-          compute_type(type_name)
-        end
-      rescue NameError
-        raise SubclassNotFound,
-          "The single-table inheritance mechanism failed to locate the subclass: '#{type_name}'. " +
-          "This error is raised because the column '#{inheritance_column}' is reserved for storing the class in case of inheritance. " +
-          "Please rename this column if you didn't intend it to be used for storing the inheritance class " +
-          "or overwrite #{name}.inheritance_column to use another column for that information."
       end
 
       def type_condition(table = arel_table)

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -225,18 +225,16 @@ module ActiveRecord
               raise ActiveRecord::SubclassNotFound.new("Invalid single-table inheritance type: #{subclass_name} is not a subclass of #{name}")
             end
 
-            return subclass
-          end
-        else
-          if subclass_name.present? && subclass_name != self.name
-            subclass = subclass_name.safe_constantize
-
-            unless descendants.include?(subclass)
-              raise ActiveRecord::SubclassNotFound.new("Invalid single-table inheritance type: #{subclass_name} is not a subclass of #{name}")
-            end
-
             subclass
           end
+        elsif subclass_name.present? && subclass_name != self.name
+          subclass = subclass_name.safe_constantize
+
+          unless descendants.include?(subclass)
+            raise ActiveRecord::SubclassNotFound.new("Invalid single-table inheritance type: #{subclass_name} is not a subclass of #{name}")
+          end
+
+          subclass
         end
       end
     end


### PR DESCRIPTION
I outlined what I'm trying to accomplish with this pull request here: https://groups.google.com/forum/#!topic/rubyonrails-core/QVjt2cs7NL4

A brief summary of the link above:
- I had a class 'Code' and a database table 'codes'.
- 'Code' had an attribute 'units', which could be either '$' or '%'
- I wanted the STI classes to be Code::Dollar or Code::Percent
- I was able to get this by redefining find_sti_class and sti_name, but it didn't work with build or new on the parent class

These changes will attempt to get a class for inheritance from find_sti_class, and if that doesn't work, will fall through to the old way of doing things.

This allows you to match whatever string is in your inheritance column in your database with whatever class you want by redefining `find_sti_class` and `sti_name`.
