### PR TITLE
[RFC] Alias Range#overlaps? to Range#&

### DIFF
--- a/activesupport/lib/active_support/core_ext/range/overlaps.rb
+++ b/activesupport/lib/active_support/core_ext/range/overlaps.rb
@@ -5,4 +5,5 @@ class Range
   def overlaps?(other)
     cover?(other.first) || other.cover?(first)
   end
+  alias_method :&, :overlaps?
 end


### PR DESCRIPTION
This should allow us to do `(1..5) & (4..6)` to determine intersection, just like arrays: http://www.ruby-doc.org/core-2.2.0/Array.html#method-i-26 .

Happy to add tests if there's interest in this.
