### PR TITLE
Allow to unscope where conditions by arel_table with symbol

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -909,7 +909,7 @@ module ActiveRecord
         case rel
         when Arel::Nodes::Between, Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality, Arel::Nodes::NotEqual, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThanOrEqual
           subrelation = (rel.left.kind_of?(Arel::Attributes::Attribute) ? rel.left : rel.right)
-          subrelation.name == target_value
+          subrelation.name.to_s == target_value
         end
       end
 

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -143,6 +143,14 @@ class DefaultScopingTest < ActiveRecord::TestCase
     expected_5 = Developer.order('salary DESC').collect(&:name)
     received_5 = DeveloperOrderedBySalary.where.not("name" => ["Jamis", "David"]).unscope(where: :name).collect(&:name)
     assert_equal expected_5, received_5
+
+    expected_6 = Developer.order('salary DESC').collect(&:name)
+    received_6 = DeveloperOrderedBySalary.where(Developer.arel_table['name'].eq('David')).unscope(where: :name).collect(&:name)
+    assert_equal expected_6, received_6
+
+    expected_7 = Developer.order('salary DESC').collect(&:name)
+    received_7 = DeveloperOrderedBySalary.where(Developer.arel_table[:name].eq('David')).unscope(where: :name).collect(&:name)
+    assert_equal expected_7, received_7
   end
 
   def test_unscope_multiple_where_clauses


### PR DESCRIPTION
This commit fixes the following case.

``` ruby
User.where(User.arel_table[:created_at].lteq(1.year.ago)).unscope(where :created_at)
```

reproduction on rails console

```
[1] pry(main)> User.where(User.arel_table['created_at'].lteq(1.year.ago)).unscope(where: :created_at).to_sql
=> "SELECT `users`.* FROM `users`"
[2] pry(main)> User.where(User.arel_table[:created_at].lteq(1.year.ago)).unscope(where: :created_at).to_sql
=> "SELECT `users`.* FROM `users`  WHERE (`users`.`created_at` <= '2013-12-02 11:43:25')"
```

I guess it works before this commit. https://github.com/rails/rails/commit/492bad71f384c71e7e2708d6733d69f478657613
