### PR TITLE
Make year optional(mm/dd) while typecasting activerecord date type

### DIFF
--- a/activerecord/lib/active_record/type/date.rb
+++ b/activerecord/lib/active_record/type/date.rb
@@ -37,7 +37,8 @@ module ActiveRecord
       end
 
       def new_date(year, mon, mday)
-        if year && year != 0
+        year ||= ::Date.current.year
+        if year != 0
           ::Date.new(year, mon, mday) rescue nil
         end
       end

--- a/activerecord/lib/active_record/type/date.rb
+++ b/activerecord/lib/active_record/type/date.rb
@@ -37,10 +37,7 @@ module ActiveRecord
       end
 
       def new_date(year, mon, mday)
-        year ||= ::Date.current.year
-        if year != 0
-          ::Date.new(year, mon, mday) rescue nil
-        end
+        ::Date.new(year || ::Date.current.year, mon, mday) rescue nil
       end
     end
   end

--- a/activerecord/test/cases/type/date_test.rb
+++ b/activerecord/test/cases/type/date_test.rb
@@ -1,0 +1,14 @@
+require 'cases/helper'
+
+module ActiveRecord
+  module Type
+    class DateTest < ActiveRecord::TestCase
+      test 'optional year while creating new date' do
+        type = Type::Date.new
+        current_date = ::Date.current.strftime('%m/%d')
+        assert_equal ::Date.current, type.type_cast_from_user(current_date)
+        assert_equal ::Date.parse('7/15'), type.type_cast_from_user('7/15')
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/type/date_test.rb
+++ b/activerecord/test/cases/type/date_test.rb
@@ -8,6 +8,7 @@ module ActiveRecord
         current_date = ::Date.current.strftime('%m/%d')
         assert_equal ::Date.current, type.type_cast_from_user(current_date)
         assert_equal ::Date.parse('7/15'), type.type_cast_from_user('7/15')
+        assert_equal ::Date.parse('0000/7/15'), type.type_cast_from_user('0000/7/15')
       end
     end
   end


### PR DESCRIPTION
This will make the year optional while initiating any active record object with date type just like it is there for datetime.

i.e 
`User.new(created_at: '07/15')`
`#=> <#User id:1, created_at: current_year/07/15 >`

||y,

`user = User.new`
`user.assign_attributes(created_at: '07/15')`
