### PR TITLE
The `model_name` method should be called on `to_model`

### DIFF
--- a/actionview/lib/action_view/helpers/tags.rb
+++ b/actionview/lib/action_view/helpers/tags.rb
@@ -5,6 +5,7 @@ module ActionView
 
       eager_autoload do
         autoload :Base
+        autoload :Translator
         autoload :CheckBox
         autoload :CollectionCheckBoxes
         autoload :CollectionRadioButtons

--- a/actionview/lib/action_view/helpers/tags/label.rb
+++ b/actionview/lib/action_view/helpers/tags/label.rb
@@ -18,15 +18,19 @@ module ActionView
             @object_name.gsub!(/\[(.*)_attributes\]\[\d+\]/, '.\1')
 
             if object.respond_to?(:to_model)
-              key = object.model_name.i18n_key
+              model = object.to_model
+            end
+
+            if model
+              key = model.model_name.i18n_key
               i18n_default = ["#{key}.#{method_and_value}".to_sym, ""]
             end
 
             i18n_default ||= ""
             content = I18n.t("#{@object_name}.#{method_and_value}", :default => i18n_default, :scope => "helpers.label").presence
 
-            content ||= if object && object.class.respond_to?(:human_attribute_name)
-                          object.class.human_attribute_name(method_and_value)
+            content ||= if model && model.class.respond_to?(:human_attribute_name)
+                          model.class.human_attribute_name(method_and_value)
                         end
 
             content ||= @method_name.humanize

--- a/actionview/lib/action_view/helpers/tags/label.rb
+++ b/actionview/lib/action_view/helpers/tags/label.rb
@@ -15,24 +15,10 @@ module ActionView
 
           def translation
             method_and_value = @tag_value.present? ? "#{@method_name}.#{@tag_value}" : @method_name
-            @object_name.gsub!(/\[(.*)_attributes\]\[\d+\]/, '.\1')
 
-            if object.respond_to?(:to_model)
-              model = object.to_model
-            end
-
-            if model
-              key = model.model_name.i18n_key
-              i18n_default = ["#{key}.#{method_and_value}".to_sym, ""]
-            end
-
-            i18n_default ||= ""
-            content = I18n.t("#{@object_name}.#{method_and_value}", :default => i18n_default, :scope => "helpers.label").presence
-
-            content ||= if model && model.class.respond_to?(:human_attribute_name)
-                          model.class.human_attribute_name(method_and_value)
-                        end
-
+            content ||= Translator
+              .new(object, @object_name, method_and_value, "helpers.label")
+              .call
             content ||= @method_name.humanize
 
             content

--- a/actionview/lib/action_view/helpers/tags/placeholderable.rb
+++ b/actionview/lib/action_view/helpers/tags/placeholderable.rb
@@ -12,17 +12,19 @@ module ActionView
             method_and_value = tag_value.is_a?(TrueClass) ? @method_name : "#{@method_name}.#{tag_value}"
 
             if object.respond_to?(:to_model)
-              key = object.class.model_name.i18n_key
+              model = object.to_model
+            end
+
+            if model
+              key = model.model_name.i18n_key
               i18n_default = ["#{key}.#{method_and_value}".to_sym, ""]
             end
 
             i18n_default ||= ""
             placeholder ||= I18n.t("#{object_name}.#{method_and_value}", :default => i18n_default, :scope => "helpers.placeholder").presence
-
-            placeholder ||= if object && object.class.respond_to?(:human_attribute_name)
-                          object.class.human_attribute_name(method_and_value)
+            placeholder ||= if model && model.class.respond_to?(:human_attribute_name)
+                          model.class.human_attribute_name(method_and_value)
                         end
-
             placeholder ||= @method_name.humanize
 
             @options[:placeholder] = placeholder

--- a/actionview/lib/action_view/helpers/tags/placeholderable.rb
+++ b/actionview/lib/action_view/helpers/tags/placeholderable.rb
@@ -7,26 +7,12 @@ module ActionView
 
           if tag_value = @options[:placeholder]
             placeholder = tag_value if tag_value.is_a?(String)
-
-            object_name = @object_name.gsub(/\[(.*)_attributes\]\[\d+\]/, '.\1')
             method_and_value = tag_value.is_a?(TrueClass) ? @method_name : "#{@method_name}.#{tag_value}"
 
-            if object.respond_to?(:to_model)
-              model = object.to_model
-            end
-
-            if model
-              key = model.model_name.i18n_key
-              i18n_default = ["#{key}.#{method_and_value}".to_sym, ""]
-            end
-
-            i18n_default ||= ""
-            placeholder ||= I18n.t("#{object_name}.#{method_and_value}", :default => i18n_default, :scope => "helpers.placeholder").presence
-            placeholder ||= if model && model.class.respond_to?(:human_attribute_name)
-                          model.class.human_attribute_name(method_and_value)
-                        end
+            placeholder ||= Tags::Translator
+              .new(object, @object_name, method_and_value, "helpers.placeholder")
+              .call
             placeholder ||= @method_name.humanize
-
             @options[:placeholder] = placeholder
           end
         end

--- a/actionview/lib/action_view/helpers/tags/translator.rb
+++ b/actionview/lib/action_view/helpers/tags/translator.rb
@@ -1,0 +1,40 @@
+module ActionView
+  module Helpers
+    module Tags # :nodoc:
+      class Translator # :nodoc:
+        attr_reader :object, :object_name, :method_and_value, :i18n_scope
+
+        def initialize(object, object_name, method_and_value, i18n_scope)
+          @object = object
+          @object_name = object_name.gsub(/\[(.*)_attributes\]\[\d+\]/, '.\1')
+          @method_and_value = method_and_value
+          @i18n_scope = i18n_scope
+        end
+
+        def call
+          placeholder ||= I18n.t("#{object_name}.#{method_and_value}", :default => i18n_default, :scope => i18n_scope).presence
+          placeholder || human_attribute_name
+        end
+
+        def i18n_default
+          if model
+            key = model.model_name.i18n_key
+            ["#{key}.#{method_and_value}".to_sym, ""]
+          else
+            ""
+          end
+        end
+
+        def human_attribute_name
+          if model && model.class.respond_to?(:human_attribute_name)
+            model.class.human_attribute_name(method_and_value)
+          end
+        end
+
+        def model
+          @model ||= object.to_model if object.respond_to?(:to_model)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
See https://github.com/rails/rails/issues/18646

Should the same be done for the following lines? E.g. `model.respond_to?(:human_attribute_name)`
https://github.com/rails/rails/blob/v4.2.0/actionview/lib/action_view/helpers/tags/placeholderable.rb#L22-L24
