### PR TITLE
Alias the ActionDispatch::Request#uuid method to ActionDispatch::Request#request_id

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Alias the ActionDispatch::Request#uuid method to ActionDispatch::Request#request_id. Due to implementation,
+    `config.log_tags = [:request_id]` also works in substitute for
+    `config.log_tags = [:uuid]`.
+
+    *David Ilizarov*
+
 *   Remove deprecated `AbstractController::Helpers::ClassMethods::MissingHelperError`
     in favor of `AbstractController::Helpers::MissingHelperError`.
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Alias the ActionDispatch::Request#uuid method to ActionDispatch::Request#request_id. Due to implementation,
+    `config.log_tags = [:request_id]` also works in substitute for
+    `config.log_tags = [:uuid]`.
+
+    *David Ilizarov*
+
 *   Extract source code for the entire exception stack trace for
     better debugging and diagnosis.
 

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -42,6 +42,8 @@ module ActionDispatch
       METHOD
     end
 
+    alias_method :request_id, :uuid
+
     def initialize(env)
       super
       @method            = nil

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -42,8 +42,6 @@ module ActionDispatch
       METHOD
     end
 
-    alias_method :request_id, :uuid
-
     def initialize(env)
       super
       @method            = nil

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -42,8 +42,6 @@ module ActionDispatch
       METHOD
     end
 
-    alias_method :request_id, :uuid
-
     def initialize(env)
       super
       @method            = nil
@@ -236,6 +234,8 @@ module ActionDispatch
     def uuid
       @uuid ||= env["action_dispatch.request_id"]
     end
+    
+    alias_method :request_id, :uuid
 
     # Returns the lowercase name of the HTTP server software.
     def server_software

--- a/actionpack/lib/action_dispatch/middleware/request_id.rb
+++ b/actionpack/lib/action_dispatch/middleware/request_id.rb
@@ -3,7 +3,8 @@ require 'active_support/core_ext/string/access'
 
 module ActionDispatch
   # Makes a unique request id available to the action_dispatch.request_id env variable (which is then accessible through
-  # ActionDispatch::Request#uuid) and sends the same id to the client via the X-Request-Id header.
+  # ActionDispatch::Request#uuid or the alias ActionDispatch::Request#request_id) and sends the same id to the client via
+  # the X-Request-Id header.
   #
   # The unique request id is either based on the X-Request-Id header in the request, which would typically be generated
   # by a firewall, load balancer, or the web server, or, if this header is not available, a random uuid. If the

--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -142,21 +142,26 @@ module ActionDispatch
 
       %w(edit new).each do |action|
         module_eval <<-EOT, __FILE__, __LINE__ + 1
-          def #{action}_polymorphic_url(record_or_hash, options = {})         # def edit_polymorphic_url(record_or_hash, options = {})
-            polymorphic_url(                                                  #   polymorphic_url(
-              record_or_hash,                                                 #     record_or_hash,
-              options.merge(:action => "#{action}"))                          #     options.merge(:action => "edit"))
-          end                                                                 # end
-                                                                              #
-          def #{action}_polymorphic_path(record_or_hash, options = {})        # def edit_polymorphic_path(record_or_hash, options = {})
-            polymorphic_url(                                                  #   polymorphic_url(
-              record_or_hash,                                                 #     record_or_hash,
-              options.merge(:action => "#{action}", :routing_type => :path))  #     options.merge(:action => "edit", :routing_type => :path))
-          end                                                                 # end
+          def #{action}_polymorphic_url(record_or_hash, options = {})
+            polymorphic_url_for_action("#{action}", record_or_hash, options)
+          end
+
+          def #{action}_polymorphic_path(record_or_hash, options = {})
+            polymorphic_path_for_action("#{action}", record_or_hash, options)
+          end
         EOT
       end
 
       private
+
+      def polymorphic_url_for_action(action, record_or_hash, options)
+        polymorphic_url(record_or_hash, options.merge(:action => action))
+      end
+
+      def polymorphic_path_for_action(action, record_or_hash, options)
+        options = options.merge(:action => action, :routing_type => :path)
+        polymorphic_path(record_or_hash, options)
+      end
 
       class HelperMethodBuilder # :nodoc:
         CACHE = { 'path' => {}, 'url' => {} }

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1209,7 +1209,7 @@ module ActiveRecord
       # Option examples:
       #   has_many :comments, -> { order "posted_on" }
       #   has_many :comments, -> { includes :author }
