### PR TITLE
Fix NoMethodError in class-level setter of class_attribute

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -82,13 +82,11 @@ class Class
 
       define_singleton_method("#{name}=") do |val|
         singleton_class.class_eval do
-          remove_possible_method(name)
           define_method(name) { val }
         end
 
         if singleton_class?
           class_eval do
-            remove_possible_method(name)
             define_method(name) do
               if instance_variable_defined? ivar
                 instance_variable_get ivar
@@ -102,7 +100,6 @@ class Class
       end
 
       if instance_reader
-        remove_possible_method name
         define_method(name) do
           if instance_variable_defined?(ivar)
             instance_variable_get ivar

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -88,4 +88,10 @@ class ClassAttributeTest < ActiveSupport::TestCase
     val = @klass.send(:setting=, 1)
     assert_equal 1, val
   end
+
+  test 'setter is synchronized' do
+    100.times.map { |i|
+      Thread.new { @klass.setting = i }
+    }.each(&:join)
+  end
 end


### PR DESCRIPTION
@pseudomuto @dwbutler #14021

@rafaelfranca I've just removed `remove_possible_method` calls. Don't know why they were there (maybe for older rubies?). Tested on mri-2.1, jruby-1.7.11.
