### PR TITLE
Fix n+1 query problem when eager loading nil associations (fixes #18312)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix n+1 query problem when eager loading nil associations (fixes #18312)
+
+    *Sammy Larbi*
+
 *   Clear query cache on rollback.
 
     *Florian Weingarten*

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -232,6 +232,7 @@ module ActiveRecord
       end
 
       def construct(ar_parent, parent, row, rs, seen, model_cache, aliases)
+        return if ar_parent.nil?
         primary_id  = ar_parent.id
 
         parent.children.each do |node|
@@ -248,7 +249,11 @@ module ActiveRecord
 
           key = aliases.column_alias(node, node.primary_key)
           id = row[key]
-          next if id.nil?
+          if id.nil?
+            nil_association = ar_parent.association(node.reflection.name)
+            nil_association.loaded!
+            next
+          end
 
           model = seen[parent.base_klass][primary_id][node.base_klass][id]
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -77,7 +77,15 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_has_many_through_with_order
     authors = Author.includes(:favorite_authors).to_a
+    assert authors.count > 0
     assert_no_queries { authors.map(&:favorite_authors) }
+  end
+
+  def test_eager_loaded_has_one_association_with_references_does_not_run_additional_queries
+    Post.update_all(author_id: nil)
+    authors = Author.includes(:post).references(:post).to_a
+    assert authors.count > 0
+    assert_no_queries { authors.map(&:post) }
   end
 
   def test_with_two_tables_in_from_without_getting_double_quoted


### PR DESCRIPTION
See #18312 for discussion of the bug. This pull request fixes it.

It was not an issue in 4.0.0, but was by 4.1.0 and still is in 4.2.0.
