### PR TITLE
Fix handling of positional url helper arguments when format is false

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,1 +1,7 @@
+*   Fixed handling of positional url helper arguments when `format: false`. 
+
+    Fixes #17819.
+
+    *Andrew White*, *Tatiana Soukiassian*
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -280,9 +280,15 @@ module ActionDispatch
           end
 
           def handle_positional_args(controller_options, inner_options, args, result, path_params)
-
             if args.size > 0
-              if args.size < path_params.size - 1 # take format into account
+              # take format into account
+              if path_params.include?(:format)
+                path_params_size = path_params.size - 1
+              else
+                path_params_size = path_params.size
+              end
+
+              if args.size < path_params_size
                 path_params -= controller_options.keys
                 path_params -= result.keys
               end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4433,3 +4433,31 @@ class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
     assert_equal message, error.message
   end
 end
+
+class TestDefaultUrlOptions < ActionDispatch::IntegrationTest
+  class PostsController < ActionController::Base
+    def archive
+      render :text => "posts#archive"
+    end
+  end
+
+  Routes = ActionDispatch::Routing::RouteSet.new
+  Routes.draw do
+    default_url_options locale: 'en'
+    scope ':locale', format: false do
+      get '/posts/:year/:month/:day', to: 'posts#archive', as: 'archived_posts'
+    end
+  end
+
+  APP = build_app Routes
+
+  def app
+    APP
+  end
+
+  include Routes.url_helpers
+
+  def test_positional_args_with_format_false
+    assert_equal '/en/posts/2014/12/13', archived_posts_path(2014, 12, 13)
+  end
+end


### PR DESCRIPTION
There is no need to subtract one from the path_params size when there is
no format parameter because it is not present in the path_params array.

Fixes #17819.
