### PR TITLE
Fix link in documentation. [ci skip]

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -126,8 +126,8 @@ module ActionView #:nodoc:
   #     end
   #   end
   #
-  # For more information on Builder please consult the [source
-  # code](https://github.com/jimweirich/builder).
+  # For more information on Builder please consult the {source
+  # code}[https://github.com/jimweirich/builder].
   class Base
     include Helpers, ::ERB::Util, Context
 


### PR DESCRIPTION
Just simple fix for rdoc link syntax.
