### PR TITLE
Use dynamic path for dummy app location in plugin's test_helper.rb

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Change the path of dummy app location in plugin's test_helper.rb for cases
+    you specify dummy_path option.
+
+    *Yukio Mizuta*
+
 *   Fix a bug in the `gem` method for Rails templates when non-String options
     are used.
 

--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require File.expand_path("../dummy/config/environment.rb",  __FILE__)
+require File.expand_path("../../<%= options[:dummy_path] -%>/config/environment.rb",  __FILE__)
 require "rails/test_help"
 
 Rails.backtrace_cleaner.remove_silencers!

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -54,7 +54,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "README.rdoc", /Bukkits/
     assert_no_file "config/routes.rb"
-    assert_file "test/test_helper.rb"
+    assert_file "test/test_helper.rb", /require.+test\/dummy\/config\/environment/
     assert_file "test/bukkits_test.rb", /assert_kind_of Module, Bukkits/
   end
 
@@ -270,6 +270,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "spec/dummy"
     assert_file "spec/dummy/config/application.rb"
     assert_no_file "test/dummy"
+    assert_file "test/test_helper.rb", /require.+spec\/dummy\/config\/environment/
   end
 
   def test_creating_dummy_application_with_different_name
@@ -277,6 +278,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "spec/fake"
     assert_file "spec/fake/config/application.rb"
     assert_no_file "test/dummy"
+    assert_file "test/test_helper.rb", /require.+spec\/fake\/config\/environment/
   end
 
   def test_creating_dummy_without_tests_but_with_dummy_path
@@ -284,6 +286,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "spec/dummy"
     assert_file "spec/dummy/config/application.rb"
     assert_no_file "test"
+    assert_no_file "test/test_helper.rb"
     assert_file '.gitignore' do |contents|
       assert_match(/spec\/dummy/, contents)
     end


### PR DESCRIPTION
Currently if you specify a dummy-path options when you create a plugin, the test for the plugin doesn't work.

``` bash
> rails plugin new my_plugin --dummy-path=my/dummy/app
> cd my_plugin
> bundle exec rake test
/home/yukio/experiments/rails_gem/tmp/my_plugin/test/test_helper.rb:4:in `require': cannot load such file --
 /home/yukio/experiments/rails_gem/tmp/my_plugin/test/dummy/config/environment.rb (LoadError)
```

This patch will fix the cases like this. Even if you specify your own dummy_path, the test will work correctly.
