### PR TITLE
Always use SQL limit in Relation#last when limit argument given

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Rework `ActiveRecord::Relation#last` 
+    
+    1. Always find last with ruby if relation is loaded
+    2. Always use SQL instead if relation is not loaded.
+    3. Deprecated relation loading when SQL order can not be automatically reversed
+
+        Topic.order("title").load.last(3)
+          # before: SELECT ...
+          # after: No SQL
+
+        Topic.order("title").last
+          # before: SELECT * FROM `topics`
+          # after:  SELECT * FROM `topics` ORDER BY `topics`.`title` DESC LIMIT 1
+
+        Topic.order("coalesce(author, title)").last
+          # before: SELECT * FROM `topics`
+          # after:  Deprecation Warning for irreversible order
+
+    *Bogdan Gusiev*
+
 *   `ActiveRecord::Relation#reverse_order` throws `ActiveRecord::IrreversibleOrderError`
     when the order can not be reversed using current trivial algorithm.
     Also raises the same error when `#reverse_order` is called on

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -506,7 +506,7 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
-  def test_take_and_first_and_last_with_integer_should_use_sql_limit
+  def test_take_and_first_and_last_with_integer_should_use_sql
     assert_sql(/LIMIT|ROWNUM <=/) { Topic.take(3).entries }
     assert_sql(/LIMIT|ROWNUM <=/) { Topic.first(2).entries }
     assert_sql(/LIMIT|ROWNUM <=/) { Topic.last(5).entries }
@@ -516,16 +516,30 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal Topic.order("title").to_a.last(2), Topic.order("title").last(2)
   end
 
-  def test_last_with_integer_and_order_should_not_use_sql_limit
-    query = assert_sql { Topic.order("title").last(5).entries }
-    assert_equal 1, query.length
-    assert_no_match(/LIMIT/, query.first)
+  def test_last_with_integer_and_order_should_use_sql
+    relation = Topic.order("title")
+    assert_queries(1) { relation.last(5) }
+    assert !relation.loaded?
   end
 
-  def test_last_with_integer_and_reorder_should_not_use_sql_limit
-    query = assert_sql { Topic.reorder("title").last(5).entries }
-    assert_equal 1, query.length
-    assert_no_match(/LIMIT/, query.first)
+  def test_last_with_integer_and_reorder_should_use_sql
+    relation = Topic.reorder("title")
+    assert_queries(1) { relation.last(5) }
+    assert !relation.loaded?
+  end
+
+  def test_last_on_loaded_relation_should_not_use_sql
+    relation  = Topic.limit(10).load
+    assert_no_queries do
+      relation.last
+      relation.last(2)
+    end
+  end
+
+  def test_last_with_irreversible_order
+    assert_deprecated do
+      Topic.order("coalesce(author_name, title)").last
+    end
   end
 
   def test_take_and_first_and_last_with_integer_should_return_an_array


### PR DESCRIPTION
Using `Relation#last` causes entire relation to be loaded into memory. 
In most cases it is unacceptable:

``` ruby
    Topic.order(:created_at).last(2)
      # => SELECT * FROM topics ORDER BY created_at
```

We can still use `reverse_order` to let SQL do heavy lifting (AR is quite bad at that).

``` ruby
    Topic.order(:created_at).last(2)
      # => SELECT * FROM topics ORDER BY created_at DESC LIMIT 2
```

Unfortunately back to 2011 in this commit 5f5527c7 it wasn't done. And 2 x unfortunately this commit added 2 tests that need to be modified now.

@dmathieu do you still remember something about it?
