### PR TITLE
Skip StatementCache for eager loaded associations

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -407,7 +407,7 @@ module ActiveRecord
 
       private
       def get_records
-        return scope.to_a if reflection.scope_chain.any?(&:any?)
+        return scope.to_a if reflection.scope_chain.any?(&:any?) || scope.eager_loading?
 
         conn = klass.connection
         sc = reflection.association_scope_cache(conn, owner) do

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -39,7 +39,7 @@ module ActiveRecord
         end
 
         def get_records
-          return scope.limit(1).to_a if reflection.scope_chain.any?(&:any?)
+          return scope.limit(1).to_a if reflection.scope_chain.any?(&:any?) || scope.eager_loading?
 
           conn = klass.connection
           sc = reflection.association_scope_cache(conn, owner) do

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -152,6 +152,7 @@ module ActiveRecord
 
       def find_by(*args)
         return super if current_scope || !(Hash === args.first) || reflect_on_all_aggregations.any?
+        return super if default_scopes.any?
 
         hash = args.first
 

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -1,9 +1,10 @@
 require 'cases/helper'
 require 'models/post'
+require 'models/comment'
 require 'models/developer'
 
 class DefaultScopingTest < ActiveRecord::TestCase
-  fixtures :developers, :posts
+  fixtures :developers, :posts, :comments
 
   def test_default_scope
     expected = Developer.all.merge!(:order => 'salary DESC').to_a.collect { |dev| dev.salary }
@@ -376,6 +377,24 @@ class DefaultScopingTest < ActiveRecord::TestCase
     d.audit_logs.create! :message => 'foo'
 
     assert_equal 1, DeveloperWithIncludes.where(:audit_logs => { :message => 'foo' }).count
+  end
+
+  def test_default_scope_with_references_works_through_collection_association
+    post = PostWithCommentWithDefaultScopeReferencesAssociation.create!(title: "Hello World", body: "Here we go.")
+    comment = post.comment_with_default_scope_references_associations.create!(body: "Great post.", developer_id: Developer.first.id)
+    assert_equal comment, post.comment_with_default_scope_references_associations.to_a.first
+  end
+
+  def test_default_scope_with_references_works_through_association
+    post = PostWithCommentWithDefaultScopeReferencesAssociation.create!(title: "Hello World", body: "Here we go.")
+    comment = post.comment_with_default_scope_references_associations.create!(body: "Great post.", developer_id: Developer.first.id)
+    assert_equal comment, post.first_comment
+  end
+
+  def test_default_scope_with_references_works_with_find_by
+    post = PostWithCommentWithDefaultScopeReferencesAssociation.create!(title: "Hello World", body: "Here we go.")
+    comment = post.comment_with_default_scope_references_associations.create!(body: "Great post.", developer_id: Developer.first.id)
+    assert_equal comment, CommentWithDefaultScopeReferencesAssociation.find_by(id: comment.id)
   end
 
   unless in_memory_db?

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -52,3 +52,8 @@ class CommentThatAutomaticallyAltersPostBody < Comment
     comment.post.update_attributes(body: "Automatically altered")
   end
 end
+
+class CommentWithDefaultScopeReferencesAssociation < Comment
+  default_scope ->{ includes(:developer).order('developers.name').references(:developer) }
+  belongs_to :developer
+end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -218,3 +218,9 @@ class PostThatLoadsCommentsInAnAfterSaveHook < ActiveRecord::Base
     post.comments.load
   end
 end
+
+class PostWithCommentWithDefaultScopeReferencesAssociation < ActiveRecord::Base
+  self.table_name = 'posts'
+  has_many :comment_with_default_scope_references_associations, foreign_key: :post_id
+  has_one :first_comment, class_name: "CommentWithDefaultScopeReferencesAssociation", foreign_key: :post_id
+end


### PR DESCRIPTION
(Fixes #16761)

Eagerly loaded singular and collection associations are ignored by the StatementCache, which causes errors when the queries they generate reference columns that were not eagerly loaded.

This commit skips the creation of the StatementCache as a fix for these scenarios.
