### PR TITLE
Add missing options to Error Message Interpolation guide [CI skip]

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -809,7 +809,7 @@ So, for example, instead of the default error message `"cannot be blank"` you co
 
 | validation   | with option               | message                   | interpolation |
 | ------------ | ------------------------- | ------------------------- | ------------- |
-| confirmation | -                         | :confirmation             | -             |
+| confirmation | -                         | :confirmation             | attribute     |
 | acceptance   | -                         | :accepted                 | -             |
 | presence     | -                         | :blank                    | -             |
 | absence      | -                         | :present                  | -             |
@@ -829,6 +829,7 @@ So, for example, instead of the default error message `"cannot be blank"` you co
 | numericality | :equal_to                 | :equal_to                 | count         |
 | numericality | :less_than                | :less_than                | count         |
 | numericality | :less_than_or_equal_to    | :less_than_or_equal_to    | count         |
+| numericality | :other_than               | :other_than               | count         |
 | numericality | :only_integer             | :not_an_integer           | -             |
 | numericality | :odd                      | :odd                      | -             |
 | numericality | :even                     | :even                     | -             |


### PR DESCRIPTION
Confirmation validator adds `attribute` attribute: https://github.com/rails/rails/blob/fc36841dbb85652fed450e0ba8f2569b7ce59bcf/activemodel/lib/active_model/validations/confirmation.rb#L13

Numericality validator has `other_than` check https://github.com/rails/rails/blob/fc36841dbb85652fed450e0ba8f2569b7ce59bcf/activemodel/lib/active_model/validations/numericality.rb#L7
