### PR TITLE
Reference string constants rather than repeatedly allocating the same string

### DIFF
--- a/actionpack/lib/action_dispatch/http/filter_redirect.rb
+++ b/actionpack/lib/action_dispatch/http/filter_redirect.rb
@@ -1,8 +1,11 @@
 module ActionDispatch
   module Http
     module FilterRedirect
-
       FILTERED = '[FILTERED]'.freeze # :nodoc:
+      private_constant :FILTERED
+
+      REDIRECT_FILTER = 'action_dispatch.redirect_filter'.freeze #:nodoc:
+      private_constant :REDIRECT_FILTER
 
       def filtered_location
         filters = location_filter
@@ -13,16 +16,16 @@ module ActionDispatch
         end
       end
 
-    private
-
+      private
       def location_filter
         if request
-          request.env['action_dispatch.redirect_filter'] || []
+          request.env[REDIRECT_FILTER] || []
         else
           []
         end
       end
 
+      private
       def location_filter_match?(filters)
         filters.any? do |filter|
           if String === filter
@@ -32,7 +35,6 @@ module ActionDispatch
           end
         end
       end
-
     end
   end
 end

--- a/actionpack/lib/action_dispatch/http/headers.rb
+++ b/actionpack/lib/action_dispatch/http/headers.rb
@@ -1,3 +1,5 @@
+require 'action_dispatch/internal/constants'
+
 module ActionDispatch
   module Http
     # Provides access to the request's HTTP headers from the environment.
@@ -27,7 +29,8 @@ module ActionDispatch
         SERVER_SOFTWARE
       ]).freeze
 
-      HTTP_HEADER = /\A[A-Za-z0-9-]+\z/
+      HTTP_HEADER = /\A[A-Za-z0-9-]+\z/ #:nodoc:
+      HTTP_UNDERSCORE = 'HTTP_'.freeze #:nodoc:
 
       include Enumerable
       attr_reader :env
@@ -89,8 +92,8 @@ module ActionDispatch
       def env_name(key)
         key = key.to_s
         if key =~ HTTP_HEADER
-          key = key.upcase.tr('-', '_')
-          key = "HTTP_" + key unless CGI_VARIABLES.include?(key)
+          key = key.upcase.tr(Strings::HYPHEN, Strings::UNDERSCORE)
+          key = HTTP_UNDERSCORE + key unless CGI_VARIABLES.include?(key)
         end
         key
       end

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -12,13 +12,22 @@ module ActionDispatch
 
       attr_reader :variant
 
+      module Strings #:nodoc:
+        ACTION_DISPATCH_REQUEST_ACCEPTS = 'action_dispatch.request.accepts'.freeze
+        ACTION_DISPATCH_REQUEST_CONTENT_TYPE = 'action_dispatch.request.content_type'.freeze
+        ACTION_DISPATCH_REQUEST_FORMATS = 'action_dispatch.request.formats'.freeze
+        CONTENT_TYPE = 'CONTENT_TYPE'.freeze
+        HTTP_ACCEPT = 'HTTP_ACCEPT'.freeze
+      end
+      private_constant :Strings
+
       # The MIME type of the HTTP request, such as Mime::XML.
       #
       # For backward compatibility, the post \format is extracted from the
       # X-Post-Data-Format HTTP header if present.
       def content_mime_type
-        @env["action_dispatch.request.content_type"] ||= begin
-          if @env['CONTENT_TYPE'] =~ /^([^,\;]*)/
+        @env[Strings::ACTION_DISPATCH_REQUEST_CONTENT_TYPE] ||= begin
+          if @env[Strings::CONTENT_TYPE] =~ /^([^,\;]*)/
             Mime::Type.lookup($1.strip.downcase)
           else
             nil
@@ -32,8 +41,8 @@ module ActionDispatch
 
       # Returns the accepted MIME type for the request.
       def accepts
-        @env["action_dispatch.request.accepts"] ||= begin
-          header = @env['HTTP_ACCEPT'].to_s.strip
+        @env[Strings::ACTION_DISPATCH_REQUEST_ACCEPTS] ||= begin
+          header = @env[Strings::HTTP_ACCEPT].to_s.strip
 
           if header.empty?
             [content_mime_type]
@@ -54,7 +63,7 @@ module ActionDispatch
       end
 
       def formats
-        @env["action_dispatch.request.formats"] ||= begin
+        @env[Strings::ACTION_DISPATCH_REQUEST_FORMATS] ||= begin
           params_readable = begin
                               parameters[:format]
                             rescue ActionController::BadRequest
@@ -72,6 +81,7 @@ module ActionDispatch
           end
         end
       end
+
       # Sets the \variant for template.
       def variant=(variant)
         if variant.is_a?(Symbol)
@@ -99,7 +109,7 @@ module ActionDispatch
       #   end
       def format=(extension)
         parameters[:format] = extension.to_s
