### PR TITLE
Fallback to RAILS_RELATIVE_URL_ROOT in `url_for`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fallback to `ENV['RAILS_RELATIVE_URL_ROOT']` in `url_for`.
+
+    Fixed an issue where the `RAILS_RELATIVE_URL_ROOT` environment variable is not
+    prepended to the path when `url_for` is called. If `SCRIPT_NAME` (used by Rack)
+    is set, it takes precedence.
+
+    Fixes #5122.
+
+    *Yasyf Mohamedali*
+
 *   Partitioning of routes is now done when the routes are being drawn. This
     helps to decrease the time spent filtering the routes during the first request.
 

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -40,6 +40,8 @@ module ActionDispatch
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie
 
       ActionDispatch.test_app = app
+
+      ActionDispatch::Routing::RouteSet.relative_url_root = app.config.relative_url_root
     end
   end
 end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -20,6 +20,8 @@ module ActionDispatch
       # alias inspect to to_s.
       alias inspect to_s
 
+      mattr_accessor :relative_url_root
+
       class Dispatcher < Routing::Endpoint
         def initialize(defaults)
           @defaults = defaults
@@ -697,7 +699,7 @@ module ActionDispatch
       end
 
       def find_script_name(options)
-        options.delete(:script_name) || ''
+        options.delete(:script_name) || relative_url_root || ''
       end
 
       def path_for(options, route_name = nil)

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -255,6 +255,16 @@ module AbstractController
         )
       end
 
+      def test_relative_url_root_is_respected_with_environment_variable
+        # `config.relative_url_root` is set by ENV['RAILS_RELATIVE_URL_ROOT']
+        ActionDispatch::Routing::RouteSet.relative_url_root = '/subdir'
+        add_host!
+        assert_equal('https://www.basecamphq.com/subdir/c/a/i',
+          W.new.url_for(:controller => 'c', :action => 'a', :id => 'i', :protocol => 'https')
+        )
+        ActionDispatch::Routing::RouteSet.relative_url_root = nil
+      end
+
       def test_named_routes
         with_routing do |set|
           set.draw do


### PR DESCRIPTION
Fixed an issue where the `RAILS_RELATIVE_URL_ROOT` environment
variable is not prepended to the path when `url_for` is called.
If `SCRIPT_NAME` (used by Rack) is set, it takes precedence.

Fixes #5122.
