### PR TITLE
Make `Type::Numeric` inherit from `Type::Value`

### DIFF
--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -1,5 +1,4 @@
 require 'active_record/type/mutable'
-require 'active_record/type/numeric'
 require 'active_record/type/time_value'
 require 'active_record/type/value'
 
@@ -7,6 +6,7 @@ require 'active_record/type/binary'
 require 'active_record/type/boolean'
 require 'active_record/type/date'
 require 'active_record/type/date_time'
+require 'active_record/type/numeric'
 require 'active_record/type/decimal'
 require 'active_record/type/decimal_without_scale'
 require 'active_record/type/float'

--- a/activerecord/lib/active_record/type/decimal.rb
+++ b/activerecord/lib/active_record/type/decimal.rb
@@ -1,7 +1,6 @@
 module ActiveRecord
   module Type
-    class Decimal < Value # :nodoc:
-      include Numeric
+    class Decimal < Numeric # :nodoc:
 
       def type
         :decimal

--- a/activerecord/lib/active_record/type/float.rb
+++ b/activerecord/lib/active_record/type/float.rb
@@ -1,7 +1,6 @@
 module ActiveRecord
   module Type
-    class Float < Value # :nodoc:
-      include Numeric
+    class Float < Numeric # :nodoc:
 
       def type
         :float

--- a/activerecord/lib/active_record/type/integer.rb
+++ b/activerecord/lib/active_record/type/integer.rb
@@ -1,7 +1,6 @@
 module ActiveRecord
   module Type
-    class Integer < Value # :nodoc:
-      include Numeric
+    class Integer < Numeric # :nodoc:
 
       def type
         :integer

--- a/activerecord/lib/active_record/type/numeric.rb
+++ b/activerecord/lib/active_record/type/numeric.rb
@@ -1,6 +1,7 @@
 module ActiveRecord
   module Type
-    module Numeric # :nodoc:
+    class Numeric < Value # :nodoc:
+
       def number?
         true
       end


### PR DESCRIPTION
`Type::Numeric` implements behaviour from `Type::Value`. 
See https://github.com/rails/rails/blob/master/activerecord/lib/active_record/type/numeric.rb#L8-L16.

Make `Type::Numeric` inherit from `Type::Value` while `Type::Float`, `Type::Integer` inherit from `Type::Numeric`instead of Value, to make the intent of inheritance more clear.
