### PR TITLE
update queue_classic details

### DIFF
--- a/activejob/lib/active_job/queue_adapters.rb
+++ b/activejob/lib/active_job/queue_adapters.rb
@@ -7,7 +7,7 @@ module ActiveJob
   # * {Delayed Job}[https://github.com/collectiveidea/delayed_job]
   # * {Qu}[https://github.com/bkeepers/qu]
   # * {Que}[https://github.com/chanks/que]
-  # * {QueueClassic 2.x}[https://github.com/ryandotsmith/queue_classic/tree/v2.2.3]
+  # * {queue_classic}[https://github.com/QueueClassic/queue_classic]
   # * {Resque 1.x}[https://github.com/resque/resque/tree/1-x-stable]
   # * {Sidekiq}[http://sidekiq.org]
   # * {Sneakers}[https://github.com/jondot/sneakers]
@@ -20,7 +20,7 @@ module ActiveJob
   #   | Backburner        | Yes   | Yes    | Yes       | Yes        | Job     | Global  |
   #   | Delayed Job       | Yes   | Yes    | Yes       | Job        | Global  | Global  |
   #   | Que               | Yes   | Yes    | Yes       | Job        | No      | Job     |
-  #   | Queue Classic     | Yes   | Yes    | No*       | No         | No      | No      |
+  #   | queue_classic     | Yes   | Yes    | No*       | No         | No      | No      |
   #   | Resque            | Yes   | Yes    | Yes (Gem) | Queue      | Global  | Yes     |
   #   | Sidekiq           | Yes   | Yes    | Yes       | Queue      | No      | Job     |
   #   | Sneakers          | Yes   | Yes    | No        | Queue      | Queue   | No      |
@@ -29,7 +29,7 @@ module ActiveJob
   #   | Active Job        | Yes   | Yes    | Yes       | No         | No      | No      |
   #
   # NOTE:
-  # Queue Classic does not support Job scheduling. However you can implement this
+  # queue_classic does not support Job scheduling. However you can implement this
   # yourself or you can use the queue_classic-later gem. See the documentation for
   # ActiveJob::QueueAdapters::QueueClassicAdapter.
   #

--- a/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
@@ -2,7 +2,7 @@ require 'queue_classic'
 
 module ActiveJob
   module QueueAdapters
-    # == Queue Classic adapter for Active Job
+    # == queue_classic adapter for Active Job
     #
     # queue_classic provides a simple interface to a PostgreSQL-backed message
     # queue. queue_classic specializes in concurrent locking and minimizing
@@ -11,9 +11,9 @@ module ActiveJob
     # production environment and that adding another dependency (e.g. redis,
     # beanstalkd, 0mq) is undesirable.
     #
-    # Read more about Queue Classic {here}[https://github.com/ryandotsmith/queue_classic].
+    # Read more about queue_classic {here}[https://github.com/QueueClassic/queue_classic].
     #
-    # To use Queue Classic set the queue_adapter config to +:queue_classic+.
+    # To use queue_classic set the queue_adapter config to +:queue_classic+.
     #
     #   Rails.application.config.active_job.queue_adapter = :queue_classic
     class QueueClassicAdapter
@@ -25,7 +25,7 @@ module ActiveJob
         def enqueue_at(job, timestamp) #:nodoc:
           queue = build_queue(job.queue_name)
           unless queue.respond_to?(:enqueue_at)
-            raise NotImplementedError, 'To be able to schedule jobs with Queue Classic ' \
+            raise NotImplementedError, 'To be able to schedule jobs with queue_classic ' \
               'the QC::Queue needs to respond to `enqueue_at(timestamp, method, *args)`. '
               'You can implement this yourself or you can use the queue_classic-later gem.'
           end


### PR DESCRIPTION
This includes updated details about queue_classic in ActiveJob. I am one of the maintainers of queue_classic.
- the original creator always referred the project as "queue_classic", not Queue Classic (I made that mistake more than once too)
- the repo has moved to a "QueueClassic" org (I know, this feels inconsistent, but it was not possible to get "queue_classic" for the org name...so...)
- I tried current queue_classic stable (3.x) last week with ActiveJob, and it works, so I removed the "2.x" from the doc here.

Also, there is some work being done to add job scheduling and I am wondering if it should be added to the note already included in `queue_adapters.rb`?

Thanks!

/cc @senny 
