### PR TITLE
Use keyword args on committed! and rolledback!

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -69,11 +69,11 @@ module ActiveRecord
       def rollback_records
         ite = records.uniq
         while record = ite.shift
-          record.rolledback! full_rollback?
+          record.rolledback!(force_restore_state: full_rollback?)
         end
       ensure
         ite.each do |i|
-          i.rolledback!(full_rollback?, false)
+          i.rolledback!(force_restore_state: full_rollback?, should_run_callbacks: false)
         end
       end
 
@@ -88,7 +88,7 @@ module ActiveRecord
         end
       ensure
         ite.each do |i|
-          i.committed!(false)
+          i.committed!(should_run_callbacks: false)
         end
       end
 

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -300,7 +300,7 @@ module ActiveRecord
     #
     # Ensure that it is not called if the object was never persisted (failed create),
     # but call it after the commit of a destroyed object.
-    def committed!(should_run_callbacks = true) #:nodoc:
+    def committed!(should_run_callbacks: true) #:nodoc:
       _run_commit_callbacks if should_run_callbacks && destroyed? || persisted?
     ensure
       force_clear_transaction_record_state
@@ -308,7 +308,7 @@ module ActiveRecord
 
     # Call the +after_rollback+ callbacks. The +force_restore_state+ argument indicates if the record
     # state should be rolled back to the beginning or just to the last savepoint.
-    def rolledback!(force_restore_state = false, should_run_callbacks = true) #:nodoc:
+    def rolledback!(force_restore_state: false, should_run_callbacks: true) #:nodoc:
       _run_rollback_callbacks if should_run_callbacks
     ensure
       restore_transaction_record_state(force_restore_state)


### PR DESCRIPTION
As discussed before, those methods should receive a keyword args instead of just parameters.

r @chancancode @rafaelfranca 
