### PR TITLE
ActiveJob testing improvements

### DIFF
--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -1,7 +1,7 @@
 require 'rake/testtask'
 require 'rubygems/package_task'
 
-ACTIVEJOB_ADAPTERS = %w(inline delayed_job qu que queue_classic resque sidekiq sneakers sucker_punch backburner)
+ACTIVEJOB_ADAPTERS = %w(inline delayed_job qu que queue_classic resque sidekiq sneakers sucker_punch backburner test)
 ACTIVEJOB_ADAPTERS -= %w(queue_classic) if defined?(JRUBY_VERSION)
 
 task default: :test

--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -2,7 +2,7 @@ require 'active_job/queue_adapters/inline_adapter'
 require 'active_support/core_ext/string/inflections'
 
 module ActiveJob
-  # The <tt>ActionJob::QueueAdapter</tt> module is used to load the 
+  # The <tt>ActionJob::QueueAdapter</tt> module is used to load the
   # correct adapter. The default queue adapter is the :inline queue.
   module QueueAdapter #:nodoc:
     extend ActiveSupport::Concern
@@ -21,8 +21,8 @@ module ActiveJob
             ActiveJob::QueueAdapters::TestAdapter.new
           when Symbol, String
             load_adapter(name_or_adapter)
-          when Class
-            name_or_adapter
+          else
+            name_or_adapter if name_or_adapter.respond_to?(:enqueue)
           end
       end
 

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -14,6 +14,11 @@ module ActiveJob
       attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs)
       attr_writer(:enqueued_jobs, :performed_jobs)
 
+      def initialize
+        self.perform_enqueued_jobs = false
+        self.perform_enqueued_at_jobs = false
+      end
+
       # Provides a store of all the enqueued jobs with the TestAdapter so you can check them.
       def enqueued_jobs
         @enqueued_jobs ||= []
@@ -26,19 +31,19 @@ module ActiveJob
 
       def enqueue(job) #:nodoc:
         if perform_enqueued_jobs
-          performed_jobs << {job: job.class, args: job.arguments, queue: job.queue_name}
-          job.perform_now
+          performed_jobs << {job: job.class, args: job.serialize['arguments'], queue: job.queue_name}
+          Base.execute job.serialize
         else
-          enqueued_jobs << {job: job.class, args: job.arguments, queue: job.queue_name}
+          enqueued_jobs << {job: job.class, args: job.serialize['arguments'], queue: job.queue_name}
         end
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
         if perform_enqueued_at_jobs
-          performed_jobs << {job: job.class, args: job.arguments, queue: job.queue_name, at: timestamp}
-          job.perform_now
+          performed_jobs << {job: job.class, args: job.serialize['arguments'], queue: job.queue_name, at: timestamp}
+          Base.execute job.serialize
         else
-          enqueued_jobs << {job: job.class, args: job.arguments, queue: job.queue_name, at: timestamp}
+          enqueued_jobs << {job: job.class, args: job.serialize['arguments'], queue: job.queue_name, at: timestamp}
         end
       end
     end

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/hash/keys'
+
 module ActiveJob
   # Provides helper methods for testing Active Job
   module TestHelper

--- a/activejob/test/adapters/test.rb
+++ b/activejob/test/adapters/test.rb
@@ -1,0 +1,3 @@
+ActiveJob::Base.queue_adapter = :test
+ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true

--- a/activejob/test/cases/adapter_test.rb
+++ b/activejob/test/cases/adapter_test.rb
@@ -2,7 +2,6 @@ require 'helper'
 
 class AdapterTest < ActiveSupport::TestCase
   test "should load #{ENV['AJADAPTER']} adapter" do
-    ActiveJob::Base.queue_adapter = ENV['AJADAPTER'].to_sym
-    assert_equal "active_job/queue_adapters/#{ENV['AJADAPTER']}_adapter".classify.constantize, ActiveJob::Base.queue_adapter
+    assert_equal "active_job/queue_adapters/#{ENV['AJADAPTER']}_adapter".classify, ActiveJob::Base.queue_adapter.name
   end
 end


### PR DESCRIPTION
1. The `:test` adapter wasn't going through a full cycle of serialize/deserialize when performing jobs. Now it does
2. Regular AJ tests were not run for the `:test` adapter. Now they are
3. ActiveJob::TestHelper uses assert_valid_keys but doesn’t requires the file that implements that method. Now it does
