### PR TITLE
Make `:index` in migrations work with `add_column`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   The `:index` option in migrations now works with `add_column`.
+
+    *Andrey Deryabin*
+
 *   Cache `CollectionAssociation#reader` proxies separately before and after
     the owner has been saved so that the proxy is not cached without the
     owner's id.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -372,8 +372,11 @@ module ActiveRecord
       # See TableDefinition#column for details of the options you can use.
       def add_column(table_name, column_name, type, options = {})
         at = create_alter_table table_name
+        index_options = options.delete(:index)
         at.add_column(column_name, type, options)
-        execute schema_creation.accept at
+        result = Array(execute schema_creation.accept at)
+        result << add_index(table_name, column_name, index_options.is_a?(Hash) ? index_options : {}) if index_options
+        result.compact.join(";\n")
       end
 
       # Removes the given columns from the table definition.

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -80,6 +80,15 @@ class ActiveSchemaTest < ActiveRecord::TestCase
     assert_equal "ALTER TABLE `people` ADD `last_name` varchar(255)", add_column(:people, :last_name, :string)
   end
 
+  def test_add_column_with_index
+    def (ActiveRecord::Base.connection).table_exists?(*); true; end
+    def (ActiveRecord::Base.connection).index_name_exists?(*); false; end
+
+    expected = %{ALTER TABLE `people` ADD `last_name` varchar(255);
+CREATE  INDEX `index_people_on_last_name`  ON `people` (`last_name`) }
+    assert_equal expected, add_column(:people, :last_name, :string, index: true)
+  end
+
   def test_add_column_with_limit
     assert_equal "ALTER TABLE `people` ADD `key` varchar(32)", add_column(:people, :key, :string, :limit => 32)
   end

--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -180,6 +180,16 @@ module ActiveRecord
           end
         end
       end
+
+      def test_add_column_with_index
+        add_column "test_models", "first_name", :integer, index: true
+        assert index_exists?('test_models', 'first_name')
+      end
+
+      def test_add_column_with_index_as_hash
+        add_column "test_models", "first_name", :integer, index: { name: 'index_test_models_on_first_name' }
+        assert index_exists?('test_models', 'first_name', name: 'index_test_models_on_first_name')
+      end
     end
   end
 end


### PR DESCRIPTION
Option `index` works perfect in table definition constructions like

``` ruby
change_table :table do |t|
  t.integer :foo, index: true
  t.references :bar, index: true
end
```

In [documentation](https://github.com/rails/rails/blame/master/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L372) I found that `index` should works for `add_column`. I've add tests and functionality for it.

I mean

``` ruby
  add_column :table, :foo, :integer, index: true
```
