### PR TITLE
Raise an error for has_one associations which try to go :through a polymorphic association

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -46,6 +46,12 @@ module ActiveRecord
     end
   end
 
+  class HasOneAssociationPolymorphicThroughError < ActiveRecordError #:nodoc:
+    def initialize(owner_class_name, reflection)
+      super("Cannot have a has_one :through association '#{owner_class_name}##{reflection.name}' which goes through the polymorphic association '#{owner_class_name}##{reflection.through_reflection.name}'.")
+    end
+  end
+
   class HasManyThroughSourceAssociationNotFoundError < ActiveRecordError #:nodoc:
     def initialize(reflection)
       through_reflection      = reflection.through_reflection

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -821,6 +821,7 @@ module ActiveRecord
         end
 
         if through_reflection.polymorphic?
+          raise HasOneAssociationPolymorphicThroughError.new(active_record.name, self) if has_one?
           raise HasManyThroughAssociationPolymorphicThroughError.new(active_record.name, self)
         end
 

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -289,6 +289,12 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_has_one_through_polymorphic_association
+    assert_raise(ActiveRecord::HasOneAssociationPolymorphicThroughError) do
+      @member.premium_club
+    end
+  end
+
   def test_has_one_through_belongs_to_should_update_when_the_through_foreign_key_changes
     minivan = minivans(:cool_first)
 

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -27,6 +27,9 @@ class Member < ActiveRecord::Base
   has_many :clubs, :through => :current_memberships
 
   has_one :club_through_many, :through => :current_memberships, :source => :club
+
+  belongs_to :admittable, polymorphic: true
+  has_one :premium_club, through: :admittable
 end
 
 class SelfMember < ActiveRecord::Base


### PR DESCRIPTION
This PR addresses the missing exception dedicated to `has_one` associations which try to go :through a polymorphic association.

Issue raised by @georgemillo in #17263.
