### PR TITLE
Remove length limit that results failure in other tests.

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -63,7 +63,7 @@ class MigrationTest < ActiveRecord::TestCase
     end
     Person.connection.remove_column("people", "first_name") rescue nil
     Person.connection.remove_column("people", "middle_name") rescue nil
-    Person.connection.add_column("people", "first_name", :string, :limit => 40)
+    Person.connection.add_column("people", "first_name", :string, null: false)
     Person.reset_column_information
   end
 


### PR DESCRIPTION
We are not actually using this `limit` anywhere, but including this will fail tests such as [OptimisticLockingTest#test_removing_has_and_belongs_to_many_associations_upon_destroy](https://github.com/rails/rails/blob/master/activerecord/test/cases/locking_test.rb#L268) because the first name to insert is `Jonrun_before_createrun_before_validation`, which is unfortunately 41 characters long.

cc @senny
