### PR TITLE
Use each_with_object instead of inject

### DIFF
--- a/activesupport/test/load_paths_test.rb
+++ b/activesupport/test/load_paths_test.rb
@@ -2,12 +2,11 @@ require 'abstract_unit'
 
 class LoadPathsTest < ActiveSupport::TestCase
   def test_uniq_load_paths
-    load_paths_count = $LOAD_PATH.inject({}) { |paths, path|
+    load_paths_count = $LOAD_PATH.each_with_object({}) do |path, paths|
       expanded_path = File.expand_path(path)
       paths[expanded_path] ||= 0
       paths[expanded_path] += 1
-      paths
-    }
+    end
     load_paths_count[File.expand_path('../../lib', __FILE__)] -= 1
 
     load_paths_count.select! { |k, v| v > 1 }


### PR DESCRIPTION
Replace use of `inject` with `each_with_object` making the code shorter and a easier to read 
