### PR TITLE
Bugfix config.action_view.default_form_builder option

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1935,6 +1935,8 @@ module ActionView
   end
 
   ActiveSupport.on_load(:action_view) do
-    cattr_accessor(:default_form_builder) { ::ActionView::Helpers::FormBuilder }
+    cattr_accessor(:default_form_builder, instance_writer: false, instance_reader: false) do
+      ::ActionView::Helpers::FormBuilder
+    end
   end
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -494,6 +494,45 @@ module ApplicationTests
       assert last_response.body =~ /csrf\-param/
     end
 
+    test "default form builder specified as a string" do
+
+      app_file 'config/initializers/form_builder.rb', <<-RUBY
+      class CustomFormBuilder < ActionView::Helpers::FormBuilder
+        def text_field(attribute, *args)
+          label(attribute) + super(attribute, *args)
+        end
+      end
+      Rails.configuration.action_view.default_form_builder = "CustomFormBuilder"
+      RUBY
+
+      app_file 'app/models/post.rb', <<-RUBY
+      class Post
+        include ActiveModel::Model
+        attr_accessor :name
+      end
+      RUBY
+
+
+      app_file 'app/controllers/posts_controller.rb', <<-RUBY
+      class PostsController < ApplicationController
+        def index
+          render inline: "<%= begin; form_for(Post.new) {|f| f.text_field(:name)}; rescue => e; e.to_s; end %>"
+        end
+      end
+      RUBY
+
+      add_to_config <<-RUBY
+        routes.prepend do
+          resources :posts
+        end
+      RUBY
+
+      require "#{app_path}/config/environment"
+
+      get "/posts"
+      assert_match(/label/, last_response.body)
+    end
+
     test "default method for update can be changed" do
       app_file 'app/models/post.rb', <<-RUBY
       class Post


### PR DESCRIPTION
`default_form_builder` option don't currently work on Rails 4.1.1. 

I've instigated the issue and found that there is a method name 
here: https://github.com/rails/rails/blob/8ed5b46ce65db067eb583e902f851a1f60f5b406/actionview/lib/action_view/helpers/form_helper.rb#L1938

and here: https://github.com/rails/rails/blob/8ed5b46ce65db067eb583e902f851a1f60f5b406/actionview/lib/action_view/helpers/form_helper.rb#L1213

Method from the second link is overwiten by code under first link.

And the trickiest thing is that this is not reproducable in `ActionView` test suite because `FormHelperTest` instance where `form_for` is called in test don't inherit `ActionView::Base`, the instance where `form_for` is called in live application inherit this class.

```
[1141, 1150] in /Users/bogdan/.rvm/gems/ruby-2.1.5@talkable/gems/actionview-4.1.1/lib/action_view/helpers/form_helper.rb
   1141:             object = record_name
   1142:             object_name = model_name_from_record_or_class(object).param_key
   1143:           end
   1144:
   1145:           require 'byebug'; byebug
=> 1146:           builder = options[:builder] || default_form_builder
   1147:           builder.new(object_name, object, self, options)
   1148:         end
   1149:
   1150:         def default_form_builder
(byebug) is_a?(ActionView::Base)
true
(byebug)
```

`FormHelperTest` can not inherit `ActionView::Base` because of how the test env is designed:
https://github.com/rails/rails/blob/8ed5b46ce65db067eb583e902f851a1f60f5b406/actionview/test/template/form_helper_test.rb#L4

So the test here is writen for `Railtie` that is close to live application.

The best way to fix the issue is avoid unnecessary instance accessor for `default_form_builder` on `ActionView::Base`.
