### PR TITLE
activerecord: rake db:create shows underlying error message.

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -31,6 +31,7 @@ module ActiveRecord
           end
           establish_connection configuration
         else
+          $stderr.puts error.inspect
           $stderr.puts "Couldn't create database for #{configuration.inspect}, #{creation_options.inspect}"
           $stderr.puts "(If you set the charset manually, make sure you have a matching collation)" if configuration['encoding']
         end


### PR DESCRIPTION
If a non-“Access Denied” database error is raised during `rake db:create`, [the underlying error message is not displayed](https://github.com/rails/rails/blob/502c45a3428b3ce1a9892986d1bba5f8f975fb6d/activerecord/lib/active_record/tasks/mysql_database_tasks.rb#L34-35). Here's an example without this patch:

```
$ RAILS_ENV=test bin/rake db:create                                                                                                                                                                                                   
Couldn't create database for {"encoding"=>"utf8mb4", "collation"=>"utf8mb4_general_ci", "pool"=>5, "adapter"=>"mysql2", "username"=>"root", "password"=>"root", "port"=>3306, "database"=>"example_test", "host"=>"172.17.0.61"}, {:charset=>"utf8mb4", :collation=>"utf8mb4_general_ci"}
(If you set the charset manually, make sure you have a matching collation)
```

It's unclear what the actual error was, but the suggestion is that it's a charset/collation issue. Here's the equivalent example after this patch:

```
$ RAILS_ENV=test bin/rake db:create                                                                                                                                                                                                   
#<Mysql2::Error: Can't connect to MySQL server on '172.17.0.61' (113)>
Couldn't create database for {"encoding"=>"utf8mb4", "collation"=>"utf8mb4_general_ci", "pool"=>5, "adapter"=>"mysql2", "username"=>"root", "password"=>"root", "port"=>3306, "database"=>"example_test", "host"=>"172.17.0.61"}, {:charset=>"utf8mb4", :collation=>"utf8mb4_general_ci"}
(If you set the charset manually, make sure you have a matching collation)
```

This shows the actual error was an unreachable MySQL server, and the charset/collation suggestion was a [red herring](http://en.wikipedia.org/wiki/Red_herring).

I've run into this a few times, it'd be great to see it fixed.
