### PR TITLE
Remove unused "deprecated_reload" method

### DIFF
--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -45,10 +45,6 @@ class DirtyTest < ActiveModel::TestCase
     def reload
       clear_changes_information
     end
-
-    def deprecated_reload
-      reset_changes
-    end
   end
 
   setup do


### PR DESCRIPTION
The method was introduced in https://github.com/rails/rails/commit/66d0a0153578ce760d822580c5b8c0b726042ac2#diff-8cec05860729a3851ceb756f4dd90370R49
for the "reset_changes is deprecated" test, but this test was successively
removed in https://github.com/rails/rails/commit/37175a24bd508e2983247ec5d011d57df836c743#diff-8cec05860729a3851ceb756f4dd90370L194
