### PR TITLE
Fix docs: AR after/around callback returning false

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -199,7 +199,7 @@ module ActiveRecord
   # == Canceling callbacks
   #
   # If a <tt>before_*</tt> callback returns +false+, all the later callbacks and the associated action are
-  # cancelled. If an <tt>after_*</tt> callback returns +false+, all the later callbacks are cancelled.
+  # cancelled.
   # Callbacks are generally run in the order they are defined, with the exception of callbacks defined as
   # methods on the model, which are called last.
   #


### PR DESCRIPTION
Currently, the [ActiveRecord::Callbacks documentation](http://api.rubyonrails.org/classes/ActiveRecord/Callbacks.html#module-ActiveRecord::Callbacks-label-Canceling+callbacks) states:

> If a `before_*` callback returns `false`, all the later callbacks and the associated action are
> cancelled. If an `after_*` callback returns `false`, all the later callbacks are cancelled.

However, the last statement is not true: returning `false` in an `after_` callback in ActiveRecord does not prevent further `after_` callbacks from being executed.

This commit fixes the documentation and adds a test that shows how returning `false` both in an `after_save` and in an `around_save` does not prevent further callbacks from being executed.
