### PR TITLE
Remove unused Sheep fixture from AV

### DIFF
--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -111,19 +111,6 @@ class CommentRelevance
   end
 end
 
-class Sheep
-  extend ActiveModel::Naming
-  include ActiveModel::Conversion
-
-  attr_reader :id
-  def to_key; id ? [id] : nil end
-  def save; @id = 1 end
-  def new_record?; @id.nil? end
-  def name
-    @id.nil? ? 'new sheep' : "sheep ##{@id}"
-  end
-end
-
 class TagRelevance
   extend ActiveModel::Naming
   include ActiveModel::Conversion

--- a/actionview/test/template/record_identifier_test.rb
+++ b/actionview/test/template/record_identifier_test.rb
@@ -9,7 +9,6 @@ class RecordIdentifierTest < ActiveSupport::TestCase
     @record = @klass.new
     @singular = 'comment'
     @plural = 'comments'
-    @uncountable = Sheep
   end
 
   def test_dom_id_with_new_record


### PR DESCRIPTION
The `Sheep` fixture was added in eb23754e when moving template tests
from actionpack to actionview, but it's not actually used in ActionView tests.

The `Sheep` fixture is only used to test `uncountable` in ActiveModel tests,
and [is already defined](https://github.com/rails/rails/blob/e21bd333199888aa76112298735dbb9988a2d72d/activemodel/test/models/sheep.rb) in activemodel/test/models/sheep.rb
