### PR TITLE
Remove misleading equality assertions `test_partial_string_to_time`

### DIFF
--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -403,16 +403,6 @@ class StringConversionsTest < ActiveSupport::TestCase
     end
   end
 
-  def test_partial_string_to_time
-    with_env_tz "Europe/Moscow" do
-      now = Time.now
-      assert_equal Time.local(now.year, now.month, now.day, 23, 50), "23:50".to_time
-      assert_equal Time.utc(now.year, now.month, now.day, 23, 50), "23:50".to_time(:utc)
-      assert_equal Time.local(now.year, now.month, now.day, 18, 50), "13:50 -0100".to_time
-      assert_equal Time.utc(now.year, now.month, now.day, 23, 50), "22:50 -0100".to_time(:utc)
-    end
-  end
-
   def test_standard_time_string_to_time_when_current_time_is_standard_time
     with_env_tz "US/Eastern" do
       Time.stubs(:now).returns(Time.local(2012, 1, 1))


### PR DESCRIPTION
Calling `to_time` on a partial string returns a timestamp.

The exact value of this timestamp _cannot be asserted_ unless we know whether the current time is "standard time" or "daylight savings time".

Rails code is aware of this, and in fact already includes:
- [one method](https://github.com/rails/rails/blob/810b7914f39ad6a6168ff19a8c2761601654f998/activesupport/test/core_ext/string_ext_test.rb#L488L508) to assert the value of the timestamp _when current time is standard time_, and
- [another method](https://github.com/rails/rails/blob/810b7914f39ad6a6168ff19a8c2761601654f998/activesupport/test/core_ext/string_ext_test.rb#L510L530) to assert the value of the timestamp _when current time is DST_.

Having [a separate test](https://github.com/rails/rails/blob/810b7914f39ad6a6168ff19a8c2761601654f998/activesupport/test/core_ext/string_ext_test.rb#L406L414) to assert the value _without specifying DST or not_ is misleading, since it suggests that we can know the value independently of that.

Not that this separate test _has not failed so far_ simply because it uses a _specific_ time-zone "Europe/Moscow" that never switches from DST to standard time. For this and other few specific time zones, the test will still pass; however it will fail for any other time zone.

Therefore, I see two possible solutions:
1. Rename the assertions from `test_partial_string_to_time` to `test_partial_string_to_time_when_current_time_zone_does_not_use_daylight_savings`
2. Remove the assertions

This PR implements the last point (removing the assertions), since I don't think there is a lot of value in leaving a test that asserts values only based on specific preconditions (using a time zone rather than another).

I think that the other two methods linked above (`test_partial_string_to_time_when_current_time_is_standard_time` and `test_partial_string_to_time_when_current_time_is_daylight_savings`) already provide the coverage required by calling `String#to_time` with a partial string. 
