### PR TITLE
Fix transaction rollback in case of aborting thread

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -185,7 +185,7 @@ module ActiveRecord
       ensure
         unless error
           if Thread.current.status == 'aborting'
-            rollback_transaction
+            rollback_transaction if transaction
           else
             begin
               commit_transaction


### PR DESCRIPTION
It appears that in current version of ActiveRecord, in case of thread being killed during transaction block, sometimes `rollback` method can be called on `nil` (if thread is being killed right after it enters `within_new_transaction` method before `transaction` variable is set). It actually happened several times in our production app, so I came up with this simple solution. I'm not quite sure though, why there is if clause in rescue, and none in ensure in the original code.
