### PR TITLE
Cleaner queuing of jobs using Delayed Job

### DIFF
--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -5,16 +5,22 @@ module ActiveJob
     class DelayedJobAdapter
       class << self
         def enqueue(job)
-          JobWrapper.new.delay(queue: job.queue_name).perform(job.serialize)
+          Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name)
         end
 
         def enqueue_at(job, timestamp)
-          JobWrapper.new.delay(queue: job.queue_name, run_at: Time.at(timestamp)).perform(job.serialize)
+          Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name, run_at: Time.at(timestamp))
         end
       end
 
       class JobWrapper #:nodoc:
-        def perform(job_data)
+        attr_accessor :job_data
+
+        def initialize(job_data)
+          @job_data = job_data
+        end
+
+        def perform
           Base.execute(job_data)
         end
       end


### PR DESCRIPTION
I can make this even cleaner if you don't mind me removing the JobWrapper class. Delayed Job doesn't actually need the wrapper class.
