### PR TITLE
Setting scopes optionally when using enums in ActiveRecord

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -79,7 +79,7 @@ module ActiveRecord
       super
     end
 
-    def enum(definitions)
+    def enum(definitions, opts = {})
       klass = self
       definitions.each do |name, values|
         # statuses = { }
@@ -126,9 +126,11 @@ module ActiveRecord
             klass.send(:detect_enum_conflict!, name, "#{value}!")
             define_method("#{value}!") { update! name => value }
 
-            # scope :active, -> { where status: 0 }
-            klass.send(:detect_enum_conflict!, name, value, true)
-            klass.scope value, -> { klass.where name => i }
+            if opts.fetch(:scope, true)
+              # scope :active, -> { where status: 0 }
+              klass.send(:detect_enum_conflict!, name, value, true)
+              klass.scope value, -> { klass.where name => i }
+            end
           end
         end
         defined_enums[name.to_s] = enum_values

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -205,7 +205,7 @@ class EnumTest < ActiveRecord::TestCase
     end
   end
 
-  test "not setting scope" do
+  test "enum_methods doesn't define scope methods" do
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "books"
       enum status: [:proposed, :written, :published]
@@ -213,7 +213,7 @@ class EnumTest < ActiveRecord::TestCase
 
     # new generates a scope that conflicts with an AR class method
     assert_nothing_raised do
-      klass.class_eval { enum({"status_1" => [:new]}, {scope: false}) }
+      klass.class_eval { enum_methods "status_1" => [:new] }
     end
   end
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -208,15 +208,27 @@ class EnumTest < ActiveRecord::TestCase
   test "enum_methods doesn't define scope methods" do
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "books"
-      enum status: [:proposed, :written, :published]
     end
 
     # new generates a scope that conflicts with an AR class method
     assert_nothing_raised do
-      klass.class_eval { enum_methods "status_1" => [:new, :old] }
+      klass.class_eval { enum_methods "status" => [:new, :old] }
     end
 
     assert !klass.respond_to?(:old)
+  end
+
+  test "enum_methods behaves like enum" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum_methods status: [:new, :old]
+    end
+
+    @book = klass.new(status: :new)
+    assert @book.new?
+    assert_equal "new", @book.status
+    @book.old!
+    assert @book.old?
   end
 
   test "overriding enum method should not raise" do

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -213,8 +213,10 @@ class EnumTest < ActiveRecord::TestCase
 
     # new generates a scope that conflicts with an AR class method
     assert_nothing_raised do
-      klass.class_eval { enum_methods "status_1" => [:new] }
+      klass.class_eval { enum_methods "status_1" => [:new, :old] }
     end
+
+    assert !klass.respond_to?(:old)
   end
 
   test "overriding enum method should not raise" do

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -205,6 +205,18 @@ class EnumTest < ActiveRecord::TestCase
     end
   end
 
+  test "not setting scope" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum status: [:proposed, :written, :published]
+    end
+
+    # new generates a scope that conflicts with an AR class method
+    assert_nothing_raised do
+      klass.class_eval { enum({"status_1" => [:new]}, {scope: false}) }
+    end
+  end
+
   test "overriding enum method should not raise" do
     assert_nothing_raised do
       Class.new(ActiveRecord::Base) do


### PR DESCRIPTION
Currently, when creating an enum with the with the values `enum status: [:new, :old]` on a model, an exception is raised so as to not overwrite `Model.new`.

```
ArgumentError: You tried to define an enum named "status" on the model "Product", but this will generate a class method "new", which is already defined by Active Record.
```

This allows to pass an options argument when defining an enum, so the scope methods are not created.
In practice, it would look like this:

``` ruby
enum({ status: [:new] }, { scope: false })
```

I'm not a big fan of being forced to use brackets and explicit hashes, but that's the way ruby works. I'm open to suggestions/feedback :smiley: 

UPDATE 1:
I updated my PR, it now splits the behaviour of `enum` into `enum_methods` and `enum_scopes`, if you send the `enum_methods` message, it behaves exactly like enum, but it doesn't define the scopes. This allows for a cleaner syntax.
