### PR TITLE
[4-1-stable] Fix a bug where malformed query strings lead to 500

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
@@ -9,8 +9,12 @@ module ActionDispatch
     def call(env)
       status       = env["PATH_INFO"][1..-1]
       request      = ActionDispatch::Request.new(env)
-      content_type = request.formats.first
       body         = { :status => status, :error => Rack::Utils::HTTP_STATUS_CODES.fetch(status.to_i, Rack::Utils::HTTP_STATUS_CODES[500]) }
+      content_type = begin
+                       request.formats.first
+                     rescue ActionController::BadRequest
+                       Mime::HTML
+                     end
 
       render(status, content_type, body)
     end

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -8,7 +8,7 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
       case req.path
       when "/not_found"
         raise AbstractController::ActionNotFound
-      when "/bad_params"
+      when "/bad_params", "/bad_params?x[y]=1&x[y][][w]=2"
         raise ActionDispatch::ParamsParser::ParseError.new("", StandardError.new)
       when "/method_not_allowed"
         raise ActionController::MethodNotAllowed
@@ -39,6 +39,10 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     assert_equal "500 error fixture\n", body
     
     get "/bad_params", {}, {'action_dispatch.show_exceptions' => true}
+    assert_response 400
+    assert_equal "400 error fixture\n", body
+
+    get "/bad_params?x[y]=1&x[y][][w]=2", {}, {'action_dispatch.show_exceptions' => true}
     assert_response 400
     assert_equal "400 error fixture\n", body
 


### PR DESCRIPTION
This is a bugfix for #11502.

If a request contains an malformed query string, Rails responds with an internal server error insted of a bad request. This is because [`ActionDispatch::PublicExceptions` calls `request.formats`](https://github.com/rails/rails/blob/7133b0090e7509025bf71f22fb9f41404031dbbf/actionpack/lib/action_dispatch/middleware/public_exceptions.rb#L12) and [it raises an `ActionController::BadRequest`](https://github.com/rails/rails/blob/7133b0090e7509025bf71f22fb9f41404031dbbf/actionpack/lib/action_dispatch/http/request.rb#L276) from inside `ActionDispatch::ShowExceptions`, hence the 500 error.

This commit changes `PublicExceptions` to catch `BadRequest` if raised from `request.formats`.

On master, #13999 fixed this bug so we don't have to worry about it on master.
