### PR TITLE
Specify dummy app's db migrate path in plugin's test_helper.rb

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Specify dummy app's db migrate path in plugin's test_helper.rb.
+
+    Fixes #16877.
+
+    *Yukio Mizuta*
+
 *   Change the path of dummy app location in plugin's test_helper.rb for cases
     you specify dummy_path option.
 

--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
@@ -2,6 +2,9 @@
 ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../../<%= options[:dummy_path] -%>/config/environment.rb",  __FILE__)
+<% unless options[:skip_active_record] -%>
+ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../<%= options[:dummy_path] -%>/db/migrate", __FILE__)]
+<% end -%>
 require "rails/test_help"
 
 Rails.backtrace_cleaner.remove_silencers!

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -54,7 +54,10 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "README.rdoc", /Bukkits/
     assert_no_file "config/routes.rb"
-    assert_file "test/test_helper.rb", /require.+test\/dummy\/config\/environment/
+    assert_file "test/test_helper.rb" do |content|
+      assert_match(/require.+test\/dummy\/config\/environment/, content)
+      assert_match(/ActiveRecord::Migrator\.migrations_paths.+test\/dummy\/db\/migrate/, content)
+    end
     assert_file "test/bukkits_test.rb", /assert_kind_of Module, Bukkits/
   end
 
@@ -270,7 +273,10 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "spec/dummy"
     assert_file "spec/dummy/config/application.rb"
     assert_no_file "test/dummy"
-    assert_file "test/test_helper.rb", /require.+spec\/dummy\/config\/environment/
+    assert_file "test/test_helper.rb" do |content|
+      assert_match(/require.+spec\/dummy\/config\/environment/, content)
+      assert_match(/ActiveRecord::Migrator\.migrations_paths.+spec\/dummy\/db\/migrate/, content)
+    end
   end
 
   def test_creating_dummy_application_with_different_name
@@ -278,7 +284,10 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "spec/fake"
     assert_file "spec/fake/config/application.rb"
     assert_no_file "test/dummy"
-    assert_file "test/test_helper.rb", /require.+spec\/fake\/config\/environment/
+    assert_file "test/test_helper.rb" do |content|
+      assert_match(/require.+spec\/fake\/config\/environment/, content)
+      assert_match(/ActiveRecord::Migrator\.migrations_paths.+spec\/fake\/db\/migrate/, content)
+    end
   end
 
   def test_creating_dummy_without_tests_but_with_dummy_path


### PR DESCRIPTION
This patch will fix #16877. Thanks :)
