### PR TITLE
Use __dir__ due to the new supported ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ group :job do
 end
 
 # Add your own local bundler stuff
-local_gemfile = File.dirname(__FILE__) + "/.Gemfile"
+local_gemfile = __dir__ + "/.Gemfile"
 instance_eval File.read local_gemfile if File.exist? local_gemfile
 
 group :test do

--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -23,12 +23,12 @@ ActiveSupport::Deprecation.debug = true
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false
 
-FIXTURE_LOAD_PATH = File.expand_path('fixtures', File.dirname(__FILE__))
+FIXTURE_LOAD_PATH = File.expand_path('fixtures', __dir__)
 ActionMailer::Base.view_paths = FIXTURE_LOAD_PATH
 
 module Rails
   def self.root
-    File.expand_path('../', File.dirname(__FILE__))
+    File.expand_path('../', __dir__)
   end
 end
 

--- a/actionmailer/test/log_subscriber_test.rb
+++ b/actionmailer/test/log_subscriber_test.rb
@@ -36,7 +36,7 @@ class AMLogSubscriberTest < ActionMailer::TestCase
   end
 
   def test_receive_is_notified
-    fixture = File.read(File.dirname(__FILE__) + "/fixtures/raw_email")
+    fixture = File.read(__dir__ + "/fixtures/raw_email")
     TestMailer.receive(fixture)
     wait
     assert_equal(1, @logger.logged(:info).size)

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -41,7 +41,7 @@ task :release => :package do
 end
 
 task :lines do
-  load File.expand_path('..', File.dirname(__FILE__)) + '/tools/line_statistics'
+  load File.expand_path('..', __dir__) + '/tools/line_statistics'
   files = FileList["lib/**/*.rb"]
   CodeTools::LineStatistics.new(files).print_loc
 end

--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -82,7 +82,7 @@ module ActionDispatch
         end
 
         def visualizer(paths, title = 'FSM')
-          viz_dir   = File.join File.dirname(__FILE__), '..', 'visualizer'
+          viz_dir   = File.join __dir__, '..', 'visualizer'
           fsm_js    = File.read File.join(viz_dir, 'fsm.js')
           fsm_css   = File.read File.join(viz_dir, 'fsm.css')
           erb       = File.read File.join(viz_dir, 'index.html.erb')

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -1,8 +1,8 @@
 require File.expand_path('../../../load_paths', __FILE__)
 
-$:.unshift(File.dirname(__FILE__) + '/lib')
-$:.unshift(File.dirname(__FILE__) + '/fixtures/helpers')
-$:.unshift(File.dirname(__FILE__) + '/fixtures/alternate_helpers')
+$:.unshift(__dir__ + '/lib')
+$:.unshift(__dir__ + '/fixtures/helpers')
+$:.unshift(__dir__ + '/fixtures/alternate_helpers')
 
 require 'active_support/core_ext/kernel/reporting'
 
@@ -56,7 +56,7 @@ I18n.backend.store_translations 'da', {}
 I18n.backend.store_translations 'pt-BR', {}
 ORIGINAL_LOCALES = I18n.available_locales.map(&:to_s).sort
 
-FIXTURE_LOAD_PATH = File.join(File.dirname(__FILE__), 'fixtures')
+FIXTURE_LOAD_PATH = File.join(__dir__, 'fixtures')
 FIXTURES = Pathname.new(FIXTURE_LOAD_PATH)
 
 module RackTestUtils
@@ -200,7 +200,7 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
   end
 
   def with_autoload_path(path)
-    path = File.join(File.dirname(__FILE__), "fixtures", path)
+    path = File.join(__dir__, "fixtures", path)
     if ActiveSupport::Dependencies.autoload_paths.include?(path)
       yield
     else

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -3,7 +3,7 @@ require 'abstract_unit'
 
 CACHE_DIR = 'test_cache'
 # Don't change '/../temp/' cavalierly or you might hose something you don't want hosed
-FILE_STORE_PATH = File.join(File.dirname(__FILE__), '/../temp/', CACHE_DIR)
+FILE_STORE_PATH = File.join(__dir__, '/../temp/', CACHE_DIR)
 
 class FragmentCachingMetalTestController < ActionController::Metal
   abstract!

