### PR TITLE
better example for tokenizer lambda [ci skip]

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -427,7 +427,7 @@ class Essay < ActiveRecord::Base
   validates :content, length: {
     minimum: 300,
     maximum: 400,
-    tokenizer: lambda { |str| str.scan(/\w+/) },
+    tokenizer: lambda { |str| str.split(/\s+/) },
     too_short: "must have at least %{count} words",
     too_long: "must have at most %{count} words"
   }


### PR DESCRIPTION
Splitting on whitespace makes more sense in the context of counting words in an essay.

To elaborate, consider how the Unix `wc` command works

```
$ echo "Rail's tokenizer-example" | wc -w
2
```

vs how this example tokenizer would behave

```
irb(main):001:0> "Rail's tokenizer-example".scan(/\w+/).length
=> 4
```
