### PR TITLE
Patch gemfile for jruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,16 +90,16 @@ end
 platforms :jruby do
   gem 'json'
   if ENV['AR_JDBC']
-    gem 'activerecord-jdbcsqlite3-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: 'master'
+    gem 'activerecord-jdbcsqlite3-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: '1-3-stable'
     group :db do
-      gem 'activerecord-jdbcmysql-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: 'master'
-      gem 'activerecord-jdbcpostgresql-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: 'master'
+      gem 'activerecord-jdbcmysql-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: '1-3-stable'
+      gem 'activerecord-jdbcpostgresql-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: '1-3-stable'
     end
   else
-    gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0'
+    gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3'
     group :db do
-      gem 'activerecord-jdbcmysql-adapter', '>= 1.3.0'
-      gem 'activerecord-jdbcpostgresql-adapter', '>= 1.3.0'
+      gem 'activerecord-jdbcmysql-adapter', '~> 1.3'
+      gem 'activerecord-jdbcpostgresql-adapter', '~> 1.3'
     end
   end
 end


### PR DESCRIPTION
JRuby tests are currently failing related to temp directories.  

One part of the fix is a band-aid to `require 'tmpdir'` until https://github.com/jruby/activerecord-jdbc-adapter/pull/601 is merged

The other is a work-around for temp directory paths

I know the comments in the commits aren't perfect, but I wanted to get feedback on these before worrying about fine-tuning them.
