### PR TITLE
Option to set migration defaults from generator

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -3,7 +3,7 @@ require 'rails/generators/active_record'
 module ActiveRecord
   module Generators # :nodoc:
     class MigrationGenerator < Base # :nodoc:
-      argument :attributes, :type => :array, :default => [], :banner => "field[:type][:index] field[:type][:index]"
+      argument :attributes, :type => :array, :default => [], :banner => "field[:type][:index][=default] field[:type][:index][=default]"
 
       def create_migration_file
         set_local_assigns!

--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
@@ -5,7 +5,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
 <% if attribute.password_digest? -%>
       t.string :password_digest<%= attribute.inject_options %>
 <% else -%>
-      t.<%= attribute.type %> :<%= attribute.name %><%= attribute.inject_options %>
+      t.<%= attribute.type -%> :<%= attribute.name %><%= attribute.inject_options -%><% if attribute.has_default? %>, :default => <%= attribute.assigned_default %><%- end %>
 <% end -%>
 <% end -%>
 <% if options[:timestamps] %>

--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
@@ -8,7 +8,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
     add_foreign_key :<%= table_name %>, :<%= attribute.name.pluralize %>
     <%- end -%>
   <%- else -%>
-    add_column :<%= table_name %>, :<%= attribute.name %>, :<%= attribute.type %><%= attribute.inject_options %>
+    add_column :<%= table_name %>, :<%= attribute.name %>, :<%= attribute.type %><%- if attribute.has_default? -%>, :default => <%= attribute.assigned_default %><%- end -%><%= attribute.inject_options %>
     <%- if attribute.has_index? -%>
     add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>
     <%- end -%>

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -3,8 +3,7 @@ require 'rails/generators/active_record'
 module ActiveRecord
   module Generators # :nodoc:
     class ModelGenerator < Base # :nodoc:
-      argument :attributes, :type => :array, :default => [], :banner => "field[:type][:index] field[:type][:index]"
-
+      argument :attributes, :type => :array, :default => [], :banner => "field[:type][:index][=default] field[:type][:index][=default]"
       check_class_collision
 
       class_option :migration,  :type => :boolean

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -159,6 +159,28 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_add_migration_with_assigned_defaults
+    migration = "add_author_to_books"
+    run_generator [migration, "author:string:index=Anonymous"]
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/add_column :books, :author, :string, :default => 'Anonymous'/, change)
+      end
+    end
+  end
+
+  def test_add_migration_with_user_assigned_defaults_and_indices
+    migration = "add_author_and_price_to_books"
+    run_generator [migration, "author:string:index='Anonymous'", "price:decimal:index=9.99"]
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/add_column :books, :author, :string, :default => 'Anonymous'/, change)
+        assert_match(/add_column :books, :price, :decimal, :default => 9.99/, change)
+      end
+      assert_match(/add_index :books, :price/, content)
+    end
+  end
+
   def test_add_migration_with_references_options
     migration = "add_references_to_books"
     run_generator [migration, "author:belongs_to", "distributor:references{polymorphic}"]

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -173,6 +173,18 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_add_migration_with_user_defined_attribute_default
+    run_generator ["product", "price:decimal:index=12.99"]
+
+    assert_migration "db/migrate/create_products.rb" do |content|
+      assert_method :change, content do |up|
+        assert_match(/create_table :products/, up)
+        assert_match(/t.decimal :price, :default => 12.99/, up)
+      end
+      assert_match(/add_index :products, :price/, content)
+    end
+  end
+
   def test_add_migration_with_attributes_index_declaration_and_attribute_options
     run_generator ["product", "title:string{40}:index", "content:string{255}", "price:decimal{5,2}:index", "discount:decimal{5,2}:uniq", "supplier:references{polymorphic}"]
 


### PR DESCRIPTION
For example,

```
rails g migration CreatePosts title:string body:text published:boolean=false
```

will generate a migration for Posts where the "published" field defaults to false.

Covered with new tests in `model_generator_test.rb` and `migration_generator_test.rb`.

Discussion thread on this feature in rails-core mailing list:
https://groups.google.com/forum/#!topic/rubyonrails-core/9SNI6mkCJ-w
