### PR TITLE
Fix route helper to work with string params

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix route helper to work with string params
+
+    *Sammy Larbi*
+
 *   Fixed handling of positional url helper arguments when `format: false`.
 
     Fixes #17819.

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -14,6 +14,7 @@ module ActionDispatch
       end
 
       def generate(name, options, path_parameters, parameterize = nil)
+        options = options.symbolize_keys
         constraints = path_parameters.merge(options)
         missing_keys = []
 

--- a/actionpack/test/dispatch/url_generation_test.rb
+++ b/actionpack/test/dispatch/url_generation_test.rb
@@ -129,6 +129,15 @@ module TestUrlGeneration
       )
     end
 
+    test "does not raise ArgumentError: comparison of Array with Array failed" do
+      assert_raises ActionController::UrlGenerationError do
+        bar_path(id_is_purposefully_not_present: true, "symbol_mixed_with_string_would_cause_ArgumentError" => true)
+      end
+    end
+
+    test "accepts a string key for required keys" do
+      assert_equal "/bars/1", bar_path("id" => 1)
+    end
   end
 end
 


### PR DESCRIPTION
Before Rails 4.2.0, `model_path("id" => 1)` would work fine. As of Rails 4.2.0, it generated a couple of errors:
1. `ArgumentError: comparison of Array with Array failed` (due to attempting to sort a hash with mixed string/symbol keys in the case where an `UrlGenerationError` should have occurred)
2. `ActionController::UrlGenerationError`, because of missing required key :id (i.e., it ignored the `"id"` string parameter)

This fix is on 4-2-stable, so I think this would need to be ported to the master branch as well. 