-        @env["action_dispatch.request.formats"] = [Mime::Type.lookup_by_extension(parameters[:format])]
+        @env[Strings::ACTION_DISPATCH_REQUEST_FORMATS] = [Mime::Type.lookup_by_extension(parameters[:format])]
       end
 
       # Sets the \formats by string extensions. This differs from #format= by allowing you
@@ -118,7 +128,7 @@ module ActionDispatch
       #   end
       def formats=(extensions)
         parameters[:format] = extensions.first.to_s
-        @env["action_dispatch.request.formats"] = extensions.collect do |extension|
+        @env[Strings::ACTION_DISPATCH_REQUEST_FORMATS] = extensions.collect do |extension|
           Mime::Type.lookup_by_extension(extension)
         end
       end
@@ -140,7 +150,8 @@ module ActionDispatch
 
       protected
 
-      BROWSER_LIKE_ACCEPTS = /,\s*\*\/\*|\*\/\*\s*,/
+      BROWSER_LIKE_ACCEPTS = /,\s*\*\/\*|\*\/\*\s*,/ #:nodoc:
+      private_constant :BROWSER_LIKE_ACCEPTS
 
       def valid_accept_header
         (xhr? && (accept.present? || content_mime_type)) ||

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -25,6 +25,11 @@ module Mime
   EXTENSION_LOOKUP = {}
   LOOKUP           = Hash.new { |h, k| h[k] = Type.new(k) unless k.blank? }
 
+  module Strings #:nodoc:
+    QUESTION_MARK = '?'.freeze
+  end
+  private_constant :Strings
+
   class << self
     def [](type)
       return type if type.is_a?(Type)
@@ -280,7 +285,7 @@ module Mime
     def to_a; end
 
     def method_missing(method, *args)
-      if method.to_s.ends_with? '?'
+      if method.to_s.ends_with? Strings::QUESTION_MARK
         method[0..-2].downcase.to_sym == to_sym
       else
         super
@@ -288,7 +293,7 @@ module Mime
     end
 
     def respond_to_missing?(method, include_private = false) #:nodoc:
-      method.to_s.ends_with? '?'
+      method.to_s.ends_with? Strings::QUESTION_MARK
     end
   end
 
@@ -302,12 +307,12 @@ module Mime
     def ref; end
 
     def respond_to_missing?(method, include_private = false)
-      method.to_s.ends_with? '?'
+      method.to_s.ends_with? Strings::QUESTION_MARK
     end
 
     private
     def method_missing(method, *args)
-      false if method.to_s.ends_with? '?'
+      false if method.to_s.ends_with? Strings::QUESTION_MARK
     end
   end
 end

--- a/actionpack/lib/action_dispatch/http/parameter_filter.rb
+++ b/actionpack/lib/action_dispatch/http/parameter_filter.rb
@@ -2,6 +2,7 @@ module ActionDispatch
   module Http
     class ParameterFilter
       FILTERED = '[FILTERED]'.freeze # :nodoc:
+      private_constant :FILTERED
 
       def initialize(filters = [])
         @filters = filters

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -5,11 +5,15 @@ require 'active_support/deprecation'
 module ActionDispatch
   module Http
     module Parameters
-      PARAMETERS_KEY = 'action_dispatch.request.path_parameters'
+      module Strings #:nodoc:
+        ACTION_DISPATCH_REQUEST_PARAMETERS = 'action_dispatch.request.parameters'.freeze
+        ACTION_DISPATCH_REQUEST_PATH_PARAMETERS = 'action_dispatch.request.path_parameters'.freeze
+      end
+      private_constant :Strings
 
       # Returns both GET and POST \parameters in a single hash.
       def parameters
-        @env["action_dispatch.request.parameters"] ||= begin
+        @env[Strings::ACTION_DISPATCH_REQUEST_PARAMETERS] ||= begin
           params = begin
             request_parameters.merge(query_parameters)
           rescue EOFError
@@ -21,8 +25,8 @@ module ActionDispatch
       alias :params :parameters
 
       def path_parameters=(parameters) #:nodoc:
-        @env.delete('action_dispatch.request.parameters')
-        @env[PARAMETERS_KEY] = parameters
+        @env.delete(Strings::ACTION_DISPATCH_REQUEST_PARAMETERS)
+        @env[Strings::ACTION_DISPATCH_REQUEST_PATH_PARAMETERS] = parameters
       end
 
       def symbolized_path_parameters
@@ -37,7 +41,7 @@ module ActionDispatch
       #
       #   {'action' => 'my_action', 'controller' => 'my_controller'}
       def path_parameters
-        @env[PARAMETERS_KEY] ||= {}
+        @env[Strings::ACTION_DISPATCH_REQUEST_PATH_PARAMETERS] ||= {}
       end
 
     private

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -36,9 +36,11 @@ module ActionDispatch
 
     ENV_METHODS.each do |env|
       class_eval <<-METHOD, __FILE__, __LINE__ + 1
