### PR TITLE
Allow array or hash syntax for partial index conditions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow hash or array syntax for the conditions in a partial index.
+
+    *Cody Cutrer*, *Alex Robbin*
+
 *   Queries now properly type cast values that are part of a join statement,
     even when using type decorators such as `serialize`.
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -319,6 +319,22 @@ module ActiveRecord
         end
       end
 
+      def test_partial_index_from_hash
+        with_example_table do
+          @connection.add_index 'ex', %w{ id number }, :name => 'partial', :where => { :number => 100 }
+          index = @connection.indexes('ex').find { |idx| idx.name == 'partial' }
+          assert_equal "(number = 100)", index.where
+        end
+      end
+
+      def test_partial_index_from_array
+        with_example_table do
+          @connection.add_index 'ex', %w{ id number }, :name => 'partial', :where => ['number = ?', 100]
+          index = @connection.indexes('ex').find { |idx| idx.name == 'partial' }
+          assert_equal "(number = 100)", index.where
+        end
+      end
+
       def test_columns_for_distinct_zero_orders
         assert_equal "posts.id",
           @connection.columns_for_distinct("posts.id", [])


### PR DESCRIPTION
This is the newer version of #13353, based off of the latest master. It allows you to replace these migrations:

``` ruby
add_index :foos, :user_id, unique: true, where: "status IN (0, 1)"
```

With this:

``` ruby
add_index :foos, :user_id, unique: true, where: { status: [1, 2] }
```

It understands anything that `ActiveRecord::Sanitization.sanitize_sql_for_conditions` accepts.
