### PR TITLE
treetop is no longer a mail (rails) dependency

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -111,7 +111,6 @@ A standard Rails application depends on several gems, specifically:
 * i18n
 * mail
 * mime-types
-* polyglot
 * rack
 * rack-cache
 * rack-mount
@@ -121,7 +120,6 @@ A standard Rails application depends on several gems, specifically:
 * rake
 * sqlite3
 * thor
-* treetop
 * tzinfo
 
 ### `rails/commands.rb`


### PR DESCRIPTION
see https://github.com/mikel/mail/commit/2da7c7985c221272f6451b27ab8b41e84e0a6804

noticed this one while looking at https://github.com/rails/rails/issues/16614
