### PR TITLE
Clarify Rails uses erubis not stdlin ERB. [ci skip]

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -11,7 +11,8 @@ module ActionView #:nodoc:
   # = Action View Base
   #
   # Action View templates can be written in several ways. If the template file has a <tt>.erb</tt> extension then it uses a mixture of ERB
-  # (included in Ruby) and HTML. If the template file has a <tt>.builder</tt> extension then Jim Weirich's Builder::XmlMarkup library is used.
+  # (not the one the Ruby stdlib, but the erubis[https://rubygems.org/gems/erubis] implementation) and HTML.
+  # If the template file has a <tt>.builder</tt> extension then Jim Weirich's Builder::XmlMarkup library is used.
   #
   # == ERB
   #


### PR DESCRIPTION
https://github.com/rails/rails/issues/16766#issuecomment-54148778 tells me Rails uses erubis, not the stdlib ERB.

In the erubis doc, I could not find it explicitly written that it is equivalent to ERB, or ERB with some options.

As it stands, the behavior is different from ERB without options, e.g.:
- no `-` without `trim_mode='-'`
- and no auto line removal without `trim_mode='<>'`

both of which erubis and Rails do by default.

So we should say that in the docs.
