### PR TITLE
Fix for issue #17115: ActiveModel::AcceptanceValidator initialize causes an error because the overridden hash is not HashWithIndifferentAccess

### DIFF
--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -3,7 +3,7 @@ module ActiveModel
   module Validations
     class AcceptanceValidator < EachValidator # :nodoc:
       def initialize(options)
-        super({ allow_nil: true, accept: "1" }.merge!(options))
+        super(ActiveSupport::HashWithIndifferentAccess.new({ allow_nil: true, accept: "1" }).merge!(options))
         setup!(options[:class])
       end
 


### PR DESCRIPTION
Changed the hash from ordinary to HashWithIndifferentAccess in order to fix the "attributes cannot be blank" error thrown if the super class cannot extract "attributes" from the hash.
