### PR TITLE
Fix stale nested transaction records

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module ConnectionAdapters
     class TransactionState
-      attr_reader :parent
+      attr_accessor :parent
 
       VALID_STATES = Set.new([:committed, :rolledback, nil])
 
@@ -171,6 +171,7 @@ module ActiveRecord
           else
             SavepointTransaction.new(@connection, "active_record_#{@stack.size}", options)
           end
+        transaction.state.parent = @stack.last.try(:state)
         @stack.push(transaction)
         transaction
       end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -509,12 +509,13 @@ module ActiveRecord
       if transaction_state && transaction_state.finalized? && !has_transactional_callbacks?
         unless @reflects_state[depth]
           restore_transaction_record_state if transaction_state.rolledback?
-          clear_transaction_record_state
           @reflects_state[depth] = true
         end
 
         if transaction_state.parent && !@reflects_state[depth+1]
           update_attributes_from_transaction_state(transaction_state.parent, depth+1)
+        else
+          clear_transaction_record_state
         end
       end
     end

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -531,11 +531,17 @@ class TransactionTest < ActiveRecord::TestCase
     topic_1 = Topic.new(:title => 'test_1')
     topic_2 = Topic.new(:title => 'test_2')
     topic_3 = topic_without_callbacks.new(:title => 'test_3')
+    topic_4 = Topic.new(:title => 'test_4')
 
     Topic.transaction do
       assert topic_1.save
       assert topic_2.save
-      assert topic_3.save
+
+      Topic.transaction(requires_new: true) do
+        assert topic_3.save
+        assert topic_4.save
+      end
+
       @first.save
       @second.destroy
       assert topic_1.persisted?, 'persisted'
@@ -544,6 +550,8 @@ class TransactionTest < ActiveRecord::TestCase
       assert_not_nil topic_2.id
       assert topic_3.persisted?, 'persisted'
       assert_not_nil topic_3.id
+      assert topic_4.persisted?, 'persisted'
+      assert_not_nil topic_4.id
       assert @first.persisted?, 'persisted'
       assert_not_nil @first.id
       assert @second.destroyed?, 'destroyed'
@@ -556,6 +564,9 @@ class TransactionTest < ActiveRecord::TestCase
     assert_nil topic_2.id
     assert !topic_3.persisted?, 'not persisted'
     assert_nil topic_3.id
+    assert !topic_4.persisted?, 'not persisted'
+    assert_nil topic_4.id
+
     assert @first.persisted?, 'persisted'
     assert_not_nil @first.id
     assert !@second.destroyed?, 'not destroyed'


### PR DESCRIPTION
If the parent transaction fails, records without callbacks need to be reloaded properly from their previous state.

Reopening this to see if Travis can rebuild.
