### PR TITLE
Fix broken list formatting in API docs [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -13,13 +13,13 @@ module ActionView
       # * <tt>:inline</tt> - Renders an inline template similar to how it's done in the controller.
       # * <tt>:text</tt> - Renders the text passed in out.
       # * <tt>:plain</tt> - Renders the text passed in out. Setting the content
-      # type as <tt>text/plain</tt>.
+      #   type as <tt>text/plain</tt>.
       # * <tt>:html</tt> - Renders the html safe string passed in out, otherwise
-      # performs html escape on the string first. Setting the content type as
-      # <tt>text/html</tt>.
+      #   performs html escape on the string first. Setting the content type as
+      #   <tt>text/html</tt>.
       # * <tt>:body</tt> - Renders the text passed in, and inherits the content
-      # type of <tt>text/html</tt> from <tt>ActionDispatch::Response</tt>
-      # object.
+      #   type of <tt>text/html</tt> from <tt>ActionDispatch::Response</tt>
+      #   object.
       #
       # If no options hash is passed or :update specified, the default is to render a partial and use the second parameter
       # as the locals hash.


### PR DESCRIPTION
Incorrect indentation meant that text was being inappropriately broken onto a new line in the compiled output. See http://edgeapi.rubyonrails.org/classes/ActionView/Helpers/RenderingHelper.html#method-i-render
