### PR TITLE
Inconsistent flow in rails server command

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -68,6 +68,7 @@ module Rails
     end
 
     def set_environment
+      options = send(:parse_options, ARGV)
       ENV["RAILS_ENV"] ||= options[:environment]
     end
 


### PR DESCRIPTION
The problem is only happened when custom `config.root`

When rails server initialize, it call [server.rb#L70](https://github.com/rails/rails/blob/master/railties/lib/rails/commands/server.rb#L70). In here if we start server in two ways `rails s -e production` and `RAILS_ENV=production rails s`, it leads two different flows
- `rails s -e production`: `options` method in `Rack::Server` was called [rack/server.rb#L189](https://github.com/rack/rack/blob/master/lib/rack/server.rb#L189) and `@options` will be initialize and keep for other callings but at that time [commands_tasks.rb#L79](https://github.com/rails/rails/blob/master/railties/lib/rails/commands/commands_tasks.rb#L79) is not set therefore it load options as default `config.root`. In case of we set `config.root` with different value, the process go though start phase and it'll load options again but at this time it use memory variable
- `RAILS_ENV=production rails s`: The variable ENV['RAILS_ENV'] doesn't change therefore `options` method will be not call.

I think we should manually parse in `set_environment` method to prevent memory `options`
