### PR TITLE
remove unused `#await_sent`

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -148,10 +148,6 @@ module ActionDispatch # :nodoc:
       end
     end
 
-    def await_sent
-      synchronize { @cv.wait_until { @sent } }
-    end
-
     def commit!
       synchronize do
         before_committed


### PR DESCRIPTION
Seems it was unused from the start:
https://github.com/rails/rails/commit/3df07d093a1e4207caa63fd2e3b67599211f5800#diff-0b53645cdb23933ef05759b2426f069aR146.
`grep -nr 'await_sent' .`
