### PR TITLE
Remove broken http://tore.darell.no link

### DIFF
--- a/guides/source/credits.html.erb
+++ b/guides/source/credits.html.erb
@@ -40,7 +40,7 @@ Oscar Del Ben is a software engineer at <a href="http://www.wildfireapp.com/">Wi
 <% end %>
 
 <%= author('Tore Darell', 'toretore') do %>
-  Tore Darell is an independent developer based in Menton, France who specialises in cruft-free web applications using Ruby, Rails and unobtrusive JavaScript. His home on the Internet is his blog <a href="http://tore.darell.no">Sneaky Abstractions</a>.
+  Tore Darell is an independent developer based in Menton, France who specialises in cruft-free web applications using Ruby, Rails and unobtrusive JavaScript. You can follow him on <a href="http://twitter.com/toretore">Twitter</a>.
 <% end %>
 
 <%= author('Jeff Dean', 'zilkey') do %>


### PR DESCRIPTION
Replace with Twitter account, unless @toretore has a better
suggestion :ear: since http://tore.darell.no returns 404.

[ci skip]
