### PR TITLE
Improve Active Model Dirty API.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Deprecate `ActiveModel::Dirty#reset_changes` in favor of `#clear_changes_information`.
+
+    This method name is causing confusion with the `reset_#{attribute}`
+    methods. While `reset_name` set the value of the name attribute for the
+    previous value `reset_changes` only discard the changes and previous
+    changes. 
+
 *   Added `undo_changes` method to `ActiveModel::Dirty` API to restore all the
     changed values to the previous data.
 

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,11 +1,16 @@
+*   Deprecate `reset_#{attribute}` in favor of `restore_#{attribute}`.
+
+    These methods may cause confusion with the `reset_changes` that behaves differently
+    of them.
+
 *   Deprecate `ActiveModel::Dirty#reset_changes` in favor of `#clear_changes_information`.
 
     This method name is causing confusion with the `reset_#{attribute}`
     methods. While `reset_name` set the value of the name attribute for the
     previous value `reset_changes` only discard the changes and previous
-    changes. 
+    changes.
 
-*   Added `undo_changes` method to `ActiveModel::Dirty` API to restore all the
+*   Added `restore_attributes` method to `ActiveModel::Dirty` API to restore all the
     changed values to the previous data.
 
     *Igor G.*

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -15,7 +15,7 @@ module ActiveModel
   # * Call <tt>attr_name_will_change!</tt> before each change to the tracked
   #   attribute.
   # * Call <tt>changes_applied</tt> after the changes are persisted.
-  # * Call <tt>reset_changes</tt> when you want to reset the changes
+  # * Call <tt>clear_changes_information</tt> when you want to reset the changes
   #   information.
   # * Call <tt>undo_changes</tt> when you want to restore previous data.
   #
@@ -37,11 +37,14 @@ module ActiveModel
   #
   #     def save
   #       # do persistence work
+  #
   #       changes_applied
   #     end
   #
   #     def reload!
-  #       reset_changes
+  #       # get the values from the persistence layer
+  #
+  #       clear_changes_information
   #     end
   #
   #     def rollback!
@@ -184,10 +187,15 @@ module ActiveModel
         @changed_attributes = ActiveSupport::HashWithIndifferentAccess.new
       end
 
-      # Removes all dirty data: current changes and previous changes.
-      def reset_changes # :doc:
+      # Clear all dirty data: current changes and previous changes.
+      def clear_changes_information # :doc:
         @previously_changed = ActiveSupport::HashWithIndifferentAccess.new
         @changed_attributes = ActiveSupport::HashWithIndifferentAccess.new
+      end
+
+      def reset_changes
+        ActiveSupport::Deprecation.warn "#reset_changes is deprecated and will be removed on Rails 5. Please use #clear_changes_information instead."
+        clear_changes_information
       end
 
       # Restore all previous data.

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -43,6 +43,10 @@ class DirtyTest < ActiveModel::TestCase
     end
 
     def reload
+      clear_changes_information
+    end
+
+    def deprecated_reload
       reset_changes
     end
 
@@ -176,6 +180,23 @@ class DirtyTest < ActiveModel::TestCase
     assert_equal 'Dmitry', @model.changed_attributes['name']
 
     @model.reload
+
+    assert_equal ActiveSupport::HashWithIndifferentAccess.new, @model.previous_changes
+    assert_equal ActiveSupport::HashWithIndifferentAccess.new, @model.changed_attributes
+  end
+
+  test "reset_changes is deprecated" do
+    @model.name = 'Dmitry'
+    @model.name_changed?
+    @model.save
+    @model.name = 'Bob'
+
+    assert_equal [nil, 'Dmitry'], @model.previous_changes['name']
+    assert_equal 'Dmitry', @model.changed_attributes['name']
+
+    assert_deprecated do
+      @model.deprecated_reload
+    end
 
     assert_equal ActiveSupport::HashWithIndifferentAccess.new, @model.previous_changes
     assert_equal ActiveSupport::HashWithIndifferentAccess.new, @model.changed_attributes

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -51,7 +51,7 @@ class DirtyTest < ActiveModel::TestCase
     end
 
     def rollback
-      undo_changes
+      restore_attributes
     end
   end
 
@@ -115,7 +115,7 @@ class DirtyTest < ActiveModel::TestCase
 
   test "resetting attribute" do
     @model.name = "Bob"
-    @model.reset_name!
+    @model.restore_name!
     assert_nil @model.name
     assert !@model.name_changed?
   end
@@ -202,7 +202,7 @@ class DirtyTest < ActiveModel::TestCase
     assert_equal ActiveSupport::HashWithIndifferentAccess.new, @model.changed_attributes
   end
 
-  test "undo_changes should restore all previous data" do
+  test "restore_attributes should restore all previous data" do
     @model.name = 'Dmitry'
     @model.color = 'Red'
     @model.save

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -34,7 +34,7 @@ module ActiveRecord
       # <tt>reload</tt> the record and clears changed attributes.
       def reload(*)
         super.tap do
-          reset_changes
+          clear_changes_information
         end
       end
 
@@ -64,7 +64,7 @@ module ActiveRecord
         store_original_raw_attributes
       end
 
-      def reset_changes
+      def clear_changes_information
         super
         original_raw_attributes.clear
       end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -169,7 +169,19 @@ class DirtyTest < ActiveRecord::TestCase
     pirate = Pirate.create!(:catchphrase => 'Yar!')
     pirate.catchphrase = 'Ahoy!'
 
-    pirate.reset_catchphrase!
+    assert_deprecated do
+      pirate.reset_catchphrase!
+    end
+    assert_equal "Yar!", pirate.catchphrase
+    assert_equal Hash.new, pirate.changes
+    assert !pirate.catchphrase_changed?
+  end
+
+  def test_restore_attribute!
+    pirate = Pirate.create!(:catchphrase => 'Yar!')
+    pirate.catchphrase = 'Ahoy!'
+
+    pirate.restore_catchphrase!
     assert_equal "Yar!", pirate.catchphrase
     assert_equal Hash.new, pirate.changes
     assert !pirate.catchphrase_changed?
@@ -398,7 +410,7 @@ class DirtyTest < ActiveRecord::TestCase
   def test_dup_objects_should_not_copy_dirty_flag_from_creator
     pirate = Pirate.create!(:catchphrase => "shiver me timbers")
     pirate_dup = pirate.dup
-    pirate_dup.reset_catchphrase!
+    pirate_dup.restore_catchphrase!
     pirate.catchphrase = "I love Rum"
     assert pirate.catchphrase_changed?
     assert !pirate_dup.catchphrase_changed?

--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -202,7 +202,7 @@ person.valid?                        # => raises ActiveModel::StrictValidationFa
 ### ActiveModel::Naming
 
 Naming adds a number of class methods which make the naming and routing
-easier to manage. The module defines the `model_name` class method which 
+easier to manage. The module defines the `model_name` class method which
 will define a number of accessors using some `ActiveSupport::Inflector` methods.
 
 ```ruby


### PR DESCRIPTION
I did some changes on this API:
- `reset_changes` becomes `clear_changes_information`. I believe this new name matches with what it is doing.
- `reset_*` is deprecated in favor of `restore_*`. This will avoid confusion with the deprecated reset_changes.
- `undo_changes` is now `restore_attributes`. To match the behaviour of `restore_*`.

@dhh @chancancode
