### PR TITLE
Remove "annoying Ruby 1.9 hack"

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -109,12 +109,6 @@ module ActionDispatch
           svg         = to_svg
           javascripts = [states, fsm_js]
 
-          # Annoying hack for 1.9 warnings
-          fun_routes  = fun_routes
-          stylesheets = stylesheets
-          svg         = svg
-          javascripts = javascripts
-
           require 'erb'
           template = ERB.new erb
           template.result(binding)


### PR DESCRIPTION
The hack was introduced in 56fee39c392 to hide warnings displayed by Ruby 1.9.
Since Rails now requires Ruby 2, the hack can be removed.
