### PR TITLE
Add test case and documentation for skip_before_filter.

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -33,6 +33,11 @@ module AbstractController
       #
       #   only: :index, if: -> { true } # the :if option will be ignored.
       #
+      # Note that <tt>:if</tt> has priority over <tt>:except</tt> in case they
+      # are used together.
+      #
+      #   except: :index, if: -> { true } # the :except option will be ignored.
+      #
       # ==== Options
       # * <tt>only</tt>   - The callback should be run only for this action
       # * <tt>except</tt>  - The callback should be run for all actions except this action

--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -28,6 +28,11 @@ module AbstractController
       # The basic idea is that <tt>:only => :index</tt> gets converted to
       # <tt>:if => proc {|c| c.action_name == "index" }</tt>.
       #
+      # Note that <tt>:only</tt> has priority over <tt>:if</tt> in case they
+      # are used together.
+      #
+      #   only: :index, if: -> { true } # the :if option will be ignored.
+      #
       # ==== Options
       # * <tt>only</tt>   - The callback should be run only for this action
       # * <tt>except</tt>  - The callback should be run for all actions except this action

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -225,6 +225,18 @@ class FilterTest < ActionController::TestCase
     skip_before_action :clean_up_tmp, if: -> { true }
   end
 
+  class SkipFilterUsingOnlyAndConditional < ConditionalFilterController
+    before_action :clean_up_tmp
+    before_action :ensure_login
+
+    skip_before_action :ensure_login, only: :login, if: -> { false }
+    skip_before_action :clean_up_tmp, only: :login, if: -> { true }
+
+    def login
+      render text: 'ok'
+    end
+  end
+
   class ClassController < ConditionalFilterController
     before_action ConditionalClassFilter
   end
@@ -594,6 +606,11 @@ class FilterTest < ActionController::TestCase
   def test_running_conditional_skip_options
     test_process(ConditionalOptionsSkipFilter)
     assert_equal %w( ensure_login ), assigns["ran_filter"]
+  end
+
+  def test_if_is_ignored_when_used_with_only
+    test_process(SkipFilterUsingOnlyAndConditional, 'login')
+    assert_nil assigns['ran_filter']
   end
 
   def test_skipping_class_actions

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -225,12 +225,24 @@ class FilterTest < ActionController::TestCase
     skip_before_action :clean_up_tmp, if: -> { true }
   end
 
-  class SkipFilterUsingOnlyAndConditional < ConditionalFilterController
+  class SkipFilterUsingOnlyAndIf < ConditionalFilterController
     before_action :clean_up_tmp
     before_action :ensure_login
 
     skip_before_action :ensure_login, only: :login, if: -> { false }
     skip_before_action :clean_up_tmp, only: :login, if: -> { true }
+
+    def login
+      render text: 'ok'
+    end
+  end
+
+  class SkipFilterUsingIfAndExcept < ConditionalFilterController
+    before_action :clean_up_tmp
+    before_action :ensure_login
+
+    skip_before_action :ensure_login, if: -> { false }, except: :login
+    skip_before_action :clean_up_tmp, if: -> { true }, except: :login
 
     def login
       render text: 'ok'
@@ -609,8 +621,13 @@ class FilterTest < ActionController::TestCase
   end
 
   def test_if_is_ignored_when_used_with_only
-    test_process(SkipFilterUsingOnlyAndConditional, 'login')
+    test_process(SkipFilterUsingOnlyAndIf, 'login')
     assert_nil assigns['ran_filter']
+  end
+
+  def test_except_is_ignored_when_used_with_if
+    test_process(SkipFilterUsingIfAndExcept, 'login')
+    assert_equal %w(ensure_login), assigns["ran_filter"]
   end
 
   def test_skipping_class_actions


### PR DESCRIPTION
Test case for using skip_before_filter with the options :only and :if
both present. In this case, the :if option will be ignored and :only
will be executed.

---

Closes #14549 since it includes the same commit, rebased on top of the latest master in order to be merged.
