### PR TITLE
FIX: absolute_path may be nil for code added via instance_eval

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -351,7 +351,7 @@ module Rails
 
           base.called_from = begin
             call_stack = if Kernel.respond_to?(:caller_locations)
-              caller_locations.map(&:absolute_path)
+              caller_locations.map { |l| l.absolute_path || l.path }
             else
               # Remove the line number from backtraces making sure we don't leave anything behind
               caller.map { |p| p.sub(/:\d+.*/, '') }


### PR DESCRIPTION
This is critical for RC2 cause we can not work around it:

```
class A
  def initialize
    instance_eval 'def b; c; end', File.expand_path(__FILE__)
  end

  def c
    puts caller_locations[0].path.nil?
    # false
    puts caller_locations[0].absolute_path.nil?
    # true
  end
end

A.new.b
```
