### PR TITLE
removing unecessary default parameter in private method

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -189,8 +189,8 @@ module ActiveModel
 
     private
 
-    def _singularize(string, replacement='_')
-      ActiveSupport::Inflector.underscore(string).tr('/', replacement)
+    def _singularize(string)
+      ActiveSupport::Inflector.underscore(string).tr('/', '_')
     end
   end
 


### PR DESCRIPTION
'_singularize' only ever gets called with one argument
