### PR TITLE
Explicitly ignored wildcard verbs from head_routes

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Explicitly ignored wildcard verbs when searching for HEAD routes before fallback
+
+    Fixes an issue where a mounted rack app at root would intercept the HEAD 
+    request causing an incorrect behavior during the fall back to GET requests.
+
+    Example:
+    ```ruby
+    draw do
+        get '/home' => 'test#index'
+        mount rack_app, at: '/'
+    end
+    head '/home'
+    assert_response :success
+    ```
+    In this case, a HEAD request runs through the routes the first time and fails
+    to match anything. Then, it runs through the list with the fallback and matches
+    `get '/home'`. The original behavior would match the rack app in the first pass.
+
+    *Terence Sun*
+
 *   Migrating xhr methods to keyword arguments syntax
     in `ActionController::TestCase` and `ActionDispatch::Integration`
 

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -121,6 +121,7 @@ module ActionDispatch
         end
 
         def match_head_routes(routes, req)
+          routes.delete_if { |route| route.verb == // }
           head_routes = match_routes(routes, req)
 
           if head_routes.empty?

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3477,6 +3477,18 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/post/comments/new', new_comment_path
   end
 
+  def test_head_fetch_with_mount_on_root
+    draw do
+      get '/home' => 'test#index'
+      mount lambda { |env| [404, {"Content-Type" => "text/html"}, ["testing"]] }, at: '/'
+    end
+    head '/home'
+    assert_response :success
+
+    head '/'
+    assert_response :not_found
+  end
+
 private
 
   def draw(&block)


### PR DESCRIPTION
In match_head_routes, deleted the routes in which request.request_method was empty (matches all HTTP verbs) when responding to a HEAD request. This prevents catch-all routes (such as Racks) from intercepting the HEAD request.

Fixes #18698
