### PR TITLE
Revert "Rename to test_mysql_strict_mode_disabled_dont_override_global_sql_mode"

### DIFF
--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -138,12 +138,11 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     assert_equal [["STRICT_ALL_TABLES"]], result.rows
   end
 
-  def test_mysql_strict_mode_disabled_dont_override_global_sql_mode
+  def test_mysql_strict_mode_disabled
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.merge({:strict => false}))
-      global_sql_mode = ActiveRecord::Base.connection.exec_query "SELECT @@GLOBAL.sql_mode"
-      session_sql_mode = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.sql_mode"
-      assert_equal global_sql_mode.rows, session_sql_mode.rows
+      result = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.sql_mode"
+      assert_equal [['']], result.rows
     end
   end
 

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -57,12 +57,11 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     assert_equal [["STRICT_ALL_TABLES"]], result.rows
   end
 
-  def test_mysql_strict_mode_disabled_dont_override_global_sql_mode
+  def test_mysql_strict_mode_disabled
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.merge({:strict => false}))
-      global_sql_mode = ActiveRecord::Base.connection.exec_query "SELECT @@GLOBAL.sql_mode"
-      session_sql_mode = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.sql_mode"
-      assert_equal global_sql_mode.rows, session_sql_mode.rows
+      result = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.sql_mode"
+      assert_equal [['']], result.rows
     end
   end
 


### PR DESCRIPTION
This pull request reverts commit babc24c1b07c1fd58b9b3249b0256f9b0d45c0f0 to `4-1-stable` since `1a9d267f` merged to it.  Refer #16196 which has been merged to master.

This reverts commit babc24c1b07c1fd58b9b3249b0256f9b0d45c0f0.

Conflicts:

```
activerecord/test/cases/adapters/mysql/connection_test.rb
activerecord/test/cases/adapters/mysql2/connection_test.rb
```
