### PR TITLE
Return json when json is requested

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -13,7 +13,7 @@ module ActionDispatch
       'ActionController::NotImplemented'           => :not_implemented,
       'ActionController::UnknownFormat'            => :not_acceptable,
       'ActionController::InvalidAuthenticityToken' => :unprocessable_entity,
-      'ActionDispatch::ParamsParser::ParseError'   => :bad_request,
+      'ActionDispatch::ParamsParser::ParseError'   => :unprocessable_entity,
       'ActionController::BadRequest'               => :bad_request,
       'ActionController::ParameterMissing'         => :bad_request
     )

--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -25,6 +25,16 @@ module ActionDispatch
       end
 
       @app.call(env)
+    rescue ActionDispatch::ParamsParser::ParseError => error
+      if env['HTTP_ACCEPT'] =~ /application\/json/
+        error_output = "There was a problem in the JSON you submitted: #{error}"
+        return [
+          422, { "Content-Type" => "application/json" },
+          [ { status: 422, error: error_output }.to_json ]
+        ]
+      else
+        raise error
+      end
     end
 
     private

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -77,6 +77,21 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "returns a 422:unprocessable_entity status code if json is requested and invalid json is posted" do
+    with_test_routing do
+      begin
+        $stderr = StringIO.new # suppress the log
+        json = "[\"person]\": {\"name\": \"David\"}}"
+        post "/parse", json, {'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'}
+        assert_response :unprocessable_entity
+        content_type = response.headers['Content-Type']
+        assert_equal 'application/json', content_type
+      ensure
+        $stderr = STDERR
+      end
+    end
+  end
+
   test 'raw_post is not empty for JSON request' do
     with_test_routing do
       post '/parse', '{"posts": [{"title": "Post Title"}]}', 'CONTENT_TYPE' => 'application/json'

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -57,7 +57,7 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
       output = StringIO.new
       json = "[\"person]\": {\"name\": \"David\"}}"
       post "/parse", json, {'CONTENT_TYPE' => 'application/json', 'action_dispatch.show_exceptions' => true, 'action_dispatch.logger' => ActiveSupport::Logger.new(output)}
-      assert_response :bad_request
+      assert_response :unprocessable_entity
       output.rewind && err = output.read
       assert err =~ /Error occurred while parsing request parameters/
     end

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -39,8 +39,8 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     assert_equal "500 error fixture\n", body
 
     get "/bad_params", {}, {'action_dispatch.show_exceptions' => true}
-    assert_response 400
-    assert_equal "400 error fixture\n", body
+    assert_response 422
+    assert_equal "422 error fixture\n", body
 
     get "/not_found", {}, {'action_dispatch.show_exceptions' => true}
     assert_response 404

--- a/actionpack/test/fixtures/public/422.html
+++ b/actionpack/test/fixtures/public/422.html
@@ -1,0 +1,1 @@
+422 error fixture


### PR DESCRIPTION
422 (unprocessable_entity) seems like a more appropriate HTTP response code for unparsable json. Also, for a json api, it seems preferable if the response is json instead of an HTML error page.
