### PR TITLE
Remove unused AV/test/fixtures/scope

### DIFF
--- a/actionview/test/fixtures/scope/test/modgreet.erb
+++ b/actionview/test/fixtures/scope/test/modgreet.erb
@@ -1,1 +1,0 @@
-<p>Beautiful modules!</p>


### PR DESCRIPTION
The file `modgreet.erb` was added 8 years ago in 21187c0 and is not used anymore by any test.

Once Travis CI is happy with this PR, you can be sure that the fixture can be removed.
