### PR TITLE
Modifies becomes method to allow for saving of dirty nested attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Modifies the `becomes` method to allow for saving of dirty nested
+    attributes. Previously, calling `becomes` on an object with non-persisted
+    associated objects would cause loss of the objects. Checks if the objects
+    are persisted and skips copying them to the new object if they are.
+
+    Fixes #18549.
+
+    *Damian Z Mastylo*
+    
 *   Integer types will no longer raise a `RangeError` when assigning an
     attribute, but will instead raise when going to the database.
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -146,6 +146,14 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal "The First Topic", topics(:first).becomes(Reply).title
   end
 
+  def test_becomes_with_nested_attributes
+    pirate = Pirate.new
+    5.times { pirate.parrots.build }
+    destructive_pirate = pirate.becomes(DestructivePirate)
+
+    assert_equal pirate.parrots.length, destructive_pirate.parrots.length
+  end
+
   def test_becomes_includes_errors
     company = Company.new(:name => nil)
     assert !company.valid?


### PR DESCRIPTION
This fixes #18549.

The solution is not super elegant because arbitrary nested associations can only be found dynamically by grabbing nested_attributes_options keys and iterating over each to see if any exist. Additionally, the association may be a singular option or a collection, which results in having to a reflection check. If anyone has suggestions on how to clean this up, they'd be greatly appreciated.

I toyed with the idea of adding an optional parameter to cause this new behavior to get executed, or extracting it into a new method (maybe `becomes_with_nested` or something of the like). Would like feedback on this as well.

Passes all ActiveRecord test cases including the new one I added that specifically tests dirty nested attributes. 
