### PR TITLE
Add an :if_not_exists option to create_table

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add an `:if_not_exists` option to `create_table`. It does not
+    raise an error if the table already exists.
+
+    *Stefan Kanev*
+
 *   Deprecate `Reflection#source_macro`
 
     `Reflection#source_macro` is no longer needed in Active Record

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -36,6 +36,7 @@ module ActiveRecord
 
           def visit_TableDefinition(o)
             create_sql = "CREATE#{' TEMPORARY' if o.temporary} TABLE "
+            create_sql << 'IF NOT EXISTS ' if o.if_not_exists
             create_sql << "#{quote_table_name(o.name)} "
             create_sql << "(#{o.columns.map { |c| accept c }.join(', ')}) " unless o.as
             create_sql << "#{o.options}"

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -80,13 +80,14 @@ module ActiveRecord
       # An array of ColumnDefinition objects, representing the column changes
       # that have been defined.
       attr_accessor :indexes
-      attr_reader :name, :temporary, :options, :as
+      attr_reader :name, :temporary, :if_not_exists, :options, :as
 
-      def initialize(types, name, temporary, options, as = nil)
+      def initialize(types, name, temporary, if_not_exists, options, as = nil)
         @columns_hash = {}
         @indexes = {}
         @native = types
         @temporary = temporary
+        @if_not_exists = if_not_exists
         @options = options
         @as = as
         @name = name

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -132,6 +132,9 @@ module ActiveRecord
       # [<tt>:force</tt>]
       #   Set to true to drop the table before creating it.
       #   Defaults to false.
+      # [<tt>:if_not_exists</tt>]
+      #   Set to true to avoid raising an error when the table already exists.
+      #   Defaults to false.
       # [<tt>:as</tt>]
       #   SQL to use to generate the table. When this option is used, the block is
       #   ignored, as are the <tt>:id</tt> and <tt>:primary_key</tt> options.
@@ -185,6 +188,8 @@ module ActiveRecord
       #
       # See also TableDefinition#column for details on how to create columns.
       def create_table(table_name, options = {})
+        return if options[:if_not_exists] && table_exists?(table_name)
+
         td = create_table_definition table_name, options[:temporary], options[:options], options[:as]
 
         if options[:id] != false && !options[:as]

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -18,7 +18,9 @@ module ActiveRecord
 
         def visit_TableDefinition(o)
           name = o.name
-          create_sql = "CREATE#{' TEMPORARY' if o.temporary} TABLE #{quote_table_name(name)} "
+          create_sql = "CREATE#{' TEMPORARY' if o.temporary} TABLE "
+          create_sql << "IF NOT EXISTS " if o.if_not_exists
+          create_sql << "#{quote_table_name(name)} "
 
           statements = o.columns.map { |c| accept c }
           statements.concat(o.indexes.map { |column_name, options| index_in_create(name, column_name, options) })
@@ -713,7 +715,7 @@ module ActiveRecord
       end
 
       def add_column_sql(table_name, column_name, type, options = {})
-        td = create_table_definition table_name, options[:temporary], options[:options]
+        td = create_table_definition table_name, options[:temporary], false, options[:options]
         cd = td.new_column_definition(column_name, type, options)
         schema_creation.visit_AddColumn cd
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -735,8 +735,8 @@ module ActiveRecord
           $1.strip if $1
         end
 
-        def create_table_definition(name, temporary, options, as = nil) # :nodoc:
-          PostgreSQL::TableDefinition.new native_database_types, name, temporary, options, as
+        def create_table_definition(name, temporary, if_not_exists, options, as = nil) # :nodoc:
+          PostgreSQL::TableDefinition.new native_database_types, name, temporary, if_not_exists, options, as
         end
     end
   end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -104,6 +104,21 @@ class MigrationTest < ActiveRecord::TestCase
     connection.drop_table :testings rescue nil
   end
 
+  def test_create_table_with_if_not_exists_with_an_index
+    connection.drop_table :testings rescue nil
+
+    connection.create_table :testings
+
+    connection.create_table :testings, if_not_exists: true do |t|
+      t.integer :indexed_column, index: true
+    end
+
+    assert_nil connection.columns(:testings).detect { |c| c.name.to_s == 'indexed_column' },
+      "Expected not to recreate the the table"
+  ensure
+    connection.drop_table :testings rescue nil
+  end
+
   def test_create_table_with_force_true_does_not_drop_nonexisting_table
     if Person.connection.table_exists?(:testings2)
       Person.connection.drop_table :testings2

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -89,6 +89,21 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Migrator.run(:up, MIGRATIONS_ROOT + "/version_check", 20131219224947)
   end
 
+  def test_create_table_with_if_not_exists_true
+    connection.drop_table :testings rescue nil
+
+    connection.create_table :testings do |t|
+      t.integer :not_to_be_removed
+    end
+
+    connection.create_table :testings, if_not_exists: true
+
+    assert connection.columns(:testings).detect { |c| c.name.to_s == 'not_to_be_removed' },
+      "Expected not to recreate the the table"
+  ensure
+    connection.drop_table :testings rescue nil
+  end
+
   def test_create_table_with_force_true_does_not_drop_nonexisting_table
     if Person.connection.table_exists?(:testings2)
       Person.connection.drop_table :testings2


### PR DESCRIPTION
Adds an `:if_not_exists` option to `create_table` that makes it do nothing if the table already exists. I'm not sure whether it is useful, but it was mentioned in #16366 and I wanted to give a shot at implementing it.

I'm not sure about the test – I tried mimicking those in the same file (although I used `connection` instead of `Person.connection`). There might be an opportunity for a deeper refactoring of `schema_statements.rb` that I'd love to attempt if somebody gives me a few pointers (hopefully in another pull request). Either way, suggestions are welcome.

/cc @jeremy
