### PR TITLE
Concurrent load interlock (rm Rack::Lock)

### DIFF
--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -52,6 +52,7 @@ module ActionDispatch
     autoload :DebugExceptions
     autoload :ExceptionWrapper
     autoload :Flash
+    autoload :LoadInterlock
     autoload :ParamsParser
     autoload :PublicExceptions
     autoload :Reloader

--- a/actionpack/lib/action_dispatch/middleware/load_interlock.rb
+++ b/actionpack/lib/action_dispatch/middleware/load_interlock.rb
@@ -1,0 +1,12 @@
+require 'active_support/dependencies'
+require 'rack/lock'
+
+module ActionDispatch
+  class LoadInterlock < ::Rack::Lock
+    FLAG = 'activesupport.dependency_race'.freeze
+
+    def initialize(app, mutex = ::ActiveSupport::Dependencies.interlock)
+      super
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/middleware/load_interlock.rb
+++ b/actionpack/lib/action_dispatch/middleware/load_interlock.rb
@@ -1,12 +1,21 @@
 require 'active_support/dependencies'
-require 'rack/lock'
+require 'rack/body_proxy'
 
 module ActionDispatch
-  class LoadInterlock < ::Rack::Lock
-    FLAG = 'activesupport.dependency_race'.freeze
+  class LoadInterlock
+    def initialize(app)
+      @app = app
+    end
 
-    def initialize(app, mutex = ::ActiveSupport::Dependencies.interlock)
-      super
+    def call(env)
+      interlock = ActiveSupport::Dependencies.interlock
+      interlock.start_running
+      response = @app.call(env)
+      body = Rack::BodyProxy.new(response[2]) { interlock.done_running }
+      response[2] = body
+      response
+    ensure
+      interlock.done_running unless body
     end
   end
 end

--- a/activesupport/lib/active_support/concurrency/share_lock.rb
+++ b/activesupport/lib/active_support/concurrency/share_lock.rb
@@ -1,0 +1,118 @@
+require 'thread'
+require 'monitor'
+
+module ActiveSupport
+  module Concurrency
+    class ShareLock
+      include MonitorMixin
+
+      # We track Thread objects, instead of just using counters, because
+      # we need exclusive locks to be reentrant, and we need to be able
+      # to upgrade share locks to exclusive.
+
+
+      # If +loose_upgrades+ is false (the default), then a thread that
+      # is waiting on an Exclusive lock will continue to hold any Share
+      # lock that it has already established. This is safer, but can
+      # lead to deadlock.
+      #
+      # If +loose_upgrades+ is true, a thread waiting on an Exclusive
+      # lock will temporarily relinquish its Share lock. Being less
+      # strict, this behavior prevents some classes of deadlocks. For
+      # many resources, loose upgrades are sufficient: if a thread is
+      # awaiting a lock, it is not running any other code.
+      attr_reader :loose_upgrades
+
+      def initialize(loose_upgrades = false)
+        @loose_upgrades = loose_upgrades
+
+        super()
+
+        @cv = new_cond
+
+        @sharing = Hash.new(0)
+        @exclusive_thread = nil
+        @exclusive_depth = 0
+      end
+
+      def start_exclusive(no_wait=false)
+        synchronize do
+          unless @exclusive_thread == Thread.current
+            return false if no_wait && busy?
+
+            loose_shares = nil
+            if @loose_upgrades
+              loose_shares = @sharing.delete(Thread.current)
+            end
+
+            @cv.wait_while { busy? } if busy?
+
+            @exclusive_thread = Thread.current
+            @sharing[Thread.current] = loose_shares if loose_shares
+          end
+          @exclusive_depth += 1
+
+          true
+        end
+      end
+
+      def stop_exclusive
+        synchronize do
+          raise "invalid unlock" if @exclusive_thread != Thread.current
+
+          @exclusive_depth -= 1
+          if @exclusive_depth == 0
+            @exclusive_thread = nil
+            @cv.broadcast
+          end
+        end
+      end
+
+      def start_sharing
+        synchronize do
+          if @exclusive_thread && @exclusive_thread != Thread.current
+            @cv.wait_while { @exclusive_thread }
+          end
+          @sharing[Thread.current] += 1
+        end
+      end
+
+      def stop_sharing
+        synchronize do
+          if @sharing[Thread.current] > 1
+            @sharing[Thread.current] -= 1
+          else
+            @sharing.delete Thread.current
+            @cv.broadcast
+          end
+        end
+      end
+
+      def exclusive(no_wait=false)
+        if start_exclusive(no_wait)
+          begin
+            yield
+          ensure
+            stop_exclusive
+          end
+        end
+      end
+
+      def sharing
+        start_sharing
+        begin
+          yield
+        ensure
+          stop_sharing
+        end
+      end
+
+      private
+
+      def busy?
+        (@exclusive_thread && @exclusive_thread != Thread.current) ||
+          @sharing.size > (@sharing[Thread.current] > 0 ? 1 : 0)
+      end
+    end
+  end
+end

