### PR TITLE
Use latest 2.1 version of sprockets-rails

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -181,8 +181,8 @@ module Rails
 
         gemfile = if options.dev? || options.edge?
           <<-GEMFILE.strip_heredoc
-            # Use edge version of sprockets-rails
-            gem 'sprockets-rails', github: 'rails/sprockets-rails'
+            # Use latest 2.1 version of sprockets-rails
+            gem 'sprockets-rails', github: 'rails/sprockets-rails', branch: "2-1-stable"
 
             # Use SCSS for stylesheets
             gem 'sass-rails', github: 'rails/sass-rails'


### PR DESCRIPTION
@rafaelfranca with the 3.0.0.beta1 release of sprockets-rails, it is important to pin down the version of sprocket-rails for maintenance releases of Rails 4.0 and Rails 4.1.
