### PR TITLE
Enqueued email assertions

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Add `assert_enqueued_emails` and `assert_no_enqueued_emails`.
+
+        def test_emails
+          assert_enqueued_emails 2 do
+            ContactMailer.welcome.deliver_later
+            ContactMailer.welcome.deliver_later
+          end
+        end
+
+        def test_no_emails
+          assert_no_enqueued_emails do
+            # No emails enqueued here
+          end
+        end
+
+    *George Claghorn*
+
 *   Add `_mailer` suffix to mailers created via generator, following the same
     naming convention used in controllers and jobs.
 

--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -1,7 +1,11 @@
+require 'active_job'
+
 module ActionMailer
   # Provides helper methods for testing Action Mailer, including #assert_emails
   # and #assert_no_emails
   module TestHelper
+    include ActiveJob::TestHelper
+
     # Asserts that the number of emails sent matches the given number.
     #
     #   def test_emails
@@ -57,6 +61,53 @@ module ActionMailer
     #   assert_emails 0
     def assert_no_emails(&block)
       assert_emails 0, &block
+    end
+
+    # Asserts that the number of emails enqueued for later delivery matches
+    # the given number.
+    #
+    #   def test_emails
+    #     assert_enqueued_emails 0
+    #     ContactMailer.welcome.deliver_later
+    #     assert_enqueued_emails 1
+    #     ContactMailer.welcome.deliver_later
+    #     assert_enqueued_emails 2
+    #   end
+    #
+    # If a block is passed, that block should cause the specified number of
+    # emails to be enqueued.
+    #
+    #   def test_emails_again
+    #     assert_enqueued_emails 1 do
+    #       ContactMailer.welcome.deliver_later
+    #     end
+    #
+    #     assert_enqueued_emails 2 do
+    #       ContactMailer.welcome.deliver_later
+    #       ContactMailer.welcome.deliver_later
+    #     end
+    #   end
+    def assert_enqueued_emails(number, &block)
+      assert_enqueued_jobs number, only: ActionMailer::DeliveryJob, &block
+    end
+
+    # Asserts that no emails are enqueued for later delivery.
+    #
+    #   def test_no_emails
+    #     assert_no_enqueued_emails
+    #     ContactMailer.welcome.deliver_later
+    #     assert_enqueued_emails 1
+    #   end
+    #
+    # If a block is provided, it should not cause any emails to be enqueued.
+    #
+    #   def test_no_emails
+    #     assert_no_enqueued_emails do
+    #       # No emails should be enqueued from this block
+    #     end
+    #   end
+    def assert_no_enqueued_emails(&block)
+      assert_no_enqueued_jobs only: ActionMailer::DeliveryJob, &block
     end
   end
 end

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -119,6 +119,53 @@ class TestHelperMailerTest < ActionMailer::TestCase
 
     assert_match(/0 .* but 1/, error.message)
   end
+
+  def test_assert_enqueued_emails
+    assert_nothing_raised do
+      assert_enqueued_emails 1 do
+        TestHelperMailer.test.deliver_later
+      end
+    end
+  end
+
+  def test_assert_enqueued_emails_too_few_sent
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_enqueued_emails 2 do
+        TestHelperMailer.test.deliver_later
+      end
+    end
+
+    assert_match(/2 .* but 1/, error.message)
+  end
+
+  def test_assert_enqueued_emails_too_many_sent
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_enqueued_emails 1 do
+        TestHelperMailer.test.deliver_later
+        TestHelperMailer.test.deliver_later
+      end
+    end
+
+    assert_match(/1 .* but 2/, error.message)
+  end
+
+  def test_assert_no_enqueued_emails
+    assert_nothing_raised do
+      assert_no_enqueued_emails do
+        TestHelperMailer.test.deliver_now
+      end
+    end
+  end
+
+  def test_assert_no_enqueued_emails_failure
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_no_enqueued_emails do
+        TestHelperMailer.test.deliver_later
+      end
+    end
+
+    assert_match(/0 .* but 1/, error.message)
+  end
 end
 
 class AnotherTestHelperMailerTest < ActionMailer::TestCase

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -79,11 +79,19 @@ module ActiveJob
       #     end
       #   end
       #
+      # It can be asserted that no jobs of a specific kind are enqueued:
+      #
+      #   def test_no_logging
+      #     assert_no_enqueued_jobs only: LoggingJob do
+      #       HelloJob.perform_later('jeremy')
+      #     end
+      #   end
+      #
       # Note: This assertion is simply a shortcut for:
       #
       #   assert_enqueued_jobs 0, &block
-      def assert_no_enqueued_jobs(&block)
-        assert_enqueued_jobs 0, &block
+      def assert_no_enqueued_jobs(only: nil, &block)
+        assert_enqueued_jobs 0, only: only, &block
       end
 
       # Asserts that the number of performed jobs matches the given number.

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -127,6 +127,25 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     assert_match(/1 .* but 2/, error.message)
   end
 
+  def test_assert_no_enqueued_jobs_with_only_option
+    assert_nothing_raised do
+      assert_no_enqueued_jobs only: HelloJob do
+        LoggingJob.perform_later
+      end
+    end
+  end
+
+  def test_assert_no_enqueued_jobs_with_only_option_failure
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_no_enqueued_jobs only: HelloJob do
+        HelloJob.perform_later('jeremy')
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/0 .* but 1/, error.message)
+  end
+
   def test_assert_enqueued_job
     assert_enqueued_with(job: LoggingJob, queue: 'default') do
       LoggingJob.set(wait_until: Date.tomorrow.noon).perform_later


### PR DESCRIPTION
Adds `assert_enqueued_emails` and `assert_no_enqueued_emails` to the Action Mailer test helpers.

Also adds the `:only` option to `assert_no_enqueued_jobs` for parity with `assert_enqueued_jobs`.

/cc @dhh
