### PR TITLE
remove activerecord-deprecated_finders from activerecord

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -212,11 +212,7 @@ module ActiveRecord
 
       # Count all records using SQL.  Construct options and pass them with
       # scope to the target class's +count+.
-      def count(column_name = nil, count_options = {})
-        # TODO: Remove count_options argument as soon we remove support to
-        # activerecord-deprecated_finders.
-        column_name, count_options = nil, column_name if column_name.is_a?(Hash)
-
+      def count(column_name = nil)
         relation = scope
         if association_scope.distinct_value
           # This is needed because 'SELECT count(DISTINCT *)..' is not valid SQL.

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -690,10 +690,8 @@ module ActiveRecord
       #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
       #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
       #   #    ]
-      def count(column_name = nil, options = {})
-        # TODO: Remove options argument as soon we remove support to
-        # activerecord-deprecated_finders.
-        @association.count(column_name, options)
+      def count(column_name = nil)
+        @association.count(column_name)
       end
 
       # Returns the size of the collection. If the collection hasn't been loaded,

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -62,15 +62,11 @@ module ActiveRecord
       calculate :maximum, nil
     end
 
-    def calculate(operation, _column_name, _options = {})
-      # TODO: Remove _options argument as soon we remove support to
-      # activerecord-deprecated_finders.
+    def calculate(operation, _column_name)
       if [:count, :sum, :size].include? operation
         group_values.any? ? Hash.new : 0
       elsif [:average, :minimum, :maximum].include?(operation) && group_values.any?
         Hash.new
-      else
-        nil
       end
     end
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -35,21 +35,16 @@ module ActiveRecord
     #
     # Note: not all valid +select+ expressions are valid +count+ expressions. The specifics differ
     # between databases. In invalid cases, an error from the database is thrown.
-    def count(column_name = nil, options = {})
-      # TODO: Remove options argument as soon we remove support to
-      # activerecord-deprecated_finders.
-      column_name, options = nil, column_name if column_name.is_a?(Hash)
-      calculate(:count, column_name, options)
+    def count(column_name = nil)
+      calculate(:count, column_name)
     end
 
     # Calculates the average value on a given column. Returns +nil+ if there's
     # no row. See +calculate+ for examples with options.
     #
     #   Person.average(:age) # => 35.8
-    def average(column_name, options = {})
-      # TODO: Remove options argument as soon we remove support to
-      # activerecord-deprecated_finders.
-      calculate(:average, column_name, options)
+    def average(column_name)
+      calculate(:average, column_name)
     end
 
     # Calculates the minimum value on a given column. The value is returned
@@ -57,10 +52,8 @@ module ActiveRecord
     # +calculate+ for examples with options.
     #
     #   Person.minimum(:age) # => 7
-    def minimum(column_name, options = {})
-      # TODO: Remove options argument as soon we remove support to
-      # activerecord-deprecated_finders.
-      calculate(:minimum, column_name, options)
+    def minimum(column_name)
+      calculate(:minimum, column_name)
     end
 
     # Calculates the maximum value on a given column. The value is returned
@@ -68,10 +61,8 @@ module ActiveRecord
     # +calculate+ for examples with options.
     #
     #   Person.maximum(:age) # => 93
-    def maximum(column_name, options = {})
-      # TODO: Remove options argument as soon we remove support to
-      # activerecord-deprecated_finders.
-      calculate(:maximum, column_name, options)
+    def maximum(column_name)
+      calculate(:maximum, column_name)
     end
 
     # Calculates the sum of values on a given column. The value is returned
@@ -114,17 +105,15 @@ module ActiveRecord
     #   Person.group(:last_name).having("min(age) > 17").minimum(:age)
     #
     #   Person.sum("2 * age")
-    def calculate(operation, column_name, options = {})
-      # TODO: Remove options argument as soon we remove support to
-      # activerecord-deprecated_finders.
+    def calculate(operation, column_name)
       if column_name.is_a?(Symbol) && attribute_alias?(column_name)
         column_name = attribute_alias(column_name)
       end
 
       if has_include?(column_name)
-        construct_relation_for_association_calculations.calculate(operation, column_name, options)
+        construct_relation_for_association_calculations.calculate(operation, column_name)
       else
-        perform_calculation(operation, column_name, options)
+        perform_calculation(operation, column_name)
       end
     end
 
@@ -196,9 +185,7 @@ module ActiveRecord
       eager_loading? || (includes_values.present? && ((column_name && column_name != :all) || references_eager_loaded_tables?))
     end
 
-    def perform_calculation(operation, column_name, options = {})
-      # TODO: Remove options argument as soon we remove support to
-      # activerecord-deprecated_finders.
+    def perform_calculation(operation, column_name)
       operation = operation.to_s.downcase
 
       # If #count is used with #distinct / #uniq it is considered distinct. (eg. relation.distinct.count)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -352,7 +352,7 @@ class RelationTest < ActiveRecord::TestCase
   def test_null_relation_calculations_methods
     assert_no_queries(ignore_none: false) do
       assert_equal 0, Developer.none.count
-      assert_equal 0, Developer.none.calculate(:count, nil, {})
+      assert_equal 0, Developer.none.calculate(:count, nil)
       assert_equal nil, Developer.none.calculate(:average, 'salary')
     end
   end


### PR DESCRIPTION
In continuation of #17177. This PR is for Rails 5. :smile: 
