### PR TITLE
Correctly determine if migration is needed.

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -836,21 +836,20 @@ module ActiveRecord
         SchemaMigration.table_name
       end
 
-      def get_all_versions
-        SchemaMigration.all.map { |x| x.version.to_i }.sort
-      end
-
-      def current_version(connection = Base.connection)
-        sm_table = schema_migrations_table_name
-        if connection.table_exists?(sm_table)
-          get_all_versions.max || 0
+      def get_all_versions(connection = Base.connection)
+        if connection.table_exists?(schema_migrations_table_name)
+          SchemaMigration.all.map { |x| x.version.to_i }.sort
         else
-          0
+          []
         end
       end
 
+      def current_version(connection = Base.connection)
+        get_all_versions(connection).max || 0
+      end
+
       def needs_migration?(connection = Base.connection)
-        current_version(connection) < last_version
+        (migrations(migrations_paths).collect(&:version) - get_all_versions(connection)).size > 0
       end
 
       def last_version

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -81,6 +81,21 @@ class MigrationTest < ActiveRecord::TestCase
     assert_equal 0, ActiveRecord::Migrator.current_version
     assert_equal 3, ActiveRecord::Migrator.last_version
     assert_equal true, ActiveRecord::Migrator.needs_migration?
+
+    ActiveRecord::SchemaMigration.create!(:version => ActiveRecord::Migrator.last_version)
+    assert_equal true, ActiveRecord::Migrator.needs_migration?
+  ensure
+    ActiveRecord::Migrator.migrations_paths = old_path
+  end
+
+  def test_migration_detection_without_schema_migration_table
+    ActiveRecord::Base.connection.drop_table :schema_migrations
+
+    migrations_path = MIGRATIONS_ROOT + "/valid"
+    old_path = ActiveRecord::Migrator.migrations_paths
+    ActiveRecord::Migrator.migrations_paths = migrations_path
+
+    assert_equal true, ActiveRecord::Migrator.needs_migration?
   ensure
     ActiveRecord::Migrator.migrations_paths = old_path
   end


### PR DESCRIPTION
This method would assume that if last migration in the migrations directory matched the current schema version, that the database was up to date, but this does not account for new migrations with older timestamps that may be pending.

Our dev team has been running into problems with `ActiveRecord::Migration.maintain_test_schema!` not always updating our test databases when two branches containing migrations are merged.  We normally run `db:test:prepare` when this happens, but since that task is deprecated, this method probably needs to be smarter.
