### PR TITLE
`db:schema:load` and `db:structure:load` do not purge the database

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Introduce `force: :cascade` option for `create_table`. Using this option
+    will recreate tables even if they have dependent objects (like foreign keys).
+    `db/schema.rb` now uses `force: :cascade`. This makes it possible to
+    reload the schema when foreign keys are in place.
+
+    *Matthew Draper*, *Yves Senn*
+
 *   `db:schema:load` and `db:structure:load` no longer purge the database
     before loading the schema. This is left for the user to do.
     `db:test:prepare` will still purge the database.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   `db:schema:load` and `db:structure:load` no longer purge the database
+    before loading the schema. This is left for the user to do.
+    `db:test:prepare` will still purge the database.
+
+    Closes #17945.
+
+    *Yves Senn*
+
 *   Fix undesirable RangeError by Type::Integer. Add Type::UnsignedInteger.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -132,6 +132,7 @@ module ActiveRecord
       #   Make a temporary table.
       # [<tt>:force</tt>]
       #   Set to true to drop the table before creating it.
+      #   Set to +:cascade+ to drop dependent objects as well.
       #   Defaults to false.
       # [<tt>:as</tt>]
       #   SQL to use to generate the table. When this option is used, the block is
@@ -361,8 +362,12 @@ module ActiveRecord
 
       # Drops a table from the database.
       #
-      # Although this command ignores +options+ and the block if one is given, it can be helpful
-      # to provide these in a migration's +change+ method so it can be reverted.
+      # [<tt>:force</tt>]
+      #   Set to +:cascade+ to drop dependent objects as well.
+      #   Defaults to false.
+      #
+      # Although this command ignores most +options+ and the block if one is given,
+      # it can be helpful to provide these in a migration's +change+ method so it can be reverted.
       # In that case, +options+ and the block will be used by create_table.
       def drop_table(table_name, options = {})
         execute "DROP TABLE #{quote_table_name(table_name)}"

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -487,7 +487,7 @@ module ActiveRecord
       end
 
       def drop_table(table_name, options = {})
-        execute "DROP#{' TEMPORARY' if options[:temporary]} TABLE #{quote_table_name(table_name)}"
+        execute "DROP#{' TEMPORARY' if options[:temporary]} TABLE #{quote_table_name(table_name)}#{' CASCADE' if options[:force] == :cascade}"
       end
 
       def rename_index(table_name, old_name, new_name)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -120,6 +120,10 @@ module ActiveRecord
           SQL
         end
 
+        def drop_table(table_name, options = {})
+          execute "DROP TABLE #{quote_table_name(table_name)}#{' CASCADE' if options[:force] == :cascade}"
+        end
+
         # Returns true if schema exists.
         def schema_exists?(name)
           exec_query(<<-SQL, 'SCHEMA').rows.first[0].to_i > 0

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -126,7 +126,7 @@ HEADER
           else
             tbl.print ", id: false"
           end
-          tbl.print ", force: true"
+          tbl.print ", force: :cascade"
           tbl.puts " do |t|"
 
           # then dump all non-primary key columns

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -214,12 +214,10 @@ module ActiveRecord
         case format
         when :ruby
           check_schema_file(file)
-          purge(configuration)
           ActiveRecord::Base.establish_connection(configuration)
           load(file)
         when :sql
           check_schema_file(file)
-          purge(configuration)
           structure_load(configuration, file)
         else
           raise ArgumentError, "unknown format #{format.inspect}"

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -130,7 +130,7 @@ class PostgresqlLargeKeysTest < ActiveRecord::TestCase
 
   def test_omg
     schema = dump_table_schema "big_serials"
-    assert_match "create_table \"big_serials\", id: :bigserial, force: true", schema
+    assert_match "create_table \"big_serials\", id: :bigserial", schema
   end
 
   def teardown

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -415,5 +415,36 @@ module ActiveRecord
         yield
       end
     end
