### PR TITLE
Clarify the documentation of the primary_key option for associations

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1171,7 +1171,7 @@ module ActiveRecord
       #   of this class in lower-case and "_id" suffixed. So a Person class that makes a +has_many+
       #   association will use "person_id" as the default <tt>:foreign_key</tt>.
       # [:primary_key]
-      #   Specify the method that returns the primary key used for the association. By default this is +id+.
+      #   Specify the name of the column to use as the primary key for the association. By default this is +id+.
       # [:dependent]
       #   Controls what happens to the associated objects when
       #   their owner is destroyed. Note that these are implemented as


### PR DESCRIPTION
Previously the documentation stated that `primary_key` should be the name of
a _method_ that returns the primary key used for the association. This is
incorrect. This changes the documentation to say that the value must be the
name of a column.

This fixes: https://github.com/rails/rails/issues/17004.
