### PR TITLE
Skip isolated tests for PRs

### DIFF
--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -107,6 +107,7 @@ results = {}
 
 ENV['GEM'].split(',').each do |gem|
   [false, true].each do |isolated|
+    next if ENV['TRAVIS_PULL_REQUEST'] && ENV['TRAVIS_PULL_REQUEST'] != 'false' && isolated
     next if gem == 'railties' && isolated
     next if gem == 'aj:integration' && isolated
 


### PR DESCRIPTION
They're valuable, but the types of errors they catch are fairly rare: we can address them post-merge when they show up.

While commenting on https://github.com/travis-ci/travis-ci/issues/2801, I realised we can already improve things measurably.

/cc @chancancode 
