### PR TITLE
Add charset and collation options support for MySQL string and text columns.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add `:charset` and `:collation` options support for MySQL string and text columns.
+
+    Example:
+
+        create_table :foos do |t|
+          t.string :string_utf8_bin, charset: 'utf8', collation: 'utf8_bin'
+          t.text   :text_ascii,      charset: 'ascii'
+        end
+
+    *Ryuta Kamizono*
+
 *   Correctly dump `serial` and `bigserial`.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -28,6 +28,7 @@ module ActiveRecord
         @null = null
         @default = default
         @default_function = default_function
+        @table_name = nil
       end
 
       def has_default?

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -105,7 +105,10 @@ HEADER
       end
 
       def table(table, stream)
-        columns = @connection.columns(table)
+        columns = @connection.columns(table).map do |column|
+          column.instance_variable_set(:@table_name, table)
+          column
+        end
         begin
           tbl = StringIO.new
 

--- a/activerecord/test/cases/adapters/mysql/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/mysql/charset_collation_test.rb
@@ -1,0 +1,54 @@
+require "cases/helper"
+require 'support/schema_dumping_helper'
+
+class CharsetCollationTest < ActiveRecord::TestCase
+  include SchemaDumpingHelper
+  self.use_transactional_fixtures = false
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table :charset_collations, force: true do |t|
+      t.string :string_ascii_bin, charset: 'ascii', collation: 'ascii_bin'
+      t.text :text_ucs2_unicode_ci, charset: 'ucs2', collation: 'ucs2_unicode_ci'
+    end
+  end
+
+  teardown do
+    @connection.drop_table :charset_collations, if_exists: true
+  end
+
+  test "string column with charset and collation" do
+    column = @connection.columns(:charset_collations).find { |c| c.name == 'string_ascii_bin' }
+    assert_equal :string, column.type
+    assert_equal 'ascii_bin', column.collation
+  end
+
+  test "text column with charset and collation" do
+    column = @connection.columns(:charset_collations).find { |c| c.name == 'text_ucs2_unicode_ci' }
+    assert_equal :text, column.type
+    assert_equal 'ucs2_unicode_ci', column.collation
+  end
+
+  test "add column with charset and collation" do
+    @connection.add_column :charset_collations, :title, :string, charset: 'utf8', collation: 'utf8_bin'
+
+    column = @connection.columns(:charset_collations).find { |c| c.name == 'title' }
+    assert_equal :string, column.type
+    assert_equal 'utf8_bin', column.collation
+  end
+
+  test "change column with charset and collation" do
+    @connection.add_column :charset_collations, :description, :string, charset: 'utf8', collation: 'utf8_unicode_ci'
+    @connection.change_column :charset_collations, :description, :text, charset: 'utf8', collation: 'utf8_general_ci'
+
+    column = @connection.columns(:charset_collations).find { |c| c.name == 'description' }
+    assert_equal :text, column.type
+    assert_equal 'utf8_general_ci', column.collation
+  end
+
+  test "schema dump includes collation" do
+    output = dump_table_schema("charset_collations")
+    assert_match %r{t.string\s+"string_ascii_bin",\s+limit: 255,\s+collation: "ascii_bin"$}, output
+    assert_match %r{t.text\s+"text_ucs2_unicode_ci",\s+limit: 65535,\s+collation: "ucs2_unicode_ci"$}, output
+  end
+end

