### PR TITLE
Add task to display names of European time zones in the TimeZone class

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -254,6 +254,12 @@ module ActiveSupport
       def us_zones
         @us_zones ||= all.find_all { |z| z.name =~ /US|Arizona|Indiana|Hawaii|Alaska/ }
       end
+
+      # A convenience method for returning a collection of TimeZone objects
+      # for time zones in Europe.
+      def europe_zones
+        @europe_zones ||= all.find_all { |z| z.name =~ /London|Berlin|Athens|Minsk|Moscow/ }
+      end
     end
 
     include Comparable

--- a/railties/lib/rails/tasks/misc.rake
+++ b/railties/lib/rails/tasks/misc.rake
@@ -11,7 +11,7 @@ end
 
 namespace :time do
   namespace :zones do
-    desc 'Displays all time zones, also available: time:zones:us, time:zones:local -- filter with OFFSET parameter, e.g., OFFSET=-6'
+    desc 'Displays all time zones, also available: time:zones:us, time:zones:europe, time:zones:local -- filter with OFFSET parameter, e.g., OFFSET=-6'
     task :all do
       build_time_zone_list(:all)
     end
@@ -19,6 +19,11 @@ namespace :time do
     # desc 'Displays names of US time zones recognized by the Rails TimeZone class, grouped by offset. Results can be filtered with optional OFFSET parameter, e.g., OFFSET=-6'
     task :us do
       build_time_zone_list(:us_zones)
+    end
+
+    # desc 'Displays names of European time zones recognized by the Rails TimeZone class, grouped by offset. Results can be filtered with optional OFFSET parameter, e.g., OFFSET=-6'
+    task :europe do
+      build_time_zone_list(:europe_zones)
     end
 
     # desc 'Displays names of time zones recognized by the Rails TimeZone class with the same offset as the system local time'


### PR DESCRIPTION
Adds `rake time:zones:europe` helper task to complement the
existing helper task `rake time:zones:us`. Also updates the description on
`time:zones:all`.
