### PR TITLE
Ability to pass additional arguments to localtime and getlocal.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Ability to pass additional arguments to localtime and getlocal.
+    http://www.ruby-doc.org/core-2.1.3/Time.html#method-i-getlocal accepts additional arguments to get Time object in particular time zone you want like this:
+    Time.now.getlocal(14400) # => 2014-10-13 16:21:02 +0400
+    This commit allows this for ActiveSupport::TimeWithZone objects so from now on you can do this:
+    Time.current.localtime         # => 2014-10-13 12:20:20 +0000
+    Time.current.getlocal          # => 2014-10-13 12:20:57 +0000
+    Time.current.localtime(14400)  # => 2014-10-13 16:22:04 +0400
+    Time.current.getlocal(-14400)  # => 2014-10-13 08:24:59 -0400
+    Time.zone.now.localtime        # => 2014-10-13 12:39:57 +0000
+    Time.zone.now.getlocal         # => 2014-10-13 12:40:01 +0000
+    Time.zone.now.localtime(-14400)# => 2014-10-13 08:40:55 -0400
+    Time.zone.now.getlocal(14400)  # => 2014-10-13 16:41:06 +0400
+
+    *Andrey Voronkov*
+
 *   Corrected Inflector#underscore handling of multiple successive acroynms.
 
     *James Le Cuirot*

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -74,9 +74,17 @@ module ActiveSupport
     end
 
     # Returns a <tt>Time.local()</tt> instance of the simultaneous time in your
-    # system's <tt>ENV['TZ']</tt> zone.
-    def localtime
-      utc.respond_to?(:getlocal) ? utc.getlocal : utc.to_time.getlocal
+    # system's <tt>ENV['TZ']</tt>. Utc offset value can be passed as an additional argument to get time object in custom time zone:
+    #   Time.current.localtime         # => 2014-10-13 12:20:20 +0000
+    #   Time.current.getlocal          # => 2014-10-13 12:20:57 +0000
+    #   Time.current.localtime(14400)  # => 2014-10-13 16:22:04 +0400
+    #   Time.current.getlocal(-14400)  # => 2014-10-13 08:24:59 -0400
+    #   Time.zone.now.localtime        # => 2014-10-13 12:39:57 +0000
+    #   Time.zone.now.getlocal         # => 2014-10-13 12:40:01 +0000
+    #   Time.zone.now.localtime(-14400)# => 2014-10-13 08:40:55 -0400
+    #   Time.zone.now.getlocal(14400)  # => 2014-10-13 16:41:06 +0400
+    def localtime(*args)
+      utc.respond_to?(:getlocal) ? utc.getlocal(*args) : utc.to_time.getlocal(*args)
     end
     alias_method :getlocal, :localtime
 

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -47,6 +47,11 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal @twz.localtime, @twz.utc.getlocal
   end
 
+  def test_localtime_with_utc_offset_provided
+    assert_equal @twz.localtime(14400), @twz.utc.getlocal(14400)
+    assert_equal @twz.localtime(12345).utc_offset, 12345
+  end
+
   def test_utc?
     assert_equal false, @twz.utc?
     assert_equal true, ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone['UTC']).utc?
@@ -879,6 +884,12 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < ActiveSupport::TestCase
   def test_localtime
     Time.zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
     assert_equal @dt.in_time_zone.localtime, @dt.in_time_zone.utc.to_time.getlocal
+  end
+
+  def test_localtime_with_utc_offset_provided
+    Time.zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
+    assert_equal @dt.in_time_zone.localtime(14400), @dt.in_time_zone.to_time.getlocal(14400)
+    assert_equal @dt.in_time_zone.localtime(12345).utc_offset, 12345
   end
 
   def test_use_zone


### PR DESCRIPTION
http://www.ruby-doc.org/core-2.1.3/Time.html#method-i-getlocal accepts additional arguments to get Time object in particular time zone you want like this:
Time.now.getlocal(14400) # => 2014-10-13 16:21:02 +0400
This commit allows this for ActiveSupport::TimeWithZone objects so from now on you can do this:
Time.current.localtime         # => 2014-10-13 12:20:20 +0000
Time.current.getlocal          # => 2014-10-13 12:20:57 +0000
Time.current.localtime(14400)  # => 2014-10-13 16:22:04 +0400
Time.current.getlocal(-14400)  # => 2014-10-13 08:24:59 -0400
Time.zone.now.localtime        # => 2014-10-13 12:39:57 +0000
Time.zone.now.getlocal         # => 2014-10-13 12:40:01 +0000
Time.zone.now.localtime(-14400)# => 2014-10-13 08:40:55 -0400
Time.zone.now.getlocal(14400)  # => 2014-10-13 16:41:06 +0400
