### PR TITLE
Add ActiveModel::Errors#details

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,7 +1,25 @@
+*   Add `ActiveModel::Errors#details`
+
+    To be able to return type of used validator, one can now call `details`
+    on Errors instance:
+
+    ```ruby
+    class User < ActiveRecord::Base
+      validates :name, presence: true
+    end
+    ```
+
+    ```ruby
+    user = User.new; user.valid?; user.errors.details
+    => {name: [{error: :blank}]}
+    ```
+
+    *Wojciech Wnętrzak*
+
 *   Change validates_acceptance_of to accept true by default.
 
     The default for validates_acceptance_of is now "1" and true.
-    In the past, only "1" was the default and you were required to add 
+    In the past, only "1" was the default and you were required to add
     accept: true.
 
 *   Remove deprecated `ActiveModel::Dirty#reset_#{attribute}` and

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -323,4 +323,46 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors.expects(:generate_message).with(:name, :blank, { message: 'custom' })
     person.errors.add_on_blank :name, message: 'custom'
   end
+
+  test "details returns added error detail" do
+    person = Person.new
+    person.errors.add(:name, :invalid)
+    assert_equal({ name: [{ error: :invalid }] }, person.errors.details)
+  end
+
+  test "details returns added error detail with custom option" do
+    person = Person.new
+    person.errors.add(:name, :greater_than, count: 5)
+    assert_equal({ name: [{ error: :greater_than, count: 5 }] }, person.errors.details)
+  end
+
+  test "details do not include message option" do
+    person = Person.new
+    person.errors.add(:name, :invalid, message: "is bad")
+    assert_equal({ name: [{ error: :invalid }] }, person.errors.details)
+  end
+
+  test "dup duplicates details" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :invalid)
+    errors_dup = errors.dup
+    errors_dup.add(:name, :taken)
+    assert_not_same errors_dup.details, errors.details
+  end
+
+  test "delete removes details on given attribute" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :invalid)
+    errors.delete(:name)
+    assert_empty errors.details[:name]
+  end
+
+  test "clear removes details" do
+    person = Person.new
+    person.errors.add(:name, :invalid)
+
+    assert_equal 1, person.errors.details.count
+    person.errors.clear
+    assert person.errors.details.empty?
+  end
 end

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -227,8 +227,26 @@ end
 ```
 
 We'll cover validation errors in greater depth in the [Working with Validation
-Errors](#working-with-validation-errors) section. For now, let's turn to the
-built-in validation helpers that Rails provides by default.
+Errors](#working-with-validation-errors) section.
+
+### `errors.details`
+
+To check what validator type was used on invalid attribute, you can use
+`errors.details[:attribute]`. It returns array of hashes where under `:error`
+ key you will find symbol of used validator.
+
+```ruby
+class Person < ActiveRecord::Base
+  validates :name, presence: true
+end
+
+>> person = Person.new
+>> person.valid?
+>> person.errors.details[:name] #=> [{error: :blank}]
+```
+
+Using `details` with custom validators are covered in the [Working with
+Validation Errors](#working-with-validation-errors) section.
 
 Validation Helpers
 ------------------
@@ -1073,6 +1091,42 @@ Another way to do this is using `[]=` setter
   person.errors.to_a
    # => ["Name cannot contain the characters !@#%*()_-+="]
 ```
+
+### `errors.details`
+
+You can add validator type to details hash when using `errors.add` method.
+
+```ruby
+  class Person < ActiveRecord::Base
+    def a_method_used_for_validation_purposes
+      errors.add(:name, :invalid_characters)
+    end
+  end
+
+  person = Person.create(name: "!@#")
+
+  person.errors.details[:name]
+   # => [{error: :invalid_characters}]
+```
+
+To improve error details to contain not allowed characters set, you can
+pass additional options to `errors.add` method.
+
+```ruby
+  class Person < ActiveRecord::Base
+    def a_method_used_for_validation_purposes
+      errors.add(:name, :invalid_characters, not_allowed: "!@#%*()_-+=")
+    end
+  end
+
+  person = Person.create(name: "!@#")
+
+  person.errors.details[:name]
+  # => [{error: :invalid_characters, not_allowed: "!@#%*()_-+="}]
+```
+
+All built in Rails validators populate details hash with corresponding
+validator types.
 
 ### `errors[:base]`
 


### PR DESCRIPTION
To be able to return type of validator, one can now call `details`
on Errors instance:

``` ruby
class User < ActiveRecord::Base
  validates :name, presence: true
end
```

``` ruby
user = User.new; user.valid?; user.errors.details
=> {name: [{error: :blank}]}
```

The first attempt was to return structure similar to messages, like: `{name: [:invalid, :blank]}`, but there was problem with missing additional options such as `:count` in some validators.

If the idea is accepted I will add documentation and changelog.

There is ongoing discussion on https://groups.google.com/forum/#!topic/rubyonrails-core/0lxM684Tqas
