### PR TITLE
Remove redundant `to_s` in interpolation

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -48,7 +48,7 @@ module ActionDispatch
       def reqs
         @reqs ||= begin
           reqs = endpoint
-          reqs += " #{constraints.to_s}" unless constraints.empty?
+          reqs += " #{constraints}" unless constraints.empty?
           reqs
         end
       end

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -579,10 +579,10 @@ class RespondToControllerTest < ActionController::TestCase
     end
 
     get :using_defaults
-    assert_equal "using_defaults - #{[:html].to_s}", @response.body
+    assert_equal "using_defaults - #{[:html]}", @response.body
 
     get :using_defaults, :format => "xml"
-    assert_equal "using_defaults - #{[:xml].to_s}", @response.body
+    assert_equal "using_defaults - #{[:xml]}", @response.body
   end
 
   def test_format_with_custom_response_type

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -108,7 +108,7 @@ module ActiveRecord
         when Numeric, ActiveSupport::Duration then value.to_s
         when Date, Time then "'#{quoted_date(value)}'"
         when Symbol     then "'#{quote_string(value.to_s)}'"
-        when Class      then "'#{value.to_s}'"
+        when Class      then "'#{value}'"
         else
           "'#{quote_string(YAML.dump(value))}'"
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     module ColumnDumper
       def column_spec(column, types)
         spec = prepare_column_options(column, types)
-        (spec.keys - [:name, :type]).each{ |k| spec[k].insert(0, "#{k.to_s}: ")}
+        (spec.keys - [:name, :type]).each{ |k| spec[k].insert(0, "#{k}: ")}
         spec
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/cidr.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/cidr.rb
@@ -12,15 +12,15 @@ module ActiveRecord
 
             # If the subnet mask is equal to /32, don't output it
             if subnet_mask == (2**32 - 1)
-              "\"#{value.to_s}\""
+              "\"#{value}\""
             else
-              "\"#{value.to_s}/#{subnet_mask.to_s(2).count('1')}\""
+              "\"#{value}/#{subnet_mask.to_s(2).count('1')}\""
             end
           end
 
           def type_cast_for_database(value)
             if IPAddr === value
-              "#{value.to_s}/#{value.instance_variable_get(:@mask_addr).to_s(2).count('1')}"
+              "#{value}/#{value.instance_variable_get(:@mask_addr).to_s(2).count('1')}"
             else
               value
             end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -21,7 +21,7 @@ module ActiveRecord
           case value
           when Float
             if value.infinite? || value.nan?
-              "'#{value.to_s}'"
+              "'#{value}'"
             else
               super
             end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -679,9 +679,9 @@ module ActiveRecord
           variables.map do |k, v|
             if v == ':default' || v == :default
               # Sets the value to the global or compile default
-              execute("SET SESSION #{k.to_s} TO DEFAULT", 'SCHEMA')
+              execute("SET SESSION #{k} TO DEFAULT", 'SCHEMA')
             elsif !v.nil?
-              execute("SET SESSION #{k.to_s} TO #{quote(v)}", 'SCHEMA')
+              execute("SET SESSION #{k} TO #{quote(v)}", 'SCHEMA')
             end
           end
         end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -95,7 +95,7 @@ EXPECTED_TIME_ZONE_AWARE_ATTRIBUTES = false
 def verify_default_timezone_config
   if Time.zone != EXPECTED_ZONE
     $stderr.puts <<-MSG
-\n#{self.to_s}
+\n#{self}
     Global state `Time.zone` was leaked.
       Expected: #{EXPECTED_ZONE}
       Got: #{Time.zone}
@@ -103,7 +103,7 @@ def verify_default_timezone_config
   end
   if ActiveRecord::Base.default_timezone != EXPECTED_DEFAULT_TIMEZONE
     $stderr.puts <<-MSG
-\n#{self.to_s}
+\n#{self}
     Global state `ActiveRecord::Base.default_timezone` was leaked.
       Expected: #{EXPECTED_DEFAULT_TIMEZONE}
       Got: #{ActiveRecord::Base.default_timezone}
@@ -111,7 +111,7 @@ def verify_default_timezone_config
   end
   if ActiveRecord::Base.time_zone_aware_attributes != EXPECTED_TIME_ZONE_AWARE_ATTRIBUTES
     $stderr.puts <<-MSG
-\n#{self.to_s}
+\n#{self}
     Global state `ActiveRecord::Base.time_zone_aware_attributes` was leaked.
       Expected: #{EXPECTED_TIME_ZONE_AWARE_ATTRIBUTES}
       Got: #{ActiveRecord::Base.time_zone_aware_attributes}

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -68,7 +68,7 @@ class TestJSONEncoding < ActiveSupport::TestCase
                    [ 1.0/0.0,   %(null) ],
                    [ -1.0/0.0,  %(null) ],
                    [ BigDecimal('0.0')/BigDecimal('0.0'),  %(null) ],
-                   [ BigDecimal('2.5'), %("#{BigDecimal('2.5').to_s}") ]]
+                   [ BigDecimal('2.5'), %("#{BigDecimal('2.5')}") ]]
 
   StringTests   = [[ 'this is the <string>',     %("this is the \\u003cstring\\u003e")],
                    [ 'a "string" with quotes & an ampersand', %("a \\"string\\" with quotes \\u0026 an ampersand") ],


### PR DESCRIPTION
This is a continuation of 352b031a… it's my understanding that Ruby automatically calls `to_s` on any element that is interpolated inside a string; therefore there is no need to explicitly add `to_s`.
