### PR TITLE
Include exception backtrace in ActiveSupport notification payloads

### DIFF
--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -19,7 +19,7 @@ module ActiveSupport
         begin
           yield payload
         rescue Exception => e
-          payload[:exception] = [e.class.name, e.message]
+          payload[:exception] = [e.class.name, e.message, e.backtrace]
           raise e
         ensure
           finish name, payload


### PR DESCRIPTION
Currently, ActiveSupport only includes the exception class name and message in the event payload of instrumented blocks that raise exceptions.

Exception backtraces are useful, and including them in the event notifications would allow interested parties to collect this information without needing to monkey patch ActiveSupport or attempting to process multi-line log messages.

Does this change make sense? The diff here is just a proposal, if this is something people would be interested in seeing happen I'd be happy to add some tests and documentation for this change to this PR.
