### PR TITLE
Allow limit option for MySQL bigint primary key support.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Allow `:limit` option for MySQL bigint primary key support.
+
+    Example:
+
+        create_table :foos, id: :primary_key, limit: 8 do |t|
+        end
+
+        # or
+
+        create_table :foos, id: false do |t|
+          t.primary_key :id, limit: 8
+        end
+
+    *Ryuta Kamizono*
+
 *   `belongs_to` will now trigger a validation error by default if the association is not present.
     You can turn this off on a per-association basis with `optional: true`.
     (Note this new default only applies to new Rails apps that will be generated with

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -11,6 +11,16 @@ module ActiveRecord
           options[:auto_increment] ||= type == :bigint
           super
         end
+
+        def new_column_definition(name, type, options) # :nodoc:
+          column = super
+          case column.type
+          when :primary_key
+            column.type = :integer
+            column.auto_increment = true
+          end
+          column
+        end
       end
 
       class SchemaCreation < AbstractAdapter::SchemaCreation

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -282,5 +282,15 @@ if current_adapter?(:PostgreSQLAdapter, :MysqlAdapter, :Mysql2Adapter)
         assert_match %r{create_table "widgets", id: :bigint}, schema
       end
     end
+
+    if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
+      test "primary key column type with options" do
+        @connection.create_table(:widgets, id: :primary_key, limit: 8, force: true)
+        column = @connection.columns(:widgets).find { |c| c.name == 'id' }
+        assert column.auto_increment?
+        assert_equal :integer, column.type
+        assert_equal 8, column.limit
+      end
+    end
   end
 end


### PR DESCRIPTION
Example:

``` ruby
create_table :foos, id: :primary_key, limit: 8 do |t|
end

# or 

create_table :foos, id: false do |t|
  t.primary_key :id, limit: 8
end
```
