### PR TITLE
Enable Cache-Control headers on assets by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Enable static cache control for assets served by Rails in Production
+    by default. The default value is 3600 seconds.
+
+    *Richard Schneeman*
+
 *   Add `after_bundle` callbacks in Rails templates. Useful for allowing the
     generated binstubs to be added to version control.
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -22,6 +22,11 @@ Rails.application.configure do
   # Disable Rails's static asset server (Apache or NGINX will already do this).
   config.serve_static_assets = false
 
+  # Sets the cache control header of assets served from your application.
+  # Set to a high value when using Rails Asset pipeline with digests enabled.
+  # The units for `max-age` are in seconds.
+  config.static_cache_control = "public, max-age=#{1.hour}"
+
   <%- unless options.skip_sprockets? -%>
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
When using assets generated by the asset pipeline we can rely on digest filenames to serve them with a Cache-Control header with little to no problem. This PR sets that value by default to 3600 seconds (1 hour). This is the duration that the CDN will serve this file before needing to hit the Rails server (if it is set as an origin server). It is also the duration that the browser will retain the file in cache.

Ideally we want to set this to the maximum value possible `2592000` but this value affects **all** assets not just digest assets. It is up to the developer to optimize this value beyond the default.
