### PR TITLE
Allows to use a custom streamer

### DIFF
--- a/actionpack/lib/action_controller/metal/streaming.rb
+++ b/actionpack/lib/action_controller/metal/streaming.rb
@@ -211,8 +211,12 @@ module ActionController #:nodoc:
 
       # Call render_body if we are streaming instead of usual +render+.
       def _render_template(options) #:nodoc:
-        if options.delete(:stream)
-          Rack::Chunked::Body.new view_renderer.render_body(view_context, options)
+        if stream = options.delete(:stream)
+          unless stream.respond_to?(:each)
+            stream = view_renderer.render_body(view_context, options)
+          end
+
+          Rack::Chunked::Body.new stream
         else
           super
         end

--- a/actionpack/test/controller/new_base/render_streaming_test.rb
+++ b/actionpack/test/controller/new_base/render_streaming_test.rb
@@ -2,6 +2,13 @@ require 'abstract_unit'
 
 module RenderStreaming
   class BasicController < ActionController::Base
+    class CustomStreamer
+      def each
+        yield "Hello world"
+        yield "I'm streaming!"
+      end
+    end
+
     self.view_paths = [ActionView::FixtureResolver.new(
       "render_streaming/basic/hello_world.html.erb" => "Hello world",
       "render_streaming/basic/boom.html.erb" => "<%= raise 'Ruby was here!' %>",
@@ -13,6 +20,10 @@ module RenderStreaming
 
     def hello_world
       render :stream => true
+    end
+
+    def hello_world_custom_stream
+      render :stream => CustomStreamer.new
     end
 
     def layout_exception
@@ -45,6 +56,12 @@ module RenderStreaming
     test "rendering with streaming enabled at the class level" do
       get "/render_streaming/basic/hello_world"
       assert_body "b\r\nHello world\r\nb\r\n, I'm here!\r\n0\r\n\r\n"
+      assert_streaming!
+    end
+
+    test "rendering with custom streamer" do
+      get "/render_streaming/basic/hello_world_custom_stream"
+      assert_body "b\r\nHello world\r\ne\r\nI'm streaming!\r\n0\r\n\r\n"
       assert_streaming!
     end
 


### PR DESCRIPTION
I was looking for an easy way to stream non template content, but couldn't find anything. `ActionController::Streaming` does most of the needed already, so it is a matter of allowing to pass a custom object that responds to `each` instead of passing the renderer.

Anyone see an issue with this approach?
