### PR TITLE
Fixes simple missprint in docs for #cyle in text_helper

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -309,7 +309,7 @@ module ActionView
       #   <table>
       #   <% @items.each do |item| %>
       #     <tr class="<%= cycle("odd", "even") -%>">
-      #       <td>item</td>
+      #       <td><%= item %></td>
       #     </tr>
       #   <% end %>
       #   </table>


### PR DESCRIPTION
This is a fix in the documentation for #cycle to output the item from the iterated @items.
