### PR TITLE
Start running railties builds first, since they take the longest finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,6 @@ script: 'ci/travis.rb'
 before_install:
   - travis_retry gem install bundler
   - "rvm current | grep 'jruby' && export AR_JDBC=true || echo"
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
-  - ruby-head
-  - rbx-2
-  - jruby
 env:
   global:
     - JRUBY_OPTS='-J-Xmx1024M'
@@ -22,6 +15,13 @@ env:
     - "GEM=ar:sqlite3"
     - "GEM=ar:postgresql"
     - "GEM=aj:integration"
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1
+  - ruby-head
+  - rbx-2
+  - jruby
 matrix:
   allow_failures:
     - rvm: 1.9.3


### PR DESCRIPTION
This should make the Travis CI build complete somewhat faster by having the first workers pick up the `railties` tests (which are the slowest) before others.

See comparison of https://travis-ci.org/rails/rails/builds/37816675 versus https://travis-ci.org/rails/rails/builds/37814459 to understand this change.

![screen_shot_2014-10-13_at_12_47_52](https://cloud.githubusercontent.com/assets/10308/4612954/cef82f06-52cf-11e4-8c80-0336c50dc014.png)

![screen_shot_2014-10-13_at_13_01_20](https://cloud.githubusercontent.com/assets/10308/4613033/e82a3090-52d0-11e4-9050-210ee5cf4cc8.png)
