### PR TITLE
Update mail dependency of ActionMailer

### DIFF
--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'actionview', version
   s.add_dependency 'activejob', version
 
-  s.add_dependency 'mail', ['~> 2.5', '>= 2.5.4']
+  s.add_dependency 'mail', ['>= 2.5.4', '~> 2.6']
   s.add_dependency 'rails-dom-testing', '~> 1.0', '>= 1.0.2'
 end


### PR DESCRIPTION
For your consideration:

I'm working on a Rails application that requires a newer version of the **mail** gem (2.6). In order to use this version with Rails I needed to update **ActionMailer**'s dependency to allow for this version.
-  I've ran the specs against 2.6.1 with `bundle exec rake test` and have encountered no errors. 
-  I haven't deprecated any versions, so this should not introduce any backwards incompatibility. 

Thank you in advance.
