### PR TITLE
Prevent rollbacks to non-existent savepoints in MySQL.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   MySQL Deadlock errors will no longer attempt to rollback to savepoints in
+    nested transactions.
+
+    MySQL will release all savepoints when it encounters a Deadlock. This would
+    cause ActiveRecord to attempt to rollback to a non-existent savepoint
+    resulting in a `SAVEPOINT active_record_X does not exist` error.
+
 *   Fixed ActiveRecord::Relation#group method when argument is SQL reserved key word:
 
       SplitTest.group(:key).count

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -184,7 +184,7 @@ module ActiveRecord
         transaction = begin_transaction options
         yield
       rescue Exception => error
-        rollback_transaction if transaction
+        handle_transaction_exception(transaction, error) if transaction
         raise
       ensure
         unless error
@@ -210,6 +210,10 @@ module ActiveRecord
       end
 
       private
+        def handle_transaction_exception(transaction, error)
+          rollback_transaction
+        end
+
         NULL_TRANSACTION = NullTransaction.new
     end
   end

--- a/activerecord/test/cases/adapters/mysql2/transaction_manager_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/transaction_manager_test.rb
@@ -1,0 +1,52 @@
+require "cases/helper"
+
+class TransactionManagerTest < ActiveRecord::TestCase
+  fixtures :tags
+
+  self.use_transactional_fixtures = false
+
+  def setup
+    @transaction_manager = ActiveRecord::Base.connection.transaction_manager
+  end
+
+  def test_mysql2_connection_adapter_transaction_manager_instance
+    assert_kind_of(ActiveRecord::ConnectionAdapters::Mysql2TransactionManager, @transaction_manager)
+  end
+
+  def test_deadlock_errors_dont_cause_rollbacks_to_non_existent_savepoints
+    error = assert_raise(ActiveRecord::StatementInvalid) do
+      ActiveRecord::Base.connection.transaction(joinable: false) do
+        ActiveRecord::Base.connection.transaction do
+          trigger_deadlock!
+        end
+      end
+    end
+
+    msg = "expected deadlock error, got '#{error.original_exception.message}'"
+    assert_equal(1213, error.original_exception.error_number, "error_number: #{msg}")
+    assert_equal('40001', error.original_exception.sql_state, "sql_state: #{msg}")
+  end
+
+  def test_detecting_a_deadlock_error
+    assert_equal(false, @transaction_manager.send(:deadlock_error?, RuntimeError.new("Error")))
+    assert_equal(true, @transaction_manager.send(:deadlock_error?, (trigger_deadlock! rescue $!)))
+  end
+
+  private
+    def trigger_deadlock!
+      conn1, conn2 = ActiveRecord::Base.connection_pool.connection, nil
+      Thread.new { conn2 = ActiveRecord::Base.connection_pool.connection }.join
+
+      conn1.transaction do
+        conn2.transaction do
+          conn1.execute("select id, name from tags where id = 1 for update")
+          conn2.execute("select id, name from tags where id = 2 for update")
+
+          [
+            Thread.new { conn1.execute("update tags set name = 'hello' where id <> 1") },
+            Thread.new { conn2.execute("update tags set name = 'world' where id <> 2") }
+          ].each(&:join)
+        end
+      end
+    end
+end


### PR DESCRIPTION
MySQL will release all savepoints in a transaction when a deadlock
is detected. This changes the behavior of error handing in
transactions for MySQL by skipping rollbacks to any savepoints that
no longer exist after a deadlock is raised.
- Add ActiveRecord::ConnectionAdapters::Mysql2TransactionManager to
  handle mysql-specific behavior for rolling back transactions when
  a deadlock error occurs.
- Add ActiveRecord::ConnectionAdapters::TransactionManager#handle_transaction_exception
  to allow subclasses to override the error handing behavior when
  an exception is raised within a transaction.
