### PR TITLE
Fix for #9058 and #8941, append relative route also in route helpers

### DIFF
--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -213,6 +213,22 @@ class UrlOptionsTest < ActionController::TestCase
     end
   end
 
+  def test_relative_url_root_is_respected
+    rs = ActionDispatch::Routing::RouteSet.new
+    rs.draw do
+      get 'home' => 'pages#home'
+    end
+
+    options = {
+      action: "home",
+      controller: "pages",
+      only_path: true,
+      relative_url_root: "/relative_path"
+    }
+
+    assert_equal '/relative_path/home', rs.url_for(options)
+  end
+
   def test_url_helpers_does_not_become_actions
     with_routing do |set|
       set.draw do

--- a/actionpack/test/routing/helper_test.rb
+++ b/actionpack/test/routing/helper_test.rb
@@ -40,6 +40,46 @@ module ActionDispatch
           assert_equal '/ducks', x.new.ducks_path
         end
       end
+
+
+      def test_relative_url_root_is_respected_with_locale
+        orig_setup = ENV['RAILS_RELATIVE_URL_ROOT']
+        ENV['RAILS_RELATIVE_URL_ROOT'] = "moshe"
+
+        rs = ::ActionDispatch::Routing::RouteSet.new
+        rs.draw do
+          scope '/:locale', shallow_path: "/:locale", locale: /en|he/ do
+            resources :drongos
+          end
+        end
+
+        x = Class.new {
+          include rs.url_helpers
+        }
+
+        assert_equal 'moshe/he/drongos', x.new.drongos_path(locale: 'he')
+
+        ENV['RAILS_RELATIVE_URL_ROOT'] = orig_setup
+      end
+
+      def test_relative_url_root_is_respected_via_helper
+        orig_setup = ENV['RAILS_RELATIVE_URL_ROOT']
+        ENV['RAILS_RELATIVE_URL_ROOT'] = "moshe"
+
+        rs = ::ActionDispatch::Routing::RouteSet.new
+        rs.draw do
+          resources :drongos
+        end
+
+        x = Class.new {
+          include rs.url_helpers
+        }
+
+        assert_equal 'moshe/drongos', x.new.drongos_path
+
+        ENV['RAILS_RELATIVE_URL_ROOT'] = orig_setup
+      end
+
     end
   end
 end


### PR DESCRIPTION
This is a continuum of #12086, which was wrongly merged empty.

This code as is works, and prepends the relative root when *_path helper is called:

``` sh
› RAILS_RELATIVE_URL_ROOT='/tributos' rails c
Loading development environment (Rails 4.2.0.beta4)
>> Rails.application.routes.url_helpers.users_path
=> "/tributos/users"
>> exit
```

Posting this for now seeking some guidance on how to better use "config.relative_url_root" (rather than using the ENV directly.
As far as I could see, using config inside RouteSet, would require a major API change. thoughts?

/cc @iainbeeston @pixeltrix @sgrif
