### PR TITLE
test case for model class conflict with action view class

### DIFF
--- a/actionview/test/fixtures/test/template_with_constants.html.erb
+++ b/actionview/test/fixtures/test/template_with_constants.html.erb
@@ -1,0 +1,1 @@
+<%= Template::CONSTANT %>

--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -182,3 +182,7 @@ class Plane
     @to_key = [1]
   end
 end
+
+class Template
+  CONSTANT = "Simple Constant"
+end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -24,6 +24,12 @@ module RenderTestCases
     assert_match(/You invoked render but did not give any of (.+) option./, e.message)
   end
 
+  def test_should_be_render_file_with_constants
+    assert_nothing_raised RuntimeError do
+      @view.render(:file => "test/template_with_constants")
+    end
+  end
+
   def test_render_file
     assert_equal "Hello world!", @view.render(:file => "test/hello_world")
   end


### PR DESCRIPTION
```
class Template < ActiveRecord::Base
    CONSTANT = "Simple Constant"
end
```

When we use `Template::CONSTANT` on view, it raises `ActionView::Template::Error: uninitialized constant ActionView::Template::CONSTANT. I hope this would be an issue. 
