### PR TITLE
Introduce explicit way of halting callback chains by throwing :abort. Deprecate current implicit behavior of halting callback chains by returning `false` in apps ported to Rails 5.0. Completely remove that behavior in brand new Rails 5.0 apps.

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -9,7 +9,7 @@ module AbstractController
 
     included do
       define_callbacks :process_action,
-                       terminator: ->(controller,_) { controller.response_body },
+                       terminator: ->(controller, result_lambda) { result_lambda.call if result_lambda.is_a?(Proc); controller.response_body },
                        skip_after_callbacks_if_terminated: true
     end
 

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,1 +1,10 @@
+*   Deprecate returning `false` as a way to halt callback chains.
+
+    Returning `false` in a `before_` validation callback will display a
+    deprecation warning explaining that the preferred method to halt a callback
+    chain is to explicitly `throw(:abort)`.
+
+    *claudiob*
+
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,10 +1,12 @@
-*   Deprecate returning `false` as a way to halt callback chains.
+*   Change the way in which callback chains can be halted.
 
-    Returning `false` in a `before_` callback will display a
-    deprecation warning explaining that the preferred method to halt a callback
-    chain is to explicitly `throw(:abort)`.
-
-    *claudiob*
+    The preferred method to halt a callback chain from now on is to explicitly
+    `throw(:abort)`.
+    In the past, returning `false` in an ActiveModel or ActiveModel::Validations
+    `before_` callback had the side effect of halting the callback chain.
+    This is not recommended anymore and, depending on the value of the
+    `config.active_support.halt_callback_chains_on_return_false` option, will
+    either not work at all or display a deprecation warning.
 
 
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,6 +1,6 @@
 *   Deprecate returning `false` as a way to halt callback chains.
 
-    Returning `false` in a `before_` validation callback will display a
+    Returning `false` in a `before_` callback will display a
     deprecation warning explaining that the preferred method to halt a callback
     chain is to explicitly `throw(:abort)`.
 

--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -6,7 +6,7 @@ module ActiveModel
   # Provides an interface for any class to have Active Record like callbacks.
   #
   # Like the Active Record methods, the callback chain is aborted as soon as
-  # one of the methods in the chain returns +false+.
+  # one of the methods throws +:abort+.
   #
   # First, extend ActiveModel::Callbacks from the class you are creating:
   #
