### PR TITLE
Add :db_runtime to table

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -136,6 +136,7 @@ Action Controller
 | `:method`       | HTTP request verb                                         |
 | `:path`         | Request path                                              |
 | `:view_runtime` | Amount spent in view in ms                                |
+| `:db_runtime`   | Amount spent executing database queries in ms             |
 
 ```ruby
 {


### PR DESCRIPTION
It was missing from table, but is present in sample hash below

/cc @fxn
