### PR TITLE
Add NOT NULL constraint by default for references

### DIFF
--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -167,6 +167,10 @@ module Rails
           if reference? && !polymorphic?
             options[:foreign_key] = true
           end
+
+          if reference?
+            options[:null] = false
+          end
         end
       end
     end

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -190,7 +190,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
 
     assert_migration "db/migrate/#{migration}.rb" do |content|
       assert_method :change, content do |change|
-        assert_match(/add_reference :books, :author,.*\sforeign_key: true/, change)
+        assert_match(/add_reference :books, :author,.*\sforeign_key: true, null: false/, change)
         assert_match(/add_reference :books, :distributor/, change) # sanity check
         assert_no_match(/add_reference :books, :distributor,.*\sforeign_key: true/, change)
       end


### PR DESCRIPTION
changes:

``` ruby
create_table :comments do |t|
  t.references :posts, index: true, foreign_key: true
end
```

to:

``` ruby
create_table :comments do |t|
  t.references :posts, index: true, foreign_key: true, null: false
end
```
