### PR TITLE
Deprecate `(?:in|de)crement!?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate the unsafe and misleading `#(?:in|de)crement!?`.
+
+    *Tamir Duberstein*
+
 *   Honor overridden `rack.test` in Rack environment for the connection
     management middlware.
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -307,6 +307,8 @@ module ActiveRecord
     # The increment is performed directly on the underlying attribute, no setter is invoked.
     # Only makes sense for number-based attributes. Returns +self+.
     def increment(attribute, by = 1)
+      ActiveSupport::Deprecation.warn "`##{__method__}` is deprecated and will be removed in Rails 5. " \
+        "use `#update_counters` to atomically update counters in your database."
       self[attribute] ||= 0
       self[attribute] += by
       self
@@ -317,6 +319,8 @@ module ActiveRecord
     # Saving is not subjected to validation checks. Returns +true+ if the
     # record could be saved.
     def increment!(attribute, by = 1)
+      ActiveSupport::Deprecation.warn "`##{__method__}` is deprecated and will be removed in Rails 5. " \
+        "use `#update_counters` to atomically update counters in your database."
       increment(attribute, by).update_attribute(attribute, self[attribute])
     end
 
@@ -324,6 +328,8 @@ module ActiveRecord
     # The decrement is performed directly on the underlying attribute, no setter is invoked.
     # Only makes sense for number-based attributes. Returns +self+.
     def decrement(attribute, by = 1)
+      ActiveSupport::Deprecation.warn "`##{__method__}` is deprecated and will be removed in Rails 5. " \
+        "use `#update_counters` to atomically update counters in your database."
       self[attribute] ||= 0
       self[attribute] -= by
       self
@@ -334,6 +340,8 @@ module ActiveRecord
     # Saving is not subjected to validation checks. Returns +true+ if the
     # record could be saved.
     def decrement!(attribute, by = 1)
+      ActiveSupport::Deprecation.warn "`##{__method__}` is deprecated and will be removed in Rails 5. " \
+        "use `#update_counters` to atomically update counters in your database."
       decrement(attribute, by).update_attribute(attribute, self[attribute])
     end
 


### PR DESCRIPTION
These methods are useless sugar and are quite dangerous. They implement
last-write-wins while having names that suggest atomicity and safety.

The AR convention seems to prefer that `UPDATE` queries be made via
class methods - these methods are already available in `CounterCache`.

Reintroducing these methods is a tricky proposition, because doing it
right means adding a read immediately after the update to update the
in-memory value; this requires a transaction and some state tracking to
ensure that other dirty attributes are not discarded.

This is a predecessor to https://github.com/rails/rails/pull/17073 which should be safe to merge for 4.2.
