### PR TITLE
Add an :if_exists option to drop_table

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Introduce the `:if_exists` option for `drop_table`. For example:
+
+        drop_table :posts, if_exists: true
+
+    That would execute:
+
+        DROP TABLE IF EXISTS posts
+
+    If the table doesn't exist, `if_exists: false` (the default) raises an
+    exception whereas `if_exists: true` does nothing.
+
+    *Stefan Kanev*
+
 *   Deprecate `Reflection#source_macro`
 
     `Reflection#source_macro` is no longer needed in Active Record

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -364,7 +364,7 @@ module ActiveRecord
       # to provide these in a migration's +change+ method so it can be reverted.
       # In that case, +options+ and the block will be used by create_table.
       def drop_table(table_name, options = {})
-        execute "DROP TABLE #{quote_table_name(table_name)}"
+        execute "DROP TABLE#{' IF EXISTS' if options[:if_exists]} #{quote_table_name(table_name)}"
       end
 
       # Adds a new column to the named table.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -469,7 +469,13 @@ module ActiveRecord
       end
 
       def drop_table(table_name, options = {})
-        execute "DROP#{' TEMPORARY' if options[:temporary]} TABLE #{quote_table_name(table_name)}"
+        statement = "DROP "
+        statement << "TEMPORARY " if options[:temporary]
+        statement << "TABLE "
+        statement << "IF EXISTS " if options[:if_exists]
+        statement << quote_table_name(table_name)
+
+        execute statement
       end
 
       def rename_index(table_name, old_name, new_name)

--- a/activerecord/test/cases/adapters/mysql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/active_schema_test.rb
@@ -63,6 +63,10 @@ class ActiveSchemaTest < ActiveRecord::TestCase
     assert_equal "DROP TABLE `people`", drop_table(:people)
   end
 
+  def test_drop_table_if_exists
+    assert_equal "DROP TABLE IF EXISTS `people`", drop_table(:people, if_exists: true)
+  end
+
   if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
     def test_create_mysql_database_with_encoding
       assert_equal "CREATE DATABASE `matt` DEFAULT CHARACTER SET `utf8`", create_database(:matt)

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -63,6 +63,10 @@ class ActiveSchemaTest < ActiveRecord::TestCase
     assert_equal "DROP TABLE `people`", drop_table(:people)
   end
 
+  def test_drop_table_if_exists
+    assert_equal "DROP TABLE IF EXISTS `people`", drop_table(:people, if_exists: true)
+  end
+
   if current_adapter?(:Mysql2Adapter)
     def test_create_mysql_database_with_encoding
       assert_equal "CREATE DATABASE `matt` DEFAULT CHARACTER SET `utf8`", create_database(:matt)

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -23,6 +23,14 @@ class PostgresqlActiveSchemaTest < ActiveRecord::TestCase
     assert_equal %(CREATE DATABASE "aimonetti" ENCODING = 'UTF8' LC_COLLATE = 'ja_JP.UTF8' LC_CTYPE = 'ja_JP.UTF8'), create_database(:aimonetti, :encoding => :"UTF8", :collation => :"ja_JP.UTF8", :ctype => :"ja_JP.UTF8")
   end
 
+  def test_drop_table
+    assert_equal 'DROP TABLE "people"', drop_table(:people)
+  end
+
+  def test_drop_table_if_exists
+    assert_equal 'DROP TABLE IF EXISTS "people"', drop_table(:people, if_exists: true)
+  end
+
   def test_add_index
     # add_index calls index_name_exists? which can't work since execute is stubbed
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.stubs(:index_name_exists?).returns(false)


### PR DESCRIPTION
I think `drop_table` can benefit from an `if_exists: true` option, that does a `DROP TABLE IF EXISTS`. If nothing else, it can be useful for a bunch of tests that do this manually ([to](https://github.com/rails/rails/blob/master/activerecord/test/cases/migration/rename_table_test.rb#L86-L87) [name](https://github.com/rails/rails/blob/master/activerecord/test/cases/migration/table_and_index_test.rb#L9) [a](https://github.com/rails/rails/blob/master/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb#L19) [few](https://github.com/rails/rails/blob/master/activerecord/test/cases/migration/create_join_table_test.rb#L15)). The `DROP TABLE IF EXISTS` syntax seems to be supported in the popular database engines. I checked MySQL, PostgreSQL, SQLite, MS SQL Server and Oracle.

I'm not sure if `if_exists` is the best name for this option. Suggestions are welcome, if you feel that this is a useful contribution.

/cc @senny 
