### PR TITLE
ParameterFilter shouldn't try to dup symbol keys

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameter_filter.rb
+++ b/actionpack/lib/action_dispatch/http/parameter_filter.rb
@@ -56,7 +56,7 @@ module ActionDispatch
             elsif value.is_a?(Array)
               value = value.map { |v| v.is_a?(Hash) ? call(v) : v }
             elsif blocks.any?
-              key = key.dup
+              key = key.dup if key.duplicable?
               value = value.dup if value.duplicable?
               blocks.each { |b| b.call(key, value) }
             end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -997,8 +997,8 @@ class RequestParameterFilter < BaseRequestTest
       }
 
       parameter_filter = ActionDispatch::Http::ParameterFilter.new(filter_words)
-      before_filter['barg'] = {'bargain'=>'gain', 'blah'=>'bar', 'bar'=>{'bargain'=>{'blah'=>'foo'}}}
-      after_filter['barg']  = {'bargain'=>'niag', 'blah'=>'[FILTERED]', 'bar'=>{'bargain'=>{'blah'=>'[FILTERED]'}}}
+      before_filter['barg'] = {:bargain=>'gain', 'blah'=>'bar', 'bar'=>{'bargain'=>{'blah'=>'foo'}}}
+      after_filter['barg']  = {:bargain=>'niag', 'blah'=>'[FILTERED]', 'bar'=>{'bargain'=>{'blah'=>'[FILTERED]'}}}
 
       assert_equal after_filter, parameter_filter.filter(before_filter)
     end


### PR DESCRIPTION
Fixes #16764
