### PR TITLE
[Feedback] Implement Relation#or

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Added the `#or` method on ActiveRecord::Relation, allowing use of the OR
+    operator to combine WHERE or HAVING clauses.
+
+    Example:
+
+        Post.where(Post.recent.or(Post.pinned))
+        # => SELECT * FROM posts WHERE (posts.created_at < ? OR posts.pinned = 't')
+
+    *Sean Griffin*, *Matthew Draper*, *Gael Muller*, *Olivier El Mekki*
+
 *   Integer types will no longer raise a `RangeError` when assigning an
     attribute, but will instead raise when going to the database.
 

--- a/activerecord/lib/active_record/relation/or_placeholder.rb
+++ b/activerecord/lib/active_record/relation/or_placeholder.rb
@@ -1,0 +1,26 @@
+module ActiveRecord
+  class Relation
+    class OrPlaceholder
+      attr_reader :left, :right
+
+      def initialize(left, right)
+        @left = left
+        @right = right
+      end
+
+      def join(method)
+        extract_clause(left, method).or(extract_clause(right, method))
+      end
+
+      private
+
+      def extract_clause(relation_or_clause, method)
+        if Relation === relation_or_clause
+          relation_or_clause.public_send(method)
+        else
+          relation_or_clause
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -776,6 +776,21 @@ module ActiveRecord
     end
     alias uniq! distinct!
 
+
+    # Returns a predicate which can be used with +Relation#where+ or
+    # +Relation#having+. It can accept another +Relation+, or any options that
+    # would be valid when passed to +where+.
+    #
+    # Examples
+    # ==
+    #
+    #     Post.where(Post.recent.or(Post.pinned))
+    #       # => SELECT posts.* FROM posts WHERE (posts.created_at <= ? OR posts.pinned = ?)
+    #
+    # A hash would also be valid.
+    #
+    #     Post.where(Post.recent.or(pinned: true))
+    #
     def or(other, *rest)
       case other
       when Relation, Relation::WhereClause

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -791,6 +791,14 @@ module ActiveRecord
     #
     #     Post.where(Post.recent.or(pinned: true))
     #
+    # This reads most fluently inside of a named scope.
+    #
+    #     class Post < ActiveRecord::Base
+    #       def self.for_homepage
+    #         where(recent.or(pinned))
+    #       end
+    #     end
+    #
     def or(other, *rest)
       case other
       when Relation, Relation::WhereClause

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -32,10 +32,16 @@ module ActiveRecord
       end
 
       def or(other)
-        WhereClause.new(
-          [ast.or(other.ast)],
-          binds + other.binds
-        )
+        if empty?
+          other
+        elsif other.empty?
+          self
+        else
+          WhereClause.new(
+            [ast.or(other.ast)],
+            binds + other.binds
+          )
+        end
       end
 
       def to_h(table_name = nil)

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -31,6 +31,13 @@ module ActiveRecord
         )
       end
 
+      def or(other)
+        WhereClause.new(
+          [ast.or(other.ast)],
+          binds + other.binds
+        )
+      end
+
       def to_h(table_name = nil)
         equalities = predicates.grep(Arel::Nodes::Equality)
         if table_name

--- a/activerecord/test/cases/relation/where_clause_test.rb
+++ b/activerecord/test/cases/relation/where_clause_test.rb
@@ -158,6 +158,13 @@ class ActiveRecord::Relation
       assert_equal expected_binds, where_clause.or(other_clause).binds
     end
 
+    test "or does nothing with an empty where clause" do
+      where_clause = WhereClause.new([table["id"].eq(bind_param)], [attribute("id", 1)])
+
+      assert_equal where_clause, where_clause.or(WhereClause.empty)
+      assert_equal where_clause, WhereClause.empty.or(where_clause)
+    end
+
     private
 
     def table

