### PR TITLE
Use `#tr` instead of `#gsub` in Journey scanner

### DIFF
--- a/actionpack/lib/action_dispatch/journey/scanner.rb
+++ b/actionpack/lib/action_dispatch/journey/scanner.rb
@@ -50,7 +50,7 @@ module ActionDispatch
           when text = @ss.scan(/(?<!\\):\w+/)
             [:SYMBOL, text]
           when text = @ss.scan(/(?:[\w%\-~!$&'*+,;=@]|\\:|\\\(|\\\))+/)
-            [:LITERAL, text.gsub('\\', '')]
+            [:LITERAL, text.tr('\\', '')]
             # any char
           when text = @ss.scan(/./)
             [:LITERAL, text]


### PR DESCRIPTION
`#tr` is more efficient than `#gsub` and can be used as a drop in
replacement in this context.

enhance #17220 
