### PR TITLE
Log rotation by default in development and test environments

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Log rotation by default in development and test environments
+
+    *Alexey Gaziev*
+
 *   Remove `--skip-action-view` option from `Rails::Generators::AppBase`.
 
     Fixes #17023.

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -39,7 +39,11 @@ INFO
           f.binmode
           f.sync = config.autoflush_log # if true make sure every write flushes
 
-          logger = ActiveSupport::Logger.new f
+          logger_args = [f]
+          logger_args << config.logger_shift_age
+          logger_args << config.logger_shift_size if config.logger_shift_age.to_i > 0
+
+          logger = ActiveSupport::Logger.new(*logger_args.compact)
           logger.formatter = config.log_formatter
           logger = ActiveSupport::TaggedLogging.new(logger)
           logger

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -9,7 +9,8 @@ module Rails
       attr_accessor :allow_concurrency, :asset_host, :assets, :autoflush_log,
                     :cache_classes, :cache_store, :consider_all_requests_local, :console,
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters,
-                    :force_ssl, :helpers_paths, :logger, :log_formatter, :log_tags,
+                    :force_ssl, :helpers_paths,
+                    :logger, :logger_shift_age, :logger_shift_size, :log_formatter, :log_tags,
                     :railties_order, :relative_url_root, :secret_key_base, :secret_token,
                     :serve_static_assets, :ssl_options, :static_cache_control, :session_options,
                     :time_zone, :reload_classes_only_on_change,
@@ -45,6 +46,8 @@ module Rails
         @exceptions_app                = nil
         @autoflush_log                 = true
         @log_formatter                 = ActiveSupport::Logger::SimpleFormatter.new
+        @logger_shift_age              = nil
+        @logger_shift_size             = nil
         @eager_load                    = nil
         @secret_token                  = nil
         @secret_key_base               = nil

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -42,4 +42,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Rotates the log automatically every week
+  config.logger_shift_age  = 'weekly'
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -39,4 +39,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Rotates the log automatically. Keeps 5 files, each sized 10MB
+  config.logger_shift_age  = 5
+  config.logger_shift_size = 10 * 1024 * 1024 # 10 megabytes
 end


### PR DESCRIPTION
I think many of rails developers have faced problem with the enormous big log files for dev and test environments. Those who have large amount of integration and acceptance tests know what I mean. Most of the time we don't need such amount of logged information in those environments. The most that we need is to look into the last few requests or check the last test logs if it fails. I propose to rotate logs in dev and test environments automatically by default. However, I'm not sure about the size and amount of the log files we should keep. What do you think?
