### PR TITLE
Fix default queue name prefix delimiter

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -155,7 +155,7 @@ end
 # environment
 ```
 
-The default queue name prefix delimiter is '_'.  This can be changed by setting
+The default queue name prefix delimiter is '\_'.  This can be changed by setting
 `config.active_job.queue_name_delimiter` in `application.rb`:
 
 ```ruby


### PR DESCRIPTION
Now displays as underscore, and not an empty string, when converted from markdown to HTML.
Escaped the underscore per http://daringfireball.net/projects/markdown/syntax#em
Fixes rails/rails#18009
