### PR TITLE
default scopes should break the cache on singulur_association.

### DIFF
--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -41,7 +41,8 @@ module ActiveRecord
         def get_records
           if reflection.scope_chain.any?(&:any?) ||
               scope.eager_loading? ||
-              klass.current_scope
+              klass.current_scope ||
+              klass.default_scopes.any?
 
             return scope.limit(1).to_a
           end


### PR DESCRIPTION
fixes #17495  c2fc9848b1495768a4c550e4cc532882146902c9
The singulur association has a similar problem 
