### PR TITLE
remove useless methods

### DIFF
--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -123,16 +123,6 @@ module ActiveRecord
       end
     end
 
-    protected
-
-      def actually_destroyed?
-        @_actually_destroyed
-      end
-
-      def clear_destroy_state
-        @_actually_destroyed = nil
-      end
-
     private
 
       def _create_record(*)


### PR DESCRIPTION
```
grep -nr 'actually_destroyed?' .
grep -nr 'clear_destroy_state' .
```
