### PR TITLE
Fix type casting to Decimal from Float with large precision

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix Type casting to Decimal from Float with large precision.
+
+    *Tomohiro Hashidate*
+
 *   No verbose backtrace by db:drop when database does not exist.
 
     Fixes #16295.

--- a/activerecord/lib/active_record/type/decimal.rb
+++ b/activerecord/lib/active_record/type/decimal.rb
@@ -14,12 +14,25 @@ module ActiveRecord
       private
 
       def cast_value(value)
-        if value.is_a?(::Numeric) || value.is_a?(::String)
+        case value
+        when ::Float
+          BigDecimal(value, float_precision)
+        when ::Numeric, ::String
           BigDecimal(value, precision.to_i)
-        elsif value.respond_to?(:to_d)
-          value.to_d
         else
-          cast_value(value.to_s)
+          if value.respond_to?(:to_d)
+            value.to_d
+          else
+            cast_value(value.to_s)
+          end
+        end
+      end
+
+      def float_precision
+        if precision.to_i > ::Float::DIG + 1
+          ::Float::DIG + 1
+        else
+          precision.to_i
         end
       end
     end

--- a/activerecord/test/cases/type/decimal_test.rb
+++ b/activerecord/test/cases/type/decimal_test.rb
@@ -10,6 +10,11 @@ module ActiveRecord
         assert_equal BigDecimal.new("1"), type.type_cast_from_user(:"1")
       end
 
+      def test_type_cast_decimal_from_float_with_large_precision
+        type = Decimal.new(precision: ::Float::DIG + 2)
+        assert_equal BigDecimal.new("123.0"), type.type_cast_from_user(123.0)
+      end
+
       def test_type_cast_decimal_from_rational_with_precision
         type = Decimal.new(precision: 2)
         assert_equal BigDecimal("0.33"), type.type_cast_from_user(Rational(1, 3))


### PR DESCRIPTION
When I define large precision column at RDBMS,
I assign float value, raises ArgumentError (precision too large).

Cause of this probrem:
- `precision` is derived from database column definition.
- If `precision` is larger than `Float::DIG + 1`, `BigDecimal.new` raises ArgumentError

I think it is inconvenient.

this commit fixes it.
