### PR TITLE
Tiny: Remove incorrect comment in ActiveRecord::Type::Value

### DIFF
--- a/activerecord/lib/active_record/type/value.rb
+++ b/activerecord/lib/active_record/type/value.rb
@@ -3,8 +3,7 @@ module ActiveRecord
     class Value # :nodoc:
       attr_reader :precision, :scale, :limit
 
-      # Valid options are +precision+, +scale+, and +limit+. They are only
-      # used when dumping schema.
+      # Valid options are +precision+, +scale+, and +limit+.
       def initialize(options = {})
         options.assert_valid_keys(:precision, :scale, :limit)
         @precision = options[:precision]


### PR DESCRIPTION
Says it's only used for the schema, but they are in fact used for other things.

Integer verifies against the limit during casting, and Decimal uses precision during casting.

It may be true that scale is only used for the schema.
