### PR TITLE
Deprecate source_macro

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Deprecate `Reflection#source_macro`
+
+    `Reflection#source_macro` is no longer needed in Active Record
+    source so it has been deprecated. Code that used `source_macro`
+    was removed in #16353.
+
+    *Eileen M. Uchtitelle*, *Aaron Patterson*
+
 *   No verbose backtrace by db:drop when database does not exist.
 
     Fixes #16295.

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -152,7 +152,11 @@ module ActiveRecord
         JoinKeys.new(foreign_key, active_record_primary_key)
       end
 
-      def source_macro; macro; end
+      def source_macro
+        ActiveSupport::Deprecation.warn("ActiveRecord::Base.source_macro is deprecated and " \
+          "will be removed without replacement.")
+        macro
+      end
     end
     # Base class for AggregateReflection and AssociationReflection. Objects of
     # AggregateReflection and AssociationReflection are returned by the Reflection::ClassMethods.
@@ -738,6 +742,8 @@ Joining, Preloading and eager loading of these associations is deprecated and wi
 
       # The macro used by the source association
       def source_macro
+        ActiveSupport::Deprecation.warn("ActiveRecord::Base.source_macro is deprecated and " \
+          "will be removed without replacement.")
         source_reflection.source_macro
       end
 


### PR DESCRIPTION
`source_macro` is no longer used in any Active Record code. I've chosen to deprecate it because it was not marked as nodoc and may be in use outside of rails source. 

If we prefer to remove it I can alter the PR

 See #16353 for how it is no longer used.
