### PR TITLE
Show source view and backtrace on missing template errors

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_template.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_template.html.erb
@@ -4,4 +4,8 @@
 
 <div id="container">
   <h2><%= h @exception.message %></h2>
+
+  <%= render template: "rescues/_source" %>
+  <%= render template: "rescues/_trace" %>
+  <%= render template: "rescues/_request_and_response" %>
 </div>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb
@@ -27,4 +27,6 @@
 
     <%= @routes_inspector.format(ActionDispatch::Routing::HtmlTableFormatter.new(self)) %>
   <% end %>
+
+  <%= render template: "rescues/_request_and_response" %>
 </div>


### PR DESCRIPTION
This will help you debug missing template errors, especially if they
come from a programmatic template selection. Thanks to @dhh for
suggesting that.

![screen shot 2014-11-24 at 6 51 48 pm](https://cloud.githubusercontent.com/assets/604618/5168941/bbb8c510-740b-11e4-9d35-d2624b3f9532.png)

The console in the picture is coming from web-console, it won't be available without it included in the Gemfile.
