### PR TITLE
Revert "Rename to test_mysql_strict_mode_disabled_dont_override_global_sql_mode"

### DIFF
--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -134,12 +134,11 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     assert_equal [["STRICT_ALL_TABLES"]], result.rows
   end
 
-  def test_mysql_strict_mode_disabled_dont_override_global_sql_mode
+  def test_mysql_strict_mode_disabled
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.merge({:strict => false}))
-      global_sql_mode = ActiveRecord::Base.connection.exec_query "SELECT @@GLOBAL.sql_mode"
-      session_sql_mode = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.sql_mode"
-      assert_equal global_sql_mode.rows, session_sql_mode.rows
+      result = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.sql_mode"
+      assert_equal [['']], result.rows
     end
   end
 

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -60,12 +60,11 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     assert_equal [["STRICT_ALL_TABLES"]], result.rows
   end
 
-  def test_mysql_strict_mode_disabled_dont_override_global_sql_mode
+  def test_mysql_strict_mode_disabled
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.merge({:strict => false}))
-      global_sql_mode = ActiveRecord::Base.connection.exec_query "SELECT @@GLOBAL.sql_mode"
-      session_sql_mode = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.sql_mode"
-      assert_equal global_sql_mode.rows, session_sql_mode.rows
+      result = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.sql_mode"
+      assert_equal [['']], result.rows
     end
   end
 


### PR DESCRIPTION
This pull request addresses following failures when tested with MySQL 5.7.4-m14 by reverting babc24c1b07c1fd58b9b3249b0256f9b0d45c0f0 "Rename to test_mysql_strict_mode_disabled_dont_override_global_sql_mode".

``` ruby
$ for i in mysql mysql2
> do
> echo $i
> ARCONN=$i ruby -Itest test/cases/adapters/mysql/connection_test.rb -n test_mysql_strict_mode_disabled_dont_override_global_sql_mode
> done
mysql
Using mysql
Run options: -n test_mysql_strict_mode_disabled_dont_override_global_sql_mode --seed 28760

# Running:

F

Finished in 0.015911s, 62.8482 runs/s, 62.8482 assertions/s.

  1) Failure:
MysqlConnectionTest#test_mysql_strict_mode_disabled_dont_override_global_sql_mode [test/cases/adapters/mysql/connection_test.rb:142]:
Expected: [["NO_ENGINE_SUBSTITUTION"]]
  Actual: [[""]]

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
mysql2
Using mysql2
Run options: -n test_mysql_strict_mode_disabled_dont_override_global_sql_mode --seed 42108

# Running:

F

Finished in 0.016509s, 60.5734 runs/s, 60.5734 assertions/s.

  1) Failure:
MysqlConnectionTest#test_mysql_strict_mode_disabled_dont_override_global_sql_mode [test/cases/adapters/mysql/connection_test.rb:142]:
Expected: [["NO_ENGINE_SUBSTITUTION"]]
  Actual: [[""]]

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

because since a4c26249 merged to master `@@SESSION.sql_mode` becomes empty when `:strict => false` executed, before this commit it was just unchanged.

Also MySQL 5.7 the default value of sql_mode is `NO_ENGINE_SUBSTITUTION`, it was empty with MySQL 5.6.
- http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html
  >>
  The default SQL mode in MySQL 5.7 is NO_ENGINE_SUBSTITUTION. 
  <<
