### PR TITLE
Add _mailer suffix to generated file names.

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -29,4 +29,11 @@
 
     *Rafael Mendonça França*
 
+*   Add `_mailer` suffix to mailers created via generator, following the same
+naming convention used in controllers and jobs.
+
+    Closes #18074.
+
+    *Carlos Souza*
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/actionmailer/CHANGELOG.md) for previous changes.

--- a/actionmailer/lib/rails/generators/mailer/USAGE
+++ b/actionmailer/lib/rails/generators/mailer/USAGE
@@ -11,7 +11,7 @@ Example:
     rails generate mailer Notifications signup forgot_password invoice
 
     creates a Notifications mailer class, views, and test:
-        Mailer:     app/mailers/notifications.rb
+        Mailer:     app/mailers/notifications_mailer.rb
         Views:      app/views/notifications/signup.text.erb [...]
         Test:       test/mailers/notifications_test.rb
 

--- a/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
+++ b/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
@@ -4,16 +4,22 @@ module Rails
       source_root File.expand_path("../templates", __FILE__)
 
       argument :actions, type: :array, default: [], banner: "method method"
-      check_class_collision
+
+      check_class_collision suffix: "Mailer"
 
       def create_mailer_file
-        template "mailer.rb", File.join('app/mailers', class_path, "#{file_name}.rb")
+        template "mailer.rb", File.join('app/mailers', class_path, "#{file_name}_mailer.rb")
         if self.behavior == :invoke
           template "application_mailer.rb", 'app/mailers/application_mailer.rb'
         end
       end
 
       hook_for :template_engine, :test_framework
+
+      protected
+        def file_name
+          @_file_name ||= super.gsub(/\_mailer/i, '')
+        end
     end
   end
 end

--- a/actionmailer/lib/rails/generators/mailer/templates/mailer.rb
+++ b/actionmailer/lib/rails/generators/mailer/templates/mailer.rb
@@ -1,5 +1,5 @@
 <% module_namespacing do -%>
-class <%= class_name %> < ApplicationMailer
+class <%= class_name %>Mailer < ApplicationMailer
 <% actions.each do |action| -%>
 
   # Subject can be set in your I18n file at config/locales/en.yml

--- a/railties/lib/rails/generators/test_unit/mailer/mailer_generator.rb
+++ b/railties/lib/rails/generators/test_unit/mailer/mailer_generator.rb
@@ -6,15 +6,15 @@ module TestUnit # :nodoc:
       argument :actions, type: :array, default: [], banner: "method method"
 
       def check_class_collision
-        class_collisions "#{class_name}Test", "#{class_name}Preview"
+        class_collisions "#{class_name}MailerTest", "#{class_name}MailerPreview"
       end
 
       def create_test_files
-        template "functional_test.rb", File.join('test/mailers', class_path, "#{file_name}_test.rb")
+        template "functional_test.rb", File.join('test/mailers', class_path, "#{file_name}_mailer_test.rb")
       end
 
       def create_preview_files
-        template "preview.rb", File.join('test/mailers/previews', class_path, "#{file_name}_preview.rb")
+        template "preview.rb", File.join('test/mailers/previews', class_path, "#{file_name}_mailer_preview.rb")
       end
     end
   end

--- a/railties/lib/rails/generators/test_unit/mailer/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/mailer/templates/functional_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 <% module_namespacing do -%>
-class <%= class_name %>Test < ActionMailer::TestCase
+class <%= class_name %>MailerTest < ActionMailer::TestCase
 <% actions.each do |action| -%>
   test "<%= action %>" do
     mail = <%= class_name %>.<%= action %>

--- a/railties/lib/rails/generators/test_unit/mailer/templates/preview.rb
+++ b/railties/lib/rails/generators/test_unit/mailer/templates/preview.rb
@@ -1,11 +1,11 @@
 <% module_namespacing do -%>
 # Preview all emails at http://localhost:3000/rails/mailers/<%= file_path %>
-class <%= class_name %>Preview < ActionMailer::Preview
+class <%= class_name %>MailerPreview < ActionMailer::Preview
 <% actions.each do |action| -%>
 
   # Preview this email at http://localhost:3000/rails/mailers/<%= file_path %>/<%= action %>
   def <%= action %>
-    <%= class_name %>.<%= action %>
+    <%= class_name %>Mailer.<%= action %>
   end
 <% end -%>
 

