### PR TITLE
Respect sti_name

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1363,6 +1363,8 @@ module ActiveRecord
       #   Specify the class name of the association. Use it only if that name can't be inferred
       #   from the association name. So <tt>belongs_to :author</tt> will by default be linked to the Author class, but
       #   if the real class name is Person, you'll have to specify it with this option.
+      #   For a polymorphic association, a callback may be provided, which will receive the polymorphic type
+      #   and should return the appropriate class.
       # [:foreign_key]
       #   Specify the foreign key used for the association. By default this is guessed to be the name
       #   of the association with an "_id" suffix. So a class that defines a <tt>belongs_to :person</tt>
@@ -1399,6 +1401,7 @@ module ActiveRecord
       #   Specify this association is a polymorphic association by passing +true+.
       #   Note: If you've enabled the counter cache, then you may want to add the counter cache attribute
       #   to the +attr_readonly+ list in the associated classes (e.g. <tt>class Post; attr_readonly :comments_count; end</tt>).
+      #   The :class_name option may be set to a callback to map types into classes.
       # [:validate]
       #   If +false+, don't validate the associated objects when saving the parent object. +false+ by default.
       # [:autosave]

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -87,7 +87,7 @@ module ActiveRecord
             scope    = scope.where(table[key].eq(bind_val))
 
             if reflection.type
-              value    = owner.class.base_class.name
+              value    = owner.class.base_class.sti_name
               bind_val = bind scope, table.table_name, reflection.type.to_s, value, tracker
               scope    = scope.where(table[reflection.type].eq(bind_val))
             end
@@ -95,7 +95,7 @@ module ActiveRecord
             constraint = table[key].eq(foreign_table[foreign_key])
 
             if reflection.type
-              value    = chain[i + 1].klass.base_class.name
+              value    = chain[i + 1].klass.base_class.sti_name
               bind_val = bind scope, table.table_name, reflection.type.to_s, value, tracker
               scope    = scope.where(table[reflection.type].eq(bind_val))
             end

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -4,14 +4,20 @@ module ActiveRecord
     class BelongsToPolymorphicAssociation < BelongsToAssociation #:nodoc:
       def klass
         type = owner[reflection.foreign_type]
-        type.presence && type.constantize
+        if type.presence
+          if reflection.options[:class_name].is_a?(Proc)
+            reflection.options[:class_name].call(type)
+          else
+            type.constantize
+          end
+        end
       end
 
       private
 
         def replace_keys(record)
           super
-          owner[reflection.foreign_type] = record.class.base_class.name
+          owner[reflection.foreign_type] = record.class.sti_name
         end
 
         def remove_keys

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -61,7 +61,7 @@ module ActiveRecord
             end
 
             if reflection.type
-              constraint = constraint.and table[reflection.type].eq foreign_klass.base_class.name
+              constraint = constraint.and table[reflection.type].eq foreign_klass.base_class.sti_name
             end
 
             if rel && !rel.arel.constraints.empty?

--- a/activerecord/test/cases/associations/sti_name_test.rb
+++ b/activerecord/test/cases/associations/sti_name_test.rb
@@ -1,0 +1,31 @@
+require 'cases/helper'
+require 'models/sti_post'
+require 'models/sti_comment'
+
+class StiNameTest < ActiveRecord::TestCase
+  fixtures :sti_posts, :sti_comments
+
+  def test_belongs_to
+    comment = StiComment.find(100)
+    post = comment.item
+    assert_equal 1, post.id
+  end
+
+  def test_has_many
+    post = StiPost.find(1)
+    assert_equal 1, post.sti_comments.count
+  end
+
+  def test_joins
+    post = StiPost.joins(:sti_comments).select('sti_comments.id AS sti_comment_id').first
+    assert_equal 100, post[:sti_comment_id]
+  end
+
+  def test_replace
+    comment = StiComment.find(100)
+    post = StiPost.find(2)
+    comment.item = post
+    assert_equal 'sti_post', comment.item_type
+  end
+
+end

--- a/activerecord/test/fixtures/sti_comments.yml
+++ b/activerecord/test/fixtures/sti_comments.yml
@@ -1,0 +1,4 @@
+charlie:
+  id: 100
+  item_type: sti_post
+  item_id: 1

--- a/activerecord/test/fixtures/sti_posts.yml
+++ b/activerecord/test/fixtures/sti_posts.yml
@@ -1,0 +1,5 @@
+alpha:
+  id: 1
+
+bravo:
+  id: 2

--- a/activerecord/test/models/sti_comment.rb
+++ b/activerecord/test/models/sti_comment.rb
@@ -1,0 +1,3 @@
+class StiComment < ActiveRecord::Base
+  belongs_to :item, :polymorphic => true, :class_name => ->(type) { type.classify.constantize }
+end

--- a/activerecord/test/models/sti_post.rb
+++ b/activerecord/test/models/sti_post.rb
@@ -1,0 +1,6 @@
+class StiPost < ActiveRecord::Base
+  has_many :sti_comments, :as => :item
+  def self.sti_name
+    'sti_post'
+  end
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -655,6 +655,14 @@ ActiveRecord::Schema.define do
     t.string :sponsorable_type
   end
 
+  create_table :sti_comments, force: true do |t|
+    t.integer :item_id
+    t.string :item_type
+  end
+
+  create_table :sti_posts, force: true do |t|
+  end
+
   create_table :string_key_objects, id: false, primary_key: :id, force: true do |t|
     t.string     :id
     t.string     :name


### PR DESCRIPTION
The identifier stored in the `inheritance_column` should always call `sti_name`. In some places `class.name` is being called instead, which is only a problem when `sti_name` is changed from the default. 
