### PR TITLE
Disable builds AR-JDBC against master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 sudo: false
 script: 'ci/travis.rb'
 before_install:
-  - "rvm current | grep 'jruby' && export AR_JDBC=true || echo"
   - gem install bundler
 before_script:
   - bundle update


### PR DESCRIPTION
Currently, bundling `activerecord-jdbc-adapter`'s master branch seems to
be broken. See jruby/activerecord-jdbc-adapter#614

This commit partially reverts #12107

Let's see if we can pass the "bundle" stage on Travis.
