### PR TITLE
Added the SQL equivalent of the find_by method. 

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -257,6 +257,12 @@ It is equivalent to writing:
 Client.where(first_name: 'Lifo').take
 ```
 
+The SQL equivalent of the above is:
+
+```sql
+SELECT * FROM clients WHERE (clients.first_name = 'Lifo') LIMIT 1
+```
+
 The `find_by!` method behaves exactly like `find_by`, except that it will raise `ActiveRecord::RecordNotFound` if no matching record is found. For example:
 
 ```ruby


### PR DESCRIPTION
I noticed that the Query interface documentation lists the equivalent SQL for each method, but there was no SQL equivalent for the find_by, so I added it. 
