### PR TITLE
Explain ERB space removal.

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -33,7 +33,9 @@ module ActionView #:nodoc:
   #
   # If you absolutely must write from within a function use +concat+.
   #
-  # <%- and -%> suppress leading and trailing whitespace, including the trailing newline, and can be used interchangeably with <% and %>.
+  # When on a line that only contains whitespaces except for the tag, <% %> suppress leading and trailing whitespace,
+  # including the trailing newline. <% %> and <%- -%> are the same.
+  # Note however that <%= %> and <%= -%> are different: only the latter removes trailing whitespaces.
   #
   # === Using sub templates
   #


### PR DESCRIPTION
The current phrase about space removal is misleading, and too hard to understand without an example. I propose that we either:
- explain it better
- remove it completely and let people look up erubis docs now that we linked to them at https://github.com/rails/rails/pull/16774

It is misleading because:
- spaces are only removed if the entire line contains only whitespaces
- `-%>` is not interchangeable with `%>` when using the equals sign `<%= %>`.

If you think the new explanation is too long, we can consider removing everything after "The line is not removed when" as that use case is less common: at least the new information won't be ambiguous and will have a clarifying example.
