### PR TITLE
Fix misleading "Serialized attributes" section in Upgrading Guide

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -52,12 +52,6 @@ Upgrading from Rails 4.1 to Rails 4.2
 
 NOTE: This section is a work in progress.
 
-### Serialized attributes
-
-When assigning `nil` to a serialized attribute, it will be saved to the database
-as `NULL` instead of passing the `nil` value through the coder (e.g. `"null"`
-when using the `JSON` coder).
-
 Upgrading from Rails 4.0 to Rails 4.1
 -------------------------------------
 
@@ -591,6 +585,9 @@ Rails 4.0 no longer supports loading plugins from `vendor/plugins`. You must rep
 * In Rails 4.0 when a column or a table is renamed the related indexes are also renamed. If you have migrations which rename the indexes, they are no longer needed.
 
 * Rails 4.0 has changed `serialized_attributes` and `attr_readonly` to class methods only. You shouldn't use instance methods since it's now deprecated. You should change them to use class methods, e.g. `self.serialized_attributes` to `self.class.serialized_attributes`.
+
+* When assigning `nil` to a serialized attribute, it will be saved to the database as `NULL`
+instead of passing the `nil` value through the coder (e.g. `"null"` when using the `JSON` coder).
 
 * Rails 4.0 has removed `attr_accessible` and `attr_protected` feature in favor of Strong Parameters. You can use the [Protected Attributes gem](https://github.com/rails/protected_attributes) for a smooth upgrade path.
 


### PR DESCRIPTION
At this moment this section is included in "Upgrading from Rails 4.1 to Rails 4.2". However it affects upgrading to all 4.x versions from 3.x.

The change to `nil` handling in serialized attributes was actually introduced in 4.0:
- https://github.com/rails/rails/commit/39cb1bedb82814d7bf9de6834f88c31e4df27278
