### PR TITLE
Replace (slower) block.call with (faster) yield

### DIFF
--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -216,11 +216,11 @@ module ActionController #:nodoc:
     #
     # Be sure to check the documentation of +respond_with+ and
     # <tt>ActionController::MimeResponds.respond_to</tt> for more examples.
-    def respond_to(*mimes, &block)
+    def respond_to(*mimes)
       raise ArgumentError, "respond_to takes either types or a block, never both" if mimes.any? && block_given?
 
       collector = Collector.new(mimes, request.variant)
-      block.call(collector) if block_given?
+      yield collector if block_given?
 
       if format = collector.negotiate_format(request)
         _process_format(format)

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -357,11 +357,11 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   private
-  def m(name, version, &block)
+  def m(name, version)
     x = Sensor.new name, version
     x.extend(Module.new {
-      define_method(:up) { block.call(:up, x); super() }
-      define_method(:down) { block.call(:down, x); super() }
+      define_method(:up) { yield(:up, x); super() }
+      define_method(:down) { yield(:down, x); super() }
     }) if block_given?
   end
 

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -90,7 +90,7 @@ module ActiveSupport
       #     Time.current # => Wed, 24 Nov 2004 01:04:44 EST -05:00
       #   end
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
-      def travel_to(date_or_time, &block)
+      def travel_to(date_or_time)
         if date_or_time.is_a?(Date) && !date_or_time.is_a?(DateTime)
           now = date_or_time.midnight.to_time
         else
@@ -102,7 +102,7 @@ module ActiveSupport
 
         if block_given?
           begin
-            block.call
+            yield
           ensure
             travel_back
           end

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -85,10 +85,10 @@ module Rails
       #   environment(nil, env: "development") do
       #     "config.autoload_paths += %W(#{config.root}/extras)"
       #   end
-      def environment(data=nil, options={}, &block)
+      def environment(data=nil, options={})
         sentinel = /class [a-z_:]+ < Rails::Application/i
         env_file_sentinel = /Rails\.application\.configure do/
-        data = block.call if !data && block_given?
+        data = yield if !data && block_given?
 
         in_root do
           if options[:env].nil?

--- a/railties/lib/rails/generators/actions/create_migration.rb
+++ b/railties/lib/rails/generators/actions/create_migration.rb
@@ -39,7 +39,7 @@ module Rails
 
         protected
 
-        def on_conflict_behavior(&block)
+        def on_conflict_behavior
           options = base.options.merge(config)
           if identical?
             say_status :identical, :blue, relative_existing_migration
@@ -48,7 +48,7 @@ module Rails
             say_status :create, :green
             unless pretend?
               ::FileUtils.rm_rf(existing_migration)
-              block.call
+              yield
             end
           elsif options[:skip]
             say_status :skip, :yellow


### PR DESCRIPTION
Performance optimization: `yield` with an implicit `block` is faster than `block.call`.
See http://youtu.be/fGFM_UrSp70?t=10m35s and the following benchmark:

``` ruby
require 'benchmark/ips'

def fast
 yield
end

def slow(&block)
 block.call
end

Benchmark.ips do |x|
 x.report('fast') { fast{} }
 x.report('slow') { slow{} }
end

# => fast    154095 i/100ms
# => slow     71454 i/100ms

# => fast  7511067.8 (±5.0%) i/s -   37445085 in   4.999660s
# => slow  1227576.9 (±6.8%) i/s -    6145044 in   5.028356s
```
