### PR TITLE
[ActiveModel] Swap protected with private.

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -334,12 +334,11 @@ module ActiveModel
         }.tap { |mod| include mod }
       end
 
-      protected
+      private
         def instance_method_already_implemented?(method_name) #:nodoc:
           generated_attribute_methods.method_defined?(method_name)
         end
 
-      private
         # The methods +method_missing+ and +respond_to?+ of this module are
         # invoked often in a typical rails, both of which invoke the method
         # +match_attribute_method?+. The latter method iterates through an
@@ -460,12 +459,11 @@ module ActiveModel
       end
     end
 
-    protected
+    private
       def attribute_method?(attr_name) #:nodoc:
         respond_to_without_attributes?(:attributes) && attributes.include?(attr_name)
       end
 
-    private
       # Returns a struct representing the matching attribute method.
       # The struct's attributes are prefix, base and suffix.
       def match_attribute_method?(method_name)

--- a/activemodel/lib/active_model/forbidden_attributes_protection.rb
+++ b/activemodel/lib/active_model/forbidden_attributes_protection.rb
@@ -15,7 +15,7 @@ module ActiveModel
   end
 
   module ForbiddenAttributesProtection # :nodoc:
-    protected
+    private
       def sanitize_for_mass_assignment(attributes)
         if attributes.respond_to?(:permitted?) && !attributes.permitted?
           raise ActiveModel::ForbiddenAttributesError

--- a/activemodel/lib/active_model/serializers/xml.rb
+++ b/activemodel/lib/active_model/serializers/xml.rb
@@ -38,7 +38,7 @@ module ActiveModel
             decorations
           end
 
-        protected
+        private
 
           def compute_type
             return if value.nil?

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -389,7 +389,7 @@ module ActiveModel
     #   end
     alias :read_attribute_for_validation :send
 
-  protected
+  private
 
     def run_validations! #:nodoc:
       _run_validate_callbacks

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -106,7 +106,7 @@ module ActiveModel
         end
       end
 
-    protected
+    private
 
       # Overwrite run validations to include callbacks.
       def run_validations! #:nodoc:

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -58,7 +58,7 @@ module ActiveModel
         end
       end
 
-    protected
+    private
 
       def parse_raw_value_as_a_number(raw_value)
         Kernel.Float(raw_value) if raw_value !~ /\A0[xX]/

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -148,7 +148,7 @@ module ActiveModel
         validates(*(attributes << options))
       end
 
-    protected
+    private
 
       # When creating custom validators, it might be useful to be able to specify
       # additional default keys. This can be done by overwriting this method.


### PR DESCRIPTION
Defining protected visibility of methods in Ruby is commonly misused. I believe these are those places.
