### PR TITLE
Make bin/setup portable

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup
@@ -1,28 +1,30 @@
 require 'pathname'
+require 'fileutils'
+include FileUtils
 
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
 
-Dir.chdir APP_ROOT do
+chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file:
 
   puts "== Installing dependencies =="
   system "gem install bundler --conservative"
-  system "bundle check || bundle install"
+  system("bundle check") or system("bundle install")
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")
-  #   system "cp config/database.yml.sample config/database.yml"
+  #   cp "config/database.yml.sample", "config/database.yml"
   # end
 
   puts "\n== Preparing database =="
-  system "bin/rake db:setup"
+  system "ruby bin/rake db:setup"
 
   puts "\n== Removing old logs and tempfiles =="
-  system "rm -f log/*"
-  system "rm -rf tmp/cache"
+  rm_f Dir.glob("log/*")
+  rm_rf "tmp/cache"
 
   puts "\n== Restarting application server =="
-  system "touch tmp/restart.txt"
+  touch "tmp/restart.txt"
 end


### PR DESCRIPTION
I assume portability is a goal here, but the use of UNIX utilities and direct invocation of a binstub make this a nonstarter on Windows. There is also a minor issue that `rm -f log/*.log` will cause an error on csh when no log files are present.

FileUtils seems like the ideal approach.
