### PR TITLE
Replacing an each with reduce

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -251,11 +251,9 @@ module ActiveModel
     #   person.errors.to_hash(true) # => {:name=>["name cannot be nil"]}
     def to_hash(full_messages = false)
       if full_messages
-        messages = {}
-        self.messages.each do |attribute, array|
-          messages[attribute] = array.map { |message| full_message(attribute, message) }
+        self.messages.reduce({}) do |messages, (attribute, array)|
+          messages.merge!(attribute => array.map { |message| full_message(attribute, message) })
         end
-        messages
       else
         self.messages.dup
       end

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -251,8 +251,8 @@ module ActiveModel
     #   person.errors.to_hash(true) # => {:name=>["name cannot be nil"]}
     def to_hash(full_messages = false)
       if full_messages
-        self.messages.reduce({}) do |messages, (attribute, array)|
-          messages.merge!(attribute => array.map { |message| full_message(attribute, message) })
+        self.messages.each_with_object({}) do |(attribute, array), messages|
+          messages[attribute] = array.map { |message| full_message(attribute, message) }
         end
       else
         self.messages.dup


### PR DESCRIPTION
The functionality has not changed, but the code is more elegant by
using `reduce` instead of `each`.

This way no accumulator is declared, no explicit return is
needed.
