### PR TITLE
Generated fixtures won't use parent_id when generated with parent:references

### DIFF
--- a/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
+++ b/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
@@ -5,6 +5,8 @@
 <% attributes.each do |attribute| -%>
   <%- if attribute.password_digest? -%>
   password_digest: <%%= BCrypt::Password.create('secret') %>
+  <%- elsif attribute.reference? -%>
+  <%= yaml_key_value(attribute.column_name.gsub(/_id$/, ''), attribute.default) %>
   <%- else -%>
   <%= yaml_key_value(attribute.column_name, attribute.default) %>
   <%- end -%>

--- a/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
+++ b/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
@@ -6,7 +6,7 @@
   <%- if attribute.password_digest? -%>
   password_digest: <%%= BCrypt::Password.create('secret') %>
   <%- elsif attribute.reference? -%>
-  <%= yaml_key_value(attribute.column_name.gsub(/_id$/, ''), attribute.default) %>
+  <%= yaml_key_value(attribute.column_name.sub(/_id$/, ''), attribute.default) %>
   <%- else -%>
   <%= yaml_key_value(attribute.column_name, attribute.default) %>
   <%- end -%>

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -287,18 +287,18 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   def test_fixtures_use_the_references_ids
     run_generator ["LineItem", "product:references", "cart:belongs_to"]
 
-    assert_file "test/fixtures/line_items.yml", /product_id: \n  cart_id: /
+    assert_file "test/fixtures/line_items.yml", /product: \n  cart: /
     assert_generated_fixture("test/fixtures/line_items.yml",
-                             {"one"=>{"product_id"=>nil, "cart_id"=>nil}, "two"=>{"product_id"=>nil, "cart_id"=>nil}})
+                             {"one"=>{"product"=>nil, "cart"=>nil}, "two"=>{"product"=>nil, "cart"=>nil}})
   end
 
   def test_fixtures_use_the_references_ids_and_type
     run_generator ["LineItem", "product:references{polymorphic}", "cart:belongs_to"]
 
-    assert_file "test/fixtures/line_items.yml", /product_id: \n  product_type: Product\n  cart_id: /
+    assert_file "test/fixtures/line_items.yml", /product: \n  product_type: Product\n  cart: /
     assert_generated_fixture("test/fixtures/line_items.yml",
-                             {"one"=>{"product_id"=>nil, "product_type"=>"Product", "cart_id"=>nil},
-                              "two"=>{"product_id"=>nil, "product_type"=>"Product", "cart_id"=>nil}})
+                             {"one"=>{"product"=>nil, "product_type"=>"Product", "cart"=>nil},
+                              "two"=>{"product"=>nil, "product_type"=>"Product", "cart"=>nil}})
   end
 
   def test_fixtures_respect_reserved_yml_keywords


### PR DESCRIPTION
Fixes #18301

Is there anything I could do to improve this, please tell me.
