### PR TITLE
Making the actionmailer docs more explicit to understand [ci skip]

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -703,7 +703,7 @@ module ActionMailer
     # The main method that creates the message and renders the email templates. There are
     # two ways to call this method, with a block, or without a block.
     #
-    # In both the ways to call this method, it accepts a headers hash. This hash allows you to specify 
+    # It accepts a headers hash. This hash allows you to specify 
     # the most used headers in an email message, these are:
     #
     # * +:subject+ - The subject of the message, if this is omitted, Action Mailer will

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -84,7 +84,8 @@ module ActionMailer
   # name as the method in your mailer model. For example, in the mailer defined above, the template at
   # <tt>app/views/notifier/welcome.text.erb</tt> would be used to generate the email.
   #
-  # Variables defined in the model are accessible as instance variables in the view.
+  # Variables defined in the methods of your mailer model are accessible as instance variables in their 
+  # corresponding view.
   #
   # Emails by default are sent in plain text, so a sample view for our model example might look like this:
   #
@@ -702,8 +703,8 @@ module ActionMailer
     # The main method that creates the message and renders the email templates. There are
     # two ways to call this method, with a block, or without a block.
     #
-    # Both methods accept a headers hash. This hash allows you to specify the most used headers
-    # in an email message, these are:
+    # In both the ways to call this method, it accepts a headers hash. This hash allows you to specify 
+    # the most used headers in an email message, these are:
     #
     # * +:subject+ - The subject of the message, if this is omitted, Action Mailer will
     #   ask the Rails I18n class for a translated +:subject+ in the scope of

--- a/actionmailer/lib/action_mailer/delivery_job.rb
+++ b/actionmailer/lib/action_mailer/delivery_job.rb
@@ -1,6 +1,8 @@
 require 'active_job'
 
 module ActionMailer
+  # The <tt>ActionMailer::DeliveryJob</tt> class is used when you
+  # want sending emails outside of the request-response cycle.
   class DeliveryJob < ActiveJob::Base #:nodoc:
     queue_as :mailers
 

--- a/actionmailer/lib/action_mailer/delivery_job.rb
+++ b/actionmailer/lib/action_mailer/delivery_job.rb
@@ -2,7 +2,7 @@ require 'active_job'
 
 module ActionMailer
   # The <tt>ActionMailer::DeliveryJob</tt> class is used when you
-  # want sending emails outside of the request-response cycle.
+  # want to send emails outside of the request-response cycle.
   class DeliveryJob < ActiveJob::Base #:nodoc:
     queue_as :mailers
 


### PR DESCRIPTION
1. Updated the comments in actionmailer/lib/action_mailer/base.rb to make it more easy to understand while reading them.
2. Added the description to ActionMailer::DeliveryJob class in actionmailer/lib/action_mailer/delivery_job.rb . Even though it is not exposed to public api, the comment should help to better understand the role of the class and when it is of use.
