### PR TITLE
Remove custom errors page section from the guides

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1164,66 +1164,9 @@ class ClientsController < ApplicationController
 end
 ```
 
-WARNING: You shouldn't do `rescue_from Exception` or `rescue_from StandardError` unless you have a particular reason as it will cause serious side-effects (e.g. you won't be able to see exception details and tracebacks during development). If you would like to dynamically generate error pages, see [Custom errors page](#custom-errors-page).
+WARNING: You shouldn't do `rescue_from Exception` or `rescue_from StandardError` unless you have a particular reason as it will cause serious side-effects (e.g. you won't be able to see exception details and tracebacks during development).
 
 NOTE: Certain exceptions are only rescuable from the `ApplicationController` class, as they are raised before the controller gets initialized and the action gets executed. See Pratik Naik's [article](http://m.onkey.org/2008/7/20/rescue-from-dispatching) on the subject for more information.
-
-
-### Custom errors page
-
-You can customize the layout of your error handling using controllers and views.
-First define your app own routes to display the errors page.
-
-* `config/application.rb`
-
-  ```ruby
-  config.exceptions_app = self.routes
-  ```
-
-* `config/routes.rb`
-
-  ```ruby
-  match '/404', via: :all, to: 'errors#not_found'
-  match '/422', via: :all, to: 'errors#unprocessable_entity'
-  match '/500', via: :all, to: 'errors#server_error'
-  ```
-
-Create the controller and views.
-
-* `app/controllers/errors_controller.rb`
-
-  ```ruby
-  class ErrorsController < ActionController::Base
-    layout 'error'
-
-    def not_found
-      render status: :not_found
-    end
-
-    def unprocessable_entity
-      render status: :unprocessable_entity
-    end
-
-    def server_error
-      render status: :server_error
-    end
-  end
-  ```
-
-* `app/views`
-
-  ```
-  errors/
-    not_found.html.erb
-    unprocessable_entity.html.erb
-    server_error.html.erb
-  layouts/
-    error.html.erb
-  ```
-
-Do not forget to set the correct status code on the controller as shown before.
-
-WARNING: You should avoid using the database or any complex operations because the user is already on the error page. Generating another error while on an error page could cause issues like presenting an empty page for the users.
 
 Force HTTPS protocol
 --------------------


### PR DESCRIPTION
This pattern is error-prone and introduces a lot of edge cases:
- On Rails 4.2, the issue https://github.com/rails/rails/issues/15124 is back again.
- needs to implement each action for each http status otherwise the router raises an `ActionController::RoutingError (No route matches)`.
- If the router has `match "/*username",...` and an error page action is missing, Rails would pick up the "match" route and try to render the user's page.
- encourages people to do copy & paste programming.

I've seen many people who have done this, most of which have run into an issue. I believe we should stop doing `config.exceptions_app = self.routes` and use static error pages, or use [the rambulance gem](github.com/yuki24/rambulance) as a temporary solution.