### PR TITLE
Support any args in NilClass#to_s

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_s.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_s.rb
@@ -1,0 +1,12 @@
+# encoding: utf-8
+
+class NilClass
+  # +nil+ respond with any args:
+  #
+  #   nil.to_s(:foo) # => ''
+  #
+  # @return ['']
+  def to_s(*args)
+    ''
+  end
+end

--- a/activesupport/test/core_ext/object/to_s_test.rb
+++ b/activesupport/test/core_ext/object/to_s_test.rb
@@ -1,0 +1,12 @@
+require 'abstract_unit'
+require 'active_support/core_ext/object/to_s'
+
+class ToParamTest < ActiveSupport::TestCase
+  def test_nil_with_args
+    assert_equal nil.to_s(:foo), ''
+  end
+
+  def test_nil_without_args
+    assert_equal nil.to_s, ''
+  end
+end


### PR DESCRIPTION
Hi,

[Rails extends DateTime to receive one argument](https://github.com/rails/rails/blob/v4.1.6.rc2/activesupport/lib/active_support/core_ext/date_time/conversions.rb#L41) so I think we should extend NilClass to avoid the following error.

``` ruby
> user = User.new
> user.deleted_at.to_s :db
ArgumentError: wrong number of arguments (1 for 0)
```

Datetime values of ActiveRecord can often be `nil`, but everyone forget it then call this method in this way.

My current workaround is here.

``` ruby
> user = User.new
> user.deleted_at.try(:to_s, :db)
nil
```

However, it doesn't make sense that we wrap it with try everywhere.
