### PR TITLE
Ensure named path params are symbols (Fixes #16958)

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -287,6 +287,7 @@ module ActionDispatch
               }
             end
 
+            inner_options.symbolize_keys!
             result.merge!(inner_options)
           end
         end

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -80,6 +80,14 @@ module ActionDispatch
         assert_equal '/foo/1/bar/2', url_helpers.foo_bar_path(2, foo_id: 1)
       end
 
+      test "stringified controller and action keys are properly symbolized" do
+        draw do
+          root 'foo#bar'
+        end
+
+        assert_equal '/', url_helpers.root_path('controller' => 'foo', 'action' => 'bar')
+      end
+
       private
         def draw(&block)
           @set.draw(&block)


### PR DESCRIPTION
There is a regression in master in which stringified `controller` and `action` keys passed to a named route are not treated it as actual controller and action, but are rather queued as params like any other non-special string. 

Waiting for feedback on whether this should be fixed in the Route Set or not before I write a small test for it.
