### PR TITLE
Allow static asset serving from env variable

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   The value of `config.serve_static_asset` in `production.rb` will
+    default to `ENV["SERVE_STATIC_ASSETS"]` in new apps. The values
+    `"false"`, `false`, or `nil` will disable the service of static assets.
+    Any other values will enable the feature.
+
+    *Richard Schneeman*
+
 *   Remove `--skip-action-view` option from `Rails::Generators::AppBase`.
 
     Fixes #17023.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -11,12 +11,12 @@ module Rails
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters,
                     :force_ssl, :helpers_paths, :logger, :log_formatter, :log_tags,
                     :railties_order, :relative_url_root, :secret_key_base, :secret_token,
-                    :serve_static_assets, :ssl_options, :static_cache_control, :session_options,
+                    :ssl_options, :static_cache_control, :session_options,
                     :time_zone, :reload_classes_only_on_change,
                     :beginning_of_week, :filter_redirect, :x
 
       attr_writer :log_level
-      attr_reader :encoding
+      attr_reader :encoding, :serve_static_assets
 
       def initialize(*)
         super
@@ -64,6 +64,15 @@ module Rails
         @assets.js_compressor            = nil
         @assets.css_compressor           = nil
         @assets.logger                   = nil
+      end
+
+      def serve_static_assets=(serve_static_assets)
+        @serve_static_assets = case serve_static_assets
+        when "false"
+          false
+        else
+          serve_static_assets
+        end
       end
 
       def encoding=(value)

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -20,8 +20,10 @@ Rails.application.configure do
   # NGINX, varnish or squid.
   # config.action_dispatch.rack_cache = true
 
-  # Disable Rails's static asset server (Apache or NGINX will already do this).
-  config.serve_static_assets = false
+  # When enabled Rails will serve static assets. If you have configured Apache
+  # or NGINX to serve assets, this can be disabled.
+  # Values `"false"`, `false`, and `nil` will disable.
+  config.serve_static_assets = ENV['SERVE_STATIC_ASSETS']
 
   <%- unless options.skip_sprockets? -%>
   # Compress JavaScripts and CSS.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -49,6 +49,24 @@ module ApplicationTests
       FileUtils.rm_rf(new_app) if File.directory?(new_app)
     end
 
+
+    test "serve_static_assets converts false string to falsey" do
+      make_basic_app do |app|
+        app.config.serve_static_assets = :foo
+
+        app.config.serve_static_assets = "true"
+        assert_equal "true", app.config.serve_static_assets
+
+
+        app.config.serve_static_assets = "false"
+        assert_equal false, app.config.serve_static_assets
+
+
+        app.config.serve_static_assets = nil
+        assert_equal nil, app.config.serve_static_assets
+      end
+    end
+
     test "Rails.env does not set the RAILS_ENV environment variable which would leak out into rake tasks" do
       require "rails"
 


### PR DESCRIPTION
Based on conversation in #16464 we can't enable this by default for ALL applications. It was agreed that it's reasonable if the host container can set this value (i.e. docker/heroku). 

It's important that we can explicitly enable as well as disable this value as services may enable setting environment variables to different values (like `"true"` or `"false"`) but not allow unsetting the values (`nil`)
