### PR TITLE
Refactor Hash#transform_values and Hash#transform_values!

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -6,7 +6,8 @@ class Hash
   #  hash.transform_keys{ |key| key.to_s.upcase }
   #  # => {"NAME"=>"Rob", "AGE"=>"28"}
   def transform_keys
-    result = {}
+    return enum_for(:transform_keys) unless block_given?
+    result = self.class.new
     each_key do |key|
       result[yield(key)] = self[key]
     end
@@ -16,6 +17,7 @@ class Hash
   # Destructively convert all keys using the block operations.
   # Same as transform_keys but modifies +self+.
   def transform_keys!
+    return enum_for(:transform_keys!) unless block_given?
     keys.each do |key|
       self[yield(key)] = delete(key)
     end

--- a/activesupport/lib/active_support/core_ext/hash/transform_values.rb
+++ b/activesupport/lib/active_support/core_ext/hash/transform_values.rb
@@ -5,6 +5,7 @@ class Hash
   #   { a: 1, b: 2, c: 3 }.transform_values { |x| x * 2 }
   #   # => { a: 2, b: 4, c: 6 }
   def transform_values
+    return enum_for(:transform_values) unless block_given?
     result = self.class.new
     each do |key, value|
       result[key] = yield(value)
@@ -14,6 +15,7 @@ class Hash
 
   # Destructive +transform_values+
   def transform_values!
+    return enum_for(:transform_values!) unless block_given?
     each do |key, value|
       self[key] = yield(value)
     end

--- a/activesupport/lib/active_support/core_ext/hash/transform_values.rb
+++ b/activesupport/lib/active_support/core_ext/hash/transform_values.rb
@@ -4,7 +4,7 @@ class Hash
   #
   #   { a: 1, b: 2, c: 3 }.transform_values { |x| x * 2 }
   #   # => { a: 2, b: 4, c: 6 }
-  def transform_values(&block)
+  def transform_values
     result = self.class.new
     each do |key, value|
       result[key] = yield(value)

--- a/activesupport/test/core_ext/hash/transform_keys_test.rb
+++ b/activesupport/test/core_ext/hash/transform_keys_test.rb
@@ -1,0 +1,32 @@
+require 'abstract_unit'
+require 'active_support/core_ext/hash/transform_keys'
+
+class TransformKeysTest < ActiveSupport::TestCase
+  test "transform_keys returns a new hash with the keys computed from the block" do
+    original = { a: 'a', b: 'b' }
+    mapped = original.transform_keys { |k| "#{k}!".to_sym }
+
+    assert_equal({ a: 'a', b: 'b' }, original)
+    assert_equal({ a!: 'a', b!: 'b' }, mapped)
+  end
+
+  test "transform_keys! modifies the keys of the original" do
+    original = { a: 'a', b: 'b' }
+    mapped = original.transform_keys! { |k| "#{k}!".to_sym }
+
+    assert_equal({ a!: 'a', b!: 'b' }, original)
+    assert_same original, mapped
+  end
+
+  test "transform_keys returns an Enumerator if no block is given" do
+    original = { a: 'a', b: 'b' }
+    enumerator = original.transform_keys
+    assert_equal Enumerator, enumerator.class
+  end
+
+  test "transform_keys is chainable with Enumerable methods" do
+    original = { a: 'a', b: 'b' }
+    mapped = original.transform_keys.with_index { |k, i| [k, i].join.to_sym }
+    assert_equal({ a0: 'a', b1: 'b' }, mapped)
+  end
+end

--- a/activesupport/test/core_ext/hash/transform_values_test.rb
+++ b/activesupport/test/core_ext/hash/transform_values_test.rb
@@ -46,4 +46,16 @@ class TransformValuesTest < ActiveSupport::TestCase
     assert_equal 'a!', mapped[:a]
     assert_nil mapped[:b]
   end
+
+  test "transform_values returns an Enumerator if no block is given" do
+    original = { a: 'a', b: 'b' }
+    enumerator = original.transform_values
+    assert_equal Enumerator, enumerator.class
+  end
+
+  test "transform_values is chainable with Enumerable methods" do
+    original = { a: 'a', b: 'b' }
+    mapped = original.transform_values.with_index { |v, i| [v, i].join }
+    assert_equal({ a: 'a0', b: 'b1' }, mapped)
+  end
 end


### PR DESCRIPTION
This patch makes two small changes to the new Active Support core extensions `Hash#transform_values` and `Hash#transform_values!`:
1. These methods now return an `Enumerator` if no block is given. This makes them more consistent with other `Enumerable` methods and allows for method chaining, for example:
   
   ``` ruby
   {a: 1, b: 2, c: 3}.transform_values.with_index{|x, i| [x * x, i]}
   #=> {:a=>[1, 0], :b=>[4, 1], :c=>[9, 2]}
   ```
   
   Before this patch, such chaining would result in a `LocalJumpError: no block given`.
2. Since the `&block` parameter is never referenced, I’ve removed it from `Hash#transform_values`. This prevents a garbage Proc object from being constructed automatically on method invocation, resulting in measurably faster performance. Here is the benchmark I ran:
   
   ``` ruby
   require 'benchmark/ips'
   
   class Hash
     def slow(&block)
       return enum_for(:slow) unless block_given?
       result = self.class.new
       each do |key, value|
         result[key] = yield(value)
       end
       result
     end
   
     def fast
       return enum_for(:fast) unless block_given?
       result = self.class.new
       each do |key, value|
         result[key] = yield(value)
       end
       result
     end
   end
   
   HASH = {a: 1, b: 2, c: 3}
   
   Benchmark.ips do |x|
     x.report("slow") { HASH.slow { |x| x * x } }
     x.report("fast") { HASH.fast { |x| x * x } }
   end
   ```
   
   ```
   slow 388660.2 (±10.6%) i/s - 1931275 in 5.030443s
   fast 621865.9 (±11.5%) i/s - 3085425 in 5.029155s
   ```

References https://github.com/rails/rails/pull/15819. cc/ @guilleiguaran @rafaelfranca @sgrif
