### PR TITLE
Replace guides.ror.org/v4.2.0 with guides.ror.org

### DIFF
--- a/activejob/lib/active_job/queue_adapters/inline_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/inline_adapter.rb
@@ -15,7 +15,7 @@ module ActiveJob
         end
 
         def enqueue_at(*) #:nodoc:
-          raise NotImplementedError.new("Use a queueing backend to enqueue jobs in the future. Read more at http://guides.rubyonrails.org/v4.2.0/active_job_basics.html")
+          raise NotImplementedError.new("Use a queueing backend to enqueue jobs in the future. Read more at http://guides.rubyonrails.org/active_job_basics.html")
         end
       end
     end


### PR DESCRIPTION
No need to point links to http://guides.rubyonrails.org/v4.2.0/... now
that the Ruby on Rails guides point to 4.2.0.
