### PR TITLE
Add an after_bundle callback in Rails templates

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -85,6 +85,9 @@ Please refer to the [Changelog][railties] for detailed changes.
 *   Introduced `Rails.gem_version` as a convenience method to return `Gem::Version.new(Rails.version)`.
     ([Pull Request](https://github.com/rails/rails/pull/14101))
 
+*   Introduced an `after_bundle` callback in the Rails templates.
+    ([Pull Request](https://github.com/rails/rails/pull/16359))
+
 
 Action Pack
 -----------

--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -38,9 +38,11 @@ generate(:scaffold, "person name:string")
 route "root to: 'people#index'"
 rake("db:migrate")
 
-git :init
-git add: "."
-git commit: %Q{ -m 'Initial commit' }
+after_bundle do
+  git :init
+  git add: "."
+  git commit: %Q{ -m 'Initial commit' }
+end
 ```
 
 The following sections outline the primary methods provided by the API:
@@ -227,6 +229,22 @@ git :init
 git add: "."
 git commit: "-a -m 'Initial commit'"
 ```
+
+### after_bundle(&block)
+
+Registers a callback to be executed after bundler and binstub generation have
+run. Useful for adding the binstubs to version control:
+
+```ruby
+after_bundle do
+  git :init
+  git add: '.'
+  git commit: "-a -m 'Initial commit'"
+end
+```
+
+The callbacks gets executed even if `--skip-bundle` and/or `--skip-spring` has
+been passed.
 
 Advanced Usage
 --------------

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -58,6 +58,38 @@ When assigning `nil` to a serialized attribute, it will be saved to the database
 as `NULL` instead of passing the `nil` value through the coder (e.g. `"null"`
 when using the `JSON` coder).
 
+### `after_bundle` in Rails templates
+
+If you have a Rails template that adds all the files in version control, it
+fails to add the generated binstubs because it gets executed before Bundler:
+
+```ruby
+# template.rb
+generate(:scaffold, "person name:string")
+route "root to: 'people#index'"
+rake("db:migrate")
+
+git :init
+git add: "."
+git commit: %Q{ -m 'Initial commit' }
+```
+
+You can now wrap the `git` calls in an `after_bundle` block. It will be run
+after the binstubs have been generated.
+
+```ruby
+# template.rb
+generate(:scaffold, "person name:string")
+route "root to: 'people#index'"
+rake("db:migrate")
+
+after_bundle do
+  git :init
+  git add: "."
+  git commit: %Q{ -m 'Initial commit' }
+end
+```
+
 Upgrading from Rails 4.0 to Rails 4.1
 -------------------------------------
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `after_bundle` callbacks in Rails templates. Useful for allowing the
+    generated binstubs to be added to version control.
+
+    Fixes #16292.
+
+    *Stefan Kanev*
+
 *   Scaffold generator `_form` partial adds `class="field"` for password
     confirmation fields.
 

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -7,6 +7,7 @@ module Rails
       def initialize(*) # :nodoc:
         super
         @in_group = nil
+        @after_bundle_callbacks = []
       end
 
       # Adds an entry into +Gemfile+ for the supplied gem.
@@ -230,6 +231,16 @@ module Rails
       #   readme "README"
       def readme(path)
         log File.read(find_in_source_paths(path))
+      end
+
+      # Registers a callback to be executed after bundle and spring binstubs
+      # have run.
+      #
+      #   after_bundle do
+      #     git add: '.'
+      #   end
+      def after_bundle(&block)
+        @after_bundle_callbacks << block
       end
 
       protected

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -259,6 +259,12 @@ module Rails
       public_task :apply_rails_template, :run_bundle
       public_task :generate_spring_binstubs
 
+      def run_after_bundle_callbacks
+        @after_bundle_callbacks.each do |callback|
+          callback.call
+        end
+      end
+
     protected
 
       def self.banner


### PR DESCRIPTION
Closes #16292.

The following Rails template (taken from the Rails guides) does not work well with binstubs:

``` ruby
# template.rb
generate(:scaffold, "person name:string")
route "root to: 'people#index'"
rake("db:migrate")

git :init
git add: "."
git commit: %Q{ -m 'Initial commit' }
```

Since it is executed before Bundler and Spring binstub generation, the generated stubs are not added to version control. Executing the templates later wouldn't work either – that way it won't be able to add gems.

Adding an `after_bundle` callback seems to solve the issue. That way, the version control commands can be postponed after the binstubs have been generated:

``` ruby
# template.rb
generate(:scaffold, "person name:string")
route "root to: 'people#index'"
rake("db:migrate")

after_bundle do
  git :init
  git add: "."
  git commit: %Q{ -m 'Initial commit' }
end
```

This pull request implements that callback. The test is a mouthful – I'm open to suggestions for improvements :smile: 

/cc @senny 