@@ -103,7 +103,6 @@ module ActiveModel
     def define_model_callbacks(*callbacks)
       options = callbacks.extract_options!
       options = {
-        terminator: ->(_,result_lambda) { result_lambda.call == false },
         skip_after_callbacks_if_terminated: true,
         scope: [:kind, :name],
         only: [:before, :around, :after]

--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -103,7 +103,7 @@ module ActiveModel
     def define_model_callbacks(*callbacks)
       options = callbacks.extract_options!
       options = {
-        terminator: ->(_,result) { result == false },
+        terminator: ->(_,result_lambda) { result_lambda.call == false },
         skip_after_callbacks_if_terminated: true,
         scope: [:kind, :name],
         only: [:before, :around, :after]

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -15,15 +15,14 @@ module ActiveModel
     #     after_validation  :do_stuff_after_validation
     #   end
     #
-    # Like other <tt>before_*</tt> callbacks if +before_validation+ returns
-    # +false+ then <tt>valid?</tt> will not be called.
+    # Like other <tt>before_*</tt> callbacks if +before_validation+ throws
+    # +:abort+ then <tt>valid?</tt> will not be called.
     module Callbacks
       extend ActiveSupport::Concern
 
       included do
         include ActiveSupport::Callbacks
         define_callbacks :validation,
-                         terminator: ->(_,result_lambda) { result_lambda.call == false },
                          skip_after_callbacks_if_terminated: true,
                          scope: [:kind, :name]
       end

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -23,7 +23,7 @@ module ActiveModel
       included do
         include ActiveSupport::Callbacks
         define_callbacks :validation,
-                         terminator: ->(_,result) { result == false },
+                         terminator: ->(_,result_lambda) { result_lambda.call == false },
                          skip_after_callbacks_if_terminated: true,
                          scope: [:kind, :name]
       end

--- a/activemodel/test/cases/validations/callbacks_test.rb
+++ b/activemodel/test/cases/validations/callbacks_test.rb
@@ -30,8 +30,13 @@ class DogWithTwoValidators < Dog
   before_validation { self.history << 'before_validation_marker2' }
 end
 
-class DogBeforeValidatorReturningFalse < Dog
+class DogDeprecatedBeforeValidatorReturningFalse < Dog
   before_validation { false }
+  before_validation { self.history << 'before_validation_marker2' }
+end
+
+class DogBeforeValidatorThrowingAbort < Dog
+  before_validation { throw :abort }
   before_validation { self.history << 'before_validation_marker2' }
 end
 
@@ -86,11 +91,20 @@ class CallbacksWithMethodNamesShouldBeCalled < ActiveModel::TestCase
     assert_equal ['before_validation_marker1', 'before_validation_marker2'], d.history
   end
 
-  def test_further_callbacks_should_not_be_called_if_before_validation_returns_false
-    d = DogBeforeValidatorReturningFalse.new
+  def test_further_callbacks_should_not_be_called_if_before_validation_throws_abort
+    d = DogBeforeValidatorThrowingAbort.new
     output = d.valid?
     assert_equal [], d.history
     assert_equal false, output
+  end
+
+  def test_deprecated_further_callbacks_should_not_be_called_if_before_validation_returns_false
+    d = DogDeprecatedBeforeValidatorReturningFalse.new
+    assert_deprecated do
+      output = d.valid?
+      assert_equal [], d.history
+      assert_equal false, output
+    end
   end
 
   def test_further_callbacks_should_be_called_if_after_validation_returns_false

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,8 +1,12 @@
-*   Deprecate returning `false` as a way to halt callback chains.
+*   Change the way in which callback chains can be halted.
 
-    Returning `false` in a `before_` callback will display a
-    deprecation warning explaining that the preferred method to halt a callback
-    chain is to explicitly `throw(:abort)`.
+    The preferred method to halt a callback chain from now on is to explicitly
+    `throw(:abort)`.
+    In the past, returning `false` in an ActiveRecord `before_` callback had the
+    side effect of halting the callback chain.
+    This is not recommended anymore and, depending on the value of the
+    `config.active_support.halt_callback_chains_on_return_false` option, will
+    either not work at all or display a deprecation warning.
 
     *claudiob*
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Deprecate returning `false` as a way to halt callback chains.
+
+    Returning `false` in a `before_` callback will display a
+    deprecation warning explaining that the preferred method to halt a callback
+    chain is to explicitly `throw(:abort)`.
+
+    *claudiob*
+
 *   Clear query cache on rollback.
 
     *Florian Weingarten*

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -17,7 +17,7 @@ module ActiveRecord
           unless empty?
             record = klass.human_attribute_name(reflection.name).downcase
             owner.errors.add(:base, :"restrict_dependent_destroy.many", record: record)
-            false
+            throw(:abort)
           end
 
         else

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -13,7 +13,7 @@ module ActiveRecord
           if load_target
             record = klass.human_attribute_name(reflection.name).downcase
             owner.errors.add(:base, :"restrict_dependent_destroy.one", record: record)
-            false
+            throw(:abort)
           end
 
         else

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -200,7 +200,7 @@ module ActiveRecord
             after_create save_method
             after_update save_method
           else
-            define_non_cyclic_method(save_method) { save_belongs_to_association(reflection) }
+            define_non_cyclic_method(save_method) { throw(:abort) if save_belongs_to_association(reflection) == false }
             before_save save_method
           end
 

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -206,7 +206,13 @@ module ActiveRecord
 
           if reflection.validate? && !method_defined?(validation_method)
             method = (collection ? :validate_collection_association : :validate_single_association)
-            define_non_cyclic_method(validation_method) { send(method, reflection) }
+            define_non_cyclic_method(validation_method) do
+              send(method, reflection)
+              # TODO: remove the following line as soon as the return value of
+              # callbacks is ignored, that is, returning `false` does not
+              # display a deprecation warning or halts the callback chain.
+              true
+            end
             validate validation_method
           end
         end

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -192,14 +192,14 @@ module ActiveRecord
   #
   # == <tt>before_validation*</tt> returning statements
   #
-  # If the returning value of a +before_validation+ callback can be evaluated to +false+, the process will be
+  # If the +before_validation+ callback throws +:abort+, the process will be
   # aborted and <tt>Base#save</tt> will return +false+. If Base#save! is called it will raise a
   # ActiveRecord::RecordInvalid exception. Nothing will be appended to the errors object.
   #
   # == Canceling callbacks
   #
-  # If a <tt>before_*</tt> callback returns +false+, all the later callbacks and the associated action are
-  # cancelled. If an <tt>after_*</tt> callback returns +false+, all the later callbacks are cancelled.
+  # If a <tt>before_*</tt> callback throws +:abort+, all the later callbacks and
+  # the associated action are cancelled.
   # Callbacks are generally run in the order they are defined, with the exception of callbacks defined as
   # methods on the model, which are called last.
   #

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -113,9 +113,9 @@ module ActiveRecord
     # the current time. However, if you supply <tt>touch: false</tt>, these
     # timestamps will not be updated.
     #
-    # There's a series of callbacks associated with +save+. If any of the
-    # <tt>before_*</tt> callbacks return +false+ the action is cancelled and
-    # +save+ returns +false+. See ActiveRecord::Callbacks for further
+    # There's a series of callbacks associated with #save. If any of the
+    # <tt>before_*</tt> callbacks throws +:abort+ the action is cancelled and
+    # #save returns +false+. See ActiveRecord::Callbacks for further
     # details.
     #
     # Attributes marked as readonly are silently ignored if the record is
@@ -139,9 +139,9 @@ module ActiveRecord
     # the current time. However, if you supply <tt>touch: false</tt>, these
     # timestamps will not be updated.
     #
-    # There's a series of callbacks associated with <tt>save!</tt>. If any of
-    # the <tt>before_*</tt> callbacks return +false+ the action is cancelled
-    # and <tt>save!</tt> raises ActiveRecord::RecordNotSaved. See
+    # There's a series of callbacks associated with #save!. If any of
+    # the <tt>before_*</tt> callbacks throws +:abort+ the action is cancelled
+    # and #save! raises ActiveRecord::RecordNotSaved. See
     # ActiveRecord::Callbacks for further details.
     #
     # Attributes marked as readonly are silently ignored if the record is
@@ -171,10 +171,10 @@ module ActiveRecord
     # Deletes the record in the database and freezes this instance to reflect
     # that no changes should be made (since they can't be persisted).
     #
-    # There's a series of callbacks associated with <tt>destroy</tt>. If
-    # the <tt>before_destroy</tt> callback return +false+ the action is cancelled
-    # and <tt>destroy</tt> returns +false+. See
-    # ActiveRecord::Callbacks for further details.
+    # There's a series of callbacks associated with #destroy. If the
+    # <tt>before_destroy</tt> callback throws +:abort+ the action is cancelled
+    # and #destroy returns +false+.
+    # See ActiveRecord::Callbacks for further details.
     def destroy
       raise ReadOnlyRecord, "#{self.class} is marked as readonly" if readonly?
       destroy_associations
@@ -186,10 +186,10 @@ module ActiveRecord
     # Deletes the record in the database and freezes this instance to reflect
     # that no changes should be made (since they can't be persisted).
     #
-    # There's a series of callbacks associated with <tt>destroy!</tt>. If
-    # the <tt>before_destroy</tt> callback return +false+ the action is cancelled
-    # and <tt>destroy!</tt> raises ActiveRecord::RecordNotDestroyed. See
-    # ActiveRecord::Callbacks for further details.
+    # There's a series of callbacks associated with #destroy!. If the
+    # <tt>before_destroy</tt> callback throws +:abort+ the action is cancelled
+    # and #destroy! raises ActiveRecord::RecordNotDestroyed.
+    # See ActiveRecord::Callbacks for further details.
     def destroy!
       destroy || raise(ActiveRecord::RecordNotDestroyed, self)
     end

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
     included do
       define_callbacks :commit, :rollback,
-                       terminator: ->(_, result) { result == false },
+                       terminator: ->(_, result_lambda) { result_lambda.call == false },
                        scope: [:kind, :name]
 
       mattr_accessor :raise_in_transactional_callbacks, instance_writer: false

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -17,7 +17,6 @@ module ActiveRecord
 
     included do
       define_callbacks :commit, :rollback,
-                       terminator: ->(_, result_lambda) { result_lambda.call == false },
                        scope: [:kind, :name]
 
       mattr_accessor :raise_in_transactional_callbacks, instance_writer: false

--- a/activerecord/test/cases/attribute_test.rb
+++ b/activerecord/test/cases/attribute_test.rb
@@ -5,6 +5,7 @@ module ActiveRecord
   class AttributeTest < ActiveRecord::TestCase
     setup do
       @type = Minitest::Mock.new
+      @type.expect(:==, false, [false])
     end
 
     teardown do

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -49,6 +49,11 @@ class CallbackDeveloperWithFalseValidation < CallbackDeveloper
   before_validation proc { |model| model.history << [:before_validation, :should_never_get_here] }
 end
 
+class CallbackDeveloperWithHaltedValidation < CallbackDeveloper
+  before_validation proc { |model| model.history << [:before_validation, :throwing_abort]; throw(:abort) }
+  before_validation proc { |model| model.history << [:before_validation, :should_never_get_here] }
+end
+
 class ParentDeveloper < ActiveRecord::Base
   self.table_name = 'developers'
   attr_accessor :after_save_called
@@ -70,6 +75,20 @@ class ImmutableDeveloper < ActiveRecord::Base
   private
     def cancel
       false
+    end
+end
+
+class DeveloperWithCanceledCallbacks < ActiveRecord::Base
+  self.table_name = 'developers'
+
+  validates_inclusion_of :salary, :in => 50000..200000
+
+  before_save :cancel
+  before_destroy :cancel
+
+  private
+    def cancel
+      throw(:abort)
     end
 end
 
@@ -129,6 +148,23 @@ class CallbackCancellationDeveloper < ActiveRecord::Base
   before_create  { !@cancel_before_create  }
   before_update  { !@cancel_before_update  }
   before_destroy { !@cancel_before_destroy }
+
+  after_save    { @after_save_called    = true }
+  after_update  { @after_update_called  = true }
+  after_create  { @after_create_called  = true }
+  after_destroy { @after_destroy_called = true }
+end
+
+class CallbackHaltedDeveloper < ActiveRecord::Base
+  self.table_name = 'developers'
+
+  attr_reader   :after_save_called, :after_create_called, :after_update_called, :after_destroy_called
+  attr_accessor :cancel_before_save, :cancel_before_create, :cancel_before_update, :cancel_before_destroy
+
+  before_save    { throw(:abort) if defined?(@cancel_before_save) }
+  before_create  { throw(:abort) if @cancel_before_create  }
+  before_update  { throw(:abort) if @cancel_before_update  }
+  before_destroy { throw(:abort) if @cancel_before_destroy }
 
   after_save    { @after_save_called    = true }
   after_update  { @after_update_called  = true }
@@ -393,12 +429,14 @@ class CallbacksTest < ActiveRecord::TestCase
     ], david.history
   end
 
-  def test_before_save_returning_false
+  def test_deprecated_before_save_returning_false
     david = ImmutableDeveloper.find(1)
-    assert david.valid?
-    assert !david.save
-    exc = assert_raise(ActiveRecord::RecordNotSaved) { david.save! }
-    assert_equal exc.record, david
+    assert_deprecated do
+      assert david.valid?
+      assert !david.save
+      exc = assert_raise(ActiveRecord::RecordNotSaved) { david.save! }
+      assert_equal exc.record, david
+    end
 
     david = ImmutableDeveloper.find(1)
     david.salary = 10_000_000
@@ -408,38 +446,48 @@ class CallbacksTest < ActiveRecord::TestCase
 
     someone = CallbackCancellationDeveloper.find(1)
     someone.cancel_before_save = true
-    assert someone.valid?
-    assert !someone.save
+    assert_deprecated do
+      assert someone.valid?
+      assert !someone.save
+    end
     assert_save_callbacks_not_called(someone)
   end
 
-  def test_before_create_returning_false
+  def test_deprecated_before_create_returning_false
     someone = CallbackCancellationDeveloper.new
     someone.cancel_before_create = true
-    assert someone.valid?
-    assert !someone.save
+    assert_deprecated do
+      assert someone.valid?
+      assert !someone.save
+    end
     assert_save_callbacks_not_called(someone)
   end
 
-  def test_before_update_returning_false
+  def test_deprecated_before_update_returning_false
     someone = CallbackCancellationDeveloper.find(1)
     someone.cancel_before_update = true
-    assert someone.valid?
-    assert !someone.save
+    assert_deprecated do
+      assert someone.valid?
+      assert !someone.save
+    end
     assert_save_callbacks_not_called(someone)
   end
 
-  def test_before_destroy_returning_false
+  def test_deprecated_before_destroy_returning_false
     david = ImmutableDeveloper.find(1)
-    assert !david.destroy
-    exc = assert_raise(ActiveRecord::RecordNotDestroyed) { david.destroy! }
-    assert_equal exc.record, david
+    assert_deprecated do
+      assert !david.destroy
+      exc = assert_raise(ActiveRecord::RecordNotDestroyed) { david.destroy! }
+      assert_equal exc.record, david
+    end
     assert_not_nil ImmutableDeveloper.find_by_id(1)
 
     someone = CallbackCancellationDeveloper.find(1)
     someone.cancel_before_destroy = true
-    assert !someone.destroy
-    assert_raise(ActiveRecord::RecordNotDestroyed) { someone.destroy! }
+    assert_deprecated do
+      assert !someone.destroy
+      assert_raise(ActiveRecord::RecordNotDestroyed) { someone.destroy! }
+    end
     assert !someone.after_destroy_called
   end
 
@@ -450,9 +498,59 @@ class CallbacksTest < ActiveRecord::TestCase
   end
   private :assert_save_callbacks_not_called
 
+  def test_before_create_throwing_abort
+    someone = CallbackHaltedDeveloper.new
+    someone.cancel_before_create = true
+    assert someone.valid?
+    assert !someone.save
+    assert_save_callbacks_not_called(someone)
+  end
+
+  def test_before_save_throwing_abort
+    david = DeveloperWithCanceledCallbacks.find(1)
+    assert david.valid?
+    assert !david.save
+    exc = assert_raise(ActiveRecord::RecordNotSaved) { david.save! }
+    assert_equal exc.record, david
+
+    david = DeveloperWithCanceledCallbacks.find(1)
+    david.salary = 10_000_000
+    assert !david.valid?
+    assert !david.save
+    assert_raise(ActiveRecord::RecordInvalid) { david.save! }
+
+    someone = CallbackHaltedDeveloper.find(1)
+    someone.cancel_before_save = true
+    assert someone.valid?
+    assert !someone.save
+    assert_save_callbacks_not_called(someone)
+  end
+
+  def test_before_update_throwing_abort
+    someone = CallbackHaltedDeveloper.find(1)
+    someone.cancel_before_update = true
+    assert someone.valid?
+    assert !someone.save
+    assert_save_callbacks_not_called(someone)
+  end
+
+  def test_before_destroy_throwing_abort
+    david = DeveloperWithCanceledCallbacks.find(1)
+    assert !david.destroy
+    exc = assert_raise(ActiveRecord::RecordNotDestroyed) { david.destroy! }
+    assert_equal exc.record, david
+    assert_not_nil ImmutableDeveloper.find_by_id(1)
+
+    someone = CallbackHaltedDeveloper.find(1)
+    someone.cancel_before_destroy = true
+    assert !someone.destroy
+    assert_raise(ActiveRecord::RecordNotDestroyed) { someone.destroy! }
+    assert !someone.after_destroy_called
+  end
+
   def test_callback_returning_false
     david = CallbackDeveloperWithFalseValidation.find(1)
-    david.save
+    assert_deprecated { david.save }
     assert_equal [
       [ :after_find,            :method ],
       [ :after_find,            :string ],
@@ -475,6 +573,34 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :after_rollback, :proc   ],
       [ :after_rollback, :string ],
       [ :after_rollback, :method ],
+    ], david.history
+  end
+
+  def test_callback_throwing_abort
+    david = CallbackDeveloperWithHaltedValidation.find(1)
+    david.save
+    assert_equal [
+      [ :after_find,        :method ],
+      [ :after_find,        :string ],
+      [ :after_find,        :proc   ],
+      [ :after_find,        :object ],
+      [ :after_find,        :block  ],
+      [ :after_initialize,  :method ],
+      [ :after_initialize,  :string ],
+      [ :after_initialize,  :proc   ],
+      [ :after_initialize,  :object ],
+      [ :after_initialize,  :block  ],
+      [ :before_validation, :method ],
+      [ :before_validation, :string ],
+      [ :before_validation, :proc   ],
+      [ :before_validation, :object ],
+      [ :before_validation, :block  ],
+      [ :before_validation, :throwing_abort ],
+      [ :after_rollback,    :block  ],
+      [ :after_rollback,    :object ],
+      [ :after_rollback,    :proc   ],
+      [ :after_rollback,    :string ],
+      [ :after_rollback,    :method ],
     ], david.history
   end
 

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -194,6 +194,16 @@ class TransactionTest < ActiveRecord::TestCase
     assert_equal posts_count, author.posts(true).size
   end
 
