### PR TITLE
no need to pass native_database_types around

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,1 +1,8 @@
+*   `ActiveRecord::ConnectionAdapters::ColumnDumper#column_spec` and
+    `ActiveRecord::ConnectionAdapters::ColumnDumper#prepare_column_options` no
+    longer have a `types` argument. They should access
+    `connection#native_database_types` directly.
+
+    *Yves Senn*
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -6,8 +6,8 @@ module ActiveRecord
     # We can then redefine how certain data types may be handled in the schema dumper on the
     # Adapter level by over-writing this code inside the database specific adapters
     module ColumnDumper
-      def column_spec(column, types)
-        spec = prepare_column_options(column, types)
+      def column_spec(column)
+        spec = prepare_column_options(column)
         (spec.keys - [:name, :type]).each{ |k| spec[k].insert(0, "#{k}: ")}
         spec
       end
@@ -15,13 +15,13 @@ module ActiveRecord
       # This can be overridden on a Adapter level basis to support other
       # extended datatypes (Example: Adding an array option in the
       # PostgreSQLAdapter)
-      def prepare_column_options(column, types)
+      def prepare_column_options(column)
         spec = {}
         spec[:name]      = column.name.inspect
         spec[:type]      = column.type.to_s
         spec[:null]      = 'false' unless column.null
 
-        limit = column.limit || types[column.type][:limit]
+        limit = column.limit || native_database_types[column.type][:limit]
         spec[:limit]     = limit.inspect if limit
         spec[:precision] = column.precision.inspect if column.precision
         spec[:scale]     = column.scale.inspect if column.scale

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -127,7 +127,7 @@ module ActiveRecord
 
       # Adds +:array+ option to the default set provided by the
       # AbstractAdapter
-      def prepare_column_options(column, types) # :nodoc:
+      def prepare_column_options(column) # :nodoc:
         spec = super
         spec[:array] = 'true' if column.respond_to?(:array) && column.array
         spec[:default] = "\"#{column.default_function}\"" if column.default_function

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -44,7 +44,6 @@ module ActiveRecord
 
       def initialize(connection, options = {})
         @connection = connection
-        @types = @connection.native_database_types
         @version = Migrator::current_version rescue nil
         @options = options
       end
@@ -134,7 +133,7 @@ HEADER
           column_specs = columns.map do |column|
             raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
             next if column.name == pk
-            @connection.column_spec(column, @types)
+            @connection.column_spec(column)
           end.compact
 
           # find all migration keys used in this table


### PR DESCRIPTION
`native_database_types` was passed from the `SchemaDumper` back to the connection where it originally came from. I opened a PR because the signature change could break adapters outside of rails/rails.
