### PR TITLE
Use Hash#each_key instead of Hash#keys.each

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.erb
@@ -10,7 +10,7 @@
             <tr>
               <td>
                 <pre class="line_numbers">
-                  <% extract_source[:code].keys.each do |line_number| %>
+                  <% extract_source[:code].each_key do |line_number| %>
 <span><%= line_number -%></span>
                   <% end %>
                 </pre>

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -43,11 +43,11 @@ class ResourcesTest < ActionController::TestCase
           :member => member_methods,
           :path_names => path_names do |options|
 
-        collection_methods.keys.each do |action|
+        collection_methods.each_key do |action|
           assert_named_route "/messages/#{path_names[action] || action}", "#{action}_messages_path", :action => action
         end
 
-        member_methods.keys.each do |action|
+        member_methods.each_key do |action|
           assert_named_route "/messages/1/#{path_names[action] || action}", "#{action}_message_path", :action => action, :id => "1"
         end
 
@@ -150,7 +150,7 @@ class ResourcesTest < ActionController::TestCase
       end
 
       assert_restful_named_routes_for :messages do |options|
-        actions.keys.each do |action|
+        actions.each_key do |action|
           assert_named_route "/messages/#{action}", "#{action}_messages_path", :action => action
         end
       end
@@ -180,7 +180,7 @@ class ResourcesTest < ActionController::TestCase
       end
 
       assert_restful_named_routes_for :messages, :path_prefix => 'threads/1/', :name_prefix => 'thread_', :options => { :thread_id => '1' } do |options|
-        actions.keys.each do |action|
+        actions.each_key do |action|
           assert_named_route "/threads/1/messages/#{action}", "#{action}_thread_messages_path", :action => action
         end
       end
@@ -207,7 +207,7 @@ class ResourcesTest < ActionController::TestCase
       end
 
       assert_restful_named_routes_for :messages, :path_prefix => 'threads/1/', :name_prefix => 'thread_', :options => { :thread_id => '1' } do |options|
-        actions.keys.each do |action|
+        actions.each_key do |action|
           assert_named_route "/threads/1/messages/#{action}", "#{action}_thread_messages_path", :action => action
         end
       end
@@ -237,7 +237,7 @@ class ResourcesTest < ActionController::TestCase
       end
 
       assert_restful_named_routes_for :messages, :path_prefix => 'threads/1/', :name_prefix => 'thread_', :options => { :thread_id => '1' } do |options|
-        actions.keys.each do |action|
+        actions.each_key do |action|
           assert_named_route "/threads/1/messages/#{action}.xml", "#{action}_thread_messages_path", :action => action, :format => 'xml'
         end
       end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -503,7 +503,7 @@ XML
     get :test_params, :id => 20, :foo => Object.new
 
     # All elements of path_parameters should use Symbol keys
-    @request.path_parameters.keys.each do |key|
+    @request.path_parameters.each_key do |key|
       assert_kind_of Symbol, key
     end
   end

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -3,7 +3,7 @@ require 'abstract_unit'
 class MimeTypeTest < ActiveSupport::TestCase
 
   test "parse single" do
-    Mime::LOOKUP.keys.each do |mime_type|
+    Mime::LOOKUP.each_key do |mime_type|
       unless mime_type == 'image/*'
         assert_equal [Mime::Type.lookup(mime_type)], Mime::Type.parse(mime_type)
       end

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -525,7 +525,7 @@ module ActiveRecord
               conn = fs.model_class.respond_to?(:connection) ? fs.model_class.connection : connection
               table_rows = fs.table_rows
 
-              table_rows.keys.each do |table|
+              table_rows.each_key do |table|
                 conn.delete "DELETE FROM #{conn.quote_table_name(table)}", 'Fixture Delete'
               end
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -215,7 +215,7 @@ db_namespace = namespace :db do
 
       Dir["#{base_dir}/**/*.yml"].each do |file|
         if data = YAML::load(ERB.new(IO.read(file)).result)
-          data.keys.each do |key|
+          data.each_key do |key|
             key_id = ActiveRecord::FixtureSet.identify(key)
 
             if key == label || key_id == id.to_i

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -22,7 +22,7 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_instance_of TZInfo::TimezonePeriod, zone.period_for_local(Time.utc(2000))
   end
 
-  ActiveSupport::TimeZone::MAPPING.keys.each do |name|
+  ActiveSupport::TimeZone::MAPPING.each_key do |name|
     define_method("test_map_#{name.downcase.gsub(/[^a-z]/, '_')}_to_tzinfo") do
       zone = ActiveSupport::TimeZone[name]
       assert_respond_to zone.tzinfo, :period_for_local


### PR DESCRIPTION
`Hash#keys.each` allocates an array of keys; `Hash#each_key` iterates through the keys without allocating a new array. This is the reason why `Hash#each_key` exists.

This is a more comprehensive pull request that closes #17083.
###### Benchmark

``` ruby
require 'benchmark/ips'

HASH = Hash[*('aa'..'zz')]

def slow
  HASH.keys.each { |k| k }
end

def fast
  HASH.each_key { |k| k }
end

Benchmark.ips do |x|
  x.report('slow') { slow }
  x.report('fast') { fast }
end
```

```
slow 34702.1 (±9.8%) i/s - 172725 in 5.074038s
fast 46103.3 (±8.1%) i/s - 232512 in 5.076248s
```
