### PR TITLE
Clear Posts otherwise select_one might fail.

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -192,7 +192,7 @@ module ActiveRecord
     def test_select_methods_passing_a_association_relation
       author = Author.create!(name: 'john')
       Post.create!(author: author, title: 'foo', body: 'bar')
-      query = author.posts.select(:title)
+      query = author.posts.where(title: 'foo').select(:title)
       assert_equal({"title" => "foo"}, @connection.select_one(query.arel, nil, query.bind_values))
       assert_equal({"title" => "foo"}, @connection.select_one(query))
       assert @connection.select_all(query).is_a?(ActiveRecord::Result)


### PR DESCRIPTION
Sometimes `select_one` in this test will return other posts loaded from the fixtures. If we want to make sure `select_one` is correct without the `where` condition, we will have to make sure the record is the only one.

cc @senny aren't all fixtures unloaded before each test, or am I missing anything? I've been digging around to find the cause but all attempts were futile. I'm not sure if this workaround is the best approach.
