### PR TITLE
Add tests for incorrect error messages of association length validations

### DIFF
--- a/activerecord/test/cases/validations/length_validation_test.rb
+++ b/activerecord/test/cases/validations/length_validation_test.rb
@@ -44,4 +44,32 @@ class LengthValidationTest < ActiveRecord::TestCase
       assert o.valid?
     end
   end
+
+  def test_validates_size_of_association_using_is
+    repair_validations Owner do
+      Owner.validates_size_of :pets, :is => 2
+      o = Owner.new
+      assert !o.save
+      assert_equal ["is the wrong length (should have length of 2)"], o.errors[:pets]
+    end
+  end
+
+  def test_validates_size_of_association_using_minimum
+    repair_validations Owner do
+      Owner.validates_size_of :pets, :minimum => 2
+      o = Owner.new
+      assert !o.save
+      assert_equal ["is too short (minimum length is 2)"], o.errors[:pets]
+    end
+  end
+
+  def test_validates_size_of_association_using_maximum
+    repair_validations Owner do
+      Owner.validates_size_of :pets, :maximum => 2
+      o = Owner.new
+      3.times { o.pets.build('name' => 'apet') }
+      assert !o.save
+      assert_equal ["is too long (maximum length is 2)"], o.errors[:pets]
+    end
+  end
 end


### PR DESCRIPTION
Hey :)
These are tests showing issue #16735 in detail

As @s-s-w mentioned, the problem is with validating length of associations. Error messages of length validators are composed as if they were supposed to be used with strings only.

We can change error messages to be type-agnostic, for example 
`"is too short (minimum length is 2)"` 
instead of
`"is too short (minimum is 2 characters)"`
or check what exactly do we validate and decide based on that. Any other ideas?
