### PR TITLE
Make ActionMailer::Base more consistent in style

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -564,7 +564,7 @@ module ActionMailer
       end
       # Allows to set the name of current mailer.
       attr_writer :mailer_name
-      alias :controller_path :mailer_name
+      alias_method :controller_path, :mailer_name
 
       # Sets the defaults through app configuration:
       #
@@ -577,8 +577,8 @@ module ActionMailer
       end
       # Allows to set defaults through app configuration:
       #
-      alias :default_options= :default
       #  config.action_mailer.default_options = { from: 'no-reply@example.org' }
+      alias_method :default_options=, :default
 
       # Receives a raw email, parses it into an email object, decodes it,
       # instantiates a new mailer, and passes the email object to the mailer

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -7,7 +7,8 @@ require 'active_support/core_ext/module/anonymous'
 require 'action_mailer/log_subscriber'
 
 module ActionMailer
-  # Action Mailer allows you to send email from your application using a mailer model and views.
+  # Action Mailer allows you to send email from your application using a mailer
+  # model and views.
   #
   # = Mailer Models
   #
@@ -15,9 +16,10 @@ module ActionMailer
   #
   #   $ rails generate mailer Notifier
   #
-  # The generated model inherits from <tt>ActionMailer::Base</tt>. A mailer model defines methods
-  # used to generate an email message. In these methods, you can setup variables to be used in
-  # the mailer views, options on the mail itself such as the <tt>:from</tt> address, and attachments.
+  # The generated model inherits from <tt>ActionMailer::Base</tt>. A mailer
+  # model defines methods used to generate an email message. In these methods,
+  # you can setup variables to be used in the mailer views, options on the mail
+  # itself such as the <tt>:from</tt> address, and attachments.
   #
   #   class Notifier < ActionMailer::Base
   #     default from: 'no-reply@example.com',
@@ -30,29 +32,37 @@ module ActionMailer
   #     end
   #   end
   #
-  # Within the mailer method, you have access to the following methods:
+  # Within testing testing the mailer method, you have access to the following
+  # methods:
   #
-  # * <tt>attachments[]=</tt> - Allows you to add attachments to your email in an intuitive
-  #   manner; <tt>attachments['filename.png'] = File.read('path/to/filename.png')</tt>
+  # * <tt>attachments[]=</tt> - Allows you to add attachments to your email in
+  #   an intuitive manner;
+  #   <tt>attachments['filename.png'] = File.read('path/to/filename.png')</tt>
   #
-  # * <tt>attachments.inline[]=</tt> - Allows you to add an inline attachment to your email
-  #   in the same manner as <tt>attachments[]=</tt>
+  # * <tt>attachments.inline[]=</tt> - Allows you to add an inline attachment
+  #   to your email in the same manner as <tt>attachments[]=</tt>
   #
-  # * <tt>headers[]=</tt> - Allows you to specify any header field in your email such
-  #   as <tt>headers['X-No-Spam'] = 'True'</tt>. Note that declaring a header multiple times
-  #   will add many fields of the same name. Read #headers doc for more information.
+  # * <tt>headers[]=</tt> - Allows you to specify any header field in your email
+  #   such as <tt>headers['X-No-Spam'] = 'True'</tt>. Note that declaring a
+  #   header multiple times will add many fields of the same name. Read #headers
+  #   doc for more information.
   #
-  # * <tt>headers(hash)</tt> - Allows you to specify multiple headers in your email such
-  #   as <tt>headers({'X-No-Spam' => 'True', 'In-Reply-To' => '1234@message.id'})</tt>
+  # * <tt>headers(hash)</tt> - Allows you to specify multiple headers in your
+  #   email such as
+  #   <tt>
+  #     headers({'X-No-Spam' => 'True', 'In-Reply-To' => '1234@message.id'})
+  #   </tt>
   #
   # * <tt>mail</tt> - Allows you to specify email to be sent.
   #
-  # The hash passed to the mail method allows you to specify any header that a <tt>Mail::Message</tt>
-  # will accept (any valid email header including optional fields).
+  # The hash passed to the mail method allows you to specify any header that a
+  # <tt>Mail::Message</tt> will accept (any valid email header including
+  # optional fields).
   #
-  # The mail method, if not passed a block, will inspect your views and send all the views with
-  # the same name as the method, so the above action would send the +welcome.text.erb+ view
-  # file as well as the +welcome.text.html.erb+ view file in a +multipart/alternative+ email.
+  # The mail method, if not passed a block, will inspect your views and send all
+  # the views with the same name as the method, so the above action would send
+  # the +welcome.text.erb+ view file as well as the +welcome.text.html.erb+ view
+  # file in a +multipart/alternative+ email.
   #
   # If you want to explicitly render only certain templates, pass a block:
   #
@@ -77,16 +87,20 @@ module ActionMailer
   #
   # = Mailer views
   #
-  # Like Action Controller, each mailer class has a corresponding view directory in which each
-  # method of the class looks for a template with its name.
+  # Like Action Controller, each mailer class has a corresponding view directory
+  # in which each method of the class looks for a template with its name.
   #
-  # To define a template to be used with a mailing, create an <tt>.erb</tt> file with the same
-  # name as the method in your mailer model. For example, in the mailer defined above, the template at
-  # <tt>app/views/notifier/welcome.text.erb</tt> would be used to generate the email.
+  # To define a template to be used with a mailing, create an <tt>.erb</tt> file
+  # with the same name as the method in your mailer model. For example, in the
+  # mailer defined above, the template at
+  # <tt>app/views/notifier/welcome.text.erb</tt> would be used to generate the
+  # email.
   #
-  # Variables defined in the model are accessible as instance variables in the view.
+  # Variables defined in the model are accessible as instance variables in the
+  # view.
   #
-  # Emails by default are sent in plain text, so a sample view for our model example might look like this:
+  # Emails by default are sent in plain text, so a sample view for our model
+  # example might look like this:
   #
   #   Hi <%= @account.name %>,
   #   Thanks for joining our service! Please check back often.
@@ -96,7 +110,8 @@ module ActionMailer
   #   You got a new note!
   #   <%= truncate(@note.body, length: 25) %>
   #
-  # If you need to access the subject, from or the recipients in the view, you can do that through message object:
+  # If you need to access the subject, from or the recipients in the view, you
+  # can do that through message object:
   #
   #   You got a new note from <%= message.from %>!
   #   <%= truncate(@note.body, length: 25) %>
@@ -104,11 +119,13 @@ module ActionMailer
   #
   # = Generating URLs
   #
-  # URLs can be generated in mailer views using <tt>url_for</tt> or named routes. Unlike controllers from
-  # Action Pack, the mailer instance doesn't have any context about the incoming request, so you'll need
-  # to provide all of the details needed to generate a URL.
+  # URLs can be generated in mailer views using <tt>url_for</tt> or named
+  # routes. Unlike controllers from Action Pack, the mailer instance doesn't
+  # have any context about the incoming request, so you'll need to provide all
+  # of the details needed to generate a URL.
   #
-  # When using <tt>url_for</tt> you'll need to provide the <tt>:host</tt>, <tt>:controller</tt>, and <tt>:action</tt>:
+  # When using <tt>url_for</tt> you'll need to provide the <tt>:host</tt>,
+  # <tt>:controller</tt>, and <tt>:action</tt>:
   #
   #   <%= url_for(host: "example.com", controller: "welcome", action: "greeting") %>
   #
@@ -116,47 +133,55 @@ module ActionMailer
   #
   #   <%= users_url(host: "example.com") %>
   #
