### PR TITLE
Add #weekend?, #next_weekday, and #prev_weekday methods to Date, Time, and DateTime

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add `#on_weekend?`, `#next_weekday`, `#prev_weekday` methods to `Date`,
+    `Time`, and `DateTime`.
+
+    `#on_weekend?` returns true if the receiving date/time falls on a Saturday
+    or Sunday.
+
+    `#next_weekday` returns a new date/time representing the next day that does
+    not fall on a Saturday or Sunday.
+
+    `#prev_weekday` returns a new date/time representing the previous day that
+    does not fall on a Saturday or Sunday.
+
+    *George Claghorn*
+
 *   Change the default test order from `:sorted` to `:random`.
 
     *Rafael Mendonça França*

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `same_time` option to `#next_week` and `#prev_week` for `Date`, `Time`,
+    and `DateTime`.
+
+    *George Claghorn*
+
 *   Add `#on_weekend?`, `#next_weekday`, `#prev_weekday` methods to `Date`,
     `Time`, and `DateTime`.
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `#prev_day` and `#next_day` counterparts to `#yesterday` and
+    `#tomorrow` for `Date`, `Time`, and `DateTime`.
+
+    *George Claghorn*
+
 *   Add `same_time` option to `#next_week` and `#prev_week` for `Date`, `Time`,
     and `DateTime`.
 

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -13,12 +13,22 @@ module DateAndTime
 
     # Returns a new date/time representing yesterday.
     def yesterday
-      advance(:days => -1)
+      advance(days: -1)
+    end
+
+    # Returns a new date/time representing the previous day.
+    def prev_day
+      advance(days: -1)
     end
 
     # Returns a new date/time representing tomorrow.
     def tomorrow
-      advance(:days => 1)
+      advance(days: 1)
+    end
+
+    # Returns a new date/time representing the next day.
+    def next_day
+      advance(days: 1)
     end
 
     # Returns true if the date/time is today.
@@ -125,10 +135,10 @@ module DateAndTime
 
     # Returns a new date/time representing the next weekday.
     def next_weekday
-      if tomorrow.on_weekend?
+      if next_day.on_weekend?
         next_week(:monday, same_time: true)
       else
-        tomorrow
+        next_day
       end
     end
 
@@ -159,10 +169,10 @@ module DateAndTime
 
     # Returns a new date/time representing the previous weekday.
     def prev_weekday
-      if yesterday.on_weekend?
+      if prev_day.on_weekend?
         copy_time_to(beginning_of_week(:friday))
       else
-        yesterday
+        prev_day
       end
     end
     alias_method :last_weekday, :prev_weekday

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -9,6 +9,7 @@ module DateAndTime
       :saturday  => 5,
       :sunday    => 6
     }
+    WEEKEND_DAYS = [ 6, 0 ]
 
     # Returns a new date/time representing yesterday.
     def yesterday
@@ -33,6 +34,11 @@ module DateAndTime
     # Returns true if the date/time is in the future.
     def future?
       self > self.class.current
+    end
+
+    # Returns true if the date/time falls on a Saturday or Sunday.
+    def on_weekend?
+      wday.in?(WEEKEND_DAYS)
     end
 
     # Returns a new date/time the specified number of days ago.
@@ -116,6 +122,15 @@ module DateAndTime
       first_hour(weeks_since(1).beginning_of_week.days_since(days_span(given_day_in_next_week)))
     end
 
+    # Returns a new date/time representing the next weekday.
+    def next_weekday
+      if tomorrow.on_weekend?
+        next_week(:monday).change(hour: hour, min: min, sec: sec, usec: try(:usec))
+      else
+        tomorrow
+      end
+    end
+
     # Short-hand for months_since(1).
     def next_month
       months_since(1)
@@ -139,6 +154,16 @@ module DateAndTime
       first_hour(weeks_ago(1).beginning_of_week.days_since(days_span(start_day)))
     end
     alias_method :last_week, :prev_week
