### PR TITLE
Support enqueue_at in AJ inline adapter.

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Support enqueue_at in AJ inline adapter.
+
+    Previously, it was impossible to use inline adapter with delaying
+    job, like: `MyWorker.set(wait: 10.seconds).perform_later`
+    Now, this job runs immediately.
+
+    *Wojciech Wnętrzak*
+
 *   Add an `:only` option to `perform_enqueued_jobs` to filter jobs based on
     type.
 

--- a/activejob/lib/active_job/queue_adapters/inline_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/inline_adapter.rb
@@ -14,8 +14,8 @@ module ActiveJob
           Base.execute(job.serialize)
         end
 
-        def enqueue_at(*) #:nodoc:
-          raise NotImplementedError.new("Use a queueing backend to enqueue jobs in the future. Read more at http://guides.rubyonrails.org/active_job_basics.html")
+        def enqueue_at(job, _) #:nodoc:
+          Base.execute(job.serialize)
         end
       end
     end


### PR DESCRIPTION
Previously, it was impossible to use inline adapter with delaying
job, like: `MyWorker.set(wait: 10.seconds).perform_later`
Now, this job runs immediately.

This is also the default behaviour for Resque inline adapter. I didn't check the other gems.

Not sure where to add a test for this case, as nothing fails after this change.
