### PR TITLE
Conditionally convert the raw_value received by the numeric validator.

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -65,7 +65,7 @@ module ActiveModel
     protected
 
       def parse_raw_value_as_a_number(raw_value)
-        Kernel.Float(raw_value) if raw_value !~ /\A0[xX]/
+        raw_value.is_a?(Numeric) ? raw_value : Kernel.Float(raw_value) if raw_value !~ /\A0[xX]/
       rescue ArgumentError, TypeError
         nil
       end

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -72,11 +72,25 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!([11])
   end
 
+  def test_validates_numericality_with_greater_than_using_differing_numeric_types
+    Topic.validates_numericality_of :approved, greater_than: BigDecimal.new('97.18')
+
+    invalid!([-97.18, BigDecimal.new('97.18'), BigDecimal('-97.18')], 'must be greater than 97.18')
+    valid!([97.18, 98, BigDecimal.new('98')]) # Notice the 97.18 as a float is greater than 97.18 as a BigDecimal due to floating point precision
+  end
+
   def test_validates_numericality_with_greater_than_or_equal
     Topic.validates_numericality_of :approved, greater_than_or_equal_to: 10
 
     invalid!([-9, 9], 'must be greater than or equal to 10')
     valid!([10])
+  end
+
+  def test_validates_numericality_with_greater_than_or_equal_using_differing_numeric_types
+    Topic.validates_numericality_of :approved, greater_than_or_equal_to: BigDecimal.new('97.18') 
+
+    invalid!([-97.18, 97.17, 97, BigDecimal.new('97.17'), BigDecimal.new('-97.18')], 'must be greater than or equal to 97.18')
+    valid!([97.18, 98, BigDecimal.new('97.19')])
   end
 
   def test_validates_numericality_with_equal_to
@@ -86,6 +100,13 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!([10])
   end
 
+  def test_validates_numericality_with_equal_to_using_differing_numeric_types
+    Topic.validates_numericality_of :approved, equal_to: BigDecimal.new('97.18')
+
+    invalid!([-97.18, 97.18], 'must be equal to 97.18')
+    valid!([BigDecimal.new('97.18')])
+  end
+
   def test_validates_numericality_with_less_than
     Topic.validates_numericality_of :approved, less_than: 10
 
@@ -93,11 +114,25 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!([-9, 9])
   end
 
+  def test_validates_numericality_with_less_than_using_differing_numeric_types
+    Topic.validates_numericality_of :approved, less_than: BigDecimal.new('97.18')
+
+    invalid!([97.18, BigDecimal.new('97.18')], 'must be less than 97.18')
+    valid!([-97.0, 97.0, -97, 97, BigDecimal.new('-97'), BigDecimal.new('97')])
+  end
+
   def test_validates_numericality_with_less_than_or_equal_to
     Topic.validates_numericality_of :approved, less_than_or_equal_to: 10
 
     invalid!([11], 'must be less than or equal to 10')
     valid!([-10, 10])
+  end
+
+  def test_validates_numericality_with_less_than_or_equal_to_using_differing_numeric_types
+    Topic.validates_numericality_of :approved, less_than_or_equal_to: BigDecimal.new('97.18')
+
+    invalid!([97.18, 98], 'must be less than or equal to 97.18')
+    valid!([-97.18, BigDecimal.new('-97.18'), BigDecimal.new('97.18')])
   end
 
   def test_validates_numericality_with_odd
@@ -197,7 +232,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
 
   def valid!(values)
     with_each_topic_approved_value(values) do |topic, value|
-      assert topic.valid?, "#{value.inspect} not accepted as a number"
+      assert topic.valid?, "#{value.inspect} not accepted as a number with validation error: #{topic.errors[:approved].first}"
     end
   end
 


### PR DESCRIPTION
This fixes the issue where you may be comparing (using a numeric
validator such as `greater_than`) numbers of a specific Numeric type
such as `BigDecimal`. See https://github.com/rails/rails/issues/12134

Previous behavior took the numeric value to be validated and
unconditionally converted to Float. For example, due to floating point
precision, this can cause issues when comparing a Float to
a BigDecimal.

Consider the following:

```
validates :sub_total, numericality: {
  greater_than: BigDecimal('97.18')
}
```

If the `:sub_total` value `BigDecimal.new('97.18')` was validated against
the above, the following would be valid since `:sub_total` is converted
to a Float regardless of its original type. The result therefore becomes
`Kernel.Float(97.18) > BigDecimal.new('97.18')`

The above illustrated behavior is corrected with this patch by
conditionally converting the value to validate to float.
