### PR TITLE
Allow Relation#rewhere to work with infinite range values

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -913,7 +913,7 @@ module ActiveRecord
 
       where_values.reject! do |rel|
         case rel
-        when Arel::Nodes::Between, Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality, Arel::Nodes::NotEqual
+        when Arel::Nodes::Between, Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality, Arel::Nodes::NotEqual, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThanOrEqual
           subrelation = (rel.left.kind_of?(Arel::Attributes::Attribute) ? rel.left : rel.right)
           subrelation.name == target_value
         end

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -156,5 +156,26 @@ module ActiveRecord
       assert_equal 1, relation.where_values.size
       assert_equal Post.where(comments_count: 3..5), relation
     end
+
+    def test_rewhere_with_infinite_upper_bound_range
+      relation = Post.where(comments_count: 1..Float::INFINITY).rewhere(comments_count: 3..5)
+
+      assert_equal 1, relation.where_values.size
+      assert_equal Post.where(comments_count: 3..5), relation
+    end
+
+    def test_rewhere_with_infinite_lower_bound_range
+      relation = Post.where(comments_count: -Float::INFINITY..1).rewhere(comments_count: 3..5)
+
+      assert_equal 1, relation.where_values.size
+      assert_equal Post.where(comments_count: 3..5), relation
+    end
+
+    def test_rewhere_with_infinite_range
+      relation = Post.where(comments_count: -Float::INFINITY..Float::INFINITY).rewhere(comments_count: 3..5)
+
+      assert_equal 1, relation.where_values.size
+      assert_equal Post.where(comments_count: 3..5), relation
+    end
   end
 end


### PR DESCRIPTION
Addressing @sgrif 's comment [here](https://github.com/rails/rails/pull/17330#issuecomment-60541781), `Relation#rewhere` will work with infinite Range values as well.
