### PR TITLE
Conditionally permit strong parameters

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   `ActionController::Parameters#permit` can now take hashes with
+    `true`, `false`, or `nil`-valued keys. `true`-valued keys permit
+    scalar values in the resulting hash as though they were included
+    directly in the filter list; `false`- or `nil`-valued keys are
+    ignored and thus not permitted. This makes it easier to
+    conditionally permit a key:
+
+        # Only administrators can change a post's author.
+        params.require(:post).permit(:title, :body, author_id: admin?)
+
+    *Brent Royal-Gordon*
+
 *   Add `ActionController::Renderer` to render arbitrary templates
     outside controller actions.
 

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -285,6 +285,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert @params.to_h.is_a? Hash
     assert_not @params.to_h.is_a? ActionController::Parameters
     assert_equal @params.to_hash, @params.to_unsafe_h
+  end
   
   test "conditionally permitting parameters works" do
     assert_equal "32", @params[:person].permit(age: true)[:age]

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -285,5 +285,12 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert @params.to_h.is_a? Hash
     assert_not @params.to_h.is_a? ActionController::Parameters
     assert_equal @params.to_hash, @params.to_unsafe_h
+  
+  test "conditionally permitting parameters works" do
+    assert_equal "32", @params[:person].permit(age: true)[:age]
+  end
+  
+  test "conditionally forbidding parameters works" do
+    assert_equal nil, @params[:person].permit(age: false)[:age]
   end
 end


### PR DESCRIPTION
This pull request allows you to easily handle cases where a parameter should be permitted in some cases, but not others. For example:

```
# Only administrators can change a post's author.
params.require(:post).permit(:title, :body, author_id: admin?)
```

It does so by modifying the handling of hashes in `ActionController::Parameters#permit`'s parameter list. If a hash key's value is `true`, then the key is included in the permitted parameters as though it had been listed alongside any other scalar keys (`title` and `body` in this example). If the value is `false` or `nil` (to allow for the use of `Object#try`), the entry is ignored, and any parameter with that name will be rejected as usual.

Documentation and tests are included; all tests pass.
