### PR TITLE
Cache `url_helpers`

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -410,61 +410,63 @@ module ActionDispatch
       end
 
       def url_helpers(supports_path = true)
-        routes = self
+        @url_helpers ||= begin
+          routes = self
 
-        Module.new do
-          extend ActiveSupport::Concern
-          include UrlFor
+          Module.new do
+            extend ActiveSupport::Concern
+            include UrlFor
 
-          # Define url_for in the singleton level so one can do:
-          # Rails.application.routes.url_helpers.url_for(args)
-          @_routes = routes
-          class << self
-            def url_for(options)
-              @_routes.url_for(options)
+            # Define url_for in the singleton level so one can do:
+            # Rails.application.routes.url_helpers.url_for(args)
+            @_routes = routes
+            class << self
+              def url_for(options)
+                @_routes.url_for(options)
+              end
+
+              def optimize_routes_generation?
+                @_routes.optimize_routes_generation?
+              end
+
+              attr_reader :_routes
+              def url_options; {}; end
             end
 
-            def optimize_routes_generation?
-              @_routes.optimize_routes_generation?
+            url_helpers = routes.named_routes.url_helpers_module
+
+            # Make named_routes available in the module singleton
+            # as well, so one can do:
+            # Rails.application.routes.url_helpers.posts_path
+            extend url_helpers
+
+            # Any class that includes this module will get all
+            # named routes...
+            include url_helpers
+
+            if supports_path
+              path_helpers = routes.named_routes.path_helpers_module
+
+              include path_helpers
+              extend path_helpers
             end
 
-            attr_reader :_routes
-            def url_options; {}; end
+            # plus a singleton class method called _routes ...
+            included do
+              singleton_class.send(:redefine_method, :_routes) { routes }
+            end
+
+            # And an instance method _routes. Note that
+            # UrlFor (included in this module) add extra
+            # conveniences for working with @_routes.
+            define_method(:_routes) { @_routes || routes }
+
+            define_method(:_generate_paths_by_default) do
+              supports_path
+            end
+
+            private :_generate_paths_by_default
           end
-
-          url_helpers = routes.named_routes.url_helpers_module
-
-          # Make named_routes available in the module singleton
-          # as well, so one can do:
-          # Rails.application.routes.url_helpers.posts_path
-          extend url_helpers
-
-          # Any class that includes this module will get all
-          # named routes...
-          include url_helpers
-
-          if supports_path
-            path_helpers = routes.named_routes.path_helpers_module
-
-            include path_helpers
-            extend path_helpers
-          end
-
-          # plus a singleton class method called _routes ...
-          included do
-            singleton_class.send(:redefine_method, :_routes) { routes }
-          end
-
-          # And an instance method _routes. Note that
-          # UrlFor (included in this module) add extra
-          # conveniences for working with @_routes.
-          define_method(:_routes) { @_routes || routes }
-
-          define_method(:_generate_paths_by_default) do
-            supports_path
-          end
-
-          private :_generate_paths_by_default
         end
       end
 


### PR DESCRIPTION
`url_helpers` used to be memoized. This was lost in a refactoring and
this PR adds it back. We noticed this while investigating why
integration tests are slower than controller tests.

cc/ @pixeltrix 
