### PR TITLE
Update documentation to match change in #5942 [ci skip]

### DIFF
--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -54,7 +54,7 @@ module ActiveModel
       #
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "doesn't match
-      #   confirmation").
+      #   <tt>%{translated_attribute_name}</tt>").
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.


### PR DESCRIPTION
I'm not sure how to style it though.

(Extra bit)
And looking again, it's weird because the validation is set on `attribute` but the error is set on different attribute: `attribute_confirmation` - inconsistent with other built in validations as far as I can tell.
