### PR TITLE
Null transaction

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -43,8 +43,8 @@ module ActiveRecord
       end
     end
 
-    class ClosedTransaction < Transaction #:nodoc:
-      def initialize; super(nil); end
+    class NullTransaction < Transaction #:nodoc:
+      def initialize; end
       def closed?; true; end
       def open?; false; end
       def joinable?; false; end
@@ -203,14 +203,11 @@ module ActiveRecord
       end
 
       def current_transaction
-        @stack.last || closed_transaction
+        @stack.last || NULL_TRANSACTION
       end
 
       private
-
-        def closed_transaction
-          @closed_transaction ||= ClosedTransaction.new
-        end
+        NULL_TRANSACTION = NullTransaction.new
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -46,7 +46,7 @@ module ActiveRecord
 
     autoload_at 'active_record/connection_adapters/abstract/transaction' do
       autoload :TransactionManager
-      autoload :ClosedTransaction
+      autoload :NullTransaction
       autoload :RealTransaction
       autoload :SavepointTransaction
       autoload :TransactionState


### PR DESCRIPTION
From this discussion https://github.com/rails/rails/pull/16341#discussion_r15603190 .

This has only 2 simple commits.
- Move `TransactionManager` to the bottom, so we can create a constant with the value being a `Transaction` sub-class. (the constant needs to be defined prior the TransactionManager definition)
- s/ClosedTransaction/NullTransaction , and use `NullTransaction` as a constant.

review @rafaelfranca @chancancode

I have another PR, which will remove the inheritance on the `Transaction` class, but I didnt want to mix with these changes as It would make it WAY harder to follow the diff.
