### PR TITLE
[ci skip] Document format parameter of process method in AC test_case.

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -579,6 +579,7 @@ module ActionController
       #   (<tt>application/x-www-form-urlencoded</tt> or <tt>multipart/form-data</tt>).
       # - +session+: A hash of parameters to store in the session. This may be +nil+.
       # - +flash+: A hash of parameters to store in the flash. This may be +nil+.
+      # - +format+: Request format. Defaults to +nil+. Can be string or symbol.
       #
       # Example calling +create+ action and sending two params:
       #


### PR DESCRIPTION
The args are: `:params, :session, :body, :flash, :method, :format`.

This PR documents the missing `:format` argument.
