### PR TITLE
Remove Sidekiq hack for Ruby 1.9

### DIFF
--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -11,13 +11,6 @@ def sidekiq?
   @adapter == 'sidekiq'
 end
 
-def ruby_193?
-  RUBY_VERSION == '1.9.3' && RUBY_ENGINE != 'java'
-end
-
-# Sidekiq doesn't work with MRI 1.9.3
-exit if sidekiq? && ruby_193?
-
 if ENV['AJ_INTEGRATION_TESTS']
   require 'support/integration/helper'
 else


### PR DESCRIPTION
Now that Rails requires Ruby >=2, there is no need to check if
Sidekiq works in the tests (that is, if Ruby >= 1.9.3).
