### PR TITLE
`_generate_paths_by_default` should always be private.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -522,6 +522,8 @@ module ActionDispatch
           define_method(:_generate_paths_by_default) do
             supports_path
           end
+
+          private :_generate_paths_by_default
         end
       end
 

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -21,6 +21,7 @@ PROCESS_COUNT = (ENV['N'] || 4).to_i
 
 require 'active_support/testing/autorun'
 require 'abstract_controller'
+require 'abstract_controller/railties/routes_helpers'
 require 'action_controller'
 require 'action_view'
 require 'action_view/testing/resolvers'
@@ -260,7 +261,7 @@ end
 module ActionController
   class Base
     # This stub emulates the Railtie including the URL helpers from a Rails application
-    include SharedTestRoutes.url_helpers
+    extend AbstractController::Railties::RoutesHelpers.with(SharedTestRoutes)
     include SharedTestRoutes.mounted_helpers
 
     self.view_paths = FIXTURE_LOAD_PATH


### PR DESCRIPTION
Related to https://github.com/rails/rails/commit/9685080a7677abfa5d288a81c3e078368c6bb67c#commitcomment-8778271. 

Let me know if (and where) I should add a test for this.
