### PR TITLE
fixed indent of end in jdom.rb

### DIFF
--- a/activesupport/lib/active_support/xml_mini/jdom.rb
+++ b/activesupport/lib/active_support/xml_mini/jdom.rb
@@ -141,7 +141,7 @@ module ActiveSupport
       (0...attributes.length).each do |i|
          attribute_hash[CONTENT_KEY] ||= ''
          attribute_hash[attributes.item(i).name] =  attributes.item(i).value
-       end
+      end
       attribute_hash
     end
 


### PR DESCRIPTION
'end' not aligned with the code block it concludes.  
