### PR TITLE
Use the method for determining attribute methods rather than duplicating

### DIFF
--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -47,8 +47,9 @@ module ActiveRecord
         current_time = current_time_from_proper_timezone
 
         all_timestamp_attributes.each do |column|
-          if attributes.key?(column.to_s) && self.send(column).nil?
-            write_attribute(column.to_s, current_time)
+          column = column.to_s
+          if has_attribute?(column) && !attribute_present?(column)
+            write_attribute(column, current_time)
           end
         end
       end


### PR DESCRIPTION
I've been trying to reduce the number of places that care about
`attributes`, and its existence. We have a method for this check, let's
use it instead.
