### PR TITLE
Lock web-console to 2.0.0.beta1 for the first 4.2 beta

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -31,7 +31,7 @@ group :development, :test do
   <%- end -%>
 
   # Access an IRB console on exceptions page and /console in development
-  gem 'web-console'
+  gem 'web-console', '2.0.0.beta1'
 <%- if spring_install? %>
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'


### PR DESCRIPTION
The console on exception code isn't available on the stable releases
yet. Lock it for now, so the beta users get a sneak peak of the console
features.
