### PR TITLE
Give password_confirmation div the "field" class in the scaffold generator "_form" partial

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
@@ -17,7 +17,7 @@
     <%%= f.label :password %><br>
     <%%= f.password_field :password %>
   </div>
-  <div>
+  <div class="field">
     <%%= f.label :password_confirmation %><br>
     <%%= f.password_field :password_confirmation %>
 <% else -%>


### PR DESCRIPTION
Is inconsistently missing the css class used on the other fields. Also means that the default generated `scaffold.css` doesn't apply its `margin-bottom: 10px` style on this one field if it's present.
