### PR TITLE
Fix regression on after_commit in nested transactions.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix regression on after_commit that didnt fire when having nested transactions.
+
+    Fixes #16425
+
+    *arthurnn*
+
 *   Define `id_was` to get the previous value of the primary key.
 
     Currently when we call id_was and we have a custom primary key name

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -201,6 +201,7 @@ module ActiveRecord
         @state.set_state(:committed)
         @state.parent = parent.state
         connection.release_savepoint
+        records.each { |r| parent.add_record(r) }
       end
     end
   end


### PR DESCRIPTION
after_commit should not run in nested transactions, however they should
run once the outermost transaction gets committed. This patch fixes the
problem copying the records from the `Savepoint` to its parent. So the
`RealTransaction` will have all records that needs to run callbacks on it.

[fixes #16425]

review @rafaelfranca @chancancode
this should be applied on 4-0-stable too.
I will work on a different fix for master, as the code is different. 
