### PR TITLE
Add new methods to MessageVerifier

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,1 +1,9 @@
+*   Added `#verified` and `#valid_message?` methods to `ActiveSupport::MessageVerifier`
+    
+    Previously, the only way to decode a message with `ActiveSupport::MessageVerifier` was to use `#verify`, which would raise an exception on invalid messages. Now, `#verified` will return either `false` when it encounters an error or the message.
+    
+    Previously, there was no way to check if a message's format was valid without attempting to decode it. `#valid_message?` is a boolean convenience method that checks whether the message is valid without actually decoding it.
+    
+    *Logan Leger*
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -27,21 +27,29 @@ class MessageVerifierTest < ActiveSupport::TestCase
     @data = { :some => "data", :now => Time.local(2010) }
   end
 
+  def test_valid_message
+    data, hash = @verifier.generate(@data).split("--")
+    assert !@verifier.valid_message?(nil)
+    assert !@verifier.valid_message?("")
+    assert !@verifier.valid_message?("#{data.reverse}--#{hash}")
+    assert !@verifier.valid_message?("#{data}--#{hash.reverse}")
+    assert !@verifier.valid_message?("purejunk")
+  end
+
   def test_simple_round_tripping
     message = @verifier.generate(@data)
+    assert_equal @data, @verifier.verified(message)
     assert_equal @data, @verifier.verify(message)
   end
-
-  def test_missing_signature_raises
-    assert_not_verified(nil)
-    assert_not_verified("")
+  
+  def test_verified_returns_false_on_invalid_message
+    assert !@verifier.verified("purejunk")
   end
-
-  def test_tampered_data_raises
-    data, hash = @verifier.generate(@data).split("--")
-    assert_not_verified("#{data.reverse}--#{hash}")
-    assert_not_verified("#{data}--#{hash.reverse}")
-    assert_not_verified("purejunk")
+  
+  def test_verify_exception_on_invalid_message
+    assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
+      @verifier.verify("purejunk")
+    end
   end
 
   def test_alternative_serialization_method
@@ -50,6 +58,7 @@ class MessageVerifierTest < ActiveSupport::TestCase
     verifier = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!", :serializer => JSONSerializer.new)
     message = verifier.generate({ :foo => 123, 'bar' => Time.utc(2010) })
     exp = { "foo" => 123, "bar" => "2010-01-01T00:00:00.000Z" }
+    assert_equal exp, verifier.verified(message)
     assert_equal exp, verifier.verify(message)
   ensure
     ActiveSupport.use_standard_json_time_format = prev
@@ -63,6 +72,11 @@ class MessageVerifierTest < ActiveSupport::TestCase
     #
     valid_message = "BAh7BjoIZm9vbzonTWVzc2FnZVZlcmlmaWVyVGVzdDo6QXV0b2xvYWRDbGFzcwY6CUBmb29JIghmb28GOgZFVA==--f3ef39a5241c365083770566dc7a9eb5d6ace914"
     exception = assert_raise(ArgumentError, NameError) do
+      @verifier.verified(valid_message)
+    end
+    assert_includes ["uninitialized constant MessageVerifierTest::AutoloadClass",
+                    "undefined class/module MessageVerifierTest::AutoloadClass"], exception.message
+    exception = assert_raise(ArgumentError, NameError) do
       @verifier.verify(valid_message)
     end
     assert_includes ["uninitialized constant MessageVerifierTest::AutoloadClass",
@@ -74,12 +88,6 @@ class MessageVerifierTest < ActiveSupport::TestCase
       ActiveSupport::MessageVerifier.new(nil)
     end
     assert_equal exception.message, 'Secret should not be nil.'
-  end
-
-  def assert_not_verified(message)
-    assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
-      @verifier.verify(message)
-    end
   end
 end
 


### PR DESCRIPTION
This commit adds two boolean methods to `ActiveSupport::MessageVerifier`: `#verified`, to return `false` on invalid messages, and `#valid_message?`, a convenience boolean method to check the validity of a message's format.

**`#verified` method**
The first commit adds a `#verified` method to return false when an error occurs decoding the message; it continues to return the message on success. (The behavior of `#verify` remains unchanged.) Previously it was not possible to attempt to decode a message without possibly encountering an exception.

_Example_

``` ruby
@verifier = ActiveSupport::MessageVerifier.new("c0mplexs3cret")
@data = @verifier.generate("a very important message")
@verifier.verified(@data) # => "a very important message"
@verifier.verify(@data) # => "a very important message"
@verifier.verified("foo") # => false
@verifier.verify("foo") # => ActiveSupport::MessageVerifier::InvalidSignature
```

**`#valid_message?` method**
Sometimes it may be beneficial to verify the format of the message without performing the decoding. The second commit adds a `#valid_message?` boolean method which performs this validation. It has the added benefit of cleaning up a conditional in the `#verified` method. I also took some liberty restructuring the tests in this commit.

_Example_

``` ruby
@verifier = ActiveSupport::MessageVerifier.new("c0mplexs3cret")
@data = @verifier.generate("a very important message") # => "BAhJIh1hIHZlcnkgaW1wb3J0YW50IG1lc3NhZ2UGOgZFVA==--4cf27b268ccb74307099b03d2b023f68b9e9763c"
@data.valid_message?(@data) # => true
@data.valid_message?("foo") # => false
@data.valid_message?("foo--bar") # => false
first, second = @data.split("--")
@data.valid_message?("#{first.reverse}--#{second.reverse}") # => false
@data.valid_message?("#{first}--#{second.reverse}") # => false
@data.valid_message?("#{first.reverse}--#{second}") # => false
@data.valid_message?("#{second}--#{first}") # => false
@data.valid_message?("#{first}--#{first}") # => false
```
