### PR TITLE
Provide a better error message on :required association

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Change the default error message from `can't be blank` to `must exist` for
+    the presence validator of the `:required` option on `belongs_to`/`has_one` associations.
+
+    *Henrik Nygren*
+
 *   Assigning an unknown attribute key to an `ActiveModel` instance during initialization
     will now raise `ActiveModel::AttributeAssignment::UnknownAttributeError` instead of
     `NoMethodError`

--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -14,6 +14,7 @@ en:
       empty: "can't be empty"
       blank: "can't be blank"
       present: "must be blank"
+      required: "must exist"
       too_long:
         one: "is too long (maximum is 1 character)"
         other: "is too long (maximum is %{count} characters)" 

--- a/activerecord/lib/active_record/associations/builder/singular_association.rb
+++ b/activerecord/lib/active_record/associations/builder/singular_association.rb
@@ -31,7 +31,7 @@ module ActiveRecord::Associations::Builder
     def self.define_validations(model, reflection)
       super
       if reflection.options[:required]
-        model.validates_presence_of reflection.name
+        model.validates_presence_of reflection.name, message: :required
       end
     end
   end

--- a/activerecord/test/cases/associations/required_test.rb
+++ b/activerecord/test/cases/associations/required_test.rb
@@ -40,7 +40,7 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
 
     record = model.new
     assert_not record.save
-    assert_equal ["Parent can't be blank"], record.errors.full_messages
+    assert_equal ["Parent must exist"], record.errors.full_messages
 
     record.parent = Parent.new
     assert record.save
@@ -64,10 +64,30 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
 
     record = model.new
     assert_not record.save
-    assert_equal ["Child can't be blank"], record.errors.full_messages
+    assert_equal ["Child must exist"], record.errors.full_messages
 
     record.child = Child.new
     assert record.save
+  end
+
+  test "required has_one associations have a correct error message" do
+    model = subclass_of(Parent) do
+      has_one :child, required: true, inverse_of: false,
+      class_name: "RequiredAssociationsTest::Child"
+    end
+
+    record = model.create
+    assert_equal ["Child must exist"], record.errors.full_messages
+  end
+
+  test "required belongs_to associations have a correct error message" do
+    model = subclass_of(Child) do
+      belongs_to :parent, required: true, inverse_of: false,
+      class_name: "RequiredAssociationsTest::Parent"
+    end
+
+    record = model.create
+    assert_equal ["Parent must exist"], record.errors.full_messages
   end
 
   private


### PR DESCRIPTION
Changes the default error message from "can't be blank" to "must exist" for the presence validator of the  `:required` option on `belongs_to/has_one` associations.

Fixes #18696.
