### PR TITLE
Don't rescue IPAddr::InvalidAddressError

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Don't rescue `IPAddr::InvalidAddressError`.
+
+    `IPAddr::InvalidAddressError` does not exist in Ruby 1.9.3
+    and fails for JRuby in 1.9 mode.
+
+    *Peter Suschlik*
+
 *   Fix bug where the router would ignore any constraints added to redirect
     routes.
 

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -155,7 +155,7 @@ module ActionDispatch
             range = IPAddr.new(ip).to_range
             # we want to make sure nobody is sneaking a netmask in
             range.begin == range.end
-          rescue ArgumentError, IPAddr::InvalidAddressError
+          rescue ArgumentError
             nil
           end
         end


### PR DESCRIPTION
`IPAddr::InvalidAddressError` does not exist in Ruby 1.9.3 and fails for JRuby in 1.9 mode.

As `IPAddr::InvalidAddressError` is a subclass of `ArgumentError` (via `IPAddr::Error`) just rescuing `ArgumentError` is fine.
