### PR TITLE
Add a code checking about file or not to the rails db command

### DIFF
--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -178,7 +178,7 @@ module Rails
       found = commands.detect do |cmd|
         dirs_on_path.detect do |path|
           full_path_command = File.join(path, cmd)
-          File.executable? full_path_command
+          File.file?(full_path_command) && File.executable?(full_path_command)
         end
       end
 


### PR DESCRIPTION
Fix a problem using directory name as command wrongly when there is a same name directory with executable file.
