### PR TITLE
Fix includes on association with a scope

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -2,6 +2,12 @@
 
     *Yves Senn*
 
+*   Fix includes on association with a scope containing joins along with conditions
+    on the joined assoiciation.
+
+    *Siddharth Sharma*
+
+
 *   Add `Table#name` to match `TableDefinition#name`.
 
     *Cody Cutrer*

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -142,14 +142,8 @@ module ActiveRecord
 
           scope._select!   preload_values[:select] || values[:select] || table[Arel.star]
           scope.includes! preload_values[:includes] || values[:includes]
-
-          if preload_values.key? :order
-            scope.order! preload_values[:order]
-          else
-            if values.key? :order
-              scope.order! values[:order]
-            end
-          end
+          scope.joins! preload_values[:joins] || values[:joins]
+          scope.order! preload_values[:order] || values[:order]
 
           if preload_values[:readonly] || values[:readonly]
             scope.readonly!

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -427,14 +427,12 @@ module ActiveRecord
     #   => SELECT "users".* FROM "users" LEFT JOIN bookmarks ON bookmarks.bookmarkable_type = 'Post' AND bookmarks.user_id = users.id
     def joins(*args)
       check_if_method_has_arguments!(:joins, args)
-
-      args.compact!
-      args.flatten!
-
       spawn.joins!(*args)
     end
 
     def joins!(*args) # :nodoc:
+      args.compact!
+      args.flatten!
       self.joins_values += args
       self
     end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -904,6 +904,12 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_no_queries {assert_equal posts(:sti_comments), comment.post}
   end
 
+  def test_eager_association_with_scope_with_joins
+    assert_nothing_raised do
+      Post.includes(:very_special_comment_with_post_with_joins).to_a
+    end
+  end
+
   def test_preconfigured_includes_with_has_many
     posts = authors(:david).posts_with_comments
     one = posts.detect { |p| p.id == 1 }

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -78,6 +78,7 @@ class Post < ActiveRecord::Base
 
   has_one  :very_special_comment
   has_one  :very_special_comment_with_post, -> { includes(:post) }, :class_name => "VerySpecialComment"
+  has_one :very_special_comment_with_post_with_joins, -> { joins(:post).order('posts.id') }, class_name: "VerySpecialComment"
   has_many :special_comments
   has_many :nonexistant_comments, -> { where 'comments.id < 0' }, :class_name => 'Comment'
 


### PR DESCRIPTION
Fix includes on association with a scope containing joins along with conditions on the joined assoiciation.

Currently when you try to call includes on an association with a scope containing joins in it, joins will not be included in the query.

This is a fix for that issue.
