### PR TITLE
support pg's tx access and deferrable modes via transaction(opts)

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -197,9 +197,15 @@ module ActiveRecord
           execute "BEGIN"
         end
 
-        def begin_isolated_db_transaction(isolation)
+        def begin_isolated_db_transaction(opts)
           begin_db_transaction
-          execute "SET TRANSACTION ISOLATION LEVEL #{transaction_isolation_levels.fetch(isolation)}"
+
+          opts = { level: opts } unless opts.is_a? Hash
+          level = transaction_isolation_levels.fetch(opts[:level])
+          read_mode = 'READ ONLY' if opts[:read_only]
+          deferrable = 'DEFERRABLE' if opts[:deferrable]
+
+          execute "SET TRANSACTION ISOLATION LEVEL #{level} #{read_mode} #{deferrable}"
         end
 
         # Commits a transaction.

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -102,5 +102,21 @@ if ActiveRecord::Base.connection.supports_transaction_isolation?
         end
       end
     end
+
+    if ARTest.connection_name == 'postgresql'
+      test "can start a read-only deferrable serializable transaction" do
+        Tag.transaction(isolation: { level: :serializable, read_only: true, deferrable: true }) do
+          assert_raises(ActiveRecord::StatementInvalid) do
+            Tag.create
+          end
+        end
+      end
+
+      test "can start a read-write serializable transaction" do
+        Tag.transaction(isolation: { level: :serializable, read_only: false }) do
+          Tag.create
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Hey hey. Long time lurker, first time committer. 

I wanted support for postgresql's finer-grained transaction isolation controls: 

http://www.postgresql.org/docs/9.3/static/sql-set-transaction.html

So I implemented it by offering the ability to pass a hash instead of just the isolation level symbol:

``` ruby

Model.transaction(isolation: :serializable) do
  # some important read-write stuff
end

Model.transaction(isolation: { level: :serializable, read_only: true, deferrable: true }) do
   # some important but read-only stuff
end
```

Testing this stuff is pretty hard I guess, based on this comment:

https://github.com/musicglue/rails/blob/b010ad0ae1bb1e05b7495d460dade22751a59a8a/activerecord/test/cases/transaction_isolation_test.rb#L81

I've got a couple of specs that prove that the access mode works (ie. you can't write in a readonly transaction), but testing deferrable seems tricky. 

What do you think?
