### PR TITLE
A new validator: Unchanged validator

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,1 +1,7 @@
-Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activemodel/CHANGELOG.md) for previous changes.
+* Add a new validator: `UnchangedValidator`
+
+  This validates that the specified model attributes have not changed.
+
+  *Peter Marsh*
+
+-Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -33,3 +33,4 @@ en:
       other_than: "must be other than %{count}"
       odd: "must be odd"
       even: "must be even"
+      changed: "must not change"

--- a/activemodel/lib/active_model/validations/unchanged.rb
+++ b/activemodel/lib/active_model/validations/unchanged.rb
@@ -1,0 +1,33 @@
+module ActiveModel
+  module Validations
+    # == Active Model Unchanged Validator
+    class UnchangedValidator < EachValidator #:nodoc:
+      def validate_each(record, attr_name, value)#
+        if !record.new_record? && record.send(:"#{attr_name}_changed?")
+          record.errors.add(attr_name, :changed, options)
+        end
+      end
+    end
+
+    module HelperMethods
+      # Validates that the specified attributes are unchanged (unless the record is new).
+      # Happens by default on save.
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_unchanged :first_name
+      #   end
+      #
+      # The first_name attribute must be in the object and it must not have changed.
+      #
+      # Configuration options:
+      # * <tt>:message</tt> - A custom error message (default is: "must not change").
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # See <tt>ActiveModel::Validation#validates</tt> for more information
+      def validates_unchanged(*attr_names)
+        validates_with UnchangedValidator, _merge_attributes(attr_names)
+      end
+    end
+  end
+end

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -1,56 +1,7 @@
 require "cases/helper"
+require "models/dirty_model"
 
 class DirtyTest < ActiveModel::TestCase
-  class DirtyModel
-    include ActiveModel::Dirty
-    define_attribute_methods :name, :color, :size
-
-    def initialize
-      @name = nil
-      @color = nil
-      @size = nil
-    end
-
-    def name
-      @name
-    end
-
-    def name=(val)
-      name_will_change!
-      @name = val
-    end
-
-    def color
-      @color
-    end
-
-    def color=(val)
-      color_will_change! unless val == @color
-      @color = val
-    end
-
-    def size
-      @size
-    end
-
-    def size=(val)
-      attribute_will_change!(:size) unless val == @size
-      @size = val
-    end
-
-    def save
-      changes_applied
-    end
-
-    def reload
-      clear_changes_information
-    end
-
-    def deprecated_reload
-      reset_changes
-    end
-  end
-
   setup do
     @model = DirtyModel.new
   end

--- a/activemodel/test/cases/validations/unchanged_validation_test.rb
+++ b/activemodel/test/cases/validations/unchanged_validation_test.rb
@@ -1,0 +1,99 @@
+# encoding: utf-8
+require 'cases/helper'
+require 'models/dirty_model'
+
+class UnchangedValidationTest < ActiveModel::TestCase
+
+  teardown do
+    DirtyModel.clear_validators!
+  end
+
+  def test_validate_unchanged
+    d = DirtyModel.new
+    d.name = 'dave'
+    d.color = 'green'
+    d.save
+
+    DirtyModel.validates_unchanged(:name, :color)
+
+    d.name = 'bob'
+    d.color = 'green'
+    assert d.invalid?
+    assert_equal ['must not change'], d.errors[:name]
+    assert_equal [], d.errors[:color]
+
+    d = DirtyModel.new
+    assert d.valid?
+
+    d = DirtyModel.new
+    d.name = 'dave'
+    d.color = 'red'
+    d.save
+  end
+
+  def test_validates_unchanged_with_array_arguments
+    d = DirtyModel.new
+    d.name = 'dave'
+    d.color = 'green'
+    d.save
+    
+    DirtyModel.validates_unchanged %w(name color)
+
+    d.name = 'bob'
+    d.color = 'red'
+    assert d.invalid?
+    assert_equal ['must not change'], d.errors[:name]
+    assert_equal ['must not change'], d.errors[:color]
+  end
+
+  def test_validates_unchanged_with_custom_error_using_quotes
+    DirtyModel.validates_unchanged :name, message: "This string contains 'single' and \"double\" quotes"
+    d = DirtyModel.new
+    d.save
+    d.name = 'bob'
+    assert d.invalid?
+    assert_equal ["This string contains 'single' and \"double\" quotes"], d.errors[:name]
+  end
+
+  def test_validates_unchanged_with_allow_nil_option
+    d = DirtyModel.new
+    d.color = 'green'
+    d.save
+
+    DirtyModel.validates_unchanged(:color, allow_nil: true)
+
+    d.color = 'green'
+    assert d.valid?, d.errors.full_messages
+
+    d.color = 'red'
+    assert d.invalid?
+    assert_equal ['must not change'], d.errors[:color]
+
+    d.color = ""
+    assert d.invalid?
+    assert_equal ['must not change'], d.errors[:color]
+
+    d.color = nil
+    assert d.valid?, d.errors.full_messages
+  end
+
+  def test_unchanged_with_allow_blank_option
+    d = DirtyModel.new
+    d.color = 'green'
+    d.save
+
+    DirtyModel.validates_unchanged(:color, allow_blank: true)
+
+    d.color = 'green'
+    assert d.valid?, d.errors.full_messages
+
+    d.color = ""
+    assert d.valid?, d.errors.full_messages
+
+    d.color = "  "
+    assert d.valid?, d.errors.full_messages
+
+    d.color = nil
+    assert d.valid?, d.errors.full_messages
+  end
+end

