### PR TITLE
Don't raise on out-of-range datetimes passed by a user

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Don't raise when writing an attribute with an out-of-range datetime passed
+    by the user.
+
+    *Grey Baker*
+
 *   Replace deprecated `ActiveRecord::Tasks::DatabaseTasks#load_schema` with
     `ActiveRecord::Tasks::DatabaseTasks#load_schema_for`.
 

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -12,7 +12,11 @@ module ActiveRecord
           if value.is_a?(Array)
             value.map { |v| type_cast_from_user(v) }
           elsif value.respond_to?(:in_time_zone)
-            value.in_time_zone || super
+            begin
+              value.in_time_zone || super
+            rescue ArgumentError
+              nil
+            end
           end
         end
 

--- a/activerecord/test/cases/date_time_test.rb
+++ b/activerecord/test/cases/date_time_test.rb
@@ -3,6 +3,8 @@ require 'models/topic'
 require 'models/task'
 
 class DateTimeTest < ActiveRecord::TestCase
+  include InTimeZone
+
   def test_saves_both_date_and_time
     with_env_tz 'America/New_York' do
       with_timezone_config default: :utc do
@@ -27,6 +29,14 @@ class DateTimeTest < ActiveRecord::TestCase
     task.ending = nil
     assert_nil task.starting
     assert_nil task.ending
+  end
+
+  def test_assign_bad_date_time_with_timezone
+    in_time_zone "Pacific Time (US & Canada)" do
+      task = Task.new
+      task.starting = '2014-07-01T24:59:59GMT'
+      assert_nil task.starting
+    end
   end
 
   def test_assign_empty_date


### PR DESCRIPTION
Currently out-of-range user-entered datetimes cause an argument error:

``` ruby
task = Task.new(start_at: "2014-07-01T24:59:59GMT")   #=> ArgumentError
```

In contrast, when _really_ bad data is entered the error is caught and the attribute is set to `nil`, 

``` ruby
task = Task.new(start_at: "rubbish")
taks.start_at      #=> nil
```

This PR catches the argument error to make the above two scenarios consistent.
