### PR TITLE
Dump the default `nil` for PostgreSQL UUID primary key.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Dump the default `nil` for PostgreSQL UUID primary key.
+
+    *Ryuta Kamizono*
+
 *   Add a `:foreign_key` option to `references` and associated migration
     methods. The model and migration generators now use this option, rather than
     the `add_foreign_key` form.

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -121,7 +121,7 @@ HEADER
               tbl.print ", id: :bigserial"
             elsif pkcol.sql_type == 'uuid'
               tbl.print ", id: :uuid"
-              tbl.print %Q(, default: "#{pkcol.default_function}") if pkcol.default_function
+              tbl.print %Q(, default: #{pkcol.default_function.inspect})
             end
           else
             tbl.print ", id: false"

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -215,6 +215,7 @@ end
 
 class PostgresqlUUIDTestNilDefault < ActiveRecord::TestCase
   include PostgresqlUUIDHelper
+  include SchemaDumpingHelper
 
   setup do
     enable_extension!('uuid-ossp', connection)
@@ -237,6 +238,11 @@ class PostgresqlUUIDTestNilDefault < ActiveRecord::TestCase
                                     LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
                                     WHERE a.attname='id' AND a.attrelid = 'pg_uuids'::regclass").first
       assert_nil col_desc["default"]
+    end
+
+    def test_schema_dumper_for_uuid_primary_key_with_default_override_via_nil
+      schema = dump_table_schema "pg_uuids"
+      assert_match(/\bcreate_table "pg_uuids", id: :uuid, default: nil/, schema)
     end
   end
 end


### PR DESCRIPTION
UUID primary key default allows `nil` by https://github.com/rails/rails/pull/10404.
This PR will correctly dump the default `nil` for UUID primary key.
