### PR TITLE
Fix rollback of primarykey-less tables

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -387,7 +387,7 @@ module ActiveRecord
           thaw unless restore_state[:frozen?]
           @new_record = restore_state[:new_record]
           @destroyed  = restore_state[:destroyed]
-          write_attribute(self.class.primary_key, restore_state[:id])
+          write_attribute(self.class.primary_key, restore_state[:id]) if self.class.primary_key
         end
       end
     end

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -653,6 +653,28 @@ class TransactionTest < ActiveRecord::TestCase
     assert transaction.state.committed?
   end
 
+  def test_transaction_rollback_with_primarykeyless_tables
+    connection = ActiveRecord::Base.connection
+    connection.create_table(:transaction_without_primary_keys, force: true, id: false) do |t|
+       t.integer :thing_id
+    end
+    
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = 'transaction_without_primary_keys'
+      after_commit { } # necessary to trigger the has_transactional_callbacks branch
+    end
+
+    assert_no_difference(-> { klass.count }) do
+      ActiveRecord::Base.transaction do
+        klass.create!
+        raise ActiveRecord::Rollback
+      end
+    end
+    
+  ensure
+    connection.execute("DROP TABLE IF EXISTS transaction_without_primary_keys")
+  end
+
   private
 
   %w(validation save destroy).each do |filter|


### PR DESCRIPTION
Hi,

I ran into a problem while upgrading to 4.2.  If you have a table without a primary key, and an `after_commit` callback on that table (ie `has_transactional_callbacks?` returns true), then trying to rollback a transaction involving that record results in :

```
ActiveModel::MissingAttributeError: can't write unknown attribute ``
activerecord/lib/active_record/attribute.rb:124:in `with_value_from_database'
activerecord/lib/active_record/attribute_set.rb:39:in `write_from_user'
activerecord/lib/active_record/attribute_methods/write.rb:74:in `write_attribute_with_type_cast'
activerecord/lib/active_record/attribute_methods/write.rb:56:in `write_attribute'
activerecord/lib/active_record/attribute_methods/dirty.rb:92:in `write_attribute'
activerecord/lib/active_record/transactions.rb:393:in `restore_transaction_record_state'
activerecord/lib/active_record/transactions.rb:324:in `rolledback!'
activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:73:in `rollback_records'
activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:151:in `rollback'
activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:183:in `rollback_transaction'
activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:190:in `rescue in within_new_transaction'
activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:205:in `within_new_transaction'
activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
activerecord/lib/active_record/transactions.rb:220:in `transaction'
```

I think the problem arose from here - https://github.com/rails/rails/commit/35164093f5005c4312674bf3e00e2a92e2e3c7e5 (/cc @sgrif).  What do you think to the attached fix?

---

(Just in case it helps anyone Googling - I actually ran into this because Thinking Sphinx adds an after_commit callback to ActiveRecord::Base (/cc @pat).  Then, if you had any has_and_belongs_to_many associations, the generated Developer::HABTM_Projects class would cause the above exception on rollbacks.)
