### PR TITLE
Add type validator for STI

### DIFF
--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -33,3 +33,4 @@ en:
       other_than: "must be other than %{count}"
       odd: "must be odd"
       even: "must be even"
+      type: "is invalid for single-table inheritance"

--- a/activemodel/lib/active_model/validations/type.rb
+++ b/activemodel/lib/active_model/validations/type.rb
@@ -1,0 +1,11 @@
+module ActiveModel
+
+  module Validations
+    class TypeValidator < ActiveModel::EachValidator
+      def validate_each(record, attr_name, value)
+        record.errors.add(attr_name, :type, options) unless
+          value.class == String and record.class.parent.descendants.include?(value.safe_constantize)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Problem is when I use Single Table Inheritance...

``` rb
# When I have some STI models, for example...

class Player < ActiveRecord::Base
end

class Player::Football < Player
end

class Player::Baseball < Player
end

Player.create(type: 'Player::Football', ...)
=> commit transaction

Player.create(type: 'wrong_type', ...)
=> ActiveRecord::SubclassNotFound: Invalid single-table inheritance type: wrong_type is not a subclass of Player

p = Player.new
p.type = 'wrong_type'
p.save!
=> true

# Really??

Player.last
=> ActiveRecord::SubclassNotFound: The single-table inheritance mechanism failed to locate the subclass: 'wrong_type'. This error is raised because the column 'type' is reserved for
```

I think It's inconsistent behavior. So ActiveModel need validation like this PR, and all models which have `type` column should have `validates :type, type: true` like below.

``` rb
p = Player.new
p.type = 'wrong_type'
p.save!
=> ActiveRecord::RecordInvalid: type is invalid for single-table inheritance
```

I can’t  find which class I should give `validates :type, type: true`. Please give me some ideas!
