### PR TITLE
Fix documentation for ActionMailer::Base#default

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -493,7 +493,7 @@ module ActionMailer
 
       # Sets the defaults through app configuration:
       #
-      #     config.action_mailer.default { from: "no-reply@example.org" }
+      #     config.action_mailer.default(from: "no-reply@example.org")
       #
       # Aliased by ::default_options=
       def default(value = nil)


### PR DESCRIPTION
Just a little syntax error I spotted by accident. Cannot pass hash with curly braces without normal parentheses.
