### PR TITLE
[docs] Removed respond_with documentation as it was deprecated and removed from Rails

### DIFF
--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -135,18 +135,6 @@ module ActionController #:nodoc:
     #
     #   render json: @people
     #
-    # Since this is a common pattern, you can use the class method respond_to
-    # with the respond_with method to have the same results:
-    #
-    #   class PeopleController < ApplicationController
-    #     respond_to :html, :xml, :json
-    #
-    #     def index
-    #       @people = Person.all
-    #       respond_with(@people)
-    #     end
-    #   end
-    #
     # Formats can have different variants.
     #
     # The request variant is a specialization of the request format, like <tt>:tablet</tt>,
@@ -214,8 +202,8 @@ module ActionController #:nodoc:
     #     format.html.phone # this gets rendered
     #   end
     #
-    # Be sure to check the documentation of +respond_with+ and
-    # <tt>ActionController::MimeResponds.respond_to</tt> for more examples.
+    # Be sure to check the documentation of <tt>ActionController::MimeResponds.respond_to</tt>
+    # for more examples.
     def respond_to(*mimes)
       raise ArgumentError, "respond_to takes either types or a block, never both" if mimes.any? && block_given?
 
@@ -234,8 +222,8 @@ module ActionController #:nodoc:
     # A container for responses available from the current controller for
     # requests for different mime-types sent to a particular action.
     #
-    # The public controller methods +respond_with+ and +respond_to+ may be called
-    # with a block that is used to define responses to different mime-types, e.g.
+    # The public controller methods +respond_to+ may be called with a block
+    # that is used to define responses to different mime-types, e.g.
     # for +respond_to+ :
     #
     #   respond_to do |format|

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -86,8 +86,7 @@ module ActionController
     #     end
     #   end
     # To use renderers and their mime types in more concise ways, see
-    # <tt>ActionController::MimeResponds::ClassMethods.respond_to</tt> and
-    # <tt>ActionController::MimeResponds#respond_with</tt>
+    # <tt>ActionController::MimeResponds::ClassMethods.respond_to</tt>
     def self.add(key, &block)
       define_method(_render_with_renderer_method_name(key), &block)
       RENDERERS << key.to_sym


### PR DESCRIPTION
Removed documentation that still mentioned using respond_with in place of respond_to. respond_with was moved into the responders gem and deprecated inside rails, so there is no need to mention it within rails itself.

[ci skip]
