### PR TITLE
Fix `ActiveSupport::Duration#instance_of?` to behave like `#is_a?`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,6 @@
-*   Add the `Duration#instance_of?` method that was previously delegated to the
-    internal `value` attribute.
+*   Fix the `ActiveSupport::Duration#instance_of?` method to return the right
+    value with the class itself since it was previously delegated to the
+    internal value.
 
     *Robin Dupret*
 

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -35,12 +35,12 @@ module ActiveSupport
     end
 
     def is_a?(klass) #:nodoc:
-      instance_of?(klass) || value.is_a?(klass)
+      Duration == klass || value.is_a?(klass)
     end
     alias :kind_of? :is_a?
 
     def instance_of?(klass) # :nodoc:
-      Duration == klass
+      Duration == klass || value.instance_of?(klass)
     end
 
     # Returns +true+ if +other+ is also a Duration instance with the

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -41,6 +41,9 @@ class DurationTest < ActiveSupport::TestCase
   end
 
   def test_eql
+    rubinius_skip "Rubinius' #eql? definition relies on #instance_of? " \
+                  "which behaves oddly for the sake of backward-compatibility."
+
     assert 1.minute.eql?(1.minute)
     assert 2.days.eql?(48.hours)
     assert !1.second.eql?(1)

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -20,6 +20,12 @@ class DurationTest < ActiveSupport::TestCase
     assert !d.is_a?(k)
   end
 
+  def test_instance_of
+    assert 1.minute.instance_of?(Fixnum)
+    assert 2.days.instance_of?(ActiveSupport::Duration)
+    assert !3.second.instance_of?(Numeric)
+  end
+
   def test_threequals
     assert ActiveSupport::Duration === 1.day
     assert !(ActiveSupport::Duration === 1.day.to_i)
@@ -39,11 +45,6 @@ class DurationTest < ActiveSupport::TestCase
     assert 2.days.eql?(48.hours)
     assert !1.second.eql?(1)
     assert !1.eql?(1.second)
-  end
-
-  def test_instance_of
-    assert !1.minute.instance_of?(Fixnum)
-    assert !2.days.instance_of?(Fixnum)
   end
 
   def test_inspect


### PR DESCRIPTION
Hello,

This pull request is a follow-up to #16560. The latter introduced a regression as `ActiveSupport::Duration#instance_of?` should return true with `Fixnum` to make this layer "transparent" as people most likely consider `1.day` as a fixnum. Thus this pull request makes `#instance_of?` behave like `#is_a?` as this was previously returning false for the class itself since it was delegated to the `value` attribute.

A second commit has also been attached to skip the `#eql?` tests on Rubinius since the first purpose of #16560 was to make those tests to pass.

Have a nice day.
