### PR TITLE
Remove the side-effects of validates_presence_of.

### DIFF
--- a/activerecord/test/cases/validations/presence_validation_test.rb
+++ b/activerecord/test/cases/validations/presence_validation_test.rb
@@ -52,14 +52,15 @@ class PresenceValidationTest < ActiveRecord::TestCase
   end
 
   def test_validates_presence_doesnt_convert_to_array
-    Speedometer.validates_presence_of :dashboard
+    speedometer = Class.new(Speedometer)
+    speedometer.validates_presence_of :dashboard
 
     dash = Dashboard.new
 
     # dashboard has to_a method
     def dash.to_a; ['(/)', '(\)']; end
 
-    s = Speedometer.new
+    s = speedometer.new
     s.dashboard = dash
 
     assert_nothing_raised { s.valid? }


### PR DESCRIPTION
The validation added to Speedometer class will result in failures of other tests such as [this](https://github.com/rails/rails/blob/master/activerecord/test/cases/associations/has_many_associations_test.rb#L1881) and [this](https://github.com/rails/rails/blob/master/activerecord/test/cases/calculations_test.rb#L259), with the error `Validation failed: Dashboard can't be blank`.

cc @senny
