### PR TITLE
Response etags to always be weak: Prefixed 'W/' to value returned by Act...

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Response etags to always be weak: Prefixes 'W/' to value returned by
+   `ActionDispatch::Http::Cache::Response#etag=`, such that etags set in
+   `fresh_when` and `stale?` are weak.
+
+    Fixes #17556.
+
+    *Abhishek Yadav*
+
 *   Provide the name of HTTP Status code in assertions.
 
     *Sean Collins*

--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -82,7 +82,7 @@ module ActionDispatch
 
         def etag=(etag)
           key = ActiveSupport::Cache.expand_cache_key(etag)
-          super %("#{Digest::MD5.hexdigest(key)}")
+          super %(W/"#{Digest::MD5.hexdigest(key)}")
         end
 
         def etag?; etag; end

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -429,7 +429,7 @@ module ActionController
     end
 
     def test_stale_with_etag
-      @request.if_none_match = Digest::MD5.hexdigest("123")
+      @request.if_none_match = %(W/"#{Digest::MD5.hexdigest('123')}")
       get :with_stale
       assert_equal 304, response.status.to_i
     end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -461,7 +461,7 @@ class EtagRenderTest < ActionController::TestCase
   end
 
   def etag(record)
-    Digest::MD5.hexdigest(ActiveSupport::Cache.expand_cache_key(record)).inspect
+    %(W/"#{Digest::MD5.hexdigest(ActiveSupport::Cache.expand_cache_key(record))}")
   end
 end
 

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -197,11 +197,11 @@ class ResponseTest < ActiveSupport::TestCase
     }
     resp.to_a
 
-    assert_equal('"202cb962ac59075b964b07152d234b70"', resp.etag)
+    assert_equal('W/"202cb962ac59075b964b07152d234b70"', resp.etag)
     assert_equal({:public => true}, resp.cache_control)
 
     assert_equal('public', resp.headers['Cache-Control'])
-    assert_equal('"202cb962ac59075b964b07152d234b70"', resp.headers['ETag'])
+    assert_equal('W/"202cb962ac59075b964b07152d234b70"', resp.headers['ETag'])
   end
 
   test "read charset and content type" do
@@ -388,16 +388,16 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_equal('public', @response.headers['Cache-Control'])
-    assert_equal('"202cb962ac59075b964b07152d234b70"', @response.headers['ETag'])
+    assert_equal('W/"202cb962ac59075b964b07152d234b70"', @response.headers['ETag'])
 
-    assert_equal('"202cb962ac59075b964b07152d234b70"', @response.etag)
+    assert_equal('W/"202cb962ac59075b964b07152d234b70"', @response.etag)
     assert_equal({:public => true}, @response.cache_control)
   end
 
   test "response cache control from rackish app" do
     @app = lambda { |env|
       [200,
-        {'ETag' => '"202cb962ac59075b964b07152d234b70"',
+        {'ETag' => 'W/"202cb962ac59075b964b07152d234b70"',
           'Cache-Control' => 'public'}, ['Hello']]
     }
 
@@ -405,9 +405,9 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_equal('public', @response.headers['Cache-Control'])
-    assert_equal('"202cb962ac59075b964b07152d234b70"', @response.headers['ETag'])
+    assert_equal('W/"202cb962ac59075b964b07152d234b70"', @response.headers['ETag'])
 
-    assert_equal('"202cb962ac59075b964b07152d234b70"', @response.etag)
+    assert_equal('W/"202cb962ac59075b964b07152d234b70"', @response.etag)
     assert_equal({:public => true}, @response.cache_control)
   end
 


### PR DESCRIPTION
...ionDispatch::Http::Cache::Response#etag such that etags set in fresh_when and stale? are weak. Fixes #17556.
