### PR TITLE
Fixed JSON coder when loading NULL from DB

### DIFF
--- a/activerecord/lib/active_record/coders/json.rb
+++ b/activerecord/lib/active_record/coders/json.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       end
 
       def self.load(json)
-        ActiveSupport::JSON.decode(json)
+        ActiveSupport::JSON.decode(json) unless json.nil?
       end
     end
   end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -91,6 +91,24 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     assert_equal(my_post.title, t.content["title"])
   end
 
+  # This is to ensure that the JSON coder is behaving the same way as 4.0, but
+  # we can consider changing this in the future.
+  def test_json_db_null
+    Topic.serialize :content, JSON
+
+    # Force a row to have a database NULL instead of a JSON "null"
+    id = Topic.connection.insert "INSERT INTO topics (content) VALUES(NULL)"
+    t = Topic.find(id)
+
+    assert_nil t.content
+
+    t.save!
+
+    # On 4.0, re-saving a row with a database NULL will turn that into a JSON
+    # "null"
+    assert_equal 1, Topic.where('content = "null"').count
+  end
+
   def test_serialized_attribute_declared_in_subclass
     hash = { 'important1' => 'value1', 'important2' => 'value2' }
     important_topic = ImportantTopic.create("important" => hash)


### PR DESCRIPTION
This fixes an edge case with the new JSON coder introduced in #16059.

``` irb
>> JSON.load(nil)
# => nil
>> ActiveRecord::Coders::JSON.load(nil)
TypeError: no implicit conversion of nil into String
    from /Users/godfrey/.rvm/gems/ruby-2.0.0-p353/gems/json-1.8.1/lib/json/common.rb:155:in `initialize'
    from /Users/godfrey/.rvm/gems/ruby-2.0.0-p353/gems/json-1.8.1/lib/json/common.rb:155:in `new'
    from /Users/godfrey/.rvm/gems/ruby-2.0.0-p353/gems/json-1.8.1/lib/json/common.rb:155:in `parse'
    from /Users/godfrey/.rvm/gems/ruby-2.0.0-p353/gems/activesupport-4.1.2/lib/active_support/json/decoding.rb:26:in `decode'
    from /Users/godfrey/Projects/oss/rails-chancancode/activerecord/lib/active_record/coders/json.rb:9:in `load'
    from (irb):4
    from /Users/godfrey/.rvm/rubies/ruby-2.0.0-p353/bin/irb:12:in `<main>'
```

This patch ensures `ActiveRecord::Coders::JSON.load(nil)` doesn't blow up and matches the 4.0 behavior. Perhaps there are better ways to write the test case, so I'd like to get a review from others. (cc @sgrif @matthewd)

We can also consider just changing that in `ActiveSupport::JSON.decode` directly, but I think that would open up a bigger can of worms. (It's hard to say what's the behaviour on that in 4.0, because it uses MultiJson and so it depends on which adapter and version you are using. The latest JSON gem adapter seems to blow up on `nil` values as well, which I consider the correct behaviour.) (cc @jeremy)
