### PR TITLE
[ci skip] Fix comment of SourceAnnotationExtractor#find_in

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -80,9 +80,8 @@ class SourceAnnotationExtractor
 
   # Returns a hash that maps filenames under +dir+ (recursively) to arrays
   # with their annotations. Only files with annotations are included. Files
-  # with extension +.builder+, +.rb+, +.erb+, +.haml+, +.slim+, +.css+,
-  # +.scss+, +.js+, +.coffee+, +.rake+, +.sass+ and +.less+
-  # are taken into account.
+  # with extension +.builder+, +.rb+, +.rake+, +.yml+, +.yaml+, +.ruby+,
+  # +.css+, +.js+ and +.erb+ are taken into account.
   def find_in(dir)
     results = {}
 


### PR DESCRIPTION
Commit(810af6f) changed which extensions are taken into account,
so make to match comment of find_in.
And sort extensions to follow the added order.
