### PR TITLE
freezing UriEncoder::DEC2HEX and its contents

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -28,7 +28,7 @@ module ActionDispatch
           US_ASCII = Encoding::US_ASCII
           UTF_8    = Encoding::UTF_8
           EMPTY    = "".force_encoding(US_ASCII).freeze
-          DEC2HEX  = (0..255).to_a.map{ |i| ENCODE % i }.map{ |s| s.force_encoding(US_ASCII) }
+          DEC2HEX  = (0..255).map{ |i| ENCODE % i }.map{ |s| s.force_encoding(US_ASCII).freeze }.freeze
 
           ALPHA = "a-zA-Z".freeze
           DIGIT = "0-9".freeze


### PR DESCRIPTION
These are only used internally and are never modified.
