### PR TITLE
Remove hack to support BigDecimal in Ruby 1.9

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -78,17 +78,8 @@ end
 
 require 'bigdecimal'
 class BigDecimal
-  # Needed to support Ruby 1.9.x, as it doesn't allow dup on BigDecimal, instead
-  # raises TypeError exception. Checking here on the runtime whether BigDecimal
-  # will allow dup or not.
-  begin
-    BigDecimal.new('4.56').dup
-
-    def duplicable?
-      true
-    end
-  rescue TypeError
-    # can't dup, so use superclass implementation
+  def duplicable?
+    true
   end
 end
 

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -6,16 +6,7 @@ require 'active_support/core_ext/numeric/time'
 class DuplicableTest < ActiveSupport::TestCase
   RAISE_DUP  = [nil, false, true, :symbol, 1, 2.3, method(:puts)]
   ALLOW_DUP = ['1', Object.new, /foo/, [], {}, Time.now, Class.new, Module.new]
-
-  # Needed to support Ruby 1.9.x, as it doesn't allow dup on BigDecimal, instead
-  # raises TypeError exception. Checking here on the runtime whether BigDecimal
-  # will allow dup or not.
-  begin
-    bd = BigDecimal.new('4.56')
-    ALLOW_DUP << bd.dup
-  rescue TypeError
-    RAISE_DUP << bd
-  end
+  ALLOW_DUP << BigDecimal.new('4.56')
 
   def test_duplicable
     RAISE_DUP.each do |v|


### PR DESCRIPTION
Now that Rails requires Ruby >= 2.0, there is no need to check whether
`BigDecimal` exists or not.
