### PR TITLE
Custom header for request id

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Allow `config.action_dispatch.request_id_header` to set custom header key used for setting unique request id value.
+    Defaults to `'X-Request-Id'`
+    
+    Example:
+        
+        config.action_dispatch.request_id_header = 'X-REQUEST-ID'
+        
+    will set response header for request id on `X-REQUEST-ID` key.
+    
+    *Vipul A M*   
+    
 *   Response etags to always be weak: Prefixes 'W/' to value returned by
    `ActionDispatch::Http::Cache::Response#etag=`, such that etags set in
    `fresh_when` and `stale?` are weak.

--- a/actionpack/lib/action_dispatch/middleware/request_id.rb
+++ b/actionpack/lib/action_dispatch/middleware/request_id.rb
@@ -12,16 +12,17 @@ module ActionDispatch
   # The unique request id can be used to trace a request end-to-end and would typically end up being part of log files
   # from multiple pieces of the stack.
   class RequestId
-    X_REQUEST_ID = "X-Request-Id".freeze # :nodoc:
+    cattr_accessor :request_id_header
 
     def initialize(app)
+      self.request_id_header = 'X-Request-Id'
       @app = app
     end
 
     def call(env)
       req = ActionDispatch::Request.new env
       req.request_id = make_request_id(req.x_request_id)
-      @app.call(env).tap { |_status, headers, _body| headers[X_REQUEST_ID] = req.request_id }
+      @app.call(env).tap { |_status, headers, _body| headers[self.request_id_header] = req.request_id }
     end
 
     private

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -32,6 +32,7 @@ module ActionDispatch
       ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge
       ActionDispatch::Response.default_charset = app.config.action_dispatch.default_charset || app.config.encoding
       ActionDispatch::Response.default_headers = app.config.action_dispatch.default_headers
+      ActionDispatch::RequestId.request_id_header = config.action_dispatch.request_id_header
 
       ActionDispatch::ExceptionWrapper.rescue_responses.merge!(config.action_dispatch.rescue_responses)
       ActionDispatch::ExceptionWrapper.rescue_templates.merge!(config.action_dispatch.rescue_templates)

--- a/actionpack/test/dispatch/request_id_test.rb
+++ b/actionpack/test/dispatch/request_id_test.rb
@@ -50,6 +50,15 @@ class RequestIdResponseTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_custom_request_id_header_is_passed_to_response
+    original_request_id, ActionDispatch::RequestId.request_id_header = ActionDispatch::RequestId.request_id_header, 'X-REQUEST-ID'
+    with_test_route_set do
+      get '/', headers: {'HTTP_X_REQUEST_ID' => 'X' * 500}
+      assert_equal "X" * 255, @response.headers["X-REQUEST-ID"]
+    end
+  ensure
+    ActionDispatch::RequestId.request_id_header = original_request_id
+  end
 
   private
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -373,6 +373,9 @@ The schema dumper adds one additional configuration option:
 
 * `config.action_dispatch.tld_length` sets the TLD (top-level domain) length for the application. Defaults to `1`.
 
+* `config.action_dispatch.request_id_header` sets the header key to be used when setting unique request id value.
+Defaults to `'X-Request-Id'`
+
 * `config.action_dispatch.http_auth_salt` sets the HTTP Auth salt value. Defaults
 to `'http authentication'`.
 


### PR DESCRIPTION
This is based on https://github.com/rails/rails/commit/afde6fdd5ef3e6b0693a7e330777e85ef4cffddb#commitcomment-690537 (Three years later) .

The change allows  `config.action_dispatch.request_id_header` to set custom header key used for setting unique request id value. Default is set to `'X-Request-Id'`.
Based on the key, custom value will be set for the key on response.headers.

```
Example:

    config.action_dispatch.request_id_header = 'X-REQUEST-ID'
```

will set response header for request id on `X-REQUEST-ID` key.
cc @josevalim 
