### PR TITLE
Allow passing of a Class for STI subclass assignment

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Allow passing of a Class for STI subclass assignment.
+
+        # Before
+        # NoMethodError: undefined method `safe_constantize' for #<Class>
+        Post.new(type: SpecialPost)
+
+        # After
+        # Post initialized as SpecialPost
+        Post.new(type: SpecialPost).class # => SpecialPost
+
+    *Alex Robbin*
+
 *   Clear query cache on rollback.
 
     *Florian Weingarten*

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -206,7 +206,7 @@ module ActiveRecord
       end
 
       def subclass_from_attributes(attrs)
-        subclass_name = attrs.with_indifferent_access[inheritance_column]
+        subclass_name = attrs.with_indifferent_access[inheritance_column].to_s
 
         if subclass_name.present? && subclass_name != self.name
           subclass = subclass_name.safe_constantize

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -100,6 +100,11 @@ class InheritanceTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::SubclassNotFound) { Company.find(100) }
   end
 
+  def test_inheritance_assign_type_attribute_with_class
+    post = Post.new(type: SpecialPost)
+    assert_kind_of SpecialPost, post
+  end
+
   def test_inheritance_find
     assert_kind_of Firm, Company.find(1), "37signals should be a firm"
     assert_kind_of Firm, Firm.find(1), "37signals should be a firm"


### PR DESCRIPTION
Previously, if you attempted to initialize an STI-enabled class with a Class type attribute, you would receive:

``` ruby
Post.new(type: SpecialPost).class # => NoMethodError: undefined method `safe_constantize' for #<Class>
```

After this change, you are able to pass anything that responds to `to_s` as the type attribute.

``` ruby
Post.new(type: SpecialPost).class # => SpecialPost
```