--- a/actionpack/test/controller/mime/accept_format_test.rb
+++ b/actionpack/test/controller/mime/accept_format_test.rb
@@ -29,7 +29,7 @@ class StarStarMimeControllerTest < ActionController::TestCase
 end
 
 class AbstractPostController < ActionController::Base
-  self.view_paths = File.dirname(__FILE__) + "/../../fixtures/post_test/"
+  self.view_paths = __dir__ + "/../../fixtures/post_test/"
 end
 
 # For testing layouts which are set automatically

--- a/actionpack/test/controller/new_base/render_file_test.rb
+++ b/actionpack/test/controller/new_base/render_file_test.rb
@@ -2,15 +2,15 @@ require 'abstract_unit'
 
 module RenderFile
   class BasicController < ActionController::Base
-    self.view_paths = File.dirname(__FILE__)
+    self.view_paths = __dir__
 
     def index
-      render :file => File.join(File.dirname(__FILE__), *%w[.. .. fixtures test hello_world])
+      render :file => File.join(__dir__, *%w[.. .. fixtures test hello_world])
     end
 
     def with_instance_variables
       @secret = 'in the sauce'
-      render :file => File.join(File.dirname(__FILE__), '../../fixtures/test/render_file_with_ivar')
+      render :file => File.join(__dir__, '../../fixtures/test/render_file_with_ivar')
     end
 
     def relative_path
@@ -25,11 +25,11 @@ module RenderFile
 
     def pathname
       @secret = 'in the sauce'
-      render :file => Pathname.new(File.dirname(__FILE__)).join(*%w[.. .. fixtures test dot.directory render_file_with_ivar])
+      render :file => Pathname.new(__dir__).join(*%w[.. .. fixtures test dot.directory render_file_with_ivar])
     end
 
     def with_locals
-      path = File.join(File.dirname(__FILE__), '../../fixtures/test/render_file_with_locals')
+      path = File.join(__dir__, '../../fixtures/test/render_file_with_locals')
       render :file => path, :locals => {:secret => 'in the sauce'}
     end
   end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -656,7 +656,7 @@ XML
     end
   end
 
-  FILES_DIR = File.dirname(__FILE__) + '/../fixtures/multipart'
+  FILES_DIR = __dir__ + '/../fixtures/multipart'
 
   READ_BINARY = 'rb:binary'
   READ_PLAIN = 'r:binary'

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -22,7 +22,7 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
     end
   end
 
-  FIXTURE_PATH = File.dirname(__FILE__) + '/../../fixtures/multipart'
+  FIXTURE_PATH = __dir__ + '/../../fixtures/multipart'
 
   def teardown
     TestController.last_request_parameters = nil

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -92,5 +92,5 @@ end
 require 'active_support/core_ext/string/output_safety'
 
 ActiveSupport.on_load(:i18n) do
-  I18n.load_path << "#{File.dirname(__FILE__)}/action_view/locale/en.yml"
+  I18n.load_path << "#{__dir__}/action_view/locale/en.yml"
 end

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -1,10 +1,10 @@
 require File.expand_path('../../../load_paths', __FILE__)
 
-$:.unshift(File.dirname(__FILE__) + '/lib')
-$:.unshift(File.dirname(__FILE__) + '/fixtures/helpers')
-$:.unshift(File.dirname(__FILE__) + '/fixtures/alternate_helpers')
+$:.unshift(__dir__ + '/lib')
+$:.unshift(__dir__ + '/fixtures/helpers')
+$:.unshift(__dir__ + '/fixtures/alternate_helpers')
 
-ENV['TMPDIR'] = File.join(File.dirname(__FILE__), 'tmp')
+ENV['TMPDIR'] = File.join(__dir__, 'tmp')
 
 require 'active_support/core_ext/kernel/reporting'
 
@@ -48,7 +48,7 @@ I18n.backend.store_translations 'da', {}
 I18n.backend.store_translations 'pt-BR', {}
 ORIGINAL_LOCALES = I18n.available_locales.map(&:to_s).sort
 
