### PR TITLE
Include application/javascript when checking content_type

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -238,7 +238,9 @@ module ActionController #:nodoc:
 
       # Check for cross-origin JavaScript responses.
       def non_xhr_javascript_response?
-        content_type =~ %r(\Atext/javascript) && !request.xhr?
+        is_javascript_response = content_type =~ %r(\Atext/javascript) ||
+          content_type =~ %r(\Aapplication/javascript)
+        is_javascript_response && !request.xhr?
       end
 
       AUTHENTICITY_TOKEN_LENGTH = 32

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -315,6 +315,11 @@ module RequestForgeryProtectionTests
       get :negotiate_same_origin
     end
 
+    assert_cross_origin_blocked do
+      @request.accept = 'application/javascript'
+      get :negotiate_same_origin
+    end
+
     assert_cross_origin_not_blocked { xhr :get, :same_origin_js }
     assert_cross_origin_not_blocked { xhr :get, :same_origin_js, format: 'js' }
     assert_cross_origin_not_blocked do


### PR DESCRIPTION
Was looking at the code in request_forgery_protection and noticed that we check for only the `text/javascript` content type. Since `application/javascript` is now the official javascript MIME type (http://stackoverflow.com/questions/189850/what-is-the-javascript-mime-type-what-belongs-in-the-type-attribute-of-a-script), thought it would be good to include `application/javascript` when checking for content-type in #non_xhr_javascript_response?.

Let me know if there's anything I could do to improve. Thanks in advance!
