### PR TITLE
Fixed find_by("sql fragment without bindings") on 4.2.0.beta1

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fixed a regression when using `find_by` with a SQL fragment without bindings.
+
+    *Godfrey Chan*
+
 *   Fixed a regression where whitespaces were stripped from DISTINCT queries in
     PostgreSQL.
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -151,7 +151,7 @@ module ActiveRecord
       end
 
       def find_by(*args)
-        return super if current_scope || args.length > 1 || reflect_on_all_aggregations.any?
+        return super if current_scope || String === args.first || reflect_on_all_aggregations.any?
 
         hash = args.first
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -177,6 +177,10 @@ module ActiveRecord
         end
       end
 
+      def find_by!(*args)
+        find_by(*args) or raise RecordNotFound
+      end
+
       def initialize_generated_modules
         super
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1540,20 +1540,6 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "", Company.new.description
   end
 
-  ["find_by", "find_by!"].each do |meth|
-    test "#{meth} delegates to scoped" do
-      record = stub
-
-      scope = mock
-      scope.expects(meth).with(:foo, :bar).returns(record)
-
-      klass = Class.new(ActiveRecord::Base)
-      klass.stubs(:all => scope)
-
-      assert_equal record, klass.public_send(meth, :foo, :bar)
-    end
-  end
-
   test "scoped can take a values hash" do
     klass = Class.new(ActiveRecord::Base)
     assert_equal ['foo'], klass.all.merge!(select: 'foo').select_values

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1047,6 +1047,28 @@ class FinderTest < ActiveRecord::TestCase
     assert_sql(/^((?!ORDER).)*$/) { Post.find_by(id: posts(:eager_other).id) }
   end
 
+  test "find_by! with hash conditions returns the first matching record" do
+    assert_equal posts(:eager_other), Post.find_by!(id: posts(:eager_other).id)
+  end
+
+  test "find_by! with non-hash conditions returns the first matching record" do
+    assert_equal posts(:eager_other), Post.find_by!("id = #{posts(:eager_other).id}")
+  end
+
+  test "find_by! with multi-arg conditions returns the first matching record" do
+    assert_equal posts(:eager_other), Post.find_by!('id = ?', posts(:eager_other).id)
+  end
+
+  test "find_by! doesn't have implicit ordering" do
+    assert_sql(/^((?!ORDER).)*$/) { Post.find_by!(id: posts(:eager_other).id) }
+  end
+
+  test "find_by! raises RecordNotFound if the record is missing" do
+    assert_raises(ActiveRecord::RecordNotFound) do
+      Post.find_by!("1 = 0")
+    end
+  end
+
   protected
     def bind(statement, *vars)
       if vars.first.is_a?(Hash)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1027,6 +1027,26 @@ class FinderTest < ActiveRecord::TestCase
     assert_nothing_raised(ActiveRecord::StatementInvalid) { Topic.offset("3").to_a }
   end
 
+  test "find_by with hash conditions returns the first matching record" do
+    assert_equal posts(:eager_other), Post.find_by(id: posts(:eager_other).id)
+  end
+
+  test "find_by with non-hash conditions returns the first matching record" do
+    assert_equal posts(:eager_other), Post.find_by("id = #{posts(:eager_other).id}")
+  end
+
+  test "find_by with multi-arg conditions returns the first matching record" do
+    assert_equal posts(:eager_other), Post.find_by('id = ?', posts(:eager_other).id)
+  end
+
+  test "find_by returns nil if the record is missing" do
+    assert_equal nil, Post.find_by("1 = 0")
+  end
+
+  test "find_by doesn't have implicit ordering" do
+    assert_sql(/^((?!ORDER).)*$/) { Post.find_by(id: posts(:eager_other).id) }
+  end
+
   protected
     def bind(statement, *vars)
       if vars.first.is_a?(Hash)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1570,7 +1570,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   test "find_by doesn't have implicit ordering" do
-    assert_sql(/^((?!ORDER).)*$/) { Post.find_by(author_id: 2) }
+    assert_sql(/^((?!ORDER).)*$/) { Post.all.find_by(author_id: 2) }
   end
 
   test "find_by! with hash conditions returns the first matching record" do
@@ -1586,7 +1586,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   test "find_by! doesn't have implicit ordering" do
-    assert_sql(/^((?!ORDER).)*$/) { Post.find_by!(author_id: 2) }
+    assert_sql(/^((?!ORDER).)*$/) { Post.all.find_by!(author_id: 2) }
   end
 
   test "find_by! raises RecordNotFound if the record is missing" do


### PR DESCRIPTION
This fixes a regression on 4.2.0.beta1 where calling `Post.find_by("1 = 1")` would cause an error (undefined method `value` on String).

Also...
- I duplicated the `find_by` tests from `relations_test.rb` to `finder_test.rb`. Now that we have a completely different implementation for `Base.find_by` vs `Relation#find_by`, it seems wise to have a different set of tests covering it.
- I removed the (failing) tests for the find_by delegation. Now that we have tests for the actual behavior, there's no point having another test that tests the implementation (that it delegates). Further, what the test was implying is no longer true with the current implementation, because `Base.find_by` is a real method now instead of always delegating to `all`.
- I noticed that `find_by!` doesn't seem to use the query cache at the moment, so I added that as well. It doesn't seem like we have ways to test that things are actually being cached, so I didn't add test that. But I duplicated the relation test cases for the class method on `Base` in `finder_test.rb`.

cc @tenderlove @matthewd 
