### PR TITLE
Replace class_eval

### DIFF
--- a/actionpack/lib/abstract_controller/collector.rb
+++ b/actionpack/lib/abstract_controller/collector.rb
@@ -5,11 +5,9 @@ module AbstractController
     def self.generate_method_for_mime(mime)
       sym = mime.is_a?(Symbol) ? mime : mime.to_sym
       const = sym.upcase
-      class_eval <<-RUBY, __FILE__, __LINE__ + 1
-        def #{sym}(*args, &block)                # def html(*args, &block)
-          custom(Mime::#{const}, *args, &block)  #   custom(Mime::HTML, *args, &block)
-        end                                      # end
-      RUBY
+      define_method(sym) do |*args, &block|
+        custom(Mime.const_get(const), *args, &block)
+      end
     end
 
     Mime::SET.each do |mime|

--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -62,11 +62,9 @@ module AbstractController
         self._helper_methods += meths
 
         meths.each do |meth|
-          _helpers.class_eval <<-ruby_eval, __FILE__, __LINE__ + 1
-            def #{meth}(*args, &blk)                               # def current_user(*args, &blk)
-              controller.send(%(#{meth}), *args, &blk)             #   controller.send(:current_user, *args, &blk)
-            end                                                    # end
-          ruby_eval
+          _helpers.send(:define_method, meth) do |*args, &blk|
+            controller.send(meth, *args, &blk)
+          end
         end
       end
 

--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -65,14 +65,12 @@ module ActionController
 
     %w(write_fragment read_fragment exist_fragment?
        expire_fragment expire_page write_page).each do |method|
-      class_eval <<-METHOD, __FILE__, __LINE__ + 1
-        def #{method}(event)
-          return unless logger.info?
-          key_or_path = event.payload[:key] || event.payload[:path]
-          human_name  = #{method.to_s.humanize.inspect}
-          info("\#{human_name} \#{key_or_path} (\#{event.duration.round(1)}ms)")
-        end
-      METHOD
+      human_name  = method.to_s.humanize
+      define_method(method) do |event|
+        return unless logger.info?
+        key_or_path = event.payload[:key] || event.payload[:path]
+        info("#{human_name} #{key_or_path} (#{event.duration.round(1)}ms)")
+      end
     end
 
     def logger

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -12,12 +12,10 @@ module Mime
     %w(<< concat shift unshift push pop []= clear compact! collect!
     delete delete_at delete_if flatten! map! insert reject! reverse!
     replace slice! sort! uniq!).each do |method|
-      module_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{method}(*)
-          @symbols = nil
-          super
-        end
-      CODE
+      define_method(method) do |*args, &block|
+        @symbols = nil
+        super(*args, &block)
+      end
     end
   end
 

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -35,11 +35,9 @@ module ActionDispatch
         HTTP_NEGOTIATE HTTP_PRAGMA ].freeze
 
     ENV_METHODS.each do |env|
-      class_eval <<-METHOD, __FILE__, __LINE__ + 1
-        def #{env.sub(/^HTTP_/n, '').downcase}  # def accept_charset
-          @env["#{env}"]                        #   @env["HTTP_ACCEPT_CHARSET"]
-        end                                     # end
-      METHOD
+      define_method(env.sub(/^HTTP_/n, '').downcase) do # def accept_charset
+        @env[env]                                       #   @env["HTTP_ACCEPT_CHARSET"]
+      end                                               # end
     end
 
     def initialize(env)

--- a/actionpack/lib/action_dispatch/journey/nodes/node.rb
+++ b/actionpack/lib/action_dispatch/journey/nodes/node.rb
@@ -59,11 +59,7 @@ module ActionDispatch
       end
 
       %w{ Symbol Slash Dot }.each do |t|
-        class_eval <<-eoruby, __FILE__, __LINE__ + 1
-          class #{t} < Terminal;
-            def type; :#{t.upcase}; end
-          end
-        eoruby
+        const_set(t, Class.new(Terminal) { define_method(:type) { t.upcase.to_sym } })
       end
 
       class Symbol < Terminal # :nodoc:

--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -140,15 +140,13 @@ module ActionDispatch
 
 
       %w(edit new).each do |action|
-        module_eval <<-EOT, __FILE__, __LINE__ + 1
-          def #{action}_polymorphic_url(record_or_hash, options = {})
-            polymorphic_url_for_action("#{action}", record_or_hash, options)
-          end
+        define_method("#{action}_polymorphic_url") do |record_or_hash, options = {}|
+          polymorphic_url_for_action(action, record_or_hash, options)
+        end
 
-          def #{action}_polymorphic_path(record_or_hash, options = {})
-            polymorphic_path_for_action("#{action}", record_or_hash, options)
-          end
-        EOT
+        define_method("#{action}_polymorphic_path") do |record_or_hash, options = {}|
+          polymorphic_path_for_action(action, record_or_hash, options)
+        end
       end
 
       private

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -448,13 +448,11 @@ module ActionDispatch
           define_method "_#{name}" do
             RoutesProxy.new(routes, _routes_context)
           end
-        end
-
-        MountedHelpers.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-          def #{name}
-            @_#{name} ||= _#{name}
+          define_method(name) do
+            ivar = :"@_#{name}"
+            instance_variable_defined?(ivar) && instance_variable_get(ivar) || instance_variable_set(ivar, send("_#{name}"))
           end
-        RUBY
+        end
       end
 
       def url_helpers(include_path_helpers = true)

--- a/actionpack/lib/action_dispatch/routing/routes_proxy.rb
+++ b/actionpack/lib/action_dispatch/routing/routes_proxy.rb
@@ -24,13 +24,13 @@ module ActionDispatch
 
       def method_missing(method, *args)
         if routes.url_helpers.respond_to?(method)
-          self.class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def #{method}(*args)
-              options = args.extract_options!
-              args << url_options.merge((options || {}).symbolize_keys)
-              routes.url_helpers.#{method}(*args)
+          self.class.class_eval do
+            define_method(method) do |*methargs|
+              options = methargs.extract_options!
+              methargs << url_options.merge((options || {}).symbolize_keys)
+              routes.url_helpers.send(method, *methargs)
             end
-          RUBY
+          end
           send(method, *args)
         else
           super

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -852,7 +852,9 @@ class PostsController < ActionController::Base
     include AroundExceptions
   end
 
-  module_eval %w(raises_before raises_after raises_both no_raise no_action).map { |action| "def #{action}; default_action end" }.join("\n")
+  %w(raises_before raises_after raises_both no_raise no_action).map do |action|
+    define_method(action) { default_action }
+  end
 
   private
     def default_action


### PR DESCRIPTION
this is the start of an undertaking I've wanted to do for some time. rails uses class_eval and related methods that put its ruby into interpreted strings rather than directly in the ruby source, all over the place. it is a pain for a number of reasons (elaborated below), and I want to replace it. 

I've done this in a few places to start with here, but I'd like to discuss before I proceed further and determine whether this is a thing that is likely to be accepted. 

downsides of ruby being in strings to class_eval:
- for me the most major one is that every debugger I have used (ruby-debug / ruby-debug19 / debugger / byebug / rubinius-debugger) either lose track of where the code being executed lives (despite the `__FILE__, __LINE__ + 1` stuff), or just don't even know how to look for it. I use the debugger extensively to trace execution through rails when documentation is insufficient, and almost every time I end up having no idea where I am due to these string code blocks. 
- error backtraces similarly can get confused and point to the wrong thing
- more readable, and more concise code - interpolating variables into ruby strings of code is confusing and ugly
- text editors' syntax highlighting can't reliably parse it - even when the text editor recognizes it as ruby inside a  string, parsing can break easily and string interpolation within it can get particularly weird.
- just elegance. code straight in the source is much nicer then code in big blocks of text. but that's my opinion more than any solid, real reason. 

downsides of define_method / define_singleton_method:
- the only reason I know not to use define_method has been the lack of support for &block in ruby 1.8, but now that 1.8 is unsupported, I know of no reason not to. 

all tests still pass with these changes. 

what do you think, rails friends, is this a thing that can go in? 
