### PR TITLE
Do not align schema output, fixes whitespace diff noise

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -129,29 +129,8 @@ HEADER
           # find all migration keys used in this table
           keys = [:name, :limit, :precision, :scale, :default, :null]
 
-          # figure out the lengths for each column based on above keys
-          lengths = keys.map { |key|
-            column_specs.map { |spec|
-              spec[key] ? spec[key].length + 2 : 0
-            }.max
-          }
-
-          # the string we're going to sprintf our values against, with standardized column widths
-          format_string = lengths.map{ |len| "%-#{len}s" }
-
-          # find the max length for the 'type' column, which is special
-          type_length = column_specs.map{ |column| column[:type].length }.max
-
-          # add column type definition to our format string
-          format_string.unshift "    t.%-#{type_length}s "
-
-          format_string *= ''
-
           column_specs.each do |colspec|
-            values = keys.zip(lengths).map{ |key, len| colspec.key?(key) ? colspec[key] + ", " : " " * len }
-            values.unshift colspec[:type]
-            tbl.print((format_string % values).gsub(/,\s*$/, ''))
-            tbl.puts
+            tbl.puts "    t.#{colspec[:type]} #{colspec.values_at(*keys).compact.join(', ')}"
           end
 
           tbl.puts "  end"

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -50,39 +50,8 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_match %r{create_table "CamelCase"}, output
   end
 
-  def assert_line_up(lines, pattern, required = false)
-    return assert(true) if lines.empty?
-    matches = lines.map { |line| line.match(pattern) }
-    assert matches.all? if required
-    matches.compact!
-    return assert(true) if matches.empty?
-    assert_equal 1, matches.map{ |match| match.offset(0).first }.uniq.length
-  end
-
   def column_definition_lines(output = standard_dump)
     output.scan(/^( *)create_table.*?\n(.*?)^\1end/m).map{ |m| m.last.split(/\n/) }
-  end
-
-  def test_types_line_up
-    column_definition_lines.each do |column_set|
-      next if column_set.empty?
-
-      lengths = column_set.map do |column|
-        if match = column.match(/t\.(?:integer|decimal|float|datetime|timestamp|time|date|text|binary|string|boolean)\s+"/)
-          match[0].length
-        end
-      end
-
-      assert_equal 1, lengths.uniq.length
-    end
-  end
-
-  def test_arguments_line_up
-    column_definition_lines.each do |column_set|
-      assert_line_up(column_set, /:default => /)
-      assert_line_up(column_set, /:limit => /)
-      assert_line_up(column_set, /:null => /)
-    end
   end
 
   def test_no_dump_errors


### PR DESCRIPTION
We were seeing differences in whitespace when running new migrations since if you add a new longer column name or options (in some cases) it would cause whitespace changes through the schema.rb, which was annoying. Removing the code that does this simplifies the schema dumper and it now will not create diff noise.

For us, this is clearly 100% better. However, I totally accept this is largely subjective, and have zero expectation for this to be merged, but just on the off chance here it is :)
