### PR TITLE
ActiveJob: queue_adapter can be inherited

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -29,6 +29,10 @@ module ActionMailer
       options.asset_host          ||= app.config.asset_host
       options.relative_url_root   ||= app.config.relative_url_root
 
+      # deliver mails synchronously by default
+      options.delivery_job = ActiveSupport::OrderedOptions.new
+      options.delivery_job.queue_adapter ||= :inline
+
       ActiveSupport.on_load(:action_mailer) do
         include AbstractController::UrlFor
         extend ::AbstractController::Railties::RoutesHelpers.with(app.routes, false)
@@ -37,6 +41,8 @@ module ActionMailer
         register_interceptors(options.delete(:interceptors))
         register_preview_interceptors(options.delete(:preview_interceptors))
         register_observers(options.delete(:observers))
+
+        options.delete(:delivery_job).each { |k,v| DeliveryJob.send("#{k}=", v) }
 
         options.each { |k,v| send("#{k}=", v) }
 

--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -6,10 +6,10 @@ module ActiveJob
     extend ActiveSupport::Concern
 
     module ClassMethods
-      mattr_reader(:queue_adapter) { ActiveJob::QueueAdapters::InlineAdapter }
+      class_attribute :queue_adapter
 
-      def queue_adapter=(name_or_adapter)
-        @@queue_adapter = \
+      def queue_adapter_with_interpretation=(name_or_adapter)
+        self.queue_adapter_without_interpretation = \
           case name_or_adapter
           when :test
             ActiveJob::QueueAdapters::TestAdapter.new
@@ -19,6 +19,7 @@ module ActiveJob
             name_or_adapter
           end
       end
+      alias_method_chain :queue_adapter, :interpretation
 
       private
         def load_adapter(name)

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -12,7 +12,6 @@ module ActiveJob
 
     initializer "active_job.set_configs" do |app|
       options = app.config.active_job
-      options.queue_adapter ||= :inline
 
       ActiveSupport.on_load(:active_job) do
         options.each { |k,v| send("#{k}=", v) }

--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -322,7 +322,7 @@ Please refer to the [Changelog][railties] for detailed changes.
       namespace: my_app_development
 
     # config/production.rb
-    MyApp::Application.configure do
+    Rails.application.configure do
       config.middleware.use ExceptionNotifier, config_for(:exception_notification)
     end
     ```

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -138,7 +138,9 @@ You can easily change your adapter:
 ```ruby
 # be sure to have the adapter gem in your Gemfile and follow the adapter specific
 # installation and deployment instructions
-Rails.application.config.active_job.queue_adapter = :sidekiq
+ApplicationJob
+  self.queue_adapter = :sidekiq
+end
 ```
 
 
@@ -265,6 +267,12 @@ UserMailer.welcome(@user).deliver_now
 UserMailer.welcome(@user).deliver_later
 ```
 
+You can also configure ActionMailer::DeliveryJob to use a specific queue
+adapter, distinct from the one specified in `ApplicationJob`:
+
+```ruby
+Rails.application.config.action_mailer.delivery_job.queue_adapter = :sneakers
+```
 
 GlobalID
 --------

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -138,7 +138,7 @@ You can easily change your adapter:
 ```ruby
 # be sure to have the adapter gem in your Gemfile and follow the adapter specific
 # installation and deployment instructions
-YourApp::Application.config.active_job.queue_adapter = :sidekiq
+Rails.application.config.active_job.queue_adapter = :sidekiq
 ```
 
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -810,8 +810,8 @@ Rails 4.0 extracted Active Resource to its own gem. If you still need the featur
 
 ```ruby
   # config/initializers/secret_token.rb
-  Myapp::Application.config.secret_token = 'existing secret token'
-  Myapp::Application.config.secret_key_base = 'new secret key base'
+  Rails.application.config.secret_token = 'existing secret token'
+  Rails.application.config.secret_key_base = 'new secret key base'
 ```
 
 Please note that you should wait to set `secret_key_base` until you have 100% of your userbase on Rails 4.x and are reasonably sure you will not need to rollback to Rails 3.x. This is because cookies signed based on the new `secret_key_base` in Rails 4.x are not backwards compatible with Rails 3.x. You are free to leave your existing `secret_token` in place, not set the new `secret_key_base`, and ignore the deprecation warnings until you are reasonably sure that your upgrade is otherwise complete.
@@ -1105,7 +1105,7 @@ You need to change your session key to something new, or remove all sessions:
 
 ```ruby
 # in config/initializers/session_store.rb
-AppName::Application.config.session_store :cookie_store, key: 'SOMETHINGNEW'
+Rails.application.config.session_store :cookie_store, key: 'SOMETHINGNEW'
 ```
 
 or

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -73,7 +73,7 @@
           namespace: my_app_development
 
         # config/production.rb
-        MyApp::Application.configure do
+        Rails.application.configure do
           config.middleware.use ExceptionNotifier, config_for(:exception_notification)
         end
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -217,7 +217,7 @@ module Rails
     #       namespace: my_app_development
     #
     #     # config/production.rb
-    #     MyApp::Application.configure do
+    #     Rails.application.configure do
     #       config.middleware.use ExceptionNotifier, config_for(:exception_notification)
     #     end
     def config_for(name)


### PR DESCRIPTION
Application configuration now only affects DeliveryJob, not AJ::Base.

@rafaelfranca first steps towards ApplicationJob. cc @strzalek 
