### PR TITLE
Remove "rescue" clause around "require 'openssl'"

### DIFF
--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -1,12 +1,5 @@
 require 'abstract_unit'
-
-begin
-  require 'openssl'
-  OpenSSL::PKCS5
-rescue LoadError, NameError
-  $stderr.puts "Skipping KeyGenerator test: broken OpenSSL install"
-else
-
+require 'openssl'
 require 'active_support/key_generator'
 require 'active_support/message_verifier'
 
@@ -1154,6 +1147,4 @@ class CookiesTest < ActionController::TestCase
         assert_not_equal expected.split("\n"), header
       end
     end
-end
-
 end

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -1,12 +1,5 @@
 require 'abstract_unit'
-
-begin
-  require 'openssl'
-  OpenSSL::Digest::SHA1
-rescue LoadError, NameError
-  $stderr.puts "Skipping MessageEncryptor test: broken OpenSSL install"
-else
-
+require 'openssl'
 require 'active_support/time'
 require 'active_support/json'
 
@@ -96,6 +89,4 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     bits.reverse!
     ::Base64.strict_encode64(bits)
   end
-end
-
 end

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -1,12 +1,5 @@
 require 'abstract_unit'
-
-begin
-  require 'openssl'
-  OpenSSL::Digest::SHA1
-rescue LoadError, NameError
-  $stderr.puts "Skipping MessageVerifier test: broken OpenSSL install"
-else
-
+require 'openssl'
 require 'active_support/time'
 require 'active_support/json'
 
@@ -41,11 +34,11 @@ class MessageVerifierTest < ActiveSupport::TestCase
     assert_equal @data, @verifier.verified(message)
     assert_equal @data, @verifier.verify(message)
   end
-  
+
   def test_verified_returns_false_on_invalid_message
     assert !@verifier.verified("purejunk")
   end
-  
+
   def test_verify_exception_on_invalid_message
     assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
       @verifier.verify("purejunk")
@@ -89,6 +82,4 @@ class MessageVerifierTest < ActiveSupport::TestCase
     end
     assert_equal exception.message, 'Secret should not be nil.'
   end
-end
-
 end


### PR DESCRIPTION
Some `require 'openssl'` statements were surrounded by `rescue` blocks to deal with Ruby versions that did not support `OpenSSL::Digest::SHA1` or `OpenSSL::PKCS5`.

[As @jeremy explains](https://github.com/rails/rails/commit/a6a0904fcb12b876469c48b1c885aadafe9188cf#commitcomment-8826666) in the original commit:

> If jruby didn't have jruby-openssl gem, the require wouldn't work. Not sure whether either of these are still relevant today.

According to the [release notes for JRuby 1.7.13](http://www.jruby.org/2014/06/24/jruby-1-7-13.html):

> jruby-openssl 0.9.5 bundled

which means the above `rescue` block should not be needed anymore.

All the Ruby versions supported by the current version of Rails provide those OpenSSL libraries, so Travis CI should also be happy by removing the `rescue` blocks.

---

Just to confirm, with JRuby:

```
$ ruby --version #=> jruby 1.7.16.1 (1.9.3p392) 2014-10-28 4e93f31 on Java HotSpot(TM) 64-Bit Server VM 1.8.0_20-b26 +jit [darwin-x86_64]
$ irb
irb(main):001:0> require 'openssl' #=> true
irb(main):002:0> OpenSSL::Digest::SHA1 #=> OpenSSL::Digest::SHA1
irb(main):003:0> OpenSSL::PKCS5 # => OpenSSL::PKCS5
```

And with Ruby 2.1:

```
$ ruby --version #=> ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-darwin13.0]
$ irb
irb(main):001:0> require 'openssl' #=> true
irb(main):002:0> OpenSSL::Digest::SHA1 #=> OpenSSL::Digest::SHA1
irb(main):003:0> OpenSSL::PKCS5 #=> OpenSSL::PKCS5
```
