### PR TITLE
Fix spell life cycle on activejob docs 

### DIFF
--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -3,8 +3,8 @@ require 'active_support/callbacks'
 module ActiveJob
   # = Active Job Callbacks
   #
-  # Active Job provides hooks during the lifecycle of a job. Callbacks allow you
-  # to trigger logic during the lifecycle of a job. Available callbacks are:
+  # Active Job provides hooks during the life cycle of a job. Callbacks allow you
+  # to trigger logic during the life cycle of a job. Available callbacks are:
   #
   # * <tt>before_enqueue</tt>
   # * <tt>around_enqueue</tt>

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -215,8 +215,8 @@ backends you need to specify the queues to listen to.
 Callbacks
 ---------
 
-Active Job provides hooks during the lifecycle of a job. Callbacks allow you to
-trigger logic during the lifecycle of a job.
+Active Job provides hooks during the life cycle of a job. Callbacks allow you to
+trigger logic during the life cycle of a job.
 
 ### Available callbacks
 


### PR DESCRIPTION
it should be life cycle as we did 

https://github.com/rails/rails/blob/77029742814741ca7f220703e9f20e935b9d799b/guides/source/active_record_callbacks.md#L6
