### PR TITLE
Fix postgresql adapter #columns_for_distinct trimming whitespace it shouldn't

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -549,7 +549,8 @@ module ActiveRecord
               # Convert Arel node to string
               s = s.to_sql unless s.is_a?(String)
               # Remove any ASC/DESC modifiers
-              s.gsub(/\s+(?:ASC|DESC)?\s*(?:NULLS\s+(?:FIRST|LAST)\s*)?/i, '')
+              s.gsub(/\s+(?:ASC|DESC)\s*/i, '')
+               .gsub(/\s*NULLS\s+(?:FIRST|LAST)?\s*/i, '')
             }.reject(&:blank?).map.with_index { |column, i| "#{column} AS alias_#{i}" }
 
           [super, *order_columns].join(', ')

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -334,6 +334,14 @@ module ActiveRecord
           @connection.columns_for_distinct("posts.id", ["posts.created_at desc", "posts.position asc"])
       end
 
+      def test_columns_for_distinct_with_case
+        assert_equal(
+          'posts.id, CASE WHEN author.is_active THEN UPPER(author.name) ELSE UPPER(author.email) END AS alias_0',
+          @connection.columns_for_distinct('posts.id',
+            ["CASE WHEN author.is_active THEN UPPER(author.name) ELSE UPPER(author.email) END"])
+        )
+      end
+
       def test_columns_for_distinct_blank_not_nil_orders
         assert_equal "posts.id, posts.created_at AS alias_0",
           @connection.columns_for_distinct("posts.id", ["posts.created_at desc", "", "   "])


### PR DESCRIPTION
Fixes the regression described in https://github.com/rails/rails/issues/16623 present in 4.0.10rc1 & 4.1.6.rc1. It was introduced by 3d5a2019bcccc6fb01bee4811ca669f4383edb51.
