### PR TITLE
Replace checking start/end of string

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -18,7 +18,7 @@ module AbstractController
         @path  = "helpers/#{path}.rb"
         set_backtrace error.backtrace
 
-        if error.path =~ /^#{path}(\.rb)?$/
+        if error.path.start_with?(path) && error.path.end_with?('.rb', '')
           super("Missing helper file helpers/%s.rb" % path)
         else
           raise error

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -244,8 +244,10 @@ module ActionController
 
     def recycle!
       @formats = nil
-      @env.delete_if { |k, v| k =~ /^(action_dispatch|rack)\.request/ }
-      @env.delete_if { |k, v| k =~ /^action_dispatch\.rescue/ }
+      @env.delete_if do |k, _|
+        k.start_with?('action_dispatch.request', 'rack.request')
+      end
+      @env.delete_if { |k, _| k.start_with?('action_dispatch.rescue') }
       @method = @request_method = nil
       @fullpath = @ip = @remote_ip = @protocol = nil
       @env['action_dispatch.request.query_parameters'] = {}

--- a/actionpack/lib/action_dispatch/journey/visitors.rb
+++ b/actionpack/lib/action_dispatch/journey/visitors.rb
@@ -87,8 +87,8 @@ module ActionDispatch
           def visit_DOT(n);     terminal(n); end
 
           private_instance_methods(false).each do |pim|
-            next unless pim =~ /^visit_(.*)$/
-            DISPATCH_CACHE[$1.to_sym] = pim
+            next unless pim.to_s.start_with?('visit_')
+            DISPATCH_CACHE[pim[/^visit_(.*)$/, 1].to_sym] = pim
           end
       end
 

--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -65,7 +65,7 @@ module ActionDispatch
       end
 
       def gzip_file_path(path)
-        can_gzip_mime = content_type(path) =~ /\A(?:text\/|application\/javascript)/
+        can_gzip_mime = content_type(path).start_with?('text/', 'application/', 'javascript')
         gzip_path     = "#{path}.gz"
         if can_gzip_mime && File.exist?(File.join(@root, ::Rack::Utils.unescape(gzip_path)))
           gzip_path

--- a/actionpack/lib/action_dispatch/testing/assertions.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions.rb
@@ -12,7 +12,7 @@ module ActionDispatch
     include Rails::Dom::Testing::Assertions
 
     def html_document
-      @html_document ||= if @response.content_type =~ /xml$/
+      @html_document ||= if @response.content_type.end_with?('xml')
         Nokogiri::XML::Document.parse(@response.body)
       else
         Nokogiri::HTML::DocumentFragment.parse(@response.body)

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -533,7 +533,7 @@ class MetalIntegrationTest < ActionDispatch::IntegrationTest
 
   class Poller
     def self.call(env)
-      if env["PATH_INFO"] =~ /^\/success/
+      if env["PATH_INFO"].start_with?("/success")
         [200, {"Content-Type" => "text/plain", "Content-Length" => "12"}, ["Hello World!"]]
       else
         [404, {"Content-Type" => "text/plain", "Content-Length" => "0"}, []]

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3478,7 +3478,7 @@ private
   end
 
   def method_missing(method, *args, &block)
-    if method.to_s =~ /_(path|url)$/
+    if method.to_s.end_with?('_path', '_url')
       @app.routes.url_helpers.send(method, *args, &block)
     else
       super

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -210,7 +210,7 @@ module ActionView
 
         src = options[:src] = path_to_image(source)
 
-        unless src =~ /^(?:cid|data):/ || src.blank?
+        unless src.start_with?('cid:', 'data:') || src.blank?
           options[:alt] = options.fetch(:alt){ image_alt(src) }
         end
 

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -80,7 +80,7 @@ module ActionView
       case layout
       when String
         begin
-          if layout =~ /^\//
+          if layout.start_with?('/')
             with_fallbacks { find_template(layout, nil, false, keys, @details) }
           else
             find_template(layout, nil, false, keys, @details)