-  # You should use the <tt>named_route_url</tt> style (which generates absolute URLs) and avoid using the
-  # <tt>named_route_path</tt> style (which generates relative URLs), since clients reading the mail will
-  # have no concept of a current URL from which to determine a relative path.
+  # You should use the <tt>named_route_url</tt> style (which generates absolute
+  # URLs) and avoid using the <tt>named_route_path</tt> style (which generates
+  # relative URLs), since clients reading the mail will have no concept of a
+  # current URL from which to determine a relative path.
   #
-  # It is also possible to set a default host that will be used in all mailers by setting the <tt>:host</tt>
-  # option as a configuration option in <tt>config/application.rb</tt>:
+  # It is also possible to set a default host that will be used in all mailers
+  # by setting the <tt>:host</tt> option as a configuration option in
+  # <tt>config/application.rb</tt>:
   #
   #   config.action_mailer.default_url_options = { host: "example.com" }
   #
-  # When you decide to set a default <tt>:host</tt> for your mailers, then you need to make sure to use the
-  # <tt>only_path: false</tt> option when using <tt>url_for</tt>. Since the <tt>url_for</tt> view helper
-  # will generate relative URLs by default when a <tt>:host</tt> option isn't explicitly provided, passing
-  # <tt>only_path: false</tt> will ensure that absolute URLs are generated.
+  # When you decide to set a default <tt>:host</tt> for your mailers, then you
+  # need to make sure to use the <tt>only_path: false</tt> option when using
+  # <tt>url_for</tt>. Since the <tt>url_for</tt> view helper will generate
+  # relative URLs by default when a <tt>:host</tt> option isn't explicitly
+  # provided, passing <tt>only_path: false</tt> will ensure that absolute URLs
+  # are generated.
   #
   # = Sending mail
   #
-  # Once a mailer action and template are defined, you can deliver your message or create it and save it
-  # for delivery later:
+  # Once a mailer action and template are defined, you can deliver your message
+  # or create it and save it for delivery later:
   #
   #   Notifier.welcome(User.first).deliver_now # sends the email
-  #   mail = Notifier.welcome(User.first)      # => an ActionMailer::MessageDelivery object
-  #   mail.deliver_now                    # sends the email
+  #   mail = Notifier.welcome(User.first)  # => an ActionMailer::MessageDelivery object
+  #   mail.deliver_now  # sends the email
   #
-  # The <tt>ActionMailer::MessageDelivery</tt> class is a wrapper around a <tt>Mail::Message</tt> object. If
-  # you want direct access to the <tt>Mail::Message</tt> object you can call the <tt>message</tt> method on
+  # The <tt>ActionMailer::MessageDelivery</tt> class is a wrapper around a
+  # <tt>Mail::Message</tt> object. If you want direct access to the
+  # <tt>Mail::Message</tt> object you can call the <tt>message</tt> method on
   # the <tt>ActionMailer::MessageDelivery</tt> object.
   #
-  #   Notifier.welcome(User.first).message     # => a Mail::Message object
+  #   Notifier.welcome(User.first).message  # => a Mail::Message object
   #
-  # Action Mailer is nicely integrated with Active Job so you can send emails in the background (example: outside
-  # of the request-response cycle, so the user doesn't have to wait on it):
+  # Action Mailer is nicely integrated with Active Job so you can send emails
+  # in the background (example: outside of the request-response cycle, so the
+  # user doesn't have to wait on it):
   #
   #   Notifier.welcome(User.first).deliver_later # enqueue the email sending to Active Job
   #
-  # You never instantiate your mailer class. Rather, you just call the method you defined on the class itself.
+  # You never instantiate your mailer class. Rather, you just call the method
+  # you defined on the class itself.
   #
   # = Multipart Emails
   #
-  # Multipart messages can also be used implicitly because Action Mailer will automatically detect and use
-  # multipart templates, where each template is named after the name of the action, followed by the content
-  # type. Each such detected template will be added as a separate part to the message.
+  # Multipart messages can also be used implicitly because Action Mailer will
+  # automatically detect and use multipart templates, where each template is
+  # named after the name of the action, followed by the content type. Each such
+  # detected template will be added as a separate part to the message.
   #
   # For example, if the following templates exist:
   # * signup_notification.text.erb
@@ -164,14 +189,17 @@ module ActionMailer
   # * signup_notification.xml.builder
   # * signup_notification.yml.erb
   #
-  # Each would be rendered and added as a separate part to the message, with the corresponding content
-  # type. The content type for the entire message is automatically set to <tt>multipart/alternative</tt>,
-  # which indicates that the email contains multiple different representations of the same email
-  # body. The same instance variables defined in the action are passed to all email templates.
+  # Each would be rendered and added as a separate part to the message, with the
+  # corresponding content type. The content type for the entire message is
+  # automatically set to <tt>multipart/alternative</tt>, which indicates that
+  # the email contains multiple different representations of the same email
+  # body. The same instance variables defined in the action are passed to all
+  # email templates.
   #
-  # Implicit template rendering is not performed if any attachments or parts have been added to the email.
-  # This means that you'll have to manually add each part to the email and set the content type of the email
-  # to <tt>multipart/alternative</tt>.
+  # Implicit template rendering is not performed if any attachments or parts
+  # have been added to the email. This means that you'll have to manually add
+  # each part to the email and set the content type of the email to
+  # <tt>multipart/alternative</tt>.
   #
   # = Attachments
   #
@@ -184,14 +212,15 @@ module ActionMailer
   #     end
   #   end
   #
-  # Which will (if it had both a <tt>welcome.text.erb</tt> and <tt>welcome.html.erb</tt>
-  # template in the view directory), send a complete <tt>multipart/mixed</tt> email with two parts,
-  # the first part being a <tt>multipart/alternative</tt> with the text and HTML email parts inside,
-  # and the second being a <tt>application/pdf</tt> with a Base64 encoded copy of the file.pdf book
-  # with the filename +free_book.pdf+.
+  # Which will (if it had both a <tt>welcome.text.erb</tt> and
+  # <tt>welcome.html.erb</tt> template in the view directory), send a complete
+  # <tt>multipart/mixed</tt> email with two parts, the first part being a
+  # <tt>multipart/alternative</tt> with the text and HTML email parts inside,
+  # and the second being a <tt>application/pdf</tt> with a Base64 encoded copy
+  # of the file.pdf book with the filename +free_book.pdf+.
   #
-  # If you need to send attachments with no content, you need to create an empty view for it,
-  # or add an empty body parameter like this:
+  # If you need to send attachments with no content, you need to create an empty
+  # view for it, or add an empty body parameter like this:
   #
   #     class ApplicationMailer < ActionMailer::Base
   #       def welcome(recipient)
@@ -202,8 +231,8 @@ module ActionMailer
   #
   # = Inline Attachments
   #
-  # You can also specify that a file should be displayed inline with other HTML. This is useful
-  # if you want to display a corporate logo or a photo.
+  # You can also specify that a file should be displayed inline with other HTML.
+  # This is useful if you want to display a corporate logo or a photo.
   #
   #   class ApplicationMailer < ActionMailer::Base
   #     def welcome(recipient)
@@ -212,15 +241,17 @@ module ActionMailer
   #     end
   #   end
   #
-  # And then to reference the image in the view, you create a <tt>welcome.html.erb</tt> file and
-  # make a call to +image_tag+ passing in the attachment you want to display and then call
-  # +url+ on the attachment to get the relative content id path for the image source:
+  # And then to reference the image in the view, you create a
+  # <tt>welcome.html.erb</tt> file and make a call to +image_tag+ passing in the
+  # attachment you want to display and then call +url+ on the attachment to get
+  # the relative content id path for the image source:
   #
   #   <h1>Please Don't Cringe</h1>
   #
   #   <%= image_tag attachments['photo.png'].url -%>
   #
