### PR TITLE
Fix unscoping bug in preload and includes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Change preload and includes not to ignore scoping.
+    Preload and includes scope is still ignored for #5667.
+
+    Fixes #11036.
+
+    *Takashi Kokubun*
+
 *   Fix type casting to Decimal from Float with large precision.
 
     *Tomohiro Hashidate*

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -159,7 +159,7 @@ module ActiveRecord
             scope.where!(klass.table_name => { reflection.type => model.base_class.sti_name })
           end
 
-          klass.default_scoped.merge(scope)
+          klass.all.unscope(:preload, :includes).merge(scope)
         end
       end
     end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -346,7 +346,7 @@ WARNING
 
     VALID_UNSCOPING_VALUES = Set.new([:where, :select, :group, :order, :lock,
                                      :limit, :offset, :joins, :includes, :from,
-                                     :readonly, :having])
+                                     :readonly, :having, :preload])
 
     # Removes an unwanted relation that is already defined on a chain of relations.
     # This is useful when passing around chains of relations and would like to

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1154,17 +1154,19 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal Comment.find(1), Comment.preload(:post => :comments).scoping { Comment.find(1) }
   end
 
+  test "scoping with a circular includes" do
+    assert_equal Comment.find(1), Comment.includes(:post => :comments).scoping { Comment.find(1) }
+  end
+
   test "circular preload does not modify unscoped" do
     expected = FirstPost.unscoped.find(2)
     FirstPost.preload(:comments => :first_post).find(1)
     assert_equal expected, FirstPost.unscoped.find(2)
   end
 
-  test "preload ignores the scoping" do
-    assert_equal(
-      Comment.find(1).post,
-      Post.where('1 = 0').scoping { Comment.preload(:post).find(1).post }
-    )
+  test "preload does not ignore the scoping" do
+    assert_equal nil, Post.where('1 = 0').find_by(id: Comment.find(1).post_id)
+    assert_equal nil, Post.where('1 = 0').scoping { Comment.preload(:post).find(1).post }
   end
 
   test "deep preload" do


### PR DESCRIPTION
This PR fixes https://github.com/rails/rails/issues/11036.

Currently unscoped block does not work for `includes` and `preload`.
I changed `ActiveRecord::Associations::Preloader` to use [all](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/scoping/named.rb#L24-L30) instead of  [default_scoped](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/scoping/named.rb#L32-L34).
And ignore :preload and :includes scope to pass #5667.
