### PR TITLE
Fix for #12753

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -888,7 +888,10 @@ module ActiveRecord
         bp.replace connection.substitute_at(column, remapped_bind_values.count)
         remapped_bind_values[bp] = bind_value
       end
-      self.bind_values = remapped_bind_values.values
+      self.bind_values = remapped_bind_values.values.select do |bv|
+        bind_values.include? bv
+      end
+      # TODO: Inherent reliance of order of hash, is this fine?
 
       arel
     end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -879,7 +879,7 @@ module ActiveRecord
       arel.lock(lock_value) if lock_value
 
       # Reordoring all bind parameters and values
-      bind_values_seen = Array.new
+      bind_values_seen = Set.new
       bvs = arel.bind_values + bind_values
       arel.ast.grep(Arel::Nodes::BindParam).each_with_index do |bp, i|
         bind_value = bvs[i]

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -42,6 +42,11 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_equal favs, fav2
   end
 
+  def test_subselect_with_duplicated_column_object
+    post = Post.create!(:title => "foo", :body => "bar")
+    assert_equal 0, post.comments.leaves.count
+  end
+
   def test_clear_association_cache_stored
     firm = Firm.find(1)
     assert_kind_of Firm, firm

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -5,6 +5,7 @@ class Comment < ActiveRecord::Base
   scope :for_first_post, -> { where(:post_id => 1) }
   scope :for_first_author, -> { joins(:post).where("posts.author_id" => 1) }
   scope :created, -> { all }
+  scope :leaves, -> { where.not(id: select(:parent_id)) }
 
   belongs_to :post, :counter_cache => true
   belongs_to :author,   polymorphic: true

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -6,6 +6,7 @@ class Comment < ActiveRecord::Base
   scope :for_first_author, -> { joins(:post).where("posts.author_id" => 1) }
   scope :created, -> { all }
   scope :leaves, -> { where.not(id: select(:parent_id)) }
+  # NOTE: Deliberately NOT unscoped subselect
 
   belongs_to :post, :counter_cache => true
   belongs_to :author,   polymorphic: true


### PR DESCRIPTION
I did a lot of hunting around and managed to produce a failing test and isolate where issue is coming from. This also possibly relates somewhat to #15920.

I've added a note near where the "bug starts". Basically if there are two bind params both referencing a single column when we do parameter replacement they're both replace with a common index. This fails with prepared statements and executing because some of the parameters are no longer used and the adapter raises unknown data type (or similar).

I realise my test could be fixed by changing my scope to have `unscoped.select(:parent_id)` but it was the first failing test I could come up with after a lot of trying to integrate it into the codebase. Will be trying to "adjust" it to a more correct / succinct test case.

I don't know where / how to start fixing this however, so I'll CC people I've seen working on this or similar code. Any ideas? @tenderlove @sgrif @eileencodes @senny 
