### PR TITLE
Fix guides snippet for registering a custom asset pipeline processor

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -1295,7 +1295,7 @@ Now that you have a `Template` class, it's time to associate it with an
 extension for template files:
 
 ```ruby
-Sprockets.register_engine '.bang', BangBang::Template
+Rails.application.assets.register_engine '.bang', BangBang::Template
 ```
 
 Upgrading from Old Versions of Rails


### PR DESCRIPTION
For some reason, calling `register_engine` on `Sprockets` directly doesn't work. This version does.

I'm submitting this as a PR because I'm not sure if it's a bug, or if it's how things are supposed to be done.
