### PR TITLE
refactor performance of base58 by leveraging base64

### DIFF
--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -1,7 +1,9 @@
 require 'securerandom'
 
 module SecureRandom
-  BASE58_ALPHABET = ('0'..'9').to_a  + ('A'..'Z').to_a + ('a'..'z').to_a - ['0', 'O', 'I', 'l']
+  BASE58_EXCLUDES = "\+\/0=IOl"
+  private_constant :BASE58_EXCLUDES
+
   # SecureRandom.base58 generates a random base58 string.
   #
   # The argument _n_ specifies the length, of the random string to be generated.
@@ -14,10 +16,16 @@ module SecureRandom
   #   p SecureRandom.base58(24) #=> "77TMHrHJFvFDwodq8w7Ev2m7"
   #
   def self.base58(n = 16)
-    SecureRandom.random_bytes(n).unpack("C*").map do |byte|
-      idx = byte % 64
-      idx = SecureRandom.random_number(58) if idx >= 58
-      BASE58_ALPHABET[idx]
-    end.join
+    str = base64(n)
+    str.delete!(BASE58_EXCLUDES)
+
+    while str.length < n
+      append = base64(n)
+      append.delete!(BASE58_EXCLUDES)
+
+      str << append
+    end
+
+    str[0, n]
   end
 end

--- a/activesupport/test/core_ext/securerandom.rb
+++ b/activesupport/test/core_ext/securerandom.rb
@@ -17,4 +17,20 @@ class SecureRandomTest < ActiveSupport::TestCase
     assert_not_equal s1, s2
     assert_equal 24, s1.length
   end
+
+  def test_base58_minimum_length
+    assert_equal '', SecureRandom.base58(0)
+    assert_raise(ArgumentError) { SecureRandom.base58(-1) }
+  end
+
+  def test_base58_charset
+    base58_alphabet = ('0'..'9').to_a + ('A'..'Z').to_a + ('a'..'z').to_a - ['0', 'O', 'I', 'l']
+    assert_equal 58, base58_alphabet.uniq.size
+
+    s = SecureRandom.base58(1000)
+
+    s.each_char do |c|
+      assert_includes base58_alphabet, c
+    end
+  end
 end


### PR DESCRIPTION
Following the same logic at ruby's own `SecureRandom#base64` at https://github.com/ruby/ruby/blob/master/lib/securerandom.rb#L152 , except stripping out all characters we don't want in base58, and if the resulting string is shorter than requested, append this process again until we reach sufficient length (on practice, this will happen very rarely - at n=16, for example, only in 1 out of 400 times it'll have to loop even once).

Benchmarks:

``` ruby
require 'active_support/all'

module SecureRandom
  BASE58_ALPHABET = ('0'..'9').to_a + ('A'..'Z').to_a + ('a'..'z').to_a - ['0', 'O', 'I', 'l']

  def self.base58_unpack(n = 16)
    SecureRandom.random_bytes(n).unpack("C*").map do |byte|
      idx = byte % 64
      idx = SecureRandom.random_number(58) if idx >= 58
      BASE58_ALPHABET[idx]
    end.join
  end

  BASE58_EXCLUDES = "\+\/0=IOl"

  def self.base58_from_base64(n = 16)
    str = base64(n)
    str.delete!(BASE58_EXCLUDES)

    while str.length < n
      append = base64(n)
      append.delete!(BASE58_EXCLUDES)

      str << append
    end

    str[0, n]
  end
end

require 'benchmark'

TIMES = 100_000
RANGES = [1,2,4,8,16,24,32,64,128,256,512,1024]

Benchmark.bm do |x|
  RANGES.each do |size|
    x.report "base58_unpack:size-#{size}" do
      TIMES.times do
        SecureRandom.base58_unpack(size)
      end
    end

    x.report "base58_from_base64:size-#{size}" do
      TIMES.times do
        SecureRandom.base58_from_base64(size)
      end
    end
  end
end
```

``` bash
       user     system      total        real
base58_unpack:size-1  0.390000   0.000000   0.390000 (  0.392298)
base58_from_base64:size-1  0.400000   0.000000   0.400000 (  0.403399)

base58_unpack:size-2  0.450000   0.000000   0.450000 (  0.453920)
base58_from_base64:size-2  0.420000   0.000000   0.420000 (  0.415723)

base58_unpack:size-4  0.650000   0.000000   0.650000 (  0.648235)
base58_from_base64:size-4  0.410000   0.000000   0.410000 (  0.412767)

base58_unpack:size-8  0.950000   0.000000   0.950000 (  0.954853)
base58_from_base64:size-8  0.440000   0.000000   0.440000 (  0.435894)

base58_unpack:size-16  1.520000   0.000000   1.520000 (  1.517939)
base58_from_base64:size-16  0.490000   0.000000   0.490000 (  0.498985)

base58_unpack:size-24  2.130000   0.000000   2.130000 (  2.131104)
base58_from_base64:size-24  0.560000   0.000000   0.560000 (  0.568067)

base58_unpack:size-32  2.710000   0.010000   2.720000 (  2.703566)
base58_from_base64:size-32  0.660000   0.000000   0.660000 (  0.665024)

base58_unpack:size-64  4.940000   0.000000   4.940000 (  4.941257)
base58_from_base64:size-64  0.720000   0.000000   0.720000 (  0.724439)

base58_unpack:size-128  9.370000   0.010000   9.380000 (  9.374557)
base58_from_base64:size-128  0.990000   0.000000   0.990000 (  0.991037)

base58_unpack:size-256 18.470000   0.010000  18.480000 ( 18.481346)
base58_from_base64:size-256  1.600000   0.010000   1.610000 (  1.612454)

base58_unpack:size-512 36.210000   0.030000  36.240000 ( 36.236432)
base58_from_base64:size-512  2.590000   0.000000   2.590000 (  2.596457)

base58_unpack:size-1024 70.230000   0.020000  70.250000 ( 70.253835)
base58_from_base64:size-1024  4.540000   0.050000   4.590000 (  4.586708)
```

At n=1, the performance is about equal between old and new implementation, but it scales better as n increases (e.g. 300% faster for n=16, 380% faster for n=24 (Rails' use case for token generation at  https://github.com/rails/rails/commit/47316feee0f061f80e26c51fb0d41f537407ab9c ), 1400% faster for n=64, etc.
