### PR TITLE
[docs] Using the real resolver pattern in docs

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -289,7 +289,7 @@ module ActionView
   #
   #   ActionController::Base.view_paths = FileSystemResolver.new(
   #     Rails.root.join("app/views"),
-  #     ":prefix{/:locale}/:action{.:formats,}{+:variants,}{.:handlers,}"
+  #     ":prefix/:action{.:locale,}{.:formats,}{+:variants,}{.:handlers,}",
   #   )
   #
   # ==== Pattern format and variables


### PR DESCRIPTION
If someone copies the docs into their app they'll find it simply doesn't
work because the locale pattern doesn't have the same logic. This makes
the doc examples work exactly as written.

[ci skip]
