### PR TITLE
Don't mutate options param

### DIFF
--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -99,8 +99,9 @@ module ActiveSupport
     end
 
     def to_tag(key, value, options)
-      type_name = options.delete(:type)
-      merged_options = options.merge(:root => key, :skip_instruct => true)
+      merged_options = options
+      merged_options[:root] = key
+      merged_options[:skip_instruct] = true
 
       if value.is_a?(::Method) || value.is_a?(::Proc)
         if value.arity == 1
@@ -111,6 +112,7 @@ module ActiveSupport
       elsif value.respond_to?(:to_xml)
         value.to_xml(merged_options)
       else
+        type_name = options[:type]
         type_name ||= TYPE_NAMES[value.class.name]
         type_name ||= value.class.name if value && !value.respond_to?(:to_str)
         type_name   = type_name.to_s   if type_name


### PR DESCRIPTION
This proposal comes from discussion in #17152 - Here `options[:type]` is no longer being deleted from `options`, and hash assignment changed to remove merge. Here's why:

Benchmark:

```
n = 10_000_000
Benchmark.bm do |x|
  x.report do
    n.times do
      merged_options = options.merge(:root => key, :skip_instruct => true)
    end
  end
  x.report do
    n.times do
      merged_options = options
      merged_options[:root] = key
      merged_options[:skip_instruct] = true
    end
  end
end
```

Results:

```
user     system      total        real
17.240000   0.000000  17.240000 ( 16.897622)
1.670000   0.000000   1.670000 (  1.676303)

user     system      total        real
16.830000   0.000000  16.830000 ( 16.875042)
1.710000   0.000000   1.710000 (  1.718011)

user     system      total        real
17.180000   0.000000  17.180000 ( 17.253324)
1.690000   0.000000   1.690000 (  1.693748)

user     system      total        real
17.170000   0.000000  17.170000 ( 17.246582)
1.650000   0.000000   1.650000 (  1.653273)

user     system      total        real
18.160000   0.000000  18.160000 ( 18.250755)
1.670000   0.000000   1.670000 (  1.676023)
```

If either this PR or #17152 is accepted, the other can be closed.