-FIXTURE_LOAD_PATH = File.join(File.dirname(__FILE__), 'fixtures')
+FIXTURE_LOAD_PATH = File.join(__dir__, 'fixtures')
 FIXTURES = Pathname.new(FIXTURE_LOAD_PATH)
 
 module RackTestUtils
@@ -210,7 +210,7 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
   end
 
   def with_autoload_path(path)
-    path = File.join(File.dirname(__FILE__), "fixtures", path)
+    path = File.join(__dir__, "fixtures", path)
     if ActiveSupport::Dependencies.autoload_paths.include?(path)
       yield
     else

--- a/actionview/test/actionpack/abstract/abstract_controller_test.rb
+++ b/actionview/test/actionpack/abstract/abstract_controller_test.rb
@@ -43,7 +43,7 @@ module AbstractController
         super
       end
 
-      append_view_path File.expand_path(File.join(File.dirname(__FILE__), "views"))
+      append_view_path File.expand_path(File.join(__dir__, "views"))
     end
 
     class Me2 < RenderingController
@@ -153,7 +153,7 @@ module AbstractController
     class OverridingLocalPrefixes < AbstractController::Base
       include AbstractController::Rendering
       include ActionView::Rendering
-      append_view_path File.expand_path(File.join(File.dirname(__FILE__), "views"))
+      append_view_path File.expand_path(File.join(__dir__, "views"))
 
       def index
         render

--- a/actionview/test/actionpack/controller/capture_test.rb
+++ b/actionview/test/actionpack/controller/capture_test.rb
@@ -2,7 +2,7 @@ require 'abstract_unit'
 require 'active_support/logger'
 
 class CaptureController < ActionController::Base
-  self.view_paths = [ File.dirname(__FILE__) + '/../../fixtures/actionpack' ]
+  self.view_paths = [ __dir__ + '/../../fixtures/actionpack' ]
 
   def self.controller_name; "test"; end
   def self.controller_path; "test"; end

--- a/actionview/test/actionpack/controller/layout_test.rb
+++ b/actionview/test/actionpack/controller/layout_test.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/array/extract_options'
 # method has access to the view_paths array when looking for a layout to automatically assign.
 old_load_paths = ActionController::Base.view_paths
 
-ActionController::Base.view_paths = [ File.dirname(__FILE__) + '/../../fixtures/actionpack/layout_tests/' ]
+ActionController::Base.view_paths = [ __dir__ + '/../../fixtures/actionpack/layout_tests/' ]
 
 class LayoutTest < ActionController::Base
   def self.controller_path; 'views' end
@@ -118,7 +118,7 @@ end
 
 class PrependsViewPathController < LayoutTest
   def hello
-    prepend_view_path File.dirname(__FILE__) + '/../../fixtures/actionpack/layout_tests/alt/'
+    prepend_view_path __dir__ + '/../../fixtures/actionpack/layout_tests/alt/'
     render :layout => 'alt'
   end
 end

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -155,7 +155,7 @@ class TestController < ApplicationController
   # :ported:
   def render_file_with_instance_variables
     @secret = 'in the sauce'
-    path = File.join(File.dirname(__FILE__), '../../fixtures/test/render_file_with_ivar')
+    path = File.join(__dir__, '../../fixtures/test/render_file_with_ivar')
     render :file => path
   end
 
@@ -172,21 +172,21 @@ class TestController < ApplicationController
 
   def render_file_using_pathname
     @secret = 'in the sauce'
-    render :file => Pathname.new(File.dirname(__FILE__)).join('..', '..', 'fixtures', 'test', 'dot.directory', 'render_file_with_ivar')
+    render :file => Pathname.new(__dir__).join('..', '..', 'fixtures', 'test', 'dot.directory', 'render_file_with_ivar')
   end
 
   def render_file_from_template
     @secret = 'in the sauce'
-    @path = File.expand_path(File.join(File.dirname(__FILE__), '../../fixtures/test/render_file_with_ivar'))
+    @path = File.expand_path(File.join(__dir__, '../../fixtures/test/render_file_with_ivar'))
   end
 
   def render_file_with_locals
