### PR TITLE
Secure compare

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -1,5 +1,6 @@
 require 'rack/session/abstract/id'
 require 'action_controller/metal/exceptions'
+require 'active_support/security_utils'
 
 module ActionController #:nodoc:
   class InvalidAuthenticityToken < ActionControllerError #:nodoc:
@@ -305,8 +306,7 @@ module ActionController #:nodoc:
       end
 
       def compare_with_real_token(token, session)
-        # Borrow a constant-time comparison from Rack
-        Rack::Utils.secure_compare(token, real_csrf_token(session))
+        ActiveSupport::SecurityUtils.secure_compare(token, real_csrf_token(session))
       end
 
       def real_csrf_token(session)

--- a/activesupport/lib/active_support/security_utils.rb
+++ b/activesupport/lib/active_support/security_utils.rb
@@ -1,0 +1,20 @@
+module ActiveSupport
+  module SecurityUtils
+    # Constant time string comparison.
+    #
+    # The values compared should be of fixed length, such as strings
+    # that have already been processed by HMAC. This should not be used
+    # on variable length plaintext strings because it could leak length info
+    # via timing attacks.
+    def secure_compare(a, b)
+      return false unless a.bytesize == b.bytesize
+
+      l = a.unpack "C#{a.bytesize}"
+
+      res = 0
+      b.each_byte { |byte| res |= byte ^ l.shift }
+      res == 0
+    end
+    module_function :secure_compare
+  end
+end

--- a/activesupport/test/security_utils_test.rb
+++ b/activesupport/test/security_utils_test.rb
@@ -1,0 +1,9 @@
+require 'abstract_unit'
+require 'active_support/security_utils'
+
+class SecurityUtilsTest < ActiveSupport::TestCase
+  def test_secure_compare_should_perform_string_comparison
+    assert ActiveSupport::SecurityUtils.secure_compare('a', 'a')
+    assert !ActiveSupport::SecurityUtils.secure_compare('a', 'b')
+  end
+end


### PR DESCRIPTION
Add AS::SecureFactory.secure_compare for constant time string comparison

This deprecate also gems like:

https://github.com/samuelkadolph/securecompare
https://github.com/mgates/secure_compare

Also might be useful in gems like Devise: https://github.com/plataformatec/devise/blob/master/lib/devise.rb#L482
