### PR TITLE
Polymorphic `where`s should be treated as a unit.

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -29,7 +29,7 @@ module ActiveRecord
             association = klass._reflect_on_association(column)
 
             value.each do |k, v|
-              queries.concat expand(association && association.klass, table, k, v)
+              queries << expand(association && association.klass, table, k, v)
             end
           end
         else
@@ -40,7 +40,7 @@ module ActiveRecord
             table = Arel::Table.new(table_name, default_table.engine)
           end
 
-          queries.concat expand(klass, table, column, value)
+          queries << expand(klass, table, column, value)
         end
       end
 
@@ -48,23 +48,23 @@ module ActiveRecord
     end
 
     def self.expand(klass, table, column, value)
-      queries = []
-
       # Find the foreign key when using queries such as:
       # Post.where(author: author)
       #
       # For polymorphic relationships, find the foreign key and type:
       # PriceEstimate.where(estimate_of: treasure)
       if klass && reflection = klass._reflect_on_association(column)
-        if reflection.polymorphic? && base_class = polymorphic_base_class_from_value(value)
-          queries << build(table[reflection.foreign_type], base_class)
-        end
-
         column = reflection.foreign_key
+
+        if reflection.polymorphic? && base_class = polymorphic_base_class_from_value(value)
+          id_condition = build(table[column], value)
+          type_condition = build(table[reflection.foreign_type], base_class)
+          return type_condition.and(id_condition)
+        end
       end
 
-      queries << build(table[column], value)
-      queries
+      id_condition = build(table[column], value)
+      return id_condition
     end
 
     def self.polymorphic_base_class_from_value(value)

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -74,7 +74,10 @@ module ActiveRecord
       treasure = Treasure.new
       treasure.id = 1
 
-      expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: 1)
+      type_condition = PriceEstimate.arel_table[:estimate_of_type].eq('Treasure')
+      id_condition   = PriceEstimate.arel_table[:estimate_of_id].eq(1)
+
+      expected = PriceEstimate.where(type_condition.and(id_condition))
       actual   = PriceEstimate.where(estimate_of: treasure)
 
       assert_equal expected.to_sql, actual.to_sql
@@ -86,14 +89,20 @@ module ActiveRecord
       hidden = HiddenTreasure.new
       hidden.id = 2
 
-      expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: [treasure, hidden])
+      type_condition = PriceEstimate.arel_table[:estimate_of_type].eq('Treasure')
+      id_condition   = PriceEstimate.arel_table[:estimate_of_id].in([treasure, hidden])
+
+      expected = PriceEstimate.where(type_condition.and(id_condition))
       actual   = PriceEstimate.where(estimate_of: [treasure, hidden])
 
       assert_equal expected.to_sql, actual.to_sql
     end
 
     def test_polymorphic_nested_relation_where
-      expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: Treasure.where(id: [1,2]))
+      type_condition = PriceEstimate.arel_table[:estimate_of_type].eq('Treasure')
+      id_condition   = PriceEstimate.arel_table[:estimate_of_id].in(Treasure.select(:id).where(id: [1,2]).arel)
+
+      expected = PriceEstimate.where(type_condition.and(id_condition))
       actual   = PriceEstimate.where(estimate_of: Treasure.where(id: [1,2]))
 
       assert_equal expected.to_sql, actual.to_sql
@@ -103,7 +112,10 @@ module ActiveRecord
       treasure = HiddenTreasure.new
       treasure.id = 1
 
-      expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: 1)
+      type_condition = PriceEstimate.arel_table[:estimate_of_type].eq('Treasure')
+      id_condition   = PriceEstimate.arel_table[:estimate_of_id].eq(1)
+
+      expected = PriceEstimate.where(type_condition.and(id_condition))
       actual   = PriceEstimate.where(estimate_of: treasure)
 
       assert_equal expected.to_sql, actual.to_sql
@@ -113,7 +125,10 @@ module ActiveRecord
       thing = Post.new
       thing.id = 1
 
-      expected = Treasure.where(price_estimates: { thing_type: 'Post', thing_id: 1 }).joins(:price_estimates)
+      type_condition = PriceEstimate.arel_table[:thing_type].eq('Post')
+      id_condition   = PriceEstimate.arel_table[:thing_id].eq(1)
+
+      expected = Treasure.where(type_condition.and(id_condition)).joins(:price_estimates)
       actual   = Treasure.where(price_estimates: { thing: thing }).joins(:price_estimates)
 
       assert_equal expected.to_sql, actual.to_sql
@@ -123,7 +138,10 @@ module ActiveRecord
       treasure = HiddenTreasure.new
       treasure.id = 1
 
-      expected = Treasure.where(price_estimates: { estimate_of_type: 'Treasure', estimate_of_id: 1 }).joins(:price_estimates)
+      type_condition = PriceEstimate.arel_table[:estimate_of_type].eq('Treasure')
+      id_condition   = PriceEstimate.arel_table[:estimate_of_id].eq(1)
+
+      expected = Treasure.where(type_condition.and(id_condition)).joins(:price_estimates)
       actual   = Treasure.where(price_estimates: { estimate_of: treasure }).joins(:price_estimates)
 
       assert_equal expected.to_sql, actual.to_sql
