### PR TITLE
Fix issue with reaping_frequency type.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -236,7 +236,7 @@ module ActiveRecord
         @spec = spec
 
         @checkout_timeout = (spec.config[:checkout_timeout] && spec.config[:checkout_timeout].to_f) || 5
-        @reaper  = Reaper.new self, spec.config[:reaping_frequency]
+        @reaper = Reaper.new(self, (spec.config[:reaping_frequency] && spec.config[:reaping_frequency].to_f))
         @reaper.run
 
         # default max pool size to 5

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -60,7 +60,7 @@ module ActiveRecord
 
       def test_connection_pool_starts_reaper
         spec = ActiveRecord::Base.connection_pool.spec.dup
-        spec.config[:reaping_frequency] = 0.0001
+        spec.config[:reaping_frequency] = '0.0001'
 
         pool = ConnectionPool.new spec
 


### PR DESCRIPTION
When using DATABASE_URL to configure ActiveRecord, reaping_frequency does not get converted from a string to a numeric value.

reaping_frequency is eventually passed to 'sleep' and must be numeric to avoid exceptions.

This PR converts reaping_frequency to a float when present and alters an existing test to use a string frequency value, confirming that this fix works as intended.

Style utilized is of that found in nearby code as well as on the [Contributing to Ruby on Rails](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html) guide.
