### PR TITLE
give hint which route uses deprecated match

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -233,7 +233,8 @@ module ActionDispatch
                     "If you want to expose your action to both GET and POST, add `via: [:get, :post]` option.\n" \
                     "If you want to expose your action to GET, use `get` in the router:\n" \
                     "  Instead of: match \"controller#action\"\n" \
-                    "  Do: get \"controller#action\""
+                    "  Do: get \"controller#action\"\n" \
+                    "  Used options: #{options.inspect}"
               raise ArgumentError, msg
             end
 

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -234,7 +234,7 @@ module ActionDispatch
                     "If you want to expose your action to GET, use `get` in the router:\n" \
                     "  Instead of: match \"controller#action\"\n" \
                     "  Do: get \"controller#action\"\n" \
-                    "  Used options: #{options.inspect}"
+                    "  Used conditions: #{conditions.inspect}"
               raise ArgumentError, msg
             end
 


### PR DESCRIPTION
Some gem might add routes with the deprecated `match` method. It is hard to impossible to find the culprit with the present exception message.
