### PR TITLE
NameError#missing_name? can just use NameError#name if the arg is a Symbol

### DIFF
--- a/activesupport/lib/active_support/core_ext/name_error.rb
+++ b/activesupport/lib/active_support/core_ext/name_error.rb
@@ -23,8 +23,7 @@ class NameError
   #   # => true
   def missing_name?(name)
     if name.is_a? Symbol
-      last_name = (missing_name || '').split('::').last
-      last_name == name.to_s
+      self.name == name
     else
       missing_name == name.to_s
     end


### PR DESCRIPTION
[`NameError#name`](http://www.ruby-doc.org/core-2.2.0/NameError.html#method-i-name) returns a missing name as a symbol. This means that if the given name is a symbol, it doesn't have to use `#missing_name` to get the last constant name in the error message.
