### PR TITLE
[Regression 4.0 -> 4.1] Fixed AR::Relation#where edge case with Hash and other Relation

### DIFF
--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -61,6 +61,15 @@ module ActiveRecord
       assert_equal expected.to_sql, actual.to_sql
     end
 
+    def test_belongs_to_nested_where_with_relation
+      author = authors(:david)
+
+      expected = Author.where(id: author ).joins(:posts)
+      actual   = Author.where(posts: { author_id: Author.where(id: author.id) }).joins(:posts)
+
+      assert_equal expected.to_a, actual.to_a
+    end
+
     def test_polymorphic_shallow_where
       treasure = Treasure.new
       treasure.id = 1


### PR DESCRIPTION
Example:

``` ruby
Author.where(posts: { author_id: Author.where(country_id: 1) }).joins(:posts)
```

AR dont handle it properly right now because it only search for relation at first level of hash values, but not for nested hashes