@@ -148,8 +166,116 @@ module ActiveRecord
       treasure.id = 1
       decorated_treasure = treasure_decorator.new(treasure)
 
-      expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: 1)
+      type_condition = PriceEstimate.arel_table[:estimate_of_type].eq('Treasure')
+      id_condition   = PriceEstimate.arel_table[:estimate_of_id].eq(1)
+
+      expected = PriceEstimate.where(type_condition.and(id_condition))
       actual   = PriceEstimate.where(estimate_of: decorated_treasure)
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+    def test_polymorphic_shallow_where_not
+      treasure = Treasure.new
+      treasure.id = 1
+
+      type_condition = PriceEstimate.arel_table[:estimate_of_type].eq('Treasure')
+      id_condition   = PriceEstimate.arel_table[:estimate_of_id].eq(1)
+
+      expected = PriceEstimate.where.not(type_condition.and(id_condition))
+      actual   = PriceEstimate.where.not(estimate_of: treasure)
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+    def test_polymorphic_nested_array_where_not
+      treasure = Treasure.new
+      treasure.id = 1
+      hidden = HiddenTreasure.new
+      hidden.id = 2
+
+      type_condition = PriceEstimate.arel_table[:estimate_of_type].eq('Treasure')
+      id_condition   = PriceEstimate.arel_table[:estimate_of_id].in([treasure, hidden])
+
+      expected = PriceEstimate.where.not(type_condition.and(id_condition))
+      actual   = PriceEstimate.where.not(estimate_of: [treasure, hidden])
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+    def test_polymorphic_nested_relation_where_not
+      type_condition = PriceEstimate.arel_table[:estimate_of_type].eq('Treasure')
+      id_condition   = PriceEstimate.arel_table[:estimate_of_id].in(Treasure.select(:id).where(id: [1,2]).arel)
+
+      expected = PriceEstimate.where.not(type_condition.and(id_condition))
+      actual   = PriceEstimate.where.not(estimate_of: Treasure.where(id: [1,2]))
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+    def test_polymorphic_sti_shallow_where_not
+      treasure = HiddenTreasure.new
+      treasure.id = 1
+
+      type_condition = PriceEstimate.arel_table[:estimate_of_type].eq('Treasure')
+      id_condition   = PriceEstimate.arel_table[:estimate_of_id].eq(1)
+
+      expected = PriceEstimate.where.not(type_condition.and(id_condition))
+      actual   = PriceEstimate.where.not(estimate_of: treasure)
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+    def test_polymorphic_nested_where_not
+      thing = Post.new
+      thing.id = 1
+
+      type_condition = PriceEstimate.arel_table[:thing_type].eq('Post')
+      id_condition   = PriceEstimate.arel_table[:thing_id].eq(1)
+
+      expected = Treasure.where.not(type_condition.and(id_condition)).joins(:price_estimates)
+      actual   = Treasure.where.not(price_estimates: { thing: thing }).joins(:price_estimates)
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+    def test_polymorphic_sti_nested_where_not
+      treasure = HiddenTreasure.new
+      treasure.id = 1
+
+      type_condition = PriceEstimate.arel_table[:estimate_of_type].eq('Treasure')
+      id_condition   = PriceEstimate.arel_table[:estimate_of_id].eq(1)
+
+      expected = Treasure.where.not(type_condition.and(id_condition)).joins(:price_estimates)
+      actual   = Treasure.where.not(price_estimates: { estimate_of: treasure }).joins(:price_estimates)
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+    def test_decorated_polymorphic_where_not
+      treasure_decorator = Struct.new(:model) do
+        def self.method_missing(method, *args, &block)
+          Treasure.send(method, *args, &block)
+        end
+
+        def is_a?(klass)
+          model.is_a?(klass)
+        end
+
+        def method_missing(method, *args, &block)
+          model.send(method, *args, &block)
+        end
+      end
+
+      treasure = Treasure.new
+      treasure.id = 1
+      decorated_treasure = treasure_decorator.new(treasure)
+
+      type_condition = PriceEstimate.arel_table[:estimate_of_type].eq('Treasure')
+      id_condition   = PriceEstimate.arel_table[:estimate_of_id].eq(1)
+
+      expected = PriceEstimate.where.not(type_condition.and(id_condition))
+      actual   = PriceEstimate.where.not(estimate_of: decorated_treasure)
 
       assert_equal expected.to_sql, actual.to_sql
     end


### PR DESCRIPTION
ActiveRecord's default behavior around `.where.not(hash)` is to ensure that each key is appropriately filtered out from the query, with the effect being that the query is populated with `(key1 != value1) AND (key2 != value2)`. In general, this feels like a fair implementation, despite not being a direct negation of `.where(hash)`.

However, ActiveRecord also supports filtering on a polymorphic association. This works as expected, internally being expanded to a condition that verifies both the relation_id and the relation_type. Negating one of these conditions, however, excludes rows that share a relation_type or a relation_id.

Fixes #16983.
