### PR TITLE
Respect the database default charset for `schema_migrations` table.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Respect the database default charset for `schema_migrations` table.
+
+    The charset of `version` column in `schema_migrations` table is depend
+    on the database default charset and collation rather than the encoding
+    of the connection.
+
+    *Ryuta Kamizono*
+
 *   Raise `ArgumentError` when passing `nil` or `false` to `Relation#merge`.
 
     These are not valid values to merge in a relation so it should warn the users

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -39,7 +39,7 @@ module ActiveRecord
 
       MAX_INDEX_LENGTH_FOR_UTF8MB4 = 191
       def initialize_schema_migrations_table
-        if @config[:encoding] == 'utf8mb4'
+        if charset == 'utf8mb4'
           ActiveRecord::SchemaMigration.create_table(MAX_INDEX_LENGTH_FOR_UTF8MB4)
         else
           ActiveRecord::SchemaMigration.create_table

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -18,20 +18,28 @@ module ActiveRecord
           smtn = ActiveRecord::Migrator.schema_migrations_table_name
           connection.drop_table smtn, if_exists: true
 
-          config = connection.instance_variable_get(:@config)
-          original_encoding = config[:encoding]
+          database_name = connection.current_database
+          database_info = connection.select_one("SELECT * FROM information_schema.schemata WHERE schema_name = '#{database_name}'")
 
-          config[:encoding] = 'utf8mb4'
+          original_charset = database_info["DEFAULT_CHARACTER_SET_NAME"]
+          original_collation = database_info["DEFAULT_COLLATION_NAME"]
+
+          execute("ALTER DATABASE #{database_name} DEFAULT CHARACTER SET utf8mb4")
+
           connection.initialize_schema_migrations_table
 
           assert connection.column_exists?(smtn, :version, :string, limit: Mysql2Adapter::MAX_INDEX_LENGTH_FOR_UTF8MB4)
         ensure
-          config[:encoding] = original_encoding
+          execute("ALTER DATABASE #{database_name} DEFAULT CHARACTER SET #{original_charset} COLLATE #{original_collation}")
         end
 
         private
         def connection
           @connection ||= ActiveRecord::Base.connection
+        end
+
+        def execute(sql)
+          connection.execute(sql)
         end
       end
     end


### PR DESCRIPTION
The charset of `version` column in `schema_migrations` table is depend
on the database default charset and collation rather than the encoding
of the connection.

How to reproduce:

``` bash
# rails new apps default encoding: utf8
$ rails new foo -d mysql && cd foo
# existing database charset utf8mb4
$ mysql -u root -e "CREATE DATABASE foo_development CHARACTER SET utf8mb4"
# create index fails
$ rake db:migrate
rake aborted!
ActiveRecord::StatementInvalid: Mysql2::Error: Index column size too large. The maximum column size is 767 bytes.: CREATE UNIQUE INDEX `unique_schema_migrations`  ON `schema_migrations` (`version`)
```
