### PR TITLE
Don't remove mailer layouts files

### DIFF
--- a/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
+++ b/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
@@ -8,7 +8,9 @@ module Rails
 
       def create_mailer_file
         template "mailer.rb", File.join('app/mailers', class_path, "#{file_name}.rb")
-        template "application_mailer.rb", 'app/mailers/application_mailer.rb'
+        if self.behavior == :invoke
+          template "application_mailer.rb", 'app/mailers/application_mailer.rb'
+        end
       end
 
       hook_for :template_engine, :test_framework

--- a/railties/lib/rails/generators/erb/mailer/mailer_generator.rb
+++ b/railties/lib/rails/generators/erb/mailer/mailer_generator.rb
@@ -9,9 +9,11 @@ module Erb # :nodoc:
         view_base_path = File.join("app/views", class_path, file_name)
         empty_directory view_base_path
 
-        formats.each do |format|
-          layout_path = File.join("app/views/layouts", filename_with_extensions("mailer", format))
-          template filename_with_extensions(:layout, format), layout_path
+        if self.behavior == :invoke
+          formats.each do |format|
+            layout_path = File.join("app/views/layouts", filename_with_extensions("mailer", format))
+            template filename_with_extensions(:layout, format), layout_path
+          end
         end
 
         actions.each do |action|

--- a/railties/test/generators/mailer_generator_test.rb
+++ b/railties/test/generators/mailer_generator_test.rb
@@ -152,4 +152,19 @@ class MailerGeneratorTest < Rails::Generators::TestCase
       end
     end
   end
+
+  def test_mailer_on_revoke
+    run_generator
+    run_generator ["notifier"], behavior: :revoke
+
+    assert_no_file "app/mailers/notifier.rb"
+    assert_no_file "app/views/notifier/foo.text.erb"
+    assert_no_file "app/views/notifier/bar.text.erb"
+    assert_no_file "app/views/notifier/foo.html.erb"
+    assert_no_file "app/views/notifier/bar.html.erb"
+
+    assert_file "app/mailers/application_mailer.rb"
+    assert_file "app/views/layouts/mailer.text.erb"
+    assert_file "app/views/layouts/mailer.html.erb"
+  end
 end


### PR DESCRIPTION
Because it becomes the error in other mailer when I use the same layout file in multiple mailer, I think that the layout file should not delete it.
