### PR TITLE
Fix for double ActiveJob::DeserializationErorr

### DIFF
--- a/activejob/test/cases/rescue_test.rb
+++ b/activejob/test/cases/rescue_test.rb
@@ -28,4 +28,9 @@ class RescueTest < ActiveSupport::TestCase
     assert_includes JobBuffer.values, 'DeserializationError original exception was Person::RecordNotFound'
     assert_not_includes JobBuffer.values, 'performed beautifully'
   end
+
+  test "should not wrap DeserializationError in DeserializationError" do
+    RescueJob.enqueue [Person.new(404)]
+    assert_includes JobBuffer.values, 'DeserializationError original exception was Person::RecordNotFound'
+  end
 end


### PR DESCRIPTION
If an argument that cannot be serialized is not in the first level of arguments (it's in an array or hash) the error is double wrapped inside DeserializationError. Example:

``` ruby
# enqueueing the Person object from the AJ testing wrapped in an array
RescueJob.enqueue [Person.new(404)]
# will raise 

> puts e.inspect
#<ActiveJob::DeserializationError: Error while trying to deserialize arguments: Error while trying to deserialize arguments: Cannot find person with ID=404>

> puts e.class.name
ActiveJob::DeserializationError

> puts e.original_exception.class.name
ActiveJob::DeserializationError

> puts e.original_exception.original_exception.class.name
Person::RecordNotFound
```
