### PR TITLE
Improve sentence flow in Debugging guide.

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -544,7 +544,7 @@ This way an irb session will be started within the context you invoked it. But
 be warned: this is an experimental feature.
 
 The `var` method is the most convenient way to show variables and their values.
-Let's let `byebug` to help us with it.
+Let's let `byebug` help us with it.
 
 ```
 (byebug) help var


### PR DESCRIPTION
This small grammatical change improves the flow of a sentence within the Debugging Rails Applications section of the guides.
