### PR TITLE
Accept a collection in fresh_when and stale?

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Expand `ActionController::ConditionalGet#fresh_when` and `stale?` to also
+    accept a collection of records as the first argument, so that the
+    following code can be written in a shorter form.
+
+        # Before
+        def index
+          @article = Article.all
+          fresh_when(etag: @articles, last_modified: @articles.maximum(:created_at))
+        end
+
+        # After
+        def index
+          @article = Article.all
+          fresh_when(@articles)
+        end
+
+    *claudiob*
+
 *   Explicitly ignored wildcard verbs when searching for HEAD routes before fallback
 
     Fixes an issue where a mounted rack app at root would intercept the HEAD 


### PR DESCRIPTION
The methods `fresh_when` and `stale?` from `ActionController::ConditionalGet` accept a single record as a short form for a hash ([see docs](http://api.rubyonrails.org/classes/ActionController/ConditionalGet.html)). For instance:

``` ruby
  def show
    @article = Article.find(params[:id])
    fresh_when(@article)
  end
```

is just a short form for:

``` ruby
  def show
    @article = Article.find(params[:id])
    fresh_when(etag: @article, last_modified: @article.created_at)
  end
```

This commit extends `fresh_when` and `stale?` to also accept a collection of records, so that a short form similar to the one above can be used in an `index` action. 
After this commit, the following code:

``` ruby
def index
  @article = Article.all
  fresh_when(etag: @articles, last_modified: @articles.maximum(:created_at))
end
```

can be simply written as:

``` ruby
def index
  @article = Article.all
  fresh_when(@articles)
end
```
