### PR TITLE
Prevent Symbol GC

### DIFF
--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -53,10 +53,13 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_symbols_table_ref
+    gc_disabled = GC.disable if RUBY_VERSION >= '2.2.0'
     Post.where("author_id" => nil)  # warm up
     x = Symbol.all_symbols.count
     Post.where("title" => {"xxxqqqq" => "bar"})
     assert_equal x, Symbol.all_symbols.count
+  ensure
+    GC.enable if gc_disabled == false
   end
 
   # find should handle strings that come from URLs


### PR DESCRIPTION
Test failure in ruby-head , I think maybe that it caused Symbol GC.

https://travis-ci.org/rails/rails/jobs/42937185#L207-L210

```
  1) Failure:
FinderTest#test_symbols_table_ref [/home/travis/build/rails/rails/activerecord/test/cases/finder_test.rb:59]:
Expected: 33348
  Actual: 33345
```
