### PR TITLE
`class_eval` -> `define_method`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -61,7 +61,7 @@ module ActiveRecord
 
     Relation::MULTI_VALUE_METHODS.each do |name|
       define_method "#{name}_values" do
-        @values[name] || []
+        @values[name] ||= []
       end
 
       define_method "#{name}_values=" do |values|

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -60,35 +60,29 @@ module ActiveRecord
     end
 
     Relation::MULTI_VALUE_METHODS.each do |name|
-      class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name}_values                   # def select_values
-          @values[:#{name}] || []            #   @values[:select] || []
-        end                                  # end
-                                             #
-        def #{name}_values=(values)          # def select_values=(values)
-          raise ImmutableRelation if @loaded #   raise ImmutableRelation if @loaded
-          check_cached_relation
-          @values[:#{name}] = values         #   @values[:select] = values
-        end                                  # end
-      CODE
+      define_method "#{name}_values" do
+        @values[name] || []
+      end
+
+      define_method "#{name}_values=" do |values|
+        raise ImmutableRelation if @loaded
+        check_cached_relation
+        @values[name] = values
+      end
     end
 
     (Relation::SINGLE_VALUE_METHODS - [:create_with]).each do |name|
-      class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name}_value                    # def readonly_value
-          @values[:#{name}]                  #   @values[:readonly]
-        end                                  # end
-      CODE
+      define_method "#{name}_value" do
+        @values[name]
+      end
     end
 
     Relation::SINGLE_VALUE_METHODS.each do |name|
-      class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name}_value=(value)            # def readonly_value=(value)
-          raise ImmutableRelation if @loaded #   raise ImmutableRelation if @loaded
-          check_cached_relation
-          @values[:#{name}] = value          #   @values[:readonly] = value
-        end                                  # end
-      CODE
+      define_method "#{name}_value=" do |value|
+        raise ImmutableRelation if @loaded
+        check_cached_relation
+        @values[name] = value
+      end
     end
 
     def check_cached_relation # :nodoc:

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -55,7 +55,7 @@ class FinderTest < ActiveRecord::TestCase
     Post.where("author_id" => nil)  # warm up
     x = Symbol.all_symbols.count
     Post.where("title" => {"xxxqqqq" => "bar"})
-    assert_equal x, Symbol.all_symbols.count
+    assert_operator(Symbol.all_symbols.count, :<=, x)
   end
 
   # find should handle strings that come from URLs


### PR DESCRIPTION
This provides a call-time speedup and is easier to read.

This PR picks up from the work done in https://github.com/rails/rails/pull/10765. Here's the benchmark I used:

``` ruby
require 'benchmark/ips'
require 'minitest'

Benchmark.ips do |x|
  x.config(:time => 5, :warmup => 2)

  x.report('relations_test') do
    begin
      $stdout = File.new('/dev/null', 'w')
      Minitest.run %w(test/cases/relations_test.rb)
    ensure
      $stdout = STDOUT
    end
  end
end
```

And the results:

```
~/Development/rails/activerecord define-method|REBASE-i 1/2 ruby -Itest ar_bench.rb
Calculating -------------------------------------
      relations_test       100 i/100ms
-------------------------------------------------
      relations_test     1109.4 (±14.1%) i/s -       5500 in   5.058918s
~/Development/rails/activerecord define-method|REBASE-i 1/2 git rebase --continue
Stopped at c877a5e6492834f4e4bfafcd6492e0e2c0df3ed5... `class_eval` -> `define_method`
You can amend the commit now, with

    git commit --amend

Once you are satisfied with your changes, run

    git rebase --continue

~/Development/rails/activerecord define-method|REBASE-i 2/2 ruby -Itest ar_bench.rb
Calculating -------------------------------------
      relations_test        95 i/100ms
-------------------------------------------------
      relations_test     1319.2 (±7.0%) i/s -       6650 in   5.066859s
```

Closes #10765