--- a/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
@@ -1,0 +1,54 @@
+require "cases/helper"
+require 'support/schema_dumping_helper'
+
+class CharsetCollationTest < ActiveRecord::TestCase
+  include SchemaDumpingHelper
+  self.use_transactional_fixtures = false
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table :charset_collations, force: true do |t|
+      t.string :string_ascii_bin, charset: 'ascii', collation: 'ascii_bin'
+      t.text :text_ucs2_unicode_ci, charset: 'ucs2', collation: 'ucs2_unicode_ci'
+    end
+  end
+
+  teardown do
+    @connection.drop_table :charset_collations, if_exists: true
+  end
+
+  test "string column with charset and collation" do
+    column = @connection.columns(:charset_collations).find { |c| c.name == 'string_ascii_bin' }
+    assert_equal :string, column.type
+    assert_equal 'ascii_bin', column.collation
+  end
+
+  test "text column with charset and collation" do
+    column = @connection.columns(:charset_collations).find { |c| c.name == 'text_ucs2_unicode_ci' }
+    assert_equal :text, column.type
+    assert_equal 'ucs2_unicode_ci', column.collation
+  end
+
+  test "add column with charset and collation" do
+    @connection.add_column :charset_collations, :title, :string, charset: 'utf8', collation: 'utf8_bin'
+
+    column = @connection.columns(:charset_collations).find { |c| c.name == 'title' }
+    assert_equal :string, column.type
+    assert_equal 'utf8_bin', column.collation
+  end
+
+  test "change column with charset and collation" do
+    @connection.add_column :charset_collations, :description, :string, charset: 'utf8', collation: 'utf8_unicode_ci'
+    @connection.change_column :charset_collations, :description, :text, charset: 'utf8', collation: 'utf8_general_ci'
+
+    column = @connection.columns(:charset_collations).find { |c| c.name == 'description' }
+    assert_equal :text, column.type
+    assert_equal 'utf8_general_ci', column.collation
+  end
+
+  test "schema dump includes collation" do
+    output = dump_table_schema("charset_collations")
+    assert_match %r{t.string\s+"string_ascii_bin",\s+limit: 255,\s+collation: "ascii_bin"$}, output
+    assert_match %r{t.text\s+"text_ucs2_unicode_ci",\s+limit: 65535,\s+collation: "ucs2_unicode_ci"$}, output
+  end
+end

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -24,6 +24,11 @@ ActiveRecord::Schema.define do
   add_index :key_tests, :pizza, :using => :btree, :name => 'index_key_tests_on_pizza'
   add_index :key_tests, :snacks, :name => 'index_key_tests_on_snack'
 
+  create_table :collation_tests, id: false, force: true do |t|
+    t.string :string_cs_column, limit: 1, collation: 'utf8_bin'
+    t.string :string_ci_column, limit: 1, collation: 'utf8_general_ci'
+  end
+
   ActiveRecord::Base.connection.execute <<-SQL
 DROP PROCEDURE IF EXISTS ten;
 SQL
@@ -33,15 +38,6 @@ CREATE PROCEDURE ten() SQL SECURITY INVOKER
 BEGIN
 	select 10;
 END
-SQL
-
-  ActiveRecord::Base.connection.drop_table "collation_tests", if_exists: true
-
-  ActiveRecord::Base.connection.execute <<-SQL
-CREATE TABLE collation_tests (
-  string_cs_column VARCHAR(1) COLLATE utf8_bin,
-  string_ci_column VARCHAR(1) COLLATE utf8_general_ci
-) CHARACTER SET utf8 COLLATE utf8_general_ci
 SQL
 
   ActiveRecord::Base.connection.drop_table "enum_tests", if_exists: true

--- a/activerecord/test/schema/mysql_specific_schema.rb
+++ b/activerecord/test/schema/mysql_specific_schema.rb
@@ -24,6 +24,11 @@ ActiveRecord::Schema.define do
   add_index :key_tests, :pizza, :using => :btree, :name => 'index_key_tests_on_pizza'
   add_index :key_tests, :snacks, :name => 'index_key_tests_on_snack'
 
+  create_table :collation_tests, id: false, force: true do |t|
+    t.string :string_cs_column, limit: 1, collation: 'utf8_bin'
+    t.string :string_ci_column, limit: 1, collation: 'utf8_general_ci'
+  end
+
   ActiveRecord::Base.connection.execute <<-SQL
 DROP PROCEDURE IF EXISTS ten;
 SQL
@@ -44,15 +49,6 @@ CREATE PROCEDURE topics() SQL SECURITY INVOKER
 BEGIN
 	select * from topics limit 1;
 END
-SQL
-
-  ActiveRecord::Base.connection.drop_table "collation_tests", if_exists: true
-
-  ActiveRecord::Base.connection.execute <<-SQL
-CREATE TABLE collation_tests (
-  string_cs_column VARCHAR(1) COLLATE utf8_bin,
-  string_ci_column VARCHAR(1) COLLATE utf8_general_ci
-) CHARACTER SET utf8 COLLATE utf8_general_ci
 SQL
 
   ActiveRecord::Base.connection.drop_table "enum_tests", if_exists: true


### PR DESCRIPTION
MySQL is possible to specify charset and collation in each column.

This is useful to for a case-sensitive search or specify charset `ascii` to secret_token column.

Index size of string column depends on maxlen of that charset. In the case of strict_mode, it can be in error INSERT of characters that are not included in that charset.
