### PR TITLE
Fixed AR::Relation#where edge case with Hash and other Relation

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -931,9 +931,7 @@ module ActiveRecord
         opts = PredicateBuilder.resolve_column_aliases(klass, opts)
         attributes = @klass.send(:expand_hash_conditions_for_aggregates, opts)
 
-        attributes.values.grep(ActiveRecord::Relation) do |rel|
-          self.bind_values += rel.bind_values
-        end
+        add_relations_to_bind_values(attributes)
 
         PredicateBuilder.build_from_hash(klass, attributes, table)
       else
@@ -1084,6 +1082,20 @@ module ActiveRecord
     def check_if_method_has_arguments!(method_name, args)
       if args.blank?
         raise ArgumentError, "The method .#{method_name}() must contain arguments."
+      end
+    end
+
+    # This function is recursive just for better readablity.
+    # #where argument doesn't support more than one level nested hash in real world.
+    def add_relations_to_bind_values(attributes)
+      if attributes.is_a?(Hash)
+        attributes.each_value do |value|
+          if value.is_a?(ActiveRecord::Relation)
+            self.bind_values += value.bind_values
+          else
+            add_relations_to_bind_values(value)
+          end
+        end
       end
     end
   end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -60,6 +60,15 @@ module ActiveRecord
       assert_equal expected.to_sql, actual.to_sql
     end
 
+    def test_belongs_to_nested_where_with_relation
+      author = authors(:david)
+
+      expected = Author.where(id: author ).joins(:posts)
+      actual   = Author.where(posts: { author_id: Author.where(id: author.id) }).joins(:posts)
+
+      assert_equal expected.to_a, actual.to_a
+    end
+
     def test_polymorphic_shallow_where
       treasure = Treasure.new
       treasure.id = 1


### PR DESCRIPTION
Backport #16502 to 4.1 stable

Example:

  Author.where(posts: { author_id: Author.where(country_id: 1) }).joins(:posts)
