### PR TITLE
[ci skip] Fix broken url in plugins guide

### DIFF
--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -440,5 +440,5 @@ $ bin/rake rdoc
 
 * [Developing a RubyGem using Bundler](https://github.com/radar/guides/blob/master/gem-development.md)
 * [Using .gemspecs as Intended](http://yehudakatz.com/2010/04/02/using-gemspecs-as-intended/)
-* [Gemspec Reference](http://docs.rubygems.org/read/chapter/20)
+* [Gemspec Reference](http://guides.rubygems.org/specification-reference/)
 * [GemPlugins: A Brief Introduction to the Future of Rails Plugins](http://www.intridea.com/blog/2008/6/11/gemplugins-a-brief-introduction-to-the-future-of-rails-plugins)


### PR DESCRIPTION
Cannot access an old URL.  Probably http://guides.rubygems.org/specification-reference/ is a right URL
