### PR TITLE
Some ActionView renderer refactors

### DIFF
--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -29,8 +29,9 @@ module ActionView
 
     def extract_details(options)
       @lookup_context.registered_details.each_with_object({}) do |key, details|
-        next unless value = options[key]
-        details[key] = Array(value)
+        value = options[key]
+
+        details[key] = Array(value) if value
       end
     end
 
@@ -41,6 +42,7 @@ module ActionView
     def prepend_formats(formats)
       formats = Array(formats)
       return if formats.empty? || @lookup_context.html_fallback_for_js
+
       @lookup_context.formats = formats | @lookup_context.formats
     end
   end

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -312,6 +312,8 @@ module ActionView
       end
     end
 
+    private
+
     def render_collection
       return nil if @collection.blank?
 

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -6,13 +6,10 @@ module ActionView
       @view    = context
       @details = extract_details(options)
       template = determine_template(options)
-      context  = @lookup_context
 
       prepend_formats(template.formats)
 
-      unless context.rendered_format
-        context.rendered_format = template.formats.first || formats.first
-      end
+      @lookup_context.rendered_format ||= (template.formats.first || formats.first)
 
       render_template(template, options[:layout], options[:locals])
     end

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -14,8 +14,10 @@ module ActionView
       render_template(template, options[:layout], options[:locals])
     end
 
+    private
+
     # Determine the template to be rendered using the given options.
-    def determine_template(options) #:nodoc:
+    def determine_template(options)
       keys = options.fetch(:locals, {}).keys
 
       if options.key?(:body)

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -324,6 +324,10 @@ module RenderTestCases
       @controller_view.render(customers, :greeting => "Hello")
   end
 
+  def test_render_partial_using_collection_without_path
+    assert_equal "hi good customer: david0", @controller_view.render([ GoodCustomer.new("david") ], greeting: "hi")
+  end
+
   def test_render_partial_without_object_or_collection_does_not_generate_partial_name_local_variable
     exception = assert_raises ActionView::Template::Error do
       @controller_view.render("partial_name_local_variable")
@@ -386,6 +390,14 @@ module RenderTestCases
     assert_equal 'source: "Hello, <%= name %>!"', @view.render(inline: "Hello, <%= name %>!", locals: { name: "Josh" }, type: :foo)
   ensure
     ActionView::Template.unregister_template_handler :foo
+  end
+
+  def test_render_body
+    assert_equal 'some body', @view.render(body: 'some body')
+  end
+
+  def test_render_plain
+    assert_equal 'some plaintext', @view.render(plain: 'some plaintext')
   end
 
   def test_render_knows_about_types_registered_when_extensions_are_checked_earlier_in_initialization


### PR DESCRIPTION
Some small refactors to Action View renderers:
- Marked methods private which don't work on their own anyways (e.g. in `PartialRenderer`, only the main `render` method sets up instance vars which are needed for the other render methods to work).
- Added some missing test coverage
- Simple line-level code cleanup

Leaving commits separate for review, can squash before merge if approved.

I think more substantial refactors can be done to the renderers, but want to start with the simpler stuff first.
