### PR TITLE
Use latest 2.1 version of sprockets-rails

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -243,8 +243,8 @@ module Rails
 
         gems = []
         if options.dev? || options.edge?
-          gems << GemfileEntry.github('sprockets-rails', 'rails/sprockets-rails', nil,
-                                    'Use edge version of sprockets-rails')
+          gems << GemfileEntry.github('sprockets-rails', 'rails/sprockets-rails', '2-1-stable',
+                                    'Use latest 2.1 version of sprockets-rails')
           gems << GemfileEntry.github('sass-rails', 'rails/sass-rails', nil,
                                     'Use SCSS for stylesheets')
         else


### PR DESCRIPTION
@rafaelfranca with the 3.0.0.beta1 release of sprockets-rails, it is important to pin down the version of sprocket-rails for maintenance releases of Rails 4.0 and Rails 4.1.
