### PR TITLE
remove warning

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -90,7 +90,7 @@ module ActiveRecord
 
       def undefine_attribute_methods # :nodoc:
         generated_attribute_methods.synchronize do
-          super if @attribute_methods_generated
+          super if defined?(@attribute_methods_generated)
           @attribute_methods_generated = false
         end
       end


### PR DESCRIPTION
warning: instance variable @attribute_methods_generated not initialized
