### PR TITLE
No verbose backtrace by db:drop when database does not exist.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   No verbose backtrace by db:drop when database does not exist.
+
+    Fixes #16295.
+
+    *Kenn Ejima*
+
 *   Add support for Postgresql JSONB.
 
     Example:

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -110,6 +110,8 @@ module ActiveRecord
       def drop(*arguments)
         configuration = arguments.first
         class_for_adapter(configuration['adapter']).new(*arguments).drop
+      rescue ActiveRecord::NoDatabaseError
+        $stderr.puts "#{configuration['database']} does not exist"
       rescue Exception => error
         $stderr.puts error, *(error.backtrace)
         $stderr.puts "Couldn't drop #{configuration['database']}"


### PR DESCRIPTION
`rake db:drop` should consider `ActiveRecord::NoDatabaseError` as part of "normal" condition, not exception. We know why it occurred and we don't need verbose backtrace for that.

This change will remove the necessity of running `rake db:create` when and only when you have a new machine or a new member - you just need a single rake task to reset database like `rake db:reset` or your own custom rake task. Showing full backtrace is just confusing for a new member to the team.

Now,

```
$ rake db:drop
Unknown database 'myapp_development'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/connection_adapters/mysql2_adapter.rb:23:in `rescue in mysql2_connection'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/connection_adapters/mysql2_adapter.rb:10:in `mysql2_connection'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:435:in `new_connection'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:445:in `checkout_new_connection'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:416:in `acquire_connection'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:351:in `block in checkout'
[RUBY_PATH]/rubies/ruby-2.1.0/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:350:in `checkout'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:265:in `block in connection'
[RUBY_PATH]/rubies/ruby-2.1.0/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:264:in `connection'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:541:in `retrieve_connection'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/connection_handling.rb:113:in `retrieve_connection'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/connection_handling.rb:87:in `connection'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/tasks/mysql_database_tasks.rb:8:in `connection'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/tasks/mysql_database_tasks.rb:41:in `drop'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/tasks/database_tasks.rb:109:in `drop'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/tasks/database_tasks.rb:121:in `block in drop_current'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/tasks/database_tasks.rb:209:in `block in each_current_configuration'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/tasks/database_tasks.rb:208:in `each'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/tasks/database_tasks.rb:208:in `each_current_configuration'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/tasks/database_tasks.rb:120:in `drop_current'
[RUBY_PATH]/gems/ruby-2.1.0/gems/activerecord-4.1.2/lib/active_record/railties/databases.rake:28:in `block (2 levels) in <top (required)>'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/task.rb:240:in `call'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/task.rb:240:in `block in execute'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/task.rb:235:in `each'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/task.rb:235:in `execute'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/task.rb:179:in `block in invoke_with_call_chain'
[RUBY_PATH]/rubies/ruby-2.1.0/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/task.rb:201:in `block in invoke_prerequisites'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/task.rb:199:in `each'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/task.rb:199:in `invoke_prerequisites'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/task.rb:178:in `block in invoke_with_call_chain'
[RUBY_PATH]/rubies/ruby-2.1.0/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/task.rb:165:in `invoke'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/application.rb:150:in `invoke_task'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/application.rb:106:in `block (2 levels) in top_level'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/application.rb:106:in `each'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/application.rb:106:in `block in top_level'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/application.rb:115:in `run_with_threads'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/application.rb:100:in `top_level'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/application.rb:78:in `block in run'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/application.rb:176:in `standard_exception_handling'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/lib/rake/application.rb:75:in `run'
[RUBY_PATH]/gems/ruby-2.1.0/gems/rake-10.3.2/bin/rake:33:in `<top (required)>'
[RUBY_PATH]/gems/ruby-2.1.0/bin/rake:23:in `load'
[RUBY_PATH]/gems/ruby-2.1.0/bin/rake:23:in `<main>'
[RUBY_PATH]/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `eval'
[RUBY_PATH]/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `<main>'
Couldn't drop myapp_development
```

will become:

```
$ rake db:drop
Couldn't drop myapp_development
```
