### PR TITLE
Clarify that /console is an optional feature

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -33,7 +33,7 @@ group :development, :test do
   gem 'byebug'
   <%- end -%>
 
-  # Access an IRB console on exceptions page and /console in development
+  # Access an IRB console on each exception page or by using <%%= console %> in any view
   gem 'web-console', '~> 2.0.0.beta2'
 <%- if spring_install? %>
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring


### PR DESCRIPTION
When I installed 4.2.0.beta1, I thought (based on this comment) that I could run `rails server` then go to `http://localhost:3000/console` to play with the console. Totally reasonable that you have to do more configuration, but it would be nice for the comment to indicate that.
