### PR TITLE
Add a margin to body and padding to th, td in scaffold.css.

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold/templates/scaffold.css
+++ b/railties/lib/rails/generators/rails/scaffold/templates/scaffold.css
@@ -4,6 +4,7 @@ body, p, ol, ul, td {
   font-family: verdana, arial, helvetica, sans-serif;
   font-size:   13px;
   line-height: 18px;
+  margin: 33px;
 }
 
 pre {
@@ -15,6 +16,16 @@ pre {
 a { color: #000; }
 a:visited { color: #666; }
 a:hover { color: #fff; background-color:#000; }
+
+th {
+  padding-bottom: 5px;
+}
+
+td {
+  padding-bottom: 7px;
+  padding-left: 5px;
+  padding-right: 5px;
+}
 
 div.field, div.actions {
   margin-bottom: 10px;


### PR DESCRIPTION
In scaffold.css, adding a small margin to body and some padding to the table th and td makes the resulting views more attractive and more readable.

Here is an image showing the current scaffolding:  
![user_scaffold_without_padding_and_margin](https://cloud.githubusercontent.com/assets/905505/5749398/70e7e59c-9bfd-11e4-90ab-984c9913ebc8.png)

Here is an image with the proposed changes:

![user_scaffold_with_padding_and_margin](https://cloud.githubusercontent.com/assets/905505/5749367/189fc3fa-9bfd-11e4-9ed4-c6e2ba7a4f6d.png)
