### PR TITLE
Add `:force` option to `rename_table`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add `:force` option to `rename_table`.
+
+    Example:
+
+        rename_table(:test_models, :octopi, force: true)
+
+    Even if an `:octopi` table exists, `rename_table` does nothing raises
+    because drop the table before rename it.
+
+    *Ryuta Kamizono*
+
 *   Add `ActiveRecord::Base#accessed_fields`, which can be used to quickly
     discover which fields were read from a model when you are looking to only
     select the data you need from the database.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -366,7 +366,7 @@ module ActiveRecord
       #
       #   rename_table('octopuses', 'octopi')
       #
-      def rename_table(table_name, new_name)
+      def rename_table(table_name, new_name, options = {})
         raise NotImplementedError, "rename_table is not implemented"
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -496,7 +496,10 @@ module ActiveRecord
       #
       # Example:
       #   rename_table('octopuses', 'octopi')
-      def rename_table(table_name, new_name)
+      def rename_table(table_name, new_name, options = {})
+        if options[:force] && table_exists?(new_name) && table_exists?(table_name)
+          drop_table(new_name, options)
+        end
         execute "RENAME TABLE #{quote_table_name(table_name)} TO #{quote_table_name(new_name)}"
         rename_table_indexes(table_name, new_name)
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -402,8 +402,11 @@ module ActiveRecord
         #
         # Example:
         #   rename_table('octopuses', 'octopi')
-        def rename_table(table_name, new_name)
+        def rename_table(table_name, new_name, options = {})
           clear_cache!
+          if options[:force] && table_exists?(new_name) && table_exists?(table_name)
+            drop_table(new_name, options)
+          end
           execute "ALTER TABLE #{quote_table_name(table_name)} RENAME TO #{quote_table_name(new_name)}"
           pk, seq = pk_and_sequence_for(new_name)
           if seq && seq.identifier == "#{table_name}_#{pk}_seq"

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -431,7 +431,10 @@ module ActiveRecord
       #
       # Example:
       #   rename_table('octopuses', 'octopi')
-      def rename_table(table_name, new_name)
+      def rename_table(table_name, new_name, options = {})
+        if options[:force] && table_exists?(new_name) && table_exists?(table_name)
+          drop_table(new_name, options)
+        end
         exec_query "ALTER TABLE #{quote_table_name(table_name)} RENAME TO #{quote_table_name(new_name)}"
         rename_table_indexes(table_name, new_name)
       end

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -68,6 +68,13 @@ module ActiveRecord
 
           assert_equal ['special_url_idx'], connection.indexes(:octopi).map(&:name)
         end
+
+        def test_rename_table_to_existent_table_with_force_true_does_nothing_raised
+          connection.create_table :octopi
+          assert_nothing_raised { rename_table(:test_models, :octopi, force: true) }
+          assert connection.table_exists? :octopi
+          assert_not connection.table_exists? :test_models
+        end
       end
 
       if current_adapter?(:PostgreSQLAdapter)


### PR DESCRIPTION
The PR adds `:force` option to `rename_table` like an option of `create_table`.

Example:

``` ruby
rename_table(:test_models, :octopi, force: true)
```

Even if an `:octopi` table exists, `rename_table` does nothing raises
because drop the table before rename it.
