### PR TITLE
Remove UTF-8 magic comments

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 require 'set'
 

--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 require 'active_job'
 require 'minitest/mock'

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 
 class TestHelperMailer < ActionMailer::Base

--- a/actionpack/lib/action_dispatch/journey/nfa/dot.rb
+++ b/actionpack/lib/action_dispatch/journey/nfa/dot.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module ActionDispatch
   module Journey # :nodoc:
     module NFA # :nodoc:

--- a/actionpack/lib/action_dispatch/journey/visitors.rb
+++ b/actionpack/lib/action_dispatch/journey/visitors.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module ActionDispatch
   module Journey # :nodoc:
     class Format

--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 require 'active_support/core_ext/object/to_param'
 require 'active_support/core_ext/regexp'
 require 'active_support/dependencies/autoload'

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 require 'controller/fake_controllers'
 require 'active_support/core_ext/object/with_options'

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 
 module TestFileUtils

--- a/actionpack/test/controller/url_for_integration_test.rb
+++ b/actionpack/test/controller/url_for_integration_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 require 'controller/fake_controllers'
 require 'active_support/core_ext/object/with_options'

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 
 class MultipartParamsParsingTest < ActionDispatch::IntegrationTest

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 require 'erb'
 require 'abstract_unit'
 require 'controller/fake_controllers'

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 require 'rbconfig'
 require 'zlib'

--- a/actionpack/test/journey/router/utils_test.rb
+++ b/actionpack/test/journey/router/utils_test.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 require 'abstract_unit'
 
 module ActionDispatch

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 require 'abstract_unit'
 
 module ActionDispatch

--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/string/output_safety'
 require 'active_support/number_helper'

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'abstract_unit'
 require 'action_view/dependency_tracker'
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 require 'controller/fake_models'
 

--- a/actionview/test/template/streaming_render_test.rb
+++ b/actionview/test/template/streaming_render_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 
 class TestController < ActionController::Base

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 
 class TextHelperTest < ActionView::TestCase

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 require 'minitest/mock'
 

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 require 'active_support/core_ext/array/conversions'
 require 'active_support/core_ext/string/inflections'
 

--- a/activemodel/test/cases/validations/absence_validation_test.rb
+++ b/activemodel/test/cases/validations/absence_validation_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 require 'models/topic'
 require 'models/person'

--- a/activemodel/test/cases/validations/acceptance_validation_test.rb
+++ b/activemodel/test/cases/validations/acceptance_validation_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 
 require 'models/topic'

--- a/activemodel/test/cases/validations/callbacks_test.rb
+++ b/activemodel/test/cases/validations/callbacks_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 
 class Dog

--- a/activemodel/test/cases/validations/conditional_validation_test.rb
+++ b/activemodel/test/cases/validations/conditional_validation_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 
 require 'models/topic'

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 
 require 'models/topic'

--- a/activemodel/test/cases/validations/exclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/exclusion_validation_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 
 require 'models/topic'

--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 
 require 'models/topic'

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 require "cases/helper"
 require 'models/person'
 

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 require 'active_support/all'
 

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 
 require 'models/topic'

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 
 require 'models/topic'

--- a/activemodel/test/cases/validations/presence_validation_test.rb
+++ b/activemodel/test/cases/validations/presence_validation_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 
 require 'models/topic'

--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 require 'models/person'
 require 'models/topic'

--- a/activemodel/test/cases/validations/validations_context_test.rb
+++ b/activemodel/test/cases/validations/validations_context_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 
 require 'models/topic'

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 
 require 'models/topic'

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 
 require 'models/topic'

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 module ActiveRecord
   module NullRelation # :nodoc:
     def exec_queries

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require 'arel/collectors/bind'
 
 module ActiveRecord

--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "cases/helper"
 require 'support/ddl_helper'
 

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 
 class PostgresqlArrayTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require "cases/helper"
 require 'support/connection_helper'
 require 'support/schema_dumping_helper'

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 
 class PostgresqlByteaTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 
 if ActiveRecord::Base.connection.supports_extensions?

--- a/activerecord/test/cases/adapters/postgresql/composite_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/composite_test.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require "cases/helper"
 require 'support/connection_helper'
 

--- a/activerecord/test/cases/adapters/postgresql/domain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/domain_test.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require "cases/helper"
 require 'support/connection_helper'
 

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require "cases/helper"
 require 'support/connection_helper'
 

--- a/activerecord/test/cases/adapters/postgresql/full_text_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/full_text_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 
 class PostgresqlFullTextTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require "cases/helper"
 require 'support/connection_helper'
 require 'support/schema_dumping_helper'

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 
 if ActiveRecord::Base.connection.supports_extensions?

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 require 'support/schema_dumping_helper'
 

