### PR TITLE
Upgrade to coffee-rails 4.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'mocha', '~> 0.14', require: false
 
 gem 'rack-cache', '~> 1.2'
 gem 'jquery-rails', '~> 4.0.0.beta2'
-gem 'coffee-rails', '~> 4.0.0'
+gem 'coffee-rails', '~> 4.1.0'
 gem 'turbolinks', '~> 2.2.3'
 
 # require: false so bcrypt is loaded only when has_secure_password is used.

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -265,11 +265,11 @@ module Rails
       end
 
       def coffee_gemfile_entry
-        comment = 'Use CoffeeScript for .js.coffee assets and views'
+        comment = 'Use CoffeeScript for .coffee assets and views'
         if options.dev? || options.edge?
           GemfileEntry.github 'coffee-rails', 'rails/coffee-rails', comment
         else
-          GemfileEntry.version 'coffee-rails', '~> 4.0.0', comment
+          GemfileEntry.version 'coffee-rails', '~> 4.1.0', comment
         end
       end
 


### PR DESCRIPTION
Upgrades default Gemfile coffee-rails version to 4.1.0.

The preferred extension format is now just `.coffee` instead of `.js.coffee`.

See Also
- https://github.com/rails/coffee-rails/pull/61
- https://github.com/rails/coffee-rails/issues/62

cc @rafaelfranca @spastorino @guilleiguaran
