### PR TITLE
Use the plugin API to the getter and setters

### DIFF
--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -144,11 +144,11 @@ module ActionView
         end
 
         def sanitized_allowed_tags
-          Rails::Html::WhiteListSanitizer.allowed_tags
+          sanitizer_vendor.white_list_sanitize.allowed_tags
         end
 
         def sanitized_allowed_attributes
-          Rails::Html::WhiteListSanitizer.allowed_attributes
+          sanitizer_vendor.white_list_sanitize.allowed_attributes
         end
 
         # Gets the Rails::Html::FullSanitizer instance used by +strip_tags+. Replace with
@@ -191,7 +191,7 @@ module ActionView
         #   end
         #
         def sanitized_allowed_tags=(tags)
-          Rails::Html::WhiteListSanitizer.allowed_tags = tags
+          sanitizer_vendor.white_list_sanitize.allowed_tags = tags
         end
 
         # Replaces the allowed HTML attributes for the +sanitize+ helper.
@@ -201,7 +201,7 @@ module ActionView
         #   end
         #
         def sanitized_allowed_attributes=(attributes)
-          Rails::Html::WhiteListSanitizer.allowed_attributes = attributes
+          sanitizer_vendor.white_list_sanitize.allowed_attributes = attributes
         end
       end
     end


### PR DESCRIPTION
To avoid having to redefine these methods on the deprecated plugin we should be using the `sanitizer_vendor` API.

cc @kaspth

PS: I think we should undeprecate the `:protocol_separator`, `:uri_attributes`, `:bad_tags`, `:allowed_css_properties`, `:allowed_css_keywords`, `:shorthand_css_properties`, `:allowed_protocols` options on the deprecated gem right?
