### PR TITLE
Grammar: "By default, Rails loads generators from your load path." [ci skip]

### DIFF
--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -93,7 +93,7 @@ module Rails
   #     end
   #   end
   #
-  # By default, Rails load generators from your load path. However, if you want to place
+  # By default, Rails loads generators from your load path. However, if you want to place
   # your generators at a different location, you can specify in your Railtie a block which
   # will load them during normal generators lookup:
   #


### PR DESCRIPTION
I would have gone with either:
 `By default, Rails loads generators from your load path`
or
`By default, Rails will load generators from your load path`

Just a small one but I felt compelled to correct it.
