### PR TITLE
Show proper traces on Windows for the error pages

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -87,8 +87,7 @@ module ActionDispatch
 
     def source_extracts
       backtrace.map do |trace|
-        file, line = trace.split(":")
-        line_number = line.to_i
+        file, line_number = extract_file_and_line_number(trace)
 
         {
           code: source_fragment(file, line_number),
@@ -137,6 +136,13 @@ module ActionDispatch
           Hash[*(start+1..(lines.count+start)).zip(lines).flatten]
         end
       end
+    end
+
+    def extract_file_and_line_number(trace)
+      # Split by the first colon followed by some digits, which works for both
+      # Windows and Unix path styles.
+      file, line = trace.match(/^(.+?):(\d+).*$/, &:captures) || trace
+      [file, line.to_i]
     end
 
     def expand_backtrace

--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -34,6 +34,23 @@ module ActionDispatch
       assert_equal [ code: 'foo', line_number: 42 ], wrapper.source_extracts
     end
 
+    test '#source_extracts works with Windows paths' do
+      exc = TestError.new("c:/path/to/rails/app/controller.rb:27:in 'index':")
+
+      wrapper = ExceptionWrapper.new({}, exc)
+      wrapper.expects(:source_fragment).with('c:/path/to/rails/app/controller.rb', 27).returns('nothing')
+
+      assert_equal [ code: 'nothing', line_number: 27 ], wrapper.source_extracts
+    end
+
+    test '#source_extracts works with non standard backtrace' do
+      exc = TestError.new('invalid')
+
+      wrapper = ExceptionWrapper.new({}, exc)
+      wrapper.expects(:source_fragment).with('invalid', 0).returns('nothing')
+
+      assert_equal [ code: 'nothing', line_number: 0 ], wrapper.source_extracts
+    end
 
     test '#application_trace returns traces only from the application' do
       exception = TestError.new(caller.prepend("lib/file.rb:42:in `index'"))


### PR DESCRIPTION
This is an issue brought up by @daniel-rikowski in rails/web-console#91.

Citing his PR proposal here:

> Prior to this, backtrace lines were simply split by a single colon.
> 
> Unfortunately that is also the drive letter delimiter in Windows paths
> which resulted in a lot of empty source fragments of "C:0". ("C" from
> the drive letter and 0 from "/path/to/rails/file.rb:16".to_i)
> 
> Now the trace line is split by the first colon followed by some digits,
> which works for both Windows and Unix path styles.

Now, the PR was sent against web-console, because of the templates copy
issue we used to had. Instead of bothering the contributor to reopen the
issue against upstream Rails itself, I will make sure he gets the credit
by putting his name in [rails-contributors/hard_coded_authors.rb](https://github.com/fxn/rails-contributors/blob/master/app/models/names_manager/hard_coded_authors.rb).
