### PR TITLE
Fix for assigns(:..) resetting template assertions

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -334,9 +334,13 @@ module ActionDispatch
          xml_http_request xhr get_via_redirect post_via_redirect).each do |method|
         define_method(method) do |*args|
           reset! unless integration_session
-          reset_template_assertion
-          # reset the html_document variable, but only for new get/post calls
-          @html_document = nil unless method == 'cookies' || method == 'assigns'
+
+          # reset the html_document variable, except for cookies/assigns calls
+          unless method == 'cookies' || method == 'assigns'
+            @html_document = nil
+            reset_template_assertion
+          end
+
           integration_session.__send__(method, *args).tap do
             copy_session_variables!
           end

--- a/actionpack/test/dispatch/template_assertions_test.rb
+++ b/actionpack/test/dispatch/template_assertions_test.rb
@@ -10,7 +10,7 @@ class AssertTemplateController < ActionController::Base
   end
 
   def render_with_layout
-    @variable_for_layout = nil
+    @variable_for_layout = 'hello'
     render 'test/hello_world', layout: "layouts/standard"
   end
 
@@ -94,5 +94,17 @@ class AssertTemplateControllerTest < ActionDispatch::IntegrationTest
       session.get '/assert_template/render_nothing'
       session.assert_template file: nil
     end
+  end
+
+  def test_assigns_do_not_reset_template_assertion
+    get '/assert_template/render_with_layout'
+    assert_equal 'hello', assigns(:variable_for_layout)
+    assert_template layout: 'layouts/standard'
+  end
+
+  def test_cookies_do_not_reset_template_assertion
+    get '/assert_template/render_with_layout'
+    cookies
+    assert_template layout: 'layouts/standard'
   end
 end


### PR DESCRIPTION
When calling assigns(:...) or cookies(:...), template assertions would be reset, which they obviously shouldn't be.
