### PR TITLE
`eager_load` preserves readonly flag for associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `eager_load` preserves readonly flag for associations.
+
+    Closes #15853.
+
+    *Takashi Kokubun*
+
 *   Provide `:touch` option to `save()` to accommodate saving without updating
     timestamps.
 

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -257,6 +257,7 @@ module ActiveRecord
             construct(model, node, row, rs, seen, model_cache, aliases)
           else
             model = construct_model(ar_parent, node, row, model_cache, id, aliases)
+            model.readonly!
             seen[parent.base_klass][primary_id][node.base_klass][id] = model
             construct(model, node, row, rs, seen, model_cache, aliases)
           end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1328,7 +1328,6 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   test "eager-loading readonly association" do
-    skip "eager_load does not yet preserve readonly associations"
     # has-one
     firm = Firm.where(id: "1").eager_load(:readonly_account).first!
     assert firm.readonly_account.readonly?
@@ -1340,6 +1339,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
     # has-many :through
     david = Author.where(id: "1").eager_load(:readonly_comments).first!
     assert david.readonly_comments.first.readonly?
+
+    # belongs_to
+    post = Post.where(id: "1").eager_load(:author).first!
+    assert post.author.readonly?
   end
 
   test "preloading a polymorphic association with references to the associated table" do


### PR DESCRIPTION
Closes #15853

I changed `join_dependency` to pass skipped test in 5706d290b0a2501a713fadfb76d9e45c24d26e6a.
