### PR TITLE
Prevent Numeric#to_s from allocating an array

### DIFF
--- a/activesupport/lib/active_support/core_ext/big_decimal/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/big_decimal/conversions.rb
@@ -3,14 +3,13 @@ require 'bigdecimal/util'
 
 class BigDecimal
   DEFAULT_STRING_FORMAT = 'F'
-  def to_formatted_s(*args)
-    if args[0].is_a?(Symbol)
-      super
+  alias_method :to_default_s, :to_s
+
+  def to_s(format = nil, options = nil)
+    if format.is_a?(Symbol)
+      to_formatted_s(format, options || {})
     else
-      format = args[0] || DEFAULT_STRING_FORMAT
-      _original_to_s(format)
+      to_default_s(format || DEFAULT_STRING_FORMAT)
     end
   end
-  alias_method :_original_to_s, :to_s
-  alias_method :to_s, :to_formatted_s
 end

--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -118,18 +118,28 @@ class Numeric
     end
   end
 
-  [Float, Fixnum, Bignum, BigDecimal].each do |klass|
-    klass.send(:alias_method, :to_default_s, :to_s)
-
-    klass.send(:define_method, :to_s) do |*args|
-      if args[0].is_a?(Symbol)
-        format = args[0]
-        options = args[1] || {}
-
-        self.to_formatted_s(format, options)
-      else
-        to_default_s(*args)
+  [Fixnum, Bignum].each do |klass|
+    klass.class_eval do
+      alias_method :to_default_s, :to_s
+      def to_s(base_or_format = 10, options = nil)
+        if base_or_format.is_a?(Symbol)
+          to_formatted_s(base_or_format, options || {})
+        else
+          to_default_s(base_or_format)
+        end
       end
     end
   end
+
+  Float.class_eval do
+    alias_method :to_default_s, :to_s
+    def to_s(*args)
+      if args.empty?
+        to_default_s
+      else
+        to_formatted_s(*args)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
`benchmark/ips` don't show any significant difference:

``` ruby
Benchmark.ips do |x|
  x.report('default_to_s') { 42.to_default_s }
  x.report('as_to_s') { 42.to_s }
end
```

before the patch:

```
        default_to_s    34.094k i/100ms
             as_to_s    30.675k i/100ms
-------------------------------------------------
        default_to_s      4.916M (± 9.0%) i/s -     24.241M
             as_to_s      2.382M (± 9.2%) i/s -     11.749M
```

after the patch:

```
Calculating -------------------------------------
        default_to_s    37.690k i/100ms
             as_to_s    34.579k i/100ms
-------------------------------------------------
        default_to_s      5.024M (±11.1%) i/s -     24.536M
             as_to_s      3.294M (± 6.3%) i/s -     16.390M
```

That being said the standard deviation is pretty high, and `MemoryProfiler` don't seems to agree that splat args allocate an array. In any case splat args are slightly more costly than regular arguments especially since https://bugs.ruby-lang.org/issues/9622
