### PR TITLE
fix fixtures not loading if a belongs_to association is defined with a :foreign_key option that's a symbol

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -658,7 +658,7 @@ module ActiveRecord
                   row[association.foreign_type] = $1
                 end
 
-                fk_type = association.active_record.columns_hash[association.foreign_key].type
+                fk_type = association.active_record.columns_hash[fk_name].type
                 row[fk_name] = ActiveRecord::FixtureSet.identify(value, fk_type)
               end
             when :has_many

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -810,6 +810,15 @@ class FoxyFixturesTest < ActiveRecord::TestCase
     assert admin_accounts(:signals37).users.include?(admin_users(:david))
     assert_equal 2, admin_accounts(:signals37).users.size
   end
+
+  class Nemesis < ActiveRecord::Base
+    self.table_name = "mateys"
+    belongs_to :mortal_enemy, :class_name => 'Pirate', :foreign_key => :target_id
+  end
+
+  def test_symbol_foreign_key_id
+    ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, "nemeses", "nemeses" => Nemesis)
+  end
 end
 
 class ActiveSupportSubclassWithFixturesTest < ActiveRecord::TestCase


### PR DESCRIPTION
This regressed somewhere between 4.1 and 4.2 but making it backwards compatible requires only a tiny fix.  Instead of calling to_s again, we should reuse the fk_name already determined.
