### PR TITLE
Bugfix/through respect sti name

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -61,7 +61,7 @@ module ActiveRecord
             end
 
             if reflection.type
-              constraint = constraint.and table[reflection.type].eq foreign_klass.base_class.name
+              constraint = constraint.and table[reflection.type].eq foreign_klass.sti_name
             end
 
             if rel && !rel.arel.constraints.empty?

--- a/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
+++ b/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
@@ -17,7 +17,7 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
 
   def test_eager_association_loading_with_cascaded_two_levels
     authors = Author.all.merge!(:includes=>{:posts=>:comments}, :order=>"authors.id").to_a
-    assert_equal 3, authors.size
+    assert_equal 4, authors.size
     assert_equal 5, authors[0].posts.size
     assert_equal 3, authors[1].posts.size
     assert_equal 10, authors[0].posts.collect{|post| post.comments.size }.inject(0){|sum,i| sum+i}
@@ -25,7 +25,7 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
 
   def test_eager_association_loading_with_cascaded_two_levels_and_one_level
     authors = Author.all.merge!(:includes=>[{:posts=>:comments}, :categorizations], :order=>"authors.id").to_a
-    assert_equal 3, authors.size
+    assert_equal 4, authors.size
     assert_equal 5, authors[0].posts.size
     assert_equal 3, authors[1].posts.size
     assert_equal 10, authors[0].posts.collect{|post| post.comments.size }.inject(0){|sum,i| sum+i}
@@ -83,7 +83,7 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
 
   def test_eager_association_loading_with_cascaded_two_levels_with_two_has_many_associations
     authors = Author.all.merge!(:includes=>{:posts=>[:comments, :categorizations]}, :order=>"authors.id").to_a
-    assert_equal 3, authors.size
+    assert_equal 4, authors.size
     assert_equal 5, authors[0].posts.size
     assert_equal 3, authors[1].posts.size
     assert_equal 10, authors[0].posts.collect{|post| post.comments.size }.inject(0){|sum,i| sum+i}
@@ -91,7 +91,7 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
 
   def test_eager_association_loading_with_cascaded_two_levels_and_self_table_reference
     authors = Author.all.merge!(:includes=>{:posts=>[:comments, :author]}, :order=>"authors.id").to_a
-    assert_equal 3, authors.size
+    assert_equal 4, authors.size
     assert_equal 5, authors[0].posts.size
     assert_equal authors(:david).name, authors[0].name
     assert_equal [authors(:david).name], authors[0].posts.collect{|post| post.author.name}.uniq
@@ -159,9 +159,9 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
 
   def test_eager_association_loading_where_first_level_returns_nil
     authors = Author.all.merge!(:includes => {:post_about_thinking => :comments}, :order => 'authors.id DESC').to_a
-    assert_equal [authors(:bob), authors(:mary), authors(:david)], authors
+    assert_equal [authors(:eddie), authors(:bob), authors(:mary), authors(:david)], authors
     assert_no_queries do
-      authors[2].post_about_thinking.comments.first
+      authors[3].post_about_thinking.comments.first
     end
   end
 
@@ -178,7 +178,7 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
   def test_eager_association_loading_with_cascaded_interdependent_one_level_and_two_levels
     authors_relation = Author.all.merge!(includes: [:comments, { posts: :categorizations }], order: "authors.id")
     authors = authors_relation.to_a
-    assert_equal 3, authors.size
+    assert_equal 4, authors.size
     assert_equal 10, authors[0].comments.size
     assert_equal 1, authors[1].comments.size
     assert_equal 5, authors[0].posts.size

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -67,7 +67,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_with_ordering
     list = Post.all.merge!(:includes => :comments, :order => "posts.id DESC").to_a
