### PR TITLE
Deprecate use route

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -2,6 +2,7 @@ require 'rack/session/abstract/id'
 require 'active_support/core_ext/object/to_query'
 require 'active_support/core_ext/module/anonymous'
 require 'active_support/core_ext/hash/keys'
+require 'active_support/deprecation'
 
 require 'rails-dom-testing'
 
@@ -710,7 +711,27 @@ module ActionController
             :relative_url_root => nil,
             :_recall => @request.path_parameters)
 
-          route_name = options.delete :use_route
+          if route_name = options.delete(:use_route)
+            ActiveSupport::Deprecation.warn <<-MSG.squish
+              Passing the `use_route` option in functional tests are deprecated.
+              Support for this option in the `process` method (and the related
+              `get`, `head`, `post`, `patch`, `put` and `delete` helpers) will
+              be removed in the next version without replacement.
+
+              Functional tests are essentially unit tests for controllers and
+              they should not require knowledge to how the application's routes
+              are configured. Instead, you should explicitly pass the appropiate
+              params to the `process` method.
+
+              Previously the engines guide also contained an incorrect example
+              that recommended using this option to test an engine's controllers
+              within the dummy application. That recommendation was incorrect
+              and has since been corrected. Instead, you should override the
+              `@routes` variable in the test case with `Foo::Engine.routes`. See
+              the updated engines guide for details.
+            MSG
+          end
+
           url, query_string = @routes.path_for(options, route_name).split("?", 2)
 
           @request.env["SCRIPT_NAME"] = @controller.config.relative_url_root

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -81,14 +81,8 @@ module ActionDispatch
           if named_routes.key?(name)
             yield named_routes[name]
           else
-            if name
-              ActiveSupport::Deprecation.warn <<-MSG.squish
-                You are trying to generate the URL for a named route called
-                #{name.inspect} but no such route was found. In the future,
-                this will result in an `ActionController::UrlGenerationError`
-                exception.
-              MSG
-            end
+            # Make sure we don't show the deprecation warning more than once
+            warned = false
 
             routes = non_recursive(cache, options)
 
@@ -98,6 +92,17 @@ module ActionDispatch
               break if score < 0
 
               hash[score].sort_by { |i, _| i }.each do |_, route|
+                if name && !warned
+                  ActiveSupport::Deprecation.warn <<-MSG.squish
+                    You are trying to generate the URL for a named route called
+                    #{name.inspect} but no such route was found. In the future,
+                    this will result in an `ActionController::UrlGenerationError`
+                    exception.
+                  MSG
+
+                  warned = true
+                end
+
                 yield route
               end
             end

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -1,4 +1,5 @@
 require 'action_controller/metal/exceptions'
+require 'active_support/deprecation'
 
 module ActionDispatch
   module Journey
@@ -80,6 +81,15 @@ module ActionDispatch
           if named_routes.key?(name)
             yield named_routes[name]
           else
+            if name
+              ActiveSupport::Deprecation.warn <<-MSG.squish
+                You are trying to generate the URL for a named route called
+                #{name.inspect} but no such route was found. In the future,
+                this will result in an `ActionController::UrlGenerationError`
+                exception.
+              MSG
+            end
+
             routes = non_recursive(cache, options)
 
             hash = routes.group_by { |_, r| r.score(options) }

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1386,7 +1386,7 @@ class RouteSetTest < ActiveSupport::TestCase
     url = controller.url_for({ :controller => "connection", :only_path => true })
     assert_equal "/connection/connection", url
 
-    url = controller.url_for({ :use_route => :family_connection,
+    url = controller.url_for({ :use_route => "family_connection",
                                :controller => "connection", :only_path => true })
     assert_equal "/connection", url
   end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -528,7 +528,7 @@ XML
         get 'via_named_route', as: :a_named_route, to: 'test_case_test/test#test_uri'
       end
 
-      get :test_uri, use_route: :a_named_route
+      assert_deprecated { get :test_uri, use_route: :a_named_route }
       assert_equal '/via_named_route', @response.body
     end
   end
@@ -798,7 +798,7 @@ module EngineControllerTests
       with_routing do |set|
         set.draw { mount Engine => '/foo' }
 
-        get :index, use_route: :foo
+        assert_deprecated { get :index, use_route: :foo }
         assert_equal @response.body, 'bar'
       end
     end

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -415,7 +415,7 @@ module ActionDispatch
 
       def test_generate_with_name
         path  = Path::Pattern.from_string '/:controller(/:action)'
-        @router.routes.add_route @app, path, {}, {}, {}
+        @router.routes.add_route @app, path, {}, {}, "tasks"
 
         path, params = @formatter.generate(
           "tasks",


### PR DESCRIPTION
This is a continuation of #17453

Already in master:
- [x] Guide is fixed via b7b9e92 and backported to 4-1-stable. It should [show up on edge guide](http://edgeguides.rubyonrails.org/engines.html#functional-tests) on the next rebuild.
- [x] The engine-oriented test cases are added via 77a2764 to prevent regressions during the 4.2 series.

In this pull request:
- [x] Deprecated passing `use_route` in `process` in controller tests
- [x] Deprecated passing an invalid route name to `Formatter#generate`, fixed a few internal test case that relied on that

As far as I can tell, the `Formatter#generate` accepting invalid route names is a bug that's been around forever.

As @huoxito pointed out, currently if you pass in _anything_ that is not `nil` as the first argument to `generate`, it will try to match against just about anything that is present on the routes table. As @pixeltrix has discovered in 1555a18, this leads to incorrect results, in particular when engines are involved.

Unfortunately, this is actually why the `use_route` hack worked in the first place – the `mount Foo::Engine => '/foo'` entry in the dummy app does not actually generate a named route called "foo", so it appears that the only reason it works currently is because of this bug. So we basically documented a buggy behavior which means we can't just fix it. I added a separate deprecation for it and so we should be able to fix it in the next version.

By the way, to answer @pixeltrix's question... From what I can tell `ActionController::TestCase` on its own actually work perfectly fine with engine controllers _without any special configuration_, overriding `@routes` or whatsoever. (As demonstrated in [this test case](https://github.com/rails/rails/commit/77a276411e717353bc562c04d62e144f4410e706#diff-279ac5c088a3ee7e9f954bbc10d1b773R772).)

The reason it doesn't work out of the box in a generated engine is that the generated `test_helper` always [require the dummy application](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb#L4) and then [require the `test_help` file](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb#L11), which [defaults the `@routes` to `Rails.application.routes`](https://github.com/rails/rails/blob/master/railties/lib/rails/test_help.rb#L35).

I suppose we should improve that situation... but that's out of the scope of this PR and I'm not sure if I'll have time to work on that anytime soon. If @huoxito or anyone else is interested please feel free to explore that further :smile: 

cc @tenderlove @pixeltrix @huoxito @radar for review :smile:
