### PR TITLE
Fix rbx generated Gemfile regex

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -490,7 +490,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_psych_gem
     run_generator
-    gem_regex = /gem 'psych',\s+'~> 2.0', \s+platforms: :rbx/
+    gem_regex = /gem 'psych',\s+'~> 2.0',\s+platforms: :rbx/
 
     assert_file "Gemfile" do |content|
       if defined?(Rubinius)


### PR DESCRIPTION
https://travis-ci.org/rails/rails/jobs/39190983#L460

 1) Failure:
AppGeneratorTest#test_psych_gem
[test/generators/app_generator_test.rb:495]:
Expected /gem 'psych',\s+'~> 2.0', \s+platforms: :rbx/ to match <snip>
http://git.io/uuLVag)\ngem 'psych', '~> 2.0', platforms: :rbx\n\n
