### PR TITLE
Redefine macro checks for reflections

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -124,7 +124,7 @@ module ActiveRecord
 
         def inverse_updates_counter_named?(counter_name, reflection = reflection())
           reflection.klass._reflections.values.any? { |inverse_reflection|
-            :belongs_to == inverse_reflection.macro &&
+            inverse_reflection.belongs_to? &&
             inverse_reflection.counter_cache_column == counter_name
           }
         end

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -34,7 +34,7 @@ module ActiveRecord
 
           foreign_key  = has_many_association.foreign_key.to_s
           child_class  = has_many_association.klass
-          reflection   = child_class._reflections.values.find { |e| :belongs_to == e.macro && e.foreign_key.to_s == foreign_key && e.options[:counter_cache].present? }
+          reflection   = child_class._reflections.values.find { |e| e.belongs_to? && e.foreign_key.to_s == foreign_key && e.options[:counter_cache].present? }
           counter_name = reflection.counter_cache_column
 
           stmt = unscoped.where(arel_table[primary_key].eq(object.id)).arel.compile_update({

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -431,14 +431,10 @@ Joining, Preloading and eager loading of these associations is deprecated and wi
       end
 
       # Returns +true+ if +self+ is a +belongs_to+ reflection.
-      def belongs_to?
-        macro == :belongs_to
-      end
+      def belongs_to?; false; end
 
       # Returns +true+ if +self+ is a +has_one+ reflection.
-      def has_one?
-        macro == :has_one
-      end
+      def has_one?; false; end
 
       def association_class
         case macro
@@ -585,9 +581,7 @@ Joining, Preloading and eager loading of these associations is deprecated and wi
 
       def macro; :has_many; end
 
-      def collection?
-        true
-      end
+      def collection?; true; end
     end
 
     class HasOneReflection < AssociationReflection #:nodoc:
@@ -596,6 +590,8 @@ Joining, Preloading and eager loading of these associations is deprecated and wi
       end
 
       def macro; :has_one; end
+
+      def has_one?; true; end
     end
 
     class BelongsToReflection < AssociationReflection #:nodoc:
@@ -604,6 +600,8 @@ Joining, Preloading and eager loading of these associations is deprecated and wi
       end
 
       def macro; :belongs_to; end
+
+      def belongs_to?; true; end
     end
 
     class HasAndBelongsToManyReflection < AssociationReflection #:nodoc:


### PR DESCRIPTION
Followup to #16198

Now that the macro instance var no longer exists we can set `has_one?` and `belongs_to?` as false in the AssociationReflection and then set it to true where necessary in the BelongsToReflection or HasOneReflection.

I've also eliminated two locations that were checking against the macro symbol (`macro == :belongs_to`) rather than reusing the existing `belongs_to?` method

I made collection a one liner as well for consistency to follow along with the other methods.
