### PR TITLE
Make URI::parser#unescape handle cases where some already-decoded chars and %XX sequences are both present

### DIFF
--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -12,7 +12,7 @@ unless str == parser.unescape(parser.escape(str))
       # YK: My initial experiments say yes, but let's be sure please
       enc = str.encoding
       enc = Encoding::UTF_8 if enc == Encoding::US_ASCII
-      str.gsub(escaped) { [$&[1, 2].hex].pack('C') }.force_encoding(enc)
+      str.gsub(escaped) { [$&[1, 2].hex].pack('C').force_encoding(enc) }.force_encoding(enc)
     end
   end
 end

--- a/activesupport/test/core_ext/uri_ext_test.rb
+++ b/activesupport/test/core_ext/uri_ext_test.rb
@@ -10,4 +10,9 @@ class URIExtTest < ActiveSupport::TestCase
     parser = URI.parser
     assert_equal str, parser.unescape(parser.escape(str))
   end
+
+  def test_uri_decode_partially_decoded
+    parser = URI.parser
+    assert_equal "\u4F60\u597D, \u518D\u89C1", parser.unescape("%E4%BD%A0%E5%A5%BD, \u518D\u89C1")
+  end
 end


### PR DESCRIPTION
When a string is passed to `URI::Parser#unescape` that contains multibyte characters outside the ASCII range and `%XX` sequences, an `Encoding::CompatibilityError` exception may be raised.

This happens because the `String#gsub` used to replace the `%XX` sequences may return strings for each hex byte in `ASCII-8BIT` encoding, and the encoding of the entire string may not be compatible.

For example, if the input string is in UTF8 encoding and contains Unicode characters outside the ASCII range, and a UTF8 sequence is also present in `%XX` encoded form, an `Encoding::CompatibilityError` will be raised because the individual hex bytes will be converted to ASCII-8BIT strings which are incompatible with the UTF8 input string being substituted.

This patch forces the results of the `String#gsub` block to the input string's encoding to avoid the exception.
