### PR TITLE
Use absolute_path of caller_locations to infer engine root

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -351,7 +351,7 @@ module Rails
 
           base.called_from = begin
             call_stack = if Kernel.respond_to?(:caller_locations)
-              caller_locations.map(&:path)
+              caller_locations.map(&:absolute_path)
             else
               # Remove the line number from backtraces making sure we don't leave anything behind
               caller.map { |p| p.sub(/:\d+.*/, '') }


### PR DESCRIPTION
According to documentation `path` only returns file names. On MRI it's not the case but it's likely a bug in MRI. Rubinius tries to implement it according to documentation and Rails get broken on rbx ([relevant discussion](https://github.com/rubinius/rubinius/issues/3223)).

Affected versions of Rails are `>= 4.1.0`. Would you like me to submit a PR for 4.1 branch, too?
