### PR TITLE
Avoid relying on error messages when rescuing

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -303,8 +303,8 @@ module ActiveSupport
     def safe_constantize(camel_cased_word)
       constantize(camel_cased_word)
     rescue NameError => e
-      raise unless e.message =~ /(uninitialized constant|wrong constant name) #{const_regexp(camel_cased_word)}$/ ||
-        e.name.to_s == camel_cased_word.to_s
+      raise if e.name && !(camel_cased_word.to_s.split("::").include?(e.name.to_s) ||
+        e.name.to_s == camel_cased_word.to_s)
     rescue ArgumentError => e
       raise unless e.message =~ /not missing constant #{const_regexp(camel_cased_word)}\!$/
     end


### PR DESCRIPTION
Hello,

When we are rescuing from an error, it's a brittle approach to do checks with regular expressions on the raised message because it may change in in the future and error messages are different across implementations.

The NameError API could be improved at the MRI level but for now we need to rely on its #name. A #== check will only pass for top level constants or only when the last constant of the path is missing so we need to rely on #include? instead. For instance:

``` ruby
begin
  Namespace::Foo
rescue NameError => e
  e.name # => :Namespace
end
```

However, if the name-space already exists, only the name of the first missing constant in the path is returned (e.g. for `Math::PHI`, the name would be `:PHI`). JRuby will return a fully qualified name (`:"Math::PHI"`).

We need to keep the == check for 1.9 compatibility since const_get will raise a NameError with a name attribute set to the given string if it's one of "::" or "".

See http://git.io/jnSN7g for further information.

Have a nice day.
