### PR TITLE
Update asset_tag_helper

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -214,7 +214,10 @@ module ActionView
           options[:alt] = options.fetch(:alt){ image_alt(src) }
         end
 
-        options[:width], options[:height] = extract_dimensions(options.delete(:size)) if options[:size]
+        if dimensions = extract_dimensions(options.delete(:size))
+          options[:width], options[:height] = dimensions
+        end
+
         tag("img", options)
       end
 


### PR DESCRIPTION
If the options hash has `width`, `height`, and `size` keys but the `size` key does not match the regex's in `extract_dimensions` this method overrides the height and width keys to nil. This change will preserve those values.
