### PR TITLE
Fix protect_from_forgery docs

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -77,7 +77,7 @@ module ActionController #:nodoc:
     end
 
     module ClassMethods
-      # Turn on request forgery protection. Bear in mind that only non-GET, HTML/JavaScript requests are checked.
+      # Turn on request forgery protection. Bear in mind that GET and HEAD requests are not checked.
       #
       #   class ApplicationController < ActionController::Base
       #     protect_from_forgery


### PR DESCRIPTION
The `protect_from_forgery` docs currently read "Bear in mind that only non-GET, HTML/JavaScript requests are checked." I am pretty sure this is wrong and has been wrong for some time. Specifically, from examining the [code](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/request_forgery_protection.rb#L248-L252), `verified_request?` checks the request as long as it's a non-GET, non-HEAD request and request forgery protection is enabled. I looked back through the code history and found a [`verifiable_request_format?`](https://github.com/rails/rails/blob/4e3ed5bc44f6cd20c9e353ab63fd24b92a7942be/actionpack/lib/action_controller/request_forgery_protection.rb#L53-L55) method that checks for HTML and JavaScript which has since been removed.
