### PR TITLE
speed up fixtures by not loading all their classes

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -822,25 +822,6 @@ class ActiveSupportSubclassWithFixturesTest < ActiveRecord::TestCase
   end
 end
 
-class FixtureLoadingTest < ActiveRecord::TestCase
-  def test_logs_message_for_failed_dependency_load
-    ActiveRecord::Base.logger.expects(:warn).twice
-    ActiveRecord::TestCase.try_to_load_dependency('does_not_exist')
-  end
-
-  def test_does_not_logs_message_for_dependency_that_has_been_defined_with_set_fixture_class
-    ActiveRecord::TestCase.set_fixture_class unknown_dead_parrots: DeadParrot
-    ActiveRecord::Base.logger.expects(:warn).never
-    ActiveRecord::TestCase.try_to_load_dependency('unknown_dead_parrot')
-  end
-
-  def test_does_not_logs_message_for_successful_dependency_load
-    ActiveRecord::TestCase.expects(:require_dependency).with('works_out_fine')
-    ActiveRecord::Base.logger.expects(:warn).never
-    ActiveRecord::TestCase.try_to_load_dependency('works_out_fine')
-  end
-end
-
 class CustomNameForFixtureOrModelTest < ActiveRecord::TestCase
   ActiveRecord::FixtureSet.reset_cache
 

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -136,19 +136,6 @@ def disable_extension!(extension, connection)
   connection.reconnect!
 end
 
-unless ENV['FIXTURE_DEBUG']
-  module ActiveRecord::TestFixtures::ClassMethods
-    def try_to_load_dependency_with_silence(*args)
-      old = ActiveRecord::Base.logger.level
-      ActiveRecord::Base.logger.level = ActiveSupport::Logger::ERROR
-      try_to_load_dependency_without_silence(*args)
-      ActiveRecord::Base.logger.level = old
-    end
-
-    alias_method_chain :try_to_load_dependency, :silence
-  end
-end
-
 require "cases/validations_repair_helper"
 class ActiveSupport::TestCase
   include ActiveRecord::TestFixtures


### PR DESCRIPTION
this took our time for a test with `tixtures :all`  from 28s to 20s

most of the time, only the tables are needed and `fixtures :all` is just a developer saying "I don't know",
so let's save the complexity and overhead!

people that rely on that can do their own requires or use eager loading in test.rb

@rafaelfranca @tenderlove 
