### PR TITLE
config_accessor should better not be a public method, as with Ruby's attr_accessor

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   config_accessor became a private method, as with Ruby's attr_accessor.
+
+    *Akira Matsuda*
+
 *   `AS::Testing::TimeHelpers#travel_to` now changes `DateTime.now` as well as
     `Time.now` and `Date.today`.
 

--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -122,6 +122,7 @@ module ActiveSupport
           send("#{name}=", yield) if block_given?
         end
       end
+      private :config_accessor
     end
 
     # Reads and writes attributes from a configuration <tt>OrderedHash</tt>.

--- a/activesupport/test/configurable_test.rb
+++ b/activesupport/test/configurable_test.rb
@@ -111,6 +111,14 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
     end
   end
 
+  test 'the config_accessor method should not be publicly callable' do
+    assert_raises NoMethodError do
+      Class.new {
+        include ActiveSupport::Configurable
+      }.config_accessor :foo
+    end
+  end
+
   def assert_method_defined(object, method)
     methods = object.public_methods.map(&:to_s)
     assert methods.include?(method.to_s), "Expected #{methods.inspect} to include #{method.to_s.inspect}"


### PR DESCRIPTION
I guess it's not intentional that `config_accessor` is publicly callable.
Who actually calls the accessor from outside?
