### PR TITLE
Change internal implementation of acts_like?

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/acts_like.rb
+++ b/activesupport/lib/active_support/core_ext/date/acts_like.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/object/acts_like'
 
 class Date
   # Duck-types as a Date-like class. See Object#acts_like?.
-  def acts_like_date?
-    true
+  def acts_like?(duck_type)
+    duck_type == :date
   end
 end

--- a/activesupport/lib/active_support/core_ext/date_time/acts_like.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/acts_like.rb
@@ -2,13 +2,8 @@ require 'date'
 require 'active_support/core_ext/object/acts_like'
 
 class DateTime
-  # Duck-types as a Date-like class. See Object#acts_like?.
-  def acts_like_date?
-    true
-  end
-
-  # Duck-types as a Time-like class. See Object#acts_like?.
-  def acts_like_time?
-    true
+  # Duck-types as a Date-like and Time-like class. See Object#acts_like?.
+  def acts_like?(duck_type)
+    duck_type == :date || duck_type == :time
   end
 end

--- a/activesupport/lib/active_support/core_ext/object/acts_like.rb
+++ b/activesupport/lib/active_support/core_ext/object/acts_like.rb
@@ -1,10 +1,13 @@
 class Object
   # A duck-type assistant method. For example, Active Support extends Date
-  # to define an <tt>acts_like_date?</tt> method, and extends Time to define
-  # <tt>acts_like_time?</tt>. As a result, we can do <tt>x.acts_like?(:time)</tt> and
+  # to define an <tt>acts_like?</tt> method that returns true when invoked
+  # with the argument <tt>:date</tt>, and extends Time to define an
+  # <tt>acts_like?</tt> that returns true when invoked with <tt>:time</tt>.
+  # As a result, we can do <tt>x.acts_like?(:time)</tt> and
   # <tt>x.acts_like?(:date)</tt> to do duck-type-safe comparisons, since classes that
-  # we want to act like Time simply need to define an <tt>acts_like_time?</tt> method.
-  def acts_like?(duck)
-    respond_to? :"acts_like_#{duck}?"
+  # that we want to act like Time simply need to override the
+  # <tt>acts_like?</tt> method.
+  def acts_like?(duck_type)
+    false
   end
 end

--- a/activesupport/lib/active_support/core_ext/string/behavior.rb
+++ b/activesupport/lib/active_support/core_ext/string/behavior.rb
@@ -1,6 +1,6 @@
 class String
   # Enable more predictable duck-typing on String-like classes. See <tt>Object#acts_like?</tt>.
-  def acts_like_string?
-    true
+  def acts_like?(duck_type)
+    duck_type == :string
   end
 end

--- a/activesupport/lib/active_support/core_ext/time/acts_like.rb
+++ b/activesupport/lib/active_support/core_ext/time/acts_like.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/object/acts_like'
 
 class Time
   # Duck-types as a Time-like class. See Object#acts_like?.
-  def acts_like_time?
-    true
+  def acts_like?(duck_type)
+    duck_type == :time
   end
 end

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -46,7 +46,7 @@ module ActiveSupport #:nodoc:
       alias to_s wrapped_string
       alias to_str wrapped_string
 
-      delegate :<=>, :=~, :acts_like_string?, :to => :wrapped_string
+      delegate :<=>, :=~, :acts_like?, :to => :wrapped_string
 
       # Creates a new Chars instance by wrapping _string_.
       def initialize(string)

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -326,8 +326,8 @@ module ActiveSupport
     end
 
     # So that +self+ <tt>acts_like?(:time)</tt>.
-    def acts_like_time?
-      true
+    def acts_like?(duck_type)
+      duck_type == :time
     end
 
     # Say we're a Time to thwart type checking.
@@ -360,8 +360,6 @@ module ActiveSupport
     # Ensure proxy class responds to all methods that underlying time instance
     # responds to.
     def respond_to_missing?(sym, include_priv)
