### PR TITLE
Add exception backtrace to instrument payload

### DIFF
--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -19,7 +19,7 @@ module ActiveSupport
         begin
           yield payload
         rescue Exception => e
-          payload[:exception] = [e.class.name, e.message]
+          payload[:exception] = [e.class.name, e.message, e.backtrace]
           raise e
         ensure
           finish name, payload


### PR DESCRIPTION
When an Exception is raised, instrumentations have no way of getting the backtrace. Only the Exception name and message which is often not enough.

Further comments in Issue #16382
