### PR TITLE
Add information about "allow_destroy" requiring an ID. [ci skip]

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -81,6 +81,9 @@ module ActiveRecord
     #
     # Note that the model will _not_ be destroyed until the parent is saved.
     #
+    # Also note that the model will not be destroyed unless you also specify
+    # its id in the updated hash. 
+    #
     # === One-to-many
     #
     # Consider a member that has a number of posts:


### PR DESCRIPTION
I just wasted an absurd amount of time trying to figure out why my model wasn't being deleted even though I was setting `_destroy` to true like the instructions said. Making the documentation a little bit clearer so that someone like me doesn't waste their time in future.
