### PR TITLE
Null values will still be passed to custom serializers.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Null values will still be passed to custom serializers.
+
+    This removes an undocumented conditional case and makes the load/dump
+    contract easier to reason about.
+
+    *Xavier Shay*
+
 *   Bring back `db:test:prepare` to synchronize the test database schema.
 
     Manual synchronization using `bin/rake db:test:prepare` is required

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -13,22 +13,14 @@ module ActiveRecord
       end
 
       def type_cast_from_database(value)
-        if default_value?(value)
-          value
-        else
-          coder.load(super)
-        end
+        coder.load(super)
       end
 
       def type_cast_for_database(value)
-        return if value.nil?
-        unless default_value?(value)
-          super coder.dump(value)
-        end
+        super coder.dump(value)
       end
 
       def changed_in_place?(raw_old_value, value)
-        return false if value.nil?
         subtype.changed_in_place?(raw_old_value, coder.dump(value))
       end
 
@@ -44,12 +36,6 @@ module ActiveRecord
       def encode_with(coder)
         coder['coder'] = @coder
         super
-      end
-
-      private
-
-      def default_value?(value)
-        value == coder.load(nil)
       end
     end
   end


### PR DESCRIPTION
This removes an undocumented conditional case and makes the load/dump contract easier to reason about.

I hit this accidentally in one of my projects where I was using the null object pattern and my null object wasn't serializing to `nil` and I was storing it in a not-null column. In hindsight I should probably change the serialization behaviour, however it took a while to track down and was non-intuitive. Given that it takes _more_ code to create _less_ intuitive behaviour, I feel removing it is justified.
