### PR TITLE
Added thread-safety to LoggerSilence

### DIFF
--- a/activesupport/lib/active_support/logger_silence.rb
+++ b/activesupport/lib/active_support/logger_silence.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext/module/aliasing'
 require 'active_support/concern'
 
 module LoggerSilence

--- a/activesupport/lib/active_support/logger_silence.rb
+++ b/activesupport/lib/active_support/logger_silence.rb
@@ -1,3 +1,6 @@
+require 'logger'
+require 'thread'
+require 'active_support/core_ext/class/attribute_accessors'
 require 'active_support/core_ext/module/aliasing'
 require 'active_support/concern'
 

--- a/activesupport/lib/active_support/logger_silence.rb
+++ b/activesupport/lib/active_support/logger_silence.rb
@@ -1,4 +1,3 @@
-require 'logger'
 require 'thread'
 require 'active_support/core_ext/class/attribute_accessors'
 require 'active_support/core_ext/module/aliasing'

--- a/activesupport/lib/active_support/logger_silence.rb
+++ b/activesupport/lib/active_support/logger_silence.rb
@@ -11,11 +11,11 @@ module LoggerSilence
   end
 
   def thread_level
-    Thread.current[:logger_level]
+    Thread.current[thread_hash_level_key]
   end
 
   def thread_level=(l)
-    Thread.current[:logger_level] = l
+    Thread.current[thread_hash_level_key] = l
   end
 
   def level_with_threadsafety
@@ -39,5 +39,19 @@ module LoggerSilence
     else
       yield self
     end
+  end
+  
+  for severity in Logger::Severity.constants
+    class_eval <<-EOT, __FILE__, __LINE__ + 1
+      def #{severity.downcase}?                # def debug?
+        Logger::#{severity} >= level           #   DEBUG >= level
+      end                                      # end
+    EOT
+  end
+
+  private
+
+  def thread_hash_level_key
+    @thread_hash_level_key ||= :"ThreadSafeLogger##{object_id}@level"
   end
 end

--- a/activesupport/lib/active_support/logger_silence.rb
+++ b/activesupport/lib/active_support/logger_silence.rb
@@ -6,16 +6,35 @@ module LoggerSilence
   included do
     cattr_accessor :silencer
     self.silencer = true
+    alias_method_chain :level, :threadsafety
+    alias_method_chain :add, :threadsafety
+  end
+
+  def thread_level
+    Thread.current[:logger_level]
+  end
+
+  def thread_level=(l)
+    Thread.current[:logger_level] = l
+  end
+
+  def level_with_threadsafety
+    thread_level || level_without_threadsafety
+  end
+
+  def add_with_threadsafety(severity, message = nil, progname = nil, &block)
+    return true if @logdev.nil? or (severity || UNKNOWN) < level
+    add_without_threadsafety(severity, message, progname, &block)
   end
 
   # Silences the logger for the duration of the block.
   def silence(temporary_level = Logger::ERROR)
     if silencer
       begin
-        old_logger_level, self.level = level, temporary_level
+        self.thread_level = temporary_level
         yield self
       ensure
-        self.level = old_logger_level
+        self.thread_level = nil
       end
     else
       yield self


### PR DESCRIPTION
There are several issues related to thread-safety problems on `Logger#silence`. Most of them were fixed by just avoiding the calls to `Logger#silence`.

I'm using this fix on my projects. There's a small performance hit for non-threaded projects, but I haven't benchmarked it yet.

At least I'm not missing logs anymore.
