### PR TITLE
WIP - disallow reverse_order when the argument is string.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Donot allow the string values in the `reverse_order`. Use #reorder or pass in the hash
+    values.
+
+    Fixes: #8225, #7423 and #11571
+
+    *Aditya Kapoor*
+
 *   MySQL: set the connection collation along with the charset.
 
     Sets the connection collation to the database collation configured in

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1058,19 +1058,21 @@ module ActiveRecord
     end
 
     def reverse_sql_order(order_query)
-      order_query = ["#{quoted_table_name}.#{quoted_primary_key} ASC"] if order_query.empty?
+      order_query = "#{quoted_table_name}.#{quoted_primary_key} ASC" if order_query.empty?
 
-      order_query.flat_map do |o|
-        case o
-        when Arel::Nodes::Ordering
-          o.reverse
-        when String
-          o.to_s.split(',').map! do |s|
-            s.strip!
-            s.gsub!(/\sasc\Z/i, ' DESC') || s.gsub!(/\sdesc\Z/i, ' ASC') || s.concat(' DESC')
+      case order_query
+      when String
+        Array(order_query)
+      when Array
+        order_query.flat_map do |o|
+          case o
+          when Arel::Nodes::Ordering
+            o.reverse
+          when String
+            raise ArgumentError, "String arguments are not allowed for reverse_order. Use #reorder instead."
+          else
+            o
           end
-        else
-          o
         end
       end
     end

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -112,7 +112,7 @@ module ActiveRecord
     end
 
     test 'reverse_order!' do
-      relation = Post.order('title ASC, comments_count DESC')
+      relation = Post.order(title: :asc, comments_count: :desc)
 
       relation.reverse_order!
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -185,13 +185,13 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_finding_with_reverted_assoc_order
-    topics = Topic.order(:id => :asc).reverse_order
+    topics = Topic.order(id: :asc).reverse_order
     assert_equal 5, topics.to_a.size
     assert_equal topics(:fifth).title, topics.first.title
   end
 
   def test_order_with_hash_and_symbol_generates_the_same_sql
-    assert_equal Topic.order(:id).to_sql, Topic.order(:id => :asc).to_sql
+    assert_equal Topic.order(:id).to_sql, Topic.order(id: :asc).to_sql
   end
 
   def test_finding_with_desc_order_with_string

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -176,19 +176,19 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_order_to_unscope_reordering
-    scope = DeveloperOrderedBySalary.order('salary DESC, name ASC').reverse_order.unscope(:order)
+    scope = DeveloperOrderedBySalary.order(salary: :desc, name: :asc).reverse_order.unscope(:order)
     assert !(scope.to_sql =~ /order/i)
   end
 
   def test_unscope_reverse_order
     expected = Developer.all.collect { |dev| dev.name }
-    received = Developer.order('salary DESC').reverse_order.unscope(:order).collect { |dev| dev.name }
+    received = Developer.order(salary: :desc).reverse_order.unscope(:order).collect { |dev| dev.name }
     assert_equal expected, received
   end
 
   def test_unscope_select
     expected = Developer.order('salary ASC').collect { |dev| dev.name }
-    received = Developer.order('salary DESC').reverse_order.select(:name).unscope(:select).collect { |dev| dev.name }
+    received = Developer.order(salary: :desc).reverse_order.select(:name).unscope(:select).collect { |dev| dev.name }
     assert_equal expected, received
 
     expected_2 = Developer.all.collect { |dev| dev.id }
@@ -240,7 +240,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
     end
 
     assert_raises(ArgumentError) do
-      Developer.order('name DESC').reverse_order.unscope(:reverse_order)
+      Developer.order(name: :desc).reverse_order.unscope(:reverse_order)
     end
 
     assert_raises(ArgumentError) do

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -475,10 +475,10 @@ class NamedScopingTest < ActiveRecord::TestCase
 
   def test_scopes_to_get_newest
     post = posts(:welcome)
-    old_last_comment = post.comments.newest
+    old_last_comment = post.comments.find_most_recent
     new_comment = post.comments.create(:body => "My new comment")
-    assert_equal new_comment, post.comments.newest
-    assert_not_equal old_last_comment, post.comments.newest
+    assert_equal new_comment, post.comments.find_most_recent
+    assert_not_equal old_last_comment, post.comments.find_most_recent
   end
 
   def test_scopes_are_reset_on_association_reload

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -15,24 +15,36 @@ class RelationScopingTest < ActiveRecord::TestCase
     developers(:david)
   end
 
+  def test_reverse_order_with_string
+    assert_raise ArgumentError do
+      Developer.order("id DESC").reverse_order
+    end
+  end
+
+  def test_reverse_order_with_hash
+    assert_nothing_raised do
+      Developer.order(id: :desc).reverse_order
+    end
+  end
+
   def test_reverse_order
-    assert_equal Developer.order("id DESC").to_a.reverse, Developer.order("id DESC").reverse_order
+    assert_equal Developer.order(id: :desc).to_a.reverse, Developer.order(id: :desc).reverse_order
   end
 
   def test_reverse_order_with_arel_node
-    assert_equal Developer.order("id DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).reverse_order
+    assert_equal Developer.order(id: :desc).to_a.reverse, Developer.order(Developer.arel_table[:id].desc).reverse_order
   end
 
   def test_reverse_order_with_multiple_arel_nodes
-    assert_equal Developer.order("id DESC").order("name DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).order(Developer.arel_table[:name].desc).reverse_order
+    assert_equal Developer.order(id: :desc).order(name: :desc).to_a.reverse, Developer.order(Developer.arel_table[:id].desc).order(Developer.arel_table[:name].desc).reverse_order
   end
 
   def test_reverse_order_with_arel_nodes_and_strings
-    assert_equal Developer.order("id DESC").order("name DESC").to_a.reverse, Developer.order("id DESC").order(Developer.arel_table[:name].desc).reverse_order
+    assert_equal Developer.order(id: :desc).order(name: :desc).to_a.reverse, Developer.order(id: :desc).order(Developer.arel_table[:name].desc).reverse_order
   end
 
   def test_double_reverse_order_produces_original_order
-    assert_equal Developer.order("name DESC"), Developer.order("name DESC").reverse_order.reverse_order
+    assert_equal Developer.order(name: :desc), Developer.order(name: :desc).reverse_order.reverse_order
   end
 
   def test_scoped_find
@@ -44,14 +56,14 @@ class RelationScopingTest < ActiveRecord::TestCase
   def test_scoped_find_first
     developer = Developer.find(10)
     Developer.where("salary = 100000").scoping do
-      assert_equal developer, Developer.order("name").first
+      assert_equal developer, Developer.order(:name).first
     end
   end
 
   def test_scoped_find_last
-    highest_salary = Developer.order("salary DESC").first
+    highest_salary = Developer.order(salary: :desc).first
 
-    Developer.order("salary").scoping do
+    Developer.order(:salary).scoping do
       assert_equal highest_salary, Developer.last
     end
   end
@@ -60,7 +72,7 @@ class RelationScopingTest < ActiveRecord::TestCase
     lowest_salary  = Developer.order("salary ASC").first
     highest_salary = Developer.order("salary DESC").first
 
-    Developer.order("salary").scoping do
+    Developer.order(:salary).scoping do
       assert_equal highest_salary, Developer.last
       assert_equal lowest_salary, Developer.first
     end


### PR DESCRIPTION
- [ ] Fix existing tests
- [x] Add new tests for new behavior.

Fixes #8225, #7432 and #11571

cc @rafaelfranca 
