### PR TITLE
Fix output of `Module.nesting`.

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -123,7 +123,7 @@ end
 The nesting in (3) consists of two module objects:
 
 ```ruby
-[A::B, X::Y]
+[X::Y::A::B, X::Y]
 ```
 
 So, it not only doesn't end in `A`, which does not even belong to the nesting,


### PR DESCRIPTION
I tried these code on some Ruby versions
- 1.9.3-p545
- 2.0.0-p451
- 2.1.0
- 2.2.0

``` ruby
module X
  module Y
  end
end

module X::Y
  module A
  end
end

module X::Y
  module A::B
    p Module.nesting
    # (1)
  end
end
```

All print `[X::Y::A::B, X::Y]`
