### PR TITLE
Remove redundant reset that already happened in teardown.

### DIFF
--- a/activerecord/test/cases/attribute_decorators_test.rb
+++ b/activerecord/test/cases/attribute_decorators_test.rb
@@ -45,7 +45,6 @@ module ActiveRecord
 
     test "decoration does not eagerly load existing columns" do
       assert_no_queries do
-        Model.reset_column_information
         Model.decorate_attribute_type(:a_string, :test) { |t| StringDecorator.new(t) }
       end
     end


### PR DESCRIPTION
Sometimes this test case fails in postgres because the following query is executed:

``` sql
SELECT COUNT(*)
FROM pg_class c
LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
WHERE c.relkind IN ('r','v','m') -- (r)elation/table, (v)iew, (m)aterialized view
AND c.relname = 'attribute_decorators_model'
AND n.nspname = ANY (current_schemas(false))
```

By removing this line which is already included in `teardown`, it seems to solve the problem. But I'm not 100% sure if that's the reason behind the failure. Any thoughts, @senny?
