### PR TITLE
[guides] Fix method name inconsistency in a mailer example

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -231,7 +231,7 @@ class Notifier < ActionMailer::Base
   end
 end
 
-mail = Notifier.notify(user, ...) # Notifier#welcome is not yet called at this point
+mail = Notifier.notify(user, ...) # Notifier#notify is not yet called at this point
 mail = mail.deliver_now           # Prints "Called"
 ```
 


### PR DESCRIPTION
In the example, the mailer has `def notify(user, ...)` but the comment says `# Notifier#welcome is ...`.

cc @chancancode 
