### PR TITLE
Remove Psych hack for Ruby 1.9

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -406,16 +406,7 @@ module Rails
 
     console do
       unless ::Kernel.private_method_defined?(:y)
-        if RUBY_VERSION >= '2.0'
-          require "psych/y"
-        else
-          module ::Kernel
-            def y(*objects)
-              puts ::Psych.dump_stream(*objects)
-            end
-            private :y
-          end
-        end
+        require "psych/y"
       end
     end
 


### PR DESCRIPTION
A special `if` statement to support `Psych` for Ruby < 2.0 can be
dropped now that Rails requires Ruby >= 2.0.