-    [:other_by_mary, :other_by_bob, :misc_by_mary, :misc_by_bob, :eager_other,
+    [:post_by_eddie, :other_by_mary, :other_by_bob, :misc_by_mary, :misc_by_bob, :eager_other,
      :sti_habtm, :sti_post_and_comments, :sti_comments, :authorless, :thinking, :welcome
     ].each_with_index do |post, index|
       assert_equal posts(post), list[index]
@@ -101,25 +101,25 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_preloading_has_many_in_multiple_queries_with_more_ids_than_database_can_handle
     Comment.connection.expects(:in_clause_length).at_least_once.returns(5)
     posts = Post.all.merge!(:includes=>:comments).to_a
-    assert_equal 11, posts.size
+    assert_equal 12, posts.size
   end
 
   def test_preloading_has_many_in_one_queries_when_database_has_no_limit_on_ids_it_can_handle
     Comment.connection.expects(:in_clause_length).at_least_once.returns(nil)
     posts = Post.all.merge!(:includes=>:comments).to_a
-    assert_equal 11, posts.size
+    assert_equal 12, posts.size
   end
 
   def test_preloading_habtm_in_multiple_queries_with_more_ids_than_database_can_handle
     Comment.connection.expects(:in_clause_length).at_least_once.returns(5)
     posts = Post.all.merge!(:includes=>:categories).to_a
-    assert_equal 11, posts.size
+    assert_equal 12, posts.size
   end
 
   def test_preloading_habtm_in_one_queries_when_database_has_no_limit_on_ids_it_can_handle
     Comment.connection.expects(:in_clause_length).at_least_once.returns(nil)
     posts = Post.all.merge!(:includes=>:categories).to_a
-    assert_equal 11, posts.size
+    assert_equal 12, posts.size
   end
 
   def test_load_associated_records_in_one_query_when_adapter_has_no_limit
@@ -1245,7 +1245,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
     }
 
     assert_no_queries {
-      assert_equal 2, author.posts.size
+      assert_equal 1, author.posts.size
     }
   end
 

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -48,7 +48,7 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
 
   def test_join_conditions_allow_nil_associations
     authors = Author.includes(:essays).where(:essays => {:id => nil})
-    assert_equal 2, authors.count
+    assert_equal 3, authors.count
   end
 
   def test_find_with_implicit_inner_joins_without_select_does_not_imply_readonly

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -368,7 +368,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
       # added sort by ID as otherwise test using JRuby was failing as array elements were in different order
       assert_equal desired.sort_by(&:id), tag_with_include.tagged_posts.sort_by(&:id)
     end
-    assert_equal 5, tag_with_include.taggings.length
+    assert_equal 6, tag_with_include.taggings.length
   end
 
   def test_has_many_through_has_many_find_all
@@ -659,7 +659,9 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   end
 
   def test_preload_polymorph_many_types
-    taggings = Tagging.all.merge!(:includes => :taggable, :where => ['taggable_type != ?', 'FakeModel']).to_a
+    taggings = Tagging.all.merge!(:includes => :taggable,
+        :where => ['taggable_type NOT IN (?)', ['FakeModel', 'post_with_sti_name']]
+    ).to_a
     assert_no_queries do
       taggings.first.taggable.id
       taggings[1].taggable.id

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -1,6 +1,7 @@
 require "cases/helper"
 require 'models/author'
 require 'models/post'
+require 'models/post_with_sti_name'
 require 'models/person'
 require 'models/reference'
 require 'models/job'
@@ -455,6 +456,11 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
     scope = Post.joins(:special_comments_ratings_taggings).where(:id => posts(:sti_comments).id)
     assert scope.where("comments.type" => "Comment").empty?
     assert !scope.where("comments.type" => "SpecialComment").empty?
+  end
+
+  def test_has_many_through_with_sti_name
+    scope = PostWithStiName.joins(:tags)
+    assert !scope.where("taggings.taggable_type" => "post_with_sti_name").empty?
   end
 
   def test_nested_has_many_through_writers_should_raise_error

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -37,9 +37,9 @@ class EachTest < ActiveRecord::TestCase
 
   if Enumerator.method_defined? :size
     def test_each_should_return_a_sized_enumerator
