### PR TITLE
Fix OR in Journey patterns

### DIFF
--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -122,6 +122,11 @@ module ActionDispatch
             re = @matchers[node.left.to_sym] || '.+'
             "(#{re})"
           end
+
+          def visit_OR(node)
+            children = node.children.map { |n| visit n }
+            "(?:#{children.join(?|)})"
+          end
         end
 
         class UnanchoredRegexp < AnchoredRegexp # :nodoc:

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -16,6 +16,7 @@ module ActionDispatch
           '/:controller(.:format)'       => %r{\A/(#{x})(?:\.([^/.?]+))?\Z},
           '/:controller/*foo'            => %r{\A/(#{x})/(.+)\Z},
           '/:controller/*foo/bar'        => %r{\A/(#{x})/(.+)/bar\Z},
+          '/:foo|*bar'                   => %r{\A/(?:([^/.?]+)|(.+))\Z},
         }.each do |path, expected|
           define_method(:"test_to_regexp_#{path}") do
             strexp = Router::Strexp.build(
@@ -39,6 +40,7 @@ module ActionDispatch
           '/:controller(.:format)'       => %r{\A/(#{x})(?:\.([^/.?]+))?},
           '/:controller/*foo'            => %r{\A/(#{x})/(.+)},
           '/:controller/*foo/bar'        => %r{\A/(#{x})/(.+)/bar},
+          '/:foo|*bar'                   => %r{\A/(?:([^/.?]+)|(.+))},
         }.each do |path, expected|
           define_method(:"test_to_non_anchored_regexp_#{path}") do
             strexp = Router::Strexp.build(


### PR DESCRIPTION
Journey supported OR tokens right from the start (using the pipe character), they are translated into proper AST nodes. However, the rule for translating them into a regular expression was missing, so I added it.

I don't understand the router well enough (yet) to check if that's all that's needed to make them generally work. The code I actually started looking at, was the code for generating URLs, not sure if that works properly with OR literals in there. @tenderlove informed me, that he has some refactoring of said code pending, so I refrained from diving into it.

My main motivation for looking into this in the first place, was a conversation I had with @amatsuda about doing a spike on using [Mustermann](https://github.com/rkh/mustermann) in Rails to see if it would speed up url_helpers (it's really fast at expanding a URL pattern into a full URL).
