### PR TITLE
Bump ruby version to 2.1.0 in rails.gemspec too.

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Full-stack web application framework.'
   s.description = 'Ruby on Rails is a full-stack web framework optimized for programmer happiness and sustainable productivity. It encourages beautiful code by favoring convention over configuration.'
 
-  s.required_ruby_version     = '>= 1.9.3'
+  s.required_ruby_version     = '>= 2.1.0'
   s.required_rubygems_version = '>= 1.8.11'
 
   s.license = 'MIT'


### PR DESCRIPTION
Commit #17830 ruby version bumped to 2.1.0 in all gemspecs, except rails.gemspec. Bump ruby version to 2.1.0 in rails.gemspec too.
