### PR TITLE
Add 'require' for Hash#with_indifferent_access to active_job/arguments.rb

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/hash/indifferent_access'
+
 module ActiveJob
   # Raised when an exception is raised during job arguments deserialization.
   #


### PR DESCRIPTION
`ActiveJob::Arguments` uses Hash#with_indifferent_access.
But, activejob gem does not require Hash extension library.
When we use activejob as standalone,
we need extra require statement. This is unhandy.

This commit fixes it.
