### PR TITLE
Perf optimization for `url_for` called w/ Hash

### DIFF
--- a/actionview/lib/action_view/routing_url_for.rb
+++ b/actionview/lib/action_view/routing_url_for.rb
@@ -82,7 +82,9 @@ module ActionView
       when nil
         super({:only_path => true})
       when Hash
-        super({ :only_path => options[:host].nil? }.merge!(options.symbolize_keys))
+        options = options.symbolize_keys
+        options[:only_path] = options[:host].nil? unless options.key?(:only_path)
+        super(options)
       when :back
         _back_url
       when Symbol


### PR DESCRIPTION
Benchmarking the existing code:

``` ruby
{ :only_path => options[:host].nil? }.merge!(options.symbolize_keys)) 
```

Against optimized code, that does not do a merge:

``` ruby
options = options.symbolize_keys
options[:only_path] = options[:host].nil? unless options.key?(:only_path)
options
```

We see a statistically significant performance gain:

![](https://www.dropbox.com/s/onocpc0zfw4kjxl/Screenshot%202014-08-14%2012.45.30.png?dl=1)

Updated to not mutate incoming parameters