-    path = File.join(File.dirname(__FILE__), '../../fixtures/test/render_file_with_locals')
+    path = File.join(__dir__, '../../fixtures/test/render_file_with_locals')
     render :file => path, :locals => {:secret => 'in the sauce'}
   end
 
   def render_file_as_string_with_locals
-    path = File.expand_path(File.join(File.dirname(__FILE__), '../../fixtures/test/render_file_with_locals'))
+    path = File.expand_path(File.join(__dir__, '../../fixtures/test/render_file_with_locals'))
     render file: path, :locals => {:secret => 'in the sauce'}
   end
 

--- a/actionview/test/active_record_unit.rb
+++ b/actionview/test/active_record_unit.rb
@@ -13,7 +13,7 @@ end
 # Try to grab AR
 unless defined?(ActiveRecord) && defined?(FixtureSet)
   begin
-    PATH_TO_AR = "#{File.dirname(__FILE__)}/../../activerecord/lib"
+    PATH_TO_AR = "#{__dir__}/../../activerecord/lib"
     raise LoadError, "#{PATH_TO_AR} doesn't exist" unless File.directory?(PATH_TO_AR)
     $LOAD_PATH.unshift PATH_TO_AR
     require 'active_record'
@@ -59,13 +59,13 @@ class ActiveRecordTestConnector
 
       # Load actionpack sqlite3 tables
       def load_schema
-        File.read(File.dirname(__FILE__) + "/fixtures/db_definitions/sqlite.sql").split(';').each do |sql|
+        File.read(__dir__ + "/fixtures/db_definitions/sqlite.sql").split(';').each do |sql|
           ActiveRecord::Base.connection.execute(sql) unless sql.blank?
         end
       end
 
       def require_fixture_models
-        Dir.glob(File.dirname(__FILE__) + "/fixtures/*.rb").each {|f| require f}
+        Dir.glob(__dir__ + "/fixtures/*.rb").each {|f| require f}
       end
   end
 end

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -13,7 +13,7 @@ class FixtureTemplate
 end
 
 class FixtureFinder
-  FIXTURES_DIR = "#{File.dirname(__FILE__)}/../fixtures/digestor"
+  FIXTURES_DIR = "#{__dir__}/../fixtures/digestor"
 
   attr_reader   :details
   attr_accessor :formats

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -120,7 +120,7 @@ module RenderTestCases
   end
 
   def test_render_file_with_full_path
-    template_path = File.join(File.dirname(__FILE__), '../fixtures/test/hello_world')
+    template_path = File.join(__dir__, '../fixtures/test/hello_world')
     assert_equal "Hello world!", @view.render(:file => template_path)
   end
 

--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -41,7 +41,7 @@ namespace :test do
 
     namespace :isolated do
       task adapter => "test:env:#{adapter}" do
-        dir = File.dirname(__FILE__)
+        dir = __dir__
         Dir.glob("#{dir}/test/cases/**/*_test.rb").all? do |file|
           sh(Gem.ruby, '-w', "-I#{dir}/lib", "-I#{dir}/test", file)
         end or raise 'Failures'

--- a/activejob/lib/rails/generators/job/job_generator.rb
+++ b/activejob/lib/rails/generators/job/job_generator.rb
@@ -12,7 +12,7 @@ module Rails
       hook_for :test_framework
 
       def self.default_generator_root
-        File.dirname(__FILE__)
+        __dir__
       end
 
       def create_job_file

--- a/activejob/test/adapters/delayed_job.rb
+++ b/activejob/test/adapters/delayed_job.rb
@@ -1,6 +1,6 @@
 ActiveJob::Base.queue_adapter = :delayed_job
 
-$LOAD_PATH << File.dirname(__FILE__) + "/../support/delayed_job"
+$LOAD_PATH << __dir__ + "/../support/delayed_job"
 
 Delayed::Worker.delay_jobs = false
 Delayed::Worker.backend    = :test

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -1,4 +1,4 @@
-dir = File.dirname(__FILE__)
+dir = __dir__
 
 require 'rake/testtask'
 

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -67,5 +67,5 @@ module ActiveModel
 end
 
 ActiveSupport.on_load(:i18n) do
