### PR TITLE
Remove useless / ghost code

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1128,7 +1128,6 @@ module ActionDispatch
         class SingletonResource < Resource #:nodoc:
           def initialize(entities, options)
             super
-            @as         = nil
             @controller = (options[:controller] || plural).to_s
             @as         = options[:as]
           end


### PR DESCRIPTION
This PR removes useless explicit setting of `@as` to nil in SingletonResource initializer.

Since `@as` ivar is set to be equal to `options[:as]` right after
there no need to set `@as` variable to `nil` value explicitly.

If `options[:as]` is present `@as` will take this value otherwise
it will be set to `nil`.

I think this line comes from an old version that was left behind.
