### PR TITLE
lock suckerpunch version to 1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ group :job do
   gem 'resque', require: false
   gem 'resque-scheduler', require: false
   gem 'sidekiq', require: false
-  gem 'sucker_punch', require: false
+  gem 'sucker_punch', '1.1', require: false
   gem 'delayed_job', require: false
   gem 'queue_classic', "< 3.0.0", require: false, platforms: :ruby
   gem 'sneakers', '0.1.1.pre', require: false


### PR DESCRIPTION
@brandonhilkert, Celluloid 0.16 is not ready for production.
