### PR TITLE
Document that the default for `rails server -b` has changed

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -177,6 +177,21 @@ class UsersController < ApplicationController
 end
 ```
 
+### Default host for `rails server`
+
+Due to a [change in Rack](https://github.com/rack/rack/commit/28b014484a8ac0bbb388e7eaeeef159598ec64fc),
+`rails server` now listens on `localhost` instead of `0.0.0.0` by default. This
+should have minimal impact on the standard development workflow as both http://127.0.0.1:3000
+and http://localhost:3000 would continue to work as before on your own machine.
+
+However, with this change you would no longer be able to access the Rails server
+from a different machine (e.g. your development environment is in a virtual
+machine and you would like to access it from the host machine), you would need
+to start the server with `rails server -b 0.0.0.0` to restore the old behavior.
+
+If you do this, be sure to configure your firewall properly such that only
+trusted machines on your network can access your development server.
+
 ### Production logging
 
 The default log level in the `production` environment is now `:debug`. This

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -24,7 +24,7 @@ module Rails
           opts.on("-p", "--port=port", Integer,
                   "Runs Rails on the specified port.", "Default: 3000") { |v| options[:Port] = v }
           opts.on("-b", "--binding=IP", String,
-                  "Binds Rails to the specified IP.", "Default: 0.0.0.0") { |v| options[:Host] = v }
+                  "Binds Rails to the specified IP.", "Default: localhost") { |v| options[:Host] = v }
           opts.on("-c", "--config=file", String,
                   "Uses a custom rackup configuration.") { |v| options[:config] = v }
           opts.on("-d", "--daemon", "Runs server as a Daemon.") { options[:daemonize] = true }
@@ -125,10 +125,6 @@ module Rails
         puts "=> Booting #{ActiveSupport::Inflector.demodulize(server)}"
         puts "=> Rails #{Rails.version} application starting in #{Rails.env} on #{url}"
         puts "=> Run `rails server -h` for more startup options"
-
-        if options[:Host].to_s.match(/0\.0\.0\.0/)
-          puts "=> Notice: server is listening on all interfaces (#{options[:Host]}). Consider using 127.0.0.1 (--binding option)"
-        end
 
         puts "=> Ctrl-C to shutdown server" unless options[:daemonize]
       end


### PR DESCRIPTION
I want to cut down the number of blockers before beta2, so here is a quick fix for #16578.

We can just as easily keep the old default on Rails side, but after a quick chat with @jeremy we are leaning towards using the new default from Rack.

cc @rafaelfranca @dhh @jeremy @tenderlove @matthewd @NZKoz 
