### PR TITLE
Use parallel bundler install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ notifications:
     on_failure: always
     rooms:
       - secure: "YA1alef1ESHWGFNVwvmVGCkMe4cUy4j+UcNvMUESraceiAfVyRMAovlQBGs6\n9kBRm7DHYBUXYC2ABQoJbQRLDr/1B5JPf/M8+Qd7BKu8tcDC03U01SMHFLpO\naOs/HLXcDxtnnpL07tGVsm0zhMc5N8tq4/L3SHxK7Vi+TacwQzI="
-bundler_args: --without test
+bundler_args: --without test --jobs 3 --retry 3
 services:
   - memcached
   - redis


### PR DESCRIPTION
Travis recommends a default of 3.
See: http://docs.travis-ci.com/user/languages/ruby/#Default-Test-Script
