### PR TITLE
Dont mess with default order engines load (4.1.6.rc1 regression)

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -414,8 +414,14 @@ module Rails
       end
     end
 
+    # Return an array of railties respecting the order they're loaded
+    # and the order specified by the +railties_order+ config.
+    #
+    # While when running initializers we need engines in reverse
+    # order here when copying migrations from railties we need then in the same
+    # order as given by +railties_order+
     def migration_railties # :nodoc:
-      (ordered_railties & railties_without_main_app).reverse
+      ordered_railties.flatten - [self]
     end
 
   protected
@@ -448,11 +454,6 @@ module Rails
       super
     end
 
-    def railties_without_main_app # :nodoc:
-      @railties_without_main_app ||= Rails::Railtie.subclasses.map(&:instance) +
-        Rails::Engine.subclasses.map(&:instance)
-    end
-
     # Returns the ordered railties for this application considering railties_order.
     def ordered_railties #:nodoc:
       @ordered_railties ||= begin
@@ -472,13 +473,13 @@ module Rails
 
         index = order.index(:all)
         order[index] = all
-        order.reverse.flatten
+        order
       end
     end
 
     def railties_initializers(current) #:nodoc:
       initializers = []
-      ordered_railties.each do |r|
+      ordered_railties.reverse.flatten.each do |r|
         if r == self
           initializers += current
         else

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -144,6 +144,42 @@ module RailtiesTest
       end
     end
 
+    test "dont reverse default railties order" do
+      @api = engine "api" do |plugin|
+        plugin.write "lib/api.rb", <<-RUBY
+          module Api
+            class Engine < ::Rails::Engine; end
+          end
+        RUBY
+      end
+
+      # added last but here is loaded before api engine
+      @core = engine "core" do |plugin|
+        plugin.write "lib/core.rb", <<-RUBY
+          module Core
+            class Engine < ::Rails::Engine; end
+          end
+        RUBY
+      end
+
+      @core.write "db/migrate/1_create_users.rb", <<-RUBY
+        class CreateUsers < ActiveRecord::Migration; end
+      RUBY
+
+      @api.write "db/migrate/2_create_keys.rb", <<-RUBY
+        class CreateKeys < ActiveRecord::Migration; end
+      RUBY
+
+      boot_rails
+
+      Dir.chdir(app_path) do
+        output  = `bundle exec rake railties:install:migrations`.split("\n")
+
+        assert_match(/Copied migration \d+_create_users.core_engine.rb from core_engine/, output.first)
+        assert_match(/Copied migration \d+_create_keys.api_engine.rb from api_engine/, output.last)
+      end
+    end
+
     test "mountable engine should copy migrations within engine_path" do
       @plugin.write "lib/bukkits.rb", <<-RUBY
         module Bukkits


### PR DESCRIPTION
When copying migrations some engines might depend on schema from other
engine so we can't blindly reverse all railties collection as that would
affect the order they were originally loaded. This patch helps to only
apply the order from engines specified in `railties_order`

related https://github.com/rails/rails/issues/16614 and https://github.com/rails/rails/pull/15269

I tried to fix this without changing what gets returned by `ordered_railties` but it's was getting too complicated and `ordered_railties` is private api only used by `railties_initializers`, afaik, so I think it's fine? Returning the original specified railties + all other railties in a single array key makes it easier to reverse only where we really need to. Please let me know if that doesn't make any sense.

Motivation here was to fix the spree builds, there we have an api engine with migrations that depend on the core engine so it's important that rails copies the core migrations first.

apologize for the lack of specs here, was trying to reproduce it via a test but failed miserably, will give another try later today or tomorrow.
