### PR TITLE
Add an `:only` option to `perform_enqueued_jobs` to filter jobs based on type.

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -44,5 +44,39 @@
 
     *Isaac Seymour*
 
+*   Add an `:only` option to `perform_enqueued_jobs` to filter jobs based on
+    type.
+
+    This allows specific jobs to be tested, while preventing others from
+    being performed unnecessarily.
+
+    Example:
+
+        def test_hello_job
+          assert_performed_jobs 1, only: HelloJob do
+            HelloJob.perform_later('jeremy')
+            LoggingJob.perform_later
+          end
+        end
+
+    An array may also be specified, to support testing multiple jobs.
+
+    Example:
+
+        def test_hello_and_logging_jobs
+          assert_nothing_raised do
+            assert_performed_jobs 2, only: [HelloJob, LoggingJob] do
+              HelloJob.perform_later('jeremy')
+              LoggingJob.perform_later('stewie')
+              RescueJob.perform_later('david')
+            end
+          end
+        end
+
+    Fixes #18802.
+
+    *Michael Ryan*
+
+
 
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activejob/CHANGELOG.md) for previous changes.

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -11,7 +11,7 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :test
     class TestAdapter
       delegate :name, to: :class
-      attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs)
+      attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter)
       attr_writer(:enqueued_jobs, :performed_jobs)
 
       def initialize
@@ -30,22 +30,33 @@ module ActiveJob
       end
 
       def enqueue(job) #:nodoc:
-        if perform_enqueued_jobs
-          performed_jobs << {job: job.class, args: job.serialize['arguments'], queue: job.queue_name}
-          Base.execute job.serialize
-        else
-          enqueued_jobs << {job: job.class, args: job.serialize['arguments'], queue: job.queue_name}
-        end
+        return if filtered?(job)
+
+        job_data = { job: job.class, args: job.serialize['arguments'], queue: job.queue_name }
+        enqueue_or_perform(perform_enqueued_jobs, job, job_data)
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
-        if perform_enqueued_at_jobs
-          performed_jobs << {job: job.class, args: job.serialize['arguments'], queue: job.queue_name, at: timestamp}
-          Base.execute job.serialize
-        else
-          enqueued_jobs << {job: job.class, args: job.serialize['arguments'], queue: job.queue_name, at: timestamp}
-        end
+        return if filtered?(job)
+
+        job_data = { job: job.class, args: job.serialize['arguments'], queue: job.queue_name, at: timestamp }
+        enqueue_or_perform(perform_enqueued_at_jobs, job, job_data)
       end
+
+      private
+
+        def enqueue_or_perform(perform, job, job_data)
+          if perform
+            performed_jobs << job_data
+            Base.execute job.serialize
+          else
+            enqueued_jobs << job_data
+          end
+        end
+
+        def filtered?(job)
+          filter && !Array(filter).include?(job.class)
+        end
     end
   end
 end

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/date'
 require 'jobs/hello_job'
 require 'jobs/logging_job'
 require 'jobs/nested_job'
+require 'jobs/rescue_job'
 require 'models/person'
 
 class EnqueuedJobsTest < ActiveJob::TestCase
@@ -277,6 +278,83 @@ class PerformedJobsTest < ActiveJob::TestCase
     error = assert_raise ActiveSupport::TestCase::Assertion do
       assert_no_performed_jobs do
         HelloJob.perform_later('jeremy')
+      end
+    end
+
+    assert_match(/0 .* but 1/, error.message)
+  end
+
+  def test_assert_performed_jobs_with_only_option
+    assert_nothing_raised do
+      assert_performed_jobs 1, only: HelloJob do
+        HelloJob.perform_later('jeremy')
+        LoggingJob.perform_later
+      end
+    end
+  end
+
+  def test_assert_performed_jobs_with_only_option_as_array
+    assert_nothing_raised do
+      assert_performed_jobs 2, only: [HelloJob, LoggingJob] do
+        HelloJob.perform_later('jeremy')
+        LoggingJob.perform_later('stewie')
+        RescueJob.perform_later('david')
+      end
+    end
+  end
+
+  def test_assert_performed_jobs_with_only_option_and_none_sent
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_performed_jobs 1, only: HelloJob do
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/1 .* but 0/, error.message)
+  end
+
+  def test_assert_performed_jobs_with_only_option_and_too_few_sent
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_performed_jobs 5, only: HelloJob do
+        HelloJob.perform_later('jeremy')
+        4.times { LoggingJob.perform_later }
+      end
+    end
+
+    assert_match(/5 .* but 1/, error.message)
+  end
+
+  def test_assert_performed_jobs_with_only_option_and_too_many_sent
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_performed_jobs 1, only: HelloJob do
+        2.times { HelloJob.perform_later('jeremy') }
+      end
+    end
+
+    assert_match(/1 .* but 2/, error.message)
+  end
+
+  def test_assert_no_performed_jobs_with_only_option
+    assert_nothing_raised do
+      assert_no_performed_jobs only: HelloJob do
+        LoggingJob.perform_later
+      end
+    end
+  end
+
+  def test_assert_no_performed_jobs_with_only_option_as_array
+    assert_nothing_raised do
+      assert_no_performed_jobs only: [HelloJob, RescueJob] do
+        LoggingJob.perform_later
+      end
+    end
+  end
+
+  def test_assert_no_performed_jobs_with_only_option_failure
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_no_performed_jobs only: HelloJob do
+        HelloJob.perform_later('jeremy')
+        LoggingJob.perform_later
       end
     end
 


### PR DESCRIPTION
This allows specific jobs to be tested, while preventing others from being performed unnecessarily. An array may also be specified, to support testing multiple jobs.

Fixes #18802.
