### PR TITLE
Move callback method names to the only place they're used.

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -270,13 +270,6 @@ module ActiveRecord
   module Callbacks
     extend ActiveSupport::Concern
 
-    CALLBACKS = [
-      :after_initialize, :after_find, :after_touch, :before_validation, :after_validation,
-      :before_save, :around_save, :after_save, :before_create, :around_create,
-      :after_create, :before_update, :around_update, :after_update,
-      :before_destroy, :around_destroy, :after_destroy, :after_commit, :after_rollback
-    ]
-
     module ClassMethods
       include ActiveModel::Callbacks
     end

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -28,8 +28,14 @@ class CallbackDeveloper < ActiveRecord::Base
     end
   end
 
-  ActiveRecord::Callbacks::CALLBACKS.each do |callback_method|
-    next if callback_method.to_s =~ /^around_/
+  [
+    :before_create, :after_create,
+    :before_destroy, :after_destroy,
+    :before_save, :after_save,
+    :before_update, :after_update,
+    :before_validation, :after_validation,
+    :after_commit, :after_rollback, :after_initialize, :after_find, :after_touch,
+  ].each do |callback_method|
     define_callback_method(callback_method)
     send(callback_method, callback_string(callback_method))
     send(callback_method, callback_proc(callback_method))


### PR DESCRIPTION
The only place this constant with a list of callback method names was used was in a single test file, so I moved the list there. 
