### PR TITLE
Validation test fixes

### DIFF
--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -171,9 +171,8 @@ class ValidationsTest < ActiveModel::TestCase
       # A common mistake -- we meant to call 'validates'
       Topic.validate :title, presence: true
     end
-    message = 'Unknown key: :presence. Valid keys are: :on, :if, :unless. Perhaps you meant to call `validates` instead of `validate`?'
-    assert_includes error.message, "Unknown key: :presence"
-    assert_includes error.message, "Perhaps you meant to call `validates` instead of `validate`?"
+    message = 'Unknown key: :presence. Valid keys are: :on, :if, :unless, :prepend. Perhaps you meant to call `validates` instead of `validate`?'
+    assert_equal message, error.message
   end
 
   def test_callback_options_to_validate


### PR DESCRIPTION
- Fixed unused variable
- Changed test to verify complete message instead of verifying if message contains text.
