### PR TITLE
Don't accept params[:to] as HWIA in redirect_to

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -68,6 +68,7 @@ module ActionController
     # <tt>ActionController::RedirectBackError</tt>.
     def redirect_to(options = {}, response_status = {}) #:doc:
       raise ActionControllerError.new("Cannot redirect to nil!") unless options
+      raise ActionControllerError.new("Cannot accept HashWithIndifferentAccess coming from params!") if options.is_a?(HashWithIndifferentAccess)
       raise AbstractController::DoubleRenderError if response_body
 
       self.status        = _extract_redirect_to_status(options, response_status)


### PR DESCRIPTION
It is severe client side vulnerability (http://homakov.blogspot.com/2013/11/stealing-user-session-with-open.html). For a while I've been seeing this in many high-profile applications including songkick, airbnb and others.

Whenever you have `redirect_to params[:url]` it is 

1) XSS  using url[status]=200&url[protocol]=javascript&url[f]=%0Aeval(name)

2) way to steal httponly session cookie url[status]=1

Easy to trick user into clicking "redirect" link: http://cobased.com/track?hash=1405177298=http://ok.com/-f45294c86953da8388e2f0f8dff42a14823a4529&url[status]=200&url[protocol]=javascript&url[f]=%0Aeval(name)

This is barely a breaking change because only those who actually pass a hash coming from params will notice the exception. Something like ?params[controller]=&params[action]= is clearly antipattern and we should merge it, IMO. (If something is missing here, maybe you can fix it in your own PR, because i'm not a programmer.)
