### PR TITLE
PERF: optimise type lookup to avoid invoking procs

### DIFF
--- a/activerecord/lib/active_record/type/hash_lookup_type_map.rb
+++ b/activerecord/lib/active_record/type/hash_lookup_type_map.rb
@@ -1,6 +1,12 @@
 module ActiveRecord
   module Type
     class HashLookupTypeMap < TypeMap # :nodoc:
+
+      def initialize
+        @cache = {}
+        super
+      end
+
       delegate :key?, to: :@mapping
 
       def lookup(type, *args)
@@ -8,11 +14,23 @@ module ActiveRecord
       end
 
       def fetch(type, *args, &block)
-        @mapping.fetch(type, block).call(type, *args)
+        cache = (@cache[type] ||= {})
+        resolved = cache[args]
+
+        unless resolved
+          resolved = cache[args] = @mapping.fetch(type, block).call(type, *args)
+        end
+
+        resolved
       end
 
       def alias_type(type, alias_type)
         register_type(type) { |_, *args| lookup(alias_type, *args) }
+      end
+
+      def register_type(key, value=nil, &block)
+        @cache = {}
+        super(key, value, &block)
       end
     end
   end


### PR DESCRIPTION
Mostly resolves #17641

```
require 'benchmark/ips'
require 'stackprof'

require File.expand_path("../../config/environment", __FILE__)

connection = ActiveRecord::Base.connection

sql = "select #{(1..10).map{|i| "#{i} #{(96+i).chr}" }.join(", ")}"
puts "SQL is #{sql}"

Benchmark.ips do |b|
  b.report("select_all") do |times|
    while times > 0
      connection.select_all(sql)
      times -= 1
    end
  end
end
```

cc @sgrif @tenderlove 

Before:

```
sam@ubuntu discourse % RAILS_MASTER=1 RAILS_ENV=production ruby script/select_all_bench.rb
SQL is select 1 a, 2 b, 3 c, 4 d, 5 e, 6 f, 7 g, 8 h, 9 i, 10 j
Calculating -------------------------------------
          select_all   328.000  i/100ms
-------------------------------------------------
          select_all      3.337k (± 5.5%) i/s -     16.728k

```

after 

```
SQL is select 1 a, 2 b, 3 c, 4 d, 5 e, 6 f, 7 g, 8 h, 9 i, 10 j
Calculating -------------------------------------
          select_all   507.000  i/100ms
-------------------------------------------------
          select_all      5.409k (± 5.1%) i/s -     27.378k
```

So we are still a touch slower than 4.1 but almost there
