### PR TITLE
If Rails is not defined, check ENV["RAILS_ENV"] and ENV["RACK_ENV"] in ActiveRecord::ConnectionHandling

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -1,6 +1,6 @@
 module ActiveRecord
   module ConnectionHandling
-    RAILS_ENV   = -> { Rails.env if defined?(Rails) }
+    RAILS_ENV   = -> { (Rails.env if defined?(Rails)) || ENV["RAILS_ENV"] || ENV["RACK_ENV"] }
     DEFAULT_ENV = -> { RAILS_ENV.call || "default_env" }
 
     # Establishes the connection to the database. Accepts a hash as input where

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -5,10 +5,14 @@ module ActiveRecord
     class MergeAndResolveDefaultUrlConfigTest < ActiveRecord::TestCase
       def setup
         @previous_database_url = ENV.delete("DATABASE_URL")
+        @previous_rack_env = ENV.delete("RACK_ENV")
+        @previous_rails_env = ENV.delete("RAILS_ENV")
       end
 
       teardown do
         ENV["DATABASE_URL"] = @previous_database_url
+        ENV["RACK_ENV"] = @previous_rack_env
+        ENV["RAILS_ENV"] = @previous_rails_env
       end
 
       def resolve_config(config)
@@ -27,11 +31,51 @@ module ActiveRecord
         assert_equal expected, actual
       end
 
+      def test_resolver_with_database_uri_and_current_env_symbol_key_and_rails_env
+        ENV['DATABASE_URL'] = "postgres://localhost/foo"
+        ENV['RAILS_ENV']    = "foo"
+
+        config   = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
+        actual   = resolve_spec(:foo, config)
+        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost" }
+        assert_equal expected, actual
+      end
+
+      def test_resolver_with_database_uri_and_current_env_symbol_key_and_rack_env
+        ENV['DATABASE_URL'] = "postgres://localhost/foo"
+        ENV['RACK_ENV']     = "foo"
+
+        config   = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
+        actual   = resolve_spec(:foo, config)
+        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost" }
+        assert_equal expected, actual
+      end
+
       def test_resolver_with_database_uri_and_and_current_env_string_key
         ENV['DATABASE_URL'] = "postgres://localhost/foo"
         config   = { "default_env" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
         actual   = assert_deprecated { resolve_spec("default_env", config) }
         expected = { "adapter"=>"postgresql", "database"=>"foo", "host"=>"localhost" }
+        assert_equal expected, actual
+      end
+
+      def test_resolver_with_database_uri_and_and_current_env_string_key_and_rails_env
+        ENV['DATABASE_URL'] = "postgres://localhost/foo"
+        ENV['RAILS_ENV'] = "foo"
+
+        config   = { "not_production" => {"adapter" => "not_postgres", "database" => "not_foo" } }
+        actual   = assert_deprecated { resolve_spec("foo", config) }
+        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost" }
+        assert_equal expected, actual
+      end
+
+      def test_resolver_with_database_uri_and_and_current_env_string_key_and_rack_env
+        ENV['DATABASE_URL'] = "postgres://localhost/foo"
+        ENV['RACK_ENV'] = "foo"
+
+        config   = { "not_production" => {"adapter" => "not_postgres", "database" => "not_foo" } }
+        actual   = assert_deprecated { resolve_spec("foo", config) }
+        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost" }
         assert_equal expected, actual
       end
 
@@ -139,6 +183,51 @@ module ActiveRecord
         assert_equal nil,      actual["production"]
         assert_equal nil,      actual["development"]
         assert_equal nil,      actual["test"]
+        assert_equal nil,      actual[:default_env]
+        assert_equal nil,      actual[:production]
+        assert_equal nil,      actual[:development]
+        assert_equal nil,      actual[:test]
+      end
+
+      def test_blank_with_database_url_with_rails_env
+        ENV['RAILS_ENV'] = "not_production"
+        ENV['DATABASE_URL'] = "postgres://localhost/foo"
+
+        config   = {}
+        actual   = resolve_config(config)
+        expected = { "adapter"  => "postgresql",
+                     "database" => "foo",
+                     "host"     => "localhost" }
+
+        assert_equal expected, actual["not_production"]
+        assert_equal nil,      actual["production"]
+        assert_equal nil,      actual["default_env"]
+        assert_equal nil,      actual["development"]
+        assert_equal nil,      actual["test"]
+        assert_equal nil,      actual[:default_env]
+        assert_equal nil,      actual[:not_production]
+        assert_equal nil,      actual[:production]
+        assert_equal nil,      actual[:development]
+        assert_equal nil,      actual[:test]
+      end
+
+      def test_blank_with_database_url_with_rack_env
+        ENV['RACK_ENV'] = "not_production"
+        ENV['DATABASE_URL'] = "postgres://localhost/foo"
+
+        config   = {}
+        actual   = resolve_config(config)
+        expected = { "adapter"  => "postgresql",
+                     "database" => "foo",
+                     "host"     => "localhost" }
+
+        assert_equal expected, actual["not_production"]
+        assert_equal nil,      actual["production"]
+        assert_equal nil,      actual["default_env"]
+        assert_equal nil,      actual["development"]
+        assert_equal nil,      actual["test"]
+        assert_equal nil,      actual[:default_env]
+        assert_equal nil,      actual[:not_production]
         assert_equal nil,      actual[:production]
         assert_equal nil,      actual[:development]
         assert_equal nil,      actual[:test]


### PR DESCRIPTION
This fixes a regression introduced by 6cc0367.

ActiveRecord, if used without Rails, always checks the "default_env" environment. This would be OK, except that Sinatra also supports environments, and it runs with {RACK|RAILS}_ENV=production. This patch adds a fallback to RAILS_ENV and RACK_ENV (and ultimately default_env) if Rails.env doesn't exist.

Feedback requested on the tests, because I feel like there may need to be some more work there.

Also, this can probably cleanly apply against 4.1's stable branch.

Output of `rake test:sqlite3`:

```
Finished in 31.919725s, 132.6766 runs/s, 365.8866 assertions/s.

4235 runs, 11679 assertions, 0 failures, 0 errors, 2 skips

You have skipped tests. Run with --verbose for details.
```
