### PR TITLE
Refactor callback setup to use lambda instead of eval

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -156,7 +156,7 @@ module ActiveModel
         if options.key?(:on)
           options = options.dup
           options[:if] = Array(options[:if])
-          options[:if].unshift lambda { |o|
+          options[:if].unshift ->(o) {
             Array(options[:on]).include?(o.validation_context)
           }
         end

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -58,7 +58,7 @@ module ActiveModel
           if options.is_a?(Hash) && options[:on]
             options[:if] = Array(options[:if])
             options[:on] = Array(options[:on])
-            options[:if].unshift lambda { |o|
+            options[:if].unshift ->(o) {
               options[:on].include? o.validation_context
             }
           end
@@ -98,7 +98,9 @@ module ActiveModel
           options[:if] = Array(options[:if])
           if options[:on]
             options[:on] = Array(options[:on])
-            options[:if].unshift("#{options[:on]}.include? self.validation_context")
+            options[:if].unshift ->(o) {
+              options[:on].include? o.validation_context
+            }
           end
           set_callback(:validation, :after, *(args << options), &block)
         end


### PR DESCRIPTION
Replace the use of an evaluated string literal with a lamba.
