### PR TITLE
remove unused `#form_data?`

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -282,8 +282,16 @@ module ActionDispatch
       end
     end
 
+    # Determine whether the request body contains form-data by checking
+    # the request Content-Type for one of the media-types:
+    # "application/x-www-form-urlencoded" or "multipart/form-data". The
+    # list of form-data media types can be modified through the
+    # +FORM_DATA_MEDIA_TYPES+ array.
+    #
+    # A request body is not assumed to contain form-data when no
+    # Content-Type header is provided and the request_method is POST.
     def form_data?
-      FORM_DATA_MEDIA_TYPES.include?(content_mime_type.to_s)
+      FORM_DATA_MEDIA_TYPES.include?(media_type)
     end
 
     def body_stream #:nodoc:

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1172,3 +1172,23 @@ class RequestVariant < BaseRequestTest
     end
   end
 end
+
+class RequestFormData < BaseRequestTest
+  test 'media_type is from the FORM_DATA_MEDIA_TYPES array' do
+    assert stub_request('CONTENT_TYPE' => 'application/x-www-form-urlencoded').form_data?
+    assert stub_request('CONTENT_TYPE' => 'multipart/form-data').form_data?
+  end
+
+  test 'media_type is not from the FORM_DATA_MEDIA_TYPES array' do
+    assert !stub_request('CONTENT_TYPE' => 'application/xml').form_data?
+    assert !stub_request('CONTENT_TYPE' => 'multipart/related').form_data?
+  end
+
+  test 'no Content-Type header is provided and the request_method is POST' do
+    request = stub_request('REQUEST_METHOD' => 'POST')
+
+    assert_equal '', request.media_type
+    assert_equal 'POST', request.request_method
+    assert !request.form_data?
+  end
+end


### PR DESCRIPTION
It’s used [only once](https://github.com/rack/rack/blob/ab172af1b63f0d8e91ce579dd2907c43b96cf82a/lib/rack/request.rb#L206) inside rack’s `#POST`.
However rails [overrides](https://github.com/rails/rails/blob/e595d91ac2c07371b441f8b04781e7c03ac44135/actionpack/lib/action_dispatch/http/request.rb#L306) rack’s `#POST`. So there is no calls for `#form_data?`.
