### PR TITLE
Use sprockets-rails 2.2.x on base app and allow greater version

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'railties',      version
 
   s.add_dependency 'bundler',         '>= 1.3.0', '< 2.0'
-  s.add_dependency 'sprockets-rails', '~> 3.0.0.beta1'
+  s.add_dependency 'sprockets-rails', '>= 2.0.0'
 end

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -239,8 +239,6 @@ module Rails
 
         gems = []
         if options.dev? || options.edge?
-          gems << GemfileEntry.github('sprockets-rails', 'rails/sprockets-rails',
-                                    'Use edge version of sprockets-rails')
           gems << GemfileEntry.github('sass-rails', 'rails/sass-rails',
                                     'Use SCSS for stylesheets')
         else


### PR DESCRIPTION
At the moment, this Gemfile wont work:

``` ruby
gem "rails", github: "rails/rails"
gem 'sprockets-rails', github: 'rails/sprockets-rails'
gem 'sass-rails', github: "rails/sass-rails"
```

This wont work because:
`sass-rails`(master) requires `sprockets` < 3.0 (https://github.com/rails/sass-rails/blob/63818c118e10258d760fa6b82cf9bedcb0a6c9cb/sass-rails.gemspec#L21)
`sprockets-rails`(master) requires `sprockets` 3.0.x (https://github.com/rails/sprockets-rails/blob/059d4707d27681a14cdcbbcb42a984f811c6dae5/sprockets-rails.gemspec#L14)

sprockets-rails 2.2.1 has been released, http://rubygems.org/gems/sprockets-rails/versions/2.2.1, so we can make rails requires version 2.2+, and have the default app generator pointing to `~> 2.2.1`.

This will fix the broken test `test_generation_runs_bundle_install_with_full_and_mountable`

@rafaelfranca thoughts? lemme know if something in here doesnt make sense.
