### PR TITLE
Better error message in case of miss use of a  match instruction

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -233,7 +233,8 @@ module ActionDispatch
                     "If you want to expose your action to both GET and POST, add `via: [:get, :post]` option.\n" \
                     "If you want to expose your action to GET, use `get` in the router:\n" \
                     "  Instead of: match \"controller#action\"\n" \
-                    "  Do: get \"controller#action\""
+                    "  Do: get \"controller#action\"\n" \
+                    "  Caught for \"#{path} => #{options[:to]}\"."
               raise ArgumentError, msg
             end
 


### PR DESCRIPTION
As part of a migration of a large project from Rails 3 to Rails 4.
Think 1K LOC in routes.rb and multiple gems that add their own routes, I suggest adding a more specific info into why this `ArgumentError` was raised.
