### PR TITLE
Document *all* the options accepted by form_for

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -164,6 +164,21 @@ module ActionView
       # * <tt>:namespace</tt> - A namespace for your form to ensure uniqueness of
       #   id attributes on form elements. The namespace attribute will be prefixed
       #   with underscore on the generated HTML id.
+      # * <tt>:method</tt> - The method to use when submitting the form, usually
+      #   either "get" or "post". If "patch", "put", "delete", or another verb
+      #   is used, a hidden input with name <tt>_method</tt> is added to
+      #   simulate the verb over post.
+      # * <tt>:authenticity_token</tt> - Authenticity token to use in the form.
+      #   Use only if you need to pass custom authenticity token string, or to
+      #   not add authenticity_token field at all (by passing <tt>false</tt>).
+      #   Remote forms may omit the embedded authenticity token by setting
+      #   <tt>config.action_view.embed_authenticity_token_in_remote_forms = false</tt>.
+      #   This is helpful when you're fragment-caching the form. Remote forms
+      #   get the authenticity token from the <tt>meta</tt> tag, so embedding is
+      #   unnecessary unless you support browsers without JavaScript.
+      # * <tt>:remote</tt> - If set to true, will allow the Unobtrusive
+      #   JavaScript drivers to control the submit behavior. By default this
+      #   behavior is an ajax submit.
       # * <tt>:html</tt> - Optional HTML attributes for the form tag.
       #
       # Also note that +form_for+ doesn't create an exclusive scope. It's still


### PR DESCRIPTION
Document _all_ the options accepted by form_for

The [current documentation of form_for](http://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-form_for) is incomplete:

> The rightmost argument to form_for is an optional hash of options -
> 
>   :url - The URL the form is to be submitted to. This may be represented in the same way as values passed to url_for or link_to. So for example you may use a named route directly. When the model is represented by a string or symbol, as in the example above, if the :url option is not specified, by default the form will be sent back to the current url (We will describe below an alternative resource-oriented usage of form_for in which the URL does not need to be specified explicitly).
> 
>   :namespace - A namespace for your form to ensure uniqueness of id attributes on form elements. The namespace attribute will be prefixed with underscore on the generated HTML id.
> 
>   :html - Optional HTML attributes for the form tag.

This commit completes the documentation by specifying that:
- `:authenticity_token` is also a valid option (as [documented here](https://github.com/rails/rails/blob/b0f44c9ff0be84ebc42760029adeeb9dd954655f/actionview/lib/action_view/helpers/form_helper.rb#L396))
- `:method` is also a valid option (as [tested here](https://github.com/rails/rails/blob/b0f44c9ff0be84ebc42760029adeeb9dd954655f/actionview/test/template/form_helper_test.rb#L1819))
- `:remote` is also a valid option (as [tested here](https://github.com/rails/rails/blob/b0f44c9ff0be84ebc42760029adeeb9dd954655f/actionview/test/template/form_helper_test.rb#L1850))

[ci skip]
