### PR TITLE
Getting the location of the server

### DIFF
--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -48,13 +48,6 @@ module ActionController
   #     render plain: "This server hosted at #{location}"
   #   end
   # 
-  # The location of the server is also available in request object itself 
-  #
-  #  def server_ip
-  #     location = request.remote_ip
-  #     render plain: "This server hosted at #{location}"
-  #  end
-  #
   # == Parameters
   #
   # All request parameters, whether they come from a GET or POST request, or from the URL, are available through the params method

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -44,9 +44,16 @@ module ActionController
   # The full request object is available via the request accessor and is primarily used to query for HTTP headers:
   #
   #   def server_ip
-  #     location = request.env["SERVER_ADDR"]
+  #     location = request.env["REMOTE_ADDR"]
   #     render plain: "This server hosted at #{location}"
   #   end
+  # 
+  # The location of the server is also available in request object itself 
+  #
+  #  def server_ip
+  #     location = request.remote_ip
+  #     render plain: "This server hosted at #{location}"
+  #  end
   #
   # == Parameters
   #


### PR DESCRIPTION
Getting the location of the server by using request.env['REMOTE_ADDR'] or request.ip instead of request.env['SERVER_ADDR']
