### PR TITLE
remove unused #await_close

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -189,12 +189,6 @@ module ActionController
         !@aborted
       end
 
-      def await_close
-        synchronize do
-          @cv.wait_until { @closed }
-        end
-      end
-
       def on_error(&block)
         @error_callback = block
       end


### PR DESCRIPTION
The method was added in https://github.com/rails/rails/commit/30d21dfcb7fafe49b3805b8249454485a90097b6#diff-5055d9f16b442adb1d2f0f65903a196bR141.
With the method call in https://github.com/rails/rails/commit/30d21dfcb7fafe49b3805b8249454485a90097b6#diff-cc7bb557df2247c0a42bc180fdb6eb05R47.
Later one more method call was added in https://github.com/rails/rails/commit/401787db4bc428dce88b04e343a64c6a6c3b681c#diff-cc7bb557df2247c0a42bc180fdb6eb05R183.
And both method calls were deleted in https://github.com/rails/rails/commit/3df07d093a1e4207caa63fd2e3b67599211f5800#diff-cc7bb557df2247c0a42bc180fdb6eb05L47 and https://github.com/rails/rails/commit/3df07d093a1e4207caa63fd2e3b67599211f5800#diff-cc7bb557df2247c0a42bc180fdb6eb05L189.

Just do `grep -nr 'await_close' .`.
