### PR TITLE
Allow authentication header to not have to specify 'token=' key.

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -397,6 +397,7 @@ module ActionController
     #
     #   RewriteRule ^(.*)$ dispatch.fcgi [E=X-HTTP_AUTHORIZATION:%{HTTP:Authorization},QSA,L]
     module Token
+      TOKEN_KEY = 'token='
       TOKEN_REGEX = /^Token /
       AUTHN_PAIR_DELIMITERS = /(?:,|;|\t+)/
       extend self
@@ -471,7 +472,13 @@ module ActionController
       # pairs by the standardized `:`, `;`, or `\t` delimiters defined in
       # `AUTHN_PAIR_DELIMITERS`.
       def raw_params(auth)
-        auth.sub(TOKEN_REGEX, '').split(/\s*#{AUTHN_PAIR_DELIMITERS}\s*/)
+        _raw_params = auth.sub(TOKEN_REGEX, '').split(/\s*#{AUTHN_PAIR_DELIMITERS}\s*/)
+
+        if !(_raw_params.first =~ %r{\A#{TOKEN_KEY}})
+          _raw_params[0] = "#{TOKEN_KEY}#{_raw_params.first}"
+        end
+
+        _raw_params
       end
 
       # Encodes the given token and options into an Authorization header value.
@@ -481,7 +488,7 @@ module ActionController
       #
       # Returns String.
       def encode_credentials(token, options = {})
-        values = ["token=#{token.to_s.inspect}"] + options.map do |key, value|
+        values = ["#{TOKEN_KEY}#{token.to_s.inspect}"] + options.map do |key, value|
           "#{key}=#{value.to_s.inspect}"
         end
         "Token #{values * ", "}"

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -162,17 +162,36 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     assert_equal(expected, actual)
   end
 
+  test "token_and_options returns right token when token key is not specified in header" do
+    token = "rcHu+HzSFw89Ypyhn/896A="
+
+    actual = ActionController::HttpAuthentication::Token.token_and_options(
+      sample_request_without_token_key(token)
+    ).first
+
+    expected = token
+    assert_equal(expected, actual)
+  end
+
   private
 
     def sample_request(token, options = {nonce: "def"})
       authorization = options.inject([%{Token token="#{token}"}]) do |arr, (k, v)|
         arr << "#{k}=\"#{v}\""
       end.join(", ")
-      @sample_request ||= OpenStruct.new authorization: authorization
+      mock_authorization_request(authorization)
     end
 
     def malformed_request
-      @malformed_request ||= OpenStruct.new authorization: %{Token token=}
+      mock_authorization_request(%{Token token=})
+    end
+
+    def sample_request_without_token_key(token)
+      mock_authorization_request(%{Token #{token}})
+    end
+
+    def mock_authorization_request(authorization)
+      OpenStruct.new(authorization: authorization)
     end
 
     def encode_credentials(token, options = {})


### PR DESCRIPTION
Fixes: https://github.com/rails/rails/issues/17108.
