### PR TITLE
Fix undesirable RangeError by Type::Integer. Add Type::UnsignedInteger.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix undesirable RangeError by Type::Integer. Add Type::UnsignedInteger.
+
+    *Ryuta Kamizono*
+
 *   Add `foreign_type` option to `has_one` and `has_many` association macros.
 
     This option enables to define the column name of associated object's type for polymorphic associations.

--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -17,6 +17,7 @@ require 'active_record/type/serialized'
 require 'active_record/type/string'
 require 'active_record/type/text'
 require 'active_record/type/time'
+require 'active_record/type/unsigned_integer'
 
 require 'active_record/type/type_map'
 require 'active_record/type/hash_lookup_type_map'

--- a/activerecord/lib/active_record/type/integer.rb
+++ b/activerecord/lib/active_record/type/integer.rb
@@ -5,7 +5,7 @@ module ActiveRecord
 
       def initialize(*)
         super
-        @range = -max_value...max_value
+        @range = min_value...max_value
       end
 
       def type
@@ -45,6 +45,10 @@ module ActiveRecord
       def max_value
         limit = self.limit || 4
         1 << (limit * 8 - 1) # 8 bits per byte with one bit for sign
+      end
+
+      def min_value
+        -max_value
       end
     end
   end

--- a/activerecord/lib/active_record/type/unsigned_integer.rb
+++ b/activerecord/lib/active_record/type/unsigned_integer.rb
@@ -1,0 +1,15 @@
+module ActiveRecord
+  module Type
+    class UnsignedInteger < Integer # :nodoc:
+      private
+
+      def max_value
+        super * 2
+      end
+
+      def min_value
+        0
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/adapters/mysql/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/mysql/unsigned_type_test.rb
@@ -1,0 +1,30 @@
+require "cases/helper"
+
+class UnsignedTypeTest < ActiveRecord::TestCase
+  self.use_transactional_fixtures = false
+
+  class UnsignedType < ActiveRecord::Base
+  end
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table("unsigned_types", force: true) do |t|
+      t.column :unsigned_integer, "int unsigned"
+    end
+  end
+
+  teardown do
+    @connection.drop_table "unsigned_types"
+  end
+
+  test "unsigned int max value is in range" do
+    assert expected = UnsignedType.create(unsigned_integer: 4294967295)
+    assert_equal expected, UnsignedType.find_by(unsigned_integer: 4294967295)
+  end
+
+  test "minus value is out of range" do
+    assert_raise(RangeError) do
+      UnsignedType.create(unsigned_integer: -10)
+    end
+  end
+end

--- a/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
@@ -1,0 +1,30 @@
+require "cases/helper"
+
+class UnsignedTypeTest < ActiveRecord::TestCase
+  self.use_transactional_fixtures = false
+
+  class UnsignedType < ActiveRecord::Base
+  end
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table("unsigned_types", force: true) do |t|
+      t.column :unsigned_integer, "int unsigned"
+    end
+  end
+
+  teardown do
+    @connection.drop_table "unsigned_types"
+  end
+
+  test "unsigned int max value is in range" do
+    assert expected = UnsignedType.create(unsigned_integer: 4294967295)
+    assert_equal expected, UnsignedType.find_by(unsigned_integer: 4294967295)
+  end
+
+  test "minus value is out of range" do
+    assert_raise(RangeError) do
+      UnsignedType.create(unsigned_integer: -10)
+    end
+  end
+end

--- a/activerecord/test/cases/type/unsigned_integer_test.rb
+++ b/activerecord/test/cases/type/unsigned_integer_test.rb
@@ -1,0 +1,18 @@
+require "cases/helper"
+require "models/company"
+
+module ActiveRecord
+  module Type
+    class UnsignedIntegerTest < ActiveRecord::TestCase
+      test "unsigned int max value is in range" do
+        assert_equal(4294967295, UnsignedInteger.new.type_cast_from_user("4294967295"))
+      end
+
+      test "minus value is out of range" do
+        assert_raises(::RangeError) do
+          UnsignedInteger.new.type_cast_from_user("-1")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR separated from #17696.

``` sql
CREATE TABLE `foos` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `unsigned_int` int(10) unsigned NOT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
```

```
# rails c
Loading development environment (Rails 4.2.0.beta4)

irb(main):001:0> Foo.create(unsigned_int: 4294967295)
RangeError: 4294967295 is out of range for ActiveRecord::Type::Integer with limit 4

irb(main):002:0> Foo.connection.execute("INSERT INTO foos(unsigned_int) VALUES (4294967295)")
   (4.7ms)  INSERT INTO foos(unsigned_int) VALUES (4294967295)
=> nil

irb(main):003:0> Foo.where(unsigned_int: 4294967295).first
RangeError: 4294967295 is out of range for ActiveRecord::Type::Integer with limit 4

irb(main):004:0> Foo.connection.select_one("SELECT * FROM foos WHERE unsigned_int = 4294967295")
   (6.3ms)  SELECT * FROM foos WHERE unsigned_int = 4294967295
=> {"id"=>1, "unsigned_int"=>4294967295}
```
