### PR TITLE
A little performance improvement using 'take' method over 'first'

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -21,7 +21,7 @@ class Array
   #   %w( a b c ).to(-10)  # => []
   def to(position)
     if position >= 0
-      first position + 1
+      take position + 1
     else
       self[0..position]
     end


### PR DESCRIPTION
Tested using Ruby 2.2

```
require 'benchmark'
n = 5_000_000

Benchmark.bmbm do |x|
  x.report('Array#first') do
    n.times do
      %w( a b c d ).first 2 + 1
    end
  end

  x.report('Array#take') do
    n.times do
      %w( a b c d ).take 2 + 1
    end
  end
end
```

Output

```
Rehearsal -----------------------------------------------
Array#first   3.700000   0.020000   3.720000 (  3.748538)
Array#take    3.610000   0.020000   3.630000 (  3.650994)
-------------------------------------- total: 7.350000sec

                  user     system      total        real
Array#first   3.550000   0.000000   3.550000 (  3.559413)
Array#take    3.470000   0.010000   3.480000 (  3.482277)
Santoshs-MacBook-Pro:code santosh $
```
