### PR TITLE
Add Firebird support to test suite

### DIFF
--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -502,7 +502,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   def test_typecast_attribute_from_select_to_false
     Topic.create(:title => 'Budget')
     # Oracle does not support boolean expressions in SELECT
-    if current_adapter?(:OracleAdapter)
+    if current_adapter?(:OracleAdapter, :FbAdapter)
       topic = Topic.all.merge!(:select => "topics.*, 0 as is_test").first
     else
       topic = Topic.all.merge!(:select => "topics.*, 1=2 as is_test").first
@@ -513,7 +513,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   def test_typecast_attribute_from_select_to_true
     Topic.create(:title => 'Budget')
     # Oracle does not support boolean expressions in SELECT
-    if current_adapter?(:OracleAdapter)
+    if current_adapter?(:OracleAdapter, :FbAdapter)
       topic = Topic.all.merge!(:select => "topics.*, 1 as is_test").first
     else
       topic = Topic.all.merge!(:select => "topics.*, 2=2 as is_test").first

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -88,6 +88,7 @@ class BasicsTest < ActiveRecord::TestCase
       'Mysql2Adapter'     => '`',
       'PostgreSQLAdapter' => '"',
       'OracleAdapter'     => '"',
+      'FbAdapter'         => '"'
     }.fetch(classname) {
       raise "need a bad char for #{classname}"
     }
@@ -111,7 +112,7 @@ class BasicsTest < ActiveRecord::TestCase
     assert_nil Edge.primary_key
   end
 
-  unless current_adapter?(:PostgreSQLAdapter, :OracleAdapter, :SQLServerAdapter)
+  unless current_adapter?(:PostgreSQLAdapter, :OracleAdapter, :SQLServerAdapter, :FbAdapter)
     def test_limit_with_comma
       assert Topic.limit("1,2").to_a
     end

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -39,33 +39,35 @@ module ActiveRecord
         end
       end
 
-      def test_rename_table
-        rename_table :test_models, :octopi
+      unless current_adapter?(:FbAdapter) # Firebird cannot rename tables
+        def test_rename_table
+          rename_table :test_models, :octopi
 
-        connection.execute "INSERT INTO octopi (#{connection.quote_column_name('id')}, #{connection.quote_column_name('url')}) VALUES (1, 'http://www.foreverflying.com/octopus-black7.jpg')"
+          connection.execute "INSERT INTO octopi (#{connection.quote_column_name('id')}, #{connection.quote_column_name('url')}) VALUES (1, 'http://www.foreverflying.com/octopus-black7.jpg')"
 
-        assert_equal 'http://www.foreverflying.com/octopus-black7.jpg', connection.select_value("SELECT url FROM octopi WHERE id=1")
-      end
+          assert_equal 'http://www.foreverflying.com/octopus-black7.jpg', connection.select_value("SELECT url FROM octopi WHERE id=1")
+        end
 
-      def test_rename_table_with_an_index
-        add_index :test_models, :url
+        def test_rename_table_with_an_index
+          add_index :test_models, :url
 
-        rename_table :test_models, :octopi
+          rename_table :test_models, :octopi
 
-        connection.execute "INSERT INTO octopi (#{connection.quote_column_name('id')}, #{connection.quote_column_name('url')}) VALUES (1, 'http://www.foreverflying.com/octopus-black7.jpg')"
+          connection.execute "INSERT INTO octopi (#{connection.quote_column_name('id')}, #{connection.quote_column_name('url')}) VALUES (1, 'http://www.foreverflying.com/octopus-black7.jpg')"
 
-        assert_equal 'http://www.foreverflying.com/octopus-black7.jpg', connection.select_value("SELECT url FROM octopi WHERE id=1")
-        index = connection.indexes(:octopi).first
-        assert index.columns.include?("url")
-        assert_equal 'index_octopi_on_url', index.name
-      end
+          assert_equal 'http://www.foreverflying.com/octopus-black7.jpg', connection.select_value("SELECT url FROM octopi WHERE id=1")
+          index = connection.indexes(:octopi).first
+          assert index.columns.include?("url")
+          assert_equal 'index_octopi_on_url', index.name
+        end
 
-      def test_rename_table_does_not_rename_custom_named_index
-        add_index :test_models, :url, name: 'special_url_idx'
+        def test_rename_table_does_not_rename_custom_named_index
+          add_index :test_models, :url, name: 'special_url_idx'
 
-        rename_table :test_models, :octopi
+          rename_table :test_models, :octopi
 
-        assert_equal ['special_url_idx'], connection.indexes(:octopi).map(&:name)
+          assert_equal ['special_url_idx'], connection.indexes(:octopi).map(&:name)
+        end
       end
 
       if current_adapter?(:PostgreSQLAdapter)

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -341,6 +341,8 @@ class SchemaDumperTest < ActiveRecord::TestCase
     # Oracle supports precision up to 38 and it identifies decimals with scale 0 as integers
     if current_adapter?(:OracleAdapter)
       assert_match %r{t.integer\s+"atoms_in_universe",\s+precision: 38}, output
+    elsif current_adapter?(:FbAdapter)
+      assert_match %r{t.integer\s+"atoms_in_universe",\s+precision: 18}, output
     else
       assert_match %r{t.decimal\s+"atoms_in_universe",\s+precision: 55}, output
     end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -479,6 +479,8 @@ ActiveRecord::Schema.define do
     # Oracle/SQLServer supports precision up to 38
     if current_adapter?(:OracleAdapter, :SQLServerAdapter)
       t.decimal :atoms_in_universe, precision: 38, scale: 0
+    elsif current_adapter?(:FbAdapter)
+      t.decimal :atoms_in_universe, precision: 18, scale: 0
     else
       t.decimal :atoms_in_universe, precision: 55, scale: 0
     end


### PR DESCRIPTION
This allows the [Firebird Adapter](https://github.com/rowland/activerecord-fb-adapter) to run against ActiveRecord's test suite. It was initially brought up in https://github.com/rails/rails/pull/17424.

Integration for ActiveRecord's suite was added to the adapter in this PR: https://github.com/rowland/activerecord-fb-adapter/pull/43.
