### PR TITLE
Properly referencing AR::RecordNotFound in AJ guide rescuing example

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -242,7 +242,7 @@ job:
 class GuestsCleanupJob < ActiveJob::Base
   queue_as :default
 
-  rescue_from(ActiveRecord:NotFound) do |exception|
+  rescue_from(ActiveRecord::RecordNotFound) do |exception|
    # do something with the exception
   end
 


### PR DESCRIPTION
I mainly noticed the incorrect namespacing with a single colon but then I realised AR::NotFound doesn't exist either.