+  def test_cancellation_from_returning_false_in_before_filter
+    def @first.before_save_for_transaction
+      false
+    end
+
+    assert_deprecated do
+      @first.save
+    end
+  end
+
   def test_cancellation_from_before_destroy_rollbacks_in_destroy
     add_cancelling_before_destroy_with_db_side_effect_to_topic @first
     nbooks_before_destroy = Book.count
@@ -650,7 +660,7 @@ class TransactionTest < ActiveRecord::TestCase
       meta = class << topic; self; end
       meta.send("define_method", "before_#{filter}_for_transaction") do
         Book.create
-        false
+        throw(:abort)
       end
     end
   end

--- a/activerecord/test/models/bird.rb
+++ b/activerecord/test/models/bird.rb
@@ -7,6 +7,6 @@ class Bird < ActiveRecord::Base
   attr_accessor :cancel_save_from_callback
   before_save :cancel_save_callback_method, :if => :cancel_save_from_callback
   def cancel_save_callback_method
-    false
+    throw(:abort)
   end
 end

--- a/activerecord/test/models/bulb.rb
+++ b/activerecord/test/models/bulb.rb
@@ -46,6 +46,6 @@ end
 
 class FailedBulb < Bulb
   before_destroy do
-    false
+    throw(:abort)
   end
 end

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -11,7 +11,7 @@ class Parrot < ActiveRecord::Base
   attr_accessor :cancel_save_from_callback
   before_save :cancel_save_callback_method, :if => :cancel_save_from_callback
   def cancel_save_callback_method
