### PR TITLE
Remove the tmp/sessions folder and its clear task

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -383,8 +383,8 @@ rake db:create          # Create the database from config/database.yml for the c
 rake log:clear          # Truncates all *.log files in log/ to zero bytes (specify which logs with LOGS=test,development)
 rake middleware         # Prints out your Rack middleware stack
 ...
-rake tmp:clear          # Clear session, cache, and socket files from tmp/ (narrow w/ tmp:sessions:clear, tmp:cache:clear, tmp:sockets:clear)
-rake tmp:create         # Creates tmp directories for sessions, cache, sockets, and pids
+rake tmp:clear          # Clear cache and socket files from tmp/ (narrow w/ tmp:cache:clear, tmp:sockets:clear)
+rake tmp:create         # Creates tmp directories for cache, sockets, and pids
 ```
 INFO: You can also use `rake -T`  to get the list of tasks.
 
@@ -496,15 +496,14 @@ Rails comes with a test suite called Minitest. Rails owes its stability to the u
 
 ### `tmp`
 
-The `Rails.root/tmp` directory is, like the *nix /tmp directory, the holding place for temporary files like sessions (if you're using a file store for sessions), process id files, and cached actions.
+The `Rails.root/tmp` directory is, like the *nix /tmp directory, the holding place for temporary files like process id files and cached actions.
 
 The `tmp:` namespaced tasks will help you clear and create the `Rails.root/tmp` directory:
 
 * `rake tmp:cache:clear` clears `tmp/cache`.
-* `rake tmp:sessions:clear` clears `tmp/sessions`.
 * `rake tmp:sockets:clear` clears `tmp/sockets`.
-* `rake tmp:clear` clears all the three: cache, sessions and sockets.
-* `rake tmp:create` creates tmp directories for sessions, cache, sockets, and pids.
+* `rake tmp:clear` clears all cache and sockets files.
+* `rake tmp:create` creates tmp directories for cache, sockets and pids.
 
 ### Miscellaneous
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -174,7 +174,7 @@ of the files and folders that Rails created by default:
 |Rakefile|This file locates and loads tasks that can be run from the command line. The task definitions are defined throughout the components of Rails. Rather than changing Rakefile, you should add your own tasks by adding files to the lib/tasks directory of your application.|
 |README.rdoc|This is a brief instruction manual for your application. You should edit this file to tell others what your application does, how to set it up, and so on.|
 |test/|Unit tests, fixtures, and other test apparatus. These are covered in [Testing Rails Applications](testing.html).|
-|tmp/|Temporary files (like cache, pid, and session files).|
+|tmp/|Temporary files (like cache and pid files).|
 |vendor/|A place for all third-party code. In a typical Rails application this includes vendored gems.|
 
 Hello, Rails!

--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -359,7 +359,7 @@ private
   end
 
   def create_tmp_directories
-    %w(cache pids sessions sockets).each do |dir_to_make|
+    %w(cache pids sockets).each do |dir_to_make|
       FileUtils.mkdir_p(File.join(Rails.root, 'tmp', dir_to_make))
     end
   end
@@ -375,13 +375,12 @@ private
   end
 ```
 
-This is where the first output of the Rails initialization happens. This
-method creates a trap for `INT` signals, so if you `CTRL-C` the server,
-it will exit the process. As we can see from the code here, it will
-create the `tmp/cache`, `tmp/pids`, `tmp/sessions` and `tmp/sockets`
-directories. It then calls `wrapped_app` which is responsible for
-creating the Rack app, before creating and assigning an
-instance of `ActiveSupport::Logger`.
+This is where the first output of the Rails initialization happens. This method
+creates a trap for `INT` signals, so if you `CTRL-C` the server, it will exit the
+process. As we can see from the code here, it will create the `tmp/cache`,
+`tmp/pids`, and `tmp/sockets` directories. It then calls `wrapped_app` which is
+responsible for creating the Rack app, before creating and assigning an instance
+of `ActiveSupport::Logger`.
 
 The `super` method will call `Rack::Server.start` which begins its definition like this:
 

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -130,7 +130,7 @@ module Rails
       end
 
       def create_tmp_directories
-        %w(cache pids sessions sockets).each do |dir_to_make|
+        %w(cache pids sockets).each do |dir_to_make|
           FileUtils.mkdir_p(File.join(Rails.root, 'tmp', dir_to_make))
         end
       end

--- a/railties/lib/rails/tasks/tmp.rake
+++ b/railties/lib/rails/tasks/tmp.rake
@@ -1,9 +1,8 @@
 namespace :tmp do
-  desc "Clear session, cache, and socket files from tmp/ (narrow w/ tmp:sessions:clear, tmp:cache:clear, tmp:sockets:clear)"
-  task clear: [ "tmp:sessions:clear",  "tmp:cache:clear", "tmp:sockets:clear"]
+  desc "Clear cache and socket files from tmp/ (narrow w/ tmp:cache:clear, tmp:sockets:clear)"
+  task clear: ["tmp:cache:clear", "tmp:sockets:clear"]
 
-  tmp_dirs = [ 'tmp/sessions',
-               'tmp/cache',
+  tmp_dirs = [ 'tmp/cache',
                'tmp/sockets',
                'tmp/pids',
                'tmp/cache/assets/development',
@@ -14,13 +13,6 @@ namespace :tmp do
 
   desc "Creates tmp directories for sessions, cache, sockets, and pids"
   task create: tmp_dirs
-
-  namespace :sessions do
-    # desc "Clears all files in tmp/sessions"
-    task :clear do
-      FileUtils.rm(Dir['tmp/sessions/[^.]*'])
-    end
-  end
 
   namespace :cache do
     # desc "Clears all files and directories in tmp/cache"


### PR DESCRIPTION
Hello,

Commit 1aea470 introduced the `tmp/sessions` directory but this was at a time when the default way to store sessions was on the file system under the `tmp` directory. It looks like this directory is not needed anymore so let's get rid of it.

Just for the record, this has been spotted by yui-knk in https://github.com/rails/rails/pull/17564#issuecomment-62305622.

Have a nice day.
