### PR TITLE
activerecord/connection_pool: honor overidden rack.test in tests

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Honor overridden `rack.test` in Rack environment for the connection
+    management middlware.
+
+    *Simon Eskildsen*
+
 *   Add a truncate method to the connection.
 
     *Aaron Patterson*

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -640,7 +640,7 @@ module ActiveRecord
       end
 
       def call(env)
-        testing = env.key?('rack.test')
+        testing = env['rack.test']
 
         response = @app.call(env)
         response[2] = ::Rack::BodyProxy.new(response[2]) do

--- a/activerecord/test/cases/connection_management_test.rb
+++ b/activerecord/test/cases/connection_management_test.rb
@@ -96,6 +96,14 @@ module ActiveRecord
         assert ActiveRecord::Base.connection_handler.active_connections?
       end
 
+      def test_connections_closed_if_exception_and_explicitly_not_test
+        @env['rack.test'] = false
+        app       = Class.new(App) { def call(env); raise NotImplementedError; end }.new
+        explosive = ConnectionManagement.new(app)
+        assert_raises(NotImplementedError) { explosive.call(@env) }
+        assert !ActiveRecord::Base.connection_handler.active_connections?
+      end
+
       test "doesn't clear active connections when running in a test case" do
         @env['rack.test'] = true
         @management.call(@env)


### PR DESCRIPTION
Honoring an overidden `rack.test` allows testing closed connection between multiple requests. This is useful if you're working on database resiliency, to ensure the connection is in the expected state from one request to another on the same worker.
