### PR TITLE
String#pluralize to accept boolean parameter

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -11,6 +11,7 @@ class String
   #
   # If the optional parameter +count+ is specified,
   # the singular form will be returned if <tt>count == 1</tt>.
+  # or <tt>count == false</tt>.
   # For any other value of +count+ the plural will be returned.
   #
   # If the optional parameter +locale+ is specified,
@@ -26,11 +27,13 @@ class String
   #   'CamelOctopus'.pluralize     # => "CamelOctopi"
   #   'apple'.pluralize(1)         # => "apple"
   #   'apple'.pluralize(2)         # => "apples"
+  #   'apple'.pluralize(false)     # => "apple"
+  #   'apple'.pluralize(true)      # => "apples"
   #   'ley'.pluralize(:es)         # => "leyes"
   #   'ley'.pluralize(1, :es)      # => "ley"
   def pluralize(count = nil, locale = :en)
     locale = count if count.is_a?(Symbol)
-    if count == 1
+    if count == 1 or count.is_a?(FalseClass)
       self.dup
     else
       ActiveSupport::Inflector.pluralize(self, locale)

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -58,6 +58,8 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal("blargles", "blargle".pluralize(0))
     assert_equal("blargle", "blargle".pluralize(1))
     assert_equal("blargles", "blargle".pluralize(2))
+    assert_equal("blargle", "blargle".pluralize(false))
+    assert_equal("blargles", "blargle".pluralize(true))
   end
 
   test 'pluralize with count = 1 still returns new string' do


### PR DESCRIPTION
Gives possibility to write:

```
multiple = some_method_returning_boolean_value
"thing".pluralize(multiple)
```
