### PR TITLE
ActiveJob: delegate deserialization to the job class

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,1 +1,26 @@
+* `ActiveJob::Base.deserialize` delegates to the job class
+
+  Since `ActiveJob::Base#deserialize` can be overriden by subclasses (like `ActiveJob::Base#serialize`)
+  this allows jobs to attach arbitrary metadata when they get serialized and read it back when they get
+  performed. E.g.
+
+      class DeliverWebhookJob < ActiveJob::Base
+        def serialize
+          super.merge('attempt_number' => (@attempt_number || 0) + 1)
+        end
+
+        def deserialize(job_data)
+          super(job_data)
+          @attempt_number = job_data['attempt_number']
+        end
+
+        rescue_from(TimeoutError) do |ex|
+          raise ex if @attempt_number > 5
+          retry_job(wait: 10)
+        end
+      end
+
+  *Isaac Seymour*
+
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activejob/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
Renames `ActiveJob::Base.deserialize` to `ActiveJob::Base.instantitate_from_job_data` (not convinced this is a good name), and delegates full deserialization to `ActiveJob::Base#deserialize`. This allows subclasses to override `ActiveJob::Base#deserialize` (they can already override `#serialize`) to attach metadata to the job. Without this, the only way to attach metadata to a job and retrieve it is by monkey-patching `ActiveJob::Base.deserialize` :see_no_evil: 
