### PR TITLE
Ensure url_for generates full url by default

### DIFF
--- a/actionmailer/test/fixtures/url_test_mailer/exercise_url_for.erb
+++ b/actionmailer/test/fixtures/url_test_mailer/exercise_url_for.erb
@@ -1,0 +1,1 @@
+<%= url_for(@options) %> <%= @from_method %>


### PR DESCRIPTION
By default `url_for` should generate a full URL when used in a mailer #16497. This PR adds tests that will verify this ability.
