### PR TITLE
A `NullRelation` should represent nothing. 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   A `NullRelation` should represent nothing. This fixes a bug where
+    `Comment.where(post_id: Post.none)` returned a non-empty result.
+
+    Closes #15176.
+
+    *Matthew Draper*, *Yves Senn*
+
 *   Include default column limits in schema.rb. Allows defaults to be changed
     in the future without affecting old migrations that assumed old defaults.
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -687,11 +687,11 @@ module ActiveRecord
     #   end
     #
     def none
-      extending(NullRelation)
+      where("1=0").extending!(NullRelation)
     end
 
     def none! # :nodoc:
-      extending!(NullRelation)
+      where!("1=0").extending!(NullRelation)
     end
 
     # Sets readonly attributes for the returned relation. If value is

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -18,6 +18,10 @@ module ActiveRecord
       def attribute_alias?(name)
         false
       end
+
+      def sanitize_sql(sql)
+        sql
+      end
     end
 
     def relation

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -420,6 +420,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal        nil, ac.engines.maximum(:id)
   end
 
+  def test_null_relation_in_where_condition
+    assert_operator 0, :<, Comment.count # precondition, make sure there are comments.
+    assert_equal 0, Comment.where(post_id: Post.none).to_a.size
+  end
+
   def test_joins_with_nil_argument
     assert_nothing_raised { DependentFirm.joins(nil).first }
   end


### PR DESCRIPTION
Closes #15176.
