### PR TITLE
Remove redundant substitute index when constructing bind values

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -267,7 +267,7 @@ module ActiveRecord
 
       # Returns a bind substitution value given a bind +index+ and +column+
       # NOTE: The column param is currently being used by the sqlserver-adapter
-      def substitute_at(column, index)
+      def substitute_at(column, index = 0)
         Arel::Nodes::BindParam.new '?'
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -156,7 +156,7 @@ module ActiveRecord
           end
         end
 
-        def substitute_at(column, index)
+        def substitute_at(column, index = 0)
           Arel::Nodes::BindParam.new "$#{index + 1}"
         end
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -958,8 +958,7 @@ module ActiveRecord
       when Hash
         opts = PredicateBuilder.resolve_column_aliases(klass, opts)
 
-        bv_len = bind_values.length
-        tmp_opts, bind_values = create_binds(opts, bv_len)
+        tmp_opts, bind_values = create_binds(opts)
         self.bind_values += bind_values
 
         attributes = @klass.send(:expand_hash_conditions_for_aggregates, tmp_opts)
@@ -971,7 +970,7 @@ module ActiveRecord
       end
     end
 
-    def create_binds(opts, idx)
+    def create_binds(opts)
       bindable, non_binds = opts.partition do |column, value|
         case value
         when String, Integer, ActiveRecord::StatementCache::Substitute
@@ -984,9 +983,9 @@ module ActiveRecord
       new_opts = {}
       binds = []
 
-      bindable.each_with_index do |(column,value), index|
+      bindable.each do |(column,value)|
         binds.push [@klass.columns_hash[column.to_s], value]
-        new_opts[column] = connection.substitute_at(column, index + idx)
+        new_opts[column] = connection.substitute_at(column)
       end
 
       non_binds.each { |column,value| new_opts[column] = value }


### PR DESCRIPTION
We end up re-ordering them either way when we construct the Arel AST (in order
to deal with rewhere, etc), so we shouldn't bother giving it a number in the
first place beforehand.
