### PR TITLE
Don't fight against ourselves for the default log level

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -117,7 +117,7 @@ module Rails
       end
 
       def log_level
-        @log_level ||= Rails.env.production? ? :info : :debug
+        @log_level ||= :debug
       end
 
       def colorize_logging

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -44,8 +44,8 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Set to :info to decrease the log volume.
-  config.log_level = :debug
+  # Decrease the log volume.
+  # config.log_level = :info
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
If we want to always default to `:debug`, let's just do that.

At which point the production.rb entry can become an "uncomment to change" instead.
