### PR TITLE
add query (?) method to store_accessor

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   add a query (?) method for attributes defined using store_accessor.
+
+    *Herman verschooten*
+
 *   `default_sequence_name` from the PostgreSQL adapter returns a `String`.
 
     *Yves Senn*

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -89,6 +89,10 @@ module ActiveRecord
             define_method(key) do
               read_store_attribute(store_attribute, key)
             end
+
+            define_method("#{key}?") do
+              !(self.send(key).nil?)
+            end
           end
         end
 

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -41,6 +41,13 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal 'red', @john.color
   end
 
+  test "query (?) method for attribute exposed by accessors" do
+    @john.height = 'tall'
+    assert_equal true, @john.height?
+    @john.height = nil
+    assert_equal false, @john.height?
+  end
+
   test "updating the store will mark it as changed" do
     @john.color = 'red'
     assert @john.settings_changed?


### PR DESCRIPTION
The accessor methods generated for store or store_accessor attributes
lack a ? method the normal active record attributes do have.
This add that method by verifying if the value is not nil?.

```
class TestModel < ActiveRecord::Base
  store_accessor :data, :width, :height
end

test_model = TestModel.new(data: {width: 5})
test_model.width?   #=> true
test_model.height?  #=> false
```
