### PR TITLE
Make Time and DateTime #end_of_* methods consistent

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -111,7 +111,7 @@ class DateTime
 
   # Returns a new DateTime representing the end of the day (23:59:59).
   def end_of_day
-    change(:hour => 23, :min => 59, :sec => 59)
+    change(:hour => 23, :min => 59, :sec => 59 + Rational(999_999_999, 1_000_000_000))
   end
   alias :at_end_of_day :end_of_day
 
@@ -123,7 +123,7 @@ class DateTime
 
   # Returns a new DateTime representing the end of the hour (hh:59:59).
   def end_of_hour
-    change(:min => 59, :sec => 59)
+    change(:min => 59, :sec => 59 + Rational(999_999_999, 1_000_000_000))
   end
   alias :at_end_of_hour :end_of_hour
 
@@ -135,7 +135,7 @@ class DateTime
 
   # Returns a new DateTime representing the end of the minute (hh:mm:59).
   def end_of_minute
-    change(:sec => 59)
+    change(:sec => 59 + Rational(999_999_999, 1_000_000_000))
   end
   alias :at_end_of_minute :end_of_minute
 

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -5,7 +5,8 @@ require 'time_zone_test_helpers'
 
 class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   def date_time_init(year,month,day,hour,minute,second,*args)
-    DateTime.civil(year,month,day,hour,minute,second)
+    sec_fractions = args.empty? ? 0 : args.first * Rational(1, 1_000_000)
+    DateTime.civil(year,month,day,hour,minute,second + sec_fractions)
   end
 
   include DateAndTimeBehavior
@@ -89,7 +90,8 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_end_of_day
-    assert_equal DateTime.civil(2005,2,4,23,59,59), DateTime.civil(2005,2,4,10,10,10).end_of_day
+    assert_equal DateTime.civil(2005,2,4,23,59,59+Rational(999_999_999, 1_000_000_000)), DateTime.civil(2005,2,4,10,10,10).end_of_day
+    assert_equal Time.local(2005,2,4,10,10,10).end_of_day.to_datetime, DateTime.civil(2005,2,4,10,10,10).end_of_day
   end
 
   def test_beginning_of_hour
@@ -97,7 +99,8 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_end_of_hour
-    assert_equal DateTime.civil(2005,2,4,19,59,59), DateTime.civil(2005,2,4,19,30,10).end_of_hour
+    assert_equal DateTime.civil(2005,2,4,19,59,59+Rational(999_999_999, 1_000_000_000)), DateTime.civil(2005,2,4,19,30,10).end_of_hour
+    assert_equal Time.local(2005,2,4,19,30,10).end_of_hour.to_datetime, DateTime.civil(2005,2,4,19,30,10).end_of_hour
   end
 
   def test_beginning_of_minute
@@ -105,13 +108,15 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_end_of_minute
-    assert_equal DateTime.civil(2005,2,4,19,30,59), DateTime.civil(2005,2,4,19,30,10).end_of_minute
+    assert_equal DateTime.civil(2005,2,4,19,30,59+Rational(999_999_999, 1_000_000_000)), DateTime.civil(2005,2,4,19,30,10).end_of_minute
+    assert_equal Time.local(2005,2,4,19,30,10).end_of_minute.to_datetime, DateTime.civil(2005,2,4,19,30,10).end_of_minute
   end
 
   def test_end_of_month
-    assert_equal DateTime.civil(2005,3,31,23,59,59), DateTime.civil(2005,3,20,10,10,10).end_of_month
-    assert_equal DateTime.civil(2005,2,28,23,59,59), DateTime.civil(2005,2,20,10,10,10).end_of_month
-    assert_equal DateTime.civil(2005,4,30,23,59,59), DateTime.civil(2005,4,20,10,10,10).end_of_month
+    assert_equal DateTime.civil(2005,3,31,23,59,59+Rational(999_999_999, 1_000_000_000)), DateTime.civil(2005,3,20,10,10,10).end_of_month
+    assert_equal DateTime.civil(2005,2,28,23,59,59+Rational(999_999_999, 1_000_000_000)), DateTime.civil(2005,2,20,10,10,10).end_of_month
+    assert_equal DateTime.civil(2005,4,30,23,59,59+Rational(999_999_999, 1_000_000_000)), DateTime.civil(2005,4,20,10,10,10).end_of_month
+    assert_equal Time.local(2005,2,4,10,10,10).end_of_month.to_datetime, DateTime.civil(2005,2,4,10,10,10).end_of_month
   end
 
   def test_last_year


### PR DESCRIPTION
Before:
  Time.now.end_of_month.to_datetime != DateTime.now.end_of_month,

After: 
  Time.now.end_of_month.to_datetime == DateTime.now.end_of_month

That's because of Time using sec_fractions for end_of_\* methods, while DateTime's methods ignored sec_fractions (even though it's supported by the class). 

This fixes https://github.com/rails/rails/pull/16955
