### PR TITLE
Add RUNNING_UNIT_TESTS to ActionMailer [ci skip]

### DIFF
--- a/actionmailer/RUNNING_UNIT_TESTS.rdoc
+++ b/actionmailer/RUNNING_UNIT_TESTS.rdoc
@@ -1,0 +1,17 @@
+== Running with Rake
+
+The easiest way to run the unit tests is through Rake. The default task runs
+the entire test suite for all classes. For more information, check out the
+full array of rake tasks with "rake -T".
+
+Rake can be found at http://docs.seattlerb.org/rake/.
+
+== Running by hand
+
+Run a single test suite:
+
+   rake test TEST=path/to/test.rb
+
+Run one test in a test suite:
+
+   rake test TEST=path/to/test.rb TESTOPTS="--name=test_something"


### PR DESCRIPTION
ActionPack, ActionRecord and ActionView folders have their own
`RUNNING_UNIT_TESTS.rdoc` file. ActionMailer should too… right?

In my opinion, it makes sense, and it could also be added to the
other folders that are missing it (ActiveJob, ActiveSupport, Railties)
but I'd like to know your opinion first. Thanks!
