### PR TITLE
Fix description for ActiveModel::Errors#generate_message [skip ci]

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -388,8 +388,8 @@ module ActiveModel
     # Translates an error message in its default scope
     # (<tt>activemodel.errors.messages</tt>).
     #
-    # Error messages are first looked up in <tt>models.MODEL.attributes.ATTRIBUTE.MESSAGE</tt>,
-    # if it's not there, it's looked up in <tt>models.MODEL.MESSAGE</tt> and if
+    # Error messages are first looked up in <tt>activemodel.errors.models.MODEL.attributes.ATTRIBUTE.MESSAGE</tt>,
+    # if it's not there, it's looked up in <tt>activemodel.errors.models.MODEL.MESSAGE</tt> and if
     # that is not there also, it returns the translation of the default message
     # (e.g. <tt>activemodel.errors.messages.MESSAGE</tt>). The translated model
     # name, translated attribute name and the value are available for


### PR DESCRIPTION
In documentation for `ActiveModel::Errors#generate_message` default i18n error scopes look like this:

```
models.MODEL.attributes.ATTRIBUTE.MESSAGE
models.MODEL.MESSAGE
```

But in the method default error scopes [generates](https://github.com/rails/rails/blob/6c8cf21584ced73ade45529d11463c74b5a0c58f/activemodel/lib/active_model/errors.rb#L417-L418) like this:

``` ruby
:"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}"
:"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}
```
