### PR TITLE
Propagate frozen state during transaction changes

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -360,14 +360,12 @@ module ActiveRecord
     # Save the new record state and id of a record so it can be restored later if a transaction fails.
     def remember_transaction_record_state #:nodoc:
       @_start_transaction_state[:id] = id
-      unless @_start_transaction_state.include?(:new_record)
-        @_start_transaction_state[:new_record] = @new_record
-      end
-      unless @_start_transaction_state.include?(:destroyed)
-        @_start_transaction_state[:destroyed] = @destroyed
-      end
+      @_start_transaction_state.reverse_merge!(
+        new_record: @new_record,
+        destroyed:  @destroyed,
+        frozen?:    frozen?
+      )
       @_start_transaction_state[:level] = (@_start_transaction_state[:level] || 0) + 1
-      @_start_transaction_state[:frozen?] = frozen?
     end
 
     # Clear the new record state and id of a record.

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -562,6 +562,20 @@ class TransactionTest < ActiveRecord::TestCase
     assert !@second.destroyed?, 'not destroyed'
   end
 
+  def test_restore_frozen_state_after_double_destroy
+    topic = Topic.create
+    reply = topic.replies.create
+
+    Topic.transaction do
+      topic.destroy # calls #destroy on reply (since dependent: destroy)
+      reply.destroy
+
+      raise ActiveRecord::Rollback
+    end
+
+    assert !reply.frozen?, 'not frozen'
+  end
+
   def test_sqlite_add_column_in_transaction
     return true unless current_adapter?(:SQLite3Adapter)
 


### PR DESCRIPTION
Currently the frozen state is not propagated through transaction changes (it's needed to be able to rollback to initial state) and it leads to an exception like #18191

It was introduced in 40496430d5825f55d1b8aa063f6642b82f6c65d5, during the time when `remember_transaction_record_state` was broken and during the revert it's gone unnoticed 9d2146ac6e4c1fdc9cc157d614b1eb9968ac6a2e

This is a rare case, but as the issue above shows still can happen.
