### PR TITLE
Minitest is not a runtime dependency

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'i18n',       '>= 0.7.0.beta1', '< 0.8'
   s.add_dependency 'json',       '~> 1.7', '>= 1.7.7'
   s.add_dependency 'tzinfo',     '~> 1.1'
-  s.add_dependency 'minitest',   '~> 5.1'
   s.add_dependency 'thread_safe','~> 0.1'
+
+  s.add_development_dependency 'minitest', '~> 5.1'
 end


### PR DESCRIPTION
I hope minitest is not a runtime dependency for `activesupport`, so to avoid it from being
installed for various runtime environments it should be specified as
development dependency.
