### PR TITLE
let warn with heredocs

### DIFF
--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -1,4 +1,5 @@
 require 'delegate'
+require 'active_support/core_ext/string/filters'
 
 module ActionMailer
 
@@ -85,14 +86,22 @@ module ActionMailer
     end
 
     def deliver! #:nodoc:
-      ActiveSupport::Deprecation.warn "#deliver! is deprecated and will be removed in Rails 5. " \
-        "Use #deliver_now! to deliver immediately or #deliver_later! to deliver through Active Job."
+      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        #deliver! is deprecated and will be removed in Rails 5. Use
+        #deliver_now! to deliver immediately or #deliver_later! to
+        deliver through Active Job.
+      MSG
+
       deliver_now!
     end
 
     def deliver #:nodoc:
-      ActiveSupport::Deprecation.warn "#deliver is deprecated and will be removed in Rails 5. " \
-        "Use #deliver_now to deliver immediately or #deliver_later to deliver through Active Job."
+      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        #deliver is deprecated and will be removed in Rails 5. Use
+        #deliver_now to deliver immediately or #deliver_later to
+        deliver through Active Job.
+      MSG
+
       deliver_now
     end
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/array/wrap'
+require 'active_support/core_ext/string/filters'
 require 'active_support/deprecation'
 require 'active_support/rescuable'
 require 'action_dispatch/http/upload'
@@ -114,10 +115,12 @@ module ActionController
 
     def self.const_missing(const_name)
       super unless const_name == :NEVER_UNPERMITTED_PARAMS
-      ActiveSupport::Deprecation.warn "`ActionController::Parameters::NEVER_UNPERMITTED_PARAMS`"\
-                                      " has been deprecated. Use "\
-                                      "`ActionController::Parameters.always_permitted_parameters` instead."
-      self.always_permitted_parameters
+      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        `ActionController::Parameters::NEVER_UNPERMITTED_PARAMS` has been deprecated.
+        Use `ActionController::Parameters.always_permitted_parameters` instead.
+      MSG
+
+      always_permitted_parameters
     end
 
     # Returns a new instance of <tt>ActionController::Parameters</tt>.

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/module/attribute_accessors'
+require 'active_support/core_ext/string/filters'
 require 'active_support/deprecation'
 require 'action_dispatch/http/filter_redirect'
 require 'monitor'
@@ -288,7 +289,12 @@ module ActionDispatch # :nodoc:
     # as arrays work, and "flattening" responses, cascading to the rack body!
     # Not sensible behavior.
     def to_ary
-      ActiveSupport::Deprecation.warn 'ActionDispatch::Response#to_ary no longer performs implicit conversion to an Array. Please use response.to_a instead, or a splat like `status, headers, body = *response`'
+      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        'ActionDispatch::Response#to_ary no longer performs implicit conversion
+        to an Array. Please use response.to_a instead, or a splat like `status,
+        headers, body = *response`
+      MSG
+
       to_a
     end
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -6,6 +6,7 @@ require 'active_support/core_ext/object/to_query'
 require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/module/remove_method'
 require 'active_support/core_ext/array/extract_options'
+require 'active_support/core_ext/string/filters'
 require 'action_controller/metal/exceptions'
 require 'action_dispatch/http/request'
 require 'action_dispatch/routing/endpoint'
