### PR TITLE
Fixed bug where Hash#to_param did not order query string parmeters correctly.

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -73,11 +73,15 @@ class Hash
   #
   # This method is also aliased as +to_param+.
   def to_query(namespace = nil)
-    collect do |key, value|
-      unless (value.is_a?(Hash) || value.is_a?(Array)) && value.empty?
+    sort do |e1, e2| 
+      e1.first.to_param.to_s <=> e2.first.to_param.to_s
+    end.map do |key, value|
+      if (value.is_a?(Hash) || value.is_a?(Array)) && value.empty?
+        nil
+      else
         value.to_query(namespace ? "#{namespace}[#{key}]" : key)
       end
-    end.compact.sort! * '&'
+    end.compact * '&'
   end
 
   alias_method :to_param, :to_query

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1023,6 +1023,7 @@ class HashExtToParamTests < ActiveSupport::TestCase
     assert_equal 'hello=world', { :hello => "world" }.to_param
     assert_equal 'hello=10', { "hello" => 10 }.to_param
     assert_equal 'hello=world&say_bye=true', {:hello => "world", "say_bye" => true}.to_param
+    assert_equal 'hello=world&hello.world=true', {:hello => "world", "hello.world" => true}.to_param
   end
 
   def test_number_hash


### PR DESCRIPTION
The current Hash#to_param method sorts the query string keys after appending "=#{value}" onto the end of the key. This causes incorrect sorting of the query string if the keys have certain non-alphanumeric characters, such as ".". This bug was discovered trying to make AWS API requests via Rails, since AWS requires "." in the query string and also requires that query string parameters be sorted. 
