### PR TITLE
Allow check box checked/unchecked values to be symbols

### DIFF
--- a/actionview/lib/action_view/helpers/tags/check_box.rb
+++ b/actionview/lib/action_view/helpers/tags/check_box.rb
@@ -44,7 +44,7 @@ module ActionView
             value == !!@checked_value
           when NilClass
             false
-          when String
+          when String, Symbol
             value == @checked_value
           else
             if value.respond_to?(:include?)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -621,6 +621,20 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_symbol
+    @post.secret = :on
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="on" />',
+      check_box("post", "secret", {}, :on, :off)
+    )
+
+    @post.secret = :off
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="on" />',
+      check_box("post", "secret", {}, :on, :off)
+    )
+  end
+
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_boolean
     @post.secret = false
     assert_dom_equal(


### PR DESCRIPTION
Without this, Symbols follow the `else` condition, which raises an exception: `NoMethodError: undefined method`to_i' for Symbol`

I encountered this issue while using the [`state_machine`](https://github.com/pluginaweek/state_machine) gem with a [public state machine](https://github.com/pluginaweek/state_machine/blob/8a3ba81801782ac4ef9d4ace1209d8d50ffccdb0/lib/state_machine/integrations/active_record.rb#L99-L101).

This was present as far back as Rails 3.0.
