### PR TITLE
Overwrite descriptions generated by Generators::Base to respect acronym.

### DIFF
--- a/railties/lib/rails/generators/rails/migration/migration_generator.rb
+++ b/railties/lib/rails/generators/rails/migration/migration_generator.rb
@@ -2,7 +2,7 @@ module Rails
   module Generators
     class MigrationGenerator < NamedBase # :nodoc:
       argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
-      hook_for :orm, required: true
+      hook_for :orm, required: true, desc: "ORM to be invoked"
     end
   end
 end

--- a/railties/lib/rails/generators/rails/model/model_generator.rb
+++ b/railties/lib/rails/generators/rails/model/model_generator.rb
@@ -6,7 +6,7 @@ module Rails
       include Rails::Generators::ModelHelpers
 
       argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
-      hook_for :orm, required: true
+      hook_for :orm, required: true, desc: "ORM to be invoked"
     end
   end
 end


### PR DESCRIPTION
The acronym `ORM` appears as `Orm` in the help messages of several <kbd>generate</kbd> commands such as <kbd>rails g migration</kbd>, <kbd>rails g model</kbd>, <kbd>rails g resource</kbd> or <kbd>rails g scaffold</kbd>. 

Rather than introducing another option like `name_is_acronym_so_please_upcase: true` to prevent [`hook_for` from humanizing some names](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/base.rb#L175), I'd just call `class_method` directly, or most simply, overwrite the default description by the proper one.
