### PR TITLE
Update option to skip test in generators

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Rename `--skip-test-unit` option to `--skip-test` in app generator
+
+    *Melanie Gilman*
+
 *   Add the `method_source` gem to the default Gemfile for apps
 
     *Sean Griffin*

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -70,7 +70,7 @@ module Rails
                                           desc: 'Skip turbolinks gem'
 
         class_option :skip_test,          type: :boolean, aliases: '-T', default: false,
-                                          desc: 'Skip ActiveSupport::TestCase files'
+                                          desc: 'Skip test files'
 
         class_option :rc,                 type: :string, default: false,
                                           desc: "Path to file containing extra configuration options for rails command"

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -69,8 +69,8 @@ module Rails
         class_option :skip_turbolinks,    type: :boolean, default: false,
                                           desc: 'Skip turbolinks gem'
 
-        class_option :skip_test_unit,     type: :boolean, aliases: '-T', default: false,
-                                          desc: 'Skip Test::Unit files'
+        class_option :skip_test,          type: :boolean, aliases: '-T', default: false,
+                                          desc: 'Skip ActiveSupport::TestCase files'
 
         class_option :rc,                 type: :string, default: false,
                                           desc: "Path to file containing extra configuration options for rails command"
@@ -168,7 +168,7 @@ module Rails
       end
 
       def include_all_railties?
-        options.values_at(:skip_active_record, :skip_action_mailer, :skip_test_unit, :skip_sprockets).none?
+        options.values_at(:skip_active_record, :skip_action_mailer, :skip_test, :skip_sprockets).none?
       end
 
       def comment_if(value)

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -234,7 +234,7 @@ module Rails
       end
 
       def create_test_files
-        build(:test) unless options[:skip_test_unit]
+        build(:test) unless options[:skip_test]
       end
 
       def create_tmp_files

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -12,7 +12,7 @@ require "action_controller/railtie"
 <%= comment_if :skip_action_mailer %>require "action_mailer/railtie"
 require "action_view/railtie"
 <%= comment_if :skip_sprockets %>require "sprockets/railtie"
-<%= comment_if :skip_test_unit %>require "rails/test_unit/railtie"
+<%= comment_if :skip_test %>require "rails/test_unit/railtie"
 <% end -%>
 
 # Require the gems listed in Gemfile, including any gems

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -226,7 +226,7 @@ task default: :test
       end
 
       def create_test_files
-        build(:test) unless options[:skip_test_unit]
+        build(:test) unless options[:skip_test]
       end
 
       def create_test_dummy_files
@@ -294,7 +294,7 @@ task default: :test
       end
 
       def with_dummy_app?
-        options[:skip_test_unit].blank? || options[:dummy_path] != 'test/dummy'
+        options[:skip_test].blank? || options[:dummy_path] != 'test/dummy'
       end
 
       def self.banner

--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
-<% unless options.skip_test_unit? -%>
+<% unless options.skip_test? -%>
   s.test_files = Dir["test/**/*"]
 <% end -%>
 

--- a/railties/lib/rails/generators/rails/plugin/templates/gitignore
+++ b/railties/lib/rails/generators/rails/plugin/templates/gitignore
@@ -1,7 +1,7 @@
 .bundle/
 log/*.log
 pkg/
-<% unless options[:skip_test_unit] && options[:dummy_path] == 'test/dummy' -%>
+<% unless options[:skip_test] && options[:dummy_path] == 'test/dummy' -%>
 <%= dummy_path %>/db/*.sqlite3
 <%= dummy_path %>/db/*.sqlite3-journal
 <%= dummy_path %>/log/*.log

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb
@@ -9,7 +9,7 @@ require "action_controller/railtie"
 <%= comment_if :skip_action_mailer %>require "action_mailer/railtie"
 require "action_view/railtie"
 <%= comment_if :skip_sprockets %>require "sprockets/railtie"
-<%= comment_if :skip_test_unit %>require "rails/test_unit/railtie"
+<%= comment_if :skip_test %>require "rails/test_unit/railtie"
 <% end -%>
 
 Bundler.require(*Rails.groups)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -445,13 +445,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file 'lib/test_file.rb', 'heres test data'
   end
 
-  def test_test_unit_is_removed_from_frameworks_if_skip_test_unit_is_given
-    run_generator [destination_root, "--skip-test-unit"]
+  def test_tests_are_removed_from_frameworks_if_skip_test_is_given
+    run_generator [destination_root, "--skip-test"]
     assert_file "config/application.rb", /#\s+require\s+["']rails\/test_unit\/railtie["']/
   end
 
-  def test_no_active_record_or_test_unit_if_skips_given
-    run_generator [destination_root, "--skip-test-unit", "--skip-active-record"]
+  def test_no_active_record_or_tests_if_skips_given
+    run_generator [destination_root, "--skip-test", "--skip-active-record"]
     assert_file "config/application.rb", /#\s+require\s+["']rails\/test_unit\/railtie["']/
     assert_file "config/application.rb", /#\s+require\s+["']active_record\/railtie["']/
     assert_file "config/application.rb", /\s+require\s+["']active_job\/railtie["']/

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -339,7 +339,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_skipping_test_unit
+  def test_skipping_test_files
     run_generator [destination_root, "--skip-test"]
     assert_no_file "test"
     assert_file "bukkits.gemspec" do |contents|

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -112,7 +112,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
   def test_ensure_that_test_dummy_can_be_generated_from_a_template
     FileUtils.cd(Rails.root)
-    run_generator([destination_root, "-m", "lib/create_test_dummy_template.rb", "--skip-test-unit"])
+    run_generator([destination_root, "-m", "lib/create_test_dummy_template.rb", "--skip-test"])
     assert_file "spec/dummy"
     assert_no_file "test"
   end
@@ -321,7 +321,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_creating_dummy_without_tests_but_with_dummy_path
-    run_generator [destination_root, "--dummy_path", "spec/dummy", "--skip-test-unit"]
+    run_generator [destination_root, "--dummy_path", "spec/dummy", "--skip-test"]
     assert_file "spec/dummy"
     assert_file "spec/dummy/config/application.rb"
     assert_no_file "test"
@@ -333,14 +333,14 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
   def test_ensure_that_gitignore_can_be_generated_from_a_template_for_dummy_path
     FileUtils.cd(Rails.root)
-    run_generator([destination_root, "--dummy_path", "spec/dummy", "--skip-test-unit"])
+    run_generator([destination_root, "--dummy_path", "spec/dummy", "--skip-test"])
     assert_file ".gitignore" do |contents|
       assert_match(/spec\/dummy/, contents)
     end
   end
 
   def test_skipping_test_unit
-    run_generator [destination_root, "--skip-test-unit"]
+    run_generator [destination_root, "--skip-test"]
     assert_no_file "test"
     assert_file "bukkits.gemspec" do |contents|
       assert_no_match(/s.test_files = Dir\["test\/\*\*\/\*"\]/, contents)

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -48,7 +48,7 @@ module SharedGeneratorTests
   end
 
   def test_test_unit_is_skipped_if_required
-    run_generator [destination_root, "--skip-test-unit"]
+    run_generator [destination_root, "--skip-test"]
     assert_no_file "test"
   end
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -47,7 +47,7 @@ module SharedGeneratorTests
     assert_match(/Invalid value for \-\-database option/, content)
   end
 
-  def test_test_unit_is_skipped_if_required
+  def test_test_files_are_skipped_if_required
     run_generator [destination_root, "--skip-test"]
     assert_no_file "test"
   end


### PR DESCRIPTION
Rails no longer generates Test::Unit files by default.