-  # As we are using Action View's +image_tag+ method, you can pass in any other options you want:
+  # As we are using Action View's +image_tag+ method, you can pass in any other
+  # options you want:
   #
   #   <h1>Please Don't Cringe</h1>
   #
@@ -228,47 +259,52 @@ module ActionMailer
   #
   # = Observing and Intercepting Mails
   #
-  # Action Mailer provides hooks into the Mail observer and interceptor methods. These allow you to
-  # register classes that are called during the mail delivery life cycle.
+  # Action Mailer provides hooks into the Mail observer and interceptor methods.
+  # These allow you to register classes that are called during the mail delivery
+  # life cycle.
   #
-  # An observer class must implement the <tt>:delivered_email(message)</tt> method which will be
-  # called once for every email sent after the email has been sent.
+  # An observer class must implement the <tt>:delivered_email(message)</tt>
+  # method which will be called once for every email sent after the email has
+  # been sent.
   #
-  # An interceptor class must implement the <tt>:delivering_email(message)</tt> method which will be
-  # called before the email is sent, allowing you to make modifications to the email before it hits
-  # the delivery agents. Your class should make any needed modifications directly to the passed
+  # An interceptor class must implement the <tt>:delivering_email(message)</tt>
+  # method which will be called before the email is sent, allowing you to make
+  # modifications to the email before it hits the delivery agents. Your class
+  # should make any needed modifications directly to the passed
   # in <tt>Mail::Message</tt> instance.
   #
   # = Default Hash
   #
-  # Action Mailer provides some intelligent defaults for your emails, these are usually specified in a
-  # default method inside the class definition:
+  # Action Mailer provides some intelligent defaults for your emails, these are
+  # usually specified in a default method inside the class definition:
   #
   #   class Notifier < ActionMailer::Base
   #     default sender: 'system@example.com'
   #   end
   #
-  # You can pass in any header value that a <tt>Mail::Message</tt> accepts. Out of the box,
-  # <tt>ActionMailer::Base</tt> sets the following:
+  # You can pass in any header value that a <tt>Mail::Message</tt> accepts.
+  # Out of the box, <tt>ActionMailer::Base</tt> sets the following:
   #
-  # * <tt>mime_version: "1.0"</tt>
-  # * <tt>charset:      "UTF-8",</tt>
-  # * <tt>content_type: "text/plain",</tt>
-  # * <tt>parts_order:  [ "text/plain", "text/enriched", "text/html" ]</tt>
+  # * <tt>mime_version: '1.0'</tt>
+  # * <tt>charset:      'UTF-8',</tt>
+  # * <tt>content_type: 'text/plain',</tt>
+  # * <tt>parts_order:  [ 'text/plain', 'text/enriched', 'text/html' ]</tt>
   #
-  # <tt>parts_order</tt> and <tt>charset</tt> are not actually valid <tt>Mail::Message</tt> header fields,
-  # but Action Mailer translates them appropriately and sets the correct values.
+  # <tt>parts_order</tt> and <tt>charset</tt> are not actually valid
+  # <tt>Mail::Message</tt> header fields, but Action Mailer translates them
+  # appropriately and sets the correct values.
   #
-  # As you can pass in any header, you need to either quote the header as a string, or pass it in as
-  # an underscored symbol, so the following will work:
+  # As you can pass in any header, you need to either quote the header as a
+  # string, or pass it in as an underscored symbol, so the following will work:
   #
   #   class Notifier < ActionMailer::Base
   #     default 'Content-Transfer-Encoding' => '7bit',
   #             content_description: 'This is a description'
   #   end
   #
-  # Finally, Action Mailer also supports passing <tt>Proc</tt> objects into the default hash, so you
-  # can define methods that evaluate as the message is being generated:
+  # Finally, Action Mailer also supports passing <tt>Proc</tt> objects into the
+  # default hash, so you can define methods that evaluate as the message is
+  # being generated:
   #
   #   class Notifier < ActionMailer::Base
   #     default 'X-Special-Header' => Proc.new { my_method }
@@ -280,20 +316,23 @@ module ActionMailer
   #       end
   #   end
   #
-  # Note that the proc is evaluated right at the start of the mail message generation, so if you
-  # set something in the defaults using a proc, and then set the same thing inside of your
-  # mailer method, it will get over written by the mailer method.
+  # Note that the proc is evaluated right at the start of the mail message
+  # generation, so if you set something in the defaults using a proc, and then
+  # set the same thing inside of your mailer method, it will get over written by
+  # the mailer method.
   #
-  # It is also possible to set these default options that will be used in all mailers through
-  # the <tt>default_options=</tt> configuration in <tt>config/application.rb</tt>:
+  # It is also possible to set these default options that will be used in all
+  # mailers through the <tt>default_options=</tt> configuration in
+  # <tt>config/application.rb</tt>:
   #
   #    config.action_mailer.default_options = { from: "no-reply@example.org" }
   #
   # = Callbacks
   #
-  # You can specify callbacks using before_action and after_action for configuring your messages.
-  # This may be useful, for example, when you want to add default inline attachments for all
-  # messages sent out by a certain mailer class:
+  # You can specify callbacks using before_action and after_action for
+  # configuring your messages. This may be useful, for example, when you want to
+  # add default inline attachments for all messages sent out by a certain mailer
+  # class:
   #
   #   class Notifier < ActionMailer::Base
   #     before_action :add_inline_attachment!
@@ -314,14 +353,16 @@ module ActionMailer
   # callbacks in the same manner that you would use callbacks in classes that
   # inherit from <tt>ActionController::Base</tt>.
   #
-  # Note that unless you have a specific reason to do so, you should prefer using before_action
-  # rather than after_action in your Action Mailer classes so that headers are parsed properly.
+  # Note that unless you have a specific reason to do so, you should prefer
+  # using before_action rather than after_action in your Action Mailer classes
+  # so that headers are parsed properly.
   #
   # = Previewing emails
   #
-  # You can preview your email templates visually by adding a mailer preview file to the
-  # <tt>ActionMailer::Base.preview_path</tt>. Since most emails do something interesting
-  # with database data, you'll need to write some scenarios to load messages with fake data:
+  # You can preview your email templates visually by adding a mailer preview
+  # file to the <tt>ActionMailer::Base.preview_path</tt>. Since most emails do
+  # something interesting with database data, you'll need to write some
+  # scenarios to load messages with fake data:
   #
   #   class NotifierPreview < ActionMailer::Preview
   #     def welcome
@@ -329,18 +370,21 @@ module ActionMailer
   #     end
   #   end
   #
-  # Methods must return a <tt>Mail::Message</tt> object which can be generated by calling the mailer
-  # method without the additional <tt>deliver_now</tt> / <tt>deliver_later</tt>. The location of the
-  # mailer previews directory can be configured using the <tt>preview_path</tt> option which has a default
-  # of <tt>test/mailers/previews</tt>:
+  # Methods must return a <tt>Mail::Message</tt> object which can be generated
+  # by calling the mailer method without the additional
+  # <tt>deliver_now</tt> / <tt>deliver_later</tt>. The location of the mailer
+  # previews directory can be configured using the <tt>preview_path</tt> option
+  # which has a default of <tt>test/mailers/previews</tt>:
   #
   #   config.action_mailer.preview_path = "#{Rails.root}/lib/mailer_previews"
   #
