### PR TITLE
Deprecate :only_path option on *_url helper

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Deprecate ignored :only_path option on *_url helper.
+
+    The :only_path option is no longer valid on *_url helper methods.
+    Use the *_path helper instead.
+
+    Fixes #17294.
+
+    *Dan Olson*
+
 *   Improve Journey compliance to RFC 3986.
 
     The scanner in Journey failed to recognize routes that use literals

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -37,11 +37,16 @@ module ActionDispatch
         end
 
         def full_url_for(options)
+          if options[:only_path]
+            ActiveSupport::Deprecation.warn "Passing an :only_path option to a *_url helper is " \
+              "deprecated and will be removed in a future version. The *_url " \
+              "helper is for generating a full url, not just a path."
+          end
           host     = options[:host]
           protocol = options[:protocol]
           port     = options[:port]
 
-          unless host
+          unless host || options[:only_path]
             raise ArgumentError, 'Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true'
           end
 
@@ -91,6 +96,7 @@ module ActionDispatch
         end
 
         def build_host_url(host, port, protocol, options, path)
+          return path unless host
           if match = host.match(HOST_REGEXP)
             protocol ||= match[1] unless protocol == false
             host       = match[2]

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -69,6 +69,16 @@ module ActionDispatch
         end
       end
 
+      test ":only_path option with *_url" do
+        draw do
+          get 'foo', to: SimpleApp.new('foo#index')
+        end
+
+        assert_deprecated do
+          assert_equal '/foo', url_helpers.foo_url(:only_path => true)
+        end
+      end
+
       test "explicit keys win over implicit keys" do
         draw do
           resources :foo do


### PR DESCRIPTION
The :only_path option is being ignored in *_url helper methods. This deprecates it and encourages the use of the *_path helper instead.

Addresses #17294.
