### PR TITLE
allow reseting of request variants (backport of #18052)

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -72,11 +72,12 @@ module ActionDispatch
           end
         end
       end
+
       # Sets the \variant for template.
       def variant=(variant)
         if variant.is_a?(Symbol)
           @variant = [variant]
-        elsif variant.is_a?(Array) && variant.any? && variant.all?{ |v| v.is_a?(Symbol) }
+        elsif variant.nil? || variant.is_a?(Array) && variant.any? && variant.all?{ |v| v.is_a?(Symbol) }
           @variant = variant
         else
           raise ArgumentError, "request.variant must be set to a Symbol or an Array of Symbols, not a #{variant.class}. " \

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1143,6 +1143,13 @@ class RequestVariant < BaseRequestTest
     end
   end
 
+  test "reset variant" do
+    request = stub_request
+
+    request.variant = nil
+    assert_equal nil, request.variant
+  end
+
   test "setting variant with non symbol value" do
     request = stub_request
     assert_raise ArgumentError do


### PR DESCRIPTION
This is a backport of #18052.

The current implementation of `variants=` don't allow a resetting to nil, wich is the default value.

This results in the following code smell:

``` ruby
case request.user_agent
when /iPhone/
  request.variants = :phone
when /iPad/
  request.variants = :ipad
end
```

With the ability to reset variants to nil, it could be:

``` ruby
request.variants = case request.user_agent
when /iPhone/
  :phone
when /iPad/
  :ipad
end
```
