### PR TITLE
Use option url: false to allow entries without a link tag

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -28,5 +28,8 @@
 
     *Angelo Capilleri*
 
+*   Allow entries without a link tag in AtomFeedHelper.
+
+    *Daniel Gomez de Souza*
 
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/atom_feed_helper.rb
+++ b/actionview/lib/action_view/helpers/atom_feed_helper.rb
@@ -174,7 +174,7 @@ module ActionView
         #
         # * <tt>:published</tt>: Time first published. Defaults to the created_at attribute on the record if one such exists.
         # * <tt>:updated</tt>: Time of update. Defaults to the updated_at attribute on the record if one such exists.
-        # * <tt>:url</tt>: The URL for this entry. Defaults to the polymorphic_url for the record.
+        # * <tt>:url</tt>: The URL for this entry or false or nil for not having a link tag. Defaults to the polymorphic_url for the record.
         # * <tt>:id</tt>: The ID for this entry. Defaults to "tag:#{@view.request.host},#{@feed_options[:schema_date]}:#{record.class}/#{record.id}"
         # * <tt>:type</tt>: The TYPE for this entry. Defaults to "text/html".
         def entry(record, options = {})
@@ -191,7 +191,8 @@ module ActionView
 
             type = options.fetch(:type, 'text/html')
 
-            @xml.link(:rel => 'alternate', :type => type, :href => options[:url] || @view.polymorphic_url(record))
+            url = options.fetch(:url) { @view.polymorphic_url(record) }
+            @xml.link(:rel => 'alternate', :type => type, :href => url) if url
 
             yield AtomBuilder.new(@xml)
           end

--- a/actionview/test/template/atom_feed_helper_test.rb
+++ b/actionview/test/template/atom_feed_helper_test.rb
@@ -62,6 +62,23 @@ class ScrollsController < ActionController::Base
           end
         end
     EOT
+    FEEDS["entry_url_false_option"] = <<-EOT
+        atom_feed do |feed|
+          feed.title("My great blog!")
+          feed.updated((@scrolls.first.created_at))
+
+          @scrolls.each do |scroll|
+            feed.entry(scroll, :url => false) do |entry|
+              entry.title(scroll.title)
+              entry.content(scroll.body, :type => 'html')
+
+              entry.author do |author|
+                author.name("DHH")
+              end
+            end
+          end
+        end
+    EOT
     FEEDS["xml_block"] = <<-EOT
         atom_feed do |feed|
           feed.title("My great blog!")
@@ -334,6 +351,13 @@ class AtomFeedTest < ActionController::TestCase
     with_restful_routing(:scrolls) do
       get :index, :id => 'entry_type_options'
       assert_select "entry link[rel=alternate][type=\"text/xml\"]"
+    end
+  end
+
+  def test_feed_entry_url_false_option_adds_no_link
+    with_restful_routing(:scrolls) do
+      get :index, :id => 'entry_url_false_option'
+      assert_select "entry link", false
     end
   end
 


### PR DESCRIPTION
It should be possible to omit the link tag.
According to https://tools.ietf.org/html/rfc4287#section-4.1.2

> atom:entry elements that contain no child atom:content element MUST contain at least one atom:link element with a rel attribute value of "alternate".
