### PR TITLE
Docs: grammar fix for fetch. [ci skip]

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -237,7 +237,7 @@ module ActiveSupport
       # seconds. Because of extended life of the previous cache, other processes
       # will continue to use slightly stale data for a just a bit longer. In the
       # meantime that first process will go ahead and will write into cache the
-      # new value. After that all the processes will start getting new value.
+      # new value. After that all the processes will start getting the new value.
       # The key is to keep <tt>:race_condition_ttl</tt> small.
       #
       # If the process regenerating the entry errors out, the entry will be


### PR DESCRIPTION
Grammar fix for fetch documentation.
