### PR TITLE
Fully support datetime values in AR::Type::DateTime#type_cast_for_database

### DIFF
--- a/activerecord/lib/active_record/type/date_time.rb
+++ b/activerecord/lib/active_record/type/date_time.rb
@@ -11,7 +11,11 @@ module ActiveRecord
         zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
 
         if value.acts_like?(:time)
-          value.send(zone_conversion_method)
+          if value.respond_to?(zone_conversion_method)
+            value.send(zone_conversion_method)
+          else
+            value
+          end
         else
           super
         end

--- a/activerecord/test/cases/date_time_test.rb
+++ b/activerecord/test/cases/date_time_test.rb
@@ -50,4 +50,12 @@ class DateTimeTest < ActiveRecord::TestCase
     topic.bonus_time = ''
     assert_nil topic.bonus_time
   end
+
+  def test_assign_in_local_timezone
+    now = DateTime.now
+    with_timezone_config default: :local do
+      task = Task.new starting: now
+      assert now, task.starting
+    end
+  end
 end


### PR DESCRIPTION
Fixes #18296

Since this method is inspired by https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L81, I've added the same conditioning to take into account `DateTime`.

Also I think the method should be extracted to be shared across `AR::Type::Time`, `AR::Type::Date` as well. It can be done in a separate commit.
