### PR TITLE
UrlGenerationError are not catched as 404 anymore

### DIFF
--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -25,7 +25,7 @@ module ActionController
     end
   end
 
-  class ActionController::UrlGenerationError < RoutingError #:nodoc:
+  class ActionController::UrlGenerationError < ActionControllerError #:nodoc:
   end
 
   class MethodNotAllowed < ActionControllerError #:nodoc:

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -60,6 +60,21 @@ module ApplicationTests
       assert_equal "YOU FAILED BRO", last_response.body
     end
 
+    test "url generation error when action_dispatch.show_exceptions is set raises an exception" do
+      controller :foo, <<-RUBY
+        class FooController < ActionController::Base
+          def index
+            raise ActionController::UrlGenerationError
+          end
+        end
+      RUBY
+      
+      app.config.action_dispatch.show_exceptions = true
+
+      get '/foo'
+      assert_equal 500, last_response.status
+    end
+
     test "unspecified route when action_dispatch.show_exceptions is not set raises an exception" do
       app.config.action_dispatch.show_exceptions = false
 


### PR DESCRIPTION
Fixes: https://github.com/rails/rails/issues/14185

Since `UrlGenerationError` inherits from `RoutingError`, it is handled as a 404 by default.

In my opinion it's not a good idea. Failing to generate an URL should be a 500 not a 404, and it should not be silently swallowed but reported to whatever error handler is present.
