### PR TITLE
Fix comment typo in debugger.rb

### DIFF
--- a/activesupport/lib/active_support/core_ext/kernel/debugger.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/debugger.rb
@@ -1,6 +1,6 @@
 module Kernel
   unless respond_to?(:debugger)
-    # Starts a debugging session if the +debugger+ gem has been loaded (call rails server --debugger to do load it).
+    # Starts a debugging session if the +debugger+ gem has been loaded (call rails server --debugger to load it).
     def debugger
       message = "\n***** Debugger requested, but was not available (ensure the debugger gem is listed in Gemfile/installed as gem): Start server with --debugger to enable *****\n"
       defined?(Rails) ? Rails.logger.info(message) : $stderr.puts(message)


### PR DESCRIPTION
Remove 'do ' from line 3 comment in debugger.rb
