### PR TITLE
`update_columns` should still cast_type_from_user.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Ensure that `update_columns` cast the values using the connection adapter's
+    `type_cast_from_user` method.
+
+    *James R. Bracy*
+
 *   Fix error message when trying to create an associated record and the foreign
     key is missing.
 

--- a/activerecord/lib/active_record/attribute.rb
+++ b/activerecord/lib/active_record/attribute.rb
@@ -103,10 +103,14 @@ module ActiveRecord
 
     class WithCastValue < Attribute # :nodoc:
       def type_cast(value)
-        value
+        type.type_cast_from_user(value)
       end
 
       def changed_in_place_from?(old_value)
+        false
+      end
+
+      def changed_from?(old_value)
         false
       end
     end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -77,6 +77,18 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert column.array
   end
 
+  def test_update_columns_should_use_connection_adapter_type_cast_from_user
+    @connection.execute "insert into pg_arrays (tags) VALUES ('{1,2,3}')"
+    x = PgArray.first
+    x.update_columns(tags: '{1,2,3,4}')
+    assert_equal ['1','2','3','4'], x.tags
+    assert_equal ['1','2','3','4'], x.reload.tags
+
+    x.update_columns(tags: ['1'])
+    assert_equal ['1'], x.tags
+    assert_equal ['1'], x.reload.tags
+  end
+
   def test_change_column_cant_make_non_array_column_to_array
     @connection.add_column :pg_arrays, :a_string, :string
     assert_raises ActiveRecord::StatementInvalid do


### PR DESCRIPTION
When setting attributes via update_column the model should still
attributes should still reflect the casted_value from the database adapter, not
what was set directly. For example:

```
# create_table :pg_arrays do |t|
#   t.string :tags, array: true
# end
class PgArray < ActiveRecord::Base
  self.table_name = 'pg_arrays'
end

x = PgArray.create(tags: [1,2,3])
# PostgreSQL array syntax should be parsed
x.update_columns(tags: '{1,2,3,4}')
```

Previously `x.tags` would return a string `"{1,2,3,4}"` because that is
what was directly set. Instead it should return the parsed array:

```
x.tags # => [1,2,3,4]
```
