### PR TITLE
[ci skip] Fix typo in rails guide for routing

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -741,7 +741,7 @@ get '*a/foo/*b', to: 'test#index'
 
 would match `zoo/woo/foo/bar/baz` with `params[:a]` equals `'zoo/woo'`, and `params[:b]` equals `'bar/baz'`.
 
-NOTE: By requesting `'/foo/bar.json'`, your `params[:pages]` will be equals to `'foo/bar'` with the request format of JSON. If you want the old 3.0.x behavior back, you could supply `format: false` like this:
+NOTE: By requesting `'/foo/bar.json'`, your `params[:pages]` will be equal to `'foo/bar'` with the request format of JSON. If you want the old 3.0.x behavior back, you could supply `format: false` like this:
 
 ```ruby
 get '*pages', to: 'pages#show', format: false


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/82835/4145321/a16e9130-33f6-11e4-907e-d0703e54f3c6.png)