-  I18n.load_path << File.dirname(__FILE__) + '/active_model/locale/en.yml'
+  I18n.load_path << __dir__ + '/active_model/locale/en.yml'
 end

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -398,4 +398,4 @@ module ActiveModel
   end
 end
 
-Dir[File.dirname(__FILE__) + "/validations/*.rb"].each { |file| require file }
+Dir[__dir__ + "/validations/*.rb"].each { |file| require file }

--- a/activemodel/test/config.rb
+++ b/activemodel/test/config.rb
@@ -1,3 +1,3 @@
-TEST_ROOT       = File.expand_path(File.dirname(__FILE__))
+TEST_ROOT       = File.expand_path(__dir__)
 FIXTURES_ROOT   = TEST_ROOT + "/fixtures"
 SCHEMA_FILE     = TEST_ROOT + "/schema.rb"

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -1,8 +1,8 @@
 require 'rake/testtask'
 require 'rubygems/package_task'
 
-require File.expand_path(File.dirname(__FILE__)) + "/test/config"
-require File.expand_path(File.dirname(__FILE__)) + "/test/support/config"
+require File.expand_path(__dir__) + "/test/config"
+require File.expand_path(__dir__) + "/test/support/config"
 
 def run_without_aborting(*tasks)
   errors = []
@@ -147,7 +147,7 @@ task :drop_postgresql_databases => 'db:postgresql:drop'
 task :rebuild_postgresql_databases => 'db:postgresql:rebuild'
 
 task :lines do
-  load File.expand_path('..', File.dirname(__FILE__)) + '/tools/line_statistics'
+  load File.expand_path('..', __dir__) + '/tools/line_statistics'
   files = FileList["lib/active_record/**/*.rb"]
   CodeTools::LineStatistics.new(files).print_loc
 end

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -169,5 +169,5 @@ ActiveSupport.on_load(:active_record) do
 end
 
 ActiveSupport.on_load(:i18n) do
-  I18n.load_path << File.dirname(__FILE__) + '/active_record/locale/en.yml'
+  I18n.load_path << __dir__ + '/active_record/locale/en.yml'
 end

--- a/activerecord/lib/rails/generators/active_record.rb
+++ b/activerecord/lib/rails/generators/active_record.rb
@@ -10,7 +10,7 @@ module ActiveRecord
 
       # Set the current directory as base for the inherited generators.
       def self.base_root
-        File.dirname(__FILE__)
+        __dir__
       end
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -92,7 +92,7 @@ class PostgresqlByteaTest < ActiveRecord::TestCase
   end
 
   def test_write_binary
-    data = File.read(File.join(File.dirname(__FILE__), '..', '..', '..', 'assets', 'example.log'))
+    data = File.read(File.join(__dir__, '..', '..', '..', 'assets', 'example.log'))
     assert(data.size > 1)
     record = ByteaDataType.create(payload: data)
     assert_not record.new_record?

--- a/activerecord/test/cases/reload_models_test.rb
+++ b/activerecord/test/cases/reload_models_test.rb
@@ -13,7 +13,7 @@ class ReloadModelsTest < ActiveRecord::TestCase
     # development environment. Note that meanwhile the class Pet is not
     # reloaded, simulating a class that is present in a plugin.
     Object.class_eval { remove_const :Owner }
-    Kernel.load(File.expand_path(File.join(File.dirname(__FILE__), "../models/owner.rb")))
+    Kernel.load(File.expand_path(File.join(__dir__, "../models/owner.rb")))
 
     pet = Pet.find_by_name('parrot')
     pet.owner = Owner.find_by_name('ashley')

--- a/activerecord/test/config.rb
+++ b/activerecord/test/config.rb
@@ -1,4 +1,4 @@
-TEST_ROOT       = File.expand_path(File.dirname(__FILE__))
+TEST_ROOT       = File.expand_path(__dir__)
 ASSETS_ROOT     = TEST_ROOT + "/assets"
 FIXTURES_ROOT   = TEST_ROOT + "/fixtures"
 MIGRATIONS_ROOT = TEST_ROOT + "/migrations"

