### PR TITLE
Prepare for partial release.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,6 +1,4 @@
-*   Deprecated TagAssertions.
-
-    Moved DomAssertions and SelectorAssertions to Action View.
+*   Deleted the deprecated TagAssertions.
 
     *Kasper Timm Hansen*
 

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -23,8 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rack',      '~> 1.6.0.alpha'
   s.add_dependency 'rack-test', '~> 0.6.2'
-  s.add_dependency 'rails-dom-testing'
-  s.add_dependency 'rails-html-sanitizer'
+  s.add_dependency 'rails-deprecated_sanitizer'
   s.add_dependency 'actionview', version
 
   s.add_development_dependency 'activemodel', version

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,32 +1,3 @@
-*   Dom and Selector assertions has extracted to rails-dom-testing to better be used in both Action Pack and Action View.
-
-    Note:
-    This also changes the substitution values syntax in `assert_select`.
-
-    `assert_select "div#?", /\d+/`
-    `assert_select "div:match('id', ?)", /\d+/`
-
-    The attribute to match should be enclosed in quotes to avoid
-    issues with Nokogiri's css selector syntax parsing.
-    It is not necessary to do so with the question mark.
-    Calling `assert_select` with an invalid selector will emit a deprecation warning and skip the assertions.
-
-    *Kasper Timm Hansen*
-
-*   The sanitizers in `sanitize_helper` have been extracted to rails-html-sanitizer. Loofah is used for sanitization instead of html-scanner.
-
-    This means:
-    `sanitize` can now take a `Loofah::Scrubber` for powerful scrubbing.
-    [See some examples of scrubbers here](https://github.com/flavorjones/loofah#loofahscrubber)
-
-    `PermitScrubber` has been added. Set the attributes and tags you want to keep and get everything else stripped.
-
-    `TargetScrubber` has been added. Set the attributes and tags you want to have stripped and keep everything else.
-
-    The documentation for `PermitScrubber` and `TargetScrubber` explains how you can gain complete control over when and how elements should be stripped.
-
-    *Kasper Timm Hansen*
-
 *   Fix that render layout: 'messages/layout' should also be added to the dependency tracker tree.
 
     *DHH*

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -23,8 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'builder',       '~> 3.1'
   s.add_dependency 'erubis',        '~> 2.7.0'
-  s.add_dependency 'rails-dom-testing'
-  s.add_dependency 'rails-html-sanitizer'
+  s.add_dependency 'rails-deprecated_sanitizer'
 
   s.add_development_dependency 'actionpack',  version
   s.add_development_dependency 'activemodel', version

--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -1,6 +1,6 @@
 require 'active_support/core_ext/object/try'
 require 'active_support/deprecation'
-require 'rails-html-sanitizer'
+require 'rails-deprecated_sanitizer'
 
 module ActionView
   # = Action View Sanitize Helpers
@@ -138,9 +138,14 @@ module ActionView
         end
 
         # Vendors the full, link and white list sanitizers.
-        # Strictly for backwards compatibility with html-scanner.
+        # This uses html-scanner for the HTML sanitization.
+        # In the next Rails version this will use Rails::Html::Sanitizer instead.
+        # To get this new behavior now, in your Gemfile, add:
+        #
+        #  gem 'rails-html-sanitizer'
+        #
         def sanitizer_vendor
-          Rails::Html::Sanitizer
+          Rails::DeprecatedSanitizer
         end
 
         def sanitized_allowed_tags

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -91,6 +91,38 @@ after_bundle do
 end
 ```
 
+### Rails Html Sanitizer
+
+There's a new choice for sanitizing HTML fragments in your applications. The
+venerable html-scanner approach is now officially being deprecated in favor of
+[`Rails Html Sanitizer`](https://github.com/rails/rails-html-sanitizer).
+
+This means the methods `sanitize`, `sanitize_css`, `strip_tags` and
+`strip_links` are backed by a new implementation.
+
+In the next major Rails version `Rails Html Sanitizer` will be the default
+sanitizer. It already is for new applications.
+
+Include this in your Gemfile to try it out today:
+
+```ruby
+gem 'rails-html-sanitizer'
+```
+
+This new sanitizer uses [Loofah](https://github.com/flavorjones/loofah) internally. Loofah in turn uses Nokogiri, which
+wraps XML parsers written in both C and Java, so sanitization should be faster
+no matter which Ruby version you run.
+
+The new version updates `sanitize`, so it can take a `Loofah::Scrubber` for
+powerful scrubbing.
+[See some examples of scrubbers here](https://github.com/flavorjones/loofah#loofahscrubber).
+
+Two new scrubbers have also been added: `PermitScrubber` and `TargetScrubber`.
+Read the [gem's readme](https://github.com/rails/rails-html-sanitizer) for more information.
+
+The documentation for `PermitScrubber` and `TargetScrubber` explains how you
+can gain complete control over when and how elements should be stripped.
+
 Upgrading from Rails 4.0 to Rails 4.1
 -------------------------------------
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -15,6 +15,9 @@ source 'https://rubygems.org'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
+# Use Rails Html Sanitizer for HTML sanitization
+gem 'rails-html-snaitizer'
+
 # Use Unicorn as the app server
 # gem 'unicorn'
 


### PR DESCRIPTION
- Default to `Rails::DeprecatedSanitizer` in `ActionView::Helpers::SanitizeHelper`.
- Add upgrade notes.
- Add sanitizer to new applications Gemfiles.
- Remove 'rails-dom-testing' as a dependency.
