### PR TITLE
ActiveModel: prevent added? from mutating messages

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `added?` method so that it doesn't mutate the error message hash when checking a
+    nonexisting error.
+
+    Previously if `added?` was called for a nonexisting error then a key was added to the
+    error message hash for the given attribute. This key is now deleted when no errors
+    exist for the given attribute.
+
+    *Matt Freer*
+
 *   Validate options passed to `ActiveModel::Validations.validate`.
 
     Preventing, in many cases, the simple mistake of using `validate` instead of `validates`.

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -340,7 +340,9 @@ module ActiveModel
     #   person.errors.added? :name, :blank # => true
     def added?(attribute, message = :invalid, options = {})
       message = normalize_message(attribute, message, options)
-      self[attribute].include? message
+      has_msg = self[attribute].include? message
+      self.messages.delete(attribute) if self[attribute].empty?
+      has_msg
     end
 
     # Returns all the full error messages in an array.

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -189,6 +189,19 @@ class ErrorsTest < ActiveModel::TestCase
     assert !person.errors.added?(:name, "cannot be blank")
   end
 
+  test "added? doesn't mutate the error messages hash when checking a nonexisting error" do
+    person = Person.new
+    person.errors.added?(:name, "cannot be blank")
+    assert !person.errors.keys.include?(:name)
+  end
+
+  test "added? doesn't delete the message key if other errors are present for the given attribute" do
+    person = Person.new
+    person.errors.add(:name, "is invalid")
+    person.errors.added?(:name, "is blank")
+    assert person.errors.keys.include?(:name), person.errors.keys
+  end
+
   test "size calculates the number of error messages" do
     person = Person.new
     person.errors.add(:name, "cannot be blank")


### PR DESCRIPTION
Previously if `added?` was called for a nonexisting error then a key was added to the error message hash for the given attribute with an empty array value. This key is now deleted when no errors exist for the given attribute.
