### PR TITLE
Prevent the retrieve_cache_key to infinite loop

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -83,6 +83,7 @@ module ActiveSupport
           expanded_cache_key << "#{prefix}/"
         end
 
+        key = key.to_a if key.respond_to?(:to_a)
         expanded_cache_key << retrieve_cache_key(key)
         expanded_cache_key
       end
@@ -92,7 +93,6 @@ module ActiveSupport
           case
           when key.respond_to?(:cache_key) then key.cache_key
           when key.is_a?(Array)            then key.map { |element| retrieve_cache_key(element) }.to_param
-          when key.respond_to?(:to_a)      then retrieve_cache_key(key.to_a)
           else                                  key.to_param
           end.to_s
         end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -114,6 +114,14 @@ class CacheKeyTest < ActiveSupport::TestCase
     assert_equal 'foo/bar/baz', ActiveSupport::Cache.expand_cache_key(%w{foo bar baz}.to_enum)
   end
 
+  def test_expand_cache_key_of_object_that_responds_to_to_a
+    key = "foo"
+    def key.to_a
+      [self]
+    end
+    assert_equal 'foo', ActiveSupport::Cache.expand_cache_key(key)
+  end
+
   private
 
   def with_env(kv)


### PR DESCRIPTION
For example:

``` ruby
key="foo"
def key.to_a
  [self]
end

ActiveSupport::Cache.expand_cache_key(key) #=> raise SystemStackError
```

String#to_a doesn't exist at ruby1.9 or later.
But if the key is something object that responds to :to_a, it is a possibility that infinite loop occurs.