-      assert_equal 11, Post.find_each(:batch_size => 1).size
-      assert_equal 5, Post.find_each(:batch_size => 2, :start => 7).size
-      assert_equal 11, Post.find_each(:batch_size => 10_000).size
+      assert_equal 12, Post.find_each(:batch_size => 1).size
+      assert_equal 6, Post.find_each(:batch_size => 2, :start => 7).size
+      assert_equal 12, Post.find_each(:batch_size => 10_000).size
     end
   end
 
@@ -61,7 +61,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_each_should_execute_if_id_is_in_select
-    assert_queries(6) do
+    assert_queries(7) do
       Post.select("id, title, type").find_each(:batch_size => 2) do |post|
         assert_kind_of Post, post
       end
@@ -202,9 +202,9 @@ class EachTest < ActiveRecord::TestCase
 
   if Enumerator.method_defined? :size
     def test_find_in_batches_should_return_a_sized_enumerator
-      assert_equal 11, Post.find_in_batches(:batch_size => 1).size
+      assert_equal 12, Post.find_in_batches(:batch_size => 1).size
       assert_equal 6, Post.find_in_batches(:batch_size => 2).size
-      assert_equal 4, Post.find_in_batches(:batch_size => 2, :start => 4).size
+      assert_equal 5, Post.find_in_batches(:batch_size => 2, :start => 4).size
       assert_equal 4, Post.find_in_batches(:batch_size => 3).size
       assert_equal 1, Post.find_in_batches(:batch_size => 10_000).size
     end

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -45,8 +45,8 @@ module ActiveRecord
 
         @cache = Marshal.load(Marshal.dump(@cache))
 
-        assert_equal 12, @cache.columns('posts').size
-        assert_equal 12, @cache.columns_hash('posts').size
+        assert_equal 13, @cache.columns('posts').size
+        assert_equal 13, @cache.columns_hash('posts').size
         assert @cache.tables('posts')
         assert_equal 'id', @cache.primary_keys('posts')
       end

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -161,10 +161,10 @@ class MergingDifferentRelationsTest < ActiveRecord::TestCase
   end
 
   test "merging order relations (using a hash argument)" do
-    posts_by_author_name = Post.limit(4).joins(:author).
+    posts_by_author_name = Post.limit(5).joins(:author).
       merge(Author.order(name: :desc)).pluck("authors.name")
 
-    assert_equal ["Mary", "Mary", "Mary", "David"], posts_by_author_name
+    assert_equal ["Mary", "Mary", "Mary", "Eddie", "David"], posts_by_author_name
   end
 
   test "relation merging (using a proc  argument)" do

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -815,7 +815,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_last
     authors = Author.all
-    assert_equal authors(:bob), authors.last
+    assert_equal authors(:eddie), authors.last
   end
 
   def test_destroy_all
@@ -858,8 +858,8 @@ class RelationTest < ActiveRecord::TestCase
   def test_select_with_aggregates
     posts = Post.select(:title, :body)
 
-    assert_equal 11, posts.count(:all)
-    assert_equal 11, posts.size
+    assert_equal 12, posts.count(:all)
+    assert_equal 12, posts.size
     assert posts.any?
     assert posts.many?
     assert_not posts.empty?
@@ -887,12 +887,12 @@ class RelationTest < ActiveRecord::TestCase
   def test_count
     posts = Post.all
 
-    assert_equal 11, posts.count
-    assert_equal 11, posts.count(:all)
-    assert_equal 11, posts.count(:id)
+    assert_equal 12, posts.count
+    assert_equal 12, posts.count(:all)
+    assert_equal 12, posts.count(:id)
 
     assert_equal 1, posts.where('comments_count > 1').count
-    assert_equal 9, posts.where(:comments_count => 0).count
+    assert_equal 10, posts.where(:comments_count => 0).count
   end
 
   def test_count_on_association_relation
@@ -910,10 +910,10 @@ class RelationTest < ActiveRecord::TestCase
     posts = Post.all
 
     assert_equal 3, posts.distinct(true).count(:comments_count)
