### PR TITLE
Fix assertion that was never run

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -287,7 +287,7 @@ class BaseTest < ActiveSupport::TestCase
       end
     end
 
-    assert_nothing_raised { LateAttachmentAccessorMailer.welcome }
+    assert_nothing_raised { LateAttachmentAccessorMailer.welcome.message }
   end
 
   # Implicit multipart


### PR DESCRIPTION
In order to test whether the `welcome` method of the ActionMailer::Base subclass raises an error, `message` must be called, otherwise the method is not executed at all.

You could just replace with `def welcome; raise StandardError; end` and you would still see a passing test.

This commit fixes the test so the assertion is actually executed, just like any other tests in the file, where `.message` is called, for instance at [line 248](https://github.com/rails/rails/blob/e4613c97c3760c5298ab19ec5120f93ac83f03b2/actionmailer/test/base_test.rb#L248) and at [line 260](https://github.com/rails/rails/blob/e4613c97c3760c5298ab19ec5120f93ac83f03b2/actionmailer/test/base_test.rb#L260).
