### PR TITLE
Add support for Rack::ContentLength middleware

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -380,6 +380,10 @@ module ActionDispatch # :nodoc:
       def to_path
         @response.stream.to_path
       end
+
+      def to_ary
+        nil
+      end
     end
 
     def rack_response(status, header)


### PR DESCRIPTION
Currently, Rails is not compatible with `Rack::ContentLength` because `ActionDispatch::Response::RackBody` instances don't respond to `to_ary` and, even though it's not part of the Rack spec, it's how Rack decides if a body has a knowable length. There's some discussion in https://github.com/rack/rack/commit/2b3abc73f3e3a23110f2c8f43458416674130511, which was later reverted leading to #1160. And a little more in https://github.com/rack/rack/commit/94952077baa9cb6a8712064baab51eba6f43adb1. 

IMO, Rack should remove the `to_ary` check. This change provides immediate support and should continue to work if / when Rack does make the change.
