### PR TITLE
String should be not html_safe by default.

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -250,4 +250,8 @@ class String
   def html_safe
     ActiveSupport::SafeBuffer.new(self)
   end
+
+  def html_safe?
+    false
+  end
 end


### PR DESCRIPTION
When using `ERB::Util#h (ERB::Util#html_escape)`, we normally just pass a string to it. And in
`unwrapped_html_escape`, the string will be checked if it is html_safe?.

  https://github.com/rails/rails/blob/3dc9c52/activesupport/lib/active_support/core_ext/string/output_safety.rb#L38

We all know string is not html_safe, but the value of `html_safe?` is returned
by `Object#html_safe?`, which is ruby's ancestor method lookup. And it will
decrease performance if the argument of `html_escape` is a string in most
cases.

So patching a `html_safe?` method in `String` might be a good idea.
