### PR TITLE
Allow fallback to LegacyKeyGenerator when secret_key_base is not set but secrets.secret_token is

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -120,7 +120,7 @@ module ActionDispatch
       # the cookie again. This is useful for creating cookies with values that the user is not supposed to change. If a signed
       # cookie was tampered with by the user (or a 3rd party), nil will be returned.
       #
-      # If +secrets.secret_key_base+ and +config.secret_token+ (deprecated) are both set,
+      # If +secrets.secret_key_base+ and +secrets.secret_token+ (deprecated) are both set,
       # legacy cookies signed with the old key generator will be transparently upgraded.
       #
       # This jar requires that you set a suitable secret for the verification on your app's +secrets.secret_key_base+.
@@ -143,7 +143,7 @@ module ActionDispatch
       # Returns a jar that'll automatically encrypt cookie values before sending them to the client and will decrypt them for read.
       # If the cookie was tampered with by the user (or a 3rd party), nil will be returned.
       #
-      # If +secrets.secret_key_base+ and +config.secret_token+ (deprecated) are both set,
+      # If +secrets.secret_key_base+ and +secrets.secret_token+ (deprecated) are both set,
       # legacy cookies signed with the old key generator will be transparently upgraded.
       #
       # This jar requires that you set a suitable secret for the verification on your app's +secrets.secret_key_base+.
@@ -479,7 +479,7 @@ module ActionDispatch
     end
 
     # UpgradeLegacySignedCookieJar is used instead of SignedCookieJar if
-    # config.secret_token and secrets.secret_key_base are both set. It reads
+    # secrets.secret_token and secrets.secret_key_base are both set. It reads
     # legacy cookies signed with the old dummy key generator and re-saves
     # them using the new key generator to provide a smooth upgrade path.
     class UpgradeLegacySignedCookieJar < SignedCookieJar #:nodoc:
@@ -537,7 +537,7 @@ module ActionDispatch
     end
 
     # UpgradeLegacyEncryptedCookieJar is used by ActionDispatch::Session::CookieStore
-    # instead of EncryptedCookieJar if config.secret_token and secrets.secret_key_base
+    # instead of EncryptedCookieJar if secrets.secret_token and secrets.secret_key_base
     # are both set. It reads legacy cookies signed with the old dummy key generator and
     # encrypts and re-saves them using the new key generator to provide a smooth upgrade path.
     class UpgradeLegacyEncryptedCookieJar < EncryptedCookieJar #:nodoc:

--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -7,8 +7,8 @@ require 'action_controller/railtie'
 class TestApp < Rails::Application
   config.root = File.dirname(__FILE__)
   config.session_store :cookie_store, key: 'cookie_store_key'
-  config.secret_token    = 'secret_token'
-  config.secret_key_base = 'secret_key_base'
+  secrets.secret_token    = 'secret_token'
+  secrets.secret_key_base = 'secret_key_base'
 
   config.logger = Logger.new($stdout)
   Rails.logger  = config.logger

--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -19,8 +19,8 @@ require 'action_controller/railtie'
 class TestApp < Rails::Application
   config.root = File.dirname(__FILE__)
   config.session_store :cookie_store, key: 'cookie_store_key'
-  config.secret_token    = 'secret_token'
-  config.secret_key_base = 'secret_key_base'
+  secrets.secret_token    = 'secret_token'
+  secrets.secret_key_base = 'secret_key_base'
 
   config.logger = Logger.new($stdout)
   Rails.logger  = config.logger

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `secret_token` is now saved in `Rails.application.secrets.secret_token`
+    and it falls back to the value of `config.secret_token` when it is not
+    present in `config/secrets.yml`.
+
+    *Benjamin Fleischer*
+
 *   Remove `--skip-action-view` option from `Rails::Generators::AppBase`.
 
     Fixes #17023.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -301,6 +301,53 @@ module ApplicationTests
       assert_equal 'some_value', verifier.verify(message)
     end
 
