### PR TITLE
Added ability to configure the queue_name_prefix delimiter to ActiveJob::QueueName.

### DIFF
--- a/activejob/lib/active_job/queue_name.rb
+++ b/activejob/lib/active_job/queue_name.rb
@@ -26,13 +26,16 @@ module ActiveJob
       def queue_name_from_part(part_name) #:nodoc:
         queue_name = part_name || default_queue_name
         name_parts = [queue_name_prefix.presence, queue_name]
-        name_parts.compact.join('_')
+        name_parts.compact.join(queue_name_delimiter)
       end
     end
 
     included do
       class_attribute :queue_name, instance_accessor: false
+      class_attribute :queue_name_delimiter, instance_accessor: false
+
       self.queue_name = default_queue_name
+      self.queue_name_delimiter = '_' # set default delimiter to '_'
     end
 
     # Returns the name of the queue the job will be run on

--- a/activejob/test/cases/queue_naming_test.rb
+++ b/activejob/test/cases/queue_naming_test.rb
@@ -64,7 +64,7 @@ class QueueNamingTest < ActiveSupport::TestCase
     end
   end
 
-  test 'queu_name_prefix prepended to the queue name' do
+  test 'queue_name_prefix prepended to the queue name with default delimiter' do
     original_queue_name_prefix = ActiveJob::Base.queue_name_prefix
     original_queue_name = HelloJob.queue_name
 
@@ -74,6 +74,23 @@ class QueueNamingTest < ActiveSupport::TestCase
       assert_equal 'aj_low', HelloJob.queue_name
     ensure
       ActiveJob::Base.queue_name_prefix = original_queue_name_prefix
+      HelloJob.queue_name = original_queue_name
+    end
+  end
+
+  test 'queue_name_prefix prepended to the queue name with custom delimiter' do
+    original_queue_name_prefix = ActiveJob::Base.queue_name_prefix
+    original_queue_name_delimiter = ActiveJob::Base.queue_name_delimiter
+    original_queue_name = HelloJob.queue_name
+
+    begin
+      ActiveJob::Base.queue_name_delimiter = '.'
+      ActiveJob::Base.queue_name_prefix = 'aj'
+      HelloJob.queue_as :low
+      assert_equal 'aj.low', HelloJob.queue_name
+    ensure
+      ActiveJob::Base.queue_name_prefix = original_queue_name_prefix
+      ActiveJob::Base.queue_name_delimiter = original_queue_name_delimiter
       HelloJob.queue_name = original_queue_name
     end
   end

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -149,6 +149,29 @@ end
 # environment
 ```
 
+The default queue name prefix delimiter is '_'.  This can be changed by setting
+`config.active_job.queue_name_delimiter` in `application.rb`:
+
+```ruby
+# config/application.rb
+module YourApp
+  class Application < Rails::Application
+    config.active_job.queue_name_prefix = Rails.env
+    config.active_job.queue_name_delimiter = '.'
+  end
+end
+
+# app/jobs/guests_cleanup.rb
+class GuestsCleanupJob < ActiveJob::Base
+  queue_as :low_priority
+  #....
+end
+
+# Now your job will run on queue production.low_priority on your
+# production environment and on staging.low_priority on your staging
+# environment
+```
+
 If you want more control on what queue a job will be run you can pass a :queue
 option to #set:
 


### PR DESCRIPTION
@seuros @cristianbica @jeremy,

I'm currently trying to update my project to use ActiveJob for delayed work, but we use queue names following an `amqp.appname.queue` format, which is incompatible with ActiveJob's current implementation of `queue_name_from_part` (hard coded '_' delimiter).  This PR adds the ability to define the prefix delimiter on a per application or per class basis.
- Added `class_attribute :queue_name_prefix_delimiter` to `ActiveJob::QueueName` to allow for developers using ActiveJob to change the delimiter.
- Added tests to ensure custom delimiters operate properly.
- Updated source guide to include a blurb about the prefix delimiter.
