### PR TITLE
prefork model with warm test dependencies

### DIFF
--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -20,27 +20,23 @@ namespace :test do
       'lib',
       "#{File.dirname(__FILE__)}/../activesupport/lib",
       "#{File.dirname(__FILE__)}/../actionpack/lib",
-      "#{File.dirname(__FILE__)}/../activemodel/lib"
+      "#{File.dirname(__FILE__)}/../activemodel/lib",
     ]
 
     if Process.respond_to?(:fork)
+      require "#{File.dirname(__FILE__)}../../load_paths"
+
       dash_i.each do |path|
-        $: << path
+        $LOAD_PATH << path
       end
-
-      require 'bundler'
-      Bundler.setup
-
-      status = 0
 
       test_files.each do |file|
-        Process.wait(Process.fork{
-          puts file
+        Process.wait(Process.fork {
+          puts "Running #{file}"
           require "./#{file}"
         })
-        status = $?.exitstatus if $?.exitstatus != 0
+        exit $?.exitstatus if $?.exitstatus != 0
       end
-      exit status if status != 0
     else
       test_files.each do |file|
         ruby "-w", "-I#{dash_i.join ':'}", file

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -19,7 +19,13 @@ namespace :test do
         "#{File.dirname(__FILE__)}/../actionpack/lib",
         "#{File.dirname(__FILE__)}/../activemodel/lib"
       ]
-      ruby "-w", "-I#{dash_i.join ':'}", file
+      dash_i.each do |path|
+        $: << path
+      end
+      require 'abstract_unit'
+      Process.wait(Process.fork{
+        load "./#{file}"
+      })
     end
   end
 end

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -10,22 +10,41 @@ namespace :test do
   task :isolated do
     dirs = (ENV["TEST_DIR"] || ENV["TEST_DIRS"] || "**").split(",")
     test_files = dirs.map { |dir| "test/#{dir}/*_test.rb" }
-    Dir[*test_files].each do |file|
-      next true if file.include?("fixtures")
-      dash_i = [
-        'test',
-        'lib',
-        "#{File.dirname(__FILE__)}/../activesupport/lib",
-        "#{File.dirname(__FILE__)}/../actionpack/lib",
-        "#{File.dirname(__FILE__)}/../activemodel/lib"
-      ]
+    test_files = Dir[*test_files]
+    test_files.reject!{|f|
+      f.include?("fixtures")
+    }
+
+    dash_i = [
+      'test',
+      'lib',
+      "#{File.dirname(__FILE__)}/../activesupport/lib",
+      "#{File.dirname(__FILE__)}/../actionpack/lib",
+      "#{File.dirname(__FILE__)}/../activemodel/lib"
+    ]
+
+    if Process.respond_to?(:fork)
       dash_i.each do |path|
         $: << path
       end
-      require 'abstract_unit'
-      Process.wait(Process.fork{
-        load "./#{file}"
-      })
+
+      require 'bundler'
+      Bundler.setup
+
+      status = 0
+
+      test_files.each do |file|
+        Process.wait(Process.fork{
+          puts file
+          require "./#{file}"
+        })
+        status = $?.exitstatus if $?.exitstatus != 0
+      end
+      exit status if status != 0
+    else
+      test_files.each do |file|
+        ruby "-w", "-I#{dash_i.join ':'}", file
+      end
     end
   end
 end


### PR DESCRIPTION
instead of shelling to ruby for railties tests, we'll use a fork to isolate any weird issues. In addition, load up `abstract unit` to warm up the environment, so each test can skip over the env booting.
# TODO
- [x] preserve exit code on failure
- [x] print which file is being run before loading for debugging
- [x] some files are reporting 0 runs, so maybe not all tests are actually being run?
