### PR TITLE
Small fix for the router visualizer

### DIFF
--- a/actionpack/lib/action_dispatch/journey/visualizer/fsm.css
+++ b/actionpack/lib/action_dispatch/journey/visualizer/fsm.css
@@ -16,10 +16,6 @@ h2 {
   font-size: 0.5em;
 }
 
-div#chart-2 {
-  height: 350px;
-}
-
 .clearfix {display: inline-block; }
 .input { overflow: show;}
 .instruction { color: #666; padding: 0 30px 20px; font-size: 0.9em}


### PR DESCRIPTION
This is a small fix for the router visualizer. The problem is that the routes overlap with the image.

Here's the screenshot how this looks now (for a dummy/scaffolded app):
![visualizer-before](https://cloud.githubusercontent.com/assets/1042682/5188348/86220686-74d4-11e4-8b62-cac86c55de60.png)

Screenshot for an app with a lot of routes:
![visualizer-before-for-many-routes](https://cloud.githubusercontent.com/assets/1042682/5188400/dec6bb92-74d4-11e4-8bde-5f851c672052.png)

This is how it looks when fixed (the routes are just rendered below the image):
![visualizer-after](https://cloud.githubusercontent.com/assets/1042682/5188408/f04d8076-74d4-11e4-8b96-c75149deb0e9.png)

For completeness sake, here's how to get the routes visualizer:

``` ruby
# in project root
bundle exec rails r 'File.write("./viz.html", Rails.application.routes.router.visualizer)'
open ./viz.html
```

Edit: btw. this was checked on chrome and safari.
