### PR TITLE
[ActiveJob] Relax activesupport version dependency [ci skip]

### DIFF
--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.files        = Dir['CHANGELOG.md', 'MIT-LICENSE', 'README.md', 'lib/**/*']
   s.require_path = 'lib'
 
-  s.add_dependency 'activesupport', version
+  s.add_dependency 'activesupport', '>= 4.1'
   s.add_dependency 'globalid', '>= 0.2.3'
 end


### PR DESCRIPTION
This will allow AJ to be installed in rails 4.1 
