### PR TITLE
Remove single space response body for head request

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Using `head` method returns empty response_body instead
+    of returning a single space " ".
+
+    The old behavior was added as a workaround for a bug in an early
+    version of Safari, where the HTTP headers are not returned correctly
+    if the response body has a 0-length. This is been fixed since and
+    the workaround is no longer necessary.
+
+    Fixes #18253.
+
+    *Prathamesh Sonpatki*
+
 *   Fix how polymorphic routes works with objects that implement `to_model`.
 
     *Travis Grathwell*

--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -29,14 +29,14 @@ module ActionController
       self.status = status
       self.location = url_for(location) if location
 
+      self.response_body = ""
+
       if include_content?(self._status_code)
         self.content_type = content_type || (Mime[formats.first] if formats)
         self.response.charset = false if self.response
-        self.response_body = " "
       else
         headers.delete('Content-Type')
         headers.delete('Content-Length')
-        self.response_body = ""
       end
     end
 

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -1003,21 +1003,21 @@ class YieldingAroundFiltersTest < ActionController::TestCase
   def test_first_action_in_multiple_before_action_chain_halts
     controller = ::FilterTest::TestMultipleFiltersController.new
     response = test_process(controller, 'fail_1')
-    assert_equal ' ', response.body
+    assert_equal '', response.body
     assert_equal 1, controller.instance_variable_get(:@try)
   end
 
   def test_second_action_in_multiple_before_action_chain_halts
     controller = ::FilterTest::TestMultipleFiltersController.new
     response = test_process(controller, 'fail_2')
-    assert_equal ' ', response.body
+    assert_equal '', response.body
     assert_equal 2, controller.instance_variable_get(:@try)
   end
 
   def test_last_action_in_multiple_before_action_chain_halts
     controller = ::FilterTest::TestMultipleFiltersController.new
     response = test_process(controller, 'fail_3')
-    assert_equal ' ', response.body
+    assert_equal '', response.body
     assert_equal 3, controller.instance_variable_get(:@try)
   end
 


### PR DESCRIPTION
- The single space response was added due to a bug in safari
  in https://github.com/rails/rails/commit/cb0f8fda9652c4d24d04693bdb82cecd3b067e5c
  and
  https://github.com/rails/rails/commit/807df4fcf021fc4d15972aa1c17ba7398d43ab0d.
- This was removed from the `render nothing: true` in
  https://github.com/rails/rails/pull/14883.
- Removing it from response of :head also. As :head is more obvious
  alternative to call `render nothing:
  true`(http://guides.rubyonrails.org/layouts_and_rendering.html#using-head-to-build-header-only-responses),
  removing it from head method also.
- Closes #18253.
