### PR TITLE
Table exists fix

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fixed ActiveRecord::Base.connection.table_exists? method to escape
+    underscore in SQL LIKE clause when using MySQL. Previously,
+    table_exists('Foo_') will return true if any table named "Foo?" exists 
+    where "?" can be any character. 
+    
+    *Kai Huang*
+
 *   Fixed ActiveRecord::Relation#group method when argument is SQL reserved key word:
 
     Example:

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -287,6 +287,10 @@ module ActiveRecord
         0
       end
 
+      def quote_like(str)
+        quote(str).gsub('_', '\_')
+      end
+
       # REFERENTIAL INTEGRITY ====================================
 
       def disable_referential_integrity #:nodoc:
@@ -410,7 +414,7 @@ module ActiveRecord
       def tables(name = nil, database = nil, like = nil) #:nodoc:
         sql = "SHOW TABLES "
         sql << "IN #{quote_table_name(database)} " if database
-        sql << "LIKE #{quote(like)}" if like
+        sql << "LIKE #{quote_like(like)}" if like
 
         execute_and_free(sql, 'SCHEMA') do |result|
           result.collect(&:first)


### PR DESCRIPTION
Added escape for underscore in SQL query LIKE clause used by ActiveRecord::Base.connection.table_exists?() when MySQL is used.

Fixes #17897
