### PR TITLE
Document lazy lookup behavior for controllers

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -588,6 +588,25 @@ you can look up the `books.index.title` value **inside** `app/views/books/index.
 
 NOTE: Automatic translation scoping by partial is only available from the `translate` view helper method.
 
+"Lazy" lookup can also be used in _controllers_:
+
+```yaml
+en:
+  books:
+    create:
+      success: Book created!
+```
+which is especially useful for setting flash messages:
+
+```ruby
+class BooksController < ApplicationController
+  def create
+    # ...
+    redirect_to books_url, notice: t('.success')
+  end
+end
+```
+
 ### Interpolation
 
 In many cases you want to abstract your translations so that **variables can be interpolated into the translation**. For this reason the I18n API provides an interpolation feature.


### PR DESCRIPTION
Pull request #7082 added lazy lookup to controllers using the translate
method, but the documentation still stated that it was available for
views only.

[ci skip]
