### PR TITLE
The email preview iframe height is fixed and does not scale to the browser size

### DIFF
--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -2,6 +2,10 @@
 <html><head>
 <meta name="viewport" content="width=device-width" />
 <style type="text/css">
+  html, body, iframe {
+    height: 100%;
+  }
+
   body {
     margin: 0;
   }
@@ -38,7 +42,6 @@
   iframe {
     border: 0;
     width: 100%;
-    height: 800px;
   }
 </style>
 </head>


### PR DESCRIPTION
On larger screens the email preview iframe is being limited to a height of 800 pixels, and the full available screen size is not being used.

I've just updated the height of the iframe and parents to be explicitly 100% so that the full height of the browser window can be used.

I've also created a pull request for the standalone mail_view gem https://github.com/basecamp/mail_view/pull/80
