### PR TITLE
Use thread_safe gem version greater or equal to 0.3.4

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'json',       '~> 1.7', '>= 1.7.7'
   s.add_dependency 'tzinfo',     '~> 1.1'
   s.add_dependency 'minitest',   '~> 5.1'
-  s.add_dependency 'thread_safe','~> 0.1'
+  s.add_dependency 'thread_safe','~> 0.3.4'
 end


### PR DESCRIPTION
Hi, 

To fix a problem with old version of `thread_safe` gem which might cause an errors like:

```
NoMethodError: undefined method `fetch_or_store' for #<ThreadSafe::Cache:0x007fc890c902d8>
```

I'm suggesting to use `thread_safe` gem with version greater or equal to 0.3.4, when the method `#fetch_or_store` was added https://github.com/ruby-concurrency/thread_safe/commit/aed23e870be68fbac2d61731f715a1add044b226
