### PR TITLE
AJ doc fixes

### DIFF
--- a/activejob/lib/active_job/base.rb
+++ b/activejob/lib/active_job/base.rb
@@ -34,17 +34,17 @@ module ActiveJob #:nodoc:
   # Records that are passed in are serialized/deserialized using Global
   # Id. More information can be found in Arguments.
   #
-  # To queue a job to be processed asynchronously immediately:
+  # To enqueue a job to be performed as soon the queueing system is free:
   #
   #   ProcessPhotoJob.perform_later(photo)
   #
-  # To queue a job to be processed at some point in the future:
+  # To enqueue a job to be processed at some point in the future:
   #
   #   ProcessPhotoJob.set(wait_until: Date.tomorrow.noon).perform_later(photo)
   #
   # More information can be found in ActiveJob::Core::ClassMethods#set
   #
-  # A job can also be processed synchronously:
+  # A job can also be processed immediately without sending to the queue:
   #
   #  ProcessPhotoJob.perform_now(photo)
   #

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -10,7 +10,7 @@ module ActiveJob
       # GlobalID::Identification instances. Arbitrary Ruby objects
       # are not supported.
       #
-      # Returns an instance of the job class queued with args available in
+      # Returns an instance of the job class queued with arguments available in
       # Job#arguments.
       def perform_later(*args)
         job_or_instantiate(*args).enqueue

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -71,7 +71,7 @@ module ActiveJob
       #
       # Note: This assertion is simply a shortcut for:
       #
-      #   assert_enqueued_jobs 0
+      #   assert_enqueued_jobs 0, &block
       def assert_no_enqueued_jobs(&block)
         assert_enqueued_jobs 0, &block
       end
@@ -130,7 +130,7 @@ module ActiveJob
       #
       # Note: This assertion is simply a shortcut for:
       #
-      #   assert_performed_jobs 0
+      #   assert_performed_jobs 0, &block
       def assert_no_performed_jobs(&block)
         assert_performed_jobs 0, &block
       end


### PR DESCRIPTION
- Fix mentioned shortcut, to what the shortcut actually is, and that it accepts blocks for `assert_no_enqueued_jobs` and `assert_no_performed_jobs` test helpers.
- args => arguments when used in actual docs.
