### PR TITLE
Allow polymorphic routes with nil when a route can still be drawn

### DIFF
--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -197,7 +197,8 @@ module ActionDispatch
 
           case record_or_hash_or_array
           when Array
-            if record_or_hash_or_array.empty? || record_or_hash_or_array.include?(nil)
+            record_or_hash_or_array = record_or_hash_or_array.compact
+            if record_or_hash_or_array.empty?
               raise ArgumentError, "Nil location provided. Can't build URI."
             end
             if record_or_hash_or_array.first.is_a?(ActionDispatch::Routing::RoutesProxy)


### PR DESCRIPTION
Suppose you have two resources routed in the following manner:

``` ruby
resources :blogs do
  resources :posts
end

resources :posts
```

When using polymorphic resource routing like `url_for([@blog, @post])`, and `@blog` is `nil` Rails should still try to match the route to the top-level posts resource.

Fixes #16754
