### PR TITLE
Fix explanation for ActionDispatch::Callbacks.

### DIFF
--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -277,7 +277,7 @@ Much of Action Controller's functionality is implemented as Middlewares. The fol
 
 **`ActionDispatch::Callbacks`**
 
-* Runs the prepare callbacks before serving the request.
+* Provide callbacks to be executed before and after the request dispatch.
 
 **`ActiveRecord::Migration::CheckPending`**
 


### PR DESCRIPTION
ActionDispatch::Callbacks dose not run the prepare callbacks,
so change with comment on ActionDispatch::Callbacks.
