### PR TITLE
WIP: First commit of improving test runner on rails

### DIFF
--- a/activesupport/lib/active_support/testing/autorun.rb
+++ b/activesupport/lib/active_support/testing/autorun.rb
@@ -2,6 +2,6 @@ gem 'minitest'
 
 require 'minitest'
 
-unless Rails::TestRunner.running?
+unless defined? Rails::TestRunner
   Minitest.autorun
 end

--- a/activesupport/lib/active_support/testing/autorun.rb
+++ b/activesupport/lib/active_support/testing/autorun.rb
@@ -2,4 +2,6 @@ gem 'minitest'
 
 require 'minitest'
 
-Minitest.autorun
+unless Rails::TestRunner.running?
+  Minitest.autorun
+end

--- a/railties/lib/rails/commands/commands_tasks.rb
+++ b/railties/lib/rails/commands/commands_tasks.rb
@@ -27,7 +27,7 @@ In addition to those, there are:
 All commands can be run with -h (or --help) for more information.
 EOT
 
-    COMMAND_WHITELIST = %w(plugin generate destroy console server dbconsole runner new version help)
+    COMMAND_WHITELIST = %w(plugin generate destroy console server dbconsole runner new version help test)
 
     def initialize(argv)
       @argv = argv
@@ -40,6 +40,13 @@ EOT
       else
         write_error_message(command)
       end
+    end
+
+    def test
+      ENV['RAILS_ENV'] ||= 'test'
+      require_application_and_environment!
+      require_command!("test")
+      Rails::TestRunner.run(argv.first)
     end
 
     def plugin

--- a/railties/lib/rails/commands/test.rb
+++ b/railties/lib/rails/commands/test.rb
@@ -1,0 +1,69 @@
+require "method_source"
+require 'minitest'
+
+module Rails
+  class TestReporter < Minitest::StatisticsReporter
+    def report
+      io.puts
+      io.puts "Failed test:"
+      io.puts
+      io.puts aggregated_results
+    end
+
+    def aggregated_results # :nodoc:
+      filtered_results = results.dup
+      filtered_results.reject!(&:skipped?) unless options[:verbose]
+      filtered_results.map do |result|
+        result.failures.map { |failure|
+          "rails test #{failure.location}\n"
+        }.join "\n"
+      end.join
+    end
+  end
+
+  def Minitest.plugin_rails_init(options)
+    self.reporter << TestReporter.new(options[:io], options)
+    if method = Rails::TestRunner.find_method
+      options[:filter] = "/^(#{method})$/"
+    end
+  end
+  Minitest.extensions << 'rails'
+
+  class TestRunner
+    class << self
+      def run(filename)
+        @filename, @line = filename.split(':')
+        $LOAD_PATH.unshift("test")
+        load @filename
+
+        Minitest.autorun
+      end
+
+      def running?
+        !!@filename
+      end
+
+      def find_method
+        return unless @line
+        method = test_methods.find do |test_method, start_line, end_line|
+          (start_line..end_line).include?(@line.to_i)
+        end
+        method.first if method
+      end
+
+      def test_methods
+        methods_map = []
+        suites = Minitest::Runnable.runnables.shuffle
+        suites.each do |suite_class|
+          suite_class.runnable_methods.each do |test_method|
+            method = suite_class.instance_method(test_method)
+            start_line = method.source_location.last
+            end_line = method.source.split("\n").size + start_line - 1
+            methods_map << [test_method, start_line, end_line]
+          end
+        end
+        methods_map
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Improving minitest runner !

This adds a `bin/rails test test/models/post_test.rb:32`

Now you can do something like:

```
[arthurnn@ralph myapp]$ bin/rails test test/models/post_test.rb
Run options: --seed 48587

# Running:

..FF.

Finished in 0.024376s, 205.1198 runs/s, 287.1677 assertions/s.

  1) Failure:
PostTest#test_failling_one [test/models/post_test.rb:32]:
Failed refutation, no message given


  2) Failure:
PostTest#test_has_likes [test/models/post_test.rb:23]:
Failed assertion, no message given.

5 runs, 7 assertions, 2 failures, 0 errors, 0 skips

Failed test:

rails test test/models/post_test.rb:32
rails test test/models/post_test.rb:23
```

and `bin/rails test test/models/post_test.rb:23` would do what you expected.

This is more of a POC from discussions with @dhh @carlosantoniodasilva @senny , I will still work on those tasks:
- [ ] add tests
- [ ] Move `rake test *` to `rails test`
- [ ] Make sure `autorun` still works if running isolated 
- [ ] cleanup command code

Please let me know what you think, and I will keep working.
