### PR TITLE
Clarify comments about sanitized_allowed_tags

### DIFF
--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -57,7 +57,7 @@ module ActionView
       # Add table tags to the default allowed tags
       #
       #   class Application < Rails::Application
-      #     config.action_view.sanitized_allowed_tags = 'table', 'tr', 'td'
+      #     config.action_view.sanitized_allowed_tags = ['table', 'tr', 'td']
       #   end
       #
       # Remove tags to the default allowed tags
@@ -176,7 +176,7 @@ module ActionView
         # Replaces the allowed tags for the +sanitize+ helper.
         #
         #   class Application < Rails::Application
-        #     config.action_view.sanitized_allowed_tags = 'table', 'tr', 'td'
+        #     config.action_view.sanitized_allowed_tags = ['table', 'tr', 'td']
         #   end
         #
 


### PR DESCRIPTION
- Clarify that arguments are expected in array format.
- Extension of https://github.com/rails/rails/pull/17390.
- https://github.com/rails/rails/pull/17390 was targeted against
  4-1-stable branch. This commit updates master.
- [ci skip]
