### PR TITLE
add implementation of respond_to? for ActiveSupport::Duration

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -7,7 +7,7 @@ module ActiveSupport
   # Time#advance, respectively. It mainly supports the methods on Numeric.
   #
   #   1.month.ago       # equivalent to Time.now.advance(months: -1)
-  class Duration < ProxyObject
+  class Duration
     attr_accessor :value, :parts
 
     def initialize(value, parts) #:nodoc:
@@ -53,6 +53,10 @@ module ActiveSupport
       end
     end
 
+    def to_s
+      @value.to_s
+    end
+
     def eql?(other)
       other.is_a?(Duration) && self == other
     end
@@ -87,6 +91,10 @@ module ActiveSupport
 
     def as_json(options = nil) #:nodoc:
       to_i
+    end
+
+    def respond_to_missing?(method, include_private=false) #:nodoc
+      @value.respond_to?(method, include_private)
     end
 
     protected

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -40,6 +40,10 @@ class DurationTest < ActiveSupport::TestCase
     assert !(1.day == 'foo')
   end
 
+  def test_to_s
+    assert_equal "1", 1.second.to_s
+  end
+
   def test_eql
     rubinius_skip "Rubinius' #eql? definition relies on #instance_of? " \
                   "which behaves oddly for the sake of backward-compatibility."
@@ -182,5 +186,10 @@ class DurationTest < ActiveSupport::TestCase
   def test_case_when
     cased = case 1.day when 1.day then "ok" end
     assert_equal cased, "ok"
+  end
+
+  def test_respond_to
+    assert_respond_to 1.day, :since
+    assert_respond_to 1.day, :zero?
   end
 end

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -4,7 +4,7 @@ require 'active_support/core_ext/object/duplicable'
 require 'active_support/core_ext/numeric/time'
 
 class DuplicableTest < ActiveSupport::TestCase
-  RAISE_DUP  = [nil, false, true, :symbol, 1, 2.3, 5.seconds, method(:puts)]
+  RAISE_DUP  = [nil, false, true, :symbol, 1, 2.3, method(:puts)]
   ALLOW_DUP = ['1', Object.new, /foo/, [], {}, Time.now, Class.new, Module.new]
 
   # Needed to support Ruby 1.9.x, as it doesn't allow dup on BigDecimal, instead


### PR DESCRIPTION
In rails 4.2.beta, calling respond_to? on a ActiveSupport::Duration no longer returns true for the methods defined in ActiveSupport::Duration. ie 

``` ruby
10.seconds.respond_to?(:since) #=> false 
```

This is because the `since`, `ago` and similar methods were removed from Numeric.

This adds a custom respond_to? method to currently return if the duration responds to these methods.
