### PR TITLE
Update the load path when an application is defined

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -88,6 +88,7 @@ module Rails
       def inherited(base)
         super
         Rails.app_class = base
+        Rails.application.add_lib_to_load_path!
       end
 
       def instance
@@ -129,8 +130,6 @@ module Rails
       # are these actually used?
       @initial_variable_values = initial_variable_values
       @block = block
-
-      add_lib_to_load_path!
     end
 
     # Returns true if the application is initialized.

--- a/railties/test/application/load_path_test.rb
+++ b/railties/test/application/load_path_test.rb
@@ -1,0 +1,19 @@
+require 'abstract_unit'
+
+class LoadPathTest < ActiveSupport::TestCase
+  class ::Rails::Application < ::Rails::Engine
+    alias :original_add_lib_to_load_path :add_lib_to_load_path!
+
+    def add_lib_to_load_path!
+      original_add_lib_to_load_path
+      $triggered = true
+    end
+  end
+
+  test "load path get updated when Rails::Application is inherited" do
+    assert_nil $triggered
+
+    class Foo < Rails::Application; end
+    assert_not_nil $triggered
+  end
+end


### PR DESCRIPTION
Hello,

As per the `#add_lib_to_load_path!`'s documentation, this method should be called any time an application inherits from Rails::Application.

I'm not sure whether the test is in the right place and if it's written the good way but let me know if anything should be changed.

Fixes #17106.

Have a nice day.
