### PR TITLE
Add fix for loading fixtures in engine tests (additional fix for #4971)

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
@@ -20,4 +20,5 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
+  ActiveSupport::TestCase.fixtures :all
 end


### PR DESCRIPTION
#17029 is not enough to fix #4971 because there is still a need to modify `test_helper.rb` manually for loading fixtures.

`test_helper.rb` in an engine should be configured to use fixtures out of the box in the same way as a normal Rails application, so I've add a fix for loading fixtures in the fixture path.
