### PR TITLE
Specify test_order to not show deprecation message

### DIFF
--- a/railties/test/generators/generator_test.rb
+++ b/railties/test/generators/generator_test.rb
@@ -5,6 +5,7 @@ require 'rails/generators/app_base'
 module Rails
   module Generators
     class GeneratorTest < ActiveSupport::TestCase
+      self.test_order = :random
       def make_builder_class
         Class.new(AppBase) do
           add_shared_options_for "application"


### PR DESCRIPTION
Running the following test was showing the below deprecation message;
the deprecation message is shown even when the entire suite is run with 
`rake test`:

> cd raities
> ruby -w -Itest test/generators/generator_test.rb

```
DEPRECATION WARNING: You did not specify a value for the
configuration option `active_support.test_order`. In
Rails 5, the default value...
```
