### PR TITLE
Correctly use the response's status code calling head

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Correctly rely on the response's status code to handle calls to `head`.
+
+    *Robin Dupret*
+
 *   Using `head` method returns empty response_body instead
     of returning a single space " ".
 

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -173,6 +173,7 @@ module ActionController
     def status
       @_status
     end
+    alias :response_code :status # :nodoc:
 
     def status=(status)
       @_status = Rack::Utils.status_code(status)
@@ -235,10 +236,6 @@ module ActionController
       else
         lambda { |env| new.dispatch(name, klass.new(env)) }
       end
-    end
-
-    def _status_code #:nodoc:
-      @_status
     end
   end
 end

--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -31,7 +31,7 @@ module ActionController
 
       self.response_body = ""
 
-      if include_content?(self._status_code)
+      if include_content?(self.response_code)
         self.content_type = content_type || (Mime[formats.first] if formats)
         self.response.charset = false if self.response
       else

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -217,6 +217,15 @@ class TestController < ActionController::Base
     head :forbidden, :x_custom_header => "something"
   end
 
+  def head_with_no_content
+    # Fill in the headers with dummy data to make
+    # sure they get removed during the testing
+    response.headers["Content-Type"] = "dummy"
+    response.headers["Content-Length"] = 42
+
+    head 204
+  end
+
   private
 
     def set_variable_for_layout
@@ -543,6 +552,14 @@ class HeadRenderTest < ActionController::TestCase
       get :head_with_integer_status, :status => code.to_s
       assert_equal message, @response.message
     end
+  end
+
+  def test_head_with_no_content
+    get :head_with_no_content
+
+    assert_equal 204, @response.status
+    assert_nil @response.headers["Content-Type"]
+    assert_nil @response.headers["Content-Length"]
   end
 
   def test_head_with_string_status


### PR DESCRIPTION
Hello,

Commit 20fece1 introduced the `_status_code` method to fix calls to `head :ok`. This method has been added on both `ActionController::Metal` and `ActionDispatch::Response`.

As for the latter, this method is just equivalent to the `response_code` one so commit aefec3c removed it from the `Reponse` object so call to the `_status_code` method on an `ActionController::Base` instance would be handled by the `Metal` class (which `Base` inherits from) but the status code is not updated according to the response at this level.

The fix is to actually rely on `response_code` for ActionController::Base instances but this method doesn't exist for bare Metal controllers so we need to define it.

Note: the `response.headers[]` calls inside the tested controller's action seem awkward but they are actually needed to make sure the the [`else` statement](https://github.com/rails/rails/blob/7d1718f49eda0f78216bb232977bf254f7f32ebb/actionpack/lib/action_controller/metal/head.rb#L37-L40) is reached as the `Content-Length` and `Content-Type` headers are most of the time not even filled when the request/response cycle ends.

/cc @carlosantoniodasilva @guilleiguaran

Have a nice day!
