### PR TITLE
Drop a table if a table is remained.

### DIFF
--- a/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
@@ -146,6 +146,7 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
   # custom create table, uses execute on connection to create a table, note: escapes table_name, does NOT escape columns
   def create_tables_directly (tables, connection = @connection)
     tables.each do |table_name, column_properties|
+      connection.drop_table(table_name, if_exists: true)
       connection.execute("CREATE TABLE `#{table_name}` ( #{column_properties} )")
     end
   end

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -145,6 +145,7 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
   # custom create table, uses execute on connection to create a table, note: escapes table_name, does NOT escape columns
   def create_tables_directly (tables, connection = @connection)
     tables.each do |table_name, column_properties|
+      connection.drop_table(table_name, if_exists: true)
       connection.execute("CREATE TABLE `#{table_name}` ( #{column_properties} )")
     end
   end


### PR DESCRIPTION
When a table is remained because teardown didn't run by previous tests
stopped, next tests is failed (it has happened to me :cry:).
