### PR TITLE
Re-enable capture'ing non-String values

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,1 +1,8 @@
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/actionview/CHANGELOG.md) for previous changes.
+
+*   Restore old behaviour for `capture` to return value as is when passed non-String values.
+
+    Fixes #17661.
+
+    *Carsten Zimmermann*
+

--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -36,7 +36,7 @@ module ActionView
       def capture(*args)
         value = nil
         buffer = with_output_buffer { value = yield(*args) }
-        if string = buffer.presence || value and string.is_a?(String)
+        if string = buffer.presence || value
           ERB::Util.html_escape string
         end
       end

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -24,8 +24,8 @@ class CaptureHelperTest < ActionView::TestCase
     assert_equal 'foobar', string
   end
 
-  def test_capture_returns_nil_if_the_returned_value_is_not_a_string
-    assert_nil @av.capture { 1 }
+  def test_capture_returns_value_even_if_the_returned_value_is_not_a_string
+    assert_equal '1', @av.capture { 1 }
   end
 
   def test_capture_escapes_html

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -64,6 +64,11 @@ class TagHelperTest < ActionView::TestCase
                  content_tag("a", "href" => "create") { "Create" }
   end
 
+  def test_content_tag_with_block_and_non_string_outside_out_of_erb
+    assert_equal content_tag("p", "1.0", nil, false),
+                 content_tag("p") { 1.0 }
+  end
+
   def test_content_tag_nested_in_content_tag_out_of_erb
     assert_equal content_tag("p", content_tag("b", "Hello")),
                  content_tag("p") { content_tag("b", "Hello") },


### PR DESCRIPTION
This has been discussed in #17661 and partially reverts the changes made in 9de83050d3a4b260d4aeb5d09ec4eb64f913ba64 and 986cac73e3c56b3dfa22fd1464f6913e38d32cc3

The test case added to `content_for` acts as a regression / acceptance test.
