### PR TITLE
Call collection_proxy#concat instead of assocations

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -961,7 +961,7 @@ module ActiveRecord
       #   #      #<Pet id: 3, name: "Choo-Choo", person_id: 1>
       #   #    ]
       def <<(*records)
-        proxy_association.concat(records) && self
+        concat(records) && self
       end
       alias_method :push, :<<
       alias_method :append, :<<


### PR DESCRIPTION
Currently collection_proxy is calling `@assocation.concat` but instead it should be calling it's own `concat` method (which then calls `@association.concat`).