-        def #{env.sub(/^HTTP_/n, '').downcase}  # def accept_charset
-          @env["#{env}"]                        #   @env["HTTP_ACCEPT_CHARSET"]
-        end                                     # end
+        def #{env.sub(/^HTTP_/n, '').downcase}
+          @env[#{env}]
+        end
+        #{env} = '#{env}'.freeze
+        private_constant :#{env}
       METHOD
     end
 

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -1,6 +1,7 @@
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/deprecation'
 require 'action_dispatch/http/filter_redirect'
+require 'action_dispatch/internal/constants'
 require 'monitor'
 
 module ActionDispatch # :nodoc:
@@ -69,7 +70,7 @@ module ActionDispatch # :nodoc:
     LOCATION     = "Location".freeze
     NO_CONTENT_CODES = [204, 304]
 
-    cattr_accessor(:default_charset) { "utf-8" }
+    cattr_accessor(:default_charset) { 'utf-8' }
     cattr_accessor(:default_headers)
 
     include Rack::Response::Helpers
@@ -219,11 +220,9 @@ module ActionDispatch # :nodoc:
       strings.join
     end
 
-    EMPTY = " "
-
     # Allows you to manually set or override the response body.
     def body=(body)
-      @blank = true if body == EMPTY
+      @blank = true if body == Strings::SPACE
 
       if body.respond_to?(:to_path)
         @stream = body
@@ -298,10 +297,10 @@ module ActionDispatch # :nodoc:
     def cookies
       cookies = {}
       if header = self[SET_COOKIE]
-        header = header.split("\n") if header.respond_to?(:to_str)
+        header = header.split(Strings::NEWLINE) if header.respond_to?(:to_str)
         header.each do |cookie|
-          if pair = cookie.split(';').first
-            key, value = pair.split("=").map { |v| Rack::Utils.unescape(v) }
+          if pair = cookie.split(Strings::SEMICOLON).first
+            key, value = pair.split(Strings::EQUALS).map { |v| Rack::Utils.unescape(v) }
             cookies[key] = value
           end
         end
@@ -390,7 +389,7 @@ module ActionDispatch # :nodoc:
       assign_default_content_type_and_charset!(header)
       handle_conditional_get!
 
-      header[SET_COOKIE] = header[SET_COOKIE].join("\n") if header[SET_COOKIE].respond_to?(:join)
+      header[SET_COOKIE] = header[SET_COOKIE].join(Strings::NEWLINE) if header[SET_COOKIE].respond_to?(:join)
 
       if NO_CONTENT_CODES.include?(@status)
         header.delete CONTENT_TYPE

--- a/actionpack/lib/action_dispatch/internal/constants.rb
+++ b/actionpack/lib/action_dispatch/internal/constants.rb
@@ -1,0 +1,31 @@
+module ActionDispatch
+  # These are internal constants used to avoid repeated object allocation
+  # in performance hot spots.
+  #
+  # This is a necessarily ugly setup, not a best practice to emulate.
+  #
+  # When Rails is on Ruby 2.1+, we'll be able to lean on its treatment of
+  # repeated 'foo'.freeze as identical objects. That's ugly too, but it's
+  # clearer than collecting a big bag of string constants.
+  #
+  # Please don't add every constant string here. Just those that get reused
+  # in multiple modules. Leave module-specific strings in those files, close
+  # to home where they're relevant to the code that relies on them.
+  module Strings #:nodoc:
+    COLON = ':'.freeze
+    COMMA = ','.freeze
+    EMPTY = ''.freeze
+    EQUALS = '='.freeze
+    HASH = '#'.freeze
+    HYPHEN = '-'.freeze
+    NEW = 'new'.freeze
+    NEWLINE = "\n".freeze
+    PERIOD = '.'.freeze
+    QUESTION_MARK = '?'.freeze
+    SEMICOLON = ';'.freeze
+    SLASH = '/'.freeze
+    SPACE = ' '.freeze
+    UNDERSCORE = '_'.freeze
+  end
+  private_constant :Strings
+end

--- a/actionpack/lib/action_dispatch/journey/nodes/node.rb
+++ b/actionpack/lib/action_dispatch/journey/nodes/node.rb
@@ -1,4 +1,5 @@
 require 'action_dispatch/journey/visitors'
+require 'action_dispatch/internal/constants'
 
 module ActionDispatch
   module Journey # :nodoc:
@@ -6,11 +7,17 @@ module ActionDispatch
       class Node # :nodoc:
         include Enumerable
 
-        attr_accessor :left, :memo
+        attr_reader :left
+        attr_accessor :memo
 
         def initialize(left)
           @left = left
           @memo = nil
+        end
+
+        def left=(left)
+          @name = nil
+          @left = left
         end
 
         def each(&block)
@@ -29,8 +36,11 @@ module ActionDispatch
           name.to_sym
         end
 
+        OMIT_FROM_NAME = '*:'.freeze
+        private_constant :OMIT_FROM_NAME
+
         def name
-          left.tr '*:', ''
+          @name ||= left.tr(OMIT_FROM_NAME, Strings::EMPTY)
         end
 
         def type
@@ -58,12 +68,12 @@ module ActionDispatch
         def literal?; false; end
       end
 
-      %w{ Symbol Slash Dot }.each do |t|
-        class_eval <<-eoruby, __FILE__, __LINE__ + 1
-          class #{t} < Terminal;
-            def type; :#{t.upcase}; end
-          end
-        eoruby
+      class Slash < Terminal
+        def type; :SLASH; end
+      end
+
+      class Dot < Terminal
+        def type; :DOT; end
       end
 
       class Symbol < Terminal # :nodoc:
@@ -79,6 +89,8 @@ module ActionDispatch
         def default_regexp?
           regexp == DEFAULT_EXP
         end
+
+        def type; :SYMBOL; end
 
         def symbol?; true; end
       end

--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -1,4 +1,5 @@
 require 'action_controller/model_naming'
+require 'action_dispatch/internal/constants'
 
 module ActionDispatch
   module Routing
@@ -304,7 +305,7 @@ module ActionDispatch
 
           route << suffix
 
-          named_route = prefix + route.join("_")
+          named_route = prefix + route.join(Strings::UNDERSCORE)
           [named_route, args]
         end
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -640,9 +640,11 @@ module ActionDispatch
           end
         end
 
+        EMPTY = ''.freeze #:nodoc:
+
         # Remove leading slashes from controllers
         def normalize_controller!
-          @options[:controller] = controller.sub(%r{^/}, '') if controller
+          @options[:controller] = controller.sub(%r{^/}, EMPTY) if controller
         end
 
         # Move 'index' action from options to recall

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -5,16 +5,41 @@ module ActionView
         include Helpers::ActiveModelInstanceTag, Helpers::TagHelper, Helpers::FormTagHelper
         include FormOptionsHelper
 
+        module Strings #:nodoc:
+          BEFORE_TYPE_CAST = '_before_type_cast'.freeze
+          BRACKET_LEFT = '['.freeze
+          BRACKET_PAIR = '[]'.freeze
+          BRACKET_RIGHT = ']'.freeze
+          EMPTY = ''.freeze
+          ID = 'id'.freeze
+          INDEX = 'index'.freeze
+          INPUT = 'input'.freeze
+          DISABLED = 'disabled'.freeze
+          HIDDEN = 'hidden'.freeze
+          MULTIPLE = 'multiple'.freeze
+          NAME = 'name'.freeze
+          NAMESPACE = 'namespace'.freeze
+          NEWLINE = "\n".freeze
+          REQUIRED = 'required'.freeze
+          SELECT = 'select'.freeze
+          SIZE = 'size'.freeze
+          UNDERSCORE = '_'.freeze
+        end
+        private_constant :Strings
+
         attr_reader :object
 
         def initialize(object_name, method_name, template_object, options = {})
           @object_name, @method_name = object_name.to_s.dup, method_name.to_s.dup
           @template_object = template_object
 
-          @object_name.sub!(/\[\]$/,"") || @object_name.sub!(/\[\]\]$/,"]")
+          @object_name.sub!(/\[\]$/, Strings::EMPTY) || @object_name.sub!(/\[\]\]$/, Strings::BRACKET_RIGHT)
+          @object_ivar = "@#{@object_name}".freeze
           @object = retrieve_object(options.delete(:object))
           @options = options
           @auto_index = retrieve_autoindex(Regexp.last_match.pre_match) if Regexp.last_match
