### PR TITLE
Fix reverse_merge on HashWithIndifferentAccess

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/hash/keys'
+require 'active_support/core_ext/hash/reverse_merge'
 
 module ActiveSupport
   # Implements a hash where keys <tt>:foo</tt> and <tt>"foo"</tt> are considered

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -1,0 +1,10 @@
+require 'abstract_unit'
+require 'active_support/hash_with_indifferent_access'
+
+class HashWithIndifferentAccessTest < ActiveSupport::TestCase
+  def test_reverse_merge
+    hash = HashWithIndifferentAccess.new key: :old_value
+    hash.reverse_merge! key: :new_value
+    assert_equal :old_value, hash[:key]
+  end
+end


### PR DESCRIPTION
Before this PR, the following code would fail:

``` ruby
require 'active_support'
require 'active_support/hash_with_indifferent_access'
hash = HashWithIndifferentAccess.new key: :old_value
hash.reverse_merge key: :new_value
```

The reason is that the `reverse_merge` method in HashWithIndifferentAccess is [defined here](https://github.com/rails/rails/blob/4e8ea13ba1a0870905a46fac5f232d9f41eef8a4/activesupport/lib/active_support/hash_with_indifferent_access.rb#L208) by invoking `super`:

``` ruby
def reverse_merge(other_hash)
  super(self.class.new_from_hash_copying_default(other_hash))
end
```

Since `HashWithIndifferentAccess` inherits from `Hash`, that `super` above invokes the `reverse_merge` method on `Hash`, but this method is not present unless it is explicitly required with:

``` ruby
require 'active_support/core_ext/hash/reverse_merge'
```

This pull request adds the previous line to `hash_with_indifferent_access.rb` so that `reverse_merge` and `reverse_merge!` work on any instance of HashWithIndifferentAccess, and make the example above pass.

This pull request also includes a test that failed before this commit and passes afterwards.
Note that the [existing test on reverse_merge](https://github.com/rails/rails/blob/4e8ea13ba1a0870905a46fac5f232d9f41eef8a4/activesupport/test/core_ext/hash_ext_test.rb#L528) does not catch the error since it is written in a test file that [manually requires the whole `core_ext/has` in the preamble](https://github.com/rails/rails/blob/4e8ea13ba1a0870905a46fac5f232d9f41eef8a4/activesupport/test/core_ext/hash_ext_test.rb#L2).
