### PR TITLE
Fixed duplicating ActiveModel::Errors#details

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/array/conversions'
 require 'active_support/core_ext/string/inflections'
+require 'active_support/core_ext/object/deep_dup'
 
 module ActiveModel
   # == Active \Model \Errors
@@ -77,7 +78,7 @@ module ActiveModel
 
     def initialize_dup(other) # :nodoc:
       @messages = other.messages.dup
-      @details  = other.details.dup
+      @details  = other.details.deep_dup
       super
     end
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -347,7 +347,7 @@ class ErrorsTest < ActiveModel::TestCase
     errors.add(:name, :invalid)
     errors_dup = errors.dup
     errors_dup.add(:name, :taken)
-    assert_not_same errors_dup.details, errors.details
+    assert_not_equal errors_dup.details, errors.details
   end
 
   test "delete removes details on given attribute" do


### PR DESCRIPTION
Original test didn't catch this, because `assert_same` uses `equal?` and we need to be more strict in this case.

```
details = {name: [{error: :invalid}]}
# => {:name=>[{:error=>:invalid}]}
details_dup = details.dup
# => {:name=>[{:error=>:invalid}]}
details_dup[:name] << {error: :blank}
# => [{:error=>:invalid}, {:error=>:blank}]
details
# => {:name=>[{:error=>:invalid}, {:error=>:blank}]}
details_dup.equal?(details)
# => false
details_dup == details
# => true
```
