### PR TITLE
Explicit route test class

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -904,8 +904,10 @@ Testing Routes
 Like everything else in your Rails application, it is recommended that you test your routes. An example test for a route in the default `show` action of `Articles` controller above should look like:
 
 ```ruby
-test "should route to article" do
-  assert_routing '/articles/1', {controller: "articles", action: "show", id: "1"}
+class ArticleRoutesTest < ActionController::TestCase
+  test "should route to article" do
+    assert_routing '/articles/1', { controller: "articles", action: "show", id: "1" }
+  end
 end
 ```
 


### PR DESCRIPTION
shows the class that the test must extend in order to have the assert_routing method available
ActionController::TestCase was used in the example because I assume is faster
ActionDispatch::IntegrationTest also works
