### PR TITLE
Always add lambda to scope chain to eliminate branch in eval_scope

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -188,11 +188,7 @@ module ActiveRecord
       end
 
       def eval_scope(klass, scope, owner)
-        if scope.is_a?(Relation)
-          scope
-        else
-          klass.unscoped.instance_exec(owner, &scope)
-        end
+        klass.unscoped.instance_exec(owner, &scope)
       end
     end
   end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -728,8 +728,11 @@ module ActiveRecord
           through_scope_chain = through_reflection.scope_chain.map(&:dup)
 
           if options[:source_type]
-            through_scope_chain.first <<
-              through_reflection.klass.where(foreign_type => options[:source_type])
+            type = foreign_type
+            source_type = options[:source_type]
+            through_scope_chain.first << lambda { |object|
+              where(type => source_type)
+            }
           end
 
           # Recursively fill out the rest of the array from the through reflection


### PR DESCRIPTION
We convert all other scopes to lambda's so it makes sense that we should always returns a lambda on a ThroughReflection as well. This eliminates the need to check if the scope is a Relation.