--- a/activesupport/bin/generate_tables
+++ b/activesupport/bin/generate_tables
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 begin
-  $:.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib'))
+  $:.unshift(File.expand_path(__dir__ + '/../lib'))
   require 'active_support'
 rescue IOError
 end

--- a/activesupport/lib/active_support/core_ext.rb
+++ b/activesupport/lib/active_support/core_ext.rb
@@ -1,3 +1,3 @@
-Dir["#{File.dirname(__FILE__)}/core_ext/*.rb"].each do |path|
+Dir["#{__dir__}/core_ext/*.rb"].each do |path|
   require path
 end

--- a/activesupport/lib/active_support/i18n.rb
+++ b/activesupport/lib/active_support/i18n.rb
@@ -10,4 +10,4 @@ end
 require 'active_support/lazy_load_hooks'
 
 ActiveSupport.run_load_hooks(:i18n)
-I18n.load_path << "#{File.dirname(__FILE__)}/locale/en.yml"
+I18n.load_path << "#{__dir__}/locale/en.yml"

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -355,7 +355,7 @@ module ActiveSupport
 
         # Returns the directory in which the data files are stored.
         def self.dirname
-          File.dirname(__FILE__) + '/../values/'
+          __dir__ + '/../values/'
         end
 
         # Returns the filename for the data file for this version.

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -105,7 +105,7 @@ class DependenciesTest < ActiveSupport::TestCase
     with_loading 'dependencies' do
       old_warnings, ActiveSupport::Dependencies.warnings_on_first_load = ActiveSupport::Dependencies.warnings_on_first_load, true
       filename = "check_warnings"
-      expanded = File.expand_path("#{File.dirname(__FILE__)}/dependencies/#{filename}")
+      expanded = File.expand_path("#{__dir__}/dependencies/#{filename}")
       $check_warnings_load_count = 0
 
       assert_not ActiveSupport::Dependencies.loaded.include?(expanded)
@@ -413,7 +413,7 @@ class DependenciesTest < ActiveSupport::TestCase
 
   def test_loadable_constants_for_path_should_handle_relative_paths
     fake_root = 'dependencies'
-    relative_root = File.dirname(__FILE__) + '/dependencies'
+    relative_root = __dir__ + '/dependencies'
     ['', '/'].each do |suffix|
       with_loading fake_root + suffix do
         assert_equal ["A::B"], ActiveSupport::Dependencies.loadable_constants_for_path(relative_root + '/a/b')
@@ -438,7 +438,7 @@ class DependenciesTest < ActiveSupport::TestCase
   end
 
   def test_loadable_constants_with_load_path_without_trailing_slash
-    path = File.dirname(__FILE__) + '/autoloading_fixtures/class_folder/inline_class.rb'
+    path = __dir__ + '/autoloading_fixtures/class_folder/inline_class.rb'
     with_loading 'autoloading_fixtures/class/' do
       assert_equal [], ActiveSupport::Dependencies.loadable_constants_for_path(path)
     end

--- a/activesupport/test/dependencies_test_helpers.rb
+++ b/activesupport/test/dependencies_test_helpers.rb
@@ -1,7 +1,7 @@
 module DependenciesTestHelpers
   def with_loading(*from)
     old_mechanism, ActiveSupport::Dependencies.mechanism = ActiveSupport::Dependencies.mechanism, :load
-    this_dir = File.dirname(__FILE__)
+    this_dir = __dir__
     parent_dir = File.dirname(this_dir)
     path_copy = $LOAD_PATH.dup
     $LOAD_PATH.unshift(parent_dir) unless $LOAD_PATH.include?(parent_dir)

--- a/activesupport/test/xml_mini/jdom_engine_test.rb
+++ b/activesupport/test/xml_mini/jdom_engine_test.rb
@@ -7,7 +7,7 @@ if RUBY_PLATFORM =~ /java/
   class JDOMEngineTest < ActiveSupport::TestCase
     include ActiveSupport
 
-    FILES_DIR = File.dirname(__FILE__) + '/../fixtures/xml'
+    FILES_DIR = __dir__ + '/../fixtures/xml'
 
     def setup
       @default_backend = XmlMini.backend

