### PR TITLE
Copy association cache on ActiveRecord::Persistence#becomes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   ActiveRecord::Persistence#becomes now copies preloaded associations to the
+    new class.
+
+    This fixes an issue where calling `includes` or `preload` on a model and
+    then converting with `#becomes` would discard the cached associations,
+    causing them to be reloaded with n+1 queries.
+
+    *Benjamin Manns*
+
 *   Fix rounding problem for PostgreSQL timestamp column.
 
     If timestamp column have the precision, it need to format according to

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -203,12 +203,14 @@ module ActiveRecord
     # like render <tt>partial: @client.becomes(Company)</tt> to render that
     # instance using the companies/company partial instead of clients/client.
     #
-    # Note: The new instance will share a link to the same attributes as the original class.
-    # So any change to the attributes in either instance will affect the other.
+    # Note: The new instance will share a link to the same attributes and associations
+    # as the original class. So any change to the attributes or associations in either
+    # instance will affect the other.
     def becomes(klass)
       became = klass.new
       became.instance_variable_set("@attributes", @attributes)
       became.instance_variable_set("@changed_attributes", @changed_attributes) if defined?(@changed_attributes)
+      became.instance_variable_set("@association_cache", @association_cache)
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became.instance_variable_set("@errors", errors)

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -7,6 +7,7 @@ require 'models/topic'
 require 'models/reply'
 require 'models/category'
 require 'models/company'
+require 'models/contract'
 require 'models/developer'
 require 'models/computer'
 require 'models/project'
@@ -166,6 +167,14 @@ class PersistenceTest < ActiveRecord::TestCase
     client = company.becomes(Client)
     assert_equal "37signals", client.name
     assert_equal %w{name}, client.changed
+  end
+
+  def test_becomes_includes_association_cache
+    company = Company.preload(:contracts).first
+    client = company.becomes(Client)
+    assert_no_queries do
+      client.contracts.to_a
+    end
   end
 
   def test_delete_many


### PR DESCRIPTION
If you preload attributes using one of the eager loading strategies, and then convert the model to another class using `becomes`, the cached associations are lost and a new set of database queries will be executed to reload the associated models. This will result in N+1 queries that (or really N+2) should already be loaded.

For example:

``` ruby
users = User.preload(widgets: :comments)
users.each do |user| # Load users, load widgets, load comments
  u = user.becomes(OtherClass) # Trash association_cache
  u.widgets.each do |widget| # Load widgets (N)
    puts "Widget: #{widget.name}"
    widget.comments.each do |comment| # Load comments (N*N)
      puts comment.text
    end
  end
end
```
