### PR TITLE
Added 'tzinfo-data' if we are using jruby

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -40,7 +40,7 @@ group :development, :test do
 <% end -%>
 end
 
-<% if RUBY_PLATFORM.match(/bccwin|cygwin|emx|mingw|mswin|wince/) -%>
+<% if RUBY_PLATFORM.match(/bccwin|cygwin|emx|mingw|mswin|wince|java/) -%>
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 <% end -%>


### PR DESCRIPTION
I develop Rails on Windows, yepp...shame on me. With JRuby I find myself to add 'tzinfo-data' gem everytime I start a new project.
`RUBY_PLATFORM` with JRuby is always 'java', so we have to match this case, but It's a little bit 
tricky to find out if we are using JRuby on Windows.
I don't want to add and if-else clause for just one case, It's a problem to add it everytime we have Platform == 'java'? Can we add it to default if platform is jruby?
Otherwise we can check if:

```
Gem.win_platform? && PLATFORM.match(/java/)
```
