### PR TITLE
Fail informatively when redirect() is called with an opaque uri.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fail informatively when `redirect` is called with an opaque url, e.g. 'localhost:3000'
+
+    *Ben Woosley*
+
 *   Deprecate implicit Array conversion for Response objects. It was added
     (using `#to_ary`) so we could conveniently use implicit splatting:
 

--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -24,7 +24,11 @@ module ActionDispatch
       def serve(req)
         req.check_path_parameters!
         uri = URI.parse(path(req.path_parameters, req))
-        
+
+        if uri.opaque
+          raise ArgumentError, "redirect does not support opaque targets"
+        end
+
         unless uri.host
           if relative_path?(uri.path)
             uri.path = "#{req.script_name}/#{uri.path}"
@@ -32,7 +36,7 @@ module ActionDispatch
             uri.path = req.script_name.empty? ? "/" : req.script_name
           end
         end
-          
+
         uri.scheme ||= req.scheme
         uri.host   ||= req.host
         uri.port   ||= req.port unless req.standard_port?
@@ -124,7 +128,7 @@ module ActionDispatch
             url_options[:script_name] = request.script_name
           end
         end
-        
+
         ActionDispatch::Http::URL.url_for url_options
       end
 

--- a/actionpack/test/dispatch/routing/concerns_test.rb
+++ b/actionpack/test/dispatch/routing/concerns_test.rb
@@ -1,120 +1,124 @@
 require 'abstract_unit'
 
-class RoutingConcernsTest < ActionDispatch::IntegrationTest
-  class Reviewable
-    def self.call(mapper, options = {})
-      mapper.resources :reviews, options
-    end
-  end
-
-  Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
-    app.draw do
-      concern :commentable do |options|
-        resources :comments, options
-      end
-
-      concern :image_attachable do
-        resources :images, only: :index
-      end
-
-      concern :reviewable, Reviewable
-
-      resources :posts, concerns: [:commentable, :image_attachable, :reviewable] do
-        resource :video, concerns: :commentable do
-          concerns :reviewable, as: :video_reviews
+module ActionDispatch
+  module Routing
+    class ConcernsTest < ActionDispatch::IntegrationTest
+      class Reviewable
+        def self.call(mapper, options = {})
+          mapper.resources :reviews, options
         end
       end
 
-      resource :picture, concerns: :commentable do
-        resources :posts, concerns: :commentable
-      end
-
-      scope "/videos" do
-        concerns :commentable, except: :destroy
-      end
-    end
-  end
-
-  include Routes.url_helpers
-  APP = RoutedRackApp.new Routes
-  def app; APP end
-
-  def test_accessing_concern_from_resources
-    get "/posts/1/comments"
-    assert_equal "200", @response.code
-    assert_equal "/posts/1/comments", post_comments_path(post_id: 1)
-  end
-
-  def test_accessing_concern_from_resource
-    get "/picture/comments"
-    assert_equal "200", @response.code
-    assert_equal "/picture/comments", picture_comments_path
-  end
-
-  def test_accessing_concern_from_nested_resource
-    get "/posts/1/video/comments"
-    assert_equal "200", @response.code
-    assert_equal "/posts/1/video/comments", post_video_comments_path(post_id: 1)
-  end
-
-  def test_accessing_concern_from_nested_resources
-    get "/picture/posts/1/comments"
-    assert_equal "200", @response.code
-    assert_equal "/picture/posts/1/comments", picture_post_comments_path(post_id: 1)
-  end
-
-  def test_accessing_concern_from_resources_with_more_than_one_concern
-    get "/posts/1/images"
-    assert_equal "200", @response.code
-    assert_equal "/posts/1/images", post_images_path(post_id: 1)
-  end
-
-  def test_accessing_concern_from_resources_using_only_option
-    get "/posts/1/image/1"
-    assert_equal "404", @response.code
-  end
-
-  def test_accessing_callable_concern_
-    get "/posts/1/reviews/1"
-    assert_equal "200", @response.code
-    assert_equal "/posts/1/reviews/1", post_review_path(post_id: 1, id: 1)
-  end
-
-  def test_callable_concerns_accept_options
-    get "/posts/1/video/reviews/1"
-    assert_equal "200", @response.code
-    assert_equal "/posts/1/video/reviews/1", post_video_video_review_path(post_id: 1, id: 1)
-  end
-
-  def test_accessing_concern_from_a_scope
-    get "/videos/comments"
-    assert_equal "200", @response.code
-  end
-
-  def test_concerns_accept_options
-    delete "/videos/comments/1"
-    assert_equal "404", @response.code
-  end
-
-  def test_with_an_invalid_concern_name
-    e = assert_raise ArgumentError do
-      ActionDispatch::Routing::RouteSet.new.tap do |app|
+      Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
         app.draw do
