### PR TITLE
Expire Marshaled Rails 3 cache entries

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -593,7 +593,7 @@ module ActiveSupport
       # Check if the entry is expired. The +expires_in+ parameter can override
       # the value set when the entry was created.
       def expired?
-        convert_version_4beta1_entry! if defined?(@value)
+        convert_version_4beta1_entry! if defined?(@v)
         @expires_in && @created_at + @expires_in <= Time.now.to_f
       end
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -570,6 +570,7 @@ module ActiveSupport
     # using short instance variable names that are lazily defined.
     class Entry # :nodoc:
       DEFAULT_COMPRESS_LIMIT = 16.kilobytes
+      MARSHAL_SIGNATURE = "\x04\x08".freeze
 
       # Create a new cache entry for the specified value. Options supported are
       # +:compress+, +:compress_threshold+, and +:expires_in+.
@@ -594,7 +595,7 @@ module ActiveSupport
       # the value set when the entry was created.
       def expired?
         convert_version_4beta1_entry! if defined?(@v)
-        @expires_in && @created_at + @expires_in <= Time.now.to_f
+        (@expires_in && @created_at + @expires_in <= Time.now.to_f) || marshaled_rails_3_value?
       end
 
       def expires_at
@@ -677,6 +678,11 @@ module ActiveSupport
             @expires_in = @x - @created_at
             remove_instance_variable(:@x)
           end
+        end
+
+        def marshaled_rails_3_value?
+          cached_value = value
+          cached_value.is_a?(String) && cached_value.start_with?(MARSHAL_SIGNATURE)
         end
     end
   end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -1001,7 +1001,7 @@ class CacheEntryTest < ActiveSupport::TestCase
     version_4beta1_entry.instance_variable_set(:@v, "hello")
     version_4beta1_entry.instance_variable_set(:@x, Time.now.to_i - 1)
     entry = Marshal.load(Marshal.dump(version_4beta1_entry))
-    assert_equal "hello", entry.value
     assert_equal true, entry.expired?
+    assert_equal "hello", entry.value
   end
 end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -979,6 +979,33 @@ class CacheEntryTest < ActiveSupport::TestCase
     assert_equal value.bytesize, entry.size
   end
 
+  def test_restoring_version_3_entries_should_be_expired
+    version_3_entry = ActiveSupport::Cache::Entry.allocate
+    version_3_entry.instance_variable_set(:@value, Marshal.dump("hello"))
+    version_3_entry.instance_variable_set(:@created_at, Time.now.to_i - 60)
+    version_3_entry.instance_variable_set(:@expires_in, 120)
+    entry = Marshal.load(Marshal.dump(version_3_entry))
+    assert_equal true, entry.expired?
+  end
+
+  def test_restoring_compressed_version_3_entries_should_not_be_expired
+    version_3_entry = ActiveSupport::Cache::Entry.allocate
+    version_3_entry.instance_variable_set(:@value, Zlib::Deflate.deflate(Marshal.dump("hello")))
+    version_3_entry.instance_variable_set(:@compressed, true)
+    entry = Marshal.load(Marshal.dump(version_3_entry))
+    assert_equal false, entry.expired?
+    assert_equal "hello", entry.value
+  end
+
+  def test_restoring_expired_version_3_entries
+    version_3_entry = ActiveSupport::Cache::Entry.allocate
+    version_3_entry.instance_variable_set(:@value, Marshal.dump("hello"))
+    version_3_entry.instance_variable_set(:@created_at, Time.now.to_i - 60)
+    version_3_entry.instance_variable_set(:@expires_in, 58.9)
+    entry = Marshal.load(Marshal.dump(version_3_entry))
+    assert_equal true, entry.expired?
+  end
+
   def test_restoring_version_4beta1_entries
     version_4beta1_entry = ActiveSupport::Cache::Entry.allocate
     version_4beta1_entry.instance_variable_set(:@v, "hello")


### PR DESCRIPTION
To give a better backward compatibility path we will expire all cache
entries that are marshaled without compressing instead of returning the
raw value.

We can't just try to load the value since it may introduce a security problem.

Fixes #17923

cc @matthewd @jeremywadsack @jeremy 