+
+          @method_before_type_cast = "#{@method_name}#{Strings::BEFORE_TYPE_CAST}".freeze
         end
 
         # This is what child classes implement.
@@ -30,10 +55,8 @@ module ActionView
 
         def value_before_type_cast(object)
           unless object.nil?
-            method_before_type_cast = @method_name + "_before_type_cast"
-
-            object.respond_to?(method_before_type_cast) ?
-              object.send(method_before_type_cast) :
+            object.respond_to?(@method_before_type_cast) ?
+              object.send(@method_before_type_cast) :
               value(object)
           end
         end
@@ -41,8 +64,8 @@ module ActionView
         def retrieve_object(object)
           if object
             object
-          elsif @template_object.instance_variable_defined?("@#{@object_name}")
-            @template_object.instance_variable_get("@#{@object_name}")
+          elsif @template_object.instance_variable_defined?(@object_ivar)
+            @template_object.instance_variable_get(@object_ivar)
           end
         rescue NameError
           # As @object_name may contain the nested syntax (item[subobject]) we need to fallback to nil.
@@ -62,37 +85,37 @@ module ActionView
           if tag_value.nil?
             add_default_name_and_id(options)
           else
-            specified_id = options["id"]
+            specified_id = options[Strings::ID]
             add_default_name_and_id(options)
 
