### PR TITLE
Add implicit receiver support to `Object#with_options`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `Object#with_options` executes block in merging option context when
+    explicit receiver in not passed.
+
+    *Pavel Pravosud*
+
 *   Fixed a compatibility issue with the `Oj` gem when cherry-picking the file
     `active_support/core_ext/object/json` without requiring `active_support/json`.
 

--- a/activesupport/lib/active_support/core_ext/object/with_options.rb
+++ b/activesupport/lib/active_support/core_ext/object/with_options.rb
@@ -34,9 +34,22 @@ class Object
   #     body    i18n.t :body, user_name: user.name
   #   end
   #
+  # When you don't pass an explicit receiver, it executes the whole block
+  # in merging options context:
+  #
+  #   class Account < ActiveRecord::Base
+  #     with_options dependent: :destroy do
+  #       has_many :customers
+  #       has_many :products
+  #       has_many :invoices
+  #       has_many :expenses
+  #     end
+  #   end
+  #
   # <tt>with_options</tt> can also be nested since the call is forwarded to its receiver.
   # Each nesting level will merge inherited defaults in addition to their own.
-  def with_options(options)
-    yield ActiveSupport::OptionMerger.new(self, options)
+  def with_options(options, &block)
+    option_merger = ActiveSupport::OptionMerger.new(self, options)
+    block.arity.zero? ? option_merger.instance_eval(&block) : block.call(option_merger)
   end
 end

--- a/activesupport/test/option_merger_test.rb
+++ b/activesupport/test/option_merger_test.rb
@@ -79,6 +79,15 @@ class OptionMergerTest < ActiveSupport::TestCase
     assert_equal ActiveSupport::OptionMerger, ActiveSupport::OptionMerger.new('', '').class
   end
 
+  def test_option_merger_implicit_receiver
+    @options.with_options foo: "bar" do
+      merge! fizz: "buzz"
+    end
+
+    expected = { hello: "world", foo: "bar", fizz: "buzz" }
+    assert_equal expected, @options
+  end
+
   private
     def method_with_options(options = {})
       options


### PR DESCRIPTION
I've noticed that 99% of the cases I use `Object#with_options` to define a bunch of associations or validations in my models. The code could be much cleaner if we wouldn't have to pass explicit receiver to `with_options` block all the time, especially if it's gonna be the only receiver.

So, this pull request makes it possible. It's also fully backwards compatible and old syntax still works as expected.

Before:

``` ruby
class Account < ActiveRecord::Base
  with_options dependent: :destroy do |assoc|
    assoc.has_many :customers
    assoc.has_many :products
    assoc.has_many :invoices
    assoc.has_many :expenses
  end
end
```

After:

``` ruby
class Account < ActiveRecord::Base
  with_options dependent: :destroy do
    has_many :customers
    has_many :products
    has_many :invoices
    has_many :expenses
  end
end
```
