### PR TITLE
Fix example code of EachValidator [ci skip]

### DIFF
--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -79,7 +79,7 @@ module ActiveModel
   #     include ActiveModel::Validations
   #     attr_accessor :title
   #
-  #     validates :title, presence: true
+  #     validates :title, presence: true, title: true
   #   end
   #
   # It can be useful to access the class that is using that validator when there are prerequisites such


### PR DESCRIPTION
We have to specify the `:title` option to really use the
`TitleValidator` defined above.
