### PR TITLE
move cache_digests rake methods into their own namespace

### DIFF
--- a/actionview/lib/action_view/tasks/dependencies.rake
+++ b/actionview/lib/action_view/tasks/dependencies.rake
@@ -2,20 +2,22 @@ namespace :cache_digests do
   desc 'Lookup nested dependencies for TEMPLATE (like messages/show or comments/_comment.html)'
   task :nested_dependencies => :environment do
     abort 'You must provide TEMPLATE for the task to run' unless ENV['TEMPLATE'].present?
-    puts JSON.pretty_generate ActionView::Digestor.new(name: template_name, finder: finder).nested_dependencies
+    puts JSON.pretty_generate ActionView::Digestor.new(name: CacheDigests.template_name, finder: CacheDigests.finder).nested_dependencies
   end
 
   desc 'Lookup first-level dependencies for TEMPLATE (like messages/show or comments/_comment.html)'
   task :dependencies => :environment do
     abort 'You must provide TEMPLATE for the task to run' unless ENV['TEMPLATE'].present?
-    puts JSON.pretty_generate ActionView::Digestor.new(name: template_name, finder: finder).dependencies
+    puts JSON.pretty_generate ActionView::Digestor.new(name: CacheDigests.template_name, finder: CacheDigests.finder).dependencies
   end
 
-  def template_name
-    ENV['TEMPLATE'].split('.', 2).first
-  end
+  class CacheDigests
+    def self.template_name
+      ENV['TEMPLATE'].split('.', 2).first
+    end
 
-  def finder
-    ApplicationController.new.lookup_context
+    def self.finder
+      ApplicationController.new.lookup_context
+    end
   end
 end


### PR DESCRIPTION
we found a bug when running this task in our CI system:

```
RAILS_ENV="test" RACK_ENV="test" bundle exec rake db:create db:schema:load --trace
```

`actionview/lib/action_view/tasks/dependencies.rake` defines two methods that end up in the global namespace, and these shadowed an attribute with the same name (`template_name`) in a FactoryGirl factory:

```
FactoryGirl.define do
  factory :foo do
    template_name "blah"
  end
end
```

which resulted in this error:

```
ArgumentError: wrong number of arguments (1 for 0)
.../gems/actionview-4.1.6/lib/action_view/tasks/dependencies.rake:14:in `template_name'
.../spec/factories/foo.rb:3:in `block (2 levels) in <top (required)>'
```

to resolve i just stuck these in their own namespace but you might consider having a namespace just for rake first (RakeHelpers or something) and then putting this class inside that one. i'm guessing this isn't the only place where the global namespace is being polluted from a rake task.
