### PR TITLE
Add ActiveSupport::Concern#includers

### DIFF
--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -138,5 +138,11 @@ module ActiveSupport
 
       mod.module_eval(&class_methods_module_definition)
     end
+
+    def includers
+      ObjectSpace.each_object.select do |obj|
+        Module === obj && obj.included_modules.include?(self)
+      end
+    end
   end
 end

--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -54,6 +54,10 @@ class ConcernTest < ActiveSupport::TestCase
     include Bar, Baz
   end
 
+  module IncluderTest
+    extend ActiveSupport::Concern
+  end
+
   def setup
     @klass = Class.new
   end
@@ -100,5 +104,10 @@ class ConcernTest < ActiveSupport::TestCase
         end
       end
     end
+  end
+
+  def test_includers
+    klass = Class.new.send(:include, IncluderTest)
+    assert_equal [klass], ConcernTest::IncluderTest.includers
   end
 end


### PR DESCRIPTION
Not sure if this method is generally useful, but I already found myself several times in a position where I'd like to know about all classes/modules including a certain concern.

Note that for this to work in the development environment you'll have to do the following:

```
Rails.application.eager_load! if Rails.env.development?
```

My first version only searched through `ActiveRecord::Base.descendants`, but I guess with people using `ActiveSupport` outside of Rails, a more generic solution is better.