--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -22,7 +22,7 @@ module ActiveRecord
 
       def load(yaml)
         return object_class.new if object_class != Object && yaml.nil?
-        return yaml unless yaml.is_a?(String) && yaml =~ /^---/
+        return yaml unless yaml.is_a?(String) && yaml.start_with?('---')
         obj = YAML.load(yaml)
 
         unless obj.is_a?(object_class) || obj.nil?

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -249,7 +249,7 @@ module ActiveRecord
         # hash and merges with the rest of the hash.
         # Connection details inside of the "url" key win any merge conflicts
         def resolve_hash_connection(spec)
-          if spec["url"] && spec["url"] !~ /^jdbc:/
+          if spec["url"] && !spec["url"].start_with?('jdbc:')
             connection_hash = resolve_url_connection(spec.delete("url"))
             spec.merge!(connection_hash)
           end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -263,7 +263,7 @@ module ActiveRecord
       # Returns an array of column objects where the primary id, all columns ending in "_id" or "_count",
       # and columns used for single table inheritance have been removed.
       def content_columns
-        @content_columns ||= columns.reject { |c| c.name == primary_key || c.name =~ /(_id|_count)$/ || c.name == inheritance_column }
+        @content_columns ||= columns.reject { |c| c.name == primary_key || c.name.end_with?('_id', '_count') || c.name == inheritance_column }
       end
 
       # Resets all the cached information about columns, which will cause them

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -86,7 +86,7 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
   end
 
   def test_calculate_honors_implicit_inner_joins_and_distinct_and_conditions
-    real_count = Author.all.to_a.select {|a| a.posts.any? {|p| p.title =~ /^Welcome/} }.length
+    real_count = Author.all.to_a.select {|a| a.posts.any? {|p| p.title.start_with?('Welcome')} }.length
     authors_with_welcoming_post_titles = Author.all.merge!(joins: :posts, where: "posts.title like 'Welcome%'").distinct.calculate(:count, 'authors.id')
     assert_equal real_count, authors_with_welcoming_post_titles, "inner join and conditions should have only returned authors posting titles starting with 'Welcome'"
   end

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -29,7 +29,7 @@ class CallbackDeveloper < ActiveRecord::Base
   end
 
   ActiveRecord::Callbacks::CALLBACKS.each do |callback_method|
-    next if callback_method.to_s =~ /^around_/
+    next if callback_method.to_s.start_with?('around_')
     define_callback_method(callback_method)
     send(callback_method, callback_string(callback_method))
     send(callback_method, callback_proc(callback_method))

--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -10,7 +10,7 @@ module ActiveSupport
         super
       end
 
-      instance_methods.each { |m| undef_method m unless m =~ /^__|^object_id$/ }
+      instance_methods.each { |m| undef_method m unless m.to_s.start_with?('__', 'object_id') }
 
       # Don't give a deprecation warning on inspect since test/unit and error
       # logs rely on it for diagnostics.

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -57,7 +57,7 @@ module ActiveSupport #:nodoc:
       # Forward all undefined methods to the wrapped string.
       def method_missing(method, *args, &block)
         result = @wrapped_string.__send__(method, *args, &block)
-        if method.to_s =~ /!$/
+        if method.to_s.end_with?('!')
           self if result
         else
           result.kind_of?(String) ? chars(result) : result

--- a/activesupport/lib/active_support/option_merger.rb
+++ b/activesupport/lib/active_support/option_merger.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/hash/deep_merge'
 module ActiveSupport
   class OptionMerger #:nodoc:
     instance_methods.each do |method|
-      undef_method(method) if method !~ /^(__|instance_eval|class|object_id)/
+      undef_method(method) unless method.to_s.start_with?('__', 'instance_eval', 'class', 'object_id')
     end
 
     def initialize(context, options)

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -118,8 +118,8 @@ class TestJSONEncoding < ActiveSupport::TestCase
       begin
         prev = ActiveSupport.use_standard_json_time_format
 
