### PR TITLE
assert template should raise ArgumentError for unsupported layout types

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -145,6 +145,8 @@ module ActionController
             assert(@_layouts.keys.any? {|l| l =~ expected_layout }, msg)
           when nil, false
             assert(@_layouts.empty?, msg)
+          else
+            raise ArgumentError, "assert_template only accepts a String, Symbol, Regexp, nil or false for :layout"
           end
         end
 

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -575,6 +575,13 @@ class AssertTemplateTest < ActionController::TestCase
     end
   end
 
+  def test_fails_expecting_not_known_layout
+    get :render_with_layout
+    assert_raise(ArgumentError) do
+      assert_template :layout => 1
+    end
+  end
+
   def test_passes_with_correct_layout
     get :render_with_layout
     assert_template :layout => "layouts/standard"


### PR DESCRIPTION
fixes that  `assert_template(layout: 1)` will not fail (false positive) and added test for this case
