### PR TITLE
Remove distinct from relation when doing a relation count

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -234,7 +234,8 @@ module ActiveRecord
 
     def execute_simple_calculation(operation, column_name, distinct) #:nodoc:
       # PostgreSQL doesn't like ORDER BY when there are no GROUP BY
-      relation = unscope(:order)
+      # Distinct value gets passed to us, and is already calculated before for a relation.
+      relation = unscope(:order).distinct(false)
 
       column_alias = column_name
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -426,6 +426,12 @@ class CalculationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_count_with_distinct_emits_single_distinct_in_query
+    assert_equal 4, Account.select(:credit_limit).distinct.count
+    queries = assert_sql { Account.select(:credit_limit).distinct.count}
+    assert_equal 1, queries.last.scan(/DISTINCT/).count
+  end
+
   def test_count_with_aliased_attribute
     assert_equal 6, Account.count(:available_credit)
   end


### PR DESCRIPTION
Remove distinct from relation when doing a relation count, since it gets added on subquery part when selecting a distinct count.

Fixes #18694
