### PR TITLE
Improving disabling integrity of PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -76,12 +76,14 @@ module ActiveRecord
         end
       end
 
+      ID = 'id'.freeze
+
       # Returns the value of the attribute identified by <tt>attr_name</tt> after
       # it has been typecast (for example, "2004-12-12" in a date column is cast
       # to a date object, like Date.new(2004, 12, 12)).
       def read_attribute(attr_name, &block)
         name = attr_name.to_s
-        name = self.class.primary_key if name == 'id'
+        name = self.class.primary_key if name == ID
         @attributes.fetch_value(name, &block)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -2,26 +2,28 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module ReferentialIntegrity # :nodoc:
-        def supports_disable_referential_integrity? # :nodoc:
-          true
+        def is_superuser? # :nodoc:
+          if execute('SHOW is_superuser')[0]['is_superuser'] === 'on'
+            true
+          else
+            false
+          end
         end
 
         def disable_referential_integrity # :nodoc:
-          if supports_disable_referential_integrity?
-            begin
-              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
-            rescue
-              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER USER" }.join(";"))
-            end
+          if is_superuser?
+            execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
+          else
+            puts 'WARNING: Rails can\'t disable referencial integrity if the Postgres user is not a superuser. ' + \
+              'It is recommended to run tests with a Postgres superuser.'
+            execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER USER" }.join(";"))
           end
           yield
         ensure
-          if supports_disable_referential_integrity?
-            begin
-              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
-            rescue
-              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER USER" }.join(";"))
-            end
+          if is_superuser?
+            execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+          else
+            execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER USER" }.join(";"))
           end
         end
       end


### PR DESCRIPTION
The Postgres connection adapter assumed that was ever possible to disable referential integrity, causing problems when it was not possible.

Disabling referential integrity is possible when the Postgres user is superuser. It can be verified with (SQL):

```
SHOW is_superuser;
```

It was added a warning when it is not possible to disable referential integrity, to help the developer know about problems when it is not possible.
