### PR TITLE
A opt-in fix for https://github.com/rails/rails/issues/12330

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Adds an option to override the default columns issued by select statements
+    for a model by overriding 'default_select_columns'. This allows an opt-in
+    fix to GH#12330.
+
+    *Todd Gardner*
+
 *   Integer types will no longer raise a `RangeError` when assigning an
     attribute, but will instead raise when going to the database.
 

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -140,7 +140,7 @@ module ActiveRecord
           scope.references_values = Array(values[:references]) + Array(preload_values[:references])
           scope.bind_values       = (reflection_binds + preload_binds)
 
-          scope._select!   preload_values[:select] || values[:select] || table[Arel.star]
+          scope._select!   preload_values[:select] || values[:select] || klass.default_select_columns
           scope.includes! preload_values[:includes] || values[:includes]
           scope.joins! preload_values[:joins] || values[:joins]
           scope.order! preload_values[:order] || values[:order]

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -102,6 +102,12 @@ module ActiveRecord
         @persistable_attribute_names ||= connection.schema_cache.columns_hash(table_name).keys
       end
 
+      # Returns an array of arel attributes to be used in select statements
+      # when the field list is not specified.
+      def default_select_columns
+        @default_select_columns ||= [arel_table[Arel.star]]
+      end
+
       def reset_column_information # :nodoc:
         super
         clear_caches_calculated_from_columns
@@ -135,6 +141,7 @@ module ActiveRecord
         @columns = nil
         @columns_hash = nil
         @content_columns = nil
+        @default_select_columns = nil
         @default_attributes = nil
         @persistable_attribute_names = nil
       end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1025,7 +1025,7 @@ module ActiveRecord
 
         arel.project(*expanded_select)
       else
-        arel.project(@klass.arel_table[Arel.star])
+        arel.project(*@klass.default_select_columns)
       end
     end
 

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -96,6 +96,7 @@ module ActiveRecord
       klass = Class.new(OverloadedType)
 
       assert_equal 6, klass.columns.length
+      assert_equal 'overloaded_types', klass.default_select_columns[0].relation.name
       assert_not klass.columns_hash.key?('wibble')
       assert_equal 6, klass.column_types.length
       assert_equal 6, klass.column_defaults.length
@@ -110,6 +111,10 @@ module ActiveRecord
       assert_equal 7, klass.column_defaults.length
       assert klass.column_names.include?('wibble')
       assert_equal 6, klass.content_columns.length
+
+      klass.table_name = 'overloaded_types_duplicate'
+
+      assert_equal 'overloaded_types_duplicate', klass.default_select_columns[0].relation.name
     end
   end
 end

--- a/activerecord/test/cases/hot_compatibility_test.rb
+++ b/activerecord/test/cases/hot_compatibility_test.rb
@@ -12,10 +12,51 @@ class HotCompatibilityTest < ActiveRecord::TestCase
 
       def self.name; 'HotCompatibility'; end
     end
+
+    @klass_owned = Class.new(ActiveRecord::Base) do
+      connection.create_table :owned_hot_compatibilities, force: true do |t|
+        t.string :foo
+        t.string :baz
+        t.references :owner_hot_compatibility
+      end
+
+      belongs_to :owner_hot_compatibility
+
+      # Overriding default_select_column is currently necessary for hot
+      # compatability on SELECT on some engines with prepared statements enabled.
+      def self.default_select_columns
+        @default_select_columns ||=
+          connection.schema_cache.columns(table_name)
+          .map { |c| arel_table[c.name] }
+      end
+
+      def self.name; 'OwnedHotCompatibility'; end
+    end
+    klass_owned = @klass_owned
+
+    @klass_owner = Class.new(ActiveRecord::Base) do
+      connection.create_table :owner_hot_compatibilities, force: true do |t|
+        t.string :bar
+      end
+
+      has_many :foo_related, -> {where(foo: "foo")}, class: klass_owned
+
+      def self.default_select_columns
+        @default_select_columns ||=
+          connection.schema_cache.columns(table_name)
+          .map { |c| arel_table[c.name] }
+      end
+
+      def self.name; 'OwnerHotCompatibility'; end
+    end
   end
 
   teardown do
-    ActiveRecord::Base.connection.drop_table :hot_compatibilities
+    [:hot_compatibilities,
+     :owned_hot_compatibilities,
+     :owner_hot_compatibilities].each do |table|
+      ActiveRecord::Base.connection.drop_table table
+    end
   end
 
   test "insert after remove_column" do
@@ -50,5 +91,66 @@ class HotCompatibilityTest < ActiveRecord::TestCase
     record.save!
     record.reload
     assert_equal 'bar', record.foo
