### PR TITLE
[ci skip] Fix Active Job grammar in api docs

### DIFF
--- a/activejob/README.md
+++ b/activejob/README.md
@@ -2,7 +2,7 @@
 
 Active Job is a framework for declaring jobs and making them run on a variety
 of queueing backends. These jobs can be everything from regularly scheduled
-clean-ups, billing charges, or mailings. Anything that can be chopped up into
+clean-ups, to billing charges, to mailings. Anything that can be chopped up into
 small units of work and run in parallel, really.
 
 It also serves as the backend for ActionMailer's #deliver_later functionality

--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -3,7 +3,7 @@ require 'active_support/callbacks'
 module ActiveJob
   # = Active Job Callbacks
   #
-  # Active Job provides hooks during the lifecycle of a job. Callbacks allows you to trigger
+  # Active Job provides hooks during the lifecycle of a job. Callbacks allow you to trigger
   # logic during the lifecycle of a job. Available callbacks:
   #
   # * <tt>before_enqueue</tt>


### PR DESCRIPTION
Ensure matching language to guides, where applicable.
