### PR TITLE
Fix translation in dependent_restrict_with_error

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
         when :restrict_with_error
           unless empty?
-            record = klass.human_attribute_name(reflection.name).downcase
+            record = reflection.active_record.human_attribute_name(reflection.name).downcase
             owner.errors.add(:base, :"restrict_dependent_destroy.many", record: record)
             false
           end


### PR DESCRIPTION
This fixes an issue where the translation would be expected on the associated model itself, instead of on the association's parent.

For example

```
class Foo < ActiveRecord::Base
  has_many :bars
end
```

Expects a translation to be present on `en.activerecord.attributes.bar.bars`

This fix changes this to expect a translation to be present on `en.activerecord.attributes.foo.bars`

This seems like a more sensible approach, since the association can be considered an attribute of the association's parent, but not as an attribute of the associated object itself.
