### PR TITLE
transform_keys! has expected behaviour when hash has duplicate keys

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -19,7 +19,11 @@ class Hash
   def transform_keys!
     return enum_for(:transform_keys!) unless block_given?
     keys.each do |key|
-      self[yield(key)] = delete(key)
+      if keys.map(&:to_s).count(key.to_s) == 1 
+        self[yield(key)] = delete(key) 
+      else
+         delete(key) 
+      end
     end
     self
   end


### PR DESCRIPTION
Refer #18515 

Benchmark ->

```
     stringify_keys!    16.595k i/100ms
 new_stringify_keys!    15.580k i/100ms
-------------------------------------------------
     stringify_keys!    409.530k (± 4.7%) i/s -      2.041M
 new_stringify_keys!    377.352k (± 4.8%) i/s -      1.885M
```

Benchmark script => [link](https://gist.github.com/sivsushruth/71cf61472d5c5ba9c9cd)
