### PR TITLE
Remove Web Console /console references in the guides

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -97,8 +97,8 @@ New applications generated from Rails 4.2 now come with the Web Console gem by
 default.
 
 Web Console is a set of debugging tools for your Rails application. It will add
-an interactive console on every error page, a `console` view helper and a VT100
-compatible terminal.
+an interactive console on every error page and a `console` view and controller 
+helper.
 
 The interactive console on the error pages let you execute code where the
 exception originated. It's quite handy being able to introspect the state that
@@ -107,9 +107,8 @@ led to the error.
 The `console` view helper launches an interactive console within the context of
 the view where it is invoked.
 
-Finally, you can launch a VT100 terminal that runs `rails console`. If you need
-to create or modify existing test data, you can do that straight from the
-browser.
+The `console` controller helper spawns an interactive console within the
+context of the controller action it was invoked in.
 
 ### Foreign key support
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -54,15 +54,6 @@ Upgrading from Rails 4.1 to Rails 4.2
 
 First, add `gem 'web-console', '~> 2.0.0.beta4'` to the `:development` group in your Gemfile and run `bundle install` (it won't have been included when you upgraded Rails). Once it's been installed, you can simply drop a reference to the console helper (i.e., `<%= console %>`) into any view you want to enable it for. A console will also be provided on any error page you view in your development environment.
 
-Additionally, you can tell Rails to automatically mount a VT100-compatible console on a predetermined path by setting the appropriate configuration flags in your development config:
-
-```ruby
-# config/environments/development.rb
-
-config.web_console.automount = true
-config.web_console.default_mount_path = '/terminal' # Optional, defaults to /console
-```
-
 ### Responders
 
 `respond_with` and the class-level `respond_to` methods have been extracted to the `responders` gem. To use them, simply add `gem 'responders', '~> 2.0'` to your Gemfile. Calls to `respond_with` and `respond_to` (again, at the class level) will no longer work without having included the `responders` gem in your dependencies:


### PR DESCRIPTION
Now that rails/web-console#74 is in, we need to remove the `/console` mentions. @chancancode Do you see more references?
