### PR TITLE
Allow configuration of ActionMailer queue name

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -409,6 +409,8 @@ module ActionMailer
   #
   # * <tt>deliveries</tt> - Keeps an array of all the emails sent out through the Action Mailer with
   #   <tt>delivery_method :test</tt>. Most useful for unit and functional testing.
+  #
+  # * <tt>deliver_later_queue_name</tt> - The name of the queue used with <tt>deliver_later</tt>
   class Base < AbstractController::Base
     include DeliveryMethods
     include Previews

--- a/actionmailer/lib/action_mailer/delivery_job.rb
+++ b/actionmailer/lib/action_mailer/delivery_job.rb
@@ -4,7 +4,7 @@ module ActionMailer
   # The <tt>ActionMailer::DeliveryJob</tt> class is used when you
   # want to send emails outside of the request-response cycle.
   class DeliveryJob < ActiveJob::Base # :nodoc:
-    queue_as :mailers
+    queue_as { ActionMailer::Base.deliver_later_queue_name }
 
     def perform(mailer, mail_method, delivery_method, *args) #:nodoc:
       mailer.constantize.public_send(mail_method, *args).send(delivery_method)

--- a/actionmailer/lib/action_mailer/delivery_methods.rb
+++ b/actionmailer/lib/action_mailer/delivery_methods.rb
@@ -16,6 +16,9 @@ module ActionMailer
       cattr_accessor :perform_deliveries
       self.perform_deliveries = true
 
+      cattr_accessor :deliver_later_queue_name
+      self.deliver_later_queue_name = :mailers
+
       self.delivery_methods = {}.freeze
       self.delivery_method  = :smtp
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -732,6 +732,19 @@ module ApplicationTests
       assert_equal [::MyMailObserver, ::MyOtherMailObserver], ::Mail.send(:class_variable_get, "@@delivery_notification_observers")
     end
 
+    test "allows setting the queue name for the ActionMailer::DeliveryJob" do
+      add_to_config <<-RUBY
+        config.action_mailer.deliver_later_queue_name = 'test_default'
+      RUBY
+
+      require "#{app_path}/config/environment"
+      require "mail"
+
+      _ = ActionMailer::Base
+
+      assert_equal 'test_default', ActionMailer::Base.send(:class_variable_get, "@@deliver_later_queue_name")
+    end
+
     test "valid timezone is setup correctly" do
       add_to_config <<-RUBY
         config.root = "#{app_path}"


### PR DESCRIPTION
Currently all mails sent with `deliver_later` are put on the `mailers` queue. This patch keeps that default but allows the queue name to be configured globally.

The motivation was trying to use https://github.com/chanks/que as the queuing backend. It's a good fit for a simple queue for a single dyno heroku app but by default only listens to one queue per application. As ActiveJob will use the `default` queue and ActionMailer the `mailers` queue jobs wouldn't get run.

The Que library might change to support more than one queue but in the meantime this will allow Rails to work with it. It will also be useful for users of other backends who might need to change where mails are queued.
