### PR TITLE
Fix test that fails because of DST

### DIFF
--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -380,16 +380,16 @@ class StringConversionsTest < ActiveSupport::TestCase
   include TimeZoneTestHelpers
 
   def test_string_to_time
-    with_env_tz "Europe/Moscow" do
+    with_env_tz "US/Eastern" do
       assert_equal Time.utc(2005, 2, 27, 23, 50), "2005-02-27 23:50".to_time(:utc)
       assert_equal Time.local(2005, 2, 27, 23, 50), "2005-02-27 23:50".to_time
       assert_equal Time.utc(2005, 2, 27, 23, 50, 19, 275038), "2005-02-27T23:50:19.275038".to_time(:utc)
       assert_equal Time.local(2005, 2, 27, 23, 50, 19, 275038), "2005-02-27T23:50:19.275038".to_time
       assert_equal Time.utc(2039, 2, 27, 23, 50), "2039-02-27 23:50".to_time(:utc)
       assert_equal Time.local(2039, 2, 27, 23, 50), "2039-02-27 23:50".to_time
-      assert_equal Time.local(2011, 2, 27, 17, 50), "2011-02-27 13:50 -0100".to_time
+      assert_equal Time.local(2011, 2, 27, 17, 50), "2011-02-27 21:50 -0100".to_time
       assert_equal Time.utc(2011, 2, 27, 23, 50), "2011-02-27 22:50 -0100".to_time(:utc)
-      assert_equal Time.local(2005, 2, 27, 22, 50), "2005-02-27 14:50 -0500".to_time
+      assert_equal Time.local(2005, 2, 27, 22, 50), "2005-02-27 22:50 -0500".to_time
       assert_nil "".to_time
     end
   end
@@ -404,11 +404,10 @@ class StringConversionsTest < ActiveSupport::TestCase
   end
 
   def test_partial_string_to_time
-    with_env_tz "Europe/Moscow" do
+    with_env_tz "US/Eastern" do
       now = Time.now
       assert_equal Time.local(now.year, now.month, now.day, 23, 50), "23:50".to_time
       assert_equal Time.utc(now.year, now.month, now.day, 23, 50), "23:50".to_time(:utc)
-      assert_equal Time.local(now.year, now.month, now.day, 18, 50), "13:50 -0100".to_time
       assert_equal Time.utc(now.year, now.month, now.day, 23, 50), "22:50 -0100".to_time(:utc)
     end
   end


### PR DESCRIPTION
## Problem

The [following test](https://github.com/rails/rails/blob/d20f7b043a537b57ff4a7911f65de2fb7b7aea7d/activesupport/test/core_ext/string_ext_test.rb#L411) fails on my machine

``` ruby
StringConversionsTest#test_partial_string_to_time [test/core_ext/string_ext_test.rb:411]:
Expected: 2014-10-30 18:50:00 +0300
  Actual: 2014-10-30 17:50:00 +0300
```
## Cause

In the United States, Daylight Saving Time ends on the first Sunday of November (see [Wikipedia article](http://en.wikipedia.org/wiki/Daylight_saving_time_by_country#Daylight_Saving_Time_rules_as_of_2014)).
In Russia, Daylight Saving Time is… undergoing changes (as pointed out in #17395 and #17409).

Since I am running the tests from a machine located in the United States (PST), the time difference expected by the test does not always hold true.
The same test might be passing when run from a machine in a different time zone.

The timezone for the tests was set to "Europe/Moscow" in #9653 by @ptfg with
the idea of fixing a test. However, @pixeltrix [later found out](https://github.com/rails/rails/pull/9653#issuecomment-16849284)
that using "US/Eastern" was okay; the error was caused by the fact that Moscow
didn't stop using DST until March 27, 2011.
## Solution

I think it's safe to set the time zone of the tests back to "US/Eastern",
since "Europe/Moscow" is a timezone that has recently been changing and
running the tests against that time zone might pass on same machines and
fail on other ones. Thanks to @matthewd for the suggestion.
## How to reproduce
1. Temporarily change the date of your machine to October 30th, 2014 (to ensure DST has not ended)
2. Set the time zone of your machine to PST
3. Run `ruby -Itest test/core_ext/string_ext_test.rb`
