### PR TITLE
Fix inaccurate docs in active_model errors [ci skip]

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -283,9 +283,9 @@ module ActiveModel
     # ActiveModel::StrictValidationFailed instead of adding the error.
     # <tt>:strict</tt> option can also be set to any other exception.
     #
-    #   person.errors.add(:name, nil, strict: true)
+    #   person.errors.add(:name, :invalid, strict: true)
     #   # => ActiveModel::StrictValidationFailed: name is invalid
-    #   person.errors.add(:name, nil, strict: NameIsInvalid)
+    #   person.errors.add(:name, :invalid, strict: NameIsInvalid)
     #   # => NameIsInvalid: name is invalid
     #
     #   person.errors.messages # => {}


### PR DESCRIPTION
The default value for the argument `message` in `ActiveModel::Errors#add` has a new behavior
since ca99ab2481d44d67bc392d0ec1125ff1439e9f94.

```
Before
  person.errors.add(:name, nil)
  # => ["is invalid"]
After
  person.errors.add(:name, nil)
  # => [nil]
```
