### PR TITLE
Transactions refactoring

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -69,6 +69,10 @@ module ActiveRecord
       def state
         @state
       end
+
+      def savepoint_name
+        nil
+      end
     end
 
     class TransactionState
@@ -233,7 +237,8 @@ module ActiveRecord
 
         super
 
-        @savepoint_name = "active_record_#{number}"
+        # Savepoint name only counts the Savepoint transactions, so we need to subtract 1
+        @savepoint_name = "active_record_#{number - 1}"
         connection.create_savepoint(@savepoint_name)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -357,7 +357,9 @@ module ActiveRecord
       end
 
       def current_savepoint_name
-        "active_record_#{open_transactions}"
+        if current_transaction.is_a? SavepointTransaction
+          current_transaction.savepoint_name
+        end
       end
 
       # Check the connection back in to the connection pool

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -45,6 +45,7 @@ module ActiveRecord
     end
 
     autoload_at 'active_record/connection_adapters/abstract/transaction' do
+      autoload :TransactionManager
       autoload :ClosedTransaction
       autoload :RealTransaction
       autoload :SavepointTransaction

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -358,9 +358,7 @@ module ActiveRecord
       end
 
       def current_savepoint_name
-        if current_transaction.is_a? SavepointTransaction
-          current_transaction.savepoint_name
-        end
+        current_transaction.savepoint_name
       end
 
       # Check the connection back in to the connection pool

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -424,6 +424,26 @@ class TransactionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_savepoints_name
+    Topic.transaction do
+      assert_nil Topic.connection.current_savepoint_name
+      assert_nil Topic.connection.current_transaction.savepoint_name
+
+      Topic.transaction(requires_new: true) do
+        assert_equal "active_record_1", Topic.connection.current_savepoint_name
+        assert_equal "active_record_1", Topic.connection.current_transaction.savepoint_name
+
+        Topic.transaction(requires_new: true) do
+          assert_equal "active_record_2", Topic.connection.current_savepoint_name
+          assert_equal "active_record_2", Topic.connection.current_transaction.savepoint_name
+        end
+
+        assert_equal "active_record_1", Topic.connection.current_savepoint_name
+        assert_equal "active_record_1", Topic.connection.current_transaction.savepoint_name
+      end
+    end
+  end
+
   def test_rollback_when_commit_raises
     Topic.connection.expects(:begin_db_transaction)
     Topic.connection.expects(:commit_db_transaction).raises('OH NOES')


### PR DESCRIPTION
This includes #16283 + 1 more commit to add a transaction stack and to keep the same public API.
My idea is to deprecate all transaction methods from the `connection` and offer the use of `connection. transaction_stack` instead. So we can slowly remove transaction concerns from the connection object.
The idea is also to instead of having the `Transaction` object that points to its parent, we have a `transaction_stack` which holds all transactions. Thus we can pop transactions before calling methods like `commit_transaction`, and if they raise an error, the transaction was already popped from the stack.

review @jonleighton @chancancode @rafaelfranca @tenderlove @spastorino
