### PR TITLE
Move DebugExceptions#traces_from_wrapper to ExceptionWrapper

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -35,7 +35,7 @@ module ActionDispatch
 
       if env['action_dispatch.show_detailed_exceptions']
         request = Request.new(env)
-        traces = traces_from_wrapper(wrapper)
+        traces = wrapper.traces
 
         trace_to_show = 'Application Trace'
         if traces[trace_to_show].empty?
@@ -105,34 +105,6 @@ module ActionDispatch
       if @routes_app.respond_to?(:routes) && (exception.is_a?(ActionController::RoutingError) || exception.is_a?(ActionView::Template::Error))
         ActionDispatch::Routing::RoutesInspector.new(@routes_app.routes.routes)
       end
-    end
-
-    # Augment the exception traces by providing ids for all unique stack frame
-    def traces_from_wrapper(wrapper)
-      application_trace = wrapper.application_trace
-      framework_trace   = wrapper.framework_trace
-      full_trace        = wrapper.full_trace
-
-      appplication_trace_with_ids = []
-      framework_trace_with_ids = []
-      full_trace_with_ids = []
-
-      if full_trace
-        full_trace.each_with_index do |trace, idx|
-          id_trace = {
-            id: idx,
-            trace: trace
-          }
-          appplication_trace_with_ids << id_trace if application_trace.include? trace
-          framework_trace_with_ids << id_trace if framework_trace.include? trace
-          full_trace_with_ids << id_trace
-        end
-      end
-      {
-        "Application Trace" => appplication_trace_with_ids,
-        "Framework Trace" => framework_trace_with_ids,
-        "Full Trace" => full_trace_with_ids
-      }
     end
   end
 end

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -57,6 +57,28 @@ module ActionDispatch
       clean_backtrace(:all)
     end
 
+    def traces
+      appplication_trace_with_ids = []
+      framework_trace_with_ids = []
+      full_trace_with_ids = []
+
+      if full_trace
+        full_trace.each_with_index do |trace, idx|
+          trace_with_id = { id: idx, trace: trace }
+
+          appplication_trace_with_ids << trace_with_id if application_trace.include?(trace)
+          framework_trace_with_ids << trace_with_id if framework_trace.include?(trace)
+          full_trace_with_ids << trace_with_id
+        end
+      end
+
+      {
+        "Application Trace" => appplication_trace_with_ids,
+        "Framework Trace" => framework_trace_with_ids,
+        "Full Trace" => full_trace_with_ids
+      }
+    end
+
     def self.status_code_for_exception(class_name)
       Rack::Utils.status_code(@@rescue_responses[class_name])
     end


### PR DESCRIPTION
`ActionDispatch::ExceptionWrapper` seems to be the more natural place for
this method to live in. Pinging @bronzle as he recently fixed an issue in this
method.
