### PR TITLE
Deprecate NamedRouteCollection#helpers.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -101,6 +101,11 @@ module ActionDispatch
           @path_helpers.include?(key) || @url_helpers.include?(key)
         end
 
+        def helpers
+          ActiveSupport::Deprecation.warn("`named_routes.helpers` is deprecated, please use `route_defined?(route_name)` to see if a named route was defined.")
+          @path_helpers + @url_helpers
+        end
+
         def helper_names
           @path_helpers.map(&:to_s) + @url_helpers.map(&:to_s)
         end


### PR DESCRIPTION
This will help RSpec users to upgrade from `4.1.x` to `4.2.0`.
