### PR TITLE
Add language directive to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: ruby
 script: 'ci/travis.rb'
 before_install:
   - travis_retry gem install bundler


### PR DESCRIPTION
Currently, Travis CI assumes that the project is in Ruby in the
absence of the `language` key.
This behavior may change in the future. (For example, switch to a "blank"
image which _may_ be created.)
