### PR TITLE
Add missing AS core extension dependency

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/module/introspection'
+require 'active_support/core_ext/module/remove_method'
 
 module ActiveModel
   class Name


### PR DESCRIPTION
Using standalone `ActiveModel::Name` throws error about undefined method `remove_possible_method`.
It's used in https://github.com/rails/rails/blob/be9b68038e83a617eb38c26147659162e4ac3d2c/activemodel/lib/active_model/naming.rb#L218
