### PR TITLE
Correct *ves singularization

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -36,7 +36,7 @@ module ActiveSupport
     inflect.singular(/([ti])a$/i, '\1um')
     inflect.singular(/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$/i, '\1sis')
     inflect.singular(/(^analy)(sis|ses)$/i, '\1sis')
-    inflect.singular(/([^f])ves$/i, '\1fe')
+    inflect.singular(/([^f])ves$/i, '\1ve')
     inflect.singular(/(hive)s$/i, '\1')
     inflect.singular(/(tive)s$/i, '\1')
     inflect.singular(/([lr])ves$/i, '\1f')


### PR DESCRIPTION
I ran into an issue recently building a Roman society simulator in Rails (!) and it took me a while to figure out that slaves was being incorrectly inflected to "slafes". Looking at the library, it looks like an error. I may well be wrong but right now the following would be incorrectly pluralized:

waves - wafe
raves - rafe
caves - cafe

...and so forth.
