### PR TITLE
copy reflection_scopes’s unscoped value when building scope for preloading

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -136,6 +136,10 @@ module ActiveRecord
           preload_values = preload_scope.values
           preload_binds  = preload_scope.bind_values
 
+          if values[:unscope]
+            scope.unscope! values[:unscope]
+          end
+
           scope.where_values      = Array(values[:where])      + Array(preload_values[:where])
           scope.references_values = Array(values[:references]) + Array(preload_values[:references])
           scope.bind_values       = (reflection_binds + preload_binds)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1895,6 +1895,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal [bulb1, bulb2], car.all_bulbs.sort_by(&:id)
   end
 
+  test 'unscopes the default scope of associated model when used with include' do
+    car = Car.create!
+    bulb = Bulb.create! name: "other", car: car
+
+    assert_equal bulb, Car.find(car.id).all_bulbs.first
+    assert_equal bulb, Car.includes(:all_bulbs).find(car.id).all_bulbs.first
+  end
+
   test "raises RecordNotDestroyed when replaced child can't be destroyed" do
     car = Car.create!
     original_child = FailedBulb.create!(car: car)


### PR DESCRIPTION
Closes #11036
