### PR TITLE
Actionpack predicate `performed?` now strictly returns a boolean.

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -185,7 +185,7 @@ module ActionController
     
     # Tests if render or redirect has already happened.
     def performed?
-      response_body || (response && response.committed?)
+      !!(response_body || (response && response.committed?))
     end
 
     def dispatch(name, request) #:nodoc:


### PR DESCRIPTION
Because `performed?` is a predicate, the convention is to return
a boolean value. The previous implementation returned
an Array of render messages instead of true.

The double bang `!!` operator has been applied around the line of
code to coerce the return value to a boolean.
