### PR TITLE
[ci skip] AJ docs fixes

### DIFF
--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -36,7 +36,7 @@ module ActiveJob
       #     def perform(video_id)
       #       Video.find(video_id).process
       #     end
-      # end
+      #   end
       #
       def before_perform(*filters, &blk)
         set_callback(:perform, :before, *filters, &blk)
@@ -55,7 +55,7 @@ module ActiveJob
       #     def perform(video_id)
       #       Video.find(video_id).process
       #     end
-      # end
+      #   end
       #
       def after_perform(*filters, &blk)
         set_callback(:perform, :after, *filters, &blk)
@@ -75,7 +75,7 @@ module ActiveJob
       #     def perform(video_id)
       #       Video.find(video_id).process
       #     end
-      # end
+      #   end
       #
       def around_perform(*filters, &blk)
         set_callback(:perform, :around, *filters, &blk)
@@ -94,7 +94,7 @@ module ActiveJob
       #     def perform(video_id)
       #       Video.find(video_id).process
       #     end
-      # end
+      #   end
       #
       def before_enqueue(*filters, &blk)
         set_callback(:enqueue, :before, *filters, &blk)
@@ -113,7 +113,7 @@ module ActiveJob
       #     def perform(video_id)
       #       Video.find(video_id).process
       #     end
-      # end
+      #   end
       #
       def after_enqueue(*filters, &blk)
         set_callback(:enqueue, :after, *filters, &blk)
@@ -134,7 +134,7 @@ module ActiveJob
       #     def perform(video_id)
       #       Video.find(video_id).process
       #     end
-      # end
+      #   end
       #
       def around_enqueue(*filters, &blk)
         set_callback(:enqueue, :around, *filters, &blk)

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -13,7 +13,7 @@ module ActiveJob
       # Job Identifier
       attr_accessor :job_id
 
-      # Queue on which the job should be run on.
+      # Queue in which the job will reside.
       attr_writer :queue_name
     end
 

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -5,9 +5,9 @@ module ActiveJob
     extend ActiveSupport::Concern
 
     module ClassMethods
-      # Push a job onto the queue.  The arguments must be legal JSON types
+      # Push a job onto the queue. The arguments must be legal JSON types
       # (string, int, float, nil, true, false, hash or array) or
-      # GlobalID::Identification instances.  Arbitrary Ruby objects
+      # GlobalID::Identification instances. Arbitrary Ruby objects
       # are not supported.
       #
       # Returns an instance of the job class queued with args available in
@@ -22,7 +22,7 @@ module ActiveJob
         end
     end
 
-    # Reschedule the job to be re-executed. This is usefull in combination
+    # Reschedule the job to be re-executed. This is useful in combination
     # with the +rescue_from+ option. When you rescue an exception from your job
     # you can ask Active Job to retry performing your job.
     #
@@ -45,7 +45,7 @@ module ActiveJob
       enqueue options
     end
 
-    # Equeue the job to be performed by the queue adapter.
+    # Enqueues the job to be performed by the queue adapter.
     #
     # ==== Options
     # * <tt>:wait</tt> - Enqueues the job with the specified delay

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -22,7 +22,7 @@ module ActiveJob
     end
 
     # Performs the job immediately. The job is not sent to the queueing adapter
-    # and will block the execution until it's finished.
+    # but directly executed by blocking the execution of others until it's finished.
     #
     #   MyJob.new(*args).perform_now
     def perform_now

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -50,7 +50,7 @@ module ActiveJob
         logger.formatter.current_tags.include?("ActiveJob")
       end
 
-    class LogSubscriber < ActiveSupport::LogSubscriber
+    class LogSubscriber < ActiveSupport::LogSubscriber #:nodoc:
       def enqueue(event)
         info do
           job = event.payload[:job]

--- a/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
@@ -14,7 +14,7 @@ module ActiveJob
         end
       end
 
-      class JobWrapper
+      class JobWrapper #:nodoc:
         class << self
           def perform(job_data)
             Base.execute job_data

--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -13,7 +13,7 @@ module ActiveJob
         end
       end
 
-      class JobWrapper
+      class JobWrapper #:nodoc:
         def perform(job_data)
           Base.execute(job_data)
         end

--- a/activejob/lib/active_job/queue_adapters/qu_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/qu_adapter.rb
@@ -15,7 +15,7 @@ module ActiveJob
         end
       end
 
-      class JobWrapper < Qu::Job
+      class JobWrapper < Qu::Job #:nodoc:
         def initialize(job_data)
           @job_data  = job_data
         end

--- a/activejob/lib/active_job/queue_adapters/que_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/que_adapter.rb
@@ -13,7 +13,7 @@ module ActiveJob
         end
       end
 
-      class JobWrapper < Que::Job
+      class JobWrapper < Que::Job #:nodoc:
         def run(job_data)
           Base.execute job_data
         end

--- a/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
@@ -28,7 +28,7 @@ module ActiveJob
         end
       end
 
-      class JobWrapper
+      class JobWrapper #:nodoc:
         class << self
           def perform(job_data)
             Base.execute job_data

--- a/activejob/lib/active_job/queue_adapters/resque_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/resque_adapter.rb
@@ -29,7 +29,7 @@ module ActiveJob
         end
       end
 
-      class JobWrapper
+      class JobWrapper #:nodoc:
         class << self
           def perform(job_data)
             Base.execute job_data

--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -23,7 +23,7 @@ module ActiveJob
         end
       end
 
-      class JobWrapper
+      class JobWrapper #:nodoc:
         include Sidekiq::Worker
 
         def perform(job_data)

--- a/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
@@ -19,7 +19,7 @@ module ActiveJob
         end
       end
 
-      class JobWrapper
+      class JobWrapper #:nodoc:
         include Sneakers::Worker
         from_queue 'default'
 

--- a/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
@@ -13,7 +13,7 @@ module ActiveJob
         end
       end
 
-      class JobWrapper
+      class JobWrapper #:nodoc:
         include SuckerPunch::Job
 
         def perform(job_data)


### PR DESCRIPTION
1. Indentation
2. Spaces issues
3. Spelling correction
4. Grammar correction
5. Add #:nodoc: to all internal classes

refer #16576 
cc: @chancancode 
