### PR TITLE
System should not be an allowed enum name

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -31,7 +31,7 @@ module ActiveRecord
       end
     }
 
-    BLACKLISTED_CLASS_METHODS = %w(private public protected)
+    BLACKLISTED_CLASS_METHODS = %w(private public protected system)
 
     class AttributeMethodCache
       def initialize

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -168,7 +168,7 @@ module ActiveRecord
         "by %{source}."
 
       def detect_enum_conflict!(enum_name, method_name, klass_method = false)
-        if klass_method && dangerous_class_method?(method_name)
+        if dangerous_class_method?(enum_name) || (klass_method && dangerous_class_method?(method_name))
           raise ArgumentError, ENUM_CONFLICT_MESSAGE % {
             enum: enum_name,
             klass: self.name,

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -174,6 +174,7 @@ class EnumTest < ActiveRecord::TestCase
       :column,     # generates class method .columns, which conflicts with an AR method
       :logger,     # generates #logger, which conflicts with an AR method
       :attributes, # generates #attributes=, which conflicts with an AR method
+      :public, :private, :protected, :system # generates a method that conflict with ruby words
     ]
 
     conflicts.each_with_index do |name, i|
@@ -194,7 +195,7 @@ class EnumTest < ActiveRecord::TestCase
       :valid,    # generates #valid?, which conflicts with an AR method
       :save,     # generates #save!, which conflicts with an AR method
       :proposed, # same value as an existing enum
-      :public, :private, :protected, # generates a method that conflict with ruby words
+      :public, :private, :protected, :system # generates a method that conflict with ruby words
     ]
 
     conflicts.each_with_index do |value, i|


### PR DESCRIPTION
Using an enum name of `system` can cause problems with `Kernel#system` which is dangerous and things could get weird. This adds `system` to the blacklisted class methods. The `detect_enum_conflict` method wasn't checking `enum_name` just the `method_name`.

I also updated the tests to include `system`.

Fixes #16288
