### PR TITLE
When your templates change, browser caches bust automatically.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   When your templates change, browser caches bust automatically.
+
+    New default: the template digest is automatically included in your ETags.
+    When you call `fresh_when @post`, the digest for `posts/show.html.erb`
+    is mixed in so future changes to the HTML will blow HTTP caches for you.
+    This makes it easy to HTTP-cache many more of your actions.
+
+    If you render a different template, you can now pass the `:template`
+    option to include its digest instead:
+
+      fresh_when @post, template: 'widgets/show'
+
+    Pass `template: false` to skip the lookup. To turn this off entirely, set:
+
+      config.action_controller.etag_with_template_digest = false
+
+    *Jeremy Kemper*
+
 *   Remove deprecated `AbstractController::Helpers::ClassMethods::MissingHelperError`
     in favor of `AbstractController::Helpers::MissingHelperError`.
 

--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -17,6 +17,7 @@ module ActionController
     autoload :ConditionalGet
     autoload :Cookies
     autoload :DataStreaming
+    autoload :EtagWithTemplateDigest
     autoload :Flash
     autoload :ForceSSL
     autoload :Head

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -213,6 +213,7 @@ module ActionController
       Rendering,
       Renderers::All,
       ConditionalGet,
+      EtagWithTemplateDigest,
       RackDelegation,
       Caching,
       MimeResponds,

--- a/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
+++ b/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
@@ -1,0 +1,50 @@
+module ActionController
+  # When our views change, they should bubble up into HTTP cache freshness
+  # and bust browser caches. So the template digest for the current action
+  # is automatically included in the ETag.
+  #
+  # Enabled by default for apps that use Action View. Disable by setting
+  #
+  #   config.action_controller.etag_with_template_digest = false
+  #
+  # Override the template to digest by passing `:template` to `fresh_when`
+  # and `stale?` calls. For example:
+  #
+  #   # We're going to render widgets/show, not posts/show
+  #   fresh_when @post, template: 'widgets/show'
+  #
+  #   # We're not going to render a template, so omit it from the ETag.
+  #   fresh_when @post, template: false
+  #
+  module EtagWithTemplateDigest
+    extend ActiveSupport::Concern
+
+    include ActionController::ConditionalGet
+
+    included do
+      class_attribute :etag_with_template_digest
+      self.etag_with_template_digest = true
+
+      ActiveSupport.on_load :action_view, yield: true do |action_view_base|
+        etag do |options|
+          determine_template_etag(options) if etag_with_template_digest
+        end
+      end
+    end
+
+    private
+    def determine_template_etag(options)
+      if template = pick_template_for_etag(options)
+        lookup_and_digest_template(template)
+      end
+    end
+
+    def pick_template_for_etag(options)
+      options.fetch(:template) { "#{controller_name}/#{action_name}" }
+    end
+
+    def lookup_and_digest_template(template)
+      ActionView::Digestor.digest name: template, finder: lookup_context
+    end
+  end
+end

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -162,7 +162,7 @@ module ActionController
       end
 
       def with_stale
-        render :text => 'stale' if stale?(:etag => "123")
+        render text: 'stale' if stale?(etag: "123", template: false)
       end
 
       def exception_in_view


### PR DESCRIPTION
New default: the template digest is automatically included in your ETags.
When you call `fresh_when @post`, the digest for `posts/show.html.erb`
is mixed in so future changes to the HTML will blow HTTP caches for you.
This makes it easy to HTTP-cache many more of your actions.

If you render a different template, you can now pass the `:template`
option to include its digest instead:

``` ruby
  fresh_when @post, template: 'widgets/show'
```

Pass `template: false` to skip the lookup. To turn this off entirely, set:

``` ruby
  config.action_controller.etag_with_template_digest = false
```
