### PR TITLE
Fixes bad href attribute in redirects fallback view

### DIFF
--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -5,9 +5,8 @@ end
 
 class RedirectController < ActionController::Base
   # empty method not used anywhere to ensure methods like
-  # `status` and `location` aren't called on `redirect_to` calls
+  # `status` aren't called on `redirect_to` calls
   def status; render :text => 'called status'; end
-  def location; render :text => 'called location'; end
 
   def simple_redirect
     redirect_to :action => "hello_world"
@@ -64,6 +63,10 @@ class RedirectController < ActionController::Base
 
   def redirect_to_url_with_unescaped_query_string
     redirect_to "http://dev.rubyonrails.org/query?status=new"
+  end
+
+  def redirect_to_with_multiple_unescaped_query_strings
+    redirect_to "http://dev.rubyonrails.org/query?status=new&foo=bar"
   end
 
   def redirect_to_url_with_complex_scheme
@@ -234,6 +237,13 @@ class RedirectTest < ActionController::TestCase
     get :redirect_to_url_with_unescaped_query_string
     assert_response :redirect
     assert_redirected_to "http://dev.rubyonrails.org/query?status=new"
+  end
+
+  def test_redirect_to_url_with_multiple_unescaped_query_strings
+    get :redirect_to_with_multiple_unescaped_query_strings
+    assert_response :redirect
+    assert_redirected_to "http://dev.rubyonrails.org/query?status=new&foo=bar"
+    assert_includes @response.body, redirect_to_url
   end
 
   def test_redirect_to_url_with_complex_scheme


### PR DESCRIPTION
I've written an failing test but unsure how to fix the issue. 
[The problem is tracked to this place](https://github.com/alex-ross/rails/blob/fixes-bad-redirect-fallback-link/actionpack/lib/action_controller/metal/redirecting.rb#L76)

``` ruby
self.response_body = "<html><body>You are being <a href=\"#{ERB::Util.unwrapped_html_escape(location)}\">redirected</a>.</body></html>"
```

We are using `unwrapped_html_escape` which will convert all `&` in the query string to `&amp;` inside the href attribute. This will then lead to an invalid query string when a user clicks on the link. For example `&foo=bar` will be `&amp;foo=bar` in the browser and if we redirects to an other application this could cause lots of problems.

I guess `unwrapped_html_escape` is important to fix some other unwanted stuff in the url but is there an way to except the `&` character here without lots of workarounds?
