### PR TITLE
Fix false assertions in AR::TestCase::AttributeMethodsTest

### DIFF
--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -738,9 +738,9 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     error = assert_raises(ActiveRecord::UnknownAttributeError) {
       @target.new(:hello => "world")
     }
-    assert @target, error.record
-    assert "hello", error.attribute
-    assert "unknown attribute: hello", error.message
+    assert_instance_of @target, error.record
+    assert_equal "hello", error.attribute
+    assert_equal "unknown attribute: hello", error.message
   end
 
   def test_methods_override_in_multi_level_subclass


### PR DESCRIPTION
This test has always been green because it uses "assert", not "assert_equal" or "assert_match", and the first argument is an truthy class/object. The first one is supposed to assert the class of the instance and the rest is  supposed to assert the equality of 2 strings.
