### PR TITLE
Fix missing index when using timestamps with index

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix missing index when using `timestamps` with the `index` option.
+
+    The `index` option used with `timestamps` should be passed to both
+    `column` definitions for `created_at` and `updated_at` rather than just
+    the first.
+
+    *Paul Mucur*
+
+*   Add support for `Set` to `Relation#where`.
+
+    *Yuki Nishijima*
+
 *   Fixed a bug where uniqueness validations would error on out of range values,
     even if an validation should have prevented it from hitting the database.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -359,6 +359,7 @@ module ActiveRecord
       def column(name, type, options = {})
         name = name.to_s
         type = type.to_sym
+        options = options.dup
 
         if @columns_hash[name] && @columns_hash[name].primary_key?
           raise ArgumentError, "you can't redefine the primary key column '#{name}'. To define a custom primary key, pass { id: false } to create_table."

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -446,6 +446,17 @@ class TimestampTest < ActiveRecord::TestCase
     toy = Toy.first
     assert_equal [:created_at, :updated_at], toy.send(:all_timestamp_attributes_in_model)
   end
+
+  def test_index_is_created_for_both_timestamps
+    ActiveRecord::Base.connection.create_table(:foos, force: true) do |t|
+      t.timestamps(:foos, null: true, index: true)
+    end
+
+    indexes = ActiveRecord::Base.connection.indexes('foos')
+    assert_equal ['created_at', 'updated_at'], indexes.flat_map(&:columns).sort
+  ensure
+    ActiveRecord::Base.connection.drop_table(:foos)
+  end
 end
 
 class TimestampsWithoutTransactionTest < ActiveRecord::TestCase


### PR DESCRIPTION
The `index` option used with `timestamps` should be passed to both `column` definitions for `created_at` and `updated_at` rather than just the first.

This was happening because `Hash#delete` is used to extract the `index` option passed to `timestamps`, thereby mutating the `options` hash in-place.
