### PR TITLE
Actually autoload all second-level directories called `app/*/concerns`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,1 +1,5 @@
+*   Autoload any second level directories called `app/*/concerns`.
+
+    *Alex Robbin*
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -39,16 +39,13 @@ module Rails
         @paths ||= begin
           paths = Rails::Paths::Root.new(@root)
 
-          paths.add "app",                 eager_load: true, glob: "*"
+          paths.add "app",                 eager_load: true, glob: "{*,*/concerns}"
           paths.add "app/assets",          glob: "*"
           paths.add "app/controllers",     eager_load: true
           paths.add "app/helpers",         eager_load: true
           paths.add "app/models",          eager_load: true
           paths.add "app/mailers",         eager_load: true
           paths.add "app/views"
-
-          paths.add "app/controllers/concerns", eager_load: true
-          paths.add "app/models/concerns",      eager_load: true
 
           paths.add "lib",                 load_path: true
           paths.add "lib/assets",          glob: "*"

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -33,6 +33,35 @@ class LoadingTest < ActiveSupport::TestCase
     assert_equal 'omg', p.title
   end
 
+  test "concerns in app are autoloaded" do
+    app_file "app/controllers/concerns/trackable.rb", <<-CONCERN
+      module Trackable
+      end
+    CONCERN
+
+    app_file "app/mailers/concerns/email_loggable.rb", <<-CONCERN
+      module EmailLoggable
+      end
+    CONCERN
+
+    app_file "app/models/concerns/orderable.rb", <<-CONCERN
+      module Orderable
+      end
+    CONCERN
+
+    app_file "app/validators/concerns/matchable.rb", <<-CONCERN
+      module Matchable
+      end
+    CONCERN
+
+    require "#{rails_root}/config/environment"
+
+    assert_nothing_raised(NameError) { Trackable }
+    assert_nothing_raised(NameError) { EmailLoggable }
+    assert_nothing_raised(NameError) { Orderable }
+    assert_nothing_raised(NameError) { Matchable }
+  end
+
   test "models without table do not panic on scope definitions when loaded" do
     app_file "app/models/user.rb", <<-MODEL
       class User < ActiveRecord::Base


### PR DESCRIPTION
I'm proposing this change under the assumption that the [Constant Autoloading and Reloading](http://guides.rubyonrails.org/v4.2.0/constant_autoloading_and_reloading.html#autoload-paths) guide's note about the default `autoload_paths` should include:

> Any existing second level directories called `app/*/concerns` in the application and engines.

However, the actual `autoload_paths` only includes `app/controllers/concerns` and `app/models/concerns`.

This change actually does autoloading of all `app/*/concerns` directories.

I couldn't find any tests for `Rails::Engine::Configuration#paths`, so any guidance on test coverage for this change would be great!
