### PR TITLE
Fix a typo in deprecation warning. #process takes method instead of http_method.

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -755,7 +755,7 @@ module ActionController
           Examples:
 
           get :show, params: { id: 1 }, session: { user_id: 1 }
-          process :update, http_method: :post, params: { id: 1 }
+          process :update, method: :post, params: { id: 1 }
         MSG
       end
 


### PR DESCRIPTION
This argument used to call `http_method`. 

![screenshot 2015-01-31 21 01 33](https://cloud.githubusercontent.com/assets/1000669/5988125/5aeb42d8-a98c-11e4-81fa-f6e521a3c87a.png)

This PR updates the deprecation message to new argument name, `method`.
