### PR TITLE
Deprecate only_path: false option on *_path route helper

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Deprecate only_path: false option on *_path route helper.
+
+    Passing only_path: false to *_path route helper methods will
+    output a deprecation warning.
+
+    Fixes #17294.
+
+    *Dan Olson*
+
 *   Improve Journey compliance to RFC 3986.
 
     The scanner in Journey failed to recognize routes that use literals

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -69,6 +69,82 @@ module ActionDispatch
         end
       end
 
+      test "only_path: true with *_url and no :host option" do
+        draw do
+          get 'foo', to: SimpleApp.new('foo#index')
+        end
+
+        assert_equal '/foo', url_helpers.foo_url(only_path: true)
+      end
+
+      test "only_path: false with *_url and no :host option" do
+        draw do
+          get 'foo', to: SimpleApp.new('foo#index')
+        end
+
+        assert_raises ArgumentError do
+          assert_equal 'http://example.com/foo', url_helpers.foo_url(only_path: false)
+        end
+      end
+
+      test "only_path: false with *_url and local :host option" do
+        draw do
+          get 'foo', to: SimpleApp.new('foo#index')
+        end
+
+        assert_equal 'http://example.com/foo', url_helpers.foo_url(only_path: false, host: 'example.com')
+      end
+
+      test "only_path: false with *_url and global :host option" do
+        @set.default_url_options = { host: 'example.com' }
+        draw do
+          get 'foo', to: SimpleApp.new('foo#index')
+        end
+
+        assert_equal 'http://example.com/foo', url_helpers.foo_url(only_path: false)
+      end
+
+      test "only_path: true with *_path" do
+        draw do
+          get 'foo', to: SimpleApp.new('foo#index')
+        end
+
+        assert_equal '/foo', url_helpers.foo_path(only_path: true)
+      end
+
+      test "only_path: false with *_path with global :host option" do
+        @set.default_url_options = { host: 'example.com' }
+        draw do
+          get 'foo', to: SimpleApp.new('foo#index')
+        end
+
+        assert_deprecated do
+          assert_equal 'http://example.com/foo', url_helpers.foo_path(only_path: false)
+        end
+      end
+
+      test "only_path: false with *_path with local :host option" do
+        draw do
+          get 'foo', to: SimpleApp.new('foo#index')
+        end
+
+        assert_deprecated do
+          assert_equal 'http://example.com/foo', url_helpers.foo_path(only_path: false, host: 'example.com')
+        end
+      end
+
+      test "only_path: false with *_path with no :host option" do
+        draw do
+          get 'foo', to: SimpleApp.new('foo#index')
+        end
+
+        assert_deprecated do
+          assert_raises ArgumentError do
+            assert_equal 'http://example.com/foo', url_helpers.foo_path(only_path: false)
+          end
+        end
+      end
+
       test "explicit keys win over implicit keys" do
         draw do
           resources :foo do


### PR DESCRIPTION
Addresses #17294

@chancancode I believe this handles all the cases you mention in #17294. Please let me know.

1) `*_url` helpers should continue to support the only_path: true | false option without deprecation
2) `*_path` helpers should continue to support the only_path: true | false option with a deprecation warning that `(*_path(..., only_path: false)` would not work on Rails 5, use `*_url` instead)
3) `*_url(...., only_path: true)` should not require the host option to be set (globally or as an argument)
