### PR TITLE
The datetime precision with zero should be dumped

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -29,7 +29,7 @@ module ActiveRecord
 
         limit = column.limit || native_database_types[column.type][:limit]
         spec[:limit]     = limit.inspect if limit
-        spec[:precision] = column.precision.inspect if column.precision && column.precision != 0
+        spec[:precision] = column.precision.inspect if column.precision
         spec[:scale]     = column.scale.inspect if column.scale
 
         default = schema_default(column) if column.has_default?

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -73,6 +73,12 @@ module ActiveRecord
         spec
       end
 
+      def prepare_column_options(column)
+        spec = super
+        spec.delete(:precision) if column.type == :datetime && column.precision == 0
+        spec
+      end
+
       class Column < ConnectionAdapters::Column # :nodoc:
         delegate :strict, :collation, :extra, to: :sql_type_metadata, allow_nil: true
 


### PR DESCRIPTION
`precision: 0` was not dumped by f1a0fa9e19b7e4ccaea191fc6cf0613880222ee7.
However, `precision: 0` is valid value for PostgreSQL timestamps.