--- a/railties/test/generators/mailer_generator_test.rb
+++ b/railties/test/generators/mailer_generator_test.rb
@@ -7,8 +7,8 @@ class MailerGeneratorTest < Rails::Generators::TestCase
 
   def test_mailer_skeleton_is_created
     run_generator
-    assert_file "app/mailers/notifier.rb" do |mailer|
-      assert_match(/class Notifier < ApplicationMailer/, mailer)
+    assert_file "app/mailers/notifier_mailer.rb" do |mailer|
+      assert_match(/class NotifierMailer < ApplicationMailer/, mailer)
       assert_no_match(/default from: "from@example.com"/, mailer)
       assert_no_match(/layout :mailer_notifier/, mailer)
     end
@@ -25,55 +25,55 @@ class MailerGeneratorTest < Rails::Generators::TestCase
 
   def test_mailer_with_i18n_helper
     run_generator
-    assert_file "app/mailers/notifier.rb" do |mailer|
+    assert_file "app/mailers/notifier_mailer.rb" do |mailer|
       assert_match(/en\.notifier\.foo\.subject/, mailer)
       assert_match(/en\.notifier\.bar\.subject/, mailer)
     end
   end
 
   def test_check_class_collision
-    Object.send :const_set, :Notifier, Class.new
+    Object.send :const_set, :NotifierMailer, Class.new
     content = capture(:stderr){ run_generator }
-    assert_match(/The name 'Notifier' is either already used in your application or reserved/, content)
+    assert_match(/The name 'NotifierMailer' is either already used in your application or reserved/, content)
   ensure
-    Object.send :remove_const, :Notifier
+    Object.send :remove_const, :NotifierMailer
   end
 
   def test_invokes_default_test_framework
     run_generator
-    assert_file "test/mailers/notifier_test.rb" do |test|
-      assert_match(/class NotifierTest < ActionMailer::TestCase/, test)
+    assert_file "test/mailers/notifier_mailer_test.rb" do |test|
+      assert_match(/class NotifierMailerTest < ActionMailer::TestCase/, test)
       assert_match(/test "foo"/, test)
       assert_match(/test "bar"/, test)
     end
