### PR TITLE
Fixed `autosave` on associations with `inverse_of:` set on both sides of the relationship

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixed `autosave` on associations with `inverse_of:` set on both sides of
+    the relationship.
+
+    *Fred Wu*
+
 *   Fix the schema dump generated for tables without constraints and with
     primary key with default value of custom PostgreSQL function result.
 

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -272,6 +272,8 @@ module ActiveRecord
       def nested_records_changed_for_autosave?
         self.class._reflections.values.any? do |reflection|
           if reflection.options[:autosave]
+            next if reflection.inverse_of && reflection.inverse_of.options[:autosave]
+
             association = association_instance_get(reflection.name)
             association && Array.wrap(association.target).any? { |a| a.changed_for_autosave? }
           end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -674,8 +674,10 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
   end
 
   def test_should_rollback_destructions_if_an_exception_occurred_while_saving_a_child
+    @pirate.parrot = Parrot.new
+
     # Stub the save method of the @pirate.ship instance to destroy and then raise an exception
-    class << @pirate.ship
+    class << @pirate.parrot
       def save(*args)
         super
         destroy
@@ -683,7 +685,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
       end
     end
 
-    @ship.pirate.catchphrase = "Changed Catchphrase"
+    @pirate.parrot.name = 'Changed name'
 
     assert_raise(RuntimeError) { assert !@pirate.save }
     assert_not_nil @pirate.reload.ship

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -18,7 +18,7 @@ class Pirate < ActiveRecord::Base
   has_many :treasures, :as => :looter
   has_many :treasure_estimates, :through => :treasures, :source => :price_estimates
 
-  has_one :ship
+  has_one :ship, inverse_of: :pirate
   has_one :update_only_ship, :class_name => 'Ship'
   has_one :non_validated_ship, :class_name => 'Ship'
   has_many :birds, -> { order('birds.id ASC') }

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -1,7 +1,7 @@
 class Ship < ActiveRecord::Base
   self.record_timestamps = false
 
-  belongs_to :pirate
+  belongs_to :pirate, inverse_of: :ship
   belongs_to :update_only_pirate, :class_name => 'Pirate'
   has_many :parts, :class_name => 'ShipPart'
 


### PR DESCRIPTION
As title suggests, when `autosave` is used in associations with `inverse_of:` set on both sides of the relationship, it throws a `SystemStackError: stack level too deep` error.

This error happens on master, 4.1, 4.0 and 3.2. Let me know if you would like me to backport it to other branches (in case the commit can't be cherry-picked) once this master version is OK'ed.

Minimum reproducable gist:

``` ruby
source 'http://rubygems.org'

gem 'rails', github: 'rails/rails'
gem 'rack',  github: 'rack/rack'
gem 'arel',  github: 'rails/arel'
gem 'sqlite3'
```

``` ruby
# uncomment for master
require 'bundler'
Bundler.setup(:default)

# uncomment for releases
# gem 'activerecord', '4.1.4'
# gem 'activerecord', '4.0.8'
# gem 'activerecord', '3.2.19'

require 'active_record'
require "minitest/autorun"
require 'minitest/pride'
require 'logger'

ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
    t.integer :super_power_id
  end
  create_table :super_powers, force: true do |t|
  end
end

class User < ActiveRecord::Base
  belongs_to :super_power, autosave: true, inverse_of: :user
end

class SuperPower < ActiveRecord::Base
  has_one :user, autosave: true, inverse_of: :super_power
end

class BugTest < MiniTest::Unit::TestCase
  def test_autosave
    super_power = SuperPower.new
    super_power.save!

    user = User.new(super_power: super_power)
    user.save!

    assert_equal true, user.save!
  end
end
```

I believe this also fixes #14030 - seems like it's the same issue, but this fix is a lot simpler.

cc @tenderlove @rafaelfranca @zzak
