### PR TITLE
Prefer `array?` rather than `array`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -30,13 +30,13 @@ module ActiveRecord
       # <tt>company_name varchar(60)</tt>.
       # It will be mapped to one of the standard Rails SQL types in the <tt>type</tt> attribute.
       # +null+ determines if this column allows +NULL+ values.
-      def initialize(name, default, cast_type, sql_type = nil, null = true)
+      def initialize(name, default, cast_type, sql_type = nil, null = true, default_function = nil)
         @name             = name
         @cast_type        = cast_type
         @sql_type         = sql_type
         @null             = null
         @default          = default
-        @default_function = nil
+        @default_function = default_function
       end
 
       def has_default?

--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -2,18 +2,17 @@ module ActiveRecord
   module ConnectionAdapters
     # PostgreSQL-specific extensions to column definitions in a table.
     class PostgreSQLColumn < Column #:nodoc:
-      attr_accessor :array
+      attr_reader :array
+      alias :array? :array
 
       def initialize(name, default, cast_type, sql_type = nil, null = true, default_function = nil)
         if sql_type =~ /\[\]$/
           @array = true
-          super(name, default, cast_type, sql_type[0..sql_type.length - 3], null)
+          sql_type = sql_type[0..sql_type.length - 3]
         else
           @array = false
-          super(name, default, cast_type, sql_type, null)
         end
-
-        @default_function = default_function
+        super
       end
 
       def serial?

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -144,7 +144,7 @@ module ActiveRecord
       # AbstractAdapter
       def prepare_column_options(column) # :nodoc:
         spec = super
-        spec[:array] = 'true' if column.respond_to?(:array) && column.array
+        spec[:array] = 'true' if column.array?
         spec[:default] = "\"#{column.default_function}\"" if column.default_function
         spec
       end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -35,13 +35,13 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
   def test_column
     assert_equal :string, @column.type
     assert_equal "character varying", @column.sql_type
-    assert @column.array
+    assert @column.array?
     assert_not @column.number?
     assert_not @column.binary?
 
     ratings_column = PgArray.columns_hash['ratings']
     assert_equal :integer, ratings_column.type
-    assert ratings_column.array
+    assert ratings_column.array?
     assert_not ratings_column.number?
   end
 
@@ -74,7 +74,7 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
 
     assert_equal :text, column.type
     assert_equal [], PgArray.column_defaults['snippets']
-    assert column.array
+    assert column.array?
   end
 
   def test_change_column_cant_make_non_array_column_to_array

--- a/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
@@ -28,7 +28,7 @@ class PostgresqlBitStringTest < ActiveRecord::TestCase
     assert_equal "bit(8)", column.sql_type
     assert_not column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_bit_string_varying_column
@@ -37,7 +37,7 @@ class PostgresqlBitStringTest < ActiveRecord::TestCase
     assert_equal "bit varying(4)", column.sql_type
     assert_not column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_default

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -34,7 +34,7 @@ if ActiveRecord::Base.connection.supports_extensions?
       assert_equal 'citext', column.sql_type
       assert_not column.number?
       assert_not column.binary?
-      assert_not column.array
+      assert_not column.array?
     end
 
     def test_change_table_supports_json

--- a/activerecord/test/cases/adapters/postgresql/composite_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/composite_test.rb
@@ -52,7 +52,7 @@ class PostgresqlCompositeTest < ActiveRecord::TestCase
     assert_equal "full_address", column.sql_type
     assert_not column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_composite_mapping
@@ -113,7 +113,7 @@ class PostgresqlCompositeWithCustomOIDTest < ActiveRecord::TestCase
     assert_equal "full_address", column.sql_type
     assert_not column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_composite_mapping

--- a/activerecord/test/cases/adapters/postgresql/domain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/domain_test.rb
@@ -31,7 +31,7 @@ class PostgresqlDomainTest < ActiveRecord::TestCase
     assert_equal "custom_money", column.sql_type
     assert column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_domain_acts_like_basetype

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -33,7 +33,7 @@ class PostgresqlEnumTest < ActiveRecord::TestCase
     assert_equal "mood", column.sql_type
     assert_not column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_enum_defaults

--- a/activerecord/test/cases/adapters/postgresql/full_text_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/full_text_test.rb
@@ -23,7 +23,7 @@ class PostgresqlFullTextTest < ActiveRecord::TestCase
     assert_equal "tsvector", column.sql_type
     assert_not column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_update_tsvector

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -28,7 +28,7 @@ class PostgresqlPointTest < ActiveRecord::TestCase
     assert_equal "point", column.sql_type
     assert_not column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_default

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -56,7 +56,7 @@ if ActiveRecord::Base.connection.supports_extensions?
       assert_equal "hstore", @column.sql_type
       assert_not @column.number?
       assert_not @column.binary?
-      assert_not @column.array
+      assert_not @column.array?
     end
 
     def test_default

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -36,7 +36,7 @@ module PostgresqlJSONSharedTestCases
     assert_equal column_type.to_s, column.sql_type
     assert_not column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_default

--- a/activerecord/test/cases/adapters/postgresql/ltree_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/ltree_test.rb
@@ -32,7 +32,7 @@ class PostgresqlLtreeTest < ActiveRecord::TestCase
     assert_equal "ltree", column.sql_type
     assert_not column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_write

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -27,7 +27,7 @@ class PostgresqlMoneyTest < ActiveRecord::TestCase
     assert_equal 2, column.scale
     assert column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_default

--- a/activerecord/test/cases/adapters/postgresql/network_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/network_test.rb
@@ -25,7 +25,7 @@ class PostgresqlNetworkTest < ActiveRecord::TestCase
     assert_equal "cidr", column.sql_type
     assert_not column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_inet_column
@@ -34,7 +34,7 @@ class PostgresqlNetworkTest < ActiveRecord::TestCase
     assert_equal "inet", column.sql_type
     assert_not column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_macaddr_column
@@ -43,7 +43,7 @@ class PostgresqlNetworkTest < ActiveRecord::TestCase
     assert_equal "macaddr", column.sql_type
     assert_not column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_network_types

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -51,7 +51,7 @@ class PostgresqlUUIDTest < ActiveRecord::TestCase
     assert_equal "uuid", column.sql_type
     assert_not column.number?
     assert_not column.binary?
-    assert_not column.array
+    assert_not column.array?
   end
 
   def test_treat_blank_uuid_as_nil

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -82,7 +82,7 @@ module ActiveRecord
           columns = connection.columns(:testings)
           array_column = columns.detect { |c| c.name == "foo" }
 
-          assert array_column.array
+          assert array_column.array?
         end
 
         def test_create_table_with_array_column
@@ -93,7 +93,7 @@ module ActiveRecord
           columns = connection.columns(:testings)
           array_column = columns.detect { |c| c.name == "foo" }
 
-          assert array_column.array
+          assert array_column.array?
         end
       end
 


### PR DESCRIPTION
Happy New Year! :tada: :sheep:

`array` can only be called to check to dump the `:array` option in the AR internal, therefore it is not necessary to determine until it is called. Do not remove `[]` from `sql_type` for the `array?` method. Lookup the `cast_type` from `sql_type` required `[]` also. It was not necessary to remove `[]`.
