### PR TITLE
fixture_file_upload returns ActionDispatch::Http::UploadedFile.

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -38,7 +38,9 @@ module ActionDispatch
       if self.class.respond_to?(:fixture_path) && self.class.fixture_path
         path = File.join(self.class.fixture_path, path)
       end
-      Rack::Test::UploadedFile.new(path, mime_type, binary)
+      file = File.open(path, "r:BINARY")
+      file.binmode if binary
+      ActionDispatch::Http::UploadedFile.new(filename: path, tempfile: file, type: mime_type)
     end
   end
 end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -651,6 +651,7 @@ XML
 
     uploaded_file = fixture_file_upload('/mona_lisa.jpg', 'image/png')
     assert_equal File.open("#{FILES_DIR}/mona_lisa.jpg", READ_PLAIN).read, uploaded_file.read
+    assert uploaded_file.tempfile
   end
 
   def test_test_uploaded_file_with_binary


### PR DESCRIPTION
Hi.

Uploaded file is an ActionDispatch::Http::UploadedFile object.
But in controller test, I use fixture_file_upload, it returns Rack::Test::UploadedFile.
Do you think that fixture_file_upload should return ActionDispatch::Http::UploadedFile?

Thanks.
