### PR TITLE
Removing :en in favor of default locale for duration#inspect

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -91,7 +91,7 @@ module ActiveSupport
         reduce(::Hash.new(0)) { |h,(l,r)| h[l] += r; h }.
         sort_by {|unit,  _ | [:years, :months, :days, :minutes, :seconds].index(unit)}.
         map     {|unit, val| "#{val} #{val == 1 ? unit.to_s.chop : unit.to_s}"}.
-        to_sentence(:locale => :en)
+        to_sentence(locale: ::I18n.default_locale)
     end
 
     def as_json(options = nil) #:nodoc:

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -70,6 +70,15 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal '14 days',                         1.fortnight.inspect
   end
 
+  def test_inspect_locale
+    current_locale = I18n.default_locale
+    I18n.default_locale = :de
+    I18n.backend.store_translations(:de, { support: { array: { last_word_connector: ' und ' } } })
+    assert_equal '10 years, 1 month und 1 day', (10.years + 1.month  + 1.day).inspect
+  ensure
+    I18n.default_locale = current_locale
+  end
+
   def test_minus_with_duration_does_not_break_subtraction_of_date_from_date
     assert_nothing_raised { Date.today - Date.today }
   end


### PR DESCRIPTION
Hi there,

i have an app without english as available locale. So i got an error when we try to inspect something like 1.day. This is done automatically when we use the dalli cache.

I would like to change the :en to ::I18n.default_locale to be sure that this is always constant and is an available locale.

Tests are all green with this change.

Calculating 
:locale => :en                              2.024k i/100ms
:locale => ::I18n.default_locale   2.236k i/100ms

:locale => :en                                  25.758k (±26.3%) i/s -    117.392k
:locale => ::I18n.default_locale       26.311k (±18.1%) i/s -    127.452k 

Is there any other intention why this should be :en?
