### PR TITLE
Close database connections that fail the verify! check. More...

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix connection pool leak when a driver error occurs during connection checkout_and_verify.
+
+    *Chethan Reddy*
+
 *   Make it possible to access fixtures excluded by a `default_scope`.
 
     *Yves Senn*

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -454,6 +454,9 @@ module ActiveRecord
           c.verify!
         end
         c
+      rescue
+        c.close
+        raise
       end
     end
 


### PR DESCRIPTION
Hello all, looking for some feedback on this change. Thank you for reviewing!

Normally, a database connection is leased, verified, reserved, and then
returned to the pool from the list of reserved connections
(on success or failure). If an exception is thrown in the verification
step, the connection is never reserved and therefore can not be found in
the reserved list to be returned to the pool.

The verification step will fail if there are database connectivity issues
(db restart, etc.) and will not return connections. Once all the
connections are used the server will no longer accept new connections
until it is restarted.

This change ensures that the connection is checked back into the pool if a
driver exception occurs during connection.verify!. This prevents the
connection being stuck in an 'in use' state.
