### PR TITLE
Ensures that primary_key method will return nil when multi-pk

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   When table has a composite primary key, the `primary_key` method for
+    sqlite3 and postgresql was only returning the first field of the key.
+    Ensures that it will return nil instead, as AR dont support composite pks.
+
+    Fixes #18070.
+
+    *arthurnn*
+
 *   `validates_size_of` / `validates_length_of` do not count records,
     which are `marked_for_destruction?`.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -385,15 +385,15 @@ module ActiveRecord
 
         # Returns just a table's primary key
         def primary_key(table)
-          row = exec_query(<<-end_sql, 'SCHEMA').rows.first
+          pks = exec_query(<<-end_sql, 'SCHEMA').rows
             SELECT attr.attname
             FROM pg_attribute attr
-            INNER JOIN pg_constraint cons ON attr.attrelid = cons.conrelid AND attr.attnum = cons.conkey[1]
+            INNER JOIN pg_constraint cons ON attr.attrelid = cons.conrelid AND attr.attnum = any(cons.conkey)
             WHERE cons.contype = 'p'
               AND cons.conrelid = '#{quote_table_name(table)}'::regclass
           end_sql
-
-          row && row.first
+          return nil unless pks.count == 1
+          pks[0][0]
         end
 
         # Renames a table.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -418,10 +418,9 @@ module ActiveRecord
       end
 
       def primary_key(table_name) #:nodoc:
-        column = table_structure(table_name).find { |field|
-          field['pk'] == 1
-        }
-        column && column['name']
+        pks = table_structure(table_name).select { |f| f['pk'] > 0 }
+        return nil unless pks.count == 1
+        pks[0]['name']
       end
 
       def remove_index!(table_name, index_name) #:nodoc:

--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -99,6 +99,12 @@ module ActiveRecord
         end
       end
 
+      def test_composite_primary_key
+        with_example_table '`id` INT(11), `number` INT(11), foo INT(11), PRIMARY KEY (`id`, `number`)' do
+          assert_nil @conn.primary_key('ex')
+        end
+      end
+
       def test_tinyint_integer_typecasting
         with_example_table '`status` TINYINT(4)' do
           insert(@conn, { 'status' => 2 }, 'ex')

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -54,6 +54,12 @@ module ActiveRecord
         end
       end
 
+      def test_composite_primary_key
+        with_example_table 'id serial, number serial, PRIMARY KEY (id, number)' do
+          assert_nil @connection.primary_key('ex')
+        end
+      end
+
       def test_primary_key_raises_error_if_table_not_found
         assert_raises(ActiveRecord::StatementInvalid) do
           @connection.primary_key('unobtainium')

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -405,6 +405,12 @@ module ActiveRecord
         end
       end
 
+      def test_composite_primary_key
+        with_example_table 'id integer, number integer, foo integer, PRIMARY KEY (id, number)' do
+          assert_nil @conn.primary_key('ex')
+        end
+      end
+
       def test_supports_extensions
         assert_not @conn.supports_extensions?, 'does not support extensions'
       end


### PR DESCRIPTION
When table has a composite primary key, the `primary_key` method for
sqlite3 and postgresql was only returning the first field of the key.

Ensures that it will return nil instead, as AR dont support composite pks.

[fixes #18070] - more context here https://github.com/rails/rails/issues/18070#issuecomment-67701444

review @rafaelfranca @tenderlove @sgrif 
