### PR TITLE
Remove finishing? method from transaction.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -357,7 +357,9 @@ module ActiveRecord
       end
 
       def current_savepoint_name
-        "active_record_#{open_transactions}"
+        if current_transaction.is_a? SavepointTransaction
+          current_transaction.savepoint_name
+        end
       end
 
       # Check the connection back in to the connection pool


### PR DESCRIPTION
The `@finishing` variable on the transaction object was a work-around for
the savepoint name, so after a rollback/commit the savepoint could be
released with the previous name.
With a little bit of refactoring we dont need it anymore, and we can store the savepoint name locally instead.

related:
9296e6939bcc786149a07dac334267c4035b623a
60c88e64e26682a954f7c8cd6669d409ffffcc8b

@jonleighton if you could double check that I didnt miss anything here would be awesome :heart:
review @chancancode @rafaelfranca @tenderlove @spastorino
