### PR TITLE
Add PostgreSQL SERIAL column support

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/serial.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/serial.rb
@@ -1,0 +1,10 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID # :nodoc:
+        class Serial < Integer # :nodoc:
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -60,6 +60,10 @@ module ActiveRecord
           column(name, :uuid, options)
         end
 
+        def serial(name, options = {})
+          column(name, :serial, options)
+        end
+
         def json(name, options = {})
           column(name, :json, options)
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -79,6 +79,7 @@ module ActiveRecord
       NATIVE_DATABASE_TYPES = {
         primary_key: "serial primary key",
         bigserial: "bigserial",
+        serial:      { name: "serial" },
         string:      { name: "character varying" },
         text:        { name: "text" },
         integer:     { name: "integer" },


### PR DESCRIPTION
Example usage:

``` ruby
create_table :food do |td|
  td.serial :version
  # test effects. Adds "version SERIAL" to the create statement
  puts schema_creation.accept(td)
end
```

I was surprised this wasn't already supported, not sure if this is desired in Rails.  If you like, I'll add tests. I'm using this on 4.2

ref: http://www.postgresql.org/docs/9.0/static/datatype-numeric.html#DATATYPE-SERIAL
