### PR TITLE
Remove warning from Plugin Generator

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -317,9 +317,9 @@ task default: :test
         @modules ||= namespaced_name.camelize.split("::")
       end
 
-      def wrap_in_modules(content)
-        content = "#{content}".strip.gsub(/\W$\n/, '')
-        modules.reverse.inject(content) do |content, mod|
+      def wrap_in_modules(unwrapped_code)
+        unwrapped_code = "#{unwrapped_code}".strip.gsub(/\W$\n/, '')
+        modules.reverse.inject(unwrapped_code) do |content, mod|
           str = "module #{mod}\n"
           str += content.lines.map { |line| "  #{line}" }.join
           str += content.present? ? "\nend" : "end"


### PR DESCRIPTION
This removes the following warning:

```
rails/railties/lib/rails/generators/rails/plugin/plugin_generator.rb:321: warning: shadowing outer local variable - content
```
