### PR TITLE
Remove warning from generator named base test

### DIFF
--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -2,16 +2,6 @@ require 'generators/generators_test_helper'
 require 'rails/generators/rails/scaffold_controller/scaffold_controller_generator'
 require 'mocha/setup' # FIXME: stop using mocha
 
-# Mock out what we need from AR::Base.
-module ActiveRecord
-  class Base
-    class << self
-      attr_accessor :pluralize_table_names
-    end
-    self.pluralize_table_names = true
-  end
-end
-
 class NamedBaseTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
   tests Rails::Generators::ScaffoldControllerGenerator


### PR DESCRIPTION
This removes the following warning:

```
railties/test/generators/named_base_test.rb:9: warning: method redefined; discarding old pluralize_table_names
activesupport/lib/active_support/core_ext/class/attribute.rb:86: warning: previous definition of pluralize_table_names was here
railties/test/generators/named_base_test.rb:9: warning: method redefined; discarding old pluralize_table_names=
activesupport/lib/active_support/core_ext/class/attribute.rb:83: warning: previous definition of pluralize_table_names= was here
```
