### PR TITLE
Don’t require already required modules

### DIFF
--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -16,11 +16,9 @@ silence_warnings do
 end
 
 require 'active_support/testing/autorun'
-require 'abstract_controller'
 require 'action_controller'
 require 'action_view'
 require 'action_view/testing/resolvers'
-require 'action_dispatch'
 require 'active_support/dependencies'
 require 'active_model'
 require 'active_record'


### PR DESCRIPTION
abstract_unit.rb requires `action_controller` which [already includes the following lines of code](https://github.com/rails/rails/blob/64fcdce1d3a6a8768ab17f3be144270456814f82/actionpack/lib/action_controller.rb#L2L3):

``` ruby
require 'abstract_controller'
require 'action_dispatch'
```
