### PR TITLE
improving the accesibility of error pages

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.erb
@@ -7,20 +7,16 @@
         </div>
         <div class="data">
           <table cellpadding="0" cellspacing="0" class="lines">
-            <tr>
-              <td>
-                <pre class="line_numbers">
-                  <% extract_source[:code].keys.each do |line_number| %>
-<span><%= line_number -%></span>
-                  <% end %>
-                </pre>
-              </td>
-<td width="100%">
-<pre>
-<% extract_source[:code].each do |line, source| -%><div class="line<%= " active" if line == extract_source[:line_number] -%>"><%= source -%></div><% end -%>
-</pre>
-</td>
-            </tr>
+            <% extract_source[:code].each do |key, value| %>
+              <tr>
+                <td class="line_numbers">
+                   <code><span><%= key -%></span></code>
+                </td>
+                <td width= "100%">
+                  <code><div class="line<%= " active" if key == extract_source[:line_number] -%>"><%= value -%></div></code>
+                </td>
+              </tr>
+            <% end -%>
           </table>
         </div>
       </div>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -98,14 +98,17 @@
 
     .source .data .line_numbers {
       background-color: #ECECEC;
-      color: #AAA;
-      padding: 1em .5em;
       border-right: 1px solid #DDD;
+      color: #AAA;
+      font-size: 11px;
+      padding: 0.1em 0.5em;
       text-align: right;
     }
 
     .line {
+      font-size: 11px;
       padding-left: 10px;
+      white-space: pre;
     }
 
     .line:hover {


### PR DESCRIPTION
This improves the accessibility on error pages adding the line number at the beginning of each line of code.

Right now all the line numbers are enumerated before of the code lines.
