### PR TITLE
Ensure append_info_to_payload is called even if an exception is raised.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,1 +1,12 @@
+*   Ensure `append_info_to_payload` is called even if an exception is raised.
+
+    Fixes an issue where when an exception is raised in the request the additonal
+    payload data is not available.
+
+    See:
+    * https://github.com/rails/rails/pull/14903
+    * https://github.com/roidrage/lograge/issues/37
+
+    *Dieter Komendera*, *Margus Pärt*
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -28,10 +28,13 @@ module ActionController
       ActiveSupport::Notifications.instrument("start_processing.action_controller", raw_payload.dup)
 
       ActiveSupport::Notifications.instrument("process_action.action_controller", raw_payload) do |payload|
-        result = super
-        payload[:status] = response.status
-        append_info_to_payload(payload)
-        result
+        begin
+          result = super
+          payload[:status] = response.status
+          result
+        ensure
+          append_info_to_payload(payload)
+        end
       end
     end
 

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -73,6 +73,16 @@ module Another
     def with_action_not_found
       raise AbstractController::ActionNotFound
     end
+
+    def append_info_to_payload(payload)
+      super
+      payload[:test_key] = "test_value"
+      @last_payload = payload
+    end
+
+    def last_payload
+      @last_payload
+    end
   end
 end
 
@@ -161,6 +171,16 @@ class ACLogSubscriberTest < ActionController::TestCase
     get :show
     wait
     assert_match(/\(Views: [\d.]+ms\)/, logs[1])
+  end
+
+  def test_append_info_to_payload_is_called_even_with_exception
+    begin
+      get :with_exception
+      wait
+    rescue Exception
+    end
+
+    assert_equal "test_value", @controller.last_payload[:test_key]
   end
 
   def test_process_action_with_filter_parameters


### PR DESCRIPTION
As #14903 seems to be stalled, this is my take.

cc @arthurnn @matthewd 

See:
- https://github.com/rails/rails/pull/14903
- https://github.com/roidrage/lograge/issues/37
