### PR TITLE
Add #key? to ActiveModel::Errors

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -98,6 +98,8 @@ module ActiveModel
     end
     # aliases include?
     alias :has_key? :include?
+    # aliases include?
+    alias :key? :include?
 
     # Get messages for +key+.
     #

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -59,6 +59,17 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal false, errors.has_key?(:name), 'errors should not have key :name'
   end
 
+  def test_key?
+    errors = ActiveModel::Errors.new(self)
+    errors[:foo] = 'omg'
+    assert_equal true, errors.key?(:foo), 'errors should have key :foo'
+  end
+
+  def test_no_key
+    errors = ActiveModel::Errors.new(self)
+    assert_equal false, errors.key?(:name), 'errors should not have key :name'
+  end
+
   test "clear errors" do
     person = Person.new
     person.validate!


### PR DESCRIPTION
Mirror Ruby's [`Hash#key?`](http://ruby-doc.org/core-2.1.3/Hash.html#method-i-key-3F)
