### PR TITLE
Pass symbol as an argument instead of a block

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -859,7 +859,7 @@ module ActionMailer
       when user_content_type.present?
         user_content_type
       when m.has_attachments?
-        if m.attachments.detect { |a| a.inline? }
+        if m.attachments.detect(&:inline?)
           ["multipart", "related", params]
         else
           ["multipart", "mixed", params]
@@ -914,7 +914,7 @@ module ActionMailer
       if templates.empty?
         raise ActionView::MissingTemplate.new(paths, name, paths, false, 'mailer')
       else
-        templates.uniq { |t| t.formats }.each(&block)
+        templates.uniq(&:formats).each(&block)
       end
     end
 

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -82,7 +82,7 @@ module AbstractController
             # Except for public instance methods of Base and its ancestors
             internal_methods +
             # Be sure to include shadowed public instance methods of this class
-            public_instance_methods(false)).uniq.map { |x| x.to_s } -
+            public_instance_methods(false)).uniq.map(&:to_s) -
             # And always exclude explicitly hidden actions
             hidden_actions.to_a
 

--- a/actionpack/lib/action_controller/metal/testing.rb
+++ b/actionpack/lib/action_controller/metal/testing.rb
@@ -24,7 +24,7 @@ module ActionController
 
     module ClassMethods
       def before_filters
-        _process_action_callbacks.find_all{|x| x.kind == :before}.map{|x| x.name}
+        _process_action_callbacks.find_all{|x| x.kind == :before}.map(&:name)
       end
     end
   end

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/string/starts_ends_with'
 module Mime
   class Mimes < Array
     def symbols
-      @symbols ||= map { |m| m.to_sym }
+      @symbols ||= map(&:to_sym)
     end
 
     %w(<< concat shift unshift push pop []= clear compact! collect!

--- a/actionpack/lib/action_dispatch/journey/nfa/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/nfa/transition_table.rb
@@ -107,7 +107,7 @@ module ActionDispatch
         end
 
         def alphabet
-          inverted.values.flat_map(&:keys).compact.uniq.sort_by { |x| x.to_s }
+          inverted.values.flat_map(&:keys).compact.uniq.sort_by(&:to_s)
         end
 
         # Returns a set of NFA states reachable from some NFA state +s+ in set

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -42,7 +42,7 @@ module ActionDispatch
         end
 
         def names
-          @names ||= spec.grep(Nodes::Symbol).map { |n| n.name }
+          @names ||= spec.grep(Nodes::Symbol).map(&:name)
         end
 
         def required_names
@@ -52,7 +52,7 @@ module ActionDispatch
         def optional_names
           @optional_names ||= spec.grep(Nodes::Group).flat_map { |group|
             group.grep(Nodes::Symbol)
-          }.map { |n| n.name }.uniq
+          }.map(&:name).uniq
         end
 
         class RegexpOffsets < Journey::Visitors::Visitor # :nodoc:

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -60,7 +60,7 @@ module ActionDispatch
       end
 
       def parts
-        @parts ||= segments.map { |n| n.to_sym }
+        @parts ||= segments.map(&:to_sym)
       end
       alias :segment_keys :parts
 
@@ -69,11 +69,11 @@ module ActionDispatch
       end
 
       def optional_parts
-        path.optional_names.map { |n| n.to_sym }
+        path.optional_names.map(&:to_sym)
       end
 
       def required_parts
-        @required_parts ||= path.required_names.map { |n| n.to_sym }
+        @required_parts ||= path.required_names.map(&:to_sym)
       end
 
       def required_default?(key)

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -68,8 +68,8 @@ module ActionDispatch
 
       def visualizer
         tt     = GTG::Builder.new(ast).transition_table
-        groups = partitioned_routes.first.map(&:ast).group_by { |a| a.to_s }
-        asts   = groups.values.map { |v| v.first }
+        groups = partitioned_routes.first.map(&:ast).group_by(&:to_s)
+        asts   = groups.values.map(&:first)
         tt.visualizer(asts)
       end
 

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -114,9 +114,7 @@ module ActionDispatch
       def collect_routes(routes)
         routes.collect do |route|
           RouteWrapper.new(route)
-        end.reject do |route|
-          route.internal?
-        end.collect do |route|
+        end.reject(&:internal?).collect do |route|
           collect_engine_routes(route)
 
           { name:   route.name,

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -543,7 +543,7 @@ module ActionDispatch
         path = conditions.delete :path_info
         ast  = conditions.delete :parsed_path_info
         path = build_path(path, ast, requirements, anchor)
-        conditions = build_conditions(conditions, path.names.map { |x| x.to_sym })
+        conditions = build_conditions(conditions, path.names.map(&:to_sym))
 
         route = @set.add_route(app, path, conditions, defaults, name)
         named_routes[name] = route if name
@@ -605,7 +605,7 @@ module ActionDispatch
           if name == :controller
             value
           elsif value.is_a?(Array)
-            value.map { |v| v.to_param }.join('/')
+            value.map(&:to_param).join('/')
           elsif param = value.to_param
             param
           end

--- a/actionpack/lib/action_dispatch/testing/test_request.rb
+++ b/actionpack/lib/action_dispatch/testing/test_request.rb
@@ -60,7 +60,7 @@ module ActionDispatch
 
     def accept=(mime_types)
       @env.delete('action_dispatch.request.accepts')
-      @env['HTTP_ACCEPT'] = Array(mime_types).collect { |mime_type| mime_type.to_s }.join(",")
+      @env['HTTP_ACCEPT'] = Array(mime_types).collect(&:to_s).join(",")
     end
 
     alias :rack_cookies :cookies

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -53,7 +53,7 @@ I18n.enforce_available_locales = false
 # Register danish language for testing
 I18n.backend.store_translations 'da', {}
 I18n.backend.store_translations 'pt-BR', {}
-ORIGINAL_LOCALES = I18n.available_locales.map {|locale| locale.to_s }.sort
+ORIGINAL_LOCALES = I18n.available_locales.map(&:to_s).sort
 
 FIXTURE_LOAD_PATH = File.join(File.dirname(__FILE__), 'fixtures')
 FIXTURES = Pathname.new(FIXTURE_LOAD_PATH)

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -10,7 +10,7 @@ class ActionController::Base
 
     def before_actions
       filters = _process_action_callbacks.select { |c| c.kind == :before }
-      filters.map! { |c| c.raw_filter }
+      filters.map!(&:raw_filter)
     end
   end
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -884,13 +884,13 @@ class RouteSetTest < ActiveSupport::TestCase
     set.draw { get ':controller/(:action(/:id))' }
     path, extras = set.generate_extras(:controller => "foo", :action => "bar", :id => 15, :this => "hello", :that => "world")
     assert_equal "/foo/bar/15", path
-    assert_equal %w(that this), extras.map { |e| e.to_s }.sort
+    assert_equal %w(that this), extras.map(&:to_s).sort
   end
 
   def test_extra_keys
     set.draw { get ':controller/:action/:id' }
     extras = set.extra_keys(:controller => "foo", :action => "bar", :id => 15, :this => "hello", :that => "world")
-    assert_equal %w(that this), extras.map { |e| e.to_s }.sort
+    assert_equal %w(that this), extras.map(&:to_s).sort
   end
 
   def test_generate_extras_not_first
@@ -900,7 +900,7 @@ class RouteSetTest < ActiveSupport::TestCase
     end
     path, extras = set.generate_extras(:controller => "foo", :action => "bar", :id => 15, :this => "hello", :that => "world")
     assert_equal "/foo/bar/15", path
-    assert_equal %w(that this), extras.map { |e| e.to_s }.sort
+    assert_equal %w(that this), extras.map(&:to_s).sort
   end
 
   def test_generate_not_first
@@ -918,7 +918,7 @@ class RouteSetTest < ActiveSupport::TestCase
       get ':controller/:action/:id'
     end
     extras = set.extra_keys(:controller => "foo", :action => "bar", :id => 15, :this => "hello", :that => "world")
-    assert_equal %w(that this), extras.map { |e| e.to_s }.sort
+    assert_equal %w(that this), extras.map(&:to_s).sort
   end
 
   def test_draw

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -83,7 +83,7 @@ class MimeTypeTest < ActiveSupport::TestCase
   test "parse broken acceptlines" do
     accept = "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/*,,*/*;q=0.5"
     expect = [Mime::HTML, Mime::XML, "image/*", Mime::TEXT, Mime::ALL]
-    assert_equal expect, Mime::Type.parse(accept).collect { |c| c.to_s }
+    assert_equal expect, Mime::Type.parse(accept).collect(&:to_s)
   end
 
   # Accept header send with user HTTP_USER_AGENT: Mozilla/4.0
@@ -91,7 +91,7 @@ class MimeTypeTest < ActiveSupport::TestCase
   test "parse other broken acceptlines" do
     accept = "image/gif, image/x-xbitmap, image/jpeg, image/pjpeg, application/x-shockwave-flash, application/vnd.ms-excel, application/vnd.ms-powerpoint, application/msword,  , pronto/1.00.00, sslvpn/1.00.00.00, */*"
     expect = ['image/gif', 'image/x-xbitmap', 'image/jpeg','image/pjpeg', 'application/x-shockwave-flash', 'application/vnd.ms-excel', 'application/vnd.ms-powerpoint', 'application/msword', 'pronto/1.00.00', 'sslvpn/1.00.00.00', Mime::ALL]
-    assert_equal expect, Mime::Type.parse(accept).collect { |c| c.to_s }
+    assert_equal expect, Mime::Type.parse(accept).collect(&:to_s)
   end
 
   test "custom type" do

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -898,7 +898,7 @@ module ActionView
 
         def translated_date_order
           date_order = I18n.translate(:'date.order', :locale => @options[:locale], :default => [])
-          date_order = date_order.map { |element| element.to_sym }
+          date_order = date_order.map(&:to_sym)
 
           forbidden_elements = date_order - [:year, :month, :day]
           if forbidden_elements.any?

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -351,12 +351,12 @@ module ActionView
         return container if String === container
 
         selected, disabled = extract_selected_and_disabled(selected).map do |r|
-          Array(r).map { |item| item.to_s }
+          Array(r).map(&:to_s)
         end
 
         container.map do |element|
           html_attributes = option_html_attributes(element)
-          text, value = option_text_and_value(element).map { |item| item.to_s }
+          text, value = option_text_and_value(element).map(&:to_s)
 
           html_attributes[:selected] ||= option_value_selected?(value, selected)
           html_attributes[:disabled] ||= disabled && option_value_selected?(value, disabled)

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -18,7 +18,7 @@ module ActionView
                            itemscope allowfullscreen default inert sortable
                            truespeed typemustmatch).to_set
 
-      BOOLEAN_ATTRIBUTES.merge(BOOLEAN_ATTRIBUTES.map {|attribute| attribute.to_sym })
+      BOOLEAN_ATTRIBUTES.merge(BOOLEAN_ATTRIBUTES.map(&:to_sym))
 
       TAG_PREFIXES = ['aria', 'data', :aria, :data].to_set
 

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -262,7 +262,7 @@ module ActionView
       def layout(layout, conditions = {})
         include LayoutConditions unless conditions.empty?
 
