### PR TITLE
Speed up JRuby tests by improving the startup time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,16 @@ rvm:
   - rbx-2
   - jruby
 env:
-  - "GEM=railties"
-  - "GEM=ap"
-  - "GEM=am,amo,as,av,aj"
-  - "GEM=ar:mysql"
-  - "GEM=ar:mysql2"
-  - "GEM=ar:sqlite3"
-  - "GEM=ar:postgresql"
+  global:
+   - JRUBY_OPTS='-J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Djruby.compile.mode=OFF -J-Djruby.compile.invokedynamic=false -J-Xmx1024M'
+  matrix:
+    - "GEM=railties"
+    - "GEM=ap"
+    - "GEM=am,amo,as,av,aj"
+    - "GEM=ar:mysql"
+    - "GEM=ar:mysql2"
+    - "GEM=ar:sqlite3"
+    - "GEM=ar:postgresql"
 matrix:
   allow_failures:
     - rvm: 1.9.3


### PR DESCRIPTION
Emulate `jruby --dev` which improves JRuby's startup time.

See
https://github.com/jruby/jruby/wiki/Improving-startup-time#use-the---dev-flag

Follow @headius' advice and give Java more memory to reduce GC time.
