### PR TITLE
MessageVerifier.new raises an appropriate exception if the secret is nil

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `MessageVerifier.new` raises an appropriate exception if the secret is `nil`.
+    This prevents `MessageVerifier#generate` from raising a cryptic error later on.
+
+    *Kostiantyn Kahanskyi*
+
 *   Introduced new configuration option `active_support.test_order` for
     specifying the order test cases are executed. This option currently defaults
     to `:sorted` but will be changed to `:random` in Rails 5.0.

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -27,7 +27,7 @@ module ActiveSupport
     class InvalidSignature < StandardError; end
 
     def initialize(secret, options = {})
-      raise ArgumentError, 'Secret should not be nil.' if secret.nil?
+      raise ArgumentError, 'Secret should not be nil.' unless secret
       @secret = secret
       @digest = options[:digest] || 'SHA1'
       @serializer = options[:serializer] || Marshal

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -27,6 +27,7 @@ module ActiveSupport
     class InvalidSignature < StandardError; end
 
     def initialize(secret, options = {})
+      raise ArgumentError, 'Secret should not be nil.' if secret.nil?
       @secret = secret
       @digest = options[:digest] || 'SHA1'
       @serializer = options[:serializer] || Marshal

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -69,6 +69,13 @@ class MessageVerifierTest < ActiveSupport::TestCase
                     "undefined class/module MessageVerifierTest::AutoloadClass"], exception.message
   end
 
+  def test_raise_error_when_secret_is_nil
+    exception = assert_raise(ArgumentError) do
+      ActiveSupport::MessageVerifier.new(nil)
+    end
+    assert_equal exception.message, 'Secret should not be nil.'
+  end
+
   def assert_not_verified(message)
     assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
       @verifier.verify(message)


### PR DESCRIPTION
Otherwise this will lead to another error later on when generating a signature:
`TypeError (no implicit conversion of nil into String)`.
