### PR TITLE
Additional help messaging to help the user resolve a conflicted migration

### DIFF
--- a/railties/lib/rails/generators/actions/create_migration.rb
+++ b/railties/lib/rails/generators/actions/create_migration.rb
@@ -55,7 +55,8 @@ module Rails
           else
             say_status :conflict, :red
             raise Error, "Another migration is already named #{migration_file_name}: " +
-                         "#{existing_migration}. Use --force to replace this migration file."
+                         "#{existing_migration}. Use --force to replace this migration" +
+                         " or --skip to ignore conflicted file."
           end
         end
 

--- a/railties/lib/rails/generators/actions/create_migration.rb
+++ b/railties/lib/rails/generators/actions/create_migration.rb
@@ -54,9 +54,9 @@ module Rails
             say_status :skip, :yellow
           else
             say_status :conflict, :red
-            raise Error, "Another migration is already named #{migration_file_name}: " +
-                         "#{existing_migration}. Use --force to replace this migration" +
-                         " or --skip to ignore conflicted file."
+            raise Error, "Another migration is already named #{migration_file_name}: " \
+              "#{existing_migration}. Use --force to replace this migration " \
+              "or --skip to ignore conflicted file."
           end
         end
 


### PR DESCRIPTION
Added additional help messaging for command line scaffold generation. When a migration already exists for the resource, the user is now alerted that they are able to skip the conflicted migration file via the --skip option.

This functionality already exists; I've just updated the help output to remind the user that skipping the migration creation is an option as well.
