### PR TITLE
Add guides for `required` model generator option

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -452,6 +452,8 @@ number of digits after the decimal point.
 are using a dynamic value (such as a date), the default will only be calculated
 the first time (i.e. on the date the migration is applied).
 * `index`        Adds an index for the column.
+* `required`     Adds `required: true` for `belongs_to` associations and
+`null: false` to the column in the migration.
 
 Some adapters may support additional options; see the adapter specific API docs
 for further information.


### PR DESCRIPTION
Update guides with the new `required` option on model generator
