### PR TITLE
[backport to 4-0-stable] Fix a bug where malformed query strings lead to 500

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
@@ -9,8 +9,12 @@ module ActionDispatch
     def call(env)
       status       = env["PATH_INFO"][1..-1]
       request      = ActionDispatch::Request.new(env)
-      content_type = request.formats.first
       body         = { :status => status, :error => Rack::Utils::HTTP_STATUS_CODES.fetch(status.to_i, Rack::Utils::HTTP_STATUS_CODES[500]) }
+      content_type = begin
+                       request.formats.first
+                     rescue ActionController::BadRequest
+                       Mime::HTML
+                     end
 
       render(status, content_type, body)
     end

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -8,7 +8,7 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
       case req.path
       when "/not_found"
         raise AbstractController::ActionNotFound
-      when "/bad_params"
+      when "/bad_params", "/bad_params?x[y]=1&x[y][][w]=2"
         raise ActionDispatch::ParamsParser::ParseError.new("", StandardError.new)
       when "/method_not_allowed"
         raise ActionController::MethodNotAllowed
@@ -39,6 +39,10 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     assert_equal "500 error fixture\n", body
     
     get "/bad_params", {}, {'action_dispatch.show_exceptions' => true}
+    assert_response 400
+    assert_equal "400 error fixture\n", body
+
+    get "/bad_params?x[y]=1&x[y][][w]=2", {}, {'action_dispatch.show_exceptions' => true}
     assert_response 400
     assert_equal "400 error fixture\n", body
 


### PR DESCRIPTION
This is a backport PR of #16871 to `4-0-stable`.
