### PR TITLE
Don't show full trace on routing errors

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -38,7 +38,7 @@ module ActionDispatch
         traces = wrapper.traces
 
         trace_to_show = 'Application Trace'
-        if traces[trace_to_show].empty?
+        if traces[trace_to_show].empty? && wrapper.rescue_template != 'routing_error'
           trace_to_show = 'Full Trace'
         end
 


### PR DESCRIPTION
Since dbcbbcf2bc58e8971672b143d1c52c0244e33f26 the full trace is shown by default on routing errors.
While this is a nice feature to have, it does take the attention off the
routes table in the routing view. I think this is what most of the people
look for in this page.

Added an exception to the default trace switching rule to remove that
noise.