+    test "application message verifier can be used when the key_generator is ActiveSupport::LegacyKeyGenerator" do
+      app_file 'config/initializers/secret_token.rb', <<-RUBY
+        Rails.application.config.secret_token = "b3c631c314c0bbca50c1b2843150fe33"
+      RUBY
+      app_file 'config/secrets.yml', <<-YAML
+        development:
+          secret_key_base:
+      YAML
+      require "#{app_path}/config/environment"
+
+
+      assert_equal app.env_config['action_dispatch.key_generator'],     Rails.application.key_generator
+      assert_equal app.env_config['action_dispatch.key_generator'].class, ActiveSupport::LegacyKeyGenerator
+      message = app.message_verifier(:sensitive_value).generate("some_value")
+      assert_equal 'some_value', Rails.application.message_verifier(:sensitive_value).verify(message)
+    end
+
+    test "warns when secrets.secret_key_base is blank and config.secret_token is set" do
+      app_file 'config/initializers/secret_token.rb', <<-RUBY
+        Rails.application.config.secret_token = "b3c631c314c0bbca50c1b2843150fe33"
+      RUBY
+      app_file 'config/secrets.yml', <<-YAML
+        development:
+          secret_key_base:
+      YAML
+      require "#{app_path}/config/environment"
+
+      assert_deprecated(/You didn't set `secret_key_base`./) do
+        app.env_config
+      end
+    end
+
+    test "uses secrets.secret_token when secrets.secret_key_base and config.secret_token are blank" do
+      app_file 'config/initializers/secret_token.rb', <<-RUBY
+        Rails.application.config.secret_token = ""
+      RUBY
+      app_file 'config/secrets.yml', <<-YAML
+        development:
+          secret_key_base:
+          secret_token: 3b7cd727ee24e8444053437c36cc66c3
+      YAML
+      require "#{app_path}/config/environment"
+
+      assert_equal '3b7cd727ee24e8444053437c36cc66c3', app.secrets.secret_token
+      assert_equal '3b7cd727ee24e8444053437c36cc66c3', app.config.secret_token
+    end
+
     test "application verifier can build different verifiers" do
       make_basic_app do |app|
         app.secrets.secret_key_base = 'b3c631c314c0bbca50c1b2843150fe33'
@@ -341,6 +388,51 @@ module ApplicationTests
       assert_equal '3b7cd727ee24e8444053437c36cc66c3', app.secrets.secret_key_base
     end
 
+    test "config.secret_token over-writes a blank secrets.secret_token" do
+      app_file 'config/initializers/secret_token.rb', <<-RUBY
+        Rails.application.config.secret_token    = "b3c631c314c0bbca50c1b2843150fe33"
+      RUBY
+      app_file 'config/secrets.yml', <<-YAML
+        development:
+          secret_key_base:
+          secret_token:
+      YAML
+      require "#{app_path}/config/environment"
+
+      assert_equal 'b3c631c314c0bbca50c1b2843150fe33', app.secrets.secret_token
+      assert_equal 'b3c631c314c0bbca50c1b2843150fe33', app.config.secret_token
+    end
+
+    test "secret_token is copied from secrets to config when set" do
+      app_file 'config/initializers/secret_token.rb', <<-RUBY
+        Rails.application.config.secret_token    = ""
+      RUBY
+      app_file 'config/secrets.yml', <<-YAML
+        development:
+          secret_key_base:
+          secret_token: 3b7cd727ee24e8444053437c36cc66c3
+      YAML
+      require "#{app_path}/config/environment"
+
+      assert_equal '3b7cd727ee24e8444053437c36cc66c3', app.secrets.secret_token
+      assert_equal '3b7cd727ee24e8444053437c36cc66c3', app.config.secret_token
+    end
+
+    test "secret_token is copied from secrets to config when different" do
+      app_file 'config/initializers/secret_token.rb', <<-RUBY
+        Rails.application.config.secret_token    = "b3c631c314c0bbca50c1b2843150fe33"
+      RUBY
+      app_file 'config/secrets.yml', <<-YAML
+        development:
+          secret_key_base:
+          secret_token: 3b7cd727ee24e8444053437c36cc66c3
+      YAML
+      require "#{app_path}/config/environment"
+
+      assert_equal '3b7cd727ee24e8444053437c36cc66c3', app.secrets.secret_token
+      assert_equal '3b7cd727ee24e8444053437c36cc66c3', app.config.secret_token
+    end
+
     test "custom secrets saved in config/secrets.yml are loaded in app secrets" do
       app_file 'config/secrets.yml', <<-YAML
         development:
@@ -360,6 +452,51 @@ module ApplicationTests
       require "#{app_path}/config/environment"
 
       assert_nil app.secrets.not_defined
+    end
+
+    test "config.secret_key_base over-writes a blank secrets.secret_key_base" do
+      app_file 'config/initializers/secret_token.rb', <<-RUBY
+        Rails.application.config.secret_key_base = "iaminallyoursecretkeybase"
+      RUBY
+      app_file 'config/secrets.yml', <<-YAML
+        development:
+          secret_key_base:
+      YAML
+      require "#{app_path}/config/environment"
+
+      assert_equal "iaminallyoursecretkeybase", app.secrets.secret_key_base
+    end
+
+    test "uses ActiveSupport::LegacyKeyGenerator as app.key_generator when secrets.secret_key_base is blank" do
+      app_file 'config/initializers/secret_token.rb', <<-RUBY
+        Rails.application.config.secret_token = "b3c631c314c0bbca50c1b2843150fe33"
+      RUBY
+      app_file 'config/secrets.yml', <<-YAML
+        development:
+          secret_key_base:
+      YAML
+      require "#{app_path}/config/environment"
+
+      assert_equal 'b3c631c314c0bbca50c1b2843150fe33', app.config.secret_token
+      assert_equal nil, app.secrets.secret_key_base
+      assert_equal app.key_generator.class, ActiveSupport::LegacyKeyGenerator
+    end
+
+    test "uses ActiveSupport::LegacyKeyGenerator with config.secret_token as app.key_generator when secrets.secret_key_base is blank" do
+      app_file 'config/initializers/secret_token.rb', <<-RUBY
+        Rails.application.config.secret_token = ""
+      RUBY
+      app_file 'config/secrets.yml', <<-YAML
+        development:
+          secret_key_base:
+      YAML
+      require "#{app_path}/config/environment"
+
+      assert_equal '', app.config.secret_token
+      assert_equal nil, app.secrets.secret_key_base
+      assert_raise ArgumentError, /\AA secret is required/ do
+        app.key_generator
+      end
     end
 
     test "protect from forgery is the default in a new app" do

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -203,7 +203,7 @@ module ApplicationTests
       RUBY
 
       add_to_config <<-RUBY
-        config.secret_token = "3b7cd727ee24e8444053437c36cc66c4"
+        secrets.secret_token = "3b7cd727ee24e8444053437c36cc66c4"
       RUBY
 
       require "#{app_path}/config/environment"
@@ -258,7 +258,7 @@ module ApplicationTests
       RUBY
 
       add_to_config <<-RUBY
-        config.secret_token = "3b7cd727ee24e8444053437c36cc66c4"
+        secrets.secret_token = "3b7cd727ee24e8444053437c36cc66c4"
       RUBY
 
       require "#{app_path}/config/environment"
@@ -317,7 +317,7 @@ module ApplicationTests
       RUBY
 
       add_to_config <<-RUBY
-        config.secret_token = "3b7cd727ee24e8444053437c36cc66c4"
+        secrets.secret_token = "3b7cd727ee24e8444053437c36cc66c4"
         secrets.secret_key_base = nil
       RUBY
 
@@ -334,7 +334,7 @@ module ApplicationTests
       get '/foo/read_signed_cookie'
       assert_equal '2', last_response.body
 
-      verifier = ActiveSupport::MessageVerifier.new(app.config.secret_token)
+      verifier = ActiveSupport::MessageVerifier.new(app.secrets.secret_token)
 
       get '/foo/read_raw_cookie'
       assert_equal 2, verifier.verify(last_response.body)['foo']

--- a/railties/test/application/multiple_applications_test.rb
+++ b/railties/test/application/multiple_applications_test.rb
@@ -8,6 +8,7 @@ module ApplicationTests
       build_app(initializers: true)
       boot_rails
       require "#{rails_root}/config/environment"
+      Rails.application.config.some_setting = 'something_or_other'
     end
 
     def teardown
@@ -18,7 +19,7 @@ module ApplicationTests
       clone = Rails.application.clone
 
       assert_equal Rails.application.config, clone.config, "The cloned application should get a copy of the config"
-      assert_equal Rails.application.config.secret_key_base, clone.config.secret_key_base, "The base secret key on the config should be the same"
+      assert_equal Rails.application.config.some_setting, clone.config.some_setting, "The some_setting on the config should be the same"
     end
 
     def test_inheriting_multiple_times_from_application
@@ -160,13 +161,14 @@ module ApplicationTests
 
     def test_inserting_configuration_into_application
       app = AppTemplate::Application.new(config: Rails.application.config)
-      new_config = Rails::Application::Configuration.new("root_of_application")
-      new_config.secret_key_base = "some_secret_key_dude"
-      app.config.secret_key_base = "a_different_secret_key"
+      app.config.some_setting = "a_different_setting"
+      assert_equal "a_different_setting", app.config.some_setting, "The configuration's some_setting should be set."
 
-      assert_equal "a_different_secret_key", app.config.secret_key_base, "The configuration's secret key should be set."
+      new_config = Rails::Application::Configuration.new("root_of_application")
+      new_config.some_setting = "some_setting_dude"
       app.config = new_config
-      assert_equal "some_secret_key_dude", app.config.secret_key_base, "The configuration's secret key should have changed."
+
+      assert_equal "some_setting_dude", app.config.some_setting, "The configuration's some_setting should have changed."
       assert_equal "root_of_application", app.config.root, "The root should have changed to the new config's root."
       assert_equal new_config, app.config, "The application's config should have changed to the new config."
     end

--- a/railties/test/application/url_generation_test.rb
+++ b/railties/test/application/url_generation_test.rb
@@ -15,7 +15,7 @@ module ApplicationTests
       require "action_view/railtie"
 
       class MyApp < Rails::Application
-        config.secret_key_base = "3b7cd727ee24e8444053437c36cc66c4"
+        secrets.secret_key_base = "3b7cd727ee24e8444053437c36cc66c4"
         config.session_store :cookie_store, key: "_myapp_session"
         config.active_support.deprecation = :log
         config.eager_load = false


### PR DESCRIPTION
Let devs upgrading from older Rails take advantage of the LegacyKeyGenerator without needing a monkeypatch to use a blank secret_key_base

This behavior may have been removed by accident.  See https://github.com/rails/rails/commit/484ff7d29e7a27216219cf5460bf675c38abf522

e.g.

``` ruby
Rails::Application.class_eval do
  # the key_generator will then use ActiveSupport::LegacyKeyGenerator.new(config.secret_token)
  fail "I'm sorry, Dave, there's no :validate_secret_key_config!" unless instance_method(:validate_secret_key_config!)
  def validate_secret_key_config! #:nodoc:
    config.secret_token = secrets.secret_token
    if config.secret_token.blank?
      raise "Missing `secret_token` for '#{Rails.env}' environment, set this value in `config/secrets.yml`"
    end 
  end 
end
```
