### PR TITLE
Combine aliased_table_for and aliased_name_for

### DIFF
--- a/activerecord/lib/active_record/associations/alias_tracker.rb
+++ b/activerecord/lib/active_record/associations/alias_tracker.rb
@@ -57,20 +57,10 @@ module ActiveRecord
       end
 
       def aliased_table_for(table_name, aliased_name)
-        table_alias = aliased_name_for(table_name, aliased_name)
-
-        if table_alias == table_name
-          Arel::Table.new(table_name)
-        else
-          Arel::Table.new(table_name).alias(table_alias)
-        end
-      end
-
-      def aliased_name_for(table_name, aliased_name)
         if aliases[table_name].zero?
           # If it's zero, we can have our table_name
           aliases[table_name] = 1
-          table_name
+          Arel::Table.new(table_name)
         else
           # Otherwise, we need to use an alias
           aliased_name = connection.table_alias_for(aliased_name)
@@ -78,11 +68,12 @@ module ActiveRecord
           # Update the count
           aliases[aliased_name] += 1
 
-          if aliases[aliased_name] > 1
+          table_alias = if aliases[aliased_name] > 1
             "#{truncate(aliased_name)}_#{aliases[aliased_name]}"
           else
             aliased_name
           end
+          Arel::Table.new(table_name).alias(table_alias)
         end
       end
 

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -94,7 +94,7 @@ module ActiveRecord
       #
       def initialize(base, associations, joins)
         @alias_tracker = AliasTracker.create(base.connection, joins)
-        @alias_tracker.aliased_name_for(base.table_name, base.table_name) # Updates the count for base.table_name to 1
+        @alias_tracker.aliased_table_for(base.table_name, base.table_name) # Updates the count for base.table_name to 1
         tree = self.class.make_tree associations
         @join_root = JoinBase.new base, build(tree, base)
         @join_root.children.each { |child| construct_tables! @join_root, child }


### PR DESCRIPTION
This refactoring reduces the number of conditionals needed to build `aliased_table_for` and removes `aliased_name_for` because it's no longer necessary.

`aliased_name_for` was also used in `JoinDependency#initialize` so that was replaced with `aliased_table_for` as well. :smile_cat: 
