### PR TITLE
Define the Duration#instance_of? method

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,6 +1,11 @@
+*   Add the `Duration#instance_of?` method that was previously delegated to the
+    internal `value` attribute.
+
+    *Robin Dupret*
+
 *   Fix rounding errors with #travel_to by resetting the usec on any passed time to zero, so we only travel
     with per-second precision, not anything deeper than that.
-    
+
     *DHH*
 
 *   Fix ActiveSupport::TestCase not to order users' test cases by default.

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -35,9 +35,13 @@ module ActiveSupport
     end
 
     def is_a?(klass) #:nodoc:
-      Duration == klass || value.is_a?(klass)
+      instance_of?(klass) || value.is_a?(klass)
     end
     alias :kind_of? :is_a?
+
+    def instance_of?(klass) # :nodoc:
+      Duration == klass
+    end
 
     # Returns +true+ if +other+ is also a Duration instance with the
     # same +value+, or if <tt>other == value</tt>.

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -41,6 +41,11 @@ class DurationTest < ActiveSupport::TestCase
     assert !1.eql?(1.second)
   end
 
+  def test_instance_of
+    assert !1.minute.instance_of?(Fixnum)
+    assert !2.days.instance_of?(Fixnum)
+  end
+
   def test_inspect
     assert_equal '0 seconds',                       0.seconds.inspect
     assert_equal '1 month',                         1.month.inspect


### PR DESCRIPTION
Hello,

This pull request adds the `#instance_of?` method to the `ActiveSupport::Duration` object. Since it is extending from `ProxyObject` which extends itself from `BasicObject`, it doesn't respond to the `#instance_of?` method. Thus, the `#method_missing` hook get triggered, delegating the method to its `value` attribute.

However, Rubinius' `#eql?` definition relies on `#instance_of?`, thus this will equal to true with a Fixnum (since its `value` attribute is a Fixnum) while it should not.

The previous behavior was wrong anyway, no matter the implementation.

Have a nice day.
