### PR TITLE
Remove Ruby 2.0.0-specific hack for ===

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -122,13 +122,6 @@ module ActiveSupport
 
     private
 
-      # We define it as a workaround to Ruby 2.0.0-p353 bug.
-      # For more information, check rails/rails#13055.
-      # Remove it when we drop support for 2.0.0-p353.
-      def ===(other) #:nodoc:
-        value === other
-      end
-
       def method_missing(method, *args, &block) #:nodoc:
         value.send(method, *args, &block)
       end


### PR DESCRIPTION
As suggested by @arthurnn in [this comment](https://github.com/rails/rails/pull/17830#issuecomment-64940837)
the hack can be removed now that Rails requires Ruby >= 2.1.
