### PR TITLE
Should escape regexp wildcard character `.`

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -112,8 +112,8 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
 
   def test_schema_dump_with_shorthand
     output = dump_table_schema "pg_arrays"
-    assert_match %r[t.string\s+"tags",\s+array: true], output
-    assert_match %r[t.integer\s+"ratings",\s+array: true], output
+    assert_match %r[t\.string\s+"tags",\s+array: true], output
+    assert_match %r[t\.integer\s+"ratings",\s+array: true], output
   end
 
   def test_select_with_strings

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -72,7 +72,7 @@ if ActiveRecord::Base.connection.supports_extensions?
 
     def test_schema_dump_with_shorthand
       output = dump_table_schema("citexts")
-      assert_match %r[t.citext "cival"], output
+      assert_match %r[t\.citext "cival"], output
     end
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/full_text_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/full_text_test.rb
@@ -39,6 +39,6 @@ class PostgresqlFullTextTest < ActiveRecord::TestCase
 
   def test_schema_dump_with_shorthand
     output = dump_table_schema("tsvectors")
-    assert_match %r{t.tsvector "text_vector"}, output
+    assert_match %r{t\.tsvector "text_vector"}, output
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -317,7 +317,7 @@ if ActiveRecord::Base.connection.supports_extensions?
 
     def test_schema_dump_with_shorthand
       output = dump_table_schema("hstores")
-      assert_match %r[t.hstore "tags",\s+default: {}], output
+      assert_match %r[t\.hstore "tags",\s+default: {}], output
     end
 
     private

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -66,7 +66,7 @@ module PostgresqlJSONSharedTestCases
 
   def test_schema_dumping
     output = dump_table_schema("json_data_type")
