### PR TITLE
Define a scope that is NOT version of another scope

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -38,21 +38,7 @@ module ActiveRecord
       #    User.where.not(name: "Jon", role: "admin")
       #    # SELECT * FROM users WHERE name != 'Jon' AND role != 'admin'
       def not(opts, *rest)
-        where_value = @scope.send(:build_where, opts, rest).map do |rel|
-          case rel
-          when NilClass
-            raise ArgumentError, 'Invalid argument for .where.not(), got nil.'
-          when Arel::Nodes::In
-            Arel::Nodes::NotIn.new(rel.left, rel.right)
-          when Arel::Nodes::Equality
-            Arel::Nodes::NotEqual.new(rel.left, rel.right)
-          when String
-            Arel::Nodes::Not.new(Arel::Nodes::SqlLiteral.new(rel))
-          else
-            Arel::Nodes::Not.new(rel)
-          end
-        end
-
+        where_value = @scope.send(:reverse_where_conditions, @scope.send(:build_where, opts, rest))
         @scope.references!(PredicateBuilder.references(opts)) if Hash === opts
         @scope.where_values += where_value
         @scope
@@ -849,6 +835,18 @@ module ActiveRecord
       self
     end
 
+    # Reverses existing where clause on the relation.
+    #
+    #  User.where(approved: true).reverse_where # => WHERE `approved` = 0
+    def reverse_where
+      spawn.reverse_where!
+    end
+
+    def reverse_where! # :nodoc:
+      self.where_values = reverse_where_conditions(where_values)
+      self
+    end
+
     # Returns the Arel object associated with the relation.
     def arel # :nodoc:
       @arel ||= build_arel
@@ -1154,6 +1152,23 @@ module ActiveRecord
           else
             add_relations_to_bind_values(value)
           end
+        end
+      end
+    end
+
+    def reverse_where_conditions(conditions)
+      conditions.map do |rel|
+        case rel
+        when NilClass
+          raise ArgumentError, 'Invalid argument for .where.not(), got nil.'
+        when Arel::Nodes::In
+          Arel::Nodes::NotIn.new(rel.left, rel.right)
+        when Arel::Nodes::Equality
+          Arel::Nodes::NotEqual.new(rel.left, rel.right)
+        when String
+          Arel::Nodes::Not.new(Arel::Nodes::SqlLiteral.new(rel))
+        else
+          Arel::Nodes::Not.new(rel)
         end
       end
     end

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -154,6 +154,29 @@ module ActiveRecord
             scope || all
           end
         end
+
+        # Adds a scope that with reverse conditions than parent scope
+        #
+        #   class Post < ActiveRecord::Base
+        #
+        #     scope :active, -> { where(active: true) }
+        #     reverse_scope :inactive, :active
+        #
+        #     scope :created_before, ->(date) { where("posts.created_at < date")
+        #     reverse_scope :created_after, :created_before
+        #
+        #
+        #     scope :trending, -> { joins(:category).where(categories: {treding: true})
+        #     reverse_scope :abandon, :trending
+        #
+        #   end
+        #
+        #   Post.inactive # => WHERE `active` != 1
+        #   Post.created_after('1986-08-05') # => WHERE NOT(posts.created_at < '1986-08-05')
+        #   Post.abandon # => INNER JOIN `categories` ON `categories`.id = `posts`.`category_id` WHERE `categories`.`treding` != 1
+        def reverse_scope(name, parent, &block)
+          scope name, proc {|*args| send(parent, *args).reverse_where! }, &block
+        end
       end
     end
   end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1741,4 +1741,18 @@ class RelationTest < ActiveRecord::TestCase
   def test_relation_join_method
     assert_equal 'Thank you for the welcome,Thank you again for the welcome', Post.first.comments.join(",")
   end
+
+  def test_reverse_where
+    assert !Topic.approved.reverse_where.first.approved?
+  end
+
+  def test_reverse_where_scope_with_arguments
+    topic = Topic.create!(:written_on => 3.days.from_now)
+    assert_equal [topic], Topic.written_before(DateTime.now).reverse_where
+  end
+
+  def test_reverse_where_with_joins
+    assert_not_includes Comment.for_first_author.reverse_where.map(&:post_id), 1
+  end
+
 end

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -513,4 +513,12 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert_equal 1, SpecialComment.where(body: 'go crazy').created.count
   end
 
+  def test_reverse_scope_without_arguments
+    assert_no_match(/e/, Comment.without_the_letter_e.pluck(:body).join)
+  end
+
+  def test_reverse_scope_with_arguments
+    assert_no_match(/body/, Comment.without_word('body').pluck(:body).join)
+  end
+
 end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -1,6 +1,12 @@
 class Comment < ActiveRecord::Base
   scope :limit_by, lambda {|l| limit(l) }
+
   scope :containing_the_letter_e, -> { where("comments.body LIKE '%e%'") }
+  reverse_scope :without_the_letter_e, :containing_the_letter_e
+
+  scope :with_word, ->(word) { where("comments.body LIKE '%#{word}%'")}
+  reverse_scope :without_word, :with_word
+
   scope :not_again, -> { where("comments.body NOT LIKE '%again%'") }
   scope :for_first_post, -> { where(:post_id => 1) }
   scope :for_first_author, -> { joins(:post).where("posts.author_id" => 1) }


### PR DESCRIPTION
I am having troubles reversing a scope conditions and supporting a mirror relations where one relation is a `not` version of another.

So Propose the following API to manage such case:

``` ruby
   class Post < ActiveRecord::Base

     scope :active, -> { where(active: true) }
     reverse_scope :inactive, :active

     scope :created_before, ->(date) { where("posts.created_at < date")
     reverse_scope :created_after, :created_before

     scope :trending, -> { joins(:category).where(categories: {treding: true})
     reverse_scope :abandon, :trending

   end

   Post.inactive # => WHERE `active` != 1
   Post.created_after('1986-08-05') # => WHERE NOT(posts.created_at < '1986-08-05')
   Post.abandon # => INNER JOIN `categories` ON `categories`.id = `posts`.`category_id` 
                #       WHERE `categories`.`treding` != 1

```

Here is bonus method `reverse_where` that is used under the hood:

``` ruby
Post.active.reverse_where
```

I've make it public and documented because people might want to use it directly.
But `reverse_scope` is a primary use case that is convenient.
