### PR TITLE
Local vars should exist in partials for falsy `:object:` values too

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Local variable in a partial is now available even if a falsy value is
+    passed to `:object` when rendering a partial.
+
+    Fixes #17373.
+
+    *Agis Anastasopoulos*
+
 *   Add support for `:enforce_utf8` option in `form_for`.
 
     This is the same option that was added in 06388b0 to `form_tag` and allows

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -366,7 +366,7 @@ module ActionView
       partial = options[:partial]
 
       if String === partial
-        @object     = options[:object]
+        @object     = options[:object] if options.has_key?(:object)
         @collection = collection_from_options
         @path       = partial
       else
@@ -506,7 +506,7 @@ module ActionView
 
     def retrieve_template_keys
       keys = @locals.keys
-      keys << @variable if @object || @collection
+      keys << @variable if defined?(@object) || @collection
       if @collection
         keys << @variable_counter
         keys << @variable_iteration


### PR DESCRIPTION
c67005f221f102fe2caca231027d9b11cf630484 made the local var in partials
available only if what passed to `:object` was truthy.

For example this would not make the local variable `foo` available inside the
partial:

```
render partial: 'foo', object: false
```

Fixes #17373.
