### PR TITLE
Add foreign_type option for polymorphic has_one and has_many.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `foreign_type` option to `has_one` and `has_many` association macros.
+
+    This option enables to define the column name of associated object's type for polymorphic associations.
+
+    *Ulisses Almeida, Kassio Borges*
+
 *   Remove deprecated behavior allowing nested arrays to be passed as query
     values.
 

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1176,6 +1176,12 @@ module ActiveRecord
       #   Specify the foreign key used for the association. By default this is guessed to be the name
       #   of this class in lower-case and "_id" suffixed. So a Person class that makes a +has_many+
       #   association will use "person_id" as the default <tt>:foreign_key</tt>.
+      # [:foreign_type]
+      #   Specify the column used to store the associated object's type, if this is a polymorphic
+      #   association. By default this is guessed to be the name of the polymorphic association
+      #   specified on "as" option with a "_type" suffix. So a class that defines a
+      #   <tt>has_many :tags, as: :taggable</tt> association will use "taggable_type" as the
+      #   default <tt>:foreign_type</tt>.
       # [:primary_key]
       #   Specify the name of the column to use as the primary key for the association. By default this is +id+.
       # [:dependent]
@@ -1323,6 +1329,12 @@ module ActiveRecord
       #   Specify the foreign key used for the association. By default this is guessed to be the name
       #   of this class in lower-case and "_id" suffixed. So a Person class that makes a +has_one+ association
       #   will use "person_id" as the default <tt>:foreign_key</tt>.
+      # [:foreign_type]
+      #   Specify the column used to store the associated object's type, if this is a polymorphic
+      #   association. By default this is guessed to be the name of the polymorphic association
+      #   specified on "as" option with a "_type" suffix. So a class that defines a
+      #   <tt>has_one :tag, as: :taggable</tt> association will use "taggable_type" as the
+      #   default <tt>:foreign_type</tt>.
       # [:primary_key]
       #   Specify the method that returns the primary key used for the association. By default this is +id+.
       # [:as]

--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -5,7 +5,7 @@ module ActiveRecord::Associations::Builder
     end
 
     def valid_options
-      super + [:primary_key, :dependent, :as, :through, :source, :source_type, :inverse_of, :counter_cache, :join_table]
+      super + [:primary_key, :dependent, :as, :through, :source, :source_type, :inverse_of, :counter_cache, :join_table, :foreign_type]
     end
 
     def self.valid_dependent_options

--- a/activerecord/lib/active_record/associations/builder/has_one.rb
+++ b/activerecord/lib/active_record/associations/builder/has_one.rb
@@ -5,7 +5,7 @@ module ActiveRecord::Associations::Builder
     end
 
     def valid_options
-      valid = super + [:as]
+      valid = super + [:as, :foreign_type]
       valid += [:through, :source, :source_type] if options[:through]
       valid
     end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -277,7 +277,7 @@ module ActiveRecord
       def initialize(name, scope, options, active_record)
         super
         @automatic_inverse_of = nil
-        @type         = options[:as] && "#{options[:as]}_type"
+        @type         = options[:as] && (options[:foreign_type] || "#{options[:as]}_type")
         @foreign_type = options[:foreign_type] || "#{name}_type"
         @constructable = calculate_constructable(macro, options)
         @association_scope_cache = {}

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -7,6 +7,7 @@ require 'models/contract'
 require 'models/topic'
 require 'models/reply'
 require 'models/category'
+require 'models/image'
 require 'models/post'
 require 'models/author'
 require 'models/essay'
@@ -1781,6 +1782,15 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     post = SubStiPost.create! :title => "fooo", :body => "baa"
     tagging = Tagging.create! :taggable => post
     assert_equal [tagging], post.taggings
+  end
+
+  def test_with_polymorphic_has_many_with_custom_columns_name
+    post = Post.create! :title => 'foo', :body => 'bar'
+    image = Image.create!
+
+    post.images << image
+
+    assert_equal [image], post.images
   end
 
   def test_build_with_polymorphic_has_many_does_not_allow_to_override_type_and_id

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -8,6 +8,7 @@ require 'models/pirate'
 require 'models/car'
 require 'models/bulb'
 require 'models/author'
+require 'models/image'
 require 'models/post'
 
 class HasOneAssociationsTest < ActiveRecord::TestCase
@@ -571,6 +572,16 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
         has_one :thing, counter_cache: true
       end
     end
+  end
+
+  def test_with_polymorphic_has_one_with_custom_columns_name
+    post = Post.create! :title => 'foo', :body => 'bar'
+    image = Image.create!
+
+    post.main_image = image
+    post.reload
+
+    assert_equal image, post.main_image
   end
 
   test 'dangerous association name raises ArgumentError' do

--- a/activerecord/test/models/image.rb
+++ b/activerecord/test/models/image.rb
@@ -1,0 +1,3 @@
+class Image < ActiveRecord::Base
+  belongs_to :imageable, foreign_key: :imageable_identifier, foreign_type: :imageable_class
+end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -128,6 +128,9 @@ class Post < ActiveRecord::Base
   has_many :taggings_using_author_id, :primary_key => :author_id, :as => :taggable, :class_name => 'Tagging'
   has_many :tags_using_author_id, :through => :taggings_using_author_id, :source => :tag
 
+  has_many :images, :as => :imageable, :foreign_key => :imageable_identifier, :foreign_type => :imageable_class
+  has_one :main_image, :as => :imageable, :foreign_key => :imageable_identifier, :foreign_type => :imageable_class, :class_name => 'Image'
+
   has_many :standard_categorizations, :class_name => 'Categorization', :foreign_key => :post_id
   has_many :author_using_custom_pk,  :through => :standard_categorizations
   has_many :authors_using_custom_pk, :through => :standard_categorizations

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -595,6 +595,11 @@ ActiveRecord::Schema.define do
     t.string :title, null: false
   end
 
+  create_table :images, force: true do |t|
+    t.integer :imageable_identifier
+    t.string :imageable_class
+  end
+
   create_table :price_estimates, force: true do |t|
     t.string :estimate_of_type
     t.integer :estimate_of_id


### PR DESCRIPTION
To be possible to use a custom column name to save/read the polymorphic
associated type in a has_many or has_one polymorphic association, now users
can use the option :foreign_type to inform in what column the associated object
type will be saved.

The issue [2822](https://github.com/rails/rails/issues/2822) is associated to this change.

I have opened this #17899 but pointing to a stable branch, now I'm opening to be able to merge on master.

I created a self contained [gist](https://gist.github.com/ulissesalmeida/80c54b03b96d9201928f) that shows how this option can be useful working on legacy database systems.
