### PR TITLE
Address ORA-00972: identifier is too long when tested with Oracle

### DIFF
--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -1,7 +1,8 @@
 class Face < ActiveRecord::Base
   belongs_to :man, :inverse_of => :face
   belongs_to :polymorphic_man, :polymorphic => true, :inverse_of => :polymorphic_face
-  belongs_to :polymorphic_man_without_inverse, :polymorphic => true
+  # Oracle identifier lengh is limited to 30 bytes or less, `polymorphic` renamed `poly`
+  belongs_to :poly_man_without_inverse, :polymorphic => true
   # These is a "broken" inverse_of for the purposes of testing
   belongs_to :horrible_man, :class_name => 'Man', :inverse_of => :horrible_face
   belongs_to :horrible_polymorphic_man, :polymorphic => true, :inverse_of => :horrible_polymorphic_face

--- a/activerecord/test/models/man.rb
+++ b/activerecord/test/models/man.rb
@@ -1,7 +1,7 @@
 class Man < ActiveRecord::Base
   has_one :face, :inverse_of => :man
   has_one :polymorphic_face, :class_name => 'Face', :as => :polymorphic_man, :inverse_of => :polymorphic_man
-  has_one :polymorphic_face_without_inverse, :class_name => 'Face', :as => :polymorphic_man_without_inverse
+  has_one :polymorphic_face_without_inverse, :class_name => 'Face', :as => :poly_man_without_inverse
   has_many :interests, :inverse_of => :man
   has_many :polymorphic_interests, :class_name => 'Interest', :as => :polymorphic_man, :inverse_of => :polymorphic_man
   # These are "broken" inverse_of associations for the purposes of testing

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -781,8 +781,8 @@ ActiveRecord::Schema.define do
     t.integer :man_id
     t.integer :polymorphic_man_id
     t.string  :polymorphic_man_type
-    t.integer :polymorphic_man_without_inverse_id
-    t.string  :polymorphic_man_without_inverse_type
+    t.integer :poly_man_without_inverse_id
+    t.string  :poly_man_without_inverse_type
     t.integer :horrible_polymorphic_man_id
     t.string  :horrible_polymorphic_man_type
   end


### PR DESCRIPTION
This pull request address the following error since #15343 has been merged to master.
Because the max identifier length of Oracle is limited to 30 bytes.

This pull request uses shorter name by renaming `polymorphic` to `poly` only for attribute names which is over 30 bytes.

``` ruby
$ cd activerecord
$ rake test_oracle
... snip ...
stmt.c:230:in oci8lib_210.so: OCIError: ORA-00972: identifier is too long: CREATE TABLE "FACES" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "DESCRIPTION" VARCHAR2(255), "MAN_ID" NUMBER(38), "POLYMORPHIC_MAN_ID" NUMBER(38), "POLYMORPHIC_MAN_TYPE" VARCHAR2(255), "POLYMORPHIC_MAN_WITHOUT_INVERSE_ID" NUMBER(38), "POLYMORPHIC_MAN_WITHOUT_INVERSE_TYPE" VARCHAR2(255), "HORRIBLE_POLYMORPHIC_MAN_ID" NUMBER(38), "HORRIBLE_POLYMORPHIC_MAN_TYPE" VARCHAR2(255)) (ActiveRecord::StatementInvalid)
... snip ...
rake aborted!
```