+  end
+
+  test "select after add_column" do
+    record = @klass_owner.create! bar: 'bar'
+
+    # do a reload to prepare the reload statement
+    record.reload
+
+    # add a new column
+    @klass_owner.connection.add_column :owner_hot_compatibilities, :baz, :string
+
+    # we can still reload the object
+    record.reload
+
+    assert_equal 'bar', record.bar
+  end
+
+  test "select in transaction after add_column" do
+    record = @klass_owner.create! bar: 'bar'
+
+    # prepare the reload statement in a transaction
+    @klass_owner.transaction do
+      record.reload
+    end
+
+    # add a new column
+    @klass_owner.connection.add_column :owner_hot_compatibilities, :baz, :string
+
+    # we can still reload the object in a transaction
+    @klass_owner.transaction do
+      record.reload
+      assert_equal 'bar', record.bar
+    end
+  end
+
+  test "association preload with conditions after add column" do
+    owner_record = @klass_owner.create! bar: 'bar'
+
+    owner_record.foo_related.create! baz: 'baz'
+
+    # prepare the association preload statement
+    @klass_owner.transaction do
+      records = @klass_owner
+        .preload(:foo_related).where(bar: 'bar').to_a
+      assert_equal 1, records.size
+      assert_equal 'bar', records[0].bar
+      assert_equal 1, records[0].foo_related.size
+      assert_equal 'baz', records[0].foo_related[0].baz
+    end
+
+    # add a column
+    @klass_owned.connection.add_column :owned_hot_compatibilities, :qux, :string
+
+    # we can still do the association preload statement
+    @klass_owner.transaction do
+      records = @klass_owner.preload(:foo_related).where(bar: 'bar').to_a
+      assert_equal 1, records.size
+      assert_equal 'bar', records[0].bar
+      assert_equal 1, records[0].foo_related.size
+      assert_equal 'baz', records[0].foo_related[0].baz
+    end
   end
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -895,6 +895,13 @@ ActiveRecord::Schema.define do
     t.string :string_with_default, default: 'the original default'
   end
 
+  create_table :overloaded_types_duplicate, force: true do |t|
+    t.float :overloaded_float, default: 500
+    t.float :unoverloaded_float
+    t.string :overloaded_string_with_limit, limit: 255
+    t.string :string_with_default, default: 'the original default'
+  end
+
   create_table :users, force: true do |t|
     t.string :token
     t.string :auth_token


### PR DESCRIPTION
This allows control of the rails SELECT behavior by letting programmers override the default \* setting. By not using \* -- and careful management of which columns you do use -- you can enable prepared statements on postgres without having to worry about production issues caused by them.

Problem Overview:

  When using prepared statements with postgres, ActiveRecord can prepare statements like "SELECT \* FROM some_table WHERE foo = ?".

  If a column is later added or removed to the table, the definition of \* changes, and the prepared statement will fail.

  The Postgres adapter correctly catches this failure and tries to deallocate the prepared statement. However, if this is in a transaction, this deallocate will fail, causing the postgres adapter not actually remove it. When the same code runs again, it encounters the same failure of prepared transaction and again fails to deallocate. The system will only recover if the same prepared statement is run outside a transaction or the system is restarted.

  The tests in hot_compatibility_test.rb demonstrate the problem.  "select in transaction after add_column" fails on postgres without any changes. (I expected "association preload with conditions after add column" to also fail without changes with the postgres adapter but it did not, and I'm not sure why -- I kind of punted on a full investigation. All added tests fail the mysql adapter (but not 2).

Problems with this solution:

  In order to set the columns for the select, a first pass might be you might be tempted to add:

```
# Warning: causes a different hot compatability problem described below.
    def self.default_select_columns
      # This doesn't use columns directly to avoid any user defined columns that aren't in the DB.
      @default_select_columns ||=
        connection.schema_cache.columns(table_name)
        .map { |c| arel_table[c.name] }
    end
```

  to your model to control your select fields. However, you have to be careful because there's still hot compatability problem when removing a field. To remove a field, you first push code excluding it from default_select_columns then push the migration removing the column. This could either be done in a "whitelist" or "blacklist" style.

Other Possible Solutions:

  There are a number of more magic solutions available if you're willing to lose the first transaction (which might be dealt with at the application level by trying each transaction at least twice?). For instance, if there existed an "after failed transaction" hook, the postgres adapter might be able to hook into that, and do the deallocation after the transaction rollback happens. However, from reading the code, I think that crosses some abstraction boundaries and might be messy (as far as I can tell, the postgres adaptor doesn't track transaction state?)
