### PR TITLE
Rely on through table name in has_many fixtures

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -703,6 +703,10 @@ module ActiveRecord
       def lhs_key
         @association.through_reflection.foreign_key
       end
+
+      def join_table
+        @association.through_reflection.table_name
+      end
     end
 
     private

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -271,7 +271,7 @@ class HasManyThroughFixture < ActiveSupport::TestCase
     Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }
   end
 
-  def test_has_many_through
+  def test_has_many_through_with_default_table_name
     pt = make_model "ParrotTreasure"
     parrot = make_model "Parrot"
     treasure = make_model "Treasure"
@@ -288,6 +288,24 @@ class HasManyThroughFixture < ActiveSupport::TestCase
     fs = ActiveRecord::FixtureSet.new parrot.connection, "parrots", parrot, parrots
     rows = fs.table_rows
     assert_equal load_has_and_belongs_to_many['parrots_treasures'], rows['parrots_treasures']
+  end
+
+  def test_has_many_through_with_renamed_table
+    pt = make_model "ParrotTreasure"
+    parrot = make_model "Parrot"
+    treasure = make_model "Treasure"
+
+    pt.belongs_to :parrot, :class => parrot
+    pt.belongs_to :treasure, :class => treasure
+
+    parrot.has_many :parrot_treasures, :class => pt
+    parrot.has_many :treasures, :through => :parrot_treasures
+
+    parrots = File.join FIXTURES_ROOT, 'parrots'
+
+    fs = ActiveRecord::FixtureSet.new parrot.connection, "parrots", parrot, parrots
+    rows = fs.table_rows
+    assert_equal load_has_and_belongs_to_many['parrots_treasures'], rows['parrot_treasures']
   end
 
   def load_has_and_belongs_to_many


### PR DESCRIPTION
The fixtures code always builds join table names via the association's [`join_table`](https://github.com/jpcody/rails/blob/8e16a00de4f77f15e405d083d535b92a23779d9d/activerecord/lib/active_record/fixtures.rb#L685) method, which will use [`derive_join_table`](https://github.com/jpcody/rails/blob/8e16a00de4f77f15e405d083d535b92a23779d9d/activerecord/lib/active_record/reflection.rb#L566) to build the table name via convention. But in the event a join table was created with a different table name, this will fall down. Using the `through_association#table_name` makes an affordance for both of these cases.

I think the existing code works from for the `ReflectionProxy` but should be overridden for the `HasManyThroughProxy` to handle if the table name is either overridden in the model or created with a different table name.
