### PR TITLE
Remove duplicate stringify_keys in range_field_tag

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -790,7 +790,7 @@ module ActionView
       # ==== Options
       # * Accepts the same options as number_field_tag.
       def range_field_tag(name, value = nil, options = {})
-        number_field_tag(name, value, options.stringify_keys.update("type" => "range"))
+        number_field_tag(name, value, options.merge(type: :range))
       end
 
       # Creates the hidden UTF8 enforcer tag. Override this method in a helper


### PR DESCRIPTION
`range_field_tag` does not need to call `stringify_keys` on its `options` parameter since the invoked `number_field_tag` is [already doing it internally](https://github.com/claudiob/rails/blob/e3207bdbba55f3806441f22b175557579bc0b051/actionview/lib/action_view/helpers/form_tag_helper.rb#L780):

``` ruby
def number_field_tag(name, value = nil, options = {})
  options = options.stringify_keys
  ...
end
```

[Note 1: My code uses merge to respect the existing behavior of duplicating the options hash before updating its keys, see #17096 (comment)]

[Note 2: My code uses symbols instead of strings (e.g.: :hidden) to look forward to future version of Ruby/Raiks (GC symbols); the result of the method, however, is the same, because the symbols are stringified inside text_field_tag]

[Note 3: I had previously created a similar PR #17096 but decided to split it into multiple PRs given the feedback received in the comments]
