### PR TITLE
Don't lose PATH_INFO in ShowExceptions middleware

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,8 +1,19 @@
+*   Preserve original path in `ShowExceptions` middleware by stashing it as
+    `env["action_dispatch.original_path"]`
+
+    `ActionDispatch::ShowExceptions` overwrites `PATH_INFO` with the status code
+    for the exception defined in `ExceptionWrapper`, so the path
+    the user was visiting when an exception occurred was not previously
+    available to any custom exceptions_app. The original `PATH_INFO` is now
+    stashed in `env["action_dispatch.original_path"]`.
+
+    *Grey Baker*
+
 *   Use `String#bytesize` instead of `String#size` when checking for cookie
     overflow.
 
     *Agis Anastasopoulos*
-   
+
 *   `render nothing: true` or rendering a `nil` body no longer add a single
     space to the response body.
 

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -42,6 +42,7 @@ module ActionDispatch
       wrapper = ExceptionWrapper.new(env, exception)
       status  = wrapper.status_code
       env["action_dispatch.exception"] = wrapper.exception
+      env["action_dispatch.original_path"] = env["PATH_INFO"]
       env["PATH_INFO"] = "/#{status}"
       response = @exceptions_app.call(env)
       response[1]['X-Cascade'] == 'pass' ? pass_response(status) : response

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -37,7 +37,7 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     get "/", {}, {'action_dispatch.show_exceptions' => true}
     assert_response 500
     assert_equal "500 error fixture\n", body
-    
+
     get "/bad_params", {}, {'action_dispatch.show_exceptions' => true}
     assert_response 400
     assert_equal "400 error fixture\n", body
@@ -92,6 +92,7 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     exceptions_app = lambda do |env|
       assert_kind_of AbstractController::ActionNotFound, env["action_dispatch.exception"]
       assert_equal "/404", env["PATH_INFO"]
+      assert_equal "/not_found_original_exception", env["action_dispatch.original_path"]
       [404, { "Content-Type" => "text/plain" }, ["YOU FAILED BRO"]]
     end
 


### PR DESCRIPTION
Leave `PATH_INFO` unchanged in `ShowExceptions` middleware, so it is
available to any custom exceptions_app.

Previously `ActionDispatch::ShowExceptions` overwrote `PATH_INFO` with
the status code for the exception defined in `ExceptionWrapper`, so the
path the user was visiting when an exception occurred was not available
to any custom exceptions_app.

`PATH_INFO` now remains unchanged, and `PublicExceptions` uses the
status code of the wrapped exception to determine which exception
template to serve, instead of the path.
