### PR TITLE
Match table names exactly on MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -422,9 +422,11 @@ module ActiveRecord
       end
 
       def tables(name = nil, database = nil, like = nil) #:nodoc:
-        sql = "SHOW TABLES "
-        sql << "IN #{quote_table_name(database)} " if database
-        sql << "LIKE #{quote(like)}" if like
+        database ||= current_database
+
+        sql = "SELECT table_name FROM information_schema.tables "
+        sql << "WHERE table_schema = #{quote(database)}"
+        sql << " AND table_name = #{quote(like)}" if like
 
         execute_and_free(sql, 'SCHEMA') do |result|
           result.collect(&:first)

--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -66,12 +66,8 @@ module ActiveRecord
         end
       end
 
-      def test_tables_quoting
-        @conn.tables(nil, "foo-bar", nil)
-        flunk
-      rescue => e
-        # assertion for *quoted* database properly
-        assert_match(/database 'foo-bar'/, e.inspect)
+      def test_table_exists_with_like_metacharacters
+        assert_not @conn.table_exists?('aut_ors'), 'nonexistent table should not exist'
       end
 
       def test_pk_and_sequence_for

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -36,14 +36,6 @@ module ActiveRecord
         assert(!@connection.table_exists?("#{@db_name}.zomg"), "table should not exist")
       end
 
-      def test_tables_quoting
-        @connection.tables(nil, "foo-bar", nil)
-        flunk
-      rescue => e
-        # assertion for *quoted* database properly
-        assert_match(/database 'foo-bar'/, e.inspect)
-      end
-
       def test_dump_indexes
         index_a_name = 'index_key_tests_on_snack'
         index_b_name = 'index_key_tests_on_pizza'

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -79,7 +79,7 @@ module ActiveRecord
     # ignored SQL, or better yet, use a different notification for the queries
     # instead examining the SQL content.
     oracle_ignored     = [/^select .*nextval/i, /^SAVEPOINT/, /^ROLLBACK TO/, /^\s*select .* from all_triggers/im, /^\s*select .* from all_constraints/im, /^\s*select .* from all_tab_cols/im]
-    mysql_ignored      = [/^SHOW TABLES/i, /^SHOW FULL FIELDS/, /^SHOW CREATE TABLE /i, /^SHOW VARIABLES /]
+    mysql_ignored      = [/^SHOW TABLES/i, /^SHOW FULL FIELDS/, /^SHOW CREATE TABLE /i, /^SHOW VARIABLES /, /^SELECT DATABASE\(\) as db$/, /^SELECT table_name FROM information_schema\.tables/]
     postgresql_ignored = [/^\s*select\b.*\bfrom\b.*pg_namespace\b/im, /^\s*select tablename\b.*from pg_tables\b/im, /^\s*select\b.*\battname\b.*\bfrom\b.*\bpg_attribute\b/im, /^SHOW search_path/i]
     sqlite3_ignored =    [/^\s*SELECT name\b.*\bFROM sqlite_master/im]
 


### PR DESCRIPTION
The `SHOW TABLES LIKE` command accepts metacharacters `%` and `_` in potentially unexpected ways. This can be avoided by querying `information_schema.tables` directly.

Fixes #17897