+
+    if ActiveRecord::Base.connection.supports_foreign_keys?
+      class ChangeSchemaWithDependentObjectsTest < ActiveRecord::TestCase
+        self.use_transactional_fixtures = false
+
+        setup do
+          @connection = ActiveRecord::Base.connection
+          @connection.create_table :trains
+          @connection.create_table(:wagons) { |t| t.references :train }
+          @connection.add_foreign_key :wagons, :trains
+        end
+
+        teardown do
+          [:wagons, :trains].each do |table|
+            @connection.drop_table(table) if @connection.table_exists?(table)
+          end
+        end
+
+        def test_create_table_with_force_cascade_drops_dependent_objects
+          skip "MySQL > 5.5 does not drop dependent objects with DROP TABLE CASCADE" if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
+          # can't re-create table referenced by foreign key
+          assert_raises(ActiveRecord::StatementInvalid) do
+            @connection.create_table :trains, force: true
+          end
+
+          # can recreate referenced table with force: :cascade
+          @connection.create_table :trains, force: :cascade
+          assert_equal [], @connection.foreign_keys(:wagons)
+        end
+      end
+    end
   end
 end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -40,6 +40,11 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "schema_migrations"}, output
   end
 
+  def test_schema_dump_uses_force_cascade_on_create_table
+    output = dump_table_schema "authors"
+    assert_match %r{create_table "authors", force: :cascade}, output
+  end
+
   def test_schema_dump_excludes_sqlite_sequence
     output = standard_dump
     assert_no_match %r{create_table "sqlite_sequence"}, output

--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -662,6 +662,9 @@ Please refer to the [Changelog][active-record] for detailed changes.
 
 ### Notable changes
 
+*   `SchemaDumper` uses `force: :cascade` on `create_table`. This makes it
+    possible to reload a schema when foreign keys are in place.
+
 *   Added a `:required` option to singular associations, which defines a
     presence validation on the association.
     ([Pull Request](https://github.com/rails/rails/pull/16056))

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -156,6 +156,31 @@ module ApplicationTests
         end
       end
 
+      test 'db:schema:load and db:structure:load do not purge the existing database' do
+        Dir.chdir(app_path) do
+          `bin/rails runner 'ActiveRecord::Base.connection.create_table(:posts) {|t| t.string :title }'`
+
+          app_file 'db/schema.rb', <<-RUBY
+            ActiveRecord::Schema.define(version: 20140423102712) do
+              create_table(:comments) {}
+            end
+          RUBY
+
+          list_tables = lambda { `bin/rails runner 'p ActiveRecord::Base.connection.tables'`.strip }
+
+          assert_equal '["posts"]', list_tables[]
+          `bin/rake db:schema:load`
+          assert_equal '["posts", "comments", "schema_migrations"]', list_tables[]
+
+          app_file 'db/structure.sql', <<-SQL
+            CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar(255));
+          SQL
+
+          `bin/rake db:structure:load`
+          assert_equal '["posts", "comments", "schema_migrations", "users"]', list_tables[]
+        end
+      end
+
       def db_test_load_structure
         Dir.chdir(app_path) do
           `rails generate model book title:string;


### PR DESCRIPTION
Closes #17945

There are environments (like Heroku) where it's not possible to purge a database. This rendered `db:schema:load` and `db:structure:load` useless in such circumstances.

The original behavior (until `Rails 4.0`) was as follows:
- `db/schema.rb` used `create_table force: true` to make it possible to run against an already populated database. It would basically recreate every table defined in the schema and leave the rest alone.
- With `db:structure:load` it was up to the user to create an acceptable database state before loading `structure.sql`.

The introduction of foreign keys complicates things a bit. Simply using `force: true` won't be enough. The database will reject dropping a table, which is referenced by a foreign key. This patch solves that problem by introducing `force: :cascade`, which drops dependent objects as well. New `db/schema.rb` files will be created with `force: :cascade` instead of `force: true`.

**Note:**

Sadly [MySQL does no longer support `CASCADE`](http://dev.mysql.com/doc/refman/5.5/en/drop-table.html):

> RESTRICT and CASCADE are permitted to make porting easier. In MySQL 5.5, they do nothing.

While it is possible to `disable_referential_integrity` and drop the tables, this will only remove the table and not dependent foreign keys. Resulting in a later error when `db/schema.rb` tries to recreate the foreign key.