+
+    # Returns a new date/time representing the previous weekday.
+    def prev_weekday
+      if yesterday.on_weekend?
+        beginning_of_week(:friday).change(hour: hour, min: min, sec: sec, usec: try(:usec))
+      else
+        yesterday
+      end
+    end
+    alias_method :last_weekday, :prev_weekday
 
     # Short-hand for months_ago(1).
     def prev_month

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -115,6 +115,13 @@ module DateAndTimeBehavior
     end
   end
 
+  def test_next_week_at_same_time
+    assert_equal date_time_init(2005,2,28,15,15,10),  date_time_init(2005,2,22,15,15,10).next_week(:monday, same_time: true)
+    assert_equal date_time_init(2005,3,4,15,15,10),   date_time_init(2005,2,22,15,15,10).next_week(:friday, same_time: true)
+    assert_equal date_time_init(2006,10,30,0,0,0), date_time_init(2006,10,23,0,0,0).next_week(:monday, same_time: true)
+    assert_equal date_time_init(2006,11,1,0,0,0),  date_time_init(2006,10,23,0,0,0).next_week(:wednesday, same_time: true)
+  end
+
   def test_next_weekday_on_wednesday
     assert_equal date_time_init(2015,1,8,0,0,0), date_time_init(2015,1,7,0,0,0).next_weekday
     assert_equal date_time_init(2015,1,8,15,15,10), date_time_init(2015,1,7,15,15,10).next_weekday
@@ -157,6 +164,14 @@ module DateAndTimeBehavior
       assert_equal Time.local(2012, 3, 13), Time.local(2012, 3, 21).prev_week(:tuesday)
       assert_equal Time.local(2012, 3, 19), Time.local(2012, 3, 21).prev_week(:monday)
     end
+  end
+
+  def test_prev_week_at_same_time
+    assert_equal date_time_init(2005,2,21,15,15,10),  date_time_init(2005,3,1,15,15,10).prev_week(:monday, same_time: true)
+    assert_equal date_time_init(2005,2,22,15,15,10),  date_time_init(2005,3,1,15,15,10).prev_week(:tuesday, same_time: true)
+    assert_equal date_time_init(2005,2,25,15,15,10),  date_time_init(2005,3,1,15,15,10).prev_week(:friday, same_time: true)
+    assert_equal date_time_init(2006,10,30,0,0,0), date_time_init(2006,11,6,0,0,0).prev_week(:monday, same_time: true)
+    assert_equal date_time_init(2006,11,15,0,0,0), date_time_init(2006,11,23,0,0,0).prev_week(:wednesday, same_time: true)
   end
 
   def test_prev_weekday_on_wednesday

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -6,9 +6,19 @@ module DateAndTimeBehavior
     assert_equal date_time_init(2005,2,28,10,10,10), date_time_init(2005,3,2,10,10,10).yesterday.yesterday
   end
 
+  def test_prev_day
+    assert_equal date_time_init(2005,2,21,10,10,10), date_time_init(2005,2,22,10,10,10).prev_day
+    assert_equal date_time_init(2005,2,28,10,10,10), date_time_init(2005,3,2,10,10,10).prev_day.prev_day
+  end
+
   def test_tomorrow
     assert_equal date_time_init(2005,2,23,10,10,10), date_time_init(2005,2,22,10,10,10).tomorrow
     assert_equal date_time_init(2005,3,2,10,10,10),  date_time_init(2005,2,28,10,10,10).tomorrow.tomorrow
+  end
+
+  def test_next_day
+    assert_equal date_time_init(2005,2,23,10,10,10), date_time_init(2005,2,22,10,10,10).next_day
+    assert_equal date_time_init(2005,3,2,10,10,10),  date_time_init(2005,2,28,10,10,10).next_day.next_day
   end
 
   def test_days_ago

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -115,6 +115,21 @@ module DateAndTimeBehavior
     end
   end
 
