### PR TITLE
Tiny: DRY default limit in ActiveRecord::Type::Integer

### DIFF
--- a/activerecord/lib/active_record/type/integer.rb
+++ b/activerecord/lib/active_record/type/integer.rb
@@ -3,6 +3,10 @@ module ActiveRecord
     class Integer < Value # :nodoc:
       include Numeric
 
+      # Column storage size in bytes.
+      # 4 bytes means a MySQL int or Postgres integer as opposed to smallint etc.
+      DEFAULT_LIMIT = 4
+
       def initialize(*)
         super
         @range = min_value...max_value
@@ -38,12 +42,12 @@ module ActiveRecord
 
       def ensure_in_range(value)
         unless range.cover?(value)
-          raise RangeError, "#{value} is out of range for #{self.class} with limit #{limit || 4}"
+          raise RangeError, "#{value} is out of range for #{self.class} with limit #{limit || DEFAULT_LIMIT}"
         end
       end
 
       def max_value
-        limit = self.limit || 4
+        limit = self.limit || DEFAULT_LIMIT
         1 << (limit * 8 - 1) # 8 bits per byte with one bit for sign
       end
 


### PR DESCRIPTION
Happened across this code and thought I'd name and DRY up the magic number 4.
