### PR TITLE
PERF: stop allocating the string "id" over and over

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -76,12 +76,14 @@ module ActiveRecord
         end
       end
 
+      ID = 'id'.freeze
+
       # Returns the value of the attribute identified by <tt>attr_name</tt> after
       # it has been typecast (for example, "2004-12-12" in a date column is cast
       # to a date object, like Date.new(2004, 12, 12)).
       def read_attribute(attr_name, &block)
         name = attr_name.to_s
-        name = self.class.primary_key if name == 'id'
+        name = self.class.primary_key if name == ID
         @attributes.fetch_value(name, &block)
       end
 


### PR DESCRIPTION
This one is HUGE, on our front page this cut down 5000 allocations of the string "id"
