### PR TITLE
HashWithIndifferentAccess#to_hash renamed to #deep_to_hash. Replacement #to_hash method only converts self to regular Hash.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   `HashWithIndifferentAccess#symbolize_keys` respects any nested
+    `HashWithIndifferentAccess` instances.
+
+    Before:
+
+    {a: { b: 'b'} }.with_indifferent_access.symbolize_keys[:a][:b] # => nil
+
+    After:
+
+    {a: { b: 'b'} }.with_indifferent_access.symbolize_keys[:a][:b] # => 'b'
+
+    Originally `#symbolize_keys` had a side-effect of recursively transforming nested
+    `HashWithIndifferentAccess` instances to an instance of `Hash` (via the `#to_hash`
+    method). `#to_hash` now performs a shallow copy of values to preserve any nested
+    `HashWithIndifferentAccess` instances.
+
+    The new method `#deep_to_hash` replaces the behaviour of `#to_hash`. `#deep_to_hash`
+    is used in `#deep_symbolize_keys`.
+
+    *Gordon Chan*
+
 *   Match `HashWithIndifferentAccess#default`'s behaviour with `Hash#default`
 
     *David Cornu*


### PR DESCRIPTION
Currently `#to_hash` recursively converts any nested `HashWithIndifferentAccess` objects to regular a `Hash` which is inconsistent to the expected usage and behavior of `#to_*` methods.

This has an impact on `HashWithIndifferentAccess#symbolize_keys` (discussed in #16247) such that the values of any nested hash can no longer be accessed indifferently. For example:

``` ruby
hash_wia = {a: { b: 'b'} }.with_indifferent_access
=>  {"a" => { "b" => "b" } }

hash_wia.symbolize_keys[:a][:b]
=> nil # I should expect nested hashes can still be indifferently accessible
```

This change reverts `#to_hash` back to the behavior prior to #10266 (nested hashes remain as `HashWithIndifferentAccess` and values are accessible by `Symbol` or `String`).

A `#deep_to_hash` method is added which implements the current behavior of `#to_hash` (converts nested hashes to regular hashes).