-          resources :posts, concerns: :foo
+          concern :commentable do |options|
+            resources :comments, options
+          end
+
+          concern :image_attachable do
+            resources :images, only: :index
+          end
+
+          concern :reviewable, Reviewable
+
+          resources :posts, concerns: [:commentable, :image_attachable, :reviewable] do
+            resource :video, concerns: :commentable do
+              concerns :reviewable, as: :video_reviews
+            end
+          end
+
+          resource :picture, concerns: :commentable do
+            resources :posts, concerns: :commentable
+          end
+
+          scope "/videos" do
+            concerns :commentable, except: :destroy
+          end
         end
       end
+
+      include Routes.url_helpers
+      APP = RoutedRackApp.new Routes
+      def app; APP end
+
+      def test_accessing_concern_from_resources
+        get "/posts/1/comments"
+        assert_equal "200", @response.code
+        assert_equal "/posts/1/comments", post_comments_path(post_id: 1)
+      end
+
+      def test_accessing_concern_from_resource
+        get "/picture/comments"
+        assert_equal "200", @response.code
+        assert_equal "/picture/comments", picture_comments_path
+      end
+
+      def test_accessing_concern_from_nested_resource
+        get "/posts/1/video/comments"
+        assert_equal "200", @response.code
+        assert_equal "/posts/1/video/comments", post_video_comments_path(post_id: 1)
+      end
+
+      def test_accessing_concern_from_nested_resources
+        get "/picture/posts/1/comments"
+        assert_equal "200", @response.code
+        assert_equal "/picture/posts/1/comments", picture_post_comments_path(post_id: 1)
+      end
+
+      def test_accessing_concern_from_resources_with_more_than_one_concern
+        get "/posts/1/images"
+        assert_equal "200", @response.code
+        assert_equal "/posts/1/images", post_images_path(post_id: 1)
+      end
+
+      def test_accessing_concern_from_resources_using_only_option
+        get "/posts/1/image/1"
+        assert_equal "404", @response.code
+      end
+
+      def test_accessing_callable_concern_
+        get "/posts/1/reviews/1"
+        assert_equal "200", @response.code
+        assert_equal "/posts/1/reviews/1", post_review_path(post_id: 1, id: 1)
+      end
+
+      def test_callable_concerns_accept_options
+        get "/posts/1/video/reviews/1"
+        assert_equal "200", @response.code
+        assert_equal "/posts/1/video/reviews/1", post_video_video_review_path(post_id: 1, id: 1)
+      end
+
+      def test_accessing_concern_from_a_scope
+        get "/videos/comments"
+        assert_equal "200", @response.code
+      end
+
+      def test_concerns_accept_options
+        delete "/videos/comments/1"
+        assert_equal "404", @response.code
+      end
+
+      def test_with_an_invalid_concern_name
+        e = assert_raise ArgumentError do
+          ActionDispatch::Routing::RouteSet.new.tap do |app|
+            app.draw do
+              resources :posts, concerns: :foo
+            end
+          end
+        end
+
+        assert_equal "No concern named foo was found!", e.message
+      end
+
+      def test_concerns_executes_block_in_context_of_current_mapper
+        mapper = ActionDispatch::Routing::Mapper.new(ActionDispatch::Routing::RouteSet.new)
+        mapper.concern :test_concern do
+          resources :things
+          return self
+        end
+
+        assert_equal mapper, mapper.concerns(:test_concern)
+      end
     end
