### PR TITLE
Remove one AV fixture (duplicate of an AP fixture)

### DIFF
--- a/actionview/test/fixtures/functional_caching/fragment_cached_without_digest.html.erb
+++ b/actionview/test/fixtures/functional_caching/fragment_cached_without_digest.html.erb
@@ -1,3 +1,0 @@
-<body>
-<%= cache 'nodigest', skip_digest: true do %><p>ERB</p><% end %>
-</body>


### PR DESCRIPTION
Both ActionPack and ActionView include `test/fixtures/functional_caching/fragment_cached_without_digest.html.erb`.

The [ActionPack file](https://github.com/rails/rails/blob/master/actionpack/test/fixtures/functional_caching/fragment_cached_without_digest.html.erb) is used by the tests.

The [ActionView file](https://github.com/rails/rails/blob/master/actionview/test/fixtures/functional_caching/fragment_cached_without_digest.html.erb) is not: it was introduced in eb23754e when some tests and
fixtures were moved from AP to AV, but no tests in AV uses the fixture.

Long story short: if Travis CI is happy with removing the fixture, you can
be sure that is not needed anymore!
