### PR TITLE
Remove 'if exists' from drop table statement then use `table_exists?`

### DIFF
--- a/activerecord/test/cases/associations/required_test.rb
+++ b/activerecord/test/cases/associations/required_test.rb
@@ -18,8 +18,8 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.execute("DROP TABLE IF EXISTS parents")
-    @connection.execute("DROP TABLE IF EXISTS children")
+    @connection.execute("DROP TABLE parents") if @connection.table_exists? 'parents'
+    @connection.execute("DROP TABLE children") if @connection.table_exists? 'children'
   end
 
   test "belongs_to associations are not required by default" do

--- a/activerecord/test/cases/attribute_decorators_test.rb
+++ b/activerecord/test/cases/attribute_decorators_test.rb
@@ -28,7 +28,7 @@ module ActiveRecord
 
     teardown do
       return unless @connection
-      @connection.execute 'DROP TABLE IF EXISTS attribute_decorators_model'
+      @connection.execute 'DROP TABLE attribute_decorators_model' if @connection.table_exists? 'attribute_decorators_model'
       Model.attribute_type_decorations.clear
       Model.reset_column_information
     end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -29,8 +29,8 @@ module ActiveRecord
 
       teardown do
         if defined?(@connection)
-          @connection.execute "DROP TABLE IF EXISTS astronauts"
-          @connection.execute "DROP TABLE IF EXISTS rockets"
+          @connection.execute "DROP TABLE astronauts" if @connection.table_exists? 'astronauts' 
+          @connection.execute "DROP TABLE rockets" if @connection.table_exists? 'rockets'
         end
       end
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -441,7 +441,7 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
 
   teardown do
     return unless @connection
-    @connection.execute 'DROP TABLE IF EXISTS defaults'
+    @connection.execute 'DROP TABLE defaults' if @connection.table_exists? 'defaults'
   end
 
   def test_schema_dump_defaults_with_universally_supported_types


### PR DESCRIPTION
This pull request addresses `ActiveRecord::StatementInvalid: OCIError: ORA-00933: SQL command not properly ended` errors with Oracle database. Since Oracle database does not support 'drop table if exists' statement.

One of current test case output is here:

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/attribute_decorators_test.rb -n test_attributes_can_be_decorated
Using oracle
Run options: -n test_attributes_can_be_decorated --seed 63611

# Running:

E

Finished in 0.138139s, 7.2391 runs/s, 14.4781 assertions/s.

  1) Error:
ActiveRecord::AttributeDecoratorsTest#test_attributes_can_be_decorated:
ActiveRecord::StatementInvalid: OCIError: ORA-00933: SQL command not properly ended: DROP TABLE IF EXISTS attribute_decorators_model
    stmt.c:230:in oci8lib_210.so
    /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/ruby-oci8-2.1.7/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/ruby-oci8-2.1.7/lib/oci8/oci8.rb:278:in `exec_internal'
    /home/yahonda/.rvm/gems/ruby-2.1.2@rails42/gems/ruby-oci8-2.1.7/lib/oci8/oci8.rb:269:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:429:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:10:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:458:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:452:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1270:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:10:in `execute'
    test/cases/attribute_decorators_test.rb:31:in `block in <class:AttributeDecoratorsTest>'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:438:in `instance_exec'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:438:in `block in make_lambda'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:257:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:257:in `block in simple'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:87:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:87:in `run_callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:45:in `after_teardown'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:820:in `after_teardown'

1 runs, 2 assertions, 0 failures, 1 errors, 0 skips
$
```

I understand `if exists` is much simpler and supported by SQLite, PostgreSQL and MySQL, I'd like to execute Rails unit tests with Oracle database to keep support compatibility with Rails. I tested this commit does not cause regressions with sqlite, mysql, mysql2 and postgresql adapters.
