### PR TITLE
adjust args of Bundler.require in guides [ci skip]

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -768,7 +768,7 @@ file (in `config/application.rb`):
 ```ruby
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
-Bundler.require(:default, Rails.env)
+Bundler.require(*Rails.groups)
 ```
 
 ### vendor/plugins


### PR DESCRIPTION
Arguments of Bundler.require of generator has been changed from rails4.0.4.

https://github.com/rails/rails/blob/v4.0.4/railties/lib/rails/generators/rails/app/templates/config/application.rb#L16
