### PR TITLE
[ci skip] Better explanation of config.assets.compile=false

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -149,7 +149,10 @@ that filenames are consistent based on their content.
 
 Fingerprinting is enabled by default for production and disabled for all other
 environments. You can enable or disable it in your configuration through the
-`config.assets.digest` option.
+`config.assets.digest` option. This option only works in `development`
+mode or when `config.assets.compile` is set to `true`. However, keep in mind
+that setting `config.assets.compile` to `true` in `production` mode would compile
+your assets on every request, drastically reducing performance.
 
 More reading:
 


### PR DESCRIPTION
`config.assets.digest = false` doesn't do anything in production, without `config.assets.compile = true`

This issue was discovered jointly with my friend. @arsood.