-        conditions.each {|k, v| conditions[k] = Array(v).map {|a| a.to_s} }
+        conditions.each {|k, v| conditions[k] = Array(v).map(&:to_s) }
         self._layout_conditions = conditions
 
         self._layout = layout

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -75,7 +75,7 @@ module ActionView
       def sub_template_message
         if @sub_templates
           "Trace of template inclusion: " +
-          @sub_templates.collect { |template| template.inspect }.join(", ")
+          @sub_templates.collect(&:inspect).join(", ")
         else
           ""
         end

--- a/actionview/lib/action_view/template/handlers.rb
+++ b/actionview/lib/action_view/template/handlers.rb
@@ -42,7 +42,7 @@ module ActionView #:nodoc:
       end
 
       def template_handler_extensions
-        @@template_handlers.keys.map {|key| key.to_s }.sort
+        @@template_handlers.keys.map(&:to_s).sort
       end
 
       def registered_template_handler(extension)

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -139,7 +139,7 @@ module ActionView
     # resolver is fresher before returning it.
     def cached(key, path_info, details, locals) #:nodoc:
       name, prefix, partial = path_info
-      locals = locals.map { |x| x.to_s }.sort!
+      locals = locals.map(&:to_s).sort!
 
       if key
         @cache.cache(key, name, prefix, partial, locals) do

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -9,7 +9,7 @@ module ActionView
         self.types = Set.new
 
         def self.register(*t)
-          types.merge(t.map { |type| type.to_s })
+          types.merge(t.map(&:to_s))
         end
 
         register :html, :text, :js, :css,  :xml, :json

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -46,7 +46,7 @@ I18n.enforce_available_locales = false
 # Register danish language for testing
 I18n.backend.store_translations 'da', {}
 I18n.backend.store_translations 'pt-BR', {}
-ORIGINAL_LOCALES = I18n.available_locales.map {|locale| locale.to_s }.sort
+ORIGINAL_LOCALES = I18n.available_locales.map(&:to_s).sort
 
 FIXTURE_LOAD_PATH = File.join(File.dirname(__FILE__), 'fixtures')
 FIXTURES = Pathname.new(FIXTURE_LOAD_PATH)

--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -39,7 +39,7 @@ class ViewLoadPathsTest < ActionController::TestCase
 
   def assert_paths(*paths)
     controller = paths.first.is_a?(Class) ? paths.shift : @controller
-    assert_equal expand(paths), controller.view_paths.map { |p| p.to_s }
+    assert_equal expand(paths), controller.view_paths.map(&:to_s)
   end
 
   def test_template_load_path_was_set_correctly

--- a/actionview/test/template/erb_util_test.rb
+++ b/actionview/test/template/erb_util_test.rb
@@ -84,7 +84,7 @@ class ErbUtilTest < ActiveSupport::TestCase
   end
 
   def test_rest_in_ascii
-    (0..127).to_a.map {|int| int.chr }.each do |chr|
+    (0..127).to_a.map(&:chr).each do |chr|
       next if %('"&<>).include?(chr)
       assert_equal chr, html_escape(chr)
     end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -16,7 +16,7 @@ module RenderTestCases
     I18n.backend.store_translations 'pt-BR', {}
 
     # Ensure original are still the same since we are reindexing view paths
-    assert_equal ORIGINAL_LOCALES, I18n.available_locales.map {|l| l.to_s }.sort
+    assert_equal ORIGINAL_LOCALES, I18n.available_locales.map(&:to_s).sort
   end
 
   def test_render_without_options

--- a/activejob/test/support/delayed_job/delayed/backend/test.rb
+++ b/activejob/test/support/delayed_job/delayed/backend/test.rb
@@ -43,9 +43,7 @@ module Delayed
         end
 
         def self.create(attrs = {})
-          new(attrs).tap do |o|
-            o.save
-          end
+          new(attrs).tap(&:save)
         end
 
         def self.create!(*args); create(*args); end

--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -48,7 +48,7 @@ module SidekiqJobsManager
 
   def can_run?
     begin
-      Sidekiq.redis { |conn| conn.connect }
+      Sidekiq.redis(&:connect)
     rescue
       return false
     end

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -59,7 +59,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
 
   def test_validates_numericality_of_with_integer_only_and_proc_as_value
     Topic.send(:define_method, :allow_only_integers?, lambda { false })
-    Topic.validates_numericality_of :approved, only_integer: Proc.new {|topic| topic.allow_only_integers? }
+    Topic.validates_numericality_of :approved, only_integer: Proc.new(&:allow_only_integers?)
 
     invalid!(NIL + BLANK + JUNK)
     valid!(FLOATS + INTEGERS + BIGDECIMAL + INFINITY)
@@ -130,7 +130,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
 
   def test_validates_numericality_with_proc
     Topic.send(:define_method, :min_approved, lambda { 5 })
-    Topic.validates_numericality_of :approved, greater_than_or_equal_to: Proc.new {|topic| topic.min_approved }
+    Topic.validates_numericality_of :approved, greater_than_or_equal_to: Proc.new(&:min_approved)
 
     invalid!([3, 4])
     valid!([5, 6])

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -282,7 +282,7 @@ class ValidationsTest < ActiveModel::TestCase
       ActiveModel::Validations::FormatValidator,
       ActiveModel::Validations::LengthValidator,
       ActiveModel::Validations::PresenceValidator
-    ], validators.map { |v| v.class }.sort_by { |c| c.to_s }
+    ], validators.map(&:class).sort_by(&:to_s)
   end
 
   def test_list_of_validators_will_be_empty_when_empty

--- a/activerecord/examples/performance.rb
+++ b/activerecord/examples/performance.rb
@@ -39,8 +39,8 @@ class Exhibit < ActiveRecord::Base
     where("notes IS NOT NULL")
   end
 
-  def self.look(exhibits) exhibits.each { |e| e.look } end
-  def self.feel(exhibits) exhibits.each { |e| e.feel } end
+  def self.look(exhibits) exhibits.each(&:look) end
+  def self.feel(exhibits) exhibits.each(&:feel) end
 end
 
 def progress_bar(int); print "." if (int%100).zero? ; end

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -57,7 +57,7 @@ module ActiveRecord
       through_reflection      = reflection.through_reflection
       source_reflection_names = reflection.source_reflection_names
       source_associations     = reflection.through_reflection.klass._reflections.keys
-      super("Could not find the source association(s) #{source_reflection_names.collect{ |a| a.inspect }.to_sentence(:two_words_connector => ' or ', :last_word_connector => ', or ', :locale => :en)} in model #{through_reflection.klass}. Try 'has_many #{reflection.name.inspect}, :through => #{through_reflection.name.inspect}, :source => <name>'. Is it one of #{source_associations.to_sentence(:two_words_connector => ' or ', :last_word_connector => ', or ', :locale => :en)}?")
+      super("Could not find the source association(s) #{source_reflection_names.collect(&:inspect).to_sentence(:two_words_connector => ' or ', :last_word_connector => ', or ', :locale => :en)} in model #{through_reflection.klass}. Try 'has_many #{reflection.name.inspect}, :through => #{through_reflection.name.inspect}, :source => <name>'. Is it one of #{source_associations.to_sentence(:two_words_connector => ' or ', :last_word_connector => ', or ', :locale => :en)}?")
     end
   end
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -62,9 +62,9 @@ module ActiveRecord
       # Implements the ids writer method, e.g. foo.item_ids= for Foo.has_many :items
       def ids_writer(ids)
         pk_type = reflection.primary_key_type
-        ids = Array(ids).reject { |id| id.blank? }
+        ids = Array(ids).reject(&:blank?)
         ids.map! { |i| pk_type.type_cast_from_user(i) }
-        replace(klass.find(ids).index_by { |r| r.id }.values_at(*ids))
+        replace(klass.find(ids).index_by(&:id).values_at(*ids))
       end
 
       def reset
@@ -289,7 +289,7 @@ module ActiveRecord
         elsif !loaded? && !association_scope.group_values.empty?
           load_target.size
         elsif !loaded? && !association_scope.distinct_value && target.is_a?(Array)
-          unsaved_records = target.select { |r| r.new_record? }
+          unsaved_records = target.select(&:new_record?)
           unsaved_records.size + count_records
         else
           count_records
@@ -506,7 +506,7 @@ module ActiveRecord
         def delete_or_destroy(records, method)
           records = records.flatten
           records.each { |record| raise_on_type_mismatch!(record) }
-          existing_records = records.reject { |r| r.new_record? }
+          existing_records = records.reject(&:new_record?)
 
           if existing_records.empty?
             remove_records(existing_records, records, method)
@@ -609,7 +609,7 @@ module ActiveRecord
         # specified, then #find scans the entire collection.
         def find_by_scan(*args)
           expects_array = args.first.kind_of?(Array)
-          ids           = args.flatten.compact.map{ |arg| arg.to_s }.uniq
+          ids           = args.flatten.compact.map(&:to_s).uniq
 
           if ids.size == 1
             id = ids.first

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -161,9 +161,7 @@ module ActiveRecord
             if scope.klass.primary_key
               count = scope.destroy_all.length
             else
-              scope.each do |record|
-                record._run_destroy_callbacks
-              end
+              scope.each(&:_run_destroy_callbacks)
 
               arel = scope.arel
 

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -20,7 +20,7 @@ module ActiveRecord
         end
 
         def columns
-          @tables.flat_map { |t| t.column_aliases }
+          @tables.flat_map(&:column_aliases)
         end
 
         # An array of [column_name, alias] pairs for the table

--- a/activerecord/lib/active_record/associations/preloader/has_many_through.rb
+++ b/activerecord/lib/active_record/associations/preloader/has_many_through.rb
@@ -8,7 +8,7 @@ module ActiveRecord
           records_by_owner = super
 
           if reflection_scope.distinct_value
-            records_by_owner.each_value { |records| records.uniq! }
+            records_by_owner.each_value(&:uniq!)
           end
 
           records_by_owner

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -87,7 +87,7 @@ module ActiveRecord
         end
       end
       unless errors.empty?
-        error_descriptions = errors.map { |ex| ex.message }.join(",")
+        error_descriptions = errors.map(&:message).join(",")
         raise MultiparameterAssignmentErrors.new(errors), "#{errors.size} error(s) on assignment of multiparameter attributes [#{error_descriptions}]"
       end
     end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -263,9 +263,9 @@ module ActiveRecord
         if new_record
           association && association.target
         elsif autosave
-          association.target.find_all { |record| record.changed_for_autosave? }
+          association.target.find_all(&:changed_for_autosave?)
         else
-          association.target.find_all { |record| record.new_record? }
+          association.target.find_all(&:new_record?)
         end
       end
 
@@ -275,7 +275,7 @@ module ActiveRecord
         self.class._reflections.values.any? do |reflection|
           if reflection.options[:autosave]
             association = association_instance_get(reflection.name)
