### PR TITLE
Don't autosave unchanged has_one through records

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Don't autosave unchanged has_one through records
+
+    *Alan Kennedy*, *Steve Parrington*
+
 *   When a thread is killed, rollback the active transaction, instead of
     committing it during the stack unwind. Previously, we could commit half-
     completed work. This fix only works for Ruby 2.0+; on 1.9, we can't

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -403,7 +403,9 @@ module ActiveRecord
 
       # If the record is new or it has changed, returns true.
       def record_changed?(reflection, record, key)
-        record.new_record? || record[reflection.foreign_key] != key || record.attribute_changed?(reflection.foreign_key)
+        record.new_record? ||
+          (record.attributes.keys.include?(reflection.foreign_key) && record[reflection.foreign_key] != key) ||
+          record.attribute_changed?(reflection.foreign_key)
       end
 
       # Saves the associated record if it's new or <tt>:autosave</tt> is enabled.

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -19,6 +19,9 @@ require 'models/treasure'
 require 'models/eye'
 require 'models/electron'
 require 'models/molecule'
+require 'models/member'
+require 'models/member_detail'
+require 'models/organization'
 
 class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
   def test_autosave_validation
@@ -1113,6 +1116,27 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
 
   def test_should_not_load_the_associated_model
     assert_queries(1) { @pirate.catchphrase = 'Arr'; @pirate.save! }
+  end
+end
+
+class TestAutosaveAssociationOnAHasOneThroughAssociation < ActiveRecord::TestCase
+  self.use_transactional_fixtures = false unless supports_savepoints?
+
+  def setup
+    super
+    organization = Organization.create
+    @member = Member.create
+    MemberDetail.create(organization: organization, member: @member)
+  end
+
+  def test_should_not_has_one_through_model
+    class << @member.organization
+      def save(*args)
+        super
+        raise 'Oh noes!'
+      end
+    end
+    assert_nothing_raised { @member.save }
   end
 end
 


### PR DESCRIPTION
`has_one` associations (including `has_one :through`) go through the autosave logic on saves to check if they need to be saved.

Problem is that the logic that decides if a record needs to be autosaved for `has_one :through` always returns true and the record is saved. This causes `after_commit` callbacks to be triggered which can be unexpected.

Taking the example for the test: A Minivan has one Dashboard through Speedometer

Given an existing minivan with a dashboard, if that minivan is saved without changes this appears in the SQL logs:

```
BEGIN
COMMIT
```

The problem is that if Dashboard has `after_commit` callbacks set they get triggered, even though it didn't participate in the transaction.

We've modified the autosave logic check so that the save is not called on `has_one :through` records.

However I think this unexpected behaviour could be two bugs:
- one that this PR fixes, essentially a defensive fix.
- the other one being that `has_one :through` records should not even be attempted to be autosaved. (We aren't sure about this or how to fix without spending more time on it)

What are people's thoughts on the issue and proposed fix in general?
