### PR TITLE
Replace occurences of alias_method_chain with their Module#prepend counterpart

### DIFF
--- a/activesupport/lib/active_support/core_ext/marshal.rb
+++ b/activesupport/lib/active_support/core_ext/marshal.rb
@@ -1,9 +1,6 @@
-require 'active_support/core_ext/module/aliasing'
-
-module Marshal
-  class << self
-    def load_with_autoloading(source)
-      load_without_autoloading(source)
+module MarshalWithAutoloading
+    def load(source)
+      super(source)
     rescue ArgumentError, NameError => exc
       if exc.message.match(%r|undefined class/module (.+)|)
         # try loading the class/module
@@ -15,7 +12,10 @@ module Marshal
         raise exc
       end
     end
+end
 
-    alias_method_chain :load, :autoloading
+Marshal.module_eval do
+  class << self
+    prepend(MarshalWithAutoloading)
   end
 end

--- a/activesupport/lib/active_support/core_ext/range/each.rb
+++ b/activesupport/lib/active_support/core_ext/range/each.rb
@@ -1,18 +1,14 @@
-require 'active_support/core_ext/module/aliasing'
+module RangeSupportingTimeWithZone #:nodoc:
 
-class Range #:nodoc:
-
-  def each_with_time_with_zone(&block)
+  def each(&block)
     ensure_iteration_allowed
-    each_without_time_with_zone(&block)
+    super(&block)
   end
-  alias_method_chain :each, :time_with_zone
 
-  def step_with_time_with_zone(n = 1, &block)
+  def step(n = 1, &block)
     ensure_iteration_allowed
-    step_without_time_with_zone(n, &block)
+    super(n, &block)
   end
-  alias_method_chain :step, :time_with_zone
 
   private
   def ensure_iteration_allowed
@@ -21,3 +17,5 @@ class Range #:nodoc:
     end
   end
 end
+
+Range.prepend(RangeSupportingTimeWithZone)

--- a/activesupport/lib/active_support/core_ext/range/include_range.rb
+++ b/activesupport/lib/active_support/core_ext/range/include_range.rb
@@ -1,6 +1,4 @@
-require 'active_support/core_ext/module/aliasing'
-
-class Range
+module RangeSupportingInclude
   # Extends the default Range#include? to support range comparisons.
   #  (1..5).include?(1..5) # => true
   #  (1..5).include?(2..3) # => true
@@ -9,15 +7,15 @@ class Range
   # The native Range#include? behavior is untouched.
   #  ('a'..'f').include?('c') # => true
   #  (5..9).include?(11) # => false
-  def include_with_range?(value)
+  def include?(value)
     if value.is_a?(::Range)
       # 1...10 includes 1..9 but it does not include 1..10.
       operator = exclude_end? && !value.exclude_end? ? :< : :<=
-      include_without_range?(value.first) && value.last.send(operator, last)
+      super(value.first) && value.last.send(operator, last)
     else
-      include_without_range?(value)
+      super(value)
     end
   end
-
-  alias_method_chain :include?, :range
 end
+
+Range.prepend(RangeSupportingInclude)

--- a/activesupport/test/core_ext/marshal_test.rb
+++ b/activesupport/test/core_ext/marshal_test.rb
@@ -15,7 +15,7 @@ class MarshalTest < ActiveSupport::TestCase
     sanity_data = ["test", [1, 2, 3], {a: [1, 2, 3]}, ActiveSupport::TestCase]
     sanity_data.each do |obj|
       dumped = Marshal.dump(obj)
-      assert_equal Marshal.load_without_autoloading(dumped), Marshal.load(dumped)
+      assert_nothing_raised { Marshal.load(dumped) }
     end
   end
 


### PR DESCRIPTION
There is still one [here](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/object/json.rb#L41) and [there](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/deprecation/method_wrappers.rb#L34) where I could not find a working replacement with passing tests.

The advantages are quite minor but I believe it is still an improvement.
