### PR TITLE
ActiveJob: allow empty queue names

### DIFF
--- a/activejob/lib/active_job/queue_name.rb
+++ b/activejob/lib/active_job/queue_name.rb
@@ -24,7 +24,7 @@ module ActiveJob
       end
 
       def queue_name_from_part(part_name) #:nodoc:
-        queue_name = part_name.to_s.presence || default_queue_name
+        queue_name = part_name || default_queue_name
         name_parts = [queue_name_prefix.presence, queue_name]
         name_parts.compact.join('_')
       end

--- a/activejob/test/cases/queue_naming_test.rb
+++ b/activejob/test/cases/queue_naming_test.rb
@@ -18,6 +18,26 @@ class QueueNamingTest < ActiveSupport::TestCase
     end
   end
 
+  test 'allows a blank queue name' do
+    begin
+      original_queue_name = HelloJob.queue_name
+      HelloJob.queue_as ""
+      assert_equal "", HelloJob.new.queue_name
+    ensure
+      HelloJob.queue_name = original_queue_name
+    end
+  end
+
+  test 'does not use a nil queue name' do
+    begin
+      original_queue_name = HelloJob.queue_name
+      HelloJob.queue_as nil
+      assert_equal "default", HelloJob.new.queue_name
+    ensure
+      HelloJob.queue_name = original_queue_name
+    end
+  end
+
   test 'evals block given to queue_as to determine queue' do
     begin
       original_queue_name = HelloJob.queue_name


### PR DESCRIPTION
As discussed in #17195, Que uses blank queue names by default for
performance reasons. At the very least, ActiveJob should allow users to
choose "" as their queue name. This adds a failing test to show that
this doesn't currently work, and then adds a patch to allow this behavior.
