### PR TITLE
Fix another false assertions

### DIFF
--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -98,8 +98,8 @@ class DurationTest < ActiveSupport::TestCase
 
   def test_since_and_ago
     t = Time.local(2000)
-    assert t + 1, 1.second.since(t)
-    assert t - 1, 1.second.ago(t)
+    assert_equal t + 1, 1.second.since(t)
+    assert_equal t - 1, 1.second.ago(t)
   end
 
   def test_since_and_ago_without_argument

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -182,7 +182,7 @@ module ApplicationTests
 
     test "application is always added to eager_load namespaces" do
       require "#{app_path}/config/application"
-      assert Rails.application, Rails.application.config.eager_load_namespaces
+      assert_includes Rails.application.config.eager_load_namespaces, AppTemplate::Application
     end
 
     test "the application can be eager loaded even when there are no frameworks" do


### PR DESCRIPTION
Found another false assertions. related to https://github.com/rails/rails/pull/16998

To find false assertions, I used this method and put it into `ActiveSupport::TestCase`:

``` ruby
def assert(test, msg = nil)
  if !(msg.nil? || msg.is_a?(Proc)) && !msg.is_a?(String) || msg == test
    raise "false assertion: test: #{test}, msg: #{msg}"
  else
    super
  end
end
```

It might not be able to capture all of them but it's better than nothing.
