### PR TITLE
Fix test encoding

### DIFF
--- a/actionpack/test/dispatch/uploaded_file_test.rb
+++ b/actionpack/test/dispatch/uploaded_file_test.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'abstract_unit'
 
 module ActionDispatch


### PR DESCRIPTION
Declare encoding for Ruby 1.9.3. Fixes this test:

https://github.com/goddamnhippie/rails/blob/master/actionpack/test/dispatch/uploaded_file_test.rb#L16-L19

It fails on travis:

https://travis-ci.org/rails/rails/jobs/30029315#L190-L193
