### PR TITLE
Call to_s before checking html_safe? during concat

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -238,8 +238,9 @@ module ActiveSupport #:nodoc:
     private
 
     def html_escape_interpolated_argument(arg)
+      arg = arg.to_s
       (!html_safe? || arg.html_safe?) ? arg :
-        arg.to_s.gsub(ERB::Util::HTML_ESCAPE_REGEXP, ERB::Util::HTML_ESCAPE)
+        arg.gsub(ERB::Util::HTML_ESCAPE_REGEXP, ERB::Util::HTML_ESCAPE)
     end
   end
 end


### PR DESCRIPTION
This mirrors the behaviour of [unwrapped_html_escape](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/string/output_safety.rb#L35) and makes it less surprising when concatting a string with an object that implements to_s.

``` ruby
class Post
  def to_s
    "<div>world</div>".html_safe
  end
end

string = "<div>hello</div>".html_safe + Post.new
string.html_safe?
=> false # BEFORE PATCH
=> true # AFTER PATCH
```
