### PR TITLE
Indicate link_to creates an anchor element

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -46,9 +46,9 @@ module ActionView
       end
       protected :_back_url
 
-      # Creates a link tag of the given +name+ using a URL created by the set of +options+.
+      # Creates an anchor element of the given +name+ using a URL created by the set of +options+.
       # See the valid options in the documentation for +url_for+. It's also possible to
-      # pass a String instead of an options hash, which generates a link tag that uses the
+      # pass a String instead of an options hash, which generates an anchor element that uses the
       # value of the String as the href for the link. Using a <tt>:back</tt> Symbol instead
       # of an options hash will generate a link to the referrer (a JavaScript back link
       # will be used in place of a referrer if none exists). If +nil+ is passed as the name


### PR DESCRIPTION
The `link_to` helper generates an HTML anchor element (consisting of opening and closing anchor tags and an element body). The docs currently state the a link tag is generated (which would indicate a tag like `<link>`, which is another valid HTML tag), so this change clarifies that an anchor element is actually generated.

[ci skip]
