### PR TITLE
Fix a typo in ActiveRecord::Persistence docs

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -124,7 +124,7 @@ module ActiveRecord
 
     # Saves the model.
     #
-    # If the model is new a record gets created in the database, otherwise
+    # If the model is a new record it gets created in the database, otherwise
     # the existing record gets updated.
     #
     # With <tt>save!</tt> validations always run. If any of them fail


### PR DESCRIPTION
Fixes a grammatical error for `ActiveRecord::Persistence.save!`.
