### PR TITLE
Add support for Reply-To field in mail_to helper

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -428,6 +428,7 @@ module ActionView
       # * <tt>:body</tt> - Preset the body of the email.
       # * <tt>:cc</tt> - Carbon Copy additional recipients on the email.
       # * <tt>:bcc</tt> - Blind Carbon Copy additional recipients on the email.
+      # * <tt>:reply_to</tt> - Preset the Reply-To field of the email.
       #
       # ==== Obfuscation
       # Prior to Rails 4.0, +mail_to+ provided options for encoding the address
@@ -457,9 +458,9 @@ module ActionView
         html_options, name = name, nil if block_given?
         html_options = (html_options || {}).stringify_keys
 
-        extras = %w{ cc bcc body subject }.map! { |item|
+        extras = %w{ cc bcc body subject reply_to }.map! { |item|
           option = html_options.delete(item) || next
-          "#{item}=#{Rack::Utils.escape_path(option)}"
+          "#{item.dasherize}=#{Rack::Utils.escape_path(option)}"
         }.compact
         extras = extras.empty? ? '' : '?' + extras.join('&')
 

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -493,8 +493,8 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_mail_with_options
     assert_dom_equal(
-      %{<a href="mailto:me@example.com?cc=ccaddress%40example.com&amp;bcc=bccaddress%40example.com&amp;body=This%20is%20the%20body%20of%20the%20message.&amp;subject=This%20is%20an%20example%20email">My email</a>},
-      mail_to("me@example.com", "My email", cc: "ccaddress@example.com", bcc: "bccaddress@example.com", subject: "This is an example email", body: "This is the body of the message.")
+      %{<a href="mailto:me@example.com?cc=ccaddress%40example.com&amp;bcc=bccaddress%40example.com&amp;body=This%20is%20the%20body%20of%20the%20message.&amp;subject=This%20is%20an%20example%20email&amp;reply-to=foo%40bar.com">My email</a>},
+      mail_to("me@example.com", "My email", cc: "ccaddress@example.com", bcc: "bccaddress@example.com", subject: "This is an example email", body: "This is the body of the message.", reply_to: "foo@bar.com")
     )
   end
 


### PR DESCRIPTION
Although not explicitly listed as allowed in the [RFC for the 'mailto' URI scheme](http://www.ietf.org/rfc/rfc6068.txt), it is also not explicitly defined as disallowed. In that respect, this new "reply-to" field seems to be in the same boat as the existing "bcc" and "cc" fields.

This is verified to work as expected in Apple Mail on Yosemite. I have not checked in other clients.
