### PR TITLE
Updated weblinks for all change logs to correct url

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -584,10 +584,10 @@ See the
 the many people who spent many hours making Rails the stable and robust
 framework it is today. Kudos to all of them.
 
-[railties]:       https://github.com/rails/rails/blob/4-2-stable/railties/CHANGELOG.md
-[action-pack]:    https://github.com/rails/rails/blob/4-2-stable/actionpack/CHANGELOG.md
-[action-view]:    https://github.com/rails/rails/blob/4-2-stable/actionview/CHANGELOG.md
-[action-mailer]:  https://github.com/rails/rails/blob/4-2-stable/actionmailer/CHANGELOG.md
-[active-record]:  https://github.com/rails/rails/blob/4-2-stable/activerecord/CHANGELOG.md
-[active-model]:   https://github.com/rails/rails/blob/4-2-stable/activemodel/CHANGELOG.md
-[active-support]: https://github.com/rails/rails/blob/4-2-stable/activesupport/CHANGELOG.md
+[railties]:       https://github.com/rails/rails/blob/master/railties/CHANGELOG.md
+[action-pack]:    https://github.com/rails/rails/blob/master/actionpack/CHANGELOG.md
+[action-view]:    https://github.com/rails/rails/blob/master/actionview/CHANGELOG.md
+[action-mailer]:  https://github.com/rails/rails/blob/master/actionmailer/CHANGELOG.md
+[active-record]:  https://github.com/rails/rails/blob/master/activerecord/CHANGELOG.md
+[active-model]:   https://github.com/rails/rails/blob/master/activemodel/CHANGELOG.md
+[active-support]: https://github.com/rails/rails/blob/master/activesupport/CHANGELOG.md


### PR DESCRIPTION
The links for the change logs were all wrong and pointing https://github.com/rails/rails/blob/4-2-stable/ which does not currently exist
