### PR TITLE
[ci skip] Remove outdate note of :dependent in guide

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1532,8 +1532,6 @@ Controls what happens to the associated objects when their owner is destroyed:
 * `:restrict_with_exception` causes an exception to be raised if there are any associated records
 * `:restrict_with_error` causes an error to be added to the owner if there are any associated objects
 
-NOTE: This option is ignored when you use the `:through` option on the association.
-
 ##### `:foreign_key`
 
 By convention, Rails assumes that the column used to hold the foreign key on the other model is the name of this model with the suffix `_id` added. The `:foreign_key` option lets you set the name of the foreign key directly:


### PR DESCRIPTION
Since rails 3.1 released, it's support the :dependent option on has_many :through associations(05bcb8ce), should remove the outdate note.
