### PR TITLE
Add and Remove string/strip require

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/string/strip'
+
 module ActiveRecord
   module ConnectionAdapters
     class AbstractAdapter

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -2,7 +2,6 @@ require 'date'
 require 'set'
 require 'bigdecimal'
 require 'bigdecimal/util'
-require 'active_support/core_ext/string/strip'
 
 module ActiveRecord
   module ConnectionAdapters #:nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -1,4 +1,5 @@
 require 'arel/visitors/bind_visitor'
+require 'active_support/core_ext/string/strip'
 
 module ActiveRecord
   module ConnectionAdapters


### PR DESCRIPTION
Method .strip_heredoc is defined in
active_support/core_ext/string/strip.rb so we need to require it.

[fixes #16677]
review @chancancode @codeodor @robin850
