### PR TITLE
Only redefine association autosave callback if it isn't defined by the current class

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -860,6 +860,16 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal [dev], company.developers
   end
 
+  def test_collection_singular_ids_setter_with_accepts_nested_attributes
+    club = Club.new
+    member = Member.first
+
+    club.member_ids = [member.id]
+    club.save!
+
+    assert_equal [member], club.members
+  end
+
   def test_collection_singular_ids_setter_with_string_primary_keys
     assert_nothing_raised do
       book = books(:awdr)

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -8,6 +8,8 @@ class Club < ActiveRecord::Base
 
   has_many :favourites, -> { where(memberships: { favourite: true }) }, through: :memberships, source: :member
 
+  accepts_nested_attributes_for :memberships
+
   private
 
   def private_method

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -429,7 +429,7 @@ ActiveRecord::Schema.define do
 
   create_table :memberships, force: true do |t|
     t.datetime :joined_on
-    t.integer :club_id, :member_id
+    t.integer :club_id, :member_id, null: false
     t.boolean :favourite, default: false
     t.string :type
   end


### PR DESCRIPTION
Addresses #17015 and #16494. Reverts the majority of the changes from #15358 but retains the test coverage.

TL;DR on the discussion in #17015: the fix in #15358 ensured that subclasses that redeclare associations get newly-defined autosave callbacks. Unfortunately, enabling `accepts_nested_attributes_for` can cause this redefinition within a single class, breaking the order of callbacks and causing records to be saved in the wrong order.

This PR reinstates the method-definition check removed in #15358 but restricts it to only match definitions on the current class rather than inherited ones.

Several other changes are included, mostly for symmetry and to prevent additional similar bugs:
- the definition in the `reflection.has_one?` branch now uses `define_non_cyclic_method` to match the other branches of the conditional. It could be argued that two models who both `has_one` each other are probably incorrect DB design, but that still shouldn't produce infinite recursion.
- similarly, the `method_defined?` check in the validation conditional (line 208) has been changed to match the check for `save_method` on line 182. I don't have a test case for this, but it would likely manifest in the same "redefinition in subclasses" sorts of situations that #15358 addressed.

I've included the test written by @pranas and mentioned in https://github.com/rails/rails/issues/17015#issuecomment-67736744 as a separate commit as it accurately reflects the code's authorship. Let me know if I should squash, etc.

4.2.0 is also affected by this bug. Happy to backport this when it gets merged.

/cc @tenderlove @sgrif 
