### PR TITLE
Cache the fixture set filenames that have already been loaded

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -812,6 +812,9 @@ module ActiveRecord
       teardown_fixtures
     end
 
+    mattr_reader :required_fixture_set_names
+    @@required_fixture_set_names = []
+
     included do
       class_attribute :fixture_path, :instance_writer => false
       class_attribute :fixture_table_names
@@ -876,7 +879,10 @@ module ActiveRecord
           fixture_set_names = fixture_table_names
         end
 
+        fixture_set_names -= ActiveRecord::TestFixtures::required_fixture_set_names
+
         fixture_set_names.each do |file_name|
+          ActiveRecord::TestFixtures::required_fixture_set_names << file_name
           file_name = file_name.singularize if config.pluralize_table_names
           try_to_load_dependency(file_name)
         end


### PR DESCRIPTION
Test frameworks such as RSpec include ActiveRecord::TestFixtures for each individual test suite class, and since they generate one such test suite class for each 'describe' or 'context' call, there are many such classes in a full suite.

The fixtures method is therefore called many times in a large test file/set.  It calls require_fixture_classes, which calls singularize and try_to_load_dependency/require_dependency for each fixture configured, both of which are quite slow, making this repetition a major slow-down - adding several seconds to the start-up time for some of our test files.

This patch improves the load time of large files by 88% in my testing.  It simply memoizes the list of fixture files already put through the singularize/try_to_load_dependency loop (using a module-level accessor so that it persists across those multiple test classes).  Since requires are global, there's no need to repeat this work for each test class.