-            association && Array.wrap(association.target).any? { |a| a.changed_for_autosave? }
+            association && Array.wrap(association.target).any?(&:changed_for_autosave?)
           end
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -320,9 +320,7 @@ module ActiveRecord
             checkin conn
             conn.disconnect! if conn.requires_reloading?
           end
-          @connections.delete_if do |conn|
-            conn.requires_reloading?
-          end
+          @connections.delete_if(&:requires_reloading?)
           @available.clear
           @connections.each do |conn|
             @available.add conn

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -781,7 +781,7 @@ module ActiveRecord
         version = version.to_i
         sm_table = quote_table_name(ActiveRecord::Migrator.schema_migrations_table_name)
 
-        migrated = select_values("SELECT version FROM #{sm_table}").map { |v| v.to_i }
+        migrated = select_values("SELECT version FROM #{sm_table}").map(&:to_i)
         paths = migrations_paths.map {|p| "#{p}/[0-9]*_*.rb" }
         versions = Dir[*paths].map do |filename|
           filename.split('/').last.split('_').first.to_i

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -398,7 +398,7 @@ module ActiveRecord
         sql << "LIKE #{quote(like)}" if like
 
         execute_and_free(sql, 'SCHEMA') do |result|
-          result.collect { |field| field.first }
+          result.collect(&:first)
         end
       end
 
@@ -786,7 +786,7 @@ module ActiveRecord
       private
 
       def version
-        @version ||= full_version.scan(/^(\d+)\.(\d+)\.(\d+)/).flatten.map { |v| v.to_i }
+        @version ||= full_version.scan(/^(\d+)\.(\d+)\.(\d+)/).flatten.map(&:to_i)
       end
 
       def mariadb?

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -423,9 +423,7 @@ module ActiveRecord
 
           cols = nil
           if metadata = stmt.result_metadata
-            cols = cache[:cols] ||= metadata.fetch_fields.map { |field|
-              field.name
-            }
+            cols = cache[:cols] ||= metadata.fetch_fields.map(&:name)
             metadata.free
           end
 

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -61,9 +61,7 @@ module ActiveRecord
       end
 
       def size
-        [@columns, @columns_hash, @primary_keys, @tables].map { |x|
-          x.size
-        }.inject :+
+        [@columns, @columns_hash, @primary_keys, @tables].map(&:size).inject :+
       end
 
       # Clear out internal caches for table with +table_name+.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -88,11 +88,11 @@ module ActiveRecord
         include Comparable
 
         def initialize(version_string)
-          @version = version_string.split('.').map { |v| v.to_i }
+          @version = version_string.split('.').map(&:to_i)
         end
 
         def <=>(version_string)
-          @version <=> version_string.split('.').map { |v| v.to_i }
+          @version <=> version_string.split('.').map(&:to_i)
         end
       end
 
@@ -556,7 +556,7 @@ module ActiveRecord
           end
           copy_table_indexes(from, to, options[:rename] || {})
           copy_table_contents(from, to,
-            @definition.columns.map {|column| column.name},
+            @definition.columns.map(&:name),
             options[:rename] || {})
         end
 
@@ -569,7 +569,7 @@ module ActiveRecord
               name = name[1..-1]
             end
 
-            to_column_names = columns(to).map { |c| c.name }
+            to_column_names = columns(to).map(&:name)
             columns = index.columns.map {|c| rename[c] || c }.select do |column|
               to_column_names.include?(column)
             end
@@ -586,7 +586,7 @@ module ActiveRecord
         def copy_table_contents(from, to, columns, rename = {}) #:nodoc:
           column_mappings = Hash[columns.map {|name| [name, name]}]
           rename.each { |a| column_mappings[a.last] = a.first }
-          from_columns = columns(from).collect {|col| col.name}
+          from_columns = columns(from).collect(&:name)
           columns = columns.find_all{|col| from_columns.include?(column_mappings[col])}
           quoted_columns = columns.map { |col| quote_column_name(col) } * ','
 

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -745,7 +745,7 @@ module ActiveRecord
       end
 
       def column_names
-        @column_names ||= @connection.columns(@table_name).collect { |c| c.name }
+        @column_names ||= @connection.columns(@table_name).collect(&:name)
       end
 
       def read_fixture_files(path, model_class)
@@ -868,7 +868,7 @@ module ActiveRecord
           fixture_set_names = Dir["#{fixture_path}/{**,*}/*.{yml}"]
           fixture_set_names.map! { |f| f[(fixture_path.to_s.size + 1)..-5] }
         else
-          fixture_set_names = fixture_set_names.flatten.map { |n| n.to_s }
+          fixture_set_names = fixture_set_names.flatten.map(&:to_s)
         end
 
         self.fixture_table_names |= fixture_set_names
@@ -908,7 +908,7 @@ module ActiveRecord
 
       def uses_transaction(*methods)
         @uses_transaction = [] unless defined?(@uses_transaction)
-        @uses_transaction.concat methods.map { |m| m.to_s }
+        @uses_transaction.concat methods.map(&:to_s)
       end
 
       def uses_transaction?(method)

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -192,7 +192,7 @@ module ActiveRecord
 
       def type_condition(table = arel_table)
         sti_column = table[inheritance_column]
-        sti_names  = ([self] + descendants).map { |model| model.sti_name }
+        sti_names  = ([self] + descendants).map(&:sti_name)
 
         sti_column.in(sti_names)
       end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -647,7 +647,7 @@ module ActiveRecord
     end
 
     def method_missing(method, *arguments, &block)
-      arg_list = arguments.map{ |a| a.inspect } * ', '
+      arg_list = arguments.map(&:inspect) * ', '
 
       say_with_time "#{method}(#{arg_list})" do
         unless @connection.respond_to? :revert

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -257,7 +257,7 @@ module ActiveRecord
 
       # Returns an array of column names as strings.
       def column_names
-        @column_names ||= columns.map { |column| column.name }
+        @column_names ||= columns.map(&:name)
       end
 
       # Returns an array of column objects where the primary id, all columns ending in "_id" or "_count",

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -366,7 +366,7 @@ namespace :railties do
   namespace :install do
     # desc "Copies missing migrations from Railties (e.g. engines). You can specify Railties to use with FROM=railtie1,railtie2"
     task :migrations => :'db:load_config' do
-      to_load = ENV['FROM'].blank? ? :all : ENV['FROM'].split(",").map {|n| n.strip }
+      to_load = ENV['FROM'].blank? ? :all : ENV['FROM'].split(",").map(&:strip)
       railties = {}
       Rails.application.migration_railties.each do |railtie|
         next unless to_load == :all || to_load.include?(railtie.railtie_name)

--- a/activerecord/lib/active_record/readonly_attributes.rb
+++ b/activerecord/lib/active_record/readonly_attributes.rb
@@ -11,7 +11,7 @@ module ActiveRecord
       # Attributes listed as readonly will be used to create a new record but update operations will
       # ignore these fields.
       def attr_readonly(*attributes)
-        self._attr_readonly = Set.new(attributes.map { |a| a.to_s }) + (self._attr_readonly || [])
+        self._attr_readonly = Set.new(attributes.map(&:to_s)) + (self._attr_readonly || [])
       end
 
       # Returns an array of all the attributes that have been specified as readonly.

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -791,7 +791,7 @@ module ActiveRecord
       def source_reflection_name # :nodoc:
         return @source_reflection_name if @source_reflection_name
 
-        names = [name.to_s.singularize, name].collect { |n| n.to_sym }.uniq
+        names = [name.to_s.singularize, name].collect(&:to_sym).uniq
         names = names.find_all { |n|
           through_reflection.klass._reflect_on_association(n)
         }

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -400,7 +400,7 @@ module ActiveRecord
       if conditions
         where(conditions).destroy_all
       else
-        to_a.each {|object| object.destroy }.tap { reset }
+        to_a.each(&:destroy).tap { reset }
       end
     end
 
@@ -644,7 +644,7 @@ module ActiveRecord
         preloader.preload @records, associations
       end
 
-      @records.each { |record| record.readonly! } if readonly_value
+      @records.each(&:readonly!) if readonly_value
 
       @loaded = true
       @records
@@ -666,7 +666,7 @@ module ActiveRecord
       joined_tables += [table.name, table.table_alias]
 
       # always convert table names to downcase as in Oracle quoted table names are in uppercase
-      joined_tables = joined_tables.flatten.compact.map { |t| t.downcase }.uniq
+      joined_tables = joined_tables.flatten.compact.map(&:downcase).uniq
 
       (references_values - joined_tables).any?
     end
@@ -675,7 +675,7 @@ module ActiveRecord
       return [] if string.blank?
       # always convert table names to downcase as in Oracle quoted table names are in uppercase
       # ignore raw_sql_ that is used by Oracle adapter as alias for limit/offset subqueries
-      string.scan(/([a-zA-Z_][.\w]+).?\./).flatten.map{ |s| s.downcase }.uniq - ['raw_sql_']
+      string.scan(/([a-zA-Z_][.\w]+).?\./).flatten.map(&:downcase).uniq - ['raw_sql_']
     end
   end
 end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -415,7 +415,7 @@ module ActiveRecord
     end
 
     def using_limitable_reflections?(reflections)
-      reflections.none? { |r| r.collection? }
+      reflections.none?(&:collection?)
     end
 
     protected

--- a/activerecord/lib/active_record/serialization.rb
+++ b/activerecord/lib/active_record/serialization.rb
@@ -11,7 +11,7 @@ module ActiveRecord #:nodoc:
     def serializable_hash(options = nil)
       options = options.try(:clone) || {}
 
-      options[:except] = Array(options[:except]).map { |n| n.to_s }
+      options[:except] = Array(options[:except]).map(&:to_s)
       options[:except] |= Array(self.class.inheritance_column)
 
       super(options)

--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -79,7 +79,7 @@ module ActiveRecord
       end
 
       def bind(values)
-        bvs = @bind_values.map { |pair| pair.dup }
+        bvs = @bind_values.map(&:dup)
         @indexes.each_with_index { |offset,i| bvs[offset][1] = values[i] }
         bvs
       end

--- a/activerecord/lib/active_record/validations/presence.rb
+++ b/activerecord/lib/active_record/validations/presence.rb
@@ -8,7 +8,7 @@ module ActiveRecord
           associated_records = Array.wrap(record.send(attribute))
 
           # Superclass validates presence. Ensure present records aren't about to be destroyed.
-          if associated_records.present? && associated_records.all? { |r| r.marked_for_destruction? }
+          if associated_records.present? && associated_records.all?(&:marked_for_destruction?)
             record.errors.add(attribute, :blank, options)
           end
         end

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -47,9 +47,7 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     assert !@connection.active?
 
     # Repair all fixture connections so other tests won't break.
-    @fixture_connections.each do |c|
-      c.verify!
-    end
+    @fixture_connections.each(&:verify!)
   end
 
   def test_successful_reconnection_after_timeout_with_manual_reconnect

--- a/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
@@ -101,7 +101,7 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
     gs = nil
     assert_nothing_raised { gs = Select.find(2).groups }
     assert_equal gs.length, 2
