### PR TITLE
Add bigint primary key support for MySQL.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Support for any type primary key.
+
+    Fixes #14194.
+
+    *Ryuta Kamizono*
+
 *   Dump the default `nil` for PostgreSQL UUID primary key.
 
     *Ryuta Kamizono*

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add bigint primary key support for MySQL.
+
+    Example:
+
+        create_table :foos, id: :bigint do |t|
+        end
+
+    *Ryuta Kamizono*
+
 *   Support for any type primary key.
 
     Fixes #14194.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -65,6 +65,7 @@ module ActiveRecord
             column_options[:column] = o
             column_options[:first] = o.first
             column_options[:after] = o.after
+            column_options[:auto_increment] = o.auto_increment
             column_options[:primary_key] = o.primary_key
             column_options
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -30,7 +30,7 @@ module ActiveRecord
           def visit_ColumnDefinition(o)
             sql_type = type_to_sql(o.type, o.limit, o.precision, o.scale)
             column_sql = "#{quote_column_name(o.name)} #{sql_type}"
-            add_column_options!(column_sql, column_options(o)) unless o.primary_key?
+            add_column_options!(column_sql, column_options(o)) unless o.type == :primary_key
             column_sql
           end
 
@@ -65,6 +65,7 @@ module ActiveRecord
             column_options[:column] = o
             column_options[:first] = o.first
             column_options[:after] = o.after
+            column_options[:primary_key] = o.primary_key
             column_options
           end
 
@@ -88,6 +89,9 @@ module ActiveRecord
             end
             if options[:auto_increment] == true
               sql << " AUTO_INCREMENT"
+            end
+            if options[:primary_key] == true
+              sql << " PRIMARY KEY"
             end
             sql
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -15,7 +15,7 @@ module ActiveRecord
     # are typically created by methods in TableDefinition, and added to the
     # +columns+ attribute of said TableDefinition object, in order to be used
     # for generating a number of table creation or table changing SQL statements.
-    class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :primary_key, :sql_type, :cast_type) #:nodoc:
+    class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :auto_increment, :primary_key, :sql_type, :cast_type) #:nodoc:
 
       def primary_key?
         primary_key || type.to_sym == :primary_key
@@ -413,6 +413,7 @@ module ActiveRecord
         column.null        = options[:null]
         column.first       = options[:first]
         column.after       = options[:after]
+        column.auto_increment = options[:auto_increment]
         column.primary_key = type == :primary_key || options[:primary_key]
         column
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -6,6 +6,13 @@ module ActiveRecord
     class AbstractMysqlAdapter < AbstractAdapter
       include Savepoints
 
+      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+        def primary_key(name, type = :primary_key, options = {})
+          options[:auto_increment] ||= type == :bigint
+          super
+        end
+      end
+
       class SchemaCreation < AbstractAdapter::SchemaCreation
         def visit_AddColumn(o)
           add_column_position!(super, column_options(o))
@@ -857,6 +864,10 @@ module ActiveRecord
           when 'SET NULL'; :nullify
           end
         end
+      end
+
+      def create_table_definition(name, temporary, options, as = nil) # :nodoc:
+        TableDefinition.new(native_database_types, name, temporary, options, as)
       end
 
       class MysqlString < Type::String # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -4,15 +4,6 @@ module ActiveRecord
       class SchemaCreation < AbstractAdapter::SchemaCreation
         private
 
-        def visit_ColumnDefinition(o)
-          sql = super
-          if o.primary_key? && o.type != :primary_key
-            sql << " PRIMARY KEY "
-            add_column_options!(sql, column_options(o))
-          end
-          sql
-        end
-
         def column_options(o)
           column_options = super
           column_options[:array] = o.array

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -195,6 +195,30 @@ class PrimaryKeyWithNoConnectionTest < ActiveRecord::TestCase
   end
 end
 
+class PrimaryKeyAnyTypeTest < ActiveRecord::TestCase
+  self.use_transactional_fixtures = false
+
+  class Barcode < ActiveRecord::Base
+  end
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table(:barcodes, primary_key: "code", id: :string, limit: 42, force: true)
+  end
+
+  teardown do
+    @connection.execute("DROP TABLE IF EXISTS barcodes")
+  end
+
+  def test_any_type_primary_key
+    assert_equal "code", Barcode.primary_key
+
+    column_type = Barcode.type_for_attribute(Barcode.primary_key)
+    assert_equal :string, column_type.type
+    assert_equal 42, column_type.limit
+  end
+end
+
 if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
   class PrimaryKeyWithAnsiQuotesTest < ActiveRecord::TestCase
     self.use_transactional_fixtures = false


### PR DESCRIPTION
This PR will support bigint primary key for MySQL, such as bigserial for PostgreSQL.

Example:

``` ruby
create_table :foos, id: :bigint do |t|
end
```
