### PR TITLE
Refactor out Dir.glob from ActionDispatch::Static

### DIFF
--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -37,6 +37,10 @@ module StaticTests
     assert_html "/foo/index.html", get("/foo")
   end
 
+  def test_serves_file_with_same_name_before_index_in_directory
+    assert_html "/bar.html", get("/bar")
+  end
+
   def test_served_static_file_with_non_english_filename
     jruby_skip "Stop skipping if following bug gets fixed: " \
       "http://jira.codehaus.org/browse/JRUBY-7192"

--- a/actionpack/test/fixtures/public/bar.html
+++ b/actionpack/test/fixtures/public/bar.html
@@ -1,0 +1,1 @@
+/bar.html

--- a/actionpack/test/fixtures/public/bar/index.html
+++ b/actionpack/test/fixtures/public/bar/index.html
@@ -1,0 +1,1 @@
+/bar/index.html

--- a/actionpack/test/fixtures/公共/bar.html
+++ b/actionpack/test/fixtures/公共/bar.html
@@ -1,0 +1,1 @@
+/bar.html

--- a/actionpack/test/fixtures/公共/bar/index.html
+++ b/actionpack/test/fixtures/公共/bar/index.html
@@ -1,0 +1,1 @@
+/bar/index.html


### PR DESCRIPTION
Refactor out Dir.glob from ActionDispatch::Static

Dir.glob can be a security concern. The original use was to provide logic of fallback files. Example a request to `/` should render the file from `/public/index.html`. We can replace the dir glob with the specific logic it represents. The glob {,index,index.html} will look for the current path, then in the directory of the path with index file and then in the directory of the path with index.html. This PR replaces the glob logic by manually checking each potential match. Best case scenario this results in one less file API request, worst case, this has one more file API request.

Related to #16464

Update: added a test for when a file of a given name (`public/bar.html` and a directory `public/bar` both exist in the same root directory). Changed logic to accommodate this scenario.
