### PR TITLE
Revert "Replace String index juggling with Pathname goodness in db:fixtures:load"

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -196,7 +196,7 @@ db_namespace = namespace :db do
       fixture_files = if ENV['FIXTURES']
                         ENV['FIXTURES'].split(',')
                       else
-                        Pathname.glob("#{fixtures_dir}/**/*.yml").map {|f| f.basename.sub_ext('').to_s }
+                        Dir["#{fixtures_dir}/**/*.yml"].map {|f| f[(fixtures_dir.size + 1)..-5] }
                       end
 
       ActiveRecord::FixtureSet.create_fixtures(fixtures_dir, fixture_files)

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -109,6 +109,16 @@ module ApplicationTests
         db_fixtures_load database_url_db_name
       end
 
+      test 'db:fixtures:load with namespaced fixture' do
+        require "#{app_path}/config/environment"
+        Dir.chdir(app_path) do
+          `rails generate model admin::book title:string;
+           bundle exec rake db:migrate db:fixtures:load`
+          require "#{app_path}/app/models/admin/book"
+          assert_equal 2, Admin::Book.count
+        end
+      end
+
       def db_structure_dump_and_load(expected_database)
         Dir.chdir(app_path) do
           `rails generate model book title:string;


### PR DESCRIPTION
This reverts commit 482fdad5ef8a73688b50bba3991dd4ef6f286edd.

Fixes https://github.com/rails/rails/issues/17237.
