### PR TITLE
ActionMailer: mark mail as called after instead of before processing it

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -775,7 +775,6 @@ module ActionMailer
     def mail(headers = {}, &block)
       return @_message if @_mail_was_called && headers.blank? && !block
 
-      @_mail_was_called = true
       m = @_message
 
       # At the beginning, do not consider class default for content_type
@@ -803,6 +802,8 @@ module ActionMailer
 
       # Render the templates and blocks
       responses = collect_responses(headers, &block)
+      @_mail_was_called = true
+
       create_parts_from_responses(m, responses)
 
       # Setup content type, reapply charset and handle parts order

--- a/actionmailer/lib/action_mailer/mail_helper.rb
+++ b/actionmailer/lib/action_mailer/mail_helper.rb
@@ -29,7 +29,7 @@ module ActionMailer
 
     # Access the message attachments list.
     def attachments
-      @_message.attachments
+      mailer.attachments
     end
 
     # Returns +text+ wrapped at +len+ columns and indented +indent+ spaces.

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -259,6 +259,20 @@ class BaseTest < ActiveSupport::TestCase
     assert_match(/Can't add attachments after `mail` was called./, e.message)
   end
 
+  test "adding inline attachments while rendering mail works" do
+    class LateInlineAttachmentMailer < ActionMailer::Base
+      def on_render
+        mail from: "welcome@example.com", to: "to@example.com"
+      end
+    end
+
+    mail = LateInlineAttachmentMailer.on_render
+    assert_nothing_raised { mail.message }
+
+    assert_equal ["image/jpeg; filename=controller_attachments.jpg",
+                  "image/jpeg; filename=attachments.jpg"], mail.attachments.inline.map {|a| a['Content-Type'].to_s }
+  end
+
   test "accessing attachments works after mail was called" do
     class LateAttachmentAccessorMailer < ActionMailer::Base
       def welcome

--- a/actionmailer/test/fixtures/base_test/late_inline_attachment_mailer/on_render.erb
+++ b/actionmailer/test/fixtures/base_test/late_inline_attachment_mailer/on_render.erb
@@ -1,0 +1,7 @@
+<h1>Adding an inline image while rendering</h1>
+
+<% controller.attachments.inline["controller_attachments.jpg"] = 'via controller.attachments.inline' %>
+<%= image_tag attachments['controller_attachments.jpg'].url %>
+
+<% attachments.inline["attachments.jpg"] = 'via attachments.inline' %>
+<%= image_tag attachments['attachments.jpg'].url %>


### PR DESCRIPTION
#16163 introduced raising an exception when mail attachments get added after the method `mail` was called since it seems to produce problems with the email body. The change checks if `@_mail_was_called` is true which gets set on one of the first lines in `mail`. I suggest that we move it to the end of the method.

The background why I request this change is that we add inline attachments as the mail view gets rendered by overwriting the `image_tag` view helper. 

```
  def image_tag(path, options={})
    if URI.parse(path).relative?
      controller.attachments.inline[path] ||= File.read("#{Rails.root}/app/assets/images/#{path}")
      path = attachments[path].url
    end
    super(path, options)
  end
```

This way all the images we use get attached transparently. Very convenient.

The above change raises because `@_mail_was_called` the time the view is rendered. The big question is, if my change would reintroduce the problem or support both requirements. Maybe @joakimk or @senny can help with that?
