### PR TITLE
Mock the requests in recognize_path with a whole environment

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -751,12 +751,11 @@ module ActionDispatch
       end
 
       def recognize_path(path, environment = {})
-        method = (environment[:method] || "GET").to_s.upcase
         path = Journey::Router::Utils.normalize_path(path) unless path =~ %r{://}
         extras = environment[:extras] || {}
 
         begin
-          env = Rack::MockRequest.env_for(path, {:method => method})
+          env = Rack::MockRequest.env_for(path, environment)
         rescue URI::InvalidURIError => e
           raise ActionController::RoutingError, e.message
         end

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1870,6 +1870,10 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
     get 'projects/:project_id' => "project#index", :as => "project"
     get 'clients' => "projects#index"
 
+    get 'constrained_news', to: "news#index", constraints: ->(request) {
+      request.headers['X-Custom-Header'].present?
+    }
+
     get 'ignorecase/geocode/:postalcode' => 'geocode#show', :postalcode => /hx\d\d-\d[a-z]{2}/i
     get 'extended/geocode/:postalcode' => 'geocode#show',:constraints => {
                   :postalcode => /# Postcode format
@@ -1969,6 +1973,9 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
 
     assert_equal({:controller => 'news', :action => 'index' }, @routes.recognize_path('/', :method => :get))
     assert_equal({:controller => 'news', :action => 'index', :format => 'rss'}, @routes.recognize_path('/news.rss', :method => :get))
+
+    assert_equal({:controller => 'news', :action => 'index'}, @routes.recognize_path('constrained_news', :method => :get, 'HTTP_X_CUSTOM_HEADER' => '1'))
+    assert_raise(ActionController::RoutingError) { @routes.recognize_path('constrained_news') }
 
     assert_raise(ActionController::RoutingError) { @routes.recognize_path('/none', :method => :get) }
   end


### PR DESCRIPTION
If you have complex route constraints, which depend on specific headers,
for example, you cannot recognize them with the current state of
`recognize_path`. I've hit this in an app.

Currently, I pass `environment` to the Rack mock request, so I can
plug the HTTP headers I need for the constraint to pass. Did it in a
way, that doesn't change the current interface of the method. Don't know
how many people use the method directly in practice, though.

If you guys think that we can add this to `assert_recognizes` as well, I
can do it.

Please, @pixeltrix if you have another plan of action for this method,
I'll be glad to help out.

A few possibly related issues: #8679, #8294, #6922.
