### PR TITLE
Fix example code for `Rails::Generators::Testing::Behaviour`

### DIFF
--- a/railties/lib/rails/generators/testing/behaviour.rb
+++ b/railties/lib/rails/generators/testing/behaviour.rb
@@ -50,7 +50,7 @@ module Rails
         #   class AppGeneratorTest < Rails::Generators::TestCase
         #     tests AppGenerator
         #     destination File.expand_path("../tmp", File.dirname(__FILE__))
-        #     teardown :cleanup_destination_root
+        #     setup :prepare_destination
         #
         #     test "database.yml is not created when skipping Active Record" do
         #       run_generator %w(myapp --skip-active-record)


### PR DESCRIPTION
`cleanup_destination_root` method is not found anywhere.
Instead, `prepare_destination` clean up distination root on setup.
