### PR TITLE
Include error message for first! to match last!

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -143,7 +143,7 @@ module ActiveRecord
     # Same as +first+ but raises <tt>ActiveRecord::RecordNotFound</tt> if no record
     # is found. Note that <tt>first!</tt> accepts no arguments.
     def first!
-      find_nth! 0
+      find_nth! 0 or raise RecordNotFound.new("Couldn't find #{@klass.name} with [#{arel.where_sql(@klass.arel_engine)}]")
     end
 
     # Find the last record (or last N records if a parameter is supplied).


### PR DESCRIPTION
Check out this SO question: http://stackoverflow.com/questions/27627812/first-on-ar-collectionproxy-raises-undefined-method-for-nil-after-updati/27691893#27691893

Looks like the first! method should be re-implemented to give errors, as would be expected with a bang method.