-      #   has_many :people, -> { where("deleted = 0").order("name") }, class_name: "Person"
+      #   has_many :people, -> { where(deleted: false).order(:name) }, class_name: "Person"
       #   has_many :tracks, -> { order "position" }, dependent: :destroy
       #   has_many :comments, dependent: :nullify
       #   has_many :tags, as: :taggable

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1209,7 +1209,7 @@ module ActiveRecord
       # Option examples:
       #   has_many :comments, -> { order "posted_on" }
       #   has_many :comments, -> { includes :author }
-      #   has_many :people, -> { where(deleted: false).order(:name) }, class_name: "Person"
+      #   has_many :people, -> { where(deleted: false).order("name") }, class_name: "Person"
       #   has_many :tracks, -> { order "position" }, dependent: :destroy
       #   has_many :comments, dependent: :nullify
       #   has_many :tags, as: :taggable

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -51,7 +51,7 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_symbols_table_ref
-    Post.first # warm up
+    Post.where("author_id" => nil)  # warm up
     x = Symbol.all_symbols.count
     Post.where("title" => {"xxxqqqq" => "bar"})
     assert_equal x, Symbol.all_symbols.count

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -66,6 +66,9 @@ module ActiveRecord
         def test_mysql_rename_column_preserves_auto_increment
           rename_column "test_models", "id", "id_test"
           assert_equal "auto_increment", connection.columns("test_models").find { |c| c.name == "id_test" }.extra
+          TestModel.reset_column_information
+        ensure
+          rename_column "test_models", "id_test", "id"
         end
       end
 

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -93,7 +93,7 @@ module ActiveRecord
     # ignored SQL, or better yet, use a different notification for the queries
     # instead examining the SQL content.
     oracle_ignored     = [/^select .*nextval/i, /^SAVEPOINT/, /^ROLLBACK TO/, /^\s*select .* from all_triggers/im, /^\s*select .* from all_constraints/im, /^\s*select .* from all_tab_cols/im]
-    mysql_ignored      = [/^SHOW TABLES/i, /^SHOW FULL FIELDS/, /^SHOW CREATE TABLE /i]
+    mysql_ignored      = [/^SHOW TABLES/i, /^SHOW FULL FIELDS/, /^SHOW CREATE TABLE /i, /^SHOW VARIABLES /]
     postgresql_ignored = [/^\s*select\b.*\bfrom\b.*pg_namespace\b/im, /^\s*select\b.*\battname\b.*\bfrom\b.*\bpg_attribute\b/im, /^SHOW search_path/i]
     sqlite3_ignored =    [/^\s*SELECT name\b.*\bFROM sqlite_master/im]
 


### PR DESCRIPTION
When writing code, and wanting access to the `"X-Request-ID"` header, one uses the ActionDispatch::Request#uuid method. 

Generally, in actual code it looks like `request.uuid`. While I understand what this means, it isn't particularly clear. When one considers that it comes from the `"action_dispatch.request_id"` environment variable and that everything else I noticed in the Rails code corresponds to the convention in the following example, I think it serves to be a viable change. For instance, `request.remote_ip` corresponds to `"action_dispatch.remote_ip"`, and that is just one such example. 

Further, something that drives the point home to me is that `request.uuid` has the same tone as `person.string`, which returns the first name of that person. Sure, it is a string, but the method should be called `person.first_name` instead to be more descriptive. I am sure you agree with this.

After carefully examining the implementation of `config.log_tags = [:uuid]` which is closely related to the request_id uses in Rails, `config.log_tags = [:request_id]` will automatically begin working, because in the source code you have `request.send(tag)`, when `tag` is a symbol. By aliasing the method, this ensure that the functionality still works and further will continue to work for anyone who still opts to use ActionDispatch::Request#uuid instead of ActionDispatch::Request#request_id.

One last point: I searched through the Rails code and found no tests for the ActionDispatch::Request#uuid method. Due to the fact that I'm simply aliasing it and checked the implementation to make sure no changes had to be made for the log_tags code, I didn't include tests.
