### PR TITLE
Fix for custom_configuration when use only one key

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -155,15 +155,19 @@ module Rails
       def annotations
         SourceAnnotationExtractor::Annotation
       end
-      
+
       private
         class Custom
           def initialize
             @configurations = Hash.new
           end
-    
+
           def method_missing(method, *args)
-            @configurations[method] ||= ActiveSupport::OrderedOptions.new
+            if method.to_s =~ /=$/
+              @configurations[$`.to_sym] = args.first
+            else
+              @configurations[method] ||= ActiveSupport::OrderedOptions.new
+            end
           end
         end
     end

--- a/railties/test/application/configuration/custom_test.rb
+++ b/railties/test/application/configuration/custom_test.rb
@@ -5,11 +5,13 @@ class ApplicationTests::ConfigurationTests::CustomTest < ApplicationTests::Confi
     add_to_config <<-RUBY
       config.x.resque.inline_jobs = :always
       config.x.resque.timeout     = 60
+      config.x.super_debugger = true
     RUBY
     require_environment
 
     assert_equal :always, Rails.configuration.x.resque.inline_jobs
     assert_equal 60, Rails.configuration.x.resque.timeout
     assert_nil Rails.configuration.x.resque.nothing
+    assert_equal true, Rails.configuration.x.super_debugger
   end
 end


### PR DESCRIPTION
When I set only one key in custom_configuration, cannot acquire a value.

``` ruby
config.x.super_debugger = true
```

``` ruby
Rails.configuration.x.super_debugger   # => {}
```

I think that able to acquire a value is good, how about?
