### PR TITLE
Fix ruby 2.2 comparable warnings

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -589,7 +589,7 @@ module ActiveRecord
 
           # interpolate the fixture label
           row.each do |key, value|
-            row[key] = label if value == "$LABEL"
+            row[key] = label if value.is_a?(String) && value == "$LABEL"
           end
 
           # generate a primary key if necessary

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -223,6 +223,7 @@ module ActiveSupport
     # Compare this time zone to the parameter. The two are compared first on
     # their offsets, and then by name.
     def <=>(zone)
+      return unless zone.respond_to?(:utc_offset) && zone.respond_to?(:name)
       result = (utc_offset <=> zone.utc_offset)
       result = (name <=> zone.name) if result == 0
       result


### PR DESCRIPTION
Both changes fix issues with warning messages displayed.

The time_with_zone change doesn't appear to be a problem in master on Ruby 2.2, but it does cause the warning message issue in 3-2-stable.
