### PR TITLE
Use include_blank value as option label

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -133,8 +133,14 @@ module ActionView
         option_tags ||= ""
         html_name = (options[:multiple] == true && !name.to_s.ends_with?("[]")) ? "#{name}[]" : name
 
-        if options.delete(:include_blank)
-          option_tags = content_tag(:option, '', :value => '').safe_concat(option_tags)
+        
+        if options.include?(:include_blank)
+          include_blank = options.delete(:include_blank)
+          if include_blank == true
+            include_blank = ''
+          end
+          
+          option_tags = content_tag(:option, include_blank, :value => '').safe_concat(option_tags)
         end
 
         if prompt = options.delete(:prompt)

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -224,6 +224,12 @@ class FormTagHelperTest < ActionView::TestCase
     expected = %(<select id="places" name="places"><option value=""></option><option>Home</option><option>Work</option><option>Pub</option></select>)
     assert_dom_equal expected, actual
   end
+  
+  def test_select_tag_with_include_blank_string
+    actual = select_tag "places", "<option>Home</option><option>Work</option><option>Pub</option>".html_safe, :include_blank => 'Choose'
+    expected = %(<select id="places" name="places"><option value="">Choose</option><option>Home</option><option>Work</option><option>Pub</option></select>)
+    assert_dom_equal expected, actual
+  end
 
   def test_select_tag_with_prompt
     actual = select_tag "places", "<option>Home</option><option>Work</option><option>Pub</option>".html_safe, :prompt => "string"


### PR DESCRIPTION
Update select_tag to reflect documentation and behave the same as form builder select. If the value of include_blank is not boolean true, use that value as the option label.
