### PR TITLE
Cleaner StrongParameters whitelisting

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Add `whitelist_params` to ActionController::Base to allow simpler and cleaner
+    way to whitelist strong parameters in a controller:
+
+    Example:
+      # app/controller/users_controller.rb
+
+      class UsersController < ApplicationController
+
+        whitelist_params create: {user: [:name, :age]}
+
+        def create
+          @user = User.new(create_params[:user])
+        end
+      end
+
+    *Elad Meidar*
+
 *   Allow `config.action_dispatch.trusted_proxies` to accept an IPAddr object.
 
     Example:

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -263,6 +263,18 @@ module ActionController
       PROTECTED_IVARS
     end
 
+    class << self
+      # DSL wrapper for strong parameters
+      def whitelist_parameters(options = {})
+        action_names = options.keys
+        action_names.each do |action_name|
+          define_method("#{action_name.to_s}_params") do
+            base = options[action_name].keys.first
+            params.require(base).permit(*options[action_name][base])
+          end
+        end
+      end
+    end
     ActiveSupport.run_load_hooks(:action_controller, self)
   end
 end

--- a/actionpack/test/controller/permitted_params_test.rb
+++ b/actionpack/test/controller/permitted_params_test.rb
@@ -10,6 +10,16 @@ class PeopleController < ActionController::Base
   end
 end
 
+class VilliansController < ActionController::Base
+
+  whitelist_parameters create: {villian: [:name]}
+
+  def create
+    render text: create_params.permitted? ? "permitted" : "forbidden"
+  end
+
+end
+
 class ActionControllerPermittedParamsTest < ActionController::TestCase
   tests PeopleController
 
@@ -22,4 +32,15 @@ class ActionControllerPermittedParamsTest < ActionController::TestCase
     post :create_with_permit, { person: { name: "Mjallo!" } }
     assert_equal "permitted", response.body
   end
+end
+
+class ActionControllerWhitelistedParamsTest < ActionController::TestCase
+
+  tests VilliansController
+
+  test "parameters are permitted using #whitelist_params" do
+    post :create, {villian: {name: "Joker"}}
+    assert_equal "permitted", response.body
+  end
+
 end


### PR DESCRIPTION
Ever since SP replaced attr_protected / accessible, I felt a little bit uncomfortable with the additional method it requires you to add to every controller. Since almost all the additional *_params look the same (require + permit something) I created this helper to make it easier to whitelist parameters list for a specific action:

so instead of doing something like this - 

``` ruby
  class UsersController < ActionController


    def new
      @user = User.new
    end

    def create

      # Here we are using the parameter whitelisting method
      @user = User.new(user_params)
      if @user.save
        redirect_to users_url, notice: "User created"
      else
        render :new
      end
    end


    private

    # Parameter whitelisting method
    def user_params
      params.require(:user).permit(:name, :age)
    end
  end
```

this change allows you use the `whitelist_params` method:

``` ruby
  class UsersController < ApplicationController

    filter_parameters create: {user: [:name, :age]}

    def create
      @user = User.new(create_params) # => create_params is available via BetterStrongParams and the filter_parameters DSL.
      if @user.save
        redirect_to treasure_url
      else
        redirect_to jail_url
      end
    end
  end
```

Two things:
1. Not sure I added the method in the right place, under ActionController::Base
2. Tests. feels like I could use a few more ideas.
