### PR TITLE
Expose bug in HMT assocation delete_all with a where clause

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -222,6 +222,17 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_delete_all_with_where_deletes_join_record
+    person = people(:david)
+    assert_equal 1, person.jobs.count
+
+    assert_difference 'Reference.count', -1 do
+      assert_no_difference 'Job.count' do
+        person.jobs.where(references: {favourite: person.references.first.favourite}).delete_all
+      end
+    end
+  end
+
   def test_concat
     person = people(:david)
     post   = posts(:thinking)


### PR DESCRIPTION
[Do not merge]

I've found this bug in AR that adding `where` between a HMT association and `delete_all` changes the behaviour dangerously - `DELETE` is fired on the source table, not on the join table.

For now I could just reproduce it in a test case, I'd be happy to work on a fix, but I'd need some directions.
