### PR TITLE
Disallow appended newlines when parsing as integer

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -67,7 +67,7 @@ module ActiveModel
       end
 
       def parse_raw_value_as_an_integer(raw_value)
-        raw_value.to_i if raw_value.to_s =~ /\A[+-]?\d+\Z/
+        raw_value.to_i if raw_value.to_s =~ /\A[+-]?\d+\z/
       end
 
       def filtered_options(value)


### PR DESCRIPTION
\Z allows appended newlines where \z does not.
