### PR TITLE
Don't center the routes table on routing errors

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -1,6 +1,6 @@
 <% content_for :style do %>
   #route_table {
-    margin: 0 auto 0;
+    margin: 0;
     border-collapse: collapse;
   }
 


### PR DESCRIPTION
Now that the routes table has content underneath it, it does look kinda off, at least to me.

Currently:

![screen shot 2014-11-24 at 10 51 28 pm](https://cloud.githubusercontent.com/assets/604618/5173039/c571ecfe-742d-11e4-9f95-e117f8dcf057.png)

Proposing:

![screen shot 2014-11-24 at 10 54 20 pm](https://cloud.githubusercontent.com/assets/604618/5173047/cfb833e4-742d-11e4-847f-f5bdfcb44617.png)
