### PR TITLE
Correcting #respond_to? method arity

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -169,7 +169,7 @@ module ActionDispatch # :nodoc:
     end
     alias_method :status_message, :message
 
-    def respond_to?(method)
+    def respond_to?(method, include_private = false)
       if method.to_s == 'to_path'
         stream.respond_to?(:to_path)
       else

--- a/railties/lib/rails/railtie/configuration.rb
+++ b/railties/lib/rails/railtie/configuration.rb
@@ -80,7 +80,7 @@ module Rails
         to_prepare_blocks << blk if blk
       end
 
-      def respond_to?(name)
+      def respond_to?(name, include_private = false)
         super || @@options.key?(name.to_sym)
       end
 


### PR DESCRIPTION
Both of the following methods had method arity of 1:
- Rails::Railtie::Configuration#respond_to?
- ActionDispatch::Response#respond_to?

Other instances of #respond_to? in Rails have a method arity of -2.
The method arity of -2 matches the interface for Ruby 1.9.3, 2.0.0,
2.1.2, and 2.1.0.

See:
http://ruby-doc.org/core-2.1.0/Object.html#method-i-respond_to-3F
http://ruby-doc.org/core-2.1.2/Object.html#method-i-respond_to-3F
http://ruby-doc.org/core-2.0.0/Object.html#method-i-respond_to-3F
http://ruby-doc.org/core-1.9.3/Object.html#method-i-respond_to-3F

Closes rails/rails#16685
