### PR TITLE
WIP: Failing test for disabling autosave in a subclass

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -619,6 +619,17 @@ class TestDefaultAutosaveAssociationOnNewRecord < ActiveRecord::TestCase
     assert !account.persisted?
   end
 
+  def test_autosave_new_record_on_has_one_can_be_disabled_per_subclass
+    firm = NoAutosaveFirm.new("name" => "some firm")
+    account = Account.new("credit_limit" => 1000)
+
+    assert !account.persisted?
+    firm.account = account
+
+    firm.save!
+    assert !account.persisted?, 'account should not have been saved'
+  end
+
   def test_autosave_new_record_with_after_create_callback
     post = PostWithAfterCreateCallback.new(title: 'Captain Murphy', body: 'is back')
     post.comments.build(body: 'foo')

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -97,6 +97,10 @@ class Firm < Company
     end
 end
 
+class NoAutosaveFirm < Firm
+  has_one :account, foreign_key: 'firm_id', autosave: false
+end
+
 class DependentFirm < Company
   has_one :account, :foreign_key => "firm_id", :dependent => :nullify
   has_many :companies, :foreign_key => 'client_of', :dependent => :nullify


### PR DESCRIPTION
This is a continuation of the discussion in #17015 and #18198. The underlying issue is that redefining associations in subclasses causes multiple runs of `add_autosave_association_callbacks` which can break things.

The original issue in #17015 is no longer present, as `accepts_nested_attributes_for` no longer double-adds the callbacks (since 56a3d5ec9183a9bcbf140d4102d45e3928f2617a). However, the callbacks are still fragile and can cause weird sequencing bugs when associations are redefined in subclasses.

For instance, the attached test case fails because `Firm` defines the autosave callbacks, capturing the then-current value of `reflection` with autosave set to nil. The subsequent redefinition attempt from `NoAutosaveFirm` fails to turn off autosave, since the method is not redefined.

I haven't found a test case for it yet, but I believe the underlying callback-reordering-leads-to-out-of-order-writes issue that caused #17015 can still be triggered given the correct set of associations in subclasses.

There's also a relatively minor issue regarding the documentation for `add_autosave_association_callbacks` [here](https://github.com/rails/rails/blob/dd53c0679d307378cfd7fadc67a5c180f2a61562/activerecord/lib/active_record/autosave_association.rb#L174) - that's not a true statement for `has_many` or `belongs_to` associations.

I don't have a clear idea what the resolution of this is; adding additional `method_defined_within?(save_method, self)` guards still seems like a band-aid over the actual issue of not having a clear set of save-dependency metadata.
