### PR TITLE
Add `SchemaMigration.create_table` support any unicode charsets for MySQL.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `SchemaMigration.create_table` support any unicode charsets for MySQL.
+
+    *Ryuta Kamizono*
+
 *   PostgreSQL, no longer disables user triggers if system triggers can't be
     disabled. Disabling user triggers does not fulfill what the method promises.
     Rails currently requires superuser privileges for this method.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -235,6 +235,16 @@ module ActiveRecord
         end
       end
 
+      MAX_INDEX_LENGTH_FOR_CHARSETS_OF_4BYTES_MAXLEN = 191
+      CHARSETS_OF_4BYTES_MAXLEN = ['utf8mb4', 'utf16', 'utf16le', 'utf32']
+      def initialize_schema_migrations_table
+        if CHARSETS_OF_4BYTES_MAXLEN.include?(charset)
+          ActiveRecord::SchemaMigration.create_table(MAX_INDEX_LENGTH_FOR_CHARSETS_OF_4BYTES_MAXLEN)
+        else
+          ActiveRecord::SchemaMigration.create_table
+        end
+      end
+
       # Returns true, since this connection adapter supports migrations.
       def supports_migrations?
         true

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -37,15 +37,6 @@ module ActiveRecord
         configure_connection
       end
 
-      MAX_INDEX_LENGTH_FOR_UTF8MB4 = 191
-      def initialize_schema_migrations_table
-        if charset == 'utf8mb4'
-          ActiveRecord::SchemaMigration.create_table(MAX_INDEX_LENGTH_FOR_UTF8MB4)
-        else
-          ActiveRecord::SchemaMigration.create_table
-        end
-      end
-
       def supports_explain?
         true
       end

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 
 module ActiveRecord
   module ConnectionAdapters
-    class Mysql2Adapter
+    class AbstractMysqlAdapter
       class SchemaMigrationsTest < ActiveRecord::TestCase
         def test_renaming_index_on_foreign_key
           connection.add_index "engines", "car_id"
@@ -28,7 +28,7 @@ module ActiveRecord
 
           connection.initialize_schema_migrations_table
 
-          assert connection.column_exists?(smtn, :version, :string, limit: Mysql2Adapter::MAX_INDEX_LENGTH_FOR_UTF8MB4)
+          assert connection.column_exists?(smtn, :version, :string, limit: AbstractMysqlAdapter::MAX_INDEX_LENGTH_FOR_CHARSETS_OF_4BYTES_MAXLEN)
         ensure
           execute("ALTER DATABASE #{database_name} DEFAULT CHARACTER SET #{original_charset} COLLATE #{original_collation}")
         end


### PR DESCRIPTION
MySQL unicode support is not only `utf8mb4`.
Then, The index length problem is not only `utf8mb4`.

http://dev.mysql.com/doc/refman/5.6/en/charset-unicode.html

```
SELECT * FROM information_schema.character_sets WHERE maxlen > 3;
+--------------------+----------------------+------------------+--------+
| CHARACTER_SET_NAME | DEFAULT_COLLATE_NAME | DESCRIPTION      | MAXLEN |
+--------------------+----------------------+------------------+--------+
| utf8mb4            | utf8mb4_general_ci   | UTF-8 Unicode    |      4 |
| utf16              | utf16_general_ci     | UTF-16 Unicode   |      4 |
| utf16le            | utf16le_general_ci   | UTF-16LE Unicode |      4 |
| utf32              | utf32_general_ci     | UTF-32 Unicode   |      4 |
+--------------------+----------------------+------------------+--------+
```
