### PR TITLE
Check for Rails.env instead of Rails

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -1,6 +1,6 @@
 module ActiveRecord
   module ConnectionHandling
-    RAILS_ENV   = -> { (Rails.env if defined?(Rails)) || ENV["RAILS_ENV"] || ENV["RACK_ENV"] }
+    RAILS_ENV   = -> { (Rails.env if defined?(Rails.env)) || ENV["RAILS_ENV"] || ENV["RACK_ENV"] }
     DEFAULT_ENV = -> { RAILS_ENV.call || "default_env" }
 
     # Establishes the connection to the database. Accepts a hash as input where


### PR DESCRIPTION
`Rails` constant is added by rails-html-sanitizer leading to bugs in
non-Rails apps using ActiveRecord and ActionMailer

To reproduce:

```
unless File.exist?('Gemfile')
  File.write('Gemfile', <<-GEMFILE)
    source 'https://rubygems.org'
    gem 'rails', github: 'rails/rails'
    gem 'arel', github: 'rails/arel'
    gem 'sqlite3'
  GEMFILE

  system 'bundle'
end

require 'bundler'
Bundler.setup(:default)

require 'active_record'
require 'action_mailer'
require 'minitest/autorun'
require 'logger'

class TestMailer < ActionMailer::Base
end


class BugTest < Minitest::Test
  def test_establish_connection
    ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:') # => NoMethodError: undefined method `env' for Rails:Module
  end
end
```
