### PR TITLE
pluck_hashes

### DIFF
--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -10,6 +10,10 @@ module ActiveRecord
       []
     end
 
+    def pluck_hashes(*cols)
+      []
+    end
+
     def delete_all(_conditions = nil)
       0
     end


### PR DESCRIPTION
The `mysql2` gem returns results as a hash. This is useful in many contexts; for example, in a rails method to fetch a bunch of data as JSON.

Currently, the canonical way to do this is with `as_json`:

```
User.where(<some conditions>).limit(500).select("id", "name", "unix_timestamp(created_at) as joined").as_json(exclude: :id)
```

But this is slow, as it instantiates a `User` object for each row. The need to exclude the `id` column is also cumbersome and unidiomatic. One solution is to use `pluck`:

```
User.where(<some conditions>).limit(500).pluck("id", "name", "unix_timestamp(created_at) as joined")
```

Which gives the right data, but doesn't give the column names. You could zip together a hash, but that would be kludgey and weird, and not guaranteed to respect the naming in `as`.

So I wrote this method, which I use to good effect, and I think it should be part of ActiveRecord
