### PR TITLE
Don't encourage validating boolean columns

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -523,9 +523,6 @@ If you validate the presence of an object associated via a `has_one` or
 `has_many` relationship, it will check that the object is neither `blank?` nor
 `marked_for_destruction?`.
 
-Since `false.blank?` is true, if you want to validate the presence of a boolean
-field you should use `validates :field_name, inclusion: { in: [true, false] }`.
-
 The default error message is _"can't be blank"_.
 
 ### `absence`


### PR DESCRIPTION
The validation guides mention declaring an inclusion validation against
a boolean column, like so:

```
 validates_inclusion_of :boolean_column, in: [true, false]
```

Such a validation is unnecessary, as it is impossible for a boolean
column to _not_ accept true or false as valid values. We should not be
encouraging people to do this.
