### PR TITLE
Allow URL helpers to work with optional scopes

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fixed usage of optional scopes in URL helpers.
+
+    *Alex Robbin*
+
 *   Add `ActionController::Parameters#to_unsafe_h` to return an unfiltered
     `Hash` representation of Parameters object. This is now a preferred way to
     retrieve unfiltered parameters as we will stop inheriting `AC::Parameters`

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -287,7 +287,7 @@ module ActionDispatch
                 path_params -= result.keys
               end
               path_params.each { |param|
-                result[param] = inner_options[param] || args.shift
+                result[param] = inner_options.fetch(param) { args.shift }
               }
             end
 

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -160,6 +160,18 @@ module ActionDispatch
         assert_equal '/foo/1/bar/2', url_helpers.foo_bar_path(2, foo_id: 1)
       end
 
+      test "having an optional scope with resources" do
+        draw do
+          scope "(/:foo)" do
+            resources :users
+          end
+        end
+
+        assert_equal '/users/1', url_helpers.user_path(1)
+        assert_equal '/users/1', url_helpers.user_path(1, foo: nil)
+        assert_equal '/a/users/1', url_helpers.user_path(1, foo: 'a')
+      end
+
       test "stringified controller and action keys are properly symbolized" do
         draw do
           root 'foo#bar'


### PR DESCRIPTION
Backport of #18022.

Conflicts:
    actionpack/CHANGELOG.md
