### PR TITLE
Add specs for adding-to/clear has_many collections’s behavior on `updated_at`

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -28,6 +28,7 @@ require 'models/college'
 require 'models/student'
 require 'models/pirate'
 require 'models/ship'
+require 'models/ship_part'
 require 'models/tyre'
 
 class HasManyAssociationsTestForReorderWithJoinDependency < ActiveRecord::TestCase
@@ -81,6 +82,30 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     Student.create(active: true, college_id: college.id, name: 'Sarah')
 
     assert_equal college.students, Student.where(active: true, college_id: college.id)
+  end
+
+  def test_add_record_to_collection_should_change_its_updated_at
+    ship = Ship.create(name: 'dauntless')
+    part = ShipPart.create(name: 'cockpit')
+    updated_at = part.updated_at
+
+    ship.parts << part
+
+    assert_equal part.ship, ship
+    assert_not_equal part.updated_at, updated_at
+  end
+
+  def test_clear_collection_should_not_change_updated_at
+    # GH#17161: .clear calls delete_all (and returns the association),
+    # which is intended to not touch associated objects's updated_at field
+    ship = Ship.create(name: 'dauntless')
+    part = ShipPart.create(name: 'cockpit', ship_id: ship.id)
+
+    ship.parts.clear
+    part.reload
+
+    assert_equal nil, part.ship
+    assert !part.updated_at_changed?
   end
 
   def test_create_from_association_should_respect_default_scope

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -650,6 +650,7 @@ ActiveRecord::Schema.define do
   create_table :ship_parts, force: true do |t|
     t.string :name
     t.integer :ship_id
+    t.datetime :updated_at
   end
 
   create_table :speedometers, force: true, id: false do |t|


### PR DESCRIPTION
There are behaviors mentioned in #17161 that:
1. are not documented properly, and
2. don't have specs

This PR addresses the spec absence. For `has_many` collections,
1. addition (`<<`) should update the associated object's `updated_at` (if any)
2. `.clear`, depending on `options[:dependent]`, calls `delete_all`, `destroy_all`, or nullifies the associated object(s)' foreign key.
