### PR TITLE
Rename default_form_builder to avoid collision

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1188,11 +1188,11 @@ module ActionView
             object_name = model_name_from_record_or_class(object).param_key
           end
 
-          builder = options[:builder] || default_form_builder
+          builder = options[:builder] || build_default_form_builder
           builder.new(object_name, object, self, options)
         end
 
-        def default_form_builder
+        def build_default_form_builder
           builder = ActionView::Base.default_form_builder
           builder.respond_to?(:constantize) ? builder.constantize : builder
         end


### PR DESCRIPTION
The [Configuring Action View](http://guides.rubyonrails.org/configuring.html#configuring-action-view) guides say the following:

> `config.action_view.default_form_builder` tells Rails which form builder to use by default. The default is ActionView::Helpers::FormBuilder. If you want your form builder class to be loaded after initialization (so it's reloaded on each request in development), you can pass it as a String

Unfortunately, when you set `config.action_view.default_form_builder` as a string, it is set as a class-level attr_accessor on ActionView::Base. Then [line 1191 on master](https://github.com/jpcody/rails/blob/7b740f31cc6f88fe20a51eb7da1468082e6fdb5a/actionview/lib/action_view/helpers/form_helper.rb#L1191) attempts to call an internal method to constantize this string, but instead, it receives the `default_form_builder` cattr_accessor as a string and attempts to call `new` on it on the subsequent line.

This problem only appears when setting this configuration before the file is required, and quite honestly, I couldn't discern how to write a test for the case. But as it's only a naming collision, it seemed innocuous enough to submit as a PR.

Thoughts?
