### PR TITLE
fix infinite retry loop in Marshal.load autoloading logic

### DIFF
--- a/activesupport/lib/active_support/core_ext/marshal.rb
+++ b/activesupport/lib/active_support/core_ext/marshal.rb
@@ -6,6 +6,9 @@ module Marshal
       load_without_autoloading(source)
     rescue ArgumentError, NameError => exc
       if exc.message.match(%r|undefined class/module (.+)|)
+        processed_names ||= {}
+        raise exc if processed_names[$1]
+        processed_names[$1] = true
         # try loading the class/module
         $1.constantize
         # if it is a IO we need to go back to read the object

--- a/activesupport/test/core_ext/marshal_test.rb
+++ b/activesupport/test/core_ext/marshal_test.rb
@@ -122,7 +122,7 @@ class MarshalTest < ActiveSupport::TestCase
     end
   end
 
-  test "that loading a abstract nested class raises an error" do
+  test "that loading an abstract nested class raises an error" do
     dumped = nil
     class SomeAbstractParent
       class SomeChild

--- a/activesupport/test/core_ext/marshal_test.rb
+++ b/activesupport/test/core_ext/marshal_test.rb
@@ -8,7 +8,7 @@ class MarshalTest < ActiveSupport::TestCase
 
   def teardown
     ActiveSupport::Dependencies.clear
-    remove_constants(:E, :ClassFolder)
+    remove_constants(:E, :ClassFolder, :SomeAbstractParent, :SomeParent)
   end
 
   test "that Marshal#load still works" do
@@ -119,6 +119,27 @@ class MarshalTest < ActiveSupport::TestCase
       with_autoloading_fixtures do
         assert_kind_of E, Marshal.load(f)
       end
+    end
+  end
+
+  test "that loading a abstract nested class raises an error" do
+    dumped = nil
+    class SomeAbstractParent
+      class SomeChild
+      end
+    end
+
+    class SomeParent < SomeAbstractParent
+      class SomeChild
+      end
+    end
+
+    dumped = Marshal.dump(SomeParent::SomeChild.new)
+
+    SomeParent.send(:remove_const, :SomeChild)
+
+    assert_raise(ArgumentError) do
+      Marshal.load(dumped)
     end
   end
 end


### PR DESCRIPTION
Fix an infinite-retry loop in the Marshal.load autoloading logic extension, by short-circuiting if the name has already been processed for autoloading and yet continues to fail to load.

As shown in the test case and in this gist: https://gist.github.com/seanwalbran/db04918c54a31f238587, the issue is triggered specifically in the scenario where an object had been dumped as a 'concrete' nested class (i.e., defined on the subclass), but is being loaded in a context where the nested class has since been rendered 'non-concrete' (i.e., defined only by the superclass).   

A real-life hang example occurs if you take an ActiveRecord::Base object dumped (e.g., to memcached) under rails 4.1.x and attempt to load it under rails 4.2.0, where ActiveRecord::ConnectionAdapters::Mysql2Adapter::Column is no longer a concrete nested class as of the following commit: https://github.com/rails/rails/commit/e781aa31fc52a7c696115302ef4d4e02bfd1533b#diff-e7dead35794529e0cc5d0b2d788f8235L33
