### PR TITLE
Remove unused 1:1 association :remote option

### DIFF
--- a/activerecord/lib/active_record/associations/builder/singular_association.rb
+++ b/activerecord/lib/active_record/associations/builder/singular_association.rb
@@ -3,7 +3,7 @@
 module ActiveRecord::Associations::Builder
   class SingularAssociation < Association #:nodoc:
     def valid_options
-      super + [:remote, :dependent, :primary_key, :inverse_of, :required]
+      super + [:dependent, :primary_key, :inverse_of, :required]
     end
 
     def self.define_accessors(model, reflection)


### PR DESCRIPTION
This option is unused, left over from pre-1.0 Rails to internally distinguish the location of the foreign key.
