### PR TITLE
Get rid of merged_options variable and merge-bang options

### DIFF
--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -100,16 +100,16 @@ module ActiveSupport
 
     def to_tag(key, value, options)
       type_name = options.delete(:type)
-      merged_options = options.merge(:root => key, :skip_instruct => true)
+      options.merge!(:root => key, :skip_instruct => true)
 
       if value.is_a?(::Method) || value.is_a?(::Proc)
         if value.arity == 1
-          value.call(merged_options)
+          value.call(options)
         else
-          value.call(merged_options, key.to_s.singularize)
+          value.call(options, key.to_s.singularize)
         end
       elsif value.respond_to?(:to_xml)
-        value.to_xml(merged_options)
+        value.to_xml(options)
       else
         type_name ||= TYPE_NAMES[value.class.name]
         type_name ||= value.class.name if value && !value.respond_to?(:to_str)


### PR DESCRIPTION
The Benchmark

```
n = 1000000
Benchmark.bm do |x|
  x.report do
    n.times do
      merged_options = options.merge(:root => key, :skip_instruct => true) # Currently creates a new variable and does not merge-bang
    end
  end
  x.report do
    n.times do
      options.merge!(:root => key, :skip_instruct => true) # Proposed, get rid of un-necessary variable and merge-bang the options
    end
  end
end
```

The Results

```
 user     system      total        real
   2.030000   0.000000   2.030000 (  1.854676)
   0.720000   0.000000   0.720000 (  0.687461)

 user     system      total        real
   1.940000   0.000000   1.940000 (  1.881605)
   0.730000   0.000000   0.730000 (  0.721945)

 user     system      total        real
   1.970000   0.000000   1.970000 (  1.952000)
   0.740000   0.000000   0.740000 (  0.740447)

 user     system      total        real
   1.870000   0.000000   1.870000 (  1.853891)
   0.720000   0.000000   0.720000 (  0.723833)

 user     system      total        real
   1.950000   0.000000   1.950000 (  1.941125)
   0.740000   0.000000   0.740000 (  0.734391)
```
