### PR TITLE
Don't re-initialize safe string

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -210,6 +210,11 @@ module ActiveSupport #:nodoc:
       defined?(@html_safe) && @html_safe
     end
 
+    def html_safe
+      @html_safe = true
+      self
+    end
+
     def to_s
       self
     end


### PR DESCRIPTION
There are cases where either a customer calls html_safe or it is called internally on an already safe string. When that happens we should return self instead of a new SafeBuffer

``` ruby

require 'benchmark/ips'
require 'erb'
require 'active_support/core_ext/kernel/singleton_class'
require 'active_support/core_ext/string/output_safety'


string = "foo"
safe = ActiveSupport::SafeBuffer.new(string)
safe_too = safe.dup


safe.define_singleton_method(:html_safe) do
  ActiveSupport::SafeBuffer.new(self)
end 

safe_too.define_singleton_method(:html_safe) do
  @html_safe = true
  self 
end

Benchmark.ips do |x|
  x.report("safe") { safe.html_safe }
  x.report("safe_too") { safe_too.html_safe }
end
```

Results

```
Calculating -------------------------------------
                safe     45950 i/100ms
            safe_too    121646 i/100ms
-------------------------------------------------
                safe   664721.6 (±7.1%) i/s -    3308400 in   5.005413s
            safe_too  4751968.1 (±7.0%) i/s -   23720970 in   5.021281s
```
