### PR TITLE
Implement `==` on `Type::Value` and `Attribute`

### DIFF
--- a/activerecord/lib/active_record/attribute.rb
+++ b/activerecord/lib/active_record/attribute.rb
@@ -62,6 +62,13 @@ module ActiveRecord
       true
     end
 
+    def ==(other)
+      self.class == other.class &&
+        name == other.name &&
+        value_before_type_cast == other.value_before_type_cast &&
+        type == other.type
+    end
+
     protected
 
     def initialize_dup(other)

--- a/activerecord/lib/active_record/type/value.rb
+++ b/activerecord/lib/active_record/type/value.rb
@@ -76,6 +76,13 @@ module ActiveRecord
         false
       end
 
+      def ==(other)
+        self.class == other.class &&
+          precision == other.precision &&
+          scale == other.scale &&
+          limit == other.limit
+      end
+
       private
 
       def type_cast(value)

--- a/activerecord/test/cases/attribute_test.rb
+++ b/activerecord/test/cases/attribute_test.rb
@@ -138,5 +138,35 @@ module ActiveRecord
     test "uninitialized attributes have no value" do
       assert_nil Attribute.uninitialized(:foo, nil).value
     end
+
+    test "attributes equal other attributes with the same constructor arguments" do
+      first = Attribute.from_database(:foo, 1, Type::Integer.new)
+      second = Attribute.from_database(:foo, 1, Type::Integer.new)
+      assert_equal first, second
+    end
+
+    test "attributes do not equal attributes with different names" do
+      first = Attribute.from_database(:foo, 1, Type::Integer.new)
+      second = Attribute.from_database(:bar, 1, Type::Integer.new)
+      assert_not_equal first, second
+    end
+
+    test "attributes do not equal attributes with different types" do
+      first = Attribute.from_database(:foo, 1, Type::Integer.new)
+      second = Attribute.from_database(:foo, 1, Type::Float.new)
+      assert_not_equal first, second
+    end
+
+    test "attributes do not equal attributes with different values" do
+      first = Attribute.from_database(:foo, 1, Type::Integer.new)
+      second = Attribute.from_database(:foo, 2, Type::Integer.new)
+      assert_not_equal first, second
+    end
+
+    test "attributes do not equal attributes of other classes" do
+      first = Attribute.from_database(:foo, 1, Type::Integer.new)
+      second = Attribute.from_user(:foo, 1, Type::Integer.new)
+      assert_not_equal first, second
+    end
   end
 end

--- a/activerecord/test/cases/types_test.rb
+++ b/activerecord/test/cases/types_test.rb
@@ -149,6 +149,12 @@ module ActiveRecord
         end
       end
 
+      def test_type_equality
+        assert_equal Type::Value.new, Type::Value.new
+        assert_not_equal Type::Value.new, Type::Integer.new
+        assert_not_equal Type::Value.new(precision: 1), Type::Value.new(precision: 2)
+      end
+
       if current_adapter?(:SQLite3Adapter)
         def test_binary_encoding
           type = SQLite3Binary.new


### PR DESCRIPTION
This was a small self contained piece of the refactoring that I am
working on, which required these objects to be comparable.
