### PR TITLE
Use 'public_send' over the 'send' method for object's properties and public methods.

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -245,7 +245,7 @@ module ActiveRecord
     def update_attribute(name, value)
       name = name.to_s
       verify_readonly_attribute(name)
-      send("#{name}=", value)
+      public_send("#{name}=", value)
       save(validate: false) if changed?
     end
 
@@ -352,7 +352,7 @@ module ActiveRecord
     # method toggles directly the underlying value without calling any setter.
     # Returns +self+.
     def toggle(attribute)
-      self[attribute] = !send("#{attribute}?")
+      self[attribute] = !public_send("#{attribute}?")
       self
     end
 


### PR DESCRIPTION
Use 'public_send' over the 'send' method for object's properties and public methods. Because properties of the object are always public to the object.
