### PR TITLE
Clarified the deprecation warning message in ActionController

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -754,8 +754,11 @@ module ActionController
 
           Examples:
 
-          get :show, params: { id: 1 }, session: { user_id: 1 }
-          process :update, method: :post, params: { id: 1 }
+          BEFORE: get :show, id: 1, session: { user_id: 1 }
+          AFTER: get :show, params: { id: 1 }, session: { user_id: 1 } 
+
+          BEFORE: patch :update, project: { id: 1 }
+          AFTER: patch :update, params: { project: { id: 1 } }
         MSG
       end
 

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -318,13 +318,25 @@ module ActionDispatch
 
             Examples:
 
+            BEFORE:
+            get '/profile',
+              id: 1,
+              headers: { 'X-Extra-Header' => '123' },
+              env: { 'action_dispatch.custom' => 'custom' }
+
+            AFTER:
             get '/profile',
               params: { id: 1 },
               headers: { 'X-Extra-Header' => '123' },
               env: { 'action_dispatch.custom' => 'custom' }
 
+            BEFORE:
             xhr :post, '/profile',
-              params: { id: 1 }
+              profile: { id: 1 }
+
+            AFTER:
+            xhr :post, '/profile',
+              params: { profile: { id: 1 } }
           MSG
         end
 


### PR DESCRIPTION
Previous deprecation warnings were confusing. It appeared
as though the two examples were before/after usages. Now there
are examples of before/after for each 'get' and 'patch'.
