### PR TITLE
Use SCHEMA instead of DB_STRUCTURE for specifiying structure file.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Use `SCHEMA` instead of `DB_STRUCTURE` for specifiying structure file.
+
+    This makes the db:structure tasks consistent with test:load_structure.
+
+    *Dieter Komendera*
+
 *   Fix accessing of fixtures having non-string labels like Fixnum.
 
     *Prathamesh Sonpatki*

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -269,9 +269,9 @@ db_namespace = namespace :db do
   end
 
   namespace :structure do
-    desc 'Dump the database structure to db/structure.sql. Specify another file with DB_STRUCTURE=db/my_structure.sql'
+    desc 'Dump the database structure to db/structure.sql. Specify another file with SCHEMA=db/my_structure.sql'
     task :dump => [:environment, :load_config] do
-      filename = ENV['DB_STRUCTURE'] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "structure.sql")
+      filename = ENV['SCHEMA'] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "structure.sql")
       current_config = ActiveRecord::Tasks::DatabaseTasks.current_config
       ActiveRecord::Tasks::DatabaseTasks.structure_dump(current_config, filename)
 
@@ -287,7 +287,7 @@ db_namespace = namespace :db do
 
     desc "Recreate the databases from the structure.sql file"
     task :load => [:environment, :load_config] do
-      ActiveRecord::Tasks::DatabaseTasks.load_schema_current(:sql, ENV['DB_STRUCTURE'])
+      ActiveRecord::Tasks::DatabaseTasks.load_schema_current(:sql, ENV['SCHEMA'])
     end
 
     task :load_if_sql => ['db:create', :environment] do

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -227,7 +227,7 @@ module ApplicationTests
     def test_rake_dump_structure_should_respect_db_structure_env_variable
       Dir.chdir(app_path) do
         # ensure we have a schema_migrations table to dump
-        `bundle exec rake db:migrate db:structure:dump DB_STRUCTURE=db/my_structure.sql`
+        `bundle exec rake db:migrate db:structure:dump SCHEMA=db/my_structure.sql`
       end
       assert File.exist?(File.join(app_path, 'db', 'my_structure.sql'))
     end


### PR DESCRIPTION
`rake test:load_structure` already uses `SCHEMA` and there's no need to maintain two different env vars.
