### PR TITLE
[Enh] Made the ActiveModel::Dirty#clear_attribute_changes method public

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -255,7 +255,7 @@ module ActiveModel
       end
 
       # Remove changes information for the provided attributes.
-      def clear_attribute_changes(attributes)
+      def clear_attribute_changes(attributes) # :doc:
         attributes_changed_by_setter.except!(*attributes)
       end
   end


### PR DESCRIPTION
In Rails 4.2 it is impossible to define a custom default value for a model's
attribute without making it appear as _changed?, especially when the model
is first initialized. Making this method public will allow such a behaviour,
without the need to use private APIs.
