### PR TITLE
Make test:isolated run without bundler for Action Mailer

### DIFF
--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -1,9 +1,8 @@
 # encoding: utf-8
-gem 'activejob'
-require 'active_job'
 require 'abstract_unit'
+require 'active_job'
 require 'minitest/mock'
-require_relative 'mailers/delayed_mailer'
+require 'mailers/delayed_mailer'
 
 class MessageDeliveryTest < ActiveSupport::TestCase
 


### PR DESCRIPTION
Hello,

This pull request makes it possible to run Action Mailer tests in isolation without the `bundle exec` prefix since we were requiring gems before requiring abstract_unit.

We don't need the `gem` call thus and the `require_relative` since the test directory should be present in the load path when we run any test.

Have a nice day.
