### PR TITLE
Redefine attribute methods after the column information have been reset

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -304,6 +304,8 @@ module ActiveRecord
         @default_attributes = nil
         @inheritance_column = nil unless defined?(@explicit_inheritance_column) && @explicit_inheritance_column
         @relation           = nil
+
+        define_attribute_methods
       end
 
       private

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -698,6 +698,13 @@ class DirtyTest < ActiveRecord::TestCase
     assert binary.changed?
   end
 
+  test "reset_column_information redefine attribute methods" do
+    model = Person.first!
+    assert model.respond_to?(:id_changed?)
+    Person.reset_column_information
+    assert model.respond_to?(:id_changed?)
+  end
+
   private
     def with_partial_writes(klass, on = true)
       old = klass.partial_writes?


### PR DESCRIPTION
Fixes: https://github.com/rails/rails/issues/17900

@sgrif for review please.
