### PR TITLE
Fix for configuring rails guide

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -112,7 +112,7 @@ numbers. New applications filter out passwords by adding the following `config.f
 
 * `config.log_tags` accepts a list of methods that the `request` object responds to. This makes it easy to tag log lines with debug information like subdomain and request id - both very helpful in debugging multi-user production applications.
 
-* `config.logger` accepts a logger conforming to the interface of Log4r or the default Ruby `Logger` class. Defaults to an instance of `ActiveSupport::Logger`, with auto flushing off in production mode.
+* `config.logger` accepts a logger conforming to the interface of Log4r or the default Ruby `Logger` class. Defaults to an instance of `ActiveSupport::Logger`.
 
 * `config.middleware` allows you to configure the application's middleware. This is covered in depth in the [Configuring Middleware](#configuring-middleware) section below.
 


### PR DESCRIPTION
`ActiveSupport::Logger` has no concept like auto flushing since it has no userspace buffering.
It's a remnant of `ActiveSupport::BufferedLogger` epoch which was since removed from rails.
