### PR TITLE
Consistent foreign key name generation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Foreign keys added by migrations were given random, generated names. This
+    meant a different `structure.sql` would be generated every time a developer
+    ran migrations on their machine.
+
+    The generated part of foreign key names is now a hash of the table name and
+    column name, which is consistent every time you run the migration.
+
+    *Chris Sinjakli*
+
 *   Validation errors would be raised for parent records when an association
     was saved when the parent had `validate: false`. It should not be the
     responsibility of the model to validate an associated object unless the

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1,4 +1,6 @@
 require 'active_record/migration/join_table'
+require 'active_support/core_ext/string/access'
+require 'digest'
 
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
@@ -990,8 +992,10 @@ module ActiveRecord
       end
 
       def foreign_key_name(table_name, options) # :nodoc:
+        identifier = "#{table_name}_#{options.fetch(:column)}_fk"
+        hashed_identifier = Digest::SHA256.hexdigest(identifier).first(10)
         options.fetch(:name) do
-          "fk_rails_#{SecureRandom.hex(5)}"
+          "fk_rails_#{hashed_identifier}"
         end
       end
 

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -57,7 +57,7 @@ module ActiveRecord
         assert_equal "rockets", fk.to_table
         assert_equal "rocket_id", fk.column
         assert_equal "id", fk.primary_key
-        assert_match(/^fk_rails_.{10}$/, fk.name)
+        assert_equal("fk_rails_78146ddd2e", fk.name)
       end
 
       def test_add_foreign_key_with_column
@@ -71,7 +71,7 @@ module ActiveRecord
         assert_equal "rockets", fk.to_table
         assert_equal "rocket_id", fk.column
         assert_equal "id", fk.primary_key
-        assert_match(/^fk_rails_.{10}$/, fk.name)
+        assert_equal("fk_rails_78146ddd2e", fk.name)
       end
 
       def test_add_foreign_key_with_non_standard_primary_key


### PR DESCRIPTION
Following up on [a discussion](https://groups.google.com/forum/#!topic/rubyonrails-core/psnWNqZ4XWg) from the rubyonrails-core list.

Rails 4.2 added support for foreign keys in database migrations. The names for those foreign keys are randomly generated, which means every developer who runs the migrations on their machine generates a conflicting `structure.sql`.

This PR switches to a consistent algorithm for FK name generation, using a hash of the table and column names.

I believe this change is non-breaking (migrations which people have already run with Rails 4.2 are unaffected), so can be backported into `4-2-stable`. I'm not sure on the process for that, but I'm happy to put in another PR against that branch if that's how it's done.
