### PR TITLE
Travis: Test on jruby-head only for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ rvm:
   - 2.2
   - ruby-head
   - rbx-2
-  - jruby
+  - jruby-head
 matrix:
   allow_failures:
     - env: "GEM=ar:mysql"
     - rvm: rbx-2
-    - rvm: jruby
+    - rvm: jruby-head
     - env: "GEM=aj"
     - env: "GEM=aj:integration"
   fast_finish: true


### PR DESCRIPTION
Arel head does not support 1.9 anymore.

Let's how far we get with `JRuby 9.0.0.0.pre1`
