### PR TITLE
Remove warning from ActionView::Helpers::Tags::Translator

### DIFF
--- a/actionview/lib/action_view/helpers/tags/translator.rb
+++ b/actionview/lib/action_view/helpers/tags/translator.rb
@@ -14,9 +14,11 @@ module ActionView
           translated_attribute || human_attribute_name
         end
 
-        private
+        protected
 
         attr_reader :object_name, :method_and_value, :scope, :model
+
+        private
 
         def i18n_default
           if model


### PR DESCRIPTION
This removes the following warning:

```
/GitHub/rails/actionview/lib/action_view/helpers/tags/translator.rb:19: warning: private attribute?
```
