### PR TITLE
allow '1' or true for acceptance validation.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Change validates_acceptance_of to accept true by default.
+
+    The default for validates_acceptance_of is now "1" and true.
+    In the past, only "1" was the default and you were required to add 
+    accept: true.
+
 *   Remove deprecated `ActiveModel::Dirty#reset_#{attribute}` and
     `ActiveModel::Dirty#reset_changes`.
 

--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -3,12 +3,12 @@ module ActiveModel
   module Validations
     class AcceptanceValidator < EachValidator # :nodoc:
       def initialize(options)
-        super({ allow_nil: true, accept: "1" }.merge!(options))
+        super({ allow_nil: true, accept: ["1", true] }.merge!(options))
         setup!(options[:class])
       end
 
       def validate_each(record, attribute, value)
-        unless value == options[:accept]
+        unless acceptable_option?(value)
           record.errors.add(attribute, :accepted, options.except(:accept, :allow_nil))
         end
       end
@@ -19,6 +19,10 @@ module ActiveModel
         attr_writers = attributes.reject { |name| klass.attribute_method?("#{name}=") }
         klass.send(:attr_reader, *attr_readers)
         klass.send(:attr_writer, *attr_writers)
+      end
+
+      def acceptable_option?(value)
+        Array(options[:accept]).include?(value)
       end
     end
 

--- a/activemodel/test/cases/validations/acceptance_validation_test.rb
+++ b/activemodel/test/cases/validations/acceptance_validation_test.rb
@@ -65,4 +65,10 @@ class AcceptanceValidationTest < ActiveModel::TestCase
   ensure
     Person.clear_validators!
   end
+
+  def test_validates_acceptance_of_true
+    Topic.validates_acceptance_of(:terms_of_service)
+
+    assert Topic.new(terms_of_service: true).valid?
+  end
 end


### PR DESCRIPTION
While pairing on a project this morning we were confused as to why this code kept failing:

``` ruby
# user.rb
class User < ActiveRecord::Base
  attr_accessor :terms_and_conditions
  validates_acceptance_of :terms_and_conditions
end
```

``` ruby
describe User do
  it "is valid" do
    user = User.new(terms_and_conditions: true)
    expect(user).to be_valid
  end
end
```

After looking through the source we found that the default value is: "1". This seems nonintuitive. To make this test pass we had to change our code to this:

``` ruby
# user.rb
class User
  attr_accessor :terms_and_conditions
  validates_acceptance_of :terms_and_conditions, accept: true
end
```

This Pull Request changes the default accept from "1" to ["1", true]. Allowing you to specify an array of options. It supports single values as well for backwards compatibility.

/cc @speasley
