### PR TITLE
Use request_method instead of method in instrumentation

### DIFF
--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -21,7 +21,7 @@ module ActionController
         :action     => self.action_name,
         :params     => request.filtered_parameters,
         :format     => request.format.try(:ref),
-        :method     => request.method,
+        :method     => request.request_method,
         :path       => (request.fullpath rescue "unknown")
       }
 


### PR DESCRIPTION
Looks like Instrumentation is using ActionDispatch::Request#method while the true method is returned by ActionDispatch::Request#request_method

Originally came from https://github.com/roidrage/lograge/issues/93
