### PR TITLE
Add doc for `:touch` option of AR::Base#save

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -109,6 +109,10 @@ module ActiveRecord
     # validate: false, validations are bypassed altogether. See
     # ActiveRecord::Validations for more information.
     #
+    # By default, #save also sets the +updated_at+/+updated_on+ attributes to
+    # the current time. However, if you supply <tt>touch: false</tt>, these
+    # timestamps will not be updated.
+    #
     # There's a series of callbacks associated with +save+. If any of the
     # <tt>before_*</tt> callbacks return +false+ the action is cancelled and
     # +save+ returns +false+. See ActiveRecord::Callbacks for further
@@ -130,6 +134,10 @@ module ActiveRecord
     # With <tt>save!</tt> validations always run. If any of them fail
     # ActiveRecord::RecordInvalid gets raised. See ActiveRecord::Validations
     # for more information.
+    #
+    # By default, #save! also sets the +updated_at+/+updated_on+ attributes to
+    # the current time. However, if you supply <tt>touch: false</tt>, these
+    # timestamps will not be updated.
     #
     # There's a series of callbacks associated with <tt>save!</tt>. If any of
     # the <tt>before_*</tt> callbacks return +false+ the action is cancelled


### PR DESCRIPTION
ActiveRecord::Base `save` and `save!` take an option boolean `:touch` parameter since #18225 (stems from #18202).

This commit documents that parameter.

![new](https://cloud.githubusercontent.com/assets/10076/5574294/713e80d0-8fbb-11e4-8c2b-a492fd0c8331.png)

[ci skip]