-            if specified_id.blank? && options["id"].present?
-              options["id"] += "_#{sanitized_value(tag_value)}"
+            if specified_id.blank? && options[Strings::ID].present?
+              options[Strings::ID] += "_#{sanitized_value(tag_value)}"
             end
           end
         end
 
         def add_default_name_and_id(options)
-          if options.has_key?("index")
-            options["name"] ||= options.fetch("name"){ tag_name_with_index(options["index"], options["multiple"]) }
-            options["id"] = options.fetch("id"){ tag_id_with_index(options["index"]) }
-            options.delete("index")
+          if options.has_key?(Strings::INDEX)
+            options[Strings::NAME] ||= options.fetch(Strings::NAME){ tag_name_with_index(options[Strings::INDEX], options[Strings::MULTIPLE]) }
+            options[Strings::ID] = options.fetch(Strings::ID){ tag_id_with_index(options[Strings::INDEX]) }
+            options.delete(Strings::INDEX)
           elsif defined?(@auto_index)
-            options["name"] ||= options.fetch("name"){ tag_name_with_index(@auto_index, options["multiple"]) }
-            options["id"] = options.fetch("id"){ tag_id_with_index(@auto_index) }
+            options[Strings::NAME] ||= options.fetch(Strings::NAME){ tag_name_with_index(@auto_index, options[Strings::MULTIPLE]) }
+            options[Strings::ID] = options.fetch(Strings::ID){ tag_id_with_index(@auto_index) }
           else
-            options["name"] ||= options.fetch("name"){ tag_name(options["multiple"]) }
-            options["id"] = options.fetch("id"){ tag_id }
+            options[Strings::NAME] ||= options.fetch(Strings::NAME){ tag_name(options[Strings::MULTIPLE]) }
+            options[Strings::ID] = options.fetch(Strings::ID){ tag_id }
           end
 
-          options["id"] = [options.delete('namespace'), options["id"]].compact.join("_").presence
+          options[Strings::ID] = [options.delete(Strings::NAMESPACE), options[Strings::ID]].compact.join(Strings::UNDERSCORE).presence
         end
 
         def tag_name(multiple = false)
-          "#{@object_name}[#{sanitized_method_name}]#{"[]" if multiple}"
+          "#{@object_name}[#{sanitized_method_name}]#{Strings::BRACKET_PAIR if multiple}"
         end
 
         def tag_name_with_index(index, multiple = false)
-          "#{@object_name}[#{index}][#{sanitized_method_name}]#{"[]" if multiple}"
+          "#{@object_name}[#{index}][#{sanitized_method_name}]#{Strings::BRACKET_PAIR if multiple}"
         end
 
         def tag_id
@@ -104,15 +127,15 @@ module ActionView
         end
 
         def sanitized_object_name
-          @sanitized_object_name ||= @object_name.gsub(/\]\[|[^-a-zA-Z0-9:.]/, "_").sub(/_$/, "")
+          @sanitized_object_name ||= @object_name.gsub(/\]\[|[^-a-zA-Z0-9:.]/, Strings::UNDERSCORE).sub(/_$/, Strings::EMPTY)
         end
 
         def sanitized_method_name
-          @sanitized_method_name ||= @method_name.sub(/\?$/,"")
+          @sanitized_method_name ||= @method_name.sub(/\?$/, Strings::EMPTY)
         end
 
         def sanitized_value(value)
-          value.to_s.gsub(/\s/, "_").gsub(/[^-\w]/, "").downcase
+          value.to_s.gsub(/\s/, Strings::UNDERSCORE).gsub(/[^-\w]/, Strings::EMPTY).downcase
         end
 
         def select_content_tag(option_tags, options, html_options)
@@ -120,25 +143,25 @@ module ActionView
           add_default_name_and_id(html_options)
           options[:include_blank] ||= true unless options[:prompt] || select_not_required?(html_options)
           value = options.fetch(:selected) { value(object) }
-          select = content_tag("select", add_options(option_tags, options, value), html_options)
+          select = content_tag(Strings::SELECT, add_options(option_tags, options, value), html_options)
 
-          if html_options["multiple"] && options.fetch(:include_hidden, true)
-            tag("input", :disabled => html_options["disabled"], :name => html_options["name"], :type => "hidden", :value => "") + select
+          if html_options[Strings::MULTIPLE] && options.fetch(:include_hidden, true)
+            tag(Strings::INPUT, :disabled => html_options[Strings::DISABLED], :name => html_options[Strings::NAME], :type => Strings::HIDDEN, :value => Strings::EMPTY) + select
           else
             select
           end
         end
 
         def select_not_required?(html_options)
