### PR TITLE
always reorder bind parameters. fixes #15920

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -866,6 +866,13 @@ module ActiveRecord
       arel.from(build_from) if from_value
       arel.lock(lock_value) if lock_value
 
+      # Reorder bind indexes if joins produced bind values
+      bvs = arel.bind_values + bind_values
+      arel.ast.grep(Arel::Nodes::BindParam).each_with_index do |bp, i|
+        column = bvs[i].first
+        bp.replace connection.substitute_at(column, i)
+      end
+
       arel
     end
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -23,7 +23,7 @@ require 'models/interest'
 
 class AssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :developers_projects,
-           :computers, :people, :readers
+           :computers, :people, :readers, :authors, :author_favorites
 
   def test_eager_loading_should_not_change_count_of_children
     liquid = Liquid.create(:name => 'salty')
@@ -33,6 +33,13 @@ class AssociationsTest < ActiveRecord::TestCase
 
     liquids = Liquid.includes(:molecules => :electrons).references(:molecules).where('molecules.id is not null')
     assert_equal 1, liquids[0].molecules.length
+  end
+
+  def test_subselect
+    author = authors :david
+    favs = author.author_favorites
+    fav2 = author.author_favorites.where(:author => Author.where(id: author.id)).to_a
+    assert_equal favs, fav2
   end
 
   def test_clear_association_cache_stored


### PR DESCRIPTION
Conflicts:
    activerecord/lib/active_record/relation/query_methods.rb
