### PR TITLE
Remove unneeded `require 'as/deprecation'`

### DIFF
--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -1,5 +1,4 @@
 require 'active_support/core_ext/object/try'
-require 'active_support/deprecation'
 require 'rails-html-sanitizer'
 
 module ActionView

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -1,6 +1,5 @@
 require 'set'
 require 'active_support/concern'
-require 'active_support/deprecation'
 
 module ActiveRecord
   module Delegation # :nodoc:

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -9,7 +9,6 @@ require 'active_support/testing/isolation'
 require 'active_support/testing/constant_lookup'
 require 'active_support/testing/time_helpers'
 require 'active_support/core_ext/kernel/reporting'
-require 'active_support/deprecation'
 
 module ActiveSupport
   class TestCase < ::Minitest::Test


### PR DESCRIPTION
Tests on Travis CI should still pass after removing `require 'active_support/deprecation'`
from these files since the related deprecations have been removed.
