### PR TITLE
Support unscoping default_scope in eager_loaded associations

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -52,7 +52,7 @@ module ActiveRecord
             end
             scope_chain_index += 1
 
-            scope_chain_items.concat [klass.send(:build_default_scope, ActiveRecord::Relation.create(klass, table))].compact
+            scope_chain_items.unshift(*[klass.send(:build_default_scope, ActiveRecord::Relation.create(klass, table))].compact)
 
             rel = scope_chain_items.inject(scope_chain_items.shift) do |left, right|
               left.merge right

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -151,6 +151,10 @@ module ActiveRecord
             end
           end
 
+          if values.key? :unscope
+            scope.unscope_values = values[:unscope]
+          end
+
           if preload_values[:readonly] || values[:readonly]
             scope.readonly!
           end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -768,6 +768,22 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_eager_with_unscoping_default_scope_sql_query
+    posts = PostUnscopingDefaultScope.includes(:comments).references(:posts)
+    
+    assert_not posts.to_sql.include?('"deleted_at" IS NULL')
+  end
+
+  def test_eager_with_unscoping_default_scope_contains_deleted_comment
+    post = PostUnscopingDefaultScope.create!(title: "title", body: "body")
+    CommentWithDefaultScope.create!(body: "body", post: post)
+    CommentWithDefaultScope.create!(body: "body", post: post, deleted_at: '2014/01/01')
+
+    posts = PostUnscopingDefaultScope.includes(:comments).references(:posts).to_a
+    
+    assert_equal 2, posts.first.comments.count
+  end
+
   def find_all_ordered(className, include=nil)
     className.all.merge!(:order=>"#{className.table_name}.#{className.primary_key}", :includes=>include).to_a
   end
@@ -997,6 +1013,22 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
     post_with_readers = Post.includes(:lazy_readers_skimmers_or_not).find(post.id)
     assert_equal 2, post_with_readers.lazy_readers_skimmers_or_not.to_a.size
+  end
+
+  def test_preload_with_unscoping_default_scope_sql_query
+    posts = PostUnscopingDefaultScope.includes(:comments)
+    
+    assert_not posts.to_sql.include?('"deleted_at" IS NULL')
+  end
+
+  def test_preload_with_unscoping_default_scope_contains_deleted_comment
+    post = PostUnscopingDefaultScope.create!(title: "title", body: "body")
+    CommentWithDefaultScope.create!(body: "body", post: post)
+    CommentWithDefaultScope.create!(body: "body", post: post, deleted_at: '2014/01/01')
+
+    posts = PostUnscopingDefaultScope.includes(:comments).to_a
+    
+    assert_equal 2, posts.first.comments.count
   end
 
   def test_eager_loading_with_conditions_on_string_joined_table_preloads

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -57,3 +57,9 @@ class CommentWithDefaultScopeReferencesAssociation < Comment
   default_scope ->{ includes(:developer).order('developers.name').references(:developer) }
   belongs_to :developer
 end
+
+class CommentWithDefaultScope < Comment
+  belongs_to :post, class_name: "PostUnscopingDefaultScope", foreign_key: :post_id
+
+  default_scope { where(deleted_at: nil) }
+end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -181,6 +181,11 @@ class SubStiPost < StiPost
   self.table_name = Post.table_name
 end
 
+class PostUnscopingDefaultScope < Post
+  self.table_name = 'posts'
+  has_many :comments, -> { unscope(where: :deleted_at) }, class_name: "CommentWithDefaultScope", foreign_key: :post_id
+end
+
 class FirstPost < ActiveRecord::Base
   self.table_name = 'posts'
   default_scope { where(:id => 1) }

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -199,6 +199,7 @@ ActiveRecord::Schema.define do
     t.string :resource_id
     t.string :resource_type
     t.integer :developer_id
+    t.datetime :deleted_at
   end
 
   create_table :companies, force: true do |t|


### PR DESCRIPTION
For eager_loaded joins move the default scope to the front of the scope chain to be merged first.
For preloading check values for unscope and add to the scope being built unscope_values.
On preload, no need to change merge sequence given default scope is merged first.
