### PR TITLE
Fix TypeError in Fixture creation

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -633,7 +633,7 @@ module ActiveRecord
 
           # interpolate the fixture label
           row.each do |key, value|
-            row[key] = value.gsub("$LABEL", label) if value.is_a?(String)
+            row[key] = value.gsub("$LABEL", label.to_s) if value.is_a?(String)
           end
 
           # generate a primary key if necessary


### PR DESCRIPTION
Ruby 4.2 started doing `value.gsub('$LABEL', label)` for fixture label interpolation, but you can have have valid YAML where `label` isn't a String. 

For example:

``` YAML
0:
  name: John
  email: johndoe@gmail.com
1:
  name: Jane
  email: janedoe@gmail.com
```

This YAML will create a label that is a Fixnum, causing `TypeError: no implicit conversion of Fixnum into String.`
