### PR TITLE
Print out a meaningful error when ActiveRecord::ReadOnlyRecord is raised

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -188,7 +188,7 @@ module ActiveRecord
     # and <tt>destroy</tt> returns +false+. See
     # ActiveRecord::Callbacks for further details.
     def destroy
-      raise ReadOnlyRecord if readonly?
+      raise ReadOnlyRecord, "#{self.class} is marked as readonly" if readonly?
       destroy_associations
       destroy_row if persisted?
       @destroyed = true
@@ -519,7 +519,7 @@ module ActiveRecord
     end
 
     def create_or_update
-      raise ReadOnlyRecord if readonly?
+      raise ReadOnlyRecord, "#{self.class} is marked as readonly" if readonly?
       result = new_record? ? _create_record : _update_record
       result != false
     end

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -22,9 +22,12 @@ class ReadOnlyTest < ActiveRecord::TestCase
       assert !dev.save
       dev.name = 'Forbidden.'
     end
-    assert_raise(ActiveRecord::ReadOnlyRecord) { dev.save  }
-    assert_raise(ActiveRecord::ReadOnlyRecord) { dev.save! }
-    assert_raise(ActiveRecord::ReadOnlyRecord) { dev.destroy }
+    e = assert_raise(ActiveRecord::ReadOnlyRecord) { dev.save  }
+    assert_equal "Developer is marked as readonly", e.message
+    e = assert_raise(ActiveRecord::ReadOnlyRecord) { dev.save! }
+    assert_equal "Developer is marked as readonly", e.message
+    e = assert_raise(ActiveRecord::ReadOnlyRecord) { dev.destroy }
+    assert_equal "Developer is marked as readonly", e.message
   end
 
 


### PR DESCRIPTION
Currently, there is no messages which get printed out. Convoluted system
may have hooks that create other objects in which case we only fail with
no messages. This commit changes this information allowing you to know
which object is the one that actually raised the error.
