### PR TITLE
Fix some issues in 4.2 release notes.

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -177,9 +177,6 @@ Please refer to the [Changelog][railties] for detailed changes.
 *   Introduced `Rails.gem_version` as a convenience method to return `Gem::Version.new(Rails.version)`.
     ([Pull Request](https://github.com/rails/rails/pull/14101))
 
-*   Introduced an `after_bundle` callback in the Rails templates.
-    ([Pull Request](https://github.com/rails/rails/pull/16359))
-
 
 Action Pack
 -----------


### PR DESCRIPTION
Hi,

I removed duplicate line in Railties section (first occurence at line 121).

And I changed the documentation URL by [http://edgeapi.rubyonrails.org/](http://edgeapi.rubyonrails.org/) because the URL [http://api.rubyonrails.org/v4.2.0](http://api.rubyonrails.org/v4.2.0) doesn't exist. Maybe it's a delay of the documentation deployment?
