### PR TITLE
Make sure assertion passes for postgresql.

### DIFF
--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -130,7 +130,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   def test_has_many_through_has_one_through_with_has_one_source_reflection_preload
     members = assert_queries(4) { Member.includes(:nested_sponsors).to_a }
     mustache = sponsors(:moustache_club_sponsor_for_groucho)
-    assert_no_queries do
+    assert_no_queries(ignore_none: false) do
       assert_equal [mustache], members.first.nested_sponsors
     end
   end


### PR DESCRIPTION
Similar to #L191, otherwise the test will sometimes fail in postgresql because `SHOW max_identifier_length` query is executed.

cc @senny
