### PR TITLE
[ci skip] Modify a web-console PR link

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -123,7 +123,7 @@ Please refer to the [Changelog][railties] for detailed changes.
 ### Notable changes
 
 *   Introduced `web-console` in the default application Gemfile.
-    ([Pull Request](https://github.com/rails/rails/pull/16532))
+    ([Pull Request](https://github.com/rails/rails/pull/11667))
 
 *   Added a `required` option to the model generator for associations.
     ([Pull Request](https://github.com/rails/rails/pull/16062))


### PR DESCRIPTION
I think whether https://github.com/rails/rails/pull/11667 is appropriate, how about?
