### PR TITLE
Fix regression where router was overwriting PATH_INFO

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix regression where path was getting overwritten when route anchor was false, and X-Cascade pass
+
+    fixes #17035.
+
+    *arthurnn*
+
 *   Fix a bug where malformed query strings lead to 500.
 
     fixes #11502.

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -63,9 +63,9 @@ module ActionDispatch
 
           unless route.path.anchored
             env['SCRIPT_NAME'] = (script_name.to_s + match.to_s).chomp('/')
-            path_info = match.post_match
-            env['PATH_INFO']   = path_info
-            env['PATH_INFO']   = "/" + path_info unless path_info.start_with? "/"
+            matched_path = match.post_match
+            env['PATH_INFO']   = matched_path
+            env['PATH_INFO']   = "/" + matched_path unless matched_path.start_with? "/"
           end
 
           env[@params_key] = (set_params || {}).merge parameters

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -615,6 +615,8 @@ class ApplicationIntegrationTest < ActionDispatch::IntegrationTest
     get 'bar', :to => 'application_integration_test/test#index', :as => :bar
 
     mount MountedApp => '/mounted', :as => "mounted"
+    get 'fooz' => proc { |env| [ 200, {'X-Cascade' => 'pass'}, [ "omg" ] ] }, anchor: false
+    get 'fooz', :to => 'application_integration_test/test#index'
   end
 
   def app
@@ -629,6 +631,12 @@ class ApplicationIntegrationTest < ActionDispatch::IntegrationTest
 
   test "includes mounted helpers" do
     assert_equal '/mounted/baz', mounted.baz_path
+  end
+
+  test "path after cascade pass" do
+    get '/fooz'
+    assert_equal 'index', response.body
+    assert_equal '/fooz', path
   end
 
   test "route helpers after controller access" do


### PR DESCRIPTION
On cda64c834bb98a2213f57d57efc40afd6ca527ad `path_info` variable already existed before, so we are overwriting its value.
Add regression test and rename the variable.

[fixes #16926]
[related #17035]

review @rafaelfranca @matthewd @tenderlove 