-    assert_match(/t.#{column_type.to_s}\s+"payload",\s+default: {}/, output)
+    assert_match(/t\.#{column_type.to_s}\s+"payload",\s+default: {}/, output)
   end
 
   def test_cast_value_on_write

--- a/activerecord/test/cases/adapters/postgresql/ltree_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/ltree_test.rb
@@ -48,6 +48,6 @@ class PostgresqlLtreeTest < ActiveRecord::TestCase
 
   def test_schema_dump_with_shorthand
     output = dump_table_schema("ltrees")
-    assert_match %r[t.ltree "path"], output
+    assert_match %r[t\.ltree "path"], output
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -56,7 +56,7 @@ class PostgresqlMoneyTest < ActiveRecord::TestCase
   def test_schema_dumping
     output = dump_table_schema("postgresql_moneys")
     assert_match %r{t\.money\s+"wealth",\s+scale: 2$}, output
-    assert_match %r{t\.money\s+"depth",\s+scale: 2,\s+default: 150.55$}, output
+    assert_match %r{t\.money\s+"depth",\s+scale: 2,\s+default: 150\.55$}, output
   end
 
   def test_create_and_update_money

--- a/activerecord/test/cases/adapters/postgresql/network_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/network_test.rb
@@ -85,8 +85,8 @@ class PostgresqlNetworkTest < ActiveRecord::TestCase
 
   def test_schema_dump_with_shorthand
     output = dump_table_schema("postgresql_network_addresses")
-    assert_match %r{t.inet\s+"inet_address",\s+default: "192.168.1.1"}, output
-    assert_match %r{t.cidr\s+"cidr_address",\s+default: "192.168.1.0/24"}, output
-    assert_match %r{t.macaddr\s+"mac_address",\s+default: "ff:ff:ff:ff:ff:ff"}, output
+    assert_match %r{t\.inet\s+"inet_address",\s+default: "192\.168\.1\.1"}, output
+    assert_match %r{t\.cidr\s+"cidr_address",\s+default: "192\.168\.1\.0/24"}, output
+    assert_match %r{t\.macaddr\s+"mac_address",\s+default: "ff:ff:ff:ff:ff:ff"}, output
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -454,7 +454,7 @@ class SchemaForeignKeyTest < ActiveRecord::TestCase
     end
     @connection.add_foreign_key "wagons", "my_schema.trains", column: "train_id"
     output = dump_table_schema "wagons"
-    assert_match %r{\s+add_foreign_key "wagons", "my_schema.trains", column: "train_id"$}, output
+    assert_match %r{\s+add_foreign_key "wagons", "my_schema\.trains", column: "train_id"$}, output
   ensure
     @connection.execute "DROP TABLE IF EXISTS wagons"
     @connection.execute "DROP TABLE IF EXISTS my_schema.trains"

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -114,7 +114,7 @@ class PostgresqlUUIDTest < ActiveRecord::TestCase
 
   def test_schema_dump_with_shorthand
     output = dump_table_schema "uuid_data_type"
-    assert_match %r{t.uuid "guid"}, output
+    assert_match %r{t\.uuid "guid"}, output
   end
 
   def test_uniqueness_validation_ignores_uuid

--- a/activerecord/test/cases/adapters/postgresql/xml_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/xml_test.rb
@@ -50,6 +50,6 @@ class PostgresqlXMLTest < ActiveRecord::TestCase
 
   def test_schema_dump_with_shorthand
     output = dump_table_schema("xml_data_type")
-    assert_match %r{t.xml "payload"}, output
+    assert_match %r{t\.xml "payload"}, output
   end
 end

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -8,7 +8,7 @@ module ActiveRecord
         Arel::Nodes::InfixOperation.new('~', column, Arel.sql(value.source))
       end)
 
-      assert_match %r{["`]topics["`].["`]title["`] ~ rails}i, Topic.where(title: /rails/).to_sql
+      assert_match %r{["`]topics["`]\.["`]title["`] ~ rails}i, Topic.where(title: /rails/).to_sql
     ensure
       Topic.reset_column_information
     end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -204,25 +204,25 @@ class SchemaDumperTest < ActiveRecord::TestCase
   if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
     def test_schema_dump_should_add_default_value_for_mysql_text_field
       output = standard_dump
-      assert_match %r{t.text\s+"body",\s+limit: 65535,\s+null: false$}, output
+      assert_match %r{t\.text\s+"body",\s+limit: 65535,\s+null: false$}, output
     end
 
     def test_schema_dump_includes_length_for_mysql_binary_fields
       output = standard_dump
-      assert_match %r{t.binary\s+"var_binary",\s+limit: 255$}, output
-      assert_match %r{t.binary\s+"var_binary_large",\s+limit: 4095$}, output
+      assert_match %r{t\.binary\s+"var_binary",\s+limit: 255$}, output
+      assert_match %r{t\.binary\s+"var_binary_large",\s+limit: 4095$}, output
     end
 
     def test_schema_dump_includes_length_for_mysql_blob_and_text_fields
       output = standard_dump
-      assert_match %r{t.binary\s+"tiny_blob",\s+limit: 255$}, output
-      assert_match %r{t.binary\s+"normal_blob",\s+limit: 65535$}, output
-      assert_match %r{t.binary\s+"medium_blob",\s+limit: 16777215$}, output
-      assert_match %r{t.binary\s+"long_blob",\s+limit: 4294967295$}, output
-      assert_match %r{t.text\s+"tiny_text",\s+limit: 255$}, output
-      assert_match %r{t.text\s+"normal_text",\s+limit: 65535$}, output
-      assert_match %r{t.text\s+"medium_text",\s+limit: 16777215$}, output
-      assert_match %r{t.text\s+"long_text",\s+limit: 4294967295$}, output
+      assert_match %r{t\.binary\s+"tiny_blob",\s+limit: 255$}, output
+      assert_match %r{t\.binary\s+"normal_blob",\s+limit: 65535$}, output
+      assert_match %r{t\.binary\s+"medium_blob",\s+limit: 16777215$}, output
+      assert_match %r{t\.binary\s+"long_blob",\s+limit: 4294967295$}, output
+      assert_match %r{t\.text\s+"tiny_text",\s+limit: 255$}, output
+      assert_match %r{t\.text\s+"normal_text",\s+limit: 65535$}, output
+      assert_match %r{t\.text\s+"medium_text",\s+limit: 16777215$}, output
+      assert_match %r{t\.text\s+"long_text",\s+limit: 4294967295$}, output
     end
 
     def test_schema_dumps_index_type
@@ -235,19 +235,19 @@ class SchemaDumperTest < ActiveRecord::TestCase
   if mysql_56?
     def test_schema_dump_includes_datetime_precision
       output = standard_dump
-      assert_match %r{t.datetime\s+"written_on",\s+precision: 6$}, output
+      assert_match %r{t\.datetime\s+"written_on",\s+precision: 6$}, output
     end
   end
 
   def test_schema_dump_includes_decimal_options
     output = dump_all_table_schema([/^[^n]/])
-    assert_match %r{precision: 3,[[:space:]]+scale: 2,[[:space:]]+default: 2.78}, output
+    assert_match %r{precision: 3,[[:space:]]+scale: 2,[[:space:]]+default: 2\.78}, output
   end
 
   if current_adapter?(:PostgreSQLAdapter)
     def test_schema_dump_includes_bigint_default
       output = standard_dump
-      assert_match %r{t.integer\s+"bigint_default",\s+limit: 8,\s+default: 0}, output
+      assert_match %r{t\.integer\s+"bigint_default",\s+limit: 8,\s+default: 0}, output
     end
 
     if ActiveRecord::Base.connection.supports_extensions?
@@ -271,11 +271,11 @@ class SchemaDumperTest < ActiveRecord::TestCase
     output = standard_dump
     # Oracle supports precision up to 38 and it identifies decimals with scale 0 as integers
     if current_adapter?(:OracleAdapter)
-      assert_match %r{t.integer\s+"atoms_in_universe",\s+precision: 38}, output
+      assert_match %r{t\.integer\s+"atoms_in_universe",\s+precision: 38}, output
     elsif current_adapter?(:FbAdapter)
-      assert_match %r{t.integer\s+"atoms_in_universe",\s+precision: 18}, output
+      assert_match %r{t\.integer\s+"atoms_in_universe",\s+precision: 18}, output
     else
-      assert_match %r{t.decimal\s+"atoms_in_universe",\s+precision: 55}, output
+      assert_match %r{t\.decimal\s+"atoms_in_universe",\s+precision: 55}, output
     end
   end
 
@@ -284,7 +284,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     match = output.match(%r{create_table "goofy_string_id"(.*)do.*\n(.*)\n})
     assert_not_nil(match, "goofy_string_id table not found")
     assert_match %r(id: false), match[1], "no table id not preserved"
-    assert_match %r{t.string\s+"id",.*?null: false$}, match[2], "non-primary key id column not preserved"
+    assert_match %r{t\.string\s+"id",.*?null: false$}, match[2], "non-primary key id column not preserved"
   end
 
   def test_schema_dump_keeps_id_false_when_id_is_false_and_unique_not_null_column_added

--- a/activerecord/test/cases/xml_serialization_test.rb
+++ b/activerecord/test/cases/xml_serialization_test.rb
@@ -19,7 +19,7 @@ class XmlSerializationTest < ActiveRecord::TestCase
 
   def test_should_serialize_default_root_with_namespace
     @xml = Contact.new.to_xml :namespace=>"http://xml.rubyonrails.org/contact"
-    assert_match %r{^<contact xmlns="http://xml.rubyonrails.org/contact">},  @xml
+    assert_match %r{^<contact xmlns="http://xml\.rubyonrails\.org/contact">},  @xml
     assert_match %r{</contact>$}, @xml
   end
 


### PR DESCRIPTION
`.` is regexp meta character. It should be escape for `assert_match` correctly.
