### PR TITLE
Fix Time#change when used with :usec and offset times

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix bug where Time#change would not properly handle :usec and :nsec options
+    in cases where it would call Time#new.
+
+    *Agis Anastasopoulos*
+
 *   Time#change now supports a :nsec option
 
     *Agis Anastasopoulos*

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Time#change now supports a :nsec option
+
+    *Agis Anastasopoulos*
+
 *   Added instance_eval version to Object#try, so you can do this:
 
       person.try { name.first }

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -64,11 +64,11 @@ class Time
 
   # Returns a new Time where one or more of the elements have been changed according
   # to the +options+ parameter. The time options (<tt>:hour</tt>, <tt>:min</tt>,
-  # <tt>:sec</tt>, <tt>:usec</tt>) reset cascadingly, so if only the hour is passed,
-  # then minute, sec, and usec is set to 0. If the hour and minute is passed, then
-  # sec and usec is set to 0.  The +options+ parameter takes a hash with any of these
-  # keys: <tt>:year</tt>, <tt>:month</tt>, <tt>:day</tt>, <tt>:hour</tt>, <tt>:min</tt>,
-  # <tt>:sec</tt>, <tt>:usec</tt>.
+  # <tt>:sec</tt>, <tt>:usec</tt>, <tt>:nsec</tt>) reset cascadingly, so if only the
+  # hour is passed, then minute, sec, and usec is set to 0. If the hour and minute is
+  # passed, then sec and usec is set to 0. The +options+ parameter takes a hash with any
+  # of these keys: <tt>:year</tt>, <tt>:month</tt>, <tt>:day</tt>, <tt>:hour</tt>,
+  # <tt>:min</tt>, <tt>:sec</tt>, <tt>:usec</tt>, <tt>:nsec</tt>.
   #
   #   Time.new(2012, 8, 29, 22, 35, 0).change(day: 1)              # => Time.new(2012, 8, 1, 22, 35, 0)
   #   Time.new(2012, 8, 29, 22, 35, 0).change(year: 1981, day: 1)  # => Time.new(1981, 8, 1, 22, 35, 0)
@@ -80,7 +80,10 @@ class Time
     new_hour  = options.fetch(:hour, hour)
     new_min   = options.fetch(:min, options[:hour] ? 0 : min)
     new_sec   = options.fetch(:sec, (options[:hour] || options[:min]) ? 0 : sec)
-    new_usec  = options.fetch(:usec, (options[:hour] || options[:min] || options[:sec]) ? 0 : Rational(nsec, 1000))
+    new_usec  = options.fetch(:usec, (options[:hour] || options[:min] || options[:sec]) ? 0 : usec)
+    new_nsec  = options.fetch(:nsec, (options[:hour] || options[:min] || options[:sec] || options[:usec]) ? 0 : nsec)
+
+    new_usec = new_nsec == 0 ? new_usec : new_nsec.to_r / 1000
 
     if utc?
       ::Time.utc(new_year, new_month, new_day, new_hour, new_min, new_sec, new_usec)

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -90,7 +90,8 @@ class Time
     elsif zone
       ::Time.local(new_year, new_month, new_day, new_hour, new_min, new_sec, new_usec)
     else
-      ::Time.new(new_year, new_month, new_day, new_hour, new_min, new_sec + (new_usec.to_r / 1000000), utc_offset)
+      new_sec = new_usec == 0 ? new_sec : new_usec.to_r / 1000000
+      ::Time.new(new_year, new_month, new_day, new_hour, new_min, new_sec, utc_offset)
     end
   end
 

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -387,6 +387,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.local(2005,1,2,11, 6, 0, 0), Time.local(2005,1,2,11,22,33,44).change(:min  => 6)
     assert_equal Time.local(2005,1,2,11,22, 7, 0), Time.local(2005,1,2,11,22,33,44).change(:sec  => 7)
     assert_equal Time.local(2005,1,2,11,22,33, 8), Time.local(2005,1,2,11,22,33,44).change(:usec => 8)
+    assert_equal Time.local(2005,1,2,11,22,33, 8), Time.local(2005,1,2,11,22,33,2).change(:nsec => 8000)
   end
 
   def test_utc_change
@@ -396,6 +397,8 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.utc(2005,2,22,16),       Time.utc(2005,2,22,15,15,10).change(:hour => 16)
     assert_equal Time.utc(2005,2,22,16,45),    Time.utc(2005,2,22,15,15,10).change(:hour => 16, :min => 45)
     assert_equal Time.utc(2005,2,22,15,45),    Time.utc(2005,2,22,15,15,10).change(:min => 45)
+    assert_equal Time.utc(2005,2,22,15,15,15,45), Time.utc(2005,2,22,15,15,15,15,15).change(:usec => 45)
+    assert_equal Time.utc(2005,2,22,15,15,15,45), Time.utc(2005,2,22,15,15,15,15,15).change(:nsec => 45000)
   end
 
   def test_offset_change
@@ -475,7 +478,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_advance_with_nsec
     t = Time.at(0, Rational(108635108, 1000))
-    assert_equal t, t.advance(:months => 0)
+    assert_equal t, t.advance(:nsec => 0)
   end
 
   def test_advance_gregorian_proleptic

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -408,6 +408,9 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.new(2005,2,22,16,0,0,"-08:00"),   Time.new(2005,2,22,15,15,10,"-08:00").change(:hour => 16)
     assert_equal Time.new(2005,2,22,16,45,0,"-08:00"),  Time.new(2005,2,22,15,15,10,"-08:00").change(:hour => 16, :min => 45)
     assert_equal Time.new(2005,2,22,15,45,0,"-08:00"),  Time.new(2005,2,22,15,15,10,"-08:00").change(:min => 45)
+    assert_equal Time.new(2005,2,22,15,15,45,"-08:00"),  Time.new(2005,2,22,15,15,10,"-08:00").change(:sec => 45)
+    assert_equal Time.new(2005,2,22,15,15,45,"-08:00"),  Time.new(2005,2,22,15,15,15,"-08:00").change(:usec => 45000000)
+    assert_equal Time.new(2005,2,22,15,15,45,"-08:00"),  Time.new(2005,2,22,15,15,15,"-08:00").change(:nsec => 45000000000)
   end
 
   def test_advance


### PR DESCRIPTION
This is a follow-up of #16758 and the branch is based on it.

Fixes #16759.
