### PR TITLE
Add support for timetz fields

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -354,6 +354,7 @@ module ActiveRecord
         register_type 'timestamptz', OID::Timestamp.new
         register_type 'date', OID::Date.new
         register_type 'time', OID::Time.new
+        register_type 'timetz', OID::Time.new
 
         register_type 'path', OID::Identity.new
         register_type 'point', OID::Point.new


### PR DESCRIPTION
While upgrading an app to rails 4, I noticed messages like this in my development log:
`unknown OID: field_name(1266) (SELECT  ...)`

In addition, the `time_select` helpers on the field fail with `undefined method `min' for "12:00:00+00":String` because the field is interpreted as a string rather than typecast to a time.

The warning message is produced <a href="https://github.com/rails/rails/blob/4-0-stable/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L754">by this code in the postgres adapter</a>. I think its well known that postgres has both `timestamp` and `timestamptz` for date and time, but for time of day only, postgres also has both `time` and `timetz`. This patch registers `timetz` which enables my application to work as expected.

This patch is targeted to 4.0, but the same fix applies in 4.1, and I have another branch of very similar name for 4.1 in my fork. 

On master, it appears another one line fix would work for <a href="https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L450">this code</a>, but it is untested:

``` ruby
m.alias_type 'timetz', 'time'
```

I can submit a patch for master if necessary.
