### PR TITLE
Remove redundant require of file

### DIFF
--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -3,7 +3,6 @@ require 'cases/helper'
 require 'models/person'
 require 'models/topic'
 require 'models/person_with_validator'
-require 'validators/email_validator'
 require 'validators/namespace/email_validator'
 
 class ValidatesTest < ActiveModel::TestCase


### PR DESCRIPTION
This file was required inside 'test/validators/namespace/email_validator.rb'
that's already required here. Therefore I removed the redundant require.
