### PR TITLE
Make `String#remove` and `String#remove!` accept multiple arguments

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `String#remove` and `String#remove!` accept multiple arguments.
+
+    *Pavel Pravosud*
+
 *   Corrected Inflector#underscore handling of multiple successive acroynms.
 
     *James Le Cuirot*

--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -20,14 +20,18 @@ class String
     self
   end
 
-  # Returns a new string with all occurrences of the pattern removed. Short-hand for String#gsub(pattern, '').
-  def remove(pattern)
-    gsub pattern, ''
+  # Returns a new string with all occurrences of the patterns removed.
+  def remove(*patterns)
+    dup.remove!(*patterns)
   end
 
-  # Alters the string by removing all occurrences of the pattern. Short-hand for String#gsub!(pattern, '').
-  def remove!(pattern)
-    gsub! pattern, ''
+  # Alters the string by removing all occurrences of the patterns.
+  def remove!(*patterns)
+    patterns.each do |pattern|
+      gsub! pattern, ""
+    end
+
+    self
   end
 
   # Truncates a given +text+ after a given <tt>length</tt> if +text+ is longer than <tt>length</tt>:

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -260,8 +260,18 @@ class StringInflectionsTest < ActiveSupport::TestCase
   end
 
   def test_remove
-    assert_equal "Summer", "Fast Summer".remove(/Fast /)
-    assert_equal "Summer", "Fast Summer".remove!(/Fast /)
+    original = "This is a good day to die"
+    assert_equal "This is a good day", original.remove(" to die")
+    assert_equal "This is a good day", original.remove(" to ", /die/)
+    assert_equal "This is a good day to die", original
+  end
+
+  def test_remove!
+    original = "This is a very good day to die"
+    assert_equal "This is a good day to die", original.remove!(" very")
+    assert_equal "This is a good day to die", original
+    assert_equal "This is a good day", original.remove!(" to ", /die/)
+    assert_equal "This is a good day", original
   end
 
   def test_constantize


### PR DESCRIPTION
Quite often when I use `String#remove` I need to remove multiple patterns from the string at once. This change makes method handle multiple arguments without breaking backwards compatibility.

Before:

``` ruby
["this", "that", /and that/].each do |pattern|
  text.remove! pattern
end
```

After:

``` ruby
text.remove! "this", "that", /and that/
```
