### PR TITLE
Use the correct connection for reset_pk_sequence

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -534,12 +534,10 @@ module ActiveRecord
                   conn.insert_fixture(row, fixture_set_name)
                 end
               end
-            end
 
-            # Cap primary key sequences to max(pk).
-            if connection.respond_to?(:reset_pk_sequence!)
-              fixture_sets.each do |fs|
-                connection.reset_pk_sequence!(fs.table_name)
+              # Cap primary key sequences to max(pk).
+              if conn.respond_to?(:reset_pk_sequence!)
+                conn.reset_pk_sequence!(fs.table_name)
               end
             end
           end


### PR DESCRIPTION
When a fs.model_class.connection uses a different database than connection, connection.reset_pk_sequence will fail with an exception causing fixture load to rollback. This is reproducible for any ActiveRecord::Base class that calls establish_connection with a different database.
