### PR TITLE
sets script_name to always be a string.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -729,7 +729,7 @@ module ActionDispatch
       end
 
       def find_script_name(options)
-        options.delete(:script_name) { '' }
+        options.delete(:script_name) { '' } || ''
       end
 
       def path_for(options, route_name = nil) # :nodoc:

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -729,7 +729,7 @@ module ActionDispatch
       end
 
       def find_script_name(options)
-        options.delete(:script_name) { '' } || ''
+        options.delete(:script_name) || ''
       end
 
       def path_for(options, route_name = nil) # :nodoc:


### PR DESCRIPTION
see issue: #17615
and commit: 8cbcd19d7079db1b5df6ddb3b813fea57cd5cc38
which states script_name should always return a string
when script_name is nil in the options hash, script_name is set to nil.

```
options = {script_name: nil}
script_name = options.delete(:script_name) {‘’} # => nil
```
