### PR TITLE
Fix support for HashWithIndifferentAccess in named route helpers

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -241,6 +241,7 @@ module ActionDispatch
 
           def call(t, args, inner_options)
             controller_options = t.url_options
+            inner_options = inner_options.try(:symbolize_keys)
             options = controller_options.merge @options
             hash = handle_positional_args(controller_options,
                                           inner_options || {},

--- a/actionpack/lib/action_dispatch/routing/routes_proxy.rb
+++ b/actionpack/lib/action_dispatch/routing/routes_proxy.rb
@@ -27,7 +27,7 @@ module ActionDispatch
           self.class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{method}(*args)
               options = args.extract_options!
-              args << url_options.merge((options || {}).symbolize_keys)
+              args << url_options.merge(options || {})
               routes.url_helpers.#{method}(*args)
             end
           RUBY


### PR DESCRIPTION
closes #18609

`HashWithIndifferentAccess` is special-cased since it stores underlying
symbol keys as strings while route helpers has deprecated and removed
support for string keys.

/cc @rafaelfranca 
