### PR TITLE
Add missing AS require

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -2,6 +2,7 @@ require 'date'
 require 'set'
 require 'bigdecimal'
 require 'bigdecimal/util'
+require 'active_support/core_ext/string/strip'
 
 module ActiveRecord
   module ConnectionAdapters #:nodoc:


### PR DESCRIPTION
`strip_heredoc` method is defined on active_support/core_ext/string.
https://github.com/rails/rails/blob/ea3ba34506c72d636096245016b5ef9cfe27c566/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L64

review @rafaelfranca @sgrif
