### PR TITLE
Add expiration support for message_verifier and message_encryptor

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -29,6 +29,7 @@ module ActiveSupport
     end
 
     class InvalidMessage < StandardError; end
+    ExpiredMessage = ActiveSupport::PerishableEnvelope::ExpiredMessage
     OpenSSLCipherError = OpenSSL::Cipher::CipherError
 
     # Initialize a new MessageEncryptor. +secret+ must be at least as long as
@@ -49,13 +50,17 @@ module ActiveSupport
       @sign_secret = sign_secret
       @cipher = options[:cipher] || 'aes-256-cbc'
       @verifier = MessageVerifier.new(@sign_secret || @secret, digest: options[:digest] || 'SHA1', serializer: NullSerializer)
-      @serializer = options[:serializer] || Marshal
+      @serializer = PerishableEnvelope.new(options[:serializer] || Marshal)
     end
 
     # Encrypt and sign a message. We need to sign the message in order to avoid
     # padding attacks. Reference: http://www.limited-entropy.com/padding-oracle-attacks.
-    def encrypt_and_sign(value)
-      verifier.generate(_encrypt(value))
+    def encrypt_and_sign(value, expiration=nil)
+      if expiration.present?
+        verifier.generate(_encrypt(@serializer.dump(value, expiration)))
+      else
+        verifier.generate(_encrypt(@serializer.dump(value)))
+      end
     end
 
     # Decrypt and verify a message. We need to verify the message in order to
@@ -74,7 +79,7 @@ module ActiveSupport
       # Rely on OpenSSL for the initialization vector
       iv = cipher.random_iv
 
-      encrypted_data = cipher.update(@serializer.dump(value))
+      encrypted_data = cipher.update(value)
       encrypted_data << cipher.final
 
       "#{::Base64.strict_encode64 encrypted_data}--#{::Base64.strict_encode64 iv}"

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -56,11 +56,7 @@ module ActiveSupport
     # Encrypt and sign a message. We need to sign the message in order to avoid
     # padding attacks. Reference: http://www.limited-entropy.com/padding-oracle-attacks.
     def encrypt_and_sign(value, expiration=nil)
-      if expiration.present?
-        verifier.generate(_encrypt(@serializer.dump(value, expiration)))
-      else
-        verifier.generate(_encrypt(@serializer.dump(value)))
-      end
+      verifier.generate(_encrypt(@serializer.dump(value, expiration)))
     end
 
     # Decrypt and verify a message. We need to verify the message in order to

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -62,7 +62,7 @@ module ActiveSupport
     end
 
     def is_expired?(timestamp)
-      timestamp && Time.now > Time.iso8601(timestamp)
+      timestamp && Time.now.utc > Time.iso8601(timestamp)
     end
   end
 
@@ -94,11 +94,7 @@ module ActiveSupport
     end
 
     def generate(value, expiration=nil)
-      if expiration.present?
-        data = ::Base64.strict_encode64(@serializer.dump(value,expiration))
-      else
-        data = ::Base64.strict_encode64(@serializer.dump(value))
-      end
+      data = ::Base64.strict_encode64(@serializer.dump(value,expiration))
       "#{data}--#{generate_digest(data)}"
     end
 

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -23,13 +23,58 @@ module ActiveSupport
   # hash upon initialization:
   #
   #   @verifier = ActiveSupport::MessageVerifier.new('s3Krit', serializer: YAML)
+
+  # PerishableEnvelope is used to envelop a serializer(like:Marshal, YAML or JSON) to provide the serializer ability to serialize Time(-like) Object and check the expiration when load it.
+  class PerishableEnvelope # :nodoc:
+    class ExpiredMessage < StandardError; end
+    SIGNATURE = "\0"
+
+    def initialize(serializer)
+      @serializer = serializer
+    end
+
+    def dump(value, expiration=nil)
+      if expiration.present?
+        "#{SIGNATURE}--#{encode_expiration(expiration)}--#{@serializer.dump(value)}"
+      else
+        @serializer.dump(value)
+      end
+    end
+
+    def load(value)
+      if value.start_with?(SIGNATURE)
+        values = value.split("--")
+        values.shift
+        expiration = values.shift
+        raise ExpiredMessage if is_expired?(expiration)
+        value = values.join("--")
+      end
+      @serializer.load(value)
+    end
+
+    private
+    def encode_expiration(time)
+      if time.respond_to?(:to_time)
+        time.to_time.utc.iso8601
+      else
+        raise ArgumentError
+      end
+    end
+
+    def is_expired?(timestamp)
+      timestamp && Time.now > Time.iso8601(timestamp)
+    end
+  end
+
+
   class MessageVerifier
     class InvalidSignature < StandardError; end
