### PR TITLE
Testing Guides: adding TIP about database permission problems [ci skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -122,6 +122,8 @@ Rails by default automatically loads all fixtures from the `test/fixtures` folde
 * Load the fixture data into the table
 * Dump the fixture data into a variable in case you want to access it directly
 
+TIP: In order to remove existing data from the database, Rails tries to disable referential integrity triggers (like foreign keys and check constraints). If you are getting annoying permission errors on running tests, make sure the database user has privilege to disable these triggers in testing environment. (In PostgreSQL, just superusers can disable all triggers. Read more about PostgreSQL permissions [here](http://blog.endpoint.com/2012/10/postgres-system-triggers-error.html))
+
 #### Fixtures are Active Record objects
 
 Fixtures are instances of Active Record. As mentioned in point #3 above, you can access the object directly because it is automatically setup as a local variable of the test case. For example:


### PR DESCRIPTION
Adding a tip in the guides about possible database permission problems on loading fixtures to the database.

Reference #17542

See algo: https://github.com/rails/rails/pull/17726
