### PR TITLE
Allow symbol as values for `tokenizer` of `LengthValidator`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow symbol as values for `tokenize` of `LengthValidator`
+
+    *Kensuke Naito*
+
 *   Validate options passed to `ActiveModel::Validations.validate`.
 
     Preventing, in many cases, the simple mistake of using `validate` instead of `validates`.

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -331,6 +331,19 @@ class LengthValidationTest < ActiveModel::TestCase
     assert_equal ["Your essay must be at least 5 words."], t.errors[:content]
   end
 
+
+  def test_validates_length_of_with_symbol
+    Topic.validates_length_of :content, minimum: 5, too_short: "Your essay must be at least %{count} words.",
+                                        tokenizer: :my_word_tokenizer
+    t = Topic.new(content: "this content should be long enough")
+    assert t.valid?
+
+    t.content = "not long enough"
+    assert t.invalid?
+    assert t.errors[:content].any?
+    assert_equal ["Your essay must be at least 5 words."], t.errors[:content]
+  end
+
   def test_validates_length_of_for_fixnum
     Topic.validates_length_of(:approved, is: 4)
 

--- a/activemodel/test/models/topic.rb
+++ b/activemodel/test/models/topic.rb
@@ -37,4 +37,8 @@ class Topic
     errors.add attr, "is missing" unless send(attr)
   end
 
+  def my_word_tokenizer(str)
+   str.scan(/\w+/)
+  end
+
 end


### PR DESCRIPTION
This commit allows to specify a method name for `tokenizer` of `LengthValidator`.

```
class Article
  include ActiveModel::Model

  validates_length_of :content,
    :minimum => 10,
    :message => "must be at least 10 words",
    :tokenizer => :tokenize_by_words

  def tokenize_by_words(text)
    text.scan(/\w+/)
  end
end
```

This makes the code easy to read, and is useful when the same tokenizer is used across the models.

Although it could be provided as a custom validator,  I would love to have this function in core ActiveModel. Please let me know what you think. 
