### PR TITLE
add a Table#name accessor like TableDefinition#name

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `Table#name` to match `TableDefinition#name`
+
+    *Cody Cutrer*
+
 *   Cache `CollectionAssociation#reader` proxies separately before and after
     the owner has been saved so that the proxy is not cached without the
     owner's id.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -414,8 +414,10 @@ module ActiveRecord
     class Table
       include TimestampDefaultDeprecation
 
+      attr_reader :name
+
       def initialize(table_name, base)
-        @table_name = table_name
+        @name = table_name
         @base = base
       end
 
@@ -425,12 +427,12 @@ module ActiveRecord
       # ====== Creating a simple column
       #  t.column(:name, :string)
       def column(column_name, type, options = {})
-        @base.add_column(@table_name, column_name, type, options)
+        @base.add_column(name, column_name, type, options)
       end
 
       # Checks to see if a column exists. See SchemaStatements#column_exists?
       def column_exists?(column_name, type = nil, options = {})
-        @base.column_exists?(@table_name, column_name, type, options)
+        @base.column_exists?(name, column_name, type, options)
       end
 
       # Adds a new index to the table. +column_name+ can be a single Symbol, or
@@ -443,19 +445,19 @@ module ActiveRecord
       # ====== Creating a named index
       #  t.index([:branch_id, :party_id], unique: true, name: 'by_branch_party')
       def index(column_name, options = {})
-        @base.add_index(@table_name, column_name, options)
+        @base.add_index(name, column_name, options)
       end
 
       # Checks to see if an index exists. See SchemaStatements#index_exists?
       def index_exists?(column_name, options = {})
-        @base.index_exists?(@table_name, column_name, options)
+        @base.index_exists?(name, column_name, options)
       end
 
       # Renames the given index on the table.
       #
       #  t.rename_index(:user_id, :account_id)
       def rename_index(index_name, new_index_name)
-        @base.rename_index(@table_name, index_name, new_index_name)
+        @base.rename_index(name, index_name, new_index_name)
       end
 
       # Adds timestamps (+created_at+ and +updated_at+) columns to the table. See SchemaStatements#add_timestamps
@@ -463,7 +465,7 @@ module ActiveRecord
       #  t.timestamps
       def timestamps(options = {})
         emit_warning_if_null_unspecified(options)
-        @base.add_timestamps(@table_name, options)
+        @base.add_timestamps(name, options)
       end
 
       # Changes the column's definition according to the new options.
@@ -472,7 +474,7 @@ module ActiveRecord
       #  t.change(:name, :string, limit: 80)
       #  t.change(:description, :text)
       def change(column_name, type, options = {})
-        @base.change_column(@table_name, column_name, type, options)
+        @base.change_column(name, column_name, type, options)
       end
 
       # Sets a new default value for a column. See SchemaStatements#change_column_default
@@ -480,7 +482,7 @@ module ActiveRecord
       #  t.change_default(:qualification, 'new')
       #  t.change_default(:authorized, 1)
       def change_default(column_name, default)
-        @base.change_column_default(@table_name, column_name, default)
+        @base.change_column_default(name, column_name, default)
       end
 
       # Removes the column(s) from the table definition.
@@ -488,7 +490,7 @@ module ActiveRecord
       #  t.remove(:qualification)
       #  t.remove(:qualification, :experience)
       def remove(*column_names)
-        @base.remove_columns(@table_name, *column_names)
+        @base.remove_columns(name, *column_names)
       end
 
       # Removes the given index from the table.
@@ -502,21 +504,21 @@ module ActiveRecord
       # ====== Remove the index named by_branch_party in the table_name table
       #   t.remove_index name: :by_branch_party
       def remove_index(options = {})
-        @base.remove_index(@table_name, options)
+        @base.remove_index(name, options)
       end
 
       # Removes the timestamp columns (+created_at+ and +updated_at+) from the table.
       #
       #  t.remove_timestamps
       def remove_timestamps
-        @base.remove_timestamps(@table_name)
+        @base.remove_timestamps(name)
       end
 
       # Renames a column.
       #
       #  t.rename(:description, :name)
       def rename(column_name, new_column_name)
-        @base.rename_column(@table_name, column_name, new_column_name)
+        @base.rename_column(name, column_name, new_column_name)
       end
 
       # Adds a reference. Optionally adds a +type+ column, if <tt>:polymorphic</tt> option is provided.
@@ -531,7 +533,7 @@ module ActiveRecord
       def references(*args)
         options = args.extract_options!
         args.each do |ref_name|
-          @base.add_reference(@table_name, ref_name, options)
+          @base.add_reference(name, ref_name, options)
         end
       end
       alias :belongs_to :references
@@ -546,7 +548,7 @@ module ActiveRecord
       def remove_references(*args)
         options = args.extract_options!
         args.each do |ref_name|
-          @base.remove_reference(@table_name, ref_name, options)
+          @base.remove_reference(name, ref_name, options)
         end
       end
       alias :remove_belongs_to :remove_references
@@ -558,8 +560,8 @@ module ActiveRecord
       [:string, :text, :integer, :float, :decimal, :datetime, :timestamp, :time, :date, :binary, :boolean].each do |column_type|
         define_method column_type do |*args|
           options = args.extract_options!
-          args.each do |name|
-            @base.add_column(@table_name, name, column_type, options)
+          args.each do |column_name|
+            @base.add_column(name, column_name, column_type, options)
           end
         end
       end

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -213,6 +213,12 @@ module ActiveRecord
           t.rename :bar, :baz
         end
       end
+
+      def test_table_name_set
+        with_change_table do |t|
+          assert_equal :delete_me, t.name
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
we have a gem that dynamically creates tables (based on date), but passes the `Table` object on to the client for further manipulating the schema. it's useful for that client to be able to access the dynamic name. I thought it could looking at the docs for `TableDefinition`, until I realized that `change_table` creates a `Table`, not a `TableDefinition`
