### PR TITLE
Move transaction callbacks config into initializer

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -31,10 +31,5 @@ module <%= app_const_base %>
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-    <%- unless options.skip_active_record? -%>
-
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
-    <%- end -%>
   end
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/transactional_callbacks.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/transactional_callbacks.rb.tt
@@ -1,0 +1,8 @@
+# Be sure to restart your server when you modify this file.
+
+# Do not swallow errors in after_commit/after_rollback callbacks.
+<%- if options.skip_active_record? -%>
+# Rails.application.config.active_record.raise_in_transactional_callbacks = true
+<%- else -%>
+Rails.application.config.active_record.raise_in_transactional_callbacks = true
+<%- end -%>


### PR DESCRIPTION
Stems from comment by @dhh: https://github.com/rails/rails/pull/17227#commitcomment-9079727:

> I'd like for the option to be put in an initializer instead, though.
> It's not worthy of such high promise as the application.rb.

Style-wise, I am always adding the new initializer file to a Rails app, even
when the app is created with `--skip-active-record`. In this case, the line of
code in the initializer is commented out.

I think this is better than **skipping** the initializer and is more coherent
with the other initializers. Is that okay? :christmas_tree:
