### PR TITLE
Fixing behaviour of where unscoping to not leak

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -907,7 +907,7 @@ module ActiveRecord
     def where_unscoping(target_value)
       target_value = target_value.to_s
 
-      where_values.reject! do |rel|
+      self.where_values = where_values.reject do |rel|
         case rel
         when Arel::Nodes::Between, Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality, Arel::Nodes::NotEqual, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThanOrEqual
           subrelation = (rel.left.kind_of?(Arel::Attributes::Attribute) ? rel.left : rel.right)
@@ -915,7 +915,7 @@ module ActiveRecord
         end
       end
 
-      bind_values.reject! { |col,_| col.name == target_value }
+      self.bind_values = bind_values.reject { |col,_| col.name == target_value }
     end
 
     def custom_join_ast(table, joins)

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -110,6 +110,20 @@ module ActiveRecord
       assert_equal 'alone', bind.last
     end
 
+    def test_rewhere_does_not_overwrite_original_query
+      relation = Post.where(title: 'hello')
+
+      assert_equal 1, relation.where_values.size
+
+      relation.rewhere(title: 'alone')
+
+      assert_equal 1, relation.where_values.size
+      value = relation.where_values.first
+      bind = relation.bind_values.first
+      assert_bound_ast value, Post.arel_table[@name], Arel::Nodes::Equality
+      assert_equal 'hello', bind.last
+    end
+
     def test_rewhere_with_multiple_overwriting_conditions
       relation = Post.where(title: 'hello').where(body: 'world').rewhere(title: 'alone', body: 'again')
 


### PR DESCRIPTION
As per issue #17738 this will prevent calls to .unscope from
altering the original query's where_values collection.

The new test in where_chain_test.rb passes.

The test 'HasManyThroughAssociationsTest#test_has_many_through_unscope_default_scope'
now fails and needs more investigation.

Submitting this as a PR despite the broken test so that other contributors can investigate the new test and help figure out the underlying cause (I had a brief look but couldn't see why it started breaking after the change).
