### PR TITLE
Allow multiple params to be required at once

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -216,9 +216,10 @@ module ActionController
       self
     end
 
-    # Ensures that a parameter is present. If it's present, returns
-    # the parameter at the given +key+, otherwise raises an
-    # <tt>ActionController::ParameterMissing</tt> error.
+    # Ensures that a parameter or list of parameters are present.
+    # If all are present, returns the parameter at the last +key+,
+    # otherwise raises an <tt>ActionController::ParameterMissing</tt>
+    # error on the first parameter to not be present.
     #
     #   ActionController::Parameters.new(person: { name: 'Francesco' }).require(:person)
     #   # => {"name"=>"Francesco"}
@@ -228,13 +229,22 @@ module ActionController
     #
     #   ActionController::Parameters.new(person: {}).require(:person)
     #   # => ActionController::ParameterMissing: param not found: person
-    def require(key)
-      value = self[key]
-      if value.present? || value == false
-        value
-      else
-        raise ParameterMissing.new(key)
-      end
+    #
+    #   ActionController::Parameters.new.require(:id, :person)
+    #   # => ActionController::ParameterMissing: param not found: id
+    #
+    #   ActionController::Parameters.new(id: 1, person: { name: 'Francesco' }).require(:id, :person)
+    #   # => {"name"=>"Francesco"}
+    def require(*keys)
+      keys.map do |key|
+        value = self[key]
+
+        if value.present? || value == false
+          value
+        else
+          raise ParameterMissing.new(key)
+        end
+      end.last
     end
 
     # Alias of #require.

--- a/actionpack/test/controller/required_params_test.rb
+++ b/actionpack/test/controller/required_params_test.rb
@@ -5,6 +5,11 @@ class BooksController < ActionController::Base
     params.require(:book).require(:name)
     head :ok
   end
+
+  def update
+    params.require(:id, :book).require(:name)
+    head :ok
+  end
 end
 
 class ActionControllerRequiredParamsTest < ActionController::TestCase
@@ -18,6 +23,10 @@ class ActionControllerRequiredParamsTest < ActionController::TestCase
     assert_raise ActionController::ParameterMissing do
       post :create, { book: { title: "Mjallo!" } }
     end
+
+    assert_raise ActionController::ParameterMissing, "param not found: id" do
+      patch :update, { magazine: { name: "Mjallo!" } }
+    end
   end
 
   test "required parameters that are present will not raise" do
@@ -29,6 +38,7 @@ class ActionControllerRequiredParamsTest < ActionController::TestCase
     post :create, { book: { name: false } }
     assert_response :ok
   end
+
 end
 
 class ParametersRequireTest < ActiveSupport::TestCase
@@ -47,5 +57,9 @@ class ParametersRequireTest < ActiveSupport::TestCase
     assert_raises(ActionController::ParameterMissing) do
       ActionController::Parameters.new(person: {}).require(:person)
     end
+  end
+
+  test "required parameters should return the value of the last key passed" do
+    assert_equal(false, ActionController::Parameters.new(person: false, id: 1).require(:id, :person))
   end
 end


### PR DESCRIPTION
This is [already supported](https://github.com/rails/strong_parameters#require-multiple-parameters) in Strong Parameters, with the format:

``` ruby
params.require(:token)
params.require(:post).permit(:title)
```

However, this can quickly get _very_ verbose.

In several situations, I've found myself having to require 10+ parameters on a single controller action, and resorted to adding a private method to `ApplicationController` along the lines of:

``` ruby
def require_params(*required)
  required.each { |key| params.require(key) }
end
```

By changing `ActionController::Parameters#require` to take an array of keys, iterate over it, and return the last element's value, we preserve the original API while allowing some new patterns to develop.

The original example would instead look like this:

``` ruby
params.require(:token, :post).permit(:title)
```

One example of this convenience of is extracting common requirements into an anonymous `before_action`.

Compare

``` ruby
before_action do
  params.require(:first)
  ...
  params.require(:last)
end
```

with

``` ruby
before_action { params.require(:first, ..., :last) }
```

**NOTE:** When multiple required parameters are missing, only the first one will raise `ActionController::ParameterMissing`
