### PR TITLE
Add necessary 'require reverse_merge' to HAWI.rb

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/hash/keys'
+require 'active_support/core_ext/hash/reverse_merge'
 
 module ActiveSupport
   # Implements a hash where keys <tt>:foo</tt> and <tt>"foo"</tt> are considered

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -1,0 +1,10 @@
+require 'abstract_unit'
+require 'active_support/hash_with_indifferent_access'
+
+class HashWithIndifferentAccessTest < ActiveSupport::TestCase
+  def test_reverse_merge
+    hash = HashWithIndifferentAccess.new key: :old_value
+    hash.reverse_merge! key: :new_value
+    assert_equal :old_value, hash[:key]
+  end
+end


### PR DESCRIPTION
Hashes with indifferent access should support `reverse_merge` out-of-the-box but they don't; for instance the following code fails:

``` ruby
require 'active_support'
require 'active_support/hash_with_indifferent_access'
hash = HashWithIndifferentAccess.new key: :old_value
hash.reverse_merge key: :new_value
# => NoMethodError: super: no superclass method `reverse_merge' for {"key"=>:old_value}:ActiveSupport::HashWithIndifferentAccess

```

This PR fixes the case above by simply requiring `active_support/core_ext/hash/reverse_merge` in `hash_with_indifferent_access.rb` and adding a test that confirms the fix.

---

Here are more details about the bugfix.
Currently, `reverse_merge` is [defined in HashWithIndifferentAccess](https://github.com/rails/rails/blob/4e8ea13ba1a0870905a46fac5f232d9f41eef8a4/activesupport/lib/active_support/hash_with_indifferent_access.rb#L208) by invoking `super`, that is by invoking `Hash#reverse_merge`:

``` ruby
def reverse_merge(other_hash)
  super(self.class.new_from_hash_copying_default(other_hash))
end
```

However, Ruby's `Hash` does not have the `reverse_merge` by default: it must be added by ActiveSupport, and that requires the following line of code to be present:

``` ruby
require 'active_support/core_ext/hash/reverse_merge'
```
