### PR TITLE
Deprecate `ActiveModel::Errors` `get`, `set` and `[]=` methods.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecate `ActiveModel::Errors#get`, `ActiveModel::Errors#set` and
+    `ActiveModel::Errors#[]=` methods that have inconsistent behaviour.
+
+    *Wojciech Wnętrzak*
+
 *   Change the default error message from `can't be blank` to `must exist` for
     the presence validator of the `:required` option on `belongs_to`/`has_one` associations.
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -29,28 +29,28 @@ class ErrorsTest < ActiveModel::TestCase
 
   def test_delete
     errors = ActiveModel::Errors.new(self)
-    errors[:foo] = 'omg'
+    errors[:foo] << 'omg'
     errors.delete(:foo)
     assert_empty errors[:foo]
   end
 
   def test_include?
     errors = ActiveModel::Errors.new(self)
-    errors[:foo] = 'omg'
+    errors[:foo] << 'omg'
     assert errors.include?(:foo), 'errors should include :foo'
   end
 
   def test_dup
     errors = ActiveModel::Errors.new(self)
-    errors[:foo] = 'bar'
+    errors[:foo] << 'bar'
     errors_dup = errors.dup
-    errors_dup[:bar] = 'omg'
+    errors_dup[:bar] << 'omg'
     assert_not_same errors_dup.messages, errors.messages
   end
 
   def test_has_key?
     errors = ActiveModel::Errors.new(self)
-    errors[:foo] = 'omg'
+    errors[:foo] << 'omg'
     assert_equal true, errors.has_key?(:foo), 'errors should have key :foo'
   end
 
@@ -61,7 +61,7 @@ class ErrorsTest < ActiveModel::TestCase
 
   def test_key?
     errors = ActiveModel::Errors.new(self)
-    errors[:foo] = 'omg'
+    errors[:foo] << 'omg'
     assert_equal true, errors.key?(:foo), 'errors should have key :foo'
   end
 
@@ -81,37 +81,41 @@ class ErrorsTest < ActiveModel::TestCase
 
   test "get returns the errors for the provided key" do
     errors = ActiveModel::Errors.new(self)
-    errors[:foo] = "omg"
+    errors[:foo] << "omg"
 
-    assert_equal ["omg"], errors.get(:foo)
+    assert_deprecated do
+      assert_equal ["omg"], errors.get(:foo)
+    end
   end
 
   test "sets the error with the provided key" do
     errors = ActiveModel::Errors.new(self)
-    errors.set(:foo, "omg")
+    assert_deprecated do
+      errors.set(:foo, "omg")
+    end
 
     assert_equal({ foo: "omg" }, errors.messages)
   end
 
   test "error access is indifferent" do
     errors = ActiveModel::Errors.new(self)
-    errors[:foo] = "omg"
+    errors[:foo] << "omg"
 
     assert_equal ["omg"], errors["foo"]
   end
 
   test "values returns an array of messages" do
     errors = ActiveModel::Errors.new(self)
-    errors.set(:foo, "omg")
-    errors.set(:baz, "zomg")
+    errors.messages[:foo] = "omg"
+    errors.messages[:baz] = "zomg"
 
     assert_equal ["omg", "zomg"], errors.values
   end
 
   test "keys returns the error keys" do
     errors = ActiveModel::Errors.new(self)
-    errors.set(:foo, "omg")
-    errors.set(:baz, "zomg")
+    errors.messages[:foo] << "omg"
+    errors.messages[:baz] << "zomg"
 
     assert_equal [:foo, :baz], errors.keys
   end
@@ -133,7 +137,9 @@ class ErrorsTest < ActiveModel::TestCase
 
   test "assign error" do
     person = Person.new
-    person.errors[:name] = 'should not be nil'
+    assert_deprecated do
+      person.errors[:name] = 'should not be nil'
+    end
     assert_equal ["should not be nil"], person.errors[:name]
   end
 


### PR DESCRIPTION
They have inconsistent behaviour currently.

As discussed in https://github.com/rails/rails/pull/18631

Do you think we can go further and deprecate also `add_on_blank` and `add_on_empty`?
Not sure what is the usecase for them and it's easy enough to write it on your own when needed.
