### PR TITLE
Add class level case operator support for error dispatching in Rescuable

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Added support for error dispatcher classes in ActiveSupport::Rescuable. Now it acts closer to Ruby's rescue.
+
+        class BaseController < ApplicationController
+          module ErrorDispatcher
+            def self.===(other)
+              Exception === other && other.respond_to?(:status)
+            end
+          end
+
+          rescue_from ErrorDispatcher do |error|
+            render status: error.status, json: { error: error.to_s }
+          end
+        end
+
+    *Genadi Samokovarov*
+
 *   Added `#verified` and `#valid_message?` methods to `ActiveSupport::MessageVerifier`
 
     Previously, the only way to decode a message with `ActiveSupport::MessageVerifier` was to use `#verify`, which would raise an exception on invalid messages. Now `#verified` can also be used, which returns `nil` on messages that cannot be decoded.

--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -60,7 +60,7 @@ module ActiveSupport
         end
 
         klasses.each do |klass|
-          key = if klass.is_a?(Class) && klass <= Exception
+          key = if klass.is_a?(Module) && klass.respond_to?(:===)
             klass.name
           elsif klass.is_a?(String)
             klass
@@ -101,7 +101,7 @@ module ActiveSupport
         # itself when rescue_from CONSTANT is executed.
         klass = self.class.const_get(klass_name) rescue nil
         klass ||= klass_name.constantize rescue nil
-        exception.is_a?(klass) if klass
+        klass === exception if klass
       end
 
       case rescuer


### PR DESCRIPTION
Ruby rescue dispatches exceptions by calling a class level case operator. Take this one as an example:

``` ruby
module ErrorDispatcher
  def self.===(other)
    Exception === other
  end
end

begin
  raise
rescue ErrorDispatcher
  puts "Yep, it is dispatched."
end
```

I'm proposing to add this support to `ActiveSupport::Rescuable`. I wanted to do this in an application, where we already had a global `rescue_from`. I didn't wanted to introduce another one, for the same dispatching logic and put a class level case operator on a specific error. I don't expect this to be a common case, but I like the symmetry with Ruby's rescue.

A couple of technicalities: I didn't change the current error message, because I think its clear enough and I don't know how to explain all that semantics in a reasonable message :disappointed_relieved: I also kept a couple of `klass` references for a cleaner diff.

Ruby's rescue requires the target to be a `Module`. So we can't go for object level case operator support.
