### PR TITLE
Pure rack apps can be mounted with a name

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -580,13 +580,7 @@ module ActionDispatch
           raise "A rack application must be specified" unless path
 
           rails_app = rails_app? app
-
-          if rails_app
-            options[:as]  ||= app.railtie_name
-          else
-            # non rails apps can't have an :as
-            options[:as]  = nil
-          end
+          options[:as] ||= app.railtie_name if rails_app
 
           target_as       = name_for_action(options[:as], path)
           options[:via] ||= :all

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -235,7 +235,7 @@ module ActionDispatch
 
         assert_equal [
           "Prefix Verb URI Pattern Controller#Action",
-          "            /foo        #{RackApp.name} {:constraint=>( my custom constraint )}"
+          "   foo      /foo        #{RackApp.name} {:constraint=>( my custom constraint )}"
         ], output
       end
 

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -123,6 +123,26 @@ module ApplicationTests
       assert_equal '/archives', last_response.body
     end
 
+    test "mount named rack app" do
+      controller :foo, <<-RUBY
+        class FooController < ApplicationController
+          def index
+            render text: my_blog_path
+          end
+        end
+      RUBY
+
+      app_file 'config/routes.rb', <<-RUBY
+        Rails.application.routes.draw do
+          mount lambda { |env| [200, {}, [env["PATH_INFO"]]] }, at: "/blog", as: "my_blog"
+          get '/foo' => 'foo#index'
+        end
+      RUBY
+
+      get '/foo'
+      assert_equal '/blog', last_response.body
+    end
+
     test "multiple controllers" do
       controller :foo, <<-RUBY
         class FooController < ApplicationController


### PR DESCRIPTION
This is a 4.2 regression from 4.1. In 4.1 you used to be able to name a mounted rack middleware. And the edgeapis still state it is possible.

See https://github.com/rails/rails/commit/9b15828b5c347395b42066a588c88e5eb4e72279#commitcomment-8764492

@rafaelfranca @tenderlove for review please.
