### PR TITLE
Unsafe default translations should not be marked html_safe

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Default translations that have a lower precidence than an html safe default,
+    but are not themselves safe, should not be marked as html_safe.
+
+    *Justin Coyne*
+
 *   Make possible to use blocks with short version of `render "partial"` helper.
 
     *Nikolay Shebanov*

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -145,6 +145,12 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal true, translation.html_safe?
   end
 
+  def test_translate_with_last_default_not_named_html
+    translation = translate(:'translations.missing', :default => [:'translations.missing_html', :'translations.foo'])
+    assert_equal 'Foo', translation
+    assert_equal false, translation.html_safe?
+  end
+
   def test_translate_with_string_default
     translation = translate(:'translations.missing', default: 'A Generic String')
     assert_equal 'A Generic String', translation


### PR DESCRIPTION
Previously default translation keys that didn't end in `_html`, but came
after a missing key that ended in `_html` were being returned as
html_safe. Now they are not. Fixes #18257
