### PR TITLE
Helper #number_to_human_size should display proper unit.

### DIFF
--- a/activesupport/lib/active_support/locale/en.yml
+++ b/activesupport/lib/active_support/locale/en.yml
@@ -99,13 +99,19 @@ en:
         # %u is the storage unit, %n is the number (default: 2 MB)
         format: "%n %u"
         units:
-          byte:
+          byte: &byte
             one:   "Byte"
             other: "Bytes"
           kb: "KB"
           mb: "MB"
           gb: "GB"
           tb: "TB"
+        binary_units:
+          byte: *byte
+          kb: "KiB"
+          mb: "MiB"
+          gb: "GiB"
+          tb: "TiB"
       # Used in NumberHelper.number_to_human()
       decimal_units:
         format: "%n %u"

--- a/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
@@ -35,7 +35,8 @@ module ActiveSupport
 
         def storage_unit_key
           key_end = smaller_than_base? ? 'byte' : STORAGE_UNITS[exponent]
-          "human.storage_units.units.#{key_end}"
+          units_key = opts[:prefix] == :si ? "units" : "binary_units"
+          "human.storage_units.#{units_key}.#{key_end}"
         end
 
         def exponent


### PR DESCRIPTION
There are ambiguous abbreviations which have been being used in Rails: KB, GB...
These are now considered the SI ones which divides units on a decimal basis.
However, the way we are used to divide file sizes is binary and there are proper units for it.
More about that on: http://en.wikipedia.org/wiki/File_size.

Anyway, I found this very simple way of using number_to_human_size's :prefix option to automatically set the units.
I hope this is useful.
