### PR TITLE
Apply schema cache dump when creating connections

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -220,7 +220,7 @@ module ActiveRecord
 
       include MonitorMixin
 
-      attr_accessor :automatic_reconnect, :checkout_timeout
+      attr_accessor :automatic_reconnect, :checkout_timeout, :schema_cache
       attr_reader :spec, :connections, :size, :reaper
 
       # Creates a new ConnectionPool object. +spec+ is a ConnectionSpecification
@@ -432,7 +432,9 @@ module ActiveRecord
       end
 
       def new_connection
-        Base.send(spec.adapter_method, spec.config)
+        Base.send(spec.adapter_method, spec.config).tap do |conn|
+          conn.schema_cache = schema_cache.dup if schema_cache
+        end
       end
 
       def current_connection_id #:nodoc:

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -13,6 +13,14 @@ module ActiveRecord
         @tables       = {}
       end
 
+      def initialize_dup(other)
+        super
+        @columns      = @columns.dup
+        @columns_hash = @columns_hash.dup
+        @primary_keys = @primary_keys.dup
+        @tables       = @tables.dup
+      end
+
       def primary_keys(table_name)
         @primary_keys[table_name] ||= table_exists?(table_name) ? connection.primary_key(table_name) : nil
       end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -93,6 +93,7 @@ module ActiveRecord
               cache = Marshal.load File.binread filename
               if cache.version == ActiveRecord::Migrator.current_version
                 self.connection.schema_cache = cache
+                self.connection_pool.schema_cache = cache.dup
               else
                 warn "Ignoring db/schema_cache.dump because it has expired. The current schema version is #{ActiveRecord::Migrator.current_version}, but the one in the cache is #{cache.version}."
               end

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -341,6 +341,21 @@ module ActiveRecord
           handler.establish_connection anonymous, nil
         }
       end
+
+      def test_pool_sets_connection_schema_cache
+        connection = pool.checkout
+        schema_cache = SchemaCache.new connection
+        schema_cache.add(:posts)
+        pool.schema_cache = schema_cache
+
+        pool.with_connection do |conn|
+          assert_not_same pool.schema_cache, conn.schema_cache
+          assert_equal pool.schema_cache.size, conn.schema_cache.size
+          assert_same pool.schema_cache.columns(:posts), conn.schema_cache.columns(:posts)
+        end
+
+        pool.checkin connection
+      end
     end
   end
 end


### PR DESCRIPTION
The `db:schema:cache:dump` rake task dumps the database schema structure to `db/schema_cache.dump`. If this file is present, the schema details are loaded into the currently checked out connection by a railtie while Rails is booting, to avoid having to query the database for its schema.

The schema cache dump is only applied to the initial connection used to boot the application though; other connections from the same pool are created with an empty schema cache, and still have to load the structure of each table directly from the database.

With this change, a copy of the schema cache is associated with the connection pool and applied to connections as they are created.
