### PR TITLE
Avoid skipping Sidekiq tests on Rubinius

### DIFF
--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -10,18 +10,12 @@ def sidekiq?
   @adapter == 'sidekiq'
 end
 
-def rubinius?
-  RUBY_ENGINE == 'rbx'
-end
-
 def ruby_193?
   RUBY_VERSION == '1.9.3' && RUBY_ENGINE != 'java'
 end
 
-#Sidekiq don't work with MRI 1.9.3
-#Travis uses rbx 2.6 which don't support unicode characters in methods.
-#Remove the check when Travis change to rbx 2.7+
-exit  if sidekiq?  && (ruby_193? || rubinius?)
+# Sidekiq doesn't work with MRI 1.9.3
+exit if sidekiq? && ruby_193?
 
 require "adapters/#{@adapter}"
 


### PR DESCRIPTION
Hello,

Now that Travis provides support for Rubinius 2.2.10, we can run the Sidekiq tests against this version.

Have a nice day.
