### PR TITLE
Remove deprecated `reset_changes` and `reset_attribute!` methods.

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -200,15 +200,6 @@ module ActiveModel
         @changed_attributes = ActiveSupport::HashWithIndifferentAccess.new
       end
 
-      def reset_changes
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
-          `#reset_changes` is deprecated and will be removed on Rails 5.
-          Please use `#clear_changes_information` instead.
-        MSG
-
-        clear_changes_information
-      end
-
       # Handle <tt>*_change</tt> for +method_missing+.
       def attribute_change(attr)
         [changed_attributes[attr], __send__(attr)] if attribute_changed?(attr)
@@ -225,16 +216,6 @@ module ActiveModel
         end
 
         set_attribute_was(attr, value)
-      end
-
-      # Handle <tt>reset_*!</tt> for +method_missing+.
-      def reset_attribute!(attr)
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
-          `#reset_#{attr}!` is deprecated and will be removed on Rails 5.
-          Please use `#restore_#{attr}!` instead.
-        MSG
-
-        restore_attribute!(attr)
       end
 
       # Handle <tt>restore_*!</tt> for +method_missing+.

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -45,10 +45,6 @@ class DirtyTest < ActiveModel::TestCase
     def reload
       clear_changes_information
     end
-
-    def deprecated_reload
-      reset_changes
-    end
   end
 
   setup do
@@ -176,23 +172,6 @@ class DirtyTest < ActiveModel::TestCase
     assert_equal 'Dmitry', @model.changed_attributes['name']
 
     @model.reload
-
-    assert_equal ActiveSupport::HashWithIndifferentAccess.new, @model.previous_changes
-    assert_equal ActiveSupport::HashWithIndifferentAccess.new, @model.changed_attributes
-  end
-
-  test "reset_changes is deprecated" do
-    @model.name = 'Dmitry'
-    @model.name_changed?
-    @model.save
-    @model.name = 'Bob'
-
-    assert_equal [nil, 'Dmitry'], @model.previous_changes['name']
-    assert_equal 'Dmitry', @model.changed_attributes['name']
-
-    assert_deprecated do
-      @model.deprecated_reload
-    end
 
     assert_equal ActiveSupport::HashWithIndifferentAccess.new, @model.previous_changes
     assert_equal ActiveSupport::HashWithIndifferentAccess.new, @model.changed_attributes

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -165,18 +165,6 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal parrot.name_change, parrot.title_change
   end
 
-  def test_reset_attribute!
-    pirate = Pirate.create!(:catchphrase => 'Yar!')
-    pirate.catchphrase = 'Ahoy!'
-
-    assert_deprecated do
-      pirate.reset_catchphrase!
-    end
-    assert_equal "Yar!", pirate.catchphrase
-    assert_equal Hash.new, pirate.changes
-    assert !pirate.catchphrase_changed?
-  end
-
   def test_restore_attribute!
     pirate = Pirate.create!(:catchphrase => 'Yar!')
     pirate.catchphrase = 'Ahoy!'


### PR DESCRIPTION
Delivering a Rails 5 promise :wink:

cc @chancancode 