-    false
+    throw(:abort)
   end
 end
 

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -56,7 +56,7 @@ class Pirate < ActiveRecord::Base
   attr_accessor :cancel_save_from_callback, :parrots_limit
   before_save :cancel_save_callback_method, :if => :cancel_save_from_callback
   def cancel_save_callback_method
-    false
+    throw(:abort)
   end
 
   private

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -14,7 +14,7 @@ class Ship < ActiveRecord::Base
   attr_accessor :cancel_save_from_callback
   before_save :cancel_save_callback_method, :if => :cancel_save_from_callback
   def cancel_save_callback_method
-    false
+    throw(:abort)
   end
 end
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Deprecate returning `false` as a way to halt callback chains.
+
+    Returning `false` in a callback will display a deprecation warning
+    explaining that the preferred method to halt a callback chain is to
+    explicitly `throw(:abort)`.
+
+    *claudiob*
+
 *   Changes arguments and default value of CallbackChain's :terminator option
 
     Chains of callbacks defined without an explicit `:terminator` option will

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Changes arguments and default value of CallbackChain's :terminator option
+
+    Chains of callbacks defined without an explicit `:terminator` option will
+    now be halted as soon as a `before_` callback throws `:abort`.
+
+    Chains of callbacks defined with a `:terminator` option will maintain their
+    existing behavior of halting as soon as a `before_` callback matches the
+    terminator's expectation. For instance, ActiveModel's callbacks will still
+    halt the chain when a `before_` callback returns `false`.
+
+    *claudiob*
+
 *   Deprecate `MissingSourceFile` in favor of `LoadError`.
 
     `MissingSourceFile` was just an alias to `LoadError` and was not being

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,8 +1,30 @@
-*   Deprecate returning `false` as a way to halt callback chains.
+*   Change the way in which callback chains can be halted.
 
