### PR TITLE
Fix AR::Relation to unscope exlusive range conditions

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -906,11 +906,8 @@ module ActiveRecord
       target_value = target_value.to_s
 
       where_values.reject! do |rel|
-        case rel
-        when Arel::Nodes::Between, Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality, Arel::Nodes::NotEqual, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThanOrEqual
-          subrelation = (rel.left.kind_of?(Arel::Attributes::Attribute) ? rel.left : rel.right)
-          subrelation.name.to_s == target_value
-        end
+        next unless rel.kind_of?(Arel::Nodes::Node)
+        rel.none? { |node| node.kind_of?(Arel::Attributes::Attribute) && node.name.to_s != target_value }
       end
 
       bind_values.reject! { |col,_| col.name == target_value }

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -157,6 +157,13 @@ module ActiveRecord
       assert_equal Post.where(comments_count: 3..5), relation
     end
 
+    def test_rewhere_with_exclusive_range
+      relation = Post.where(comments_count: 1...3).rewhere(comments_count: 3..5)
+
+      assert_equal 1, relation.where_values.size
+      assert_equal Post.where(comments_count: 3..5), relation
+    end
+
     def test_rewhere_with_infinite_upper_bound_range
       relation = Post.where(comments_count: 1..Float::INFINITY).rewhere(comments_count: 3..5)
 


### PR DESCRIPTION
An inclusive range condition like `where(created_at: 1.day.ago..Time.now)` works, but an exclusive one like `where(created_at: 1.day.ago...Time.now)` doesn't.

reproduction on rails console

```
irb(main):001:0> User.unscoped.where(created_at: 1.day.ago...Time.now).unscope(where: :created_at).to_sql
=> "SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"created_at\" >= '2014-12-03 17:28:01.731356' AND \"users\".\"created_at\" < '2014-12-04 17:28:01.731977')"
```

An exclusive range condition turns to `Arel::Node::And` that contains `Arel::Nodes::GreaterThanOrEqual` and `Arel::Nodes::LessThan`. Previous logic doesn't work with `Arel::Node::And`. So I refactored to detect `Arel::Attributes::Attribute` directly.
