### PR TITLE
Add support for ARIA attributes in tags

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add support for ARIA attributes in tags.
+
+    Example:
+
+        <%= f.text_field :name, aria: { required: "true", hidden: "false" } %>
+
+    now generates:
+
+         <input aria-hidden="false" aria-required="true" id="user_name" name="user[name]" type="text">
+
+    *Paola Garcia Casadiego*
+
 *   Provide a `builder` object when using the `label` form helper in block form.
 
     The new `builder` object responds to `translation`, allowing I18n fallback support

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -148,9 +148,9 @@ module ActionView
           return if options.blank?
           attrs = []
           options.each_pair do |key, value|
-            if key.to_s == 'data' && value.is_a?(Hash)
+            if (key.to_s == 'data' || key.to_s == 'aria') && value.is_a?(Hash)
               value.each_pair do |k, v|
-                attrs << data_tag_option(k, v, escape)
+                attrs << prefix_tag_option(key, k, v, escape)
               end
             elsif BOOLEAN_ATTRIBUTES.include?(key)
               attrs << boolean_tag_option(key) if value
@@ -161,8 +161,8 @@ module ActionView
           " #{attrs.sort! * ' '}" unless attrs.empty?
         end
 
-        def data_tag_option(key, value, escape)
-          key   = "data-#{key.to_s.dasherize}"
+        def prefix_tag_option(prefix, key, value, escape)
+          key = "#{prefix}-#{key.to_s.dasherize}"
           unless value.is_a?(String) || value.is_a?(Symbol) || value.is_a?(BigDecimal)
             value = value.to_json
           end

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -156,4 +156,11 @@ class TagHelperTest < ActionView::TestCase
         tag('a', { data => { a_float: 3.14, a_big_decimal: BigDecimal.new("-123.456"), a_number: 1, string: 'hello', symbol: :foo, array: [1, 2, 3], hash: { key: 'value'}, string_with_quotes: 'double"quote"party"' } })
     }
   end
+
+  def test_aria_attributes
+    ['aria', :aria].each { |aria|
+      assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-array="[1,2,3]" aria-hash="{&quot;key&quot;:&quot;value&quot;}" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />',
+        tag('a', { aria => { a_float: 3.14, a_big_decimal: BigDecimal.new("-123.456"), a_number: 1, string: 'hello', symbol: :foo, array: [1, 2, 3], hash: { key: 'value'}, string_with_quotes: 'double"quote"party"' } })
+    }
+  end
 end


### PR DESCRIPTION
As part of our work in Rails Girls Summer of Code we have added support for ARIA attributes in tag helpers, so the users can set the attributes in this way:

``` ruby
<%= f.text_field :name, aria: { required: "true", hidden: "false" } %>
```

And this will generate:

``` html
<input aria-hidden="false" aria-required="true" id="user_name" name="user[name]" type="text">
```

We used the implementation of the `data` attributes as base for this.
