### PR TITLE
Add a note to has_one association

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -146,6 +146,8 @@ class CreateSuppliers < ActiveRecord::Migration
 end
 ```
 
+It's important to note that in this example, there is nothing preventing multiple rows in the `accounts` table having the same `supplier_id` foreign key. This means that when you look up `Supplier.first.account`, for example, it will always return the first row found.
+
 ### The `has_many` Association
 
 A `has_many` association indicates a one-to-many connection with another model. You'll often find this association on the "other side" of a `belongs_to` association. This association indicates that each instance of the model has zero or more instances of another model. For example, in an application containing customers and orders, the customer model could be declared like this:


### PR DESCRIPTION
Mention possibility of multiple associated records.

I'm not sure if the correct way to use `has_one` is to always have a validation that prevents creating multiple associated records, or to never create multiple records in the first place. 

Either way, it seems like `has_one` is easy to do wrong. 

PS, first PR here. Hopefully I didn't break any rules/contribution guidelines/miss existing documentation about this. 

Thanks!
