### PR TITLE
Using the more elegant each_with_object instead of each

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -104,8 +104,9 @@ module ActiveModel
         attribute_names -= Array(except).map(&:to_s)
       end
 
-      hash = {}
-      attribute_names.each { |n| hash[n] = read_attribute_for_serialization(n) }
+      hash = attribute_names.each_with_object({}) do |n, hash|
+        hash[n] = read_attribute_for_serialization(n)
+      end
 
       Array(options[:methods]).each { |m| hash[m.to_s] = send(m) if respond_to?(m) }
 


### PR DESCRIPTION
A tiny change, but this way the accumulator does not need to be declared and initialized separate from the code block that populates it.
