### PR TITLE
[ci skip] Reword a comment in concern's documentation

### DIFF
--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -95,7 +95,7 @@ module ActiveSupport
   #   end
   #
   #   class Host
-  #     include Bar # works, Bar takes care now of its dependencies
+  #     include Bar # It works, now Bar takes care of its dependencies
   #   end
   module Concern
     class MultipleIncludedBlocks < StandardError #:nodoc:


### PR DESCRIPTION
Nothing biggie. Skimmed through `ActiveSupport::Concern` docs these days
and this one comment seemed a bit off.
