### PR TITLE
Bugfix collection association #create method

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -414,12 +414,16 @@ module ActiveRecord
 
       def replace_on_target(record, index, skip_callbacks)
         callback(:before_add, record) unless skip_callbacks
+
+        was_loaded = loaded?
         yield(record) if block_given?
 
-        if index
-          @target[index] = record
-        else
-          @target << record
+        unless !was_loaded && loaded?
+          if index
+            @target[index] = record
+          else
+            @target << record
+          end
         end
 
         callback(:after_add, record) unless skip_callbacks

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2348,6 +2348,12 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal [first_bulb, second_bulb], car.bulbs
   end
 
+  test 'double insertion of new object to association when same association used in the after create callback of a new object' do
+    car = Car.create!
+    car.bulbs << TrickyBulb.new
+    assert_equal 1, car.bulbs.size
+  end
+
   def test_association_force_reload_with_only_true_is_deprecated
     company = Company.find(1)
 

--- a/activerecord/test/models/bulb.rb
+++ b/activerecord/test/models/bulb.rb
@@ -50,3 +50,9 @@ class FailedBulb < Bulb
     throw(:abort)
   end
 end
+
+class TrickyBulb < Bulb
+  after_create do |record|
+    record.car.bulbs.to_a
+  end
+end


### PR DESCRIPTION
When same association is loaded in the model creation callback
The new object is inserted into association twice.

``` ruby
Car.has_many :bulbs
Bulb.belongs_to :car
Bulb.after_create do |record|
  record.car.bulbs.to_a # force loading
end

car = Car.create!
car.bulbs << Bulb.new
assert_equal 1, car.bulbs.size # returns 2 right now
```