-    assert(gs.collect{|x| x.id}.sort == [2, 3])
+    assert(gs.collect(&:id).sort == [2, 3])
   end
 
   # has_and_belongs_to_many with reserved-word table name
@@ -110,7 +110,7 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
     s = nil
     assert_nothing_raised { s = Distinct.find(1).selects }
     assert_equal s.length, 2
-    assert(s.collect{|x|x.id}.sort == [1, 2])
+    assert(s.collect(&:id).sort == [1, 2])
   end
 
   # activerecord model introspection with reserved-word table and column names

--- a/activerecord/test/cases/adapters/mysql/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/schema_test.rb
@@ -81,7 +81,7 @@ module ActiveRecord
 
         table = 'key_tests'
 
-        indexes = @connection.indexes(table).sort_by {|i| i.name}
+        indexes = @connection.indexes(table).sort_by(&:name)
         assert_equal 3,indexes.size
 
         index_a = indexes.select{|i| i.name == index_a_name}[0]

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -44,9 +44,7 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     assert !@connection.active?
 
     # Repair all fixture connections so other tests won't break.
-    @fixture_connections.each do |c|
-      c.verify!
-    end
+    @fixture_connections.each(&:verify!)
   end
 
   def test_successful_reconnection_after_timeout_with_manual_reconnect

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -100,7 +100,7 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
     gs = nil
     assert_nothing_raised { gs = Select.find(2).groups }
     assert_equal gs.length, 2
-    assert(gs.collect{|x| x.id}.sort == [2, 3])
+    assert(gs.collect(&:id).sort == [2, 3])
   end
 
   # has_and_belongs_to_many with reserved-word table name
@@ -109,7 +109,7 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
     s = nil
     assert_nothing_raised { s = Distinct.find(1).selects }
     assert_equal s.length, 2
-    assert(s.collect{|x|x.id}.sort == [1, 2])
+    assert(s.collect(&:id).sort == [1, 2])
   end
 
   # activerecord model introspection with reserved-word table and column names

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -51,7 +51,7 @@ module ActiveRecord
 
         table = 'key_tests'
 
-        indexes = @connection.indexes(table).sort_by {|i| i.name}
+        indexes = @connection.indexes(table).sort_by(&:name)
         assert_equal 3,indexes.size
 
         index_a = indexes.select{|i| i.name == index_a_name}[0]

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -177,9 +177,7 @@ module ActiveRecord
         "successfully querying with the same connection pid."
 
       # Repair all fixture connections so other tests won't break.
-      @fixture_connections.each do |c|
-        c.verify!
-      end
+      @fixture_connections.each(&:verify!)
     end
 
     def test_set_session_variable_true

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -412,7 +412,7 @@ class SchemaTest < ActiveRecord::TestCase
 
     def do_dump_index_tests_for_schema(this_schema_name, first_index_column_name, second_index_column_name, third_index_column_name, fourth_index_column_name)
       with_schema_search_path(this_schema_name) do
-        indexes = @connection.indexes(TABLE_NAME).sort_by {|i| i.name}
+        indexes = @connection.indexes(TABLE_NAME).sort_by(&:name)
         assert_equal 4,indexes.size
 
         do_dump_index_assertions_for_one_index(indexes[0], INDEX_A_NAME, first_index_column_name)

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -327,11 +327,11 @@ module ActiveRecord
 
       def test_columns
         with_example_table do
-          columns = @conn.columns('ex').sort_by { |x| x.name }
+          columns = @conn.columns('ex').sort_by(&:name)
           assert_equal 2, columns.length
-          assert_equal %w{ id number }.sort, columns.map { |x| x.name }
-          assert_equal [nil, nil], columns.map { |x| x.default }
-          assert_equal [true, true], columns.map { |x| x.null }
+          assert_equal %w{ id number }.sort, columns.map(&:name)
+          assert_equal [nil, nil], columns.map(&:default)
+          assert_equal [true, true], columns.map(&:null)
         end
       end
 

--- a/activerecord/test/cases/associations/eager_load_nested_include_test.rb
+++ b/activerecord/test/cases/associations/eager_load_nested_include_test.rb
@@ -70,9 +70,7 @@ class EagerLoadPolyAssocsTest < ActiveRecord::TestCase
 
   teardown do
     [Circle, Square, Triangle, PaintColor, PaintTexture,
-     ShapeExpression, NonPolyOne, NonPolyTwo].each do |c|
-      c.delete_all
-    end
+     ShapeExpression, NonPolyOne, NonPolyTwo].each(&:delete_all)
   end
 
   def generate_test_object_graphs

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -338,31 +338,31 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_eager_association_loading_with_belongs_to_and_limit
     comments = Comment.all.merge!(:includes => :post, :limit => 5, :order => 'comments.id').to_a
     assert_equal 5, comments.length
-    assert_equal [1,2,3,5,6], comments.collect { |c| c.id }
+    assert_equal [1,2,3,5,6], comments.collect(&:id)
   end
 
   def test_eager_association_loading_with_belongs_to_and_limit_and_conditions
     comments = Comment.all.merge!(:includes => :post, :where => 'post_id = 4', :limit => 3, :order => 'comments.id').to_a
     assert_equal 3, comments.length
-    assert_equal [5,6,7], comments.collect { |c| c.id }
+    assert_equal [5,6,7], comments.collect(&:id)
   end
 
   def test_eager_association_loading_with_belongs_to_and_limit_and_offset
     comments = Comment.all.merge!(:includes => :post, :limit => 3, :offset => 2, :order => 'comments.id').to_a
     assert_equal 3, comments.length
-    assert_equal [3,5,6], comments.collect { |c| c.id }
+    assert_equal [3,5,6], comments.collect(&:id)
   end
 
   def test_eager_association_loading_with_belongs_to_and_limit_and_offset_and_conditions
     comments = Comment.all.merge!(:includes => :post, :where => 'post_id = 4', :limit => 3, :offset => 1, :order => 'comments.id').to_a
     assert_equal 3, comments.length
-    assert_equal [6,7,8], comments.collect { |c| c.id }
+    assert_equal [6,7,8], comments.collect(&:id)
   end
 
   def test_eager_association_loading_with_belongs_to_and_limit_and_offset_and_conditions_array
     comments = Comment.all.merge!(:includes => :post, :where => ['post_id = ?',4], :limit => 3, :offset => 1, :order => 'comments.id').to_a
     assert_equal 3, comments.length
-    assert_equal [6,7,8], comments.collect { |c| c.id }
+    assert_equal [6,7,8], comments.collect(&:id)
   end
 
   def test_eager_association_loading_with_belongs_to_and_conditions_string_with_unquoted_table_name
@@ -377,7 +377,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
       comments = Comment.all.merge!(:includes => :post, :where => {:posts => {:id => 4}}, :limit => 3, :order => 'comments.id').to_a
     end
     assert_equal 3, comments.length
-    assert_equal [5,6,7], comments.collect { |c| c.id }
+    assert_equal [5,6,7], comments.collect(&:id)
     assert_no_queries do
       comments.first.post
     end
@@ -406,13 +406,13 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_eager_association_loading_with_belongs_to_and_limit_and_multiple_associations
     posts = Post.all.merge!(:includes => [:author, :very_special_comment], :limit => 1, :order => 'posts.id').to_a
     assert_equal 1, posts.length
-    assert_equal [1], posts.collect { |p| p.id }
+    assert_equal [1], posts.collect(&:id)
   end
 
   def test_eager_association_loading_with_belongs_to_and_limit_and_offset_and_multiple_associations
     posts = Post.all.merge!(:includes => [:author, :very_special_comment], :limit => 1, :offset => 1, :order => 'posts.id').to_a
     assert_equal 1, posts.length
-    assert_equal [2], posts.collect { |p| p.id }
+    assert_equal [2], posts.collect(&:id)
   end
 
   def test_eager_association_loading_with_belongs_to_inferred_foreign_key_from_association_name
@@ -545,13 +545,13 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_eager_with_has_many_and_limit_and_conditions
     posts = Post.all.merge!(:includes => [ :author, :comments ], :limit => 2, :where => "posts.body = 'hello'", :order => "posts.id").to_a
     assert_equal 2, posts.size
-    assert_equal [4,5], posts.collect { |p| p.id }
+    assert_equal [4,5], posts.collect(&:id)
   end
 
   def test_eager_with_has_many_and_limit_and_conditions_array
     posts = Post.all.merge!(:includes => [ :author, :comments ], :limit => 2, :where => [ "posts.body = ?", 'hello' ], :order => "posts.id").to_a
     assert_equal 2, posts.size
-    assert_equal [4,5], posts.collect { |p| p.id }
+    assert_equal [4,5], posts.collect(&:id)
   end
 
   def test_eager_with_has_many_and_limit_and_conditions_array_on_the_eagers

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -555,7 +555,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
   def test_dynamic_find_all_should_respect_readonly_access
     projects(:active_record).readonly_developers.each { |d| assert_raise(ActiveRecord::ReadOnlyRecord) { d.save!  } if d.valid?}
-    projects(:active_record).readonly_developers.each { |d| d.readonly? }
+    projects(:active_record).readonly_developers.each(&:readonly?)
   end
 
   def test_new_with_values_in_collection

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1219,7 +1219,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert !clients.empty?, "37signals has clients after load"
     destroyed = companies(:first_firm).clients_of_firm.destroy_all
     assert_equal clients.sort_by(&:id), destroyed.sort_by(&:id)
-    assert destroyed.all? { |client| client.frozen? }, "destroyed clients should be frozen"
+    assert destroyed.all?(&:frozen?), "destroyed clients should be frozen"
     assert companies(:first_firm).clients_of_firm.empty?, "37signals has no clients after destroy all"
     assert companies(:first_firm).clients_of_firm(true).empty?, "37signals has no clients after destroy all and refresh"
   end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -41,7 +41,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   def test_preload_sti_rhs_class
     developers = Developer.includes(:firms).all.to_a
     assert_no_queries do
-      developers.each { |d| d.firms }
+      developers.each(&:firms)
     end
   end
 

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -54,7 +54,7 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
   def test_find_with_implicit_inner_joins_without_select_does_not_imply_readonly
     authors = Author.joins(:posts)
     assert_not authors.empty?, "expected authors to be non-empty"
-    assert authors.none? {|a| a.readonly? }, "expected no authors to be readonly"
+    assert authors.none?(&:readonly?), "expected no authors to be readonly"
   end
 
   def test_find_with_implicit_inner_joins_honors_readonly_with_select

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -393,18 +393,18 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_polymorphic_has_one
-    assert_equal Tagging.find(1,2).sort_by { |t| t.id }, authors(:david).taggings_2
+    assert_equal Tagging.find(1,2).sort_by(&:id), authors(:david).taggings_2
   end
 
   def test_has_many_through_polymorphic_has_many
-    assert_equal taggings(:welcome_general, :thinking_general), authors(:david).taggings.distinct.sort_by { |t| t.id }
+    assert_equal taggings(:welcome_general, :thinking_general), authors(:david).taggings.distinct.sort_by(&:id)
   end
 
   def test_include_has_many_through_polymorphic_has_many
     author            = Author.includes(:taggings).find authors(:david).id
     expected_taggings = taggings(:welcome_general, :thinking_general)
     assert_no_queries do
