### PR TITLE
Generators add foreign keys on references

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
@@ -15,5 +15,8 @@ class <%= migration_class_name %> < ActiveRecord::Migration
 <% attributes_with_index.each do |attribute| -%>
     add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>
 <% end -%>
+<% attributes.select(&:reference?).reject(&:polymorphic?).each do |attribute| -%>
+    add_foreign_key :<%= table_name %>, :<%= attribute.name.pluralize %>
+<% end -%>
   end
 end

--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
@@ -4,6 +4,9 @@ class <%= migration_class_name %> < ActiveRecord::Migration
 <% attributes.each do |attribute| -%>
   <%- if attribute.reference? -%>
     add_reference :<%= table_name %>, :<%= attribute.name %><%= attribute.inject_options %>
+    <%- unless attribute.polymorphic? -%>
+    add_foreign_key :<%= table_name %>, :<%= attribute.name.pluralize %>
+    <%- end -%>
   <%- else -%>
     add_column :<%= table_name %>, :<%= attribute.name %>, :<%= attribute.type %><%= attribute.inject_options %>
     <%- if attribute.has_index? -%>
@@ -26,6 +29,9 @@ class <%= migration_class_name %> < ActiveRecord::Migration
 <%- if migration_action -%>
   <%- if attribute.reference? -%>
     remove_reference :<%= table_name %>, :<%= attribute.name %><%= attribute.inject_options %>
+    <%- unless attribute.polymorphic? -%>
+    remove_foreign_key :<%= table_name %>, :<%= attribute.name.pluralize %>
+    <%- end -%>
   <%- else -%>
     <%- if attribute.has_index? -%>
     remove_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Generated migrations add the appropriate foreign key constraints to
+    references.
+
+    *Derek Prior*
+
 *   Deprecate different default for `log_level` in production.
 
     *Godfrey Chan*, *Matthew Draper*

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -85,6 +85,18 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_remove_migration_with_references_removes_foreign_keys
+    migration = "remove_references_from_books"
+    run_generator [migration, "author:belongs_to", "distributor:references{polymorphic}"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/remove_foreign_key :books, :authors/, change)
+        assert_no_match(/remove_foreign_key :books, :distributors/, change)
+      end
+    end
+  end
+
   def test_add_migration_with_attributes_and_indices
     migration = "add_title_with_index_and_body_to_posts"
     run_generator [migration, "title:string:index", "body:text", "user_id:integer:uniq"]
@@ -171,6 +183,18 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_add_migration_with_references_adds_foreign_keys
+    migration = "add_references_to_books"
+    run_generator [migration, "author:belongs_to", "distributor:references{polymorphic}"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/add_foreign_key :books, :authors/, change)
+        assert_no_match(/add_foreign_key :books, :distributors/, change)
+      end
+    end
+  end
+
   def test_create_join_table_migration
     migration = "add_media_join_table"
     run_generator [migration, "artist_id", "musics:uniq"]
@@ -205,7 +229,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
       end
     end
   end
-  
+
   def test_properly_identifies_usage_file
     assert generator_class.send(:usage_path)
   end

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -407,6 +407,27 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_foreign_key_is_added_for_references
+    run_generator ["account", "supplier:belongs_to", "user:references"]
+
+    assert_migration "db/migrate/create_accounts.rb" do |m|
+      assert_method :change, m do |up|
+        assert_match(/add_foreign_key :accounts, :suppliers/, up)
+        assert_match(/add_foreign_key :accounts, :users/, up)
+      end
+    end
+  end
+
+  def test_foreign_key_is_skipped_for_polymorphic_references
+    run_generator ["account", "supplier:belongs_to{polymorphic}"]
+
+    assert_migration "db/migrate/create_accounts.rb" do |m|
+      assert_method :change, m do |up|
+        assert_no_match(/add_foreign_key :accounts, :suppliers/, up)
+      end
+    end
+  end
+
   private
     def assert_generated_fixture(path, parsed_contents)
       fixture_file = File.new File.expand_path(path, destination_root)


### PR DESCRIPTION
If you run a generator such as:

```
rails generate model accounts supplier:references
```

The resulting migration will now add the corresponding foreign key
constraint unless the reference was specified to be polymorphic.
