### PR TITLE
Fix lookup of fixtures with non-string(like Fixnum) label

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix accessing of fixtures having non-string labels like Fixnum by converting
+    the label into string only if its a symbol.
+
+    *Prathamesh Sonpatki*
+
 *   Remove deprecated support to preload instance-dependent associations.
 
     *Yves Senn*

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -882,7 +882,7 @@ module ActiveRecord
               @fixture_cache[fs_name] ||= {}
 
               instances = fixture_names.map do |f_name|
-                f_name = f_name.to_s
+                f_name = f_name.to_s if f_name.is_a?(Symbol)
                 @fixture_cache[fs_name].delete(f_name) if force_reload
 
                 if @loaded_fixtures[fs_name][f_name]

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -792,6 +792,10 @@ class FoxyFixturesTest < ActiveRecord::TestCase
     assert_equal("X marks the spot!", pirates(:mark).catchphrase)
   end
 
+  def test_supports_label_interpolation_for_fixnum_label
+    assert_equal("#1 pirate!", pirates(1).catchphrase)
+  end
+
   def test_supports_polymorphic_belongs_to
     assert_equal(pirates(:redbeard), treasures(:sapphire).looter)
     assert_equal(parrots(:louis), treasures(:ruby).looter)

--- a/activerecord/test/fixtures/pirates.yml
+++ b/activerecord/test/fixtures/pirates.yml
@@ -10,3 +10,6 @@ redbeard:
 
 mark:
   catchphrase: "X $LABELs the spot!"
+
+1:
+  catchphrase: "#$LABEL pirate!"


### PR DESCRIPTION
- This feature was added in https://github.com/rails/rails/commit/7b910917.
- But test was not added. This commit adds a test for the change in behavior with non-string labels.
