### PR TITLE
Replace Array#shuffle.first with Array#sample

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -88,13 +88,13 @@ module ActionDispatch
           erb       = File.read File.join(viz_dir, 'index.html.erb')
           states    = "function tt() { return #{to_json}; }"
 
-          fun_routes = paths.shuffle.first(3).map do |ast|
+          fun_routes = paths.sample(3).map do |ast|
             ast.map { |n|
               case n
               when Nodes::Symbol
                 case n.left
                 when ':id' then rand(100).to_s
-                when ':format' then %w{ xml json }.shuffle.first
+                when ':format' then %w{ xml json }.sample
                 else
                   'omg'
                 end


### PR DESCRIPTION
Similar to https://github.com/rails/rails/pull/17099, `Array#shuffle` allocates an extra array. `Array#sample` indexes into the array without allocating an extra array. This is the reason why `Array#sample` exists. It is also more than 15X faster.
###### Benchmark

``` ruby
require 'benchmark/ips'

ARRAY = (1..100).to_a

def slow
  ARRAY.shuffle.first
end

def fast
  ARRAY.sample
end

Benchmark.ips do |x|
  x.report('slow') { slow }
  x.report('fast') { fast }
end
```
###### Ruby 2.1.2

```
slow  324806.7 (±8.1%) i/s - 1620738 in 5.028042s
fast 5069719.9 (±9.5%) i/s - 24872400 in 5.011482s
```
