### PR TITLE
GET params to polymorphic_url

### DIFF
--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -68,7 +68,7 @@ module ActionDispatch
       # Someone could pass a hash with GET params as last value:
       #
       #   polymorphic_url([user, :blog, post, :theme => "dark"]) # => "http://example.com/users/1/blog/posts/1?theme=dark"
-      #   polymorphic_url([user, :blog, post, :theme => "dark", :referral => "john"]) # => "http://example.com/users/1/blog/posts/1?theme=dark&referral=jphn"
+      #   polymorphic_url([user, :blog, post, :theme => "dark", :referral => "John"]) # => "http://example.com/users/1/blog/posts/1?theme=dark&referral=John"
       #   
       # ==== Options
       #

--- a/actionpack/test/activerecord/polymorphic_routes_test.rb
+++ b/actionpack/test/activerecord/polymorphic_routes_test.rb
@@ -430,6 +430,32 @@ class PolymorphicRoutesTest < ActionController::TestCase
     end
   end
 
+  def test_with_get_params
+    with_test_routes do
+      @tax.save
+      assert_equal "http://example.com/taxes?state=FL", polymorphic_url([:taxes, state: "FL"])
+    end
+  end
+
+  def test_class_with_get_params
+    with_test_routes do
+      @tax.save
+      assert_equal "http://example.com/taxes?state=TX", polymorphic_url([Tax, state: "TX"])
+    end
+  end
+
+  def test_with_namespace
+    with_admin_test_routes do
+      assert_equal "http://example.com/admin/taxes?state=NY&type=VAT", polymorphic_url([:admin, @tax.class, state: "NY", type: "VAT"])
+    end
+  end
+
+  def with_explicit_empty_get_params
+    with_admin_test_routes do
+      assert_equal "http://example.com/taxes", polymorphic_url([@tax.class, {}])
+    end
+  end
+
  # Tests for uncountable names
   def test_uncountable_resource
     with_test_routes do

--- a/actionpack/test/activerecord/polymorphic_routes_test.rb
+++ b/actionpack/test/activerecord/polymorphic_routes_test.rb
@@ -350,6 +350,12 @@ class PolymorphicRoutesTest < ActionController::TestCase
     end
   end
 
+  def test_with_irregular_plural_new_record
+    with_test_routes do
+      assert_equal "http://example.com/taxes", polymorphic_url(@tax)
+    end
+  end
+
   def test_with_irregular_plural_destroyed_record
     with_test_routes do
       @tax.destroy
@@ -433,20 +439,20 @@ class PolymorphicRoutesTest < ActionController::TestCase
   def test_with_get_params
     with_test_routes do
       @tax.save
-      assert_equal "http://example.com/taxes?state=FL", polymorphic_url([:taxes, state: "FL"])
+      assert_equal "http://example.com/taxes?state=FL", polymorphic_url([:taxes, :state => "FL"])
     end
   end
 
   def test_class_with_get_params
     with_test_routes do
       @tax.save
-      assert_equal "http://example.com/taxes?state=TX", polymorphic_url([Tax, state: "TX"])
+      assert_equal "http://example.com/taxes?state=TX", polymorphic_url([Tax, :state => "TX"])
     end
   end
 
   def test_with_namespace
     with_admin_test_routes do
-      assert_equal "http://example.com/admin/taxes?state=NY&type=VAT", polymorphic_url([:admin, @tax.class, state: "NY", type: "VAT"])
+      assert_equal "http://example.com/admin/taxes?state=NY&type=VAT", polymorphic_url([:admin, @tax.class, :state => "NY", :type => "VAT"])
     end
   end
 


### PR DESCRIPTION
Usually to add get params to url we need to write whole path:

``` ruby
link_to "Edit", edit_client_unit_path(@client, @unit, type: "wheel")
#=> /client/1/unit/2/edit?type=wheel
```

While it looks more naturally to use cool polymorphic style:

``` ruby
link_to "Edit", [:edit, @client, @unit, type: "wheel"]
#=> /client/1/unit/2/edit?type=wheel
```
