### PR TITLE
Ensure ActiveSupport::Deprecation is loaded for Module.deprecate extension

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/deprecation.rb
+++ b/activesupport/lib/active_support/core_ext/module/deprecation.rb
@@ -1,3 +1,5 @@
+require 'active_support/deprecation'
+
 class Module
   #   deprecate :foo
   #   deprecate bar: 'message'


### PR DESCRIPTION
It was possible to load subsets of Active Support, such as 'active_support/core_ext/class/delegating_attributes.rb' without loading the actual deprecation logic.

This change ensures that the deprecation logic is loaded whenever the core extension is loaded.
