### PR TITLE
Allow config options to deliver all emails async (through activejob)

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,9 +1,14 @@
+*   Added config.action_mailer.default_deliver_later boolean flag and #deliver_now / #deliver_now!
+    methods. When #deliver / #deliver! is called, based on the value of default_deliver_later
+    it will call #deliver_now / #deliver_now! or #deliver_later / #deliver_later!.
+
+    *Cristian Bica*
+
 *   Added #deliver_later in addition to #deliver, which will enqueue a job to render and
-    deliver the mail instead of delivering it right at that moment. The job is enqueued 
+    deliver the mail instead of delivering it right at that moment. The job is enqueued
     using the new Active Job framework in Rails, and will use whatever queue is configured for Rails.
-    
+
     *DHH/Abdelkader Boudih/Cristian Bica*
-    
 
 *   Make ActionMailer::Previews methods class methods. Previously they were
     instance methods and ActionMailer tries to render a message when they

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -433,6 +433,9 @@ module ActionMailer
       parts_order:  [ "text/plain", "text/enriched", "text/html" ]
     }.freeze
 
+    cattr_accessor :default_deliver_later
+    self.default_deliver_later = false
+
     class << self
       # Register one or more Observers which will be notified when mail is delivered.
       def register_observers(*observers)

--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -20,6 +20,30 @@ module ActionMailer
       __getobj__
     end
 
+    def deliver!
+      if ActionMailer::Base.default_deliver_later
+        deliver_later!
+      else
+        deliver_now!
+      end
+    end
+
+    def deliver
+      if ActionMailer::Base.default_deliver_later
+        deliver_later
+      else
+        deliver_now
+      end
+    end
+
+    def deliver_now!
+      message.deliver!
+    end
+
+    def deliver_now
+      message.deliver
+    end
+
     def deliver_later!(options={})
       enqueue_delivery :deliver!, options
     end


### PR DESCRIPTION
By setting config.action_mailer.deliver_all_emails_later to true all
emails will be sent trough activejob (a call to  `deliver` will be
forwarded to `deliver_later`).

This is very usefull when people will adopt activejob. Emails are sent
from a lot of places in the code and nobody wants to search for them. 
There are also emails sent from gems (ex: devise) that needs to be 
handled.