-      assert_equal expected_taggings, author.taggings.distinct.sort_by { |t| t.id }
+      assert_equal expected_taggings, author.taggings.distinct.sort_by(&:id)
     end
   end
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -48,7 +48,7 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_kind_of Firm, firm
 
     firm.clear_association_cache
-    assert_equal Firm.find(1).clients.collect{ |x| x.name }.sort, firm.clients.collect{ |x| x.name }.sort
+    assert_equal Firm.find(1).clients.collect(&:name).sort, firm.clients.collect(&:name).sort
   end
 
   def test_clear_association_cache_new_record

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -774,13 +774,13 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
   def test_should_destroy_has_many_as_part_of_the_save_transaction_if_they_were_marked_for_destruction
     2.times { |i| @pirate.birds.create!(:name => "birds_#{i}") }
 
-    assert !@pirate.birds.any? { |child| child.marked_for_destruction? }
+    assert !@pirate.birds.any?(&:marked_for_destruction?)
 
-    @pirate.birds.each { |child| child.mark_for_destruction }
+    @pirate.birds.each(&:mark_for_destruction)
     klass = @pirate.birds.first.class
     ids = @pirate.birds.map(&:id)
 
-    assert @pirate.birds.all? { |child| child.marked_for_destruction? }
+    assert @pirate.birds.all?(&:marked_for_destruction?)
     ids.each { |id| assert klass.find_by_id(id) }
 
     @pirate.save
@@ -814,14 +814,14 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
     @pirate.birds.each { |bird| bird.name = '' }
     assert !@pirate.valid?
 
-    @pirate.birds.each { |bird| bird.destroy }
+    @pirate.birds.each(&:destroy)
     assert @pirate.valid?
   end
 
   def test_a_child_marked_for_destruction_should_not_be_destroyed_twice_while_saving_has_many
     @pirate.birds.create!(:name => "birds_1")
 
-    @pirate.birds.each { |bird| bird.mark_for_destruction }
+    @pirate.birds.each(&:mark_for_destruction)
     assert @pirate.save
 
     @pirate.birds.each { |bird| bird.expects(:destroy).never }
@@ -888,7 +888,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
       association_name_with_callbacks = "birds_with_#{callback_type}_callbacks"
 
       @pirate.send(association_name_with_callbacks).create!(:name => "Crowe the One-Eyed")
-      @pirate.send(association_name_with_callbacks).each { |c| c.mark_for_destruction }
+      @pirate.send(association_name_with_callbacks).each(&:mark_for_destruction)
       child_id = @pirate.send(association_name_with_callbacks).first.id
 
       @pirate.ship_log.clear
@@ -906,8 +906,8 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
   def test_should_destroy_habtm_as_part_of_the_save_transaction_if_they_were_marked_for_destruction
     2.times { |i| @pirate.parrots.create!(:name => "parrots_#{i}") }
 
-    assert !@pirate.parrots.any? { |parrot| parrot.marked_for_destruction? }
-    @pirate.parrots.each { |parrot| parrot.mark_for_destruction }
+    assert !@pirate.parrots.any?(&:marked_for_destruction?)
+    @pirate.parrots.each(&:mark_for_destruction)
 
     assert_no_difference "Parrot.count" do
       @pirate.save
@@ -940,14 +940,14 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
     @pirate.parrots.each { |parrot| parrot.name = '' }
     assert !@pirate.valid?
 
-    @pirate.parrots.each { |parrot| parrot.destroy }
+    @pirate.parrots.each(&:destroy)
     assert @pirate.valid?
   end
 
   def test_a_child_marked_for_destruction_should_not_be_destroyed_twice_while_saving_habtm
     @pirate.parrots.create!(:name => "parrots_1")
 
-    @pirate.parrots.each { |parrot| parrot.mark_for_destruction }
+    @pirate.parrots.each(&:mark_for_destruction)
     assert @pirate.save
 
     Pirate.transaction do
@@ -992,7 +992,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
       association_name_with_callbacks = "parrots_with_#{callback_type}_callbacks"
 
       @pirate.send(association_name_with_callbacks).create!(:name => "Crowe the One-Eyed")
-      @pirate.send(association_name_with_callbacks).each { |c| c.mark_for_destruction }
+      @pirate.send(association_name_with_callbacks).each(&:mark_for_destruction)
       child_id = @pirate.send(association_name_with_callbacks).first.id
 
       @pirate.ship_log.clear

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -934,7 +934,7 @@ class FinderTest < ActiveRecord::TestCase
       joins('LEFT JOIN developers_projects ON developers.id = developers_projects.developer_id').
       where('project_id=1').to_a
     assert_equal 3, developers_on_project_one.length
-    developer_names = developers_on_project_one.map { |d| d.name }
+    developer_names = developers_on_project_one.map(&:name)
     assert developer_names.include?('David')
     assert developer_names.include?('Jamis')
   end
@@ -989,7 +989,7 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_select_values
-    assert_equal ["1","2","3","4","5","6","7","8","9", "10", "11"], Company.connection.select_values("SELECT id FROM companies ORDER BY id").map! { |i| i.to_s }
+    assert_equal ["1","2","3","4","5","6","7","8","9", "10", "11"], Company.connection.select_values("SELECT id FROM companies ORDER BY id").map!(&:to_s)
     assert_equal ["37signals","Summit","Microsoft", "Flamboyant Software", "Ex Nihilo", "RailsCore", "Leetsoft", "Jadedpixel", "Odegy", "Ex Nihilo Part Deux", "Apex"], Company.connection.select_values("SELECT name FROM companies ORDER BY id")
   end
 
@@ -1015,7 +1015,7 @@ class FinderTest < ActiveRecord::TestCase
       where(client_of: [2, 1, nil],
             name: ['37signals', 'Summit', 'Microsoft']).
       order('client_of DESC').
-      map { |x| x.client_of }
+      map(&:client_of)
 
     assert client_of.include?(nil)
     assert_equal [2, 1].sort, client_of.compact.sort
@@ -1025,7 +1025,7 @@ class FinderTest < ActiveRecord::TestCase
     client_of = Company.
       where(client_of: [nil]).
       order('client_of DESC').
-      map { |x| x.client_of }
+      map(&:client_of)
 
     assert_equal [], client_of.compact
   end

--- a/activerecord/test/cases/migration/column_positioning_test.rb
+++ b/activerecord/test/cases/migration/column_positioning_test.rb
@@ -25,30 +25,30 @@ module ActiveRecord
 
       if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
         def test_column_positioning
-          assert_equal %w(first second third), conn.columns(:testings).map {|c| c.name }
+          assert_equal %w(first second third), conn.columns(:testings).map(&:name)
         end
 
         def test_add_column_with_positioning
           conn.add_column :testings, :new_col, :integer
-          assert_equal %w(first second third new_col), conn.columns(:testings).map {|c| c.name }
+          assert_equal %w(first second third new_col), conn.columns(:testings).map(&:name)
         end
 
         def test_add_column_with_positioning_first
           conn.add_column :testings, :new_col, :integer, :first => true
-          assert_equal %w(new_col first second third), conn.columns(:testings).map {|c| c.name }
+          assert_equal %w(new_col first second third), conn.columns(:testings).map(&:name)
         end
 
         def test_add_column_with_positioning_after
           conn.add_column :testings, :new_col, :integer, :after => :first
-          assert_equal %w(first new_col second third), conn.columns(:testings).map {|c| c.name }
+          assert_equal %w(first new_col second third), conn.columns(:testings).map(&:name)
         end
 
         def test_change_column_with_positioning
           conn.change_column :testings, :second, :integer, :first => true
-          assert_equal %w(second first third), conn.columns(:testings).map {|c| c.name }
+          assert_equal %w(second first third), conn.columns(:testings).map(&:name)
 
           conn.change_column :testings, :second, :integer, :after => :third
-          assert_equal %w(first third second), conn.columns(:testings).map {|c| c.name }
+          assert_equal %w(first third second), conn.columns(:testings).map(&:name)
         end
       end
     end

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -149,7 +149,7 @@ class MigratorTest < ActiveRecord::TestCase
   def test_up_calls_up
     migrations = [Sensor.new(nil, 0), Sensor.new(nil, 1), Sensor.new(nil, 2)]
     ActiveRecord::Migrator.new(:up, migrations).migrate
-    assert migrations.all? { |m| m.went_up }
+    assert migrations.all?(&:went_up)
     assert migrations.all? { |m| !m.went_down }
     assert_equal 2, ActiveRecord::Migrator.current_version
   end
@@ -160,7 +160,7 @@ class MigratorTest < ActiveRecord::TestCase
     migrations = [Sensor.new(nil, 0), Sensor.new(nil, 1), Sensor.new(nil, 2)]
     ActiveRecord::Migrator.new(:down, migrations).migrate
     assert migrations.all? { |m| !m.went_up }
-    assert migrations.all? { |m| m.went_down }
+    assert migrations.all?(&:went_down)
     assert_equal 0, ActiveRecord::Migrator.current_version
   end
 

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -13,7 +13,7 @@ require 'active_support/hash_with_indifferent_access'
 
 class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   teardown do
-    Pirate.accepts_nested_attributes_for :ship, :allow_destroy => true, :reject_if => proc { |attributes| attributes.empty? }
+    Pirate.accepts_nested_attributes_for :ship, :allow_destroy => true, :reject_if => proc(&:empty?)
   end
 
   def test_base_should_have_an_empty_nested_attributes_options
@@ -300,13 +300,13 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
   end
 
   def test_should_not_destroy_an_existing_record_if_allow_destroy_is_false
-    Pirate.accepts_nested_attributes_for :ship, :allow_destroy => false, :reject_if => proc { |attributes| attributes.empty? }
+    Pirate.accepts_nested_attributes_for :ship, :allow_destroy => false, :reject_if => proc(&:empty?)
 
     @pirate.update(ship_attributes: { id: @pirate.ship.id, _destroy: '1' })
 
     assert_equal @ship, @pirate.reload.ship
 
-    Pirate.accepts_nested_attributes_for :ship, :allow_destroy => true, :reject_if => proc { |attributes| attributes.empty? }
+    Pirate.accepts_nested_attributes_for :ship, :allow_destroy => true, :reject_if => proc(&:empty?)
   end
 
   def test_should_also_work_with_a_HashWithIndifferentAccess
@@ -494,12 +494,12 @@ class TestNestedAttributesOnABelongsToAssociation < ActiveRecord::TestCase
   end
 
   def test_should_not_destroy_an_existing_record_if_allow_destroy_is_false
-    Ship.accepts_nested_attributes_for :pirate, :allow_destroy => false, :reject_if => proc { |attributes| attributes.empty? }
+    Ship.accepts_nested_attributes_for :pirate, :allow_destroy => false, :reject_if => proc(&:empty?)
 
     @ship.update(pirate_attributes: { id: @ship.pirate.id, _destroy: '1' })
     assert_nothing_raised(ActiveRecord::RecordNotFound) { @ship.pirate.reload }
   ensure
