### PR TITLE
Reload the reference when the reference id is assigned

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -73,7 +73,7 @@ module ActiveRecord
       #
       # Note that if the target has not been loaded, it is not considered stale.
       def stale_target?
-        !inversed && loaded? && @stale_state != stale_state
+        (!inversed || loaded?) && @stale_state != stale_state
       end
 
       # Sets the target of this association to <tt>\target</tt>, and the \loaded flag to +true+.

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -19,6 +19,7 @@ require 'models/invoice'
 require 'models/line_item'
 require 'models/column'
 require 'models/record'
+require 'models/entrant'
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
@@ -947,6 +948,18 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
     assert post.save
     assert_equal post.author_id, author2.id
+  end
+
+  def test_change_reference_id_should_change_reference
+    course1 = Course.create!(:name => 'Course 1')
+    course2 = Course.create!(:name => 'Course 2')
+    entrant = Entrant.create!(:course => course1, :name => 'Entrant')
+
+    founded_entrant = course1.entrants.find entrant.id
+    founded_entrant.course_id = course2.id
+
+    assert_equal course2.id, founded_entrant.course_id
+    assert_equal course2.id, founded_entrant.course.id
   end
 
   test 'dangerous association name raises ArgumentError' do


### PR DESCRIPTION
Example:

```
comment = Comment.create!(:post => post1)

found_comment = post1.comments.find comment.id
found_comment.post_id = post2.id

assert_equal post2.id, found_comment.post.id # no longer fails
```

Fixes #18633.
