### PR TITLE
mention the :without option [ci skip]

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -361,6 +361,8 @@ class Product < ActiveRecord::Base
 end
 ```
 
+Alternatively, you can require that the specified attribute does _not_ match the regular expression by using the `:without` option.
+
 The default error message is _"is invalid"_.
 
 ### `inclusion`


### PR DESCRIPTION
As pointed out in the `ActiveModel::Validations::HelperMethods #validates_format_of` documentation.
