### PR TITLE
Fix bug in ActionMailer guide.

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -50,7 +50,7 @@ create    test/mailers/previews/user_mailer_preview.rb
 ```ruby
 # app/mailers/application_mailer.rb
 class ApplicationMailer < ActionMailer::Base
-  default "from@example.com"
+  default from: "from@example.com"
   layout 'mailer'
 end
 


### PR DESCRIPTION
When setting a mailer's default from address, you have to pass a hash
with a `:from` key; you can't pass just an email address.
