### PR TITLE
AR::RecordNotSaved & RecordNotDestroyed from save!/destroy! should include an error message

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -71,9 +71,9 @@ module ActiveRecord
   class RecordNotDestroyed < ActiveRecordError
     attr_reader :record
 
-    def initialize(record)
+    def initialize(message, record = nil)
       @record = record
-      super()
+      super(message)
     end
   end
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -148,7 +148,7 @@ module ActiveRecord
     # Attributes marked as readonly are silently ignored if the record is
     # being updated.
     def save!(*args)
-      create_or_update(*args) || raise(RecordNotSaved.new(nil, self))
+      create_or_update(*args) || raise(RecordNotSaved.new("Failed to save the record", self))
     end
 
     # Deletes the record in the database and freezes this instance to
@@ -193,7 +193,7 @@ module ActiveRecord
     # and #destroy! raises ActiveRecord::RecordNotDestroyed.
     # See ActiveRecord::Callbacks for further details.
     def destroy!
-      destroy || raise(ActiveRecord::RecordNotDestroyed, self)
+      destroy || raise(RecordNotDestroyed.new("Failed to destroy the record", self))
     end
 
     # Returns an instance of the specified +klass+ with the attributes of the

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2131,11 +2131,12 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     car = Car.create!
     original_child = FailedBulb.create!(car: car)
 
-    assert_raise(ActiveRecord::RecordNotDestroyed) do
+    error = assert_raise(ActiveRecord::RecordNotDestroyed) do
       car.failed_bulbs = [FailedBulb.create!]
     end
 
     assert_equal [original_child], car.reload.failed_bulbs
+    assert_equal "Failed to destroy the record", error.message
   end
 
   test 'updates counter cache when default scope is given' do

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -451,6 +451,7 @@ class CallbacksTest < ActiveRecord::TestCase
       assert !david.save
       exc = assert_raise(ActiveRecord::RecordNotSaved) { david.save! }
       assert_equal exc.record, david
+      assert_equal "Failed to save the record", exc.message
     end
 
     david = ImmutableDeveloper.find(1)
@@ -494,6 +495,7 @@ class CallbacksTest < ActiveRecord::TestCase
       assert !david.destroy
       exc = assert_raise(ActiveRecord::RecordNotDestroyed) { david.destroy! }
       assert_equal exc.record, david
+      assert_equal "Failed to destroy the record", exc.message
     end
     assert_not_nil ImmutableDeveloper.find_by_id(1)
 


### PR DESCRIPTION
When calling `AR::Base.save!` or `AR::Base.destroy!` and raising one of the exceptions, give a meaningful error message so that people can easily understand why it's failing to save/destroy.

cc @arthurnn @rafaelfranca
