### PR TITLE
Always default the log_level to :info for Railties

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -143,6 +143,7 @@ module TestHelpers
         config.active_support.deprecation = :log
         config.active_support.test_order = :random
         config.action_controller.allow_forgery_protection = false
+        config.log_level = :info
       RUBY
     end
 


### PR DESCRIPTION
See also #16622 and a6de6f5

Changelog: #17755 
Test: #17756 

cc @chancancode @matthewd 