+    ExpiredMessage = ActiveSupport::PerishableEnvelope::ExpiredMessage
 
     def initialize(secret, options = {})
       @secret = secret
       @digest = options[:digest] || 'SHA1'
-      @serializer = options[:serializer] || Marshal
+      @serializer = PerishableEnvelope.new(options[:serializer] || Marshal)
     end
 
     def verify(signed_message)
@@ -48,8 +93,12 @@ module ActiveSupport
       end
     end
 
-    def generate(value)
-      data = ::Base64.strict_encode64(@serializer.dump(value))
+    def generate(value, expiration=nil)
+      if expiration.present?
+        data = ::Base64.strict_encode64(@serializer.dump(value,expiration))
+      else
+        data = ::Base64.strict_encode64(@serializer.dump(value))
+      end
       "#{data}--#{generate_digest(data)}"
     end
 

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -69,6 +69,26 @@ class MessageVerifierTest < ActiveSupport::TestCase
                     "undefined class/module MessageVerifierTest::AutoloadClass"], exception.message
   end
 
+  def test_raise_error_when_the_message_is_expired
+    message = @verifier.generate(@data, 1.hour.from_now)
+    assert_nothing_raised(ActiveSupport::MessageVerifier::ExpiredMessage) do
+      assert_equal @data, @verifier.verify(message)
+    end
+
+    travel 59.minutes
+
+    assert_nothing_raised(ActiveSupport::MessageVerifier::ExpiredMessage) do
+      assert_equal @data, @verifier.verify(message)
+    end
+
+    travel 1.minute
+    travel 1.second
+
+    assert_raise(ActiveSupport::MessageVerifier::ExpiredMessage) do
+      @verifier.verify(message)
+    end
+  end
+
   def assert_not_verified(message)
     assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
       @verifier.verify(message)

--- a/activesupport/test/perishableserializer_test.rb
+++ b/activesupport/test/perishableserializer_test.rb
@@ -1,0 +1,49 @@
+require 'abstract_unit'
+
+class PerishableSerializerTest < ActiveSupport::TestCase
+  class NullSerializer
+    def self.load(value)
+      value
+    end
+
+    def self.dump(value)
+      value
+    end
+  end
+
+  def setup
+    @serializer = ActiveSupport::PerishableSerializer.new(NullSerializer)
+  end
+
+  # test the output of the dump, it should start with '\0' with the format '\0--expiration--value'
+  def test_output_with_expiration
+    data = @serializer.dump("value", 1.hour.from_now)
+    assert data.start_with?("\0")
+    assert_equal 3, data.split("--").size
+  end
+
+  def test_value_with_double_dash
+    data = @serializer.dump("value--value--value", 1.hour.from_now)
+    assert_equal "value--value--value", @serializer.load(data)
+  end
+
+  def test_without_expiration
+    data = @serializer.dump("value")
+    assert_equal "value", @serializer.load(data)
+  end
+
+  def test_expiration
+    data = @serializer.dump("value", 1.hour.from_now)
+    assert_equal "value", @serializer.load(data)
+
+    travel 59.minutes
+
+    assert_equal "value", @serializer.load(data)
+
+    travel 1.minute
+
+    assert_raise(ActiveSupport::PerishableSerializer::ExpiredMessage) do
+      @serializer.load(data)
+    end
+  end
+end


### PR DESCRIPTION
The patch will bake the expiration into message_verifier's signed message and message_encryptor's encrypted message to prevent the expiration from being forged. It will check the expiration every time you try to verify a signed message or decrypt an encrypted message. If the message is expired, it will raise an exception ExpiredMessage.

``` ruby
encrypted_message = encryptor.encrypt_and_sign( data, 1.hour.from_now)
encryptor.decrypt_and_verify(encrypted_message) #=> data if not expired
encryptor.decrypt_and_verify(encrypted_message) #> raise ExpiredMessage if expired
```

cc @rafaelfranca @chancancode
