### PR TITLE
Add an activerecord relation blacklisted array method

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -40,7 +40,7 @@ module ActiveRecord
     BLACKLISTED_ARRAY_METHODS = [
       :compact!, :flatten!, :reject!, :reverse!, :rotate!, :map!,
       :shuffle!, :slice!, :sort!, :sort_by!, :delete_if,
-      :keep_if, :pop, :shift, :delete_at, :compact, :select!
+      :keep_if, :pop, :shift, :delete_at, :compact, :select!, :[]=
     ].to_set # :nodoc:
 
     delegate :to_xml, :to_yaml, :length, :collect, :map, :each, :all?, :include?, :to_ary, :join, to: :to_a


### PR DESCRIPTION
`:[]=` is destructive method.
And this is not used in ActiveRecord::Relation.
It's a nonsense.
