### PR TITLE
Fix for certain cases where request.path were missing the leading slash

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix a bug where in certain scenarios request.path and request.fullpath lose
+    the leading slash.
+
+    Fixes #16926
+
+    *Scott Moak*
+
 *   Fix a bug where malformed query strings lead to 500.
 
     fixes #11502.

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -64,8 +64,10 @@ module ActionDispatch
           unless route.path.anchored
             env['SCRIPT_NAME'] = (script_name.to_s + match.to_s).chomp('/')
             path_info = match.post_match
+            unless path_info.start_with? "/"
+              path_info = "/" + path_info
+            end
             env['PATH_INFO']   = path_info
-            env['PATH_INFO']   = "/" + path_info unless path_info.start_with? "/"
           end
 
           env[@params_key] = (set_params || {}).merge parameters


### PR DESCRIPTION
In certain cases request.path or request.fullpath lost the leading
slash. This fixes #16926 
