### PR TITLE
Rescue Rack::Utils::ParameterTypeError instead of TypeError

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -298,7 +298,7 @@ module ActionDispatch
     # Override Rack's GET method to support indifferent access
     def GET
       @env["action_dispatch.request.query_parameters"] ||= Utils.deep_munge(normalize_encode_params(super || {}))
-    rescue TypeError, Rack::Utils::InvalidParameterError => e
+    rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e
       raise ActionController::BadRequest.new(:query, e)
     end
     alias :query_parameters :GET
@@ -306,7 +306,7 @@ module ActionDispatch
     # Override Rack's POST method to support indifferent access
     def POST
       @env["action_dispatch.request.request_parameters"] ||= Utils.deep_munge(normalize_encode_params(super || {}))
-    rescue TypeError, Rack::Utils::InvalidParameterError => e
+    rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e
       raise ActionController::BadRequest.new(:request, e)
     end
     alias :request_parameters :POST

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -915,7 +915,7 @@ class RequestParameters < BaseRequestTest
 
     2.times do
       assert_raises(ActionController::BadRequest) do
-        # rack will raise a TypeError when parsing this query string
+        # rack will raise a Rack::Utils::ParameterTypeError when parsing this query string
         request.parameters
       end
     end
@@ -941,7 +941,7 @@ class RequestParameters < BaseRequestTest
     )
 
     assert_raises(ActionController::BadRequest) do
-      # rack will raise a TypeError when parsing this query string
+      # rack will raise a Rack::Utils::ParameterTypeError when parsing this query string
       request.parameters
     end
   end
@@ -950,7 +950,7 @@ class RequestParameters < BaseRequestTest
     request = stub_request("QUERY_STRING" => "x[y]=1&x[y][][w]=2")
 
     e = assert_raises(ActionController::BadRequest) do
-      # rack will raise a TypeError when parsing this query string
+      # rack will raise a Rack::Utils::ParameterTypeError when parsing this query string
       request.parameters
     end
 


### PR DESCRIPTION
As of rack/rack@167b6480235ff00ed5f355698bf00ec2f250f72e, Rack raises `Rack::Utils::ParameterTypeError` which inherits `TypeError`. In terms of the behaviour, Rescuing `TypeError` still works but this method shouldn't rescue if `TypeError` is raised for other reasons.
