### PR TITLE
Extract iterator method in AR::SchemaDumper

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -92,16 +92,9 @@ HEADER
 
       def tables(stream)
         sorted_tables = @connection.tables.sort
-        sorted_tables.each do |tbl|
-          next if ['schema_migrations', ignore_tables].flatten.any? do |ignored|
-            case ignored
-            when String; remove_prefix_and_suffix(tbl) == ignored
-            when Regexp; remove_prefix_and_suffix(tbl) =~ ignored
-            else
-              raise StandardError, 'ActiveRecord::SchemaDumper.ignore_tables accepts an array of String and / or Regexp values.'
-            end
-          end
-          table(tbl, stream)
+
+        sorted_tables.each do |table_name|
+          table(table_name, stream) unless ignored?(table_name)
         end
 
         # dump foreign keys at the end to make sure all dependent tables exist.
@@ -253,6 +246,17 @@ HEADER
 
       def remove_prefix_and_suffix(table)
         table.gsub(/^(#{@options[:table_name_prefix]})(.+)(#{@options[:table_name_suffix]})$/,  "\\2")
+      end
+
+      def ignored?(table_name)
+        ['schema_migrations', ignore_tables].flatten.any? do |ignored|
+          case ignored
+          when String; remove_prefix_and_suffix(table_name) == ignored
+          when Regexp; remove_prefix_and_suffix(table_name) =~ ignored
+          else
+            raise StandardError, 'ActiveRecord::SchemaDumper.ignore_tables accepts an array of String and / or Regexp values.'
+          end
+        end
       end
   end
 end


### PR DESCRIPTION
Gems which wish to tie into ActiveRecord::SchemaDumper need to duplicate this
logic currently. [Foreigner](https://github.com/matthuhiggins/foreigner/blob/master/lib/foreigner/schema_dumper.rb#L36-L43) is one such example, as is a library I'm
currently working on but which hasn't been released yet:

``` ruby
def tables_with_foreign_keys(stream)
  tables_without_foreign_keys(stream)
  @connection.tables.sort.each do |table|
    next if ['schema_migrations', ignore_tables].flatten.any? do |ignored|
      case ignored
      when String; table == ignored
      when Regexp; table =~ ignored
      else
        raise StandardError, 'ActiveRecord::SchemaDumper.ignore_tables accepts an array of String and / or Regexp values.'
      end
    end
    foreign_keys(table, stream)
  end
end
```

Extract the skip logic to a method, making it much simpler to follow this same
behavior in gems that are tying into the migration flow and let them dump only
tables that aren't skipped without copying this block of code. The above code
could then be simplified to:

``` ruby
    def tables_with_foreign_keys(stream)
      tables_without_foreign_keys(stream)
      @connection.tables.sort.each do |table|
        foreign_keys(table, stream) unless ignored?(table)
      end
    end
```

This _could_ be further simplified to assume tables, but for my use case I'm
trying to add views which wouldn't be returned by the [`tables`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L95-L102) method.
