### PR TITLE
Update error message of Active Model's validate method

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -142,9 +142,14 @@ module ActiveModel
       #   value.
       def validate(*args, &block)
         options = args.extract_options!
+        valid_keys = [:on, :if, :unless]
 
         if args.all? { |arg| arg.is_a?(Symbol) }
-          options.assert_valid_keys([:on, :if, :unless])
+          options.each_key do |k|
+            unless valid_keys.include?(k)
+              raise ArgumentError.new("Unknown key: #{k.inspect}. Valid keys are: #{valid_keys.map(&:inspect).join(', ')}. Perhaps you meant to call validates instead of validate.")
+            end
+          end
         end
 
         if options.key?(:on)


### PR DESCRIPTION
Updated error message to indicate user that perhaps she meant to call `validates` instead of `validate`.
