### PR TITLE
Added underscore prefix for unused local parameters as per the ruby ...

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -196,7 +196,7 @@ module ActiveRecord
       eager_loading? || (includes_values.present? && ((column_name && column_name != :all) || references_eager_loaded_tables?))
     end
 
-    def perform_calculation(operation, column_name, options = {})
+    def perform_calculation(operation, column_name, _options = {})
       # TODO: Remove options argument as soon we remove support to
       # activerecord-deprecated_finders.
       operation = operation.to_s.downcase


### PR DESCRIPTION
... style guide

https://github.com/bbatsov/ruby-style-guide/blob/master/README.md#underscore-unused-vars
