### PR TITLE
Add irregular verb to inflector

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -64,6 +64,7 @@ module ActiveSupport
     inflect.irregular('sex', 'sexes')
     inflect.irregular('move', 'moves')
     inflect.irregular('zombie', 'zombies')
+    inflect.irregular('wave', 'waves')
 
     inflect.uncountable(%w(equipment information rice money species series fish sheep jeans police))
   end

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -35,6 +35,8 @@ module InflectorTestCases
     "salesperson" => "salespeople",
     "person"      => "people",
 
+    "wave"        => "waves",
+
     "spokesman"   => "spokesmen",
     "man"         => "men",
     "woman"       => "women",
@@ -319,6 +321,7 @@ module InflectorTestCases
     'move'   => 'moves',
     'cow'    => 'kine', # Test inflections with different starting letters
     'zombie' => 'zombies',
-    'genus'  => 'genera'
+    'genus'  => 'genera',
+    'wave'   => 'waves'
   }
 end


### PR DESCRIPTION
Hi all,

I just found an issue with the active support inflector while trying to create an association using a model called waves. Looks like the singularization of the word "waves" is returning me "wafe" which is incorrect.

Thanks!
