### PR TITLE
technical correction in guides under 'Generating an engine'

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -74,13 +74,13 @@ options as appropriate to the need. For the "blorgh" example, you will need to
 create a "mountable" engine, running this command in a terminal:
 
 ```bash
-$ bin/rails plugin new blorgh --mountable
+$ rails plugin new blorgh --mountable
 ```
 
 The full list of options for the plugin generator may be seen by typing:
 
 ```bash
-$ bin/rails plugin --help
+$ rails plugin --help
 ```
 
 The `--mountable` option tells the generator that you want to create a

--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -39,13 +39,13 @@ to run integration tests using a dummy Rails application. Create your
 plugin with the command:
 
 ```bash
-$ bin/rails plugin new yaffle
+$ rails plugin new yaffle
 ```
 
 See usage and options by asking for help:
 
 ```bash
-$ bin/rails plugin new --help
+$ rails plugin new --help
 ```
 
 Testing Your Newly Generated Plugin


### PR DESCRIPTION
`bin/rails` would not exist outside of a rails project
