### PR TITLE
Showing a warning when PostgreSQL can't disable foreign key constraints

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -7,14 +7,23 @@ module ActiveRecord
         end
 
         def disable_referential_integrity # :nodoc:
+          original_exception = nil
           if supports_disable_referential_integrity?
             begin
               execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
-            rescue
+            rescue => e
+              original_exception = e
               execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER USER" }.join(";"))
             end
           end
-          yield
+
+          begin
+            yield
+          rescue ActiveRecord::InvalidForeignKey
+            warn "WARNING: Rails can't disable referential integrity: #{original_exception.message}"
+            raise
+          end
+
         ensure
           if supports_disable_referential_integrity?
             begin

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -1,0 +1,30 @@
+require 'cases/helper'
+
+class PostgreSQLReferentialIntegrityTest < ActiveRecord::TestCase
+  class AFakeAdapter
+    include ActiveRecord::ConnectionAdapters::PostgreSQL::ReferentialIntegrity
+
+    def tables
+      ['a_table']
+    end
+
+    def quote_table_name(name)
+      "\"#{name}\""
+    end
+
+    def execute(sql)
+      raise 'Forcing a exception' if sql.match(/DISABLE TRIGGER ALL/)
+    end
+  end
+
+  def test_should_reraise_invalid_foreign_key_exception_and_show_warning
+    warning = capture(:stderr) do
+      assert_raises(ActiveRecord::InvalidForeignKey) do
+        AFakeAdapter.new.disable_referential_integrity do
+          raise ActiveRecord::InvalidForeignKey, 'Should be re-raised'
+        end
+      end
+    end
+    assert_match (/WARNING: Rails can't disable referential integrity/), warning
+  end
+end


### PR DESCRIPTION
PostgreSQL can't properly disable foreign key constraints when the PostgreSQL user is not superuser. Added a warning when `ActiveRecord::InvalidForeignKey` is throw to make the user aware about the issue.

Reference #17542

---

@senny @matthewd I had technical problems with the other PR (https://github.com/rails/rails/pull/17663) and had to open another one.
