### PR TITLE
Fixed ActiveModel::Errors#get to return [] when no error on given key.

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -71,7 +71,7 @@ module ActiveModel
     #   end
     def initialize(base)
       @base     = base
-      @messages = {}
+      @messages = Hash.new { |messages, attribute| messages[attribute] = [] }
       @details  = Hash.new { |details, attribute| details[attribute] = [] }
     end
 
@@ -109,7 +109,7 @@ module ActiveModel
     #
     #   person.errors.messages   # => {:name=>["cannot be nil"]}
     #   person.errors.get(:name) # => ["cannot be nil"]
-    #   person.errors.get(:age)  # => nil
+    #   person.errors.get(:age)  # => []
     def get(key)
       messages[key]
     end
@@ -127,7 +127,7 @@ module ActiveModel
     #
     #   person.errors.get(:name)    # => ["cannot be nil"]
     #   person.errors.delete(:name) # => ["cannot be nil"]
-    #   person.errors.get(:name)    # => nil
+    #   person.errors.get(:name)    # => []
     def delete(key)
       messages.delete(key)
       details.delete(key)
@@ -139,7 +139,7 @@ module ActiveModel
     #   person.errors[:name]  # => ["cannot be nil"]
     #   person.errors['name'] # => ["cannot be nil"]
     def [](attribute)
-      get(attribute.to_sym) || set(attribute.to_sym, [])
+      messages[attribute.to_sym]
     end
 
     # Adds to the supplied attribute the supplied error message.
@@ -383,7 +383,7 @@ module ActiveModel
     #   person.errors.full_messages_for(:name)
     #   # => ["Name is too short (minimum is 5 characters)", "Name can't be blank"]
     def full_messages_for(attribute)
-      (get(attribute) || []).map { |message| full_message(attribute, message) }
+      messages[attribute].map { |message| full_message(attribute, message) }
     end
 
     # Returns a full message for a given attribute.

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -86,6 +86,11 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["omg"], errors.get(:foo)
   end
 
+  test "get returns empty array when no errors for the provided key" do
+    errors = ActiveModel::Errors.new(self)
+    assert_equal [], errors.get(:foo)
+  end
+
   test "sets the error with the provided key" do
     errors = ActiveModel::Errors.new(self)
     errors.set(:foo, "omg")


### PR DESCRIPTION
Previously:

``` ruby
user = User.new
user.errors.get(:email) #=> nil
user.errors[:email] #=> []
user.errors.get(:email) => []
```

This is a followup to https://github.com/rails/rails/pull/18322#issuecomment-68726191
Not sure if this needs a changelog.

I can see more inconsistency in this class:
- `errors.messages[:key]` and `errors.get(:key)` can be accessed only by symbol, but `errors["key"]` can be access by both string or symbol
- `errors.set(:key, ["error"])` is overwriting all errors, but `errors[:key] = "error"` (which should do the same thing) pushes error to existing ones.
- `errors.set("key", ["error"])`will not convert key to symbol, but `errors["key"] = "error"` and `errors.add("key", :invalid)` will convert it.

What would you say about deprecating methods `get`, `set` and `[]=`? They are so inconsistent that it would be best to get rid of them.
