### PR TITLE
Missing test for form values before type cast

### DIFF
--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -694,6 +694,13 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_text_area_with_value_before_type_cast
+    assert_dom_equal(
+      %{<textarea id="post_id" name="post[id]">\n123</textarea>},
+      text_area("post", "id")
+    )
+  end
+
   def test_text_area_with_html_entities
     @post.body = "The HTML Entity for & is &amp;"
     assert_dom_equal(


### PR DESCRIPTION
https://github.com/rails/rails/pull/16225 was closed for being mostly cosmetic, but I think at least the test coverage has value. Without this, https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/tags/base.rb#L36 isn't covered anywhere in AV.
