### PR TITLE
Moved #create! method from Validations to Persistence module

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -36,6 +36,18 @@ module ActiveRecord
         end
       end
 
+      # Creates an object just like Base.create but calls <tt>save!</tt> instead of +save+
+      # so an exception is raised if the record is invalid.
+      def create!(attributes = nil, &block)
+        if attributes.is_a?(Array)
+          attributes.collect { |attr| create!(attr, &block) }
+        else
+          object = new(attributes, &block)
+          object.save!
+          object
+        end
+      end
+
       # Given an attributes hash, +instantiate+ returns a new instance of
       # the appropriate class. Accepts only keys as strings.
       #

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -29,21 +29,6 @@ module ActiveRecord
     extend ActiveSupport::Concern
     include ActiveModel::Validations
 
-    module ClassMethods
-      # Creates an object just like Base.create but calls <tt>save!</tt> instead of +save+
-      # so an exception is raised if the record is invalid.
-      def create!(attributes = nil, &block)
-        if attributes.is_a?(Array)
-          attributes.collect { |attr| create!(attr, &block) }
-        else
-          object = new(attributes)
-          yield(object) if block_given?
-          object.save!
-          object
-        end
-      end
-    end
-
     # The validation process on save can be skipped by passing <tt>validate: false</tt>.
     # The regular Base#save method is replaced with this when the validations
     # module is mixed in, which it is by default.


### PR DESCRIPTION
Not sure why `create!` is defined in Validations. Maybe historical reasons, but all other methods like `save`, `save!` and `create` defined in Persistence and only overwritten in Validations. That is why moved `create!` to Persistence as well.
