### PR TITLE
Fix empty host for an asset url when asset_host proc returns nil

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Return an absolute instead of relative path from an asset url in the case
+    of the `asset_host` proc returning nil
+
+    *Jolyon Pawlyn*
+
 *   Fix `html_escape_once` to properly handle hex escape sequences (e.g. &#x1a2b;)
 
     *John F. Douthat*

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -203,7 +203,6 @@ module ActionView
         request = self.request if respond_to?(:request)
         host = options[:host]
         host ||= config.asset_host if defined? config.asset_host
-        host ||= request.base_url if request && options[:protocol] == :request
 
         if host.respond_to?(:call)
           arity = host.respond_to?(:arity) ? host.arity : host.method(:call).arity
@@ -214,6 +213,7 @@ module ActionView
           host = host % (Zlib.crc32(source) % 4)
         end
 
+        host ||= request.base_url if request && options[:protocol] == :request
         return unless host
 
         if host =~ URI_REGEXP

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -546,6 +546,14 @@ class AssetTagHelperTest < ActionView::TestCase
     assert_equal "http://cdn.example.com/images/file.png", image_path("file.png")
   end
 
+  def test_image_url_with_asset_host_proc_returning_nil
+    @controller.config.asset_host = Proc.new { nil }
+    @controller.request = Struct.new(:base_url, :script_name).new("http://www.example.com", nil)
+
+    assert_equal "/images/rails.png", image_path("rails.png")
+    assert_equal "http://www.example.com/images/rails.png", image_url("rails.png")
+  end
+
   def test_caching_image_path_with_caching_and_proc_asset_host_using_request
     @controller.config.asset_host = Proc.new do |source, request|
       if request.ssl?


### PR DESCRIPTION
If a CDN can be dynamically enabled in an app, when it is switched off and the asset_host proc returns nil, all asset urls are relative instead of absolute. This fix makes the urls absolute.
