### PR TITLE
Change the default `null` value for timestamps

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -838,9 +838,9 @@ module ActiveRecord
       #
       #   add_timestamps(:suppliers)
       #
-      def add_timestamps(table_name)
-        add_column table_name, :created_at, :datetime
-        add_column table_name, :updated_at, :datetime
+      def add_timestamps(table_name, options = {})
+        add_column table_name, :created_at, :datetime, options
+        add_column table_name, :updated_at, :datetime, options
       end
 
       # Removes the timestamp columns (+created_at+ and +updated_at+) from the table definition.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -764,8 +764,8 @@ module ActiveRecord
         "DROP INDEX #{index_name}"
       end
 
-      def add_timestamps_sql(table_name)
-        [add_column_sql(table_name, :created_at, :datetime), add_column_sql(table_name, :updated_at, :datetime)]
+      def add_timestamps_sql(table_name, options = {})
+        [add_column_sql(table_name, :created_at, :datetime, options), add_column_sql(table_name, :updated_at, :datetime, options)]
       end
 
       def remove_timestamps_sql(table_name)

--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
@@ -9,7 +9,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
 <% end -%>
 <% end -%>
 <% if options[:timestamps] %>
-      t.timestamps
+      t.timestamps null: false
 <% end -%>
     end
 <% attributes_with_index.each do |attribute| -%>

--- a/activerecord/test/cases/adapters/mysql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/active_schema_test.rb
@@ -105,7 +105,7 @@ class ActiveSchemaTest < ActiveRecord::TestCase
     with_real_execute do
       begin
         ActiveRecord::Base.connection.create_table :delete_me do |t|
-          t.timestamps
+          t.timestamps null: true
         end
         ActiveRecord::Base.connection.remove_timestamps :delete_me
         assert !column_present?('delete_me', 'updated_at', 'datetime')

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -105,7 +105,7 @@ class ActiveSchemaTest < ActiveRecord::TestCase
     with_real_execute do
       begin
         ActiveRecord::Base.connection.create_table :delete_me do |t|
-          t.timestamps
+          t.timestamps null: true
         end
         ActiveRecord::Base.connection.remove_timestamps :delete_me
         assert !column_present?('delete_me', 'updated_at', 'datetime')

--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -87,7 +87,7 @@ class TimestampTest < ActiveRecord::TestCase
 
   def test_timestamps_helper_with_custom_precision
     ActiveRecord::Base.connection.create_table(:foos) do |t|
-      t.timestamps :precision => 4
+      t.timestamps :null => true, :precision => 4
     end
     assert_equal 4, activerecord_column_option('foos', 'created_at', 'precision')
     assert_equal 4, activerecord_column_option('foos', 'updated_at', 'precision')
@@ -95,7 +95,7 @@ class TimestampTest < ActiveRecord::TestCase
 
   def test_passing_precision_to_timestamp_does_not_set_limit
     ActiveRecord::Base.connection.create_table(:foos) do |t|
-      t.timestamps :precision => 4
+      t.timestamps :null => true, :precision => 4
     end
     assert_nil activerecord_column_option("foos", "created_at", "limit")
     assert_nil activerecord_column_option("foos", "updated_at", "limit")
@@ -104,14 +104,14 @@ class TimestampTest < ActiveRecord::TestCase
   def test_invalid_timestamp_precision_raises_error
     assert_raises ActiveRecord::ActiveRecordError do
       ActiveRecord::Base.connection.create_table(:foos) do |t|
-        t.timestamps :precision => 7
+        t.timestamps :null => true, :precision => 7
       end
     end
   end
 
   def test_postgres_agrees_with_activerecord_about_precision
     ActiveRecord::Base.connection.create_table(:foos) do |t|
-      t.timestamps :precision => 4
+      t.timestamps :null => true, :precision => 4
     end
     assert_equal '4', pg_datetime_precision('foos', 'created_at')
     assert_equal '4', pg_datetime_precision('foos', 'updated_at')

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -176,8 +176,11 @@ module ActiveRecord
       end
 
       def test_create_table_with_timestamps_should_create_datetime_columns
-        connection.create_table table_name do |t|
-          t.timestamps
+        # FIXME: Remove the silence when we change the default `null` behavior
+        ActiveSupport::Deprecation.silence do
+          connection.create_table table_name do |t|
+            t.timestamps
+          end
         end
         created_columns = connection.columns(table_name)
 

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -88,8 +88,8 @@ module ActiveRecord
 
       def test_timestamps_creates_updated_at_and_created_at
         with_change_table do |t|
-          @connection.expect :add_timestamps, nil, [:delete_me]
-          t.timestamps
+          @connection.expect :add_timestamps, nil, [:delete_me, null: true]
+          t.timestamps null: true
         end
       end
 

--- a/activerecord/test/cases/migration/helper.rb
+++ b/activerecord/test/cases/migration/helper.rb
@@ -22,7 +22,7 @@ module ActiveRecord
         super
         @connection = ActiveRecord::Base.connection
         connection.create_table :test_models do |t|
-          t.timestamps
+          t.timestamps null: true
         end
 
         TestModel.reset_column_information

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -561,7 +561,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
           t.string :qualification, :experience
           t.integer :age, :default => 0
           t.date :birthdate
-          t.timestamps
+          t.timestamps null: true
         end
       end
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -138,7 +138,7 @@ ActiveRecord::Schema.define do
     t.integer :engines_count
     t.integer :wheels_count
     t.column :lock_version, :integer, null: false, default: 0
-    t.timestamps
+    t.timestamps null: false
   end
 
   create_table :categories, force: true do |t|
@@ -537,7 +537,7 @@ ActiveRecord::Schema.define do
     t.references :best_friend_of
     t.integer    :insures, null: false, default: 0
     t.timestamp :born_at
-    t.timestamps
+    t.timestamps null: false
   end
 
   create_table :peoples_treasures, id: false, force: true do |t|
@@ -548,7 +548,7 @@ ActiveRecord::Schema.define do
   create_table :pets, primary_key: :pet_id, force: true do |t|
     t.string :name
     t.integer :owner_id, :integer
-    t.timestamps
+    t.timestamps null: false
   end
 
   create_table :pirates, force: true do |t|
@@ -726,13 +726,13 @@ ActiveRecord::Schema.define do
     t.string   :parent_title
     t.string   :type
     t.string   :group
-    t.timestamps
+    t.timestamps null: true
   end
 
   create_table :toys, primary_key: :toy_id, force: true do |t|
     t.string :name
     t.integer :pet_id, :integer
-    t.timestamps
+    t.timestamps null: false
   end
 
   create_table :traffic_lights, force: true do |t|

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -222,7 +222,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
   def test_migration_with_timestamps
     run_generator
-    assert_migration "db/migrate/create_accounts.rb", /t.timestamps/
+    assert_migration "db/migrate/create_accounts.rb", /t.timestamps null: false/
   end
 
   def test_migration_timestamps_are_skipped


### PR DESCRIPTION
As per discussion, this changes the model generators to specify
`null: false` for timestamp columns. A warning is now emitted if
`timestamps` is called without a `null` option specified, so we can
safely change the behavior when no option is specified in Rails 5.
