### PR TITLE
Fix documentation of SQLite3Adapter.columns

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -193,7 +193,7 @@ module ActiveRecord
       #
       #   person = Person.new
       #   person.column_for_attribute(:name) # the result depends on the ConnectionAdapter
-      #   # => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x007ff4ab083980 @name="name", @sql_type="varchar(255)", @null=true, ...>
+      #   # => #<ActiveRecord::ConnectionAdapters::Column:0x007ff4ab083980 @name="name", @sql_type="varchar(255)", @null=true, ...>
       #
       #   person.column_for_attribute(:nothing)
       #   # => nil

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -385,7 +385,7 @@ module ActiveRecord
         table_name && tables(nil, table_name).any?
       end
 
-      # Returns an array of +SQLite3Column+ objects for the table specified by +table_name+.
+      # Returns an array of +Column+ objects for the table specified by +table_name+.
       def columns(table_name) #:nodoc:
         table_structure(table_name).map do |field|
           case field["dflt_value"]


### PR DESCRIPTION
As of https://github.com/rails/rails/commit/e781aa31fc52a7c696115302ef4d4e02bfd1533b SQLite3Column has been dropped.
