### PR TITLE
Deprecate implicit AD::Response splatting and Array conversion

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Deprecate implicit Array conversion for Response objects. It was added
+    (using `#to_ary`) so we could conveniently use implicit splatting:
+
+        status, headers, body = response
+
+    But it also means `response + response` works and `[response].flatten`
+    cascades down to the Rack body. Nonsense behavior. Instead, rely on
+    explicit conversion and splatting with `#to_a`:
+
+        status, header, body = *response
+
+    *Jeremy Kemper*
+
 *   Don't rescue `IPAddr::InvalidAddressError`.
 
     `IPAddr::InvalidAddressError` does not exist in Ruby 1.9.3

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/module/attribute_accessors'
+require 'active_support/deprecation'
 require 'action_dispatch/http/filter_redirect'
 require 'monitor'
 
@@ -274,12 +275,22 @@ module ActionDispatch # :nodoc:
     end
 
     # Turns the Response into a Rack-compatible array of the status, headers,
-    # and body.
+    # and body. Allows explict splatting:
+    #
+    #   status, headers, body = *response
     def to_a
       rack_response @status, @header.to_hash
     end
     alias prepare! to_a
-    alias to_ary   to_a
+
+    # Be super clear that a response object is not an Array. Defining this
+    # would make implicit splatting work, but it also makes adding responses
+    # as arrays work, and "flattening" responses, cascading to the rack body!
+    # Not sensible behavior.
+    def to_ary
+      ActiveSupport::Deprecation.warn 'ActionDispatch::Response#to_ary no longer performs implicit conversion to an Array. Please use response.to_a instead, or a splat like `status, headers, body = *response`'
+      to_a
+    end
 
     # Returns the response cookies, converted to a Hash of (name => value) pairs
     #


### PR DESCRIPTION
Deprecate implicit Array conversion for Response objects. It was added (using `#to_ary`) so we could conveniently use implicit splatting:

``` ruby
status, headers, body = response
```

But it also means `response + response` works and `[response].flatten` cascades down to the Rack body. Nonsense behavior. Instead, rely on explicit conversion and splatting with `#to_a`:

``` ruby
status, header, body = *response
```
