### PR TITLE
Remove wrapping <div> in form helpers from doc

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -51,9 +51,7 @@ module ActionView
     # The HTML generated for this would be (modulus formatting):
     #
     #   <form action="/people" class="new_person" id="new_person" method="post">
-    #     <div style="display:none">
-    #       <input name="authenticity_token" type="hidden" value="NrOp5bsjoLRuK8IW5+dQEYjKGUJDe7TQoZVvq95Wteg=" />
-    #     </div>
+    #     <input name="authenticity_token" type="hidden" value="NrOp5bsjoLRuK8IW5+dQEYjKGUJDe7TQoZVvq95Wteg=" />
     #     <label for="person_first_name">First name</label>:
     #     <input id="person_first_name" name="person[first_name]" type="text" /><br />
     #
@@ -81,10 +79,8 @@ module ActionView
     # the code above as is would yield instead:
     #
     #   <form action="/people/256" class="edit_person" id="edit_person_256" method="post">
-    #     <div style="display:none">
-    #       <input name="_method" type="hidden" value="patch" />
-    #       <input name="authenticity_token" type="hidden" value="NrOp5bsjoLRuK8IW5+dQEYjKGUJDe7TQoZVvq95Wteg=" />
-    #     </div>
+    #     <input name="_method" type="hidden" value="patch" />
+    #     <input name="authenticity_token" type="hidden" value="NrOp5bsjoLRuK8IW5+dQEYjKGUJDe7TQoZVvq95Wteg=" />
     #     <label for="person_first_name">First name</label>:
     #     <input id="person_first_name" name="person[first_name]" type="text" value="John" /><br />
     #
@@ -315,9 +311,7 @@ module ActionView
       # The HTML generated for this would be:
       #
       #   <form action='http://www.example.com' method='post' data-remote='true'>
-      #     <div style='display:none'>
-      #       <input name='_method' type='hidden' value='patch' />
-      #     </div>
+      #     <input name='_method' type='hidden' value='patch' />
       #     ...
       #   </form>
       #
@@ -333,9 +327,7 @@ module ActionView
       # The HTML generated for this would be:
       #
       #   <form action='http://www.example.com' method='post' data-behavior='autosave' name='go'>
-      #     <div style='display:none'>
-      #       <input name='_method' type='hidden' value='patch' />
-      #     </div>
+      #     <input name='_method' type='hidden' value='patch' />
       #     ...
       #   </form>
       #

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -229,59 +229,51 @@ module ActionView
       # ==== Examples
       #   <%= button_to "New", action: "new" %>
       #   # => "<form method="post" action="/controller/new" class="button_to">
-      #   #      <div><input value="New" type="submit" /></div>
+      #   #      <input value="New" type="submit" />
       #   #    </form>"
       #
       #   <%= button_to "New", new_articles_path %>
       #   # => "<form method="post" action="/articles/new" class="button_to">
-      #   #      <div><input value="New" type="submit" /></div>
+      #   #      <input value="New" type="submit" />
       #   #    </form>"
       #
       #   <%= button_to [:make_happy, @user] do %>
       #     Make happy <strong><%= @user.name %></strong>
       #   <% end %>
       #   # => "<form method="post" action="/users/1/make_happy" class="button_to">
-      #   #      <div>
-      #   #        <button type="submit">
-      #   #          Make happy <strong><%= @user.name %></strong>
-      #   #        </button>
-      #   #      </div>
+      #   #      <button type="submit">
+      #   #        Make happy <strong><%= @user.name %></strong>
+      #   #      </button>
       #   #    </form>"
       #
       #   <%= button_to "New", { action: "new" }, form_class: "new-thing" %>
       #   # => "<form method="post" action="/controller/new" class="new-thing">
-      #   #      <div><input value="New" type="submit" /></div>
+      #   #      <input value="New" type="submit" />
       #   #    </form>"
       #
       #
       #   <%= button_to "Create", { action: "create" }, remote: true, form: { "data-type" => "json" } %>
       #   # => "<form method="post" action="/images/create" class="button_to" data-remote="true" data-type="json">
-      #   #      <div>
-      #   #        <input value="Create" type="submit" />
-      #   #        <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"/>
-      #   #      </div>
+      #   #      <input value="Create" type="submit" />
+      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"/>
       #   #    </form>"
       #
       #
       #   <%= button_to "Delete Image", { action: "delete", id: @image.id },
       #                                   method: :delete, data: { confirm: "Are you sure?" } %>
       #   # => "<form method="post" action="/images/delete/1" class="button_to">
-      #   #      <div>
-      #   #        <input type="hidden" name="_method" value="delete" />
-      #   #        <input data-confirm='Are you sure?' value="Delete Image" type="submit" />
-      #   #        <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"/>
-      #   #      </div>
+      #   #      <input type="hidden" name="_method" value="delete" />
+      #   #      <input data-confirm='Are you sure?' value="Delete Image" type="submit" />
+      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"/>
       #   #    </form>"
       #
       #
       #   <%= button_to('Destroy', 'http://www.example.com',
       #             method: "delete", remote: true, data: { confirm: 'Are you sure?', disable_with: 'loading...' }) %>
       #   # => "<form class='button_to' method='post' action='http://www.example.com' data-remote='true'>
-      #   #       <div>
-      #   #         <input name='_method' value='delete' type='hidden' />
-      #   #         <input value='Destroy' type='submit' data-disable-with='loading...' data-confirm='Are you sure?' />
-      #   #         <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"/>
-      #   #       </div>
+      #   #       <input name='_method' value='delete' type='hidden' />
+      #   #       <input value='Destroy' type='submit' data-disable-with='loading...' data-confirm='Are you sure?' />
+      #   #       <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"/>
       #   #     </form>"
       #   #
       def button_to(name = nil, options = nil, html_options = nil, &block)


### PR DESCRIPTION
[ci skip]

89ff1f8 and 1de258e6 removed from the HTML generated by the form helpers the `<div>` that was wrapping the field elements inside the `<form>`.

This commit updates the documentation of the methods to reflect the two commits above.
