### PR TITLE
Don't double check trace origin in ExceptionWrapper#traces

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -65,8 +65,12 @@ module ActionDispatch
       full_trace.each_with_index do |trace, idx|
         trace_with_id = { id: idx, trace: trace }
 
-        appplication_trace_with_ids << trace_with_id if application_trace.include?(trace)
-        framework_trace_with_ids << trace_with_id if framework_trace.include?(trace)
+        if application_trace.include?(trace)
+          appplication_trace_with_ids << trace_with_id
+        else
+          framework_trace_with_ids << trace_with_id
+        end
+
         full_trace_with_ids << trace_with_id
       end
 


### PR DESCRIPTION
If a trace isn't an application one, then it comes from a framework.
That's the [definition](https://github.com/gsamokovarov/rails/blob/ff1902789d45190dd298b65342699d6043dd8ef2/activesupport/lib/active_support/backtrace_cleaner.rb#L99-L101) of framework trace. We can speed up the traces
generation if we don't double check that.
