### PR TITLE
Add `set_delivery_method` and `restore_delivery_method` to `ActionMailer::TestCase.

### DIFF
--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -68,6 +68,15 @@ module ActionMailer
           ActionMailer::Base.deliveries.clear
         end
 
+        def set_delivery_method(method)
+          @old_delivery_method = ActionMailer::Base.delivery_method
+          ActionMailer::Base.delivery_method = method
+        end
+
+        def restore_delivery_method
+          ActionMailer::Base.delivery_method = @old_delivery_method
+        end
+
         def set_expected_mail
           @expected = Mail.new
           @expected.content_type ["text", "plain", { "charset" => charset }]


### PR DESCRIPTION
This way these methods are available outside the ActionMailer test suite, but
they are still duplicated inside `test/abstract_unit` for test cases that don't
inherit from the `ActionMailer::TestCase` class.
