### PR TITLE
Fix rounding problem for PostgreSQL timestamp column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix rounding problem for PostgreSQL timestamp column.
+
+    If timestamp column have the precision, it need to format according to
+    the precision of timestamp column.
+
+    *Ryuta Kamizono*
+
 *   Respect the database default charset for `schema_migrations` table.
 
     The charset of `version` column in `schema_migrations` table is depend

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -917,18 +917,10 @@ module ActiveRecord
       end
 
       class MysqlDateTime < Type::DateTime # :nodoc:
-        def type_cast_for_database(value)
-          if value.acts_like?(:time) && value.respond_to?(:usec)
-            result = super.to_s(:db)
-            case precision
-            when 1..6
-              "#{result}.#{sprintf("%0#{precision}d", value.usec / 10 ** (6 - precision))}"
-            else
-              result
-            end
-          else
-            super
-          end
+        private
+
+        def has_precision?
+          precision || 0
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/date_time.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/date_time.rb
@@ -5,6 +5,15 @@ module ActiveRecord
         class DateTime < Type::DateTime # :nodoc:
           include Infinity
 
+          def type_cast_for_database(value)
+            if has_precision? && value.acts_like?(:time) && value.year <= 0
+              bce_year = format("%04d", -value.year + 1)
+              super.sub(/^-?\d+/, bce_year) + " BC"
+            else
+              super
+            end
+          end
+
           def cast_value(value)
             if value.is_a?(::String)
               case value

--- a/activerecord/lib/active_record/type/date_time.rb
+++ b/activerecord/lib/active_record/type/date_time.rb
@@ -11,20 +11,27 @@ module ActiveRecord
       end
 
       def type_cast_for_database(value)
+        return super unless value.acts_like?(:time)
+
         zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
 
-        if value.acts_like?(:time)
-          if value.respond_to?(zone_conversion_method)
-            value.send(zone_conversion_method)
-          else
-            value
-          end
+        if value.respond_to?(zone_conversion_method)
+          value = value.send(zone_conversion_method)
+        end
+
+        return value unless has_precision?
+
+        result = value.to_s(:db)
+        if value.respond_to?(:usec) && (1..6).cover?(precision)
+          "#{result}.#{sprintf("%0#{precision}d", value.usec / 10 ** (6 - precision))}"
         else
-          super
+          result
         end
       end
 
       private
+
+      alias has_precision? precision
 
       def cast_value(string)
         return string unless string.is_a?(::String)


### PR DESCRIPTION
If timestamp column have the precision, it need to format according to
the precision of timestamp column.
