### PR TITLE
Remove to_s from reflection.type in add_constraints

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -115,7 +115,7 @@ module ActiveRecord
 
             if reflection.type
               value    = owner.class.base_class.name
-              bind_val = bind scope, table.table_name, reflection.type.to_s, value, tracker
+              bind_val = bind scope, table.table_name, reflection.type, value, tracker
               scope    = scope.where(table[reflection.type].eq(bind_val))
             end
           else
@@ -123,7 +123,7 @@ module ActiveRecord
 
             if reflection.type
               value    = chain[i + 1].klass.base_class.name
-              bind_val = bind scope, table.table_name, reflection.type.to_s, value, tracker
+              bind_val = bind scope, table.table_name, reflection.type, value, tracker
               scope    = scope.where(table[reflection.type].eq(bind_val))
             end
 


### PR DESCRIPTION
The instance var is already saved as a string in the initialization
method of AssociationReflection.

See https://github.com/rails/rails/blob/master/activerecord/lib/active_record/reflection.rb#L273
