### PR TITLE
Fix uniqueness validations on tables without a primary key

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -17,7 +17,9 @@ module ActiveRecord
         value = map_enum_attribute(finder_class, attribute, value)
 
         relation = build_relation(finder_class, table, attribute, value)
-        relation = relation.where.not(finder_class.primary_key => record.id) if record.persisted?
+        if record.persisted? && finder_class.primary_key
+          relation = relation.where.not(finder_class.primary_key => record.id)
+        end
         relation = scope_relation(record, table, relation)
         relation = relation.merge(options[:conditions]) if options[:conditions]
 

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -35,6 +35,13 @@ class TopicWithUniqEvent < Topic
   validates :event, uniqueness: true
 end
 
+class ModelWithoutPrimaryKey < ActiveRecord::Base
+  # 'mateys' table has nil primary_key
+  self.table_name = 'mateys'
+
+  validates :pirate_id, uniqueness: true
+end
+
 class UniquenessValidationTest < ActiveRecord::TestCase
   fixtures :topics, 'warehouse-things'
 
@@ -402,5 +409,15 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert_equal topic.replies.size, 1
     assert reply.valid?
     assert topic.valid?
+  end
+
+  def test_validate_uniqueness_on_model_without_primary_key
+    first_record = ModelWithoutPrimaryKey.create!(pirate_id: 1)
+    assert first_record.valid?, 'saved record should be valid if it succeeded'
+
+    record = ModelWithoutPrimaryKey.create(pirate_id: 2)
+    record.decrement(:pirate_id)
+    assert_not record.valid?
+    assert_equal ['has already been taken'], record.errors[:pirate_id]
   end
 end


### PR DESCRIPTION
If uniqueness validations are set up on a model whose corresponding table has been created with `id: false` or where `self.primary_key = nil` is specified, they will crash.