--- a/activesupport/lib/active_support/dependencies/interlock.rb
+++ b/activesupport/lib/active_support/dependencies/interlock.rb
@@ -1,0 +1,35 @@
+require 'active_support/concurrency/share_lock'
+
+module ActiveSupport
+  module Dependencies #:nodoc:
+    class Interlock
+      def initialize
+        @lock = ActiveSupport::Concurrency::ShareLock.new(true)
+      end
+
+      def loading
+        @lock.exclusive do
+          yield
+        end
+      end
+
+      def start_running
+        @lock.start_sharing
+      end
+
+      def done_running
+        @lock.stop_sharing
+      end
+
+      def running
+        @lock.sharing do
+          yield
+        end
+      end
+
+      # Match the Mutex API, so we can be used by Rack::Lock
+      alias :lock :start_running
+      alias :unlock :done_running
+    end
+  end
+end

--- a/activesupport/lib/active_support/dependencies/interlock.rb
+++ b/activesupport/lib/active_support/dependencies/interlock.rb
@@ -1,9 +1,9 @@
 require 'active_support/concurrency/share_lock'
 
-module ActiveSupport
+module ActiveSupport #:nodoc:
   module Dependencies #:nodoc:
     class Interlock
-      def initialize
+      def initialize # :nodoc:
         @lock = ActiveSupport::Concurrency::ShareLock.new(true)
       end
 
@@ -36,10 +36,6 @@ module ActiveSupport
           yield
         end
       end
-
-      # Match the Mutex API, so we can be used by Rack::Lock
-      alias :lock :start_running
-      alias :unlock :done_running
     end
   end
 end

--- a/activesupport/lib/active_support/dependencies/interlock.rb
+++ b/activesupport/lib/active_support/dependencies/interlock.rb
@@ -13,6 +13,16 @@ module ActiveSupport
         end
       end
 
+      # Attempt to obtain a "loading" (exclusive) lock. If possible,
+      # execute the supplied block while holding the lock. If there is
+      # concurrent activity, return immediately (without executing the
+      # block) instead of waiting.
+      def attempt_loading
+        @lock.exclusive(true) do
+          yield
+        end
+      end
+
       def start_running
         @lock.start_sharing
       end

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -32,26 +32,18 @@ module Rails
 
             middleware.use ::Rack::Lock
 
-          elsif config.allow_concurrency
-            # Do nothing, even if we know this is dangerous
+          elsif config.allow_concurrency == :unsafe
+            # Do nothing, even if we know this is dangerous. This is the
+            # historical behaviour for true.
 
           else
-            # Default concurrency setting
+            # Default concurrency setting: enabled, but safe
 
-            if config.cache_classes && config.eager_load
-              # No lock required
-
-            elsif config.cache_classes
-              # The load interlock is required, but not a full request
-              # lock
+            unless config.cache_classes && config.eager_load
+              # Without cache_classes + eager_load, the load interlock
+              # is required for proper operation
 
               middleware.use ::ActionDispatch::LoadInterlock
-
-            else
-              # If we're reloading on each request, they all need to be
-              # run in isolation
-
-              middleware.use ::Rack::Lock
             end
           end
 

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -86,8 +86,10 @@ module Rails
       # added in the hook are taken into account.
       initializer :set_clear_dependencies_hook, group: :all do
         callback = lambda do
