### PR TITLE
Allow URL helpers to work with optional scopes

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fixed usage of optional scopes in URL helpers.
+
+    *Alex Robbin*
+
 *   Fixed handling of positional url helper arguments when `format: false`. 
 
     Fixes #17819.

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -293,7 +293,7 @@ module ActionDispatch
                 path_params -= result.keys
               end
               path_params.each { |param|
-                result[param] = inner_options[param] || args.shift
+                result[param] = inner_options.fetch(param) { args.shift }
               }
             end
 

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -160,6 +160,18 @@ module ActionDispatch
         assert_equal '/foo/1/bar/2', url_helpers.foo_bar_path(2, foo_id: 1)
       end
 
+      test "having an optional scope with resources" do
+        draw do
+          scope "(/:foo)" do
+            resources :users
+          end
+        end
+
+        assert_equal '/users/1', url_helpers.user_path(1)
+        assert_equal '/users/1', url_helpers.user_path(1, foo: nil)
+        assert_equal '/a/users/1', url_helpers.user_path(1, foo: 'a')
+      end
+
       test "stringified controller and action keys are properly symbolized" do
         draw do
           root 'foo#bar'


### PR DESCRIPTION
I believe 84bf3a08150e9e10a29282a7a671a052f00bcd31 introduced a subtle bug with the way you can use URL helpers. As an example, if these are the routes:

``` ruby
scope "(/:product)" do
  resources :users
end
```

I am no longer able to call the URL helper with `product: nil`:

``` ruby
user_path(1, product: nil)
```

Within `handle_positional_args`, we do this:

``` ruby
result[param] = inner_options[param] || args.shift
```

`inner_options[param]` will return `nil` in this case, which will fall back to `args.shift`. Changing to `fetch` with a block that gets called as a fallback should correct this behavior.

This should be included in `4-2-stable` as well, but I'll wait to issue a backport PR until this is accepted!
