### PR TITLE
Replace drop sql statement to drop_table method

### DIFF
--- a/activerecord/test/cases/associations/required_test.rb
+++ b/activerecord/test/cases/associations/required_test.rb
@@ -18,8 +18,8 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.execute("DROP TABLE parents") if @connection.table_exists? 'parents'
-    @connection.execute("DROP TABLE children") if @connection.table_exists? 'children'
+    @connection.drop_table 'parents' if @connection.table_exists? 'parents'
+    @connection.drop_table 'children' if @connection.table_exists? 'children'
   end
 
   test "belongs_to associations are not required by default" do

--- a/activerecord/test/cases/attribute_decorators_test.rb
+++ b/activerecord/test/cases/attribute_decorators_test.rb
@@ -28,7 +28,7 @@ module ActiveRecord
 
     teardown do
       return unless @connection
-      @connection.execute 'DROP TABLE attribute_decorators_model' if @connection.table_exists? 'attribute_decorators_model'
+      @connection.drop_table 'attribute_decorators_model' if @connection.table_exists? 'attribute_decorators_model'
       Model.attribute_type_decorations.clear
       Model.reset_column_information
     end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -29,8 +29,8 @@ module ActiveRecord
 
       teardown do
         if defined?(@connection)
-          @connection.execute "DROP TABLE astronauts" if @connection.table_exists? 'astronauts' 
-          @connection.execute "DROP TABLE rockets" if @connection.table_exists? 'rockets'
+          @connection.drop_table "astronauts" if @connection.table_exists? 'astronauts' 
+          @connection.drop_table "rockets" if @connection.table_exists? 'rockets'
         end
       end
 


### PR DESCRIPTION
This pull request addresses `ActiveRecord::StatementInvalid: OCIError: ORA-00955: name is already used by an existing object` errors for creating existing sequence objects by replacing drop sql statement to drop_table method to drop sequences at the same time each tables dropped.

Since Oracle database tables and sequences to generate 'id' value are independent Oracle enhanced adapter `drop_table` method takes care which sequences "depend on" which tables. 

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/associations/required_test.rb -n test_belongs_to_associations_are_not_required_by_default
Using oracle
Run options: -n test_belongs_to_associations_are_not_required_by_default --seed 43677

# Running:

E

Finished in 0.035119s, 28.4749 runs/s, 0.0000 assertions/s.

  1) Error:
RequiredAssociationsTest#test_belongs_to_associations_are_not_required_by_default:
ActiveRecord::StatementInvalid: OCIError: ORA-00955: name is already used by an existing object: CREATE SEQUENCE "PARENTS_SEQ" START WITH 10000
    stmt.c:230:in oci8lib_220.so
    /home/yahonda/.rvm/gems/ruby-head@rails42/gems/ruby-oci8-2.1.7/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/.rvm/gems/ruby-head@rails42/gems/ruby-oci8-2.1.7/lib/oci8/oci8.rb:278:in `exec_internal'
    /home/yahonda/.rvm/gems/ruby-head@rails42/gems/ruby-oci8-2.1.7/lib/oci8/oci8.rb:269:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:429:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb:88:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:10:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:464:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:458:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1279:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_database_statements.rb:10:in `execute'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:415:in `create_sequence_and_trigger'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_schema_statements.rb:84:in `create_table'
    test/cases/associations/required_test.rb:14:in `block in <class:RequiredAssociationsTest>'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:438:in `instance_exec'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:438:in `block in make_lambda'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:186:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:186:in `block in simple'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:87:in `call'
    /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:87:in `run_callbacks'
    /home/yahonda/git/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:41:in `before_setup'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:820:in `before_setup'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

Confirmed this commit does not cause regressions for sqlite, mysql, mysql2 and postgresql adapters.
