### PR TITLE
Clean up grammar in scaffold index view, by removing the word 'Listing' ...

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
@@ -1,6 +1,6 @@
 <p id="notice"><%%= notice %></p>
 
-<h1>Listing <%= plural_table_name.titleize %></h1>
+<h1><%= plural_table_name.titleize %></h1>
 
 <table>
   <thead>


### PR DESCRIPTION
...from list title.

Including the word "Listing" in the heading/title for a list of rows in the scaffolding index view is grammatically redundant. IMO, showing only the pluralized and titleized name of the model is visually more attractive.
