### PR TITLE
Make error message clearer that :on requires a symbol, not a string

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -265,7 +265,7 @@ module ActiveRecord
 
       def assert_valid_transaction_action(actions)
         if (actions - ACTIONS).any?
-          raise ArgumentError, ":on conditions for after_commit and after_rollback callbacks have to be one of #{ACTIONS.join(",")}"
+          raise ArgumentError, ":on conditions for after_commit and after_rollback callbacks have to be one of #{ACTIONS}"
         end
       end
     end

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -371,10 +371,14 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
 
   def test_after_rollback_callbacks_should_validate_on_condition
     assert_raise(ArgumentError) { Topic.after_rollback(on: :save) }
+    e = assert_raise(ArgumentError) { Topic.after_rollback(on: 'create') }
+    assert_match(/:on conditions for after_commit and after_rollback callbacks have to be one of \[:create, :destroy, :update\]/, e.message)
   end
 
   def test_after_commit_callbacks_should_validate_on_condition
     assert_raise(ArgumentError) { Topic.after_commit(on: :save) }
+    e = assert_raise(ArgumentError) { Topic.after_commit(on: 'create') }
+    assert_match(/:on conditions for after_commit and after_rollback callbacks have to be one of \[:create, :destroy, :update\]/, e.message)
   end
 
   def test_saving_a_record_with_a_belongs_to_that_specifies_touching_the_parent_should_call_callbacks_on_the_parent_object


### PR DESCRIPTION
The validation added in 5a3dc8092d19c816b0b1203945639cb91d065847 will
reject values for the `:on` option for after_commit and after_rollback
callbacks that are string values like `"create"`.

However, the error message says ":on conditions for after_commit and
after_rollback callbacks have to be one of create,destroy,update". That
looks like a string value _would_ be valid.

This commit changes the error message to say ":on conditions for
after_commit and after_rollback callbacks have to be one of [:create,
:destroy, :update]", making it clearer that symbols are required.

I discovered this in upgrading an app to rails 4 where we had an `after_commit` activerecord hook with the options `on: "create"`. Strings used to be vaild, but with the combination of PR #5100 adding the validation, PR #9356 removing the `.to_sym` call in the validation method, and then PR #11096 removing the `.to_sym` call in the actual use of the option value, strings are no longer valid. 

I'm fine with requiring symbols here, as long as the error message makes that clear, which is what this pull request does. I'd also be happy to put back the `.to_sym` calls to allow strings again if yinz would rather. 

I also didn't make a changelog entry since this is practically just documentation; let me know if I should add one and I will be happy to.