--- a/activemodel/test/models/dirty_model.rb
+++ b/activemodel/test/models/dirty_model.rb
@@ -1,11 +1,14 @@
   class DirtyModel
     include ActiveModel::Dirty
+    include ActiveModel::Validations
+
     define_attribute_methods :name, :color, :size
 
     def initialize
       @name = nil
       @color = nil
       @size = nil
+      @new_record = true
     end
 
     def name
@@ -37,6 +40,7 @@
 
     def save
       changes_applied
+      @new_record = false
     end
 
     def reload
@@ -45,5 +49,9 @@
 
     def deprecated_reload
       reset_changes
+    end
+
+    def new_record?
+      @new_record
     end
   end

--- a/activemodel/test/models/dirty_model.rb
+++ b/activemodel/test/models/dirty_model.rb
@@ -1,0 +1,49 @@
+  class DirtyModel
+    include ActiveModel::Dirty
+    define_attribute_methods :name, :color, :size
+
+    def initialize
+      @name = nil
+      @color = nil
+      @size = nil
+    end
+
+    def name
+      @name
+    end
+
+    def name=(val)
+      name_will_change!
+      @name = val
+    end
+
+    def color
+      @color
+    end
+
+    def color=(val)
+      color_will_change! unless val == @color
+      @color = val
+    end
+
+    def size
+      @size
+    end
+
+    def size=(val)
+      attribute_will_change!(:size) unless val == @size
+      @size = val
+    end
+
+    def save
+      changes_applied
+    end
+
+    def reload
+      clear_changes_information
+    end
+
+    def deprecated_reload
+      reset_changes
+    end
+  end


### PR DESCRIPTION
This ensures that the specified model attributes have not changed. For example:

```
class Person < ActiveRecord::Base
  validates_unchanged :first_name
end

p = Person.first
#=>  #<Person id: 1, first_name: 'Dave'>

p.first_name = 'Bob'
p.valid?
#=> false

p.first_name = 'Dave'
p.valid?
#=> true
```

This is most useful when there are attributes on a model that should only be
set once, or at least only rarely.

I've have had a couple of instances where I've required a validator like this, and a quick Google turns up some instances of other people online asking for something similar - I think it may be useful.

There's two things I think need to be carefully looked at in this PR:
1. Tests - the style of the tests for various validators are quite different. I tried to follow the examples of presence_validator_test.rb and absence_validator_test.rb - please let me know if you would like me to change/improve the tests for this validator.
2. This validator requires the model to include `ActiveModel::Dirty` which means it doesn't work out-of-the-box with plain Ruby classes (as the other validators do). Is that ok?
