### PR TITLE
Fixed undefined method error when doing http basic authentication.

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -106,11 +106,11 @@ module ActionController
       end
 
       def auth_scheme(request)
-        request.authorization.split(' ', 2).first
+        request.authorization.to_s.split(' ', 2).first
       end
 
       def auth_param(request)
-        request.authorization.split(' ', 2).second
+        request.authorization.to_s.split(' ', 2).second
       end
 
       def encode_credentials(user_name, password)

--- a/actionpack/test/controller/http_basic_authentication_test.rb
+++ b/actionpack/test/controller/http_basic_authentication_test.rb
@@ -83,6 +83,13 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
       assert_response :unauthorized
       assert_equal "HTTP Basic: Access denied.\n", @response.body, "Authentication didn't fail for request header #{header} and long credentials"
     end
+
+    test "unsuccessful authentication with #{header.downcase} and no credentials" do
+      get :show
+
+      assert_response :unauthorized
+      assert_equal "HTTP Basic: Access denied.\n", @response.body, "Authentication didn't fail for request header #{header} and no credentials"
+    end
   end
 
   def test_encode_credentials_has_no_newline


### PR DESCRIPTION
Fixed error `undefined method `split' for nil:NilClass` when

``` ruby
name, password = ActionController::HttpAuthentication::Basic.user_name_and_password(request)
```

when `request.authorization` returns nil, `auth_param` and `auth_scheme` raise error.
