### PR TITLE
Support operator class on PostgreSQL index creation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   PostgreSQL migrations support for index operator class.
+
+    *Cristian Bica*
+
 *   Honor overridden `rack.test` in Rack environment for the connection
     management middleware.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -214,6 +214,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support index opclass?
+      def supports_index_opclass?
+        false
+      end
+
       # Does this adapter support explain?
       def supports_explain?
         false

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -150,6 +150,10 @@ module ActiveRecord
         true
       end
 
+      def supports_index_opclass?
+        true
+      end
+
       def supports_transaction_isolation?
         true
       end

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -49,6 +49,21 @@ class PostgresqlActiveSchemaTest < ActiveRecord::TestCase
 
     expected = %(CREATE UNIQUE INDEX  "index_people_on_last_name" ON "people" USING gist ("last_name") WHERE state = 'active')
     assert_equal expected, add_index(:people, :last_name, :unique => true, :where => "state = 'active'", :using => :gist)
+
+    expected = %(CREATE  INDEX  "index_people_on_last_name" ON "people"  ("last_name" ASC))
+    assert_equal expected, add_index(:people, :last_name, :order => "ASC")
+
+    expected = %(CREATE  INDEX  "index_people_on_first_name_and_last_name" ON "people"  ("first_name", "last_name" DESC))
+    assert_equal expected, add_index(:people, [:first_name, :last_name], :order => {:last_name => "DESC"})
+
+    expected = %(CREATE  INDEX  "index_people_on_last_name" ON "people" USING gin ("last_name" gin_trgm_ops))
+    assert_equal expected, add_index(:people, :last_name, using: "gin", :opclass => "gin_trgm_ops")
+
+    expected = %(CREATE  INDEX  "index_people_on_first_name_and_last_name" ON "people" USING gin ("first_name", "last_name" gin_trgm_ops))
+    assert_equal expected, add_index(:people, [:first_name, :last_name], using: "gin", :opclass => {:last_name => "gin_trgm_ops"})
+
+    expected = %(CREATE  INDEX  "index_people_on_last_name" ON "people" USING gin ("last_name" gin_trgm_ops ASC))
+    assert_equal expected, add_index(:people, :last_name, using: "gin", :order => "ASC", :opclass => "gin_trgm_ops")
   end
 
   private

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -182,6 +182,14 @@ module ActiveRecord
           connection.remove_index("testings", "last_name")
           assert !connection.index_exists?("testings", "last_name")
         end
+
+        def test_add_index_with_operator_class
+          connection.add_index("testings", "last_name", :opclass => "varchar_pattern_ops")
+          assert connection.index_exists?("testings", "last_name")
+
+          connection.remove_index("testings", "last_name")
+          assert !connection.index_exists?("testings", "last_name")
+        end
       end
 
       private


### PR DESCRIPTION
The use case for this is for example when you try to create a gin/gist index on a text column. Before this PR I had to do:

``` ruby
class AddFulltextIndexesToUsers < ActiveRecord::Migration
  def up
    execute <<-SQL
      CREATE  INDEX "index_users_on_bio" ON "users" USING gin ("bio" gin_trgm_ops)
    SQL
  end

  def down
    execute <<-SQL
      DROP INDEX "index_users_on_bio"
    SQL
  end
end
```

now I can do

``` ruby
class AddFulltextIndexesToUsers < ActiveRecord::Migration
  def change
    add_index  :users, :bio,  using: 'gin', opclass: "gin_trgm_ops"
  end
end
```
