### PR TITLE
Refactor join_keys to remove complex conditionals

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -37,14 +37,9 @@ module ActiveRecord
             table = tables.shift
             klass = reflection.klass
 
-            case reflection.source_macro
-            when :belongs_to
-              key         = reflection.association_primary_key
-              foreign_key = reflection.foreign_key
-            else
-              key         = reflection.foreign_key
-              foreign_key = reflection.active_record_primary_key
-            end
+            join_keys   = reflection.join_keys(klass)
+            key         = join_keys.key
+            foreign_key = join_keys.foreign_key
 
             constraint = build_constraint(klass, table, key, foreign_table, foreign_key)
 


### PR DESCRIPTION
This PR refactors join_keys to remove complex conditionals.

Each part of the conditional is now moved into the Reflection associated with it. This is made possible by reducing the need for `source_macro` (and eventually the deprecation of `source_macro`) through adding `join_id_for` to each reflection that needs it as well.

Because the conditional in `join_association` is the same we can replace that with the `join_keys` method from Reflection. :smile_cat: 

This reduces the complexity of `join_keys` quite a bit. This is towards a larger refactoring of `add_constraints` and `join_constraints`. 
