### PR TITLE
Fix PredicateBuilder::ArrayHandler so that it uses the correct Arel pred...

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -28,6 +28,12 @@
 
     Fixes #16623.
 
+*   Fix PredicateBuilder::ArrayHandler's handling of nested arrays to leverage the correct Arel predicate node.
+
+    Fixes #16580
+
+    *Dan Olson*
+
 *   Fix has_many :through relation merging failing when dynamic conditions are
     passed as a lambda with an arity of one.
 

--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -2,6 +2,7 @@ module ActiveRecord
   class PredicateBuilder
     class ArrayHandler # :nodoc:
       def call(attribute, value)
+        value = value.flatten
         return attribute.in([]) if value.empty?
 
         values = value.map { |x| x.is_a?(Base) ? x.id : x }

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -180,6 +180,16 @@ module ActiveRecord
       assert_equal 0, Post.where(:id => []).count
     end
 
+    def test_where_with_table_name_and_nested_array
+      titles = [
+        "Welcome to the weblog",
+        "So I was thinking"
+      ]
+      assert_sql(/WHERE ["`]posts["`].["`]title["`] IN \('Welcome to the weblog', 'So I was thinking'\)/) do
+        Post.where(:title => [titles]).to_a
+      end
+    end
+
     def test_where_with_table_name_and_nested_empty_array
       assert_equal [], Post.where(:id => [[]]).to_a
     end


### PR DESCRIPTION
...icate when given a nested array

Fixes #16580

PredicateBuilder::ArrayHandler was using the incorrect Arel predicate (Arel::Nodes::Equality) when given a nested array. This fix restores the behavior on 4.1 stable and will utilize Arel::Nodes::In when given a nested array.
