### PR TITLE
Add a deprecation warning for abiguous boolean values

### DIFF
--- a/activerecord/lib/active_record/type/boolean.rb
+++ b/activerecord/lib/active_record/type/boolean.rb
@@ -10,8 +10,15 @@ module ActiveRecord
       def cast_value(value)
         if value == ''
           nil
+        elsif ConnectionAdapters::Column::TRUE_VALUES.include?(value)
+          true
         else
-          ConnectionAdapters::Column::TRUE_VALUES.include?(value)
+          if !ConnectionAdapters::Column::FALSE_VALUES.include?(value)
+            ActiveSupport::Deprecation.warn(<<-EOM)
+              You attempted to assign a value which is not explicitly true or false to a boolean column. Currently this value casts to false. This will change to match Ruby's sematics, and will cast to true in Rails 5.0. If you would like to maintain the current behavior, you should explicitly handle the values you would like cast to false.
+            EOM
+          end
+          false
         end
       end
     end

--- a/activerecord/test/cases/types_test.rb
+++ b/activerecord/test/cases/types_test.rb
@@ -29,10 +29,12 @@ module ActiveRecord
         assert_equal false, type.type_cast_from_user('FALSE')
         assert_equal false, type.type_cast_from_user('off')
         assert_equal false, type.type_cast_from_user('OFF')
-        assert_equal false, type.type_cast_from_user(' ')
-        assert_equal false, type.type_cast_from_user("\u3000\r\n")
-        assert_equal false, type.type_cast_from_user("\u0000")
-        assert_equal false, type.type_cast_from_user('SOMETHING RANDOM')
+        assert_deprecated do
+          assert_equal false, type.type_cast_from_user(' ')
+          assert_equal false, type.type_cast_from_user("\u3000\r\n")
+          assert_equal false, type.type_cast_from_user("\u0000")
+          assert_equal false, type.type_cast_from_user('SOMETHING RANDOM')
+        end
       end
 
       def test_type_cast_integer


### PR DESCRIPTION
In Rails 5.0, we'd like to change the behavior of boolean columns in
Rails to be closer to Ruby's semantics. Currently we have a small set
of values which are "truthy", and all others are "falsy". In Rails 5.0,
we will reverse this to have a small number of values which are "falsy",
and all others will become "truthy".

In the interim, all values which are ambiguous must emit a deprecation
warning.
