### PR TITLE
Add ActiveRecord::Timestamp#without_timestamps to skip timestamps easily

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ActiveRecord::Timestamp#without_timestamps` to skip timestamps easily.
+
+    *Takashi Kokubun*
+
 *   Fix undesirable RangeError by Type::Integer. Add Type::UnsignedInteger.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -40,6 +40,13 @@ module ActiveRecord
       clear_timestamp_attributes
     end
 
+    def without_timestamps
+      previous, self.record_timestamps = self.record_timestamps, false
+      yield
+    ensure
+      self.record_timestamps = previous
+    end
+
   private
 
     def _create_record

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -73,6 +73,16 @@ class TimestampTest < ActiveRecord::TestCase
     assert_equal @previously_updated_at, @developer.updated_at
   end
 
+  def test_saving_when_instance_without_timestamps_doesnt_update_its_timestamp
+    @developer.without_timestamps do
+      @developer.name = "John Smith"
+      @developer.save!
+    end
+    assert Developer.record_timestamps
+
+    assert_equal @previously_updated_at, @developer.updated_at
+  end
+
   def test_touching_an_attribute_updates_timestamp
     previously_created_at = @developer.created_at
     @developer.touch(:created_at)


### PR DESCRIPTION
I've written following code many times.

``` rb
@model.record_timestamps = false
@model.update(foo: bar)
@model.record_timestamps = true
```

It's very boring to write, so I added `without_timestamps`. With the method, you can write:

``` rb
@model.without_timestamps do
  @model.update(foo: bar)
end
```
