### PR TITLE
Remove global helpers from the ActionMailer test suite.

### DIFF
--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -32,15 +32,6 @@ module Rails
   end
 end
 
-def set_delivery_method(method)
-  @old_delivery_method = ActionMailer::Base.delivery_method
-  ActionMailer::Base.delivery_method = method
-end
-
-def restore_delivery_method
-  ActionMailer::Base.delivery_method = @old_delivery_method
-end
-
 # Skips the current run on Rubinius using Minitest::Assertions#skip
 def rubinius_skip(message = '')
   skip message if RUBY_ENGINE == 'rbx'

--- a/actionmailer/test/asset_host_test.rb
+++ b/actionmailer/test/asset_host_test.rb
@@ -9,11 +9,8 @@ class AssetHostMailer < ActionMailer::Base
   end
 end
 
-class AssetHostTest < ActiveSupport::TestCase
+class AssetHostTest < ActionMailer::TestCase
   def setup
-    set_delivery_method :test
-    ActionMailer::Base.perform_deliveries = true
-    ActionMailer::Base.deliveries.clear
     AssetHostMailer.configure do |c|
       c.asset_host = "http://www.example.com"
     end


### PR DESCRIPTION
Follow up for #16571. One alternative to this would be to reopen the `ActiveSupport::TestCase` class and implement those helpers there, but we would still have the duplicated code around.
