### PR TITLE
Reverse order

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -179,7 +179,7 @@ module ActiveRecord
   end
 
   UnknownAttributeError = ActiveSupport::Deprecation::DeprecatedConstantProxy.new( # :nodoc:
-    'ActiveRecord::UnknownAttributeError', 
+    'ActiveRecord::UnknownAttributeError',
     'ActiveModel::AttributeAssignment::UnknownAttributeError'
   )
 
@@ -240,5 +240,9 @@ module ActiveRecord
   #
   # The mysql, mysql2 and postgresql adapters support setting the transaction isolation level.
   class TransactionIsolationError < ActiveRecordError
+  end
+
+  # Raised when Active Record fails to reverse an order statement.
+  class UnreversableOrderError < ActiveRecordError
   end
 end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -188,6 +188,14 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal topics(:fifth).title, topics.first.title
   end
 
+  def test_reverse_order_works_with_nulls_first_or_last
+    to_reverse = "title DESC NULLS LAST, author_name  NULLS  FIRST  "
+    expected   = "title ASC NULLS FIRST, author_name DESC NULLS LAST"
+
+    reversed = Topic.order(to_reverse).reverse_order
+    assert_equal [expected], reversed.order_values
+  end
+
   def test_order_with_hash_and_symbol_generates_the_same_sql
     assert_equal Topic.order(:id).to_sql, Topic.order(:id => :asc).to_sql
   end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -196,6 +196,24 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal [expected], reversed.order_values
   end
 
+  def test_reverse_order_parses_expressions
+    expr = %q[(CONCAT(title, '"(''', author_name))] # Meaningless expression meant to test parsing of () and quotes
+    to_reverse = "#{expr} DESC , author_name  "
+    expected   = "#{expr} ASC, author_name DESC"
+
+    reversed = Topic.order(to_reverse).reverse_order
+    assert_equal [expected], reversed.order_values
+  end
+
+  def test_reverse_order_raises_on_invalid_expressions
+    assert_raise(ActiveRecord::UnreversableOrderError) do
+      Topic.order("CONCAT(title, author_name").reverse_order # missing closing parenthesis
+    end
+    assert_raise(ActiveRecord::UnreversableOrderError) do
+      Topic.order("CONCAT(title, ')").reverse_order # missing closing quote
+    end
+  end
+
   def test_order_with_hash_and_symbol_generates_the_same_sql
     assert_equal Topic.order(:id).to_sql, Topic.order(:id => :asc).to_sql
   end


### PR DESCRIPTION
Current implementation of `reverse_order` will produce invalid SQL from any valid `order_values` if they contain either:
- NULLS FIRST or LAST, or
- an expression with a comma (either as an argument separator or part of a string literal)

This PR fixes this. The first case is handled with dealing more carefully with the last words, the second case is dealt by parsing the SQL string if necessary so it is split correctly.

Note: while the examples given in the tests are simplistic, I discovered this issue when trying to reverse actual orders (by geographical distance).

Thanks
