### PR TITLE
Convert enum values in read attribute

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -120,7 +120,7 @@ module ActiveRecord
 
             # def active?() status == 0 end
             klass.send(:detect_enum_conflict!, name, "#{value}?")
-            define_method("#{value}?") { self[name] == i }
+            define_method("#{value}?") { self[name] == value.to_s }
 
             # def active!() update! status: :active end
             klass.send(:detect_enum_conflict!, name, "#{value}!")
@@ -133,21 +133,33 @@ module ActiveRecord
         end
         defined_enums[name.to_s] = enum_values
       end
-      # Convert the enums in read_attribute
-      define_method(:read_attribute) do |attr_name|
-        attr_name = attr_name.to_s
-        read_attribute = super(attr_name)
-        if defined_enums.keys.include?(attr_name)
-          read_attribute = defined_enums[attr_name].key(read_attribute)
-        end
-        read_attribute
-      end
     end
 
     private
       def _enum_methods_module
         @_enum_methods_module ||= begin
           mod = Module.new do
+            def read_attribute(attr_name)
+              attr_name = attr_name.to_s
+              read_attribute = super(attr_name)
+              if defined_enums.keys.include?(attr_name)
+                if defined_enums[attr_name].has_value?(read_attribute)
+                  read_attribute = defined_enums[attr_name].key(read_attribute)
+                end
+              end
+              read_attribute
+            end
+
+            def attributes
+              attributes = super()
+              defined_enums.each do |name, values|
+                if attributes.has_key? name
+                  attributes[name] = values.key(attributes[name])
+                end
+              end
+              attributes
+            end
+
             private
               def save_changed_attribute(attr_name, old)
                 if (mapping = self.class.defined_enums[attr_name.to_s])

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -108,11 +108,11 @@ module ActiveRecord
 
           # def status() statuses.key self[:status] end
           klass.send(:detect_enum_conflict!, name, name)
-          define_method(name) { enum_values.key self[name] }
+          define_method(name) { self[name] }
 
           # def status_before_type_cast() statuses.key self[:status] end
           klass.send(:detect_enum_conflict!, name, "#{name}_before_type_cast")
-          define_method("#{name}_before_type_cast") { enum_values.key self[name] }
+          define_method("#{name}_before_type_cast") { self[name] }
 
           pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
           pairs.each do |value, i|
@@ -135,8 +135,9 @@ module ActiveRecord
       end
       # Convert the enums in read_attribute
       define_method(:read_attribute) do |attr_name|
+        attr_name = attr_name.to_s
         read_attribute = super(attr_name)
-        if defined_enums.include?(attr_name)
+        if defined_enums.keys.include?(attr_name)
           read_attribute = defined_enums[attr_name].key(read_attribute)
         end
         read_attribute

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -133,6 +133,14 @@ module ActiveRecord
         end
         defined_enums[name.to_s] = enum_values
       end
+      # Convert the enums in read_attribute
+      define_method(:read_attribute) do |attr_name|
+        read_attribute = super(attr_name)
+        if defined_enums.include?(attr_name)
+          read_attribute = defined_enums[attr_name].key(read_attribute)
+        end
+        read_attribute
+      end
     end
 
     private

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -291,5 +291,6 @@ class EnumTest < ActiveRecord::TestCase
   test "read attribute returns enum label" do
     assert_equal "proposed", @book.attributes["status"]
     assert_equal "proposed", @book["status"]
+    assert_equal "proposed", @book.status
   end
 end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -287,4 +287,9 @@ class EnumTest < ActiveRecord::TestCase
     book2.status = :uploaded
     assert_equal ['drafted', 'uploaded'], book2.status_change
   end
+
+  test "read attribute returns enum label" do
+    assert_equal "proposed", @book.attributes["status"]
+    assert_equal "proposed", @book["status"]
+  end
 end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -286,4 +286,9 @@ class EnumTest < ActiveRecord::TestCase
     book2.status = :uploaded
     assert_equal ['drafted', 'uploaded'], book2.status_change
   end
+
+  test "read attribute returns enum label" do
+    assert_equal "proposed", @book.attributes["status"]
+    assert_equal "proposed", @book["status"]
+  end
 end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -290,5 +290,6 @@ class EnumTest < ActiveRecord::TestCase
   test "read attribute returns enum label" do
     assert_equal "proposed", @book.attributes["status"]
     assert_equal "proposed", @book["status"]
+    assert_equal "proposed", @book.status
   end
 end


### PR DESCRIPTION
Fix for issue #16459 and issue #14017 
class Post < ActiveRecord::Base
  enum status: [:live, :inactive, :deleted]
end

post = Post.new(:status => :live)
post.status # => "live"

The following are some of the changes after fix
# Before:

<code>post.attributes = {"id"=>1, "post"=>nil, "status"=> 0}</code>
# After :

<code>post.attributes = {"id"=>1, "post"=>nil, "status"=> "live"}</code>
# Before:

<code>post[:status] = 0</code>
# After :

<code>post[:status] = "live"</code>
# Before:

<code>post["status"] = 0</code>
# After :

<code>post["status"] = "live"</code>
# Before:

<code>Post.first => Post id: 1, post: nil, status: 0,created_at: "2014-09-05 18:22:20", updated_at: "2014-09-05 18:22:20"</code>
# After:

<code>Post.first => Post id: 1, post: nil, status: "live" ,created_at: "2014-09-05 18:22:20", updated_at: "2014-09-05 18:22:20"</code>
