### PR TITLE
Add ActiveRecord::Tasks::DatabaseTasks.migrate

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -41,10 +41,7 @@ db_namespace = namespace :db do
 
   desc "Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)."
   task :migrate => [:environment, :load_config] do
-    ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
-    ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths, ENV["VERSION"] ? ENV["VERSION"].to_i : nil) do |migration|
-      ENV["SCOPE"].blank? || (ENV["SCOPE"] == migration.scope)
-    end
+    ActiveRecord::Tasks::DatabaseTasks.migrate
     db_namespace['_dump'].invoke if ActiveRecord::Base.dump_schema_after_migration
   end
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -127,6 +127,16 @@ module ActiveRecord
         }
       end
 
+      def migrate
+        verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
+        version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
+        scope   = ENV['SCOPE']
+        Migration.verbose = verbose
+        Migrator.migrate(Migrator.migrations_paths, version) do |migration|
+          scope.blank? || scope == migration.scope
+        end
+      end
+
       def charset_current(environment = env)
         charset ActiveRecord::Base.configurations[environment]
       end

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -273,6 +273,19 @@ module ActiveRecord
     end
   end
 
+  class DatabaseTasksMigrateTest < ActiveRecord::TestCase
+    def test_migrate_receives_correct_env_vars
+      verbose, version = ENV['VERBOSE'], ENV['VERSION']
+
+      ENV['VERBOSE'] = 'false'
+      ENV['VERSION'] = '4'
+
+      ActiveRecord::Migrator.expects(:migrate).with(ActiveRecord::Migrator.migrations_paths, 4)
+      ActiveRecord::Tasks::DatabaseTasks.migrate
+    ensure
+      ENV['VERBOSE'], ENV['VERSION'] = verbose, version
+    end
+  end
 
   class DatabaseTasksPurgeTest < ActiveRecord::TestCase
     include DatabaseTasksSetupper


### PR DESCRIPTION
This extracts the logic that was embedded in a Rake task into a static method.
Bonus: the first test for `rake db:migrate`
