### PR TITLE
Cache the value of `changed_attributes` when calling `changes_applied`

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -54,7 +54,19 @@ module ActiveRecord
       end
 
       def changed_attributes
-        super.reverse_merge(attributes_changed_in_place).freeze
+        # This should only be set by methods which will call changed_attributes
+        # multiple times when it is known that the computed value cannot change.
+        if defined?(@cached_changed_attributes)
+          @cached_changed_attributes
+        else
+          super.reverse_merge(attributes_changed_in_place).freeze
+        end
+      end
+
+      def changes
+        cache_changed_attributes do
+          super
+        end
       end
 
       private
@@ -156,6 +168,13 @@ module ActiveRecord
         attribute_names.each do |attr|
           store_original_raw_attribute(attr)
         end
+      end
+
+      def cache_changed_attributes
+        @cached_changed_attributes = changed_attributes
+        yield
+      ensure
+        remove_instance_variable(:@cached_changed_attributes)
       end
     end
   end


### PR DESCRIPTION
`changes_applied` calles `changes`, which will call `changed_attributes`
multiple times in a loop. This method actually performs work now, so we
should cache the results while looping over it when we know it cannot
change.