--- a/activerecord/test/cases/adapters/postgresql/ltree_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/ltree_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 
 class PostgresqlLtreeTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 require 'support/schema_dumping_helper'
 

--- a/activerecord/test/cases/adapters/postgresql/network_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/network_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 
 class PostgresqlNetworkTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 require 'support/ddl_helper'
 require 'support/connection_helper'

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 require 'support/schema_dumping_helper'
 

--- a/activerecord/test/cases/adapters/postgresql/xml_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/xml_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'cases/helper'
 
 class PostgresqlXMLTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 require 'models/owner'
 require 'tempfile'

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_create_folder_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_create_folder_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 require 'models/owner'
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "cases/helper"
 require 'active_support/concurrency/latch'
 require 'models/post'

--- a/activerecord/test/cases/binary_test.rb
+++ b/activerecord/test/cases/binary_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 
 # Without using prepared statements, it makes no sense to test

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'cases/helper'
 require 'models/company'
 require 'models/developer'

--- a/activerecord/test/cases/validations/length_validation_test.rb
+++ b/activerecord/test/cases/validations/length_validation_test.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require "cases/helper"
 require 'models/owner'
 require 'models/pet'

--- a/activerecord/test/cases/validations/presence_validation_test.rb
+++ b/activerecord/test/cases/validations/presence_validation_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 require 'models/man'
 require 'models/face'

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 require 'models/topic'
 require 'models/reply'

--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "cases/helper"
 require 'models/topic'
 require 'models/reply'

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 ActiveRecord::Schema.define do
   def except(adapter_names_to_exclude)
     unless [adapter_names_to_exclude].flatten.include?(adapter_name)

--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Object
   # An object is blank if it's false, empty, or a whitespace string.
   # For example, '', '   ', +nil+, [], and {} are all blank.

--- a/activesupport/lib/active_support/core_ext/string/multibyte.rb
+++ b/activesupport/lib/active_support/core_ext/string/multibyte.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'active_support/multibyte'
 
 class String

--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'uri'
 str = "\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E" # Ni-ho-nn-go in UTF-8, means Japanese.
 parser = URI::Parser.new

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'active_support/inflections'
 
 module ActiveSupport

--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'active_support/core_ext/string/multibyte'
 require 'active_support/i18n'
 

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'active_support/json'
 require 'active_support/core_ext/string/access'
 require 'active_support/core_ext/string/behavior'

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 module ActiveSupport
   module Multibyte
     module Unicode

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'abstract_unit'
 require 'active_support/core_ext/object/blank'
 

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'date'
 require 'abstract_unit'
 require 'inflector_test_cases'

--- a/activesupport/test/core_ext/uri_ext_test.rb
+++ b/activesupport/test/core_ext/uri_ext_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 require 'uri'
 require 'active_support/core_ext/uri'

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module InflectorTestCases
   SingularToPlural = {
     "search"      => "searches",

--- a/activesupport/test/json/decoding_test.rb
+++ b/activesupport/test/json/decoding_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 require 'active_support/json'
 require 'active_support/time'

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'securerandom'
 require 'abstract_unit'
 require 'active_support/core_ext/string/inflections'

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 require 'multibyte_test_helpers'
 require 'active_support/core_ext/string/multibyte'

--- a/activesupport/test/multibyte_conformance_test.rb
+++ b/activesupport/test/multibyte_conformance_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'abstract_unit'
 require 'multibyte_test_helpers'
 

--- a/activesupport/test/multibyte_proxy_test.rb
+++ b/activesupport/test/multibyte_proxy_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'abstract_unit'
 
 class MultibyteProxyText < ActiveSupport::TestCase

--- a/activesupport/test/multibyte_test_helpers.rb
+++ b/activesupport/test/multibyte_test_helpers.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module MultibyteTestHelpers
   UNICODE_STRING = 'こにちわ'.freeze
   ASCII_STRING = 'ohayo'.freeze

--- a/activesupport/test/multibyte_unicode_database_test.rb
+++ b/activesupport/test/multibyte_unicode_database_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 
 

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 require 'active_support/inflector/transliterate'
 

--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'redcarpet'
 require 'nokogiri'
 require 'rails_guides/markdown/renderer'

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require 'isolation/abstract_unit'
 require 'rack/test'
 require 'active_support/json'

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'isolation/abstract_unit'
 require 'rack/test'
 

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'isolation/abstract_unit'
 require 'rack/test'
 

--- a/railties/test/application/middleware/static_test.rb
+++ b/railties/test/application/middleware/static_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'isolation/abstract_unit'
 require 'rack/test'
 

--- a/railties/test/path_generation_test.rb
+++ b/railties/test/path_generation_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'abstract_unit'
 require 'active_support/core_ext/object/with_options'
 require 'active_support/core_ext/object/json'


### PR DESCRIPTION
They are not needed anymore since Rails now requires Ruby >= 2.1.
