### PR TITLE
support for db-specific options to add_foreign_key

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support for db-specific options to add_foreign_key
+
+    *Jon Jensen*
+
 *   Honor overridden `rack.test` in Rack environment for the connection
     management middleware.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -53,6 +53,7 @@ module ActiveRecord
             SQL
             sql << " #{action_sql('DELETE', o.on_delete)}" if o.on_delete
             sql << " #{action_sql('UPDATE', o.on_update)}" if o.on_update
+            sql << " #{o.sql_options}" if o.sql_options
             sql
           end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -46,6 +46,10 @@ module ActiveRecord
         options[:on_update]
       end
 
+      def sql_options
+        options[:sql_options]
+      end
+
       def custom_primary_key?
         options[:primary_key] != default_primary_key
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -698,6 +698,8 @@ module ActiveRecord
       #   Action that happens <tt>ON DELETE</tt>. Valid values are +:nullify+, +:cascade:+ and +:restrict+
       # [<tt>:on_update</tt>]
       #   Action that happens <tt>ON UPDATE</tt>. Valid values are +:nullify+, +:cascade:+ and +:restrict+
+      # [<tt>:sql_options</tt>]
+      #   A string of db-specific options to be appended to the end of the statement, e.g. <tt>"DEFERRABLE INITIALLY DEFERRED"</tt> or <tt>"NOT VALID"</tt>
       def add_foreign_key(from_table, to_table, options = {})
         return unless supports_foreign_keys?
 
@@ -708,7 +710,8 @@ module ActiveRecord
           primary_key: options[:primary_key],
           name: foreign_key_name(from_table, options),
           on_delete: options[:on_delete],
-          on_update: options[:on_update]
+          on_update: options[:on_update],
+          sql_options: options[:sql_options]
         }
         at = create_alter_table from_table
         at.add_foreign_key to_table, options

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -228,6 +228,7 @@ HEADER
 
             parts << "on_update: #{foreign_key.on_update.inspect}" if foreign_key.on_update
             parts << "on_delete: #{foreign_key.on_delete.inspect}" if foreign_key.on_delete
+            parts << "sql_options: #{foreign_key.sql_options.inspect}" if foreign_key.sql_options
 
             "  #{parts.join(', ')}"
           end


### PR DESCRIPTION
`:sql_options` can be used to pass along arbitrary clauses to the generated
`ADD FOREIGN KEY` statement, e.g. `"DEFERRABLE INITIALLY DEFERRED"`

also include logic to infer `:sql_options` for postgres when dumping so that
schema.rb is accurate. no such logic is needed for mysql, as it doesn't
support any options beyond what's already on master.
