### PR TITLE
Include newer `find_by` syntax example in 4.2 release notes for Adequate Record

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -92,6 +92,9 @@ Post.find(2)  # Subsequent calls reuse the cached prepared statement
 Post.find_by_title('first post')
 Post.find_by_title('second post')
 
+Post.find_by(title: 'first post')
+Post.find_by(title: 'second post')
+
 post.comments
 post.comments(true)
 ```


### PR DESCRIPTION
As per tenderlove's blog post http://tenderlovemaking.com/2014/02/19/adequaterecord-pro-like-activerecord.html, the newer `Post.find_by(name: name)` is also supported by Adequate Record.

Updated the release notes to reflect this and to remove any ambiguity.
