### PR TITLE
Default url_to to a full URL in mailer when possible

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   All urls generated via `link_to` and `url_for` in the mailer views will now
+    be returned as full urls. This means that `link_to "foo", @user` should
+    provide a working url by default
+
+    *Richard Schneeman*
+
 *   Added #deliver_later, #deliver_now and deprecate #deliver in favour of
     #deliver_now. #deliver_later will enqueue a job to render and deliver
     the mail instead of delivering it right at that moment. The job is enqueued

--- a/actionmailer/test/fixtures/url_test_mailer/exercise_url_for.erb
+++ b/actionmailer/test/fixtures/url_test_mailer/exercise_url_for.erb
@@ -1,0 +1,1 @@
+<%= url_for(@options) %> <%= @from_method %>

--- a/actionmailer/test/url_test.rb
+++ b/actionmailer/test/url_test.rb
@@ -23,9 +23,34 @@ class UrlTestMailer < ActionMailer::Base
     mail(to: recipient, subject: "[Signed up] Welcome #{recipient}",
       from: "system@loudthinking.com", date: Time.local(2004, 12, 12))
   end
+
+  def exercise_url_for(options)
+    @from_method = url_for(options)
+    @options     = options
+    mail(to: "foo@foo.com", subject: "Welcome",
+      from: "system@loudthinking.com", date: Time.local(2004, 12, 12))
+  end
 end
 
 class ActionMailerUrlTest < ActionMailer::TestCase
+
+  class FakeBasecampKlass
+    def self.model_name
+      OpenStruct.new(route_key: "welcome")
+    end
+
+    def persisted?
+      false
+    end
+
+    def model_name
+      self.class.model_name
+    end
+
+    def to_model
+      self
+    end
+  end
 
   def encode( text, charset="UTF-8" )
     quoted_printable( text, charset )
@@ -42,6 +67,37 @@ class ActionMailerUrlTest < ActionMailer::TestCase
 
   def setup
     @recipient = 'test@localhost'
+  end
+
+  def test_url_for
+    UrlTestMailer.delivery_method = :test
+
+    AppRoutes.draw do
+      get ':controller(/:action(/:id))'
+      get '/welcome'  => "foo#bar", as: "welcome"
+    end
+
+    # class
+    expected = "http://www.basecamphq.com/welcome http://www.basecamphq.com/welcome"
+    created = UrlTestMailer.exercise_url_for(FakeBasecampKlass)
+    assert_equal expected, created.body.to_s.chomp
+
+    # Array
+    created = UrlTestMailer.exercise_url_for([FakeBasecampKlass])
+    assert_equal expected, created.body.to_s.chomp
+
+    # Model
+    created = UrlTestMailer.exercise_url_for(FakeBasecampKlass.new)
+    assert_equal expected, created.body.to_s.chomp
+
+    # symbol
+    created = UrlTestMailer.exercise_url_for(:welcome)
+    assert_equal expected, created.body.to_s.chomp
+
+    # string
+    expected = "foo foo"
+    created = UrlTestMailer.exercise_url_for("http://foo/")
+    assert_equal "http://foo/ http://foo/", created.body.to_s.chomp
   end
 
   def test_signed_up_with_url

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -427,7 +427,7 @@ module ActionDispatch
         RUBY
       end
 
-      def url_helpers(include_path_helpers = true)
+      def url_helpers(allow_path = true)
         routes = self
 
         Module.new do
@@ -454,10 +454,16 @@ module ActionDispatch
           # named routes...
           include url_helpers
 
-          if include_path_helpers
+          if allow_path
             path_helpers = routes.named_routes.path_helpers_module
           else
             path_helpers = routes.named_routes.path_helpers_module(true)
+
+            # Delegate mailer url_for to the controller
+            # this should always return a full URL.
+            def url_for(options)
+              self.controller.url_for(options)
+            end
           end
 
           include path_helpers


### PR DESCRIPTION
[close #16497]

Currently `link_to ..., @user` will generate a non working link inside of a mailer. This is because it delegates to url_for https://github.com/rails/rails/blob/master/actionview/lib/action_view/routing_url_for.rb#L95 which produces a path by default instead of a url. This PR defaults all output of `url_for` to be a full url (instead of a path) when possible.

It is important to note that there is a `url_for` inside of the mailer view (as referenced above) and there is also a `url_for` that can be called inside of a mailer method:

```
class UrlTestMailer < ActionMailer::Base

  def exercise_url_for(options)
    @from_method = url_for(options)
    mail(to: "foo@foo.com", subject: "Welcome",
      from: "system@loudthinking.com", date: Time.local(2004, 12, 12))
  end
end
```

This second `url_for`, called from a mailer method directly delegates to a **different** `url_for` located in https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing/url_for.rb. This second `url_for` produces a URL by default.

This PR merges both behaviors by having the view `url_for` invoke the `url_for` defined on the mailer (the "controller" in this case). This should prevent #16497 and provide seamless mailer experience
