### PR TITLE
autocomplete="off" on password field by default

### DIFF
--- a/actionview/lib/action_view/helpers/tags/password_field.rb
+++ b/actionview/lib/action_view/helpers/tags/password_field.rb
@@ -3,7 +3,7 @@ module ActionView
     module Tags # :nodoc:
       class PasswordField < TextField # :nodoc:
         def render
-          @options = {:value => nil}.merge!(@options)
+          @options = {:value => nil, :autocomplete => 'off' }.merge!(@options)
           super
         end
       end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -409,15 +409,15 @@ class FormHelperTest < ActionView::TestCase
       text_field("post", "title")
     )
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" type="password" />',
+      '<input id="post_title" name="post[title]" type="password" autocomplete="off" />',
       password_field("post", "title")
     )
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" type="password" value="Hello World" />',
+      '<input id="post_title" name="post[title]" type="password" value="Hello World" autocomplete="off" />',
       password_field("post", "title", value: @post.title)
     )
     assert_dom_equal(
-      '<input id="person_name" name="person[name]" type="password" />',
+      '<input id="person_name" name="person[name]" type="password" autocomplete="off" />',
       password_field("person", "name")
     )
   end


### PR DESCRIPTION
 by default set the `autocomplete="off"` argument on password input 

pls read why here https://github.com/rails/rails/issues/18453

special thanks to @simi and @rafaelfranca for suggestions on this 
