### PR TITLE
Includes HABTM returns correct size now

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Includes HABTM returns correct size now. It's caused by the join dependency
+    only instantiates one HABTM object because the join table hasn't a primary key.
+
+    Fixes #16032.
+
+    Examples:
+
+        before:
+
+        Project.first.salaried_developers.size # => 3
+        Project.includes(:salaried_developers).first.salaried_developers.size # => 1
+
+        after:
+
+        Project.first.salaried_developers.size # => 3
+        Project.includes(:salaried_developers).first.salaried_developers.size # => 3
+
+    *Bigxiang*
+
 *   Dump the default `nil` for PostgreSQL UUID primary key.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -151,7 +151,8 @@ module ActiveRecord
 
         message_bus.instrument('instantiation.active_record', payload) do
           result_set.each { |row_hash|
-            parent = parents[row_hash[primary_key]] ||= join_root.instantiate(row_hash, column_aliases)
+            parent_key = primary_key ? row_hash[primary_key] : row_hash
+            parent = parents[parent_key] ||= join_root.instantiate(row_hash, column_aliases)
             construct(parent, join_root, row_hash, result_set, seen, model_cache, aliases)
           }
         end
@@ -233,7 +234,7 @@ module ActiveRecord
       end
 
       def construct(ar_parent, parent, row, rs, seen, model_cache, aliases)
-        primary_id  = ar_parent.id
+        primary_id  = ar_parent.id || row
 
         parent.children.each do |node|
           if node.reflection.collection?

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -902,4 +902,23 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
       DeveloperWithSymbolClassName.new
     end
   end
+
+  def test_preloaded_associations_size
+    assert_equal Project.first.salaried_developers.size,
+      Project.preload(:salaried_developers).first.salaried_developers.size
+
+    assert_equal Project.includes(:salaried_developers).references(:salaried_developers).first.salaried_developers.size,
+      Project.preload(:salaried_developers).first.salaried_developers.size
+
+    # Nested HATBM
+    first_project = Developer.first.projects.first
+    preloaded_first_project =
+      Developer.preload(projects: :salaried_developers).
+        first.
+        projects.
+        detect { |p| p.id == first_project.id }
+
+    assert preloaded_first_project.salaried_developers.loaded?, true
+    assert_equal first_project.salaried_developers.size, preloaded_first_project.salaried_developers.size
+  end
 end


### PR DESCRIPTION
It's caused by the join dependency, only instantiates one HABTM object because the join table hasn't a primary key.
Updated commit from @bigxiang commit dbaa837

Fixes #16032.

Examples:

```
before:

Project.first.salaried_developers.size # => 3
Project.includes(:salaried_developers).first.salaried_developers.size # => 1

after:

Project.first.salaried_developers.size # => 3
Project.includes(:salaried_developers).first.salaried_developers.size # => 3
```
