### PR TITLE
Message on AR::UnknownAttributeError should include the class name of a record

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   `AR::UnknownAttributeError` now includes the class name of a record.
+
+    This would be helpful if 2 models have an attribute that has a similar
+    name to the other one. e.g.:
+
+        User.new(name: "Yuki Nishijima", project_attributes: {name: "kaminari"})
+        # => ActiveRecord::UnknownAttributeError: unknown attribute on User: name
+
+    *Yuki Nishijima*
+
 *   Fix regression causing `after_create` callbacks to run before associated
     records are autosaved.
 

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -167,7 +167,7 @@ module ActiveRecord
     def initialize(record, attribute)
       @record = record
       @attribute = attribute.to_s
-      super("unknown attribute: #{attribute}")
+      super("unknown attribute on #{@record.class}: #{attribute}")
     end
 
   end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -736,11 +736,11 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   def test_bulk_update_raise_unknown_attribute_error
     error = assert_raises(ActiveRecord::UnknownAttributeError) {
-      @target.new(:hello => "world")
+      Topic.new(:hello => "world")
     }
-    assert_instance_of @target, error.record
+    assert_instance_of Topic, error.record
     assert_equal "hello", error.attribute
-    assert_equal "unknown attribute: hello", error.message
+    assert_equal "unknown attribute on Topic: hello", error.message
   end
 
   def test_methods_override_in_multi_level_subclass


### PR DESCRIPTION
This would be helpful if 2 models have an attribute that has a similar name to the other. e.g.
before:

``` ruby
User.new(name: "Yuki Nishijima", projects_attributes: [name: "kaminari"])
# => ActiveRecord::UnknownAttributeError: unknown attribute: name
```

after:

``` ruby
User.new(name: "Yuki Nishijima", projects_attributes: [name: "kaminari"])
# => ActiveRecord::UnknownAttributeError: unknown attribute on User: name
```
