### PR TITLE
Modify config_for to return HashWithIndifferentAccess

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -226,7 +226,7 @@ module Rails
       if yaml.exist?
         require "yaml"
         require "erb"
-        (YAML.load(ERB.new(yaml.read).result) || {})[Rails.env] || {}
+        ((YAML.load(ERB.new(yaml.read).result) || {})[Rails.env] || {}).with_indifferent_access
       else
         raise "Could not load configuration. No such file - #{yaml}"
       end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1026,6 +1026,7 @@ module ApplicationTests
       require "#{app_path}/config/environment"
 
       assert_equal 'custom key', Rails.application.config.my_custom_config['key']
+      assert_equal 'custom key', Rails.application.config.my_custom_config[:key]
     end
 
     test "config_for raises an exception if the file does not exist" do


### PR DESCRIPTION
I want to return HashWithIndifferentAccess instead of Hash.

For example, When I use `config_for` for `exception_notification`, `exception_notification` use symbols to get parameter.
Threfore, I need conversion processing. 
