### PR TITLE
Allow `joins` to be unscoped

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow `joins` to be unscoped.
+
+    Closes #13775.
+
+    *Takashi Kokubun*
+
 *   Rework `ActiveRecord::Relation#last` 
     
     1. Always find last with ruby if relation is loaded

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -54,12 +54,18 @@ module ActiveRecord
             end
             scope_chain_index += 1
 
-            relation = ActiveRecord::Relation.create(
-              klass,
-              table,
-              predicate_builder,
-            )
-            scope_chain_items.concat [klass.send(:build_default_scope, relation)].compact
+            klass_scope =
+              if klass.current_scope
+                klass.current_scope.clone
+              else
+                relation = ActiveRecord::Relation.create(
+                  klass,
+                  table,
+                  predicate_builder,
+                )
+                klass.send(:build_default_scope, relation)
+              end
+            scope_chain_items.concat [klass_scope].compact
 
             rel = scope_chain_items.inject(scope_chain_items.shift) do |left, right|
               left.merge right

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -374,6 +374,18 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_equal 10, DeveloperCalledJamis.unscoped { DeveloperCalledJamis.poor }.length
   end
 
+  def test_default_scope_with_joins
+    assert_equal Comment.where(post_id: SpecialPostWithDefaultScope.pluck(:id)).count,
+                 Comment.joins(:special_post_with_default_scope).count
+    assert_equal Comment.where(post_id: Post.pluck(:id)).count,
+                 Comment.joins(:post).count
+  end
+
+  def test_unscoped_with_joins_should_not_have_default_scope
+    assert_equal SpecialPostWithDefaultScope.unscoped { Comment.joins(:special_post_with_default_scope).to_a },
+                 Comment.joins(:post).to_a
+  end
+
   def test_default_scope_select_ignored_by_aggregations
     assert_equal DeveloperWithSelect.all.to_a.count, DeveloperWithSelect.count
   end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -14,6 +14,7 @@ class Comment < ActiveRecord::Base
   has_many :ratings
 
   belongs_to :first_post, :foreign_key => :post_id
+  belongs_to :special_post_with_default_scope, foreign_key: :post_id
 
   has_many :children, :class_name => 'Comment', :foreign_key => :parent_id
   belongs_to :parent, :class_name => 'Comment', :counter_cache => :children_count


### PR DESCRIPTION
Closes https://github.com/rails/rails/issues/13775

Because `unscoped` alters current_scope, join_dependency should use it if exists.
