### PR TITLE
Skip spring install in Cygwin due to fork() bad support.

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -342,7 +342,7 @@ module Rails
       end
 
       def spring_install?
-        !options[:skip_spring] && Process.respond_to?(:fork)
+        !options[:skip_spring] && Process.respond_to?(:fork) && !RUBY_PLATFORM.include?("cygwin")
       end
 
       def run_bundle


### PR DESCRIPTION
Process.respond_to?(:fork) returns true in Cygwin, but due to platform difference, spring will failed to work as expected in Unix-like systems.

See also: https://www.cygwin.com/faq.html#faq.using.fixing-fork-failures
