### PR TITLE
Extracted silence_stream method to new module in activesupport/testing

### DIFF
--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -1,4 +1,5 @@
 require 'cases/helper'
+require 'active_support/testing/stream'
 require 'support/ddl_helper'
 require 'support/schema_dumping_helper'
 
@@ -8,6 +9,7 @@ module ActiveRecord
     class ForeignKeyTest < ActiveRecord::TestCase
       include DdlHelper
       include SchemaDumpingHelper
+      include ActiveSupport::Testing::Stream
 
       class Rocket < ActiveRecord::Base
       end
@@ -221,17 +223,6 @@ module ActiveRecord
         silence_stream($stdout) { migration.migrate(:down) }
       end
 
-      private
-
-      def silence_stream(stream)
-        old_stream = stream.dup
-        stream.reopen(IO::NULL)
-        stream.sync = true
-        yield
-      ensure
-        stream.reopen(old_stream)
-        old_stream.close
-      end
     end
   end
 end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1,3 +1,4 @@
+require 'active_support/testing/stream'
 require "cases/helper"
 require "cases/migration/helper"
 require 'bigdecimal/util'
@@ -718,6 +719,8 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
 end
 
 class CopyMigrationsTest < ActiveRecord::TestCase
+  include ActiveSupport::Testing::Stream
+
   def setup
   end
 
@@ -927,23 +930,4 @@ class CopyMigrationsTest < ActiveRecord::TestCase
     ActiveRecord::Base.logger = old
   end
 
-  private
-
-  def quietly
-    silence_stream(STDOUT) do
-      silence_stream(STDERR) do
-        yield
-      end
-    end
-  end
-
-  def silence_stream(stream)
-    old_stream = stream.dup
-    stream.reopen(IO::NULL)
-    stream.sync = true
-    yield
-  ensure
-    stream.reopen(old_stream)
-    old_stream.close
-  end
 end

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -1,33 +1,19 @@
 require 'active_support/test_case'
+require 'active_support/testing/stream'
 
 module ActiveRecord
   # = Active Record Test Case
   #
   # Defines some test assertions to test against SQL queries.
   class TestCase < ActiveSupport::TestCase #:nodoc:
+    include ActiveSupport::Testing::Stream
+
     def teardown
       SQLCounter.clear_log
     end
 
     def assert_date_from_db(expected, actual, message = nil)
       assert_equal expected.to_s, actual.to_s, message
-    end
-
-    def capture(stream)
-      stream = stream.to_s
-      captured_stream = Tempfile.new(stream)
-      stream_io = eval("$#{stream}")
-      origin_stream = stream_io.dup
-      stream_io.reopen(captured_stream)
-
-      yield
-
-      stream_io.rewind
-      return captured_stream.read
-    ensure
-      captured_stream.close
-      captured_stream.unlink
-      stream_io.reopen(origin_stream)
     end
 
     def capture_sql

--- a/activesupport/lib/active_support/testing/stream.rb
+++ b/activesupport/lib/active_support/testing/stream.rb
@@ -1,0 +1,42 @@
+module ActiveSupport
+  module Testing
+    module Stream #:nodoc:
+      private
+
+      def silence_stream(stream)
+        old_stream = stream.dup
+        stream.reopen(IO::NULL)
+        stream.sync = true
+        yield
+      ensure
+        stream.reopen(old_stream)
+        old_stream.close
+      end
+
+      def quietly
+        silence_stream(STDOUT) do
+          silence_stream(STDERR) do
+            yield
+          end
+        end
+      end
+
+      def capture(stream)
+        stream = stream.to_s
+        captured_stream = Tempfile.new(stream)
+        stream_io = eval("$#{stream}")
+        origin_stream = stream_io.dup
+        stream_io.reopen(captured_stream)
+
+        yield
+
+        stream_io.rewind
+        return captured_stream.read
+      ensure
+        captured_stream.close
+        captured_stream.unlink
+        stream_io.reopen(origin_stream)
+      end
+    end
+  end
+end

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -1,4 +1,5 @@
 require 'abstract_unit'
+require 'active_support/testing/stream'
 
 class Deprecatee
   def initialize
@@ -36,6 +37,8 @@ end
 
 
 class DeprecationTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Stream
+
   def setup
     # Track the last warning.
     @old_behavior = ActiveSupport::Deprecation.behavior
@@ -356,20 +359,4 @@ class DeprecationTest < ActiveSupport::TestCase
       deprecator
     end
 
-    def capture(stream)
-      stream = stream.to_s
-      captured_stream = Tempfile.new(stream)
-      stream_io = eval("$#{stream}")
-      origin_stream = stream_io.dup
-      stream_io.reopen(captured_stream)
-
-      yield
-
-      stream_io.rewind
-      return captured_stream.read
-    ensure
-      captured_stream.close
-      captured_stream.unlink
-      stream_io.reopen(origin_stream)
-    end
 end

