### PR TITLE
Includes HABTM returns correct size now. Fixes #16032 and #15244 on rails 4-1-stable

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Includes HABTM returns correct size now. It's caused by the join dependency
+    only instantiates one HABTM object because the join table hasn't a primary key.
+
+    Fixes #16032.
+
+    Examples:
+
+        before:
+
+        Project.first.salaried_developers.size # => 3
+        Project.includes(:salaried_developers).first.salaried_developers.size # => 1
+
+        after:
+
+        Project.first.salaried_developers.size # => 3
+        Project.includes(:salaried_developers).first.salaried_developers.size # => 3
+
+    *Bigxiang*
+
 *   Renaming a table in pg also renames the primary key index.
 
     Fixes #12856

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix preload HABTM associations with hashed conditions
+
+    Fixes #15244
+
+    *scambra*
+
 *   Includes HABTM returns correct size now. It's caused by the join dependency
     only instantiates one HABTM object because the join table hasn't a primary key.
 

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -225,7 +225,7 @@ module ActiveRecord
       end
 
       def construct(ar_parent, parent, row, rs, seen, model_cache, aliases)
-        primary_id  = ar_parent.id || ar_parent
+        primary_id  = ar_parent
 
         parent.children.each do |node|
           if node.reflection.collection?

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -144,7 +144,7 @@ module ActiveRecord
         column_aliases = aliases.column_aliases join_root
 
         result_set.each { |row_hash|
-          primary_id = type_caster.type_cast row_hash[primary_key]
+          primary_id = type_caster.type_cast primary_key ? row_hash[primary_key] : row_hash.object_id
           parent = parents[primary_id] ||= join_root.instantiate(row_hash, column_aliases)
           construct(parent, join_root, row_hash, result_set, seen, model_cache, aliases)
         }
@@ -225,7 +225,7 @@ module ActiveRecord
       end
 
       def construct(ar_parent, parent, row, rs, seen, model_cache, aliases)
-        primary_id  = ar_parent.id
+        primary_id  = ar_parent.id || ar_parent.object_id
 
         parent.children.each do |node|
           if node.reflection.collection?

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -144,7 +144,7 @@ module ActiveRecord
         column_aliases = aliases.column_aliases join_root
 
         result_set.each { |row_hash|
-          primary_id = type_caster.type_cast primary_key ? row_hash[primary_key] : row_hash.object_id
+          primary_id = type_caster.type_cast primary_key ? row_hash[primary_key] : row_hash
           parent = parents[primary_id] ||= join_root.instantiate(row_hash, column_aliases)
           construct(parent, join_root, row_hash, result_set, seen, model_cache, aliases)
         }
@@ -225,7 +225,7 @@ module ActiveRecord
       end
 
       def construct(ar_parent, parent, row, rs, seen, model_cache, aliases)
-        primary_id  = ar_parent.id || ar_parent.object_id
+        primary_id  = ar_parent.id || ar_parent
 
         parent.children.each do |node|
           if node.reflection.collection?

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -225,7 +225,7 @@ module ActiveRecord
       end
 
       def construct(ar_parent, parent, row, rs, seen, model_cache, aliases)
-        primary_id  = ar_parent
+        primary_id  = ar_parent.id || row
 
         parent.children.each do |node|
           if node.reflection.collection?

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -83,7 +83,7 @@ module ActiveRecord
               scope.where_values    = reflection_scope.values[:where]
             end
 
-            scope.references! reflection_scope.values[:references]
+            scope.references! reflection_scope.values[:references].presence
             scope.order! reflection_scope.values[:order] if scope.eager_loading?
           end
 

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -884,17 +884,17 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_equal true, child.save
   end
 
-  def test_included_associations_size
+  def test_preloaded_associations_size
     assert_equal Project.first.salaried_developers.size,
-      Project.includes(:salaried_developers).first.salaried_developers.size
+      Project.preload(:salaried_developers).first.salaried_developers.size
 
     assert_equal Project.includes(:salaried_developers).references(:salaried_developers).first.salaried_developers.size,
-      Project.includes(:salaried_developers).first.salaried_developers.size
+      Project.preload(:salaried_developers).first.salaried_developers.size
 
     # Nested HATBM
     first_project = Developer.first.projects.first
     preloaded_first_project =
-      Developer.includes(projects: :salaried_developers).
+      Developer.preload(projects: :salaried_developers).
         first.
         projects.
         detect { |p| p.id == first_project.id }

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -883,4 +883,26 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     child.special_projects << SpecialProject.new("name" => "Special Project")
     assert_equal true, child.save
   end
+
+  def test_included_associations_size
+    assert_equal Project.first.salaried_developers.size,
+      Project.includes(:salaried_developers).first.salaried_developers.size
+
+    assert_equal Project.includes(:salaried_developers).references(:salaried_developers).first.salaried_developers.size,
+      Project.includes(:salaried_developers).first.salaried_developers.size
+
+    # Nested HATBM
+    first_project = Developer.first.projects.first
+    preloaded_first_project =
+      Developer.includes(projects: :salaried_developers).
+        first.
+        projects.
+        detect { |p| p.id == first_project.id }
+
+    assert preloaded_first_project.salaried_developers.loaded?
+    assert_equal first_project.salaried_developers.size, preloaded_first_project.salaried_developers.size
+
+    assert_equal Project.first.developers.where(:name => 'David').size, Project.preload(:developers_named_david).first.developers_named_david.size
+    assert_equal Project.first.developers.where(:name => 'David').size, Project.preload(:developers_named_david_with_hash_conditions).first.developers_named_david.size
+  end
 end


### PR DESCRIPTION
Includes HABTM returns correct size now. It's caused by the join dependency
only instantiates one HABTM object because the join table hasn't a primary key.
Updated commit from @bigxiang commit dbaa837

Fixes #16032.

Examples:

```
before:

Project.first.salaried_developers.size # => 3
Project.includes(:salaried_developers).first.salaried_developers.size # => 1

after:

Project.first.salaried_developers.size # => 3
Project.includes(:salaried_developers).first.salaried_developers.size # => 3
```
