### PR TITLE
Add (failing) test for `:some_method.to_proc`-type callback filter

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -437,7 +437,7 @@ module ActiveSupport
             }
           end
 
-          if filter.arity <= 0
+          if filter.arity == 0
             lambda { |target, _| target.instance_exec(&filter) }
           else
             lambda { |target, _| target.instance_exec(target, &filter) }

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -486,6 +486,7 @@ module CallbacksTest
         [:before_save, :proc],
         [:before_save, :symbol],
         [:before_save, :symbol],
+        [:before_save, :sym_to_proc],
         [:before_save, :string],
         [:before_save, :string],
         [:before_save, :combined_symbol],
@@ -799,11 +800,12 @@ module CallbacksTest
       end
     end
 
-    def test_proc_negative_called_with_empty_list
+    def test_proc_negative_arity
       calls = []
       klass = build_class(->(*args) { calls << args })
-      klass.new.run
-      assert_equal [[]], calls
+      instance = klass.new
+      instance.run
+      assert_equal [[instance]], calls
     end
   end
 
@@ -854,7 +856,7 @@ module CallbacksTest
       z = []
       object = build_class(->(*args) { z << args }).new
       object.run
-      assert_equal [], z.flatten
+      assert_equal [object], z.flatten
     end
 
     def test_proc_arity0

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -194,6 +194,8 @@ module CallbacksTest
     before_save Proc.new { |r| r.history << "b00m" }, :if => :no
     before_save Proc.new { |r| r.history << [:before_save, :symbol] }, :unless => :no
     before_save Proc.new { |r| r.history << "b00m" }, :unless => :yes
+    # symbol to proc
+    before_save Proc.new { |r| r.history << [:before_save, :sym_to_proc] }, :if => :yes.to_proc
     # string
     before_save Proc.new { |r| r.history << [:before_save, :string] }, :if => 'yes'
     before_save Proc.new { |r| r.history << "b00m" }, :if => 'no'


### PR DESCRIPTION
Currently this yields an `ArgumentError: no receiver given` error due to
the transformations done to the filter proc in `ActiveSupport::Callbacks::Callback#make_lambda`

This behaviour originates from
https://github.com/rails/rails/commit/6189e2714b730d4ae0da11884b8082cbee0fb44c#diff-1ecd313ff0ab827af30014553cf8918dR356

Probably debatable if this is a problem, since people could just use `:some_method` as the filter. However, when/if one runs into this, it does seem pretty strange and it is hard to understand the root of the problem. 

One would guess that e.g.

``` ruby
validates :something, if: proc {|x| x.should_validate?}
```

behaves the same as

``` ruby
validates :something, if: proc(&:should_validate?)
```

or

``` ruby
validates :something, if: :should_validate?.to_proc
```

The latter two both yield the `ArgumentError: no receiver given` in https://github.com/rails/rails/blob/master/activesupport/lib/active_support/callbacks.rb#L441.

What do you think? A fix would probably further complicate the `ActiveSupport::Callbacks::Callback#make_lambda` method.