--- a/railties/lib/rails/generators/testing/behaviour.rb
+++ b/railties/lib/rails/generators/testing/behaviour.rb
@@ -2,6 +2,7 @@ require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/hash/reverse_merge'
 require 'active_support/core_ext/kernel/reporting'
+require 'active_support/testing/stream'
 require 'active_support/concern'
 require 'rails/generators'
 
@@ -10,6 +11,7 @@ module Rails
     module Testing
       module Behaviour
         extend ActiveSupport::Concern
+        include ActiveSupport::Testing::Stream
 
         included do
           class_attribute :destination_root, :current_path, :generator_class, :default_arguments
@@ -101,22 +103,6 @@ module Rails
             Dir.glob("#{dirname}/[0-9]*_*.rb").grep(/\d+_#{file_name}.rb$/).first
           end
 
-          def capture(stream)
-            stream = stream.to_s
-            captured_stream = Tempfile.new(stream)
-            stream_io = eval("$#{stream}")
-            origin_stream = stream_io.dup
-            stream_io.reopen(captured_stream)
-
-            yield
-
-            stream_io.rewind
-            return captured_stream.read
-          ensure
-            captured_stream.close
-            captured_stream.unlink
-            stream_io.reopen(origin_stream)
-          end
       end
     end
   end

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -4,6 +4,7 @@ require File.expand_path("../../../load_paths", __FILE__)
 
 require 'stringio'
 require 'active_support/testing/autorun'
+require 'active_support/testing/stream'
 require 'fileutils'
 
 require 'active_support'
@@ -28,26 +29,10 @@ def jruby_skip(message = '')
 end
 
 class ActiveSupport::TestCase
+  include ActiveSupport::Testing::Stream
+
   # FIXME: we have tests that depend on run order, we should fix that and
   # remove this method call.
   self.test_order = :sorted
 
-  private
-
-  def capture(stream)
-    stream = stream.to_s
-    captured_stream = Tempfile.new(stream)
-    stream_io = eval("$#{stream}")
-    origin_stream = stream_io.dup
-    stream_io.reopen(captured_stream)
-
-    yield
-
-    stream_io.rewind
-    return captured_stream.read
-  ensure
-    captured_stream.close
-    captured_stream.unlink
-    stream_io.reopen(origin_stream)
-  end
 end

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -1,5 +1,6 @@
 require 'abstract_unit'
 require 'active_support/core_ext/module/remove_method'
+require 'active_support/testing/stream'
 require 'rails/generators'
 require 'rails/generators/test_case'
 
@@ -23,6 +24,8 @@ require 'action_dispatch'
 require 'action_view'
 
 module GeneratorsTestHelper
+  include ActiveSupport::Testing::Stream
+
   def self.included(base)
     base.class_eval do
       destination File.join(Rails.root, "tmp")
@@ -42,21 +45,4 @@ module GeneratorsTestHelper
     FileUtils.cp routes, destination
   end
 
-  def quietly
-    silence_stream(STDOUT) do
-      silence_stream(STDERR) do
-        yield
-      end
-    end
-  end
-
-  def silence_stream(stream)
-    old_stream = stream.dup
-    stream.reopen(IO::NULL)
-    stream.sync = true
-    yield
-  ensure
-    stream.reopen(old_stream)
-    old_stream.close
-  end
 end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -11,6 +11,7 @@ require 'fileutils'
 require 'bundler/setup' unless defined?(Bundler)
 require 'active_support'
 require 'active_support/testing/autorun'
+require 'active_support/testing/stream'
 require 'active_support/test_case'
 
 RAILS_FRAMEWORK_ROOT = File.expand_path("#{File.dirname(__FILE__)}/../../..")
@@ -309,45 +310,10 @@ class ActiveSupport::TestCase
   include TestHelpers::Paths
   include TestHelpers::Rack
   include TestHelpers::Generation
+  include ActiveSupport::Testing::Stream
 
   self.test_order = :sorted
 
-  private
-
-  def capture(stream)
-    stream = stream.to_s
-    captured_stream = Tempfile.new(stream)
-    stream_io = eval("$#{stream}")
-    origin_stream = stream_io.dup
-    stream_io.reopen(captured_stream)
-
-    yield
-
-    stream_io.rewind
-    return captured_stream.read
-  ensure
-    captured_stream.close
-    captured_stream.unlink
-    stream_io.reopen(origin_stream)
-  end
-
-  def quietly
-    silence_stream(STDOUT) do
-      silence_stream(STDERR) do
-        yield
-      end
-    end
-  end
-
-  def silence_stream(stream)
-    old_stream = stream.dup
-    stream.reopen(IO::NULL)
-    stream.sync = true
-    yield
-  ensure
-    stream.reopen(old_stream)
-    old_stream.close
-  end
 end
 
 # Create a scope and build a fixture rails app


### PR DESCRIPTION
- Extracted silence_stream method to new module in activesupport/testing
- Added include for the same in ActiveSupport::Test.
- Removed occurrences of silence_stream being used elsewhere.
- Reordered activesupport testcase requires alphabetically.

cc @senny 
