### PR TITLE
Remove duplicate 'select' database statement

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -337,8 +337,9 @@ module ActiveRecord
 
         # Returns an ActiveRecord::Result instance.
         def select(sql, name = nil, binds = [])
+          exec_query(sql, name, binds)
         end
-        undef_method :select
+
 
         # Returns the last auto-generated ID from the affected table.
         def insert_sql(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil)

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -232,11 +232,6 @@ module ActiveRecord
 
       alias exec_without_stmt exec_query
 
-      # Returns an ActiveRecord::Result instance.
-      def select(sql, name = nil, binds = [])
-        exec_query(sql, name)
-      end
-
       def insert_sql(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil)
         super
         id_value || @connection.last_id

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -465,7 +465,7 @@ module ActiveRecord
 
       def select(sql, name = nil, binds = [])
         @connection.query_with_result = true
-        rows = exec_query(sql, name, binds)
+        rows = super
         @connection.more_results && @connection.next_result    # invoking stored procedures with CLIENT_MULTI_RESULTS requires this to tidy up else connection will be dropped
         rows
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -698,12 +698,6 @@ module ActiveRecord
           exec_query("SELECT currval('#{sequence_name}')", 'SQL')
         end
 
-        # Executes a SELECT query and returns the results, performing any data type
-        # conversions that are required to be performed here instead of in PostgreSQLColumn.
-        def select(sql, name = nil, binds = [])
-          exec_query(sql, name, binds)
-        end
-
         # Returns the list of a table's column names, data types, and default values.
         #
         # The underlying query is roughly:

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -514,10 +514,6 @@ module ActiveRecord
           register_class_with_limit m, %r(char)i, SQLite3String
         end
 
-        def select(sql, name = nil, binds = []) #:nodoc:
-          exec_query(sql, name, binds)
-        end
-
         def table_structure(table_name)
           structure = exec_query("PRAGMA table_info(#{quote_table_name(table_name)})", 'SCHEMA').to_hash
           raise(ActiveRecord::StatementInvalid, "Could not find table '#{table_name}'") if structure.empty?


### PR DESCRIPTION
The `select` method has the same definition in almost all database adapters, so it can be moved from the database-specific adapters (PostgreSQl, MySQL, SQLite) to the abstract `database_statement`:

``` ruby
def select(sql, name = nil, binds = [])
  exec_query(sql, name, binds)
end
```

---

More details about this commit: the only two DB-specific adapters that have a different definition of `select` are MySQLAdapter and MySQL2Adapter.

In MySQLAdapter, `select` invokes `exec_query(sql, name, binds)`, so calling `super` achieves the same goal with less repetition.

In MySQL2Adapter, `select` invokes `exec_query(sql, name)`, that is, it does not pass the `binds` parameter like other methods do. However, MySQL2Adapter's `exec_query` works exactly the same whether this parameters is passed or not, so the output does not change. Here is [MySQL2Adapter's `exec_query`](https://github.com/rails/rails/blob/74a527cc63ef56f3d0a42cf638299958dc7cb08c/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L228L231):

``` ruby
def exec_query(sql, name = 'SQL', binds = [])
  result = execute(sql, name)
  ActiveRecord::Result.new(result.fields, result.to_a)
end
```
