### PR TITLE
Fix in has_secure_password for passwords containing only spaces.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Passwords with spaces only allowed in `ActiveModel::SecurePassword`.
+
+    Presence validation can be used to resore old behavior.
+
+    *Yevhene Shemet*
+
 *   Validate options passed to `ActiveModel::Validations.validate`.
 
     Preventing, in many cases, the simple mistake of using `validate` instead of `validates`.

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -105,7 +105,7 @@ module ActiveModel
       attr_reader :password
 
       # Encrypts the password into the +password_digest+ attribute, only if the
-      # new password is not blank.
+      # new password is not empty.
       #
       #   class User < ActiveRecord::Base
       #     has_secure_password validations: false
@@ -119,7 +119,7 @@ module ActiveModel
       def password=(unencrypted_password)
         if unencrypted_password.nil?
           self.password_digest = nil
-        elsif unencrypted_password.present?
+        elsif !unencrypted_password.empty?
           @password = unencrypted_password
           cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
           self.password_digest = BCrypt::Password.create(unencrypted_password, cost: cost)

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -40,6 +40,11 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert @user.valid?(:create), 'user should be valid'
   end
 
+  test "create a new user with validation and a spaces only password" do
+    @user.password = ' ' * 72
+    assert @user.valid?(:create), 'user should be valid'
+  end
+
   test "create a new user with validation and a blank password" do
     @user.password = ''
     assert !@user.valid?(:create), 'user should be invalid'
@@ -103,6 +108,11 @@ class SecurePasswordTest < ActiveModel::TestCase
   test "updating an existing user with validation and a blank password" do
     @existing_user.password = ''
     assert @existing_user.valid?(:update), 'user should be valid'
+  end
+
+  test "updating an existing user with validation and a spaces only password" do
+    @user.password = ' ' * 72
+    assert @user.valid?(:update), 'user should be valid'
   end
 
   test "updating an existing user with validation and a blank password and password_confirmation" do


### PR DESCRIPTION
Steps:
1. Existing model with has_secure_password. With encrypted_password stored.
2. User try to update password with password containing only spaces.
3. Password is discarded. Model is valid and stored. Password is not changed but no error massage given.