-
-    assert_equal "No concern named foo was found!", e.message
-  end
-
-  def test_concerns_executes_block_in_context_of_current_mapper
-    mapper = ActionDispatch::Routing::Mapper.new(ActionDispatch::Routing::RouteSet.new)
-    mapper.concern :test_concern do
-      resources :things
-      return self
-    end
-
-    assert_equal mapper, mapper.concerns(:test_concern)
   end
 end

--- a/actionpack/test/dispatch/routing/redirection_test.rb
+++ b/actionpack/test/dispatch/routing/redirection_test.rb
@@ -1,0 +1,299 @@
+# encoding: UTF-8
+require 'abstract_unit'
+
+module ActionDispatch
+  module Routing
+    class RedirectionTest < ActionDispatch::IntegrationTest
+      class YoutubeFavoritesRedirector
+        def self.call(params, request)
+          "http://www.youtube.com/watch?v=#{params[:youtube_id]}"
+        end
+      end
+
+      class GrumpyRestrictor
+        def self.matches?(request)
+          false
+        end
+      end
+
+      def test_login_redirect
+        draw do
+          get 'account/login', :to => redirect("/login")
+        end
+
+        get '/account/login'
+        verify_redirect 'http://www.example.com/login'
+      end
+
+      def test_logout_redirect_without_to
+        draw do
+          get 'account/logout' => redirect("/logout"), :as => :logout_redirect
+        end
+
+        assert_equal '/account/logout', logout_redirect_path
+        get '/account/logout'
+        verify_redirect 'http://www.example.com/logout'
+      end
+
+      def test_namespace_redirect
+        draw do
+          namespace :private do
+            root :to => redirect('/private/index')
+            get "index", :to => 'private#index'
+          end
+        end
+
+        get '/private'
+        verify_redirect 'http://www.example.com/private/index'
+      end
+
+      def test_redirect_with_failing_constraint
+        draw do
+          get 'hi', to: redirect("/foo"), constraints: GrumpyRestrictor
+        end
+
+        get '/hi'
+        assert_equal 404, status
+      end
+
+      def test_redirect_with_passing_constraint
+        draw do
+          get 'hi', to: redirect("/foo"), constraints: ->(req) { true }
+        end
+
+        get '/hi'
+        assert_equal 301, status
+      end
+
+      def test_redirect_modulo
+        draw do
+          get 'account/modulo/:name', :to => redirect("/%{name}s")
+        end
+
+        get '/account/modulo/name'
+        verify_redirect 'http://www.example.com/names'
+      end
+
+      def test_redirect_proc
+        draw do
+          get 'account/proc/:name', :to => redirect {|params, req| "/#{params[:name].pluralize}" }
+        end
+
+        get '/account/proc/person'
+        verify_redirect 'http://www.example.com/people'
+      end
+
+      def test_redirect_proc_with_request
+        draw do
+          get 'account/proc_req' => redirect {|params, req| "/#{req.method}" }
+        end
+
+        get '/account/proc_req'
+        verify_redirect 'http://www.example.com/GET'
+      end
+
+      def test_redirect_hash_with_subdomain
+        draw do
+          get 'mobile', :to => redirect(:subdomain => 'mobile')
+        end
+
+        get '/mobile'
+        verify_redirect 'http://mobile.example.com/mobile'
+      end
+
+      def test_redirect_hash_with_domain_and_path
+        draw do
+          get 'documentation', :to => redirect(:domain => 'example-documentation.com', :path => '')
+        end
+
+        get '/documentation'
+        verify_redirect 'http://www.example-documentation.com'
+      end
+
+      def test_redirect_hash_with_path
+        draw do
+          get 'new_documentation', :to => redirect(:path => '/documentation/new')
+        end
+
+        get '/new_documentation'
+        verify_redirect 'http://www.example.com/documentation/new'
+      end
+
+      def test_redirect_hash_with_host
+        draw do
+          get 'super_new_documentation', :to => redirect(:host => 'super-docs.com')
+        end
+
+        get '/super_new_documentation?section=top'
+        verify_redirect 'http://super-docs.com/super_new_documentation?section=top'
+      end
+
+      def test_redirect_hash_path_substitution
+        draw do
+          get 'stores/:name', :to => redirect(:subdomain => 'stores', :path => '/%{name}')
+        end
+
+        get '/stores/iernest'
+        verify_redirect 'http://stores.example.com/iernest'
+      end
+
+      def test_redirect_hash_path_substitution_with_catch_all
+        draw do
+          get 'stores/:name(*rest)', :to => redirect(:subdomain => 'stores', :path => '/%{name}%{rest}')
+        end
+
+        get '/stores/iernest/products'
+        verify_redirect 'http://stores.example.com/iernest/products'
+      end
+
+      def test_redirect_class
+        draw do
+          get 'youtube_favorites/:youtube_id/:name', :to => redirect(YoutubeFavoritesRedirector)
+        end
+
+        get '/youtube_favorites/oHg5SJYRHA0/rick-rolld'
+        verify_redirect 'http://www.youtube.com/watch?v=oHg5SJYRHA0'
+      end
+
+      def test_redirect_with_complete_url_and_status
+        draw do
+          get 'account/google' => redirect('http://www.google.com/', :status => 302)
+        end
+
+        get '/account/google'
+        verify_redirect 'http://www.google.com/', 302
+      end
+
+      def test_redirect_with_port
+        draw do
+          get 'account/login', :to => redirect("/login")
+        end
+
+        previous_host, self.host = self.host, 'www.example.com:3000'
+
+        get '/account/login'
+        verify_redirect 'http://www.example.com:3000/login'
+      ensure
+        self.host = previous_host
+      end
+
+      def test_redirect_https
+        draw do
+          get 'secure', :to => redirect("/secure/login")
+        end
+
+        with_https do
+          get '/secure'
+          verify_redirect 'https://www.example.com/secure/login'
+        end
+      end
+
+      def test_redirect_argument_error
+        routes = Class.new { include ActionDispatch::Routing::Redirection }.new
+        assert_raises(ArgumentError) { routes.redirect Object.new }
+      end
+
+    private
+
+      def draw(&block)
+        self.class.stub_controllers do |routes|
+          routes.default_url_options = { host: 'www.example.com' }
+          routes.draw(&block)
+          @app = RoutedRackApp.new routes
+        end
+      end
+
+      def with_https
+        old_https = https?
+        https!
+        yield
+      ensure
+        https!(old_https)
+      end
+
+      def verify_redirect(url, status=301)
+        assert_equal status, @response.status
+        assert_equal url, @response.headers['Location']
+        assert_equal expected_redirect_body(url), @response.body
+      end
+
+      def expected_redirect_body(url)
+        %(<html><body>You are being <a href="#{ERB::Util.h(url)}">redirected</a>.</body></html>)
+      end
+
+    end
+
+    class TestRedirectInterpolation < ActionDispatch::IntegrationTest
+      Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
+        app.draw do
+          ok = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, []] }
+
+          get "/foo/:id" => redirect("/foo/bar/%{id}")
+          get "/bar/:id" => redirect(:path => "/foo/bar/%{id}")
+          get "/baz/:id" => redirect("/baz?id=%{id}&foo=?&bar=1#id-%{id}")
+          get "/foo/bar/:id" => ok
+          get "/baz" => ok
+        end
+      end
+
+      APP = build_app Routes
+      def app; APP end
+
+      test "redirect escapes interpolated parameters with redirect proc" do
+        get "/foo/1%3E"
+        verify_redirect "http://www.example.com/foo/bar/1%3E"
+      end
+
+      test "redirect escapes interpolated parameters with option proc" do
+        get "/bar/1%3E"
+        verify_redirect "http://www.example.com/foo/bar/1%3E"
+      end
+
+      test "path redirect escapes interpolated parameters correctly" do
+        get "/foo/1%201"
+        verify_redirect "http://www.example.com/foo/bar/1%201"
+
+        get "/baz/1%201"
+        verify_redirect "http://www.example.com/baz?id=1+1&foo=?&bar=1#id-1%201"
+      end
+
+    private
+      def verify_redirect(url, status=301)
+        assert_equal status, @response.status
+        assert_equal url, @response.headers['Location']
+        assert_equal expected_redirect_body(url), @response.body
+      end
+
+      def expected_redirect_body(url)
+        %(<html><body>You are being <a href="#{ERB::Util.h(url)}">redirected</a>.</body></html>)
+      end
+    end
+
+    class TestRedirectRouteGeneration < ActionDispatch::IntegrationTest
+      stub_controllers do |routes|
+        Routes = routes
+        Routes.draw do
+          get '/account', to: redirect('/myaccount'), as: 'account'
+          get '/:locale/account', to: redirect('/%{locale}/myaccount'), as: 'localized_account'
+        end
+      end
+
+      APP = build_app Routes
+      def app
+        APP
+      end
+
+      include Routes.url_helpers
+
+      def test_redirect_doesnt_match_unnamed_route
+        assert_raise(ActionController::UrlGenerationError) do
+          assert_equal '/account?controller=products', url_for(controller: 'products', action: 'index', only_path: true)
+        end
+
+        assert_raise(ActionController::UrlGenerationError) do
+          assert_equal '/de/account?controller=products', url_for(controller: 'products', action: 'index', :locale => 'de', only_path: true)
+        end
+      end
+    end
+  end
+end

