### PR TITLE
A typo fix and a small clarification on `autoload_paths`

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -461,8 +461,9 @@ Also, this collection is configurable via `config.autoload_paths`. For example,
 by adding this to `config/application.rb`:
 
 ```ruby
-config.autoload_paths += "#{Rails.root}/lib"
+config.autoload_paths << "#{Rails.root}/lib"
 ```
+`config.autoload_paths` is accessible from environment-specific configuration files, but any changes made to it outside `config/application.rb` don't have an effect.
 
 The value of `autoload_paths` can be inspected. In a just generated application
 it is (edited):


### PR DESCRIPTION
I'm not sure if it's useful to mention in this doc that you can't have environment-specific `autoload_paths`. This is something I stumbled on and thought it could save someone's time.
