### PR TITLE
Remove multi-assignments

### DIFF
--- a/actionpack/lib/action_controller/middleware.rb
+++ b/actionpack/lib/action_controller/middleware.rb
@@ -2,7 +2,8 @@ module ActionController
   class Middleware < Metal
     class ActionMiddleware
       def initialize(controller, app)
-        @controller, @app = controller, app
+        @controller = controller
+        @app = app
       end
 
       def call(env)

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -141,7 +141,8 @@ module ActionDispatch
       def with_routing
         old_routes, @routes = @routes, ActionDispatch::Routing::RouteSet.new
         if defined?(@controller) && @controller
-          old_controller, @controller = @controller, @controller.clone
+          old_controller = @controller
+          @controller = @controller.clone
           _routes = @routes
 
           @controller.singleton_class.send(:include, _routes.url_helpers)

--- a/actionpack/test/abstract/translation_test.rb
+++ b/actionpack/test/abstract/translation_test.rb
@@ -35,13 +35,15 @@ module AbstractController
       end
 
       def test_default_translation
-        key, expected = 'one.two', 'bar'
+        key = 'one.two'
+        expected = 'bar'
         I18n.stubs(:translate).with(key).returns(expected)
         assert_equal expected, @controller.t(key)
       end
 
       def test_localize
-        time, expected = Time.gm(2000), 'Sat, 01 Jan 2000 00:00:00 +0000'
+        time = Time.gm(2000)
+        expected = 'Sat, 01 Jan 2000 00:00:00 +0000'
         I18n.stubs(:localize).with(time).returns(expected)
         assert_equal expected, @controller.l(time)
       end

--- a/actionpack/test/dispatch/callbacks_test.rb
+++ b/actionpack/test/dispatch/callbacks_test.rb
@@ -12,7 +12,7 @@ class DispatcherTest < ActiveSupport::TestCase
   end
 
   def setup
-    Foo.a, Foo.b = 0, 0
+    Foo.a = Foo.b = 0
     ActionDispatch::Callbacks.reset_callbacks(:call)
   end
 

--- a/actionpack/test/dispatch/reloader_test.rb
+++ b/actionpack/test/dispatch/reloader_test.rb
@@ -59,7 +59,7 @@ class ReloaderTest < ActiveSupport::TestCase
   end
 
   def test_condition_specifies_when_to_reload
-    i, j = 0, 0, 0, 0
+    i = j = 0
     Reloader.to_prepare { |*args| i += 1 }
     Reloader.to_cleanup { |*args| j += 1 }
     app = Reloader.new(lambda { |env| [200, {}, []] }, lambda { i < 3 })

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -56,7 +56,8 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
   end
 
   test "localize rescue error page" do
-    old_locale, I18n.locale = I18n.locale, :da
+    old_locale = I18n.locale
+    I18n.locale = :da
 
     begin
       @app = ProductionApp

--- a/actionview/lib/action_view/dependency_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker.rb
@@ -81,7 +81,8 @@ module ActionView
       end
 
       def initialize(name, template)
-        @name, @template = name, template
+        @name = name
+        @template = template
       end
 
       def dependencies

--- a/actionview/lib/action_view/flows.rb
+++ b/actionview/lib/action_view/flows.rb
@@ -48,11 +48,13 @@ module ActionView
 
         begin
           @waiting_for = key
-          view.output_buffer, @parent = @child, view.output_buffer
+          @parent = view.output_buffer
+          view.output_buffer = @child
           Fiber.yield
         ensure
           @waiting_for = nil
-          view.output_buffer, @child = @parent, view.output_buffer
+          @child = view.output_buffer
+          view.output_buffer = @parent
         end
       end
 

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -92,7 +92,8 @@ module ActionView
 
       # Temporary skip passing the details_key forward.
       def disable_cache
-        old_value, @cache = @cache, false
+        old_value = @cache
+        @cache = false
         yield
       ensure
         @cache = old_value

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -8,7 +8,8 @@ module ActionView
 
     def initialize(original_config, lookup_context)
       original_config = original_config.original_config if original_config.respond_to?(:original_config)
-      @original_config, @lookup_context = original_config, lookup_context
+      @original_config = original_config
+      @lookup_context = lookup_context
     end
 
     def locale
