### PR TITLE
Default HTML email parts to Content-Transfer-Encoding: Quoted-Printable

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -878,8 +878,15 @@ module ActionMailer
 
     def insert_part(container, response, charset) #:nodoc:
       response[:charset] ||= charset
+      response[:content_transfer_encoding] ||= content_transfer_encoding_for_type(response[:content_type])
       part = Mail::Part.new(response)
       container.add_part(part)
+    end
+
+    def content_transfer_encoding_for_type(content_type)
+      case Mime::Type.parse(content_type.to_s)[0]
+      when Mime::HTML then "quoted-printable"
+      end
     end
 
     ActiveSupport.run_load_hooks(:action_mailer, self)

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -141,7 +141,7 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal(2, email.parts.length)
     assert_equal("multipart/mixed", email.mime_type)
     assert_equal("text/html", email.parts[0].mime_type)
-    assert_equal("Attachment with content", email.parts[0].body.encoded)
+    assert_equal("Attachment with content=\r\n", email.parts[0].body.encoded)
     assert_equal("application/pdf", email.parts[1].mime_type)
     assert_equal("VGhpcyBpcyB0ZXN0IEZpbGUgY29udGVudA==\r\n", email.parts[1].body.encoded)
   end
@@ -240,7 +240,7 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("text/plain", email.parts[0].mime_type)
     assert_equal("TEXT Implicit Multipart", email.parts[0].body.encoded)
     assert_equal("text/html", email.parts[1].mime_type)
-    assert_equal("HTML Implicit Multipart", email.parts[1].body.encoded)
+    assert_equal("HTML Implicit Multipart=\r\n", email.parts[1].body.encoded)
   end
 
   test "implicit multipart with sort order" do
@@ -263,7 +263,7 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("text/plain", email.parts[1].parts[0].mime_type)
     assert_equal("TEXT Implicit Multipart", email.parts[1].parts[0].body.encoded)
     assert_equal("text/html", email.parts[1].parts[1].mime_type)
-    assert_equal("HTML Implicit Multipart", email.parts[1].parts[1].body.encoded)
+    assert_equal("HTML Implicit Multipart=\r\n", email.parts[1].parts[1].body.encoded)
   end
 
   test "implicit multipart with attachments and sort order" do
@@ -284,7 +284,7 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("text/plain", email.parts[0].mime_type)
     assert_equal("Implicit with locale TEXT", email.parts[0].body.encoded)
     assert_equal("text/html", email.parts[1].mime_type)
-    assert_equal("Implicit with locale EN HTML", email.parts[1].body.encoded)
+    assert_equal("Implicit with locale EN HTML=\r\n", email.parts[1].body.encoded)
   end
 
   test "implicit multipart with other locale" do
@@ -295,7 +295,7 @@ class BaseTest < ActiveSupport::TestCase
       assert_equal("text/plain", email.parts[0].mime_type)
       assert_equal("Implicit with locale PL TEXT", email.parts[0].body.encoded)
       assert_equal("text/html", email.parts[1].mime_type)
-      assert_equal("Implicit with locale HTML", email.parts[1].body.encoded)
+      assert_equal("Implicit with locale HTML=\r\n", email.parts[1].body.encoded)
     end
   end
 
@@ -329,7 +329,7 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("text/plain", email.parts[0].mime_type)
     assert_equal("TEXT Explicit Multipart", email.parts[0].body.encoded)
     assert_equal("text/html", email.parts[1].mime_type)
-    assert_equal("HTML Explicit Multipart", email.parts[1].body.encoded)
+    assert_equal("HTML Explicit Multipart=\r\n", email.parts[1].body.encoded)
   end
 
   test "explicit multipart have a boundary" do
@@ -344,7 +344,7 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("text/plain", email.parts[1].parts[0].mime_type)
     assert_equal("TEXT Explicit Multipart", email.parts[1].parts[0].body.encoded)
     assert_equal("text/html", email.parts[1].parts[1].mime_type)
-    assert_equal("HTML Explicit Multipart", email.parts[1].parts[1].body.encoded)
+    assert_equal("HTML Explicit Multipart=\r\n", email.parts[1].parts[1].body.encoded)
   end
 
   test "explicit multipart with templates" do
@@ -354,7 +354,7 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("text/plain", email.parts[0].mime_type)
     assert_equal("TEXT Explicit Multipart Templates", email.parts[0].body.encoded)
     assert_equal("text/html", email.parts[1].mime_type)
-    assert_equal("HTML Explicit Multipart Templates", email.parts[1].body.encoded)
+    assert_equal("HTML Explicit Multipart Templates=\r\n", email.parts[1].body.encoded)
   end
 
   test "explicit multipart with format.any" do
@@ -364,7 +364,7 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("text/plain", email.parts[0].mime_type)
     assert_equal("Format with any!", email.parts[0].body.encoded)
     assert_equal("text/html", email.parts[1].mime_type)
-    assert_equal("Format with any!", email.parts[1].body.encoded)
+    assert_equal("Format with any!=\r\n", email.parts[1].body.encoded)
   end
 
   test "explicit multipart with format(Hash)" do
@@ -375,7 +375,7 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("text/plain", email.parts[0].mime_type)
     assert_equal("base64", email.parts[0].content_transfer_encoding)
     assert_equal("text/html", email.parts[1].mime_type)
-    assert_equal("7bit", email.parts[1].content_transfer_encoding)
+    assert_equal("quoted-printable", email.parts[1].content_transfer_encoding)
   end
 
   test "explicit multipart with one part is rendered as body and options are merged" do
@@ -392,7 +392,7 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("text/plain", email.parts[0].mime_type)
     assert_equal("[:text]", email.parts[0].body.encoded)
     assert_equal("text/html", email.parts[1].mime_type)
-    assert_equal("[:html]", email.parts[1].body.encoded)
+    assert_equal("[:html]=\r\n", email.parts[1].body.encoded)
   end
 
   test "explicit multipart with sort order" do


### PR DESCRIPTION
**The problem**: If an email template generates a line longer than 998 characters, it is likely that the outgoing mail server will insert a line break after the 998th character. 

In plain-text emails, this often results in a word split across two lines—ugly, but rarely a problem, since the convention is to hard-wrap at 72 columns.

But this behavior is particularly problematic in HTML emails, where e.g. rendering an autolinked paragraph can result in a long string of markup with the URL mangled by inadvertent whitespace.

**The explanation**: According to [RFC 2822](http://tools.ietf.org/html/rfc2822#section-2.1.1),

> Each line of characters [in a message body] MUST be no more than
> 998 characters, and SHOULD be no more than 78 characters, excluding
> the CRLF.

Many mail servers, notably Postfix, enforce this line limit by inserting a CRLF at position 999.

Action Mailer currently does not set a default Content-Transfer-Encoding for HTML email parts, and so the Mail library defaults to `7bit` or `8bit` accordingly. Message bodies in these encodings are raw and unmodified. That means if you generate a 1500-character line in your HTML template, that line goes through unmodified to the mail server.

Two alternative encodings solve this issue, each in a different way:
1. The `Base64` encoding is impervious to whitespace and can be wrapped at any column.
2. The `Quoted-Printable` encoding never generates lines longer than 76 characters.

**The solution**: Default HTML email parts to a Content-Transfer-Encoding of `Quoted-Printable`, as per [this post on the Postfix mailing list](https://groups.yahoo.com/neo/groups/postfix-users/conversations/topics/273296). Either encoding will work, but Quoted-Printable tends to be more space-efficient than Base64 for Latin-language HTML.
