### PR TITLE
Accommodate url_for_test to be in sync with the deprecation of passing only_path

### DIFF
--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -25,8 +25,7 @@ module AbstractController
 
         path = klass.new.fun_path({:controller => :articles,
                                    :baz        => "baz",
-                                   :zot        => "zot",
-                                   :only_path  => true })
+                                   :zot        => "zot"})
         # :bar key isn't provided
         assert_equal '/foo/zot', path
       end
@@ -291,7 +290,9 @@ module AbstractController
           assert_equal '/brave/new/world',
             controller.url_for(:controller => 'brave', :action => 'new', :id => 'world', :only_path => true)
 
-          assert_equal("/home/sweet/home/alabama", controller.home_path(:user => 'alabama', :host => 'unused', :only_path => true))
+          assert_deprecated do
+            assert_equal("/home/sweet/home/alabama", controller.home_path(:user => 'alabama', :host => 'unused', :only_path => true))
+          end
           assert_equal("/home/sweet/home/alabama", controller.home_path('alabama'))
         end
       end


### PR DESCRIPTION
Accommodate url_for_test to be in sync with the deprecation of passing `only_path: true` option.
