### PR TITLE
fix dependency

### DIFF
--- a/activesupport/lib/active_support/core_ext/numeric/time.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/time.rb
@@ -1,6 +1,8 @@
 require 'active_support/duration'
 require 'active_support/core_ext/time/calculations'
 require 'active_support/core_ext/time/acts_like'
+require 'active_support/core_ext/date/calculations'
+require 'active_support/core_ext/date/acts_like'
 
 class Numeric
   # Enables the use of time calculations and declarations, like 45.minutes + 2.hours + 4.years.


### PR DESCRIPTION
fix dependency

``` ruby
require 'active_support/core_ext/numeric/time'
1.hour.ago
# => 2015-01-12 01:13:58 +0800
2.days.ago
# => NoMethodError: undefined method `advance' for #<Date: 2015-01-12 ((2457035j,0s,0n),+0s,2299161j)>
#  from /Users/tonytonyjan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/activesupport-4.2.0/lib/active_support/core_ext/time/calculations.rb:118:in `advance'
#  from /Users/tonytonyjan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/activesupport-4.2.0/lib/active_support/duration.rb:115:in `block in sum'
#  from /Users/tonytonyjan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/activesupport-4.2.0/lib/active_support/duration.rb:110:in `each'
#  from /Users/tonytonyjan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/activesupport-4.2.0/lib/active_support/duration.rb:110:in `inject'
#  from /Users/tonytonyjan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/activesupport-4.2.0/lib/active_support/duration.rb:110:in `sum'
#  from /Users/tonytonyjan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/activesupport-4.2.0/lib/active_support/duration.rb:85:in `ago'
#  from (irb):4
#  from /Users/tonytonyjan/.rbenv/versions/2.2.0/bin/irb:11:in `<main>'
require 'active_support/core_ext/date/calculations'
2.days.ago
# => 2015-01-10 02:29:15 +0800
```
