### PR TITLE
Fix ActiveModel, ActiveRecord, ActiveJob README links

### DIFF
--- a/activejob/README.md
+++ b/activejob/README.md
@@ -89,8 +89,11 @@ by default has been mixed into Active Record classes.
 ## Supported queueing systems
 
 Active Job has built-in adapters for multiple queueing backends (Sidekiq,
-Resque, Delayed Job and others). To get an up-to-date list of the adapters
-see the API Documentation for [ActiveJob::QueueAdapters](http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html).
+Resque, Delayed Job and others). To get an up-to-date list of the adapters,
+see the `queue_adapters` directory [here](https://github.com/rails/rails/tree/master/activejob/lib/active_job/queue_adapters).
+In addition, the current version of Edge Rails has API Documentation for
+[ActiveJob::QueueAdapters](http://edgeapi.rubyonrails.org/classes/ActiveJob/QueueAdapters.html)
+that may be of use.
 
 ## Auxiliary gems
 

--- a/activemodel/README.rdoc
+++ b/activemodel/README.rdoc
@@ -54,7 +54,7 @@ behavior out of the box:
     person.clear_name
     person.clear_age
 
-  {Learn more}[link:classes/ActiveModel/AttributeMethods.html]
+  {Learn more}[link:lib/active_model/attribute_methods.rb]
 
 * Callbacks for certain operations
 
@@ -72,7 +72,7 @@ behavior out of the box:
   This generates +before_create+, +around_create+ and +after_create+
   class methods that wrap your create method.
 
-  {Learn more}[link:classes/ActiveModel/Callbacks.html]
+  {Learn more}[link:lib/active_model/callbacks.rb]
 
 * Tracking value changes
 
@@ -108,7 +108,7 @@ behavior out of the box:
     person.save
     person.previous_changes # => {'name' => ['bob, 'robert']}
 
-  {Learn more}[link:classes/ActiveModel/Dirty.html]
+  {Learn more}[link:lib/active_model/dirty.rb]
 
 * Adding +errors+ interface to objects
 
@@ -139,7 +139,7 @@ behavior out of the box:
     person.errors.full_messages
     # => ["Name cannot be nil"]
 
-  {Learn more}[link:classes/ActiveModel/Errors.html]
+  {Learn more}[link:lib/active_model/errors.rb]
 
 * Model name introspection
 
@@ -150,7 +150,7 @@ behavior out of the box:
     NamedPerson.model_name.name   # => "NamedPerson"
     NamedPerson.model_name.human  # => "Named person"
 
-  {Learn more}[link:classes/ActiveModel/Naming.html]
+  {Learn more}[link:lib/active_model/naming.rb]
 
 * Making objects serializable
 
@@ -184,7 +184,7 @@ behavior out of the box:
     s = SerialPerson.new
     s.to_xml              # => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<serial-person...
 
-  {Learn more}[link:classes/ActiveModel/Serialization.html]
+  {Learn more}[link:lib/active_model/serialization.rb]
 
 * Internationalization (i18n) support
 
@@ -195,7 +195,7 @@ behavior out of the box:
     Person.human_attribute_name('my_attribute')
     # => "My attribute"
 
-  {Learn more}[link:classes/ActiveModel/Translation.html]
+  {Learn more}[link:lib/active_model/translation.rb]
 
 * Validation support
 
@@ -213,7 +213,7 @@ behavior out of the box:
     person.first_name = 'zoolander'
     person.valid?  # => false
 
-  {Learn more}[link:classes/ActiveModel/Validations.html]
+  {Learn more}[link:lib/active_model/validations.rb]
 
 * Custom validators
   
@@ -235,7 +235,7 @@ behavior out of the box:
     p.name = "Bob"
     p.valid?                  # =>  true
 
-  {Learn more}[link:classes/ActiveModel/Validator.html]
+  {Learn more}[link:lib/active_model/validator.rb]
 
 
 == Download and installation

--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -20,7 +20,7 @@ A short rundown of some of the major features:
    class Product < ActiveRecord::Base
    end
 
-  {Learn more}[link:classes/ActiveRecord/Base.html]
+  {Learn more}[link:lib/active_record/base.rb]
 
 The Product class is automatically mapped to the table named "products",
 which might look like this:
@@ -43,7 +43,7 @@ This would also define the following accessors: `Product#name` and
      belongs_to :conglomerate
    end
 
-  {Learn more}[link:classes/ActiveRecord/Associations/ClassMethods.html]
+  {Learn more}[link:lib/active_record/associations.rb]
 
 
 * Aggregations of value objects.
@@ -55,7 +55,7 @@ This would also define the following accessors: `Product#name` and
                  mapping: [%w(address_street street), %w(address_city city)]
    end
 
-  {Learn more}[link:classes/ActiveRecord/Aggregations/ClassMethods.html]
+  {Learn more}[link:lib/active_record/aggregations.rb]
 
 
 * Validation rules that can differ for new or existing objects.
@@ -67,7 +67,7 @@ This would also define the following accessors: `Product#name` and
       validates :password, :email_address, confirmation: true, on: :create
     end
 
-  {Learn more}[link:classes/ActiveRecord/Validations.html]
+  {Learn more}[link:lib/active_record/validations.rb]
 
 
 * Callbacks available for the entire life cycle (instantiation, saving, destroying, validating, etc.).
@@ -77,7 +77,7 @@ This would also define the following accessors: `Product#name` and
      # the `invalidate_payment_plan` method gets called just before Person#destroy
    end
 
-  {Learn more}[link:classes/ActiveRecord/Callbacks.html]
+  {Learn more}[link:lib/active_record/callbacks.rb]
 
 
 * Inheritance hierarchies.
@@ -87,7 +87,7 @@ This would also define the following accessors: `Product#name` and
    class Client < Company; end
    class PriorityClient < Client; end
 
-  {Learn more}[link:classes/ActiveRecord/Base.html]
+  {Learn more}[link:lib/active_record/inheritance.rb]
 
 
 * Transactions.
@@ -98,7 +98,7 @@ This would also define the following accessors: `Product#name` and
       mary.deposit(100)
     end
 
-  {Learn more}[link:classes/ActiveRecord/Transactions/ClassMethods.html]
+  {Learn more}[link:lib/active_record/transactions.rb]
 
 
 * Reflections on columns, associations, and aggregations.
@@ -107,7 +107,7 @@ This would also define the following accessors: `Product#name` and
     reflection.klass # => Client (class)
     Firm.columns # Returns an array of column descriptors for the firms table
 
-  {Learn more}[link:classes/ActiveRecord/Reflection/ClassMethods.html]
+  {Learn more}[link:lib/active_record/reflection.rb]
 
 
 * Database abstraction through simple adapters.
@@ -124,10 +124,10 @@ This would also define the following accessors: `Product#name` and
       database: 'activerecord'
     )
 
-  {Learn more}[link:classes/ActiveRecord/Base.html] and read about the built-in support for
-  MySQL[link:classes/ActiveRecord/ConnectionAdapters/MysqlAdapter.html],
-  PostgreSQL[link:classes/ActiveRecord/ConnectionAdapters/PostgreSQLAdapter.html], and
-  SQLite3[link:classes/ActiveRecord/ConnectionAdapters/SQLite3Adapter.html].
+  {Learn more}[link:lib/active_record/base.rb] and read about the built-in support for
+  MySQL[link:lib/active_record/connection_adapters/mysql_adapter.rb],
+  PostgreSQL[link:lib/active_record/connection_adapters/postgresql_adapter.rb], and
+  SQLite3[link:lib/active_record/connection_adapters/sqlite3_adapter.rb].
 
 
 * Logging support for Log4r[https://github.com/colbygk/log4r] and Logger[http://www.ruby-doc.org/stdlib/libdoc/logger/rdoc].
@@ -156,7 +156,7 @@ This would also define the following accessors: `Product#name` and
       end
     end
 
-  {Learn more}[link:classes/ActiveRecord/Migration.html]
+  {Learn more}[link:lib/active_record/migration.rb]
 
 
 == Philosophy


### PR DESCRIPTION
The 'Learn More' links in the READMEs for `ActiveModel` and `ActiveRecord` that previously pointed to non-existent `.html` files have been updated to point to the corresponding `.rb` files in the source. In addition, a dead link to the Rails API for `ActiveJob::QueueAdapters` has been replaced with a link to the queue adapters directory in the source and a link to the Edge Rails API for `ActiveJob::QueueAdapters` for convenience.
