### PR TITLE
globalid method name change from 'global_id' to 'to_global_id' breaks activejob

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -38,7 +38,7 @@ module ActiveJob
       def serialize_argument(argument)
         case argument
         when GlobalID::Identification
-          argument.global_id.to_s
+          argument.to_global_id.to_s
         when *TYPE_WHITELIST
           argument
         when Array


### PR DESCRIPTION
This is in reference to : 
https://github.com/rails/globalid/blob/master/lib/global_id/identification.rb#L7

This change should be merged in once whenever ActiveJob is updated to reference the latest globalid.
