### PR TITLE
Call gsub with a Regexp instead of a String

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -90,7 +90,7 @@ module ActiveSupport
     #   'SSLError'.underscore.camelize # => "SslError"
     def underscore(camel_cased_word)
       return camel_cased_word unless camel_cased_word =~ /[A-Z-]|::/
-      word = camel_cased_word.to_s.gsub('::', '/')
+      word = camel_cased_word.to_s.gsub(/::/, '/')
       word.gsub!(/(?:(?<=([A-Za-z\d]))|\b)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1 && '_'}#{$2.downcase}" }
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
       word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')

--- a/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
@@ -13,7 +13,7 @@ module ActiveSupport
         end
 
         rounded_number = NumberToRoundedConverter.convert(number, options)
-        format.gsub('%n', rounded_number).gsub('%u', options[:unit])
+        format.gsub(/%n/, rounded_number).gsub(/%u/, options[:unit])
       end
 
       private

--- a/activesupport/lib/active_support/number_helper/number_to_percentage_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_percentage_converter.rb
@@ -5,7 +5,7 @@ module ActiveSupport
 
       def convert
         rounded_number = NumberToRoundedConverter.convert(number, options)
-        options[:format].gsub('%n', rounded_number)
+        options[:format].gsub(/%n/, rounded_number)
       end
     end
   end


### PR DESCRIPTION
String#gsub works around 13% faster when using a Regexp in lieu of a String.
