### PR TITLE
Use ActiveModel::TestCase instead of ActiveSupport

### DIFF
--- a/activemodel/test/cases/forbidden_attributes_protection_test.rb
+++ b/activemodel/test/cases/forbidden_attributes_protection_test.rb
@@ -17,7 +17,7 @@ class ProtectedParams < ActiveSupport::HashWithIndifferentAccess
   end
 end
 
-class ActiveModelMassUpdateProtectionTest < ActiveSupport::TestCase
+class ActiveModelMassUpdateProtectionTest < ActiveModel::TestCase
   test "forbidden attributes cannot be used for mass updating" do
     params = ProtectedParams.new({ "a" => "b" })
     assert_raises(ActiveModel::ForbiddenAttributesError) do

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -17,4 +17,4 @@ require 'mocha/setup' # FIXME: stop using mocha
 # FIXME: we have tests that depend on run order, we should fix that and
 # remove this method call.
 require 'active_support/test_case'
-ActiveSupport::TestCase.test_order = :sorted
+ActiveModel::TestCase.test_order = :sorted


### PR DESCRIPTION
As active_model's test_case inherits from active_supports test_case it
makes sense for everything within active_model to use it's own
test_case.
