### PR TITLE
No need to allocate another SafeBuffer object if it's already html_safe?.

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -210,6 +210,10 @@ module ActiveSupport #:nodoc:
       defined?(@html_safe) && @html_safe
     end
 
+    def html_safe
+      html_safe? ? self : super
+    end
+
     def to_s
       self
     end


### PR DESCRIPTION
When calling `html_escape` on SafeBuffer object, a new SafeBuffer
object will always be allocated:

  https://github.com/rails/rails/blob/3dc9c52/activesupport/lib/active_support/core_ext/string/output_safety.rb#L22

It might be not necessary when `html_escape` a html_safe SafeBuffer object.
So for html_safe SafeBuffer object, we should just return itself for
`html_safe` method.

Benchmark result are attached as below:

```
Calculating -------------------------------------
return-self-if-html-safe
                         20116 i/100ms
-------------------------------------------------
return-self-if-html-safe
                      1189398.8 (±11.7%) i/s -    5813524 in   5.000982

Calculating -------------------------------------
new-safe-buffer-even-if-html-safe
                         13813 i/100ms
-------------------------------------------------
new-safe-buffer-even-if-html-safe
                       370526.7 (±12.0%) i/s -    1823316 in   5.007097
```
