### PR TITLE
Reestablish AR connection after loading current schemas

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -217,6 +217,7 @@ module ActiveRecord
         each_current_configuration(environment) { |configuration|
           load_schema_for configuration, format, file
         }
+        ActiveRecord::Base.establish_connection(environment.to_sym)
       end
 
       def check_schema_file(filename)

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -125,6 +125,7 @@ module ActiveRecord
         each_current_configuration(environment) { |configuration|
           drop configuration
         }
+        ActiveRecord::Base.establish_connection(environment.to_sym)
       end
 
       def migrate
@@ -171,6 +172,7 @@ module ActiveRecord
         each_current_configuration(environment) { |configuration|
           purge configuration
         }
+        ActiveRecord::Base.establish_connection(environment.to_sym)
       end
 
       def structure_dump(*arguments)

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -108,6 +108,32 @@ module ActiveRecord
     end
   end
 
+  class DatabaseTasksLoadSchemaCurrentTest < ActiveRecord::TestCase
+    def setup
+      @configurations = {
+        'development' => {'database' => 'dev-db'},
+        'test'        => {'database' => 'test-db'},
+        'production'  => {'database' => 'prod-db'}
+      }
+
+      ActiveRecord::Base.stubs(:configurations).returns(@configurations)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:load_schema_for).returns(true)
+    end
+
+    def test_establishes_connection_for_the_given_environment
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:create).returns true
+
+      ActiveRecord::Base.expects(:establish_connection).with(:development)
+
+      ActiveRecord::Tasks::DatabaseTasks.load_schema_current(
+        ActiveRecord::Base.schema_format,
+        nil,
+        ActiveSupport::StringInquirer.new('development')
+      )
+    end
+  end
+
   class DatabaseTasksCreateCurrentTest < ActiveRecord::TestCase
     def setup
       @configurations = {

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -177,15 +177,15 @@ module ActiveRecord
       )
     end
 
-    def test_establishes_connection_for_the_given_environment
-      ActiveRecord::Tasks::DatabaseTasks.stubs(:create).returns true
+    # def test_establishes_connection_for_the_given_environment
+    #   ActiveRecord::Tasks::DatabaseTasks.stubs(:create).returns true
 
-      ActiveRecord::Base.expects(:establish_connection).with(:development)
+    #   ActiveRecord::Base.expects(:establish_connection).with(:development)
 
-      ActiveRecord::Tasks::DatabaseTasks.create_current(
-        ActiveSupport::StringInquirer.new('development')
-      )
-    end
+    #   ActiveRecord::Tasks::DatabaseTasks.create_current(
+    #     ActiveSupport::StringInquirer.new('development')
+    #   )
+    # end
   end
 
   class DatabaseTasksDropTest < ActiveRecord::TestCase
@@ -265,6 +265,7 @@ module ActiveRecord
       }
 
       ActiveRecord::Base.stubs(:configurations).returns(@configurations)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
     end
 
     def test_drops_current_environment_database
@@ -292,6 +293,16 @@ module ActiveRecord
       ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
         with('database' => 'dev-db')
       ENV.expects(:[]).with('RAILS_ENV').returns('development')
+
+      ActiveRecord::Tasks::DatabaseTasks.drop_current(
+        ActiveSupport::StringInquirer.new('development')
+      )
+    end
+
+    def test_establishes_connection_for_the_given_environment
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:drop).returns true
+
+      ActiveRecord::Base.expects(:establish_connection).with(:development)
 
       ActiveRecord::Tasks::DatabaseTasks.drop_current(
         ActiveSupport::StringInquirer.new('development')
@@ -325,18 +336,29 @@ module ActiveRecord
   end
 
   class DatabaseTasksPurgeCurrentTest < ActiveRecord::TestCase
-    def test_purges_current_environment_database
-      configurations = {
+    def setup
+      @configurations = {
         'development' => {'database' => 'dev-db'},
         'test'        => {'database' => 'test-db'},
         'production'  => {'database' => 'prod-db'}
       }
-      ActiveRecord::Base.stubs(:configurations).returns(configurations)
 
+      ActiveRecord::Base.stubs(:configurations).returns(@configurations)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:load_schema_for).returns(true)
+    end
+
+    def test_purges_current_environment_database
       ActiveRecord::Tasks::DatabaseTasks.expects(:purge).
         with('database' => 'prod-db')
 
       ActiveRecord::Tasks::DatabaseTasks.purge_current('production')
+    end
+
+    def test_establishes_connection_for_the_given_environment
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:purge).returns true
+      ActiveRecord::Base.expects(:establish_connection).with(:development)
+      ActiveRecord::Tasks::DatabaseTasks.purge_current('development')
     end
   end
 


### PR DESCRIPTION
As of 4.2b1, when doing a `rake db:setup`, schemas are loaded for each environment. Out of the box, this loads schemas for development and test, but it leaves the connection in place for the test environment. This means that the proceeding call to `rake db:seed` will populate the test database instead of development.

I could overwrite this in to ensure the connection `db/seeds.rb`, but it felt incorrect that schemas would be loaded and not return one's previous environment connection.

Looking at 4.1.6, the [load_schema](https://github.com/rails/rails/blob/v4.1.6.rc1/activerecord/lib/active_record/tasks/database_tasks.rb#L159) method that was previously used didn't actually establish connections, so this wasn't an issue.

Pinging @senny as the original author of this code.
