### PR TITLE
Move column option handling to new_column_definition

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -326,7 +326,6 @@ module ActiveRecord
         end
 
         column.limit       = limit
-        column.array       = options[:array] if column.respond_to?(:array)
         column.precision   = options[:precision]
         column.scale       = options[:scale]
         column.default     = options[:default]

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -131,12 +131,10 @@ module ActiveRecord
           column name, type, options
         end
 
-        def column(name, type = nil, options = {})
-          super
-          column = self[name]
+        def new_column_definition(name, type, options) # :nodoc:
+          column = super
           column.array = options[:array]
-
-          self
+          column
         end
 
         private


### PR DESCRIPTION
TableDefinition#column is not called from `add_column`.
Use TableDefinition#new_column_definition for column option handling.
