### PR TITLE
Clarify `#update_all` doc about values processing

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -305,7 +305,8 @@ module ActiveRecord
     # Updates all records with details given if they match a set of conditions supplied, limits and order can
     # also be supplied. This method constructs a single SQL UPDATE statement and sends it straight to the
     # database. It does not instantiate the involved models and it does not trigger Active Record callbacks
-    # or validations.
+    # or validations. Values passed to `update_all` will not go through ActiveRecord's type-casting behavior.
+    # It should receive only values that can be passed as-is to the SQL database.
     #
     # ==== Parameters
     #


### PR DESCRIPTION
This clarify the fact that `#update_all` doesn't type-cast passed
values and that these values are written as-is in the SQL DB.

Fix #17242
