### PR TITLE
Fix inability to pass arguments to getlocal.

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -75,8 +75,8 @@ module ActiveSupport
 
     # Returns a <tt>Time.local()</tt> instance of the simultaneous time in your
     # system's <tt>ENV['TZ']</tt> zone.
-    def localtime
-      utc.respond_to?(:getlocal) ? utc.getlocal : utc.to_time.getlocal
+    def localtime(*args)
+      utc.respond_to?(:getlocal) ? utc.getlocal(*args) : utc.to_time.getlocal(*args)
     end
     alias_method :getlocal, :localtime
 

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -76,7 +76,8 @@ module ActiveSupport
     # Returns a <tt>Time.local()</tt> instance of the simultaneous time in your
     # system's <tt>ENV['TZ']</tt> zone.
     def localtime(*args)
-      utc.respond_to?(:getlocal) ? utc.getlocal(*args) : utc.to_time.getlocal(*args)
+      utc = utc.to_time unless utc.respond_to?(:getlocal)
+      utc.getlocal(*args)
     end
     alias_method :getlocal, :localtime
 


### PR DESCRIPTION
Before this patch you cannot pass additional arguments to ActiveSupport::TimeWithZone#getlocal
You can do this:
Time.now.getlocal(14400) # 2014-09-22 20:20:18 +0400
Now you can do this either (was throwing "wrong number of arguments (1 for 0)" before):
Time.current.getlocal(14400) 
Time.zone.now.getlocal(14400)
