### PR TITLE
Support symbol foreign key to delete

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -740,7 +740,7 @@ module ActiveRecord
         end
 
         fk_name_to_delete = options.fetch(:name) do
-          fk_to_delete = foreign_keys(from_table).detect {|fk| fk.column == options[:column] }
+          fk_to_delete = foreign_keys(from_table).detect {|fk| fk.column == options[:column].to_s }
 
           if fk_to_delete
             fk_to_delete.name

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -162,6 +162,14 @@ module ActiveRecord
         assert_equal [], @connection.foreign_keys("astronauts")
       end
 
+      def test_remove_foreign_key_by_symbol_column
+        @connection.add_foreign_key :astronauts, :rockets, column: :rocket_id
+
+        assert_equal 1, @connection.foreign_keys("astronauts").size
+        @connection.remove_foreign_key :astronauts, column: :rocket_id
+        assert_equal [], @connection.foreign_keys("astronauts")
+      end
+
       def test_remove_foreign_key_by_name
         @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", name: "fancy_named_fk"
 


### PR DESCRIPTION
Hi,

`remove_foreign_key :accounts, column: :owner_id` in the doc doesn't work because the compared column name is string. Could you consider to fix this issue?
