### PR TITLE
GET params to polymorphic_url

### DIFF
--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -189,7 +189,6 @@ module ActionDispatch
 
         def self.polymorphic_method(recipient, record_or_hash_or_array, action, type, options)
           builder = get action, type
-
           case record_or_hash_or_array
           when Array
             if record_or_hash_or_array.empty? || record_or_hash_or_array.include?(nil)
@@ -198,19 +197,21 @@ module ActionDispatch
             if record_or_hash_or_array.first.is_a?(ActionDispatch::Routing::RoutesProxy)
               recipient = record_or_hash_or_array.shift
             end
+            if record_or_hash_or_array.last.is_a?(Hash)
+              options.merge!(record_or_hash_or_array.last)
+              record_or_hash_or_array = record_or_hash_or_array[0..-2]
+            end
 
             method, args = builder.handle_list record_or_hash_or_array
           when String, Symbol
             method, args = builder.handle_string record_or_hash_or_array
           when Class
             method, args = builder.handle_class record_or_hash_or_array
-
           when nil
             raise ArgumentError, "Nil location provided. Can't build URI."
           else
             method, args = builder.handle_model record_or_hash_or_array
           end
-
 
           if options.empty?
             recipient.send(method, *args)

--- a/actionview/test/activerecord/polymorphic_routes_test.rb
+++ b/actionview/test/activerecord/polymorphic_routes_test.rb
@@ -566,7 +566,20 @@ class PolymorphicRoutesTest < ActionController::TestCase
     end
   end
 
- # Tests for uncountable names
+  def test_with_array_containing_get_paramters
+    with_test_routes do
+      assert_url "http://example.com/taxes?state=FL&type=VAT", [:taxes, state: 'FL', type: 'VAT']
+    end
+  end
+
+  def test_with_namespace_and_action_and_get_paramters
+    with_admin_test_routes do
+      @tax.save
+      assert_url "http://example.com/admin/taxes/#{@tax.id}/edit?state=FL&type=VAT", [:edit, :admin, @tax, state: 'FL', type: 'VAT']
+    end
+  end
+
+  # Tests for uncountable names
   def test_uncountable_resource
     with_test_routes do
       @series.save


### PR DESCRIPTION
Usually to add get params to url we need to write whole path:

``` ruby
link_to "Edit", edit_client_unit_path(@client, @unit, type: "wheel")
#=> /client/1/unit/2/edit?type=wheel
```

While it looks more naturally to use cool polymorphic style:

``` ruby
link_to "Edit", [:edit, @client, @unit, type: "wheel"]
#=> /client/1/unit/2/edit?type=wheel
```
