### PR TITLE
Fix digest ETAG test.

### DIFF
--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -188,7 +188,7 @@ module ApplicationTests
         end
       end
 
-      etag = "5af83e3196bf99f440f31f2e1a6c9afe".inspect
+      etag = "W/" + ("5af83e3196bf99f440f31f2e1a6c9afe".inspect)
 
       get "/"
       assert_equal 200, last_response.status


### PR DESCRIPTION
After https://github.com/rack/rack/commit/12528d4567d8e6c1c7e9422fee6cd8b43c4389bf
ETag will include a `W/` before the digest.. We need to fix the test accordingly. 
