### PR TITLE
Fix route helper to work with string params

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix route helper to work with string params
+
+    *Sammy Larbi*
+
 *   For actions with no corresponding templates, render `head :no_content`
     instead of raising an error. This allows for slimmer API controller
     methods that simply work, without needing further instructions.

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -246,7 +246,7 @@ module ActionDispatch
             controller_options = t.url_options
             options = controller_options.merge @options
             hash = handle_positional_args(controller_options,
-                                          inner_options || {},
+                                          deprecate_non_symbol_options(inner_options) || {},
                                           args,
                                           options,
                                           @segment_keys)
@@ -274,6 +274,20 @@ module ActionDispatch
             end
 
             result.merge!(inner_options)
+          end
+
+          def deprecate_non_symbol_options(options)
+            options ||= {}
+            if options.keys.any?{|k| !k.is_a? Symbol }
+              deprecated_options = options.keys.select{|k| !k.is_a? Symbol }
+              msg = "Calling URL helpers with string keys #{deprecated_options.join(", ")} is deprecated. Use symbols instead."
+              ActiveSupport::Deprecation.warn(msg)
+              deprecated_options.each do |option|
+                value = options.delete(option)
+                options[option.to_sym] = value
+              end
+            end
+            options
           end
         end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4476,19 +4476,6 @@ class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
     error = assert_raises(ActionController::UrlGenerationError, message){ product_path(id: nil) }
     assert_equal message, error.message
   end
-
-  test "url helpers raise message with mixed parameters when generation fails " do
-    url, missing = { action: 'show', controller: 'products', id: nil, "id"=>"url-tested"}, [:id]
-    message = "No route matches #{url.inspect} missing required keys: #{missing.inspect}"
-
-    # Optimized url helper
-    error = assert_raises(ActionController::UrlGenerationError){ product_path(nil, 'id'=>'url-tested') }
-    assert_equal message, error.message
-
-    # Non-optimized url helper
-    error = assert_raises(ActionController::UrlGenerationError, message){ product_path(id: nil, 'id'=>'url-tested') }
-    assert_equal message, error.message
-  end
 end
 
 class TestDefaultUrlOptions < ActionDispatch::IntegrationTest

--- a/actionpack/test/dispatch/url_generation_test.rb
+++ b/actionpack/test/dispatch/url_generation_test.rb
@@ -129,6 +129,15 @@ module TestUrlGeneration
       )
     end
 
+    test "does not raise ArgumentError: comparison of Array with Array failed" do
+      assert_raises ActionController::UrlGenerationError do
+        bar_path(id_is_purposefully_not_present: true, "symbol_mixed_with_string_would_cause_ArgumentError" => true)
+      end
+    end
+
+    test "accepts a string key for required keys" do
+      assert_equal "/bars/1", bar_path("id" => 1)
+    end
   end
 end
 


### PR DESCRIPTION
This is a redo of #18173, with the change made against the master branch, as requested by @sgrif.

Before Rails 4.2.0, `model_path("id" => 1)` would work fine. As of Rails 4.2.0, it generates a couple of errors:
1. `ArgumentError: comparison of Array with Array failed` (due to attempting to sort a hash with mixed string/symbol keys)
2. `ActionController::UrlGenerationError`, because of missing required key :id (i.e., it ignored the "id" string parameter)
