### PR TITLE
Fix typo in "Hello World" template in German

### DIFF
--- a/actionpack/test/controller/localized_templates_test.rb
+++ b/actionpack/test/controller/localized_templates_test.rb
@@ -19,7 +19,7 @@ class LocalizedTemplatesTest < ActionController::TestCase
   def test_localized_template_is_used
     I18n.locale = :de
     get :hello_world
-    assert_equal "Gutten Tag", @response.body
+    assert_equal "Guten Tag", @response.body
   end
 
   def test_default_locale_template_is_used_when_locale_is_missing
@@ -34,7 +34,7 @@ class LocalizedTemplatesTest < ActionController::TestCase
     I18n.fallbacks[:"de-AT"] = [:de]
 
     get :hello_world
-    assert_equal "Gutten Tag", @response.body
+    assert_equal "Guten Tag", @response.body
   end
 
   def test_localized_template_has_correct_header_with_no_format_in_template_name

--- a/actionpack/test/fixtures/localized/hello_world.de.html
+++ b/actionpack/test/fixtures/localized/hello_world.de.html
@@ -1,1 +1,1 @@
-Gutten Tag
+Guten Tag


### PR DESCRIPTION
I triple checked this with my A1 German teacher :laughing:.

[ci skip]
