### PR TITLE
Allow bypassing readonly in Activerecord.{save,destroy}

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -288,7 +288,7 @@ module ActiveRecord
       define_model_callbacks :save, :create, :update, :destroy
     end
 
-    def destroy #:nodoc:
+    def destroy(*) #:nodoc:
       _run_destroy_callbacks { super }
     end
 

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -277,7 +277,7 @@ module ActiveRecord
       self.class.transaction(options, &block)
     end
 
-    def destroy #:nodoc:
+    def destroy(*) #:nodoc:
       with_transaction_returning_status { super }
     end
 

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -32,6 +32,28 @@ class ReadOnlyTest < ActiveRecord::TestCase
 
     e = assert_raise(ActiveRecord::ReadOnlyRecord) { dev.destroy }
     assert_equal "Developer is marked as readonly", e.message
+
+    e = assert_raise(ActiveRecord::ReadOnlyRecord) { dev.destroy! }
+    assert_equal "Developer is marked as readonly", e.message
+  end
+
+  def test_can_disable_readonly_check
+    dev = Developer.find(1)
+    assert !dev.readonly?
+
+    dev.readonly!
+    assert dev.readonly?
+
+    assert_nothing_raised do
+      dev.name = 'Luscious forbidden fruit.'
+      assert !dev.save
+      dev.name = 'Forbidden.'
+
+      assert dev.save(check_readonly: false)
+      assert dev.save!(check_readonly: false)
+      assert dev.destroy(check_readonly: false)
+      assert dev.destroy!(check_readonly: false)
+    end
   end
 
 


### PR DESCRIPTION
This is useful if you want to save a record even though it is marked as readonly.

[A scenario where this is useful](http://stackoverflow.com/questions/27723375/bypass-readonly-when-saving-activerecord/27723606)

I have not updated any docs, but if this patch looks okay, I'll also update the documentation.