@@ -325,20 +326,22 @@ module ActionDispatch
       LEGACY  = ->(options) {
         if options.key?(:only_path)
           if options[:only_path]
-            ActiveSupport::Deprecation.warn \
-              "You are calling a `*_path` helper with the `only_path` option " \
-              "explicitly set to `true`. This option will stop working on " \
-              "path helpers in Rails 5. Simply remove the `only_path: true` " \
-              "argument from your call as it is redundant when applied to a " \
-              "path helper."
+            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+              You are calling a `*_path` helper with the `only_path` option
+              explicitly set to `true`. This option will stop working on
+              path helpers in Rails 5. Simply remove the `only_path: true`
+              argument from your call as it is redundant when applied to a
+              path helper.
+            MSG
 
             PATH.call(options)
           else
-            ActiveSupport::Deprecation.warn \
-              "You are calling a `*_path` helper with the `only_path` option " \
-              "explicitly set to `false`. This option will stop working on " \
-              "path helpers in Rails 5. Use the corresponding `*_url` helper " \
-              "instead."
+            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+              You are calling a `*_path` helper with the `only_path` option
+              explicitly set to `false`. This option will stop working on
+              path helpers in Rails 5. Use the corresponding `*_url` helper
+              instead.
+            MSG
 
             FULL.call(options)
           end

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -1,6 +1,7 @@
 require "pathname"
 require "active_support/core_ext/class"
 require "active_support/core_ext/module/attribute_accessors"
+require 'active_support/core_ext/string/filters'
 require "action_view/template"
 require "thread"
 require "thread_safe"
@@ -251,9 +252,10 @@ module ActionView
 
       extension = pieces.pop
       unless extension
-        message = "The file #{path} did not specify a template handler. The default is currently ERB, " \
-                  "but will change to RAW in the future."
-        ActiveSupport::Deprecation.warn message
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          The file #{path} did not specify a template handler. The default is
+          currently ERB, but will change to RAW in the future.
+        MSG
       end
 
       handler = Template.handler_for_extension(extension)

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/string/filters'
+
 module ActiveRecord
   # = Active Record Has Many Through Association
   module Associations
@@ -63,11 +65,12 @@ module ActiveRecord
 
         save_through_record(record)
         if has_cached_counter? && !through_reflection_updates_counter_cache?
-          ActiveSupport::Deprecation.warn \
-            "Automatic updating of counter caches on through associations has been " \
-            "deprecated, and will be removed in Rails 5.0. Instead, please set the " \
-            "appropriate counter_cache options on the has_many and belongs_to for " \
-            "your associations to #{through_reflection.name}."
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Automatic updating of counter caches on through associations has been
+            deprecated, and will be removed in Rails 5.0. Instead, please set the
+            appropriate counter_cache options on the has_many and belongs_to for
+            your associations to #{through_reflection.name}.
+          MSG
 
           update_counter_in_database(1)
         end

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/enumerable'
+require 'active_support/core_ext/string/filters'
 require 'mutex_m'
 require 'thread_safe'
 
@@ -205,9 +206,11 @@ module ActiveRecord
       def column_for_attribute(name)
         column = columns_hash[name.to_s]
         if column.nil?
-          ActiveSupport::Deprecation.warn \
-            "`column_for_attribute` will return a null object for non-existent columns " \
-            "in Rails 5.0. Use `has_attribute?` if you need to check for an attribute's existence."
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            `column_for_attribute` will return a null object for non-existent
+            columns in Rails 5.0. Use `has_attribute?` if you need to check for
+            an attribute's existence.
+          MSG
         end
         column
       end

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/string/filters'
+
 module ActiveRecord
   module AttributeMethods
     module Serialization
@@ -51,8 +53,10 @@ module ActiveRecord
         end
 
         def serialized_attributes
-          ActiveSupport::Deprecation.warn "`serialized_attributes` is deprecated " \
-            "without replacement, and will be removed in Rails 5.0."
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            `serialized_attributes` is deprecated without replacement, and will
+            be removed in Rails 5.0.
+          MSG
 
           @serialized_attributes ||= Hash[
             columns.select { |t| t.cast_type.is_a?(Type::Serialized) }.map { |c|

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -2,6 +2,7 @@ require 'thread'
 require 'thread_safe'
 require 'monitor'
 require 'set'
+require 'active_support/core_ext/string/filters'
 
 module ActiveRecord
   # Raised when a connection could not be obtained within the connection
@@ -518,10 +519,11 @@ module ActiveRecord
       end
 
       def connection_pools
-        ActiveSupport::Deprecation.warn(
-          "In the next release, this will return the same as #connection_pool_list. " \
-          "(An array of pools, rather than a hash mapping specs to pools.)"
-        )
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          In the next release, this will return the same as #connection_pool_list.
+          (An array of pools, rather than a hash mapping specs to pools.)
+        MSG
+
         Hash[connection_pool_list.map { |pool| [pool.spec, pool] }]
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -60,11 +60,12 @@ module ActiveRecord
       def emit_warning_if_null_unspecified(options)
         return if options.key?(:null)
 
-        ActiveSupport::Deprecation.warn \
-          "`timestamp` was called without specifying an option for `null`. In Rails " \
-          "5.0, this behavior will change to `null: false`. You should manually " \
-          "specify `null: true` to prevent the behavior of your existing migrations " \
-          "from changing."
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          `timestamp` was called without specifying an option for `null`. In Rails
+          5.0, this behavior will change to `null: false`. You should manually
+          specify `null: true` to prevent the behavior of your existing migrations
+          from changing.
+        MSG
       end
     end
 

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'active_support/core_ext/string/filters'
 
 module ActiveRecord
   module ConnectionAdapters
@@ -221,8 +222,12 @@ module ActiveRecord
           # this ambiguous behaviour and in the future this function
           # can be removed in favor of resolve_url_connection.
           if configurations.key?(spec) || spec !~ /:/
-            ActiveSupport::Deprecation.warn "Passing a string to ActiveRecord::Base.establish_connection " \
-              "for a configuration lookup is deprecated, please pass a symbol (#{spec.to_sym.inspect}) instead"
+            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+              Passing a string to ActiveRecord::Base.establish_connection for a
+              configuration lookup is deprecated, please pass a symbol
+              (#{spec.to_sym.inspect}) instead
+            MSG
+
             resolve_symbol_connection(spec)
           else
             resolve_url_connection(spec)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/string/filters'
+
 module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
@@ -25,10 +27,11 @@ module ActiveRecord
             if !infinity?(from) && extracted[:exclude_start]
               if from.respond_to?(:succ)
                 from = from.succ
-                ActiveSupport::Deprecation.warn \
-                  "Excluding the beginning of a Range is only partialy supported " \
-                  "through `#succ`. This is not reliable and will be removed in " \
-                  "the future."
+                ActiveSupport::Deprecation.warn(<<-MSG.squish)
+                  Excluding the beginning of a Range is only partialy supported
+                  through `#succ`. This is not reliable and will be removed in
+                  the future.
+                MSG
               else
                 raise ArgumentError, "The Ruby Range object does not support excluding the beginning of a Range. (unsupported value: '#{value}')"
               end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -1,6 +1,7 @@
+require 'thread'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/object/duplicable'
-require 'thread'
+require 'active_support/core_ext/string/filters'
 
 module ActiveRecord
   module Core
@@ -88,8 +89,10 @@ module ActiveRecord
       mattr_accessor :maintain_test_schema, instance_accessor: false
 
       def self.disable_implicit_join_references=(value)
-        ActiveSupport::Deprecation.warn("Implicit join references were removed with Rails 4.1." \
-                                        "Make sure to remove this configuration because it does nothing.")
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          Implicit join references were removed with Rails 4.1.
+          Make sure to remove this configuration because it does nothing.
+        MSG
       end
 
       class_attribute :default_connection_handler, instance_writer: false
@@ -135,8 +138,10 @@ module ActiveRecord
         id  = ids.first
         if ActiveRecord::Base === id
           id = id.id
-          ActiveSupport::Deprecation.warn "You are passing an instance of ActiveRecord::Base to `find`." \
-            "Please pass the id of the object by calling `.id`"
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            You are passing an instance of ActiveRecord::Base to `find`.
+            Please pass the id of the object by calling `.id`
+          MSG
         end
         key = primary_key
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1,4 +1,5 @@
 require 'thread'
+require 'active_support/core_ext/string/filters'
 
 module ActiveRecord
   # = Active Record Reflection
@@ -153,8 +154,11 @@ module ActiveRecord
       end
 
       def source_macro
-        ActiveSupport::Deprecation.warn("ActiveRecord::Base.source_macro is deprecated and " \
-          "will be removed without replacement.")
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActiveRecord::Base.source_macro is deprecated and will be removed
+          without replacement.
+        MSG
+
         macro
       end
     end
@@ -339,13 +343,14 @@ module ActiveRecord
         return unless scope
 
         if scope.arity > 0
-          ActiveSupport::Deprecation.warn \
-            "The association scope '#{name}' is instance dependent (the scope " \
-            "block takes an argument). Preloading happens before the individual " \
-            "instances are created. This means that there is no instance being " \
-            "passed to the association scope. This will most likely result in " \
-            "broken or incorrect behavior. Joining, Preloading and eager loading " \
-            "of these associations is deprecated and will be removed in the future."
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            The association scope '#{name}' is instance dependent (the scope
+            block takes an argument). Preloading happens before the individual
+            instances are created. This means that there is no instance being
+            passed to the association scope. This will most likely result in
+            broken or incorrect behavior. Joining, Preloading and eager loading
+            of these associations is deprecated and will be removed in the future.
+          MSG
         end
       end
       alias :check_eager_loadable! :check_preloadable!
@@ -746,8 +751,11 @@ module ActiveRecord
 
       # The macro used by the source association
       def source_macro
-        ActiveSupport::Deprecation.warn("ActiveRecord::Base.source_macro is deprecated and " \
-          "will be removed without replacement.")
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActiveRecord::Base.source_macro is deprecated and will be removed
+          without replacement.
+        MSG
+
         source_reflection.source_macro
       end
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -1,4 +1,5 @@
 require 'active_support/deprecation'
+require 'active_support/core_ext/string/filters'
 
 module ActiveRecord
   module FinderMethods
@@ -284,8 +285,10 @@ module ActiveRecord
     def exists?(conditions = :none)
       if Base === conditions
         conditions = conditions.id
-        ActiveSupport::Deprecation.warn "You are passing an instance of ActiveRecord::Base to `exists?`." \
-          "Please pass the id of the object by calling `.id`"
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          You are passing an instance of ActiveRecord::Base to `exists?`.
+          Please pass the id of the object by calling `.id`
+        MSG
       end
 
       return false if !conditions
@@ -435,8 +438,10 @@ module ActiveRecord
     def find_one(id)
       if ActiveRecord::Base === id
         id = id.id
-        ActiveSupport::Deprecation.warn "You are passing an instance of ActiveRecord::Base to `find`." \
-          "Please pass the id of the object by calling `.id`"
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          You are passing an instance of ActiveRecord::Base to `find`.
+          Please pass the id of the object by calling `.id`
+        MSG
       end
 
       column = columns_hash[primary_key]

--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/string/filters'
+
 module ActiveRecord
   class PredicateBuilder
     class ArrayHandler # :nodoc:
@@ -6,9 +8,12 @@ module ActiveRecord
         nils, values = values.partition(&:nil?)
 
         if values.any? { |val| val.is_a?(Array) }
-          ActiveSupport::Deprecation.warn "Passing a nested array to Active Record " \
-            "finder methods is deprecated and will be removed. Flatten your array " \
-            "before using it for 'IN' conditions."
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Passing a nested array to Active Record finder methods is
+            deprecated and will be removed. Flatten your array before using
+            it for 'IN' conditions.
+          MSG
+
           values = values.flatten
         end
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/array/wrap'
+require 'active_support/core_ext/string/filters'
 require 'active_model/forbidden_attributes_protection'
 
 module ActiveRecord
@@ -94,8 +95,10 @@ module ActiveRecord
     def check_cached_relation # :nodoc:
       if defined?(@arel) && @arel
         @arel = nil
-        ActiveSupport::Deprecation.warn "Modifying already cached Relation. The " \
-          "cache will be reset. Use a cloned Relation to prevent this warning."
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          Modifying already cached Relation. The cache will be reset. Use a
+          cloned Relation to prevent this warning.
+        MSG
       end
     end
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/string/filters'
+
 module ActiveRecord
   module Tasks # :nodoc:
     class DatabaseAlreadyExists < StandardError; end # :nodoc:
@@ -187,9 +189,10 @@ module ActiveRecord
       end
 
       def load_schema(format = ActiveRecord::Base.schema_format, file = nil)
-        ActiveSupport::Deprecation.warn \
-          "This method will act on a specific connection in the future. " \
-          "To act on the current connection, use `load_schema_current` instead."
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          This method will act on a specific connection in the future.
+          To act on the current connection, use `load_schema_current` instead.
+        MSG
 
         load_schema_current(format, file)
       end


### PR DESCRIPTION
The current style for warning messages without newlines uses
concatenation of string literals with manual trailing spaces
where needed.

Heredocs have better readability, and with `squish` we can still
produce a single line.

This is a similar use case to the one that motivated defining
`strip_heredoc`, heredocs are super clean.
