### PR TITLE
Add missing require "rack/test"

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/string/filters'
 require 'active_support/deprecation'
 require 'active_support/rescuable'
 require 'action_dispatch/http/upload'
+require 'rack/test'
 require 'stringio'
 require 'set'
 


### PR DESCRIPTION
Strong parameters included `Rack::Test::UploadedFile` as a permitted scalar in 91d1ac0, adding an implicit dependency on `rack/test`. This commit makes that explicit so that cherry-picking on Rails modules (for instance using rails-api) doesn't break strong parameters.
