### PR TITLE
Fix json autoload

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fixed a compatibility issue with the `Oj` gem when cherry-picking the file
+    `active_support/core_ext/object/json` without requiring `active_support/json`.
+
+    Fixes #16131.
+
+    *Godfrey Chan*
+
 *   Make `Hash#with_indifferent_access` copy the default proc too.
 
     *arthurnn*, *Xanders*

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -162,7 +162,7 @@ end
 
 class Time
   def as_json(options = nil) #:nodoc:
-    if ActiveSupport.use_standard_json_time_format
+    if ActiveSupport::JSON::Encoding.use_standard_json_time_format
       xmlschema(ActiveSupport::JSON::Encoding.time_precision)
     else
       %(#{strftime("%Y/%m/%d %H:%M:%S")} #{formatted_offset(false)})
@@ -172,7 +172,7 @@ end
 
 class Date
   def as_json(options = nil) #:nodoc:
-    if ActiveSupport.use_standard_json_time_format
+    if ActiveSupport::JSON::Encoding.use_standard_json_time_format
       strftime("%Y-%m-%d")
     else
       strftime("%Y/%m/%d")
@@ -182,7 +182,7 @@ end
 
 class DateTime
   def as_json(options = nil) #:nodoc:
-    if ActiveSupport.use_standard_json_time_format
+    if ActiveSupport::JSON::Encoding.use_standard_json_time_format
       xmlschema(ActiveSupport::JSON::Encoding.time_precision)
     else
       strftime('%Y/%m/%d %H:%M:%S %z')

--- a/activesupport/test/core_ext/object/json_cherry_pick_test.rb
+++ b/activesupport/test/core_ext/object/json_cherry_pick_test.rb
@@ -1,0 +1,42 @@
+require 'abstract_unit'
+
+# These test cases were added to test that cherry-picking the json extensions
+# works correctly, primarily for dependencies problems reported in #16131. They
+# need to be executed in isolation to reproduce the scenario correctly, because
+# other test cases might have already loaded additional dependencies.
+
+class JsonCherryPickTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  def test_time_as_json
+    require_or_skip 'active_support/core_ext/object/json'
+
+    expected = Time.new(2004, 7, 25)
+    actual   = Time.parse(expected.as_json)
+
+    assert_equal expected, actual
+  end
+
+  def test_date_as_json
+    require_or_skip 'active_support/core_ext/object/json'
+
+    expected = Date.new(2004, 7, 25)
+    actual   = Date.parse(expected.as_json)
+
+    assert_equal expected, actual
+  end
+
+  def test_datetime_as_json
+    require_or_skip 'active_support/core_ext/object/json'
+
+    expected = DateTime.new(2004, 7, 25)
+    actual   = DateTime.parse(expected.as_json)
+
+    assert_equal expected, actual
+  end
+
+  private
+    def require_or_skip(file)
+      require(file) || skip("'#{file}' was already loaded")
+    end
+end


### PR DESCRIPTION
When requiring the json core_ext, we are relying on AS's autoload to load the `json/encoding` file to avoid a circular dependency. Here we are incorrectly referencing the delegated config which is not yet available until we load `json/encoding`.

The fix is pretty straight forward, but adding a regression test for this is tricky. @jeremy wdyt about the test I added here? It [works](https://travis-ci.org/rails/rails/jobs/29762777), but have some doubts about it. Do you have better suggestions?

Fixes #16131
