### PR TITLE
Add test for ActiveModel `after_validation`, `after_` and `around_` callbacks returning false

### DIFF
--- a/activemodel/test/cases/validations/callbacks_test.rb
+++ b/activemodel/test/cases/validations/callbacks_test.rb
@@ -30,9 +30,14 @@ class DogWithTwoValidators < Dog
   before_validation { self.history << 'before_validation_marker2' }
 end
 
-class DogValidatorReturningFalse < Dog
+class DogBeforeValidatorReturningFalse < Dog
   before_validation { false }
   before_validation { self.history << 'before_validation_marker2' }
+end
+
+class DogAfterValidatorReturningFalse < Dog
+  after_validation { false }
+  after_validation { self.history << 'after_validation_marker' }
 end
 
 class DogWithMissingName < Dog
@@ -82,10 +87,16 @@ class CallbacksWithMethodNamesShouldBeCalled < ActiveModel::TestCase
   end
 
   def test_further_callbacks_should_not_be_called_if_before_validation_returns_false
-    d = DogValidatorReturningFalse.new
+    d = DogBeforeValidatorReturningFalse.new
     output = d.valid?
     assert_equal [], d.history
     assert_equal false, output
+  end
+
+  def test_further_callbacks_should_be_called_if_after_validation_returns_false
+    d = DogAfterValidatorReturningFalse.new
+    d.valid?
+    assert_equal ['after_validation_marker'], d.history
   end
 
   def test_validation_test_should_be_done


### PR DESCRIPTION
This stems from https://github.com/rails/rails/pull/17227#discussion_r21641358

It's simply a clarification of the current behavior by which if an `after_validation` callback returns `false`, then further `after_` callbacks **are not halted**.

Similarly, if an `after_` or `around_` ActiveModel callback returns +false+, then the callback chain **is not halted**.

The callback chain in ActiveModel is only halted when a `before_` callback returns `false`.
