### PR TITLE
Use directly TZInfo::Timezone without proxy

### DIFF
--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -2330,7 +2330,7 @@ class DateHelperTest < ActionView::TestCase
     # The love zone is UTC+0
     mytz = Class.new(ActiveSupport::TimeZone) {
       attr_accessor :now
-    }.create('tenderlove', 0)
+    }.create('tenderlove', 0, ActiveSupport::TimeZone.find_tzinfo('UTC'))
 
     now       = Time.mktime(2004, 6, 15, 16, 35, 0)
     mytz.now  = now

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -202,7 +202,7 @@ module ActiveSupport
       end
 
       def find_tzinfo(name)
-        TZInfo::TimezoneProxy.new(MAPPING[name] || name)
+        TZInfo::Timezone.new(MAPPING[name] || name)
       end
 
       alias_method :create, :new
@@ -237,7 +237,7 @@ module ActiveSupport
         case arg
           when String
           begin
-            @lazy_zones_map[arg] ||= create(arg).tap(&:utc_offset)
+            @lazy_zones_map[arg] ||= create(arg)
           rescue TZInfo::InvalidTimezoneIdentifier
             nil
           end

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -395,15 +395,10 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_raise(ArgumentError) { ActiveSupport::TimeZone[false] }
   end
 
-  def test_unknown_zone_should_have_tzinfo_but_exception_on_utc_offset
-    zone = ActiveSupport::TimeZone.create("bogus")
-    assert_instance_of TZInfo::TimezoneProxy, zone.tzinfo
-    assert_raise(TZInfo::InvalidTimezoneIdentifier) { zone.utc_offset }
-  end
-
-  def test_unknown_zone_with_utc_offset
-    zone = ActiveSupport::TimeZone.create("bogus", -21_600)
-    assert_equal(-21_600, zone.utc_offset)
+  def test_unknown_zone_raises_exception
+    assert_raise TZInfo::InvalidTimezoneIdentifier do
+      ActiveSupport::TimeZone.create("bogus")
+    end
   end
 
   def test_unknown_zones_dont_store_mapping_keys


### PR DESCRIPTION
Use directly TZInfo::Timezone without proxy since real timezone is loaded anyway in `#utc_offset` which is called during `#create`.

The purpose of `TZInfo::TimezoneProxy` was to offload parsing tzinfo to improve startup time.
But it was defeated by calling `#utc_offset` on creation of `AS::TimeZone` instance.
This is why the time to run `AS::TimeZone.all` has not changed after this PR.

Also there was an edge-case when `AS::TimeZone` instance could have been created with bogus timezone if utc_offset was provided. But this would break almost any other method since a lot of them depend on real `TZInfo::Timezone` instance.