-    Ship.accepts_nested_attributes_for :pirate, :allow_destroy => true, :reject_if => proc { |attributes| attributes.empty? }
+    Ship.accepts_nested_attributes_for :pirate, :allow_destroy => true, :reject_if => proc(&:empty?)
   end
 
   def test_should_work_with_update_as_well
@@ -855,7 +855,7 @@ end
 
 module NestedAttributesLimitTests
   def teardown
-    Pirate.accepts_nested_attributes_for :parrots, :allow_destroy => true, :reject_if => proc { |attributes| attributes.empty? }
+    Pirate.accepts_nested_attributes_for :parrots, :allow_destroy => true, :reject_if => proc(&:empty?)
   end
 
   def test_limit_with_less_records

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -127,7 +127,7 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_difference('Topic.count', -topics_by_mary.size) do
       destroyed = Topic.destroy_all(conditions).sort_by(&:id)
       assert_equal topics_by_mary, destroyed
-      assert destroyed.all? { |topic| topic.frozen? }, "destroyed topics should be frozen"
+      assert destroyed.all?(&:frozen?), "destroyed topics should be frozen"
     end
   end
 
@@ -137,7 +137,7 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_difference('Client.count', -2) do
       destroyed = Client.destroy([2, 3]).sort_by(&:id)
       assert_equal clients, destroyed
-      assert destroyed.all? { |client| client.frozen? }, "destroyed clients should be frozen"
+      assert destroyed.all?(&:frozen?), "destroyed clients should be frozen"
     end
   end
 

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -13,7 +13,7 @@ class PooledConnectionsTest < ActiveRecord::TestCase
   teardown do
     ActiveRecord::Base.clear_all_connections!
     ActiveRecord::Base.establish_connection(@connection)
-    @per_test_teardown.each {|td| td.call }
+    @per_test_teardown.each(&:call)
   end
 
   # Will deadlock due to lack of Monitor timeouts in 1.9

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -50,13 +50,13 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_columns_are_returned_in_the_order_they_were_declared
-    column_names = Topic.columns.map { |column| column.name }
+    column_names = Topic.columns.map(&:name)
     assert_equal %w(id title author_name author_email_address written_on bonus_time last_read content important approved replies_count unique_replies_count parent_id parent_title type group created_at updated_at), column_names
   end
 
   def test_content_columns
     content_columns        = Topic.content_columns
-    content_column_names   = content_columns.map {|column| column.name}
+    content_column_names   = content_columns.map(&:name)
     assert_equal 13, content_columns.length
     assert_equal %w(title author_name author_email_address written_on bonus_time last_read content important group approved parent_title created_at updated_at).sort, content_column_names.sort
   end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -249,7 +249,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_finding_with_reorder
     topics = Topic.order('author_name').order('title').reorder('id').to_a
-    topics_titles = topics.map{ |t| t.title }
+    topics_titles = topics.map(&:title)
     assert_equal ['The First Topic', 'The Second Topic of the day', 'The Third Topic of the day', 'The Fourth Topic of the day', 'The Fifth Topic of the day'], topics_titles
   end
 
@@ -441,7 +441,7 @@ class RelationTest < ActiveRecord::TestCase
       where('project_id=1').to_a
 
     assert_equal 3, developers_on_project_one.length
-    developer_names = developers_on_project_one.map { |d| d.name }
+    developer_names = developers_on_project_one.map(&:name)
     assert developer_names.include?('David')
     assert developer_names.include?('Jamis')
   end
@@ -652,8 +652,8 @@ class RelationTest < ActiveRecord::TestCase
     expected_taggings = taggings(:welcome_general, :thinking_general)
 
     assert_no_queries do
-      assert_equal expected_taggings, author.taggings.distinct.sort_by { |t| t.id }
-      assert_equal expected_taggings, author.taggings.uniq.sort_by { |t| t.id }
+      assert_equal expected_taggings, author.taggings.distinct.sort_by(&:id)
+      assert_equal expected_taggings, author.taggings.uniq.sort_by(&:id)
     end
 
     authors = Author.all

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -8,8 +8,8 @@ class DefaultScopingTest < ActiveRecord::TestCase
   fixtures :developers, :posts, :comments
 
   def test_default_scope
-    expected = Developer.all.merge!(:order => 'salary DESC').to_a.collect { |dev| dev.salary }
-    received = DeveloperOrderedBySalary.all.collect { |dev| dev.salary }
+    expected = Developer.all.merge!(:order => 'salary DESC').to_a.collect(&:salary)
+    received = DeveloperOrderedBySalary.all.collect(&:salary)
     assert_equal expected, received
   end
 
@@ -86,14 +86,14 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_scope_overwrites_default
-    expected = Developer.all.merge!(order: 'salary DESC, name DESC').to_a.collect { |dev| dev.name }
-    received = DeveloperOrderedBySalary.by_name.to_a.collect { |dev| dev.name }
+    expected = Developer.all.merge!(order: 'salary DESC, name DESC').to_a.collect(&:name)
+    received = DeveloperOrderedBySalary.by_name.to_a.collect(&:name)
     assert_equal expected, received
   end
 
   def test_reorder_overrides_default_scope_order
-    expected = Developer.order('name DESC').collect { |dev| dev.name }
-    received = DeveloperOrderedBySalary.reorder('name DESC').collect { |dev| dev.name }
+    expected = Developer.order('name DESC').collect(&:name)
+    received = DeveloperOrderedBySalary.reorder('name DESC').collect(&:name)
     assert_equal expected, received
   end
 
@@ -146,34 +146,34 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_unscope_multiple_where_clauses
-    expected = Developer.order('salary DESC').collect { |dev| dev.name }
-    received = DeveloperOrderedBySalary.where(name: 'Jamis').where(id: 1).unscope(where: [:name, :id]).collect { |dev| dev.name }
+    expected = Developer.order('salary DESC').collect(&:name)
+    received = DeveloperOrderedBySalary.where(name: 'Jamis').where(id: 1).unscope(where: [:name, :id]).collect(&:name)
     assert_equal expected, received
   end
 
   def test_unscope_string_where_clauses_involved
     dev_relation = Developer.order('salary DESC').where("created_at > ?", 1.year.ago)
-    expected = dev_relation.collect { |dev| dev.name }
+    expected = dev_relation.collect(&:name)
 
     dev_ordered_relation = DeveloperOrderedBySalary.where(name: 'Jamis').where("created_at > ?", 1.year.ago)
-    received = dev_ordered_relation.unscope(where: [:name]).collect { |dev| dev.name }
+    received = dev_ordered_relation.unscope(where: [:name]).collect(&:name)
 
     assert_equal expected, received
   end
 
   def test_unscope_with_grouping_attributes
-    expected = Developer.order('salary DESC').collect { |dev| dev.name }
-    received = DeveloperOrderedBySalary.group(:name).unscope(:group).collect { |dev| dev.name }
+    expected = Developer.order('salary DESC').collect(&:name)
+    received = DeveloperOrderedBySalary.group(:name).unscope(:group).collect(&:name)
     assert_equal expected, received
 
-    expected_2 = Developer.order('salary DESC').collect { |dev| dev.name }
-    received_2 = DeveloperOrderedBySalary.group("name").unscope(:group).collect { |dev| dev.name }
+    expected_2 = Developer.order('salary DESC').collect(&:name)
+    received_2 = DeveloperOrderedBySalary.group("name").unscope(:group).collect(&:name)
     assert_equal expected_2, received_2
   end
 
   def test_unscope_with_limit_in_query
-    expected = Developer.order('salary DESC').collect { |dev| dev.name }
-    received = DeveloperOrderedBySalary.limit(1).unscope(:limit).collect { |dev| dev.name }
+    expected = Developer.order('salary DESC').collect(&:name)
+    received = DeveloperOrderedBySalary.limit(1).unscope(:limit).collect(&:name)
     assert_equal expected, received
   end
 
@@ -183,42 +183,42 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_unscope_reverse_order
-    expected = Developer.all.collect { |dev| dev.name }
-    received = Developer.order('salary DESC').reverse_order.unscope(:order).collect { |dev| dev.name }
+    expected = Developer.all.collect(&:name)
+    received = Developer.order('salary DESC').reverse_order.unscope(:order).collect(&:name)
     assert_equal expected, received
   end
 
   def test_unscope_select
-    expected = Developer.order('salary ASC').collect { |dev| dev.name }
-    received = Developer.order('salary DESC').reverse_order.select(:name).unscope(:select).collect { |dev| dev.name }
+    expected = Developer.order('salary ASC').collect(&:name)
+    received = Developer.order('salary DESC').reverse_order.select(:name).unscope(:select).collect(&:name)
     assert_equal expected, received
 
-    expected_2 = Developer.all.collect { |dev| dev.id }
-    received_2 = Developer.select(:name).unscope(:select).collect { |dev| dev.id }
+    expected_2 = Developer.all.collect(&:id)
+    received_2 = Developer.select(:name).unscope(:select).collect(&:id)
     assert_equal expected_2, received_2
   end
 
   def test_unscope_offset
-    expected = Developer.all.collect { |dev| dev.name }
-    received = Developer.offset(5).unscope(:offset).collect { |dev| dev.name }
+    expected = Developer.all.collect(&:name)
+    received = Developer.offset(5).unscope(:offset).collect(&:name)
     assert_equal expected, received
   end
 
   def test_unscope_joins_and_select_on_developers_projects
-    expected = Developer.all.collect { |dev| dev.name }
-    received = Developer.joins('JOIN developers_projects ON id = developer_id').select(:id).unscope(:joins, :select).collect { |dev| dev.name }
+    expected = Developer.all.collect(&:name)
+    received = Developer.joins('JOIN developers_projects ON id = developer_id').select(:id).unscope(:joins, :select).collect(&:name)
     assert_equal expected, received
   end
 
   def test_unscope_includes
-    expected = Developer.all.collect { |dev| dev.name }
-    received = Developer.includes(:projects).select(:id).unscope(:includes, :select).collect { |dev| dev.name }
+    expected = Developer.all.collect(&:name)
+    received = Developer.includes(:projects).select(:id).unscope(:includes, :select).collect(&:name)
     assert_equal expected, received
   end
 
   def test_unscope_having
-    expected = DeveloperOrderedBySalary.all.collect { |dev| dev.name }
-    received = DeveloperOrderedBySalary.having("name IN ('Jamis', 'David')").unscope(:having).collect { |dev| dev.name }
+    expected = DeveloperOrderedBySalary.all.collect(&:name)
+    received = DeveloperOrderedBySalary.having("name IN ('Jamis', 'David')").unscope(:having).collect(&:name)
     assert_equal expected, received
   end
 
