### PR TITLE
Alias the ActionDispatch::Request#uuid method to ActionDispatch::Request#request_id

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*  Alias the ActionDispatch::Request#uuid method to ActionDispatch::Request#request_id. Due to implementation, `config.log_tags = [:request_id]` also works in substitute for `config.log_tags = [:uuid]`.
+
+    *David Ilizarov*
+
 *   Remove deprecated `AbstractController::Helpers::ClassMethods::MissingHelperError`
     in favor of `AbstractController::Helpers::MissingHelperError`.
 

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -235,6 +235,8 @@ module ActionDispatch
       @uuid ||= env["action_dispatch.request_id"]
     end
 
+    alias_method :request_id, :uuid
+
     # Returns the lowercase name of the HTTP server software.
     def server_software
       (@env['SERVER_SOFTWARE'] && /^([a-zA-Z]+)/ =~ @env['SERVER_SOFTWARE']) ? $1.downcase : nil

--- a/actionpack/lib/action_dispatch/middleware/request_id.rb
+++ b/actionpack/lib/action_dispatch/middleware/request_id.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/string/access'
 
 module ActionDispatch
   # Makes a unique request id available to the action_dispatch.request_id env variable (which is then accessible through
-  # ActionDispatch::Request#uuid) and sends the same id to the client via the X-Request-Id header.
+  # ActionDispatch::Request#uuid or the alias ActionDispatch::Request#request_id) and sends the same id to the client via the X-Request-Id header.
   #
   # The unique request id is either based on the X-Request-Id header in the request, which would typically be generated
   # by a firewall, load balancer, or the web server, or, if this header is not available, a random uuid. If the


### PR DESCRIPTION
When writing code, and wanting access to the `"X-Request-ID"` header, one uses the ActionDispatch::Request#uuid method.

Generally, in actual code it looks like `request.uuid`. While I understand what this means, it isn't particularly clear. When one considers that it comes from the `"action_dispatch.request_id"` environment variable and that everything else I noticed in the Rails code corresponds to the convention in the following example, I think it serves to be a viable change. For instance, `request.remote_ip` corresponds to `"action_dispatch.remote_ip"`, and that is just one such example.

Further, something that drives the point home to me is that `request.uuid` has the same tone as `person.string`, which returns the first name of that person. Sure, it is a string, but the method should be called `person.first_name` instead to be more descriptive. I am sure you agree with this.

After carefully examining the implementation of `config.log_tags = [:uuid]` which is closely related to the request_id uses in Rails, `config.log_tags = [:request_id]` will automatically begin working, because in the source code you have `request.send(tag)`, when `tag` is a symbol. By aliasing the method, this ensure that the functionality still works and further will continue to work for anyone who still opts to use ActionDispatch::Request#uuid instead of ActionDispatch::Request#request_id.

One last point: I searched through the Rails code and found no tests for the ActionDispatch::Request#uuid method. Due to the fact that I'm simply aliasing it and checked the implementation to make sure no changes had to be made for the log_tags code, I didn't include tests.
