### PR TITLE
Introduce arguments for perform in JobGenerator

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,1 +1,2 @@
+*  Added optional arguments to JobGenerator.
 *  Started project.

--- a/activejob/lib/rails/generators/job/job_generator.rb
+++ b/activejob/lib/rails/generators/job/job_generator.rb
@@ -6,6 +6,7 @@ module Rails
       desc 'This generator creates an active job file at app/jobs'
 
       class_option :queue, type: :string, default: 'default', desc: 'The queue name for the generated job'
+      argument :collaborators, type: :array, default: ['*args'], banner: 'arg arg arg'
 
       check_class_collision suffix: 'Job'
 

--- a/activejob/lib/rails/generators/job/templates/job.rb
+++ b/activejob/lib/rails/generators/job/templates/job.rb
@@ -2,7 +2,7 @@
 class <%= class_name %>Job < ActiveJob::Base
   queue_as :<%= options[:queue] %>
 
-  def perform(*args)
+  def perform(<%= collaborators.join(", ") %>)
     # Do something later
   end
 end

--- a/railties/test/generators/job_generator_test.rb
+++ b/railties/test/generators/job_generator_test.rb
@@ -1,0 +1,48 @@
+require 'generators/generators_test_helper'
+require 'rails/generators/job/job_generator'
+
+class JobGeneratorTest < Rails::Generators::TestCase
+  include GeneratorsTestHelper
+
+  def test_job_skeleton_is_created
+    run_generator ["refresh_counters"]
+    assert_file "app/jobs/refresh_counters_job.rb" do |job|
+      assert_match(/class RefreshCountersJob < ActiveJob::Base/, job)
+      assert_match(/def perform\(\*args\)/, job)
+    end
+  end
+
+  def test_job_queue_param
+    run_generator ["refresh_counters", "--queue", "important"]
+    assert_file "app/jobs/refresh_counters_job.rb" do |job|
+      assert_match(/class RefreshCountersJob < ActiveJob::Base/, job)
+      assert_match(/queue_as :important/, job)
+    end
+  end
+
+  def test_job_namespace
+    run_generator ["admin/refresh_counters", "--queue", "admin"]
+    assert_file "app/jobs/admin/refresh_counters_job.rb" do |job|
+      assert_match(/class Admin::RefreshCountersJob < ActiveJob::Base/, job)
+      assert_match(/queue_as :admin/, job)
+    end
+  end
+
+  def test_job_single_collaborator
+    run_generator ["refresh_counters", "user", "--queue", "important"]
+    assert_file "app/jobs/refresh_counters_job.rb" do |job|
+      assert_match(/class RefreshCountersJob < ActiveJob::Base/, job)
+      assert_match(/def perform\(user\)/, job)
+      assert_match(/queue_as :important/, job)
+    end
+  end
+
+  def test_job_perform_multiple_collaborators
+    run_generator ["refresh_counters", "user", "dashboard", "--queue", "important"]
+    assert_file "app/jobs/refresh_counters_job.rb" do |job|
+      assert_match(/class RefreshCountersJob < ActiveJob::Base/, job)
+      assert_match(/def perform\(user, dashboard\)/, job)
+      assert_match(/queue_as :important/, job)
+    end
+  end
+end


### PR DESCRIPTION
Generate an `ActiveJob` with arguments in `perform`
### Usage

``` bash
rails generate job send_csv account user
```
### Generates

``` ruby
class SendCsvJob < ActiveJob::Base
  def perform(account, user)
    # Do something later
  end
end
```

The part to note is `perform(account, user)` in place of the generic `perform(*args)`. Calling the generator without arguments defaults to `perform(*args)`
