### PR TITLE
DateTime#<=> return nil when compare to the invalid String as Time.

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -168,7 +168,7 @@ class DateTime
     if other.kind_of?(Infinity)
       super
     elsif other.respond_to? :to_datetime
-      super other.to_datetime
+      super other.to_datetime rescue nil
     else
       nil
     end

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -335,6 +335,13 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal(-1, DateTime.civil(2000) <=> ActiveSupport::TimeWithZone.new( Time.utc(2000, 1, 1, 0, 0, 1), ActiveSupport::TimeZone['UTC'] ))
   end
 
+  def test_compare_with_string
+    assert_equal   1, DateTime.civil(2000) <=> Time.utc(1999, 12, 31, 23, 59, 59).to_s
+    assert_equal   0, DateTime.civil(2000) <=> Time.utc(2000, 1, 1, 0, 0, 0).to_s
+    assert_equal( -1, DateTime.civil(2000) <=> Time.utc(2000, 1, 1, 0, 0, 1).to_s)
+    assert_equal nil, DateTime.civil(2000) <=> "Invalid as Time"
+  end
+
   def test_to_f
     assert_equal 946684800.0, DateTime.civil(2000).to_f
     assert_equal 946684800.0, DateTime.civil(1999,12,31,19,0,0,Rational(-5,24)).to_f

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -721,6 +721,13 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal(-1, Time.utc(2000) <=> ActiveSupport::TimeWithZone.new( Time.utc(2000, 1, 1, 0, 0, 1), ActiveSupport::TimeZone['UTC'] ))
   end
 
+  def test_compare_with_string
+    assert_equal   1, Time.utc(2000) <=> Time.utc(1999, 12, 31, 23, 59, 59, 999).to_s
+    assert_equal   0, Time.utc(2000) <=> Time.utc(2000, 1, 1, 0, 0, 0).to_s
+    assert_equal( -1, Time.utc(2000) <=> Time.utc(2000, 1, 1, 0, 0, 1, 0).to_s)
+    assert_equal nil, Time.utc(2000) <=> 'Invalid as Time'
+  end
+
   def test_at_with_datetime
     assert_equal Time.utc(2000, 1, 1, 0, 0, 0), Time.at(DateTime.civil(2000, 1, 1, 0, 0, 0))
 


### PR DESCRIPTION
## before

``` ruby
p Time.now ==  'a'  # => false
p Time.now <=> 'a'  # => nil

require 'active_support'
require 'active_support/core_ext'

p Time.now ==  'a'  # => false
p Time.now <=> 'a'  # => invalid date (ArgumentError)
```

and on ruby 2.2, Time.now == 'a' warning.

> warning: Comparable#== will no more rescue exceptions of #<=> in the next release.
> warning: Return nil in #<=> if the comparison is inappropriate or avoid such comparison.
## after
- Error handling.
- Quiet warnings.

``` ruby
p Time.now ==  'a'  # => false
p Time.now <=> 'a'  # => nil

require 'active_support'
require 'active_support/core_ext'

p Time.now ==  'a'  # => false
p Time.now <=> 'a'  # => nil
```
### See also

https://bugs.ruby-lang.org/issues/7688
