### PR TITLE
TransactionManager should call rollback records

### DIFF
--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -201,7 +201,7 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
   def test_call_after_rollback_when_commit_fails
     @first.after_commit_block { |r| r.history << :after_commit }
     @first.after_rollback_block { |r| r.history << :after_rollback }
-    
+
     assert_raises RuntimeError do
       @first.transaction do
         tx = @first.class.connection.transaction_manager.current_transaction


### PR DESCRIPTION
As discussed previously the transaction object should not call `commit_records` or `rollback_records`. TransactionManager should be the one that commit/rollback the records.

`commit_records` was moved to the transaction manager layer on #18458. This moves `rollback_records` too.

review @jeremy @brainopia
