### PR TITLE
reverse_order being called for all batch calls as a fix for the issue when using find_in_batches and reverse_order

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,1 +1,2 @@
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activerecord/CHANGELOG.md) for previous changes.
+reverse_order will be called for all batch calls as a fix for the issue when using find_in_batches and reverse_order

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -113,7 +113,7 @@ module ActiveRecord
         logger.warn("Scoped order and limit are ignored, it's forced to be batch order and batch size")
       end
 
-      relation = relation.reorder(batch_order).limit(batch_size)
+      relation = relation.reverse_order.reorder(batch_order).limit(batch_size)
       records = start ? relation.where(table[primary_key].gteq(start)).to_a : relation.to_a
 
       while records.any?


### PR DESCRIPTION
I am not sure if the is the right fix, but this works just fine. Kindly explain if not. 
Will write tests if this seems fine.

```
2.1.0 :002 > Post.where('id < ?', 100).reverse_order.find_in_batches(batch_size: 10) { |batch| puts batch.map(&:id).to_s }
Scoped order and limit are ignored, it's forced to be batch order and batch size
  Post Load (0.2ms)  SELECT  "posts".* FROM "posts" WHERE (id < 100)  ORDER BY "posts"."id" ASC LIMIT 10
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
  Post Load (0.1ms)  SELECT  "posts".* FROM "posts" WHERE (id < 100) AND ("posts"."id" > 10)  ORDER BY "posts"."id" ASC LIMIT 10
[11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
  Post Load (0.1ms)  SELECT  "posts".* FROM "posts" WHERE (id < 100) AND ("posts"."id" > 20)  ORDER BY "posts"."id" ASC LIMIT 10
[21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
  Post Load (0.1ms)  SELECT  "posts".* FROM "posts" WHERE (id < 100) AND ("posts"."id" > 30)  ORDER BY "posts"."id" ASC LIMIT 10
 => nil 
```

```
2.1.0 :003 > Post.where('id < ?', 100).find_in_batches(batch_size: 10) { |batch| puts batch.map(&:id).to_s }
  Post Load (39.0ms)  SELECT  "posts".* FROM "posts" WHERE (id < 100)  ORDER BY "posts"."id" ASC LIMIT 10
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
  Post Load (0.2ms)  SELECT  "posts".* FROM "posts" WHERE (id < 100) AND ("posts"."id" > 10)  ORDER BY "posts"."id" ASC LIMIT 10
[11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
  Post Load (4.5ms)  SELECT  "posts".* FROM "posts" WHERE (id < 100) AND ("posts"."id" > 20)  ORDER BY "posts"."id" ASC LIMIT 10
[21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
  Post Load (0.1ms)  SELECT  "posts".* FROM "posts" WHERE (id < 100) AND ("posts"."id" > 30)  ORDER BY "posts"."id" ASC LIMIT 10
 => nil 
```
