### PR TITLE
Do not rescue Exception in ActionDispatch::ParamsParser

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -47,7 +47,7 @@ module ActionDispatch
         else
           false
         end
-      rescue Exception => e # JSON or Ruby code block errors
+      rescue => e # JSON or Ruby code block errors
         logger(env).debug "Error occurred while parsing request parameters.\nContents:\n\n#{request.raw_post}"
 
         raise ParseError.new(e.message, e)

--- a/actionpack/test/controller/webservice_test.rb
+++ b/actionpack/test/controller/webservice_test.rb
@@ -83,6 +83,16 @@ class WebServiceTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_parsing_json_doesnot_rescue_exception
+    with_test_route_set do
+      with_params_parsers Mime::JSON => Proc.new { |data| raise Interrupt } do
+        assert_raises(Interrupt) do
+          post "/", '{"title":"JSON"}}', 'CONTENT_TYPE' => 'application/json'
+        end
+      end
+    end
+  end
+
   private
     def with_params_parsers(parsers = {})
       old_session = @integration_session


### PR DESCRIPTION
Unlike `ShowExceptions` or `PublicExceptions`, `ParamsParser` shouldn't transform exceptions like `Interrupt` or `NoMemoryError` into `ParserError`.
