### PR TITLE
Remove block from super

### DIFF
--- a/actionview/lib/action_view/helpers/tags/search_field.rb
+++ b/actionview/lib/action_view/helpers/tags/search_field.rb
@@ -3,18 +3,21 @@ module ActionView
     module Tags # :nodoc:
       class SearchField < TextField # :nodoc:
         def render
-          super do |options|
-            if options["autosave"]
-              if options["autosave"] == true
-                options["autosave"] = request.host.split(".").reverse.join(".")
-              end
-              options["results"] ||= 10
-            end
+          options = @options.stringify_keys
 
-            if options["onsearch"]
-              options["incremental"] = true unless options.has_key?("incremental")
+          if options["autosave"]
+            if options["autosave"] == true
+              options["autosave"] = request.host.split(".").reverse.join(".")
             end
+            options["results"] ||= 10
           end
+
+          if options["onsearch"]
+            options["incremental"] = true unless options.has_key?("incremental")
+          end
+
+          @options = options
+          super
         end
       end
     end

--- a/actionview/lib/action_view/helpers/tags/text_field.rb
+++ b/actionview/lib/action_view/helpers/tags/text_field.rb
@@ -11,7 +11,6 @@ module ActionView
           options["size"] = options["maxlength"] unless options.key?("size")
           options["type"] ||= field_type
           options["value"] = options.fetch("value") { value_before_type_cast(object) } unless field_type == "file"
-          yield options if block_given?
           add_default_name_and_id(options)
           tag("input", options)
         end


### PR DESCRIPTION
in a previous commit : 5c7b5dc741f6980de2592e9b113ae385000a6da7 I fixed the modified options variable that was never saved(because it was overwritten in the textfield class), for this i just yielded the options variable and call it from from super (which looks kinda hacky and weird :disappointed: ), i refactored this just by returning the overwritten options to the instance variable again
