### PR TITLE
Use WeakRef to store records on transactions.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Use WeakRef to store records on transactions in order to restore state.
+    Also this avoids a massive memory grow, due the nature of WeakRef, that
+    would allow records to be garbage collected.
+
+    Fixes #15549.
+
+    *arthurnn*
+
 *   Fixed ActiveRecord::Relation#group method when argument is SQL reserved key word:
 
     Example:

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -8,7 +8,6 @@ module ActiveRecord
       # Returns this record's primary key value wrapped in an Array if one is
       # available.
       def to_key
-        sync_with_transaction_state
         key = self.id
         [key] if key
       end
@@ -16,32 +15,27 @@ module ActiveRecord
       # Returns the primary key value.
       def id
         if pk = self.class.primary_key
-          sync_with_transaction_state
           _read_attribute(pk)
         end
       end
 
       # Sets the primary key value.
       def id=(value)
-        sync_with_transaction_state
         write_attribute(self.class.primary_key, value) if self.class.primary_key
       end
 
       # Queries the primary key value.
       def id?
-        sync_with_transaction_state
         query_attribute(self.class.primary_key)
       end
 
       # Returns the primary key value before type cast.
       def id_before_type_cast
-        sync_with_transaction_state
         read_attribute_before_type_cast(self.class.primary_key)
       end
 
       # Returns the primary key previous value.
       def id_was
-        sync_with_transaction_state
         attribute_was(self.class.primary_key)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -78,11 +78,7 @@ module ActiveRecord
         ite.each do |i|
           i.rolledback!(force_restore_state: full_rollback?, should_run_callbacks: false)
         end
-        @records.uniq.each do |r|
-          if r.weakref_alive?
-            r.rolledback!(force_restore_state: full_rollback?, should_run_callbacks: false)
-          end
-        end
+        each_record { |r| r.rolledback!(force_restore_state: full_rollback?, should_run_callbacks: false) }
       end
 
       def commit
@@ -98,10 +94,12 @@ module ActiveRecord
         ite.each do |i|
           i.committed!(should_run_callbacks: false)
         end
-        @records.uniq.each do |i|
-          if i.weakref_alive?
-            i.committed!(should_run_callbacks: false)
-          end
+        each_record { |r| r.committed!(should_run_callbacks: false) }
+      end
+
+      def each_record
+        @records.uniq.each do |record|
+          yield record if record.weakref_alive?
         end
       end
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -482,50 +482,11 @@ module ActiveRecord
       Hash[methods.map! { |method| [method, public_send(method)] }].with_indifferent_access
     end
 
-    def set_transaction_state(state) # :nodoc:
-      @transaction_state = state
-    end
-
     def has_transactional_callbacks? # :nodoc:
-      !_rollback_callbacks.empty? || !_commit_callbacks.empty? || !_create_callbacks.empty?
+      !_rollback_callbacks.empty? || !_commit_callbacks.empty?
     end
 
     private
-
-    # Updates the attributes on this particular ActiveRecord object so that
-    # if it is associated with a transaction, then the state of the AR object
-    # will be updated to reflect the current state of the transaction
-    #
-    # The @transaction_state variable stores the states of the associated
-    # transaction. This relies on the fact that a transaction can only be in
-    # one rollback or commit (otherwise a list of states would be required)
-    # Each AR object inside of a transaction carries that transaction's
-    # TransactionState.
-    #
-    # This method checks to see if the ActiveRecord object's state reflects
-    # the TransactionState, and rolls back or commits the ActiveRecord object
-    # as appropriate.
-    #
-    # Since ActiveRecord objects can be inside multiple transactions, this
-    # method recursively goes through the parent of the TransactionState and
-    # checks if the ActiveRecord object reflects the state of the object.
-    def sync_with_transaction_state
-      update_attributes_from_transaction_state(@transaction_state, 0)
-    end
-
-    def update_attributes_from_transaction_state(transaction_state, depth)
-      if transaction_state && transaction_state.finalized? && !has_transactional_callbacks?
-        unless @reflects_state[depth]
-          restore_transaction_record_state if transaction_state.rolledback?
-          clear_transaction_record_state
-          @reflects_state[depth] = true
-        end
-
-        if transaction_state.parent && !@reflects_state[depth+1]
-          update_attributes_from_transaction_state(transaction_state.parent, depth+1)
-        end
-      end
-    end
 
     # Under Ruby 1.9, Array#flatten will call #to_ary (recursively) on each of the elements
     # of the array, and then rescues from the possible NoMethodError. If those elements are

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -83,13 +83,11 @@ module ActiveRecord
     # Returns true if this object hasn't been saved yet -- that is, a record
     # for the object doesn't exist in the database yet; otherwise, returns false.
     def new_record?
-      sync_with_transaction_state
       @new_record
     end
 
     # Returns true if this object has been destroyed, otherwise returns false.
     def destroyed?
-      sync_with_transaction_state
       @destroyed
     end
 


### PR DESCRIPTION
In order to restore state on records we need to store all records
touched in the transaction. However if we store all records, we will be
holding a hard reference to them, not allowing them to be garbage
collected. #9068 kinda solved the GC issue inversing the dependency.
As we are on ruby 2.2+ we can use WeakRef, and wont need to inverse that
depedency to restore state.

[fixes #15549] - Because records with a 'create' callback were still
been stored, and memory grow was still a problem for those.

review @chancancode @jeremy @rafaelfranca @sgrif @wangjohn 

All tests are green, and you can run this https://github.com/rails/rails/issues/15549#issuecomment-46035848 , and memory will not grow like crazy.
