### PR TITLE
Fixed AR::Relation#group method when argument is a SQL reserved keyword

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fixed ActiveRecord::Relation#group method when argument is SQL reserved key word:
+
+      SplitTest.group(:key).count
+      Property.group(:value).count
+
+    *Bogdan Gusiev*
+
 *   Added the `#or` method on ActiveRecord::Relation, allowing use of the OR
     operator to combine WHERE or HAVING clauses.
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -887,11 +887,11 @@ module ActiveRecord
       arel.having(having_clause.ast) unless having_clause.empty?
       arel.take(connection.sanitize_limit(limit_value)) if limit_value
       arel.skip(offset_value.to_i) if offset_value
-      arel.group(*group_values.uniq.reject(&:blank?)) unless group_values.empty?
+      arel.group(*arel_columns(group_values.uniq.reject(&:blank?))) unless group_values.empty?
 
       build_order(arel)
 
-      build_select(arel, select_values.uniq)
+      build_select(arel)
 
       arel.distinct(distinct_value)
       arel.from(build_from) unless from_clause.empty?
@@ -990,19 +990,21 @@ module ActiveRecord
         .map { |join| table.create_string_join(Arel.sql(join)) }
     end
 
-    def build_select(arel, selects)
-      if !selects.empty?
-        expanded_select = selects.map do |field|
-          if (Symbol === field || String === field) && columns_hash.key?(field.to_s)
-            arel_table[field]
-          else
-            field
-          end
-        end
-
-        arel.project(*expanded_select)
+    def build_select(arel)
+      if select_values.any?
+        arel.project(*arel_columns(select_values.uniq))
       else
         arel.project(@klass.arel_table[Arel.star])
+      end
+    end
+
+    def arel_columns(columns)
+      columns.map do |field|
+        if (Symbol === field || String === field) && columns_hash.key?(field.to_s)
+          arel_table[field]
+        else
+          field
+        end
       end
     end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -16,6 +16,7 @@ require 'models/engine'
 require 'models/tyre'
 require 'models/minivan'
 require 'models/aircraft'
+require "models/possession"
 
 
 class RelationTest < ActiveRecord::TestCase
@@ -1480,6 +1481,10 @@ class RelationTest < ActiveRecord::TestCase
       .having(id: post.id).where(title: post.title).group(:id)
 
     assert_equal [post], having_then_where
+  end
+
+  def test_grouping_by_column_with_reserved_name
+    assert_equal [], Possession.select(:where).group(:where).to_a
   end
 
   def test_references_triggers_eager_loading


### PR DESCRIPTION
Fixed ActiveRecord::Relation#group method when argument is SQL reserved key word:

``` ruby
SplitTest.group(:key).count
Property.group(:value).count
```

Bonus: removed unnecessary argument for `build_select`