-  # An overview of all previews is accessible at <tt>http://localhost:3000/rails/mailers</tt>
-  # on a running development server instance.
+  # An overview of all previews is accessible at
+  # <tt>http://localhost:3000/rails/mailers</tt> on a running development server
+  # instance.
   #
-  # Previews can also be intercepted in a similar manner as deliveries can be by registering
-  # a preview interceptor that has a <tt>previewing_email</tt> method:
+  # Previews can also be intercepted in a similar manner as deliveries can be by
+  # registering a preview interceptor that has a <tt>previewing_email</tt>
+  # method:
   #
   #   class CssInlineStyler
   #     def self.previewing_email(message)
@@ -350,63 +394,83 @@ module ActionMailer
   #
   #   config.action_mailer.preview_interceptors :css_inline_styler
   #
-  # Note that interceptors need to be registered both with <tt>register_interceptor</tt>
-  # and <tt>register_preview_interceptor</tt> if they should operate on both sending and
-  # previewing emails.
+  # Note that interceptors need to be registered both with
+  # <tt>register_interceptor</tt>
+  # and <tt>register_preview_interceptor</tt> if they should operate on both
+  # sending and previewing emails.
   #
   # = Configuration options
   #
   # These options are specified on the class level, like
   # <tt>ActionMailer::Base.raise_delivery_errors = true</tt>
   #
-  # * <tt>default_options</tt> - You can pass this in at a class level as well as within the class itself as
-  #   per the above section.
+  # * <tt>default_options</tt> - You can pass this in at a class level as well
+  #   as within the class itself as per the above section.
   #
-  # * <tt>logger</tt> - the logger is used for generating information on the mailing run if available.
-  #   Can be set to +nil+ for no logging. Compatible with both Ruby's own +Logger+ and Log4r loggers.
+  # * <tt>logger</tt> - the logger is used for generating information on the
+  #   mailing run if available. Can be set to +nil+ for no logging.
+  #   Compatible with both Ruby's own +Logger+ and Log4r loggers.
   #
-  # * <tt>smtp_settings</tt> - Allows detailed configuration for <tt>:smtp</tt> delivery method:
-  #   * <tt>:address</tt> - Allows you to use a remote mail server. Just change it from its default
-  #     "localhost" setting.
-  #   * <tt>:port</tt> - On the off chance that your mail server doesn't run on port 25, you can change it.
-  #   * <tt>:domain</tt> - If you need to specify a HELO domain, you can do it here.
-  #   * <tt>:user_name</tt> - If your mail server requires authentication, set the username in this setting.
-  #   * <tt>:password</tt> - If your mail server requires authentication, set the password in this setting.
-  #   * <tt>:authentication</tt> - If your mail server requires authentication, you need to specify the
-  #     authentication type here.
-  #     This is a symbol and one of <tt>:plain</tt> (will send the password in the clear), <tt>:login</tt> (will
-  #     send password Base64 encoded) or <tt>:cram_md5</tt> (combines a Challenge/Response mechanism to exchange
-  #     information and a cryptographic Message Digest 5 algorithm to hash important information)
-  #   * <tt>:enable_starttls_auto</tt> - Detects if STARTTLS is enabled in your SMTP server and starts
-  #     to use it. Defaults to <tt>true</tt>.
-  #   * <tt>:openssl_verify_mode</tt> - When using TLS, you can set how OpenSSL checks the certificate. This is
-  #     really useful if you need to validate a self-signed and/or a wildcard certificate. You can use the name
-  #     of an OpenSSL verify constant (<tt>'none'</tt>, <tt>'peer'</tt>, <tt>'client_once'</tt>,
-  #     <tt>'fail_if_no_peer_cert'</tt>) or directly the constant (<tt>OpenSSL::SSL::VERIFY_NONE</tt>,
+  # * <tt>smtp_settings</tt> - Allows detailed configuration for <tt>:smtp</tt>
+  #   delivery method:
+  #   * <tt>:address</tt> - Allows you to use a remote mail server. Just change
+  #     it from its default 'localhost' setting.
+  #   * <tt>:port</tt> - On the off chance that your mail server doesn't run on
+  #     port 25, you can change it.
+  #   * <tt>:domain</tt> - If you need to specify a HELO domain, you can do it
+  #     here.
+  #   * <tt>:user_name</tt> - If your mail server requires authentication, set
+  #     the username in this setting.
+  #   * <tt>:password</tt> - If your mail server requires authentication, set
+  #     the password in this setting.
+  #   * <tt>:authentication</tt> - If your mail server requires authentication,
+  #     you need to specify the authentication type here.
+  #     This is a symbol and one of <tt>:plain</tt> (will send the password in
+  #     the clear), <tt>:login</tt> (will send password Base64 encoded) or
+  #     <tt>:cram_md5</tt> (combines a Challenge/Response mechanism to exchange
+  #     information and a cryptographic Message Digest 5 algorithm to hash
+  #     important information)
+  #   * <tt>:enable_starttls_auto</tt> - Detects if STARTTLS is enabled in your
+  #     SMTP server and starts to use it. Defaults to <tt>true</tt>.
+  #   * <tt>:openssl_verify_mode</tt> - When using TLS, you can set how OpenSSL
+  #     checks the certificate. This is really useful if you need to validate a
+  #     self-signed and/or a wildcard certificate. You can use the name of an
+  #     OpenSSL verify constant (<tt>'none'</tt>, <tt>'peer'</tt>,
+  #     <tt>'client_once'</tt>, <tt>'fail_if_no_peer_cert'</tt>) or directly the
+  #     constant (<tt>OpenSSL::SSL::VERIFY_NONE</tt>,
   #     <tt>OpenSSL::SSL::VERIFY_PEER</tt>, ...).
   #
-  # * <tt>sendmail_settings</tt> - Allows you to override options for the <tt>:sendmail</tt> delivery method.
-  #   * <tt>:location</tt> - The location of the sendmail executable. Defaults to <tt>/usr/sbin/sendmail</tt>.
-  #   * <tt>:arguments</tt> - The command line arguments. Defaults to <tt>-i -t</tt> with <tt>-f sender@address</tt>
-  #     added automatically before the message is sent.
+  # * <tt>sendmail_settings</tt> - Allows you to override options for the
+  #   <tt>:sendmail</tt> delivery method.
+  #   * <tt>:location</tt> - The location of the sendmail executable. Defaults
+  #     to <tt>/usr/sbin/sendmail</tt>.
+  #   * <tt>:arguments</tt> - The command line arguments. Defaults to
+  #     <tt>-i -t</tt> with <tt>-f sender@address</tt> added automatically
+  #     before the message is sent.
   #
-  # * <tt>file_settings</tt> - Allows you to override options for the <tt>:file</tt> delivery method.
-  #   * <tt>:location</tt> - The directory into which emails will be written. Defaults to the application
+  # * <tt>file_settings</tt> - Allows you to override options for the
+  #   <tt>:file</tt> delivery method.
+  #   * <tt>:location</tt> - The directory into which emails will be written.
+  #     Defaults to the application
   #     <tt>tmp/mails</tt>.
   #
-  # * <tt>raise_delivery_errors</tt> - Whether or not errors should be raised if the email fails to be delivered.
+  # * <tt>raise_delivery_errors</tt> - Whether or not errors should be raised if
+  #   the email fails to be delivered.
   #
