### PR TITLE
[Railsguides] Fix style for rescue responses doc

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -368,24 +368,25 @@ encrypted cookies salt value. Defaults to `'signed encrypted cookie'`.
 
   ```ruby
   config.action_dispatch.rescue_responses = {
-     'ActionController::RoutingError'             => :not_found,
-     'AbstractController::ActionNotFound'         => :not_found,
-     'ActionController::MethodNotAllowed'         => :method_not_allowed,
-     'ActionController::UnknownHttpMethod'        => :method_not_allowed,
-     'ActionController::NotImplemented'           => :not_implemented,
-     'ActionController::UnknownFormat'            => :not_acceptable,
-     'ActionController::InvalidAuthenticityToken' => :unprocessable_entity,
-     'ActionDispatch::ParamsParser::ParseError'   => :bad_request,
-     'ActionController::BadRequest'               => :bad_request,
-     'ActionController::ParameterMissing'         => :bad_request,
-     'ActiveRecord::RecordNotFound'               => :not_found,
-     'ActiveRecord::StaleObjectError'             => :conflict,
-     'ActiveRecord::RecordInvalid'                => :unprocessable_entity,
-     'ActiveRecord::RecordNotSaved'               => :unprocessable_entity
+    'ActionController::RoutingError'           => :not_found,
+    'AbstractController::ActionNotFound'       => :not_found,
+    'ActionController::MethodNotAllowed'       => :method_not_allowed,
+    'ActionController::UnknownHttpMethod'      => :method_not_allowed,
+    'ActionController::NotImplemented'         => :not_implemented,
+    'ActionController::UnknownFormat'          => :not_acceptable,
+    'ActionDispatch::ParamsParser::ParseError' => :bad_request,
+    'ActionController::BadRequest'             => :bad_request,
+    'ActionController::ParameterMissing'       => :bad_request,
+    'ActiveRecord::RecordNotFound'             => :not_found,
+    'ActiveRecord::StaleObjectError'           => :conflict,
+    'ActiveRecord::RecordInvalid'              => :unprocessable_entity,
+    'ActiveRecord::RecordNotSaved'             => :unprocessable_entity,
+    'ActionController::InvalidAuthenticityToken'
+                                            => :unprocessable_entity
   }
   ```
 
-  Any execptions that are not configured will be assigned to 500 Internal server error.
+  Any execption that is not configured will be assigned to 500 Internal server error.
 
 * `ActionDispatch::Callbacks.before` takes a block of code to run before the request.
 


### PR DESCRIPTION
This is a follow-up commit to https://github.com/rails/rails/pull/17076
- Changed _Any *__s that are..._ to _Any *_\* that is...*
- Fixed style for default rescue_responses setting

Although, this is not still very good:
![screen shot 2014-10-02 at 9 58 11 pm](https://cloud.githubusercontent.com/assets/386234/4501027/eafa3410-4aa0-11e4-87fa-15dd7aa449fe.png)

cc @zzak @vipulnsward
