### PR TITLE
allow 'all' for :domain option in addition to :all

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -155,7 +155,7 @@ module ActionDispatch
       def handle_options(options) #:nodoc:
         options[:path] ||= "/"
 
-        if options[:domain] == :all
+        if options[:domain].respond_to?(:to_sym) && options[:domain].to_sym == :all
           # if there is a provided tld length then we use it otherwise default domain regexp
           domain_regexp = options[:tld_length] ? /([^.]+\.?){#{options[:tld_length]}}$/ : DOMAIN_REGEXP
 

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -99,8 +99,18 @@ class CookiesTest < ActionController::TestCase
       head :ok
     end
 
+    def set_cookie_with_domain_all_as_string
+      cookies[:user_name] = {:value => "rizwanreza", :domain => 'all'}
+      head :ok
+    end
+
     def delete_cookie_with_domain
       cookies.delete(:user_name, :domain => :all)
+      head :ok
+    end
+
+    def delete_cookie_with_domain_all_as_string
+      cookies.delete(:user_name, :domain => 'all')
       head :ok
     end
 


### PR DESCRIPTION
fix allows for :all behavior when 'all' string is passed as an option
