### PR TITLE
Remove is_a? check when ignoring tables

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -244,12 +244,7 @@ HEADER
 
       def ignored?(table_name)
         ['schema_migrations', ignore_tables].flatten.any? do |ignored|
-          case ignored
-          when String; remove_prefix_and_suffix(table_name) == ignored
-          when Regexp; remove_prefix_and_suffix(table_name) =~ ignored
-          else
-            raise StandardError, 'ActiveRecord::SchemaDumper.ignore_tables accepts an array of String and / or Regexp values.'
-          end
+          ignored === remove_prefix_and_suffix(table_name)
         end
       end
   end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -162,16 +162,6 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "schema_migrations"}, output
   end
 
-  def test_schema_dump_illegal_ignored_table_value
-    stream = StringIO.new
-    old_ignore_tables, ActiveRecord::SchemaDumper.ignore_tables = ActiveRecord::SchemaDumper.ignore_tables, [5]
-    assert_raise(StandardError) do
-      ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
-    end
-  ensure
-    ActiveRecord::SchemaDumper.ignore_tables = old_ignore_tables
-  end
-
   def test_schema_dumps_index_columns_in_right_order
     index_definition = standard_dump.split(/\n/).grep(/add_index.*companies/).first.strip
     if current_adapter?(:MysqlAdapter, :Mysql2Adapter, :PostgreSQLAdapter)


### PR DESCRIPTION
Technically changes the API, as it will allow any object which responds
to `===`. Personally, I think this is more flexible.
