### PR TITLE
Fix typos in migration generator comment

### DIFF
--- a/railties/lib/rails/generators/migration.rb
+++ b/railties/lib/rails/generators/migration.rb
@@ -4,7 +4,7 @@ require 'rails/generators/actions/create_migration'
 module Rails
   module Generators
     # Holds common methods for migrations. It assumes that migrations has the
-    # [0-9]*_name format and can be used by another frameworks (like Sequel)
+    # [0-9]*_name format and can be used by other frameworks (like Sequel)
     # just by implementing the next migration version method.
     module Migration
       extend ActiveSupport::Concern

--- a/railties/lib/rails/generators/migration.rb
+++ b/railties/lib/rails/generators/migration.rb
@@ -3,7 +3,7 @@ require 'rails/generators/actions/create_migration'
 
 module Rails
   module Generators
-    # Holds common methods for migrations. It assumes that migrations has the
+    # Holds common methods for migrations. It assumes that migrations have the
     # [0-9]*_name format and can be used by other frameworks (like Sequel)
     # just by implementing the next migration version method.
     module Migration


### PR DESCRIPTION
1. Change "assumes that migrations **has**" to "assumes that migrations **have**".
2. Change "used by **another** frameworks (like Sequel)" to "used by **other** frameworks (like Sequel)".
   Another option would be to change it to "another framework". I can do that instead if anyone prefers.