--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -5,7 +5,7 @@ require 'rails'
 require 'action_controller/railtie'
 
 class TestApp < Rails::Application
-  config.root = File.dirname(__FILE__)
+  config.root = __dir__
   config.session_store :cookie_store, key: 'cookie_store_key'
   secrets.secret_token    = 'secret_token'
   secrets.secret_key_base = 'secret_key_base'

--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -15,7 +15,7 @@ require 'rails'
 require 'action_controller/railtie'
 
 class TestApp < Rails::Application
-  config.root = File.dirname(__FILE__)
+  config.root = __dir__
   config.session_store :cookie_store, key: 'cookie_store_key'
   secrets.secret_token    = 'secret_token'
   secrets.secret_key_base = 'secret_key_base'

--- a/guides/rails_guides.rb
+++ b/guides/rails_guides.rb
@@ -1,4 +1,4 @@
-pwd = File.dirname(__FILE__)
+pwd = __dir__
 $:.unshift pwd
 
 # This is a predicate useful for the doc:guides task of applications.

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -123,7 +123,7 @@ module RailsGuides
     end
 
     def initialize_dirs(output)
-      @guides_dir = File.join(File.dirname(__FILE__), '..')
+      @guides_dir = File.join(__dir__, '..')
       @source_dir = "#@guides_dir/source/#@lang"
       @output_dir = if output
         output

