### PR TITLE
Fix nested multipart preview

### DIFF
--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -56,18 +56,23 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
     def find_preferred_part(*formats)
       if @email.multipart?
         formats.each do |format|
-          return find_part(format) if @email.parts.any?{ |p| p.mime_type == format }
+          if part = find_part(format)
+            return part
+          end
         end
-      else
-        @email
       end
+      @email
     end
 
     def find_part(format)
       if @email.multipart?
-        @email.parts.find{ |p| p.mime_type == format }
+        all_parts(@email).find{ |p| p.mime_type == format && !p.attachment? }
       elsif @email.mime_type == format
         @email
       end
+    end
+
+    def all_parts(email)
+      email.parts.flat_map{ |p| p.body.multipart? ? p.body.parts : p }
     end
 end

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -404,6 +404,45 @@ module ApplicationTests
       assert_match /html part/, last_response.body
     end
 
+    test "mailer preview multipart related email with inlined image" do
+      mailer 'notifier', <<-RUBY
+        class Notifier < ActionMailer::Base
+          default from: "from@example.com"
+
+          def foo
+            attachments.inline['image.png'] = 'image content'
+            mail to: "to@example.org"
+          end
+        end
+      RUBY
+
+      text_template 'notifier/foo', <<-RUBY
+        text part
+      RUBY
+      html_template 'notifier/foo', <<-RUBY
+        html part with image: <%= image_tag attachments['image.png'].url %>
+      RUBY
+
+      mailer_preview 'notifier', <<-RUBY
+        class NotifierPreview < ActionMailer::Preview
+          def foo
+            Notifier.foo
+          end
+        end
+      RUBY
+
+      app('development')
+
+      get "/rails/mailers/notifier/foo?part=text%2Fplain"
+      assert_equal 200, last_response.status
+      assert_match /text part/, last_response.body
+
+      get "/rails/mailers/notifier/foo?part=text%2Fhtml"
+      assert_equal 200, last_response.status
+      assert_match /html part/, last_response.body
+      assert_match %r{src="data:image/png;base64,#{Base64.encode64('image content')}"}, last_response.body
+    end
+
     test "message header uses full display names" do
       mailer 'notifier', <<-RUBY
         class Notifier < ActionMailer::Base


### PR DESCRIPTION
This patch addresses both issues that arose in #14435 :
- NoMethodError when previewing nested multipart emails (which happened not only with multipart/related, but also with multipart/mixed emails, i.e. when having an html/text email with a pdf attached.)
- Inlining of images which are referenced by cid: identifiers as data URIs in HTML parts.

So this does what PR #14519 does regarding the image inlining (however I did it slightly different), but also has a test and more general fix for the NoMethodError problem, inspired by suggestion from @stefan-lz in https://github.com/rails/rails/pull/14519#issuecomment-68323281 .
Also related: PR #15569 
