### PR TITLE
Raise a better exception for renaming long indexes for mysql adapters

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -499,6 +499,9 @@ module ActiveRecord
 
       def rename_index(table_name, old_name, new_name)
         if supports_rename_index?
+          if new_name.length > allowed_index_name_length
+            raise ArgumentError, "Index name '#{new_name}' on table '#{table_name}' is too long; the limit is #{allowed_index_name_length} characters"
+          end
           execute "ALTER TABLE #{quote_table_name(table_name)} RENAME INDEX #{quote_table_name(old_name)} TO #{quote_table_name(new_name)}"
         else
           super


### PR DESCRIPTION
This pull request addresses following failures when tested with MySQL 5.7.5-m15 `Server version: 5.7.5-m15 MySQL Community Server (GPL)`. 
- mysql adapter

``` ruby
$ ARCONN=mysql ruby -Itest test/cases/migration/index_test.rb -n test_rename_index_too_long
Using mysql
Run options: -n test_rename_index_too_long --seed 13501

# Running:

F

Finished in 0.023741s, 42.1204 runs/s, 42.1204 assertions/s.

  1) Failure:
ActiveRecord::Migration::IndexTest#test_rename_index_too_long [test/cases/migration/index_test.rb:43]:
[ArgumentError] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"Mysql::Error: Identifier name 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' is too long: ALTER TABLE `testings` RENAME INDEX `old_idx` TO `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`">
---Backtrace---
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:306:in `query'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:306:in `block in execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:477:in `block in log'
/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:471:in `log'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:306:in `execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:502:in `rename_index'
test/cases/migration/index_test.rb:44:in `block in test_rename_index_too_long'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```
- mysql2 adapter

``` ruby
$ ARCONN=mysql2 ruby -Itest test/cases/migration/index_test.rb -n test_rename_index_too_long
Using mysql2
Run options: -n test_rename_index_too_long --seed 33658

# Running:

F

Finished in 0.021795s, 45.8822 runs/s, 45.8822 assertions/s.

  1) Failure:
ActiveRecord::Migration::IndexTest#test_rename_index_too_long [test/cases/migration/index_test.rb:43]:
[ArgumentError] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"Mysql2::Error: Identifier name 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' is too long: ALTER TABLE `testings` RENAME INDEX `old_idx` TO `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`">
---Backtrace---
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:306:in `query'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:306:in `block in execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:477:in `block in log'
/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:471:in `log'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:306:in `execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb:223:in `execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:502:in `rename_index'
test/cases/migration/index_test.rb:44:in `block in test_rename_index_too_long'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```
