### PR TITLE
ActiveRecord deprecated finders are broken in 4.2

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -124,6 +124,8 @@ module ActiveRecord
       def find(*ids)
         # We don't have cache keys for this stuff yet
         return super unless ids.length == 1
+        # Allow symbols to super to maintain compatibility for deprecated finders until Rails 5
+        return super if ids.first.kind_of?(Symbol)
         return super if block_given? ||
                         primary_key.nil? ||
                         default_scopes.any? ||


### PR DESCRIPTION
References: https://github.com/rails/activerecord-deprecated_finders/issues/25

Maintain compatibility for:
- ActiveRecord::Base#find(:all)
- ActiveRecord::Base#find(:first)
- ActiveRecord::Base#find(:last)

I've got a solution and pointed a build at it. Viewable at Gemfile-edge @ https://travis-ci.org/kongregate/activerecord-deprecated_finders/builds/35390651.
