### PR TITLE
Change error message for typo in helper's name

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   When a typo in helper's name is made, controller raises
+    NameError with proper message instead of showing message about circular
+    dependency.
+
+    Fixes #16468.
+
+    *Marcin Nieborak*
+
 *   Improve Journey compliance to RFC 3986.
 
     The scanner in Journey failed to recognize routes that use literals

--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -150,7 +150,11 @@ module AbstractController
             rescue LoadError => e
               raise AbstractController::Helpers::MissingHelperError.new(e, file_name)
             end
-            file_name.camelize.constantize
+            file_name.camelize.tap do |helper_name|
+              unless Object.const_defined?(helper_name)
+                raise NameError, "Couldn't find #{helper_name}, expected it to be defined in app/helpers/#{file_name}.rb"
+              end
+            end.constantize
           when Module
             arg
           else

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -60,6 +60,12 @@ class HelpersPathsController < ActionController::Base
   end
 end
 
+class TypoController < ActionController::Base
+  path = File.expand_path('../../fixtures/bad_helpers', __FILE__)
+  $:.unshift(path)
+  self.helpers_path = path
+end
+
 module LocalAbcHelper
   def a() end
   def b() end
@@ -201,11 +207,15 @@ class HelperTest < ActiveSupport::TestCase
     # fun/pdf_helper.rb
     assert methods.include?(:foobar)
   end
-  
+
   def test_helper_proxy_config
     AllHelpersController.config.my_var = 'smth'
-    
     assert_equal 'smth', AllHelpersController.helpers.config.my_var
+  end
+
+  def test_helper_typo_error_message
+    e = assert_raise(NameError) {TypoController.helper :typo }
+    assert_equal "Couldn't find TypoHelper, expected it to be defined in app/helpers/typo_helper.rb", e.message
   end
 
   private

--- a/actionpack/test/fixtures/bad_helpers/typo_helper.rb
+++ b/actionpack/test/fixtures/bad_helpers/typo_helper.rb
@@ -1,0 +1,2 @@
+module TaipoHelper
+end

--- a/railties/test/application/misspelled_helper_test.rb
+++ b/railties/test/application/misspelled_helper_test.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+require 'isolation/abstract_unit'
+require 'rack/test'
+require 'active_support/json'
+
+module ApplicationTests
+  class MisspelledHelperTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include Rack::Test::Methods
+
+    setup do
+      build_app
+      simple_controller
+
+      app_file 'app/helpers/foo_helper.rb', 'module BarHelper; end'
+
+      boot_rails
+    end
+
+    teardown { teardown_app }
+
+    test "loading a misspelled helper returns a helpful error message" do
+      e = assert_raise(NameError) { get 'foo/index' }
+      assert_equal "Couldn't find FooHelper, expected it to be defined in app/helpers/foo_helper.rb", e.message
+    end
+  end
+end


### PR DESCRIPTION
I've tried to make the error message more helpful, when helper name is misspelled. I created new type of error (MissingHelperModuleError) which is raised when expected constant is not loaded. I'd appreciate any feedback  about my solution.

Fixes #16468
