### PR TITLE
Add include_omission_length option to String truncate

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add include_omission_length option to String truncate
+
+    *Ejay Canaria*
+
 *   Fix that render layout: 'messages/layout' should also be added to the dependency tracker tree.
 
     *DHH*

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -104,6 +104,10 @@ class TextHelperTest < ActionView::TestCase
     assert_equal "Hello Big[...]", truncate("Hello Big World!", :omission => "[...]", :length => 15, :separator => ' ')
   end
 
+  def test_truncate_with_include_omission_length
+    assert_equal "Hello...", truncate("Hello World", length: 5, include_omission_length: true)
+  end
+
   def test_truncate_multibyte
     assert_equal "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 ...".force_encoding(Encoding::UTF_8),
       truncate("\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 \354\225\204\353\235\274\353\246\254\354\230\244".force_encoding(Encoding::UTF_8), :length => 10)

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,7 +1,10 @@
+*   Add include_omission_length option to String truncate
+
+    *Ejay Canaria*
+
+
 *   Added Object#itself which returns the object itself. Useful when dealing with a chaining scenario, like Active Record scopes:
-
         Event.public_send(state.presence_in([ :trashed, :drafted ]) || :itself).order(:created_at)
-
     *DHH*
 
 *   `Object#with_options` executes block in merging option context when

--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -48,16 +48,23 @@ class String
   #
   #   'And they found that many people were sleeping better.'.truncate(25, omission: '... (continued)')
   #   # => "And they f... (continued)"
+  #
+  # Set <tt>:include_omission_length<tt> to true to include the omission length from the total length
+  # of the truncated string:
+  #
+  #   'Once upon a time in a world far far away'.truncate(4, include_omission_length: true)
+  #   # => "Once..."
   def truncate(truncate_at, options = {})
     return dup unless length > truncate_at
 
     omission = options[:omission] || '...'
-    length_with_room_for_omission = truncate_at - omission.length
+    truncation_length = options[:include_omission_length] ? truncate_at : (truncate_at - omission.length)
+
     stop = \
       if options[:separator]
-        rindex(options[:separator], length_with_room_for_omission) || length_with_room_for_omission
+        rindex(options[:separator], truncation_length) || truncation_length
       else
-        length_with_room_for_omission
+        truncation_length
       end
 
     "#{self[0, stop]}#{omission}"

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -229,6 +229,10 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal "Hello Big[...]", "Hello Big World!".truncate(15, :omission => "[...]", :separator => /\s/)
   end
 
+  def test_truncate_with_include_omission_length
+    assert_equal "Hello...", "Hello World".truncate(5, include_omission_length: true)
+  end
+
   def test_truncate_words
     assert_equal "Hello Big World!", "Hello Big World!".truncate_words(3)
     assert_equal "Hello Big...", "Hello Big World!".truncate_words(2)


### PR DESCRIPTION
This will add the omission length to the final length of the
truncated string.

```
"Hello World".truncate(5, include_omission_length: true)
# => "Hello..."
```
