### PR TITLE
Remove ecosystem link from guides

### DIFF
--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -36,7 +36,6 @@
         <li class="more-info"><a href="https://github.com/rails/rails">Code</a></li>
         <li class="more-info"><a href="http://rubyonrails.org/screencasts">Screencasts</a></li>
         <li class="more-info"><a href="http://rubyonrails.org/documentation">Documentation</a></li>
-        <li class="more-info"><a href="http://rubyonrails.org/ecosystem">Ecosystem</a></li>
         <li class="more-info"><a href="http://rubyonrails.org/community">Community</a></li>
         <li class="more-info"><a href="http://weblog.rubyonrails.org/">Blog</a></li>
       </ul>


### PR DESCRIPTION
Right now, there's an [ecosystem link](http://rubyonrails.org/ecosystem) in the header of [the guides pages](http://guides.rubyonrails.org):

![screen shot 2014-11-28 at 11 25 24](https://cloud.githubusercontent.com/assets/111963/5227336/c019a924-76f1-11e4-8be3-e52e82e5d9f2.png)

Unfortunately the ecosystem page no longer exists on rubyonrails.org.

![screen shot 2014-11-28 at 11 25 35](https://cloud.githubusercontent.com/assets/111963/5227338/c4ee463a-76f1-11e4-86a4-e9764a629cbf.png)

This PR removes that dead link.

_NOTES:_

I realise that this is a docrails change, but I wanted to double check first that there isn't a new, or better, page for ecosystem out there.
