### PR TITLE
Test to ensure content_tag works when fixing #17661

### DIFF
--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -50,6 +50,11 @@ class TagHelperTest < ActionView::TestCase
     assert_dom_equal "<div>Hello world!</div>", buffer
   end
 
+  def test_content_tag_with_block_in_erb_containing_non_displayed_erb
+    buffer = render_erb("<%= content_tag(:p) do %><% 1 %><% end %>")
+    assert_dom_equal "<p></p>", buffer
+  end
+
   def test_content_tag_with_block_and_options_in_erb
     buffer = render_erb("<%= content_tag(:div, :class => 'green') do %>Hello world!<% end %>")
     assert_dom_equal %(<div class="green">Hello world!</div>), buffer


### PR DESCRIPTION
After c2fe093, which was reverted yesterday, there will likely be
future PRs to address #17661.

The test `actionview/test/template/capture_helper_test.rb
# test_capture_returns_nil_if_the_returned_value_is_not_a_string` should

have errored with c2fe093, but it was rewritten in the PR to not raise.
My guess is that it may have seemed irrelevant to the content_tag tests
or already covered by them.

This test provides additional protection by being in the content_tag
test suite to explicitly raise a red flag in future cases.
