### PR TITLE
Change `rails` to `bin/rails` in getting started, fix #1748 [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -173,7 +173,7 @@ start a web server on your development machine. You can do this by running the
 following in the root directory of your rails application:
 
 ```bash
-$ rails server
+$ bin/rails server
 ```
 
 TIP: Compiling CoffeeScript to JavaScript requires a JavaScript runtime and the
@@ -224,7 +224,7 @@ tell it you want a controller called "welcome" with an action called "index",
 just like this:
 
 ```bash
-$ rails generate controller welcome index
+$ bin/rails generate controller welcome index
 ```
 
 Rails will create several files and a route for you.
@@ -388,7 +388,7 @@ It's inside this class that you'll define methods that will become the actions
 for this controller. These actions will perform CRUD operations on the posts
 within our system.
 
-NOTE: There are `public`, `private` and `protected` methods in Ruby, 
+NOTE: There are `public`, `private` and `protected` methods in Ruby,
 but only `public` methods can be actions for controllers.
 For more details check out [Programming Ruby](http://www.ruby-doc.org/docs/ProgrammingRuby/).
 


### PR DESCRIPTION
Update documentation in "Getting Started", section 4. Prefix the command `rails` with `bin/rails`.

Fix #17484 opened by @nickxyzt
