### PR TITLE
Add docs for AS::TestCase::test_order

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -73,11 +73,11 @@ module ActiveSupport
 
   @@test_order = nil
 
-  def self.test_order=(new_order)
+  def self.test_order=(new_order) # :nodoc:
     @@test_order = new_order
   end
 
-  def self.test_order
+  def self.test_order # :nodoc:
     @@test_order
   end
 end

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -16,10 +16,25 @@ module ActiveSupport
     Assertion = Minitest::Assertion
 
     class << self
+      # Sets the order in which test cases are run.
+      #
+      #   ActiveSupport::TestCase.test_order = :random # => :random
+      #
+      # Valid values are:
+      # * +:random+   (to run tests in random order)
+      # * +:parallel+ (to run tests in parallel)
+      # * +:sorted+   (to run tests alphabetically by method name)
+      # * +:alpha+    (equivalent to +:sorted+)
       def test_order=(new_order)
         ActiveSupport.test_order = new_order
       end
 
+      # Returns the order in which test cases are run.
+      #
+      #   ActiveSupport::TestCase.test_order # => :sorted
+      #
+      # Possible values are +:random+, +:parallel+, +:alpha+, +:sorted+.
+      # Defaults to +:sorted+.
       def test_order
         test_order = ActiveSupport.test_order
 


### PR DESCRIPTION
Document `test_order` and `test_order=` from `ActiveSupport::TestCase`.

[ci skip]

---

The reason why I'm opening this PR on [rails/rails](https://github.com/rails/rails) rather than pushing to [rails/docrails](https://github.com/rails/docrails) is because I wanted some feedback.
- Do you think it's a good idea to specify the possible values for `test_order`?
- Do you think the documentation should explain what these values mean?
- Or do you think there should be a link to [Minitest API doc](http://docs.seattlerb.org/minitest) instead?
