### PR TITLE
ActionMailer https on URL with force_ssl = true

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `config.force_ssl = true` will set
+    `config.action_mailer.default_url_options = { protocol: 'https' }`
+
+    *Andrew Kampjes*
+
 *   Add `config.action_mailer.deliver_later_queue_name` configuration to set the
     mailer queue name.
 

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -132,6 +132,8 @@ module ActionMailer
   #
   #   config.action_mailer.default_url_options = { host: "example.com" }
   #
+  # By default when <tt>config.force_ssl</tt> is true, URLs generated for hosts will use the HTTPS protocol.
+  #
   # = Sending mail
   #
   # Once a mailer action and template are defined, you can deliver your message or defer its creation and

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -16,6 +16,11 @@ module ActionMailer
       paths   = app.config.paths
       options = app.config.action_mailer
 
+      if app.config.force_ssl
+        options.default_url_options ||= {}
+        options.default_url_options[:protocol] ||= 'https'
+      end
+
       options.assets_dir      ||= paths["public"].first
       options.javascripts_dir ||= paths["public/javascripts"].first
       options.stylesheets_dir ||= paths["public/stylesheets"].first

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -50,6 +50,17 @@ module ApplicationTests
       assert_equal "test.rails", ActionMailer::Base.default_url_options[:host]
     end
 
+    test "Default to HTTPS for ActionMailer URLs when force_ssl is on" do
+      app_file "config/environments/development.rb", <<-RUBY
+        Rails.application.configure do
+          config.force_ssl = true
+        end
+      RUBY
+
+      require "#{app_path}/config/environment"
+      assert_equal "https", ActionMailer::Base.default_url_options[:protocol]
+    end
+
     test "includes url helpers as action methods" do
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do


### PR DESCRIPTION
`config.force_ssl = true` will set
config.action_mailer.default_url_options = { protocol: 'https' }

If you have turned on force_ssl, and then gone to the effort of setting
a config.action_mailer.default_url_options = {host: 'example.com'} then
you are probably pointing people back to your current app and want
https on that too.
