### PR TITLE
Add digest config option for SignedCookiesJar

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `config.action_dispatch.cookies_digest` option for setting custom
+    digest. The default remains the same - 'SHA1'.
+
+    *Łukasz Strzałkowski*
+
 *   Extract source code for the entire exception stack trace for
     better debugging and diagnosis.
 

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -90,6 +90,7 @@ module ActionDispatch
     SECRET_TOKEN = "action_dispatch.secret_token".freeze
     SECRET_KEY_BASE = "action_dispatch.secret_key_base".freeze
     COOKIES_SERIALIZER = "action_dispatch.cookies_serializer".freeze
+    COOKIES_DIGEST = "action_dispatch.cookies_digest".freeze
 
     # Cookies can typically store 4096 bytes.
     MAX_COOKIE_SIZE = 4096
@@ -212,7 +213,8 @@ module ActionDispatch
           secret_token: env[SECRET_TOKEN],
           secret_key_base: env[SECRET_KEY_BASE],
           upgrade_legacy_signed_cookies: env[SECRET_TOKEN].present? && env[SECRET_KEY_BASE].present?,
-          serializer: env[COOKIES_SERIALIZER]
+          serializer: env[COOKIES_SERIALIZER],
+          digest: env[COOKIES_DIGEST]
         }
       end
 
@@ -441,6 +443,10 @@ module ActionDispatch
             serializer
           end
         end
+
+        def digest
+          @options[:digest] || 'SHA1'
+        end
     end
 
     class SignedCookieJar #:nodoc:
@@ -451,7 +457,7 @@ module ActionDispatch
         @parent_jar = parent_jar
         @options = options
         secret = key_generator.generate_key(@options[:signed_cookie_salt])
-        @verifier = ActiveSupport::MessageVerifier.new(secret, serializer: NullSerializer)
+        @verifier = ActiveSupport::MessageVerifier.new(secret, digest: digest, serializer: NullSerializer)
       end
 
       def [](name)

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -369,6 +369,23 @@ class CookiesTest < ActionController::TestCase
     assert_equal 'Jamie', @controller.send(:cookies).permanent[:user_name]
   end
 
+  def test_signed_cookie_using_default_digest
+    get :set_signed_cookie
+    cookies = @controller.send :cookies
+    assert_not_equal 45, cookies[:user_id]
+    assert_equal 45, cookies.signed[:user_id]
+    assert_equal 'SHA1', cookies.signed.instance_variable_get(:"@verifier").instance_variable_get(:"@digest")
+  end
+
+  def test_signed_cookie_using_custom_digest
+    @request.env["action_dispatch.cookies_digest"] = 'SHA256'
+    get :set_signed_cookie
+    cookies = @controller.send :cookies
+    assert_not_equal 45, cookies[:user_id]
+    assert_equal 45, cookies.signed[:user_id]
+    assert_equal 'SHA256', cookies.signed.instance_variable_get(:"@verifier").instance_variable_get(:"@digest")
+  end
+
   def test_signed_cookie_using_default_serializer
     get :set_signed_cookie
     cookies = @controller.send :cookies

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   The `Rails.application.message_verifier` now returns ActiveSupport::MessageVerifier
+    preconfigured with `:digest` and `:serializer` values set to `config.action_dispatch.cookies_digest`
+    and `config.action_dispatch.cookies_serializer` accordingly.
+
+    *Łukasz Strzałkowski*
+
 *   Add `after_bundle` callbacks in Rails templates. Useful for allowing the
     generated binstubs to be added to version control.
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -200,7 +200,7 @@ module Rails
     def message_verifier(verifier_name)
       @message_verifiers[verifier_name] ||= begin
         secret = key_generator.generate_key(verifier_name.to_s)
-        ActiveSupport::MessageVerifier.new(secret)
+        ActiveSupport::MessageVerifier.new(secret, digest: config.action_dispatch.cookies_digest, serializer: config.action_dispatch.cookies_serializer)
       end
     end
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -257,6 +257,7 @@ module Rails
           "action_dispatch.encrypted_cookie_salt" => config.action_dispatch.encrypted_cookie_salt,
           "action_dispatch.encrypted_signed_cookie_salt" => config.action_dispatch.encrypted_signed_cookie_salt,
           "action_dispatch.cookies_serializer" => config.action_dispatch.cookies_serializer
+          "action_dispatch.cookies_digest" => config.action_dispatch.cookies_digest
         })
       end
     end


### PR DESCRIPTION
Two commits with small improvements:
- `config.action_dispatch.cookies_digest` config option
- `AS::MessageVerifier` now returns object preconfigured with `config.action_dispatch.cookies_serializer` && `config.action_dispatch.cookies_digest` values.

/cc @chancancode @tamird