--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -261,6 +261,6 @@ relative paths to your template's location.
 
 ```ruby
 def source_paths
-  [File.expand_path(File.dirname(__FILE__))]
+  [File.expand_path(__dir__)]
 end
 ```

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -338,7 +338,7 @@ send_file('/var/www/uploads/' + params[:filename])
 Simply pass a file name like "../../../etc/passwd" to download the server's login information. A simple solution against this, is to _check that the requested file is in the expected directory_:
 
 ```ruby
-basename = File.expand_path(File.join(File.dirname(__FILE__), '../../files'))
+basename = File.expand_path(File.join(__dir__, '../../files'))
 filename = File.expand_path(File.join(basename, @file.public_filename))
 raise if basename !=
      File.expand_path(File.join(File.dirname(filename), '../../../'))

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -15,9 +15,9 @@ namespace :test do
       dash_i = [
         'test',
         'lib',
-        "#{File.dirname(__FILE__)}/../activesupport/lib",
-        "#{File.dirname(__FILE__)}/../actionpack/lib",
-        "#{File.dirname(__FILE__)}/../activemodel/lib"
+        "#{__dir__}/../activesupport/lib",
+        "#{__dir__}/../actionpack/lib",
+        "#{__dir__}/../activemodel/lib"
       ]
       ruby "-w", "-I#{dash_i.join ':'}", file
     end
@@ -25,7 +25,7 @@ namespace :test do
 end
 
 Rake::TestTask.new('test:regular') do |t|
-  t.libs << 'test' << "#{File.dirname(__FILE__)}/../activesupport/lib"
+  t.libs << 'test' << "#{__dir__}/../activesupport/lib"
   t.pattern = 'test/**/*_test.rb'
   t.warning = true
   t.verbose = true

--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -215,7 +215,7 @@ module Rails
       # Returns the base root for a common set of generators. This is used to dynamically
       # guess the default source root.
       def self.base_root
-        File.dirname(__FILE__)
+        __dir__
       end
 
       # Cache source root and add lib/generators/base/generator/templates to

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -153,7 +153,7 @@ module Rails
   module Generators
     # We need to store the RAILS_DEV_PATH in a constant, otherwise the path
     # can change in Ruby 1.8.7 when we FileUtils.cd.
-    RAILS_DEV_PATH = File.expand_path("../../../../../..", File.dirname(__FILE__))
+    RAILS_DEV_PATH = File.expand_path("../../../../../..", __dir__)
     RESERVED_NAMES = %w[application destroy plugin runner test]
 
     class AppGenerator < AppBase # :nodoc:

--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
@@ -15,7 +15,7 @@ require "rails/test_help"
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
 # Load support files
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+Dir["#{__dir__}/support/**/*.rb"].each { |f| require f }
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)

--- a/railties/lib/rails/generators/test_case.rb
+++ b/railties/lib/rails/generators/test_case.rb
@@ -14,7 +14,7 @@ module Rails
     #
     #   class AppGeneratorTest < Rails::Generators::TestCase
     #     tests AppGenerator
-    #     destination File.expand_path("../tmp", File.dirname(__FILE__))
+    #     destination File.expand_path("../tmp", __dir__)
     #   end
     #
     # If you want to ensure your destination root is clean before running each test,
@@ -22,7 +22,7 @@ module Rails
     #
     #   class AppGeneratorTest < Rails::Generators::TestCase
     #     tests AppGenerator
-    #     destination File.expand_path("../tmp", File.dirname(__FILE__))
+    #     destination File.expand_path("../tmp", __dir__)
     #     setup :prepare_destination
     #   end
     class TestCase < ActiveSupport::TestCase

--- a/railties/lib/rails/generators/testing/behaviour.rb
+++ b/railties/lib/rails/generators/testing/behaviour.rb
@@ -38,7 +38,7 @@ module Rails
 
           # Sets the destination of generator files:
           #
-          #   destination File.expand_path("../tmp", File.dirname(__FILE__))
+          #   destination File.expand_path("../tmp", __dir__)
           def destination(path)
             self.destination_root = path
           end
@@ -49,7 +49,7 @@ module Rails
         #
         #   class AppGeneratorTest < Rails::Generators::TestCase
         #     tests AppGenerator
-        #     destination File.expand_path("../tmp", File.dirname(__FILE__))
+        #     destination File.expand_path("../tmp", __dir__)
         #     setup :prepare_destination
         #
         #     test "database.yml is not created when skipping Active Record" do

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -13,7 +13,7 @@ require 'rails/all'
 
 module TestApp
   class Application < Rails::Application
-    config.root = File.dirname(__FILE__)
+    config.root = __dir__
     secrets.secret_key_base = 'b3c631c314c0bbca50c1b2843150fe33'
   end
 end

--- a/railties/test/code_statistics_calculator_test.rb
+++ b/railties/test/code_statistics_calculator_test.rb
@@ -46,7 +46,7 @@ class CodeStatisticsCalculatorTest < ActiveSupport::TestCase
   end
 
   test 'calculate statistics using #add_by_file_path' do
-    tmp_path = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', 'tmp'))
+    tmp_path = File.expand_path(File.join(__dir__, 'fixtures', 'tmp'))
     FileUtils.mkdir_p(tmp_path)
 
     code = <<-'CODE'

--- a/railties/test/fixtures/lib/generators/usage_template/usage_template_generator.rb
+++ b/railties/test/fixtures/lib/generators/usage_template/usage_template_generator.rb
@@ -1,5 +1,5 @@
 require 'rails/generators'
 
 class UsageTemplateGenerator < Rails::Generators::Base
-  source_root File.expand_path("templates", File.dirname(__FILE__))
+  source_root File.expand_path("templates", __dir__)
 end

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -221,7 +221,7 @@ class GeneratorsTest < Rails::Generators::TestCase
   end
 
   def test_usage_with_embedded_ruby
-    require File.expand_path("fixtures/lib/generators/usage_template/usage_template_generator", File.dirname(__FILE__))
+    require File.expand_path("fixtures/lib/generators/usage_template/usage_template_generator", __dir__)
     output = capture(:stdout) { Rails::Generators.invoke :usage_template, ['--help'] }
     assert_match(/:: 2 ::/, output)
   end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -13,7 +13,7 @@ require 'active_support'
 require 'active_support/testing/autorun'
 require 'active_support/test_case'
 
-RAILS_FRAMEWORK_ROOT = File.expand_path("#{File.dirname(__FILE__)}/../../..")
+RAILS_FRAMEWORK_ROOT = File.expand_path("#{__dir__}/../../..")
 
 # These files do not require any others and are needed
 # to run the tests


### PR DESCRIPTION
Since we don't support 1.9 anymore, we can use **dir** when available. Thanks!
