### PR TITLE
Add tip for running binstubs on Windows [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -193,6 +193,9 @@ following in the `blog` directory:
 $ bin/rails server
 ```
 
+TIP: If you are using Windows, you have to pass the scripts under the `bin` 
+folder directly to the Ruby interpreter e.g. `ruby bin\rails server`.
+
 TIP: Compiling CoffeeScript and JavaScript asset compression requires you
 have a JavaScript runtime available on your system, in the absence
 of a runtime you will see an `execjs` error during asset compilation.


### PR DESCRIPTION
The default command prompt under Windows doesn't run binstubs correctly
while PowerShell needs to find the location of the Ruby interpreter for
it to work properly. Passing the binstubs manually to the interpreter
solves this problem.

This change applies to guides from 4.1.8 onwards.
