### PR TITLE
Add ability to use interpolation in redirection (for subdomain)

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Support interpolation for subdomain in routing redirection.
+
+    Example:
+
+        get '/companies/:subdomain', to: redirect(subdomain: '%{subdomain}', path: '/')
+
+    http://example.com/companies/company will redirect to http://company.example.com
+
+    *Airat Shigapov*
+
 *   Migrating to keyword arguments syntax in `ActionController::TestCase` and
     `ActionDispatch::Integration` HTTP request methods.
 

--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -111,8 +111,12 @@ module ActionDispatch
           :params   => request.query_parameters
         }.merge! options
 
-        if !params.empty? && url_options[:path].match(/%\{\w*\}/)
-          url_options[:path] = (url_options[:path] % escape_path(params))
+        if !params.empty?
+          %i(path subdomain).each do |param|
+            if url_options[param] && url_options[param].match(/%\{\w*\}/)
+              url_options[param] = (url_options[param] % escape_path(params))
+            end
+          end
         end
 
         unless options[:host] || options[:domain]

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -256,6 +256,15 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     verify_redirect 'http://super-docs.com/super_new_documentation?section=top'
   end
 
+  def test_redirect_hash_subdomain_substitution
+    draw do
+      get 'stores/:name', :to => redirect(:subdomain => '%{name}', :path => '/')
+    end
+
+    get '/stores/iernest'
+    verify_redirect 'http://iernest.example.com/'
+  end
+
   def test_redirect_hash_path_substitution
     draw do
       get 'stores/:name', :to => redirect(:subdomain => 'stores', :path => '/%{name}')


### PR DESCRIPTION
This allows to use interpolation for subdomain in redirection as well as it was done for path:

``` ruby
get '/companies/:subdomain', to: redirect(subdomain: '%{subdomain}', path: '/')


# http://example.com/companies/company will redirect to http://company.example.com/
```
