### PR TITLE
Fix form_for to work with objects that implement to_model

### DIFF
--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -247,7 +247,7 @@ module ActionDispatch
           args  = []
 
           model = record.to_model
-          name = if record.persisted?
+          name = if model.persisted?
                    args << model
                    model.model_name.singular_route_key
                  else
@@ -290,11 +290,12 @@ module ActionDispatch
           when Class
             @key_strategy.call record.model_name
           else
-            if record.persisted?
-              args << record.to_model
-              record.to_model.model_name.singular_route_key
+            model = record.to_model
+            if model.persisted?
+              args << model
+              model.model_name.singular_route_key
             else
-              @key_strategy.call record.to_model.model_name
+              @key_strategy.call model.model_name
             end
           end
 

--- a/actionview/test/activerecord/polymorphic_routes_test.rb
+++ b/actionview/test/activerecord/polymorphic_routes_test.rb
@@ -25,15 +25,17 @@ class Series < ActiveRecord::Base
   self.table_name = 'projects'
 end
 
-class ModelDelegator < ActiveRecord::Base
-  self.table_name = 'projects'
-
+class ModelDelegator
   def to_model
     ModelDelegate.new
   end
 end
 
 class ModelDelegate
+  def persisted?
+    true
+  end
+
   def model_name
     ActiveModel::Name.new(self.class)
   end
@@ -605,10 +607,15 @@ class PolymorphicRoutesTest < ActionController::TestCase
     end
   end
 
-  def test_routing_a_to_model_delegate
+  def test_routing_to_a_model_delegate
     with_test_routes do
-      @delegator.save
       assert_url "http://example.com/model_delegates/overridden", @delegator
+    end
+  end
+
+  def test_nested_routing_to_a_model_delegate
+    with_test_routes do
+      assert_url "http://example.com/foo/model_delegates/overridden", [:foo, @delegator]
     end
   end
 
@@ -645,6 +652,9 @@ class PolymorphicRoutesTest < ActionController::TestCase
         end
         resources :series
         resources :model_delegates
+        namespace :foo do
+          resources :model_delegates
+        end
       end
 
       extend @routes.url_helpers


### PR DESCRIPTION
Previously, if you tried to use form_for with a presenter object
that implements to_model, it would crash in
action_dispatch/routing/polymorphic_routes.rb when asking the presenter
whether it is .persisted?

Now, we always ask .persisted? of the to_model object instead.

This seems to been an issue since 1606fc9d840da869a60213bc889da6fcf1fdc431
