### PR TITLE
Use EXEEXT

### DIFF
--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -172,7 +172,9 @@ module Rails
       commands = Array(commands)
 
       dirs_on_path = ENV['PATH'].to_s.split(File::PATH_SEPARATOR)
-      commands += commands.map{|cmd| "#{cmd}.exe"} if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+      unless (ext = RbConfig::CONFIG['EXEEXT']).empty?
+        commands = commands.map{|cmd| "#{cmd}#{ext}"}
+      end
 
       full_path_command = nil
       found = commands.detect do |cmd|


### PR DESCRIPTION
Use the configured variable EXEEXT, instead of hardcoded suffix and
platform names.

And on such platforms, files which do not end with the suffix are not
executable, so the original names are not necessary, in general.
