### PR TITLE
Do not depend on queue_classic on JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'resque-scheduler', require: false
 gem 'sidekiq', require: false
 gem 'sucker_punch', require: false
 gem 'delayed_job', require: false
-gem 'queue_classic', require: false
+gem 'queue_classic', require: false, platforms: :ruby
 gem 'sneakers', '0.1.1.pre', require: false
 gem 'que', require: false
 gem 'backburner', require: false

--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -20,6 +20,7 @@ end
 task default: :test
 
 ACTIVEJOB_ADAPTERS = %w(inline delayed_job qu que queue_classic resque sidekiq sneakers sucker_punch backburner)
+ACTIVEJOB_ADAPTERS -= %w(queue_classic) if defined?(JRUBY_VERSION)
 
 desc 'Run all adapter tests'
 task :test do


### PR DESCRIPTION
Before this commit Rails failed to bundle on JRuby:
https://travis-ci.org/rails/rails/jobs/32948994#L268

Reason: https://github.com/ryandotsmith/queue_classic depends on `pg` which is not supported on JRuby.
The replacement https://github.com/bdon/queue_classic_java seems to be dead and has not been released yet.

After this commit the tests run (with failures) on Travis:
https://travis-ci.org/rails/rails/jobs/32964951
