### PR TITLE
Add SI prefix option to numeric bytes core extension

### DIFF
--- a/activesupport/lib/active_support/core_ext/numeric/bytes.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/bytes.rb
@@ -1,44 +1,66 @@
 class Numeric
-  KILOBYTE = 1024
-  MEGABYTE = KILOBYTE * 1024
-  GIGABYTE = MEGABYTE * 1024
-  TERABYTE = GIGABYTE * 1024
-  PETABYTE = TERABYTE * 1024
-  EXABYTE  = PETABYTE * 1024
+  # See http://physics.nist.gov/cuu/Units/prefixes.html for definition of SI prefixes
+  KILOBYTE = 1000
+  MEGABYTE = KILOBYTE * 1000
+  GIGABYTE = MEGABYTE * 1000
+  TERABYTE = GIGABYTE * 1000
+  PETABYTE = TERABYTE * 1000
+  EXABYTE  = PETABYTE * 1000
+
+  # See http://physics.nist.gov/cuu/Units/binary.html for definition of binary prefixes
+  KIBIBYTE = 1024
+  MEBIBYTE = KIBIBYTE * 1024
+  GIBIBYTE = MEBIBYTE * 1024
+  TEBIBYTE = GIBIBYTE * 1024
+  PEBIBYTE = TEBIBYTE * 1024
+  EXBIBYTE = PEBIBYTE * 1024
 
   # Enables the use of byte calculations and declarations, like 45.bytes + 2.6.megabytes
-  def bytes
+  def bytes(opts={})
     self
   end
   alias :byte :bytes
 
-  def kilobytes
-    self * KILOBYTE
+  def kilobytes(opts={})
+    self * (si_prefix?(opts) ? KILOBYTE : KIBIBYTE)
   end
   alias :kilobyte :kilobytes
 
-  def megabytes
-    self * MEGABYTE
+  def megabytes(opts={})
+    self * (si_prefix?(opts) ? MEGABYTE : MEBIBYTE)
   end
   alias :megabyte :megabytes
 
-  def gigabytes
-    self * GIGABYTE
+  def gigabytes(opts={})
+    self * (si_prefix?(opts) ? GIGABYTE : GIBIBYTE)
   end
   alias :gigabyte :gigabytes
 
-  def terabytes
-    self * TERABYTE
+  def terabytes(opts={})
+    self * (si_prefix?(opts) ? TERABYTE : TEBIBYTE)
   end
   alias :terabyte :terabytes
 
-  def petabytes
-    self * PETABYTE
+  def petabytes(opts={})
+    self * (si_prefix?(opts) ? PETABYTE : PEBIBYTE)
   end
   alias :petabyte :petabytes
 
-  def exabytes
-    self * EXABYTE
+  def exabytes(opts={})
+    self * (si_prefix?(opts) ? EXABYTE : EXBIBYTE)
   end
   alias :exabyte :exabytes
+
+  private
+
+    def si_prefix?(opts)
+      case opts
+      when Symbol
+        opts == :si
+      when Hash
+        opts.symbolize_keys[:prefix] == :si
+      else
+        false
+      end
+    end
 end

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -97,6 +97,14 @@ class NumericExtDateTest < ActiveSupport::TestCase
 end
 
 class NumericExtSizeTest < ActiveSupport::TestCase
+  def test_unit_prefix
+    assert_equal 1000.kilobytes(:binary), 1000.kilobytes(:prefix => :binary)
+    assert_equal 1000.kilobytes(:binary), 1000.kilobytes("prefix" => :binary)
+
+    assert_equal 1000.kilobytes(:si), 1000.kilobytes(:prefix => :si)
+    assert_equal 1000.kilobytes(:si), 1000.kilobytes("prefix" => :si)
+  end
+
   def test_unit_in_terms_of_another
     assert_equal 1024.bytes, 1.kilobyte
     assert_equal 1024.kilobytes, 1.megabyte
@@ -108,6 +116,17 @@ class NumericExtSizeTest < ActiveSupport::TestCase
     assert_equal 256.megabytes * 20 + 5.gigabytes, 10.gigabytes
     assert_equal 1.kilobyte ** 5, 1.petabyte
     assert_equal 1.kilobyte ** 6, 1.exabyte
+
+    assert_equal 1000.bytes(:si), 1.kilobyte(:si)
+    assert_equal 1000.kilobytes(:si), 1.megabyte(:si)
+    assert_equal 3500.0.kilobytes(:si), 3.5.megabytes(:si)
+    assert_equal 3500.0.megabytes(:si), 3.5.gigabytes(:si)
+    assert_equal 1.kilobyte(:si) ** 4, 1.terabyte(:si)
+    assert_equal 1000.kilobytes(:si) + 2.megabytes(:si), 3.megabytes(:si)
+    assert_equal 2.gigabytes(:si) / 4, 500.megabytes(:si)
+    assert_equal 250.megabytes(:si) * 20 + 5.gigabytes(:si), 10.gigabytes(:si)
+    assert_equal 1.kilobyte(:si) ** 5, 1.petabyte(:si)
+    assert_equal 1.kilobyte(:si) ** 6, 1.exabyte(:si)
   end
 
   def test_units_as_bytes_independently
@@ -123,6 +142,19 @@ class NumericExtSizeTest < ActiveSupport::TestCase
     assert_equal 3377699720527872, 3.petabyte
     assert_equal 3458764513820540928, 3.exabytes
     assert_equal 3458764513820540928, 3.exabyte
+
+    assert_equal 3000000, 3.megabytes(:si)
+    assert_equal 3000000, 3.megabyte(:si)
+    assert_equal 3000, 3.kilobytes(:si)
+    assert_equal 3000, 3.kilobyte(:si)
+    assert_equal 3000000000, 3.gigabytes(:si)
+    assert_equal 3000000000, 3.gigabyte(:si)
+    assert_equal 3000000000000, 3.terabytes(:si)
+    assert_equal 3000000000000, 3.terabyte(:si)
+    assert_equal 3000000000000000, 3.petabytes(:si)
+    assert_equal 3000000000000000, 3.petabyte(:si)
+    assert_equal 3000000000000000000, 3.exabytes(:si)
+    assert_equal 3000000000000000000, 3.exabyte(:si)
   end
 end
 


### PR DESCRIPTION
I am aware that you guys already had a discussion about the use of SI and binary prefixes.

However, I am missing some kind of symmetry between the `number_to_human_size` helper and the numeric bytes core extension.

While `1.kilobyte`, `1.megabyte` etc. use the binary prefix, `number_to_human_size` actually allows you to choose a prefix (:si or :binary). This can lead to some odd behavior:  

``` ruby
NumberHelper.number_to_human_size(1.kilobyte, prefix: :si) # => "1.02 KB"
```

I added an option to the numeric bytes core extension:

``` ruby
1.kilobyte              # => 1024
1.kilobyte(:si)         # => 1000
1.kilobyte(prefix: :si) # => 1000

NumberHelper.number_to_human_size(1.kilobyte(:si), prefix: :si) # => "1 KB"
```

Maybe this isn't the best solution, so I am open for ideas and changes.
