### PR TITLE
Add #record attribute to RecordNotFound and RecordDestroyed exceptions.

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -52,10 +52,29 @@ module ActiveRecord
   # Raised by ActiveRecord::Base.save! and ActiveRecord::Base.create! methods when record cannot be
   # saved because record is invalid.
   class RecordNotSaved < ActiveRecordError
+    attr_reader :record
+
+    def initialize(record)
+      @record = record
+      super()
+    end
   end
 
   # Raised by ActiveRecord::Base.destroy! when a call to destroy would return false.
+  #
+  #   begin
+  #     complex_operation_that_internally_calls_destroy!
+  #   rescue ActiveRecord::RecordNotDestroyed => invalid
+  #     puts invalid.record.errors
+  #   end
+  #
   class RecordNotDestroyed < ActiveRecordError
+    attr_reader :record
+
+    def initialize(record)
+      @record = record
+      super()
+    end
   end
 
   # Superclass for all database execution errors.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -139,7 +139,7 @@ module ActiveRecord
     # Attributes marked as readonly are silently ignored if the record is
     # being updated.
     def save!(*)
-      create_or_update || raise(RecordNotSaved)
+      create_or_update || raise(RecordNotSaved, self)
     end
 
     # Deletes the record in the database and freezes this instance to
@@ -181,7 +181,7 @@ module ActiveRecord
     # and <tt>destroy!</tt> raises ActiveRecord::RecordNotDestroyed. See
     # ActiveRecord::Callbacks for further details.
     def destroy!
-      destroy || raise(ActiveRecord::RecordNotDestroyed)
+      destroy || raise(ActiveRecord::RecordNotDestroyed, self)
     end
 
     # Returns an instance of the specified +klass+ with the attributes of the

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -443,7 +443,8 @@ class CallbacksTest < ActiveRecord::TestCase
     david = ImmutableDeveloper.find(1)
     assert david.valid?
     assert !david.save
-    assert_raise(ActiveRecord::RecordNotSaved) { david.save! }
+    exc = assert_raise(ActiveRecord::RecordNotSaved) { david.save! }
+    assert_equal exc.record, david
 
     david = ImmutableDeveloper.find(1)
     david.salary = 10_000_000
@@ -477,7 +478,8 @@ class CallbacksTest < ActiveRecord::TestCase
   def test_before_destroy_returning_false
     david = ImmutableDeveloper.find(1)
     assert !david.destroy
-    assert_raise(ActiveRecord::RecordNotDestroyed) { david.destroy! }
+    exc = assert_raise(ActiveRecord::RecordNotDestroyed) { david.destroy! }
+    assert_equal exc.record, david
     assert_not_nil ImmutableDeveloper.find_by_id(1)
 
     someone = CallbackCancellationDeveloper.find(1)


### PR DESCRIPTION
This allows these exceptions to be handled generically in conjunction with RecordInvalid.
