### PR TITLE
[WIP] New API for serialized attributes (and store)

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -96,8 +96,14 @@ module ActiveRecord
   end
 
   module Coders
+    extend ActiveSupport::Autoload
+
     autoload :YAMLColumn, 'active_record/coders/yaml_column'
-    autoload :JSON, 'active_record/coders/json'
+    autoload :YAML
+    autoload :JSON
+    autoload :Restricted
+    autoload :Legacy
+    autoload :DefaultValue
   end
 
   module AttributeMethods

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -3,50 +3,113 @@ module ActiveRecord
     module Serialization
       extend ActiveSupport::Concern
 
+      CODERS = { # :nodoc:
+        json: ActiveRecord::Coders::JSON,
+        yaml: ActiveRecord::Coders::YAML
+      }.freeze
+
       module ClassMethods
         # If you have an attribute that needs to be saved to the database as an
         # object, and retrieved as the same object, then specify the name of that
-        # attribute using this method and it will be handled automatically. The
-        # serialization is done through YAML. If +class_name+ is specified, the
-        # serialized object must be of that class on retrieval or
-        # <tt>SerializationTypeMismatch</tt> will be raised.
-        #
-        # A notable side effect of serialized attributes is that the model will
-        # be updated on every save, even if it is not dirty.
+        # attribute using this method and it will be handled automatically.
         #
         # ==== Parameters
         #
         # * +attr_name+ - The field name that should be serialized.
-        # * +class_name_or_coder+ - Optional, a coder object, which responds to `.load` / `.dump`
-        #   or a class name that the object type should be equal to.
+        # * +options+ - Optional, a hash that contains one or more of the
+        #   following options.
+        #
+        # ===== Options
+        #
+        # [:class_name]
+        #   By default, you can store any type of objects in a serialized
+        #   column. You can optionally restrict it down to a specific class (and
+        #   its subclasses). For example, you can pass +Hash+ here to ensure
+        #   only +Hash+ values are allowed. Specifying this option will also
+        #   default the attribute to its empty value (e.g. an empty hash if set
+        #   to +Hash+). Note that if you specify this option, the coder you
+        #   choose must be able to serialiaze and deserialize instances of this
+        #   class in both directions.
+        #
+        # [:coder]
+        #   By default, the serialization is done through YAML. You can
+        #   customize this behavior by passing a different coder with this
+        #   option. Passing +:yaml+ or +:json+ will use the built-in YAML or
+        #   JSON coders. If you need more control over how objects are
+        #   serialized, you can also pass a custom serializer object that
+        #   implments the API described in the next section.
+        #
+        # ===== Custom Coders
+        #
+        # If a custom coder object is supplied, it must respond to the following
+        # methods:
+        #
+        # * <tt>deserialize_from_database(raw_data)</tt> - this method will be
+        #   passed the serialized data retrived from the database and should
+        #   return it in its deserialized form.
+        #
+        # * <tt>serialize_for_database(value)</tt> - this method will be passed
+        #   the deserialized value and should return it in its serialized form
+        #   that is suitable for writing to the database.
+        #
+        # Note that +nil+ values are written directly to the database as +NULL+,
+        # therefore your custom coder does not have to explicitly handle null
+        # values.
+        #
+        # For example:
+        #
+        #   class Base64MarshalCoder
+        #     def self.deserialize_from_database(raw_data)
+        #       Marshal.load Base64.strict_decode64(raw_data)
+        #     end
+        #
+        #     def self.serialize_for_database(value)
+        #       Base64.strict_encode64 Marshal.dump(value)
+        #     end
+        #   end
         #
         # ==== Example
         #
-        #   # Serialize a preferences attribute.
+        #   # Serialize a preferences attribute using the default YAML coder.
         #   class User < ActiveRecord::Base
         #     serialize :preferences
         #   end
         #
         #   # Serialize preferences using JSON as coder.
         #   class User < ActiveRecord::Base
-        #     serialize :preferences, JSON
+        #     serialize :preferences, coder: :json
         #   end
         #
-        #   # Serialize preferences as Hash using YAML coder.
+        #   # Serialize preferences as Hash using the default YAML coder.
         #   class User < ActiveRecord::Base
-        #     serialize :preferences, Hash
+        #     serialize :preferences, class_name: Hash
         #   end
