### PR TITLE
 Run SQL only if attribute changed for update_attribute method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Don't run SQL if attribute value is not changed for update_attribute method.
+
+    *Prathamesh Sonpatki*
+
 *   `time` columns can now affected by `time_zone_aware_attributes`. If you have
     set `config.time_zone` to a value other than `'UTC'`, they will be treated
     as in that time zone by default in Rails 5.1. If this is not the desired

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -246,7 +246,7 @@ module ActiveRecord
       name = name.to_s
       verify_readonly_attribute(name)
       send("#{name}=", value)
-      save(validate: false)
+      save(validate: false) if changed?
     end
 
     # Updates the attributes of the model from the passed-in hash and saves the

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -356,6 +356,16 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal("David", topic_reloaded.author_name)
   end
 
+  def test_update_attribute_does_not_run_sql_if_attribute_is_not_changed
+    klass = Class.new(Topic) do
+      def self.name; 'Topic'; end
+    end
+    topic = klass.create(title: 'Another New Topic')
+    assert_queries(0) do
+      topic.update_attribute(:title, 'Another New Topic')
+    end
+  end
+
   def test_delete
     topic = Topic.find(1)
     assert_equal topic, topic.delete, 'topic.delete did not return self'


### PR DESCRIPTION
- This is based on https://github.com/rails/rails/issues/18400 but
  tackling same issue with update_attribute method instead of update method.
