### PR TITLE
Don't calculate in-place changes twice

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -43,14 +43,6 @@ module ActiveRecord
         calculate_changes_from_defaults
       end
 
-      def changed?
-        super || changed_in_place.any?
-      end
-
-      def changed
-        super | changed_in_place
-      end
-
       def changes_applied
         super
         store_original_raw_attributes


### PR DESCRIPTION
Now that `changed_attributes` includes in place changes, we don't need
to override these methods in Active Record. Partially fixes the
performance regression caused by #16189
