### PR TITLE
Remove environment dependency for db:schema:load

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -240,7 +240,7 @@ db_namespace = namespace :db do
     end
 
     desc 'Load a schema.rb file into the database'
-    task :load => [:environment, :load_config] do
+    task :load => [:load_config] do
       ActiveRecord::Tasks::DatabaseTasks.load_schema_current(:ruby, ENV['SCHEMA'])
     end
 


### PR DESCRIPTION
All of the behavior :environment was giving (that db:schema:load needed) was
provided as well with :load_config.

This will address an issue introduced in
https://github.com/rails/rails/pull/15394. The fact that db:schema:load now
drops and creates the database causes the Octopus gem to have [an
issue](https://github.com/tchandy/octopus/issues/273) during the drop step for
the test database (which wasn't happening in db:schema:load before). The error
looks like:

```
    ActiveRecord::StatementInvalid: PG::ObjectInUse: ERROR:  cannot drop the currently open database
    : DROP DATABASE IF EXISTS "app_test"
```

Because of the timing, this issue is present in master, 4-2-*, and 4.1.8.

Ping @sgrif
