### PR TITLE
Ability to pass additional arguments to getlocal.

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -75,8 +75,9 @@ module ActiveSupport
 
     # Returns a <tt>Time.local()</tt> instance of the simultaneous time in your
     # system's <tt>ENV['TZ']</tt> zone.
-    def localtime
-      utc.respond_to?(:getlocal) ? utc.getlocal : utc.to_time.getlocal
+    def localtime(*args)
+      time_object = utc.respond_to?(:getlocal) ? utc : utc.to_time
+      time_object.getlocal(*args)
     end
     alias_method :getlocal, :localtime
 


### PR DESCRIPTION
http://www.ruby-doc.org/core-2.1.3/Time.html#method-i-getlocal accepts additional arguments to get Time object in particular time zone you want like this:
Time.now.getlocal(14400) # My current timezone is Moscow +0400
This commit allows this for ActiveSupport::TimeWithZone objects so from now on you can do this:
Time.current.getlocal(14400) # 2014-09-23 12:53:05 +0400
Time.zone.now.getlocal(14400) # 2014-09-23 12:53:05 +0400
