### PR TITLE
`ActiveModel::Serializers::JSON#as_json` does deep `as_json`

### DIFF
--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -97,7 +97,7 @@ module ActiveModel
           { root => serializable_hash(options) }
         else
           serializable_hash(options)
-        end
+        end.as_json
       end
 
       # Sets the model +attributes+ from a JSON string. Returns +self+.

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -136,7 +136,7 @@ class JsonSerializationTest < ActiveModel::TestCase
       assert_kind_of Hash, json
       assert_kind_of Hash, json['contact']
       %w(name age created_at awesome preferences).each do |field|
-        assert_equal @contact.send(field), json['contact'][field]
+        assert_equal @contact.send(field).as_json, json['contact'][field]
       end
     ensure
       Contact.include_root_in_json = original_include_root_in_json


### PR DESCRIPTION
This corrects a bug where `#as_json` on `ActiveModel`s with date fields
does not return a hash of primitives, as would be expected. That is,
prior to this change, `#as_json` would return a hash of Ruby objects
that do not all have direct corollaries in JSON.

cc @ryanhall07
