### PR TITLE
Cleanup association to not use activerecord-deprecated_finders

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -15,13 +15,10 @@ module ActiveRecord::Associations::Builder
   class Association #:nodoc:
     class << self
       attr_accessor :extensions
-      # TODO: This class accessor is needed to make activerecord-deprecated_finders work.
-      # We can move it to a constant in 5.0.
-      attr_accessor :valid_options
     end
     self.extensions = []
 
-    self.valid_options = [:class_name, :class, :foreign_key, :validate]
+    VALID_OPTIONS = [:class_name, :class, :foreign_key, :validate]
 
     attr_reader :name, :scope, :options
 
@@ -44,17 +41,15 @@ module ActiveRecord::Associations::Builder
     def self.create_builder(model, name, scope, options, &block)
       raise ArgumentError, "association names must be a Symbol" unless name.kind_of?(Symbol)
 
-      new(model, name, scope, options, &block)
-    end
-
-    def initialize(model, name, scope, options)
-      # TODO: Move this to create_builder as soon we drop support to activerecord-deprecated_finders.
       if scope.is_a?(Hash)
         options = scope
         scope   = nil
       end
 
-      # TODO: Remove this model argument as soon we drop support to activerecord-deprecated_finders.
+      new(name, scope, options, &block)
+    end
+
+    def initialize(name, scope, options)
       @name    = name
       @scope   = scope
       @options = options
@@ -75,7 +70,7 @@ module ActiveRecord::Associations::Builder
     end
 
     def valid_options
-      Association.valid_options + Association.extensions.flat_map(&:valid_options)
+      VALID_OPTIONS + Association.extensions.flat_map(&:valid_options)
     end
 
     def validate_options

--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -14,7 +14,7 @@ module ActiveRecord::Associations::Builder
 
     attr_reader :block_extension
 
-    def initialize(model, name, scope, options)
+    def initialize(name, scope, options)
       super
       @mod = nil
       if block_given?

--- a/activerecord/test/cases/associations/extension_test.rb
+++ b/activerecord/test/cases/associations/extension_test.rb
@@ -75,7 +75,7 @@ class AssociationsExtensionsTest < ActiveRecord::TestCase
   private
 
     def extend!(model)
-      builder = ActiveRecord::Associations::Builder::HasMany.new(model, :association_name, nil, {}) { }
+      builder = ActiveRecord::Associations::Builder::HasMany.new(:association_name, nil, {}) { }
       builder.define_extensions(model)
     end
 end


### PR DESCRIPTION
Now that rails 4.2 :tada: is in beta we can start removing `activerecord-deprecated_finders` from the code. This cleans up the association changing `valid_options` to a constant (`VALID_OPTIONS`), removing the extra model argument from initialize and bumping `scope.is_a?(Hash)` where it belongs in `create_builder`.

Note this is for Rails 5 not Rails 4. :smile_cat: 

cc/ @tenderlove 
