### PR TITLE
Don't run a query if it can't return any results

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Don't make a trip to the database if a query's where clause would return zero results.
+
+    Fixes #16506
+
+    *Dan Olson*
+
 *   Fix has_many :through relation merging failing when dynamic conditions are
     passed as a lambda with an arity of one.
 

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -58,11 +58,14 @@ module ActiveRecord
     end
 
     private
-      # Detect negation of results via 1=0
+      # Detect negation of results via 1=0 outside of any subqueries
       def impossible_where_clause?(sanitized_sql)
         negation_regex = /(WHERE|(?:AND))\s+1=0/
+        subquery_regex = /\(+SELECT.*\)/
         sql_to_test = sanitized_sql.respond_to?(:to_sql) ? sanitized_sql.to_sql : sanitized_sql
-        sql_to_test.match(negation_regex)
+        sql_to_test.split(subquery_regex).any? do |fragment|
+          !!fragment.match(negation_regex)
+        end
       end
   end
 end

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -61,7 +61,7 @@ module ActiveRecord
       # Detect negation of results via 1=0 outside of any subqueries
       def impossible_where_clause?(sanitized_sql)
         negation_regex = /(WHERE|(?:AND))\s+1=0/
-        subquery_regex = /\(+SELECT.*\)/
+        subquery_regex = /\([[:space:]]*SELECT.*\)/m
         sql_to_test = sanitized_sql.respond_to?(:to_sql) ? sanitized_sql.to_sql : sanitized_sql
         sql_to_test.split(subquery_regex).any? do |fragment|
           !!fragment.match(negation_regex)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -261,7 +261,7 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
-    def test_find_with_impossible_where_clause_in_subquery_with_formatting
+  def test_find_with_impossible_where_clause_in_subquery_with_formatting
     assert_queries do
       sql = <<-SQL
         SELECT *
@@ -270,6 +270,26 @@ class FinderTest < ActiveRecord::TestCase
           SELECT post_id
           FROM comments
           WHERE 1=0
+        )
+      SQL
+      posts = Comment.find_by_sql(sql)
+      assert_equal [], posts
+    end
+  end
+
+  def test_find_with_impossible_where_clause_in_formatted_nested_subquery
+    assert_queries do
+      sql = <<-SQL
+        SELECT *
+        FROM authors
+        WHERE id IN (
+          SELECT author_id
+          FROM posts
+          WHERE id IN (
+            SELECT post_id
+            FROM comments
+            WHERE 1=0
+          )
         )
       SQL
       posts = Comment.find_by_sql(sql)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -261,6 +261,22 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+    def test_find_with_impossible_where_clause_in_subquery_with_formatting
+    assert_queries do
+      sql = <<-SQL
+        SELECT *
+        FROM posts
+        WHERE id IN (
+          SELECT post_id
+          FROM comments
+          WHERE 1=0
+        )
+      SQL
+      posts = Comment.find_by_sql(sql)
+      assert_equal [], posts
+    end
+  end
+
   def test_find_with_impossible_where_clause_in_nested_subquery
     assert_queries do
       posts = Author.find_by_sql("SELECT * FROM authors WHERE id IN (select author_id FROM posts WHERE id IN (SELECT post_id FROM comments WHERE 1=0) AND 1=0)")

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -247,6 +247,34 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal [Account], accounts.collect(&:class).uniq
   end
 
+  def test_find_with_impossible_where_clause
+    assert_no_queries do
+      posts = Post.find_by_sql("SELECT * FROM posts WHERE 1=0")
+      assert_equal [], posts
+    end
+  end
+
+  def test_find_with_impossible_where_clause_in_subquery
+    assert_queries do
+      posts = Comment.find_by_sql("SELECT * FROM posts WHERE id IN (SELECT post_id FROM comments WHERE 1=0)")
+      assert_equal [], posts
+    end
+  end
+
+  def test_find_with_impossible_where_clause_in_nested_subquery
+    assert_queries do
+      posts = Author.find_by_sql("SELECT * FROM authors WHERE id IN (select author_id FROM posts WHERE id IN (SELECT post_id FROM comments WHERE 1=0) AND 1=0)")
+      assert_equal [], posts
+    end
+  end
+
+  def test_find_with_impossible_where_clause_outside_of_subquery
+    assert_no_queries do
+      posts = Post.find_by_sql("SELECT * FROM posts WHERE id IN (SELECT post_id FROM comments WHERE post_id = 1) AND 1=0")
+      assert_equal [], posts
+    end
+  end
+
   def test_take
     assert_equal topics(:first), Topic.take
   end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -180,6 +180,18 @@ module ActiveRecord
       assert_equal 0, Post.where(:id => []).count
     end
 
+    def test_where_with_attribute_and_empty_array_runs_no_queries
+      assert_no_queries do
+        assert_equal [], Post.where(:id => []).to_a
+      end
+    end
+
+    def test_where_with_multiple_attributes_and_empty_array_runs_no_queries
+      assert_no_queries do
+        assert_equal [], Post.where(:title => "I don't have any comments", :id => []).to_a
+      end
+    end
+
     def test_where_with_table_name_and_nested_empty_array
       assert_equal [], Post.where(:id => [[]]).to_a
     end


### PR DESCRIPTION
Fixes #16506

Don't make a trip to the database if a query's WHERE clause ensures it would return zero results. For example:

```
Post.where(id: []).to_sql
'SELECT "posts".* FROM "posts" WHERE 1=0'
```
