### PR TITLE
[ActiveJob] Autoload adapters

### DIFF
--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -30,4 +30,5 @@ module ActiveJob
   extend ActiveSupport::Autoload
 
   autoload :Base
+  autoload :QueueAdapters
 end

--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -17,7 +17,6 @@ module ActiveJob
 
     private
       def load_adapter(name)
-        require "active_job/queue_adapters/#{name}_adapter"
         "ActiveJob::QueueAdapters::#{name.to_s.camelize}Adapter".constantize
       end
   end

--- a/activejob/lib/active_job/queue_adapters.rb
+++ b/activejob/lib/active_job/queue_adapters.rb
@@ -1,0 +1,16 @@
+module ActiveJob
+  module QueueAdapters
+    extend ActiveSupport::Autoload
+
+    autoload :InlineAdapter
+    autoload :BackburnerAdapter
+    autoload :DelayedJobAdapter
+    autoload :QuAdapter
+    autoload :QueAdapter
+    autoload :QueueClassicAdapter
+    autoload :ResqueAdapter
+    autoload :SidekiqAdapter
+    autoload :SneakersAdapter
+    autoload :SuckerPunchAdapter
+  end
+end


### PR DESCRIPTION
That will fix a bug when a backend don't require the adapter first

fixes: https://github.com/mperham/sidekiq/issues/1912

That will also autoload the TestAdapter when required instead of always requiring it. (WIP)

cc @mperham @dhh @rafaelfranca 
