### PR TITLE
Extract join values to merge as an original type

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Fix nesting merge `#joins' with String argument raises `ActiveRecord::ConfigurationError`.
+
+    Example:
+	# Before
+	```ruby
+	User.joins(:comments).merge(
+	  Comment.joins(:article).merge(
+	    Article.joins(
+	      'LEFT OUTER JOIN categories ON articles.id = categories.article_id'
+	    )
+	  )
+	) # => ActiveRecord::ConfigurationError
+	```
+
+    *Takamichi Yoshikawa*
+
 *   Fix has_many :through relation merging failing when dynamic conditions are
     passed as a lambda with an arity of one.
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,8 +1,8 @@
 *   Fix nesting merge `#joins' with String argument raises `ActiveRecord::ConfigurationError`.
 
     Example:
-	# Before
 	```ruby
+	# Before
 	User.joins(:comments).merge(
 	  Comment.joins(:article).merge(
 	    Article.joins(

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -100,7 +100,7 @@ module ActiveRecord
           join_dependency = ActiveRecord::Associations::JoinDependency.new(other.klass,
                                                                            joins_dependency,
                                                                            [])
-          relation.joins! rest
+          relation.joins!(*rest)
 
           @relation = relation.joins join_dependency
         end


### PR DESCRIPTION
`ActiveRecord::QueryMethods#joins!` receives arguments as variable
length arguments. So that it saves join values as Array.

This affects `ActiveRecord::Relation::Merger#merge_joins` which
handles joins by its type. If String joins merged twice, the second
merge process raises `ActiveRecord::ConfigurationError`