-      # consistently respond false to acts_like?(:date), regardless of whether #time is a Time or DateTime
-      return false if sym.to_sym == :acts_like_date?
       time.respond_to?(sym, include_priv)
     end
 

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -355,7 +355,7 @@ end
 
 class DateExtBehaviorTest < ActiveSupport::TestCase
   def test_date_acts_like_date
-    assert Date.new.acts_like_date?
+    assert Date.new.acts_like?(:date)
   end
 
   def test_freeze_doesnt_clobber_memoized_instance_methods

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -275,11 +275,11 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_acts_like_date
-    assert DateTime.new.acts_like_date?
+    assert DateTime.new.acts_like?(:date)
   end
 
   def test_acts_like_time
-    assert DateTime.new.acts_like_time?
+    assert DateTime.new.acts_like?(:time)
   end
 
   def test_utc?

--- a/activesupport/test/core_ext/object/acts_like_test.rb
+++ b/activesupport/test/core_ext/object/acts_like_test.rb
@@ -3,8 +3,8 @@ require 'active_support/core_ext/object'
 
 class ObjectTests < ActiveSupport::TestCase
   class DuckTime
-    def acts_like_time?
-      true
+    def acts_like?(duck_type)
+      duck_type == :time
     end
   end
 

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -562,7 +562,7 @@ end
 
 class StringBehaviourTest < ActiveSupport::TestCase
   def test_acts_like_string
-    assert 'Bambi'.acts_like_string?
+    assert 'Bambi'.acts_like?(:string)
   end
 end
 

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -685,7 +685,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_acts_like_time
-    assert Time.new.acts_like_time?
+    assert Time.new.acts_like?(:time)
   end
 
   def test_formatted_offset_with_utc

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -372,7 +372,6 @@ class TimeWithZoneTest < ActiveSupport::TestCase
   end
 
   def test_acts_like_time
-    assert @twz.acts_like_time?
     assert @twz.acts_like?(:time)
     assert ActiveSupport::TimeWithZone.new(DateTime.civil(2000), @time_zone).acts_like?(:time)
   end

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -472,7 +472,7 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
   end
 
   def test_acts_like_string
-    assert 'Bambi'.mb_chars.acts_like_string?
+    assert 'Bambi'.mb_chars.acts_like?(:string)
   end
 end
 

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -274,11 +274,12 @@ NOTE: Defined in `active_support/core_ext/kernel/singleton_class.rb`.
 The method `acts_like?` provides a way to check whether some class acts like some other class based on a simple convention: a class that provides the same interface as `String` defines
 
 ```ruby
-def acts_like_string?
+def acts_like?(duck_type)
+  duck_type.in? [:string]
 end
 ```
 
-which is only a marker, its body or return value are irrelevant. Then, client code can query for duck-type-safeness this way:
+Then, client code can query for duck-type-safeness this way:
 
 ```ruby
 some_klass.acts_like?(:string)


### PR DESCRIPTION
This commit modifies the internal way in which classes need to override
`Object#acts_like?` in order to declare that they behave like a given class.

The public API of `acts_like?` is not affected: all the uses of `acts_like?`
will still work and will be faster, since the new implementation gets rid
of `respond_to?` in the method implementation.

---

More details on this commit.

According to the [Rails guides](http://edgeguides.rubyonrails.org/active_support_core_extensions.html#acts-like-questionmark-duck):

> The method acts_like? provides a way to check whether some class acts like some other class based on a simple convention: a class that provides the same interface as String defines
> 
> def acts_like_string?
> end
> 
> which is only a marker, its body or return value are irrelevant.

This convention was introduced seven years ago in f28eef9a and is implemented as:

``` ruby
def acts_like?(duck)
  respond_to? :"acts_like_#{duck}?"
end
```

This PR makes the implementation above _more performant_ by:
- removing the need to call `respond_to?`
- removing the need to add internal methods like `acts_like_string?` to the objects

[This gist](https://gist.github.com/claudiob/35d6ea765aeeb86d24c1) shows an example benchmark comparing old and new implementation,
based off the code of [acts_like_test.rb](https://github.com/rails/rails/blame/master/activesupport/test/core_ext/object/acts_like_test.rb).
