### PR TITLE
Support more PostgreSQL and SQLite3 index options

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     # Abstract representation of an index definition on a table. Instances of
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#indexes
-    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using) #:nodoc:
+    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using, :opclasses, :collations, :nulls) #:nodoc:
     end
 
     # Abstract representation of a column definition. Instances of this type

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -203,8 +203,28 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support index length?
+      def supports_index_length?
+        false
+      end
+
+      # Does this adapter support index operator class?
+      def supports_index_operator_class?
+        false
+      end
+
+      # Does this adapter support index collation?
+      def supports_index_collation?
+        false
+      end
+
       # Does this adapter support index sort order?
       def supports_index_sort_order?
+        false
+      end
+
+      # Does this adapter support index null order?
+      def supports_index_null_order?
         false
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -160,8 +160,20 @@ module ActiveRecord
         true
       end
 
-      def supports_index_sort_order?
+      def supports_index_collation?
+        postgresql_version >= 90100
+      end
+
+      def supports_index_operator_class?
         true
+      end
+
+      def supports_index_sort_order?
+        postgresql_version >= 80300
+      end
+
+      def supports_index_null_order?
+        postgresql_version >= 80300
       end
 
       def supports_partial_index?

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -191,14 +191,14 @@ HEADER
             ]
             statement_parts << 'unique: true' if index.unique
 
-            index_lengths = (index.lengths || []).compact
-            statement_parts << "length: #{Hash[index.columns.zip(index.lengths)].inspect}" if index_lengths.any?
-
-            index_orders = index.orders || {}
-            statement_parts << "order: #{index.orders.inspect}" if index_orders.any?
+            statement_parts << "length: #{index.lengths.inspect}" if index.lengths.present?
+            statement_parts << "order: #{index.orders.inspect}" if index.orders.present?
             statement_parts << "where: #{index.where.inspect}" if index.where
             statement_parts << "using: #{index.using.inspect}" if index.using
             statement_parts << "type: #{index.type.inspect}" if index.type
+            statement_parts << "opclass: #{index.opclasses.inspect}" if index.opclasses.present?
+            statement_parts << "collate: #{index.collations.inspect}" if index.collations.present?
+            statement_parts << "nulls: #{index.nulls.inspect}" if index.nulls.present?
 
             "  #{statement_parts.join(', ')}"
           end

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -49,6 +49,15 @@ class PostgresqlActiveSchemaTest < ActiveRecord::TestCase
 
     expected = %(CREATE UNIQUE INDEX  "index_people_on_last_name" ON "people" USING gist ("last_name") WHERE state = 'active')
     assert_equal expected, add_index(:people, :last_name, :unique => true, :where => "state = 'active'", :using => :gist)
+
+    expected = %(CREATE  INDEX  "index_people_on_last_name" ON "people"  ("last_name" varchar_pattern_ops))
+    assert_equal expected, add_index(:people, :last_name, opclass: :varchar_pattern_ops)
+
+    expected = %(CREATE  INDEX  "index_people_on_last_name" ON "people" USING gist ("last_name" gist_trgm_ops))
+    assert_equal expected, add_index(:people, :last_name, using: :gist, opclass: :gist_trgm_ops)
+
+    expected = %(CREATE  INDEX  "index_people_on_last_name" ON "people"  ("last_name" COLLATE "C" varchar_pattern_ops DESC NULLS LAST))
+    assert_equal expected, add_index(:people, :last_name, collate: "C", opclass: :varchar_pattern_ops, order: :desc, nulls: :last)
   end
 
   private

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -176,6 +176,54 @@ class SchemaDumperTest < ActiveRecord::TestCase
     end
   end
 
