### PR TITLE
Pass block for logging.

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -303,10 +303,12 @@ module ActionController
       logger = ActionController::Base.logger
       return unless logger
 
-      message = "\n#{exception.class} (#{exception.message}):\n"
-      message << exception.annoted_source_code.to_s if exception.respond_to?(:annoted_source_code)
-      message << "  " << exception.backtrace.join("\n  ")
-      logger.fatal("#{message}\n\n")
+      logger.fatal do
+        message = "\n#{exception.class} (#{exception.message}):\n"
+        message << exception.annoted_source_code.to_s if exception.respond_to?(:annoted_source_code)
+        message << "  " << exception.backtrace.join("\n  ")
+        "#{message}\n\n"
+      end
     end
 
     def response_body=(body)


### PR DESCRIPTION
This follows the good practice listed on http://guides.rubyonrails.org/debugging_rails_applications.html#impact-of-logs-on-performance.
