### PR TITLE
Allow to set AJ adapter for block

### DIFF
--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -25,6 +25,14 @@ module ActiveJob
             name_or_adapter
           end
       end
+      
+      def with_adapter(adapter)
+        old_adapter = queue_adapter
+        self.queue_adapter = adapter
+        yield
+      ensure
+        self.queue_adapter = old_adapter
+      end
 
       private
         def load_adapter(name)


### PR DESCRIPTION
This should be useful for testing. It allows to run easily some test with `:test` adapter and others with `:inline`.

If you like the idea, I'll add changelog (and test?).
