### PR TITLE
Booting exception handler

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -80,6 +80,7 @@ module Rails
     autoload :Bootstrap,              'rails/application/bootstrap'
     autoload :Configuration,          'rails/application/configuration'
     autoload :DefaultMiddlewareStack, 'rails/application/default_middleware_stack'
+    autoload :DefaultBootingHandler,  'rails/application/default_booting_handler'
     autoload :Finisher,               'rails/application/finisher'
     autoload :Railties,               'rails/engine/railties'
     autoload :RoutesReloader,         'rails/application/routes_reloader'
@@ -349,7 +350,7 @@ module Rails
     # group is :default
     def initialize!(group=:default) #:nodoc:
       raise "Application has been already initialized." if @initialized
-      run_initializers(group, self)
+      config.booting_handler.call! { run_initializers(group, self) }
       @initialized = true
       self
     end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -8,7 +8,7 @@ module Rails
     class Configuration < ::Rails::Engine::Configuration
       attr_accessor :allow_concurrency, :asset_host, :autoflush_log,
                     :cache_classes, :cache_store, :consider_all_requests_local, :console,
-                    :eager_load, :exceptions_app, :file_watcher, :filter_parameters,
+                    :eager_load, :exceptions_app, :booting_handler, :file_watcher, :filter_parameters,
                     :force_ssl, :helpers_paths, :logger, :log_formatter, :log_tags,
                     :railties_order, :relative_url_root, :secret_key_base, :secret_token,
                     :serve_static_files, :ssl_options, :static_cache_control, :session_options,
@@ -43,6 +43,7 @@ module Rails
         @reload_classes_only_on_change = true
         @file_watcher                  = ActiveSupport::FileUpdateChecker
         @exceptions_app                = nil
+        @booting_handler               = Rails::Application::DefaultBootingHandler
         @autoflush_log                 = true
         @log_formatter                 = ActiveSupport::Logger::SimpleFormatter.new
         @eager_load                    = nil

--- a/railties/lib/rails/application/default_booting_handler.rb
+++ b/railties/lib/rails/application/default_booting_handler.rb
@@ -1,0 +1,13 @@
+module Rails
+  class Application
+    class DefaultBootingHandler
+      def self.call!(&block)
+        new.call!(&block)
+      end
+
+      def call!(&block)
+        block.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
At [Rollbar](http://rollbar.com) many customers have asked us how to report exceptions to our API when the server even doesnt start cause some error in initializers or other point of the booting process.

We've thought a kind of wrapper over `Rails::Application#initialize!` can be good, so users can report in some way these errors.

Users could configure the app in this way:

``` ruby
class MyApp < Rails::Application
  config.booting_handler = Rollbar.rails_booting_handler
end

# Where Rollbar.rails_booting_handler returns a class like this one, provided by Rollbar:

module Rollbar
  module Rails
    class BootingHandler
      def self.call!(&block); new.call!(&block); end

      def call!(&block)
        begin
          block.call
        rescue => e
          Rollbar.error(e)
          raise e
        end
      end
    end
  end
end

```

This PR offers a simple solution for this and/or just a point where discuss about a feature like this. No tests added yet. 