@@ -281,8 +281,8 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_order_in_default_scope_should_not_prevail
-    expected = Developer.all.merge!(order: 'salary desc').to_a.collect { |dev| dev.salary }
-    received = DeveloperOrderedBySalary.all.merge!(order: 'salary').to_a.collect { |dev| dev.salary }
+    expected = Developer.all.merge!(order: 'salary desc').to_a.collect(&:salary)
+    received = DeveloperOrderedBySalary.all.merge!(order: 'salary').to_a.collect(&:salary)
     assert_equal expected, received
   end
 

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -43,7 +43,7 @@ module ActiveRecord
       patterns_to_match.each do |pattern|
         failed_patterns << pattern unless SQLCounter.log_all.any?{ |sql| pattern === sql }
       end
-      assert failed_patterns.empty?, "Query pattern(s) #{failed_patterns.map{ |p| p.inspect }.join(', ')} not found.#{SQLCounter.log.size == 0 ? '' : "\nQueries:\n#{SQLCounter.log.join("\n")}"}"
+      assert failed_patterns.empty?, "Query pattern(s) #{failed_patterns.map(&:inspect).join(', ')} not found.#{SQLCounter.log.size == 0 ? '' : "\nQueries:\n#{SQLCounter.log.join("\n")}"}"
     end
 
     def assert_queries(num = 1, options = {})

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -13,7 +13,7 @@ class TransactionTest < ActiveRecord::TestCase
   fixtures :topics, :developers, :authors, :posts
 
   def setup
-    @first, @second = Topic.find(1, 2).sort_by { |t| t.id }
+    @first, @second = Topic.find(1, 2).sort_by(&:id)
   end
 
   def test_persisted_in_a_model_with_custom_primary_key_after_failed_save
@@ -699,7 +699,7 @@ if current_adapter?(:PostgreSQLAdapter)
           end
         end
 
-        threads.each { |t| t.join }
+        threads.each(&:join)
       end
     end
 
@@ -747,7 +747,7 @@ if current_adapter?(:PostgreSQLAdapter)
           Developer.connection.close
         end
 
-        threads.each { |t| t.join }
+        threads.each(&:join)
       end
 
       assert_equal original_salary, Developer.find(1).salary

--- a/activerecord/test/cases/validations_repair_helper.rb
+++ b/activerecord/test/cases/validations_repair_helper.rb
@@ -5,9 +5,7 @@ module ActiveRecord
     module ClassMethods
       def repair_validations(*model_classes)
         teardown do
-          model_classes.each do |k|
-            k.clear_validators!
-          end
+          model_classes.each(&:clear_validators!)
         end
       end
     end
@@ -15,9 +13,7 @@ module ActiveRecord
     def repair_validations(*model_classes)
       yield if block_given?
     ensure
-      model_classes.each do |k|
-        k.clear_validators!
-      end
+      model_classes.each(&:clear_validators!)
     end
   end
 end

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -2,7 +2,7 @@ class Customer < ActiveRecord::Base
   cattr_accessor :gps_conversion_was_run
 
   composed_of :address, :mapping => [ %w(address_street street), %w(address_city city), %w(address_country country) ], :allow_nil => true
-  composed_of :balance, :class_name => "Money", :mapping => %w(balance amount), :converter => Proc.new { |balance| balance.to_money }
+  composed_of :balance, :class_name => "Money", :mapping => %w(balance amount), :converter => Proc.new(&:to_money)
   composed_of :gps_location, :allow_nil => true
   composed_of :non_blank_gps_location, :class_name => "GpsLocation", :allow_nil => true, :mapping => %w(gps_location gps_location),
               :converter => lambda { |gps| self.gps_conversion_was_run = true; gps.blank? ? nil : GpsLocation.new(gps)}

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -36,8 +36,8 @@ class Pirate < ActiveRecord::Base
 
   has_one :foo_bulb, -> { where :name => 'foo' }, :foreign_key => :car_id, :class_name => "Bulb"
 
-  accepts_nested_attributes_for :parrots, :birds, :allow_destroy => true, :reject_if => proc { |attributes| attributes.empty? }
-  accepts_nested_attributes_for :ship, :allow_destroy => true, :reject_if => proc { |attributes| attributes.empty? }
+  accepts_nested_attributes_for :parrots, :birds, :allow_destroy => true, :reject_if => proc(&:empty?)
+  accepts_nested_attributes_for :ship, :allow_destroy => true, :reject_if => proc(&:empty?)
   accepts_nested_attributes_for :update_only_ship, :update_only => true
   accepts_nested_attributes_for :parrots_with_method_callbacks, :parrots_with_proc_callbacks,
     :birds_with_method_callbacks, :birds_with_proc_callbacks, :allow_destroy => true

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -6,7 +6,7 @@ class Ship < ActiveRecord::Base
   has_many :parts, :class_name => 'ShipPart'
 
   accepts_nested_attributes_for :parts, :allow_destroy => true
-  accepts_nested_attributes_for :pirate, :allow_destroy => true, :reject_if => proc { |attributes| attributes.empty? }
+  accepts_nested_attributes_for :pirate, :allow_destroy => true, :reject_if => proc(&:empty?)
   accepts_nested_attributes_for :update_only_pirate, :update_only => true
 
   validates_presence_of :name

--- a/activesupport/bin/generate_tables
+++ b/activesupport/bin/generate_tables
@@ -55,7 +55,7 @@ module ActiveSupport
           codepoint.combining_class   = Integer($4)
           #codepoint.bidi_class        = $5
           codepoint.decomp_type       = $7
-          codepoint.decomp_mapping    = ($8=='') ? nil : $8.split.collect { |element| element.hex }
+          codepoint.decomp_mapping    = ($8=='') ? nil : $8.split.collect(&:hex)
           #codepoint.bidi_mirrored     = ($13=='Y') ? true : false
           codepoint.uppercase_mapping = ($16=='') ? 0 : $16.hex
           codepoint.lowercase_mapping = ($17=='') ? 0 : $17.hex

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -92,7 +92,7 @@ class Array
       if empty?
         'null'
       else
-        collect { |element| element.id }.join(',')
+        collect(&:id).join(',')
       end
     else
       to_default_s

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -31,13 +31,13 @@ class Hash
   #   hash.stringify_keys
   #   # => {"name"=>"Rob", "age"=>"28"}
   def stringify_keys
-    transform_keys{ |key| key.to_s }
+    transform_keys(&:to_s)
   end
 
   # Destructively convert all keys to strings. Same as
   # +stringify_keys+, but modifies +self+.
   def stringify_keys!
-    transform_keys!{ |key| key.to_s }
+    transform_keys!(&:to_s)
   end
 
   # Returns a new hash with all keys converted to symbols, as long as
@@ -105,14 +105,14 @@ class Hash
   #   hash.deep_stringify_keys
   #   # => {"person"=>{"name"=>"Rob", "age"=>"28"}}
   def deep_stringify_keys
-    deep_transform_keys{ |key| key.to_s }
+    deep_transform_keys(&:to_s)
   end
 
   # Destructively convert all keys to strings.
   # This includes the keys from the root hash and from all
   # nested hashes and arrays.
   def deep_stringify_keys!
-    deep_transform_keys!{ |key| key.to_s }
+    deep_transform_keys!(&:to_s)
   end
 
   # Returns a new hash with all keys converted to symbols, as long as

--- a/activesupport/lib/active_support/core_ext/object/deep_dup.rb
+++ b/activesupport/lib/active_support/core_ext/object/deep_dup.rb
@@ -25,7 +25,7 @@ class Array
   #   array[1][2] # => nil
   #   dup[1][2]   # => 4
   def deep_dup
-    map { |it| it.deep_dup }
+    map(&:deep_dup)
   end
 end
 

--- a/activesupport/lib/active_support/core_ext/object/instance_variables.rb
+++ b/activesupport/lib/active_support/core_ext/object/instance_variables.rb
@@ -23,6 +23,6 @@ class Object
   #
   #   C.new(0, 1).instance_variable_names # => ["@y", "@x"]
   def instance_variable_names
-    instance_variables.map { |var| var.to_s }
+    instance_variables.map(&:to_s)
   end
 end

--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -38,7 +38,7 @@ class Array
   # Calls <tt>to_param</tt> on all its elements and joins the result with
   # slashes. This is used by <tt>url_for</tt> in Action Pack.
   def to_param
-    collect { |e| e.to_param }.join '/'
+    collect(&:to_param).join '/'
   end
 
   # Converts an array into a string suitable for use as a URL query string,

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -742,7 +742,7 @@ module ActiveSupport #:nodoc:
     protected
       def log_call(*args)
         if log_activity?
