### PR TITLE
Actionview image tag size option override

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -207,6 +207,7 @@ module ActionView
       #   # => <img alt="Icon" class="menu_icon" src="/icons/icon.gif" />
       def image_tag(source, options={})
         options = options.symbolize_keys
+        check_for_image_tag_errors(options)
 
         src = options[:src] = path_to_image(source)
 
@@ -323,6 +324,12 @@ module ActionView
             size.split('x')
           elsif size =~ %r{\A\d+\z}
             [size, size]
+          end
+        end
+
+        def check_for_image_tag_errors(options)
+          if options[:size] && (options[:height] || options[:width])
+            raise ArgumentError, "Cannot pass a :size option with a :height or :width option"
           end
         end
     end

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -464,6 +464,14 @@ class AssetTagHelperTest < ActionView::TestCase
     assert_equal({:size => '16x10'}, options)
   end
 
+  def test_image_tag_raises_an_error_for_competing_size_arguments
+    exception = assert_raise(ArgumentError) do
+      image_tag("gold.png", :height => "100", :width => "200", :size => "45x70")
+    end
+
+    assert_equal("Cannot pass a :size option with a :height or :width option", exception.message)
+  end
+
   def test_favicon_link_tag
     FaviconLinkToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end


### PR DESCRIPTION
If the options hash has width, height, and size keys but the size key does not match the regex in `extract_dimensions` this method overrides the height and width keys to nil. This change will preserve those values.
