### PR TITLE
Hide potentially sensitive ActiveJob params from logs

### DIFF
--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -6,8 +6,6 @@ module ActiveJob
   module Logging #:nodoc:
     extend ActiveSupport::Concern
 
-    FILTERED = '[FILTERED]'.freeze
-
     included do
       cattr_accessor(:logger) { ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT)) }
 
@@ -86,20 +84,20 @@ module ActiveJob
           event.payload[:adapter].name.demodulize.remove('Adapter') + "(#{event.payload[:job].queue_name})"
         end
 
-        def global_id_or_filtered(argument)
+        def global_id_or_inspected(argument)
           if argument.is_a?(GlobalID::Identification)
             argument.to_global_id.to_s
           else
-            FILTERED
+            argument.inspect
           end
         end
 
         def args_info(job)
           if job.arguments.any?
             ' with arguments: ' +
-              job.arguments.map { |arg| global_id_or_filtered(arg) }.join(', ')
+              job.arguments.map { |arg| global_id_or_inspected(arg) }.join(', ')
           else
-            ""
+            ''
           end
         end
 

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -85,11 +85,7 @@ module ActiveJob
         end
 
         def global_id_or_inspected(argument)
-          if argument.is_a?(GlobalID::Identification)
-            argument.to_global_id.to_s
-          else
-            argument.inspect
-          end
+          argument.try(:to_global_id).try(:to_s) || argument.inspect
         end
 
         def args_info(job)

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -84,14 +84,10 @@ module ActiveJob
           event.payload[:adapter].name.demodulize.remove('Adapter') + "(#{event.payload[:job].queue_name})"
         end
 
-        def global_id_or_inspected(argument)
-          argument.try(:to_global_id).try(:to_s) || argument.inspect
-        end
-
         def args_info(job)
           if job.arguments.any?
             ' with arguments: ' +
-              job.arguments.map { |arg| global_id_or_inspected(arg) }.join(', ')
+              job.arguments.map { |arg| arg.try(:to_global_id).try(:to_s) || arg.inspect }.join(', ')
           else
             ''
           end

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -42,24 +42,24 @@ class AdapterTest < ActiveSupport::TestCase
 
 
   def test_uses_active_job_as_tag
-    HelloJob.perform_later nil
+    HelloJob.perform_later "Cristian"
     assert_match(/\[ActiveJob\]/, @logger.messages)
   end
 
   def test_uses_job_name_as_tag
-    LoggingJob.perform_later nil
+    LoggingJob.perform_later "Dummy"
     assert_match(/\[LoggingJob\]/, @logger.messages)
   end
 
   def test_uses_job_id_as_tag
-    LoggingJob.perform_later nil
+    LoggingJob.perform_later "Dummy"
     assert_match(/\[LOGGING-JOB-ID\]/, @logger.messages)
   end
 
   def test_logs_correct_queue_name
     original_queue_name = LoggingJob.queue_name
     LoggingJob.queue_as :php_jobs
-    LoggingJob.perform_later nil
+    LoggingJob.perform_later("Dummy")
     assert_match(/to .*?\(php_jobs\).*/, @logger.messages)
   ensure
     LoggingJob.queue_name = original_queue_name
@@ -75,12 +75,12 @@ class AdapterTest < ActiveSupport::TestCase
 
   def test_enqueue_job_logging
     HelloJob.perform_later "Cristian"
-    assert_match(/Enqueued HelloJob \(Job ID: .*?\) to .*?:.*\[FILTERED\]/, @logger.messages)
+    assert_match(/Enqueued HelloJob \(Job ID: .*?\) to .*?:.*Cristian/, @logger.messages)
   end
 
   def test_perform_job_logging
     LoggingJob.perform_later "Dummy"
-    assert_match(/Performing LoggingJob from .*? with arguments:.*\[FILTERED\]/, @logger.messages)
+    assert_match(/Performing LoggingJob from .*? with arguments:.*Dummy/, @logger.messages)
     assert_match(/Dummy, here is it: Dummy/, @logger.messages)
     assert_match(/Performed LoggingJob from .*? in .*ms/, @logger.messages)
   end
@@ -90,8 +90,8 @@ class AdapterTest < ActiveSupport::TestCase
     assert_match(/\[LoggingJob\] \[.*?\]/, @logger.messages)
     assert_match(/\[ActiveJob\] Enqueued NestedJob \(Job ID: .*\) to/, @logger.messages)
     assert_match(/\[ActiveJob\] \[NestedJob\] \[NESTED-JOB-ID\] Performing NestedJob from/, @logger.messages)
-    assert_match(/\[ActiveJob\] \[NestedJob\] \[NESTED-JOB-ID\] Enqueued LoggingJob \(Job ID: .*?\) to .* with arguments: \[FILTERED\]/, @logger.messages)
-    assert_match(/\[ActiveJob\].*\[LoggingJob\] \[LOGGING-JOB-ID\] Performing LoggingJob from .* with arguments: \[FILTERED\]/, @logger.messages)
+    assert_match(/\[ActiveJob\] \[NestedJob\] \[NESTED-JOB-ID\] Enqueued LoggingJob \(Job ID: .*?\) to .* with arguments: "NestedJob"/, @logger.messages)
+    assert_match(/\[ActiveJob\].*\[LoggingJob\] \[LOGGING-JOB-ID\] Performing LoggingJob from .* with arguments: "NestedJob"/, @logger.messages)
     assert_match(/\[ActiveJob\].*\[LoggingJob\] \[LOGGING-JOB-ID\] Dummy, here is it: NestedJob/, @logger.messages)
     assert_match(/\[ActiveJob\].*\[LoggingJob\] \[LOGGING-JOB-ID\] Performed LoggingJob from .* in/, @logger.messages)
     assert_match(/\[ActiveJob\] \[NestedJob\] \[NESTED-JOB-ID\] Performed NestedJob from .* in/, @logger.messages)
@@ -99,14 +99,14 @@ class AdapterTest < ActiveSupport::TestCase
 
   def test_enqueue_at_job_logging
     HelloJob.set(wait_until: 24.hours.from_now).perform_later "Cristian"
-    assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*\[FILTERED\]/, @logger.messages)
+    assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
   rescue NotImplementedError
     skip
   end
 
   def test_enqueue_in_job_logging
     HelloJob.set(wait: 2.seconds).perform_later "Cristian"
-    assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*\[FILTERED\]/, @logger.messages)
+    assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
   rescue NotImplementedError
     skip
   end


### PR DESCRIPTION
- Show GlobalID instead of full object .inspect output

Latest iteration of #17746.
