### PR TITLE
Improved the error messaging for the DangerousAttributeError exception

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -111,7 +111,7 @@ module ActiveRecord
       #   # => false
       def instance_method_already_implemented?(method_name)
         if dangerous_attribute_method?(method_name)
-          raise DangerousAttributeError, "#{method_name} is defined by Active Record"
+          raise DangerousAttributeError, "#{method_name} is defined by Active Record. Check to make sure that you don't have an attribute or method with the same name."
         end
 
         if superclass == Base


### PR DESCRIPTION
When the DangerousAttributeError exception is thrown, it's not entirely clear where the conflict is originating from.  Now the user is alerted that the conflict is a similarly named column.

I ran into this issue the other day when a column "valid" was added via a migration.  I received the message:

```
valid? is defined by Active Record
```

By the looks of that message, I thought that I had created a method called valid? on my model (which wasn't the case). It took me a while to track down that a column named 'valid' had been added to the table via a migration.