-    assert_equal 11, posts.distinct(false).count(:comments_count)
+    assert_equal 12, posts.distinct(false).count(:comments_count)
 
     assert_equal 3, posts.distinct(true).select(:comments_count).count
-    assert_equal 11, posts.distinct(false).select(:comments_count).count
+    assert_equal 12, posts.distinct(false).select(:comments_count).count
   end
 
   def test_count_explicit_columns
@@ -923,7 +923,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal [0], posts.select('comments_count').where('id is not null').group('id').order('id').count.values.uniq
     assert_equal 0, posts.where('id is not null').select('comments_count').count
 
-    assert_equal 11, posts.select('comments_count').count('id')
+    assert_equal 12, posts.select('comments_count').count('id')
     assert_equal 0, posts.select('comments_count').count
     assert_equal 0, posts.count(:comments_count)
     assert_equal 0, posts.count('comments_count')
@@ -938,12 +938,12 @@ class RelationTest < ActiveRecord::TestCase
   def test_size
     posts = Post.all
 
-    assert_queries(1) { assert_equal 11, posts.size }
+    assert_queries(1) { assert_equal 12, posts.size }
     assert ! posts.loaded?
 
     best_posts = posts.where(:comments_count => 0)
     best_posts.to_a # force load
-    assert_no_queries { assert_equal 9, best_posts.size }
+    assert_no_queries { assert_equal 10, best_posts.size }
   end
 
   def test_size_with_limit
@@ -954,7 +954,7 @@ class RelationTest < ActiveRecord::TestCase
 
     best_posts = posts.where(:comments_count => 0)
     best_posts.to_a # force load
-    assert_no_queries { assert_equal 9, best_posts.size }
+    assert_no_queries { assert_equal 10, best_posts.size }
   end
 
   def test_size_with_zero_limit
@@ -1624,7 +1624,7 @@ class RelationTest < ActiveRecord::TestCase
         [post.num_posts, post.author.try(:name)]
       end
 
-      expected = [[1, nil], [5, "David"], [3, "Mary"], [2, "Bob"]]
+      expected = [[1, nil], [5, "David"], [3, "Mary"], [2, "Bob"], [1, "Eddie"]]
       assert_equal expected, result
     end
   end

--- a/activerecord/test/fixtures/posts.yml
+++ b/activerecord/test/fixtures/posts.yml
@@ -80,3 +80,10 @@ other_by_mary:
   title: other post by mary
   body: hello
   type: Post
+
+with_sti_name:
+  id: 12
+  author_id: 2
+  title: post with a non-standard STI name
+  body: hello
+  sti_type: post_with_sti_name

--- a/activerecord/test/fixtures/taggings.yml
+++ b/activerecord/test/fixtures/taggings.yml
@@ -76,3 +76,9 @@ normal_comment_rating:
   id: 13
   taggable_id: 1
   taggable_type: Rating
+
+sti_name:
+  id: 14
+  tag_id: 1
+  taggable_id: 1
+  taggable_type: post_with_sti_name

--- a/activerecord/test/models/post_with_sti_name.rb
+++ b/activerecord/test/models/post_with_sti_name.rb
@@ -1,0 +1,10 @@
+class PostWithStiName < Post
+  def self.sti_name
+    name.underscore
+  end
+
+  # Use a different column to avoid conficts with standard Post class STI mechanism
+  def self.inheritance_column
+    :sti_type
+  end
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -568,6 +568,7 @@ ActiveRecord::Schema.define do
       t.text    :body, null: false
     end
     t.string  :type
+    t.string  :sti_type
     t.integer :comments_count, default: 0
     t.integer :taggings_count, default: 0
     t.integer :taggings_with_delete_all_count, default: 0


### PR DESCRIPTION
When deriving the value to look for in a polymorphic through relationship, this will only by default be the name of the base ActiveRecord class. This is handled by and may be overridden with the `sti_name` class method of the model.

https://github.com/rails/rails/commit/03118bc5afe99aaaf463a834d8a1ae16c918f6e8#commitcomment-7478184
