### PR TITLE
Fix numericality validation with large numbers

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `ActiveModel::Validations::NumericalityValidator` so that it works with large numbers
+
+    nearing `1_000_000_000_000_000_000`
+
+    *John Duff*
+
 *   Passwords with spaces only allowed in `ActiveModel::SecurePassword`.
 
     Presence validation can be used to restore old behavior.

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -61,7 +61,11 @@ module ActiveModel
     protected
 
       def parse_raw_value_as_a_number(raw_value)
-        Kernel.Float(raw_value) if raw_value !~ /\A0[xX]/
+        if raw_value.is_a?(Numeric)
+          raw_value
+        elsif raw_value !~ /\A0[xX]/
+          Kernel.Float(raw_value)
+        end
       rescue ArgumentError, TypeError
         nil
       end

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -22,6 +22,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
   BIGDECIMAL = BIGDECIMAL_STRINGS.collect! { |bd| BigDecimal.new(bd) }
   JUNK = ["not a number", "42 not a number", "0xdeadbeef", "0xinvalidhex", "0Xdeadbeef", "00-1", "--3", "+-3", "+3-1", "-+019.0", "12.12.13.12", "123\nnot a number"]
   INFINITY = [1.0/0.0]
+  LARGE_NUMBER = 1_000_000_000_000_000_000
 
   def test_default_validates_numericality_of
     Topic.validates_numericality_of :approved
@@ -91,6 +92,13 @@ class NumericalityValidationTest < ActiveModel::TestCase
 
     invalid!([10], 'must be less than 10')
     valid!([-9, 9])
+  end
+
+  def test_validates_numericality_with_less_than_large_numbers
+    Topic.validates_numericality_of :approved, less_than: LARGE_NUMBER
+
+    invalid!([LARGE_NUMBER], "must be less than #{LARGE_NUMBER}")
+    valid!([LARGE_NUMBER-1])
   end
 
   def test_validates_numericality_with_less_than_or_equal_to


### PR DESCRIPTION
When you use `LARGE_NUMBER-1` `Kernel.Float` actually rounds the number up to `LARGE_NUMBER`. Solution I took was to check if the number was `Numeric` and if it is you don't need to use `Kernel.Float` to parse it.

I'm not 100% sure on the approach I took so would love feedback from people more experienced with this piece of code.

@rafaelfranca @arthurnn suggested I tag you on this PR.
