### PR TITLE
Raises ArgumentError when try to define a scope without a callable

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -139,6 +139,9 @@ module ActiveRecord
         #   Article.published.featured.latest_article
         #   Article.featured.titles
         def scope(name, body, &block)
+          raise ArgumentError, 'You need to suply a callable as scope body' unless
+            body.respond_to?(:call)
+
           if dangerous_class_method?(name)
             raise ArgumentError, "You tried to define a scope named \"#{name}\" " \
               "on the model \"#{self.name}\", but Active Record already defined " \

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -132,6 +132,12 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert_equal Post.ranked_by_comments.limit_by(5), Post.top(5)
   end
 
+  def test_scopes_body_is_a_callable
+    assert_raises(ArgumentError, 'You need to suply a callable as scope body') do
+      Post.class_eval { scope :containing_the_letter_z, where("body LIKE '%z%'") }
+    end
+  end
+
   def test_active_records_have_scope_named__all__
     assert !Topic.all.empty?
 


### PR DESCRIPTION
This changes the actual exception

```
NoMethodError: undefined method `call' for #<ActiveRecord::Relation []>
```

to a `ArgumentError` when try to define a scope without a callable.