-          !html_options["required"] || html_options["multiple"] || html_options["size"].to_i > 1
+          !html_options[Strings::REQUIRED] || html_options[Strings::MULTIPLE] || html_options[Strings::SIZE].to_i > 1
         end
 
         def add_options(option_tags, options, value = nil)
           if options[:include_blank]
-            option_tags = content_tag_string('option', options[:include_blank].kind_of?(String) ? options[:include_blank] : nil, :value => '') + "\n" + option_tags
+            option_tags = content_tag_string('option', options[:include_blank].kind_of?(String) ? options[:include_blank] : nil, :value => Strings::EMPTY) + Strings::NEWLINE + option_tags
           end
           if value.blank? && options[:prompt]
-            option_tags = content_tag_string('option', prompt_text(options[:prompt]), :value => '') + "\n" + option_tags
+            option_tags = content_tag_string('option', prompt_text(options[:prompt]), :value => Strings::EMPTY) + Strings::NEWLINE + option_tags
           end
           option_tags
         end

--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -5,8 +5,6 @@ module ActionView
   #
   # Provides functionality so that Rails can output logs from Action View.
   class LogSubscriber < ActiveSupport::LogSubscriber
-    VIEWS_PATTERN = /^app\/views\//
-
     def initialize
       @root = nil
       super
@@ -14,8 +12,8 @@ module ActionView
 
     def render_template(event)
       info do
-        message = "  Rendered #{from_rails_root(event.payload[:identifier])}"
-        message << " within #{from_rails_root(event.payload[:layout])}" if event.payload[:layout]
+        message = "  Rendered #{scrub_rails_root(event.payload[:identifier])}"
+        message << " within #{scrub_rails_root(event.payload[:layout])}" if event.payload[:layout]
         message << " (#{event.duration.round(1)}ms)"
       end
     end
@@ -26,17 +24,10 @@ module ActionView
       ActionView::Base.logger
     end
 
