### PR TITLE
Fix I18n regression introduced by #13832

### DIFF
--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -39,12 +39,14 @@ module ActionView
         options = options.dup
         options[:default] = wrap_translate_defaults(options[:default]) if options[:default]
 
-        # If the user has specified rescue_format then pass it all through, otherwise use
-        # raise and do the work ourselves
-        options[:raise] ||= ActionView::Base.raise_on_missing_translations
-
-        raise_error = options[:raise] || options.key?(:rescue_format)
-        unless raise_error
+        # If the user has explicitly decided to NOT raise errors, pass that option to I18n.
+        # Otherwise, tell I18n to raise an exception, which we rescue further in this method.
+        # Note: `raise_error` refers to us re-raising the error in this method. I18n is forced to raise by default.
+        if options[:raise] == false || (options.key?(:rescue_format) && options[:rescue_format].nil?)
+          raise_error = false
+          options[:raise] = false
+        else
+          raise_error = options[:raise] || options[:rescue_format] || ActionView::Base.raise_on_missing_translations
           options[:raise] = true
         end
 

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -1,11 +1,20 @@
 require 'abstract_unit'
 
+module I18n
+  class CustomExceptionHandler
+    def self.call(exception, locale, key, options)
+      'from CustomExceptionHandler'
+    end
+  end
+end
+
 class TranslationHelperTest < ActiveSupport::TestCase
   include ActionView::Helpers::TranslationHelper
 
   attr_reader :request, :view
 
   setup do
+    I18n.exception_handler = nil
     I18n.backend.store_translations(:en,
       :translations => {
         :templates => {
@@ -70,6 +79,16 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_raise(I18n::MissingTranslationData) do
       translate(:"translations.missing", :raise => true)
     end
+  end
+
+  def test_uses_custom_exception_handler_when_specified
+    I18n.exception_handler = I18n::CustomExceptionHandler
+    assert_equal 'from CustomExceptionHandler', translate(:"translations.missing", raise: false)
+  end
+
+  def test_uses_custom_exception_handler_when_specified_for_html
+    I18n.exception_handler = I18n::CustomExceptionHandler
+    assert_equal 'from CustomExceptionHandler', translate(:"translations.missing_html", raise: false)
   end
 
   def test_i18n_translate_defaults_to_nil_rescue_format


### PR DESCRIPTION
Previously, when the `:raise` options was set to `false`, it would get overwritten to `true`, preventing custom exception handlers to be used.
