### PR TITLE
simplify rake test vs rake test:all

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -792,7 +792,7 @@ when you initiate a Rails project.
 
 | Tasks                   | Description |
 | ----------------------- | ----------- |
-| `rake test`             | Runs all unit, functional and integration tests. You can also simply run `rake` as Rails will run all the tests by default |
+| `rake test`             | Runs all tests in the test folder. You can also simply run `rake` as Rails will run all the tests by default |
 | `rake test:controllers` | Runs all the controller tests from `test/controllers` |
 | `rake test:functionals` | Runs all the functional tests from `test/controllers`, `test/mailers`, and `test/functional` |
 | `rake test:helpers`     | Runs all the helper tests from `test/helpers` |
@@ -801,8 +801,7 @@ when you initiate a Rails project.
 | `rake test:mailers`     | Runs all the mailer tests from `test/mailers` |
 | `rake test:models`      | Runs all the model tests from `test/models` |
 | `rake test:units`       | Runs all the unit tests from `test/models`, `test/helpers`, and `test/unit` |
-| `rake test:all`         | Runs all tests quickly by merging all types and not resetting db |
-| `rake test:all:db`      | Runs all tests quickly by merging all types and resetting db |
+| `rake test:db`          | Runs all tests and resets the db |
 
 
 Brief Note About `Minitest`

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -181,4 +181,10 @@
 
     *Yves Senn*, *Carlos Antonio da Silva*, *Robin Dupret*
 
+*   Make `rake test` run all tests in test folder.
+
+    Deprecate `rake test:all` and replace `rake test:all:db` with `rake test:db`
+
+    *David Geukers*
+
 Please check [4-1-stable](https://github.com/rails/rails/blob/4-1-stable/railties/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
Remove rake test:all and replace rake test with former definition of rake test:all.  Also rename rake test:all:db to rake test:db
