### PR TITLE
Clarify ActiveRecord testing guidelines [ci skip]

### DIFF
--- a/activerecord/RUNNING_UNIT_TESTS.rdoc
+++ b/activerecord/RUNNING_UNIT_TESTS.rdoc
@@ -20,11 +20,11 @@ example:
 
 Simply executing <tt>bundle exec rake test</tt> is equivalent to the following:
 
-  $ bundle exec rake test_mysql
-  $ bundle exec rake test_mysql2
-  $ bundle exec rake test_postgresql
-  $ bundle exec rake test_sqlite3
-  $ bundle exec rake test_sqlite3_mem
+  $ bundle exec rake test:mysql
+  $ bundle exec rake test:mysql2
+  $ bundle exec rake test:postgresql
+  $ bundle exec rake test:sqlite3
+  $ bundle exec rake test:sqlite3_mem
 
 There should be tests available for each database backend listed in the {Config
 File}[rdoc-label:label-Config+File]. (the exact set of available tests is

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -287,7 +287,12 @@ $ ruby -w -Itest test/mail_layout_test.rb -n test_explicit_class_layout
 The `-n` option allows you to run a single method instead of the whole
 file.
 
-##### Testing Active Record
+#### Testing Active Record
+
+First, create the databases you'll need. For MySQL and PostgreSQL, 
+running the SQL statements `create database activerecord_unittest` and 
+`create database activerecord_unittest2` is sufficient. This is not 
+necessary for SQLite3.
 
 This is how you run the Active Record test suite only for SQLite3:
 


### PR DESCRIPTION
1. Specify that you need to create the test databases, and that no special
   Rails command needs to be run to do that.
2. Although the underscore style of `rake test_mysql` works, make the
   documentation of running the tests in RUNNING_UNIT_TESTS.rdoc
   consistent with the "Contributing..." guide.
3. Promote "Testing Active Record" to not be a subsection of
   "Running a Single Test," since it doesn't make sense as a subsection
   of that.
