### PR TITLE
Add optional arguments to JobGenerator

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add optional arguments to JobGenerator, to generate arguments within perform
+
+    Example:
+
+        rails generate job send_csv account user
+
+    Generates:
+
+        class SendCsvJob < ActiveJob::Base
+          def perform(account, user)
+            # Do something later
+          end
+        end
+
+    *Dan Ott*
+
 *   Add `:only` option to `assert_enqueued_jobs`, to check the number of times
     a specific kind of job is enqueued.
 
@@ -38,5 +54,4 @@
 
     *Isaac Seymour*
 
-
-Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activejob/CHANGELOG.md) for previous changes.
+*  Started project.

--- a/activejob/lib/rails/generators/job/job_generator.rb
+++ b/activejob/lib/rails/generators/job/job_generator.rb
@@ -6,6 +6,7 @@ module Rails
       desc 'This generator creates an active job file at app/jobs'
 
       class_option :queue, type: :string, default: 'default', desc: 'The queue name for the generated job'
+      argument :collaborators, type: :array, default: ['*args'], banner: 'arg arg arg'
 
       check_class_collision suffix: 'Job'
 

--- a/activejob/lib/rails/generators/job/templates/job.rb
+++ b/activejob/lib/rails/generators/job/templates/job.rb
@@ -2,7 +2,7 @@
 class <%= class_name %>Job < ActiveJob::Base
   queue_as :<%= options[:queue] %>
 
-  def perform(*args)
+  def perform(<%= collaborators.join(", ") %>)
     # Do something later
   end
 end

--- a/railties/test/generators/job_generator_test.rb
+++ b/railties/test/generators/job_generator_test.rb
@@ -8,6 +8,7 @@ class JobGeneratorTest < Rails::Generators::TestCase
     run_generator ["refresh_counters"]
     assert_file "app/jobs/refresh_counters_job.rb" do |job|
       assert_match(/class RefreshCountersJob < ActiveJob::Base/, job)
+      assert_match(/def perform\(\*args\)/, job)
     end
   end
 
@@ -24,6 +25,24 @@ class JobGeneratorTest < Rails::Generators::TestCase
     assert_file "app/jobs/admin/refresh_counters_job.rb" do |job|
       assert_match(/class Admin::RefreshCountersJob < ActiveJob::Base/, job)
       assert_match(/queue_as :admin/, job)
+    end
+  end
+
+  def test_job_single_collaborator
+    run_generator ["refresh_counters", "user", "--queue", "important"]
+    assert_file "app/jobs/refresh_counters_job.rb" do |job|
+      assert_match(/class RefreshCountersJob < ActiveJob::Base/, job)
+      assert_match(/def perform\(user\)/, job)
+      assert_match(/queue_as :important/, job)
+    end
+  end
+
+  def test_job_perform_multiple_collaborators
+    run_generator ["refresh_counters", "user", "dashboard", "--queue", "important"]
+    assert_file "app/jobs/refresh_counters_job.rb" do |job|
+      assert_match(/class RefreshCountersJob < ActiveJob::Base/, job)
+      assert_match(/def perform\(user, dashboard\)/, job)
+      assert_match(/queue_as :important/, job)
     end
   end
 end


### PR DESCRIPTION
To generate arguments within perform.

Example:

``` bash
rails generate job send_csv account user
```

Generates:

``` ruby
class SendCsvJob < ActiveJob::Base
  def perform(account, user)
    # Do something later
  end
end
```
