### PR TITLE
[ci skip] Remove deprecated testing tasks

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -792,8 +792,7 @@ when you initiate a Rails project.
 
 | Tasks                   | Description |
 | ----------------------- | ----------- |
-| `rake test`             | Runs all tests in the test folder by default |
-| `rake test:all`         | Runs tests quickly by merging all types and not resetting the db |
+| `rake test`             | Runs all tests in the `test` folder by default |
 | `rake test:controllers` | Runs all the controller tests from `test/controllers` |
 | `rake test:functionals` | Runs all the functional tests from `test/controllers`, `test/mailers`, and `test/functional` |
 | `rake test:helpers`     | Runs all the helper tests from `test/helpers` |
@@ -802,8 +801,7 @@ when you initiate a Rails project.
 | `rake test:mailers`     | Runs all the mailer tests from `test/mailers` |
 | `rake test:models`      | Runs all the model tests from `test/models` |
 | `rake test:units`       | Runs all the unit tests from `test/models`, `test/helpers`, and `test/unit` |
-| `rake test:db`          | Runs all tests and resets the db |
-| `rake test:all:db`      | Runs tests quickly by merging all types and resets the db |
+| `rake test:db`          | Runs all tests in the `test` folder and resets the db |
 
 
 Brief Note About `Minitest`


### PR DESCRIPTION
This has changed recently here (https://github.com/rails/rails/commit/2a31ea5545dbbeeafaaabb622a3053e361018898) and so `rake test:all` and `rake test:all:db` tasks are deprecated. 

@carlosantoniodasilva thanks for pointing that it got deprecated.
