### PR TITLE
Show correct routes prefix with namespace

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Show correct routes prefix with namespace.
+
+    *Yuichi Takada*
+
 *   Improve Journey compliance to RFC 3986.
 
     The scanner in Journey failed to recognize routes that use literals

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1534,8 +1534,9 @@ module ActionDispatch
 
           action = action.to_s.dup
 
-          if action =~ /^[\w\-\/]+$/
+          if action =~ /^[\w\-\/\:]+$/
             options[:action] ||= action.tr('-', '_') unless action.include?("/")
+            action = action.split('/:').first
           else
             action = nil
           end

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -299,6 +299,44 @@ module ActionDispatch
         assert_equal ["Prefix Verb URI Pattern            Controller#Action",
                       "       GET  /:controller(/:action) (?-mix:api\\/[^\\/]+)#:action"], output
       end
+
+      def test_rake_routes_with_namespace
+        output = draw do
+          namespace :foo do
+            match '/a',       to: 'a#index',  via: 'get'
+            match '/a/:id',   to: 'a#show',   via: 'get'
+            match '/a/:id',   to: 'a#update', via: 'patch'
+            match '/b',       to: 'b#index',  via: 'get'
+            match '/b/:id',   to: 'b#show',   via: 'get'
+            match '/b/:id',   to: 'b#update', via: 'patch'
+          end
+        end
+
+        assert_equal [
+          "Prefix Verb  URI Pattern          Controller#Action",
+          " foo_a GET   /foo/a(.:format)     foo/a#index",
+          "       GET   /foo/a/:id(.:format) foo/a#show",
+          "       PATCH /foo/a/:id(.:format) foo/a#update",
+          " foo_b GET   /foo/b(.:format)     foo/b#index",
+          "       GET   /foo/b/:id(.:format) foo/b#show",
+          "       PATCH /foo/b/:id(.:format) foo/b#update",
+        ], output
+      end
+
+      def test_rake_routes_with_namespace_only_show_action
+        output = draw do
+          namespace :foo do
+            match '/a/:id',  to: 'a#show',  via: 'get'
+            match '/b/:id',  to: 'b#show',  via: 'get'
+          end
+        end
+
+        assert_equal [
+          "Prefix Verb URI Pattern          Controller#Action",
+          " foo_a GET  /foo/a/:id(.:format) foo/a#show",
+          " foo_b GET  /foo/b/:id(.:format) foo/b#show",
+        ], output
+      end
     end
   end
 end

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -133,7 +133,7 @@ module ActionDispatch
 
         assert_equal [
           "Prefix Verb URI Pattern            Controller#Action",
-          "       GET  /api/:action(.:format) api#:action"
+          "   api GET  /api/:action(.:format) api#:action"
         ], output
       end
 
@@ -166,7 +166,7 @@ module ActionDispatch
 
         assert_equal [
           "Prefix Verb URI Pattern           Controller#Action",
-          %Q[       GET  /photos/:id(.:format) photos#show {:format=>"jpg"}]
+          %Q[photos GET  /photos/:id(.:format) photos#show {:format=>"jpg"}]
         ], output
       end
 
@@ -177,7 +177,7 @@ module ActionDispatch
 
         assert_equal [
           "Prefix Verb URI Pattern           Controller#Action",
-          "       GET  /photos/:id(.:format) photos#show {:id=>/[A-Z]\\d{5}/}"
+          "photos GET  /photos/:id(.:format) photos#show {:id=>/[A-Z]\\d{5}/}"
         ], output
       end
 
@@ -216,7 +216,7 @@ module ActionDispatch
 
         assert_equal [
           "Prefix Verb URI Pattern        Controller#Action",
-          "       GET  /foo/:id(.:format) #{RackApp.name} {:id=>/[A-Z]\\d{5}/}"
+          "   foo GET  /foo/:id(.:format) #{RackApp.name} {:id=>/[A-Z]\\d{5}/}"
         ], output
       end
 


### PR DESCRIPTION
When I write config/routes.rb like this,

``` ruby
namespace :foo do
  match '/a',       to: 'a#index',  via: 'get'
  match '/a/:id',   to: 'a#show',   via: 'get'
  match '/b',       to: 'b#index',  via: 'get'
  match '/b/:id',   to: 'b#show',   via: 'get'
end
```

`rake routes` command shows as bellow.

```
Prefix Verb URI Pattern          Controller#Action
 foo_a GET  /foo/a(.:format)     foo/a#index
   foo GET  /foo/a/:id(.:format) foo/a#show
 foo_b GET  /foo/b(.:format)     foo/b#index
       GET  /foo/b/:id(.:format) foo/b#show
```

I think it should be displayed like this.

```
Prefix Verb URI Pattern          Controller#Action
 foo_a GET  /foo/a(.:format)     foo/a#index
       GET  /foo/a/:id(.:format) foo/a#show
 foo_b GET  /foo/b(.:format)     foo/b#index
       GET  /foo/b/:id(.:format) foo/b#show
```

So I fixed it.
