### PR TITLE
Adding preorder to change order presedence

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     delegate :find_by, :find_by!, to: :all
     delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, to: :all
     delegate :find_each, :find_in_batches, to: :all
-    delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins,
+    delegate :select, :group, :order, :except, :reorder, :preorder, :limit, :offset, :joins,
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly,
              :having, :create_with, :uniq, :distinct, :references, :none, :unscope, to: :all
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, to: :all

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -348,6 +348,22 @@ module ActiveRecord
       self
     end
 
+    # Allows to move order presendence to first place in the order chain:
+    #
+    #   User.order(:name).preorder(:id)
+    #   => SELECT "users".* FROM "users" ORDER BY "users"."id" ASC, "users"."name" ASC
+    def preorder(*args)
+      check_if_method_has_arguments!(:preorder, args)
+      spawn.preorder!(*args)
+    end
+
+    def preorder!(*args) # :nodoc:
+      preprocess_order_args(args)
+
+      self.order_values = args + order_values
+      self
+    end
+
     VALID_UNSCOPING_VALUES = Set.new([:where, :select, :group, :order, :lock,
                                      :limit, :offset, :joins, :includes, :from,
                                      :readonly, :having])

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -300,6 +300,17 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal entrants(:third).name, entrants.first.name
   end
 
+  def test_finding_last_with_arel_preorder
+    topics = Topic.preorder(Topic.arel_table[:id].asc)
+    assert_equal topics(:fifth).title, topics.last.title
+  end
+
+  def test_finding_with_preorder_concatenated
+    topics = Topic.order('author_name').preorder('title')
+    assert_equal 5, topics.to_a.size
+    assert_equal topics(:fifth).title, topics.first.title
+  end
+
   def test_finding_with_group
     developers = Developer.group("salary").select("salary").to_a
     assert_equal 4, developers.size
@@ -465,6 +476,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_raises(ArgumentError) { Topic.preload() }
     assert_raises(ArgumentError) { Topic.group() }
     assert_raises(ArgumentError) { Topic.reorder() }
+    assert_raises(ArgumentError) { Topic.preorder() }
   end
 
   def test_blank_like_arguments_to_query_methods_dont_raise_errors
@@ -473,6 +485,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_nothing_raised { Topic.preload([]) }
     assert_nothing_raised { Topic.group([]) }
     assert_nothing_raised { Topic.reorder([]) }
+    assert_nothing_raised { Topic.preorder([]) }
   end
 
   def test_scoped_responds_to_delegated_methods


### PR DESCRIPTION
Sometimes application developers need to add a new superseding order in to an existing order chain. In order to give precedence to a new sorting without touching previously defined ones, it's possible to add the `preorder` scoped statement.

Example: 

```
User.order(:name).preorder(:id)
=> SELECT "users".* FROM "users" ORDER BY "users"."id" ASC, "users"."name" ASC
```
