### PR TITLE
ActionMailer::Base can unregister interceptor(s).

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `Base.unregister_interceptor`, `Base.unregister_interceptors`,
+    `Base.unregister_preview_interceptor` and `Base.unregister_preview_interceptors`.
+    This makes it possible to dynamically add and remove email interceptors
+    at runtime in the same way they're registered.
+
+    *Claudio Ortolina*
+
 *   Add `assert_enqueued_emails` and `assert_no_enqueued_emails`.
 
         def test_emails

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -434,6 +434,7 @@ module ActionMailer
     helper ActionMailer::MailHelper
 
     private_class_method :new #:nodoc:
+    private_class_method :find_class #:nodoc:
 
     class_attribute :default_params
     self.default_params = {
@@ -454,16 +455,16 @@ module ActionMailer
         interceptors.flatten.compact.each { |interceptor| register_interceptor(interceptor) }
       end
 
+      # Unregister one or more Interceptors which would be called before mail is sent.
+      def unregister_interceptors(*interceptors)
+        interceptors.flatten.compact.each { |interceptor| unregister_interceptor(interceptor) }
+      end
+
       # Register an Observer which will be notified when mail is delivered.
       # Either a class, string or symbol can be passed in as the Observer.
       # If a string or symbol is passed in it will be camelized and constantized.
       def register_observer(observer)
-        delivery_observer = case observer
-          when String, Symbol
-            observer.to_s.camelize.constantize
-          else
-            observer
-          end
+        delivery_observer = find_class(observer)
 
         Mail.register_observer(delivery_observer)
       end
@@ -472,14 +473,18 @@ module ActionMailer
       # Either a class, string or symbol can be passed in as the Interceptor.
       # If a string or symbol is passed in it will be camelized and constantized.
       def register_interceptor(interceptor)
-        delivery_interceptor = case interceptor
-          when String, Symbol
-            interceptor.to_s.camelize.constantize
-          else
-            interceptor
-          end
+        delivery_interceptor = find_class(interceptor)
 
         Mail.register_interceptor(delivery_interceptor)
+      end
+
+      # Unregister a previously registered interceptor.
+      # Either a class, string or symbol can be passed in as the Interceptor.
+      # If a string or symbol is passed in it will be camelized and constantized.
+      def unregister_interceptor(interceptor)
+        delivery_interceptor = find_class(interceptor)
+
+        Mail.unregister_interceptor(delivery_interceptor)
       end
 
       # Returns the name of current mailer. This method is also being used as a path for a view lookup.
@@ -833,6 +838,15 @@ module ActionMailer
       end
 
       m
+    end
+
+    def self.find_class(klass_or_string_or_symbol)
+      case klass_or_string_or_symbol
+      when String, Symbol
+        klass_or_string_or_symbol.to_s.camelize.constantize
+      else
+        klass_or_string_or_symbol
+      end
     end
 
   protected

--- a/actionmailer/lib/action_mailer/preview.rb
+++ b/actionmailer/lib/action_mailer/preview.rb
@@ -30,19 +30,37 @@ module ActionMailer
         interceptors.flatten.compact.each { |interceptor| register_preview_interceptor(interceptor) }
       end
 
+      # Unregister one or more previously registered Interceptors.
+      def unregister_preview_interceptors(*interceptors)
+        interceptors.flatten.compact.each { |interceptor| unregister_preview_interceptor(interceptor) }
+      end
+
       # Register an Interceptor which will be called before mail is previewed.
       # Either a class or a string can be passed in as the Interceptor. If a
       # string is passed in it will be <tt>constantize</tt>d.
       def register_preview_interceptor(interceptor)
-        preview_interceptor = case interceptor
-          when String, Symbol
-            interceptor.to_s.camelize.constantize
-          else
-            interceptor
-          end
-
+        preview_interceptor = find_class(interceptor)
         unless preview_interceptors.include?(preview_interceptor)
           preview_interceptors << preview_interceptor
+        end
+      end
+
+      # Unregister a previously registered Interceptor.
+      # Either a class or a string can be passed in as the Interceptor. If a
+      # string is passed in it will be <tt>constantize</tt>d.
+      def unregister_preview_interceptor(interceptor)
+        preview_interceptor = find_class(interceptor)
+        preview_interceptors.delete(preview_interceptor)
+      end
+
+      private
+
+      def find_class(klass_or_string_or_symbol) #:nodoc:
+        case klass_or_string_or_symbol
+        when String, Symbol
+          klass_or_string_or_symbol.to_s.camelize.constantize
+        else
+          klass_or_string_or_symbol
         end
       end
     end

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -688,6 +688,47 @@ class BaseTest < ActiveSupport::TestCase
     end
   end
 
+  test "you can unregister an interceptor to the mail object that gets passed the mail object before delivery" do
+    mail_side_effects do
+      ActionMailer::Base.register_interceptor(MyInterceptor)
+      ActionMailer::Base.unregister_interceptor(MyInterceptor)
+      mail = BaseMailer.welcome
+      MyInterceptor.expects(:delivering_email).with(mail).never
+      mail.deliver_now
+    end
+  end
+
+  test "you can unregister an interceptor using its stringified name to the mail object that gets passed the mail object before delivery" do
+    mail_side_effects do
+      ActionMailer::Base.register_interceptor("BaseTest::MyInterceptor")
+      ActionMailer::Base.unregister_interceptor("BaseTest::MyInterceptor")
+      mail = BaseMailer.welcome
+      MyInterceptor.expects(:delivering_email).with(mail).never
+      mail.deliver_now
+    end
+  end
+
+  test "you can unregister an interceptor using its symbolized underscored name to the mail object that gets passed the mail object before delivery" do
+    mail_side_effects do
+      ActionMailer::Base.register_interceptor(:"base_test/my_interceptor")
+      ActionMailer::Base.unregister_interceptor(:"base_test/my_interceptor")
+      mail = BaseMailer.welcome
+      MyInterceptor.expects(:delivering_email).with(mail).never
+      mail.deliver_now
+    end
+  end
+
+  test "you can unregister multiple interceptors to the mail object that both get passed the mail object before delivery" do
+    mail_side_effects do
+      ActionMailer::Base.register_interceptors("BaseTest::MyInterceptor", MySecondInterceptor)
+      ActionMailer::Base.unregister_interceptors("BaseTest::MyInterceptor", MySecondInterceptor)
+      mail = BaseMailer.welcome
+      MyInterceptor.expects(:delivering_email).with(mail).never
+      MySecondInterceptor.expects(:delivering_email).with(mail).never
+      mail.deliver_now
+    end
+  end
+
   test "being able to put proc's into the defaults hash and they get evaluated on mail sending" do
     mail1 = ProcMailer.welcome['X-Proc-Method']
     yesterday = 1.day.ago
@@ -905,6 +946,43 @@ class BasePreviewInterceptorsTest < ActiveSupport::TestCase
     BaseMailerPreview.any_instance.stubs(:welcome).returns(mail)
     MyInterceptor.expects(:previewing_email).with(mail)
     MySecondInterceptor.expects(:previewing_email).with(mail)
+    BaseMailerPreview.call(:welcome)
+  end
+
+  test "you can unregister a preview interceptor to the mail object that gets passed the mail object before previewing" do
+    ActionMailer::Base.register_preview_interceptor(MyInterceptor)
+    ActionMailer::Base.unregister_preview_interceptor(MyInterceptor)
+    mail = BaseMailer.welcome
+    BaseMailerPreview.any_instance.stubs(:welcome).returns(mail)
+    MyInterceptor.expects(:previewing_email).with(mail).never
+    BaseMailerPreview.call(:welcome)
+  end
+
+  test "you can unregister a preview interceptor using its stringified name to the mail object that gets passed the mail object before previewing" do
+    ActionMailer::Base.register_preview_interceptor("BasePreviewInterceptorsTest::MyInterceptor")
+    ActionMailer::Base.unregister_preview_interceptor("BasePreviewInterceptorsTest::MyInterceptor")
+    mail = BaseMailer.welcome
+    BaseMailerPreview.any_instance.stubs(:welcome).returns(mail)
+    MyInterceptor.expects(:previewing_email).with(mail).never
+    BaseMailerPreview.call(:welcome)
+  end
+
+  test "you can unregister an interceptor using its symbolized underscored name to the mail object that gets passed the mail object before previewing" do
+    ActionMailer::Base.register_preview_interceptor(:"base_preview_interceptors_test/my_interceptor")
+    ActionMailer::Base.unregister_preview_interceptor(:"base_preview_interceptors_test/my_interceptor")
+    mail = BaseMailer.welcome
+    BaseMailerPreview.any_instance.stubs(:welcome).returns(mail)
+    MyInterceptor.expects(:previewing_email).with(mail).never
+    BaseMailerPreview.call(:welcome)
+  end
+
+  test "you can unregister multiple preview interceptors to the mail object that both get passed the mail object before previewing" do
+    ActionMailer::Base.register_preview_interceptors("BasePreviewInterceptorsTest::MyInterceptor", MySecondInterceptor)
+    ActionMailer::Base.unregister_preview_interceptors("BasePreviewInterceptorsTest::MyInterceptor", MySecondInterceptor)
+    mail = BaseMailer.welcome
+    BaseMailerPreview.any_instance.stubs(:welcome).returns(mail)
+    MyInterceptor.expects(:previewing_email).with(mail).never
+    MySecondInterceptor.expects(:previewing_email).with(mail).never
     BaseMailerPreview.call(:welcome)
   end
 end


### PR DESCRIPTION
This adds the ability to unregister a previously registered interceptor using `ActionMailer::Base.unregister_interceptors` or `ActionMailer::Base.unregister_interceptor`.

For preview interceptors, it's possible to use `ActionMailer::Base.unregister_preview_interceptors` or `ActionMailer::Base.unregister_preview_interceptor`.

It also refactors the logic to conditionally constantize a string/symbol into a separate method (this is also used by `register_observer`.
