### PR TITLE
ActiveRecord: release connection on reconnect failure.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -453,6 +453,9 @@ module ActiveRecord
           c.verify!
         end
         c
+      rescue
+        disconnect!
+        raise
       end
     end
 


### PR DESCRIPTION
When trying to checkout connection from connection pool,
checkout()(and checkout_and_verify) verify whether the connection
is active or not.
And, if the connection is not active, connection adapters try to
reconnect to server.  And, if database is down at this moment,
reconnect fails and exception is raised.
(Ex: Mysql2::Error: Can't connect to local MySQL server through socket xxx)

But, ConnectionPool does not catch the exception, but leaks current
disconnected connection to @connection.
So, if database's temporary down happens several times and exceeds
the number of connection pool(5 by default), activerecord will be
no more available, even if database server is already recovered.

This patch fix it by catching exception and releasing connection.
