### PR TITLE
Warning about middleware not auto-reloading

### DIFF
--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -99,6 +99,10 @@ To find out more about different `rackup` options:
 $ rackup --help
 ```
 
+### Development and auto-reloading
+
+Middlewares are loaded once and are not monitored for changes. You will have to restart the server for changes to be reflected in the running application.
+
 Action Dispatcher Middleware Stack
 ----------------------------------
 


### PR DESCRIPTION
Add a section in the guide to explain that Rails can't auto-reload
a middleware on code change.

Fix #16806
