### PR TITLE
Make AC::Params.permit_all_parameters thread safe

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -100,7 +100,6 @@ module ActionController
   #   params[:key]  # => "value"
   #   params["key"] # => "value"
   class Parameters < ActiveSupport::HashWithIndifferentAccess
-    cattr_accessor :permit_all_parameters, instance_accessor: false
     cattr_accessor :action_on_unpermitted_parameters, instance_accessor: false
 
     # By default, never raise an UnpermittedParameters exception if these
@@ -121,6 +120,16 @@ module ActionController
       MSG
 
       always_permitted_parameters
+    end
+
+    # Returns the value of +permit_all_parameters+.
+    def self.permit_all_parameters
+      Thread.current[:action_controller_permit_all_parameters]
+    end
+
+    # Sets the value of +permit_all_parameters+.
+    def self.permit_all_parameters=(value)
+      Thread.current[:action_controller_permit_all_parameters] = value
     end
 
     # Returns a new instance of <tt>ActionController::Parameters</tt>.


### PR DESCRIPTION
As discussed in #16299([1](https://github.com/rails/rails/pull/16299#discussion_r15424533)), this attribute is not thread safe and could potentially create a security issue.
