### PR TITLE
Mark eager loaded has_one as loaded fix #17166

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -242,14 +242,18 @@ module ActiveRecord
           else
             if ar_parent.association_cache.key?(node.reflection.name)
               model = ar_parent.association(node.reflection.name).target
-              construct(model, node, row, rs, seen, model_cache, aliases)
+              construct(model, node, row, rs, seen, model_cache, aliases) if model
               next
             end
           end
 
           key = aliases.column_alias(node, node.primary_key)
           id = row[key]
-          next if id.nil?
+          if id.nil?
+            other = ar_parent.association(node.reflection.name)
+            other.loaded!
+            next
+          end
 
           model = seen[parent.base_klass][primary_id][node.base_klass][id]
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -704,6 +704,11 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal companies(:first_firm, :reload).account, f.account
   end
 
+  def test_eager_with_has_one_does_not_issue_extra_queries_for_nulls
+    post = Post.all.merge!(:eager_load => [ :very_special_comment ]).find(3)
+    assert_no_queries { post.very_special_comment }
+  end
+
   def test_eager_with_multi_table_conditional_properly_counts_the_records_when_using_size
     author = authors(:david)
     posts_with_no_comments = author.posts.select { |post| post.comments.blank? }


### PR DESCRIPTION
Fix n query case on eager loaded has_one associations, see #17166 
