### PR TITLE
Replace `if exists` with `table_exists?` and drop table with `drop_table`

### DIFF
--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -10,8 +10,8 @@ module ActiveRecord
       end
 
       teardown do
-        @connection.execute("drop table if exists testings")
-        @connection.execute("drop table if exists testing_parents")
+        @connection.drop_table("testings") if @connection.table_exists? "testings"
+        @connection.drop_table("testing_parents") if @connection.table_exists? "testing_parents"
       end
 
       test "foreign keys can be created with the table" do

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -210,7 +210,7 @@ class PrimaryKeyAnyTypeTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.execute("DROP TABLE IF EXISTS barcodes")
+    @connection.drop_table(:barcodes) if @connection.table_exists? :barcodes
   end
 
   def test_any_type_primary_key


### PR DESCRIPTION
This pull request replace `if exists` with `table_exists?` and drop table with `drop_table` since 'drop table if exists' statement does not always work with some databases such as Oracle, also whose drop table statement will not drop sequence objects.

There is a similar pull request #16778 and  #16867. Unlike these two, `rake test_oracle` does not show any valid failures. Instead `INSERT INTO "SCHEMA_MIGRATIONS" ("VERSION") VALUES (:a1)` statement will be waiting forever to get `TX enqueue` wait, to get row level locking.
