### PR TITLE
After rack 1.6.0, by default, the rack will also out put the log which is not intent in rails.

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -114,6 +114,7 @@ module Rails
         daemonize:          false,
         debugger:           false,
         pid:                File.expand_path("tmp/pids/server.pid"),
+        quiet:              true,
         config:             File.expand_path("config.ru")
       })
     end


### PR DESCRIPTION
Such change will also resolve the quiet_assets [#36](https://github.com/evrone/quiet_assets/issues/36)
