### PR TITLE
Add :only option to assert_enqueued_jobs

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,16 @@
+*  Add :only option to assert_enqueued_jobs
+
+   With the option, assert_enqueued_jobs will check the number of times a specific kind of job is enqueued:
+
+      def test_logging_job
+        assert_enqueued_jobs 1, only: LoggingJob do
+          LoggingJob.perform_later
+          HelloJob.perform_later('jeremy')
+        end
+      end
+
+   *George Claghorn*
+
 *  `ActiveJob::Base.deserialize` delegates to the job class
 
 

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -42,16 +42,24 @@ module ActiveJob
       #       HelloJob.perform_later('rafael')
       #     end
       #   end
-      def assert_enqueued_jobs(number)
+      #
+      # The number of times a specific job is enqueued can be asserted.
+      #
+      #   def test_logging_job
+      #     assert_enqueued_jobs 2, only: LoggingJob do
+      #       LoggingJob.perform_later
+      #       HelloJob.perform_later('jeremy')
+      #     end
+      #   end
+      def assert_enqueued_jobs(number, only: nil)
         if block_given?
-          original_count = enqueued_jobs.size
+          original_count = enqueued_jobs_size(only: only)
           yield
-          new_count = enqueued_jobs.size
-          assert_equal original_count + number, new_count,
-                       "#{number} jobs expected, but #{new_count - original_count} were enqueued"
+          new_count = enqueued_jobs_size(only: only)
+          assert_equal original_count + number, new_count, "#{number} jobs expected, but #{new_count - original_count} were enqueued"
         else
-          enqueued_jobs_size = enqueued_jobs.size
-          assert_equal number, enqueued_jobs_size, "#{number} jobs expected, but #{enqueued_jobs_size} were enqueued"
+          actual_count = enqueued_jobs_size(only: only)
+          assert_equal number, actual_count, "#{number} jobs expected, but #{actual_count} were enqueued"
         end
       end
 
@@ -214,6 +222,14 @@ module ActiveJob
 
         def clear_performed_jobs
           performed_jobs.clear
+        end
+
+        def enqueued_jobs_size(only: nil)
+          if only
+            enqueued_jobs.select { |job| job[:job] == only }.size
+          else
+            enqueued_jobs.size
+          end
         end
     end
   end

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -87,6 +87,46 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     assert_match(/0 .* but 1/, error.message)
   end
 
+  def test_assert_enqueued_jobs_with_only_option
+    assert_nothing_raised do
+      assert_enqueued_jobs 1, only: HelloJob do
+        HelloJob.perform_later('jeremy')
+        LoggingJob.perform_later
+      end
+    end
+  end
+
+  def test_assert_enqueued_jobs_with_only_option_and_none_sent
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_enqueued_jobs 1, only: HelloJob do
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/1 .* but 0/, error.message)
+  end
+
+  def test_assert_enqueued_jobs_with_only_option_and_too_few_sent
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_enqueued_jobs 5, only: HelloJob do
+        HelloJob.perform_later('jeremy')
+        4.times { LoggingJob.perform_later }
+      end
+    end
+
+    assert_match(/5 .* but 1/, error.message)
+  end
+
+  def test_assert_enqueued_jobs_with_only_option_and_too_many_sent
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_enqueued_jobs 1, only: HelloJob do
+        2.times { HelloJob.perform_later('jeremy') }
+      end
+    end
+
+    assert_match(/1 .* but 2/, error.message)
+  end
+
   def test_assert_enqueued_job
     assert_enqueued_with(job: LoggingJob, queue: 'default') do
       LoggingJob.set(wait_until: Date.tomorrow.noon).perform_later


### PR DESCRIPTION
With the option, `assert_enqueued_jobs` will check the number of times a specific kind of job is enqueued:

``` ruby
def test_logging_job
  assert_enqueued_jobs 1, only: LoggingJob do
    LoggingJob.perform_later
    HelloJob.perform_later('jeremy')
  end
end
```

/cc @dhh
