### PR TITLE
Time#change throws exception with an out-of-range :usec

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Make Time#change throw an exception if the :usec option is out of range and
+    the time has an offset other than UTC or local.
+
+    *Agis Anastasopoulos*
+
 *   `Method` objects now report themselves as not `duplicable?`. This allows
     hashes and arrays containing `Method` objects to be `deep_dup`ed.
 

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -87,6 +87,7 @@ class Time
     elsif zone
       ::Time.local(new_year, new_month, new_day, new_hour, new_min, new_sec, new_usec)
     else
+      raise ArgumentError, 'argument out of range' if new_usec > 999999
       ::Time.new(new_year, new_month, new_day, new_hour, new_min, new_sec + (new_usec.to_r / 1000000), utc_offset)
     end
   end

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -405,6 +405,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.new(2005,2,22,16,0,0,"-08:00"),   Time.new(2005,2,22,15,15,10,"-08:00").change(:hour => 16)
     assert_equal Time.new(2005,2,22,16,45,0,"-08:00"),  Time.new(2005,2,22,15,15,10,"-08:00").change(:hour => 16, :min => 45)
     assert_equal Time.new(2005,2,22,15,45,0,"-08:00"),  Time.new(2005,2,22,15,15,10,"-08:00").change(:min => 45)
+    assert_raise(ArgumentError) { Time.new(2005, 2, 22, 15, 15, 45, "-08:00").change(:usec => 1000000) }
   end
 
   def test_advance


### PR DESCRIPTION
https://github.com/rails/rails/commit/98b46bf5e201307cae56ee14bf41363a539779c5 didn't properly handled cases where `:usec` was out of range.

Passing a `:usec` that's out of range now throws an `ArgumentError` as it should.

Fixes #16759.