-        def serialize(attr_name, class_name_or_coder = Object)
-          # When ::JSON is used, force it to go through the Active Support JSON encoder
-          # to ensure special objects (e.g. Active Record models) are dumped correctly
-          # using the #as_json hook.
-          coder = if class_name_or_coder == ::JSON
-                    Coders::JSON
-                  elsif [:load, :dump].all? { |x| class_name_or_coder.respond_to?(x) }
-                    class_name_or_coder
-                  else
-                    Coders::YAMLColumn.new(class_name_or_coder)
-                  end
+        #
+        #   # It defaults to the empty value of +class_name+ when set.
+        #   User.new.preferences # => {}
+        def serialize(attr_name, options = {})
+          options = convert_legacy_argument_to_options(attr_name, options)
+          options.assert_valid_keys(:coder, :class_name)
+
+          coder = lookup_coder(options[:coder])
+
+          if options[:class_name] && options[:class_name] != Object
+            coder = ActiveRecord::Coders::Restricted.new(coder, options[:class_name])
+          end
+
+          unless is_coder?(coder, false)
+            ActiveSupport::Deprecation.warn \
+              "Passing a coder implemting the legacy API (`load` and `dump`) is " \
+              "deprecated and will not be supported on Rails 5.0. Migrate your " \
+              "coder to use the new API or use one of the built-in coders by " \
+              "passing `coder: :json` or `coder: :yaml` instead. Refer to the " \
+              "documentation for `serialize` for details."
+
+            coder = ActiveRecord::Coders::Legacy.new(coder)
+          end
+
+          # The DefaultValue coder also handles nil-guarding
+          coder = ActiveRecord::Coders::DefaultValue.new(coder, options[:class_name])
 
           decorate_attribute_type(attr_name, :serialize) do |type|
             Type::Serialized.new(type, coder)
@@ -64,6 +127,56 @@ module ActiveRecord
             }
           ]
         end
+
+        private
+          def convert_legacy_argument_to_options(attr_name, arg)
+            if arg.is_a?(Hash)
+              arg
+            elsif arg == ::JSON
+              ActiveSupport::Deprecation.warn \
+                "Passing a coder as the second argument to `serialize` is " \
+                "deprecated, and will be removed in Rails 5.0. Please use " \
+                "`serialize #{attr_name.inspect}, coder: :json` instead."
+
+              {coder: :json}
+            elsif is_coder?(arg)
+              ActiveSupport::Deprecation.warn \
+                "Passing a coder as the second argument to `serialize` is " \
+                "deprecated, and will be removed in Rails 5.0. Please use " \
+                "`serialize #{attr_name.inspect}, coder: MyCoder` instead."
+
+              {coder: arg}
+            else
+              ActiveSupport::Deprecation.warn \
+                "Passing a class name as the second argument to `serialize` " \
+                "is deprecated, and will be removed in Rails 5.0. Please use " \
+                "`serialize #{attr_name.inspect}, class_name: #{arg.inspect}` " \
+                "instead."
+
+              {class_name: arg}
+            end
+          end
+
+          def lookup_coder(coder)
+            if is_coder?(coder)
+              coder
+            elsif CODERS.key?(coder)
+              CODERS[coder]
+            elsif coder.nil?
+              CODERS[:yaml]
+            else
+              raise ArgumentError, "Unknown coder #{coder.inspect}"
+            end
+          end
+
+          def is_coder?(obj, check_legacy = true)
+            [:deserialize_from_database, :serialize_for_database].all? { |x| obj.respond_to?(x) } ||
+              (check_legacy && is_legacy_coder?(obj))
+          end
+
+          def is_legacy_coder?(obj)
+            [:load, :dump].all? { |x| obj.respond_to?(x) }
+          end
       end
     end
   end

--- a/activerecord/lib/active_record/coders/default_value.rb
+++ b/activerecord/lib/active_record/coders/default_value.rb
@@ -1,0 +1,24 @@
+module ActiveRecord
+  module Coders # :nodoc:
+    class DefaultValue # :nodoc:
+      def initialize(coder, object_class)
+        @coder = coder
+        @object_class = object_class unless object_class == Object
+      end
+
+      def serialize_for_database(obj)
+        @coder.serialize_for_database(obj) unless obj.nil?
+      end
+
+      def deserialize_from_database(raw_data)
+        obj = @coder.deserialize_from_database(raw_data) unless raw_data.nil?
+        obj.nil? ? default_value : obj
+      end
+
+      private
+        def default_value
+          @object_class && @object_class.new rescue nil
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/coders/json.rb
+++ b/activerecord/lib/active_record/coders/json.rb
@@ -1,12 +1,12 @@
 module ActiveRecord
   module Coders # :nodoc:
     class JSON # :nodoc:
