### PR TITLE
Pretty-print request params on exception page

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -1,5 +1,6 @@
 require 'action_controller/metal/exceptions'
 require 'active_support/core_ext/module/attribute_accessors'
+require 'pp'
 
 module ActionDispatch
   class ExceptionWrapper

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
@@ -10,7 +10,14 @@
   clean_params.delete("action")
   clean_params.delete("controller")
 
-  request_dump = clean_params.empty? ? 'None' : clean_params.inspect.gsub(',', ",\n")
+  request_dump = if clean_params.empty?
+    'None'
+  else
+    pretty_params = ""
+    PP.pp(clean_params, pretty_params, 200)
+
+    pretty_params
+  end
 
   def debug_hash(object)
     object.to_hash.sort_by { |k, _| k.to_s }.map { |k, v| "#{k}: #{v.inspect rescue $!.message}" }.join("\n")


### PR DESCRIPTION
Bringing some love to query params formatting on exception page.

_Before:_
![screen shot 2014-12-01 at 01 02 17](https://cloud.githubusercontent.com/assets/522155/5241917/4bf39cd8-78f6-11e4-97b5-630c901ca142.jpg)

_After:_
![screen shot 2014-12-01 at 01 02 00](https://cloud.githubusercontent.com/assets/522155/5241918/505ab856-78f6-11e4-9ede-d162ee851880.jpg)
