### PR TITLE
Fix predicate method name for enum attributes by appending name of the enum attribute to the generated method

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -120,7 +120,7 @@ module ActiveRecord
 
             # def active?() status == 0 end
             klass.send(:detect_enum_conflict!, name, "#{value}?")
-            define_method("#{value}?") { self[name] == i }
+            define_method("#{name}_#{value}?") { self[name] == i }
 
             # def active!() update! status: :active end
             klass.send(:detect_enum_conflict!, name, "#{value}!")

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -9,11 +9,11 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "query state by predicate" do
-    assert @book.proposed?
-    assert_not @book.written?
-    assert_not @book.published?
+    assert @book.status_proposed?
+    assert_not @book.status_written?
+    assert_not @book.status_published?
 
-    assert @book.unread?
+    assert @book.read_status_unread?
   end
 
   test "query state with strings" do
@@ -28,27 +28,27 @@ class EnumTest < ActiveRecord::TestCase
 
   test "update by declaration" do
     @book.written!
-    assert @book.written?
+    assert @book.status_written?
   end
 
   test "update by setter" do
     @book.update! status: :written
-    assert @book.written?
+    assert @book.status_written?
   end
 
   test "enum methods are overwritable" do
     assert_equal "do publish work...", @book.published!
-    assert @book.published?
+    assert @book.status_published?
   end
 
   test "direct assignment" do
     @book.status = :written
-    assert @book.written?
+    assert @book.status_written?
   end
 
   test "assign string value" do
     @book.status = "written"
-    assert @book.written?
+    assert @book.status_written?
   end
 
   test "enum changed attributes" do
@@ -151,13 +151,13 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "building new objects with enum scopes" do
-    assert Book.written.build.written?
-    assert Book.read.build.read?
+    assert Book.written.build.status_written?
+    assert Book.read.build.read_status_read?
   end
 
   test "creating new objects with enum scopes" do
-    assert Book.written.create.written?
-    assert Book.read.create.read?
+    assert Book.written.create.status_written?
+    assert Book.read.create.read_status_read?
   end
 
   test "_before_type_cast returns the enum label (required for form fields)" do


### PR DESCRIPTION
This tries to fix #17415. I just added code and fixed existing tests. Please let me know your thoughts on this alternative. 

Thanks to @guilhermeFranco for suggesting this here - https://github.com/rails/rails/issues/17415#issuecomment-61639801. I will add you to the changelog if this is acceptable solution.
