### PR TITLE
Deprecate string options in URL helpers

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Deprecate use of string keys in URL helpers.
+
+    Use symbols instead.
+
+    Fixes #16958.
+
+    *Byron Bischoff*, *Melanie Gilman*
+
 *   Deprecate the `only_path` option on `*_path` helpers.
 
     In cases where this option is set to `true`, the option is redundant and can

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -271,7 +271,7 @@ module ActionDispatch
             controller_options = t.url_options
             options = controller_options.merge @options
             hash = handle_positional_args(controller_options,
-                                          inner_options || {},
+                                          deprecate_string_options(inner_options) || {},
                                           args,
                                           options,
                                           @segment_keys)
@@ -292,6 +292,22 @@ module ActionDispatch
             end
 
             result.merge!(inner_options)
+          end
+
+          DEPRECATED_STRING_OPTIONS = %w[controller action]
+
+          def deprecate_string_options(options)
+            options ||= {}
+            deprecated_string_options = options.keys & DEPRECATED_STRING_OPTIONS
+            if deprecated_string_options.any?
+              msg = "Calling URL helpers with string keys #{deprecated_string_options.join(", ")} is deprecated. Use symbols instead."
+              ActiveSupport::Deprecation.warn(msg)
+              deprecated_string_options.each do |option|
+                value = options.delete(option)
+                options[option.to_sym] = value
+              end
+            end
+            options
           end
         end
 

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -160,6 +160,26 @@ module ActionDispatch
         assert_equal '/foo/1/bar/2', url_helpers.foo_bar_path(2, foo_id: 1)
       end
 
+      test "stringified controller and action keys are properly symbolized" do
+        draw do
+          root 'foo#bar'
+        end
+
+        assert_deprecated do
+          assert_equal '/', url_helpers.root_path('controller' => 'foo', 'action' => 'bar')
+        end
+      end
+
+      test "mix of string and symbol keys are properly symbolized" do
+        draw do
+          root 'foo#bar'
+        end
+
+        assert_deprecated do
+          assert_equal '/', url_helpers.root_path('controller' => 'foo', :action => 'bar')
+        end
+      end
+
       private
         def draw(&block)
           @set.draw(&block)


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/16958

I pretty much implemented @bronzle's fix in the issue comments, so he should have credit too.
