### PR TITLE
Remove defunct ivars

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_part.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_part.rb
@@ -19,7 +19,6 @@ module ActiveRecord
 
         def initialize(base_klass, children)
           @base_klass = base_klass
-          @column_names_with_alias = nil
           @children = children
         end
 

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -297,16 +297,13 @@ module ActiveRecord
         undefine_attribute_methods
         connection.schema_cache.clear_table_cache!(table_name) if table_exists?
 
-        @arel_engine             = nil
-        @column_names            = nil
-        @column_types            = nil
-        @content_columns         = nil
-        @default_attributes      = nil
-        @dynamic_methods_hash    = nil
-        @inheritance_column      = nil unless defined?(@explicit_inheritance_column) && @explicit_inheritance_column
-        @relation                = nil
-        @time_zone_column_names  = nil
-        @cached_time_zone        = nil
+        @arel_engine        = nil
+        @column_names       = nil
+        @column_types       = nil
+        @content_columns    = nil
+        @default_attributes = nil
+        @inheritance_column = nil unless defined?(@explicit_inheritance_column) && @explicit_inheritance_column
+        @relation           = nil
       end
 
       private


### PR DESCRIPTION
@column_names_with_alias, @dynamic_methods_hash, @time_zone_column_names, and @cached_time_zone are initialized but unused.
