### PR TITLE
Use attribute assignment module logic during ActiveModel initialization.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Assigning an unknown attribute key to an `ActiveModel` instance during initialization
+    will now raise `ActiveModel::AttributeAssignment::UnknownAttributeError` instead of
+    `NoMethodError`
+
+    ```ruby
+    User.new(foo: 'some value')
+    # => ActiveModel::AttributeAssignment::UnknownAttributeError: unknown attribute 'foo' for User.
+    ```
+
+    *Eugene Gilburg*
+
 *   Extracted `ActiveRecord::AttributeAssignment` to `ActiveModel::AttributeAssignment`
     allowing to use it for any object as an includable module
 

--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -57,6 +57,7 @@ module ActiveModel
   # (see below).
   module Model
     extend ActiveSupport::Concern
+    include ActiveModel::AttributeAssignment
     include ActiveModel::Validations
     include ActiveModel::Conversion
 
@@ -75,10 +76,8 @@ module ActiveModel
     #   person = Person.new(name: 'bob', age: '18')
     #   person.name # => "bob"
     #   person.age  # => "18"
-    def initialize(params={})
-      params.each do |attr, value|
-        self.public_send("#{attr}=", value)
-      end if params
+    def initialize(attributes={})
+      assign_attributes(attributes) if attributes
 
       super()
     end

--- a/activemodel/test/cases/model_test.rb
+++ b/activemodel/test/cases/model_test.rb
@@ -70,6 +70,8 @@ class ModelTest < ActiveModel::TestCase
   end
 
   def test_mixin_initializer_when_args_dont_exist
-    assert_raises(NoMethodError) { SimpleModel.new(hello: 'world') }
+    assert_raises(ActiveModel::AttributeAssignment::UnknownAttributeError) do
+      SimpleModel.new(hello: 'world')
+    end
   end
 end


### PR DESCRIPTION
Builds upon @bogdan 's work in https://github.com/rails/rails/pull/10776 

Since we now have dedicated logic for attribute assignment, reuse it during initialization of Active Models. Active Record initialization already uses it ( https://github.com/rails/rails/blob/master/activerecord/lib/active_record/core.rb#L284 ).

This has a behavior change where passing an unknown key during Active Model initialization will now raise an `UnknownAttributeError` instead of `NoMethodError`. This makes it more consistent with Active Record behavior, and I think this change is minor enough not to worry about deprecation, but I added a note in changelog just in case.
