### PR TITLE
Deprecate `Class` handler in `PredicateBuilder`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecate passing a class as a value in a query. Users should pass strings
+    instead.
+
+    *Melanie Gilman*
+
 *   `add_timestamps` and `remove_timestamps` now properly reversible with
     options.
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -712,7 +712,9 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_find_by_classname
     Author.create!(:name => Mary.name)
-    assert_equal 1, Author.where(:name => Mary).size
+    assert_deprecated do
+      assert_equal 1, Author.where(:name => Mary).size
+    end
   end
 
   def test_find_by_id_with_list_of_ar


### PR DESCRIPTION
Users should pass strings to queries instead of classes