-  # * <tt>delivery_method</tt> - Defines a delivery method. Possible values are <tt>:smtp</tt> (default),
-  #   <tt>:sendmail</tt>, <tt>:test</tt>, and <tt>:file</tt>. Or you may provide a custom delivery method
-  #   object e.g. +MyOwnDeliveryMethodClass+. See the Mail gem documentation on the interface you need to
-  #   implement for a custom delivery agent.
+  # * <tt>delivery_method</tt> - Defines a delivery method. Possible values are
+  #   <tt>:smtp</tt> (default), <tt>:sendmail</tt>, <tt>:test</tt>, and
+  #   <tt>:file</tt>. Or you may provide a custom delivery method object e.g.
+  #   +MyOwnDeliveryMethodClass+. See the Mail gem documentation on the
+  #   interface you need to implement for a custom delivery agent.
   #
-  # * <tt>perform_deliveries</tt> - Determines whether emails are actually sent from Action Mailer when you
-  #   call <tt>.deliver</tt> on an email message or on an Action Mailer method. This is on by default but can
-  #   be turned off to aid in functional testing.
+  # * <tt>perform_deliveries</tt> - Determines whether emails are actually sent
+  #   from Action Mailer when you call <tt>.deliver</tt> on an email message or
+  #   on an Action Mailer method. This is on by default but can be turned off to
+  #   aid in functional testing.
   #
-  # * <tt>deliveries</tt> - Keeps an array of all the emails sent out through the Action Mailer with
-  #   <tt>delivery_method :test</tt>. Most useful for unit and functional testing.
+  # * <tt>deliveries</tt> - Keeps an array of all the emails sent out through
+  #   the Action Mailer with <tt>delivery_method :test</tt>. Most useful for
+  #   unit and functional testing.
   class Base < AbstractController::Base
     include DeliveryMethods
     include Previews
@@ -423,7 +487,9 @@ module ActionMailer
 
     include ActionView::Layouts
 
-    PROTECTED_IVARS = AbstractController::Rendering::DEFAULT_PROTECTED_INSTANCE_VARIABLES + [:@_action_has_layout]
+    PROTECTED_IVARS =
+      AbstractController::Rendering::DEFAULT_PROTECTED_INSTANCE_VARIABLES +
+      [:@_action_has_layout]
 
     def _protected_ivars # :nodoc:
       PROTECTED_IVARS
@@ -442,19 +508,26 @@ module ActionMailer
     }.freeze
 
     class << self
-      # Register one or more Observers which will be notified when mail is delivered.
+      # Register one or more Observers which will be notified when mail is
+      # delivered.
       def register_observers(*observers)
-        observers.flatten.compact.each { |observer| register_observer(observer) }
+        observers.flatten.compact.each do |observer|
+          register_observer(observer)
+        end
       end
 
-      # Register one or more Interceptors which will be called before mail is sent.
+      # Register one or more Interceptors which will be called before mail is
+      # sent.
       def register_interceptors(*interceptors)
-        interceptors.flatten.compact.each { |interceptor| register_interceptor(interceptor) }
+        interceptors.flatten.compact.each do |interceptor|
+          register_interceptor(interceptor)
+        end
       end
 
       # Register an Observer which will be notified when mail is delivered.
       # Either a class, string or symbol can be passed in as the Observer.
-      # If a string or symbol is passed in it will be camelized and constantized.
+      # If a string or symbol is passed in it will be camelized and
+      # constantized.
       def register_observer(observer)
         delivery_observer = case observer
           when String, Symbol
@@ -468,7 +541,8 @@ module ActionMailer
 
       # Register an Interceptor which will be called before mail is sent.
       # Either a class, string or symbol can be passed in as the Interceptor.
-      # If a string or symbol is passed in it will be camelized and constantized.
+      # If a string or symbol is passed in it will be camelized and
+      # constantized.
       def register_interceptor(interceptor)
         delivery_interceptor = case interceptor
           when String, Symbol
@@ -480,8 +554,9 @@ module ActionMailer
         Mail.register_interceptor(delivery_interceptor)
       end
 
-      # Returns the name of current mailer. This method is also being used as a path for a view lookup.
-      # If this is an anonymous mailer, this method will return +anonymous+ instead.
+      # Returns the name of current mailer. This method is also being used as a
+      # path for a view lookup. If this is an anonymous mailer, this method will
+      # return +anonymous+ instead.
       def mailer_name
         @mailer_name ||= anonymous? ? "anonymous" : name.underscore
       end
@@ -517,24 +592,28 @@ module ActionMailer
       #     end
       #   end
       def receive(raw_mail)
-        ActiveSupport::Notifications.instrument("receive.action_mailer") do |payload|
-          mail = Mail.new(raw_mail)
-          set_payload_for_mail(payload, mail)
-          new.receive(mail)
-        end
+        ActiveSupport::Notifications
+          .instrument('receive.action_mailer') do |payload|
+            mail = Mail.new(raw_mail)
+            set_payload_for_mail(payload, mail)
+            new.receive(mail)
+          end
       end
 
-      # Wraps an email delivery inside of <tt>ActiveSupport::Notifications</tt> instrumentation.
+      # Wraps an email delivery inside of <tt>ActiveSupport::Notifications</tt>
+      # instrumentation.
       #
-      # This method is actually called by the <tt>Mail::Message</tt> object itself
-      # through a callback when you call <tt>:deliver</tt> on the <tt>Mail::Message</tt>,
-      # calling +deliver_mail+ directly and passing a <tt>Mail::Message</tt> will do
-      # nothing except tell the logger you sent the email.
+      # This method is actually called by the <tt>Mail::Message</tt> object
+      # itself through a callback when you call <tt>:deliver</tt> on the
+      # <tt>Mail::Message</tt>, calling +deliver_mail+ directly and passing a
+      # <tt>Mail::Message</tt> will do nothing except tell the logger you sent
+      # the email.
       def deliver_mail(mail) #:nodoc:
-        ActiveSupport::Notifications.instrument("deliver.action_mailer") do |payload|
-          set_payload_for_mail(payload, mail)
-          yield # Let Mail do the delivery actions
-        end
+        ActiveSupport::Notifications
+          .instrument('deliver.action_mailer') do |payload|
+            set_payload_for_mail(payload, mail)
+            yield # Let Mail do the delivery actions
+          end
       end
 
       def respond_to?(method, include_private = false) #:nodoc:
@@ -583,12 +662,13 @@ module ActionMailer
         action: method_name
       }
 
-      ActiveSupport::Notifications.instrument("process.action_mailer", payload) do
-        lookup_context.skip_default_locale!
+      ActiveSupport::Notifications
+        .instrument('process.action_mailer', payload) do
+          lookup_context.skip_default_locale!
 
-        super
-        @_message = NullMail.new unless @_mail_was_called
-      end
+          super
+          @_message = NullMail.new unless @_mail_was_called
+        end
     end
 
     class NullMail #:nodoc:
@@ -608,8 +688,8 @@ module ActionMailer
       self.class.mailer_name
     end
 
-    # Allows you to pass random and unusual headers to the new <tt>Mail::Message</tt>
-    # object which will add them to itself.
+    # Allows you to pass random and unusual headers to the new
+    # <tt>Mail::Message</tt> object which will add them to itself.
     #
     #   headers['X-Special-Domain-Specific-Header'] = "SecretValue"
     #
@@ -619,7 +699,8 @@ module ActionMailer
     #   headers 'X-Special-Domain-Specific-Header' => "SecretValue",
     #           'In-Reply-To' => incoming.message_id
     #
-    # The resulting <tt>Mail::Message</tt> will have the following in its header:
+    # The resulting <tt>Mail::Message</tt> will have the following in its
+    # header:
     #
     #   X-Special-Domain-Specific-Header: SecretValue
     #
