### PR TITLE
ActionDispatch::Request#xml_http_request? should return boolean

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -218,7 +218,7 @@ module ActionDispatch
     # (case-insensitive), which may need to be manually added depending on the
     # choice of JavaScript libraries and frameworks.
     def xml_http_request?
-      @env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i
+      @env['HTTP_X_REQUESTED_WITH'].downcase == 'xmlhttprequest'
     end
     alias :xhr? :xml_http_request?
 


### PR DESCRIPTION
`ActionDispatch::Request#xml_http_request?` returns a result of pattern-matching operator which return value is not boolean, but can be `nil` or integer (position of matched string).
Actually, success match and opposite cases both conveting to `false` (`0` and `nil`), which can cause a great headache.

Superclass `Rack::Request#xhr?` is closer to truth but it is case-sensitive. Maybe it's better to make a PR to Rack for this?
