### PR TITLE
Fix `touch: true` in polymorphic relations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fixed `touch: true` in polymorphic relationships. Prior to the change the
+    other end of `belongs_to polymorphic: true, touch: true` was not touched
+    when the record is updated.
+
+    Fixes #16446.
+
+    *Stefan Kanev*
+
 *   When calling `update_columns` on a record that is not persisted, the error
     message now reflects whether that object is a new record or has been
     destroyed.

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -521,7 +521,10 @@ Joining, Preloading and eager loading of these associations is deprecated and wi
         def valid_inverse_reflection?(reflection)
           reflection &&
             klass.name == reflection.active_record.name &&
-            can_find_inverse_of_automatically?(reflection)
+            reflection.options[:inverse_of] != false &&
+            VALID_AUTOMATIC_INVERSE_MACROS.include?(reflection.macro) &&
+            (INVALID_AUTOMATIC_INVERSE_OPTIONS - [:polymorphic]).none? { |opt| reflection.options[opt] } &&
+            !reflection.scope
         end
 
         # Checks to see if the reflection doesn't have any options that prevent

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -1,5 +1,4 @@
 require "cases/helper"
-require 'models/man'
 require 'models/face'
 require 'models/interest'
 require 'models/zine'
@@ -10,6 +9,9 @@ require 'models/comment'
 require 'models/car'
 require 'models/bulb'
 require 'models/mixed_case_monkey'
+require 'models/man'
+require 'models/pet'
+require 'models/aircraft'
 
 class AutomaticInverseFindingTests < ActiveRecord::TestCase
   fixtures :ratings, :comments, :cars
@@ -101,15 +103,37 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     assert !club_reflection.has_inverse?, "A has_many_through association should not find an inverse automatically"
   end
 
-  def test_polymorphic_relationships_should_still_not_have_inverses_when_non_polymorphic_relationship_has_the_same_name
-    man_reflection = Man.reflect_on_association(:polymorphic_face_without_inverse)
-    face_reflection = Face.reflect_on_association(:man)
-
-    assert_respond_to face_reflection, :has_inverse?
-    assert face_reflection.has_inverse?, "For this test, the non-polymorphic association must have an inverse"
+  def test_the_has_many_side_of_a_polymorphic_relation_can_have_an_inverse
+    man_reflection = Man.reflect_on_association(:polymorphic_faces_without_inverse)
+    face_reflection = Face.reflect_on_association(:poly_man_without_inverse)
 
     assert_respond_to man_reflection, :has_inverse?
-    assert !man_reflection.has_inverse?, "The target of a polymorphic association should not find an inverse automatically"
+    assert man_reflection.has_inverse?, "A has_many :as relation should be able to automatically find an inverse"
+
+    assert_respond_to face_reflection, :has_inverse?
+    assert !face_reflection.has_inverse?, "A polymorphic relation cannot automatically find its inverse"
+  end
+
+  def test_belongs_to_with_scope_should_not_have_inverses_in_either_direction
+    pet_reflection = Pet.reflect_on_association(:man)
+    man_reflection = Man.reflect_on_association(:pet)
+
+    assert_respond_to pet_reflection, :has_inverse?
+    assert !pet_reflection.has_inverse?, "A belongs_to association should not find automatically an inverse with a scope"
+
+    assert_respond_to man_reflection, :has_inverse?
+    assert !man_reflection.has_inverse?, "A has_one association with a scope should not find its inverse automatically"
+  end
+
+  def test_belongs_to_with_foreign_key_should_not_have_inverses_in_either_direction
+    man_reflection = Man.reflect_on_association(:aircraft)
+    aircraft_reflection = Aircraft.reflect_on_association(:man)
+
+    assert_respond_to man_reflection, :has_inverse?
+    assert !man_reflection.has_inverse?, "A belongs_to association should not find automatically an inverse with a foreign_key"
+
+    assert_respond_to aircraft_reflection, :has_inverse?
+    assert !aircraft_reflection.has_inverse?, "A has_one association with a foreign key should not find its inverse automatically"
   end
 end
 

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -12,6 +12,7 @@ require 'models/bulb'
 require 'models/engine'
 require 'models/wheel'
 require 'models/treasure'
+require 'models/price_estimate'
 
 class LockWithoutDefault < ActiveRecord::Base; end
 
