### PR TITLE
3-2-stable: add ruby 2.2 compatibility

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -50,15 +50,15 @@ module ActiveRecord
           [options[:limit], count].compact.min
         end
 
-        def has_cached_counter?(reflection = reflection)
+        def has_cached_counter?(reflection = reflection())
           owner.attribute_present?(cached_counter_attribute_name(reflection))
         end
 
-        def cached_counter_attribute_name(reflection = reflection)
+        def cached_counter_attribute_name(reflection = reflection())
           "#{reflection.name}_count"
         end
 
-        def update_counter(difference, reflection = reflection)
+        def update_counter(difference, reflection = reflection())
           if has_cached_counter?(reflection)
             counter = cached_counter_attribute_name(reflection)
             owner.class.update_counters(owner.id, counter => difference)
@@ -77,7 +77,7 @@ module ActiveRecord
         #     it will be decremented twice.
         #
         # Hence this method.
-        def inverse_updates_counter_cache?(reflection = reflection)
+        def inverse_updates_counter_cache?(reflection = reflection())
           counter_name = cached_counter_attribute_name(reflection)
           reflection.klass.reflect_on_all_associations(:belongs_to).any? { |inverse_reflection|
             inverse_reflection.counter_cache_column == counter_name

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -138,6 +138,12 @@ class DateTime
 
   # Layers additional behavior on DateTime#<=> so that Time and ActiveSupport::TimeWithZone instances can be compared with a DateTime
   def <=>(other)
-    super other.kind_of?(Infinity) ? other : other.to_datetime
+    if other.kind_of?(Infinity)
+      super
+    elsif other.respond_to? :to_datetime
+      super other.to_datetime
+    else
+      nil
+    end
   end
 end

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -267,7 +267,7 @@ module ActiveSupport
     #
     #   Time.zone.now                 # => Fri, 31 Dec 1999 14:00:00 HST -10:00
     #   Time.zone.parse('22:30:00')   # => Fri, 31 Dec 1999 22:30:00 HST -10:00
-    def parse(str, now=now)
+    def parse(str, now=now())
       parts = Date._parse(str, false)
       return if parts.empty?
 


### PR DESCRIPTION
Fixes some warnings that were preventing our rails app from running on ruby 2.2.0-rc1 with rails 3.2.
