### PR TITLE
Hide ActiveJob arguments

### DIFF
--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -52,21 +52,21 @@ module ActiveJob
 
     class LogSubscriber < ActiveSupport::LogSubscriber #:nodoc:
       def enqueue(event)
-        info do
+        debug do
           job = event.payload[:job]
           "Enqueued #{job.class.name} (Job ID: #{job.job_id}) to #{queue_name(event)}" + args_info(job)
         end
       end
 
       def enqueue_at(event)
-        info do
+        debug do
           job = event.payload[:job]
           "Enqueued #{job.class.name} (Job ID: #{job.job_id}) to #{queue_name(event)} at #{scheduled_at(event)}" + args_info(job)
         end
       end
 
       def perform_start(event)
-        info do
+        debug do
           job = event.payload[:job]
           "Performing #{job.class.name} from #{queue_name(event)}" + args_info(job)
         end


### PR DESCRIPTION
- Changes the default ActiveJob logger to log arguments at the debug
  level, since inspecting all arguments has the potential for exposing
  sensitive information to the logger (especially since it can be inspecting an
  ActiveRecord object if you send one in and it gets serialized/deserialized with GlobalID). Rails doesn't normally log potentially
  sensitive, unfiltered arguments above the debug level.

Example output from ActiveJob's logger:

`[ActiveJob] Enqueued UserUpdateJob (Job ID: d6f1040b-fb28-448b-8e3f-ff7ebb35fb5f) to Sidekiq(default) with arguments: #<User id: 1, created_at: "2014-10-27 00:40:08", updated_at: "2014-11-24 14:56:30", email: "example@example.com", password_digest: "$2a$10$1234...">`

Note that there may be a better option for this, like running arguments through the filter_parameters list, but I didn't want to overcomplicate this logging code.
