### PR TITLE
Return value of yielded block in File.atomic_write

### DIFF
--- a/activesupport/lib/active_support/core_ext/file/atomic.rb
+++ b/activesupport/lib/active_support/core_ext/file/atomic.rb
@@ -20,7 +20,7 @@ class File
 
     temp_file = Tempfile.new(basename(file_name), temp_dir)
     temp_file.binmode
-    yield temp_file
+    return_val = yield temp_file
     temp_file.close
 
     if File.exist?(file_name)
@@ -40,6 +40,9 @@ class File
       chown(old_stat.uid, old_stat.gid, file_name)
       # This operation will affect filesystem ACL's
       chmod(old_stat.mode, file_name)
+
+      # Make sure we return the result of the yielded block
+      return_val
     rescue Errno::EPERM, Errno::EACCES
       # Changing file ownership failed, moving on.
     end

--- a/activesupport/test/core_ext/file_test.rb
+++ b/activesupport/test/core_ext/file_test.rb
@@ -57,6 +57,16 @@ class AtomicWriteTest < ActiveSupport::TestCase
     File.unlink(file_name) rescue nil
   end
 
+  def test_atomic_write_returns_result_from_yielded_block
+    block_return_value = File.atomic_write(file_name, Dir.pwd) do |file|
+      "Hello world!"
+    end
+
+    assert_equal "Hello world!", block_return_value
+  ensure
+    File.unlink(file_name) rescue nil
+  end
+
   private
     def file_name
       "atomic.file"


### PR DESCRIPTION
Staying true to Ruby convention, we now return the value of the yielded block from `File.atomic_write {...}`. This mimics the behavior of MRI's `File.open {...}`.
