### PR TITLE
Error message testing fix

### DIFF
--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -857,12 +857,14 @@ class RenderTest < ActionController::TestCase
 
   # :ported:
   def test_attempt_to_access_object_method
-    assert_raise(AbstractController::ActionNotFound, "No action responded to [clone]") { get :clone }
+    e = assert_raise(AbstractController::ActionNotFound) { get :clone }
+    assert_equal "The action 'clone' could not be found for TestController", e.message
   end
 
   # :ported:
   def test_private_methods
-    assert_raise(AbstractController::ActionNotFound, "No action responded to [determine_layout]") { get :determine_layout }
+    e = assert_raise(AbstractController::ActionNotFound) { get :determine_layout }
+    assert_equal "The action 'determine_layout' could not be found for TestController", e.message
   end
 
   # :ported:

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -62,9 +62,10 @@ module RenderTestCases
 
   def test_render_template_with_a_missing_partial_of_another_format
     @view.lookup_context.formats = [:html]
-    assert_raise ActionView::Template::Error, "Missing partial /_missing with {:locale=>[:en], :formats=>[:json], :handlers=>[:erb, :builder]}" do
+    e = assert_raise ActionView::Template::Error do
       @view.render(:template => "with_format", :formats => [:json])
     end
+    assert_match(/Missing partial \/_missing with {:locale=>\[\:en\], :formats=>\[\:json\], :variants=>\[\], :handlers=>\[\:erb, :builder, :raw, :ruby\]/, e.message)
   end
 
   def test_render_file_with_locale

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -183,10 +183,11 @@ class TestERBTemplate < ActiveSupport::TestCase
   end
 
   def test_error_when_template_isnt_valid_utf8
-    assert_raises(ActionView::Template::Error, /\xFC/) do
+    e = assert_raises ActionView::Template::Error do
       @template = new_template("hello \xFCmlat", :virtual_path => nil)
       render
     end
+    assert_match /\xFC/, e.message
   end
 
   def with_external_encoding(encoding)

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -328,9 +328,10 @@ module ActionView
     test "supports specifying locals (failing)" do
       controller.controller_path = "test"
       render(:template => "test/calling_partial_with_layout")
-      assert_raise ActiveSupport::TestCase::Assertion, /Somebody else.*David/m do
+      e = assert_raise ActiveSupport::TestCase::Assertion do
         assert_template :partial => "_partial_for_use_in_layout", :locals => { :name => "Somebody Else" }
       end
+      assert_match(/Somebody Else.*David/m, e.message)
     end
 
     test 'supports different locals on the same partial' do

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -951,11 +951,15 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
   test 'dangerous association name raises ArgumentError' do
     [:errors, 'errors', :save, 'save'].each do |name|
-      assert_raises(ArgumentError, "Association #{name} should not be allowed") do
+      e = assert_raises(ArgumentError, "Association #{name} should not be allowed") do
         Class.new(ActiveRecord::Base) do
           belongs_to name
         end
       end
+      message  = "You tried to define an association named #{name} on the model ,"
+      message += " but this will conflict with a method #{name} already defined"
+      message += " by Active Record. Please choose a different association name."
+      assert_equal message, e.message
     end
   end
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -89,9 +89,10 @@ class AssociationsTest < ActiveRecord::TestCase
   end
 
   def test_bad_collection_keys
-    assert_raise(ArgumentError, 'ActiveRecord should have barked on bad collection keys') do
+    e = assert_raise(ArgumentError, 'ActiveRecord should have barked on bad collection keys') do
       Class.new(ActiveRecord::Base).has_many(:wheels, :name => 'wheels')
     end
+    assert e.message.include? "Unknown key:"
   end
 
   def test_should_construct_new_finder_sql_after_create

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -177,9 +177,10 @@ class EnumTest < ActiveRecord::TestCase
     ]
 
     conflicts.each_with_index do |name, i|
-      assert_raises(ArgumentError, "enum name `#{name}` should not be allowed") do
+      e = assert_raises(ArgumentError) do
         klass.class_eval { enum name => ["value_#{i}"] }
       end
+      assert_match /You tried to define an enum named \"#{name}\" on the model/, e.message
     end
   end
 
@@ -199,9 +200,10 @@ class EnumTest < ActiveRecord::TestCase
     ]
 
     conflicts.each_with_index do |value, i|
-      assert_raises(ArgumentError, "enum value `#{value}` should not be allowed") do
+      e = assert_raises(ArgumentError, "enum value `#{value}` should not be allowed") do
         klass.class_eval { enum "status_#{i}" => [value] }
       end
+      assert_match /You tried to define an enum named .* on the model/, e.message
     end
   end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -511,14 +511,16 @@ class MigrationTest < ActiveRecord::TestCase
   if current_adapter?(:MysqlAdapter, :Mysql2Adapter, :PostgreSQLAdapter)
     def test_out_of_range_limit_should_raise
       Person.connection.drop_table :test_limits rescue nil
-      assert_raise(ActiveRecord::ActiveRecordError, "integer limit didn't raise") do
+      e = assert_raise(ActiveRecord::ActiveRecordError, "integer limit didn't raise") do
         Person.connection.create_table :test_integer_limits, :force => true do |t|
           t.column :bigone, :integer, :limit => 10
         end
       end
 
+      assert_match /No integer type has byte size 10/, e.message
+
       unless current_adapter?(:PostgreSQLAdapter)
-        assert_raise(ActiveRecord::ActiveRecordError, "text limit didn't raise") do
+        e = assert_raise(ActiveRecord::ActiveRecordError, "text limit didn't raise") do
           Person.connection.create_table :test_text_limits, :force => true do |t|
             t.column :bigtext, :text, :limit => 0xfffffffff
           end

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -317,13 +317,15 @@ class NamedScopingTest < ActiveRecord::TestCase
     ]
 
     conflicts.each do |name|
-      assert_raises(ArgumentError, "scope `#{name}` should not be allowed") do
+      e = assert_raises(ArgumentError, "scope `#{name}` should not be allowed") do
         klass.class_eval { scope name, ->{ where(approved: true) } }
       end
+      assert_match /You tried to define a scope named \"#{name}\" on the model/, e.message
 
-      assert_raises(ArgumentError, "scope `#{name}` should not be allowed") do
+      e = assert_raises(ArgumentError, "scope `#{name}` should not be allowed") do
         subklass.class_eval { scope name, ->{ where(approved: true) } }
       end
+      assert_match /You tried to define a scope named \"#{name}\" on the model/, e.message
     end
 
     non_conflicts.each do |name|


### PR DESCRIPTION
The testing of error messages have been implemented wrongly a few times.
This is an attempt to fix it.

For example, some of these test should have failed with the new code.
The reason they are not failling with the new string is the fact they
were not being tested beforehand.
