### PR TITLE
Deprecate `SafeBuffer#gsub` and `SafeBuffer#sub` with block parameters

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecated `SafeBuffer#gsub` and `SafeBuffer#sub` with block parameters,
+    because magic variables such as `$1` wouldn't work with them.
+
+    * Leandro Facchinetti *
+
 *   Added method `#eql?` to `ActiveSupport::Duration`, in addition to `#==`.
 
     Currently, the following returns `false`, contrary to expectation:

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -129,11 +129,23 @@ class Numeric
 end
 
 module ActiveSupport #:nodoc:
+  # HTML safe +String+. Some methods that accept blocks don't work in
+  # +ActiveSupport::SafeBuffer+ the same way they do in +Strings+. The reason
+  # is the way Ruby magic variables such as <tt>$1</tt> work. For example:
+  #
+  #   'abc'.gsub(/(a)/) { "<#$1>" }
+  #    # => "<a>bc"
+  #   'abc'.html_safe.gsub(/(a)/) { "<#$1>" }
+  #    # => "<>bc"
+  #
+  # Methods with this behavior have their block forms deprecated and are going
+  # to be removed in future verions.
   class SafeBuffer < String
     UNSAFE_STRING_METHODS = %w(
       capitalize chomp chop delete downcase gsub lstrip next reverse rstrip
       slice squeeze strip sub succ swapcase tr tr_s upcase
     )
+    UNSAFE_WITH_BLOCK_STRING_METHODS = %w(gsub sub)
 
     alias_method :original_concat, :concat
     private :original_concat
@@ -222,17 +234,22 @@ module ActiveSupport #:nodoc:
       coder.represent_scalar nil, to_str
     end
 
+    def titleize
+      to_str.titleize
+    end
+
     UNSAFE_STRING_METHODS.each do |unsafe_method|
       if unsafe_method.respond_to?(unsafe_method)
         class_eval <<-EOT, __FILE__, __LINE__ + 1
-          def #{unsafe_method}(*args, &block)       # def capitalize(*args, &block)
-            to_str.#{unsafe_method}(*args, &block)  #   to_str.capitalize(*args, &block)
-          end                                       # end
+          def #{unsafe_method}(*args, &block)                   # def capitalize(*args, &block)
+            check_unsafe_with_block('#{unsafe_method}', &block) #   check_unsafe_with_block('capitalize', &block)
+            to_str.#{unsafe_method}(*args, &block)              #   to_str.capitalize(*args, &block)
+          end                                                   # end
 
-          def #{unsafe_method}!(*args)              # def capitalize!(*args)
-            @html_safe = false                      #   @html_safe = false
-            super                                   #   super
-          end                                       # end
+          def #{unsafe_method}!(*args)                          # def capitalize!(*args)
+            @html_safe = false                                  #   @html_safe = false
+            super                                               #   super
+          end                                                   # end
         EOT
       end
     end
@@ -242,6 +259,12 @@ module ActiveSupport #:nodoc:
     def html_escape_interpolated_argument(arg)
       (!html_safe? || arg.html_safe?) ? arg :
         arg.to_s.gsub(ERB::Util::HTML_ESCAPE_REGEXP, ERB::Util::HTML_ESCAPE)
+    end
+
+    def check_unsafe_with_block(unsafe_method, &block)
+      if UNSAFE_WITH_BLOCK_STRING_METHODS.include?(unsafe_method) && !block.nil?
+        ActiveSupport::Deprecation.deprecation_warning "ActiveSupport::SafeBuffer##{unsafe_method} with block is deprecated and will be removed in the future. Use ActiveSupport::SafeBuffer#to_str and call ##{unsafe_method} on the result, instead."
+      end
     end
   end
 end

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -141,6 +141,18 @@ class SafeBufferTest < ActiveSupport::TestCase
     assert !y.html_safe?, "should not be safe"
   end
 
+  test "Should deprecate gsub with block" do
+    assert_deprecated do
+      @buffer.gsub('') { '' }
+    end
+  end
+
+  test "Should deprecate sub with block" do
+    assert_deprecated do
+      @buffer.sub('') { '' }
+    end
+  end
+
   test 'Should work with interpolation (array argument)' do
     x = 'foo %s bar'.html_safe % ['qux']
     assert_equal 'foo qux bar', x


### PR DESCRIPTION
They may cause problems because magic variables such as `$1`
wouldn't work.
