### PR TITLE
Fix that `exists?(id)` could incorrectly return false when the first column returned for the existing record has a null value

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix that `exists?(id)` could incorrectly return false when the first column
+    returned for the existing record has a null value.
+
+    *Ben Woosley*
+
 *   `time` columns can now affected by `time_zone_aware_attributes`. If you have
     set `config.time_zone` to a value other than `'UTC'`, they will be treated
     as in that time zone by default in Rails 5.0. If this is not the desired

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -307,7 +307,7 @@ module ActiveRecord
         relation = relation.where(conditions)
       else
         unless conditions == :none
-          relation = where(primary_key => conditions)
+          relation = relation.where(primary_key => conditions)
         end
       end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -138,6 +138,13 @@ class FinderTest < ActiveRecord::TestCase
   # ensures +exists?+ runs valid SQL by excluding order value
   def test_exists_with_order
     assert_equal true, Topic.order(:id).distinct.exists?
+    assert_equal true, Topic.order(:id).distinct.exists?(Topic.first.id)
+  end
+
+  # ensure +exists?+ overwrites the scope select with its own
+  def test_exists_with_select
+    assert_equal true, Topic.select('null').exists?
+    assert_equal true, Topic.select('null').exists?(Topic.first.id)
   end
 
   def test_exists_with_includes_limit_and_empty_result


### PR DESCRIPTION
Without this, when the relation is overwritten with the result from `#where`, the earlier modifications are dropped, including the `#select(ONE_AS_ONE)` setting. Without this setting, the `connection.select_value` runs `SELECT *` and returns the first of the values returned. If it happens that that row in question happens to have a null value in whatever column is its first (which I assume is usually not the case as the `#id` is generally first), then `#exists?` will incorrectly return `false`.

Even when `#exists?` returns the correct answer, this represents a potentially significant performance regression as without the `#limit(1)` any number of records may be returned by the underlying `#select_all`.

Seems this was introduced in: f317cc8bc007978d7b135ddd1acdd7e3d1e582a3
Also relevant: d99974b27cac1d3ed3af6bef0b7551044a8c9923
