### PR TITLE
Cleanup Transaction inheritance.

### DIFF
--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -552,7 +552,7 @@ class TransactionTest < ActiveRecord::TestCase
     assert !transaction.state.rolledback?
     assert !transaction.state.committed?
 
-    transaction.perform_rollback
+    transaction.rollback
 
     assert transaction.state.rolledback?
     assert !transaction.state.committed?
@@ -566,7 +566,7 @@ class TransactionTest < ActiveRecord::TestCase
     assert !transaction.state.rolledback?
     assert !transaction.state.committed?
 
-    transaction.perform_commit
+    transaction.commit
 
     assert !transaction.state.rolledback?
     assert transaction.state.committed?


### PR DESCRIPTION
Transaction class doesnt need to encapsulate the transaction state using
inheritance.
This removes all Transaction subclasses, and let the Transaction object
controls different actions based on its own state. Basically the only
actions would behave differently are `being`,`commit`,`rollback` as they
could act in a savepoint or in a real transaction.

[related to https://github.com/rails/rails/pull/16341#issuecomment-50791622]

review @chancancode @tenderlove @rafaelfranca @jeremy
