### PR TITLE
Inconsistency between Time and DateTime end_of_* methods

### DIFF
--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -114,6 +114,16 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal DateTime.civil(2005,4,30,23,59,59), DateTime.civil(2005,4,20,10,10,10).end_of_month
   end
 
+  # As Time#end_of_month adds a big Rationale as miliseconds, while
+  # DateTime#end_of_month has precision only up to the seconds, the result is
+  # that Time#end_of_month > DateTime#end_of_month
+  #
+  # Goes the same for all DateTime#end_of_*
+  def test_end_of_month_is_consisted_with_time
+    assert_equal Time.parse('2005-04-30 13:30').end_of_month.to_datetime,
+      DateTime.parse('2005-04-30 13:30').end_of_month
+  end
+
   def test_last_year
     assert_equal DateTime.civil(2004,6,5,10),  DateTime.civil(2005,6,5,10,0,0).last_year
   end


### PR DESCRIPTION
There's a difference with the way activesupports' end_of_[month/day/etc] work for Time and DateTime, as they use different precision (usecs for Time and seconds for DateTime). As usecs are also available on the DateTime class (just not used for end_of_\* methods), the result is that a Time.now.end_of_month.to_date_time > DateTime.now.end_of_month

This introduces subtle bugs in applications mixing Time and DateTime.

Possible solutions:
1. We skip miliseconds when changing a Time object to a DateTime, that way we'll keep DateTime's precision as seconds and miliseconds will be always 0.
2. We add milisecond support for end_of_\* methods in DateTime, it'd be a more breaking change.

I'd recommend solution 1 and I'm happy to submit a patch if you decide that's indeeed the correct way to solve it.
