### PR TITLE
[ci skip] change the line orientation on asset precompile page

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -208,9 +208,7 @@ precompiling works.
 
 NOTE: You must have an ExecJS supported runtime in order to use CoffeeScript.
 If you are using Mac OS X or Windows, you have a JavaScript runtime installed in
-your operating system. Check
-[ExecJS](https://github.com/sstephenson/execjs#readme) documentation to know all
-supported JavaScript runtimes.
+your operating system. Check [ExecJS](https://github.com/sstephenson/execjs#readme) documentation to know all supported JavaScript runtimes.
 
 You can also disable generation of controller specific asset files by adding the
 following to your `config/application.rb` configuration:


### PR DESCRIPTION
Before
![screen shot 2014-09-09 at 1 23 32 pm](https://cloud.githubusercontent.com/assets/1955930/4198256/d6adbe30-37f6-11e4-99f6-45d3a660f1b8.png)

After
![screen shot 2014-09-09 at 1 24 49 pm](https://cloud.githubusercontent.com/assets/1955930/4198258/dcccbbfe-37f6-11e4-9830-be806fc820f1.png)
