### PR TITLE
Changed distinct method to use column names as inputs #17706

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -786,6 +786,9 @@ module ActiveRecord
     #
     #   User.select(:name).distinct.distinct(false)
     #   # => You can also remove the uniqueness
+    #   
+    #   User.distinct(:name)
+    #   # => Returns all columns in record per distinct name 
     def distinct(value = true)
       spawn.distinct!(value)
     end
@@ -893,7 +896,11 @@ module ActiveRecord
 
       build_select(arel)
 
-      arel.distinct(distinct_value)
+      if ((distinct_value.is_a? TrueClass) || (distinct_value.is_a? FalseClass) || distinct_value.nil?)
+        arel.distinct(distinct_value)
+      else
+        arel.distinct_on(Arel.sql(distinct_value))
+      end
       arel.from(build_from) unless from_clause.empty?
       arel.lock(lock_value) if lock_value
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Added the ability to select distinct on a particular column.
+
+      Events.distinct(true)
+      Events.distinct(:id) 
+
+      if ((distinct_value.is_a? TrueClass) || (distinct_value.is_a? FalseClass) || distinct_value.nil?)
+        arel.distinct(distinct_value)
+      else
+        arel.distinct_on(Arel.sql(distinct_value))
+      end
+ 
+    Both distinct method calls should now work. GH#17706
+ 
+    *Isobeye Daso*
+
 *   Rename `--skip-test-unit` option to `--skip-test` in app generator
 
     *Melanie Gilman*


### PR DESCRIPTION
The distinct method now takes in column names for selecting all rows in distinct records. This should solve #17706 .

Example: Events.distinct(:id) => "Select Distinct ON ( id) \* From Events"
