### PR TITLE
Time includes DateAndTime::Zones acts_like(:time)

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -1,4 +1,5 @@
 require 'active_support/time_with_zone'
+require 'active_support/core_ext/time/acts_like'
 require 'active_support/core_ext/date_and_time/zones'
 
 class Time


### PR DESCRIPTION
```
require 'active_support/core_ext/time/zones'
require 'active_support/core_ext/time/conversions'
Time.zone = 'Eastern Time (US & Canada)'
puts Time.now.utc.in_time_zone
```

Running the above code results in:

```
~/.rvm/gems/ruby-1.9.3-p392/gems/activesupport-4.1.6/lib/active_support/core_ext/date_and_time/zones.rb:41:in `to_time': wrong number of arguments(1 for 0) (ArgumentError)
```

because `Time.acts_like?(:time) == false`.  This PR fixes that by making sure that whenever Time includes DateAndTime::Zones (which uses `acts_like?(:time)`), Time does in fact act like time.