--- a/actionpack/test/dispatch/routing/redirection_test.rb
+++ b/actionpack/test/dispatch/routing/redirection_test.rb
@@ -177,6 +177,16 @@ module ActionDispatch
         self.host = previous_host
       end
 
+      def test_redirect_with_opaque_target
+        draw do
+          get 'account/google' => redirect('localhost:3000')
+        end
+
+        assert_raises(ArgumentError) do
+          get '/account/google'
+        end
+      end
+
       def test_redirect_https
         draw do
           get 'secure', :to => redirect("/secure/login")

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1,7 +1,5 @@
 # encoding: UTF-8
-require 'erb'
 require 'abstract_unit'
-require 'controller/fake_controllers'
 
 class TestRoutingMapper < ActionDispatch::IntegrationTest
   SprocketsApp = lambda { |env|
@@ -11,18 +9,6 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   class IpRestrictor
     def self.matches?(request)
       request.ip =~ /192\.168\.1\.1\d\d/
-    end
-  end
-
-  class GrumpyRestrictor
-    def self.matches?(request)
-      false
-    end
-  end
-
-  class YoutubeFavoritesRedirector
-    def self.call(params, request)
-      "http://www.youtube.com/watch?v=#{params[:youtube_id]}"
     end
   end
 
@@ -62,55 +48,6 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
     assert_equal 'http://rubyonrails.org/login', url_for(:controller => 'sessions', :action => 'create')
     assert_equal 'http://rubyonrails.org/login', login_url
-  end
-
-  def test_login_redirect
-    draw do
-      get 'account/login', :to => redirect("/login")
-    end
-
-    get '/account/login'
-    verify_redirect 'http://www.example.com/login'
-  end
-
-  def test_logout_redirect_without_to
-    draw do
-      get 'account/logout' => redirect("/logout"), :as => :logout_redirect
-    end
-
-    assert_equal '/account/logout', logout_redirect_path
-    get '/account/logout'
-    verify_redirect 'http://www.example.com/logout'
-  end
-
-  def test_namespace_redirect
-    draw do
-      namespace :private do
-        root :to => redirect('/private/index')
-        get "index", :to => 'private#index'
-      end
-    end
-
-    get '/private'
-    verify_redirect 'http://www.example.com/private/index'
-  end
-
-  def test_redirect_with_failing_constraint
-    draw do
-      get 'hi', to: redirect("/foo"), constraints: ::TestRoutingMapper::GrumpyRestrictor
-    end
-
-    get '/hi'
-    assert_equal 404, status
-  end
-
-  def test_redirect_with_passing_constraint
-    draw do
-      get 'hi', to: redirect("/foo"), constraints: ->(req) { true }
-    end
-
-    get '/hi'
-    assert_equal 301, status
   end
 
   def test_namespace_with_controller_segment
@@ -191,96 +128,6 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     get '/session/crush'
     assert_equal 'sessions#crush', @response.body
     assert_equal '/session/crush', crush_session_path
-  end
-
-  def test_redirect_modulo
-    draw do
-      get 'account/modulo/:name', :to => redirect("/%{name}s")
-    end
-
-    get '/account/modulo/name'
-    verify_redirect 'http://www.example.com/names'
-  end
-
-  def test_redirect_proc
-    draw do
-      get 'account/proc/:name', :to => redirect {|params, req| "/#{params[:name].pluralize}" }
-    end
-
-    get '/account/proc/person'
-    verify_redirect 'http://www.example.com/people'
-  end
-
-  def test_redirect_proc_with_request
-    draw do
-      get 'account/proc_req' => redirect {|params, req| "/#{req.method}" }
-    end
-
-    get '/account/proc_req'
-    verify_redirect 'http://www.example.com/GET'
-  end
-
-  def test_redirect_hash_with_subdomain
-    draw do
-      get 'mobile', :to => redirect(:subdomain => 'mobile')
-    end
-
-    get '/mobile'
-    verify_redirect 'http://mobile.example.com/mobile'
-  end
-
-  def test_redirect_hash_with_domain_and_path
-    draw do
-      get 'documentation', :to => redirect(:domain => 'example-documentation.com', :path => '')
-    end
-
-    get '/documentation'
-    verify_redirect 'http://www.example-documentation.com'
-  end
-
-  def test_redirect_hash_with_path
-    draw do
-      get 'new_documentation', :to => redirect(:path => '/documentation/new')
-    end
-
-    get '/new_documentation'
-    verify_redirect 'http://www.example.com/documentation/new'
-  end
-
-  def test_redirect_hash_with_host
-    draw do
-      get 'super_new_documentation', :to => redirect(:host => 'super-docs.com')
-    end
-
-    get '/super_new_documentation?section=top'
-    verify_redirect 'http://super-docs.com/super_new_documentation?section=top'
-  end
-
-  def test_redirect_hash_path_substitution
-    draw do
-      get 'stores/:name', :to => redirect(:subdomain => 'stores', :path => '/%{name}')
-    end
-
-    get '/stores/iernest'
-    verify_redirect 'http://stores.example.com/iernest'
-  end
-
-  def test_redirect_hash_path_substitution_with_catch_all
-    draw do
-      get 'stores/:name(*rest)', :to => redirect(:subdomain => 'stores', :path => '/%{name}%{rest}')
-    end
-
-    get '/stores/iernest/products'
-    verify_redirect 'http://stores.example.com/iernest/products'
-  end
-
-  def test_redirect_class
-    draw do
-      get 'youtube_favorites/:youtube_id/:name', :to => redirect(YoutubeFavoritesRedirector)
-    end
-
-    get '/youtube_favorites/oHg5SJYRHA0/rick-rolld'
-    verify_redirect 'http://www.youtube.com/watch?v=oHg5SJYRHA0'
   end
 
   def test_openid
@@ -1489,28 +1336,6 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     get '/sign_in'
     assert_equal 'sessions#new', @response.body
     assert_equal '/sign_in', sign_in_path
-  end
-
-  def test_redirect_with_complete_url_and_status
-    draw do
-      get 'account/google' => redirect('http://www.google.com/', :status => 302)
-    end
-
-    get '/account/google'
-    verify_redirect 'http://www.google.com/', 302
-  end
-
-  def test_redirect_with_port
-    draw do
-      get 'account/login', :to => redirect("/login")
-    end
-
-    previous_host, self.host = self.host, 'www.example.com:3000'
-
-    get '/account/login'
-    verify_redirect 'http://www.example.com:3000/login'
-  ensure
-    self.host = previous_host
   end
 
   def test_normalize_namespaced_matches
@@ -2866,17 +2691,6 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/my_account', wiki_account_path
   end
 
-  def test_redirect_https
-    draw do
-      get 'secure', :to => redirect("/secure/login")
-    end
-
-    with_https do
-      get '/secure'
-      verify_redirect 'https://www.example.com/secure/login'
-    end
-  end
-
   def test_path_parameters_is_not_stale
     draw do
       scope '/countries/:country', :constraints => lambda { |params, req| %w(all France).include?(params[:country]) } do
@@ -2996,11 +2810,6 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     get '/lists/2/todos/1'
     assert_equal 'Not Found', @response.body
     assert_raises(ActionController::UrlGenerationError){ list_todo_path(:list_id => '2', :id => '1') }
-  end
-
-  def test_redirect_argument_error
-    routes = Class.new { include ActionDispatch::Routing::Redirection }.new
-    assert_raises(ArgumentError) { routes.redirect Object.new }
   end
 
   def test_named_route_check
@@ -3485,14 +3294,6 @@ private
     end
   end
 
-  def with_https
-    old_https = https?
-    https!
-    yield
-  ensure
-    https!(old_https)
-  end
-
   def verify_redirect(url, status=301)
     assert_equal status, @response.status
     assert_equal url, @response.headers['Location']
@@ -3880,52 +3681,6 @@ class TestTildeAndMinusPaths < ActionDispatch::IntegrationTest
     assert_equal "200", @response.code
   end
 
-end
-
-class TestRedirectInterpolation < ActionDispatch::IntegrationTest
-  Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
-    app.draw do
-      ok = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, []] }
-
-      get "/foo/:id" => redirect("/foo/bar/%{id}")
-      get "/bar/:id" => redirect(:path => "/foo/bar/%{id}")
-      get "/baz/:id" => redirect("/baz?id=%{id}&foo=?&bar=1#id-%{id}")
-      get "/foo/bar/:id" => ok
-      get "/baz" => ok
-    end
-  end
-
-  APP = build_app Routes
-  def app; APP end
-
-  test "redirect escapes interpolated parameters with redirect proc" do
-    get "/foo/1%3E"
-    verify_redirect "http://www.example.com/foo/bar/1%3E"
-  end
-
-  test "redirect escapes interpolated parameters with option proc" do
-    get "/bar/1%3E"
-    verify_redirect "http://www.example.com/foo/bar/1%3E"
-  end
-
-  test "path redirect escapes interpolated parameters correctly" do
-    get "/foo/1%201"
-    verify_redirect "http://www.example.com/foo/bar/1%201"
-
-    get "/baz/1%201"
-    verify_redirect "http://www.example.com/baz?id=1+1&foo=?&bar=1#id-1%201"
-  end
-
-private
-  def verify_redirect(url, status=301)
-    assert_equal status, @response.status
-    assert_equal url, @response.headers['Location']
-    assert_equal expected_redirect_body(url), @response.body
-  end
-
-  def expected_redirect_body(url)
-    %(<html><body>You are being <a href="#{ERB::Util.h(url)}">redirected</a>.</body></html>)
-  end
 end
 
 class TestConstraintsAccessingParameters < ActionDispatch::IntegrationTest
