### PR TITLE
Provide a builder for form labels to customize wrapping around I18n content

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Provide a `builder` object when using the `label` form helper in block form.
+
+    The new `builder` object responds to `translation`, allowing I18n fallback support
+    when you want to customize how a particular label is presented.
+
+    *Alex Robbin*
+
 *   Add I18n support for input/textarea placeholder text.
 
     Placeholder I18n follows the same convention as `label` I18n.

--- a/actionview/lib/action_view/helpers/tags/label.rb
+++ b/actionview/lib/action_view/helpers/tags/label.rb
@@ -2,6 +2,39 @@ module ActionView
   module Helpers
     module Tags # :nodoc:
       class Label < Base # :nodoc:
+        class LabelBuilder # :nodoc:
+          attr_reader :object
+
+          def initialize(template_object, object_name, method_name, object, tag_value)
+            @template_object = template_object
+            @object_name = object_name
+            @method_name = method_name
+            @object = object
+            @tag_value = tag_value
+          end
+
+          def translation
+            method_and_value = @tag_value.present? ? "#{@method_name}.#{@tag_value}" : @method_name
+            @object_name.gsub!(/\[(.*)_attributes\]\[\d+\]/, '.\1')
+
+            if object.respond_to?(:to_model)
+              key = object.model_name.i18n_key
+              i18n_default = ["#{key}.#{method_and_value}".to_sym, ""]
+            end
+
+            i18n_default ||= ""
+            content = I18n.t("#{@object_name}.#{method_and_value}", :default => i18n_default, :scope => "helpers.label").presence
+
+            content ||= if object && object.class.respond_to?(:human_attribute_name)
+                          object.class.human_attribute_name(method_and_value)
+                        end
+
+            content ||= @method_name.humanize
+
+            content
+          end
+        end
+
         def initialize(object_name, method_name, template_object, content_or_options = nil, options = nil)
           options ||= {}
 
@@ -32,33 +65,24 @@ module ActionView
           options.delete("namespace")
           options["for"] = name_and_id["id"] unless options.key?("for")
 
-          if block_given?
-            content = @template_object.capture(&block)
+          builder = LabelBuilder.new(@template_object, @object_name, @method_name, @object, tag_value)
+
+          content = if block_given?
+            @template_object.capture(builder, &block)
+          elsif @content.present?
+            @content.to_s
           else
-            method_and_value = tag_value.present? ? "#{@method_name}.#{tag_value}" : @method_name
-            content = if @content.blank?
-                        @object_name.gsub!(/\[(.*)_attributes\]\[\d+\]/, '.\1')
-
-                        if object.respond_to?(:to_model)
-                          key = object.model_name.i18n_key
-                          i18n_default = ["#{key}.#{method_and_value}".to_sym, ""]
-                        end
-
-                        i18n_default ||= ""
-                        I18n.t("#{@object_name}.#{method_and_value}", :default => i18n_default, :scope => "helpers.label").presence
-                      else
-                        @content.to_s
-                      end
-
-            content ||= if object && object.class.respond_to?(:human_attribute_name)
-                          object.class.human_attribute_name(method_and_value)
-                        end
-
-            content ||= @method_name.humanize
+            render_component(builder)
           end
 
           label_tag(name_and_id["id"], content, options)
         end
+
+        private
+
+          def render_component(builder)
+            builder.translation
+          end
       end
     end
   end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -319,6 +319,15 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_label_with_block_and_builder
+    with_locale :label do
+      assert_dom_equal(
+        '<label for="post_body"><b>Write entire text here</b></label>',
+        label(:post, :body) { |b| "<b>#{b.translation}</b>".html_safe }
+      )
+    end
+  end
+
   def test_label_with_block_in_erb
     assert_equal(
       %{<label for="post_message">\n  Message\n  <input id="post_message" name="post[message]" type="text" />\n</label>},


### PR DESCRIPTION
The problem I'm trying to solve is when you have a `label` that you also want to include an input inside of, but you also want to include the default I18n'd content for the label. Example:

``` html+erb
<%= f.label :terms, class: "checkbox" do %>
  <%= f.check_box :terms %>
  <%= t("helpers.label.user.terms") %>
<% end %>
```

Unfortunately, this doesn't fall back to the other I18n values as a normal `f.label :terms` call would.

In comes the new builder, which behaves similarly to `collection_radio_buttons` and `collection_check_boxes`. The above can now be written like this:

``` html+erb
<%= f.label :terms, class: "checkbox" do |b| %>
  <%= f.check_box :terms %>
  <%= b.translation %>
<% end %>
```

It should still work if you don't want to use the yielded `builder` argument, so no backwards compatibility issues to worry about.
