### PR TITLE
Initial update of cookies/cookie_store to permit changing secret keys

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -520,22 +520,22 @@ module ActionDispatch
         secret = key_generator.generate_key(@options[:encrypted_cookie_salt])
         sign_secret = key_generator.generate_key(@options[:encrypted_signed_cookie_salt])
         @encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret, digest: digest, serializer: ActiveSupport::MessageEncryptor::NullSerializer)
-        @valid_keys.push({"secret" => secret, "sign_secret" => sign_secret})
+        @valid_keys.push({"secret": secret, "sign_secret": sign_secret})
       end
 
       # This method needs a better name
       def validate_cookie_with_all_keys(cookie)
         valid = false
-        valid_keys.each do |key_pair|
+        @valid_keys.each do |key_pair|
           begin
-            secret = key_pair["secret"]
-            sign_secret = key_pair["sign_secret"]
+            secret = key_pair[:"secret"]
+            sign_secret = key_pair[:"sign_secret"]
             temp_encryptor = ActiveSupport::MessageEncryptor.new(secret,
               sign_secret, digest: digest,
               serializer: ActiveSupport::MessageEncryptor::NullSerializer)
             temp_encryptor.decrypt_and_verify(cookie)
             valid = true
-          rescue InvalidMessage
+          rescue ActiveSupport::MessageEncryptor::InvalidMessage
             valid ||= false
           end
         end

--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -118,6 +118,12 @@ module ActionDispatch
         request = ActionDispatch::Request.new(env)
         request.cookie_jar.signed_or_encrypted
       end
+
+      def valid_cookie?(env)
+        cookie = get_cookie(env)
+        cookie_jar(env).validate_cookie_with_all_keys(cookie)
+      end
+
     end
   end
 end

--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -123,7 +123,6 @@ module ActionDispatch
         cookie = get_cookie(env)
         cookie_jar(env).validate_cookie_with_all_keys(cookie)
       end
-
     end
   end
 end

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -764,14 +764,17 @@ class CookiesTest < ActionController::TestCase
     cookies.encrypted[:test1] = "test1"
 
     @request.env["action_dispatch.secret_key_base"] = "315fcfbb748b8f072e34a0db321cbafa"
-    @request.env["action_dispatch.secret_key_base"] = "315fcfbb748b8f072e34a0db321cbafa"
     @request.env["action_dispatch.key_generator"] = ActiveSupport::KeyGenerator.new("315fcfbb748b8f072e34a0db321cbafa", iterations: 2)
     key_generator = @request.env["action_dispatch.key_generator"]
     enc_salt = @request.env["action_dispatch.encrypted_cookie_salt"]
     signed_salt = @request.env["action_dispatch.encrypted_signed_cookie_salt"]
-    cookies.encrypted.set_key(key_generator, {encrypted_cookie_salt: enc_salt, encrypted_signed_cookie_salt: signed_salt})
-    cookies.encrypted[:test2] = "test2"
-    cookies.encrypted.validate_cookie_with_all_keys(cookies.encrypted[:test2])
+    cookies.encrypted.set_key(key_generator,
+      {encrypted_cookie_salt: enc_salt,
+       encrypted_signed_cookie_salt: signed_salt
+      })
+    #cookies.encrypted[:test2] = "test2"
+    get :set_signed_cookie
+    #cookies.encrypted.validate_cookie_with_all_keys("bar")
   end
 
   def test_legacy_signed_cookie_is_read_and_transparently_upgraded_by_signed_cookie_jar_if_both_secret_token_and_secret_key_base_are_set


### PR DESCRIPTION
`cookies` and `cookie_store` (should) now support changing secret keys without invalidating all cookies made with an old key. When an `EncryptedCookieJar` is created, it initializes a list of `(secret_key, sign_secret)`pairs, which is updated whenever the key is changed. Decrypting a cookie is achieved by checking the result of decrypting with every key stored, and validating the cookie if any of the decryptions do not fail.
