### PR TITLE
An array type is a part of `sql_type`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -28,7 +28,7 @@ module ActiveRecord
           end
 
           def visit_ColumnDefinition(o)
-            o.sql_type = type_to_sql(o.type, o.limit, o.precision, o.scale)
+            o.sql_type ||= type_to_sql(o.type, o.limit, o.precision, o.scale)
             column_sql = "#{quote_column_name(o.name)} #{o.sql_type}"
             add_column_options!(column_sql, column_options(o)) unless o.type == :primary_key
             column_sql

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -4,30 +4,15 @@ module ActiveRecord
       class SchemaCreation < AbstractAdapter::SchemaCreation
         private
 
-        def column_options(o)
-          column_options = super
-          column_options[:array] = o.array
-          column_options
-        end
-
-        def add_column_options!(sql, options)
-          if options[:array]
-            sql << '[]'
-          end
+        def visit_ColumnDefinition(o)
+          o.sql_type = type_to_sql(o.type, o.limit, o.precision, o.scale)
+          o.sql_type << '[]' if o.array
           super
         end
 
         def quote_default_expression(value, column)
           if column.type == :uuid && value =~ /\(\)/
             value
-          else
-            super
-          end
-        end
-
-        def type_for_column(column)
-          if column.array
-            @conn.lookup_cast_type("#{column.sql_type}[]")
           else
             super
           end


### PR DESCRIPTION
`sql_type` is reused in `lookup_cast_type`. If making it a part of
`sql_type` when handled array option first, it isn't necessary to do
again.
