### PR TITLE
[ci skip] Fix what is pushed to nesting about eval family

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -151,9 +151,10 @@ executed, and popped after it.
 
 * A singleton class opened with `class << object` gets pushed, and popped later.
 
-* When any of the `*_eval` family of methods is called using a string argument,
+* When `instance_eval` is called using a string argument,
 the singleton class of the receiver is pushed to the nesting of the eval'ed
-code.
+code. When `class_eval` or `module_eval` is called using a string argument,
+the receiver is pushed to the nesting of the eval'ed code.
 
 * The nesting at the top-level of code interpreted by `Kernel#load` is empty
 unless the `load` call receives a true value as second argument, in which case


### PR DESCRIPTION
I tried these code on some Ruby versions

1.9.3-p545
2.0.0-p451
2.1.0
2.2.0

``` ruby
class A
end

A.class_eval("p Module.nesting")
A.module_eval("p Module.nesting")
A.instance_eval("p Module.nesting")
A.new.instance_eval("p Module.nesting")
```

All print

``` ruby
[A]
[A]
[#<Class:A>]
[#<Class:#<A:0x007fbf710d0ad8>>]
```
