### PR TITLE
Bump version of bcrypt gem to 3.1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'turbolinks'
 # require: false so bcrypt is loaded only when has_secure_password is used.
 # This is to avoid ActiveModel (and by extension the entire framework)
 # being dependent on a binary library.
-gem 'bcrypt', '~> 3.1.7', require: false
+gem 'bcrypt', '~> 3.1.9', require: false
 
 # This needs to be with require false to avoid
 # it being automatically loaded by sprockets

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -29,9 +29,9 @@ module ActiveModel
       # For further customizability, it is possible to supress the default
       # validations by passing <tt>validations: false</tt> as an argument.
       #
-      # Add bcrypt (~> 3.1.7) to Gemfile to use #has_secure_password:
+      # Add bcrypt (~> 3.1.9) to Gemfile to use #has_secure_password:
       #
-      #   gem 'bcrypt', '~> 3.1.7'
+      #   gem 'bcrypt', '~> 3.1.9'
       #
       # Example using Active Record (which automatically includes ActiveModel::SecurePassword):
       #

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -13,7 +13,7 @@ source 'https://rubygems.org'
 <% end -%>
 
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+# gem 'bcrypt', '~> 3.1.9'
 
 # Use Unicorn as the app server
 # gem 'unicorn'


### PR DESCRIPTION
Version 3.1.9 of the bcrypt gem adds support for Ruby 2.1 on Windows.
