### PR TITLE
Password setter should always update @password

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -117,10 +117,10 @@ module ActiveModel
       #   user.password = 'mUc3m00RsqyRe'
       #   user.password_digest # => "$2a$10$4LEA7r4YmNHtvlAvHhsYAeZmk/xeUVtMTYqwIvYY76EW5GUqDiP4."
       def password=(unencrypted_password)
+        @password = unencrypted_password
         if unencrypted_password.nil?
           self.password_digest = nil
         elsif !unencrypted_password.empty?
-          @password = unencrypted_password
           cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
           self.password_digest = BCrypt::Password.create(unencrypted_password, cost: cost)
         end


### PR DESCRIPTION
Even if the `unencrypted_password` parameter is blank the update should be reflected in the instance variable `@password`

The expected behavior is:

```
user.password = "example"
user.password = ""
user.password # => ""
```
