### PR TITLE
specify protocol for external links to json project

### DIFF
--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -12,7 +12,7 @@ module ActiveSupport
     
     class << self
       # Parses a JSON string (JavaScript Object Notation) into a hash.
-      # See www.json.org for more info.
+      # See http://www.json.org for more info.
       #
       #   ActiveSupport::JSON.decode("{\"team\":\"rails\",\"players\":\"36\"}")
       #   => {"team" => "rails", "players" => "36"}

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -13,7 +13,7 @@ module ActiveSupport
 
   module JSON
     # Dumps objects in JSON (JavaScript Object Notation).
-    # See www.json.org for more info.
+    # See http://www.json.org for more info.
     #
     #   ActiveSupport::JSON.encode({ team: 'rails', players: '36' })
     #   # => "{\"team\":\"rails\",\"players\":\"36\"}"


### PR DESCRIPTION
Without protocol specified, `RDoc` delivers `http://api.rubyonrails.org/classes/ActiveSupport/www.json.org` as resulting link.

[ci skip]
