### PR TITLE
specify protocol for external link to json project

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -13,7 +13,7 @@ module ActiveSupport
 
   module JSON
     # Dumps objects in JSON (JavaScript Object Notation).
-    # See www.json.org for more info.
+    # See http://www.json.org for more info.
     #
     #   ActiveSupport::JSON.encode({ team: 'rails', players: '36' })
     #   # => "{\"team\":\"rails\",\"players\":\"36\"}"


### PR DESCRIPTION
Without protocol specified, `RDoc` delivers `http://api.rubyonrails.org/classes/ActiveSupport/www.json.org` as resulting link.

[ci skip]
