### PR TITLE
Replace parallel assignment with sequential for better performance

### DIFF
--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -47,7 +47,8 @@ module ActionView
     # Renders the given template. A string representing the layout can be
     # supplied as well.
     def render_template(template, layout_name = nil, locals = nil) #:nodoc:
-      view, locals = @view, locals || {}
+      view = @view
+      locals = locals || {}
 
       render_with_layout(layout_name, locals) do |layout|
         instrument(:template, :identifier => template.identifier, :layout => layout.try(:virtual_path)) do

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -26,7 +26,8 @@ module ActionView
 
     # Overwrite process to setup I18n proxy.
     def process(*) #:nodoc:
-      old_config, I18n.config = I18n.config, I18nProxy.new(I18n.config, lookup_context)
+      old_config = I18n.config
+      I18n.config = I18nProxy.new(I18n.config, lookup_context)
       super
     ensure
       I18n.config = old_config


### PR DESCRIPTION
These methods are hot spots, since are involved in each request. And anyway this syntax looks better and is diff-friendly.
