### PR TITLE
Fixed undefined method `i18n_key' for nil:NilClass for labels in non AR ...

### DIFF
--- a/actionview/lib/action_view/helpers/tags/translator.rb
+++ b/actionview/lib/action_view/helpers/tags/translator.rb
@@ -6,7 +6,7 @@ module ActionView
           @object_name = object_name.gsub(/\[(.*)_attributes\]\[\d+\]/, '.\1')
           @method_and_value = method_and_value
           @scope = scope
-          @model = object.respond_to?(:to_model) ? object.to_model : object
+          @model = object.respond_to?(:to_model) ? object.to_model : nil
         end
 
         def translate

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -259,6 +259,18 @@ class FormHelperTest < ActionView::TestCase
     end
   end
 
+  def test_label_with_non_active_record_object
+    form_for(OpenStruct.new(name:'ok'), as: 'person', url: 'an_url', html: { id: 'create-person' }) do |f|
+      f.label(:name)
+    end
+
+    expected = whole_form("an_url", "create-person", "new_person", method: "post") do
+      '<label for="person_name">Name</label>'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_label_with_for_attribute_as_symbol
     assert_dom_equal('<label for="my_for">Title</label>', label(:post, :title, nil, for: "my_for"))
   end


### PR DESCRIPTION
...form_for

Refactoring at #18647 broke using non active record objects in form_for. This patch
restores the original behaviour where we only compute i18 key when object.respond_to?(:to_model)
