### PR TITLE
Rename #source_extract to #source_extracts in ExceptionWrapper

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -53,7 +53,7 @@ module ActionDispatch
           show_source_idx: source_to_show_id,
           trace_to_show: trace_to_show,
           routes_inspector: routes_inspector(exception),
-          source_extract: wrapper.source_extract,
+          source_extracts: wrapper.source_extracts,
           line_number: wrapper.line_number,
           file: wrapper.file
         )

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -81,13 +81,13 @@ module ActionDispatch
       Rack::Utils.status_code(@@rescue_responses[class_name])
     end
 
-    def source_extract
+    def source_extracts
       backtrace.map do |trace|
         file, line = trace.split(":")
         line_number = line.to_i
+
         {
           code: source_fragment(file, line_number),
-          file: file,
           line_number: line_number
         }
       end

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.erb
@@ -1,22 +1,22 @@
-<% @source_extract.each_with_index do |extract_source, index| %>
-  <% if extract_source[:code] %>
+<% @source_extracts.each_with_index do |source_extract, index| %>
+  <% if source_extract[:code] %>
     <div class="source <%="hidden" if @show_source_idx != index%>" id="frame-source-<%=index%>">
       <div class="info">
-        Extracted source (around line <strong>#<%= extract_source[:line_number] %></strong>):
+        Extracted source (around line <strong>#<%= source_extract[:line_number] %></strong>):
       </div>
       <div class="data">
         <table cellpadding="0" cellspacing="0" class="lines">
           <tr>
             <td>
               <pre class="line_numbers">
-                <% extract_source[:code].each_key do |line_number| %>
+                <% source_extract[:code].each_key do |line_number| %>
 <span><%= line_number -%></span>
                 <% end %>
               </pre>
             </td>
 <td width="100%">
 <pre>
-<% extract_source[:code].each do |line, source| -%><div class="line<%= " active" if line == extract_source[:line_number] -%>"><%= source -%></div><% end -%>
+<% source_extract[:code].each do |line, source| -%><div class="line<%= " active" if line == source_extract[:line_number] -%>"><%= source -%></div><% end -%>
 </pre>
 </td>
           </tr>

--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -25,13 +25,13 @@ module ActionDispatch
       @environment = { 'action_dispatch.backtrace_cleaner' => cleaner }
     end
 
-    test '#source_extract fetches source fragments for every backtrace entry' do
+    test '#source_extracts fetches source fragments for every backtrace entry' do
       exception = TestError.new("lib/file.rb:42:in `index'")
       wrapper = ExceptionWrapper.new({}, exception)
 
       wrapper.expects(:source_fragment).with('lib/file.rb', 42).returns('foo')
 
-      assert_equal [ code: 'foo', file: 'lib/file.rb', line_number: 42 ], wrapper.source_extract
+      assert_equal [ code: 'foo', line_number: 42 ], wrapper.source_extracts
     end
 
 


### PR DESCRIPTION
It returns multiple source extracts since 1ed264bc. Also cleaned its
result structure, as we no longer need the file in a code extract.
