### PR TITLE
Make HWIA copy the default proc too.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make `Hash#with_indifferent_access` copy the default proc too.
+
+    *arthurnn*, *Xanders*
+
 *   Add `String#truncate_words` to truncate a string by a number of words.
 
     *Mohamed Osama*

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -75,6 +75,7 @@ module ActiveSupport
       hash = hash.to_hash
       new(hash).tap do |new_hash|
         new_hash.default = hash.default
+        new_hash.default_proc = hash.default_proc if hash.default_proc
       end
     end
 

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1543,6 +1543,17 @@ class HashToXmlTest < ActiveSupport::TestCase
     assert_equal 3, hash_wia.default
   end
 
+  def test_should_copy_the_default_proc_when_converting_to_hash_with_indifferent_access
+    hash = Hash.new do
+      2 + 1
+    end
+    assert_equal 3, hash[:foo]
+
+    hash_wia = hash.with_indifferent_access
+    assert_equal 3, hash_wia[:foo]
+    assert_equal 3, hash_wia[:bar]
+  end
+
   # The XML builder seems to fail miserably when trying to tag something
   # with the same name as a Kernel method (throw, test, loop, select ...)
   def test_kernel_method_names_to_xml


### PR DESCRIPTION
As described on #16279, when calling `with_indifferent_access` on a hash, we should no drop the default proc.

Maybe this is because of some particular reason I missed out, please let me know.

[fixes #16279]

review @chancancode @rafaelfranca
