### PR TITLE
Add link to API Documentation Guidelines

### DIFF
--- a/guides/source/ruby_on_rails_guides_guidelines.md
+++ b/guides/source/ruby_on_rails_guides_guidelines.md
@@ -54,6 +54,7 @@ API Documentation Guidelines
 The guides and the API should be coherent and consistent where appropriate. In particular, these sections of the [API Documentation Guidelines](api_documentation_guidelines.html) also apply to the guides:
 
 * [Wording](api_documentation_guidelines.html#wording)
+* [English](api_documentation_guidelines.html#english)
 * [Example Code](api_documentation_guidelines.html#example-code)
 * [Filenames](api_documentation_guidelines.html#file-names)
 * [Fonts](api_documentation_guidelines.html#fonts)


### PR DESCRIPTION
Link to the "English" section to specify American English be used for the Guides
[ci skip]
Regarding #17481 
