### PR TITLE
Silence Minitest for plugin tests.

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
@@ -10,7 +10,9 @@ ActiveRecord::Migrator.migrations_paths << File.expand_path('../../db/migrate', 
 <% end -%>
 require "rails/test_help"
 
-Rails.backtrace_cleaner.remove_silencers!
+# Filter out Minitest backtrace while allowing backtrace from other libraries
+# to be shown.
+Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -57,6 +57,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "test/test_helper.rb" do |content|
       assert_match(/require.+test\/dummy\/config\/environment/, content)
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+test\/dummy\/db\/migrate/, content)
+      assert_match(/Minitest\.backtrace_filter = Minitest::BacktraceFilter\.new/, content)
     end
     assert_file "test/bukkits_test.rb", /assert_kind_of Module, Bukkits/
   end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/17340.

Rails::BacktraceCleaner's silencers are removed to obtain the full backtrace for all libraries included in the plugin which can be helpful when debugging errors. However, we will silence traces for Minitest as it adds noise to the backtrace.

cc/ @rafaelfranca  @chancancode 
