### PR TITLE
Fixed #select form builder helper to support block without html output

### DIFF
--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -3,7 +3,7 @@ module ActionView
     module Tags # :nodoc:
       class Select < Base # :nodoc:
         def initialize(object_name, method_name, template_object, choices, options, html_options)
-          @choices = block_given? ? template_object.capture { yield } : choices
+          @choices = block_given? ? template_object.capture { yield || "" } : choices
           @choices = @choices.to_a if @choices.is_a?(Range)
 
           @html_options = html_options

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -591,6 +591,19 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_under_fields_for_with_block_without_options
+    @post = Post.new
+
+    output_buffer = fields_for :post, @post do |f|
+      concat(f.select(:category) {})
+    end
+
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"></select>",
+      output_buffer
+    )
+  end
+
   def test_select_with_multiple_to_add_hidden_input
     output_buffer =  select(:post, :category, "", {}, :multiple => true)
     assert_dom_equal(


### PR DESCRIPTION
Example code:

``` haml
= form.select(:campaign_id) do
  - available_campaigns.each do |c|
    %option{value: c.id}= c.name
```

Cause nil exception when `available_campaigns` is empty Array.