-        ActiveSupport.escape_html_entities_in_json  = class_tests !~ /^Standard/
-        ActiveSupport.use_standard_json_time_format = class_tests =~ /^Standard/
+        ActiveSupport.escape_html_entities_in_json  = !class_tests.to_s.start_with?('Standard')
+        ActiveSupport.use_standard_json_time_format = class_tests.to_s.start_with?('Standard')
         self.class.const_get(class_tests).each do |pair|
           assert_equal pair.last, sorted_json(ActiveSupport::JSON.encode(pair.first))
         end

--- a/activesupport/test/multibyte_conformance_test.rb
+++ b/activesupport/test/multibyte_conformance_test.rb
@@ -112,7 +112,7 @@ class MultibyteConformanceTest < ActiveSupport::TestCase
         until f.eof? || (max_test_lines > 38 and lines > max_test_lines)
           lines += 1
           line = f.gets.chomp!
-          next if (line.empty? || line =~ /^\#/)
+          next if (line.empty? || line.start_with?('#'))
 
           cols, comment = line.split("#")
           cols = cols.split(";").map{|e| e.strip}.reject{|e| e.empty? }

--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -34,7 +34,7 @@ module Rails
           if available_environments.include? env
             options[:environment] = env
           else
-            options[:environment] = %w(production development test).detect {|e| e =~ /^#{env}/} || env
+            options[:environment] = %w(production development test).detect {|e| e.start_with?(env)} || env
           end
         end
 

--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -142,7 +142,7 @@ module Rails
         if available_environments.include? env
           options[:environment] = env
         else
-          options[:environment] = %w(production development test).detect {|e| e =~ /^#{env}/} || env
+          options[:environment] = %w(production development test).detect {|e| e.start_with?(env)} || env
         end
       end
 

--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -226,7 +226,7 @@ module Rails
         # Invoke source_root so the default_source_root is set.
         base.source_root
 
-        if base.name && base.name !~ /Base$/
+        if base.name && !base.name.end_with?('Base')
           Rails::Generators.subclasses << base
 
           Rails::Generators.templates_path.each do |path|

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -118,7 +118,7 @@ module Rails
       end
 
       def foreign_key?
-        !!(name =~ /_id$/)
+        name.end_with?('_id')
       end
 
       def reference?
@@ -142,7 +142,7 @@ module Rails
       end
 
       def password_digest?
-        name == 'password' && type == :digest 
+        name == 'password' && type == :digest
       end
 
       def inject_options

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -301,7 +301,7 @@ module Rails
       end
 
       def valid_const?
-        if app_const =~ /^\d/
+        if app_const.start_with?("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
           raise Error, "Invalid application name #{app_name}. Please give a name which does not start with numbers."
         elsif RESERVED_NAMES.include?(app_name)
           raise Error, "Invalid application name #{app_name}. Please give a name which does not match one of the reserved rails words."

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -329,7 +329,7 @@ task default: :test
       def valid_const?
         if original_name =~ /[^0-9a-zA-Z_]+/
           raise Error, "Invalid plugin name #{original_name}. Please give a name which use only alphabetic or numeric or \"_\" characters."
-        elsif camelized =~ /^\d/
+        elsif camelized.start_with?("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
           raise Error, "Invalid plugin name #{original_name}. Please give a name which does not start with numbers."
         elsif RESERVED_NAMES.include?(name)
           raise Error, "Invalid plugin name #{original_name}. Please give a name which does not match one of the reserved rails words."
@@ -381,7 +381,7 @@ end
       end
 
       def inside_application?
-        rails_app_path && app_path =~ /^#{rails_app_path}/
+        rails_app_path && app_path.start_with?(rails_app_path.to_s)
       end
 
       def relative_path

--- a/railties/lib/rails/test_unit/sub_test_task.rb
+++ b/railties/lib/rails/test_unit/sub_test_task.rb
@@ -81,7 +81,7 @@ module Rails
       end
 
       def test_file?(file)
-        file =~ /^test/ && File.file?(file) && !File.directory?(file)
+        file.start_with?('test') && File.file?(file) && !File.directory?(file)
       end
 
       def opt_names


### PR DESCRIPTION
Replace `=~ /^str/`, `=~ /str$/`, `!~ /^str/`, and `!~ /str$/` to `start_with?` and `end_with?` when possible. Mostly it's 1,6x faster, some more impressive benchmarks:

**actionpack/lib/abstract_controller/helpers.rb**:

``` ruby
Benchmark.ips do |x|
  x.report('=~') { error.path =~ /^#{path}(\.rb)?$/ }
  x.report('start/end') { error.path.start_with?(path) && error.path.end_with?('.rb', '') }
  x.compare!
end
```

```
Calculating -------------------------------------
                  =~      7097 i/100ms
           start/end     29688 i/100ms
-------------------------------------------------
                  =~   104752.3 (±8.3%) i/s -     525178 in   5.049548s
           start/end  2423935.7 (±10.8%) i/s -   11964264 in   5.003489s

Comparison:
           start/end:  2423935.7 i/s
                  =~:   104752.3 i/s - 23.14x slower
```
## 

**actionpack/lib/action_dispatch/journey/visitors.rb**:

``` ruby
Benchmark.ips do |x|
  x.report('=~') do
    next unless pim =~ /^visit_(.*)$/
    DISPATCH_CACHE[$1.to_sym] = pim
  end
  x.report('start/end') do
    next unless pim.to_s.start_with?('visit_')
    DISPATCH_CACHE[pim[/^visit_(.*)$/, 1].to_sym] = pim
  end
  x.compare!
end
```

```
Calculating -------------------------------------
                  =~     58993 i/100ms
           start/end     73946 i/100ms
-------------------------------------------------
                  =~  1832025.8 (±6.6%) i/s -    9143915 in   5.012602s
           start/end  2944646.4 (±8.2%) i/s -   14641308 in   5.006457s

Comparison:
           start/end:  2944646.4 i/s
                  =~:  1832025.8 i/s - 1.61x slower
```
## 

**actionview/lib/action_view/helpers/asset_tag_helper.rb**:

``` ruby
Benchmark.ips do |x|
  x.report('=~') { src =~ /^(?:cid|data):/ }
  x.report('start/end') { src.start_with?('cid:', 'data:') }
  x.compare!
end
```

```
Calculating -------------------------------------
                  =~     26869 i/100ms
           start/end     29965 i/100ms
-------------------------------------------------
                  =~  1853626.9 (±8.5%) i/s -    9189198 in   4.996903s
           start/end  2894114.5 (±13.0%) i/s -   14173445 in   4.993368s

Comparison:
           start/end:  2894114.5 i/s
                  =~:  1853626.9 i/s - 1.56x slower
```
## 

**actionview/lib/action_view/renderer/template_renderer.rb**:

``` ruby
Benchmark.ips do |x|
  x.report('=~') { layout =~ /^\// }
  x.report('start/end') { layout.start_with?('/') }
  x.compare!
end
```

```
Calculating -------------------------------------
                  =~     25597 i/100ms
           start/end     33362 i/100ms
-------------------------------------------------
                  =~  1451851.0 (±9.4%) i/s -    7192757 in   5.000724s
           start/end  4360476.8 (±14.0%) i/s -   21251594 in   4.996049s

Comparison:
           start/end:  4360476.8 i/s
                  =~:  1451851.0 i/s - 3.00x slower
```
## 

**activesupport/lib/active_support/multibyte/chars.rb**:

``` ruby
Benchmark.ips do |x|
  x.report('=~') { method.to_s =~ /!$/ }
  x.report('start/end') { method.to_s.end_with?('!') }
  x.compare!
end
```

```
Calculating -------------------------------------
                  =~     25899 i/100ms
           start/end     30125 i/100ms
-------------------------------------------------
                  =~  2046233.9 (±9.2%) i/s -   10126509 in   4.998104s
           start/end  3313337.1 (±12.0%) i/s -   16267500 in   4.994593s

Comparison:
           start/end:  3313337.1 i/s
                  =~:  2046233.9 i/s - 1.62x slower
```
