### PR TITLE
Remove unnecessary autoloading of class

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -36,7 +36,6 @@ module ActiveRecord
       autoload :DatabaseStatements
       autoload :DatabaseLimits
       autoload :Quoting
-      autoload :ConnectionPool
       autoload :QueryCache
       autoload :Savepoints
     end


### PR DESCRIPTION
As this is not included in the abstract_adapter I don't think we should
be autoloading it. Therefore I've removed the unnecessary autoloading.
