### PR TITLE
Don't let #{application,framework,full}_trace be nil

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -62,14 +62,12 @@ module ActionDispatch
       framework_trace_with_ids = []
       full_trace_with_ids = []
 
-      if full_trace
-        full_trace.each_with_index do |trace, idx|
-          trace_with_id = { id: idx, trace: trace }
+      full_trace.each_with_index do |trace, idx|
+        trace_with_id = { id: idx, trace: trace }
 
-          appplication_trace_with_ids << trace_with_id if application_trace.include?(trace)
-          framework_trace_with_ids << trace_with_id if framework_trace.include?(trace)
-          full_trace_with_ids << trace_with_id
-        end
+        appplication_trace_with_ids << trace_with_id if application_trace.include?(trace)
+        framework_trace_with_ids << trace_with_id if framework_trace.include?(trace)
+        full_trace_with_ids << trace_with_id
       end
 
       {
@@ -84,7 +82,7 @@ module ActionDispatch
     end
 
     def source_extract
-      exception.backtrace.map do |trace|
+      backtrace.map do |trace|
         file, line = trace.split(":")
         line_number = line.to_i
         {
@@ -92,10 +90,14 @@ module ActionDispatch
           file: file,
           line_number: line_number
         }
-      end if exception.backtrace
+      end
     end
 
     private
+
+    def backtrace
+      Array(@exception.backtrace)
+    end
 
     def original_exception(exception)
       if registered_original_exception?(exception)
@@ -111,9 +113,9 @@ module ActionDispatch
 
     def clean_backtrace(*args)
       if backtrace_cleaner
-        backtrace_cleaner.clean(@exception.backtrace, *args)
+        backtrace_cleaner.clean(backtrace, *args)
       else
-        @exception.backtrace
+        backtrace
       end
     end
 

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.erb
@@ -1,29 +1,27 @@
-<% if @source_extract %>
-  <% @source_extract.each_with_index do |extract_source, index| %>
-    <% if extract_source[:code] %>
-      <div class="source <%="hidden" if @show_source_idx != index%>" id="frame-source-<%=index%>">
-        <div class="info">
-          Extracted source (around line <strong>#<%= extract_source[:line_number] %></strong>):
-        </div>
-        <div class="data">
-          <table cellpadding="0" cellspacing="0" class="lines">
-            <tr>
-              <td>
-                <pre class="line_numbers">
-                  <% extract_source[:code].each_key do |line_number| %>
+<% @source_extract.each_with_index do |extract_source, index| %>
+  <% if extract_source[:code] %>
+    <div class="source <%="hidden" if @show_source_idx != index%>" id="frame-source-<%=index%>">
+      <div class="info">
+        Extracted source (around line <strong>#<%= extract_source[:line_number] %></strong>):
+      </div>
+      <div class="data">
+        <table cellpadding="0" cellspacing="0" class="lines">
+          <tr>
+            <td>
+              <pre class="line_numbers">
+                <% extract_source[:code].each_key do |line_number| %>
 <span><%= line_number -%></span>
-                  <% end %>
-                </pre>
-              </td>
+                <% end %>
+              </pre>
+            </td>
 <td width="100%">
 <pre>
 <% extract_source[:code].each do |line, source| -%><div class="line<%= " active" if line == extract_source[:line_number] -%>"><%= source -%></div><% end -%>
 </pre>
 </td>
-            </tr>
-          </table>
-        </div>
+          </tr>
+        </table>
       </div>
-    <% end %>
+    </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
Those three can be nil when exception backtrace is nil. This happens and
that forced a couple of nil guards in the code. I'm proposing to make
those always return an array, even on nil backtrace.
