### PR TITLE
Remove --skip-action-view option from application generator

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Remove --skip-action-view option from Rails::Generators::AppBase
+
+    Fixes #17023.
+
+    *Dan Olson*
+
 *   Specify dummy app's db migrate path in plugin's test_helper.rb.
 
     Fixes #16877.

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -44,9 +44,6 @@ module Rails
         class_option :skip_gems,          type: :array, default: [],
                                           desc: 'Skip the provided gems files'
 
-        class_option :skip_action_view,   type: :boolean, aliases: '-V', default: false,
-                                          desc: 'Skip Action View files'
-
         class_option :skip_sprockets,     type: :boolean, aliases: '-S', default: false,
                                           desc: 'Skip Sprockets files'
 
@@ -167,7 +164,7 @@ module Rails
       end
 
       def include_all_railties?
-        !options[:skip_active_record] && !options[:skip_action_view] && !options[:skip_test_unit] && !options[:skip_sprockets]
+        !options[:skip_active_record] && !options[:skip_test_unit] && !options[:skip_sprockets]
       end
 
       def comment_if(value)

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -9,7 +9,7 @@ require "active_job/railtie"
 <%= comment_if :skip_active_record %>require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
-<%= comment_if :skip_action_view %>require "action_view/railtie"
+require "action_view/railtie"
 <%= comment_if :skip_sprockets %>require "sprockets/railtie"
 <%= comment_if :skip_test_unit %>require "rails/test_unit/railtie"
 <% end -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb
@@ -7,7 +7,7 @@ require 'rails/all'
 <%= comment_if :skip_active_record %>require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
-<%= comment_if :skip_action_view %>require "action_view/railtie"
+require "action_view/railtie"
 <%= comment_if :skip_sprockets %>require "sprockets/railtie"
 <%= comment_if :skip_test_unit %>require "rails/test_unit/railtie"
 <% end -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -268,11 +268,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_generator_if_skip_action_view_is_given
-    run_generator [destination_root, "--skip-action-view"]
-    assert_file "config/application.rb", /#\s+require\s+["']action_view\/railtie["']/
-  end
-
   def test_generator_if_skip_sprockets_is_given
     run_generator [destination_root, "--skip-sprockets"]
     assert_no_file "config/initializers/assets.rb"


### PR DESCRIPTION
Removes the `--skip-action-view` option when generating a new app using `rails new`. Fixes #17023.
