### PR TITLE
Making json parsing more strict by removing quirks mode as the default

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -394,7 +394,7 @@ module ActionDispatch
 
     class JsonSerializer
       def self.load(value)
-        ActiveSupport::JSON.decode(value)
+        ActiveSupport::JSON.decode_loose(value)
       end
 
       def self.dump(value)

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -136,11 +136,15 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
-  test "parses json with non-object JSON content" do
-    assert_parses(
-      {"user" => {"_json" => "string content" }, "_json" => "string content" },
-      "\"string content\"", { 'CONTENT_TYPE' => 'application/json' }
-    )
+  test "logs error if parsing json with non-object JSON content unsuccessful" do
+    with_test_routing(UsersController) do
+      output = StringIO.new
+      json = "\"string content\""
+      post "/parse", params: json, headers: { 'CONTENT_TYPE' => 'application/json', 'action_dispatch.show_exceptions' => true, 'action_dispatch.logger' => ActiveSupport::Logger.new(output) }
+      assert_response :bad_request
+      output.rewind && err = output.read
+      assert err =~ /Error occurred while parsing request parameters/
+    end
   end
 
   private

--- a/actionview/test/template/erb_util_test.rb
+++ b/actionview/test/template/erb_util_test.rb
@@ -51,7 +51,7 @@ class ErbUtilTest < ActiveSupport::TestCase
 
   def test_json_escape_does_not_alter_json_string_meaning
     JSON_ESCAPE_TEST_CASES.each do |(raw, _)|
-      assert_equal ActiveSupport::JSON.decode(raw), ActiveSupport::JSON.decode(json_escape(raw))
+      assert_equal ActiveSupport::JSON.decode_loose(raw), ActiveSupport::JSON.decode_loose(json_escape(raw))
     end
   end
 

--- a/activerecord/lib/active_record/coders/json.rb
+++ b/activerecord/lib/active_record/coders/json.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       end
 
       def self.load(json)
-        ActiveSupport::JSON.decode(json) unless json.nil?
+        ActiveSupport::JSON.decode_loose(json) unless json.nil?
       end
     end
   end

--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -23,6 +23,24 @@ module ActiveSupport
             "and has been removed."
         end
 
+        data = ::JSON.parse(json)
+
+        if ActiveSupport.parse_json_times
+          convert_dates_from(data)
+        else
+          data
+        end
+      end
+
+      # Parses a JSON string (JavaScript Object Notation) into a hash, with quirks mode enabled.
+      # Makes it possible to generate single JSON values in addition to documents.
+      def decode_loose(json, options = {})
+        if options.present?
+          raise ArgumentError, "In Rails 4.1, ActiveSupport::JSON.decode no longer " \
+            "accepts an options hash for MultiJSON. MultiJSON reached its end of life " \
+            "and has been removed."
+        end
+
         data = ::JSON.parse(json, quirks_mode: true)
 
         if ActiveSupport.parse_json_times

--- a/activesupport/test/json/decoding_test.rb
+++ b/activesupport/test/json/decoding_test.rb
@@ -60,7 +60,21 @@ class TestJSONDecoding < ActiveSupport::TestCase
     %q({"a":"\u000a"}) => {"a"=>"\n"},
     %q({"a":"Line1\u000aLine2"}) => {"a"=>"Line1\nLine2"},
     # prevent json unmarshalling
-    %q({"json_class":"TestJSONDecoding::Foo"}) => {"json_class"=>"TestJSONDecoding::Foo"},
+    %q({"json_class":"TestJSONDecoding::Foo"}) => {"json_class"=>"TestJSONDecoding::Foo"}
+  }
+
+  TESTS.each_with_index do |(json, expected), index|
+    test "json decodes #{index}" do
+      with_parse_json_times(true) do
+        silence_warnings do
+          assert_equal expected, ActiveSupport::JSON.decode(json), "JSON decoding \
+          failed for #{json}"
+        end
+      end
+    end
+  end
+
+  TESTS_LOOSE = {
     # json "fragments" - these are invalid JSON, but ActionPack relies on this
     %q("a string") => "a string",
     %q(1.1) => 1.1,
@@ -71,11 +85,11 @@ class TestJSONDecoding < ActiveSupport::TestCase
     %q(null) => nil
   }
 
-  TESTS.each_with_index do |(json, expected), index|
-    test "json decodes #{index}" do
+  TESTS_LOOSE.each_with_index do |(json, expected), index|
+    test "json decodes #{TESTS.length + index}" do
       with_parse_json_times(true) do
         silence_warnings do
-          assert_equal expected, ActiveSupport::JSON.decode(json), "JSON decoding \
+          assert_equal expected, ActiveSupport::JSON.decode_loose(json), "JSON decoding \
           failed for #{json}"
         end
       end


### PR DESCRIPTION
In response to issue #18699, made strict JSON parsing the default, and created a separate method to enable quirks mode, which is needed by ActionPack.  Changed tests to use the quirks mode parsing method when necessary.
