### PR TITLE
Issue #17197: Using required and index on ActiveRecord generator creates wrong migration

### DIFF
--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -407,6 +407,16 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+   def test_required_with_index_adds_null_false_to_column
+    run_generator ["account", "supplier:references:index{required}"]
+
+    assert_migration "db/migrate/create_accounts.rb" do |m|
+      assert_method :change, m do |up|
+        assert_match(/t\.references :supplier,.*\snull: false/, up)
+      end
+    end
+  end
+
   private
     def assert_generated_fixture(path, parsed_contents)
       fixture_file = File.new File.expand_path(path, destination_root)


### PR DESCRIPTION
https://github.com/rails/rails/issues/17197
