### PR TITLE
has_many :through with dynamic condition merging

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix has_many :through relation merging failing when dynamic conditions are
+    passed as a lambda with an arity of one.
+
+    Fixes #16128
+
+    *Agis Anastasopoulos*
+
 *   Fixed the `Relation#exists?` to work with polymorphic associations.
 
     Fixes #15821.

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -15,7 +15,11 @@ module ActiveRecord
           scope = super
           reflection.chain.drop(1).each do |reflection|
             relation = reflection.klass.all
-            relation.merge!(reflection.scope) if reflection.scope
+
+            reflection_scope = reflection.scope
+            if reflection_scope && reflection_scope.arity.zero?
+              relation.merge!(reflection_scope)
+            end
 
             scope.merge!(
               relation.except(:select, :create_with, :includes, :preload, :joins, :eager_load)

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -4,6 +4,7 @@ require 'models/comment'
 require 'models/developer'
 require 'models/post'
 require 'models/project'
+require 'models/rating'
 
 class RelationMergingTest < ActiveRecord::TestCase
   fixtures :developers, :comments, :authors, :posts
@@ -143,5 +144,17 @@ class MergingDifferentRelationsTest < ActiveRecord::TestCase
       merge(Author.order(name: :desc)).pluck("authors.name")
 
     assert_equal ["Mary", "Mary", "Mary", "David"], posts_by_author_name
+  end
+
+  test "relation merging (using a proc  argument)" do
+    dev = Developer.where(name: "Jamis").first
+
+    comment_1 = dev.comments.create!(body: "I'm Jamis", post: Post.first)
+    rating_1 = comment_1.ratings.create!
+
+    comment_2 = dev.comments.create!(body: "I'm John", post: Post.first)
+    rating_2 = comment_2.ratings.create!
+
+    assert_equal dev.ratings, [rating_1]
   end
 end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -9,6 +9,7 @@ class Comment < ActiveRecord::Base
   belongs_to :post, :counter_cache => true
   belongs_to :author,   polymorphic: true
   belongs_to :resource, polymorphic: true
+  belongs_to :developer
 
   has_many :ratings
 

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -46,6 +46,8 @@ class Developer < ActiveRecord::Base
   has_many :audit_logs
   has_many :contracts
   has_many :firms, :through => :contracts, :source => :firm
+  has_many :comments, ->(developer) { where(body: "I'm #{developer.name}") }
+  has_many :ratings, through: :comments
 
   scope :jamises, -> { where(:name => 'Jamis') }
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -198,6 +198,7 @@ ActiveRecord::Schema.define do
     t.references :author, polymorphic: true
     t.string :resource_id
     t.string :resource_type
+    t.integer :developer_id
   end
 
   create_table :companies, force: true do |t|


### PR DESCRIPTION
Fixes #16128.

This bug was introduced in rails@c35e438 so it's present in versions 4.1.2-rc1 and later.

rails@c35e438 adds handling for scope merging in `has_many :through` relations, but does _not_ take into account the case where the scope is passed with an argument (ie. the current record).

To reproduce see https://gist.github.com/Agis-/5f1f0d664d2cd08dfb9b
