### PR TITLE
Pass route_name from use_route on path_for [4.2.0 regression]

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -22,7 +22,7 @@ module ActionDispatch
           # Skip this route unless a name has been provided or it is a
           # standard Rails route since we can't determine whether an options
           # hash passed to url_for matches a Rack application or a redirect.
-          next unless name || route.dispatcher?
+          next unless named_routes[name] || route.dispatcher?
 
           missing_keys = missing_keys(route, parameterized_parts)
           next unless missing_keys.empty?

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -850,3 +850,35 @@ class IntegrationWithRoutingTest < ActionDispatch::IntegrationTest
     end
   end
 end
+
+class EngineControllerRoutingTest < ActionController::TestCase
+  module FooEngine
+    class Engine < ::Rails::Engine
+      isolate_namespace FooEngine
+      routes.draw do
+        get '/index', :to => 'spree/orders#index'
+      end
+    end
+
+    class OrdersController < ActionController::Base
+      def index
+        render :text => request.fullpath
+      end
+    end
+  end
+
+  def setup
+    @controller = FooEngine::OrdersController.new
+    @routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
+      r.draw do
+        mount FooEngine::Engine, :at => '/'
+      end
+    end
+  end
+
+  def test_process_with_use_route
+    assert_raises(ActionController::UrlGenerationError) do
+      process :index, "GET", :use_route => :lalala
+    end
+  end
+end

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1039,20 +1039,8 @@ typical `GET` to a controller in a controller's functional test like this:
 get :index
 ```
 
-It may not function correctly. This is because the application doesn't know how
-to route these requests to the engine unless you explicitly tell it **how**. To
-do this, you must also pass the `:use_route` option as a parameter on these
-requests:
-
-```ruby
-get :index, use_route: :blorgh
-```
-
-This tells the application that you still want to perform a `GET` request to the
-`index` action of this controller, but you want to use the engine's route to get
-there, rather than the application's one.
-
-Another way to do this is to assign the `@routes` instance variable to `Engine.routes` in your test setup:
+You'll need to assign the `@routes` instance variable to `Engine.routes` in
+your test setup:
 
 ```ruby
 setup do


### PR DESCRIPTION
engines need it to be able to get a proper request uri on tests, the
value was lost in https://github.com/rails/rails/commit/212057b912627b9c4056f911a43c83b18ae3ab34

will look into adding a regression test

// @tenderlove 
