### PR TITLE
Ordinal and Ordinalize now support I18n

### DIFF
--- a/activesupport/lib/active_support/core_ext/integer/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/integer/inflections.rb
@@ -10,8 +10,8 @@ class Integer
   #  1003.ordinalize  # => "1003rd"
   #  -11.ordinalize   # => "-11th"
   #  -1001.ordinalize # => "-1001st"
-  def ordinalize
-    ActiveSupport::Inflector.ordinalize(self)
+  def ordinalize(locale = :en)
+    ActiveSupport::Inflector.ordinalize(self, locale)
   end
 
   # Ordinal returns the suffix used to denote the position
@@ -23,7 +23,7 @@ class Integer
   #  1003.ordinal  # => "rd"
   #  -11.ordinal   # => "th"
   #  -1001.ordinal # => "st"
-  def ordinal
-    ActiveSupport::Inflector.ordinal(self)
+  def ordinal(locale = :en)
+    ActiveSupport::Inflector.ordinal(self, locale)
   end
 end

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -318,17 +318,17 @@ module ActiveSupport
     #   ordinal(1003)  # => "rd"
     #   ordinal(-11)   # => "th"
     #   ordinal(-1021) # => "st"
-    def ordinal(number)
+    def ordinal(number, locale = :en)
       abs_number = number.to_i.abs
 
       if (11..13).include?(abs_number % 100)
-        "th"
+        I18n.translate(:'number.ordinals.th', locale: locale)
       else
         case abs_number % 10
-          when 1; "st"
-          when 2; "nd"
-          when 3; "rd"
-          else    "th"
+          when 1; I18n.translate(:'number.ordinals.st', locale: locale)
+          when 2; I18n.translate(:'number.ordinals.nd', locale: locale)
+          when 3; I18n.translate(:'number.ordinals.rd', locale: locale)
+          else    I18n.translate(:'number.ordinals.th', locale: locale)
         end
       end
     end
@@ -342,8 +342,8 @@ module ActiveSupport
     #   ordinalize(1003)  # => "1003rd"
     #   ordinalize(-11)   # => "-11th"
     #   ordinalize(-1021) # => "-1021st"
-    def ordinalize(number)
-      "#{number}#{ordinal(number)}"
+    def ordinalize(number, locale = :en)
+      "#{number}#{ordinal(number, locale)}"
     end
 
     private

--- a/activesupport/lib/active_support/locale/en.yml
+++ b/activesupport/lib/active_support/locale/en.yml
@@ -131,3 +131,9 @@ en:
           billion: Billion
           trillion: Trillion
           quadrillion: Quadrillion
+
+    ordinals:
+      st: 'st'
+      nd: 'nd'
+      rd: 'rd'
+      th: 'th'

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -8,6 +8,22 @@ class InflectorTest < ActiveSupport::TestCase
   include InflectorTestCases
   include ConstantizeTestCases
 
+  def setup
+    I18n.backend.store_translations 'du',
+      number: {
+        ordinals: {
+          st: 'est',
+          nd: 'end',
+          rd: 'erd',
+          th: 'eth'
+        }
+      }
+  end
+
+  def teardown
+    I18n.backend.reload!
+  end
+
   def test_pluralize_plurals
     assert_equal "plurals", ActiveSupport::Inflector.pluralize("plurals")
     assert_equal "Plurals", ActiveSupport::Inflector.pluralize("Plurals")
@@ -328,15 +344,43 @@ class InflectorTest < ActiveSupport::TestCase
     end
   end
 
-  def test_ordinal
+  def test_ordinal_with_default_locale
     OrdinalNumbers.each do |number, ordinalized|
       assert_equal(ordinalized, number + ActiveSupport::Inflector.ordinal(number))
     end
   end
 
-  def test_ordinalize
+  def test_ordinal_with_locale
+    { '0' => '0eth',
+      '1' => '1est',
+      '2' => '2end',
+      '3' => '3erd',
+      '4' => '4eth',
+      '11' => '11eth',
+      '12' => '12eth',
+      '13' => '13eth'
+    }.each do |number, ordinalized|
+      assert_equal(ordinalized, number + ActiveSupport::Inflector.ordinal(number, :du))
+    end
+  end
+
+  def test_ordinalize_with_default_locale
     OrdinalNumbers.each do |number, ordinalized|
       assert_equal(ordinalized, ActiveSupport::Inflector.ordinalize(number))
+    end
+  end
+
+  def test_ordinalize_with_locale
+    { '0' => '0eth',
+      '1' => '1est',
+      '2' => '2end',
+      '3' => '3erd',
+      '4' => '4eth',
+      '11' => '11eth',
+      '12' => '12eth',
+      '13' => '13eth'
+    }.each do |number, ordinalized|
+      assert_equal(ordinalized, ActiveSupport::Inflector.ordinalize(number, :du))
     end
   end
 


### PR DESCRIPTION
I think `ordinal` and `ordinalize` should also support I18n.
