### PR TITLE
Set Psych as the YAML engine for Rubinius

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,12 @@ platforms :jruby do
   end
 end
 
+platforms :rbx do
+  # The rubysl-yaml gem doesn't ship with Psych by default
+  # as it needs libyaml that isn't always available.
+  gem 'psych', '~> 2.0'
+end
+
 # gems that are necessary for ActiveRecord tests with Oracle database
 if ENV['ORACLE_ENHANCED']
   platforms :ruby do

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -114,6 +114,7 @@ module Rails
          jbuilder_gemfile_entry,
          sdoc_gemfile_entry,
          spring_gemfile_entry,
+         psych_gemfile_entry,
          @extra_entries].flatten.find_all(&@gem_filter)
       end
 
@@ -311,6 +312,14 @@ module Rails
         return [] unless spring_install?
         comment = 'Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring'
         GemfileEntry.new('spring', nil, comment, group: :development)
+      end
+
+      def psych_gemfile_entry
+        return [] unless defined?(Rubinius)
+
+        comment = 'Use Psych as the YAML engine, instead of Syck, so serialized ' \
+                  'data can be read safely from different rubies (see http://git.io/uuLVag)'
+        GemfileEntry.new('psych', '~> 2.0', comment, platforms: :rbx)
       end
 
       def bundle_command(command)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -488,6 +488,19 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_psych_gem
+    run_generator
+    gem_regex = /gem 'psych',\s+'~> 2.0', \s+platforms: :rbx/
+
+    assert_file "Gemfile" do |content|
+      if defined?(Rubinius)
+        assert_match(gem_regex, content)
+      else
+        assert_no_match(gem_regex, content)
+      end
+    end
+  end
+
   protected
 
   def action(*args, &block)


### PR DESCRIPTION
Hello,

Since the rubysl-yaml gem doesn't ship with Psych by default because of its dependency on libyaml, on Rubinius, the default engine is Syck. However, if we want to be able to run the application safely on different rubies, we need to make people using Rubinius rely on Psych.

See http://git.io/uuLVag for further information.

Have a nice day.
