### PR TITLE
Documentation update for form_for options

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -35,7 +35,6 @@ module ActionView
       #   This is helpful when you're fragment-caching the form. Remote forms get the
       #   authenticity token from the <tt>meta</tt> tag, so embedding is unnecessary unless you
       #   support browsers without JavaScript.
-      # * A list of parameters to feed to the URL the form will be posted to.
       # * <tt>:remote</tt> - If set to true, will allow the Unobtrusive JavaScript drivers to control the
       #   submit behavior. By default this behavior is an ajax submit.
       # * <tt>:enforce_utf8</tt> - If set to false, a hidden input with name utf8 is not output.

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -39,6 +39,7 @@ module ActionView
       # * <tt>:remote</tt> - If set to true, will allow the Unobtrusive JavaScript drivers to control the
       #   submit behavior. By default this behavior is an ajax submit.
       # * <tt>:enforce_utf8</tt> - If set to false, a hidden input with name utf8 is not output.
+      # * Any other key creates standard HTML attributes for the tag.
       #
       # ==== Examples
       #   form_tag('/posts')


### PR DESCRIPTION
Two updates:
1. The removed line is incorrect.  It is true for the first param (`url_for_options`), but that's not what's being documented here -- these docs are for the second param (`options`).  The content of this line is handled by the docs up on [lines 23-24](https://github.com/rails/rails/blob/b47d8dea25aa4c1b0d02603adc00cf63f2163f21/actionview/lib/action_view/helpers/form_tag_helper.rb#L23-L24) which specify that `url_for_options` takes the options specified by `url_for`.
2. The added line clarifies that unknown attributes will be added as HTML attributes -- this is specified for all the other helpers in this file, just not this one (even though it's true for this one as well).
