### PR TITLE
Call after_commit callbacks on transactional fixtures tests.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Run after_commit callbacks on tests that have `use_transactional_fixtures = true`.
+
+    *arthurnn*
+
 *   Remove support for the `protected_attributes` gem.
 
     *Carlos Antonio da Silva + Roberto Miranda*

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -216,7 +216,7 @@ module ActiveRecord
         # rollbacks are silently swallowed
       end
 
-      attr_reader :transaction_manager #:nodoc:
+      attr_accessor :transaction_manager #:nodoc:
 
       delegate :within_new_transaction, :open_transactions, :current_transaction, :begin_transaction, :commit_transaction, :rollback_transaction, to: :transaction_manager
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -153,14 +153,17 @@ module ActiveRecord
       end
 
       def begin_transaction(options = {})
-        transaction =
-          if @stack.empty?
-            RealTransaction.new(@connection, options)
-          else
-            SavepointTransaction.new(@connection, "active_record_#{@stack.size}", options)
-          end
+        transaction = create_transaction(options)
         @stack.push(transaction)
         transaction
+      end
+
+      def create_transaction(options)
+        if @stack.empty?
+          RealTransaction.new(@connection, options)
+        else
+          SavepointTransaction.new(@connection, "active_record_#{@stack.size}", options)
+        end
       end
 
       def commit_transaction

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -288,7 +288,12 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :after_save,                  :string ],
       [ :after_save,                  :proc   ],
       [ :after_save,                  :object ],
-      [ :after_save,                  :block  ]
+      [ :after_save,                  :block  ],
+      [ :after_commit,                :block  ],
+      [ :after_commit,                :object ],
+      [ :after_commit,                :proc   ],
+      [ :after_commit,                :string ],
+      [ :after_commit,                :method ]
     ], david.history
   end
 
@@ -357,7 +362,12 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :after_save,                  :string ],
       [ :after_save,                  :proc   ],
       [ :after_save,                  :object ],
-      [ :after_save,                  :block  ]
+      [ :after_save,                  :block  ],
+      [ :after_commit,                :block  ],
+      [ :after_commit,                :object ],
+      [ :after_commit,                :proc   ],
+      [ :after_commit,                :string ],
+      [ :after_commit,                :method ]
     ], david.history
   end
 
@@ -408,7 +418,12 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :after_destroy,               :string ],
       [ :after_destroy,               :proc   ],
       [ :after_destroy,               :object ],
-      [ :after_destroy,               :block  ]
+      [ :after_destroy,               :block  ],
+      [ :after_commit,                :block  ],
+      [ :after_commit,                :object ],
+      [ :after_commit,                :proc   ],
+      [ :after_commit,                :string ],
+      [ :after_commit,                :method ]
     ], david.history
   end
 


### PR DESCRIPTION
Now with the new transaction manager, we can override that behaviour and
have a test transaction manager that can creates special transactions
that have some extra behaviour, like call callbacks on savepoint transactions.

The idea here, is `ActiveRecord::TestFixtures::TransactionManager` is responsible to maintain this order of transactions on the stack: `[:real, :test, :savepoint, ...]` , like that, we can have the test transaction be a savepoint one, however that runs `after_commit` callbacks.

review @jeremy @rafaelfranca @chancancode @dhh 

[related #18415]
[fixes #16831]