-    Returning `false` in a callback will display a deprecation warning
-    explaining that the preferred method to halt a callback chain is to
-    explicitly `throw(:abort)`.
+    The preferred method to halt a callback chain from now on is to explicitly
+    `throw(:abort)`.
+    In the past, returning `false` in an ActiveSupport callback had the side
+    effect of halting the callback chain. This is not recommended anymore and,
+    depending on the value of
+    `Callbacks::CallbackChain.halt_and_display_warning_on_return_false`, will
+    either not work at all or display a deprecation warning.
+
+
+*   Add Callbacks::CallbackChain.halt_and_display_warning_on_return_false
+
+    Setting `Callbacks::CallbackChain.halt_and_display_warning_on_return_false`
+    to true will let an app support the deprecated way of halting callback
+    chains by returning `false`.
+
+    Setting the value to false will tell the app to ignore any `false` value
+    returned by callbacks, and only halt the chain upon `throw(:abort)`.
+
+    The value can also be set with the Rails configuration option
+    `config.active_support.halt_callback_chains_on_return_false`.
+
+    When the configuration option is missing, its value is `true`, so older apps
+    ported to Rails 5.0 will not break (but display a deprecation warning).
+    For new Rails 5.0 apps, its value is set to `false` in an initializer, so
+    these apps will support the new behavior by default.
 
     *claudiob*
 
