### PR TITLE
Rely on NameError#name instead of its error message

### DIFF
--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -807,6 +807,8 @@ class TimeWithZoneTest < ActiveSupport::TestCase
   end
 
   def test_no_method_error_has_proper_context
+    rubinius_skip "Error message inconsistency"
+
     e = assert_raises(NoMethodError) {
       @twz.this_method_does_not_exist
     }


### PR DESCRIPTION
Hello,

This pull request simply avoids assertions against error messages as they may change in the future and are different across implementations.

Have a nice day.
