### PR TITLE
Refactor add_constraints complex loop conditional

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -45,20 +45,20 @@ module ActiveRecord
       end
 
       def self.get_bind_values(owner, chain)
-        bvs = []
-        chain.each_with_index do |reflection, i|
-          if reflection == chain.last
-            bvs << reflection.join_id_for(owner)
-            if reflection.type
-              bvs << owner.class.base_class.name
-            end
-          else
-            if reflection.type
-              bvs << chain[i + 1].klass.base_class.name
-            end
+        binds = []
+        last_reflection = chain.last
+
+        binds << last_reflection.join_id_for(owner)
+        if last_reflection.type
+          binds << owner.class.base_class.name
+        end
+
+        chain.each_cons(2).each do |reflection, next_reflection|
+          if reflection.type
+            binds << next_reflection.klass.base_class.name
           end
         end
-        bvs
+        binds
       end
 
       private
@@ -96,38 +96,55 @@ module ActiveRecord
         bind_value scope, column, value, tracker
       end
 
+      def last_chain_scope(scope, table, reflection, owner, tracker, assoc_klass)
+        join_keys = reflection.join_keys(assoc_klass)
+        key = join_keys.key
+        foreign_key = join_keys.foreign_key
+
+        bind_val = bind scope, table.table_name, key.to_s, owner[foreign_key], tracker
+        scope    = scope.where(table[key].eq(bind_val))
+
+        if reflection.type
+          value    = owner.class.base_class.name
+          bind_val = bind scope, table.table_name, reflection.type, value, tracker
+          scope    = scope.where(table[reflection.type].eq(bind_val))
+        else
+          scope
+        end
+      end
+
+      def next_chain_scope(scope, table, reflection, chain, tracker, assoc_klass, foreign_table, next_reflection)
+        join_keys = reflection.join_keys(assoc_klass)
+        key = join_keys.key
+        foreign_key = join_keys.foreign_key
+
+        constraint = table[key].eq(foreign_table[foreign_key])
+
+        if reflection.type
+          value    = next_reflection.klass.base_class.name
+          bind_val = bind scope, table.table_name, reflection.type, value, tracker
+          scope    = scope.where(table[reflection.type].eq(bind_val))
+        end
+
+        scope = scope.joins(join(foreign_table, constraint))
+      end
+
       def add_constraints(scope, owner, assoc_klass, refl, tracker)
         chain = refl.chain
         scope_chain = refl.scope_chain
 
         tables = construct_tables(chain, assoc_klass, refl, tracker)
 
+        reflection = chain.last
+        table = tables.last
+        scope = last_chain_scope(scope, table, reflection, owner, tracker, assoc_klass)
+
         chain.each_with_index do |reflection, i|
           table, foreign_table = tables.shift, tables.first
 
-          join_keys = reflection.join_keys(assoc_klass)
-          key = join_keys.key
-          foreign_key = join_keys.foreign_key
-
-          if reflection == chain.last
-            bind_val = bind scope, table.table_name, key.to_s, owner[foreign_key], tracker
-            scope    = scope.where(table[key].eq(bind_val))
-
-            if reflection.type
-              value    = owner.class.base_class.name
-              bind_val = bind scope, table.table_name, reflection.type, value, tracker
-              scope    = scope.where(table[reflection.type].eq(bind_val))
-            end
-          else
-            constraint = table[key].eq(foreign_table[foreign_key])
-
-            if reflection.type
-              value    = chain[i + 1].klass.base_class.name
-              bind_val = bind scope, table.table_name, reflection.type, value, tracker
-              scope    = scope.where(table[reflection.type].eq(bind_val))
-            end
-
-            scope = scope.joins(join(foreign_table, constraint))
+          unless reflection == chain.last
+            next_reflection = chain[i + 1]
+            scope = next_chain_scope(scope, table, reflection, chain, tracker, assoc_klass, foreign_table, next_reflection)
           end
 
           is_first_chain = i == 0


### PR DESCRIPTION
This refactoring breaks the conditional inside the loop in `add_constraints` into two separate methods to better see their purpose. Eventually @tenderlove and I intend to remove the need for these separated methods altogether.

The changes allowed us to move the `last_chain_scope` method call outside the loop. `get_bind_values` must match this section of `add_constraints` because of how the bind value caching works. Then the code was refactored to use `each_cons` instead of `chain[i + 1]` in `get_bind_values`. The use of `each_cons` makes it clear we need to get the `next_reflection`.

There is more work that needs to be done before `chain[i + 1]` can be removed from `next_chain_scope/add_constraints`. 

I'm open to be names for `last_chain_scope` and `next_chain_scope` if anyone has better ideas :smile_cat: 

As mentioned in previous PR's this is part of a larger refactoring to make `add_constraints` a clearer, DRYer method.
