### PR TITLE
Synchronizing instance_writer for Class#class_attribute

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -79,6 +79,7 @@ class Class
       define_singleton_method("#{name}?") { !!public_send(name) } if instance_predicate
 
       ivar = "@#{name}"
+      mutex = Mutex.new
 
       define_singleton_method("#{name}=") do |val|
         singleton_class.class_eval do
@@ -113,7 +114,11 @@ class Class
         define_method("#{name}?") { !!public_send(name) } if instance_predicate
       end
 
-      attr_writer name if instance_writer
+      if instance_writer
+        define_method("#{name}=") do |val|
+          mutex.synchronize { instance_variable_set(ivar, val) }
+        end
+      end
     end
   end
 

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -88,4 +88,18 @@ class ClassAttributeTest < ActiveSupport::TestCase
     val = @klass.send(:setting=, 1)
     assert_equal 1, val
   end
+
+  test 'setter is synchronized' do
+    threads = []
+    thread_count = 100
+    Thread.abort_on_exception = true
+
+    @klass.setting = 0
+    thread_count.times do
+      threads << Thread.new { @klass.setting += 1 }
+    end
+
+    threads.each(&:join)
+    assert_equal thread_count, @klass.setting
+  end
 end


### PR DESCRIPTION
@printercu and @dwbutler for review

Making `Class#class_attribute` thread-safe. Tested with MRI and JRuby 1.7.13.

Fixes #14021
