### PR TITLE
Better fork detection in ActiveSupport::Testing::Isolation

### DIFF
--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -1,5 +1,3 @@
-require 'rbconfig'
-
 module ActiveSupport
   module Testing
     module Isolation
@@ -12,7 +10,7 @@ module ActiveSupport
       end
 
       def self.forking_env?
-        !ENV["NO_FORK"] && ((RbConfig::CONFIG['host_os'] !~ /mswin|mingw/) && (RUBY_PLATFORM !~ /java/))
+        !ENV["NO_FORK"] && Process.respond_to?(:fork)
       end
 
       @@class_setup_mutex = Mutex.new


### PR DESCRIPTION
Process.respond_to?(:fork) returns false if fork is not available.
More on http://www.ruby-doc.org/core-2.0.0/Process.html#method-c-fork
