### PR TITLE
Include link_to show a post when index view created

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -887,7 +887,7 @@ class ArticlesController < ApplicationController
   # snipped for brevity
 ```
 
-And then finally, add the view for this action, located at
+And then finally, add the view for this action (including a link to show a specific post), located at
 `app/views/articles/index.html.erb`:
 
 ```html+erb
@@ -903,6 +903,7 @@ And then finally, add the view for this action, located at
     <tr>
       <td><%= article.title %></td>
       <td><%= article.text %></td>
+      <td><%= link_to 'Show', post %></td>
     </tr>
   <% end %>
 </table>


### PR DESCRIPTION
I've worked through the Getting Started with Rails guide several times. Each time through I always get thrown when adding the link to show a specific post is added at the same time the link to edit a post is added to the index view. I updated the index view code in 5.8 to include adding the link to show a specific post.
