### PR TITLE
added dependency of test-unit into activesupport

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency('i18n',       '~> 0.6', '>= 0.6.4')
   s.add_dependency('multi_json', '~> 1.0')
+  s.add_dependency('test-unit', '~> 2.5')
 end


### PR DESCRIPTION
this pull request is related with https://github.com/rails/rails/pull/18160 

test-unit will be removed from standard library of Ruby 2.2. I understood to fix only security issue on 3-2-stable branch.

/cc @tmm1
