### PR TITLE
be more general with adapter name

### DIFF
--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -44,7 +44,7 @@ module Rails
 
         find_cmd_and_exec(['mysql', 'mysql5'], *args)
 
-      when "postgresql", "postgres", "postgis"
+      when /postgres|postgis/
         ENV['PGUSER']     = config["username"] if config["username"]
         ENV['PGHOST']     = config["host"] if config["host"]
         ENV['PGPORT']     = config["port"].to_s if config["port"]


### PR DESCRIPTION
Hi,
a lately subclassed the postgres adapter as I needed very special features in a project. Unfortunately the dbconsole wasn't working any more. The cause is a too strict comparison. The mysql adapter test is more general why shouldn't the postgres be more general ,too? I didn't change the others but I think they could also be more general. I don't think somebody will name their adapter "mysql-oracle-postgis".

THX
