### PR TITLE
Use system /tmp for temp files when testing actionpack

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -4,8 +4,6 @@ $:.unshift(File.dirname(__FILE__) + '/lib')
 $:.unshift(File.dirname(__FILE__) + '/fixtures/helpers')
 $:.unshift(File.dirname(__FILE__) + '/fixtures/alternate_helpers')
 
-ENV['TMPDIR'] = File.join(File.dirname(__FILE__), 'tmp')
-
 require 'active_support/core_ext/kernel/reporting'
 
 # These are the normal settings that will be set up by Railties
@@ -466,7 +464,7 @@ class ForkingExecutor
   def initialize size
     @size  = size
     @queue = Server.new
-    file   = File.join Dir.tmpdir, Dir::Tmpname.make_tmpname('tests', 'fd')
+    file   = File.join Dir.tmpdir, Dir::Tmpname.make_tmpname('rails-tests', 'fd')
     @url   = "drbunix://#{file}"
     @pool  = nil
     DRb.start_service @url, @queue


### PR DESCRIPTION
https://github.com/rails/rails/commit/c64bff2c87ebf363703c63ecd4a96d56a1a78364 added support for running the actionpack tests in parallel, and DRb tries to.

However it introduced https://github.com/rails/rails-dev-box/issues/76 since one cannot connect to a socket file that's inside a Vagrant synced folder due to security restrictions.

Also rename the temporary files to make it obvious that they're rails-related, since now they're placed outside the project's directory.

Fixes https://github.com/rails/rails-dev-box/issues/76
