### PR TITLE
Fix Duplicate web-console entries in Gemfile

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -111,7 +111,6 @@ module Rails
          jbuilder_gemfile_entry,
          sdoc_gemfile_entry,
          psych_gemfile_entry,
-         console_gemfile_entry,
          @extra_entries].flatten.find_all(&@gem_filter)
       end
 
@@ -265,15 +264,6 @@ module Rails
       def sdoc_gemfile_entry
         comment = 'bundle exec rake doc:rails generates the API under doc/api.'
         GemfileEntry.new('sdoc', '~> 0.4.0', comment, group: :doc)
-      end
-
-      def console_gemfile_entry
-        comment = 'Use Rails Console on the Browser'
-        if options.dev? || options.edge?
-          GemfileEntry.github 'web-console', 'rails/web-console', nil, comment
-        else
-          []
-        end
       end
 
       def coffee_gemfile_entry

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -32,7 +32,11 @@ group :development, :test do
   <%- end -%>
 
   # Access an IRB console on exception pages or by using <%%= console %> in views
+  <%- if options.dev? || options.edge? -%>
+  gem 'web-console', github: "rails/web-console"
+  <%- else -%>
   gem 'web-console', '~> 2.0'
+  <%- end -%>
 <%- if spring_install? %>
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -420,6 +420,24 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem 'web-console'
   end
 
+  def test_web_console_with_dev_option
+    run_generator [destination_root, "--dev"]
+
+    assert_file "Gemfile" do |content|
+      assert_match(/gem 'web-console',\s+github: "rails\/web-console"/, content)
+      assert_no_match(/gem 'web-console', '~> 2.0'/, content)
+    end
+  end
+
+  def test_web_console_with_edge_option
+    run_generator [destination_root, "--edge"]
+
+    assert_file "Gemfile" do |content|
+      assert_match(/gem 'web-console',\s+github: "rails\/web-console"/, content)
+      assert_no_match(/gem 'web-console', '~> 2.0'/, content)
+    end
+  end
+
   def test_spring
     run_generator
     assert_gem 'spring'


### PR DESCRIPTION
I got following error when invoking bundle install after creating new edge rails app using 'ruby edge_rails new --dev'.

  You cannot specify the same gem twice with different version requirements.
  You specified: web-console (>= 0) and web-console (~> 2.0)

So I removed duplicate entry of web-console in Gemfile.
I'm not sure if we should wait until next release of web-console which allows rails 5.0 is released, though.

Please let me know if I've misunderstood.

Thanks!
