### PR TITLE
Remove @state.parent assignment on commit

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -72,7 +72,7 @@ module ActiveRecord
     end
 
     class TransactionState
-      attr_accessor :parent
+      attr_reader :parent
 
       VALID_STATES = Set.new([:committed, :rolledback, nil])
 
@@ -245,7 +245,6 @@ module ActiveRecord
 
       def perform_commit
         @state.set_state(:committed)
-        @state.parent = parent.state
         connection.release_savepoint(@savepoint_name)
       end
     end


### PR DESCRIPTION
This piece of code was introduced on
67d8bb963d5d51fc644d6b1ca20164efb4cee6d7 , which was calling
`committed?` in the `transaction_state` before calling the `committed!`
method. However on 7386ffc781fca07a0c656db49fdb54678caef809, the
`committed?` check was removed and replaced by a `finalized?`, which
only checks if the state is not nil. Thus we can remove that line.

review @chancancode @tenderlove @wangjohn @rafaelfranca
