### PR TITLE
Delegate comparison operator to value

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -103,6 +103,8 @@ module ActiveSupport
       @value.respond_to?(method, include_private)
     end
 
+    delegate :<=>, to: :value
+
     protected
 
       def sum(sign, time = ::Time.current) #:nodoc:

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -200,4 +200,16 @@ class DurationTest < ActiveSupport::TestCase
   def test_hash
     assert_equal 1.minute.hash, 60.seconds.hash
   end
+
+  def test_comparable
+    assert_equal(-1, (0.seconds <=> 1.second))
+    assert_equal(-1, (1.second <=> 1.minute))
+    assert_equal(-1, (1 <=> 1.minute))
+    assert_equal(0, (0.seconds <=> 0.seconds))
+    assert_equal(0, (0.seconds <=> 0.minutes))
+    assert_equal(0, (1.second <=> 1.second))
+    assert_equal(1, (1.second <=> 0.second))
+    assert_equal(1, (1.minute <=> 1.second))
+    assert_equal(1, (61 <=> 1.minute))
+  end
 end


### PR DESCRIPTION
Fix for regression where `0.seconds <=> 1.second` was returning `nil`
