### PR TITLE
Change reference to associated model when association_id changes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Change reference to associated model when association_id changes.
+
+    Example:
+
+        comment = Comment.create!(:post => post1)
+
+        found_comment = post1.comments.find comment.id
+        found_comment.post_id = post2.id
+
+        assert_equal post2.id, found_comment.post.id # no longer fails
+
+    Fixes #18633.
+
+    *Yasyf Mohamedali*
+
 *   Validation errors would be raised for parent records when an association
     was saved when the parent had `validate: false`. It should not be the
     responsibility of the model to validate an associated object unless the

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -769,6 +769,21 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal companies(:another_firm), client.firm_with_condition
   end
 
+  def test_reassigning_the_association_id_updates_the_reference
+    record1 = RecordWithColumns.create!
+    record2 = RecordWithColumns.create!
+    column = Column.create!(:record => record1)
+
+    found_column = record1.columns.find column.id
+    found_column.record_id = record2.id
+
+    record2_proxy = found_column.send(:association, :record)
+    assert !record2_proxy.inversed
+
+    assert_equal record2.id, found_column.record.id
+    assert_equal record2.id, found_column.record_id
+  end
+
   def test_polymorphic_reassignment_of_associated_id_updates_the_object
     sponsor = sponsors(:moustache_club_sponsor_for_groucho)
 

--- a/activerecord/test/models/record.rb
+++ b/activerecord/test/models/record.rb
@@ -1,2 +1,8 @@
 class Record < ActiveRecord::Base
 end
+
+class RecordWithColumns < Record
+  self.table_name = "records"
+
+  has_many :columns, :foreign_key => 'record_id'
+end


### PR DESCRIPTION
Example:

```
comment = Comment.create!(:post => post1)

found_comment = post1.comments.find comment.id
found_comment.post_id = post2.id

assert_equal post2.id, found_comment.post.id # no longer fails
```

Fixes #18633.
