### PR TITLE
Allow variants to be set through the URL

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow variants to be set through the URL
+
+    request.variant can be set by setting :format. For example, accessing
+    http://example.com/posts.html+partial or `request.format = 'html+partial'` set
+    both `format: :html` and `request.variant = [:partial]` automatically.
+
+    *Hong ChulJu*
+
 *   Explicitly ignored wildcard verbs when searching for HEAD routes before fallback
 
     Fixes an issue where a mounted rack app at root would intercept the HEAD 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,8 +1,8 @@
 *   Allow variants to be set through the URL
 
     request.variant can be set by setting :format. For example, accessing
-    http://example.com/posts.html+partial or `request.format = 'html+partial'` set
-    both `format: :html` and `request.variant = [:partial]` automatically.
+    http://example.com/posts.html+partial or `request.format = 'html+phone'` set
+    both `format: :html` and `request.variant = [:phone]` automatically.
 
     *Hong ChulJu*
 

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -156,15 +156,12 @@ module ActionDispatch
       end
 
       private
-
-      def extract_variant!
-        if parameters.key?(:format)
-          segments = parameters[:format].to_s.split("+")
-          parameters[:format] = segments[0]
-          variants = segments[1..-1].map!(&:to_sym)
-          self.variant = variants unless variants.empty?
+        def extract_variant!
+          if parameters.key?(:format)
+            parameters[:format], *variants = parameters[:format].to_s.split("+")
+            self.variant = variants.map(&:to_sym) unless variants.empty?
+          end
         end
-      end
     end
   end
 end

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -781,4 +781,16 @@ class RespondToControllerTest < ActionController::TestCase
     assert_equal "text/html", @response.content_type
     assert_equal "phone", @response.body
   end
+
+  def test_variant_from_format
+    get :format_any_variant_any, format: "js+tablet"
+    assert_equal "text/javascript", @response.content_type
+    assert_equal "tablet", @response.body
+  end
+
+  def test_multiple_variants_from_format
+    get :format_any_variant_any, format: "js+mobile+phone"
+    assert_equal "text/javascript", @response.content_type
+    assert_equal "phone", @response.body
+  end
 end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1156,4 +1156,26 @@ class RequestVariant < BaseRequestTest
       request.variant = "mobile"
     end
   end
+
+  test "setting variant from setting format" do
+    request = stub_request
+
+    request.format = "html+mobile"
+    assert_equal [:mobile], request.variant
+  end
+
+  test "setting variant from setting formats" do
+    request = stub_request
+
+    request.formats = ["html+mobile+phone", "xml+phone"]
+    assert_equal [:mobile, :phone], request.variant
+  end
+
+  test "setting format without variant shouid not overwriting existing variant" do
+    request = stub_request
+
+    request.variant = [:mobile]
+    request.format = "html"
+    assert_equal [:mobile], request.variant
+  end
 end


### PR DESCRIPTION
#18818

variant can be extracted from :format. :format param is splited on `+` character. For example, if format: 'html+phone+tablet', then request.variant is set to [:phone, :tablet]. Setting :format directly (request.format, request.formats) or accessing from URL causes variant setting automatically.
