### PR TITLE
Speed up ActionController::Renderer `normalize_keys` by ~28%.

### DIFF
--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/hash/keys'
+
 module ActionController
   # ActionController::Renderer allows to render arbitrary templates
   # without requirement of being in controller actions.
@@ -71,20 +73,15 @@ module ActionController
 
     private
       def normalize_keys(env)
-        env.dup.tap do |new_env|
-          convert_symbols!   new_env
+        http_header_format(env).tap do |new_env|
           handle_method_key! new_env
           handle_https_key!  new_env
         end
       end
 
-      def convert_symbols!(env)
-        env.keys.each do |key|
-          if key.is_a? Symbol
-            value = env.delete key
-            key = key.to_s.upcase 
-            env[key] = value
-          end
+      def http_header_format(env)
+        env.transform_keys do |key|
+          key.is_a?(Symbol) ? key.to_s.upcase : key
         end
       end
 


### PR DESCRIPTION
Previously env was duplicated and then had it's keys mutated. This iterates through the hash twice.
Using `transform_keys`, duplication and key mutation is a single iteration.

I didn't find `convert_symbols` to be very telling, so I renamed it to `http_header_format` (though I'd love a better name still).

Here's the benchmark that showcases the speed increase:

``` ruby
require 'benchmark/ips'
require 'active_support/core_ext/hash/keys'

env = {
  http_host: 'example.org',
  https: false,
  method: 'get',
  script_name: '',
  'rack.input' => ''
}

Benchmark.ips do |x|
  x.report('dup + bang transform') {
    env.dup.tap do |new_env|
      new_env.keys.each do |key|
        if key.is_a?(Symbol)
          new_env[key.to_s.upcase] = new_env.delete(key)
        end
      end
    end
  }

  x.report('transform_keys') {
    env.transform_keys do |key|
      key.is_a?(Symbol) ? key.to_s.upcase : key
    end
  }

  x.compare!
end
```

which results in an around 28% speed increase:

``` bash
Calculating -------------------------------------
dup + bang transform     7.239k i/100ms
      transform_keys     8.800k i/100ms
-------------------------------------------------
dup + bang transform     88.735k (± 3.4%) i/s -    448.818k
      transform_keys    113.369k (± 3.6%) i/s -    572.000k

Comparison:
      transform_keys:   113369.5 i/s
dup + bang transform:    88735.4 i/s - 1.28x slower
```
