### PR TITLE
Fix appending table_name to select and group when used with subquery (fr...

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1064,11 +1064,15 @@ module ActiveRecord
     end
 
     def arel_columns(columns)
-      columns.map do |field|
-        if (Symbol === field || String === field) && columns_hash.key?(field.to_s)
-          arel_table[field]
-        else
-          field
+      if from_value
+        columns
+      else
+        columns.map do |field|
+          if (Symbol === field || String === field) && columns_hash.key?(field.to_s)
+            arel_table[field]
+          else
+            field
+          end
         end
       end
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -161,6 +161,17 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_select_with_subquery_in_from_does_not_use_original_table_name
+    relation = Comment.group(:type).select('COUNT(post_id) AS post_count, type')
+    subquery = Comment.from(relation).select('type','post_count')
+    assert_equal(relation.map(&:post_count).sort,subquery.map(&:post_count).sort)
+  end
+
+  def test_group_with_subquery_in_from_does_not_use_original_table_name
+    relation = Comment.group(:type).select('COUNT(post_id) AS post_count,type')
+    subquery = Comment.from(relation).group('type').average("post_count")
+    assert_equal(relation.map(&:post_count).sort,subquery.values.sort)
+  end
 
   def test_finding_with_conditions
     assert_equal ["David"], Author.where(:name => 'David').map(&:name)


### PR DESCRIPTION
...om)

When we use a subquery like Comment.from(subquery) it's almost always wrong choiche to
add the 'comments.' when using select or group. Fixes #18743
