### PR TITLE
reduce allocations and change some String process methods for asset_path helper

### DIFF
--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -109,6 +109,7 @@ module ActionView
     #
     module AssetUrlHelper
       URI_REGEXP = %r{^[-a-z]+://|^(?:cid|data):|^//}i
+      URI_SUFFIX_REGEXP = /([\?#].+)$/
 
       # Computes the path to asset in public directory. If :type
       # options is set, a file extension will be appended and scoped
@@ -125,26 +126,27 @@ module ActionView
         return "" unless source.present?
         return source if source =~ URI_REGEXP
 
-        tail, source = source[/([\?#].+)$/], source.sub(/([\?#].+)$/, '')
+        tail = source[URI_SUFFIX_REGEXP] || ''
+        source.chomp!(tail)
 
         if extname = compute_asset_extname(source, options)
-          source = "#{source}#{extname}"
+          source.concat(extname)
         end
 
-        if source[0] != ?/
+        unless source.start_with?('/'.freeze)
           source = compute_asset_path(source, options)
         end
 
         relative_url_root = defined?(config.relative_url_root) && config.relative_url_root
         if relative_url_root
-          source = File.join(relative_url_root, source) unless source.starts_with?("#{relative_url_root}/")
+          source = File.join(relative_url_root, source) unless source.starts_with?(relative_url_root)
         end
 
         if host = compute_asset_host(source, options)
           source = File.join(host, source)
         end
 
-        "#{source}#{tail}"
+        source.concat(tail)
       end
       alias_method :path_to_asset, :asset_path # aliased to avoid conflicts with an asset_path named route
 

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -109,7 +109,6 @@ module ActionView
     #
     module AssetUrlHelper
       URI_REGEXP = %r{^[-a-z]+://|^(?:cid|data):|^//}i
-      URI_SUFFIX_REGEXP = /([\?#].+)$/
 
       # Computes the path to asset in public directory. If :type
       # options is set, a file extension will be appended and scoped
@@ -126,7 +125,7 @@ module ActionView
         return "" unless source.present?
         return source if source =~ URI_REGEXP
 
-        tail = source[URI_SUFFIX_REGEXP] || ''
+        tail = source[/([\?#].+)$/] || ''
         source.chomp!(tail)
 
         if extname = compute_asset_extname(source, options)


### PR DESCRIPTION
~ 20% performance up

benchmark: https://gist.github.com/huacnlee/96374e46bb35c7351878

```
## Before

Total allocated 13
Total retained 0

## After

Total allocated 4
Total retained 0

## Benchmark

Calculating -------------------------------------
   asset_path before      9196 i/100ms
    asset_path after     10588 i/100ms
-------------------------------------------------
   asset_path before   112359.4 (±5.7%) i/s -     560956 in   5.008435s
    asset_path after   134550.6 (±6.0%) i/s -     677632 in   5.054601s

Comparison:
    asset_path after:   134550.6 i/s
   asset_path before:   112359.4 i/s - 1.20x slower
```
