### PR TITLE
Changes default render behavior from file to template.

### DIFF
--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -108,7 +108,7 @@ module ActionView
       end
 
       # Normalize args by converting render "foo" to render :action => "foo" and
-      # render "foo/bar" to render :file => "foo/bar".
+      # render "foo/bar" to render :template => "foo/bar".
       # :api: private
       def _normalize_args(action=nil, options={})
         options = super(action, options)
@@ -118,7 +118,7 @@ module ActionView
           options = action
         when String, Symbol
           action = action.to_s
-          key = action.include?(?/) ? :file : :action
+          key = action.include?(?/) ? :template : :action
           options[key] = action
         else
           options[:partial] = action

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -91,17 +91,17 @@ class TestController < ApplicationController
 
   # :ported:
   def render_hello_world
-    render :template => "test/hello_world"
+    render "test/hello_world"
   end
 
   def render_hello_world_with_last_modified_set
     response.last_modified = Date.new(2008, 10, 10).to_time
-    render :template => "test/hello_world"
+    render "test/hello_world"
   end
 
   # :ported: compatibility
   def render_hello_world_with_forward_slash
-    render :template => "/test/hello_world"
+    render "/test/hello_world"
   end
 
   # :ported:
@@ -111,7 +111,7 @@ class TestController < ApplicationController
 
   # :deprecated:
   def render_template_in_top_directory_with_slash
-    render :template => '/shared'
+    render '/shared'
   end
 
   # :ported:
@@ -160,13 +160,6 @@ class TestController < ApplicationController
   end
 
   # :ported:
-  def render_file_as_string_with_instance_variables
-    @secret = 'in the sauce'
-    path = File.expand_path(File.join(File.dirname(__FILE__), '../../fixtures/test/render_file_with_ivar'))
-    render path
-  end
-
-  # :ported:
   def render_file_not_using_full_path
     @secret = 'in the sauce'
     render :file => 'test/render_file_with_ivar'
@@ -194,7 +187,7 @@ class TestController < ApplicationController
 
   def render_file_as_string_with_locals
     path = File.expand_path(File.join(File.dirname(__FILE__), '../../fixtures/test/render_file_with_locals'))
-    render path, :locals => {:secret => 'in the sauce'}
+    render file: path, :locals => {:secret => 'in the sauce'}
   end
 
   def accessing_request_in_template
@@ -791,12 +784,6 @@ class RenderTest < ActionController::TestCase
   def test_render_file
     get :hello_world_file
     assert_equal "Hello world!", @response.body
-  end
-
-  # :ported:
-  def test_render_file_as_string_with_instance_variables
-    get :render_file_as_string_with_instance_variables
-    assert_equal "The secret is in the sauce\n", @response.body
   end
 
   # :ported:


### PR DESCRIPTION
Currently the default behavior of `render "foo/bar"` is to expand to `render file: "foo/bar"`.

That means that the file being looked up is not restricted to the view paths, or the rails root path, and can lead to potentially vulnerable leaks from the filesystem.

This pull request changes the default behavior to `render template: "foo/bar"` instead of `render file: "foo/bar"`, which is restricted to the view paths, as exposing a high level of access to the file system outside of rails views should potentially be explicitly opt-in and not the default.

This may result in a more secure system without having to know the low level underpinnings of the ActionView::Rendering implementation, and I'm submitting this to open a conversation about it. When I first came across this it appeared to be a security issue, and reached out to the security team before looking into it and realizing it was the behavior as designed.
