### PR TITLE
PostgreSQL, Fix change detection caused by superfluous bytea unescaping

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
@@ -5,6 +5,7 @@ module ActiveRecord
         class Bytea < Type::Binary # :nodoc:
           def type_cast_from_database(value)
             return if value.nil?
+            return value.to_s if value.is_a?(Type::Binary::Data)
             PGconn.unescape_bytea(super)
           end
         end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -688,7 +688,14 @@ class DirtyTest < ActiveRecord::TestCase
       serialize :data
     end
 
-    klass.create!(data: "foo")
+    binary = klass.create!(data: "\\\\foo")
+
+    assert_not binary.changed?
+
+    binary.data = binary.data.dup
+
+    assert_not binary.changed?
+
     binary = klass.last
 
     assert_not binary.changed?


### PR DESCRIPTION
and fix compatibility with pg-0.18.0.

This showed up when running BinaryTest#test_load_save with the more restrictive input string handling of pg-0.18.0.pre20141117110243.gem . It raises a `ArgumentError: string contains null byte` 

This also extends a test so that it shows this bug, independently of the pg version.

The same issue is present in 4.0 and 4.1 branch. It is solved in #17650, since that makes use of the ruby-pg en-/decoder capabilities.
