### PR TITLE
Document overloaded button_to method with sdoc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'bcrypt', '~> 3.1.7', require: false
 gem 'uglifier', '>= 1.3.0', require: false
 
 group :doc do
-  gem 'sdoc', '~> 0.4.0'
+  gem 'sdoc', github: 'voloko/sdoc' #, '~> 0.4.2'
   gem 'redcarpet', '~> 3.1.2', platforms: :ruby
   gem 'w3c_validators'
   gem 'kindlerb'

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -276,6 +276,11 @@ module ActionView
       #   #       <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"/>
       #   #     </form>"
       #   #
+      #
+      # :call-seq:
+      #   button_to(name = nil, options = nil, html_options = nil)
+      #   button_to(options = nil, html_options = nil, &block)
+      #
       def button_to(name = nil, options = nil, html_options = nil, &block)
         html_options, options = options, name if block_given?
         options      ||= {}


### PR DESCRIPTION
This PR helps readers understand that `button_to` can be called with two different sets of parameters by replacing its documentation title from:

![old](https://cloud.githubusercontent.com/assets/10076/4693667/4ad55dee-57a6-11e4-9fdf-ee4999576fca.png)

to:

![new](https://cloud.githubusercontent.com/assets/10076/4693668/4adb7a08-57a6-11e4-849e-565332048ae9.png)

This PR stems from [a Google Group discussion](https://groups.google.com/forum/#!topic/rubyonrails-core/_BZXBWXuuP4) where @fxn said:

> So I'd like a solution similar to the one in the Ruby API (only covers return type), something compact that stays out of the way, but it is there if you want to look at it. If :call-seq: was not enough we could perhaps define a new directive. Time will say.

Rails code-base already uses `:call-seq:` in other places like [this](https://github.com/rails/rails/blob/0dfc4fa1774296ebbbf891f101e2a39225af6502/actionpack/lib/abstract_controller/callbacks.rb#L160) and [this](https://github.com/rails/rails/blob/0dfc4fa1774296ebbbf891f101e2a39225af6502/activemodel/lib/active_model/naming.rb#L127-127) and `:call-seq` is also what is used in the documentation of the Ruby language to indicate methods that can be overloaded.

[ci skip]

---

Side note on this commit: `sdoc` is being loaded from GitHub in order to include the change made by https://github.com/voloko/sdoc/pull/78 -- eventually, that change might be included in 0.4.2 and `sdoc` included from RubyGems again.
