### PR TITLE
Pass enforce_utf8 option from form_for to form_tag

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -420,6 +420,7 @@ module ActionView
         html_options[:data]   = options.delete(:data)   if options.has_key?(:data)
         html_options[:remote] = options.delete(:remote) if options.has_key?(:remote)
         html_options[:method] = options.delete(:method) if options.has_key?(:method)
+        html_options[:enforce_utf8] = options.delete(:enforce_utf8) if options.has_key?(:enforce_utf8)
         html_options[:authenticity_token] = options.delete(:authenticity_token)
 
         builder = instantiate_builder(object_name, object, options)


### PR DESCRIPTION
Currently `form_for` invokes `form_tag` passing all the options accepted
by `form_tag` except for one: `enforce_utf8`.

This option was added in 06388b0 to allow users to prevent the hidden
field with the UTF-8 character from appearing in the output.

This commit implements the same behavior also for `form_for`.
