### PR TITLE
Fix MessageVerifier's #verified in CHANGELOG

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,9 +1,9 @@
 *   Added `#verified` and `#valid_message?` methods to `ActiveSupport::MessageVerifier`
-    
-    Previously, the only way to decode a message with `ActiveSupport::MessageVerifier` was to use `#verify`, which would raise an exception on invalid messages. Now, `#verified` will return either `false` when it encounters an error or the message.
-    
+
+    Previously, the only way to decode a message with `ActiveSupport::MessageVerifier` was to use `#verify`, which would raise an exception on invalid messages. Now `#verified` can also be used, which returns `nil` on messages that cannot be decoded.
+
     Previously, there was no way to check if a message's format was valid without attempting to decode it. `#valid_message?` is a boolean convenience method that checks whether the message is valid without actually decoding it.
-    
+
     *Logan Leger*
 
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activesupport/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
[ci skip]

As confirmed by @lleger (the author of `verified`) [in this comment](https://github.com/rails/rails/pull/17727#issuecomment-65488743):

> Actually, it no longer returns false explicitly (bc8cc56), so I guess the CHANGELOG isn't totally accurate. It returns nil instead (but the functionality isn't practically different).
