### PR TITLE
Revert "Do not gsub non ASCII characters in header anchor.".

### DIFF
--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -47,7 +47,7 @@ module RailsGuides
       end
 
       def dom_id_text(text)
-        text.downcase.gsub(/\?/, '-questionmark').gsub(/!/, '-bang').gsub(/\s+/, '-')
+        text.downcase.gsub(/\?/, '-questionmark').gsub(/!/, '-bang').gsub(/[^a-z0-9]+/, ' ').strip.gsub(/\s+/, '-')
       end
 
       def engine

--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -26,7 +26,7 @@ coverage before going in. You should also first upgrade to Rails 4.1 in case you
 haven't and make sure your application still runs as expected before attempting
 to upgrade to Rails 4.2. A list of things to watch out for when upgrading is
 available in the
-[Upgrading Ruby on Rails](upgrading_ruby_on_rails.html#upgrading-from-rails-4.1-to-rails-4.2)
+[Upgrading Ruby on Rails](upgrading_ruby_on_rails.html#upgrading-from-rails-4-1-to-rails-4-2)
 guide.
 
 


### PR DESCRIPTION
This reverts commit 699babe.

Also change the upgrading_ruby_on_rails link back to original in 4_2_release_notes.

---

I do not have good solution to take care all non-english substution :sweat: . I do not know if there are any translations out there depend on this code. So it's best revert to where it was. Then I [modify my translation's markdown.rb](https://github.com/docrails-tw/guides/commit/e0038a17e00ed1eccecc0a4a1d08b456cf2711d8) to take care my chinese translations.

Related: #16545 #16576

cc @chancancode
