### PR TITLE
Fix `test_types_line_up` when column type missing

### DIFF
--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -73,10 +73,10 @@ class SchemaDumperTest < ActiveRecord::TestCase
       next if column_set.empty?
 
       lengths = column_set.map do |column|
-        if match = column.match(/t\.(?:integer|decimal|float|datetime|timestamp|time|date|text|binary|string|boolean|uuid|point)\s+"/)
+        if match = column.match(/t\.(?:integer|decimal|float|datetime|timestamp|time|date|text|binary|string|boolean|xml|uuid|point)\s+"/)
           match[0].length
         end
-      end
+      end.compact
 
       assert_equal 1, lengths.uniq.length
     end


### PR DESCRIPTION
a column type `xml` is missing in regexp pattarn. However,
`assert_equal 1, lengths.uniq.length` is success when `lengths` are all
`nil` because a column type is missing. a test will be failed by using
`compact` when a column type is missing.
