### PR TITLE
Remove skip-gems from 4-2 release notes

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -358,10 +358,6 @@ Please refer to the [Changelog][railties] for detailed changes.
 
     ([Pull Request](https://github.com/rails/rails/pull/16129))
 
-*   Introduced a `--skip-gems` option in the app generator to skip gems such as
-    `turbolinks` and `coffee-rails` that do not have their own specific flags.
-    ([Commit](https://github.com/rails/rails/commit/10565895805887d4faf004a6f71219da177f78b7))
-
 *   Introduced a `bin/setup` script to enable automated setup code when
     bootstrapping an application.
     ([Pull Request](https://github.com/rails/rails/pull/15189))


### PR DESCRIPTION
- This option was removed in https://github.com/rails/rails/commit/bf17c8a531bc80.
- [ci skip]