@@ -654,23 +735,28 @@ module ActionMailer
     #
     #  mail.attachments['filename.jpg'] = File.read('/path/to/filename.jpg')
     #
-    # If you do this, then Mail will take the file name and work out the mime type
-    # set the Content-Type, Content-Disposition, Content-Transfer-Encoding and
-    # base64 encode the contents of the attachment all for you.
+    # If you do this, then Mail will take the file name and work out the mime
+    # type set the Content-Type, Content-Disposition, Content-Transfer-Encoding
+    # and base64 encode the contents of the attachment all for you.
     #
-    # You can also specify overrides if you want by passing a hash instead of a string:
+    # You can also specify overrides if you want by passing a hash instead of a
+    # string:
     #
-    #  mail.attachments['filename.jpg'] = {mime_type: 'application/x-gzip',
-    #                                      content: File.read('/path/to/filename.jpg')}
+    #  mail.attachments['filename.jpg'] = {
+    #    mime_type: 'application/x-gzip',
+    #    content: File.read('/path/to/filename.jpg')
+    #  }
     #
-    # If you want to use a different encoding than Base64, you can pass an encoding in,
-    # but then it is up to you to pass in the content pre-encoded, and don't expect
-    # Mail to know how to decode this data:
+    # If you want to use a different encoding than Base64, you can pass an
+    # encoding in, but then it is up to you to pass in the content pre-encoded,
+    # and don't expect Mail to know how to decode this data:
     #
     #  file_content = SpecialEncode(File.read('/path/to/filename.jpg'))
-    #  mail.attachments['filename.jpg'] = {mime_type: 'application/x-gzip',
-    #                                      encoding: 'SpecialEncoding',
-    #                                      content: file_content }
+    #  mail.attachments['filename.jpg'] = {
+    #    mime_type: 'application/x-gzip',
+    #    encoding: 'SpecialEncoding',
+    #    content: file_content
+    #  }
     #
     # You can also search for specific attachments:
     #
@@ -699,23 +785,23 @@ module ActionMailer
         end
     end
 
-    # The main method that creates the message and renders the email templates. There are
-    # two ways to call this method, with a block, or without a block.
+    # The main method that creates the message and renders the email templates.
+    # There are two ways to call this method, with a block, or without a block.
     #
-    # Both methods accept a headers hash. This hash allows you to specify the most used headers
-    # in an email message, these are:
+    # Both methods accept a headers hash. This hash allows you to specify the
+    # most used headers in an email message, these are:
     #
-    # * +:subject+ - The subject of the message, if this is omitted, Action Mailer will
-    #   ask the Rails I18n class for a translated +:subject+ in the scope of
-    #   <tt>[mailer_scope, action_name]</tt> or if this is missing, will translate the
-    #   humanized version of the +action_name+
-    # * +:to+ - Who the message is destined for, can be a string of addresses, or an array
-    #   of addresses.
-    # * +:from+ - Who the message is from
-    # * +:cc+ - Who you would like to Carbon-Copy on this email, can be a string of addresses,
+    # * +:subject+ - The subject of the message, if this is omitted, Action
+    #   Mailer will ask the Rails I18n class for a translated +:subject+ in the
+    #   scope of <tt>[mailer_scope, action_name]</tt> or if this is missing,
+    #   will translate the humanized version of the +action_name+
+    # * +:to+ - Who the message is destined for, can be a string of addresses,
     #   or an array of addresses.
-    # * +:bcc+ - Who you would like to Blind-Carbon-Copy on this email, can be a string of
-    #   addresses, or an array of addresses.
+    # * +:from+ - Who the message is from
+    # * +:cc+ - Who you would like to Carbon-Copy on this email, can be a string
+    #   of addresses, or an array of addresses.
+    # * +:bcc+ - Who you would like to Blind-Carbon-Copy on this email, can be a
+    #   string of addresses, or an array of addresses.
     # * +:reply_to+ - Who to set the Reply-To header of the email to.
     # * +:date+ - The date to say the email was sent on.
     #
@@ -743,8 +829,8 @@ module ActionMailer
     # templates in the view paths using by default the mailer name and the
     # method name that it is being called from, it will then create parts for
     # each of these templates intelligently, making educated guesses on correct
-    # content type and sequence, and return a fully prepared <tt>Mail::Message</tt>
-    # ready to call <tt>:deliver</tt> on to send.
+    # content type and sequence, and return a fully prepared
+    # <tt>Mail::Message</tt> ready to call <tt>:deliver</tt> on to send.
     #
     # For example:
     #
@@ -811,10 +897,20 @@ module ActionMailer
       m.charset = charset = headers[:charset]
 
       # Set configure delivery behavior
-      wrap_delivery_behavior!(headers.delete(:delivery_method), headers.delete(:delivery_method_options))
+      wrap_delivery_behavior!(
+        headers.delete(:delivery_method),
+        headers.delete(:delivery_method_options)
+      )
 
       # Assign all headers except parts_order, content_type and body
-      assignable = headers.except(:parts_order, :content_type, :body, :template_name, :template_path)
+      assignable = headers.except(
+        :parts_order,
+        :content_type,
+        :body,
+        :template_name,
+        :template_path
+      )
+
       assignable.each { |k, v| m[k] = v }
 
       # Render the templates and blocks
@@ -864,20 +960,29 @@ module ActionMailer
       end
     end
 
-    # Translates the +subject+ using Rails I18n class under <tt>[mailer_scope, action_name]</tt> scope.
-    # If it does not find a translation for the +subject+ under the specified scope it will default to a
-    # humanized version of the <tt>action_name</tt>.
-    # If the subject has interpolations, you can pass them through the +interpolations+ parameter.
+    # Translates the +subject+ using Rails I18n class under
+    # <tt>[mailer_scope, action_name]</tt> scope. If it does not find a
+    # translation for the +subject+ under the specified scope it will default to
+    # a humanized version of the <tt>action_name</tt>. If the subject has
+    # interpolations, you can pass them through the +interpolations+ parameter.
     def default_i18n_subject(interpolations = {})
       mailer_scope = self.class.mailer_name.tr('/', '.')
-      I18n.t(:subject, interpolations.merge(scope: [mailer_scope, action_name], default: action_name.humanize))
+      I18n.t(
+        :subject,
+        interpolations.merge(
+          scope: [mailer_scope, action_name],
+          default: action_name.humanize
+        )
+      )
     end
 
     def collect_responses(headers) #:nodoc:
       responses = []
 
       if block_given?
-        collector = ActionMailer::Collector.new(lookup_context) { render(action_name) }
+        collector =
+          ActionMailer::Collector.new(lookup_context) { render(action_name) }
+
         yield(collector)
         responses = collector.responses
       elsif headers[:body]
@@ -886,7 +991,8 @@ module ActionMailer
           content_type: self.class.default[:content_type] || "text/plain"
         }
       else
-        templates_path = headers.delete(:template_path) || self.class.mailer_name
+        templates_path =
+          headers.delete(:template_path) || self.class.mailer_name
         templates_name = headers.delete(:template_name) || action_name
 
         each_template(Array(templates_path), templates_name) do |template|
@@ -905,7 +1011,13 @@ module ActionMailer
     def each_template(paths, name, &block) #:nodoc:
       templates = lookup_context.find_all(name, paths)
       if templates.empty?
-        raise ActionView::MissingTemplate.new(paths, name, paths, false, 'mailer')
+        fail ActionView::MissingTemplate.new(
+          paths,
+          name,
+          paths,
+          false,
+          'mailer'
+        )
       else
         templates.uniq { |t| t.formats }.each(&block)
       end

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -680,7 +680,7 @@ module ActionMailer
         true
       end
 
