### PR TITLE
Fix hwia isolated tests

### DIFF
--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1549,6 +1549,14 @@ class HashToXmlTest < ActiveSupport::TestCase
     assert_not_same hash_wia, hash_wia.with_indifferent_access
   end
 
+
+  def test_allows_setting_frozen_array_values_with_indifferent_access
+    value = [1, 2, 3].freeze
+    hash = HashWithIndifferentAccess.new
+    hash[:key] = value
+    assert_equal hash[:key], value
+  end
+
   def test_should_copy_the_default_value_when_converting_to_hash_with_indifferent_access
     hash = Hash.new(3)
     hash_wia = hash.with_indifferent_access

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -8,10 +8,4 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_equal :old_value, hash[:key]
   end
 
-  def test_frozen_value
-    value = [1, 2, 3].freeze
-    hash = {}.with_indifferent_access
-    hash[:key] = value
-    assert_equal hash[:key], value
-  end
 end


### PR DESCRIPTION
- Moved hwia frozen value assignment test to hash_ext_test similar to other tests
- Fixed the wrong use of with_indifferent_access on hash in the test which failed for isolated tests
- Renamed to appropriately specify what the test does
