### PR TITLE
clarify debugger platform invocation

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -25,10 +25,11 @@ gem 'rails-dom-testing', github: 'rails/rails-dom-testing'
 
 group :development, :test do
 <% unless defined?(JRUBY_VERSION) -%>
-  # Call 'debugger' anywhere in the code to stop execution and get a debugger console
   <%- if RUBY_VERSION < '2.0.0' -%>
+  # Call 'debugger' anywhere in the code to stop execution and get a debugger console
   gem 'debugger'
   <%- else -%>
+  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
   <%- end -%>
 


### PR DESCRIPTION
The comment/instructions in the created Gemfile for invoking the debugger are incorrect for a higher version of Ruby when using the byebye gem. (i.e. you don't call `debugger`, you call `byebug` if you're using a more recent Ruby).
