### PR TITLE
Normalize string for `StringInquirer`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Change `ActiveSuport::StringInquirer` to normalize string
+    before checking for equality
+
+    *Alex Williams*
+
 *   Fix ActiveSupport::TestCase not to order users' test cases by default.
     If this change breaks your tests because your tests are order dependent, you need to explicitly call
     ActiveSupport::TestCase.my_tests_are_order_dependent! at the top of your tests.

--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -17,7 +17,7 @@ module ActiveSupport
 
       def method_missing(method_name, *arguments)
         if method_name[-1] == '?'
-          self == method_name[0..-2]
+          self.downcase.strip == method_name[0..-2]
         else
           super
         end

--- a/activesupport/test/string_inquirer_test.rb
+++ b/activesupport/test/string_inquirer_test.rb
@@ -20,4 +20,10 @@ class StringInquirerTest < ActiveSupport::TestCase
   def test_respond_to
     assert_respond_to @string_inquirer, :development?
   end
+
+  def test_normalizes_string
+    @string_inquirer = ActiveSupport::StringInquirer.new("\n PRODUCTION")
+
+    assert @string_inquirer.production?
+  end
 end


### PR DESCRIPTION
Currently strings are not normalized when inquired.

``` ruby
" production".inquiry.production?
#=> false

"Production".inquiry.production?
#=> false

"\nPRODUCTION".inquiry.production?
#=> false
```

To inquiry strings like that you have to write the following

``` ruby
"Production".inquiry.Production?
#=> true

" production".inquiry.send(" production?")
#=> true
```

This is of course very displeasing to the eye.

What we care about is the content of the string, which should be agnostic to it's casing and whitespace.
