### PR TITLE
Fix name_for_action in routing

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1739,9 +1739,10 @@ module ActionDispatch
               member_name = parent_resource.member_name
             end
 
-            name = @scope.action_name(name_prefix, prefix, collection_name, member_name)
+            action_name = @scope.action_name(name_prefix, prefix, collection_name, member_name)
+            candidate = action_name.select(&:present?).join('_')
 
-            if candidate = name.compact.join("_").presence
+            unless candidate.empty?
               # If a name was not explicitly given, we check if it is valid
               # and return nil in case it isn't. Otherwise, we pass the invalid name
               # forward so the underlying router engine treats it and raises an exception.

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3439,6 +3439,44 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/bar/comments/1', comment_path('1')
   end
 
+  def test_resource_where_as_is_empty
+    draw do
+      resource :post, as: ''
+
+      scope 'post', as: 'post' do
+        resource :comment, as: ''
+      end
+    end
+
+    assert_equal '/post/new', new_path
+    assert_equal '/post/comment/new', new_post_path
+  end
+
+  def test_resources_where_as_is_empty
+    draw do
+      resources :posts, as: ''
+
+      scope 'posts', as: 'posts' do
+        resources :comments, as: ''
+      end
+    end
+
+    assert_equal '/posts/new', new_path
+    assert_equal '/posts/comments/new', new_posts_path
+  end
+
+  def test_scope_where_as_is_empty
+    draw do
+      scope 'post', as: '' do
+        resource :user
+        resources :comments
+      end
+    end
+
+    assert_equal '/post/user/new', new_user_path
+    assert_equal '/post/comments/new', new_comment_path
+  end
+
 private
 
   def draw(&block)


### PR DESCRIPTION
When `options[:as]` is an empty string, it should not add underscore to the end of string.
This change happed to 0127f028.

```
Rails.application.routes.draw do
  resource :user, as: ''
end
```

```
$ rake routes
#4.2
  new_ GET    /user/new(.:format)  users#new
 edit_ GET    /user/edit(.:format) users#edit

#4.1.9
   new GET    /user/new(.:format)  users#new
  edit GET    /user/edit(.:format) users#edit
```
