### PR TITLE
Add ActiveSupport::Inflector.constantize_only

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -77,6 +77,19 @@ class String
     ActiveSupport::Inflector.safe_constantize(self)
   end
 
+  # +constantize_only+ tries to find a declared constant with the name specified
+  # in the string. Additionally it will check the constant against the provided
+  # whitelist and raise an +ArgumentError+ for a non-whitelisted constant.
+  # See ActiveSupport::Inflector.constantize_only
+  #
+  #   'Module'.constantize_only('Module')         #=> Module
+  #   'Module'.constantize_only(Module)           #=> Module
+  #   'Class'.constantize_only(['Module', Class]) #=> Class
+  #   'Class'.constantize_only('Fixnum')          #=> NameError: Can't constantize 'Class'
+  def constantize_only(*whitelist)
+    ActiveSupport::Inflector.constantize_only(self, whitelist)
+  end
+
   # By default, +camelize+ converts strings to UpperCamelCase. If the argument to camelize
   # is set to <tt>:lower</tt> then camelize produces lowerCamelCase.
   #

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -309,6 +309,31 @@ module ActiveSupport
       raise unless e.message =~ /not missing constant #{const_regexp(camel_cased_word)}\!$/
     end
 
+    # Tries to find a constant with the name specified in the argument string.
+    #
+    # 'Module'.constantize_only('Module')         #=> Module
+    # 'Test::Unit'.constantize_only('Test::Unit') #=> Test::Unit
+    #
+    # The name is assumed to be the one of a top-level constant, no matter
+    # whether it starts with "::" or not. No lexical context is taken into
+    # account:
+    #
+    #   C = 'outside'
+    #   module M
+    #     C = 'inside'
+    #     C                         # => 'inside'
+    #     'C'.constantize_only('C') # => 'outside', same as ::C
+    #   end
+    #
+    # Internally this uses +safe_constantize+, so +nil+ is returned when the
+    # name is not in CamelCase or the constant (or part of it) is unknown.
+    #
+    # NameError is raised when the name is not whitelisted.
+    def constantize_only(string, *whitelist)
+      return string.safe_constantize if whitelist.flatten.find { |c| string == c.to_s }
+      raise NameError.new("Can't constantize '#{string}'")
+    end
+
     # Returns the suffix that should be added to a number to denote the position
     # in an ordered sequence such as 1st, 2nd, 3rd, 4th.
     #

--- a/activesupport/test/constantize_test_cases.rb
+++ b/activesupport/test/constantize_test_cases.rb
@@ -83,4 +83,13 @@ module ConstantizeTestCases
     assert_nil yield("Ace::Gas::ConstantizeTestCases")
     assert_nil yield("#<Class:0x7b8b718b>::Nested_1")
   end
+
+  def run_constantize_only_tests_on
+    assert_equal Ace, yield("Ace", "Ace")
+    assert_equal Ace, yield("Ace", Ace)
+    assert_equal Ace, yield("Ace", ["Ace", Ace::Base])
+    assert_equal Ace::Base, yield("Ace::Base", [Ace, Ace::Base])
+    assert_nil yield("ConstantizeOnly", "ConstantizeOnly")
+    assert_raises(NameError) { yield("ace", "Base") }
+  end
 end

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -324,6 +324,12 @@ class InflectorTest < ActiveSupport::TestCase
     end
   end
 
+  def test_constantize_only
+    run_constantize_only_tests_on do |string, whitelist|
+      ActiveSupport::Inflector.constantize_only(string, whitelist)
+    end
+  end
+
   def test_ordinal
     OrdinalNumbers.each do |number, ordinalized|
       assert_equal(ordinalized, number + ActiveSupport::Inflector.ordinal(number))


### PR DESCRIPTION
This works like `ActiveSupport::Inflector.constantize`, but additionally checks the constant against a provided whitelist, which is useful for constantizing user input, e.g. from params.

``` ruby
'Module'.constantize_only('Module')         #=> Module
'Test::Unit'.constantize_only('Test::Unit') #=> Test::Unit
```

Internally this uses `safe_constantize`, so `nil` is returned when the name is not in CamelCase or the constant (or part of it) is unknown. `NameError` is raised when the name is not whitelisted.