-      def self.dump(obj)
+      def self.serialize_for_database(obj)
         ActiveSupport::JSON.encode(obj)
       end
 
-      def self.load(json)
-        ActiveSupport::JSON.decode(json) unless json.nil?
+      def self.deserialize_from_database(json)
+        ActiveSupport::JSON.decode(json)
       end
     end
   end

--- a/activerecord/lib/active_record/coders/legacy.rb
+++ b/activerecord/lib/active_record/coders/legacy.rb
@@ -1,0 +1,17 @@
+module ActiveRecord
+  module Coders # :nodoc:
+    class Legacy # :nodoc:
+      def initialize(coder)
+        @coder = coder
+      end
+
+      def serialize_for_database(obj)
+        @coder.dump(obj)
+      end
+
+      def deserialize_from_database(raw_data)
+        @coder.load(raw_data)
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/coders/restricted.rb
+++ b/activerecord/lib/active_record/coders/restricted.rb
@@ -1,0 +1,28 @@
+module ActiveRecord
+  module Coders # :nodoc:
+    class Restricted # :nodoc:
+      def initialize(coder, object_class)
+        @coder = coder
+        @object_class = object_class || Object
+      end
+
+      def serialize_for_database(obj)
+        @coder.serialize_for_database validate!(obj)
+      end
+
+      def deserialize_from_database(raw_data)
+        validate! @coder.deserialize_from_database(raw_data)
+      end
+
+      private
+        def validate!(obj)
+          unless obj.is_a?(@object_class)
+            raise SerializationTypeMismatch,
+              "Attribute was supposed to be a #{@object_class}, but was a #{obj.class}. -- #{obj.inspect}"
+          end
+
+          obj
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/coders/yaml.rb
+++ b/activerecord/lib/active_record/coders/yaml.rb
@@ -1,0 +1,15 @@
+require 'yaml'
+
+module ActiveRecord
+  module Coders # :nodoc:
+    class YAML # :nodoc:
+      def self.serialize_for_database(obj)
+        ::YAML.dump obj
+      end
+
+      def self.deserialize_from_database(yaml)
+        ::YAML.load yaml
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -17,13 +17,13 @@ module ActiveRecord
           raise SerializationTypeMismatch,
             "Attribute was supposed to be a #{object_class}, but was a #{obj.class}. -- #{obj.inspect}"
         end
-        YAML.dump obj
+        ::YAML.dump obj
       end
 
       def load(yaml)
         return object_class.new if object_class != Object && yaml.nil?
         return yaml unless yaml.is_a?(String) && yaml =~ /^---/
-        obj = YAML.load(yaml)
+        obj = ::YAML.load(yaml)
 
         unless obj.is_a?(object_class) || obj.nil?
           raise SerializationTypeMismatch,

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -6,6 +6,8 @@ module ActiveRecord
       attr_reader :subtype, :coder
 
       def initialize(subtype, coder)
+        raise subtype.to_s if coder.nil?
+
         @subtype = subtype
         @coder = coder
         super(subtype)
@@ -15,14 +17,14 @@ module ActiveRecord
         if default_value?(value)
           value
         else
-          coder.load(super)
+          coder.deserialize_from_database(super)
         end
       end
 
       def type_cast_for_database(value)
         return if value.nil?
         unless default_value?(value)
-          super coder.dump(value)
+          super coder.serialize_for_database(value)
         end
       end
 
@@ -44,7 +46,7 @@ module ActiveRecord
       private
 
       def default_value?(value)
-        value == coder.load(nil)
+        value == coder.deserialize_from_database(nil)
       end
     end
   end


### PR DESCRIPTION
Motivations:
- `load` and `dump` is too generic, we have more specific requirements in AR so some of the built-in objects that responds to `load` and `dump` doesn't work correctly here (#15594)
- Break up the overloaded `class_name_or_coder` attribute

Todo:
- [x] Implement new API on `serialize`
- [x] Pass existing tests for `serialize`
- [x] Update documentations for `serialize`
- [ ] Implement new API on `store`
- [ ] Pass existing tests for `store`
- [ ] Update documentations for `store`
- [ ] Remove `YAMLColumn`
- [ ] Remove deprecated code from existing tests
- [ ] Test new additions, if any
- [ ] Switch default to JSON (#16470)

cc @jeremy @tenderlove @matthewd @rafaelfranca @senny @sgrif @zzak
