### PR TITLE
Replace Enumerable#reverse.each with Enumerable#reverse_each

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -1035,7 +1035,7 @@ module ActionView
         def build_selects_from_types(order)
           select = ''
           first_visible = order.find { |type| !@options[:"discard_#{type}"] }
-          order.reverse.each do |type|
+          order.reverse_each do |type|
             separator = separator(type) unless type == first_visible # don't add before first visible field
             select.insert(0, separator.to_s + send("select_#{type}").to_s)
           end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -19,7 +19,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
   def test_dump_schema_information_outputs_lexically_ordered_versions
     versions = %w{ 20100101010101 20100201010101 20100301010101 }
-    versions.reverse.each do |v|
+    versions.reverse_each do |v|
       ActiveRecord::SchemaMigration.create!(:version => v)
     end
 

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -559,7 +559,7 @@ module ActiveSupport
       # This is used internally to append, prepend and skip callbacks to the
       # CallbackChain.
       def __update_callbacks(name) #:nodoc:
-        ([self] + ActiveSupport::DescendantsTracker.descendants(self)).reverse.each do |target|
+        ([self] + ActiveSupport::DescendantsTracker.descendants(self)).reverse_each do |target|
           chain = target.get_callbacks name
           yield target, chain.dup
         end

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -490,8 +490,8 @@ class InflectorTest < ActiveSupport::TestCase
         assert_equal [], inflect.uncountables
 
         # restore all the inflections
-        singulars.reverse.each { |singular| inflect.singular(*singular) }
-        plurals.reverse.each   { |plural|   inflect.plural(*plural) }
+        singulars.reverse_each { |singular| inflect.singular(*singular) }
+        plurals.reverse_each   { |plural|   inflect.plural(*plural) }
         inflect.uncountable(uncountables)
 
         assert_equal singulars, inflect.singulars

--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -12,7 +12,7 @@ module Rails
 
       def add_routes
         unless options[:skip_routes]
-          actions.reverse.each do |action|
+          actions.reverse_each do |action|
             route generate_routing_code(action)
           end
         end


### PR DESCRIPTION
Similar to https://github.com/rails/rails/pull/17099, `Enumerable#reverse` allocates an extra array. `Enumerable#reverse_each` yields each value without allocating an extra array. This is the reason why `Enumerable#reverse_each` exists. It is also about 17% faster.
###### Benchmark

``` ruby
require 'benchmark/ips'

ARRAY = (1..100).to_a

def slow
  ARRAY.reverse.each{|x| x}
end

def fast
  ARRAY.reverse_each{|x| x}
end

Benchmark.ips do |x|
  x.report('slow') { slow }
  x.report('fast') { fast }
end
```
###### Ruby 2.1.2

```
slow 156173.2 (±9.2%) i/s - 770040 in 5.009112s
fast 182859.3 (±7.8%) i/s - 914486 in 5.035575s
```