@@ -271,6 +272,24 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     p.destroy
     assert p.treasures.empty?
     assert RichPerson.connection.select_all("SELECT * FROM peoples_treasures WHERE rich_person_id = 1").empty?
+  end
+
+  def test_belongs_to_touch
+    car = Car.create!
+    car.bulbs << Bulb.create!
+    car.name = 'Delorean'
+    car.save!
+
+    assert_equal 2, car.lock_version
+  end
+
+  def test_belongs_to_touch_polymorphic
+    car = Car.create!
+    car.price_estimates << PriceEstimate.create!
+    car.name = 'Delorean'
+    car.save!
+
+    assert_equal 2, car.lock_version
   end
 
   def test_yaml_dumping_with_lock_column

--- a/activerecord/test/models/aircraft.rb
+++ b/activerecord/test/models/aircraft.rb
@@ -1,4 +1,5 @@
 class Aircraft < ActiveRecord::Base
   self.pluralize_table_names = false
   has_many :engines, :foreign_key => "car_id"
+  belongs_to :man
 end

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -10,6 +10,7 @@ class Car < ActiveRecord::Base
   has_many :tyres
   has_many :engines, :dependent => :destroy
   has_many :wheels, :as => :wheelable, :dependent => :destroy
+  has_many :price_estimates, as: :estimate_of
 
   scope :incl_tyres, -> { includes(:tyres) }
   scope :incl_engines, -> { includes(:engines) }

--- a/activerecord/test/models/man.rb
+++ b/activerecord/test/models/man.rb
@@ -1,11 +1,13 @@
 class Man < ActiveRecord::Base
   has_one :face, :inverse_of => :man
   has_one :polymorphic_face, :class_name => 'Face', :as => :polymorphic_man, :inverse_of => :polymorphic_man
-  has_one :polymorphic_face_without_inverse, :class_name => 'Face', :as => :poly_man_without_inverse
+  has_many :polymorphic_faces_without_inverse, :class_name => 'Face', :as => :poly_man_without_inverse
   has_many :interests, :inverse_of => :man
   has_many :polymorphic_interests, :class_name => 'Interest', :as => :polymorphic_man, :inverse_of => :polymorphic_man
   # These are "broken" inverse_of associations for the purposes of testing
   has_one :dirty_face, :class_name => 'Face', :inverse_of => :dirty_man
   has_many :secret_interests, :class_name => 'Interest', :inverse_of => :secret_man
   has_one :mixed_case_monkey
+  has_one :pet, -> { where(name: "Man's best friend") }
+  has_one :aircraft, foreign_key: 'pilot_id'
 end

--- a/activerecord/test/models/pet.rb
+++ b/activerecord/test/models/pet.rb
@@ -3,6 +3,7 @@ class Pet < ActiveRecord::Base
 
   self.primary_key = :pet_id
   belongs_to :owner, :touch => true
+  belongs_to :man
   has_many :toys
 
   class << self

--- a/activerecord/test/models/price_estimate.rb
+++ b/activerecord/test/models/price_estimate.rb
@@ -1,4 +1,4 @@
 class PriceEstimate < ActiveRecord::Base
-  belongs_to :estimate_of, :polymorphic => true
+  belongs_to :estimate_of, polymorphic: true, touch: true
   belongs_to :thing, polymorphic: true
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define do
 
   create_table :aircraft, force: true do |t|
     t.string :name
+    t.references :pilot
   end
 
   create_table :articles, force: true do |t|
@@ -548,6 +549,7 @@ ActiveRecord::Schema.define do
   create_table :pets, primary_key: :pet_id, force: true do |t|
     t.string :name
     t.integer :owner_id, :integer
+    t.references :man
     t.timestamps
   end
 


### PR DESCRIPTION
Fixes #16446.

`touch: true` relies on the inverse of a relationship. It couldn't be found automatically for a `has_many :as`. This change allows for the inverse of `has_many` side of a polymorphic relation to be discovered automatically (but not the other way around).

There was a test explicitly checking that the inverse of `has_many :foo, as: :bar` cannot be automatically discovered. The test was introduced in #15343, fixing #15337. I executed [the gist with the reproduction](https://gist.github.com/dontfidget/c5cf589d4fb8994afd8b) after my change and it runs without errors. I couldn't see the relation between the test and issue, so I changed the test.

/cc @senny
