### PR TITLE
Fix Sidekiq ActiveJob integration setup

### DIFF
--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -48,7 +48,8 @@ module SidekiqJobsManager
 
   def can_run?
     begin
-      Sidekiq.redis { |conn| conn.connect }
+      Sidekiq.redis { |conn| conn.info }
+      Sidekiq.logger = nil
     rescue
       return false
     end


### PR DESCRIPTION
- .connect on a Redis connection wasn't valid
- Reset logger after we're done testing for redis connection to avoid
  "closed stream" error when starting server for real from a fork

I'm not sure when this started happening, since these tests don't fail Travis (is that intentional?) even though they should work fine there.
