### PR TITLE
correct GlobalID mixin name in the guides

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -286,7 +286,7 @@ class TrashableCleanupJob
 end
 ```
 
-This works with any class that mixes in `ActiveModel::GlobalIdentification`, which
+This works with any class that mixes in `GlobalID::Identification`, which
 by default has been mixed into Active Model classes.
 
 


### PR DESCRIPTION
This needs to be `GlobalID::Identification`. In version 4.2.0.beta2, `ActiveModel` does not have a `GlobalIdentification` namespace. I was using `ActiveJob` with a `Mongoid` model when I came across this issue. Mixing in `GlobalID::Identification` fixed it for me. So I think an update to the guide is all that is necessary.
