### PR TITLE
purge database before loading schema, take 2

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -297,7 +297,14 @@
 
     Fixes #8328.
 
-    *Sean Griffin*
+    Sean Griffin
+
+*   Fixed automatic maintaining test schema to properly handle sql structure
+    schema format.
+
+    Fixes #15394.
+
+    *Wojciech Wnętrzak*
 
 *   Pluck now works when selecting columns from different tables with the same
     name.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Deprecate `DatabaseTasks.load_schema` to act on the current connection.
+    Use `.load_schema_current` instead. In the future `load_schema` will
+    require the `configuration` to act on as an argument.
+
+    *Yves Senn*
+
+*   Fixed automatic maintaining test schema to properly handle sql structure
+    schema format.
+
+    Fixes #15394.
+
+    *Wojciech Wnętrzak*
+
 *   Fix type casting to Decimal from Float with large precision.
 
     *Tomohiro Hashidate*
@@ -297,14 +310,7 @@
 
     Fixes #8328.
 
-    Sean Griffin
-
-*   Fixed automatic maintaining test schema to properly handle sql structure
-    schema format.
-
-    Fixes #15394.
-
-    *Wojciech Wnętrzak*
+    *Sean Griffin*
 
 *   Pluck now works when selecting columns from different tables with the same
     name.

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -399,7 +399,7 @@ module ActiveRecord
 
       def load_schema_if_pending!
         if ActiveRecord::Migrator.needs_migration?
-          ActiveRecord::Tasks::DatabaseTasks.load_schema
+          ActiveRecord::Tasks::DatabaseTasks.load_schema_current
           check_pending!
         end
       end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -240,7 +240,7 @@ db_namespace = namespace :db do
 
     desc 'Load a schema.rb file into the database'
     task :load => [:environment, :load_config] do
-      ActiveRecord::Tasks::DatabaseTasks.load_schema(:ruby, ENV['SCHEMA'])
+      ActiveRecord::Tasks::DatabaseTasks.load_schema_current(:ruby, ENV['SCHEMA'])
     end
 
     task :load_if_ruby => ['db:create', :environment] do
@@ -286,7 +286,7 @@ db_namespace = namespace :db do
 
     desc "Recreate the databases from the structure.sql file"
     task :load => [:environment, :load_config] do
-      ActiveRecord::Tasks::DatabaseTasks.load_schema(:sql, ENV['DB_STRUCTURE'])
+      ActiveRecord::Tasks::DatabaseTasks.load_schema_current(:sql, ENV['DB_STRUCTURE'])
     end
 
     task :load_if_sql => ['db:create', :environment] do
@@ -317,9 +317,8 @@ db_namespace = namespace :db do
     task :load_schema => %w(db:test:deprecated db:test:purge) do
       begin
         should_reconnect = ActiveRecord::Base.connection_pool.active_connection?
-        ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations['test'])
         ActiveRecord::Schema.verbose = false
-        db_namespace["schema:load"].invoke
+        ActiveRecord::Tasks::DatabaseTasks.load_schema_for ActiveRecord::Base.configurations['test'], :ruby, ENV['SCHEMA']
       ensure
         if should_reconnect
           ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[ActiveRecord::Tasks::DatabaseTasks.env])
@@ -329,12 +328,7 @@ db_namespace = namespace :db do
 
     # desc "Recreate the test database from an existent structure.sql file"
     task :load_structure => %w(db:test:deprecated db:test:purge) do
-      begin
-        ActiveRecord::Tasks::DatabaseTasks.current_config(:config => ActiveRecord::Base.configurations['test'])
-        db_namespace["structure:load"].invoke
-      ensure
-        ActiveRecord::Tasks::DatabaseTasks.current_config(:config => nil)
-      end
+      ActiveRecord::Tasks::DatabaseTasks.load_schema_for ActiveRecord::Base.configurations['test'], :sql, ENV['SCHEMA']
     end
 
     # desc "Recreate the test database from a fresh schema"

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -188,10 +188,12 @@ module ActiveRecord
         when :ruby
           file ||= File.join(db_dir, "schema.rb")
           check_schema_file(file)
+          purge(current_config)
           load(file)
         when :sql
           file ||= File.join(db_dir, "structure.sql")
           check_schema_file(file)
+          purge(current_config)
           structure_load(current_config, file)
         else
           raise ArgumentError, "unknown format #{format.inspect}"

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -21,7 +21,11 @@ module ActiveRecord
 
         FileUtils.rm(file) if File.exist?(file)
       end
-      alias :purge :drop
+
+      def purge
+        drop
+        create
+      end
 
       def charset
         connection.encoding


### PR DESCRIPTION
This brings back the behavior introduced by #15394 which was reverted with 5c87b5c

The original patch introduced regressions where the wrong database was purged before loading the schema. The rake tasks no longer open specific connections but tell `DatabaseTasks` on what `configuration` to act on.

I had to create a temporary method `load_schema_for` because `DatabaseTasks` is public API and `load_schema` needs a new first argument. After the deprecation cycle we can rename `load_schema_for` back to `load_schema`.

This functionality is required to for the foreign key support of `schema.rb`.

_I can squash the commits if necessary but wanted to have the diff to the patch explicit for the review._
