### PR TITLE
Mention web-console in 4.2 release notes

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -69,6 +69,9 @@ Please refer to the [Changelog][railties] for detailed changes.
 
 ### Notable changes
 
+*   Introduced `web-console` in the default application Gemfile.
+    ([Pull Request](https://github.com/rails/rails/pull/16532))
+
 *   Added a `required` option to the model generator for associations.
     ([Pull Request](https://github.com/rails/rails/pull/16062))
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   The [web-console](https://github.com/rails/web-console) gem is now
+    installed by default for new applications. It can help you debug
+    development exceptions by spawnig an interactive console in its cause
+    binding.
+
+    *Ryan Dao*, *Genadi Samokovarov*, *Guillermo Iguaran*
+
 *   Add a `required` option to the model generator for associations
 
     *Sean Griffin*


### PR DESCRIPTION
Mention the web-console inclusion in the default Gemfile in the Release
notes and the railties changelog. We can eventually mention it in the
upgrade guide, if needed.