@@ -26,7 +27,8 @@ module ActionView
 
     # Overwrite process to setup I18n proxy.
     def process(*) #:nodoc:
-      old_config, I18n.config = I18n.config, I18nProxy.new(I18n.config, lookup_context)
+      old_config = I18n.config
+      I18n.config = I18nProxy.new(I18n.config, lookup_context)
       super
     ensure
       I18n.config = old_config

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -273,9 +273,10 @@ module ActionView
         # encoding of the code
         source = <<-end_src
           def #{method_name}(local_assigns, output_buffer)
-            _old_virtual_path, @virtual_path = @virtual_path, #{@virtual_path.inspect};_old_output_buffer = @output_buffer;#{locals_code};#{code}
+            _old_virtual_path = @virtual_path; @virtual_path = #{@virtual_path.inspect}; _old_output_buffer = @output_buffer; #{locals_code}; #{code}
           ensure
-            @virtual_path, @output_buffer = _old_virtual_path, _old_output_buffer
+            @virtual_path = _old_virtual_path
+            @output_buffer = _old_output_buffer
           end
         end_src
 

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -63,7 +63,8 @@ module ActionView
 
       def initialize(template, original_exception)
         super(original_exception.message)
-        @template, @original_exception = template, original_exception
+        @template = template
+        @original_exception = original_exception
         @sub_templates = nil
         set_backtrace(original_exception.backtrace)
       end

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -3220,7 +3220,8 @@ class DateHelperTest < ActionView::TestCase
 
   protected
     def with_env_tz(new_tz = 'US/Eastern')
-      old_tz, ENV['TZ'] = ENV['TZ'], new_tz
+      old_tz = ENV['TZ']
+      ENV['TZ'] = new_tz
       yield
     ensure
       old_tz ? ENV['TZ'] = old_tz : ENV.delete('TZ')

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -3376,7 +3376,8 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def with_locale(testing_locale = :label)
-    old_locale, I18n.locale = I18n.locale, testing_locale
+    old_locale = I18n.locale
+    I18n.locale = testing_locale
     yield
   ensure
     I18n.locale = old_locale

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -102,14 +102,16 @@ module RenderTestCases
   end
 
   def test_render_file_with_localization_on_context_level
-    old_locale, @view.locale = @view.locale, :da
+    old_locale = @view.locale
+    @view.locale = :da
     assert_equal "Hey verden", @view.render(:file => "test/hello_world")
   ensure
     @view.locale = old_locale
   end
 
   def test_render_file_with_dashed_locale
-    old_locale, @view.locale = @view.locale, :"pt-BR"
+    old_locale = @view.locale
+    @view.locale = :"pt-BR"
     assert_equal "Ola mundo", @view.render(:file => "test/hello_world")
   ensure
     @view.locale = old_locale

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -8,7 +8,9 @@ class SerializationTest < ActiveModel::TestCase
     attr_accessor :name, :email, :gender, :address, :friends
 
     def initialize(name, email, gender)
-      @name, @email, @gender = name, email, gender
+      @name = name
+      @email = email
+      @gender = gender
       @friends = []
     end
 

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -54,7 +54,8 @@ class ConfirmationValidationTest < ActiveModel::TestCase
 
   def test_title_confirmation_with_i18n_attribute
     begin
