### PR TITLE
Methods are not duplicable.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `Method` objects now report themselves as not `duplicable?`. This allows
+    hashes and arrays containing `Method` objects to be `deep_dup`ed.
+
+    *Peter Jaros*
+
 *   `determine_constant_from_test_name` does no longer shadow `NameError`s
     which happen during constant autoloading.
 

--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -91,3 +91,13 @@ class BigDecimal
     # can't dup, so use superclass implementation
   end
 end
+
+class Method
+  # Methods are not duplicable:
+  #
+  #  method(:puts).duplicable? # => false
+  #  method(:puts).dup         # => TypeError: allocator undefined for Method
+  def duplicable?
+    false
+  end
+end

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -4,7 +4,7 @@ require 'active_support/core_ext/object/duplicable'
 require 'active_support/core_ext/numeric/time'
 
 class DuplicableTest < ActiveSupport::TestCase
-  RAISE_DUP  = [nil, false, true, :symbol, 1, 2.3, 5.seconds]
+  RAISE_DUP  = [nil, false, true, :symbol, 1, 2.3, 5.seconds, method(:puts)]
   ALLOW_DUP = ['1', Object.new, /foo/, [], {}, Time.now, Class.new, Module.new]
 
   # Needed to support Ruby 1.9.x, as it doesn't allow dup on BigDecimal, instead


### PR DESCRIPTION
We (@dalibor and I) ran into an issue trying to `#deep_dup` a Rack env hash. Turns out somewhere in there was a `Method` object, and `Method`s can't be `dup`ed (and don't need to be, since they're immutable). This change lets us `#deep_dup` that hash.
