### PR TITLE
Backport table_rows Comparable deprecation fix

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -589,7 +589,7 @@ module ActiveRecord
 
           # interpolate the fixture label
           row.each do |key, value|
-            row[key] = label if value == "$LABEL"
+            row[key] = value.gsub("$LABEL", label.to_s) if value.is_a?(String)
           end
 
           # generate a primary key if necessary


### PR DESCRIPTION
Fix warning: Comparable#== will no more rescue exceptions of #<=> in the next release.

This is a backport from the current activerecord/fixtures.rb
