### PR TITLE
load "rack/test" before "action_controller/railtie" in bug report templates [ci skip]

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -2,6 +2,7 @@
 gem 'rails', '4.2.0'
 
 require 'rails'
+require 'rack/test'
 require 'action_controller/railtie'
 
 class TestApp < Rails::Application
@@ -27,7 +28,6 @@ class TestController < ActionController::Base
 end
 
 require 'minitest/autorun'
-require 'rack/test'
 
 # Ensure backward compatibility with Minitest 4
 Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)


### PR DESCRIPTION
I tried to use [bug report template](https://github.com/rails/rails/blob/master/guides/bug_report_templates/action_controller_gem.rb), but raised `LoadError`. 

stacktrace is as follows:

``` ruby
/home/yaginuma/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/actionpack-4.2.0/lib/action_controller/metal/strong_parameters.rb:528:in `<class:Parameters>': cannot load such file -- rack/test (LoadError)
    from /home/yaginuma/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/actionpack-4.2.0/lib/action_controller/metal/strong_parameters.rb:106:in `<module:ActionController>'
    from /home/yaginuma/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/actionpack-4.2.0/lib/action_controller/metal/strong_parameters.rb:10:in `<top (required)>'
    from /home/yaginuma/.rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:68:in `require'
    from /home/yaginuma/.rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:68:in `require'
    from /home/yaginuma/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/actionpack-4.2.0/lib/action_controller.rb:5:in `<top (required)>'
    from /home/yaginuma/.rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:68:in `require'
    from /home/yaginuma/.rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:68:in `require'
    from /home/yaginuma/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/actionpack-4.2.0/lib/action_controller/railtie.rb:2:in `<top (required)>'
    from /home/yaginuma/.rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:68:in `require'
    from /home/yaginuma/.rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:68:in `require'
    from action_controller_gem.rb:5:in `<main>'
```

strong parameters use `Rack::Test::UploadedFile`,  I think `rack/test` to have to load it earlier.
