### PR TITLE
Implement required #encode_with

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -242,6 +242,11 @@ module ActiveRecord
       @records
     end
 
+    # Serializes the relation objects Array.
+    def encode_with(coder)
+      coder.represent_seq(nil, to_a)
+    end
+
     def as_json(options = nil) #:nodoc:
       to_a.as_json(options)
     end

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -119,6 +119,10 @@ module ActiveRecord
         arel.respond_to?(method, include_private)
     end
 
+    def encode_with(coder)
+      coder.represent_seq(nil, to_a)
+    end
+
     protected
 
     def array_delegable?(method)

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -119,10 +119,6 @@ module ActiveRecord
         arel.respond_to?(method, include_private)
     end
 
-    def encode_with(coder)
-      coder.represent_seq(nil, to_a)
-    end
-
     protected
 
     def array_delegable?(method)

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -1,5 +1,6 @@
 require 'cases/helper'
 require 'models/topic'
+require 'models/reply'
 require 'models/post'
 require 'models/author'
 


### PR DESCRIPTION
While running the spec `ARCONN=mysql2 ruby -v -Itest test/cases/yaml_serialization_test.rb`
the following warning shows up:
`implementing to_yaml is deprecated, please implement "encode_with"`

That's fixed on this PR.
