### PR TITLE
use correct operator in query based on JSON document

### DIFF
--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -132,7 +132,8 @@ event = Event.first
 event.payload # => {"kind"=>"user_renamed", "change"=>["jack", "john"]}
 
 ## Query based on JSON document
-Event.where("payload->'kind' = ?", "user_renamed")
+# The -> operator returns the original JSON type (which might be an object), whereas ->> returns text
+Event.where("payload->>'kind' = ?", "user_renamed")
 ```
 
 ### Range Types


### PR DESCRIPTION
-- Brings out the difference between using '->' and '->>' in query based on JSON document
-- In the prescribed example a JSON object is being compared to a string
(raises error:    PG::UndefinedFunction: ERROR:  operator does not exist)
-- we can make use of '->>' to make sure that a string is returned
