### PR TITLE
Change AS::Testing::TimeHelpers#travel_to to also stub DateTime.now

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `AS::Testing::TimeHelpers#travel_to` now changes `DateTime.now` as well as
+    `Time.now` and `Date.today`.
+
+    *Yuki Nishijima*
+
 *   Add `file_fixture` to `ActiveSupport::TestCase`.
     It provides a simple mechanism to access sample files in your test cases.
 

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -99,6 +99,7 @@ module ActiveSupport
 
         simple_stubs.stub_object(Time, :now, now)
         simple_stubs.stub_object(Date, :today, now.to_date)
+        simple_stubs.stub_object(DateTime, :now, now.to_datetime)
 
         if block_given?
           begin

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -1,5 +1,6 @@
 require 'abstract_unit'
 require 'active_support/core_ext/date'
+require 'active_support/core_ext/date_time'
 require 'active_support/core_ext/numeric/time'
 
 class TimeTravelTest < ActiveSupport::TestCase
@@ -17,6 +18,7 @@ class TimeTravelTest < ActiveSupport::TestCase
 
     assert_equal expected_time.to_s(:db), Time.now.to_s(:db)
     assert_equal expected_time.to_date, Date.today
+    assert_equal expected_time.to_datetime.to_s(:db), DateTime.now.to_s(:db)
   end
 
   def test_time_helper_travel_with_block
@@ -25,10 +27,12 @@ class TimeTravelTest < ActiveSupport::TestCase
     travel 1.day do
       assert_equal expected_time.to_s(:db), Time.now.to_s(:db)
       assert_equal expected_time.to_date, Date.today
+      assert_equal expected_time.to_datetime.to_s(:db), DateTime.now.to_s(:db)
     end
 
     assert_not_equal expected_time.to_s(:db), Time.now.to_s(:db)
     assert_not_equal expected_time.to_date, Date.today
+    assert_not_equal expected_time.to_datetime.to_s(:db), DateTime.now.to_s(:db)
   end
 
   def test_time_helper_travel_to
@@ -37,6 +41,7 @@ class TimeTravelTest < ActiveSupport::TestCase
 
     assert_equal expected_time, Time.now
     assert_equal Date.new(2004, 11, 24), Date.today
+    assert_equal expected_time.to_datetime, DateTime.now
   end
 
   def test_time_helper_travel_to_with_block
@@ -45,10 +50,12 @@ class TimeTravelTest < ActiveSupport::TestCase
     travel_to expected_time do
       assert_equal expected_time, Time.now
       assert_equal Date.new(2004, 11, 24), Date.today
+      assert_equal expected_time.to_datetime, DateTime.now
     end
 
     assert_not_equal expected_time, Time.now
     assert_not_equal Date.new(2004, 11, 24), Date.today
+    assert_not_equal expected_time.to_datetime, DateTime.now
   end
 
   def test_time_helper_travel_back
@@ -57,16 +64,20 @@ class TimeTravelTest < ActiveSupport::TestCase
     travel_to expected_time
     assert_equal expected_time, Time.now
     assert_equal Date.new(2004, 11, 24), Date.today
+    assert_equal expected_time.to_datetime, DateTime.now
     travel_back
 
     assert_not_equal expected_time, Time.now
     assert_not_equal Date.new(2004, 11, 24), Date.today
+    assert_not_equal expected_time.to_datetime, DateTime.now
   end
 
   def test_travel_to_will_reset_the_usec_to_avoid_mysql_rouding
     travel_to Time.utc(2014, 10, 10, 10, 10, 50, 999999) do
       assert_equal 50, Time.now.sec
       assert_equal 0, Time.now.usec
+      assert_equal 50, DateTime.now.sec
+      assert_equal 0, DateTime.now.usec
     end
   end
 end


### PR DESCRIPTION
I had a case where I wanted `travel_to` to stub `DateTime.now` as well as `Time.now` and `Date.today`.
