### PR TITLE
Update Getting Started guide to reflect foreign key in migration [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1544,6 +1544,7 @@ class CreateComments < ActiveRecord::Migration
 
       t.timestamps null: false
     end
+    add_foreign_key :comments, :articles
   end
 end
 ```
@@ -1563,6 +1564,8 @@ run against the current database, so in this case you will just see:
 ==  CreateComments: migrating =================================================
 -- create_table(:comments)
    -> 0.0115s
+-- add_foreign_key(:comments, :articles)
+   -> 0.0000s
 ==  CreateComments: migrated (0.0119s) ========================================
 ```
 


### PR DESCRIPTION
Since foreign keys are now automatically added to generated migrations when :references is used (a03ea68), this updates the Getting Started guide's comment migration output to reflect that.
