### PR TITLE
Fix broken link to ActiveJob documentation

### DIFF
--- a/activejob/README.md
+++ b/activejob/README.md
@@ -90,7 +90,7 @@ by default has been mixed into Active Record classes.
 
 Active Job has built-in adapters for multiple queueing backends (Sidekiq,
 Resque, Delayed Job and others). To get an up-to-date list of the adapters
-see the API Documentation for [ActiveJob::QueueAdapters](http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html).
+see the API Documentation for [ActiveJob::QueueAdapters](http://edgeapi.rubyonrails.org/classes/ActiveJob/QueueAdapters.html).
 
 ## Auxiliary gems
 


### PR DESCRIPTION
Since ActiveJob is in a beta release, the current link returns 404:

http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html

In order to have a valid link, the URL must be:

http://edgeapi.rubyonrails.org/classes/ActiveJob/QueueAdapters.html

I think it's better to point at edgeapi than to a broken link.
The original URL can be restored as soon as 4.2.0 is officially released.

[ci skip]
