### PR TITLE
Abstract encoding strategy for ActiveSupport::MessageVerifier

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -40,7 +40,7 @@ module ActiveSupport
       data, digest = signed_message.split("--")
       if data.present? && digest.present? && ActiveSupport::SecurityUtils.secure_compare(digest, generate_digest(data))
         begin
-          @serializer.load(::Base64.strict_decode64(data))
+          @serializer.load(decode(data))
         rescue ArgumentError => argument_error
           raise InvalidSignature if argument_error.message =~ %r{invalid base64}
           raise
@@ -51,11 +51,19 @@ module ActiveSupport
     end
 
     def generate(value)
-      data = ::Base64.strict_encode64(@serializer.dump(value))
+      data = encode(@serializer.dump(value))
       "#{data}--#{generate_digest(data)}"
     end
 
     private
+      def encode(data)
+        ::Base64.strict_encode64(data)
+      end
+
+      def decode(data)
+        ::Base64.strict_decode64(data)
+      end
+
       def generate_digest(data)
         require 'openssl' unless defined?(OpenSSL)
         OpenSSL::HMAC.hexdigest(OpenSSL::Digest.const_get(@digest).new, @secret, data)


### PR DESCRIPTION
This allows `ActiveSupport::MessageVerifier` subclasses to define their own encoding strategy.  Good for handling special cases like reply-to addresses that need to be lowercase (see https://github.com/rails/rails/issues/17602).

Might make more sense to add `dump` and `load` methods too, so subclasses have full control over serialization without having to worry about `@serializer`.