@@ -13,8 +35,7 @@
 
     Chains of callbacks defined with a `:terminator` option will maintain their
     existing behavior of halting as soon as a `before_` callback matches the
-    terminator's expectation. For instance, ActiveModel's callbacks will still
-    halt the chain when a `before_` callback returns `false`.
+    terminator's expectation.
 
     *claudiob*
 

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -516,6 +516,12 @@ module ActiveSupport
 
       attr_reader :name, :config
 
+      # If true, any callback returning +false+ will halt the entire callback
+      # chain and display a deprecation message. If false, callback chains will
+      # only be halted by calling +throw :abort+. Defaults to +true+.
+      class_attribute :halt_and_display_warning_on_return_false
+      self.halt_and_display_warning_on_return_false = true
+
       def initialize(name, config)
         @name = name
         @config = {
@@ -597,7 +603,7 @@ module ActiveSupport
           terminate = true
           catch(:abort) do
             result = result_lambda.call if result_lambda.is_a?(Proc)
-            if result == false
+            if halt_and_display_warning_on_return_false && result == false
               display_deprecation_warning_for_false_terminator
             else
               terminate = false

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -55,7 +55,13 @@ module I18n
 
       reloader = ActiveSupport::FileUpdateChecker.new(I18n.load_path.dup){ I18n.reload! }
       app.reloaders << reloader
-      ActionDispatch::Reloader.to_prepare { reloader.execute_if_updated }
+      ActionDispatch::Reloader.to_prepare do
+        reloader.execute_if_updated
+        # TODO: remove the following line as soon as the return value of
+        # callbacks is ignored, that is, returning `false` does not
+        # display a deprecation warning or halts the callback chain.
+        true
+      end
       reloader.execute
 
       @i18n_inited = true

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -13,6 +13,13 @@ module ActiveSupport
       end
     end
 
+    initializer "active_support.halt_callback_chains_on_return_false", after: :load_config_initializers do |app|
+      if app.config.active_support.key? :halt_callback_chains_on_return_false
+        ActiveSupport::Callbacks::CallbackChain.halt_and_display_warning_on_return_false = \
+          app.config.active_support.halt_callback_chains_on_return_false
+      end
+    end
+
     # Sets the default value for Time.zone
     # If assigned value cannot be matched to a TimeZone, an exception will be raised.
     initializer "active_support.initialize_time_zone" do |app|

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -507,6 +507,8 @@ There are a few configuration options available in Active Support:
 
 * `config.active_support.time_precision` sets the precision of JSON encoded time values. Defaults to `3`.
 
+* `config.active_support.halt_callback_chains_on_return_false` specifies whether ActiveRecord, ActiveModel and ActiveModel::Validations callback chains can be halted by returning `false` in a 'before' callback. Defaults to `true`.
+
 * `ActiveSupport::Logger.silencer` is set to `false` to disable the ability to silence logging in a block. The default is `true`.
 
 * `ActiveSupport::Cache::Store.logger` specifies the logger to use within cache store operations.

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -53,6 +53,28 @@ Don't forget to review the difference, to see if there were any unexpected chang
 Upgrading from Rails 4.2 to Rails 5.0
 -------------------------------------
 
+### Halting callback chains by returning `false`
+
+In Rails 4.2, when a 'before' callback returns `false` in ActiveRecord,
+ActiveModel and ActiveModel::Validations, then the entire callback chain
+is halted. In other words, successive 'before' callbacks are not executed,
+and neither is the action wrapped in callbacks.
+
+In Rails 5.0, returning `false` in a callback will not have this side effect
+of halting the callback chain. Instead, callback chains must be explicitly
+halted by calling `throw(:abort)`.
+
+When you upgrade from Rails 4.2 to Rails 5.0, returning `false` in a callback
+will still halt the callback chain, but you will receive a deprecation warning
+about this upcoming change.
+
+When you are ready, you can opt into the new behavior and remove the deprecation
+warning by adding the following configuration to your `config/application.rb`:
+
+    config.active_support.halt_callback_chains_on_return_false = false
+
+See [#17227](https://github.com/rails/rails/pull/17227) for more details.
+
 Upgrading from Rails 4.1 to Rails 4.2
 -------------------------------------
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `config/initializers/callback_terminator.rb`
+
+    Newly generated Rails apps have a new initializer called
+    `callback_terminator.rb` which sets the value of the configuration option
+    `config.active_support.halt_callback_chains_on_return_false` to `false`.
+
+    As a result, new Rails apps do not halt callback chains when a callback
+    returns `false`; only when they are explicitly halted with `throw(:abort)`.
+
+    The terminator is *not* added when running `rake rails:update`, so returning
+    `false` will still work on old apps ported to Rails 5, displaying a
+    deprecation warning to prompt users to update their code to the new syntax.
+
+    *claudiob*
+
 *   Add `--skip-action-mailer` option to the app generator.
 
     *claudiob*

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -88,12 +88,19 @@ module Rails
 
     def config_when_updating
       cookie_serializer_config_exist = File.exist?('config/initializers/cookies_serializer.rb')
+      callback_terminator_config_exist = File.exist?('config/initializers/callback_terminator.rb')
 
       config
+
+      unless callback_terminator_config_exist
+        remove_file 'config/initializers/callback_terminator.rb'
+      end
 
       unless cookie_serializer_config_exist
         gsub_file 'config/initializers/cookies_serializer.rb', /json/, 'marshal'
       end
+
+
     end
 
     def database_yml

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/callback_terminator.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/callback_terminator.rb
@@ -1,0 +1,4 @@
+# Be sure to restart your server when you modify this file.
+
+# Do not halt callback chains when a callback returns false.
+Rails.application.config.active_support.halt_callback_chains_on_return_false = false

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -160,6 +160,38 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file("#{app_root}/config/initializers/cookies_serializer.rb", /Rails\.application\.config\.action_dispatch\.cookies_serializer = :json/)
   end
 
+  def test_rails_update_does_not_create_callback_terminator_initializer
+    app_root = File.join(destination_root, 'myapp')
+    run_generator [app_root]
+
+    FileUtils.rm("#{app_root}/config/initializers/callback_terminator.rb")
+
+    Rails.application.config.root = app_root
+    Rails.application.class.stubs(:name).returns("Myapp")
+    Rails.application.stubs(:is_a?).returns(Rails::Application)
+
+    generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+    generator.send(:app_const)
+    quietly { generator.send(:update_config_files) }
+    assert_no_file "#{app_root}/config/initializers/callback_terminator.rb"
+  end
+
+  def test_rails_update_does_not_remove_callback_terminator_initializer_if_already_present
+    app_root = File.join(destination_root, 'myapp')
+    run_generator [app_root]
+
+    FileUtils.touch("#{app_root}/config/initializers/callback_terminator.rb")
+
+    Rails.application.config.root = app_root
+    Rails.application.class.stubs(:name).returns("Myapp")
+    Rails.application.stubs(:is_a?).returns(Rails::Application)
+
+    generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+    generator.send(:app_const)
+    quietly { generator.send(:update_config_files) }
+    assert_file "#{app_root}/config/initializers/callback_terminator.rb"
+  end
+
   def test_rails_update_set_the_cookie_serializer_to_marchal_if_it_is_not_already_configured
     app_root = File.join(destination_root, 'myapp')
     run_generator [app_root]

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -498,17 +498,12 @@ YAML
       boot_rails
 
       initializers = Rails.application.initializers.tsort
-      index        = initializers.index { |i| i.name == "dummy_initializer" }
-      selection    = initializers[(index-3)..(index)].map(&:name).map(&:to_s)
+      dummy_index  = initializers.index  {|i| i.name == "dummy_initializer"}
+      config_index = initializers.rindex {|i| i.name == :load_config_initializers}
+      stack_index  = initializers.index  {|i| i.name == :build_middleware_stack}
 
-      assert_equal %w(
-       load_config_initializers
-       load_config_initializers
-       engines_blank_point
-       dummy_initializer
-      ), selection
-
-      assert index < initializers.index { |i| i.name == :build_middleware_stack }
+      assert config_index < dummy_index
+      assert dummy_index < stack_index
     end
 
     class Upcaser


### PR DESCRIPTION
Update (2015-01-02): a gist with the suggested release notes to add to Rails 5.0 after this commit is available at https://gist.github.com/claudiob/614c59409fb7d11f2931

---

Stems from discussion with @dhh at https://groups.google.com/forum/#!topic/rubyonrails-core/mhD4T90g0G4

@dhh – I created this work-in-progress PR to continue the conversation with some code.
Could you tell me if this is what you intended by using `:throw` with a symbol?

I have quite clear how to add the `throw` to the code in ActiveJob, but not as
much where to `catch` it in ActiveSupport. For now I have this code:

``` ruby
def run_callbacks(kind, &block)
  catch(:abort_job)  do
    send "run_#{kind}_callbacks", &block
  end
end
```

but maybe the `catch` is better located somewhere at a deeper level of the callback stack.

@dhh Thoughts? Once I have a clearer idea on how to proceed, I can complete
this PR with tests, documentations, etc. Thanks!
