### PR TITLE
Default headers, removed in controller actions, will not be reapplied to the test response

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Default headers, removed in controller actions, will not be reapplied to
+    the test response.
+
+    *Jonas Baumann*
+
 *   Deprecate all *_filter callbacks in favor of *_action callbacks.
 
     *Rafael Mendonça França*

--- a/actionpack/lib/action_dispatch/testing/test_response.rb
+++ b/actionpack/lib/action_dispatch/testing/test_response.rb
@@ -25,5 +25,12 @@ module ActionDispatch
 
     # Was there a server-side error?
     alias_method :error?, :server_error?
+
+    def merge_default_headers(original, *args)
+      # Default headers are already applied, no need to merge them a second time.
+      # This makes sure that default headers, removed in controller actions, will
+      # not be reapplied to the test response.
+      original
+    end
   end
 end


### PR DESCRIPTION
Default headers, removed in controller actions, were reapplied to the test response, although it works perfectly in production.
This change disables merging headers with the default headers a second time in the test response.

/cc @senny 
