### PR TITLE
pretty_print will use #inspect if a subclass redefines it

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -456,22 +456,26 @@ module ActiveRecord
     # Takes a PP and prettily prints this record to it, allowing you to get a nice result from `pp record`
     # when pp is required.
     def pretty_print(pp)
-      pp.object_address_group(self) do
-        if defined?(@attributes) && @attributes
-          column_names = self.class.column_names.select { |name| has_attribute?(name) || new_record? }
-          pp.seplist(column_names, proc { pp.text ',' }) do |column_name|
-            column_value = read_attribute(column_name)
-            pp.breakable ' '
-            pp.group(1) do
-              pp.text column_name
-              pp.text ':'
-              pp.breakable
-              pp.pp column_value
+      if self.class.instance_method(:inspect).owner != ActiveRecord::Base.instance_method(:inspect).owner
+        pp.text inspect
+      else
+        pp.object_address_group(self) do
+          if defined?(@attributes) && @attributes
+            column_names = self.class.column_names.select { |name| has_attribute?(name) || new_record? }
+            pp.seplist(column_names, proc { pp.text ',' }) do |column_name|
+              column_value = read_attribute(column_name)
+              pp.breakable ' '
+              pp.group(1) do
+                pp.text column_name
+                pp.text ':'
+                pp.breakable
+                pp.pp column_value
+              end
             end
+          else
+            pp.breakable ' '
+            pp.text 'not initialized'
           end
-        else
-          pp.breakable ' '
-          pp.text 'not initialized'
         end
       end
     end

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -98,4 +98,15 @@ class CoreTest < ActiveRecord::TestCase
     assert actual.start_with?(expected.split('XXXXXX').first)
     assert actual.end_with?(expected.split('XXXXXX').last)
   end
+
+  def test_pretty_print_overridden_by_inspect
+    subtopic = Class.new(Topic) do
+      def inspect
+        "inspecting topic"
+      end
+    end
+    actual = ''
+    PP.pp(subtopic.new, StringIO.new(actual))
+    assert_equal "inspecting topic\n", actual
+  end
 end


### PR DESCRIPTION
per discussion at https://github.com/rails/rails/pull/15172#issuecomment-69445752

that discussion wasn't entirely conclusive, but this may be desirable. 

@matthewd @mwesigwa
