### PR TITLE
AR relation accepts :primary_key as proc

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -85,6 +85,12 @@ module ActiveRecord
     end
   end
 
+  class NonScalarPrimaryKeyError < ActiveRecordError #:nodoc:
+    def initialize(reflection)
+      super("Can not join association #{reflection.name.inspect}, because :primary_key is a callable. Use Relation#includes or specify a join column name")
+    end
+  end
+
   class ReadOnlyAssociation < ActiveRecordError #:nodoc:
     def initialize(reflection)
       super("Cannot add to a has_many :through association. Try adding to #{reflection.through_reflection.name.inspect}.")

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -10,6 +10,10 @@ module ActiveRecord
         attr_accessor :tables
 
         def initialize(reflection, children)
+          if reflection.options[:primary_key].respond_to?(:call)
+            raise NonScalarPrimaryKeyError.new(reflection)
+          end
+
           super(reflection.klass, children)
 
           @reflection      = reflection

--- a/activerecord/test/cases/associations/association_key_as_proc_test.rb
+++ b/activerecord/test/cases/associations/association_key_as_proc_test.rb
@@ -1,0 +1,31 @@
+require 'cases/helper'
+require 'models/post'
+require 'models/comment'
+
+class AssociationKeyAsProcTest < ActiveRecord::TestCase
+  def setup
+    @post = Post.create :title => 'Some post', :body => 'Post body'
+    @parent = Comment.create :post => @post, :body => "I'm parent"
+    @child1 = Comment.create :post => @post, :body => "I'm child#1", :parent => @parent
+    @child2 = Comment.create :post => @post, :body => "I'm child#2", :parent => @parent
+    @subchild = Comment.create :post => @post, :body => "I'm subchild", :parent => @child1
+  end
+
+  def test_loading_an_association_using_proc_for_pk
+    siblings_and_children = @child1.siblings_and_children
+
+    assert siblings_and_children.include?(@child2)
+    assert siblings_and_children.include?(@subchild)
+  end
+
+  def test_loading_an_association_using_proc_for_pk_with_include
+    comment = Comment.where(:body => @child1.body).includes(:siblings_and_children).first
+    assert_no_queries { comment.siblings_and_children.length }
+  end
+
+  def test_loading_an_association_using_proc_for_pk_with_join
+    assert_raises(ActiveRecord::NonScalarPrimaryKeyError) {
+      Comment.where(:body => @child1.body).joins(:siblings_and_children).first
+    }
+  end
+end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -16,6 +16,8 @@ class Comment < ActiveRecord::Base
 
   has_many :children, :class_name => 'Comment', :foreign_key => :parent_id
   belongs_to :parent, :class_name => 'Comment', :counter_cache => :children_count
+  has_many :siblings_and_children, :class_name => 'Comment',
+    :foreign_key => :parent_id, :primary_key => proc { |c| [c.parent_id, c.id] }
 
   def self.what_are_you
     'a comment...'


### PR DESCRIPTION
Sometimes you need the power of eager loading with `includes` to avoid N+1 queries, but primary key for link is not just a column value.
Current implementation forces us to write a method, which fetches relation for each item if key for fetching isn't simple value.

I suggest to give a possibility to specify arbitrary key-values for loading with `includes`: 
- you define a proc which accepts an instance
- this proc returns keys (ID's), one or many, of linked rows in another table
- they will be fetched altogether if `includes` is used further 

I think, this is more flexible in comparison with just a column name anyway.
Of course, joins becomes impossible for this case, and I raise in this case,
but you can always specify multiple relations (one for join, another for include) if needed.

P.S.
The example given in tests I provide may look obscure, but imagine another use case:
- you have a hierarchy of tags bound to to things
- you need to fetch tags (flat) based on criteria
- each tag should have a group of things that are linked either to this tag, or it's it parents (which id's are stored in ancestry).
  I'd like to provide this in tests but tags haven't neither parent_id nor ancestry, and I used Comment instead

If you like this I will also submit a backport for 3.2 (for which I developed this actually :) )
