### PR TITLE
Optimize TimeWithZoneTest#strftime

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   TimeWithZone#strftime now delegates every directive to Time#strftime except for '%Z',
+    it also now correctly handles escaped '%' characters placed just before time zone related directives.
+
+    *Pablo Herrero*
+
 *   Corrected Inflector#underscore handling of multiple successive acroynms.
 
     *James Le Cuirot*

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -75,8 +75,8 @@ module ActiveSupport
 
     # Returns a <tt>Time.local()</tt> instance of the simultaneous time in your
     # system's <tt>ENV['TZ']</tt> zone.
-    def localtime
-      utc.respond_to?(:getlocal) ? utc.getlocal : utc.to_time.getlocal
+    def localtime(utc_offset = nil)
+      utc.respond_to?(:getlocal) ? utc.getlocal(utc_offset) : utc.to_time.getlocal(utc_offset)
     end
     alias_method :getlocal, :localtime
 
@@ -201,15 +201,11 @@ module ActiveSupport
     end
     alias_method :to_formatted_s, :to_s
 
-    # Replaces <tt>%Z</tt> and <tt>%z</tt> directives with +zone+ and
-    # +formatted_offset+, respectively, before passing to Time#strftime, so
-    # that zone information is correct
+    # Replaces <tt>%Z</tt> directive with +zone before passing to Time#strftime,
+    # so that zone information is correct.
     def strftime(format)
-      format = format.gsub('%Z', zone)
-                     .gsub('%z',   formatted_offset(false))
-                     .gsub('%:z',  formatted_offset(true))
-                     .gsub('%::z', formatted_offset(true) + ":00")
-      time.strftime(format)
+      format = format.gsub(/((?:\A|[^%])(?:%%)*)%Z/, "\\1#{zone}")
+      getlocal(utc_offset).strftime(format)
     end
 
     # Use the time in UTC for comparisons.

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -79,6 +79,11 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal '1999-12-31 19:00:00 EST -0500', @twz.strftime('%Y-%m-%d %H:%M:%S %Z %z')
   end
 
+  def test_strftime_with_escaping
+    assert_equal '%Z %z', @twz.strftime('%%Z %%z')
+    assert_equal '%EST %-0500', @twz.strftime('%%%Z %%%z')
+  end
+
   def test_inspect
     assert_equal 'Fri, 31 Dec 1999 19:00:00 EST -05:00', @twz.inspect
   end


### PR DESCRIPTION
Replace TimeWithZoneTest#strftime, with a version that doesn't create unnecessary String instances and avoid unnecessary method calls. 

Some benchmarks:

``` ruby
#Worse scenario, every formating option present (from TimeWithZone) in use: 73% faster
Benchmark.ips do |bm|
  bm.report('original') { @twz.strftime_original('%Y-%m-%d %H:%M:%S %Z %z %:z %::z') }
  bm.report('optimized') { @twz.strftime('%Y-%m-%d %H:%M:%S %Z %z %:z %::z') }
end

#Calculating -------------------------------------
#            original      2331 i/100ms
#           optimized      3990 i/100ms
#-------------------------------------------------
#            original    24536.5 (±1.1%) i/s -     123543 in   5.035705s
#           optimized    42606.0 (±1.2%) i/s -     215460 in   5.057748s

#With 2 formating options: 2.9 times faster
Benchmark.ips do |bm|
  bm.report('original') { @twz.strftime_original('%Y-%m-%d %H:%M:%S %Z %z') }
  bm.report('optimized') { @twz.strftime('%Y-%m-%d %H:%M:%S %Z %z') }
end

#Calculating -------------------------------------
#            original      2598 i/100ms
#           optimized      6959 i/100ms
#-------------------------------------------------
#            original    27054.3 (±1.0%) i/s -     137694 in   5.090060s
#           optimized    79036.4 (±1.4%) i/s -     396663 in   5.019817s


#With 1 formating options: 5.5 times faster
Benchmark.ips do |bm|
  bm.report('original') { @twz.strftime_original('%Y-%m-%d %H:%M:%S %Z') }
  bm.report('optimized') { @twz.strftime('%Y-%m-%d %H:%M:%S %Z') }
end

#Calculating -------------------------------------
#            original      2742 i/100ms
#           optimized     12840 i/100ms
#-------------------------------------------------
#            original    29109.9 (±1.4%) i/s -     148068 in   5.087531s
#           optimized   160027.8 (±1.1%) i/s -     808920 in   5.055439s



#With no formating options: 8.1 times faster
Benchmark.ips do |bm|
  bm.report('original') { @twz.strftime_original('%Y-%m-%d %H:%M:%S') }
  bm.report('optimized') { @twz.strftime('%Y-%m-%d %H:%M:%S') }
end

#Calculating -------------------------------------
#            original      2974 i/100ms
#           optimized     19257 i/100ms
#-------------------------------------------------
#            original    31817.4 (±1.0%) i/s -     160596 in   5.047983s
#           optimized   258589.2 (±3.2%) i/s -    1309476 in   5.070831s
```
