### PR TITLE
Support for custom regular expression for number_to_delimeted

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   `number_to_currency` and `number_with_delimiter` now accept custom `delimiter_pattern` option 
+     to handle placement of delimiter, to support currency formats like INR 
+     
+     Example: 
+        
+        number_to_currency(1230000, delimiter_pattern: /(\d+?)(?=(\d\d)+(\d)(?!\d))/, unit: '₹', format: "%u %n")
+        # => '₹ 12,30,000.00' 
+        
+    *Vipul A M*
+    
 *   Make `disable_with` the default behavior for submit tags. Disables the
     button on submit to prevent double submits.
 

--- a/actionview/test/template/number_helper_test.rb
+++ b/actionview/test/template/number_helper_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "abstract_unit"
 
 class NumberHelperTest < ActionView::TestCase
@@ -21,6 +22,7 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal "&lt;b&gt;1,234,567,890.50&lt;/b&gt; $", number_to_currency("1234567890.50", format: "<b>%n</b> %u")
     assert_equal "&lt;b&gt;1,234,567,890.50&lt;/b&gt; $", number_to_currency("-1234567890.50", negative_format: "<b>%n</b> %u")
     assert_equal "&lt;b&gt;1,234,567,890.50&lt;/b&gt; $", number_to_currency("-1234567890.50", 'negative_format' => "<b>%n</b> %u")
+    assert_equal '₹ 12,30,000.00', number_to_currency(1230000, delimiter_pattern: /(\d+?)(?=(\d\d)+(\d)(?!\d))/, unit: '₹', format: "%u %n")
   end
 
   def test_number_to_percentage

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   `number_to_currency` and `number_with_delimiter` now accept custom `delimiter_pattern` option 
+     to handle placement of delimiter, to support currency formats like INR 
+     
+     Example: 
+        
+        number_to_currency(1230000, delimiter_pattern: /(\d+?)(?=(\d\d)+(\d)(?!\d))/, unit: '₹', format: "%u %n")
+        # => '₹ 12,30,000.00' 
+        
+    *Vipul A M*
+    
 *   Deprecate `:prefix` option of `number_to_human_size` with no replacement.
 
     *Jean Boussier*

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -135,6 +135,9 @@ module ActiveSupport
     #   to ",").
     # * <tt>:separator</tt> - Sets the separator between the
     #   fractional and integer digits (defaults to ".").
+    # * <tt>:delimiter_pattern</tt> - Sets a custom regular expression used for
+    #   for deriving, the placement of delimiter. Helpful when using currency
+    #   formats like INR.
     #
     # ==== Examples
     #
@@ -147,6 +150,8 @@ module ActiveSupport
     #   number_to_delimited(12345678.05, locale: :fr)    # => 12 345 678,05
     #   number_to_delimited('112a')                      # => 112a
     #   number_to_delimited(98765432.98, delimiter: ' ', separator: ',')
+    #   number_helper.number_to_delimited("123456.78",
+    #   delimiter_pattern: /(\d+?)(?=(\d\d)+(\d)(?!\d))/)  # => 1,23,456.78
     #   # => 98 765 432,98
     def number_to_delimited(number, options = {})
       NumberToDelimitedConverter.convert(number, options)

--- a/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
@@ -3,7 +3,7 @@ module ActiveSupport
     class NumberToDelimitedConverter < NumberConverter #:nodoc:
       self.validate_float = true
 
-      DELIMITED_REGEX = /(\d)(?=(\d\d\d)+(?!\d))/
+      DEFAULT_DELIMITER_REGEX = /(\d)(?=(\d\d\d)+(?!\d))/
 
       def convert
         parts.join(options[:separator])
@@ -13,11 +13,16 @@ module ActiveSupport
 
         def parts
           left, right = number.to_s.split('.')
-          left.gsub!(DELIMITED_REGEX) do |digit_to_delimit|
+          left.gsub!(delimiter_pattern) do |digit_to_delimit|
             "#{digit_to_delimit}#{options[:delimiter]}"
           end
           [left, right].compact
         end
+
+        def delimiter_pattern
+          options.fetch(:delimiter_pattern, DEFAULT_DELIMITER_REGEX)
+        end
+
     end
   end
 end

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -106,6 +106,7 @@ module ActiveSupport
           assert_equal("123,456,789.78901", number_helper.number_to_delimited(123456789.78901))
           assert_equal("0.78901", number_helper.number_to_delimited(0.78901))
           assert_equal("123,456.78", number_helper.number_to_delimited("123456.78"))
+          assert_equal("1,23,456.78", number_helper.number_to_delimited("123456.78", delimiter_pattern: /(\d+?)(?=(\d\d)+(\d)(?!\d))/))
           assert_equal("123,456.78", number_helper.number_to_delimited("123456.78".html_safe))
         end
       end


### PR DESCRIPTION
The format for placement of delimiter varies in currencies like INR, where instead of `123,345,455.00`, the number would  be `12,33,45,455.00`. This adds support to allow user to provide custom handling of how the placement of delimiter is derived.

Changes :
- Extracted `DELIMITED_REGEX` to `delimited_regex` method and made use of user passed `options[:delimited_regex]` if available. Changed `DELIMITED_REGEX` to `DEFAULT)DELIMITED_REGEX` to signify what it means.
- Added tests for number to delimited and number to currency in both actionview and activesupport.
