### PR TITLE
Take DST into account when locating TimeZone from Numeric

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Take DST into account when locating TimeZone from Numeric.
+
+    When given a specific offset, use the first result found where the
+    total current offset (including any periodic deviations such as DST)
+    from UTC is equal.
+
+    Fixes #15209.
+
+    *Yasyf Mohamedali*
+
 *   Added `#without` on `Enumerable` and `Array` to return a copy of an
     enumerable without the specified elements.
 

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -239,7 +239,7 @@ module ActiveSupport
           end
           when Numeric, ActiveSupport::Duration
             arg *= 3600 if arg.abs <= 13
-            all.find { |z| z.utc_offset == arg.to_i }
+            all.find { |z| z.utc_total_offset == arg.to_i }
           else
             raise ArgumentError, "invalid argument to TimeZone[]: #{arg.inspect}"
         end
@@ -283,6 +283,12 @@ module ActiveSupport
         @current_period ||= tzinfo.current_period if tzinfo
         @current_period.utc_offset if @current_period
       end
+    end
+
+    # Returns the offset of this time zone from UTC in seconds,
+    # taking DST into account.
+    def utc_total_offset
+      tzinfo.current_period.utc_total_offset if tzinfo
     end
 
     # Returns the offset of this time zone as a formatted string, of the

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -867,6 +867,13 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < ActiveSupport::TestCase
     end
   end
 
+  def test_in_time_zone_with_dst
+    travel_to(Time.utc(2014, 5, 20, 4, 59, 59))
+    time = Time.now.in_time_zone(-4)
+    assert_equal (-4*3600), time.time_zone.utc_total_offset
+    travel_back
+  end
+
   def test_in_time_zone_with_invalid_argument
     assert_raise(ArgumentError) {  @t.in_time_zone("No such timezone exists") }
     assert_raise(ArgumentError) { @dt.in_time_zone("No such timezone exists") }


### PR DESCRIPTION
When given a specific offset, use the first result found where the
total current offset (including any periodic deviations such as DST)
from UTC is equal.

Fixes #15209.