@@ -4371,33 +4126,6 @@ class TestRackAppRouteGeneration < ActionDispatch::IntegrationTest
   include Routes.url_helpers
 
   def test_mounted_application_doesnt_match_unnamed_route
-    assert_raise(ActionController::UrlGenerationError) do
-      assert_equal '/account?controller=products', url_for(controller: 'products', action: 'index', only_path: true)
-    end
-
-    assert_raise(ActionController::UrlGenerationError) do
-      assert_equal '/de/account?controller=products', url_for(controller: 'products', action: 'index', :locale => 'de', only_path: true)
-    end
-  end
-end
-
-class TestRedirectRouteGeneration < ActionDispatch::IntegrationTest
-  stub_controllers do |routes|
-    Routes = routes
-    Routes.draw do
-      get '/account', to: redirect('/myaccount'), as: 'account'
-      get '/:locale/account', to: redirect('/%{locale}/myaccount'), as: 'localized_account'
-    end
-  end
-
-  APP = build_app Routes
-  def app
-    APP
-  end
-
-  include Routes.url_helpers
-
-  def test_redirect_doesnt_match_unnamed_route
     assert_raise(ActionController::UrlGenerationError) do
       assert_equal '/account?controller=products', url_for(controller: 'products', action: 'index', only_path: true)
     end


### PR DESCRIPTION
Absent this fix the call fails at runtime with “undefined method `empty?' for nil:NilClass” for uri.path.empty? because opaque uris have no path.

Also split the redirection tests out of routing_test.rb, which is pretty beefy.