-          ActiveSupport::DescendantsTracker.clear
-          ActiveSupport::Dependencies.clear
+          ActiveSupport::Dependencies.interlock.attempt_loading do
+            ActiveSupport::DescendantsTracker.clear
+            ActiveSupport::Dependencies.clear
+          end
         end
 
         if config.reload_classes_only_on_change

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -26,7 +26,7 @@ module ApplicationTests
       assert_equal [
         "Rack::Sendfile",
         "ActionDispatch::Static",
-        "Rack::Lock",
+        "ActionDispatch::LoadInterlock",
         "ActiveSupport::Cache::Strategy::LocalCache",
         "Rack::Runtime",
         "Rack::MethodOverride",
@@ -58,7 +58,7 @@ module ApplicationTests
       assert_equal [
         "Rack::Sendfile",
         "ActionDispatch::Static",
-        "Rack::Lock",
+        "ActionDispatch::LoadInterlock",
         "ActiveSupport::Cache::Strategy::LocalCache",
         "Rack::Runtime",
         "ActionDispatch::RequestId",
@@ -128,11 +128,11 @@ module ApplicationTests
       assert_includes middleware, "ActionDispatch::LoadInterlock"
     end
 
-    test "includes lock if cache_classes is off" do
+    test "includes interlock if cache_classes is off" do
       add_to_config "config.cache_classes = false"
       boot!
-      assert_includes middleware, "Rack::Lock"
-      assert_not_includes middleware, "ActionDispatch::LoadInterlock"
+      assert_not_includes middleware, "Rack::Lock"
+      assert_includes middleware, "ActionDispatch::LoadInterlock"
     end
 
     test "does not include lock if cache_classes is set and so is eager_load" do
@@ -143,8 +143,8 @@ module ApplicationTests
       assert_not_includes middleware, "ActionDispatch::LoadInterlock"
     end
 
-    test "does not include lock if allow_concurrency is set" do
-      add_to_config "config.allow_concurrency = true"
+    test "does not include lock if allow_concurrency is set to :unsafe" do
+      add_to_config "config.allow_concurrency = :unsafe"
       boot!
       assert_not_includes middleware, "Rack::Lock"
       assert_not_includes middleware, "ActionDispatch::LoadInterlock"

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -121,23 +121,40 @@ module ApplicationTests
       assert !middleware.include?("ActiveRecord::Migration::CheckPending")
     end
 
-    test "includes lock if cache_classes is set but eager_load is not" do
+    test "includes interlock if cache_classes is set but eager_load is not" do
       add_to_config "config.cache_classes = true"
       boot!
-      assert middleware.include?("Rack::Lock")
+      assert_not_includes middleware, "Rack::Lock"
+      assert_includes middleware, "ActionDispatch::LoadInterlock"
+    end
+
+    test "includes lock if cache_classes is off" do
+      add_to_config "config.cache_classes = false"
+      boot!
+      assert_includes middleware, "Rack::Lock"
+      assert_not_includes middleware, "ActionDispatch::LoadInterlock"
     end
 
     test "does not include lock if cache_classes is set and so is eager_load" do
       add_to_config "config.cache_classes = true"
       add_to_config "config.eager_load = true"
       boot!
-      assert !middleware.include?("Rack::Lock")
+      assert_not_includes middleware, "Rack::Lock"
+      assert_not_includes middleware, "ActionDispatch::LoadInterlock"
     end
 
     test "does not include lock if allow_concurrency is set" do
       add_to_config "config.allow_concurrency = true"
       boot!
-      assert !middleware.include?("Rack::Lock")
+      assert_not_includes middleware, "Rack::Lock"
+      assert_not_includes middleware, "ActionDispatch::LoadInterlock"
+    end
+
+    test "includes lock if allow_concurrency is disabled" do
+      add_to_config "config.allow_concurrency = false"
+      boot!
+      assert_includes middleware, "Rack::Lock"
+      assert_not_includes middleware, "ActionDispatch::LoadInterlock"
     end
 
     test "removes static asset server if serve_static_files is disabled" do


### PR DESCRIPTION
Instead of forcing `Rack::Lock` when `eager_load` and `cache_classes` aren't on, just prevent actual conflicts.

We achieve this by means of a (reentrant) shared-exclusive lock: multiple running concurrent requests are fine, but any load activity must be performed in isolation.
