### PR TITLE
Dont load app on db:structure:load

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -280,7 +280,7 @@ db_namespace = namespace :db do
     end
 
     # desc "Recreate the databases from the structure.sql file"
-    task :load => [:environment, :load_config] do
+    task :load => [:load_config] do
       ActiveRecord::Tasks::DatabaseTasks.load_schema_current(:sql, ENV['DB_STRUCTURE'])
     end
 


### PR DESCRIPTION
this will fix various issues with rails-observers (which forces observed models to load) combined with e.g. attr_encrypted whose macros depend on AR column information. see https://github.com/attr-encrypted/attr_encrypted/commit/c850d35a901c16ee138a09f51fd82c61db0c5b03#commitcomment-9545615
