### PR TITLE
Tables existence check query is executed in large quantities

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -19,6 +19,7 @@ module ActiveRecord
 
       # A cached lookup for table existence.
       def table_exists?(name)
+        prepare_tables if @tables.blank?
         return @tables[name] if @tables.key? name
 
         @tables[name] = connection.table_exists?(name)
@@ -82,6 +83,12 @@ module ActiveRecord
       def marshal_load(array)
         @version, @columns, @columns_hash, @primary_keys, @tables = array
       end
+
+      private
+
+        def prepare_tables
+          connection.tables.each { |table| @tables[table] = true }
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -19,7 +19,7 @@ module ActiveRecord
 
       # A cached lookup for table existence.
       def table_exists?(name)
-        prepare_tables if @tables.blank?
+        prepare_tables if @tables.empty?
         return @tables[name] if @tables.key? name
 
         @tables[name] = connection.table_exists?(name)


### PR DESCRIPTION
When Rails starts, tables existence check query is executed number of models.
In case of mysql,

```
SHOW TABLES LIKE 'table1';
SHOW TABLES LIKE 'table2';
SHOW TABLES LIKE 'table3';
...
SHOW TABLES LIKE 'table999';
```

Add process to get the names of all tables by one query.
