### PR TITLE
Wrap code snippets in +, not backticks, in sdoc

### DIFF
--- a/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
+++ b/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
@@ -7,8 +7,8 @@ module ActionController
   #
   #   config.action_controller.etag_with_template_digest = false
   #
-  # Override the template to digest by passing `:template` to `fresh_when`
-  # and `stale?` calls. For example:
+  # Override the template to digest by passing +:template+ to +fresh_when+
+  # and +stale?+ calls. For example:
   #
   #   # We're going to render widgets/show, not posts/show
   #   fresh_when @post, template: 'widgets/show'

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -462,14 +462,14 @@ module ActionController
         raw_params.map { |param| param.split %r/=(.+)?/ }
       end
 
-      # This removes the `"` characters wrapping the value.
+      # This removes the <tt>"</tt> characters wrapping the value.
       def rewrite_param_values(array_params)
         array_params.each { |param| (param[1] || "").gsub! %r/^"|"$/, '' }
       end
 
       # This method takes an authorization body and splits up the key-value
-      # pairs by the standardized `:`, `;`, or `\t` delimiters defined in
-      # `AUTHN_PAIR_DELIMITERS`.
+      # pairs by the standardized <tt>:</tt>, <tt>;</tt>, or <tt>\t</tt>
+      # delimiters defined in +AUTHN_PAIR_DELIMITERS+.
       def raw_params(auth)
         auth.sub(TOKEN_REGEX, '').split(/\s*#{AUTHN_PAIR_DELIMITERS}\s*/)
       end

--- a/actionview/lib/action_view/template/handlers.rb
+++ b/actionview/lib/action_view/template/handlers.rb
@@ -22,7 +22,7 @@ module ActionView #:nodoc:
 
       # Register an object that knows how to handle template files with the given
       # extensions. This can be used to implement new template types.
-      # The handler must respond to `:call`, which will be passed the template
+      # The handler must respond to +:call+, which will be passed the template
       # and should return the rendered template as a String.
       def register_template_handler(*extensions, handler)
         raise(ArgumentError, "Extension is required") if extensions.empty?

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -175,8 +175,8 @@ module ActiveRecord
       end
 
       # Removes all records from the association without calling callbacks
-      # on the associated records. It honors the `:dependent` option. However
-      # if the `:dependent` value is `:destroy` then in that case the `:delete_all`
+      # on the associated records. It honors the +:dependent+ option. However
+      # if the +:dependent+ value is +:destroy+ then in that case the +:delete_all+
       # deletion strategy for the association is applied.
       #
       # You can force a particular deletion strategy by passing a parameter.

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -234,7 +234,7 @@ module ActiveRecord
           end
         end
 
-        # Takes the environment such as `:production` or `:development`.
+        # Takes the environment such as +:production+ or +:development+.
         # This requires that the @configurations was initialized with a key that
         # matches.
         #

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -58,7 +58,7 @@ module ActiveRecord
     # * <tt>:encoding</tt> - (Optional) Sets the client encoding by executing "SET NAMES <encoding>" after connection.
     # * <tt>:reconnect</tt> - Defaults to false (See MySQL documentation: http://dev.mysql.com/doc/refman/5.0/en/auto-reconnect.html).
     # * <tt>:strict</tt> - Defaults to true. Enable STRICT_ALL_TABLES. (See MySQL documentation: http://dev.mysql.com/doc/refman/5.0/en/server-sql-mode.html)
-    # * <tt>:variables</tt> - (Optional) A hash session variables to send as `SET @@SESSION.key = value` on each database connection. Use the value `:default` to set a variable to its DEFAULT value. (See MySQL documentation: http://dev.mysql.com/doc/refman/5.0/en/set-statement.html).
+    # * <tt>:variables</tt> - (Optional) A hash session variables to send as <tt>SET @@SESSION.key = value</tt> on each database connection. Use the value +:default+ to set a variable to its DEFAULT value. (See MySQL documentation: http://dev.mysql.com/doc/refman/5.0/en/set-statement.html).
     # * <tt>:sslca</tt> - Necessary to use MySQL with an SSL connection.
     # * <tt>:sslkey</tt> - Necessary to use MySQL with an SSL connection.
     # * <tt>:sslcert</tt> - Necessary to use MySQL with an SSL connection.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -125,7 +125,7 @@ module ActiveRecord
         PostgreSQL::SchemaCreation.new self
       end
 
-      # Adds `:array` option to the default set provided by the
+      # Adds +:array+ option to the default set provided by the
       # AbstractAdapter
       def prepare_column_options(column, types) # :nodoc:
         spec = super
@@ -134,7 +134,7 @@ module ActiveRecord
         spec
       end
 
-      # Adds `:array` as a valid migration key
+      # Adds +:array+ as a valid migration key
       def migration_keys
         super + [:array]
       end


### PR DESCRIPTION
I grepped the source code for code snippets wrapped in backticks in the comments
and replaced the backticks with plus signs so they are correctly displayed in
the Rails documentation.

[ci skip]
