### PR TITLE
Remove config.assets initial values

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -53,19 +53,7 @@ module Rails
         @x                             = Custom.new
 
         @assets = ActiveSupport::OrderedOptions.new
-        @assets.enabled                  = true
-        @assets.paths                    = []
-        @assets.precompile               = [ Proc.new { |path, fn| fn =~ /app\/assets/ && !%w(.js .css).include?(File.extname(path)) },
-                                             /(?:\/|\\|\A)application\.(css|js)$/ ]
-        @assets.prefix                   = "/assets"
-        @assets.version                  = '1.0'
-        @assets.debug                    = false
-        @assets.compile                  = true
-        @assets.digest                   = false
-        @assets.cache_store              = [ :file_store, "#{root}/tmp/cache/assets/#{Rails.env}/" ]
-        @assets.js_compressor            = nil
-        @assets.css_compressor           = nil
-        @assets.logger                   = nil
+        @assets.paths = []
       end
 
       def encoding=(value)


### PR DESCRIPTION
Since the sprockets-rails plugin has existed, it has always included a hack that basically removes and undefined this configuration as soon as it loads.

https://github.com/rails/sprockets-rails/blob/5fbf78db97e8b79d7a3f6a96fe8b33fea5b5c482/lib/sprockets/railtie.rb#L11-L15

It'd be nice if we could just completely remove it from Rails. But I left in the paths stub because theres still another core dependency on it from

https://github.com/rails/rails/blob/bf7f1839bfc93b3af60e6f1a44885b8111a3a2a8/railties/lib/rails/engine.rb#L602-L606

that doesn't exist in sprockets-rails, but it'd be great if that moved out of rails core as well. I'm not really sure what else could be depending on it for other reasons. Ideas?

It'd help resolve some of the still lingering `initialize_on_precompile` issues if most of the assets environment didn't depend on the initializer stack.

Related CI test on sprockets-rails repo https://github.com/rails/sprockets-rails/pull/213

/cc @rafaelfranca 
