### PR TITLE
Add Passenger as potential app server and document the way to use it

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -15,6 +15,12 @@ source 'https://rubygems.org'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
+# Use Passenger as the app server
+# Note: instead of running 'bundle exec rails s',
+# run 'bundle exec passenger start'
+#
+# gem 'passenger'
+
 # Use Unicorn as the app server
 # gem 'unicorn'
 


### PR DESCRIPTION
This change adds Passenger (Standalone) as a potential server. Because of the way Passenger works, `rails s` doesn't start Passenger, so there's a comment telling users how to start Passenger.
