### PR TITLE
time_zone_options_for_select should not silently ignore unmatched zone

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -569,6 +569,10 @@ module ActionView
         zone_options = "".html_safe
 
         zones = model.all
+        if selected and zones.none? {|zone| zone.name == selected }
+          raise ArgumentError, "#{model}.all does not contain #{selected}"
+        end
+
         convert_zones = lambda { |list| list.map { |z| [ z.to_s, z.name ] } }
 
         if priority_zones

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -389,13 +389,9 @@ class FormOptionsHelperTest < ActionView::TestCase
   end
 
   def test_time_zone_options_with_unknown_selected
-    opts = time_zone_options_for_select( "K" )
-    assert_dom_equal "<option value=\"A\">A</option>\n" +
-                 "<option value=\"B\">B</option>\n" +
-                 "<option value=\"C\">C</option>\n" +
-                 "<option value=\"D\">D</option>\n" +
-                 "<option value=\"E\">E</option>",
-                 opts
+    assert_raise ArgumentError do
+      time_zone_options_for_select( "K" )
+    end
   end
 
   def test_time_zone_options_with_priority_zones


### PR DESCRIPTION
Raise an exception if time_zone_options_for_select is given unmatched zone.
