### PR TITLE
Prevent using String#scrub on Rubinius

### DIFF
--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -213,7 +213,8 @@ module ActiveSupport
       end
 
       # Ruby >= 2.1 has String#scrub, which is faster than the workaround used for < 2.1.
-      if '<3'.respond_to?(:scrub)
+      # Rubinius' String#scrub, however, doesn't support ASCII-incompatible chars.
+      if '<3'.respond_to?(:scrub) && !defined?(Rubinius)
         # Replaces all ISO-8859-1 or CP1252 characters by their UTF-8 equivalent
         # resulting in a valid UTF-8 string.
         #


### PR DESCRIPTION
Hello,

Rubinius' has built-in support for String#scrub but it doesn't have yet support for ASCII-incompatible chars so for now, we should rely on the old implementation of `#tidy_bytes`.

Have a nice day.
