### PR TITLE
Fix Relation#rewhere to work with Range values

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `Relation.rewhere` to work with Range values.
+
+    *Dan Olson*
+
 *   `AR::UnknownAttributeError` now includes the class name of a record.
 
         User.new(name: "Yuki Nishijima", project_attributes: {name: "kaminari"})

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -913,7 +913,7 @@ module ActiveRecord
 
       where_values.reject! do |rel|
         case rel
-        when Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality, Arel::Nodes::NotEqual
+        when Arel::Nodes::Between, Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality, Arel::Nodes::NotEqual
           subrelation = (rel.left.kind_of?(Arel::Attributes::Attribute) ? rel.left : rel.right)
           subrelation.name == target_value
         end

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -149,5 +149,12 @@ module ActiveRecord
       assert_bound_ast value, Post.arel_table['title'], Arel::Nodes::Equality
       assert_equal 'alone', bind.last
     end
+
+    def test_rewhere_with_range
+      relation = Post.where(comments_count: 1..3).rewhere(comments_count: 3..5)
+
+      assert_equal 1, relation.where_values.size
+      assert_equal Post.where(comments_count: 3..5), relation
+    end
   end
 end


### PR DESCRIPTION
I noticed `Relation.rewhere` wasn't working with ranges:

``` ruby
Post.where(comments_count: 1..3).rewhere(comments_count: 3..5).to_sql
=> "SELECT \"posts\".* FROM \"posts\" WHERE (\"posts\".\"comments_count\" BETWEEN 1 AND 3) AND (\"posts\".\"comments_count\" BETWEEN 3 AND 5)"
```

This patch ensures the above relation produces the correct SQL:

``` ruby
Post.where(comments_count: 1..3).rewhere(comments_count: 3..5).to_sql
=> "SELECT \"posts\".* FROM \"posts\" WHERE (\"posts\".\"comments_count\" BETWEEN 3 AND 5)"
```
