### PR TITLE
Remove `(?:in|de)crement!?`

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -303,40 +303,6 @@ module ActiveRecord
       updated_count == 1
     end
 
-    # Initializes +attribute+ to zero if +nil+ and adds the value passed as +by+ (default is 1).
-    # The increment is performed directly on the underlying attribute, no setter is invoked.
-    # Only makes sense for number-based attributes. Returns +self+.
-    def increment(attribute, by = 1)
-      self[attribute] ||= 0
-      self[attribute] += by
-      self
-    end
-
-    # Wrapper around +increment+ that saves the record. This method differs from
-    # its non-bang version in that it passes through the attribute setter.
-    # Saving is not subjected to validation checks. Returns +true+ if the
-    # record could be saved.
-    def increment!(attribute, by = 1)
-      increment(attribute, by).update_attribute(attribute, self[attribute])
-    end
-
-    # Initializes +attribute+ to zero if +nil+ and subtracts the value passed as +by+ (default is 1).
-    # The decrement is performed directly on the underlying attribute, no setter is invoked.
-    # Only makes sense for number-based attributes. Returns +self+.
-    def decrement(attribute, by = 1)
-      self[attribute] ||= 0
-      self[attribute] -= by
-      self
-    end
-
-    # Wrapper around +decrement+ that saves the record. This method differs from
-    # its non-bang version in that it passes through the attribute setter.
-    # Saving is not subjected to validation checks. Returns +true+ if the
-    # record could be saved.
-    def decrement!(attribute, by = 1)
-      decrement(attribute, by).update_attribute(attribute, self[attribute])
-    end
-
     # Assigns to +attribute+ the boolean opposite of <tt>attribute?</tt>. So
     # if the predicate returns +true+ the attribute will become +false+. This
     # method toggles directly the underlying value without calling any setter.

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -94,30 +94,6 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal count, Pet.joins(:toys).where(where_args).delete_all
   end
 
-  def test_increment_attribute
-    assert_equal 50, accounts(:signals37).credit_limit
-    accounts(:signals37).increment! :credit_limit
-    assert_equal 51, accounts(:signals37, :reload).credit_limit
-
-    accounts(:signals37).increment(:credit_limit).increment!(:credit_limit)
-    assert_equal 53, accounts(:signals37, :reload).credit_limit
-  end
-
-  def test_increment_nil_attribute
-    assert_nil topics(:first).parent_id
-    topics(:first).increment! :parent_id
-    assert_equal 1, topics(:first).parent_id
-  end
-
-  def test_increment_attribute_by
-    assert_equal 50, accounts(:signals37).credit_limit
-    accounts(:signals37).increment! :credit_limit, 5
-    assert_equal 55, accounts(:signals37, :reload).credit_limit
-
-    accounts(:signals37).increment(:credit_limit, 1).increment!(:credit_limit, 3)
-    assert_equal 59, accounts(:signals37, :reload).credit_limit
-  end
-
   def test_destroy_all
     conditions = "author_name = 'Mary'"
     topics_by_mary = Topic.all.merge!(:where => conditions, :order => 'id').to_a
@@ -171,25 +147,6 @@ class PersistenceTest < ActiveRecord::TestCase
     original_count = Topic.count
     Topic.delete(deleting = [1, 2])
     assert_equal original_count - deleting.size, Topic.count
-  end
-
-  def test_decrement_attribute
-    assert_equal 50, accounts(:signals37).credit_limit
-
-    accounts(:signals37).decrement!(:credit_limit)
-    assert_equal 49, accounts(:signals37, :reload).credit_limit
-
-    accounts(:signals37).decrement(:credit_limit).decrement!(:credit_limit)
-    assert_equal 47, accounts(:signals37, :reload).credit_limit
-  end
-
-  def test_decrement_attribute_by
-    assert_equal 50, accounts(:signals37).credit_limit
-    accounts(:signals37).decrement! :credit_limit, 5
-    assert_equal 45, accounts(:signals37, :reload).credit_limit
-
-    accounts(:signals37).decrement(:credit_limit, 1).decrement!(:credit_limit, 3)
-    assert_equal 41, accounts(:signals37, :reload).credit_limit
   end
 
   def test_create


### PR DESCRIPTION
These methods are useless sugar and are quite dangerous. They implement
last-write-wins while having names that suggest atomicity and safety.

The AR convention seems to prefer that `UPDATE` queries be made via
class methods - these methods are already available in `CounterCache`.

Reintroducing these methods is a tricky proposition, because doing it
right means adding a read immediately after the update to update the
in-memory value; this requires a transaction and some state tracking to
ensure that other dirty attributes are not discarded.

This might be appropriate for 5.0.

cc @bogdan
