### PR TITLE
Fix #1627: prepared statement pool can be corrupted by exception

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,1 +1,8 @@
+*   Make sure prepared statements cache is left in consistent state if exception is raised
+    in PostgreSQL adapter.
+
+    Fixes #1627.
+
+    *Andrew Bezzub*
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -182,14 +182,14 @@ module ActiveRecord
         def length;       cache.length; end
 
         def next_key
-          "a#{@counter + 1}"
+          @counter += 1
+          "a#{@counter}"
         end
 
         def []=(sql, key)
           while @max <= cache.size
             dealloc(cache.shift.last)
           end
-          @counter += 1
           cache[sql] = key
         end
 

--- a/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
@@ -35,6 +35,14 @@ module ActiveRecord
           cache['foo'] = 'bar'
           assert_nothing_raised { cache.clear }
         end
+
+        def test_next_key_always_returns_new_key
+          cache = StatementPool.new nil, 10
+          key1 = cache.next_key
+          key2 = cache.next_key
+
+          assert key1 != key2, 'each call to next_key should return different key'
+        end
       end
     end
   end


### PR DESCRIPTION
This PR should fix https://github.com/rails/rails/issues/1627

Problem:

If error is raised in the PostgreSQL adapter at the right time then statement pool is left in the inconsistent state and process has to be restarted. The only solution without this fix is to turn off prepared statements.

Explanation:

My app uses Heroku and they suggest using their version of timeout gem, that raises exception in the main thread if request takes too long:

https://github.com/heroku/rack-timeout/blob/master/lib/rack/timeout.rb#L91-L108

The "prepared statement already exists" error happens in following method in postgres adapter: https://github.com/rails/rails/blob/4-1-stable/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L864-L878

Heroku's gem created timeout exception just at the right time and it corrupted the state of the prepared statements cache. Let's assume timeout exception happens right after `@connection.prepare nextkey, sql` finishes successfully:

```
        def prepare_statement(sql)
          sql_key = sql_key(sql)
          unless @statements.key? sql_key
            nextkey = @statements.next_key
            begin
              @connection.prepare nextkey, sql
            rescue => e
              raise translate_exception_class(e, sql)
            end

            # timeout happens here!

            # Clear the queue
            @connection.get_last_result
            @statements[sql_key] = nextkey # next key is "reserved" here
          end
          @statements[sql_key]
        end
```

then Postgres has prepared statement, but `@statements` was not updated and does not know that `nextkey` was already used. So the next time when `prepare_statement` is going to be called it is guaranteed to fail because `@statements.next_key` will return the same nextkey that was already used in PG. Current version of code that determines what `next_key` is:

```
        def next_key
          "a#{@counter + 1}"
        end

        def []=(sql, key)
          while @max <= cache.size
            dealloc(cache.shift.last)
          end
          @counter += 1
          cache[sql] = key
        end
```

If `nextkey` is reserved before `@connection.prepare nextkey, sql` is started then the issue will be fixed. In this case my fix is to just generate new `next_key` every time adapter is asking for it. 

Timeout exception that caused problems from my app's log:

```
Rack::Timeout::RequestTimeoutError (Request ran for longer than 25 seconds.): 
vendor/bundle/ruby/2.1.0/gems/activerecord-4.1.6/lib/active_record/connection_adapters/postgresql_adapter.rb:537:in `dealloc' 
vendor/bundle/ruby/2.1.0/gems/activerecord-4.1.6/lib/active_record/connection_adapters/postgresql_adapter.rb:512:in `[]=' 
vendor/bundle/ruby/2.1.0/gems/activerecord-4.1.6/lib/active_record/connection_adapters/postgresql_adapter.rb:875:in `prepare_statement' 
vendor/bundle/ruby/2.1.0/gems/activerecord-4.1.6/lib/active_record/connection_adapters/postgresql_adapter.rb:826:in `exec_cache' 
vendor/bundle/ruby/2.1.0/gems/activerecord-4.1.6/lib/active_record/connection_adapters/postgresql/database_statements.rb:138:in `exec_query' 
vendor/bundle/ruby/2.1.0/gems/activerecord-4.1.6/lib/active_record/connection_adapters/postgresql_adapter.rb:954:in `select' 
vendor/bundle/ruby/2.1.0/gems/activerecord-4.1.6/lib/active_record/connection_adapters/abstract/database_statements.rb:24:in `select_all' 
vendor/bundle/ruby/2.1.0/gems/activerecord-4.1.6/lib/active_record/connection_adapters/abstract/query_cache.rb:68:in `block in select_all' 
vendor/bundle/ruby/2.1.0/gems/activerecord-4.1.6/lib/active_record/connection_adapters/abstract/query_cache.rb:83:in `cache_sql' 
vendor/bundle/ruby/2.1.0/gems/activerecord-4.1.6/lib/active_record/connection_adapters/abstract/query_cache.rb:68:in `select_all' 
vendor/bundle/ruby/2.1.0/gems/activerecord-4.1.6/lib/active_record/relation/calculations.rb:265:in `execute_simple_calculation' 
vendor/bundle/ruby/2.1.0/gems/activerecord-4.1.6/lib/active_record/relation/calculations.rb:227:in `perform_calculation' 
vendor/bundle/ruby/2.1.0/gems/activerecord-4.1.6/lib/active_record/relation/calculations.rb:119:in `calculate' 
vendor/bundle/ruby/2.1.0/gems/activerecord-4.1.6/lib/active_record/relation/calculations.rb:75:in `sum' 
```
