### PR TITLE
Correctly dump `:options` on `create_table` for MySQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Correctly dump `:options` on `create_table` for MySQL.
+
+    *Ryuta Kamizono*
+
 *   Make `unscope` aware of "less than" and "greater than" conditions.
 
     *TAKAHASHI Kazuaki*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -14,6 +14,10 @@ module ActiveRecord
         {}
       end
 
+      def table_options(table_name)
+        nil
+      end
+
       # Truncates a table alias according to the limits of the current adapter.
       def table_alias_for(table_name)
         table_name[0...table_alias_length].tr('.', '_')

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -686,6 +686,16 @@ module ActiveRecord
         end
       end
 
+      def table_options(table_name)
+        create_table_info = select_one("SHOW CREATE TABLE #{quote_table_name(table_name)}")["Create Table"]
+
+        # strip create_definitions and partition_options
+        raw_table_options = create_table_info.sub(/\A.*\n\) /m, '').sub(/\n\/\*!.*\*\/\n\z/m, '').strip
+
+        # strip AUTO_INCREMENT
+        raw_table_options.sub(/(ENGINE=\w+)(?: AUTO_INCREMENT=\d+)/, '\1')
+      end
+
       # Maps logical Rails types to MySQL-specific data types.
       def type_to_sql(type, limit = nil, precision = nil, scale = nil)
         case type.to_s

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -131,6 +131,10 @@ HEADER
             tbl.print ", id: false"
           end
           tbl.print ", force: :cascade"
+
+          table_options = @connection.table_options(table)
+          tbl.print ", options: #{table_options.inspect}" unless table_options.blank?
+
           tbl.puts " do |t|"
 
           # then dump all non-primary key columns

--- a/activerecord/test/cases/adapters/mysql/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql/table_options_test.rb
@@ -1,0 +1,42 @@
+require "cases/helper"
+require 'support/schema_dumping_helper'
+
+class MysqlTableOptionsTest < ActiveRecord::TestCase
+  include SchemaDumpingHelper
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+  end
+
+  def teardown
+    @connection.drop_table "mysql_table_options", if_exists: true
+  end
+
+  test "table options with ENGINE" do
+    @connection.create_table "mysql_table_options", force: true, options: "ENGINE=MyISAM"
+    output = dump_table_schema("mysql_table_options")
+    options = %r{create_table "mysql_table_options", force: :cascade, options: "(?<options>.*)"}.match(output)[:options]
+    assert_match %r{ENGINE=MyISAM}, options
+  end
+
+  test "table options with ROW_FORMAT" do
+    @connection.create_table "mysql_table_options", force: true, options: "ROW_FORMAT=REDUNDANT"
+    output = dump_table_schema("mysql_table_options")
+    options = %r{create_table "mysql_table_options", force: :cascade, options: "(?<options>.*)"}.match(output)[:options]
+    assert_match %r{ROW_FORMAT=REDUNDANT}, options
+  end
+
+  test "table options with CHARSET" do
+    @connection.create_table "mysql_table_options", force: true, options: "CHARSET=utf8mb4"
+    output = dump_table_schema("mysql_table_options")
+    options = %r{create_table "mysql_table_options", force: :cascade, options: "(?<options>.*)"}.match(output)[:options]
+    assert_match %r{CHARSET=utf8mb4}, options
+  end
+
+  test "table options with COLLATE" do
+    @connection.create_table "mysql_table_options", force: true, options: "COLLATE=utf8mb4_bin"
+    output = dump_table_schema("mysql_table_options")
+    options = %r{create_table "mysql_table_options", force: :cascade, options: "(?<options>.*)"}.match(output)[:options]
+    assert_match %r{COLLATE=utf8mb4_bin}, options
+  end
+end

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -1,0 +1,42 @@
+require "cases/helper"
+require 'support/schema_dumping_helper'
+
+class MysqlTableOptionsTest < ActiveRecord::TestCase
+  include SchemaDumpingHelper
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+  end
+
+  def teardown
+    @connection.drop_table "mysql_table_options", if_exists: true
+  end
+
+  test "table options with ENGINE" do
+    @connection.create_table "mysql_table_options", force: true, options: "ENGINE=MyISAM"
+    output = dump_table_schema("mysql_table_options")
+    options = %r{create_table "mysql_table_options", force: :cascade, options: "(?<options>.*)"}.match(output)[:options]
+    assert_match %r{ENGINE=MyISAM}, options
+  end
+
+  test "table options with ROW_FORMAT" do
+    @connection.create_table "mysql_table_options", force: true, options: "ROW_FORMAT=REDUNDANT"
+    output = dump_table_schema("mysql_table_options")
+    options = %r{create_table "mysql_table_options", force: :cascade, options: "(?<options>.*)"}.match(output)[:options]
+    assert_match %r{ROW_FORMAT=REDUNDANT}, options
+  end
+
+  test "table options with CHARSET" do
+    @connection.create_table "mysql_table_options", force: true, options: "CHARSET=utf8mb4"
+    output = dump_table_schema("mysql_table_options")
+    options = %r{create_table "mysql_table_options", force: :cascade, options: "(?<options>.*)"}.match(output)[:options]
+    assert_match %r{CHARSET=utf8mb4}, options
+  end
+
+  test "table options with COLLATE" do
+    @connection.create_table "mysql_table_options", force: true, options: "COLLATE=utf8mb4_bin"
+    output = dump_table_schema("mysql_table_options")
+    options = %r{create_table "mysql_table_options", force: :cascade, options: "(?<options>.*)"}.match(output)[:options]
+    assert_match %r{COLLATE=utf8mb4_bin}, options
+  end
+end


### PR DESCRIPTION
Related with #12172.

Is often used to specify table_options in MySQL. 

(For example, `"ENGINE=MyISAM"` for full-text search, `"ENGINE=InnoDB ROW_FORMAT=DYNAMIC"` or `"ENGINE=InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8"` for use InnoDB of Barracuda File Format.)

SchemaDumper should support a dump of table_options.
