### PR TITLE
Yet another one replacement map {}.flatten ----> flat_map

### DIFF
--- a/actionpack/lib/action_dispatch/journey/nfa/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/nfa/transition_table.rb
@@ -99,11 +99,11 @@ module ActionDispatch
         # Returns set of NFA states to which there is a transition on ast symbol
         # +a+ from some state +s+ in +t+.
         def move(t, a)
-          Array(t).map { |s|
+          Array(t).flat_map { |s|
             inverted[s].keys.compact.find_all { |sym|
               sym === a
             }.map { |sym| inverted[s][sym] }
-          }.flatten.uniq
+          }.uniq
         end
 
         def alphabet


### PR DESCRIPTION
In order to speed up (~X4.5)  it useful if possible to move from map ... .flatten to flat_map.
