### PR TITLE
plugin's gemfile also needs tzinfo-data in Windows

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile
@@ -45,3 +45,7 @@ end
 # gem 'byebug', group: [:development, :test]
   <%- end -%>
 <% end -%>
+
+<% if RUBY_PLATFORM.match(/bccwin|cygwin|emx|mingw|mswin|wince|java/) -%>
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+<% end -%>


### PR DESCRIPTION
```
rails plugin new foo
cd foo
rake test
```

Fails in Windows, due to the dependency on `tzinfo-data` gem. Just like 9d664b18df7a81b75e45bb99858f920de040e9fb, c8ccab05277dd5639cea509c2911af6ee35b0cf9, bf993fac57bb1cb69ec46d2bbc2f2752bcd844ae, automatic bundle doesn't hurt, I think.
