### PR TITLE
Fix regression on after_commit in nested transactions. (master)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix regression on after_commit that didnt fire when having nested transactions.
+
+    Fixes #16425
+
+    *arthurnn*
+
 *   Do not try to write timestamps when a table has no timestamps columns.
 
     Fixes #8813.

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -169,16 +169,14 @@ module ActiveRecord
         transaction = begin_transaction options
         yield
       rescue Exception => error
-        transaction.rollback if transaction
+        rollback_transaction if transaction
         raise
       ensure
         begin
-          transaction.commit unless error
+          commit_transaction unless error
         rescue Exception
           transaction.rollback
           raise
-        ensure
-          @stack.pop if transaction
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -111,6 +111,8 @@ module ActiveRecord
       def commit
         super
         connection.release_savepoint(savepoint_name)
+        parent = connection.transaction_manager.current_transaction
+        records.each { |r| parent.add_record(r) }
       end
 
       def full_rollback?; false; end


### PR DESCRIPTION
related to #16432 .

[fixes #16425]

This is practically a backport of that fix, plus 1 commit to make it work.

This is to ensure the same behaviour as 3.2
