### PR TITLE
reset_column_infomation shouldn't be part of the assertion.

### DIFF
--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -16,8 +16,8 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_serialize_does_not_eagerly_load_columns
+    Topic.reset_column_information
     assert_no_queries do
-      Topic.reset_column_information
       Topic.serialize(:content)
     end
   end


### PR DESCRIPTION
Refer to #16254.

Having `reset_column_information` sometimes fails the assertion.

cc @senny
