### PR TITLE
FeatureRequest: Add add_once to ActiveModel::Errors

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `add_once` on `ActiveModel::Errors`.
+
+    Acts just like `add` except it checks to see if the message has been
+    added already.
+
+    *Charles Smith*
+
 *   Passwords with spaces only allowed in `ActiveModel::SecurePassword`.
 
     Presence validation can be used to restore old behavior.

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -341,6 +341,23 @@ module ActiveModel
       self[attribute].include? message
     end
 
+    # Adds +message+ to the error messages on +attribute+ only if it has not 
+    # yet been added. If no +message+ is supplied, <tt>:invalid</tt> is 
+    # assumed.
+    #
+    #   person.errors.add_once(:name)
+    #   # => ["is invalid"]
+    #   person.errors.add_once(:name)
+    #   # => ["is_invalid"]
+    #   person.errors.add_once(:name, 'must be implemented')
+    #   # => ["is invalid", "must be implemented"]
+    #   person.errors.add_once(:name, 'must be implemented')
+    #   # => ["is invalid", "must be implemented"]
+    def add_once(attribute, message = :invalid, options = {})
+      add(attribute, message, options) unless added?(attribute, message, options)
+      self[attribute]
+    end
+
     # Returns all the full error messages in an array.
     #
     #   class Person

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -189,6 +189,33 @@ class ErrorsTest < ActiveModel::TestCase
     assert !person.errors.added?(:name, "cannot be blank")
   end
 
+  test "add_once adds a specific message to an attribute only once" do
+    person = Person.new
+    message = "has only one error message"
+    person.errors.add_once(:name, message)
+    person.errors.add_once(:name, message)
+    assert_equal [message], person.errors[:name]
+    assert_not_equal [message, message], person.errors[:name]
+  end
+
+  test "add_once an error with a symbol only adds the message once" do
+    person = Person.new
+    person.errors.add_once(:name, :blank)
+    person.errors.add_once(:name, :blank)
+    message = person.errors.generate_message(:name, :blank)
+    assert_equal [message], person.errors[:name]
+    assert_not_equal [message, message], person.errors[:name]
+  end
+
+  test "add_once an error with a proc only adds the same message once" do
+    person = Person.new
+    message = Proc.new { "cannot be blank" }
+    person.errors.add_once(:name, message)
+    person.errors.add_once(:name, message)
+    assert_equal ["cannot be blank"], person.errors[:name]
+    assert_not_equal ["cannot be blank", "cannot be blank"], person.errors[:name]
+  end
+
   test "size calculates the number of error messages" do
     person = Person.new
     person.errors.add(:name, "cannot be blank")


### PR DESCRIPTION
add_once adds a message to an attribute only if that attribute
does not already have that message as an error.

This simplifies code I've used in models such as:

``` ruby
message = "Some Error Message"
errors.add(:some_attribute, message) unless errors.added?(:some_attribute, message)
```

to

``` ruby
errors.add_once(:some_attribute, "Some Error Message")
```

`add_once` makes use of `add` and `added?`. Added some tests too along the lines of `add`'s tests.
