### PR TITLE
Update bug report templates to use version 4.2.0 instead of 5.0.0

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -1,5 +1,5 @@
 # Activate the gem you are reporting the issue against.
-gem 'rails', '5.0.0'
+gem 'rails', '4.2.0'
 
 require 'rails'
 require 'action_controller/railtie'

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -1,5 +1,5 @@
 # Activate the gem you are reporting the issue against.
-gem 'activerecord', '5.0.0'
+gem 'activerecord', '4.2.0'
 require 'active_record'
 require 'minitest/autorun'
 require 'logger'


### PR DESCRIPTION
- Right now master is 5.0.0. Latest gem release is 4.2.0 for which we
  are accepting bug reports. So lets use it in bug report templates.
- 5.0.0 is not installable as it's not available on Rubygems yet. So the
  gem bug templates are not usable without editing the version. Using
  4.2.0 will make them usable again.