--- a/activerecord/test/cases/relation/where_clause_test.rb
+++ b/activerecord/test/cases/relation/where_clause_test.rb
@@ -145,6 +145,19 @@ class ActiveRecord::Relation
       assert_equal where_clause.ast, where_clause_with_empty.ast
     end
 
+    test "or joins the two clauses using OR" do
+      where_clause = WhereClause.new([table["id"].eq(bind_param)], [attribute("id", 1)])
+      other_clause = WhereClause.new([table["name"].eq(bind_param)], [attribute("name", "Sean")])
+      expected_ast =
+        Arel::Nodes::Grouping.new(
+          Arel::Nodes::Or.new(table["id"].eq(bind_param), table["name"].eq(bind_param))
+        )
+      expected_binds = where_clause.binds + other_clause.binds
+
+      assert_equal expected_ast.to_sql, where_clause.or(other_clause).ast.to_sql
+      assert_equal expected_binds, where_clause.or(other_clause).binds
+    end
+
     private
 
     def table

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1794,7 +1794,7 @@ class RelationTest < ActiveRecord::TestCase
     has_author = Author.where(name: "David")
     has_title_or_author = Post.where(has_title.or(has_author)).joins(:author)
 
-    assert_equal authors(:david).posts + [post], has_title_or_author
+    assert_equal Set.new(authors(:david).posts + [post]), has_title_or_author.to_a.to_set
   end
 
   def test_or_with_having

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1779,4 +1779,28 @@ class RelationTest < ActiveRecord::TestCase
   def test_relation_join_method
     assert_equal 'Thank you for the welcome,Thank you again for the welcome', Post.first.comments.join(",")
   end
+
+  def test_or_with_two_relations
+    assert_equal Post.where(id: [1, 2]).to_a, Post.where(Post.where(id: 1).or(Post.where(id: 2)))
+  end
+
+  def test_or_with_relation_and_hash
+    assert_equal Post.where(id: [1, 2]).to_a, Post.where(Post.where(id: 1).or(id: 2))
+  end
+
+  def test_or_with_relations_for_two_different_tables
+    post = Post.create!(title: "left side of or", body: "Anything", author: authors(:mary))
+    has_title = Post.where(title: "left side of or")
+    has_author = Author.where(name: "David")
+    has_title_or_author = Post.where(has_title.or(has_author)).joins(:author)
+
+    assert_equal authors(:david).posts + [post], has_title_or_author
+  end
+
+  def test_or_with_having
+    first = Post.having(id: 1)
+    second = Post.having(id: 2)
+
+    assert_equal Post.having(id: [1, 2]).group(:id).to_a, Post.having(first.or(second)).group(:id)
+  end
 end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1803,4 +1803,12 @@ class RelationTest < ActiveRecord::TestCase
 
     assert_equal Post.having(id: [1, 2]).group(:id).to_a, Post.having(first.or(second)).group(:id)
   end
+
+  def test_or_with_null_relation
+    assert_equal [Post.find(1)], Post.where(Post.where(id: 1).or(Post.none))
+  end
+
+  def test_or_with_no_additional_parts
+    assert_equal [Post.find(1)], Post.where(Post.where(id: 1).or({}))
+  end
 end


### PR DESCRIPTION
This is an idea for another implementation of `Relation#or`, in order to
address some of the API concerns for the previous APIs. In order to make
it clear what is being changed on the relation, the result is explictly
passed to either `where` or `having`. This also removes the need to
check for "structural compatibility", since you've told us what you're
looking to use from either one. If you give two relations that don't
make sense together, it's no different than passing column names to
`where` that don't make sense, and will result in an
`ActiveRecord::StatementInvalid`.

Additionally, any arguments which would be valid to `where` or `having`
are valid arguments to `or`, as well, to allow for a slightly lighter
weight alternative.

Examples:

``` ruby
def self.for_homepage
  where(active.or(pinned))
end

def self.for_homepage
  where(active.or(pinned: true))
end
```

/cc @matthewd 
