### PR TITLE
ActiveRecord: On reconnection failure, release only failed connetion.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -454,7 +454,8 @@ module ActiveRecord
         end
         c
       rescue
-        disconnect!
+        remove c
+        c.disconnect!
         raise
       end
     end


### PR DESCRIPTION
On reconnection failure, all the connection was released.
But, it is better to release only failed connection.
This patch changes not to release all the connection but release
only failed connection.