-      def method_missing(*args)
+      def method_missing(*_args)
         nil
       end
     end

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -620,7 +620,7 @@ module ActionMailer
         super || action_methods.include?(method.to_s)
       end
 
-    protected
+      protected
 
       def set_payload_for_mail(payload, mail) #:nodoc:
         payload[:mailer]     = name
@@ -931,7 +931,7 @@ module ActionMailer
       m
     end
 
-  protected
+    protected
 
     # Used by #mail to set the content type of the message.
     #

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -960,7 +960,7 @@ module ActionMailer
       when user_content_type.present?
         user_content_type
       when m.has_attachments?
-        if m.attachments.detect { |a| a.inline? }
+        if m.attachments.find { |a| a.inline? }
           ['multipart', 'related', params]
         else
           ['multipart', 'mixed', params]

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -28,7 +28,7 @@ module ActionMailer
   #     def welcome(recipient)
   #       @account = recipient
   #       mail(to: recipient.email_address_with_name,
-  #            bcc: ["bcc@example.com", "Order Watcher <watcher@example.com>"])
+  #            bcc: ['bcc@example.com', 'Order Watcher <watcher@example.com>'])
   #     end
   #   end
   #
@@ -74,7 +74,7 @@ module ActionMailer
   # The block syntax is also useful in providing information specific to a part:
   #
   #   mail(to: user.email) do |format|
-  #     format.text(content_transfer_encoding: "base64")
+  #     format.text(content_transfer_encoding: 'base64')
   #     format.html
   #   end
   #
@@ -82,7 +82,7 @@ module ActionMailer
   #
   #   mail(to: user.email) do |format|
   #     format.text
-  #     format.html { render "some_other_template" }
+  #     format.html { render 'some_other_template' }
   #   end
   #
   # = Mailer views
@@ -127,11 +127,11 @@ module ActionMailer
   # When using <tt>url_for</tt> you'll need to provide the <tt>:host</tt>,
   # <tt>:controller</tt>, and <tt>:action</tt>:
   #
-  #   <%= url_for(host: "example.com", controller: "welcome", action: "greeting") %>
+  #   <%= url_for(host: 'example.com', controller: 'welcome', action: 'greeting') %>
   #
   # When using named routes you only need to supply the <tt>:host</tt>:
   #
-  #   <%= users_url(host: "example.com") %>
+  #   <%= users_url(host: 'example.com') %>
   #
   # You should use the <tt>named_route_url</tt> style (which generates absolute
   # URLs) and avoid using the <tt>named_route_path</tt> style (which generates
@@ -142,7 +142,7 @@ module ActionMailer
   # by setting the <tt>:host</tt> option as a configuration option in
   # <tt>config/application.rb</tt>:
   #
-  #   config.action_mailer.default_url_options = { host: "example.com" }
+  #   config.action_mailer.default_url_options = { host: 'example.com' }
   #
   # When you decide to set a default <tt>:host</tt> for your mailers, then you
   # need to make sure to use the <tt>only_path: false</tt> option when using
@@ -208,7 +208,7 @@ module ActionMailer
   #   class ApplicationMailer < ActionMailer::Base
   #     def welcome(recipient)
   #       attachments['free_book.pdf'] = File.read('path/to/file.pdf')
-  #       mail(to: recipient, subject: "New account information")
+  #       mail(to: recipient, subject: 'New account information')
   #     end
   #   end
   #
@@ -225,7 +225,7 @@ module ActionMailer
   #     class ApplicationMailer < ActionMailer::Base
   #       def welcome(recipient)
   #         attachments['free_book.pdf'] = File.read('path/to/file.pdf')
-  #         mail(to: recipient, subject: "New account information", body: "")
+  #         mail(to: recipient, subject: 'New account information', body: '')
   #       end
   #     end
   #
@@ -237,7 +237,7 @@ module ActionMailer
   #   class ApplicationMailer < ActionMailer::Base
   #     def welcome(recipient)
   #       attachments.inline['photo.png'] = File.read('path/to/photo.png')
-  #       mail(to: recipient, subject: "Here is what we look like")
+  #       mail(to: recipient, subject: 'Here is what we look like')
   #     end
   #   end
   #
@@ -325,7 +325,7 @@ module ActionMailer
   # mailers through the <tt>default_options=</tt> configuration in
   # <tt>config/application.rb</tt>:
   #
-  #    config.action_mailer.default_options = { from: "no-reply@example.org" }
+  #    config.action_mailer.default_options = { from: 'no-reply@example.org' }
   #
   # = Callbacks
   #
@@ -344,7 +344,7 @@ module ActionMailer
   #     private
   #
   #       def add_inline_attachment!
-  #         attachments.inline["footer.jpg"] = File.read('/path/to/filename.jpg')
+  #         attachments.inline['footer.jpg'] = File.read('/path/to/filename.jpg')
   #       end
   #   end
   #
@@ -376,7 +376,7 @@ module ActionMailer
   # previews directory can be configured using the <tt>preview_path</tt> option
   # which has a default of <tt>test/mailers/previews</tt>:
   #
-  #   config.action_mailer.preview_path = "#{Rails.root}/lib/mailer_previews"
+  #   config.action_mailer.preview_path = '#{Rails.root}/lib/mailer_previews'
   #
   # An overview of all previews is accessible at
   # <tt>http://localhost:3000/rails/mailers</tt> on a running development server
@@ -501,10 +501,10 @@ module ActionMailer
 
     class_attribute :default_params
     self.default_params = {
-      mime_version: "1.0",
-      charset:      "UTF-8",
-      content_type: "text/plain",
-      parts_order:  [ "text/plain", "text/enriched", "text/html" ]
+      mime_version: '1.0',
+      charset:      'UTF-8',
+      content_type: 'text/plain',
+      parts_order:  ['text/plain', 'text/enriched', 'text/html']
     }.freeze
 
     class << self
@@ -558,7 +558,7 @@ module ActionMailer
       # path for a view lookup. If this is an anonymous mailer, this method will
       # return +anonymous+ instead.
       def mailer_name
-        @mailer_name ||= anonymous? ? "anonymous" : name.underscore
+        @mailer_name ||= anonymous? ? 'anonymous' : name.underscore
       end
       # Allows to set the name of current mailer.
       attr_writer :mailer_name
@@ -566,7 +566,7 @@ module ActionMailer
 
       # Sets the defaults through app configuration:
       #
-      #     config.action_mailer.default { from: "no-reply@example.org" }
+      #     config.action_mailer.default { from: 'no-reply@example.org' }
       #
       # Aliased by ::default_options=
       def default(value = nil)
@@ -575,8 +575,8 @@ module ActionMailer
       end
       # Allows to set defaults through app configuration:
       #
-      #    config.action_mailer.default_options = { from: "no-reply@example.org" }
       alias :default_options= :default
+      #  config.action_mailer.default_options = { from: 'no-reply@example.org' }
 
       # Receives a raw email, parses it into an email object, decodes it,
       # instantiates a new mailer, and passes the email object to the mailer
@@ -647,7 +647,7 @@ module ActionMailer
 
     # Instantiate a new mailer object. If +method_name+ is not +nil+, the mailer
     # will be initialized according to the named method. If not, the mailer will
-    # remain uninitialized (useful when you only need to invoke the "receive"
+    # remain uninitialized (useful when you only need to invoke the 'receive'
     # method, for instance).
     def initialize(method_name = nil, *args)
       super()
