### PR TITLE
Change to_key implementation

### DIFF
--- a/actionpack/test/lib/controller/fake_models.rb
+++ b/actionpack/test/lib/controller/fake_models.rb
@@ -58,7 +58,7 @@ class Comment
   attr_reader :id
   attr_reader :post_id
   def initialize(id = nil, post_id = nil); @id, @post_id = id, post_id end
-  def to_key; id ? [id] : nil end
+  def to_key; id  ? id : nil end
   def save; @id = 1; @post_id = 1 end
   def persisted?; @id.present? end
   def to_param; @id.to_s; end

--- a/actionview/lib/action_view/record_identifier.rb
+++ b/actionview/lib/action_view/record_identifier.rb
@@ -47,7 +47,7 @@ module ActionView
   #     end
   #
   #     def self.find(id)
-  #       new.tap { |post| post.to_key = [id] }
+  #       new.tap { |post| post.to_key = id }
   #     end
   #   end
   module RecordIdentifier
@@ -103,7 +103,7 @@ module ActionView
     # make sure yourself that your dom ids are valid, in case you overwrite this method.
     def record_key_for_dom_id(record)
       key = convert_to_model(record).to_key
-      key ? key.join(JOIN) : key
+      key if key
     end
   end
 end

--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -61,7 +61,7 @@ class Comment
   attr_reader :id
   attr_reader :post_id
   def initialize(id = nil, post_id = nil); @id, @post_id = id, post_id end
-  def to_key; id ? [id] : nil end
+  def to_key; id ? id : nil end
   def save; @id = 1; @post_id = 1 end
   def persisted?; @id.present? end
   def to_param; @id.to_s; end
@@ -82,7 +82,7 @@ class Tag
   attr_reader :id
   attr_reader :post_id
   def initialize(id = nil, post_id = nil); @id, @post_id = id, post_id end
-  def to_key; id ? [id] : nil end
+  def to_key; id ? id : nil end
   def save; @id = 1; @post_id = 1 end
   def persisted?; @id.present? end
   def to_param; @id; end
@@ -102,7 +102,7 @@ class CommentRelevance
   attr_reader :id
   attr_reader :comment_id
   def initialize(id = nil, comment_id = nil); @id, @comment_id = id, comment_id end
-  def to_key; id ? [id] : nil end
+  def to_key; id ? id : nil end
   def save; @id = 1; @comment_id = 1 end
   def persisted?; @id.present? end
   def to_param; @id; end
@@ -118,7 +118,7 @@ class TagRelevance
   attr_reader :id
   attr_reader :tag_id
   def initialize(id = nil, tag_id = nil); @id, @tag_id = id, tag_id end
-  def to_key; id ? [id] : nil end
+  def to_key; id ? id : nil end
   def save; @id = 1; @tag_id = 1 end
   def persisted?; @id.present? end
   def to_param; @id; end
@@ -179,6 +179,6 @@ class Plane
   end
 
   def save
-    @to_key = [1]
+    @to_key = 1
   end
 end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -98,7 +98,7 @@ class FormHelperTest < ActionView::TestCase
         def full_messages() ["Author name can't be empty"] end
       }.new
     end
-    def @post.to_key; [123]; end
+    def @post.to_key; 123; end
     def @post.id; 0; end
     def @post.id_before_type_cast; "omg"; end
     def @post.id_came_from_user?; true; end

--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -49,10 +49,10 @@ module ActiveModel
     #   end
     #
     #   person = Person.create(id: 1)
-    #   person.to_key # => [1]
+    #   person.to_key # => 1
     def to_key
       key = respond_to?(:id) && id
-      key ? [key] : nil
+      key if key
     end
 
     # Returns a +string+ representing the object's key suitable for use in URLs,
@@ -69,7 +69,7 @@ module ActiveModel
     #   person = Person.create(id: 1)
     #   person.to_param # => "1"
     def to_param
-      (persisted? && key = to_key) ? key.join('-') : nil
+      (persisted? && key = to_key) ? key.to_s : nil
     end
 
     # Returns a +string+ identifying the path associated with the object.

--- a/activemodel/lib/active_model/lint.rb
+++ b/activemodel/lib/active_model/lint.rb
@@ -45,7 +45,7 @@ module ActiveModel
       # should always return +nil+.
       def test_to_param
         assert model.respond_to?(:to_param), "The model should respond to to_param"
-        def model.to_key() [1] end
+        def model.to_key() 1 end
         def model.persisted?() false end
         assert model.to_param.nil?, "to_param should return nil when `persisted?` returns false"
       end

--- a/activemodel/test/cases/conversion_test.rb
+++ b/activemodel/test/cases/conversion_test.rb
@@ -13,7 +13,7 @@ class ConversionTest < ActiveModel::TestCase
   end
 
   test "to_key default implementation returns the id in an array for persisted records" do
-    assert_equal [1], Contact.new(id: 1).to_key
+    assert_equal 1, Contact.new(id: 1).to_key
   end
 
   test "to_param default implementation returns nil for new records" do
@@ -22,10 +22,6 @@ class ConversionTest < ActiveModel::TestCase
 
   test "to_param default implementation returns a string of ids for persisted records" do
     assert_equal "1", Contact.new(id: 1).to_param
-  end
-
-  test "to_param returns the string joined by '-'" do
-    assert_equal "abc-xyz", Contact.new(id: ["abc", "xyz"]).to_param
   end
 
   test "to_param returns nil if to_key is nil" do

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -10,7 +10,7 @@ module ActiveRecord
       def to_key
         sync_with_transaction_state
         key = self.id
-        [key] if key
+        key if key
       end
 
       # Returns the primary key value.

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -15,14 +15,14 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     topic = Topic.new
     assert_nil topic.to_key
     topic = Topic.find(1)
-    assert_equal [1], topic.to_key
+    assert_equal 1, topic.to_key
   end
 
   def test_to_key_with_customized_primary_key
     keyboard = Keyboard.new
     assert_nil keyboard.to_key
     keyboard.save
-    assert_equal keyboard.to_key, [keyboard.id]
+    assert_equal keyboard.to_key, keyboard.id
   end
 
   def test_read_attribute_with_custom_primary_key
@@ -33,7 +33,7 @@ class PrimaryKeysTest < ActiveRecord::TestCase
   def test_to_key_with_primary_key_after_destroy
     topic = Topic.find(1)
     topic.destroy
-    assert_equal [1], topic.to_key
+    assert_equal 1, topic.to_key
   end
 
   def test_integer_key

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -577,7 +577,7 @@ module ApplicationTests
       app_file 'app/models/post.rb', <<-RUBY
       class Post
         include ActiveModel::Model
-        def to_key; [1]; end
+        def to_key; "1" end
         def persisted?; true; end
       end
       RUBY


### PR DESCRIPTION
to_key implementation returned array of ids, and joins the same where ever to_key gets used.

The base implementation doesn't make use of this behaviour and unnecessarily returns array and does a join.
This can safely made to return id directly instead.
We just need a unique id to be returned by the method, any custom implementation of the same, can also take care of this, instead of relying on returning an array.

Changes to signature:

``` ruby
model.to_key => id # if id present, instead of returning [id]
model.to_key => nil # if key not present
```
