### PR TITLE
Added `Relation#unscope` support for uniq/distinct

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Added support for `Relation#unscope` to work with `:uniq` and/or `:distinct` options,
+    to remove distinct clause from a relation.
+
+    *Vipul A M*
+
 *   Foreign keys added by migrations were given random, generated names. This
     meant a different `structure.sql` would be generated every time a developer
     ran migrations on their machine.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -345,7 +345,7 @@ module ActiveRecord
 
     VALID_UNSCOPING_VALUES = Set.new([:where, :select, :group, :order, :lock,
                                      :limit, :offset, :joins, :includes, :from,
-                                     :readonly, :having])
+                                     :readonly, :having, :distinct, :uniq])
 
     # Removes an unwanted relation that is already defined on a chain of relations.
     # This is useful when passing around chains of relations and would like to
@@ -904,6 +904,7 @@ module ActiveRecord
       if !VALID_UNSCOPING_VALUES.include?(scope)
         raise ArgumentError, "Called unscope() with invalid unscoping argument ':#{scope}'. Valid arguments are :#{VALID_UNSCOPING_VALUES.to_a.join(", :")}."
       end
+      scope = :distinct if scope == :uniq
 
       clause_method = Relation::CLAUSE_METHODS.include?(scope)
       multi_val_method = Relation::MULTI_VALUE_METHODS.include?(scope)

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -185,6 +185,18 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_equal expected, received
   end
 
+  def test_unscope_with_distinct_in_query
+    expected = Developer.order('salary DESC').collect(&:salary)
+    received = DeveloperOrderedBySalary.select('salary').distinct.unscope(:distinct).collect(&:salary)
+    assert_equal expected, received
+  end
+
+  def test_unscope_with_uniq_in_query
+    expected = Developer.order('salary DESC').collect(&:salary)
+    received = DeveloperOrderedBySalary.select('salary').uniq.unscope(:uniq).collect(&:salary)
+    assert_equal expected, received
+  end
+
   def test_order_to_unscope_reordering
     scope = DeveloperOrderedBySalary.order('salary DESC, name ASC').reverse_order.unscope(:order)
     assert !(scope.to_sql =~ /order/i)


### PR DESCRIPTION
While trying to fix #18694  , I found that we don't support this.
After support for this, that should be a trivial fix.
