### PR TITLE
Bind params properly when using nested hash and collection proxy in where clause.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Bind params properly when using nested hash and collection proxy in where
+    clause.
+
+    Fixes #16238.
+
+    Example:
+
+        # Before
+        Author.includes(:posts => :comments).where(comments: { post: Author.first.posts }).to_a.size
+        # => 0 in sqlite
+        # => Raise errors in mysql & postgresql
+
+        # After
+        Author.includes(:posts => :comments).where(comments: { post: Author.first.posts }).to_a.size
+        # => 1
+
+    *Bigxiang*
+
 *   Add support for Postgresql JSONB.
 
     Example:

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -952,13 +952,21 @@ WARNING
         self.bind_values += bind_values
 
         attributes = @klass.send(:expand_hash_conditions_for_aggregates, tmp_opts)
-        attributes.values.grep(ActiveRecord::Relation) do |rel|
-          self.bind_values += rel.bind_values
-        end
+        bind_values_through_nested_hashes(attributes)
 
         PredicateBuilder.build_from_hash(klass, attributes, table)
       else
         [opts]
+      end
+    end
+
+    def bind_values_through_nested_hashes(attributes)
+      attributes.values.grep(Hash) do |hash_value|
+        bind_values_through_nested_hashes(hash_value)
+      end
+
+      attributes.values.grep(ActiveRecord::Relation) do |rel|
+        self.bind_values += rel.bind_values
       end
     end
 

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -10,7 +10,7 @@ require 'models/binary'
 
 module ActiveRecord
   class WhereTest < ActiveRecord::TestCase
-    fixtures :posts, :edges, :authors, :binaries
+    fixtures :posts, :edges, :authors, :binaries, :comments
 
     def test_where_copies_bind_params
       author = authors(:david)
@@ -209,6 +209,13 @@ module ActiveRecord
     def test_where_with_integer_for_binary_column
       count = Binary.where(:data => 0).count
       assert_equal 0, count
+    end
+
+    def test_bind_params_with_nested_hash_and_collection_proxy
+      # should success anyway
+      assert_equal 1, Author.includes(:posts => :comments).where(comments: { post: Post.joins(:author).where(author_id: Author.first) }).to_a.size
+      # should fail before patched
+      assert_equal 1, Author.includes(:posts => :comments).where(comments: { post: Author.first.posts }).to_a.size
     end
   end
 end


### PR DESCRIPTION
It always couldn't bind params correctly when passing a nested hash in where clause and the hash value is a collection proxy. Collection proxy's bind values doesn't been concated to the main relation.

Fixes #16238.

Example:

``` ruby
    # Before
    Author.includes(:posts => :comments).where(comments: { post: Author.first.posts }).to_a.size
    # => 0 in sqlite
    # => Raise errors in mysql & postgresql

    # After
    Author.includes(:posts => :comments).where(comments: { post: Author.first.posts }).to_a.size
    # => 1
```
