### PR TITLE
test preloading a HABTM association with hash conditions

### DIFF
--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -902,4 +902,11 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
       DeveloperWithSymbolClassName.new
     end
   end
+
+  def test_preloaded_associations_size
+    assert_equal Project.first.developers.where(:name => 'David').size,
+      Project.preload(:developers_named_david).first.developers_named_david.size
+    assert_equal Project.first.developers.where(:name => 'David').size,
+      Project.preload(:developers_named_david_with_hash_conditions).first.developers_named_david.size
+  end
 end

--- a/activerecord/test/models/project.rb
+++ b/activerecord/test/models/project.rb
@@ -4,7 +4,7 @@ class Project < ActiveRecord::Base
   has_and_belongs_to_many :non_unique_developers, -> { order 'developers.name desc, developers.id desc' }, :class_name => 'Developer'
   has_and_belongs_to_many :limited_developers, -> { limit 1 }, :class_name => "Developer"
   has_and_belongs_to_many :developers_named_david, -> { where("name = 'David'").distinct }, :class_name => "Developer"
-  has_and_belongs_to_many :developers_named_david_with_hash_conditions, -> { where(:name => 'David').distinct }, :class_name => "Developer"
+  has_and_belongs_to_many :developers_named_david_with_hash_conditions, -> { where(:developers => {:name => 'David'}).distinct }, :class_name => "Developer"
   has_and_belongs_to_many :salaried_developers, -> { where "salary > 0" }, :class_name => "Developer"
   has_and_belongs_to_many :developers_with_callbacks, :class_name => "Developer", :before_add => Proc.new {|o, r| o.developers_log << "before_adding#{r.id || '<new>'}"},
                             :after_add => Proc.new {|o, r| o.developers_log << "after_adding#{r.id || '<new>'}"},


### PR DESCRIPTION
It's related to #15244 
I had some HABTM associations using where in the definition, which were working on rails 4.0 and started to fail on rails 4.1. I though it was a bug, but I just realized they work if I add :table_name to where conditions.

So I have fixed that kind of association in test/models/project.rb and added a test for this case.
