### PR TITLE
Deprecate *_via_redirect integration test methods

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -98,30 +98,35 @@ module ActionDispatch
       # Performs a GET request, following any subsequent redirect.
       # See +request_via_redirect+ for more information.
       def get_via_redirect(path, parameters = nil, headers_or_env = nil)
+        ActiveSupport::Deprecation.warn('`get_via_redirect` is deprecated and will be removed in the next version of Rails. Please use follow_redirect! manually after the request call for the same behavior.')
         request_via_redirect(:get, path, parameters, headers_or_env)
       end
 
       # Performs a POST request, following any subsequent redirect.
       # See +request_via_redirect+ for more information.
       def post_via_redirect(path, parameters = nil, headers_or_env = nil)
+        ActiveSupport::Deprecation.warn('`post_via_redirect` is deprecated and will be removed in the next version of Rails. Please use follow_redirect! manually after the request call for the same behavior.')
         request_via_redirect(:post, path, parameters, headers_or_env)
       end
 
       # Performs a PATCH request, following any subsequent redirect.
       # See +request_via_redirect+ for more information.
       def patch_via_redirect(path, parameters = nil, headers_or_env = nil)
+        ActiveSupport::Deprecation.warn('`patch_via_redirect` is deprecated and will be removed in the next version of Rails. Please use follow_redirect! manually after the request call for the same behavior.')
         request_via_redirect(:patch, path, parameters, headers_or_env)
       end
 
       # Performs a PUT request, following any subsequent redirect.
       # See +request_via_redirect+ for more information.
       def put_via_redirect(path, parameters = nil, headers_or_env = nil)
+        ActiveSupport::Deprecation.warn('`put_via_redirect` is deprecated and will be removed in the next version of Rails. Please use follow_redirect! manually after the request call for the same behavior.')
         request_via_redirect(:put, path, parameters, headers_or_env)
       end
 
       # Performs a DELETE request, following any subsequent redirect.
       # See +request_via_redirect+ for more information.
       def delete_via_redirect(path, parameters = nil, headers_or_env = nil)
+        ActiveSupport::Deprecation.warn('`delete_via_redirect` is deprecated and will be removed in the next version of Rails. Please use follow_redirect! manually after the request call for the same behavior.')
         request_via_redirect(:delete, path, parameters, headers_or_env)
       end
     end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -52,33 +52,43 @@ class SessionTest < ActiveSupport::TestCase
   end
 
   def test_get_via_redirect
-    path = "/somepath"; args = {:id => '1'}; headers = {"X-Test-Header" => "testvalue" }
-    @session.expects(:request_via_redirect).with(:get, path, args, headers)
-    @session.get_via_redirect(path, args, headers)
+    assert_deprecated do
+      path = "/somepath"; args = {:id => '1'}; headers = {"X-Test-Header" => "testvalue" }
+      @session.expects(:request_via_redirect).with(:get, path, args, headers)
+      @session.get_via_redirect(path, args, headers)
+    end
   end
 
   def test_post_via_redirect
-    path = "/somepath"; args = {:id => '1'}; headers = {"X-Test-Header" => "testvalue" }
-    @session.expects(:request_via_redirect).with(:post, path, args, headers)
-    @session.post_via_redirect(path, args, headers)
+    assert_deprecated do
+      path = "/somepath"; args = {:id => '1'}; headers = {"X-Test-Header" => "testvalue" }
+      @session.expects(:request_via_redirect).with(:post, path, args, headers)
+      @session.post_via_redirect(path, args, headers)
+    end
   end
 
   def test_patch_via_redirect
-    path = "/somepath"; args = {:id => '1'}; headers = {"X-Test-Header" => "testvalue" }
-    @session.expects(:request_via_redirect).with(:patch, path, args, headers)
-    @session.patch_via_redirect(path, args, headers)
+    assert_deprecated do
+      path = "/somepath"; args = {:id => '1'}; headers = {"X-Test-Header" => "testvalue" }
+      @session.expects(:request_via_redirect).with(:patch, path, args, headers)
+      @session.patch_via_redirect(path, args, headers)
+    end
   end
 
   def test_put_via_redirect
-    path = "/somepath"; args = {:id => '1'}; headers = {"X-Test-Header" => "testvalue" }
-    @session.expects(:request_via_redirect).with(:put, path, args, headers)
-    @session.put_via_redirect(path, args, headers)
+    assert_deprecated do
+      path = "/somepath"; args = {:id => '1'}; headers = {"X-Test-Header" => "testvalue" }
+      @session.expects(:request_via_redirect).with(:put, path, args, headers)
+      @session.put_via_redirect(path, args, headers)
+    end
   end
 
   def test_delete_via_redirect
-    path = "/somepath"; args = {:id => '1'}; headers = {"X-Test-Header" => "testvalue" }
-    @session.expects(:request_via_redirect).with(:delete, path, args, headers)
-    @session.delete_via_redirect(path, args, headers)
+    assert_deprecated do
+      path = "/somepath"; args = {:id => '1'}; headers = {"X-Test-Header" => "testvalue" }
+      @session.expects(:request_via_redirect).with(:delete, path, args, headers)
+      @session.delete_via_redirect(path, args, headers)
+    end
   end
 
   def test_get


### PR DESCRIPTION
As asked by @dhh in #18333.
Closes #18333.
