### PR TITLE
Require environment variables to be defined at startup

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Added the config option required_env_vars. This option allows the developer
+    to specify a series of environment variables that must be defined at
+    started (otherwise an exception is thrown).
+
+    See #17175.
+
+        # e.g.
+        config.required_env_vars = ['api_key', 'other_third_party_api_key']
+
+    *Jim Jones*, *Abdelkader Boudih*
+
 *   Add the `method_source` gem to the default Gemfile for apps
 
     *Sean Griffin*

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -351,6 +351,7 @@ module Rails
       raise "Application has been already initialized." if @initialized
       run_initializers(group, self)
       @initialized = true
+      validate_environment_vars!
       self
     end
 
@@ -524,6 +525,21 @@ module Rails
         if secrets.secret_token.blank?
           raise "Missing `secret_token` and `secret_key_base` for '#{Rails.env}' environment, set these values in `config/secrets.yml`"
         end
+      end
+    end
+
+    def validate_environment_vars!
+      required_vars = Array(config.required_env_vars)
+
+      if required_vars.any?
+        missing_env_vars = Set.new
+
+        required_vars.each do |key|
+          key = key.to_s
+          missing_env_vars << key if ENV[key].blank?
+        end
+
+        raise "Must define the environment variable(s) #{missing_env_vars.to_a.join(', ')}" if missing_env_vars.any?
       end
     end
   end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -10,7 +10,7 @@ module Rails
                     :cache_classes, :cache_store, :consider_all_requests_local, :console,
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters,
                     :force_ssl, :helpers_paths, :logger, :log_formatter, :log_tags,
-                    :railties_order, :relative_url_root, :secret_key_base, :secret_token,
+                    :railties_order, :relative_url_root, :required_env_vars, :secret_key_base, :secret_token,
                     :serve_static_files, :ssl_options, :static_cache_control, :session_options,
                     :time_zone, :reload_classes_only_on_change,
                     :beginning_of_week, :filter_redirect, :x
@@ -41,6 +41,7 @@ module Rails
         @railties_order                = [:all]
         @relative_url_root             = ENV["RAILS_RELATIVE_URL_ROOT"]
         @reload_classes_only_on_change = true
+        @required_env_vars             = Set.new
         @file_watcher                  = ActiveSupport::FileUpdateChecker
         @exceptions_app                = nil
         @autoflush_log                 = true

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -47,6 +47,9 @@ Rails.application.configure do
   # when problems arise.
   config.log_level = :debug
 
+  # Enforces that all of the following environment variables are defined before server start
+  # config.required_env_vars = ['API_KEY', 'OTHER_API_KEY']
+
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 

--- a/railties/test/application/validate_environment_vars_test.rb
+++ b/railties/test/application/validate_environment_vars_test.rb
@@ -1,0 +1,57 @@
+require "isolation/abstract_unit"
+require 'rack/test'
+require 'env_helpers'
+
+module ApplicationTests
+  class ValidateEnvironmentVarsTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include Rack::Test::Methods
+
+    def setup
+      build_app(initializers: true)
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    def app
+      @app ||= Rails.application
+    end
+
+    test "env variable must exist" do
+      ENV['FOO_API_KEY'] = '123456' # That's the combination on my luggage
+
+      add_to_env_config "development", "config.required_env_vars = ['FOO_API_KEY']"
+
+      assert_nothing_raised do
+        require "#{app_path}/config/environment"
+        app.send("validate_environment_vars!")
+      end
+    end
+
+    def test_env_variable_non_existent
+      ENV['FOO_API_KEY'] = 'xyz123'
+
+      add_to_env_config "development", "config.required_env_vars = ['Foo_API_KEY1', 'FOO_API_KEY2', :FOO_API_KEY3, 'FOO_API_KEY3']"
+
+      error = assert_raises RuntimeError do
+        require "#{app_path}/config/environment"
+        app.send("validate_environment_vars!")
+      end
+
+      assert_match /Foo_API_KEY1, FOO_API_KEY2, FOO_API_KEY3/, error.message
+    end
+
+    def test_env_variable_as_string
+      ENV['FOO_API_KEY'] = 'xyz123'
+
+      add_to_env_config "development", "config.required_env_vars = 'FOO_API_KEY'"
+
+      assert_nothing_raised do
+        require "#{app_path}/config/environment"
+        app.send("validate_environment_vars!")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added the config option required_env_vars. This option allows the developer to specify a series of environment variables that must be defined at started, otherwise an exception is thrown.

```
  # e.g.
  config.required_env_vars = ['rollbar_api_key', 'github_api_key']
```

If either the ENV['rollbar_api_key'] or ENV['github_api_key'] environmental variables aren't defined, an exception is thrown and the server fails to startup.

We've had several instances where our ops team forgot to export an API key on the server and it wasn't apparent until later.  

Especially useful for systems like Heroku where reliance on environment variables is prevalent for Rails apps.
