### PR TITLE
[guides] Use `match ..., via: :all` in the custom exceptions app

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1183,9 +1183,9 @@ First define your app own routes to display the errors page.
 * `config/routes.rb`
 
   ```ruby
-  get '/404', to: 'errors#not_found'
-  get '/422', to: 'errors#unprocessable_entity'
-  get '/500', to: 'errors#server_error'
+  match '/404', via: :all, to: 'errors#not_found'
+  match '/422', via: :all, to: 'errors#unprocessable_entity'
+  match '/500', via: :all, to: 'errors#server_error'
   ```
 
 Create the controller and views.


### PR DESCRIPTION
Using `get` results in an unexpected error page (returning empty body) for requests of other HTTP mehtods other than GET. Use `match ..., via:
:all` so the exceptions app can be more stable.
