### PR TITLE
Fix AM#Dirty introduction example

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -26,6 +26,10 @@ module ActiveModel
   #
   #     define_attribute_methods :name
   #
+  #     def initialize name = nil
+  #       @name = name
+  #     end
+  #
   #     def name
   #       @name
   #     end
@@ -54,7 +58,7 @@ module ActiveModel
   #
   # A newly instantiated object is unchanged:
   #
-  #   person = Person.find_by(name: 'Uncle Bob')
+  #   person = Person.new 'Uncle Bob'
   #   person.changed?       # => false
   #
   # Change the name:


### PR DESCRIPTION
Person class doesn't contain finder methods, hence usage of `Person.find_by` is wrong.

Added simple initialize and made use of `Person.new` instead of `Person.find_by` to clarify the docs.
[ci skip]
