### PR TITLE
`ActiveModel::Serializers::JSON#as_json` does deep `as_json`

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -125,7 +125,7 @@ module ActiveModel
     #   # => {"name" => "Napoleon"}
     #   user.serializable_hash(include: { notes: { only: 'title' }})
     #   # => {"name" => "Napoleon", "notes" => [{"title"=>"Battle of Austerlitz"}]}
-    def serializable_hash(options = nil)
+    def serializable_hash(options = nil, serialization_method = nil)
       options ||= {}
 
       attribute_names = attributes.keys
@@ -136,7 +136,11 @@ module ActiveModel
       end
 
       hash = {}
-      attribute_names.each { |n| hash[n] = read_attribute_for_serialization(n) }
+      attribute_names.each do |attribute_name|
+        attribute = read_attribute_for_serialization(attribute_name)
+        attribute = attribute.public_send(serialization_method) if serialization_method
+        hash[attribute_name] = attribute
+      end
 
       Array(options[:methods]).each { |m| hash[m.to_s] = send(m) }
 

--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -92,11 +92,13 @@ module ActiveModel
           include_root_in_json
         end
 
+        hash = serializable_hash(options, :as_json)
+
         if root
           root = model_name.element if root == true
-          { root => serializable_hash(options) }
+          { root => hash }
         else
-          serializable_hash(options)
+          hash
         end
       end
 

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -136,7 +136,7 @@ class JsonSerializationTest < ActiveModel::TestCase
       assert_kind_of Hash, json
       assert_kind_of Hash, json['contact']
       %w(name age created_at awesome preferences).each do |field|
-        assert_equal @contact.send(field), json['contact'][field]
+        assert_equal @contact.send(field).as_json, json['contact'][field]
       end
     ensure
       Contact.include_root_in_json = original_include_root_in_json

--- a/activerecord/lib/active_record/serialization.rb
+++ b/activerecord/lib/active_record/serialization.rb
@@ -8,13 +8,13 @@ module ActiveRecord #:nodoc:
       self.include_root_in_json = false
     end
 
-    def serializable_hash(options = nil)
+    def serializable_hash(options = nil, serialization_method = nil)
       options = options.try(:clone) || {}
 
       options[:except] = Array(options[:except]).map(&:to_s)
       options[:except] |= Array(self.class.inheritance_column)
 
-      super(options)
+      super(options, serialization_method)
     end
   end
 end

--- a/activerecord/test/cases/json_serialization_test.rb
+++ b/activerecord/test/cases/json_serialization_test.rb
@@ -102,7 +102,7 @@ class JsonSerializationTest < ActiveRecord::TestCase
   end
 
   def test_uses_serializable_hash_with_only_option
-    def @contact.serializable_hash(options=nil)
+    def @contact.serializable_hash(options = nil, *)
       super(only: %w(name))
     end
 
@@ -113,7 +113,7 @@ class JsonSerializationTest < ActiveRecord::TestCase
   end
 
   def test_uses_serializable_hash_with_except_option
-    def @contact.serializable_hash(options=nil)
+    def @contact.serializable_hash(options = nil, *)
       super(except: %w(age))
     end
 
@@ -137,7 +137,7 @@ class JsonSerializationTest < ActiveRecord::TestCase
     @contact = ContactSti.new(@contact.attributes)
     assert_equal 'ContactSti', @contact.type
 
-    def @contact.serializable_hash(options={})
+    def @contact.serializable_hash(options = {}, *)
       super({ except: %w(age) }.merge!(options))
     end
 


### PR DESCRIPTION
This corrects a bug where `#as_json` on `ActiveModel`s with date fields
does not return a hash of primitives, as would be expected. That is,
prior to this change, `#as_json` would return a hash of Ruby objects
that do not all have direct corollaries in JSON.

rebirth of https://github.com/rails/rails/pull/17132
