### PR TITLE
Add before_last method for arrays

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `Array#before_last` to get elements with a certain number from the end of an array.
+
+    *Mohamed Osama*
+
 *   Add `String#truncate_words` to truncate a string by a number of words.
 
     *Mohamed Osama*

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -57,4 +57,12 @@ class Array
   def forty_two
     self[41]
   end
+
+  # Equal to <tt>self[size - number]</tt>.
+  #
+  #   %w( a b c d e ).before_last(number: 2) # => "c"
+  def before_last(options = {})
+    return self[size - 2] unless options[:number]
+    self[size - options[:number] - 1]
+  end
 end

--- a/activesupport/test/core_ext/array_ext_test.rb
+++ b/activesupport/test/core_ext/array_ext_test.rb
@@ -22,7 +22,7 @@ class ArrayExtAccessTests < ActiveSupport::TestCase
     assert_equal %w(), %w( a b c ).to(-10)
   end
 
-  def test_second_through_tenth
+  def test_specific_position_access
     array = (1..42).to_a
 
     assert_equal array[1], array.second
@@ -30,6 +30,9 @@ class ArrayExtAccessTests < ActiveSupport::TestCase
     assert_equal array[3], array.fourth
     assert_equal array[4], array.fifth
     assert_equal array[41], array.forty_two
+    assert_equal array[40], array.before_last
+    assert_equal array[39], array.before_last(number: 2)
+    assert_equal array[39], array.before_last(number: 44)
   end
 end
 


### PR DESCRIPTION
As for me, I need this a lot in rails console and for some other operations while development.

The thing I feel weird is finding a method "forty_two" for array access. Seriously? :smile: 
