### PR TITLE
fix #17454: ArgumentError: invalid byte sequence in UTF-8

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Rails 3.2.20 ##
+
+*   fix regression (issue #17454): ArgumentError: invalid byte sequence 
+    in UTF-8
+
+    This regression was introduced at 3437f260a5903b651bf8b8f751345fb288fa9052
+
+    *Jordi Massaguer Pla*
+    
 ## Rails 3.2.19 (Jul 2, 2014) ##
 
 *   Fix regression when using `ActionView::Helpers::TranslationHelper#translate` with

--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -48,6 +48,7 @@ module ActionDispatch
     PATH_SEPS = Regexp.union(*[::File::SEPARATOR, ::File::ALT_SEPARATOR].compact)
 
     def clean_path_info(path_info)
+      path_info.force_encoding('binary') if path_info.respond_to? :force_encoding
       parts = path_info.split PATH_SEPS
 
       clean = []


### PR DESCRIPTION
force encoding the path to 'binary' before the split as in 55cac81
