### PR TITLE
Add AC::Parameters#to_unsafe_h

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `ActionController::Parameters#to_unsafe_h` to return an unfiltered
+    `Hash` representation of Parameters object. This is now a preferred way to
+    retrieve unfiltered parameters as we will stop inheriting `AC::Parameters`
+    object in Rails 5.0.
+
+    *Prem Sichanugrist*
+
 *   Restore handling of a bare `Authorization` header, without `token=`
     prefix.
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -172,6 +172,12 @@ module ActionController
       end
     end
 
+    # Returns an unsafe, unfiltered +Hash+ representation of this parameter.
+    def to_unsafe_h
+      to_hash
+    end
+    alias_method :to_unsafe_hash, :to_unsafe_h
+
     # Convert all hashes in values into parameters, then yield each pair like
     # the same way as <tt>Hash#each_pair</tt>
     def each_pair(&block)

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -280,4 +280,10 @@ class ParametersPermitTest < ActiveSupport::TestCase
 
     assert_equal({ "controller" => "users", "action" => "create" }, params.to_h)
   end
+
+  test "to_unsafe_h returns unfiltered params" do
+    assert @params.to_h.is_a? Hash
+    assert_not @params.to_h.is_a? ActionController::Parameters
+    assert_equal @params.to_hash, @params.to_unsafe_h
+  end
 end


### PR DESCRIPTION
As suggested in #16299([1](https://github.com/rails/rails/pull/16299#issuecomment-50220919)), this method should be a new public API for retrieving unfiltered parameters from `ActionController::Parameters` object, given that `Parameters#to_hash` will no longer work in Rails 5.0+ as we stop inheriting `Parameters` from `Hash`.

---

This is the same as #18006 but for `4-2-stable`.
