### PR TITLE
Fix rational to decimal on type_cast_from_user

### DIFF
--- a/activerecord/lib/active_record/type/decimal.rb
+++ b/activerecord/lib/active_record/type/decimal.rb
@@ -15,7 +15,7 @@ module ActiveRecord
 
       def cast_value(value)
         case value
-        when Numeric, String, Rational
+        when ::Numeric, ::String
           BigDecimal(value, precision.to_i)
         when proc { value.respond_to?(:to_d) }
           value.to_d

--- a/activerecord/lib/active_record/type/decimal.rb
+++ b/activerecord/lib/active_record/type/decimal.rb
@@ -14,7 +14,9 @@ module ActiveRecord
       private
 
       def cast_value(value)
-        if value.respond_to?(:to_d)
+        if value.class == Rational
+          BigDecimal.new(value, precision.to_i)
+        elsif value.respond_to?(:to_d)
           value.to_d
         else
           value.to_s.to_d

--- a/activerecord/lib/active_record/type/decimal.rb
+++ b/activerecord/lib/active_record/type/decimal.rb
@@ -23,7 +23,6 @@ module ActiveRecord
           cast_value(value.to_s)
         end
       end
-
     end
   end
 end

--- a/activerecord/lib/active_record/type/decimal.rb
+++ b/activerecord/lib/active_record/type/decimal.rb
@@ -14,14 +14,16 @@ module ActiveRecord
       private
 
       def cast_value(value)
-        if value.class == Rational
-          BigDecimal.new(value, precision.to_i)
-        elsif value.respond_to?(:to_d)
+        case value
+        when Numeric, String, Rational
+          BigDecimal(value, precision.to_i)
+        when proc { value.respond_to?(:to_d) }
           value.to_d
         else
-          value.to_s.to_d
+          cast_value(value.to_s)
         end
       end
+
     end
   end
 end

--- a/activerecord/test/cases/type/decimal_test.rb
+++ b/activerecord/test/cases/type/decimal_test.rb
@@ -1,0 +1,24 @@
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class DecimalTest < ActiveRecord::TestCase
+      def test_type_cast_decimal
+        type = Type::Decimal.new
+        assert_equal BigDecimal.new("0"), type.type_cast_from_user(BigDecimal.new("0"))
+        assert_equal BigDecimal.new("123"), type.type_cast_from_user(123.0)
+        assert_equal BigDecimal.new("1"), type.type_cast_from_user(:"1")
+      end
+
+      def test_type_cast_rational_to_decimal_with_precision
+        type = Type::Decimal.new(precision: 2)
+        assert_equal BigDecimal("0.33"), type.type_cast_from_user(Rational(1, 3))
+      end
+
+      def test_type_cast_rational_to_decimal_without_precision_defaults_to_18_36
+        type = Type::Decimal.new
+        assert_equal BigDecimal("0.333333333333333333E0"), type.type_cast_from_user(Rational(1, 3))
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/type/decimal_test.rb
+++ b/activerecord/test/cases/type/decimal_test.rb
@@ -1,23 +1,32 @@
 require "cases/helper"
 
 module ActiveRecord
-  module ConnectionAdapters
+  module Type
     class DecimalTest < ActiveRecord::TestCase
       def test_type_cast_decimal
-        type = Type::Decimal.new
+        type = Decimal.new
         assert_equal BigDecimal.new("0"), type.type_cast_from_user(BigDecimal.new("0"))
         assert_equal BigDecimal.new("123"), type.type_cast_from_user(123.0)
         assert_equal BigDecimal.new("1"), type.type_cast_from_user(:"1")
       end
 
-      def test_type_cast_rational_to_decimal_with_precision
-        type = Type::Decimal.new(precision: 2)
+      def test_type_cast_decimal_from_rational_with_precision
+        type = Decimal.new(precision: 2)
         assert_equal BigDecimal("0.33"), type.type_cast_from_user(Rational(1, 3))
       end
 
-      def test_type_cast_rational_to_decimal_without_precision_defaults_to_18_36
-        type = Type::Decimal.new
+      def test_type_cast_decimal_from_rational_without_precision_defaults_to_18_36
+        type = Decimal.new
         assert_equal BigDecimal("0.333333333333333333E0"), type.type_cast_from_user(Rational(1, 3))
+      end
+
+      def test_type_cast_decimal_from_object_responding_to_d
+        value = Object.new
+        def value.to_d
+          BigDecimal.new("1")
+        end
+        type = Decimal.new
+        assert_equal BigDecimal("1"), type.type_cast_from_user(value)
       end
     end
   end

--- a/activerecord/test/cases/types_test.rb
+++ b/activerecord/test/cases/types_test.rb
@@ -103,7 +103,7 @@ module ActiveRecord
       end
 
       def test_type_cast_rational_to_decimal_with_precision
-        type = Type::Decimal.new(:precision => 2)
+        type = Type::Decimal.new(precision: 2)
         assert_equal BigDecimal("0.33"), type.type_cast_from_user(Rational(1, 3))
       end
 

--- a/activerecord/test/cases/types_test.rb
+++ b/activerecord/test/cases/types_test.rb
@@ -102,6 +102,16 @@ module ActiveRecord
         assert_equal BigDecimal.new("1"), type.type_cast_from_user(:"1")
       end
 
+      def test_type_cast_rational_to_decimal_with_precision
+        type = Type::Decimal.new(:precision => 2)
+        assert_equal BigDecimal("0.33"), type.type_cast_from_user(Rational(1, 3))
+      end
+
+      def test_type_cast_rational_to_decimal_without_precision_defaults_to_18_36
+        type = Type::Decimal.new
+        assert_equal BigDecimal("0.333333333333333333E0"), type.type_cast_from_user(Rational(1, 3))
+      end
+
       def test_type_cast_binary
         type = Type::Binary.new
         assert_equal nil, type.type_cast_from_user(nil)

--- a/activerecord/test/cases/types_test.rb
+++ b/activerecord/test/cases/types_test.rb
@@ -95,23 +95,6 @@ module ActiveRecord
         assert_not type.changed?(nil, nil, nil)
       end
 
-      def test_type_cast_decimal
-        type = Type::Decimal.new
-        assert_equal BigDecimal.new("0"), type.type_cast_from_user(BigDecimal.new("0"))
-        assert_equal BigDecimal.new("123"), type.type_cast_from_user(123.0)
-        assert_equal BigDecimal.new("1"), type.type_cast_from_user(:"1")
-      end
-
-      def test_type_cast_rational_to_decimal_with_precision
-        type = Type::Decimal.new(precision: 2)
-        assert_equal BigDecimal("0.33"), type.type_cast_from_user(Rational(1, 3))
-      end
-
-      def test_type_cast_rational_to_decimal_without_precision_defaults_to_18_36
-        type = Type::Decimal.new
-        assert_equal BigDecimal("0.333333333333333333E0"), type.type_cast_from_user(Rational(1, 3))
-      end
-
       def test_type_cast_binary
         type = Type::Binary.new
         assert_equal nil, type.type_cast_from_user(nil)


### PR DESCRIPTION
We ran into a problem with Rationals and the `Decimal#cast_value` method. 
For a `Rational` type, use a precision or fallback to default `BigDecimal.new(value, 0)`

@Overbryd and @marianovalles
