### PR TITLE
Fix counter_cache for polymorphic associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix a bug where counter_cache doesn't always work with  polymorphic
+    relations.
+
+    Fixes #16407.
+
+    *Stefan Kanev*
+
 *   When calling `update_columns` on a record that is not persisted, the error
     message now reflects whether that object is a new record or has been
     destroyed.

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -35,16 +35,24 @@ module ActiveRecord::Associations::Builder
 
           if (@_after_create_counter_called ||= false)
             @_after_create_counter_called = false
-          elsif attribute_changed?(foreign_key) && !new_record? && reflection.constructable?
-            model           = reflection.klass
+          elsif attribute_changed?(foreign_key) && !new_record?
+            if reflection.polymorphic?
+              model     = attribute(reflection.foreign_type).try(:constantize)
+              model_was = attribute_was(reflection.foreign_type).try(:constantize)
+            else
+              model     = reflection.klass
+              model_was = reflection.klass
+            end
+
             foreign_key_was = attribute_was foreign_key
             foreign_key     = attribute foreign_key
 
             if foreign_key && model.respond_to?(:increment_counter)
               model.increment_counter(cache_column, foreign_key)
             end
-            if foreign_key_was && model.respond_to?(:decrement_counter)
-              model.decrement_counter(cache_column, foreign_key_was)
+
+            if foreign_key_was && model_was.respond_to?(:decrement_counter)
+              model_was.decrement_counter(cache_column, foreign_key_was)
             end
           end
         end

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -1,6 +1,7 @@
 require 'cases/helper'
 require 'models/topic'
 require 'models/car'
+require 'models/aircraft'
 require 'models/wheel'
 require 'models/engine'
 require 'models/reply'
@@ -178,6 +179,18 @@ class CounterCacheTest < ActiveRecord::TestCase
 
     assert_difference 'special.reload.replies_count', -1 do
       SpecialTopic.reset_counters(special.id, :lightweight_special_replies)
+    end
+  end
+
+  test "update counters in a polymorphic relationship" do
+    aircraft = Aircraft.create!
+
+    assert_difference 'aircraft.reload.wheels_count' do
+      aircraft.wheels << Wheel.create!
+    end
+
+    assert_difference 'aircraft.reload.wheels_count', -1 do
+      aircraft.wheels.first.destroy
     end
   end
 end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -252,18 +252,6 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     end
   end
 
-  def test_polymorphic_destroy_with_dependencies_and_lock_version
-    car = Car.create!
-
-    assert_difference 'car.wheels.count'  do
-      car.wheels << Wheel.create!
-    end
-    assert_difference 'car.wheels.count', -1  do
-      car.destroy
-    end
-    assert car.destroyed?
-  end
-
   def test_removing_has_and_belongs_to_many_associations_upon_destroy
     p = RichPerson.create! first_name: 'Jon'
     p.treasures.create!

--- a/activerecord/test/models/aircraft.rb
+++ b/activerecord/test/models/aircraft.rb
@@ -1,4 +1,5 @@
 class Aircraft < ActiveRecord::Base
   self.pluralize_table_names = false
   has_many :engines, :foreign_key => "car_id"
+  has_many :wheels, as: :wheelable
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define do
 
   create_table :aircraft, force: true do |t|
     t.string :name
+    t.integer :wheels_count, default: 0, null: false
   end
 
   create_table :articles, force: true do |t|


### PR DESCRIPTION
Fixes #16407.

[ActiveRecord::Association::Builder::BelongsTo](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/belongs_to.rb#L38) does not take into account polymorphic relationships. This change takes care of that.

Unfortunately, the fix broke a test. Fortunately, the test depended on this bug being present. I've removed it and detailed the reasons in the commit message. I'm copying it here for completeness' sake:

```
At this time, counter_cache does not work with polymorphic relationships
(which is a bug). The test was added to make sure that no
StaleObjectError is raised when the car is destroyed. No such error is
currently raised because the lock version is not incremented by
appending a wheel to the car.

Furthermore, `assert_difference` succeeds because `car.wheels.count`
does not check the counter cache, but the collection size. The test will
fail if it is replaced with `car.wheels_count || 0`.
```

/cc @senny
