### PR TITLE
Change error message in update_columns for destroyed objects

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   When calling `update_columns` on a record that is not persisted, the error
+    message now reflects whether that object is a new record or has been
+    destroyed.
+
+    *Lachlan Sylvester*
+
 *   Define `id_was` to get the previous value of the primary key.
 
     Currently when we call id_was and we have a custom primary key name

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -287,7 +287,8 @@ module ActiveRecord
     # This method raises an +ActiveRecord::ActiveRecordError+ when called on new
     # objects, or when at least one of the attributes is marked as readonly.
     def update_columns(attributes)
-      raise ActiveRecordError, "cannot update on a new record object" unless persisted?
+      raise ActiveRecordError, "cannot update a new record" if new_record?
+      raise ActiveRecordError, "cannot update a destroyed record" if destroyed?
 
       attributes.each_key do |key|
         verify_readonly_attribute(key.to_s)


### PR DESCRIPTION
When calling `update_columns` on a record that has been destroyed, the error message read "cannot update on a new record object" which is confusing as it is not a new record object.

The new message reflects the record could be a new record or a destroyed record.