@@ -691,12 +691,12 @@ module ActionMailer
     # Allows you to pass random and unusual headers to the new
     # <tt>Mail::Message</tt> object which will add them to itself.
     #
-    #   headers['X-Special-Domain-Specific-Header'] = "SecretValue"
+    #   headers['X-Special-Domain-Specific-Header'] = 'SecretValue'
     #
     # You can also pass a hash into headers of header field names and values,
     # which will then be set on the <tt>Mail::Message</tt> object:
     #
-    #   headers 'X-Special-Domain-Specific-Header' => "SecretValue",
+    #   headers 'X-Special-Domain-Specific-Header' => 'SecretValue',
     #           'In-Reply-To' => incoming.message_id
     #
     # The resulting <tt>Mail::Message</tt> will have the following in its
@@ -779,10 +779,11 @@ module ActionMailer
       def []=(_name, _content); _raise_error end
 
       private
-        def _raise_error
           raise RuntimeError, "Can't add attachments after `mail` was called.\n" \
-                              "Make sure to use `attachments[]=` before calling `mail`."
-        end
+
+      def _raise_error
+             'Make sure to use `attachments[]=` before calling `mail`.'
+      end
     end
 
     # The main method that creates the message and renders the email templates.
@@ -842,14 +843,16 @@ module ActionMailer
     #     end
     #   end
     #
-    # Will look for all templates at "app/views/notifier" with name "welcome".
-    # If no welcome template exists, it will raise an ActionView::MissingTemplate error.
+    # Will look for all templates at 'app/views/notifier' with name 'welcome'.
+    # If no welcome template exists, it will raise an
+    # ActionView::MissingTemplate error.
     #
     # However, those can be customized:
     #
     #   mail(template_path: 'notifications', template_name: 'another')
     #
-    # And now it will look for all templates at "app/views/notifications" with name "another".
+    # And now it will look for all templates at 'app/views/notifications' with
+    # name 'another'.
     #
     # If you do pass a block, you can render specific templates of your choice:
     #
@@ -861,8 +864,8 @@ module ActionMailer
     # You can even render plain text directly without using a template:
     #
     #   mail(to: 'mikel@test.lindsaar.net') do |format|
-    #     format.text { render plain: "Hello Mikel!" }
-    #     format.html { render html: "<h1>Hello Mikel!</h1>".html_safe }
+    #     format.text { render plain: 'Hello Mikel!' }
+    #     format.html { render html: '<h1>Hello Mikel!</h1>'.html_safe }
     #   end
     #
     # Which will render a +multipart/alternative+ email with +text/plain+ and
@@ -871,7 +874,7 @@ module ActionMailer
     # The block syntax also allows you to customize the part headers if desired:
     #
     #   mail(to: 'mikel@test.lindsaar.net') do |format|
-    #     format.text(content_transfer_encoding: "base64")
+    #     format.text(content_transfer_encoding: 'base64')
     #     format.html
     #   end
     #
@@ -937,7 +940,7 @@ module ActionMailer
     #
     # It will use the given +user_content_type+, or multipart if the mail
     # message has any attachments. If the attachments are inline, the content
-    # type will be "multipart/related", otherwise "multipart/mixed".
+    # type will be 'multipart/related', otherwise 'multipart/mixed'.
     #
     # If there is no content type passed in via headers, and there are no
     # attachments, or the message is multipart, then the default content type is
@@ -949,12 +952,12 @@ module ActionMailer
         user_content_type
       when m.has_attachments?
         if m.attachments.detect { |a| a.inline? }
-          ["multipart", "related", params]
+          ['multipart', 'related', params]
         else
-          ["multipart", "mixed", params]
+          ['multipart', 'mixed', params]
         end
       when m.multipart?
-        ["multipart", "alternative", params]
+        ['multipart', 'alternative', params]
       else
         m.content_type || class_default
       end
@@ -988,7 +991,7 @@ module ActionMailer
       elsif headers[:body]
         responses << {
           body: headers.delete(:body),
-          content_type: self.class.default[:content_type] || "text/plain"
+          content_type: self.class.default[:content_type] || 'text/plain'
         }
       else
         templates_path =
@@ -1028,7 +1031,7 @@ module ActionMailer
         responses[0].each { |k, v| m[k] = v }
       elsif responses.size > 1 && m.has_attachments?
         container = Mail::Part.new
-        container.content_type = "multipart/alternative"
+        container.content_type = 'multipart/alternative'
         responses.each { |r| insert_part(container, r, m.charset) }
         m.add_part(container)
       else

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -674,7 +674,9 @@ module ActionMailer
     end
 
     class NullMail #:nodoc:
-      def body; '' end
+      def body
+        ''
+      end
 
       def respond_to?(_string, _include_all=false)
         true
@@ -777,8 +779,13 @@ module ActionMailer
     end
 
     class LateAttachmentsProxy < SimpleDelegator
-      def inline; _raise_error end
-      def []=(_name, _content); _raise_error end
+      def inline
+        _raise_error
+      end
+
+      def []=(_name, _content)
+        _raise_error
+      end
 
       private
           raise RuntimeError, "Can't add attachments after `mail` was called.\n" \

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -649,7 +649,7 @@ module ActionMailer
     # will be initialized according to the named method. If not, the mailer will
     # remain uninitialized (useful when you only need to invoke the "receive"
     # method, for instance).
-    def initialize(method_name=nil, *args)
+    def initialize(method_name = nil, *args)
       super()
       @_mail_was_called = false
       @_message = Mail.new
@@ -674,7 +674,7 @@ module ActionMailer
     class NullMail #:nodoc:
       def body; '' end
 
-      def respond_to?(string, include_all=false)
+      def respond_to?(_string, _include_all=false)
         true
       end
 
@@ -885,7 +885,7 @@ module ActionMailer
 
       # Call all the procs (if any)
       default_values = {}
-      self.class.default.each do |k,v|
+      self.class.default.each do |k, v|
         default_values[k] = v.is_a?(Proc) ? instance_eval(&v) : v
       end
 
@@ -1025,7 +1025,7 @@ module ActionMailer
 
     def create_parts_from_responses(m, responses) #:nodoc:
       if responses.size == 1 && !m.has_attachments?
-        responses[0].each { |k,v| m[k] = v }
+        responses[0].each { |k, v| m[k] = v }
       elsif responses.size > 1 && m.has_attachments?
         container = Mail::Part.new
         container.content_type = "multipart/alternative"

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -529,7 +529,8 @@ module ActionMailer
       # If a string or symbol is passed in it will be camelized and
       # constantized.
       def register_observer(observer)
-        delivery_observer = case observer
+        delivery_observer =
+          case observer
           when String, Symbol
             observer.to_s.camelize.constantize
           else
@@ -544,7 +545,8 @@ module ActionMailer
       # If a string or symbol is passed in it will be camelized and
       # constantized.
       def register_interceptor(interceptor)
-        delivery_interceptor = case interceptor
+        delivery_interceptor =
+          case interceptor
           when String, Symbol
             interceptor.to_s.camelize.constantize
           else

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -788,9 +788,9 @@ module ActionMailer
       end
 
       private
-          raise RuntimeError, "Can't add attachments after `mail` was called.\n" \
 
       def _raise_error
+        fail "Can't add attachments after `mail` was called.\n" \
              'Make sure to use `attachments[]=` before calling `mail`.'
       end
     end


### PR DESCRIPTION
I thought it would be nice to have more consistency in style here. Linted with RuboCop using the defaults from The Ruby Style Guide. Some of these rules may be considered debatable (e.g. 'Use fail instead of raise' or 'Prefer find over detect'). I'd be happy to revert anything here if that's the case. 