+  def test_schema_dumps_index_collation
+    index_definition = standard_dump.split(/\n/).grep(/add_index.*company_collation_index/).first.strip
+    if current_adapter?(:PostgreSQLAdapter)
+      assert_equal 'add_index "companies", ["name"], name: "company_collation_index", using: :btree, collate: {"name"=>"C"}', index_definition
+    elsif current_adapter?(:MysqlAdapter, :Mysql2Adapter)
+      assert_equal 'add_index "companies", ["name"], name: "company_collation_index", using: :btree', index_definition
+    elsif current_adapter?(:SQLite3Adapter)
+      assert_equal 'add_index "companies", ["name"], name: "company_collation_index", collate: {"name"=>"NOCASE"}', index_definition
+    else
+      assert_equal 'add_index "companies", ["name"], name: "company_collation_index"', index_definition
+    end
+  end
+
+  def test_schema_dumps_index_opclass
+    index_definition = standard_dump.split(/\n/).grep(/add_index.*company_opclass_index/).first.strip
+    if current_adapter?(:PostgreSQLAdapter)
+      assert_equal 'add_index "companies", ["name"], name: "company_opclass_index", using: :btree, opclass: {"name"=>:varchar_pattern_ops}', index_definition
+    elsif current_adapter?(:MysqlAdapter, :Mysql2Adapter)
+      assert_equal 'add_index "companies", ["name"], name: "company_opclass_index", using: :btree', index_definition
+    else
+      assert_equal 'add_index "companies", ["name"], name: "company_opclass_index"', index_definition
+    end
+  end
+
+  def test_schema_dumps_index_order
+    index_definition = standard_dump.split(/\n/).grep(/add_index.*company_order_index/).first.strip
+    if current_adapter?(:PostgreSQLAdapter)
+      assert_equal 'add_index "companies", ["name"], name: "company_order_index", order: {"name"=>:desc}, using: :btree', index_definition
+    elsif current_adapter?(:MysqlAdapter, :Mysql2Adapter)
+      assert_equal 'add_index "companies", ["name"], name: "company_order_index", using: :btree', index_definition
+    elsif current_adapter?(:SQLite3Adapter)
+      assert_equal 'add_index "companies", ["name"], name: "company_order_index", order: {"name"=>:desc}', index_definition
+    else
+      assert_equal 'add_index "companies", ["name"], name: "company_order_index"', index_definition
+    end
+  end
+
+  def test_schema_dumps_index_nulls
+    index_definition = standard_dump.split(/\n/).grep(/add_index.*company_nulls_index/).first.strip
+    if current_adapter?(:PostgreSQLAdapter)
+      assert_equal 'add_index "companies", ["name"], name: "company_nulls_index", using: :btree, nulls: {"name"=>:first}', index_definition
+    elsif current_adapter?(:MysqlAdapter, :Mysql2Adapter)
+      assert_equal 'add_index "companies", ["name"], name: "company_nulls_index", using: :btree', index_definition
+    else
+      assert_equal 'add_index "companies", ["name"], name: "company_nulls_index"', index_definition
+    end
+  end
+
   def test_schema_dumps_partial_indices
     index_definition = standard_dump.split(/\n/).grep(/add_index.*company_partial_index/).first.strip
     if current_adapter?(:PostgreSQLAdapter)

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -215,6 +215,16 @@ ActiveRecord::Schema.define do
   add_index :companies, [:firm_id, :type, :rating], name: "company_index"
   add_index :companies, [:firm_id, :type], name: "company_partial_index", where: "rating > 10"
   add_index :companies, :name, name: 'company_name_index', using: :btree
+  if current_adapter?(:PostgreSQLAdapter)
+    add_index :companies, :name, name: 'company_collation_index', using: :btree, collate: "C"
+  elsif current_adapter?(:SQLite3Adapter)
+    add_index :companies, :name, name: 'company_collation_index', using: :btree, collate: :nocase
+  else
+    add_index :companies, :name, name: 'company_collation_index', using: :btree, collate: :foobar
+  end
+  add_index :companies, :name, name: 'company_opclass_index', using: :btree, opclass: :varchar_pattern_ops
+  add_index :companies, :name, name: 'company_order_index', using: :btree, order: :desc
+  add_index :companies, :name, name: 'company_nulls_index', using: :btree, nulls: :first
 
   create_table :vegetables, force: true do |t|
     t.string :name


### PR DESCRIPTION
This adds support for the following index options:

PostgreSQL:
- Index Collation
- Index Operator Classes
- Index NULL Order

SQLite3:
- Index Collation
- Index Order

This PR extends on work done in #16130.
