### PR TITLE
Fix AC::TemplateAssertions instance variables not resetting.

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -13,10 +13,7 @@ module ActionController
     end
 
     def setup_subscriptions
-      @_partials = Hash.new(0)
-      @_templates = Hash.new(0)
-      @_layouts = Hash.new(0)
-      @_files = Hash.new(0)
+      reset_template_assertion
       @_subscribers = []
 
       @_subscribers << ActiveSupport::Notifications.subscribe("render_template.action_view") do |_name, _start, _finish, _id, payload|
@@ -56,10 +53,15 @@ module ActionController
     end
 
     def process(*args)
+      reset_template_assertion
+      super
+    end
+
+    def reset_template_assertion
       @_partials = Hash.new(0)
       @_templates = Hash.new(0)
       @_layouts = Hash.new(0)
-      super
+      @_files = Hash.new(0)
     end
 
     # Asserts that the request was rendered with the appropriate template file or partials.

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -329,6 +329,7 @@ module ActionDispatch
          xml_http_request xhr get_via_redirect post_via_redirect).each do |method|
         define_method(method) do |*args|
           reset! unless integration_session
+          reset_template_assertion
           # reset the html_document variable, but only for new get/post calls
           @html_document = nil unless method == 'cookies' || method == 'assigns'
           integration_session.__send__(method, *args).tap do

--- a/actionpack/test/dispatch/template_assertions_test.rb
+++ b/actionpack/test/dispatch/template_assertions_test.rb
@@ -1,0 +1,58 @@
+require 'abstract_unit'
+
+class AssertTemplateController < ActionController::Base
+  def render_with_partial
+    render partial: 'test/partial'
+  end
+
+  def render_with_template
+    render 'test/hello_world'
+  end
+
+  def render_with_layout
+    @variable_for_layout = nil
+    render 'test/hello_world', layout: "layouts/standard"
+  end
+
+  def render_with_file
+    render file: 'README.rdoc'
+  end
+
+  def render_nothing
+    head :ok
+  end
+end
+
+class AssertTemplateControllerTest < ActionDispatch::IntegrationTest
+  def test_assert_template_reset_between_requests
+    get '/assert_template/render_with_template'
+    assert_template 'test/hello_world'
+
+    get '/assert_template/render_nothing'
+    assert_template nil
+  end
+
+  def test_assert_partial_reset_between_requests
+    get '/assert_template/render_with_partial'
+    assert_template partial: 'test/_partial'
+
+    get '/assert_template/render_nothing'
+    assert_template partial: nil
+  end
+
+  def test_assert_layout_reset_between_requests
+    get '/assert_template/render_with_layout'
+    assert_template layout: 'layouts/standard'
+
+    get '/assert_template/render_nothing'
+    assert_template layout: nil
+  end
+
+  def test_assert_file_reset_between_requests
+    get '/assert_template/render_with_file'
+    assert_template file: 'README.rdoc'
+
+    get '/assert_template/render_nothing'
+    assert_template file: nil
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/16119.
