### PR TITLE
Remove unused 'model' attribute in Association initializer

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -15,13 +15,10 @@ module ActiveRecord::Associations::Builder
   class Association #:nodoc:
     class << self
       attr_accessor :extensions
-      # TODO: This class accessor is needed to make activerecord-deprecated_finders work.
-      # We can move it to a constant in 5.0.
-      attr_accessor :valid_options
     end
     self.extensions = []
 
-    self.valid_options = [:class_name, :class, :foreign_key, :validate]
+    VALID_OPTIONS = [:class_name, :class, :foreign_key, :validate].freeze
 
     attr_reader :name, :scope, :options
 
@@ -32,7 +29,7 @@ module ActiveRecord::Associations::Builder
                              "Please choose a different association name."
       end
 
-      builder = create_builder model, name, scope, options, &block
+      builder = create_builder name, scope, options, &block
       reflection = builder.build(model)
       define_accessors model, reflection
       define_callbacks model, reflection
@@ -41,20 +38,19 @@ module ActiveRecord::Associations::Builder
       reflection
     end
 
-    def self.create_builder(model, name, scope, options, &block)
+    def self.create_builder(name, scope, options, &block)
       raise ArgumentError, "association names must be a Symbol" unless name.kind_of?(Symbol)
 
-      new(model, name, scope, options, &block)
+      new(name, scope, options, &block)
     end
 
-    def initialize(model, name, scope, options)
+    def initialize(name, scope, options)
       # TODO: Move this to create_builder as soon we drop support to activerecord-deprecated_finders.
       if scope.is_a?(Hash)
         options = scope
         scope   = nil
       end
 
-      # TODO: Remove this model argument as soon we drop support to activerecord-deprecated_finders.
       @name    = name
       @scope   = scope
       @options = options
@@ -75,7 +71,7 @@ module ActiveRecord::Associations::Builder
     end
 
     def valid_options
-      Association.valid_options + Association.extensions.flat_map(&:valid_options)
+      VALID_OPTIONS + Association.extensions.flat_map(&:valid_options)
     end
 
     def validate_options

--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -14,7 +14,7 @@ module ActiveRecord::Associations::Builder
 
     attr_reader :block_extension
 
-    def initialize(model, name, scope, options)
+    def initialize(name, scope, options)
       super
       @mod = nil
       if block_given?

--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -87,8 +87,7 @@ module ActiveRecord::Associations::Builder
       middle_name = [lhs_model.name.downcase.pluralize,
                      association_name].join('_').gsub(/::/, '_').to_sym
       middle_options = middle_options join_model
-      hm_builder = HasMany.create_builder(lhs_model,
-                                          middle_name,
+      hm_builder = HasMany.create_builder(middle_name,
                                           nil,
                                           middle_options)
       hm_builder.build lhs_model

--- a/activerecord/test/cases/associations/extension_test.rb
+++ b/activerecord/test/cases/associations/extension_test.rb
@@ -76,7 +76,7 @@ class AssociationsExtensionsTest < ActiveRecord::TestCase
   private
 
     def extend!(model)
-      builder = ActiveRecord::Associations::Builder::HasMany.new(model, :association_name, nil, {}) { }
+      builder = ActiveRecord::Associations::Builder::HasMany.new(:association_name, nil, {}) { }
       builder.define_extensions(model)
     end
 end


### PR DESCRIPTION
Since support for 'activerecord-deprecated_finders' was dropped, `model` attribute became obsolete and could be safely removed. Please feel free to correct me if I am mistaken.

Also, by already existed comment guidance `valid_options` was moved to a constant.
