### PR TITLE
Add a test case of nested empty array values in conditions

### DIFF
--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -180,6 +180,10 @@ module ActiveRecord
       assert_equal 0, Post.where(:id => []).count
     end
 
+    def test_where_with_table_name_and_nested_empty_array
+      assert_equal [], Post.where(:id => [[]]).to_a
+    end
+
     def test_where_with_empty_hash_and_no_foreign_key
       assert_equal 0, Edge.where(:sink => {}).count
     end


### PR DESCRIPTION
``` ruby
  Post.where(id: [[]]).to_a
```

Used to fail with a SQL syntax error (until 4.1):

``` sql
SELECT ... WHERE id in ();
```

It now properly generate:

``` sql
SELECT ... WHERE 1=0;
```

I think it have been fixed in Arel, but I'm not 100% sure.
In any case I think adding a regression test cannot harm
