### PR TITLE
Mark comments that should not be in the docs

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -285,7 +285,9 @@ module ActiveRecord
         end
       end
 
+      #--
       # DATABASE STATEMENTS ======================================
+      #++
 
       def clear_cache!
         super

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -66,7 +66,9 @@ module ActiveRecord
         exception.error_number if exception.respond_to?(:error_number)
       end
 
+      #--
       # QUOTING ==================================================
+      #++
 
       def quote_string(string)
         @connection.escape(string)
@@ -80,7 +82,9 @@ module ActiveRecord
         end
       end
 
+      #--
       # CONNECTION MANAGEMENT ====================================
+      #++
 
       def active?
         return false unless @connection
@@ -104,7 +108,9 @@ module ActiveRecord
         end
       end
 
+      #--
       # DATABASE STATEMENTS ======================================
+      #++
 
       def explain(arel, binds = [])
         sql     = "EXPLAIN #{to_sql(arel, binds.dup)}"

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -137,7 +137,9 @@ module ActiveRecord
         @connection.quote(string)
       end
 
+      #--
       # CONNECTION MANAGEMENT ====================================
+      #++
 
       def active?
         if @connection.respond_to?(:stat)
@@ -178,7 +180,9 @@ module ActiveRecord
         end
       end
 
+      #--
       # DATABASE STATEMENTS ======================================
+      #++
 
       def select_rows(sql, name = nil, binds = [])
         @connection.query_with_result = true

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -266,7 +266,9 @@ module ActiveRecord
         end
       end
 
+      #--
       # DATABASE STATEMENTS ======================================
+      #++
 
       def explain(arel, binds = [])
         sql = "EXPLAIN QUERY PLAN #{to_sql(arel, binds)}"


### PR DESCRIPTION
Some comments that are meant to separate blocks of code in a file show up
on http://api.rubyonrails.org as though they were part of the documentation.

This commit hides those comments from the documentation.

Stems from the discussion with @zzak at https://github.com/voloko/sdoc/issues/79#issuecomment-64158738

[ci skip]

---

Here's how the documentation looks _after_ and _before_ this commit:

![abstract-clearcache](https://cloud.githubusercontent.com/assets/10076/5170473/f18ae26e-73c4-11e4-95b5-baefb7f33264.png)
![mysql2-quotestring](https://cloud.githubusercontent.com/assets/10076/5170474/f18cc84a-73c4-11e4-9086-9c25380ffb1a.png)
![mysql2-active](https://cloud.githubusercontent.com/assets/10076/5170476/f18d56f2-73c4-11e4-8165-ff68c05e1f69.png)
![mysql2-explain](https://cloud.githubusercontent.com/assets/10076/5170477/f18d6750-73c4-11e4-9ca1-4780c3753bb3.png)
![mysql-active](https://cloud.githubusercontent.com/assets/10076/5170472/f18a90f2-73c4-11e4-8c96-539f60cc8959.png)
![mysql-selectrows](https://cloud.githubusercontent.com/assets/10076/5170475/f18d3708-73c4-11e4-89b6-cc0b0b2a70cb.png)
![sqlite3-explain](https://cloud.githubusercontent.com/assets/10076/5170478/f19d93be-73c4-11e4-8568-0d16e17327df.png)
