### PR TITLE
Make sure :checkout_timeout and :dead_connection_timeout are numbers

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -236,8 +236,8 @@ module ActiveRecord
 
         @spec = spec
 
-        @checkout_timeout = spec.config[:checkout_timeout] || 5
-        @dead_connection_timeout = spec.config[:dead_connection_timeout] || 5
+        @checkout_timeout = (spec.config[:checkout_timeout] && spec.config[:checkout_timeout].to_f) || 5
+        @dead_connection_timeout = (spec.config[:dead_connection_timeout] && spec.config[:dead_connection_timeout].to_f) || 5
         @reaper  = Reaper.new self, spec.config[:reaping_frequency]
         @reaper.run
 


### PR DESCRIPTION
If `:checkout_timeout` (or `:dead_connection_timeout`) is specified with `ENV['DATABASE_URL']`, then you may get 

```
NoMethodError: undefined method `-' for "5":String
from /Users/myuser/.rvm/gems/ruby-2.1.2/gems/activerecord-4.1.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:182:in `block in wait_poll'
```

For example:

```
$ rails c
Loading development environment (Rails 4.1.4)
[1] pry(main)> ENV['DATABASE_URL']
=> "postgres://myuser:@127.0.0.1/mydb?pool=3&checkout_timeout=5"
[2] pry(main)> ActiveRecord::Base.connection_config
=> {:adapter=>"postgresql", :database=>"mydb", :encoding=>"utf8", :min_messages=>"warning", :pool=>"3", :timeout=>5000, :checkout_timeout=>"5", :username=>"myuser", :host=>"127.0.0.1"}
[3] pry(main)> threads = 10.times.map { Thread.new { c = ActiveRecord::Base.connection_pool.checkout; sleep 10 } }
=> [#<Thread:0x00000106332050 sleep>,
 #<Thread:0x00000106331f38 sleep>,
 #<Thread:0x00000106331df8 sleep>,
 #<Thread:0x00000106322240 run>,
 #<Thread:0x00000106322100 run>,
 #<Thread:0x00000106321f98 run>,
 #<Thread:0x00000106321e58 run>,
 #<Thread:0x00000106321d40 run>,
 #<Thread:0x00000106321b88 run>,
 #<Thread:0x000001063219d0 run>]
[4] pry(main)> threads.each(&:join)
NoMethodError: undefined method `-' for "5":String
from /Users/myuser/.rvm/gems/ruby-2.1.2/gems/activerecord-4.1.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:182:in `block in wait_poll'
```

In this change, I use #to_f instead of #to_i because these timeouts are specified in seconds instead of milliseconds
