### PR TITLE
Adds preloaded_records method to NullPreloader - fixes #16070

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -178,6 +178,7 @@ module ActiveRecord
       class NullPreloader
         def self.new(klass, owners, reflection, preload_scope); self; end
         def self.run(preloader); end
+        def self.preloaded_records; []; end
       end
 
       def preloader_for(reflection, owners, rhs_klass)

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -270,6 +270,14 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_three_level_nested_preloading_does_not_raise_exception_when_association_does_not_exist
+    post_id = Comment.where(author_id: nil).where.not(post_id: nil).first.post_id
+
+    assert_nothing_raised do
+      Post.preload(:comments => [{:author => :essays}]).find(post_id)
+    end
+  end
+
   def test_nested_loading_through_has_one_association
     aa = AuthorAddress.all.merge!(:includes => {:author => :posts}).find(author_addresses(:david_address).id)
     assert_equal aa.author.posts.count, aa.author.posts.length


### PR DESCRIPTION
This fixes a regression where preloading association throws an exception if one of the associations in the preloading hash doesn't exist for one record reported in #16070.

I experienced the same issue after upgrading to 4.1 from 4.0.

So I wrote up this patch. I don't know if this fix is correct. But my reasoning for adding `preloaded_records` to `NullPreloader` to return an empty array is this: every preloader has the `preloaded_records` attributes, which is initialized to an empty array. In order to for the NullPreloader to work as a preloader it needs this method.

If this solution is not correct, please tell me! I'll try to see what I can do. Any hints and ideas are appreciated! If nothing else, I at least have a test case with which to reproduce the error reported in #16070.