-  protected
-
-    EMPTY = ''
-    def from_rails_root(string)
-      string = string.sub(rails_root, EMPTY)
-      string.sub!(VIEWS_PATTERN, EMPTY)
-      string
-    end
-
-    def rails_root
-      @root ||= "#{Rails.root}/"
+    private
+    def scrub_rails_root(string)
+      @scrubber ||= %r(\A#{Rails.root}/(?:app/views/)?)
+      string.sub(@scrubber, ''.freeze)
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -71,13 +71,18 @@ module ActiveRecord
         end
       end
 
-      private
+      module Strings #:nodoc:
+        CACHE = 'CACHE'.freeze
+        SQL_ACTIVE_RECORD = 'sql.active_record'.freeze
+      end
+      private_constant :Strings
 
+      private
       def cache_sql(sql, binds)
         result =
           if @query_cache[sql].key?(binds)
-            ActiveSupport::Notifications.instrument("sql.active_record",
-              :sql => sql, :binds => binds, :name => "CACHE", :connection_id => object_id)
+            ActiveSupport::Notifications.instrument(Strings::SQL_ACTIVE_RECORD,
+              :sql => sql, :binds => binds, :name => Strings::CACHE, :connection_id => object_id)
             @query_cache[sql][binds]
           else
             @query_cache[sql][binds] = yield
@@ -87,6 +92,7 @@ module ActiveRecord
 
       # If arel is locked this is a SELECT ... FOR UPDATE or somesuch. Such
       # queries should not be cached.
+      private
       def locked?(arel)
         arel.respond_to?(:locked) && arel.locked
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -265,10 +265,15 @@ module ActiveRecord
 
       # QUOTING ==================================================
 
+      module Strings #:nodoc:
+        QUESTION_MARK = '?'.freeze
+      end
+      private_constant :Strings
+
       # Returns a bind substitution value given a bind +index+ and +column+
       # NOTE: The column param is currently being used by the sqlserver-adapter
       def substitute_at(column, index)
-        Arel::Nodes::BindParam.new '?'
+        Arel::Nodes::BindParam.new Strings::QUESTION_MARK
       end
 
       # REFERENTIAL INTEGRITY ====================================

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -57,6 +57,8 @@ module ActiveRecord
         NORMAL_VALUES
       end
 
+      MERGE_BANG_METHODS = Hash.new { |h, k| h[k] = :"#{k}!" }
+
       def merge
         normal_values.each do |name|
           value = values[name]
@@ -68,7 +70,7 @@ module ActiveRecord
             if name == :select
               relation._select!(*value)
             else
-              relation.send("#{name}!", *value)
+              relation.send(MERGE_BANG_METHODS[name], *value)
             end
           end
         end

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -5,6 +5,11 @@ module ActiveRecord
     autoload :RelationHandler, 'active_record/relation/predicate_builder/relation_handler'
     autoload :ArrayHandler, 'active_record/relation/predicate_builder/array_handler'
 
+    module Strings #:nodoc:
+      PERIOD = '.'.freeze
+    end
+    private_constant :Strings
+
     def self.resolve_column_aliases(klass, hash)
       hash = hash.dup
       hash.keys.grep(Symbol) do |key|
@@ -34,12 +39,11 @@ module ActiveRecord
           end
         else
           column = column.to_s
-
-          if column.include?('.')
-            table_name, column = column.split('.', 2)
-            table = Arel::Table.new(table_name, default_table.engine)
+          split_table, split_column = column.split(Strings::PERIOD, 2)
+          if split_column
+            table = Arel::Table.new(split_table, default_table.engine)
+            column = split_column
           end
-
           queries.concat expand(klass, table, column, value)
         end
       end
@@ -85,7 +89,7 @@ module ActiveRecord
           key
         else
           key = key.to_s
-          key.split('.').first if key.include?('.')
+          key.split(Strings::PERIOD, 2).first if key.include?('.')
         end
       end.compact
     end

--- a/activesupport/lib/active_support/core_ext/object/acts_like.rb
+++ b/activesupport/lib/active_support/core_ext/object/acts_like.rb
@@ -5,6 +5,10 @@ class Object
   # <tt>x.acts_like?(:date)</tt> to do duck-type-safe comparisons, since classes that
   # we want to act like Time simply need to define an <tt>acts_like_time?</tt> method.
   def acts_like?(duck)
-    respond_to? :"acts_like_#{duck}?"
+    case duck
+    when :time then respond_to? :acts_like_time?
+    when :date then respond_to? :acts_like_date?
+    else respond_to? :"acts_like_#{duck}?"
+    end
   end
 end

--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -1,4 +1,10 @@
 class String
+  module Strings #:nodoc:
+    EMPTY = ''.freeze
+    SPACE = ' '.freeze
+  end
+  private_constant :Strings
+
   # Returns the string, first removing all whitespace on both ends of
   # the string, and then changing remaining consecutive whitespace
   # groups into one space each.
@@ -14,20 +20,20 @@ class String
 
   # Performs a destructive squish. See String#squish.
   def squish!
-    gsub!(/\A[[:space:]]+/, '')
-    gsub!(/[[:space:]]+\z/, '')
-    gsub!(/[[:space:]]+/, ' ')
+    gsub!(/\A[[:space:]]+/, Strings::EMPTY)
+    gsub!(/[[:space:]]+\z/, Strings::EMPTY)
+    gsub!(/[[:space:]]+/, Strings::SPACE)
     self
   end
 
   # Returns a new string with all occurrences of the pattern removed. Short-hand for String#gsub(pattern, '').
   def remove(pattern)
-    gsub pattern, ''
+    gsub pattern, Strings::EMPTY
   end
 
   # Alters the string by removing all occurrences of the pattern. Short-hand for String#gsub!(pattern, '').
   def remove!(pattern)
-    gsub! pattern, ''
+    gsub! pattern, Strings::EMPTY
   end
 
   # Truncates a given +text+ after a given <tt>length</tt> if +text+ is longer than <tt>length</tt>:
@@ -51,7 +57,7 @@ class String
   def truncate(truncate_at, options = {})
     return dup unless length > truncate_at
 
-    omission = options[:omission] || '...'
+    omission = options[:omission] || :'...'
     length_with_room_for_omission = truncate_at - omission.length
     stop = \
       if options[:separator]

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -16,6 +16,16 @@ module ActiveSupport
   module Inflector
     extend self
 
+    module Strings #:nodoc:
+      EMPTY = ''.freeze
+      UNDERSCORE = '_'.freeze
+      HYPHEN = '-'.freeze
+      DOUBLE_COLON = '::'.freeze
+      ID = 'id'.freeze
+      UNDERSCORE_ID = '_id'.freeze
+    end
+    private_constant :Strings
+
     # Returns the plural form of the word in the string.
     #
     # If passed an optional +locale+ parameter, the word will be
@@ -178,14 +188,14 @@ module ActiveSupport
     #   'calculus'.classify     # => "Calculu"
     def classify(table_name)
       # strip out any leading schema name
-      camelize(singularize(table_name.to_s.sub(/.*\./, '')))
+      camelize(singularize(table_name.to_s.sub(/.*\./, Strings::EMPTY)))
     end
 
     # Replaces underscores with dashes in the string.
     #
     #   'puni_puni'.dasherize # => "puni-puni"
     def dasherize(underscored_word)
-      underscored_word.tr('_', '-')
+      underscored_word.tr(Strings::UNDERSCORE, Strings::HYPHEN)
     end
 
     # Removes the module part from the expression in the string.
@@ -198,7 +208,7 @@ module ActiveSupport
     # See also +deconstantize+.
     def demodulize(path)
       path = path.to_s
-      if i = path.rindex('::')
+      if i = path.rindex(Strings::DOUBLE_COLON)
         path[(i+2)..-1]
       else
         path
@@ -215,7 +225,7 @@ module ActiveSupport
     #
     # See also +demodulize+.
     def deconstantize(path)
-      path.to_s[0, path.rindex('::') || 0] # implementation based on the one in facets' Module#spacename
+      path.to_s[0, path.rindex(Strings::DOUBLE_COLON) || 0] # implementation based on the one in facets' Module#spacename
     end
 
     # Creates a foreign key name from a class name.
@@ -226,7 +236,7 @@ module ActiveSupport
     #   'Message'.foreign_key(false) # => "messageid"
     #   'Admin::Post'.foreign_key    # => "post_id"
     def foreign_key(class_name, separate_class_name_and_id_with_underscore = true)
-      underscore(demodulize(class_name)) + (separate_class_name_and_id_with_underscore ? "_id" : "id")
+      underscore(demodulize(class_name)) + (separate_class_name_and_id_with_underscore ? Strings::UNDERSCORE_ID : Strings::ID)
     end
 
     # Tries to find a constant with the name specified in the argument string.
@@ -248,7 +258,7 @@ module ActiveSupport
     # NameError is raised when the name is not in CamelCase or the constant is
     # unknown.
     def constantize(camel_cased_word)
-      names = camel_cased_word.split('::')
+      names = camel_cased_word.split(Strings::DOUBLE_COLON)
 
       # Trigger a built-in NameError exception including the ill-formed constant in the message.
       Object.const_get(camel_cased_word) if names.empty?
@@ -354,7 +364,7 @@ module ActiveSupport
     #   const_regexp("Foo::Bar::Baz") # => "Foo(::Bar(::Baz)?)?"
     #   const_regexp("::")            # => "::"
     def const_regexp(camel_cased_word) #:nodoc:
-      parts = camel_cased_word.split("::")
+      parts = camel_cased_word.split(Strings::DOUBLE_COLON)
 
       return Regexp.escape(camel_cased_word) if parts.blank?
 

--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -168,8 +168,13 @@ module ActiveSupport
           translate_number_value_with_default(key, { locale: options[:locale] }.merge(i18n_options))
         end
 
+        module Strings #:nodoc:
+          PERIOD = '.'.freeze
+        end
+        private_constant :Strings
+
         def default_value(key)
-          key.split('.').reduce(DEFAULTS) { |defaults, k| defaults[k.to_sym] }
+          key.split(Strings::PERIOD).reduce(DEFAULTS) { |defaults, k| defaults[k.to_sym] }
         end
 
         def valid_float? #:nodoc:

--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -9,14 +9,18 @@ module ActiveSupport
   #
   #   Rails.env.production?
   class StringInquirer < String
-    private
+    module Strings #:nodoc:
+      QUESTION_MARK = '?'.freeze
+    end
+    private_constant :Strings
 
+    private
       def respond_to_missing?(method_name, include_private = false)
-        method_name[-1] == '?'
+        method_name[-1] == Strings::QUESTION_MARK
       end
 
       def method_missing(method_name, *arguments)
-        if method_name[-1] == '?'
+        if method_name[-1] == Strings::QUESTION_MARK
           self == method_name[0..-2]
         else
           super

--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -96,7 +96,7 @@ module ActiveSupport
       event.end = finished
       event.payload.merge!(payload)
 
-      method = name.split('.').first
+      method = name.split('.'.freeze, 2).first
       send(method, event)
     end
 


### PR DESCRIPTION
This is driven by @fxn's work on `StringPool` to deduplicate commonly used strings: https://github.com/rails/rails/compare/fxn/string-pools

The cases covered here are a partial treatment, guided by object allocation profiling to reveal hotspots in common Basecamp actions.
- When in doubt, don't. This technique is ugly. Profile first and justify.
- Keep string constants close to their usage. No long lists of random strings. Keep it crystal clear what relies on the strings and why.
- Only share toplevel string constants for very commonly reused strings, like the empty string, underscore, spaces, etc.
- Don't reference toplevel string constants between libraries. Reference constants within the same library. Duplicated constants are OK.

Work in progress:
- [ ] Merge @fxn's work: https://github.com/rails/rails/compare/fxn/string-pools
- [ ] Merge @tenderlove's work: https://github.com/rails/rails/pull/12879/files
- [x] Eliminate constants that are used as string keys in Hash literals, which are automatically deduped in Ruby 2.1
- [ ] Eliminate constants that are used as string keys in Hash lookup and assignment, which are automatically deduped in Ruby 2.2
- [ ] Switch back from `Strings::FOO` to `'foo'.freeze` where the latter reads better (most places), since we're targeting Ruby 2.2
