### PR TITLE
Remove unused AV/test/fixtures/blog_public

### DIFF
--- a/actionview/test/fixtures/blog_public/.gitignore
+++ b/actionview/test/fixtures/blog_public/.gitignore
@@ -1,1 +1,0 @@
-absolute/*

--- a/actionview/test/fixtures/blog_public/blog.html
+++ b/actionview/test/fixtures/blog_public/blog.html
@@ -1,1 +1,0 @@
-/blog/blog.html

--- a/actionview/test/fixtures/blog_public/index.html
+++ b/actionview/test/fixtures/blog_public/index.html
@@ -1,1 +1,0 @@
-/blog/index.html

--- a/actionview/test/fixtures/blog_public/subdir/index.html
+++ b/actionview/test/fixtures/blog_public/subdir/index.html
@@ -1,1 +1,0 @@
-/blog/subdir/index.html


### PR DESCRIPTION
The fixtures were added to support StaticTests in 401cd97 but
those tests were then removed in d5ad92ce.

If Travis CI is happy with this PR, then you can be sure that
those fixtures are not needed anymore.
