### PR TITLE
use two spaces instead of one for include root in json

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/wrap_parameters.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/wrap_parameters.rb.tt
@@ -11,6 +11,6 @@ end
 
 # To enable root element in JSON for ActiveRecord objects.
 # ActiveSupport.on_load(:active_record) do
-#  self.include_root_in_json = true
+#   self.include_root_in_json = true
 # end
 <%- end -%>


### PR DESCRIPTION
In a rails application, I uncommented this line and was Hounded. Just a small style change.
