### PR TITLE
Correct test description for large integer test

### DIFF
--- a/activerecord/test/cases/type/integer_test.rb
+++ b/activerecord/test/cases/type/integer_test.rb
@@ -68,7 +68,7 @@ module ActiveRecord
         end
       end
 
-      test "very large numbers are in range" do
+      test "very large numbers are out of range" do
         assert_raises(::RangeError) do
           Integer.new.type_cast_from_user("9999999999999999999999999999999")
         end


### PR DESCRIPTION
I believe the description for this test should be "out of range" instead of "in range" since it is asserting a `RangeError` is raised. Just a small change, but it might be confusing in the future if the description of the test is reversed.
