### PR TITLE
Improve generator name suggestions a bit.

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -159,7 +159,7 @@ module Rails
         options     = sorted_groups.map(&:last).flatten
         suggestions = options.sort_by {|suggested| levenshtein_distance(namespace.to_s, suggested) }.first(3)
         msg =  "Could not find generator '#{namespace}'. "
-        msg << "Maybe you meant #{ suggestions.map {|s| "'#{s}'"}.join(" or ") }\n"
+        msg << "Maybe you meant #{ suggestions.map {|s| "'#{s}'"}.to_sentence(last_word_connector: " or ") }\n"
         msg << "Run `rails generate --help` for more options."
         puts msg
       end
@@ -260,11 +260,9 @@ module Rails
         t = str2
         n = s.length
         m = t.length
-        max = n/2
 
         return m if (0 == n)
         return n if (0 == m)
-        return n if (n - m).abs > max
 
         d = (0..m).to_a
         x = nil


### PR DESCRIPTION
92cf133788b2bef729ffeda5ca4c87d3a011e7ba brought this feature, which was great, yet also sometimes frustrating because it always returned three suggestions at once, and some of them are indeed a bit too far off. Examples are:

<kbd>rails g foo</kbd>

```
Could not find generator 'foo'. Maybe you meant 'job' or 'css:assets' or 'generator'
```

Do we really need the last two? (I even doubt the first one). For that matter, as we have [a big shortcut (max value)](https://github.com/rails/rails/blob/79728982aa757b19cfd37b748335671660f33524/railties/lib/rails/generators.rb#L267) to calculate the distance (which I think is okay for the perf sake), the distance to longer words are computed rather incorrectly, but they can be included in the suggestions after sorted. I guess that’s why `model` or `task` (4 char distant), `assets` (6) are behind `css:assets` (10) in the above example.

I don't think it was supposed to be an impeccable suggestion feature (given the introduction of https://github.com/rails/rails/pull/15497#issue-34915375), but sometimes less is more. Me thinks that likes of suggestions are appreciated typically when we can infer a solid amount of what users meant to run, and otherwise it would just end up as haphazard items. 

If users try to run something like <kbd>rails g xyzzy</kbd>, pretty much every command available is off so it's safe to say he/she has no idea on what generator commands are. In such a case, I'd just list up generator commands, as [it used to be](https://github.com/rails/rails/blob/4ae90a7dd8f9857f5d8c90c0135dd873f90e6957/railties/lib/rails/generators.rb#L159-L160) (or <kbd>run -h</kbd>), instead of serving the least 'off' names.

After trying dozens of real-world typos, I think the threshold of the distance should be just `1`. If the input contains more than 2 typos, users can immediately notice it themselves, or they don’t know what to type. It can be raised depending on the length of the word, but the longest is `active_record:migration` and even that is now split as `["active", "record", "migration"]`, each of them is individually tested to match. 

Test cases also should be updated, but I'd like to wait until #17050 is merged.
