### PR TITLE
Dereference arel_table aliases between requests

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -228,7 +228,8 @@ module ActiveRecord
       #     scope :published_and_commented, -> { published.and(self.arel_table[:comments_count].gt(0)) }
       #   end
       def arel_table # :nodoc:
-        @arel_table ||= Arel::Table.new(table_name, type_caster: type_caster)
+        Thread.current[:"#{self.name}.arel_table"] ||=
+          Arel::Table.new(table_name, type_caster: type_caster)
       end
 
       # Returns the Arel engine.

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -109,4 +109,12 @@ class CoreTest < ActiveRecord::TestCase
     PP.pp(subtopic.new, StringIO.new(actual))
     assert_equal "inspecting topic\n", actual
   end
+
+  def test_arel_table_aliases_cache
+    10.times do
+      Fiber.new { Topic.arel_table.alias }.resume
+    end
+    Topic.arel_table.alias
+    assert_equal 1, Topic.arel_table.aliases.size
+  end
 end


### PR DESCRIPTION
Repeatedly calling `Model.arel_table.alias` pushed additional state into the memoized class variable that never got cleared.

Because Arel::Table has mutable state (which I assume is needed for alias tracking) the memoized instance should not persist across different threads.
