### PR TITLE
Allow `method: "all"` as a valid routing test option

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -38,18 +38,24 @@ module ActionDispatch
       #   # Test a custom route
       #   assert_recognizes({controller: 'items', action: 'show', id: '1'}, 'view/item1')
       def assert_recognizes(expected_options, path, extras={}, msg=nil)
-        request = recognized_request_for(path, extras, msg)
+        if path.is_a?(Hash) && path[:method].to_s == "all"
+          [:get, :post, :put, :delete].each do |method|
+            assert_recognizes(expected_options, path.merge(method: method), extras, msg)
+          end
+        else
+          request = recognized_request_for(path, extras, msg)
 
-        expected_options = expected_options.clone
+          expected_options = expected_options.clone
 
-        expected_options.stringify_keys!
+          expected_options.stringify_keys!
 
-        msg = message(msg, "") {
-          sprintf("The recognized options <%s> did not match <%s>, difference:",
-                  request.path_parameters, expected_options)
-        }
+          msg = message(msg, "") {
+            sprintf("The recognized options <%s> did not match <%s>, difference:",
+                    request.path_parameters, expected_options)
+          }
 
-        assert_equal(expected_options, request.path_parameters, msg)
+          assert_equal(expected_options, request.path_parameters, msg)
+        end
       end
 
       # Asserts that the provided options can be used to generate the provided path. This is the inverse of +assert_recognizes+.

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -1047,6 +1047,28 @@ class ResourcesTest < ActionController::TestCase
     end
   end
 
+  def test_assert_routing_accepts_all_as_a_valid_method
+    with_routing do |set|
+      set.draw do
+        match "/products", to: "products#show", via: :all
+      end
+
+      assert_routing({ method: "all", path: "/products" }, { controller: "products", action: "show" })
+    end
+  end
+
+  def test_assert_routing_fails_when_not_all_http_methods_are_recognized
+    with_routing do |set|
+      set.draw do
+        match "/products", to: "products#show", via: [:get, :post, :put]
+      end
+
+      assert_raises(Minitest::Assertion) do
+        assert_routing({ method: "all", path: "/products" }, { controller: "products", action: "show" })
+      end
+    end
+  end
+
   def test_singleton_resource_name_is_not_singularized
     with_singleton_resources(:preferences) do
       assert_singleton_restful_for :preferences


### PR DESCRIPTION
This allows the test to mirror the production code, since `via: :all` is
a valid option. The behavior in 4.1 did not actually test that it
matched all verbs, but instead defaulted to testing for "GET". This
implementation aims to better handle the intention of passing "all".

What will actually be asserted doesn't quite match up with the generated
route, since it appears to just not create a constraint on the method.
However, I don't think that we can easily test the lack of that
constraint. Testing each of the main 4 HTTP verbs seems to be a
reasonably close approximation, which should be sufficient for our
needs.

Fixes #18511.
