### PR TITLE
Integration requests should work in contexts without setup and teardown

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -67,7 +67,8 @@ module ActionController
 
     def reset_template_assertion
       RENDER_TEMPLATE_INSTANCE_VARIABLES.each do |instance_variable|
-        instance_variable_get("@_#{instance_variable}").clear
+        ivar = instance_variable_get("@_#{instance_variable}")
+        ivar.clear if ivar
       end
     end
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -850,3 +850,27 @@ class IntegrationWithRoutingTest < ActionDispatch::IntegrationTest
     end
   end
 end
+
+# to work in contexts like rspec before(:all)
+class IntegrationRequestsWithoutSetup < ActionDispatch::IntegrationTest
+  self._setup_callbacks = []
+  self._teardown_callbacks = []
+
+  class FooController < ActionController::Base
+    def ok
+      cookies[:key] = 'ok'
+      render plain: 'ok'
+    end
+  end
+
+  def test_request
+    with_routing do |routes|
+      routes.draw { get ':action' => FooController }
+      get '/ok'
+
+      assert_response 200
+      assert_equal 'ok', response.body
+      assert_equal 'ok', cookies['key']
+    end
+  end
+end


### PR DESCRIPTION
Fix #18285 

In rails 4.2.0 integration requests work only if are called inside setup-teardown cycle (for view-related assertions). But these methods (e.g, `#get`, `#post`) can be useful outside of current test to setup a context (cookies, session) for all requests, e.g., to use inside `before(:all)` with rspec.
