### PR TITLE
Include CoffeeScript and SCSS extensions in SourceAnnotationExtractor by default

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -29,7 +29,7 @@ class SourceAnnotationExtractor
     end
 
     register_extensions("builder", "rb", "rake", "yml", "yaml", "ruby") { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
-    register_extensions("css", "scss", "js") { |tag| /\/\/\s*(#{tag}):?\s*(.*)$/ }
+    register_extensions("css", "scss", "sass", "js") { |tag| /\/\/\s*(#{tag}):?\s*(.*)$/ }
     register_extensions("erb") { |tag| /<%\s*#\s*(#{tag}):?\s*(.*?)\s*%>/ }
     register_extensions("coffee") { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
 

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -29,8 +29,9 @@ class SourceAnnotationExtractor
     end
 
     register_extensions("builder", "rb", "rake", "yml", "yaml", "ruby") { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
-    register_extensions("css", "js") { |tag| /\/\/\s*(#{tag}):?\s*(.*)$/ }
+    register_extensions("css", "scss", "js") { |tag| /\/\/\s*(#{tag}):?\s*(.*)$/ }
     register_extensions("erb") { |tag| /<%\s*#\s*(#{tag}):?\s*(.*?)\s*%>/ }
+    register_extensions("coffee") { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
 
     # Returns a representation of the annotation that looks like this:
     #


### PR DESCRIPTION
As CoffeeScript and SCSS have been part of the default Rails install since 3.1, add .scss and .coffee to the default SourceAnnotationExtractor extensions. This now means that tags in CoffeeScript and SCSS files are included in `rake notes` by default.
