### PR TITLE
Fix render layout with collection

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,7 +1,14 @@
+*   Fix `render layout: @collection` with provided block
+
+    According to the documentation `render layout:` should
+    be able to render provided collection. Previously, render
+    failed with 'Missing partial'.
+
+    *Theo Delaune*
+
 *   Fix `collection_radio_buttons` hidden_field name and make it appear
     before the actual input radio tags to make the real value override
     the hidden when passed.
-
     Fixes #22773
 
     *Santiago Pastorino*

--- a/actionview/test/fixtures/posts/_post.html.erb
+++ b/actionview/test/fixtures/posts/_post.html.erb
@@ -1,0 +1,1 @@
+<%= post.title %><%= yield post %>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -380,6 +380,16 @@ module RenderTestCases
     assert_equal "Before\npartial html\nYield!\nAfter\n", render
   end
 
+  def test_render_layout_with_block_and_collection_inside
+    render = @controller_view.render(:layout => [ Post.new("Amazon"), Post.new("Yahoo") ]) { " is title !" }
+    assert_equal "Amazon is title !Yahoo is title !", render
+  end
+
+  def test_render_layout_with_block_and_collection_inside_with_locals
+    render = @controller_view.render(:layout => [ Post.new("Amazon"), Post.new("Yahoo") ]) { |post| " #{post.title} !" }
+    assert_equal "Amazon Amazon !Yahoo Yahoo !", render
+  end
+
   def test_render_inline
     assert_equal "Hello, World!", @view.render(:inline => "Hello, World!")
   end


### PR DESCRIPTION
According to the documentation `render layout:` should
be able to render provided collection. Previously, render
failed with 'Missing partial'.

Fix #17224
