### PR TITLE
Fix html_safe string access modifying frozen values

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -150,7 +150,9 @@ module ActiveSupport #:nodoc:
       else
         if html_safe?
           new_safe_buffer = super
-          new_safe_buffer.instance_variable_set :@html_safe, true
+          unless new_safe_buffer.respond_to?(:frozen?) && new_safe_buffer.frozen?
+            new_safe_buffer.instance_variable_set :@html_safe, true
+          end
           new_safe_buffer
         else
           to_str[*args]

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -165,4 +165,13 @@ class SafeBufferTest < ActiveSupport::TestCase
     x = 'foo %{x} bar'.html_safe % { x: 'qux' }
     assert x.html_safe?, 'should be safe'
   end
+
+  test 'Should not affect frozen objects when accessing characters' do
+    x = 'Hello'.html_safe
+    assert_nothing_raised do
+      x[/a/, 1]
+    end
+  end
+
+
 end


### PR DESCRIPTION
When trying to access a character on a string buffer object via `:[]`, if the object being accessed currently returns `html_safe?` as true, we used to set  `@html_safe` variable as true on new object created. When doing something like

``` ruby
x = 'Hello'.html_safe
x[/a/, 1]
```

would throw an error on ruby 2.2, since when nothing gets matched, `nil` is returned by the code and it tries to set  `@html_safe` value to true, which would error since starting ruby 2.2 nil is frozen.

This change adds a safety net to avoid setting `@html_safe = true` on frozen objects.

Fixes #18235
