### PR TITLE
Fix doc markup for `NumberHelper`

### DIFF
--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -306,12 +306,12 @@ module ActionView
       #   string containing an i18n scope where to find this hash. It
       #   might have the following keys:
       #   * *integers*: <tt>:unit</tt>, <tt>:ten</tt>,
-      #     *<tt>:hundred</tt>, <tt>:thousand</tt>, <tt>:million</tt>,
-      #     *<tt>:billion</tt>, <tt>:trillion</tt>,
-      #     *<tt>:quadrillion</tt>
+      #     <tt>:hundred</tt>, <tt>:thousand</tt>, <tt>:million</tt>,
+      #     <tt>:billion</tt>, <tt>:trillion</tt>,
+      #     <tt>:quadrillion</tt>
       #   * *fractionals*: <tt>:deci</tt>, <tt>:centi</tt>,
-      #     *<tt>:mili</tt>, <tt>:micro</tt>, <tt>:nano</tt>,
-      #     *<tt>:pico</tt>, <tt>:femto</tt>
+      #     <tt>:mili</tt>, <tt>:micro</tt>, <tt>:nano</tt>,
+      #     <tt>:pico</tt>, <tt>:femto</tt>
       # * <tt>:format</tt> - Sets the format of the output string
       #   (defaults to "%n %u"). The field types are:
       #   * %u - The quantifier (ex.: 'thousand')

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -272,12 +272,12 @@ module ActiveSupport
     #   string containing an i18n scope where to find this hash. It
     #   might have the following keys:
     #   * *integers*: <tt>:unit</tt>, <tt>:ten</tt>,
-    #     *<tt>:hundred</tt>, <tt>:thousand</tt>, <tt>:million</tt>,
-    #     *<tt>:billion</tt>, <tt>:trillion</tt>,
-    #     *<tt>:quadrillion</tt>
+    #     <tt>:hundred</tt>, <tt>:thousand</tt>, <tt>:million</tt>,
+    #     <tt>:billion</tt>, <tt>:trillion</tt>,
+    #     <tt>:quadrillion</tt>
     #   * *fractionals*: <tt>:deci</tt>, <tt>:centi</tt>,
-    #     *<tt>:mili</tt>, <tt>:micro</tt>, <tt>:nano</tt>,
-    #     *<tt>:pico</tt>, <tt>:femto</tt>
+    #     <tt>:mili</tt>, <tt>:micro</tt>, <tt>:nano</tt>,
+    #     <tt>:pico</tt>, <tt>:femto</tt>
     # * <tt>:format</tt> - Sets the format of the output string
     #   (defaults to "%n %u"). The field types are:
     #   * %u - The quantifier (ex.: 'thousand')


### PR DESCRIPTION
The character "*" is unnecessary in option candidates.
This incorrect markup was injected in e8c9aeca .

Before:
![2014-10-28 21 49 52](https://cloud.githubusercontent.com/assets/290782/4811211/c2cca0a0-5eb8-11e4-94c3-acb3145fdacb.png)

After
![2014-10-28 21 48 33](https://cloud.githubusercontent.com/assets/290782/4811210/c2c9797a-5eb8-11e4-8bd7-73bda7cd3bc8.png)
