### PR TITLE
Added SchemaDumper support for tables with jsonb columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added SchemaDumper support for tables with jsonb columns.
+
+    *Ted O'Meara*
+
 *   Deprecate `sanitize_sql_hash_for_conditions` without replacement. Using a
     `Relation` for performing queries and updates is the prefered API.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -104,6 +104,7 @@ module ActiveRecord
         macaddr:     { name: "macaddr" },
         uuid:        { name: "uuid" },
         json:        { name: "json" },
+        jsonb:       { name: "jsonb" },
         ltree:       { name: "ltree" },
         citext:      { name: "citext" },
         point:       { name: "point" },

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -3,8 +3,11 @@
 require "cases/helper"
 require 'active_record/base'
 require 'active_record/connection_adapters/postgresql_adapter'
+require 'support/schema_dumping_helper'
 
 module PostgresqlJSONSharedTestCases
+  include SchemaDumpingHelper
+
   class JsonDataType < ActiveRecord::Base
     self.table_name = 'json_data_type'
 
@@ -62,6 +65,11 @@ module PostgresqlJSONSharedTestCases
     end
   ensure
     JsonDataType.reset_column_information
+  end
+
+  def test_schema_dumping
+    output = dump_table_schema("json_data_type")
+    assert_match(/t.#{column_type.to_s}\s+"payload",\s+default: {}/, output)
   end
 
   def test_cast_value_on_write

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -271,13 +271,6 @@ class SchemaDumperTest < ActiveRecord::TestCase
       end
     end
 
-    def test_schema_dump_includes_json_shorthand_definition
-      output = standard_dump
-      if %r{create_table "postgresql_json_data_type"} =~ output
-        assert_match %r|t.json "json_data", default: {}|, output
-      end
-    end
-
     def test_schema_dump_includes_inet_shorthand_definition
       output = standard_dump
       if %r{create_table "postgresql_network_addresses"} =~ output

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -1,7 +1,9 @@
 ActiveRecord::Schema.define do
 
-  %w(postgresql_tsvectors postgresql_hstores postgresql_arrays postgresql_moneys postgresql_numbers postgresql_times postgresql_network_addresses postgresql_uuids postgresql_ltrees
-      postgresql_oids postgresql_xml_data_type defaults geometrics postgresql_timestamp_with_zones postgresql_partitioned_table postgresql_partitioned_table_parent postgresql_json_data_type postgresql_citext).each do |table_name|
+  %w(postgresql_tsvectors postgresql_hstores postgresql_arrays postgresql_moneys postgresql_numbers postgresql_times
+      postgresql_network_addresses postgresql_uuids postgresql_ltrees postgresql_oids postgresql_xml_data_type defaults
+      geometrics postgresql_timestamp_with_zones postgresql_partitioned_table postgresql_partitioned_table_parent
+      postgresql_citext).each do |table_name|
     execute "DROP TABLE IF EXISTS #{quote_table_name table_name}"
   end
 
@@ -104,15 +106,6 @@ _SQL
   CREATE TABLE postgresql_citext (
     id SERIAL PRIMARY KEY,
     text_citext citext default ''::citext
-  );
-_SQL
-  end
-
-  if 't' == select_value("select 'json'=ANY(select typname from pg_type)")
-  execute <<_SQL
-  CREATE TABLE postgresql_json_data_type (
-    id SERIAL PRIMARY KEY,
-    json_data json default '{}'::json
   );
 _SQL
   end


### PR DESCRIPTION
This fixes issues with schema dumping when using the `jsonb` datatype for Postgres. Included in this PR:
- adding `jsonb` to `NATIVE_DATABASE_TYPES`
- adding table/column creation for JSONB when testing with Postgres
- Formatting and getting `postgresql_specific_schema.rb` to 120 wide
