### PR TITLE
Let's fix form_for for singular resources

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `form_for` to properly handle singular resources.
+
+    *Gert Goet*
+
 *   Changed the meaning of `render "foo/bar"`.
 
     Previously, calling `render "foo/bar"` in a controller action is equivalent

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -442,13 +442,22 @@ module ActionView
           method: method
         )
 
-        options[:url] ||= if options.key?(:format)
-                            polymorphic_path(record, format: options.delete(:format))
-                          else
-                            polymorphic_path(record, {})
-                          end
+        options[:url] ||= form_for_default_url(action, record, options[:format])
       end
       private :apply_form_for_options!
+
+      def form_for_default_url(action, record, format) #:nodoc:
+        # polymorphic_path can't generate paths for singular resources.
+        # Instead use (edit|new)_polymorphic_path to derive the path.
+        path = if :edit == action
+                 edit_polymorphic_path(record, format: format)
+               else
+                 new_polymorphic_path(record, format: format)
+               end
+        # path might be translated; we can't just extract 'edit' or 'new'
+        path.gsub(%r|/[^/.]+(\..+)?$|, '\1')
+      end
+      private :form_for_default_url
 
       # Creates a scope around a specific model object like form_for, but
       # doesn't create the form tags themselves. This makes fields_for suitable

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -130,6 +130,8 @@ class FormHelperTest < ActionView::TestCase
       end
     end
 
+    resource :comment
+
     get "/foo", to: "controller#action"
     root to: "main#index"
   end
@@ -3297,6 +3299,31 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, builder: builder_class) { }
     assert_equal 1, initialization_count, 'form builder instantiated more than once'
   end
+
+  def test_form_for_with_new_singular_resource
+    form_for(Comment.new) {}
+    expected = whole_form('/comment', 'new_comment', 'new_comment')
+    assert_equal expected, output_buffer
+  end
+
+  def test_form_for_with_new_singular_resource_and_format
+    form_for(Comment.new, format: :json) {}
+    expected = whole_form('/comment.json', 'new_comment', 'new_comment')
+    assert_equal expected, output_buffer
+  end
+
+  def test_form_for_with_persisted_singular_resource
+    form_for(Comment.new(123)) {}
+    expected = whole_form('/comment', 'edit_comment_123', 'edit_comment', method: :patch)
+    assert_equal expected, output_buffer
+  end
+
+  def test_form_for_with_persisted_singular_resource_and_format
+    form_for(Comment.new(123), format: :json) {}
+    expected = whole_form('/comment.json', 'edit_comment_123', 'edit_comment', method: :patch)
+    assert_equal expected, output_buffer
+  end
+
 
   protected
 


### PR DESCRIPTION
This fixes #1769.

To recap that 36-month, 50+ comment issue:
When you pass an object to `form_for` it will treat the object as a plural resource.
If you pass it an object that should be created/updated as singular resource, it will result in an error or a faulty path, respectively.

Example:

``` ruby
# config/routes.rb
resource   :account

# create-form
<%= form_for(Account.new) do |f| %>
...

# update-form
<%= form_for(Account.first) do |f| %>
...
```

In both forms we would expect `/account` to be assigned to the action-attribute.

Instead for the create-form you get a `NoMethodError: undefined method "accounts_path"`.
And for the update-form the path `/account.1` is generated (and will likely cause a `ActionController::UnknownFormat`-error on submission). (The reason being that it calls `account_path(account)`, which results in `account` being turned into a format).

Reading from the original issue it causes lots of frustration and wasted time.

While the cause of the error lies somewhere in `polymorphic_path` and would be hard to fix. I think it's `form_for`'s responsibility to not 'leak it's abstraction' in such a trivial case.

This PR takes a stab at fixing it.
It essentially comes down to:
- explicitly set the default format to `nil` for the update-form
- derive the path from the new-path for the create-form

In both cases it still uses `polymorphic_path` to not interfere with generating complex namespaced/nested paths.

Hope it helps!
(If it's useful, I can squash and add a full explanation to the commit message.)
