### PR TITLE
Fix bug causing table creation to fail for models with postgresql 'money' field

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -76,11 +76,11 @@ module ActiveRecord
           column(name, :point, options)
         end
 
-        def bit(name, options)
+        def bit(name, options = {})
           column(name, :bit, options)
         end
 
-        def bit_varying(name, options)
+        def bit_varying(name, options = {})
           column(name, :bit_varying, options)
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -84,7 +84,7 @@ module ActiveRecord
           column(name, :bit_varying, options)
         end
 
-        def money(name, options)
+        def money(name, options = {})
           column(name, :money, options)
         end
       end

--- a/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
@@ -13,6 +13,8 @@ class PostgresqlBitStringTest < ActiveRecord::TestCase
     @connection.create_table('postgresql_bit_strings', :force => true) do |t|
       t.bit :a_bit, default: "00000011", limit: 8
       t.bit_varying :a_bit_varying, default: "0011", limit: 4
+      t.bit :another_bit
+      t.bit_varying :another_bit_varying
     end
   end
 

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -10,8 +10,8 @@ class PostgresqlMoneyTest < ActiveRecord::TestCase
     @connection = ActiveRecord::Base.connection
     @connection.execute("set lc_monetary = 'C'")
     @connection.create_table('postgresql_moneys', force: true) do |t|
-      t.column "wealth", "money"
-      t.column "depth", "money", default: "150.55"
+      t.money "wealth"
+      t.money "depth", default: "150.55"
     end
   end
 


### PR DESCRIPTION
Creating a new model with the postgres money type causes the migration to fail. 

I've included [an isolated gist](https://gist.github.com/meltheadorable/4af4628beb3a00a79e2b) that can reproduce the issue, but it's pretty easy to test this in an existing postgresql-backed project by doing

```
rails generate model Product price:money
rake db:migrate
```

This PR fixes that issue by adding a default options hash to the schema definition method for the money type.
