### PR TITLE
Only add Web Console on MRI

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -34,7 +34,7 @@ group :development, :test do
   <%- end -%>
 
   # Access an IRB console on exception pages or by using <%%= console %> in views
-  gem 'web-console', github: 'rails/web-console', branch: 'master'
+  gem 'web-console', github: 'rails/web-console', branch: 'master', platform: :mri
 <%- if spring_install? %>
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'


### PR DESCRIPTION
Web Console has been tested only on MRI. Doesn't work on JRuby, windows.
And may/may not work on Rubinius. So no point in shipping broken features

Fixes #16783
