### PR TITLE
Add necessary require of Minitest

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -3,6 +3,7 @@ require 'uri'
 require 'active_support/core_ext/kernel/singleton_class'
 require 'active_support/core_ext/object/try'
 require 'rack/test'
+require 'minitest'
 
 module ActionDispatch
   module Integration #:nodoc:


### PR DESCRIPTION
When I called `app` in master branch, `NameError` happens.

``` ruby
$ rails c
[1] pry(main)> app
NameError: uninitialized constant ActionDispatch::Integration::Session::Minitest
from /home/yaginuma/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/bundler/gems/rails-74c31ac5fe44/actionpack/lib/action_dispatch/testing/integration.rb:139:in `<class:Session>'
```

Probably it is thought that `Minitest` is necessary.
