### PR TITLE
Speed up static file service by caching existence checks

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -13,16 +13,51 @@ module ActionDispatch
   # located at `public/assets/application.js` if the file exists. If the file
   # does not exist a 404 "File not Found" response will be returned.
   class FileHandler
-    def initialize(root, cache_control)
-      @root          = root.chomp('/')
-      @compiled_root = /^#{Regexp.escape(root)}/
-      headers        = cache_control && { 'Cache-Control' => cache_control }
-      @file_server = ::Rack::File.new(@root, headers)
+    # Initializes a middleware capable of serving a static file. The +root+ is
+    # the path to the directory where static files are stored. The +options+:
+    #
+    # == Options:
+    # * <tt>:headers</tt> - A hash containing header key values that will be returned when assets are served
+    # * <tt>:cache_asset_lookup</tt> - When set to true the disk will not be accessed every time `match?` is called
+    #
+    # == Example:
+    #
+    #  FileHandler.new(Rails.root.join("public"), headers: { 'Cache-Control' => "public, max-age=2592000"})
+    def initialize(root, options_or_deprecated_cache_control)
+      if options_or_deprecated_cache_control.is_a?(Hash)
+        options = options_or_deprecated_cache_control
+      else
+        cache_control = options_or_deprecated_cache_control
+        options       = { headers: { 'Cache-Control' => cache_control } }
+        ActiveSupport::Deprecation.warn <<-MSG.strip_heredoc
+          #{self.class} will no longer accept a `cache_control` argument in Rails 5.
+          Switch to the `headers` keyword argument: `headers: { 'Cache-Control' => #{cache_control.inspect} }`
+        MSG
+      end
+      @root = root.chomp('/')
+      @base_hash = false
+      @base_hash = parse_root if options[:cache_asset_lookup]
+      @file_server = ::Rack::File.new(@root, options[:headers])
+    end
+
+    # This method returns true if the supplied +path+
+    # originates from a directory in the root or if the +path+
+    # contains a file in the root directory.
+    #
+    # This is an optimization for speed so that requests to paths that
+    # cannot possibly exist on the disk will not hit the file system.
+    #
+    # This functionality can be disabled by passing in the
+    # option: `cache_asset_lookup: false` on initilization
+    def base_of_path_exists_in_root_directory?(path)
+      return true unless @base_hash
+      @base_hash[path.split(File::SEPARATOR)[1]]
     end
 
     def match?(path)
       path = URI.parser.unescape(path)
       return false unless path.valid_encoding?
+      return false unless base_of_path_exists_in_root_directory?(path)
 
       paths = [path, "#{path}#{ext}", "#{path}/index#{ext}"].map { |v|
         Rack::Utils.clean_path_info v
@@ -83,6 +118,32 @@ module ActionDispatch
           false
         end
       end
+
+      # This method stores the existance of all files and directories in the
+      # root of the  FileHandler directory in a hash. This information can
+      # be used for quickly determining if a request should check the disk
+      # or not.
+      #
+      # Example: If the root directory has a `404.html` and `500.html` file:
+      #
+      #   parse_root # => {"404.html" => true, "500.html" => true }
+      #
+      # The a root file named `index.html` is given special treatment.
+      # Requests to `/index.html`, `/index` and `/` should all serve the
+      # `index.html` file if it exists.
+      def parse_root
+        base_hash = {}
+        return base_hash unless Dir.exist?(@root)
+        Dir.entries(@root).each do |file|
+          file = File.basename(file)
+          base_hash[file] = true
+          file.match(/(?<root>.*).html$/) do |match|
+            base_hash[match[:root]] = true
+          end
+        end
+        base_hash[nil] = true if base_hash["index"]
+        base_hash
+      end
   end
 
   # This middleware will attempt to return the contents of a file's body from
@@ -95,9 +156,9 @@ module ActionDispatch
   # produce a directory traversal using this middleware. Only 'GET' and 'HEAD'
   # requests will result in a file being returned.
   class Static
-    def initialize(app, path, cache_control=nil)
+    def initialize(app, path, *file_handler_args)
       @app = app
-      @file_handler = FileHandler.new(path, cache_control)
+      @file_handler = FileHandler.new(path, *file_handler_args)
     end
 
     def call(env)

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -18,7 +18,9 @@ module Rails
           middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header
 
           if config.serve_static_assets
-            middleware.use ::ActionDispatch::Static, paths["public"].first, config.static_cache_control
+            headers = {}
+            headers['Cache-Control'] = config.static_cache_control if config.static_cache_control
+            middleware.use ::ActionDispatch::Static, paths["public"].first, cache_asset_lookup: config.cache_classes, headers: headers
           end
 
           if rack_cache = load_rack_cache

--- a/railties/test/application/middleware/sendfile_test.rb
+++ b/railties/test/application/middleware/sendfile_test.rb
@@ -63,9 +63,8 @@ module ApplicationTests
         app.config.action_dispatch.x_sendfile_header = 'X-Sendfile'
         app.config.serve_static_assets = true
         app.paths["public"] = File.join(rails_root, "public")
+        app_file "public/foo.txt", "foo"
       end
-
-      app_file "public/foo.txt", "foo"
 
       get "/foo.txt", "HTTP_X_SENDFILE_TYPE" => "X-Sendfile"
       assert_equal File.join(rails_root, "public/foo.txt"), last_response.headers["X-Sendfile"]


### PR DESCRIPTION
Currently the `ActionDispatch::Static` middleware hits disk on every `GET` and `HEAD` request to check if the given request maps to a file on disk. This means that all requests that do not involve serving an asset are slowed down. If you are using this middleware and serving assets via Nginx, no asset requests will ever reach the `ActionDispatch::Static` middleware so it makes sense as a performance optimization to turn off this middleware. This PR increases the speed of the middleware to the point where the difference on non-asset requests is trivial,.

The optimization works by getting the contents of `/public` (using one call to `Dir.glob`). We then store this information in a hash. Later on each request we check to see if the path of the request is in our hash for instance a request to `/users/new` would not be in the hash because there is no root level `users/` directory, however a request to `assets/application.css` would trigger the middleware because `assets/` is in the `public/` directory. This prevents us form checking the disk except on a request which is more than likely going to contain an asset.

When benchmarked against the current `ActionDispatch::Static` we see roughly a ~68% improvement for non-asset requests:

![](https://www.dropbox.com/s/dcsrhrfh7gb44dc/Screenshot%202014-08-08%2014.05.21.png?dl=1)

While 68% is an impressive speed increase, this is only testing the middleware in isolation. When benchmarked with the entire Rails stack we still see an increase but it is roughly ~2.6% speed increase:

![](https://www.dropbox.com/s/bhb0o3tbupw0hus/Screenshot%202014-08-08%2015.06.11.png?dl=1)

Note: The scale on this one does not start at 0.

There is still a speed cost associated with using this improved middleware versus no middleware. In my benchmarks it resulted in a ~0.7% speed decrease though with a very high standard deviation. You can see in the graph that the speed of the improved middleware falls in-between the speed of the app without middleware. This means that the decrease is fairly trivial in the scope of your entire application stack. You can still disable this middleware for a performance optimization if you are deploying behind NGINX, but there is no reason why using a CDN with your Rails server as the origin server shouldn't work out of the box.

For more information about the purpose of ActionDispatch::Static and how it is currently used (or not used) to serve assets please see this reference document: https://gist.github.com/schneems/5dc42963fb3221a7a089.
