### PR TITLE
Guide for Action Mailer Basics: Un-inline if statement

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -733,7 +733,9 @@ Mailer framework. You can do this in an initializer file
 `config/initializers/sandbox_email_interceptor.rb`
 
 ```ruby
-ActionMailer::Base.register_interceptor(SandboxEmailInterceptor) if Rails.env.staging?
+if Rails.env.staging?
+  ActionMailer::Base.register_interceptor(SandboxEmailInterceptor)
+end
 ```
 
 NOTE: The example above uses a custom environment called "staging" for a


### PR DESCRIPTION
**on [rails/rails/master](https://github.com/rails/rails/blob/d233220f2921472c85142137d63f42d2d728adaa/guides/source/action_mailer_basics.md#intercepting-emails)**

The single line is long enough that it renders on two lines, causing the example to look like syntactically invalid code.

![screenshot 2014-12-29 13 07 35](https://cloud.githubusercontent.com/assets/77495/5572439/ae770306-8f5b-11e4-9a4f-f084aedf0272.png)

---

**on [JoshCheek/rails/mailer_guide_code_example](https://github.com/JoshCheek/rails/blob/mailer_guide_code_example/guides/source/action_mailer_basics.md#intercepting-emails)**

Switch to multi-line if statement so that the code sample doesn't look invalid

![screenshot 2014-12-29 13 06 56](https://cloud.githubusercontent.com/assets/77495/5572435/9962b78a-8f5b-11e4-8d36-2db42c292f44.png)
