### PR TITLE
Remove LoadError#path hack for Ruby 1.9

### DIFF
--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -28,8 +28,6 @@ class DependenciesTest < ActiveSupport::TestCase
   end
 
   def test_depend_on_path
-    skip "LoadError#path does not exist" if RUBY_VERSION < '2.0.0'
-
     expected = assert_raises(LoadError) do
       Kernel.require 'omgwtfbbq'
     end


### PR DESCRIPTION
Now that Rails requires Ruby >= 2.0 there is need to skip the `test_depend_on_path` test.
