### PR TITLE
Fix loading fixtures in engine tests

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
@@ -13,6 +13,6 @@ Rails.backtrace_cleaner.remove_silencers!
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 # Load fixtures from the engine
-if ActiveSupport::TestCase.method_defined?(:fixture_path=)
+if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
 end


### PR DESCRIPTION
`fixture_path` is a class attribute of ActiveSupport::TestCase, so `ActiveSupport::TestCase.method_defined?(:fixture_path=)` would always return false.

This should fix #4971
