### PR TITLE
Follow up to #16613

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
   - jruby
 env:
   global:
-    - JRUBY_OPTS='-J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Djruby.compile.mode=OFF -J-Djruby.compile.invokedynamic=false -J-Xmx1024M'
+    - JRUBY_OPTS='-J-Xmx1024M'
   matrix:
     - "GEM=railties"
     - "GEM=ap"

--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -10,6 +10,7 @@ Rake::TestTask.new { |t|
   t.pattern = 'test/**/*_test.rb'
   t.warning = true
   t.verbose = true
+  t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 }
 
 namespace :test do

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -16,6 +16,7 @@ Rake::TestTask.new do |t|
 
   t.warning = true
   t.verbose = true
+  t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 
 namespace :test do

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -21,6 +21,7 @@ namespace :test do
     t.test_files = Dir.glob('test/template/**/*_test.rb').sort
     t.warning = true
     t.verbose = true
+    t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
   end
 
   namespace :integration do
@@ -30,6 +31,7 @@ namespace :test do
       t.test_files = Dir.glob("test/activerecord/*_test.rb")
       t.warning = true
       t.verbose = true
+      t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
 
     desc 'ActionPack Integration Tests'
@@ -38,6 +40,7 @@ namespace :test do
       t.test_files = Dir.glob("test/actionpack/**/*_test.rb")
       t.warning = true
       t.verbose = true
+      t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
   end
 end

--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -35,6 +35,7 @@ namespace :test do
       t.libs << 'test'
       t.test_files = FileList['test/cases/**/*_test.rb']
       t.verbose = true
+      t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
 
     namespace :isolated do
@@ -52,6 +53,7 @@ namespace :test do
         t.libs << 'test'
         t.test_files = FileList['test/integration/**/*_test.rb']
         t.verbose = true
+        t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
       end
     end
   end

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -9,6 +9,7 @@ Rake::TestTask.new do |t|
   t.test_files = Dir.glob("#{dir}/test/cases/**/*_test.rb").sort
   t.warning = true
   t.verbose = true
+  t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 
 namespace :test do

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -55,6 +55,7 @@ end
 
       t.warning = true
       t.verbose = true
+      t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     }
 
     namespace :isolated do

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -7,8 +7,8 @@ Rake::TestTask.new do |t|
   t.pattern = 'test/**/*_test.rb'
   t.warning = true
   t.verbose = true
+  t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
-
 
 namespace :test do
   task :isolated do

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -29,6 +29,7 @@ Rake::TestTask.new('test:regular') do |t|
   t.pattern = 'test/**/*_test.rb'
   t.warning = true
   t.verbose = true
+  t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 
 # Generate GEM ----------------------------------------------------------------------------


### PR DESCRIPTION
Hello,

This pull request is a follow-up to #16613. It simply enables the `--dev` behavior on JRuby at the Rakefile level instead of `.travis.yml`.

Since we want this flag to be enabled anytime we are running the tests under JRuby, let's enable this at the Rakefile level so people get the performance boost on their local checkout.

Moreover, we avoid having to update this particular line anytime the option changes on the JRuby side.

The only drawback is that we have to define it in every Rakefile but there's no big deal, this is already the case for other options. The extra allocation of 1024Mb has been kept since this is not the case by default with the `--dev` flag and this has been added to reduce the GC time ; let me know if you want to remove it as well.

Have a nice day.
