### PR TITLE
Remove unused AV/test/fixtures/happy_path

### DIFF
--- a/actionview/test/fixtures/happy_path/render_action/hello_world.erb
+++ b/actionview/test/fixtures/happy_path/render_action/hello_world.erb
@@ -1,1 +1,0 @@
-Hello world!


### PR DESCRIPTION
The `test/fixtures/happy_path/render_action/hello_world.erb` file was introduced in 8ab37c7 for the `TestRenderAction` test.

That test was subsequently removed in 34f058e, so the fixture is not used anymore.

Once Travis CI is happy with this PR, you can be sure the fixture can be removed.
