### PR TITLE
Fix for assigns(:..) resetting template assertions

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -334,9 +334,11 @@ module ActionDispatch
          xml_http_request xhr get_via_redirect post_via_redirect).each do |method|
         define_method(method) do |*args|
           reset! unless integration_session
-          reset_template_assertion
           # reset the html_document variable, but only for new get/post calls
-          @html_document = nil unless method == 'cookies' || method == 'assigns'
+          unless method == 'cookies' || method == 'assigns'
+            @html_document = nil 
+            reset_template_assertion
+          end
           integration_session.__send__(method, *args).tap do
             copy_session_variables!
           end

--- a/actionpack/test/dispatch/template_assertions_test.rb
+++ b/actionpack/test/dispatch/template_assertions_test.rb
@@ -42,6 +42,7 @@ class AssertTemplateControllerTest < ActionDispatch::IntegrationTest
 
   def test_layout_reset_between_requests
     get '/assert_template/render_with_layout'
+    assert_nil assigns(:variable_for_layout)
     assert_template layout: 'layouts/standard'
 
     get '/assert_template/render_nothing'


### PR DESCRIPTION
When calling assigns(:...) or cookies(:...), template assertions would be reset, which they obviously shouldn't be.
