### PR TITLE
Update assertion methods in testing guide

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -364,8 +364,13 @@ Ideally, you would like to include a test for everything which could possibly br
 
 By now you've caught a glimpse of some of the assertions that are available. Assertions are the worker bees of testing. They are the ones that actually perform the checks to ensure that things are going as planned.
 
-There are a bunch of different types of assertions you can use.
-Here's an extract of the assertions you can use with `minitest`, the default testing library used by Rails. The `[msg]` parameter is an optional string message you can specify to make your test failure messages clearer. It's not required.
+There are a bunch of different types of assertions you can use.  Here's an
+extract of the
+[assertions](http://docs.seattlerb.org/minitest/Minitest/Assertions.html) you
+can use with [minitest](https://github.com/seattlerb/minitest), the default
+testing library used by Rails. The `[msg]` parameter is an optional string
+message you can specify to make your test failure messages clearer. It's not
+required.
 
 | Assertion                                                        | Purpose |
 | ---------------------------------------------------------------- | ------- |

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -377,8 +377,12 @@ Here's an extract of the assertions you can use with `minitest`, the default tes
 | `assert_not_same( expected, actual, [msg] )`                     | Ensures that `expected.equal?(actual)` is false.|
 | `assert_nil( obj, [msg] )`                                       | Ensures that `obj.nil?` is true.|
 | `assert_not_nil( obj, [msg] )`                                   | Ensures that `obj.nil?` is false.|
+| `assert_empty( obj, [msg] )`                                     | Ensures that `obj` is `empty?`.|
+| `assert_not_empty( obj, [msg] )`                                 | Ensures that `obj` is not `empty?`.|
 | `assert_match( regexp, string, [msg] )`                          | Ensures that a string matches the regular expression.|
 | `assert_no_match( regexp, string, [msg] )`                       | Ensures that a string doesn't match the regular expression.|
+| `assert_includes( collection, obj, [msg] )`                      | Ensures that `obj` is in `collection`.|
+| `assert_not_includes( collection, obj, [msg] )`                  | Ensures that `obj` is not in `collection`.|
 | `assert_in_delta( expecting, actual, [delta], [msg] )`           | Ensures that the numbers `expected` and `actual` are within `delta` of each other.|
 | `assert_not_in_delta( expecting, actual, [delta], [msg] )`       | Ensures that the numbers `expected` and `actual` are not within `delta` of each other.|
 | `assert_throws( symbol, [msg] ) { block }`                       | Ensures that the given block throws the symbol.|
@@ -392,6 +396,8 @@ Here's an extract of the assertions you can use with `minitest`, the default tes
 | `assert_not_respond_to( obj, symbol, [msg] )`                    | Ensures that `obj` does not respond to `symbol`.|
 | `assert_operator( obj1, operator, [obj2], [msg] )`               | Ensures that `obj1.operator(obj2)` is true.|
 | `assert_not_operator( obj1, operator, [obj2], [msg] )`           | Ensures that `obj1.operator(obj2)` is false.|
+| `assert_predicate ( obj, predicate, [msg] )`                     | Ensures that `obj.predicate` is true, e.g. `assert_predicate str, :empty?`|
+| `assert_not_predicate ( obj, predicate, [msg] )`                 | Ensures that `obj.predicate` is false, e.g. `assert_not_predicate str, :empty?`|
 | `assert_send( array, [msg] )`                                    | Ensures that executing the method listed in `array[1]` on the object in `array[0]` with the parameters of `array[2 and up]` is true. This one is weird eh?|
 | `flunk( [msg] )`                                                 | Ensures failure. This is useful to explicitly mark a test that isn't finished yet.|
 


### PR DESCRIPTION
Adds documentation for these assertion methods to the testing guide:
- `assert_empty`
- `assert_not_empty`
- `assert_includes`
- `assert_not_includes`
- `assert_predicate`
- `assert_not_predicate`

I've also linked the minitest assertions documentation page for the full list of minitest assertions, as well as the minitest github repo.

/cc @senny
