### PR TITLE
document change_column and change_column_default for abstract_mysql_adapter [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -485,7 +485,7 @@ module ActiveRecord
         end
       end
 
-      def change_column_default(table_name, column_name, default)
+      def change_column_default(table_name, column_name, default) #:nodoc:
         column = column_for(table_name, column_name)
         change_column table_name, column_name, column.sql_type, :default => default
       end


### PR DESCRIPTION
Small documentation quibble, noticed these methods were documented for other database adapters but not this one.