-    assert_file "test/mailers/previews/notifier_preview.rb" do |preview|
+    assert_file "test/mailers/previews/notifier_mailer_preview.rb" do |preview|
       assert_match(/\# Preview all emails at http:\/\/localhost\:3000\/rails\/mailers\/notifier/, preview)
-      assert_match(/class NotifierPreview < ActionMailer::Preview/, preview)
+      assert_match(/class NotifierMailerPreview < ActionMailer::Preview/, preview)
       assert_match(/\# Preview this email at http:\/\/localhost\:3000\/rails\/mailers\/notifier\/foo/, preview)
       assert_instance_method :foo, preview do |foo|
-        assert_match(/Notifier.foo/, foo)
+        assert_match(/NotifierMailer.foo/, foo)
       end
       assert_match(/\# Preview this email at http:\/\/localhost\:3000\/rails\/mailers\/notifier\/bar/, preview)
       assert_instance_method :bar, preview do |bar|
-        assert_match(/Notifier.bar/, bar)
+        assert_match(/NotifierMailer.bar/, bar)
       end
     end
   end
 
   def test_check_test_class_collision
-    Object.send :const_set, :NotifierTest, Class.new
+    Object.send :const_set, :NotifierMailerTest, Class.new
     content = capture(:stderr){ run_generator }
-    assert_match(/The name 'NotifierTest' is either already used in your application or reserved/, content)
+    assert_match(/The name 'NotifierMailerTest' is either already used in your application or reserved/, content)
   ensure
-    Object.send :remove_const, :NotifierTest
+    Object.send :remove_const, :NotifierMailerTest
   end
 
   def test_check_preview_class_collision
-    Object.send :const_set, :NotifierPreview, Class.new
+    Object.send :const_set, :NotifierMailerPreview, Class.new
     content = capture(:stderr){ run_generator }
-    assert_match(/The name 'NotifierPreview' is either already used in your application or reserved/, content)
+    assert_match(/The name 'NotifierMailerPreview' is either already used in your application or reserved/, content)
   ensure
-    Object.send :remove_const, :NotifierPreview
+    Object.send :remove_const, :NotifierMailerPreview
   end
 
   def test_invokes_default_text_template_engine
@@ -124,13 +124,13 @@ class MailerGeneratorTest < Rails::Generators::TestCase
 
   def test_mailer_with_namedspaced_mailer
     run_generator ["Farm::Animal", "moos"]
-    assert_file "app/mailers/farm/animal.rb" do |mailer|
-      assert_match(/class Farm::Animal < ApplicationMailer/, mailer)
+    assert_file "app/mailers/farm/animal_mailer.rb" do |mailer|
+      assert_match(/class Farm::AnimalMailer < ApplicationMailer/, mailer)
       assert_match(/en\.farm\.animal\.moos\.subject/, mailer)
     end
-    assert_file "test/mailers/previews/farm/animal_preview.rb" do |preview|
+    assert_file "test/mailers/previews/farm/animal_mailer_preview.rb" do |preview|
       assert_match(/\# Preview all emails at http:\/\/localhost\:3000\/rails\/mailers\/farm\/animal/, preview)
-      assert_match(/class Farm::AnimalPreview < ActionMailer::Preview/, preview)
+      assert_match(/class Farm::AnimalMailerPreview < ActionMailer::Preview/, preview)
       assert_match(/\# Preview this email at http:\/\/localhost\:3000\/rails\/mailers\/farm\/animal\/moos/, preview)
     end
     assert_file "app/views/farm/animal/moos.text.erb"
@@ -140,7 +140,7 @@ class MailerGeneratorTest < Rails::Generators::TestCase
   def test_actions_are_turned_into_methods
     run_generator
 
-    assert_file "app/mailers/notifier.rb" do |mailer|
+    assert_file "app/mailers/notifier_mailer.rb" do |mailer|
       assert_instance_method :foo, mailer do |foo|
         assert_match(/mail to: "to@example.org"/, foo)
         assert_match(/@greeting = "Hi"/, foo)
@@ -166,5 +166,12 @@ class MailerGeneratorTest < Rails::Generators::TestCase
     assert_file "app/mailers/application_mailer.rb"
     assert_file "app/views/layouts/mailer.text.erb"
     assert_file "app/views/layouts/mailer.html.erb"
+  end
+
+  def test_mailer_suffix_is_not_duplicated
+    run_generator ["notifier_mailer"]
+
+    assert_no_file "app/mailers/notifier_mailer_mailer.rb"
+    assert_file "app/mailers/notifier_mailer.rb"
   end
 end

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -146,16 +146,16 @@ class NamespacedMailerGeneratorTest < NamespacedGeneratorTestCase
 
   def test_mailer_skeleton_is_created
     run_generator
-    assert_file "app/mailers/test_app/notifier.rb" do |mailer|
+    assert_file "app/mailers/test_app/notifier_mailer.rb" do |mailer|
       assert_match(/module TestApp/, mailer)
-      assert_match(/class Notifier < ApplicationMailer/, mailer)
+      assert_match(/class NotifierMailer < ApplicationMailer/, mailer)
       assert_no_match(/default from: "from@example.com"/, mailer)
     end
   end
 
   def test_mailer_with_i18n_helper
     run_generator
-    assert_file "app/mailers/test_app/notifier.rb" do |mailer|
+    assert_file "app/mailers/test_app/notifier_mailer.rb" do |mailer|
       assert_match(/en\.notifier\.foo\.subject/, mailer)
       assert_match(/en\.notifier\.bar\.subject/, mailer)
     end
@@ -163,9 +163,9 @@ class NamespacedMailerGeneratorTest < NamespacedGeneratorTestCase
 
   def test_invokes_default_test_framework
     run_generator
-    assert_file "test/mailers/test_app/notifier_test.rb" do |test|
+    assert_file "test/mailers/test_app/notifier_mailer_test.rb" do |test|
       assert_match(/module TestApp/, test)
-      assert_match(/class NotifierTest < ActionMailer::TestCase/, test)
+      assert_match(/class NotifierMailerTest < ActionMailer::TestCase/, test)
       assert_match(/test "foo"/, test)
       assert_match(/test "bar"/, test)
     end


### PR DESCRIPTION
It is somewhat confusing that [controllers](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/controller/controller_generator.rb#L10) and [jobs](https://github.com/rails/rails/blob/master/activejob/lib/rails/generators/job/job_generator.rb#L19) follow this convention, but [mailers](https://github.com/rails/rails/blob/master/actionmailer/lib/rails/generators/mailer/mailer_generator.rb#L10) don't.