+  def test_next_weekday_on_wednesday
+    assert_equal date_time_init(2015,1,8,0,0,0), date_time_init(2015,1,7,0,0,0).next_weekday
+    assert_equal date_time_init(2015,1,8,15,15,10), date_time_init(2015,1,7,15,15,10).next_weekday
+  end
+
+  def test_next_weekday_on_friday
+    assert_equal date_time_init(2015,1,5,0,0,0), date_time_init(2015,1,2,0,0,0).next_weekday
+    assert_equal date_time_init(2015,1,5,15,15,10), date_time_init(2015,1,2,15,15,10).next_weekday
+  end
+
+  def test_next_weekday_on_saturday
+    assert_equal date_time_init(2015,1,5,0,0,0), date_time_init(2015,1,3,0,0,0).next_weekday
+    assert_equal date_time_init(2015,1,5,15,15,10), date_time_init(2015,1,3,15,15,10).next_weekday
+  end
+
   def test_next_month_on_31st
     assert_equal date_time_init(2005,9,30,15,15,10), date_time_init(2005,8,31,15,15,10).next_month
   end
@@ -142,6 +157,21 @@ module DateAndTimeBehavior
       assert_equal Time.local(2012, 3, 13), Time.local(2012, 3, 21).prev_week(:tuesday)
       assert_equal Time.local(2012, 3, 19), Time.local(2012, 3, 21).prev_week(:monday)
     end
+  end
+
+  def test_prev_weekday_on_wednesday
+    assert_equal date_time_init(2015,1,6,0,0,0), date_time_init(2015,1,7,0,0,0).prev_weekday
+    assert_equal date_time_init(2015,1,6,15,15,10), date_time_init(2015,1,7,15,15,10).prev_weekday
+  end
+
+  def test_prev_weekday_on_monday
+    assert_equal date_time_init(2015,1,2,0,0,0), date_time_init(2015,1,5,0,0,0).prev_weekday
+    assert_equal date_time_init(2015,1,2,15,15,10), date_time_init(2015,1,5,15,15,10).prev_weekday
+  end
+
+  def test_prev_weekday_on_sunday
+    assert_equal date_time_init(2015,1,2,0,0,0), date_time_init(2015,1,4,0,0,0).prev_weekday
+    assert_equal date_time_init(2015,1,2,15,15,10), date_time_init(2015,1,4,15,15,10).prev_weekday
   end
 
   def test_prev_month_on_31st
@@ -229,6 +259,21 @@ module DateAndTimeBehavior
     with_bw_default(:wednesday) do
       assert_equal date_time_init(2012,9,23,23,59,59, Rational(999999999, 1000)), date_time_init(2012,9,19,0,0,0).sunday
     end
+  end
+
+  def test_on_weekend_on_saturday
+    assert date_time_init(2015,1,3,0,0,0).on_weekend?
+    assert date_time_init(2015,1,3,15,15,10).on_weekend?
+  end
+
+  def test_on_weekend_on_sunday
+    assert date_time_init(2015,1,4,0,0,0).on_weekend?
+    assert date_time_init(2015,1,4,15,15,10).on_weekend?
+  end
+
+  def test_on_weekend_on_monday
+    assert_not date_time_init(2015,1,5,0,0,0).on_weekend?
+    assert_not date_time_init(2015,1,5,15,15,10).on_weekend?
   end
 
   def with_bw_default(bw = :monday)


### PR DESCRIPTION
Per @dhh's request in #18330:
- `#weekend?` returns true if the receiving date/time falls on a Saturday or Sunday.
- `#next_weekday` returns a new date/time representing the next day that does not fall on a Saturday or Sunday.
- `#prev_weekday` returns a new date/time representing the previous day that does not fall on a Saturday or Sunday.

Rails already provides `#yesterday` and `#tomorrow` for dates and times, so I didn't bother implementing `#prev_day` or `#next_day`.
