### PR TITLE
Avoid TZInfo::AmbiguousTime exceptions on non-DST to non-DST transitions.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Avoid a TZInfo::AmbiguousTime exception with `Time.zone.local` when the
+    clocks are set back, but the time zone does not observe DST before or after
+    the transition.
+
+    *Phil Ross*
+
 *   `HashWithIndifferentAccess.new` respects the default value or proc on objects
     that respond to `#to_hash`. `.new_from_hash_copying_default` simply invokes `.new`.
     All calls to `.new_from_hash_copying_default` are replaced with `.new`.

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -435,7 +435,9 @@ module ActiveSupport
         # so transfer time values to a utc constructor if necessary
         @time = transfer_time_values_to_utc_constructor(@time) unless @time.utc?
         begin
-          period || @time_zone.period_for_local(@time)
+          # resolve ambiguity by selecting the DST or earliest occurrence of
+          # the local time
+          period || @time_zone.period_for_local(@time, true) {|periods| periods.first }
         rescue ::TZInfo::PeriodNotFound
           # time is in the "spring forward" hour gap, so we're moving the time forward one hour and trying again
           @time += 1.hour

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -406,8 +406,8 @@ module ActiveSupport
 
     # Adjust the given time to the simultaneous time in UTC. Returns a
     # Time.utc() instance.
-    def local_to_utc(time, dst=true)
-      tzinfo.local_to_utc(time, dst)
+    def local_to_utc(time, dst=true, &block)
+      tzinfo.local_to_utc(time, dst, &block)
     end
 
     # Available so that TimeZone instances respond like TZInfo::Timezone
@@ -418,8 +418,8 @@ module ActiveSupport
 
     # Available so that TimeZone instances respond like TZInfo::Timezone
     # instances.
-    def period_for_local(time, dst=true)
-      tzinfo.period_for_local(time, dst)
+    def period_for_local(time, dst=true, &block)
+      tzinfo.period_for_local(time, dst, &block)
     end
 
     def periods_for_local(time) #:nodoc:

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -196,6 +196,17 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal 'EDT', twz.zone
   end
 
+  def test_local_handles_non_dst_clock_set_back
+    # If the clocks are set back during a transition from one non-DST observance
+    # to another, the time of the transition will be ambiguous. The earlier
+    # observance will be selected to mirror behaviour of DST to non-DST transitions.
+    # Such a transition occurred at 02:00 local time in Moscow on 26 October 2014.
+    zone = ActiveSupport::TimeZone['Moscow']
+    twz = zone.local(2014,10,26,1)
+    assert_equal Time.utc(2014,10,26,1), twz.time
+    assert_equal Time.utc(2014,10,25,21), twz.utc
+  end
+
   def test_at
     zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
     secs = 946684800.0


### PR DESCRIPTION
When the clock is set back in a time zone, there is a window of ambiguous local times that could either refer to the first or second occurrence of the time.

When the clock is set back due to a transition that ends DST, the `Time.zone.local` method handles this by interpreting the local time as DST.

However, if the clock is set back, but the time zone does not observe DST before or after the transition, then a `TZInfo::AmbiguousTime` exception is raised. This scenario occurred recently in Russia (Moscow, Magadan and other time zones):

At 02:00 local time in Moscow on 26 October 2014, the clocks where put back an hour. 01:00 local time therefore occurs twice. Moscow did not observe DST before or after the transition:

```
> Time.zone = 'Moscow'
> Time.zone.local(2014,10,26,1)
TZInfo::AmbiguousTime: 2014-10-26 01:00:00 UTC is an ambiguous local time.
    from /home/psr/.rvm/gems/ruby-2.1.3/gems/tzinfo-1.2.2/lib/tzinfo/timezone.rb:415:in `period_for_local'
    from /home/psr/rails/rails/activesupport/lib/active_support/values/time_zone.rb:413:in `period_for_local'
    from /home/psr/rails/rails/activesupport/lib/active_support/time_with_zone.rb:386:in `get_period_and_ensure_valid_local_time'
    from /home/psr/rails/rails/activesupport/lib/active_support/time_with_zone.rb:48:in `initialize'
    from /home/psr/rails/rails/activesupport/lib/active_support/values/time_zone.rb:317:in `new'
    from /home/psr/rails/rails/activesupport/lib/active_support/values/time_zone.rb:317:in `local'
```

This pull request makes a change such that non-DST to non-DST transitions that set the clock back are handled similarly to transitions that end DST:

```
> Time.zone = 'Moscow'
 => "Moscow" 
> Time.zone.local(2014,10,26,1)
 => Sun, 26 Oct 2014 01:00:00 MSK +04:00 
> Time.zone.local(2014,10,26,1).utc
 => 2014-10-25 21:00:00 UTC 
```
