### PR TITLE
Use public_send for form tags

### DIFF
--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -25,7 +25,7 @@ module ActionView
         private
 
         def value(object)
-          object.send @method_name if object
+          object.public_send @method_name if object
         end
 
         def value_before_type_cast(object)


### PR DESCRIPTION
I ran into this bug:

```
# raises ArgumentError, but works as expected with this change
fields_for OpenStruct.new(my_hash), :my_obj  do |mo|
  mo.text_field :format
end
```

Fairly edge-case, but I think using `public_send` for form tags rather than `send` is a better practice.
