### PR TITLE
Raise ActiveRecord::CannotConnect on adapter connection errors

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -5,6 +5,8 @@ require 'mysql2'
 
 module ActiveRecord
   module ConnectionHandling # :nodoc:
+    ER_BAD_DB_ERROR    = 1049
+
     # Establishes a connection to the database that's used by all Active Record objects.
     def mysql2_connection(config)
       config = config.symbolize_keys
@@ -19,7 +21,7 @@ module ActiveRecord
       options = [config[:host], config[:username], config[:password], config[:database], config[:port], config[:socket], 0]
       ConnectionAdapters::Mysql2Adapter.new(client, logger, options, config)
     rescue Mysql2::Error => error
-      if error.message.include?("Unknown database")
+      if error.error_number == ER_BAD_DB_ERROR
         raise ActiveRecord::NoDatabaseError.new(error.message, error)
       else
         raise

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -5,10 +5,6 @@ require 'mysql2'
 
 module ActiveRecord
   module ConnectionHandling # :nodoc:
-    # Can't connect to local MySQL server through socket '%s'
-    CR_CONNECTION_ERROR = 2002
-    # Can't connect to MySQL server on '%s'
-    CR_CONN_HOST_ERROR  = 2003
     # Unknown database '%s'
     ER_BAD_DB_ERROR     = 1049
 
@@ -29,10 +25,8 @@ module ActiveRecord
       case error.error_number
       when ER_BAD_DB_ERROR
         raise ActiveRecord::NoDatabaseError.new(error.message, error)
-      when CR_CONNECTION_ERROR..CR_CONN_HOST_ERROR
-        raise ActiveRecord::CannotConnect.new(error.message, error)
       else
-        raise
+        raise ActiveRecord::CannotConnect.new(error.message, error)
       end
     end
   end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -40,7 +40,7 @@ module ActiveRecord
   class AdapterNotFound < ActiveRecordError
   end
 
-  # Raised when connection to the database could not been established (for
+  # Raised when connection to the database has not been established (for
   # example when +connection=+ is given a nil object).
   class ConnectionNotEstablished < ActiveRecordError
   end
@@ -68,6 +68,10 @@ module ActiveRecord
       super(message)
       @original_exception = original_exception
     end
+  end
+
+  # Raised when a connection to the database cannot be estabalished.
+  class CannotConnect < StatementInvalid
   end
 
   # Defunct wrapper class kept for compatibility.

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -26,6 +26,20 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_cannot_connect_via_domain_socket
+    assert_raise ActiveRecord::CannotConnect do
+      configuration = {socket: "/tmp/walrus/narwhal/unicorn"}
+      ActiveRecord::Base.mysql2_connection(configuration)
+    end
+  end
+
+  def test_cannot_connect_via_tcp
+    assert_raise ActiveRecord::CannotConnect do
+      configuration = {host: "127.0.0.1", port: 54444}
+      ActiveRecord::Base.mysql2_connection(configuration)
+    end
+  end
+
   def test_truncate
     rows = ActiveRecord::Base.connection.exec_query("select count(*) from comments")
     count = rows.first.values.first


### PR DESCRIPTION
It'd be nice with an adapter-agnostic exception class for connection-class errors. This is useful for falling back to e.g. another connection (readonly in my case) or a fallback value in case AR cannot connect to the database.

If there's interest in this, I can look at adding this for some of the other adapters (e.g. `sqlite3` and `postgres`) and look at more errors (e.g. inability to route, timeouts, unknown host, unknown error, etc.). 

@arthurnn @tenderlove 
