### PR TITLE
Fix query with nested array in Active Record

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix PredicateBuilder::ArrayHandler's handling of nested arrays. Allow
+    quering for array type fields (supporter by PostgreSQL).
+
+    Fixes #16580.
+
+    *Dan Olson*, *Cristian Bica*
+
 *   Schema loading rake tasks (like `db:schema:load` and `db:setup`) maintain
     the database connection to the current environment.
 

--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -2,6 +2,16 @@ module ActiveRecord
   class PredicateBuilder
     class ArrayHandler # :nodoc:
       def call(attribute, value)
+        if value.any? { |member| member.is_a?(Array) }
+          column = attribute.relation.engine.columns_hash[attribute.name]
+          unless column.respond_to?(:array) and column.array == true
+            ActiveSupport::Deprecation.warn "Passing a nested array to Active Record " \
+              "finder methods is deprecated and will be removed. Flatten your array " \
+              "before using it for 'IN' conditions."
+            value = value.flatten
+          end
+        end
+
         return attribute.in([]) if value.empty?
 
         values = value.map { |x| x.is_a?(Base) ? x.id : x }

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -227,6 +227,11 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert_not x.changed?
   end
 
+  def test_find_on_hash
+    x = PgArray.create!(tags: %w(one two))
+    assert_equal x, PgArray.find_by(tags: [%w(one two)])
+  end
+
   def test_mutate_value_in_array
     x = PgArray.create!(hstores: [{ a: 'a' }, { b: 'b' }])
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -521,6 +521,16 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal [1,2,3,5,6,7,8,9], Comment.where(id: [1..2, 3, 5, 6..8, 9]).to_a.map(&:id).sort
   end
 
+  def test_find_on_hash_conditions_with_array_of_integers_and_arrays
+    assert_equal [1,2,3,5,6,7,8,9], Comment.where(id: [[1, 2], 3, 5, [6, [7], 8], 9]).to_a.map(&:id).sort
+  end
+
+  def test_find_on_hash_conditions_with_array_of_integers_and_arrays_is_deprecated
+    assert_deprecated do
+      Comment.where(id: [[1, 2], 3])
+    end
+  end
+
   def test_find_on_multiple_hash_conditions
     assert Topic.where(author_name: "David", title: "The First Topic", replies_count: 1, approved: false).find(1)
     assert_raise(ActiveRecord::RecordNotFound) { Topic.where(author_name: "David", title: "The First Topic", replies_count: 1, approved: true).find(1) }


### PR DESCRIPTION
`User.where(id: [[1,2],3])` was equal to `User.where(id:[1, 2, 3])`
in Rails 4.1.x but because of some refactoring in Arel this stopped
working in 4.2.0. This fixes it in Rails.

[Dan Olson & Cristian Bica]
