### PR TITLE
Fix the router ignoring constraints when used together with a redirect route

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix bug where the router would ignore any constraints added to redirect
+    routes.
+
+    Fixes #16605.
+
+    *Agis Anastasopoulos*
+
 *   Allow `config.action_dispatch.trusted_proxies` to accept an IPAddr object.
 
     Example:

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -241,8 +241,6 @@ module ActionDispatch
           end
 
           def app(blocks)
-            return to if Redirect === to
-
             if to.respond_to?(:call)
               Constraints.new(to, blocks, false)
             else


### PR DESCRIPTION
Fixes the regression described in #16605 where the router would ignore any constraints when they were used together with a redirect route.

Introduced by https://github.com/rails/rails/commit/402c2af55053c2f29319091ad21fd6fa6b90ee89.
