### PR TITLE
fix regexp for validate an integer in guides [ci skip]

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -470,7 +470,7 @@ point number. To specify that only integral numbers are allowed set
 If you set `:only_integer` to `true`, then it will use the
 
 ```ruby
-/\A[+-]?\d+\Z/
+/\A[+-]?\d+\z/
 ```
 
 regular expression to validate the attribute's value. Otherwise, it will try to


### PR DESCRIPTION
refs https://github.com/rails/rails/blob/master/activemodel/lib/active_model/validations/numericality.rb#L74
