### PR TITLE
Use #inject over #sum to build PG create DB statement

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -60,8 +60,8 @@ module ActiveRecord
         def create_database(name, options = {})
           options = { encoding: 'utf8' }.merge!(options.symbolize_keys)
 
-          option_string = options.sum do |key, value|
-            case key
+          option_string = options.inject("") do |memo, (key, value)|
+            memo += case key
             when :owner
               " OWNER = \"#{value}\""
             when :template


### PR DESCRIPTION
While investigating #16951 I found that another library's monkey-patching of
`Enumerable` was causing the test migrations helper to break when trying to
build the `CREATE DATABASE` statement. The prior approach used `#sum` to build
the string from the options hash.

As the code that combines the options to build the database statement is not
user-facing, using `#inject` here instead will remove the only place where the
database creation/migration code is dependent on ActiveSupport's monkey-patching
of `Enumerable` with `#sum`.
