### PR TITLE
Parse HTML as document fragment.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'rails-dom-testing', github: 'rails/rails-dom-testing'
+
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem 'rake', '>= 10.3'
 

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -689,7 +689,7 @@ module ActionController
       private
 
       def document_root_element
-        html_document.root
+        html_document
       end
 
       def check_required_ivars

--- a/actionpack/lib/action_dispatch/testing/assertions.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions.rb
@@ -15,7 +15,7 @@ module ActionDispatch
       @html_document ||= if @response.content_type =~ /xml$/
         Nokogiri::XML::Document.parse(@response.body)
       else
-        Nokogiri::HTML::Document.parse(@response.body)
+        Nokogiri::HTML::DocumentFragment.parse(@response.body)
       end
     end
   end

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -497,7 +497,7 @@ module ActionDispatch
     end
 
     def document_root_element
-      html_document.root
+      html_document
     end
   end
 end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -292,7 +292,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       assert_equal({}, cookies.to_hash)
       assert_equal "OK", body
       assert_equal "OK", response.body
-      assert_kind_of Nokogiri::HTML::Document, html_document
+      assert_kind_of Nokogiri::HTML::DocumentFragment, html_document
       assert_equal 1, request_count
     end
   end
@@ -308,7 +308,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       assert_equal({}, cookies.to_hash)
       assert_equal "Created", body
       assert_equal "Created", response.body
-      assert_kind_of Nokogiri::HTML::Document, html_document
+      assert_kind_of Nokogiri::HTML::DocumentFragment, html_document
       assert_equal 1, request_count
     end
   end
@@ -368,7 +368,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       assert_response :redirect
       assert_response :found
       assert_equal "<html><body>You are being <a href=\"http://www.example.com/get\">redirected</a>.</body></html>", response.body
-      assert_kind_of Nokogiri::HTML::Document, html_document
+      assert_kind_of Nokogiri::HTML::DocumentFragment, html_document
       assert_equal 1, request_count
 
       follow_redirect!

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -158,7 +158,7 @@ module ActionView
 
       # Need to experiment if this priority is the best one: rendered => output_buffer
       def document_root_element
-        Nokogiri::HTML::Document.parse(@rendered.blank? ? @output_buffer : @rendered).root
+        Nokogiri::HTML::DocumentFragment.parse(@rendered.blank? ? @output_buffer : @rendered)
       end
 
       def say_no_to_protect_against_forgery!


### PR DESCRIPTION
This is to match the changes in Rails Dom Testing rails/rails-dom-testing#20.

The gem added is temporary. The needed changes for the tests to pass haven't been relased yet.

I guess we could change `document_root_element` to be an alias of `html_document` but I don't know if that saved method call matters overall.

cc @rafaelfranca
