### PR TITLE
Guides: Corrected name for assigns key [ci skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -728,7 +728,7 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
     https!(false)
     get "/articles/all"
     assert_response :success
-    assert assigns(:products)
+    assert assigns(:articles)
   end
 end
 ```


### PR DESCRIPTION
- Integration test example is now using 'articles' name
  for both path and assigns key.
