### PR TITLE
remove unused `#generalized_table` and `#optional_parts`

### DIFF
--- a/actionpack/lib/action_dispatch/journey/nfa/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/nfa/transition_table.rb
@@ -45,51 +45,6 @@ module ActionDispatch
           (@table.keys + @table.values.flat_map(&:keys)).uniq
         end
 
-        # Returns a generalized transition graph with reduced states. The states
-        # are reduced like a DFA, but the table must be simulated like an NFA.
-        #
-        # Edges of the GTG are regular expressions.
-        def generalized_table
-          gt       = GTG::TransitionTable.new
-          marked   = {}
-          state_id = Hash.new { |h,k| h[k] = h.length }
-          alphabet = self.alphabet
-
-          stack = [eclosure(0)]
-
-          until stack.empty?
-            state = stack.pop
-            next if marked[state] || state.empty?
-
-            marked[state] = true
-
-            alphabet.each do |alpha|
-              next_state = eclosure(following_states(state, alpha))
-              next if next_state.empty?
-
-              gt[state_id[state], state_id[next_state]] = alpha
-              stack << next_state
-            end
-          end
-
-          final_groups = state_id.keys.find_all { |s|
-            s.sort.last == accepting
-          }
-
-          final_groups.each do |states|
-            id = state_id[states]
-
-            gt.add_accepting(id)
-            save = states.find { |s|
-              @memos.key?(s) && eclosure(s).sort.last == accepting
-            }
-
-            gt.add_memo(id, memo(save))
-          end
-
-          gt
-        end
-
         # Returns set of NFA states to which there is a transition on ast symbol
         # +a+ from some state +s+ in +t+.
         def following_states(t, a)

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -68,10 +68,6 @@ module ActionDispatch
         @path_formatter.evaluate path_options
       end
 
-      def optional_parts
-        path.optional_names.map(&:to_sym)
-      end
-
       def required_parts
         @required_parts ||= path.required_names.map(&:to_sym)
       end


### PR DESCRIPTION
These methods were copied from journey at https://github.com/rails/rails/commit/56fee39c392788314c44a575b3fd66e16a50c8b5#diff-d89de8881fc4b9f10cb3e4fc7b2463f3R53 and https://github.com/rails/rails/commit/56fee39c392788314c44a575b3fd66e16a50c8b5#diff-2cfaf53c860732fea8689d6f2002594bR78. However it looks the methods were unused in journey at those point as well.

`grep -nr 'generalized_table' .`
`grep -nr 'optional_parts' .`

To find other potentially unused methods in ruby projects you can use the gem _cleanup_ from https://github.com/QFocusLabs/cleanup.
