### PR TITLE
Allow sucker_punch jobs to be performed later

### DIFF
--- a/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
@@ -24,7 +24,8 @@ module ActiveJob
         end
 
         def enqueue_at(job, timestamp) #:nodoc:
-          raise NotImplementedError
+          seconds = timestamp - Time.new.to_f
+          JobWrapper.new.async.later(seconds, job.serialize)
         end
       end
 
@@ -33,6 +34,10 @@ module ActiveJob
 
         def perform(job_data)
           Base.execute job_data
+        end
+
+        def later(sec, job_data)
+          after(sec) { Base.execute job_data }
         end
       end
     end


### PR DESCRIPTION
Celluloid allows jobs to be performed after a certain amount of seconds.
Leverage this to implement enqueue_at for the sucker_punch adapter.
