### PR TITLE
Fixed passing path without leading slash to request helpers in integration tests

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -309,7 +309,7 @@ module ActionDispatch
         end
 
         def build_full_uri(path, env)
-          "#{env['rack.url_scheme']}://#{env['SERVER_NAME']}:#{env['SERVER_PORT']}#{path}"
+          URI.join("#{env['rack.url_scheme']}://#{env['SERVER_NAME']}:#{env['SERVER_PORT']}", path).to_s
         end
     end
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -506,6 +506,13 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_passing_path_without_leading_slash
+    with_test_route_set do
+      get 'get'
+      assert_equal 200, status
+    end
+  end
+
   private
     def with_test_route_set
       with_routing do |set|


### PR DESCRIPTION
In rails 4.1.x it was possible to call `get "some-path"` without leading slash in integration tests.
This is no longer true in 4.1.2.rc1.

``` Ruby
# Activate the gem you are reporting the issue against.
# gem 'rails', '4.1.8'
gem "rails", "4.2.0.rc1"

require 'rails'
require 'action_controller/railtie'

class TestApp < Rails::Application
  config.root = File.dirname(__FILE__)
  config.session_store :cookie_store, key: 'cookie_store_key'
  secrets.secret_token    = 'secret_token'
  secrets.secret_key_base = 'secret_key_base'

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger

  routes.draw do
    get '/testing' => 'test#index'
  end
end

class TestController < ActionController::Base
  include Rails.application.routes.url_helpers

  def index
    render text: 'Home'
  end
end

require 'minitest/autorun'
require 'rack/test'

class BugTest < ActionDispatch::IntegrationTest

  def test_returns_success
    get 'testing'
    assert_equal 200, response.status
  end

  private
    def app
      Rails.application
    end
end
```

This fails with:

```
  1) Error:
BugTest#test_returns_success:
URI::InvalidURIError: the scheme http does not accept registry part: www.example.com:80testing (or bad hostname?)
    /home/wojtek/.rbenv/versions/2.1.2/lib/ruby/2.1.0/uri/generic.rb:214:in `initialize'
    /home/wojtek/.rbenv/versions/2.1.2/lib/ruby/2.1.0/uri/http.rb:84:in `initialize'
    /home/wojtek/.rbenv/versions/2.1.2/lib/ruby/2.1.0/uri/common.rb:214:in `new'
    /home/wojtek/.rbenv/versions/2.1.2/lib/ruby/2.1.0/uri/common.rb:214:in `parse'
    /home/wojtek/.rbenv/versions/2.1.2/lib/ruby/2.1.0/uri/common.rb:747:in `parse'
    /home/wojtek/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rack-test-0.6.2/lib/rack/test.rb:179:in `env_for'
    /home/wojtek/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rack-test-0.6.2/lib/rack/test.rb:122:in `request'
    /home/wojtek/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/actionpack-4.2.0.rc1/lib/action_dispatch/testing/integration.rb:297:in `process'
    /home/wojtek/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/actionpack-4.2.0.rc1/lib/action_dispatch/testing/integration.rb:32:in `get'
    /home/wojtek/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/actionpack-4.2.0.rc1/lib/action_dispatch/testing/integration.rb:344:in `block (2 levels) in <module:Runner>'
    route-test-minitest.rb:36:in `test_returns_success'
```

I'm not sure if I placed test in a proper place, please let me know if something can be improved
