### PR TITLE
Legacy signed cookie upgrader not handling hash values under 4 0

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -180,7 +180,7 @@ module ActionDispatch
 
       def verify_and_upgrade_legacy_signed_message(name, signed_message)
         @legacy_verifier.verify(signed_message).tap do |value|
-          self[name] = value
+          self[name] = { value: value }
         end
       rescue ActiveSupport::MessageVerifier::InvalidSignature
         nil

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -504,17 +504,18 @@ class CookiesTest < ActionController::TestCase
     @request.env["action_dispatch.secret_token"] = "b3c631c314c0bbca50c1b2843150fe33"
     @request.env["action_dispatch.secret_key_base"] = "c3b95688f35581fad38df788add315ff"
 
-    legacy_value = ActiveSupport::MessageVerifier.new("b3c631c314c0bbca50c1b2843150fe33").generate(45)
+    value = { nr: 45 }
+    legacy_value = ActiveSupport::MessageVerifier.new("b3c631c314c0bbca50c1b2843150fe33").generate(value)
 
     @request.headers["Cookie"] = "user_id=#{legacy_value}"
     get :get_signed_cookie
 
-    assert_equal 45, @controller.send(:cookies).signed[:user_id]
+    assert_equal(value, @controller.send(:cookies).signed[:user_id])
 
     key_generator = @request.env["action_dispatch.key_generator"]
     secret = key_generator.generate_key(@request.env["action_dispatch.signed_cookie_salt"])
     verifier = ActiveSupport::MessageVerifier.new(secret)
-    assert_equal 45, verifier.verify(@response.cookies["user_id"])
+    assert_equal(value, verifier.verify(@response.cookies["user_id"]))
   end
 
   def test_legacy_signed_cookie_is_read_and_transparently_encrypted_by_encrypted_cookie_jar_if_both_secret_token_and_secret_key_base_are_set


### PR DESCRIPTION
Noticed this the hard way while trying to upgrade my rails 4.0.8 app to use encrypted cookie store

cookie created with signed cookie store:

``` ruby
[1] pry> cookies.signed[:name] = { value: { nr: 'a' } }
=> {:value=>"BAh7BjoHbnJJIgZhBjoGRVQ=--975531eb9ed8fd2527b9785dc58877b1116b6c2c",
 :path=>"/"}
```

after adding `secret_key_base` and restarting the app:

``` ruby
[1] pry> cookies.signed[:name]
=> {:nr=>"a"}
[2] pry> cookies.signed[:name]
=> nil
```

cookie is being deleted after accessing it the first time. 
I noticed this is fixed in 4.1 https://github.com/rails/rails/commit/7a3ef9842b3cbfe6dbe14700086824d163ce4d51 but not in 4.0

Thanks
