### PR TITLE
Added enqueue_at support for QueAdapter in ActiveJob

### DIFF
--- a/activejob/lib/active_job/queue_adapters/que_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/que_adapter.rb
@@ -9,7 +9,7 @@ module ActiveJob
         end
 
         def enqueue_at(job, timestamp, *args)
-          raise NotImplementedError
+          JobWrapper.enqueue job.name, *args, queue: job.queue_name, run_at: Time.at(timestamp)
         end
       end
 

--- a/activejob/test/adapters/que.rb
+++ b/activejob/test/adapters/que.rb
@@ -1,2 +1,4 @@
+require 'support/que/inline'
+
 ActiveJob::Base.queue_adapter = :que
 Que.mode = :sync

--- a/activejob/test/support/que/inline.rb
+++ b/activejob/test/support/que/inline.rb
@@ -1,0 +1,9 @@
+require 'que'
+
+Que::Job.class_eval do
+  class << self; alias_method :original_enqueue, :enqueue; end
+  def self.enqueue(*args)
+    args.pop if args.last.is_a?(Hash)
+    self.run(*args)
+  end
+end


### PR DESCRIPTION
I noticed that `enqueue_at` was not implemented in `ActiveJob::QueueAdapters::QueAdapter` - so I added it in. This also necessitated creating an inline job runner for Que - for which I just followed the style of the solutions for the other adapters, which I hope was the right approach!

Thanks everyone for their hard work on ActiveJob, I'm super excited for this feature.
