### PR TITLE
Adding #option_attributes argument to option_from_collection_for_select

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -390,9 +390,13 @@ module ActionView
       # Will not select a person with the id of 1 because 1 (an Integer) is not the same as '1' (a string)
       #   options_from_collection_for_select(@people, 'id', 'name', 1)
       # should produce the desired results.
-      def options_from_collection_for_select(collection, value_method, text_method, selected = nil)
+      
+      # Additionally, you can also also pass any other attributes to be added in option tag using +option_attributes+.
+      #   options_from_collection_for_select(@categories, 'id', 'name', nil, :title => 'description')
+      #   # => <option value="#{category.id}" title="#{category.description}">#{category.name}</option>
+      def options_from_collection_for_select(collection, value_method, text_method, selected = nil, option_attributes = {})
         options = collection.map do |element|
-          [value_for_collection(element, text_method), value_for_collection(element, value_method), option_html_attributes(element)]
+          [value_for_collection(element, text_method), value_for_collection(element, value_method), value_for_attribute_collection(element, option_attributes), option_html_attributes(element)]
         end
         selected, disabled = extract_selected_and_disabled(selected)
         select_deselect = {
@@ -752,6 +756,13 @@ module ActionView
             end.compact
           else
             selected
+          end
+        end
+
+        def value_for_attribute_collection(item, attributes)
+          attributes.inject({}) do |memo, (key, value)|
+            memo[key] = value_for_collection(item, value)
+            memo
           end
         end
 

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -83,6 +83,20 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_collection_options_with_option_attributes_without_preselected_and_disabled_value
+    assert_dom_equal(
+      "<option value=\"&lt;Abe&gt;\" title=\"To a little house\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\" title=\"To a little house\">Babe went home</option>\n<option value=\"Cabe\" title=\"To a little house\">Cabe went home</option>",
+      options_from_collection_for_select(dummy_posts, "author_name", "title", nil, :title => "body")
+    )
+  end
+
+  def test_collection_options_with_option_attributes_with_preselected_and_disabled_value
+    assert_dom_equal(
+      "<option value=\"&lt;Abe&gt;\" title=\"To a little house\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\" title=\"To a little house\" selected=\"selected\">Babe went home</option>\n<option value=\"Cabe\" title=\"To a little house\" disabled=\"disabled\">Cabe went home</option>",
+      options_from_collection_for_select(dummy_posts, "author_name", "title", { :selected => "Babe", :disabled => "Cabe" }, { :title => "body" })
+    )
+  end
+
   def test_collection_options_with_proc_for_value_method
     assert_dom_equal(
       "<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>",


### PR DESCRIPTION
Allow adding of title or any data attributes to be added in option tag generated by
option_from_collection_for_select
Added issue [#18093](https://github.com/rails/rails/issues/18093) regarding this.
