### PR TITLE
Add test for `:skip_after_callbacks_if_terminated`

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -659,16 +659,17 @@ module ActiveSupport
       # ===== Options
       #
       # * <tt>:terminator</tt> - Determines when a before filter will halt the
-      #   callback chain, preventing following callbacks from being called and
-      #   the event from being triggered. This should be a lambda to be executed.
+      #   callback chain, preventing following before and around callbacks from
+      #   being called and the event from being triggered.
+      #   This should be a lambda to be executed.
       #   The current object and the return result of the callback will be called
       #   with the lambda.
       #
       #     define_callbacks :validate, terminator: ->(target, result) { result == false }
       #
       #   In this example, if any before validate callbacks returns +false+,
-      #   other callbacks are not executed. Defaults to +false+, meaning no value
-      #   halts the chain.
+      #   any successive before and around callback is not executed.
+      #   Defaults to +false+, meaning no value halts the chain.
       #
       # * <tt>:skip_after_callbacks_if_terminated</tt> - Determines if after
       #   callbacks should be terminated by the <tt>:terminator</tt> option. By


### PR DESCRIPTION
`define_callbacks` from `ActiveSupport::Callbacks` accepts the
`:skip_after_callbacks_if_terminated` option since #4866 but the option
is not tested anywhere.

This commit adds tests and fixes documentation for the option, making it clear
that halting a callback chain only stops further `before_` and `around_`
callbacks by default.

By default, `after_` callbacks are not halted.
