### PR TITLE
mail_to helper method fix

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -458,8 +458,9 @@ module ActionView
         html_options = (html_options || {}).stringify_keys
 
         extras = %w{ cc bcc body subject }.map! { |item|
-          option = html_options.delete(item) || next
-          "#{item}=#{Rack::Utils.escape_path(option)}"
+          if option = html_options.delete(item).presence
+            "#{item}=#{Rack::Utils.escape_path(option)}"
+          end
         }.compact
         extras = extras.empty? ? '' : '?' + extras.join('&')
 

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -496,6 +496,11 @@ class UrlHelperTest < ActiveSupport::TestCase
       %{<a href="mailto:me@example.com?cc=ccaddress%40example.com&amp;bcc=bccaddress%40example.com&amp;body=This%20is%20the%20body%20of%20the%20message.&amp;subject=This%20is%20an%20example%20email">My email</a>},
       mail_to("me@example.com", "My email", cc: "ccaddress@example.com", bcc: "bccaddress@example.com", subject: "This is an example email", body: "This is the body of the message.")
     )
+
+    assert_dom_equal(
+      %{<a href="mailto:me@example.com?body=This%20is%20the%20body%20of%20the%20message.&amp;subject=This%20is%20an%20example%20email">My email</a>},
+      mail_to("me@example.com", "My email", cc: '', bcc: '', subject: "This is an example email", body: "This is the body of the message.")
+    )
   end
 
   def test_mail_to_with_img


### PR DESCRIPTION
do not generate blank options in mailTo
when mail_to generate blank options for any passed options(cc, bcc, body, subject)
then MICROSOFT OUTLOOK treats it differently and set wrong values in different options.
So, I think we should not add blank options in link.

In windows outlook:

![outlook_issue-1](https://cloud.githubusercontent.com/assets/1930730/4492059/2a73a4d6-4a3e-11e4-891d-3a4693ac511a.png)

In other mail application
![screen shot 2014-09-23 at 6 24 56 pm](https://cloud.githubusercontent.com/assets/1930730/4492089/650e41b4-4a3e-11e4-8fc0-0456e88da5d6.png)
