### PR TITLE
Add Firebird support to test suite

### DIFF
--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -348,6 +348,8 @@ class SchemaDumperTest < ActiveRecord::TestCase
     # Oracle supports precision up to 38 and it identifies decimals with scale 0 as integers
     if current_adapter?(:OracleAdapter)
       assert_match %r{t.integer\s+"atoms_in_universe",\s+precision: 38}, output
+    elsif current_adapter?(:FbAdapter)
+      assert_match %r{t.decimal\s+"atoms_in_universe",\s+precision: 18}, output
     else
       assert_match %r{t.decimal\s+"atoms_in_universe",\s+precision: 55}, output
     end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -12,7 +12,10 @@ ActiveRecord::Schema.define do
   when "Fb"
     def create_table(*args, &block)
       ActiveRecord::Base.connection.create_table(*args, &block)
-      ActiveRecord::Base.connection.execute "SET GENERATOR #{args.first}_seq TO 10000"
+      if !args.last.respond_to?(:keys) || args.last[:id] != false
+        seq_name = ActiveRecord::Base.connection.default_sequence_name(args.first)
+        ActiveRecord::Base.connection.execute "SET GENERATOR #{seq_name} TO 10000"
+      end
     end
   when "PostgreSQL"
     enable_extension!('uuid-ossp', ActiveRecord::Base.connection)

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -9,6 +9,11 @@ ActiveRecord::Schema.define do
 
   #put adapter specific setup here
   case adapter_name
+  when "Fb"
+    def create_table(*args, &block)
+      ActiveRecord::Base.connection.create_table(*args, &block)
+      ActiveRecord::Base.connection.execute "SET GENERATOR #{args.first}_seq TO 10000"
+    end
   when "PostgreSQL"
     enable_extension!('uuid-ossp', ActiveRecord::Base.connection)
     create_table :uuid_parents, id: :uuid, force: true do |t|
@@ -474,6 +479,8 @@ ActiveRecord::Schema.define do
     # Oracle/SQLServer supports precision up to 38
     if current_adapter?(:OracleAdapter, :SQLServerAdapter)
       t.decimal :atoms_in_universe, precision: 38, scale: 0
+    elsif current_adapter?(:FbAdapter)
+      t.decimal :atoms_in_universe, precision: 18, scale: 0
     else
       t.decimal :atoms_in_universe, precision: 55, scale: 0
     end


### PR DESCRIPTION
This is needed to be able to get Firebird driver to run against ActiveRecord's tests.

Details are on this pr for activerecord-fb-adapter that will be merged later in the Firebird driver 

https://github.com/rowland/activerecord-fb-adapter/pull/43
