### PR TITLE
[ci skip] config.active_record.errors_in_transactional_callbacks -> config.active_record.raise_in_transactional_callbacks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -12,7 +12,7 @@
     Example:
 
         # For not swallow errors in after_commit/after_rollback callbacks.
-        config.active_record.errors_in_transactional_callbacks = true
+        config.active_record.raise_in_transactional_callbacks = true
 
     Fixes #13460.
 


### PR DESCRIPTION
Probably `errors_in_transactional_callbacks` is typo.
