### PR TITLE
Add `:enforce_utf8` option to form_for

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add support for `:enforce_utf8` option in `form_for`.
+
+    This is the same option that was added in 06388b0 to `form_tag` and allows
+    users to skip the insertion of the UTF8 enforcer tag in a form.
+
+    * claudiob *
+
 *   Fix a bug that <%= foo(){ %> and <%= foo()do %> in view templates were not regarded
     as Ruby block calls.
 

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -164,6 +164,8 @@ module ActionView
       # * <tt>:namespace</tt> - A namespace for your form to ensure uniqueness of
       #   id attributes on form elements. The namespace attribute will be prefixed
       #   with underscore on the generated HTML id.
+      # * <tt>:enforce_utf8</tt> - If set to false, a hidden input with name
+      #   utf8 is not output.
       # * <tt>:html</tt> - Optional HTML attributes for the form tag.
       #
       # Also note that +form_for+ doesn't create an exclusive scope. It's still
@@ -420,6 +422,7 @@ module ActionView
         html_options[:data]   = options.delete(:data)   if options.has_key?(:data)
         html_options[:remote] = options.delete(:remote) if options.has_key?(:remote)
         html_options[:method] = options.delete(:method) if options.has_key?(:method)
+        html_options[:enforce_utf8] = options.delete(:enforce_utf8) if options.has_key?(:enforce_utf8)
         html_options[:authenticity_token] = options.delete(:authenticity_token)
 
         builder = instantiate_builder(object_name, object, options)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1864,6 +1864,30 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_for_enforce_utf8_true
+    form_for(:post, enforce_utf8: true) do |f|
+      concat f.text_field(:title)
+    end
+
+    expected = whole_form("/", nil, nil, enforce_utf8: true) do
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_for_enforce_utf8_false
+    form_for(:post, enforce_utf8: false) do |f|
+      concat f.text_field(:title)
+    end
+
+    expected = whole_form("/", nil, nil, enforce_utf8: false) do
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_for_with_remote_in_html
     form_for(@post, url: '/', html: { remote: true, id: 'create-post', method: :patch }) do |f|
       concat f.text_field(:title)
@@ -3313,8 +3337,14 @@ class FormHelperTest < ActionView::TestCase
 
   protected
 
-  def hidden_fields(method = nil)
-    txt = %{<input name="utf8" type="hidden" value="&#x2713;" />}
+  def hidden_fields(options = {})
+    method = options[:method]
+
+    if options.fetch(:enforce_utf8, true)
+      txt = %{<input name="utf8" type="hidden" value="&#x2713;" />}
+    else
+      txt = ''
+    end
 
     if method && !%w(get post).include?(method.to_s)
       txt << %{<input name="_method" type="hidden" value="#{method}" />}
@@ -3338,7 +3368,7 @@ class FormHelperTest < ActionView::TestCase
 
     method, remote, multipart = options.values_at(:method, :remote, :multipart)
 
-    form_text(action, id, html_class, remote, multipart, method) + hidden_fields(method) + contents + "</form>"
+    form_text(action, id, html_class, remote, multipart, method) + hidden_fields(options.slice :method, :enforce_utf8) + contents + "</form>"
   end
 
   def protect_against_forgery?


### PR DESCRIPTION
Since 06388b0 `form_tag` accepts the option `enforce_utf8` which, when set to
false, prevents the hidden "UTF8 enforcer" field from appearing in the output.

This commit implements the same behavior for `form_for`.

Stems from https://github.com/rails/rails/pull/17685#issuecomment-63871395