-          arg_str = args.collect { |arg| arg.inspect } * ', '
+          arg_str = args.collect(&:inspect) * ', '
           /in `([a-z_\?\!]+)'/ =~ caller(1).first
           selector = $1 || '<unknown>'
           log "called #{selector}(#{arg_str})"

--- a/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
@@ -59,7 +59,7 @@ module ActiveSupport
             translate_in_locale("human.decimal_units.units", raise: true)
           else
             raise ArgumentError, ":units must be a Hash or String translation scope."
-          end.keys.map { |e_name| INVERTED_DECIMAL_UNITS[e_name] }.sort_by { |e| -e }
+          end.keys.map { |e_name| INVERTED_DECIMAL_UNITS[e_name] }.sort_by(&:-@)
         end
     end
   end

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -66,7 +66,7 @@ module ActiveSupport
         exps = expressions.map { |e|
           e.respond_to?(:call) ? e : lambda { eval(e, block.binding) }
         }
-        before = exps.map { |e| e.call }
+        before = exps.map(&:call)
 
         yield
 

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -237,7 +237,7 @@ module ActiveSupport
         case arg
           when String
           begin
-            @lazy_zones_map[arg] ||= create(arg).tap { |tz| tz.utc_offset }
+            @lazy_zones_map[arg] ||= create(arg).tap(&:utc_offset)
           rescue TZInfo::InvalidTimezoneIdentifier
             nil
           end

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -71,14 +71,14 @@ class EnumerableTests < ActiveSupport::TestCase
   def test_index_by
     payments = GenericEnumerable.new([ Payment.new(5), Payment.new(15), Payment.new(10) ])
     assert_equal({ 5 => Payment.new(5), 15 => Payment.new(15), 10 => Payment.new(10) },
-                 payments.index_by { |p| p.price })
+                 payments.index_by(&:price))
     assert_equal Enumerator, payments.index_by.class
     if Enumerator.method_defined? :size
       assert_equal nil, payments.index_by.size
       assert_equal 42, (1..42).index_by.size
     end
     assert_equal({ 5 => Payment.new(5), 15 => Payment.new(15), 10 => Payment.new(10) },
-                 payments.index_by.each { |p| p.price })
+                 payments.index_by.each(&:price))
   end
 
   def test_many

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -365,7 +365,7 @@ class HashExtTest < ActiveSupport::TestCase
       :member? => true }
 
     hashes.each do |name, hash|
-      method_map.sort_by { |m| m.to_s }.each do |meth, expected|
+      method_map.sort_by(&:to_s).each do |meth, expected|
         assert_equal(expected, hash.__send__(meth, 'a'),
                      "Calling #{name}.#{meth} 'a'")
         assert_equal(expected, hash.__send__(meth, :a),

--- a/activesupport/test/core_ext/object/try_test.rb
+++ b/activesupport/test/core_ext/object/try_test.rb
@@ -52,11 +52,11 @@ class ObjectTryTest < ActiveSupport::TestCase
   end
 
   def test_try_only_block
-    assert_equal @string.reverse, @string.try { |s| s.reverse }
+    assert_equal @string.reverse, @string.try(&:reverse)
   end
 
   def test_try_only_block_bang
-    assert_equal @string.reverse, @string.try! { |s| s.reverse }
+    assert_equal @string.reverse, @string.try!(&:reverse)
   end
 
   def test_try_only_block_nil

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -281,15 +281,11 @@ class StringInflectionsTest < ActiveSupport::TestCase
   end
 
   def test_constantize
-    run_constantize_tests_on do |string|
-      string.constantize
-    end
+    run_constantize_tests_on(&:constantize)
   end
 
   def test_safe_constantize
-    run_safe_constantize_tests_on do |string|
-      string.safe_constantize
-    end
+    run_safe_constantize_tests_on(&:safe_constantize)
   end
 end
 

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -182,7 +182,7 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
   end
 
   def test_sortability
-    words = %w(builder armor zebra).sort_by { |s| s.mb_chars }
+    words = %w(builder armor zebra).sort_by(&:mb_chars)
     assert_equal %w(armor builder zebra), words
   end
 

--- a/activesupport/test/multibyte_conformance_test.rb
+++ b/activesupport/test/multibyte_conformance_test.rb
@@ -115,7 +115,7 @@ class MultibyteConformanceTest < ActiveSupport::TestCase
           next if (line.empty? || line =~ /^\#/)
 
           cols, comment = line.split("#")
-          cols = cols.split(";").map{|e| e.strip}.reject{|e| e.empty? }
+          cols = cols.split(";").map(&:strip).reject(&:empty?)
           next unless cols.length == 5
 
           # codepoints are in hex in the test suite, pack wants them as integers

--- a/activesupport/test/rescuable_test.rb
+++ b/activesupport/test/rescuable_test.rb
@@ -93,13 +93,13 @@ class RescuableTest < ActiveSupport::TestCase
 
   def test_rescues_defined_later_are_added_at_end_of_the_rescue_handlers_array
     expected = ["WraithAttack", "WraithAttack", "NuclearExplosion", "MadRonon"]
-    result = @stargate.send(:rescue_handlers).collect {|e| e.first}
+    result = @stargate.send(:rescue_handlers).collect(&:first)
     assert_equal expected, result
   end
 
   def test_children_should_inherit_rescue_definitions_from_parents_and_child_rescue_should_be_appended
     expected = ["WraithAttack", "WraithAttack", "NuclearExplosion", "MadRonon", "CoolError"]
-    result = @cool_stargate.send(:rescue_handlers).collect {|e| e.first}
+    result = @cool_stargate.send(:rescue_handlers).collect(&:first)
     assert_equal expected, result
   end
 end

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -140,6 +140,6 @@ if failures.empty?
 else
   puts
   puts "Rails build FAILED"
-  puts "Failed components: #{failures.map { |component| component.first }.join(', ')}"
+  puts "Failed components: #{failures.map(&:first).join(', ')}"
   exit(false)
 end

--- a/guides/rails_guides/kindle.rb
+++ b/guides/rails_guides/kindle.rb
@@ -70,7 +70,7 @@ module Kindle
       File.open("sections/%03d/_section.txt" % section_idx, 'w') {|f| f.puts title}
       doc.xpath("//h3[@id]").each_with_index do |h3,item_idx|
         subsection = h3.inner_text
-        content = h3.xpath("./following-sibling::*").take_while {|x| x.name != "h3"}.map {|x| x.to_html}
+        content = h3.xpath("./following-sibling::*").take_while {|x| x.name != "h3"}.map(&:to_html)
         item = Nokogiri::HTML(h3.to_html + content.join("\n"))
         item_path = "sections/%03d/%03d.html" % [section_idx, item_idx] 
         add_head_section(item, subsection)

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -41,9 +41,7 @@ module Rails
       end
 
       def finalize!
-        route_sets.each do |routes|
-          routes.finalize!
-        end
+        route_sets.each(&:finalize!)
       end
 
       def revert

--- a/railties/lib/rails/commands/plugin.rb
+++ b/railties/lib/rails/commands/plugin.rb
@@ -11,7 +11,7 @@ else
               end
     if File.exist?(railsrc)
       extra_args_string = File.read(railsrc)
-      extra_args = extra_args_string.split(/\n+/).flat_map {|l| l.split}
+      extra_args = extra_args_string.split(/\n+/).flat_map(&:split)
       puts "Using #{extra_args.join(" ")} from #{railsrc}"
       ARGV.insert(1, *extra_args)
     end

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -153,7 +153,7 @@ module Rails
     def self.invoke(namespace, args=ARGV, config={})
       names = namespace.to_s.split(':')
       if klass = find_by_namespace(names.pop, names.any? && names.join(':'))
-        args << "--help" if args.empty? && klass.arguments.any? { |a| a.required? }
+        args << "--help" if args.empty? && klass.arguments.any?(&:required?)
         klass.start(args, config)
       else
         options     = sorted_groups.map(&:last).flatten
@@ -226,7 +226,7 @@ module Rails
 
     def self.public_namespaces
       lookup!
-      subclasses.map { |k| k.namespace }
+      subclasses.map(&:namespace)
     end
 
     def self.print_generators

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -189,7 +189,7 @@ module Rails
       #   generate(:authenticated, "user session")
       def generate(what, *args)
         log :generate, what
-        argument = args.flat_map {|arg| arg.to_s }.join(" ")
+        argument = args.flat_map(&:to_s).join(" ")
 
         in_root { run_ruby_script("bin/rails generate #{what} #{argument}", verbose: false) }
       end

--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -273,7 +273,7 @@ module Rails
 
         # Use Rails default banner.
         def self.banner
-          "rails generate #{namespace.sub(/^rails:/,'')} #{self.arguments.map{ |a| a.usage }.join(' ')} [options]".gsub(/\s+/, ' ')
+          "rails generate #{namespace.sub(/^rails:/,'')} #{self.arguments.map(&:usage).join(' ')} [options]".gsub(/\s+/, ' ')
         end
 
         # Sets the base_name taking into account the current class namespace.

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -99,7 +99,7 @@ module Rails
         end
 
         def class_name
-          (class_path + [file_name]).map!{ |m| m.camelize }.join('::')
+          (class_path + [file_name]).map!(&:camelize).join('::')
         end
 
         def human_name
@@ -156,7 +156,7 @@ module Rails
 
         def assign_names!(name) #:nodoc:
           @class_path = name.include?('/') ? name.split('/') : name.split('::')
-          @class_path.map! { |m| m.underscore }
+          @class_path.map!(&:underscore)
           @file_name = @class_path.pop
         end
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -260,9 +260,7 @@ module Rails
       public_task :generate_spring_binstubs
 
       def run_after_bundle_callbacks
-        @after_bundle_callbacks.each do |callback|
-          callback.call
-        end
+        @after_bundle_callbacks.each(&:call)
       end
 
     protected

--- a/railties/lib/rails/generators/resource_helpers.rb
+++ b/railties/lib/rails/generators/resource_helpers.rb
@@ -39,7 +39,7 @@ module Rails
         def assign_controller_names!(name)
           @controller_name = name
           @controller_class_path = name.include?('/') ? name.split('/') : name.split('::')
-          @controller_class_path.map! { |m| m.underscore }
+          @controller_class_path.map!(&:underscore)
           @controller_file_name = @controller_class_path.pop
         end
 
@@ -48,7 +48,7 @@ module Rails
         end
 
         def controller_class_name
-          (controller_class_path + [controller_file_name]).map!{ |m| m.camelize }.join('::')
+          (controller_class_path + [controller_file_name]).map!(&:camelize).join('::')
         end
 
         def controller_i18n_scope

--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -8,7 +8,7 @@ module Rails
     mattr_accessor :properties
     class << (@@properties = [])
       def names
-        map {|val| val.first }
+        map(&:first)
       end
 
       def value_for(property_name)
@@ -26,7 +26,7 @@ module Rails
       end
 
       def to_s
-        column_width = properties.names.map {|name| name.length}.max
+        column_width = properties.names.map(&:length).max
         info = properties.map do |name, value|
           value = value.join(", ") if value.is_a?(Array)
           "%-#{column_width}s   %s" % [name, value]

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -77,23 +77,23 @@ module Rails
       end
 
       def all_paths
-        values.tap { |v| v.uniq! }
+        values.tap(&:uniq!)
       end
 
       def autoload_once
-        filter_by { |p| p.autoload_once? }
+        filter_by(&:autoload_once?)
       end
 
       def eager_load
-        filter_by { |p| p.eager_load? }
+        filter_by(&:eager_load?)
       end
 
       def autoload_paths
-        filter_by { |p| p.autoload? }
+        filter_by(&:autoload?)
       end
 
       def load_paths
-        filter_by { |p| p.load_path? }
+        filter_by(&:load_path?)
       end
 
     private

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -518,7 +518,7 @@ YAML
 
       def call(env)
         response = @app.call(env)
-        response[2].each { |b| b.upcase! }
+        response[2].each(&:upcase!)
         response
       end
     end


### PR DESCRIPTION
Using Ruby’s `Symbol#to_proc` is considerably more concise than using block syntax. It’s also about 20% faster (see benchmarks below). `Symbol#to_proc` is already used in many places throughout the Rails codebase, but not everywhere. This patch makes the codebase more consistent and concise. In some cases, it reduces the number of lines of code. For example, in `railties/lib/rails/application/routes_reloader.rb`:

``` ruby
def finalize!
  route_sets.each do |routes|
    routes.finalize!
  end
end
```

becomes:

``` ruby
def finalize!
  route_sets.each(&:finalize!)
end
```

The net result is 30 fewer lines of code.

For those who don’t know the history, `Symbol#to_proc` was originally part of Active Support, before being merged into the Ruby language in version 1.9 (and back-ported to 1.8.7). The Active Support implementation was slightly slower than using a block but the C implementation in MRI is considerably faster.
##### Benchmark

``` ruby
require 'benchmark/ips'

def block
  (1..100).map{|i| i.to_s}
end

def to_proc
  (1..100).map(&:to_s)
end

Benchmark.ips do |x|
  x.report('block')   { block   }
  x.report('to_proc') { to_proc }
end
```
###### Ruby 2.1.2p95

```
  block 46707.3 (±7.8%) i/s - 235768 in 5.079617s
to_proc 55143.5 (±7.2%) i/s - 276554 in 5.040752s
```
###### Ruby 2.0.0p481

```
  block 33271.0 (±6.8%) i/s - 168646 in 5.093196s
to_proc 37346.0 (±7.6%) i/s - 188870 in 5.087220s
```
###### Ruby 1.9.3p545

```
  block 31478.7 (±11.3%) i/s - 156876 in 5.056661s
to_proc 39219.9  (±7.2%) i/s - 195210 in 5.004236s
```
