### PR TITLE
Remove misleading test: around_action return false

### DIFF
--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -504,7 +504,6 @@ class FilterTest < ActionController::TestCase
 
       def non_yielding_action
         @filters  << "it didn't yield"
-        @filter_return_value
       end
 
       def action_three
@@ -528,32 +527,15 @@ class FilterTest < ActionController::TestCase
     end
   end
 
-  def test_non_yielding_around_actions_not_returning_false_do_not_raise
+  def test_non_yielding_around_actions_do_not_raise
     controller = NonYieldingAroundFilterController.new
-    controller.instance_variable_set "@filter_return_value", true
     assert_nothing_raised do
       test_process(controller, "index")
     end
-  end
-
-  def test_non_yielding_around_actions_returning_false_do_not_raise
-    controller = NonYieldingAroundFilterController.new
-    controller.instance_variable_set "@filter_return_value", false
-    assert_nothing_raised do
-      test_process(controller, "index")
-    end
-  end
-
-  def test_after_actions_are_not_run_if_around_action_returns_false
-    controller = NonYieldingAroundFilterController.new
-    controller.instance_variable_set "@filter_return_value", false
-    test_process(controller, "index")
-    assert_equal ["filter_one", "it didn't yield"], controller.assigns['filters']
   end
 
   def test_after_actions_are_not_run_if_around_action_does_not_yield
     controller = NonYieldingAroundFilterController.new
-    controller.instance_variable_set "@filter_return_value", true
     test_process(controller, "index")
     assert_equal ["filter_one", "it didn't yield"], controller.assigns['filters']
   end


### PR DESCRIPTION
When an `around_action` does not `yield`, then the corresponding action is _never_ executed and the `after_` actions are _never_ invoked.

The value returned by the `around_action` does not have any impact on this: an `around_action` can "return" `true`, `false`, or `"pizza"`, but as long as `yield` is not invoked, the corresponding action and after callbacks are not executed.

The test suite for `ActionController::Callbacks` currently includes separate tests to distinguish the cases in which a non-yielding `around_action` returns `true` or `false`.

In my opinion, having such tests is misleading, giving the impression that the returned value might have some sort of impact, while it does not. At least that's the impression I got when I read those tests.

For completeness, the tests were introduced 7 years ago by @NZKoz in e80fabb.
