### PR TITLE
Stop passing the column to the `quote` method when quoting defaults

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -56,7 +56,8 @@ module ActiveRecord
           if column.type == :uuid && value =~ /\(\)/
             value
           else
-            quote(value, column)
+            value = column.cast_type.type_cast_for_database(value)
+            quote(value)
           end
         end
 


### PR DESCRIPTION
Related the commit 8f8f8058e58dda20259c1caa61ec92542573643d.
