### PR TITLE
Add `ActiveSupport::Testing::FileFixtures`.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `file_fixture` to `ActiveSupport::TestCase`.
+    It provides a simple mechanism to access sample files in your test cases.
+
+    By default file fixtures are stored in `test/fixtures/files`. This can be
+    configured per test-case using the `file_fixture_path` class attribute.
+
+    *Yves Senn*
+
 *   Return value of yielded block in `File.atomic_write`.
 
     *Ian Ker-Seymer*

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -8,6 +8,7 @@ require 'active_support/testing/declarative'
 require 'active_support/testing/isolation'
 require 'active_support/testing/constant_lookup'
 require 'active_support/testing/time_helpers'
+require 'active_support/testing/file_fixtures'
 require 'active_support/core_ext/kernel/reporting'
 
 module ActiveSupport
@@ -55,6 +56,7 @@ module ActiveSupport
     include ActiveSupport::Testing::Assertions
     include ActiveSupport::Testing::Deprecation
     include ActiveSupport::Testing::TimeHelpers
+    include ActiveSupport::Testing::FileFixtures
     extend ActiveSupport::Testing::Declarative
 
     # test/unit backwards compatibility methods

--- a/activesupport/lib/active_support/testing/file_fixtures.rb
+++ b/activesupport/lib/active_support/testing/file_fixtures.rb
@@ -1,0 +1,34 @@
+module ActiveSupport
+  module Testing
+    # Adds simple access to sample files called file fixtures.
+    # File fixtures are normal files stored in
+    # <tt>ActiveSupport::TestCase.file_fixture_path</tt>.
+    #
+    # File fixtures are represented as +Pathname+ objects.
+    # This makes it easy to extract specific information:
+    #
+    #   file_fixture("example.txt").read # get the file's content
+    #   file_fixture("example.mp3").size # get the file size
+    module FileFixtures
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :file_fixture_path, instance_writer: false
+      end
+
+      # Returns a +Pathname+ to the fixture file named +fixture_name+.
+      #
+      # Raises ArgumentError if +fixture_name+ can't be found.
+      def file_fixture(fixture_name)
+        path = Pathname.new(File.join(file_fixture_path, fixture_name))
+
+        if path.exist?
+          path
+        else
+          msg = "the directory '%s' does not contain a file named '%s'"
+          raise ArgumentError, msg % [file_fixture_path, fixture_name]
+        end
+      end
+    end
+  end
+end

--- a/activesupport/test/file_fixtures/sample.txt
+++ b/activesupport/test/file_fixtures/sample.txt
@@ -1,0 +1,1 @@
+sample file fixture

--- a/activesupport/test/testing/file_fixtures_test.rb
+++ b/activesupport/test/testing/file_fixtures_test.rb
@@ -1,0 +1,28 @@
+require 'abstract_unit'
+
+class FileFixturesTest < ActiveSupport::TestCase
+  self.file_fixture_path = File.expand_path("../../file_fixtures", __FILE__)
+
+  test "#file_fixture returns Pathname to file fixture" do
+    path = file_fixture("sample.txt")
+    assert_kind_of Pathname, path
+    assert_match %r{activesupport/test/file_fixtures/sample.txt$}, path.to_s
+  end
+
+  test "raises an exception when the fixture file does not exist" do
+    e = assert_raises(ArgumentError) do
+      file_fixture("nope")
+    end
+    assert_match(/^the directory '[^']+test\/file_fixtures' does not contain a file named 'nope'$/, e.message)
+  end
+end
+
+class FileFixturesPathnameDirectoryTest < ActiveSupport::TestCase
+  self.file_fixture_path = Pathname.new(File.expand_path("../../file_fixtures", __FILE__))
+
+  test "#file_fixture_path returns Pathname to file fixture" do
+    path = file_fixture("sample.txt")
+    assert_kind_of Pathname, path
+    assert_match %r{activesupport/test/file_fixtures/sample.txt$}, path.to_s
+  end
+end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -125,6 +125,7 @@ module Rails
 
     def test
       empty_directory_with_keep_file 'test/fixtures'
+      empty_directory_with_keep_file 'test/fixtures/files'
       empty_directory_with_keep_file 'test/controllers'
       empty_directory_with_keep_file 'test/mailers'
       empty_directory_with_keep_file 'test/models'

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -21,6 +21,7 @@ if defined?(ActiveRecord::Base)
   class ActiveSupport::TestCase
     include ActiveRecord::TestFixtures
     self.fixture_path = "#{Rails.root}/test/fixtures/"
+    self.file_fixture_path = self.fixture_path + "files"
   end
 
   ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -33,6 +33,7 @@ DEFAULT_APP_FILES = %w(
   log
   test/test_helper.rb
   test/fixtures
+  test/fixtures/files
   test/controllers
   test/models
   test/helpers


### PR DESCRIPTION
It's a thin layer to provide easy access to sample files throughout
test-cases. This adds the directory `test/fixtures/files` to newly
generated applications.

This is something that came up in a discussion with @dhh 

Most of our applications have helpers to access some kind of sample files. Possible use-cases are:
- Test file uploads
- Sample output to compare generated documents (.csv, .docx, .pdf, ...)
- content used in test-cases like xml snippets.
- ...
