### PR TITLE
atomic_write rescue also Errno::EACCES

### DIFF
--- a/activesupport/lib/active_support/core_ext/file/atomic.rb
+++ b/activesupport/lib/active_support/core_ext/file/atomic.rb
@@ -40,7 +40,7 @@ class File
       chown(old_stat.uid, old_stat.gid, file_name)
       # This operation will affect filesystem ACL's
       chmod(old_stat.mode, file_name)
-    rescue Errno::EPERM
+    rescue Errno::EPERM, Errno::EACCES
       # Changing file ownership failed, moving on.
     end
   end


### PR DESCRIPTION
atomic_write rescue also Errno::EACCES on changing file permission. It could be raised with some type of filesystem
