### PR TITLE
[ci skip] Remove "Machinist" from testing guide

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1057,7 +1057,6 @@ The built-in `minitest` based testing is not the only way to test Rails applicat
 
 * [NullDB](http://avdi.org/projects/nulldb/), a way to speed up testing by avoiding database use.
 * [Factory Girl](https://github.com/thoughtbot/factory_girl/tree/master), a replacement for fixtures.
-* [Machinist](https://github.com/notahat/machinist/tree/master), another replacement for fixtures.
 * [Fixture Builder](https://github.com/rdy/fixture_builder), a tool that compiles Ruby factories into fixtures before a test run.
 * [MiniTest::Spec Rails](https://github.com/metaskills/minitest-spec-rails), use the MiniTest::Spec DSL within your rails tests.
 * [Shoulda](http://www.thoughtbot.com/projects/shoulda), an extension to `test/unit` with additional helpers, macros, and assertions.


### PR DESCRIPTION
Machinist isn't under active development.
I think it not to be good as an example
