### PR TITLE
Fix setting a polymorphic association's attributes to nil and saving, if that association had been non-nil and loaded

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -135,7 +135,8 @@ module ActiveRecord
       # ActiveRecord::RecordNotFound is rescued within the method, and it is
       # not reraised. The proxy is \reset and +nil+ is the return value.
       def load_target
-        @target = find_target if (@stale_state && stale_target?) || find_target?
+        reset if @stale_state && stale_target?
+        @target = find_target if find_target?
 
         loaded! unless loaded?
         target

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -465,6 +465,15 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal members(:groucho), sponsor.sponsorable
   end
 
+  def test_polymorphic_autosaving_nil_target_after_non_nil_target_loaded
+    sponsor = Sponsor.new(sponsorable_id: 1, sponsorable_type: "Member")
+    sponsor.sponsorable
+    sponsor.sponsorable_id = nil
+    sponsor.sponsorable_type = nil
+
+    sponsor.save!
+  end
+
   def test_dont_find_target_when_foreign_key_is_null
     tagging = taggings(:thinking_general)
     assert_queries(0) { tagging.super_tag }


### PR DESCRIPTION
This raised a nil deref, because the stale_state test returned true (the target was no longer valid) and so #find_target called #scope, which ran klass.all - which failed because #klass is now nil.

This only happened if saving the record holding this polymorphic association, as opposed to say referencing the association, because the latter is implemented by the SingularAssociation#reader method which called #reload if the target was stale.  This patch does something similar, but a bit less radical (calling reset).

(Note that the other cases are protected by #find_target?)

This patch also applies cleanly to 4-1-stable and 4-0-stable, where the problem was first introduced.
