### PR TITLE
Removed unnecessary call to 'convert_key' in 'HashWithIndifferentAccess#to_hash'

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -246,9 +246,9 @@ module ActiveSupport
 
     # Convert to a regular hash with string keys.
     def to_hash
-      _new_hash= {}
+      _new_hash = {}
       each do |key, value|
-        _new_hash[convert_key(key)] = convert_value(value, for: :to_hash)
+        _new_hash[key] = convert_value(value, for: :to_hash)
       end
       Hash.new(default).merge!(_new_hash)
     end


### PR DESCRIPTION
Removed unnecessary call to `convert_key` in `HashWithIndifferentAccess#to_hash` introduced in df24b8790f22384a068fece7042f04ffd2fcb33e

All the keys are already Strings by virtue of being a `HashWithIndifferentAccess`.

I ran a simple benchmark and observed a 4% performance increase when calling the `to_hash` method.

```
Benchmark.ips do |x|
  x.time = 30
  x.warmup = 5

  hash = {
    :a  => 'a',
    'b' => { :b1 => 'b1', 'b2' => { 'b3' => 'b3' } },
    :c  => 'c'
  }.with_indifferent_access

  x.report("to_hash") do
    hash.to_hash
  end
end
```
