### PR TITLE
Backport #18627 to 4-2-stable

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Preserve default format when generating URLs
+
+    Fixes an issue that would cause the format set in default_url_options to be
+    lost when generating URLs with fewer positional arguments than parameters in
+    the route definition.
+
+    Backport of #18627
+
+    *Tekin Suleyman*, *Dominic Baggott*
+
 *   Default headers, removed in controller actions, are no longer reapplied on
     the test response.
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -293,7 +293,11 @@ module ActionDispatch
                 path_params -= result.keys
               end
               path_params.each { |param|
-                result[param] = inner_options.fetch(param) { args.shift }
+                value = inner_options.fetch(param) { args.shift }
+
+                unless param == :format && value.nil?
+                  result[param] = value
+                end
               }
             end
 

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -51,6 +51,22 @@ class DefaultUrlOptionsController < ActionController::Base
   end
 end
 
+class OptionalDefaultUrlOptionsController < ActionController::Base
+  def default_url_options
+    { thing: 'default_thing' }
+  end
+end
+
+class DefaultFormatController < ActionController::Base
+  def show
+    render nothing: true
+  end
+
+  def default_url_options
+    { format: 'atom' }
+  end
+end
+
 class UrlOptionsController < ActionController::Base
   def from_view
     render :inline => "<%= #{params[:route]} %>"
@@ -272,6 +288,30 @@ class DefaultUrlOptionsTest < ActionController::TestCase
     end
   end
 
+end
+
+class DefaultFormatControllerTest < ActionController::TestCase
+  def test_default_format_preserved_when_missing_from_positional_arguments
+    with_routing do |set|
+      set.draw do
+        get "/things/:id(.:format)" => 'default_format#show', :as => :thing
+      end
+      assert_equal '/things/1.atom', thing_path("1")
+    end
+  end
+end
+
+class OptionalDefaultUrlOptionsControllerTest < ActionController::TestCase
+  def test_optional_default_url_options_are_overridden_by_missing_positional_args
+    with_routing do |set|
+      set.draw do
+        get "/:category(/:thing)" => "optional_default_url_options#show", :as => :thing
+      end
+
+      assert_equal "/things/a_thing", thing_path('things', 'a_thing')
+      assert_equal "/things/default_thing", thing_path('things')
+    end
+  end
 end
 
 class EmptyUrlOptionsTest < ActionController::TestCase


### PR DESCRIPTION
This is a backport of #18627 that only fixes the issue for `:format` so as not to break existing behaviour.

cc @pixeltrix
