### PR TITLE
Add Support for creating and dropping SQL views

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -954,6 +954,14 @@ module ActiveRecord
         raise NotImplementedError, "drop_view is not implemented"
       end
 
+      # Update a view given the SQL definition.
+      # to first drop the view if it already exists.#
+      #   update_view(:view_name, :definition)
+      #
+      def update_view(view_name, definition)
+        raise NotImplementedError, "update_view is not implemented"
+      end
+
       protected
         def add_index_sort_order(option_strings, column_names, options = {})
           if options.is_a?(Hash) && order = options[:order]

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -939,6 +939,21 @@ module ActiveRecord
         [index_name, index_type, index_columns, index_options, algorithm, using]
       end
 
+
+      # Create a view given the SQL definition.  Specify :force => true
+      # to first drop the view if it already exists.#
+      #   create_view(:view_name, :definition, :options)
+      #
+      def create_view(view_name, definition, options = {})
+        raise NotImplementedError, "create_view is not implemented"
+      end
+
+      # Drop the named view.  Specify :if_exists => true
+      # to fail silently if the view doesn't exist.
+      def drop_view(view_name, options = {})
+        raise NotImplementedError, "drop_view is not implemented"
+      end
+
       protected
         def add_index_sort_order(option_strings, column_names, options = {})
           if options.is_a?(Hash) && order = options[:order]

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -590,6 +590,28 @@ module ActiveRecord
 
           [super, *order_columns].join(', ')
         end
+
+        # Create a view given the SQL definition.  Specify :force => true
+        # to first drop the view if it already exists.#
+        #   create_view(:view_name, :definition, :options)
+        #
+        def create_view(view_name, definition, options = {})
+          definition = definition.to_sql if definition.respond_to? :to_sql
+          if options[:force]
+            drop_view(view_name, if_exists: true)
+          end
+          execute "CREATE VIEW #{quote_table_name(view_name)} AS #{definition}"
+        end
+
+        # Drop the named view.  Specify :if_exists => true
+        # to fail silently if the view doesn't exist.
+        def drop_view(view_name, options = {})
+          sql = "DROP VIEW"
+          sql += " IF EXISTS" if options[:if_exists]
+          sql += " #{quote_table_name(view_name)}"
+          execute sql
+        end
+
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -612,6 +612,15 @@ module ActiveRecord
           execute sql
         end
 
+        # Update a view given the SQL definition.
+        # to first drop the view if it already exists.#
+        #   update_view(:view_name, :definition)
+        #
+        def update_view(view_name, definition)
+          drop_view(view_name, if_exists: true)
+          create_view(view_name, definition)
+        end
+
       end
     end
   end


### PR DESCRIPTION
Add support for creating and dropping views. In a migration, a view can be created using a rails relation or literal sql

``` ruby
create_view :posts_commented_by_staff,  Post.joins(comment: user).where(users: {role: 'staff'}).uniq
create_view :uncommented_posts,        "SELECT * FROM posts LEFT OUTER JOIN comments ON comments.post_id = posts.id WHERE comments.id IS NULL"
```

And can be dropped:

``` ruby
drop_view :posts_commented_by_staff
drop_view :uncommented_posts, :if_exists => true
```

ActiveRecord works with views the same as with ordinary tables. That is, for the above views you can define

``` ruby
class PostCommentedByStaff < ActiveRecord::Base
  table_name = "posts_commented_by_staff"
end

class UncommentedPost < ActiveRecord::Base
end
```

I took this idea from [Schema Plus](https://github.com/SchemaPlus/schema_plus) gem and I opened an early PR to see if this something that Rails Team wants to include, I'll make the change needed and add the proper tests as needed.  For the moment I only tested against to PostgresSQL

Thanks
