### PR TITLE
remove un-needed sort

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -160,7 +160,7 @@ module ActionView
               attrs << tag_option(key, value, escape)
             end
           end
-          " #{attrs.sort! * ' '}" unless attrs.empty?
+          " #{attrs * ' '}" unless attrs.empty?
         end
 
         def prefix_tag_option(prefix, key, value, escape)

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -302,7 +302,7 @@ class AssetTagHelperTest < ActionView::TestCase
   def test_autodiscovery_link_tag_with_unknown_type
     result = auto_discovery_link_tag(:xml, '/feed.xml', :type => 'application/xml')
     expected = %(<link href="/feed.xml" rel="alternate" title="XML" type="application/xml" />)
-    assert_equal expected, result
+    assert_dom_equal expected, result
   end
 
   def test_asset_path_tag

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -329,7 +329,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_label_with_block_in_erb
-    assert_equal(
+    assert_dom_equal(
       %{<label for="post_message">\n  Message\n  <input id="post_message" name="post[message]" type="text" />\n</label>},
       view.render("test/label_with_block")
     )
@@ -469,8 +469,7 @@ class FormHelperTest < ActionView::TestCase
   def test_text_field_doesnt_change_param_values
     object_name = 'post[]'
     expected = '<input id="post_123_title" name="post[123][title]" type="text" value="Hello World" />'
-    assert_equal expected, text_field(object_name, "title")
-    assert_equal object_name, "post[]"
+    assert_dom_equal expected, text_field(object_name, "title")
   end
 
   def test_file_field_has_no_size
@@ -3196,7 +3195,7 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_with_string_url_option
     form_for(@post, url: 'http://www.otherdomain.com') do |f| end
 
-    assert_equal whole_form("http://www.otherdomain.com", "edit_post_123", "edit_post", method: "patch"), output_buffer
+    assert_dom_equal whole_form("http://www.otherdomain.com", "edit_post_123", "edit_post", method: "patch"), output_buffer
   end
 
   def test_form_for_with_hash_url_option
@@ -3210,14 +3209,14 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, url: @post) do |f| end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch")
-    assert_equal expected, output_buffer
+    assert_dom_equal expected, output_buffer
   end
 
   def test_form_for_with_existing_object
     form_for(@post) do |f| end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch")
-    assert_equal expected, output_buffer
+    assert_dom_equal expected, output_buffer
   end
 
   def test_form_for_with_new_object
@@ -3228,7 +3227,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(post) do |f| end
 
     expected = whole_form("/posts", "new_post", "new_post")
-    assert_equal expected, output_buffer
+    assert_dom_equal expected, output_buffer
   end
 
   def test_form_for_with_existing_object_in_list
@@ -3265,7 +3264,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, url: "/super_posts") do |f| end
 
     expected = whole_form("/super_posts", "edit_post_123", "edit_post", method: "patch")
-    assert_equal expected, output_buffer
+    assert_dom_equal expected, output_buffer
   end
 
   def test_form_for_with_default_method_as_patch


### PR DESCRIPTION
HTML doesn't care what order the elements are rendered in, so why should we?

Updates tests to use proper `assert_dom_equal` instead of `assert_equal` /cc @jeremy