-      @old_load_path, @old_backend = I18n.load_path.dup, I18n.backend
+      @old_load_path = I18n.load_path.dup
+      @old_backend = I18n.backend
       I18n.load_path.clear
       I18n.backend = I18n::Backend::Simple.new
       I18n.backend.store_translations('en', {

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -4,12 +4,12 @@ require "cases/helper"
 require 'models/person'
 
 class I18nValidationTest < ActiveModel::TestCase
-
   def setup
     Person.clear_validators!
     @person = Person.new
 
-    @old_load_path, @old_backend = I18n.load_path.dup, I18n.backend
+    @old_load_path = I18n.load_path.dup
+    @old_backend = I18n.backend
     I18n.load_path.clear
     I18n.backend = I18n::Backend::Simple.new
     I18n.backend.store_translations('en', errors: { messages: { custom: nil } })

--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -32,7 +32,8 @@ module ActiveRecord
     #    EXCHANGE_RATES = { "USD_TO_DKK" => 6 }
     #
     #    def initialize(amount, currency = "USD")
-    #      @amount, @currency = amount, currency
+    #      @amount = amount
+    #      @currency = currency
     #    end
     #
     #    def exchange_to(other_currency)

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -24,7 +24,8 @@ module ActiveRecord
       def initialize(owner, reflection)
         reflection.check_validity!
 
-        @owner, @reflection = owner, reflection
+        @owner = owner
+        @reflection = reflection
 
         reset
         reset_scope

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -28,7 +28,8 @@ module ActiveRecord
 
       # Enable the query cache within the block.
       def cache
-        old, @query_cache_enabled = @query_cache_enabled, true
+        old = @query_cache_enabled
+        @query_cache_enabled = true
         yield
       ensure
         @query_cache_enabled = old
@@ -45,7 +46,8 @@ module ActiveRecord
 
       # Disable the query cache within the block.
       def uncached
-        old, @query_cache_enabled = @query_cache_enabled, false
+        old = @query_cache_enabled
+        @query_cache_enabled = false
         yield
       ensure
         @query_cache_enabled = old

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -251,7 +251,8 @@ module ActiveRecord
         column_options = options.delete(:column_options) || {}
         column_options.reverse_merge!(null: false)
 
-        t1_column, t2_column = [table_1, table_2].map{ |t| t.to_s.singularize.foreign_key }
+        t1_column = table_1.to_s.singularize.foreign_key
+        t2_column = table_2.to_s.singularize.foreign_key
 
         create_table(join_table_name, options.merge!(id: false)) do |td|
           td.integer t1_column, column_options

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -139,7 +139,8 @@ module ActiveRecord
         "Lost connection to MySQL server during query",
         "MySQL server has gone away" ]
 
-      QUOTED_TRUE, QUOTED_FALSE = '1', '0'
+      QUOTED_TRUE = '1'
+      QUOTED_FALSE = '0'
 
       NATIVE_DATABASE_TYPES = {
         :primary_key => "int(11) auto_increment PRIMARY KEY",

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -7,7 +7,8 @@ module ActiveRecord
       attr_reader :config, :adapter_method
 
       def initialize(config, adapter_method)
-        @config, @adapter_method = config, adapter_method
+        @config = config
+        @adapter_method = adapter_method
       end
 
       def initialize_dup(original)

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -695,7 +695,8 @@ module ActiveRecord
 
           migration.version = next_migration_number(last ? last.version + 1 : 0).to_i
           new_path = File.join(destination, "#{migration.version}_#{migration.name.underscore}.#{scope}.rb")
-          old_path, migration.filename = migration.filename, new_path
+          old_path = migration.filename
+          migration.filename = new_path
           last = migration
 
           File.binwrite(migration.filename, source)

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -207,7 +207,8 @@ db_namespace = namespace :db do
     task :identify => [:environment, :load_config] do
       require 'active_record/fixtures'
 
-      label, id = ENV['LABEL'], ENV['ID']
+      label = ENV['LABEL']
+      id = ENV['ID']
       raise 'LABEL or ID required' if label.blank? && id.blank?
 
       puts %Q(The fixture ID for "#{label}" is #{ActiveRecord::FixtureSet.identify(label)}.) if label

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -4,7 +4,8 @@ module ActiveRecord
       delegate :connection, :establish_connection, to: ActiveRecord::Base
 
       def initialize(configuration, root = ActiveRecord::Tasks::DatabaseTasks.root)
-        @configuration, @root = configuration, root
+        @configuration = configuration
+        @root = root
       end
 
       def create

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -59,7 +59,8 @@ def supports_savepoints?
 end
 
 def with_env_tz(new_tz = 'US/Eastern')
-  old_tz, ENV['TZ'] = ENV['TZ'], new_tz
+  old_tz = ENV['TZ']
+  ENV['TZ'] = new_tz
   yield
 ensure
   old_tz ? ENV['TZ'] = old_tz : ENV.delete('TZ')

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -446,7 +446,7 @@ unless in_memory_db?
 
       protected
         def duel(zzz = 5)
-          t0, t1, t2, t3 = nil, nil, nil, nil
+          t0 = t1 = t2 = t3 = nil
 
           a = Thread.new do
             t0 = Time.now

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -66,7 +66,8 @@ module ActiveRecord
     end
 
     test 'extending!' do
-      mod, mod2 = Module.new, Module.new
+      mod = Module.new
+      mod2 = Module.new
 
       assert relation.extending!(mod).equal?(relation)
       assert_equal [mod], relation.extending_values

--- a/activerecord/test/cases/validations/i18n_generate_message_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_generate_message_validation_test.rb
@@ -9,7 +9,8 @@ class I18nGenerateMessageValidationTest < ActiveRecord::TestCase
   end
 
   def reset_i18n_load_path
-    @old_load_path, @old_backend = I18n.load_path.dup, I18n.backend
+    @old_load_path = I18n.load_path.dup
+    @old_backend = I18n.backend
     I18n.load_path.clear
     I18n.backend = I18n::Backend::Simple.new
     yield

--- a/activerecord/test/cases/validations/i18n_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_validation_test.rb
@@ -9,7 +9,8 @@ class I18nValidationTest < ActiveRecord::TestCase
     repair_validations(Topic, Reply)
     Reply.validates_presence_of(:title)
     @topic = Topic.new
-    @old_load_path, @old_backend = I18n.load_path.dup, I18n.backend
+    @old_load_path = I18n.load_path.dup
+    @old_backend = I18n.backend
     I18n.load_path.clear
     I18n.backend = I18n::Backend::Simple.new
     I18n.backend.store_translations('en', :errors => {:messages => {:custom => nil}})

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -31,7 +31,8 @@ class Money
   EXCHANGE_RATES = { "USD_TO_DKK" => 6, "DKK_TO_USD" => 0.6 }
 
   def initialize(amount, currency = "USD")
-    @amount, @currency = amount, currency
+    @amount = amount
+    @currency = currency
   end
 
   def exchange_to(other_currency)

--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -109,8 +109,8 @@ module ActiveSupport
         names.each do |name|
           raise NameError.new('invalid config attribute name') unless name =~ /\A[_A-Za-z]\w*\z/
 
-          reader, reader_line = "def #{name}; config.#{name}; end", __LINE__
-          writer, writer_line = "def #{name}=(value); config.#{name} = value; end", __LINE__
+          reader = "def #{name}; config.#{name}; end"; reader_line = __LINE__
+          writer = "def #{name}=(value); config.#{name} = value; end"; writer_line = __LINE__
 
           singleton_class.class_eval reader, __FILE__, reader_line
           singleton_class.class_eval writer, __FILE__, writer_line

--- a/activesupport/lib/active_support/core_ext/object/instance_variables.rb
+++ b/activesupport/lib/active_support/core_ext/object/instance_variables.rb
@@ -4,7 +4,8 @@ class Object
   #
   #   class C
   #     def initialize(x, y)
-  #       @x, @y = x, y
+  #       @x = x
+  #       @y = y
   #     end
   #   end
   #
@@ -17,7 +18,8 @@ class Object
   #
   #   class C
   #     def initialize(x, y)
-  #       @x, @y = x, y
+  #       @x = x
+  #       @y = y
   #     end
   #   end
   #

--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -44,7 +44,8 @@ class Time
     def use_zone(time_zone)
       new_zone = find_zone!(time_zone)
       begin
-        old_zone, ::Time.zone = ::Time.zone, new_zone
+        old_zone = ::Time.zone
+        ::Time.zone = new_zone
         yield
       ensure
         ::Time.zone = old_zone

--- a/activesupport/lib/active_support/dependencies/autoload.rb
+++ b/activesupport/lib/active_support/dependencies/autoload.rb
@@ -46,21 +46,24 @@ module ActiveSupport
     end
 
     def autoload_under(path)
-      @_under_path, old_path = path, @_under_path
+      old_path = @_under_path
+      @_under_path = path
       yield
     ensure
       @_under_path = old_path
     end
 
     def autoload_at(path)
-      @_at_path, old_path = path, @_at_path
+      old_path = @_at_path
+      @_at_path = path
       yield
     ensure
       @_at_path = old_path
     end
 
     def eager_autoload
-      old_eager, @_eager_autoload = @_eager_autoload, true
+      old_eager = @_eager_autoload
+      @_eager_autoload = true
       yield
     ensure
       @_eager_autoload = old_eager

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -44,7 +44,9 @@ module ActiveSupport
     attr_reader :time_zone
 
     def initialize(utc_time, time_zone, local_time = nil, period = nil)
-      @utc, @time_zone, @time = utc_time, time_zone, local_time
+      @utc = utc_time
+      @time_zone = time_zone
+      @time = local_time
       @period = @utc ? period : get_period_and_ensure_valid_local_time(period)
     end
 

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -1,7 +1,8 @@
 ORIG_ARGV = ARGV.dup
 
 begin
-  old, $VERBOSE = $VERBOSE, nil
+  old = $VERBOSE
+  $VERBOSE = nil
   require File.expand_path('../../../load_paths', __FILE__)
 ensure
   $VERBOSE = old

--- a/activesupport/test/callback_inheritance_test.rb
+++ b/activesupport/test/callback_inheritance_test.rb
@@ -5,7 +5,8 @@ class GrandParent
 
   attr_reader :log, :action_name
   def initialize(action_name)
-    @action_name, @log = action_name, []
+    @action_name = action_name
+    @log = []
   end
 
   define_callbacks :dispatch

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -94,7 +94,8 @@ module CallbacksTest
 
     attr_reader :action_name, :logger
     def initialize(action_name)
-      @action_name, @logger = action_name, []
+      @action_name = action_name
+      @logger = []
     end
 
     def log

--- a/activesupport/test/core_ext/module/attribute_aliasing_test.rb
+++ b/activesupport/test/core_ext/module/attribute_aliasing_test.rb
@@ -6,7 +6,8 @@ module AttributeAliasing
     attr_accessor :title, :Data
 
     def initialize
-      @title, @Data = nil, nil
+      @title = nil
+      @Data = nil
     end
 
     def title?

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -824,7 +824,9 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < ActiveSupport::TestCase
   include TimeZoneTestHelpers
 
   def setup
-    @t, @dt, @zone = Time.utc(2000), DateTime.civil(2000), Time.zone
+    @t = Time.utc(2000)
+    @dt = DateTime.civil(2000)
+    @zone = Time.zone
   end
 
   def teardown

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -86,7 +86,7 @@ class DeprecationTest < ActiveSupport::TestCase
   end
 
   def test_several_behaviors
-    @a, @b = nil, nil
+    @a = @b = nil
 
     ActiveSupport::Deprecation.behavior = [
       Proc.new { |msg, callstack| @a = msg },

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -11,7 +11,8 @@ class TestJSONEncoding < ActiveSupport::TestCase
 
   class Foo
     def initialize(a, b)
-      @a, @b = a, b
+      @a = a
+      @b = b
     end
   end
 

--- a/activesupport/test/ordered_hash_test.rb
+++ b/activesupport/test/ordered_hash_test.rb
@@ -27,7 +27,8 @@ class OrderedHashTest < ActiveSupport::TestCase
   end
 
   def test_assignment
-    key, value = 'purple', '5422a8'
+    key = 'purple'
+    value = '5422a8'
 
     @ordered_hash[key] = value
     assert_equal @keys.length + 1, @ordered_hash.length
@@ -37,7 +38,8 @@ class OrderedHashTest < ActiveSupport::TestCase
   end
 
   def test_delete
-    key, value = 'white', 'ffffff'
+    key = 'white'
+    value = 'ffffff'
     bad_key = 'black'
 
     @ordered_hash[key] = value

--- a/activesupport/test/time_zone_test_helpers.rb
+++ b/activesupport/test/time_zone_test_helpers.rb
@@ -8,7 +8,8 @@ module TimeZoneTestHelpers
   end
 
   def with_env_tz(new_tz = 'US/Eastern')
-    old_tz, ENV['TZ'] = ENV['TZ'], new_tz
+    old_tz = ENV['TZ']
+    ENV['TZ'] = new_tz
     yield
   ensure
     old_tz ? ENV['TZ'] = old_tz : ENV.delete('TZ')

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -23,7 +23,8 @@ class TransliterateTest < ActiveSupport::TestCase
   def test_transliterate_should_work_with_custom_i18n_rules_and_uncomposed_utf8
     char = [117, 776].pack("U*") # "ü" as ASCII "u" plus COMBINING DIAERESIS
     I18n.backend.store_translations(:de, :i18n => {:transliterate => {:rule => {"ü" => "ue"}}})
-    default_locale, I18n.locale = I18n.locale, :de
+    default_locale = I18n.locale
+    I18n.locale = :de
     assert_equal "ue", ActiveSupport::Inflector.transliterate(char)
   ensure
     I18n.locale = default_locale

--- a/activesupport/test/xml_mini_test.rb
+++ b/activesupport/test/xml_mini_test.rb
@@ -163,7 +163,8 @@ module XmlMiniTest
     module Nokogiri end
 
     setup do
-      @xml, @default_backend = ActiveSupport::XmlMini, ActiveSupport::XmlMini.backend
+      @xml = ActiveSupport::XmlMini
+      @default_backend = ActiveSupport::XmlMini.backend
     end
 
     teardown do
@@ -196,7 +197,8 @@ module XmlMiniTest
     module LibXML end
 
     setup do
-      @xml, @default_backend = ActiveSupport::XmlMini, ActiveSupport::XmlMini.backend
+      @xml = ActiveSupport::XmlMini
+      @default_backend = ActiveSupport::XmlMini.backend
     end
 
     teardown do

--- a/guides/rails_guides/indexer.rb
+++ b/guides/rails_guides/indexer.rb
@@ -27,7 +27,9 @@ module RailsGuides
         s.match?(re)
         if matched = s.matched
           matched =~ re
-          level, idx, title = $1.to_i, $2, $3.strip
+          level = $1.to_i
+          idx = $2
+          title = $3.strip
 
           if level < current_level
             # This is needed. Go figure.

--- a/guides/source/3_1_release_notes.md
+++ b/guides/source/3_1_release_notes.md
@@ -244,7 +244,8 @@ Action Pack
 
     ```ruby
     class PostsController < ApplicationController
-      USER_NAME, PASSWORD = "dhh", "secret"
+      USER_NAME = "dhh"
+      PASSWORD = "secret"
 
       before_filter :authenticate, :except => [ :index ]
 

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -440,7 +440,8 @@ corresponding values. Keys are strings:
 ```ruby
 class C
   def initialize(x, y)
-    @x, @y = x, y
+    @x = x
+    @y = y
   end
 end
 
@@ -456,7 +457,8 @@ The method `instance_variable_names` returns an array.  Each name includes the "
 ```ruby
 class C
   def initialize(x, y)
-    @x, @y = x, y
+    @x = x
+    @y = y
   end
 end
 

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -381,7 +381,8 @@ module Rails
         self.isolated = true
 
         unless mod.respond_to?(:railtie_namespace)
-          name, railtie = engine_name, self
+          name = engine_name
+          railtie = self
 
           mod.singleton_class.instance_eval do
             define_method(:railtie_namespace) { railtie }

--- a/railties/test/env_helpers.rb
+++ b/railties/test/env_helpers.rb
@@ -22,7 +22,8 @@ module EnvHelpers
   end
 
   def switch_env(key, value)
-    old, ENV[key] = ENV[key], value
+    old = ENV[key]
+    ENV[key] = value
     yield
   ensure
     ENV[key] = old

--- a/tools/profile
+++ b/tools/profile
@@ -14,7 +14,8 @@ module CodeTools
     attr_reader :path, :mode
     def initialize(path, mode=nil)
       assert_ruby_file_exists(path)
-      @path, @mode = path, mode
+      @path = path
+      @mode = mode
       require 'benchmark'
     end
 


### PR DESCRIPTION
Change a bunch of parallel assignments to sequential assignments, since the former perform additional array allocations that can worsen performance in hot paths.

Little example:

``` ruby
require 'benchmark'

N = 10_000_000

Benchmark.bm(15) do |x|
  x.report('parallel') do
    N.times do
      a, b = 10, 20
    end
  end

  x.report('sequentially') do
    N.times do
      a = 10
      b = 20
    end
  end
end
```

```
                   user     system      total        real
parallel       1.950000   0.030000   1.980000 (  2.031743)
sequentially   1.400000   0.010000   1.410000 (  1.497073)
```

@arthurnn @dylanahsmith, please take a look
