### PR TITLE
Fix wrong kwarg "record" from #18872

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -155,7 +155,7 @@ module ActionController
     #     super if stale? @article, template: 'widgets/show'
     #   end
     #
-    def stale?(record = nil, etag: nil, last_modified: nil, public: nil, template: nil)
+    def stale?(record = nil, etag: record, last_modified: nil, public: nil, template: nil)
       fresh_when(record, etag: etag, last_modified: last_modified, public: public, template: template)
       !request.fresh?(response)
     end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -299,6 +299,7 @@ class LastModifiedRenderTest < ActionController::TestCase
     get :conditional_hello_with_record
     assert_equal 304, @response.status.to_i
     assert @response.body.blank?
+    assert_not_nil @response.etag
     assert_equal @last_modified, @response.headers['Last-Modified']
   end
 


### PR DESCRIPTION
PR #18772 changed the parameters of `stale?` to use `kwargs`.
[As for this comment](https://github.com/rails/rails/pull/18872/files#r24456288) the default value for the `etag` parameter should be `record`, not `nil`.

This commit fixes the code and introduces a test that:
- passed before #18872
- fails on the current master (after #18772)
- passes again after setting the default value of `etag` to `record`.
