### PR TITLE
Invalid HTTP method will raise I18n::InvalidLocale if :en is not a valid locale.

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -341,7 +341,7 @@ module ActionDispatch
 
     private
       def check_method(name)
-        HTTP_METHOD_LOOKUP[name] || raise(ActionController::UnknownHttpMethod, "#{name}, accepted HTTP methods are #{HTTP_METHODS.to_sentence(:locale => :en)}")
+        HTTP_METHOD_LOOKUP[name] || raise(ActionController::UnknownHttpMethod, "#{name}, accepted HTTP methods are #{HTTP_METHODS[0...-1].join(', ')}, and #{HTTP_METHODS[-1]}")
         name
       end
   end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -683,6 +683,22 @@ class RequestMethod < BaseRequestTest
     end
   end
 
+  test "exception on invalid HTTP method unaffected by I18n settings" do
+    old_locales = I18n.available_locales
+    old_enforce = I18n.config.enforce_available_locales
+
+    begin
+      I18n.available_locales = [:nl]
+      I18n.config.enforce_available_locales = true
+      assert_raise(ActionController::UnknownHttpMethod) do
+        stub_request('REQUEST_METHOD' => '_RANDOM_METHOD').method
+      end
+    ensure
+      I18n.available_locales = old_locales
+      I18n.config.enforce_available_locales = old_enforce
+    end
+  end
+
   test "post masquerading as patch" do
     request = stub_request(
       'REQUEST_METHOD' => 'PATCH',


### PR DESCRIPTION
`Request#check_method` uses `to_sentence(locale: :en)`, which raises `I18n::InvalidLocale` when `I18n.available_locales` does not include `:en` and `I18n.enforce_available_locales` is `true` (default).

I inlined the `to_sentence` functionality in `check_method` to solve this. Not sure if this is the best solution, but it works.

**NOTE:** `ActionController::MethodNotAllowed` has a similar problem, but I don't know where that is tested or if it's even used anywhere.
