### PR TITLE
 Use force: true options for creating tables in bug templates

### DIFF
--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -12,10 +12,10 @@ ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:'
 ActiveRecord::Base.logger = Logger.new(STDOUT)
 
 ActiveRecord::Schema.define do
-  create_table :posts do |t|
+  create_table :posts, force: true do |t|
   end
 
-  create_table :comments do |t|
+  create_table :comments, force: true do |t|
     t.integer :post_id
   end
 end

--- a/guides/bug_report_templates/active_record_master.rb
+++ b/guides/bug_report_templates/active_record_master.rb
@@ -21,10 +21,10 @@ ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:'
 ActiveRecord::Base.logger = Logger.new(STDOUT)
 
 ActiveRecord::Schema.define do
-  create_table :posts do |t|
+  create_table :posts, force: true  do |t|
   end
 
-  create_table :comments do |t|
+  create_table :comments, force: true  do |t|
     t.integer :post_id
   end
 end


### PR DESCRIPTION
- Generally we have to run the bug templates multiple times to get them
  right and it always complains because the posts and comments tables
  already exist due to earlier runs.
- Using force: true will eliminate this issue.
