### PR TITLE
nodoc ActionView::ModelNaming module

### DIFF
--- a/actionview/lib/action_view/model_naming.rb
+++ b/actionview/lib/action_view/model_naming.rb
@@ -1,5 +1,5 @@
 module ActionView
-  module ModelNaming
+  module ModelNaming #:nodoc:
     # Converts the given object to an ActiveModel compliant one.
     def convert_to_model(object)
       object.respond_to?(:to_model) ? object.to_model : object


### PR DESCRIPTION
- Its only used by ActionView internals and not supposed to be used
  through public API.
