### PR TITLE
remove unnecessary assignment/parameter passing in AS::Callbacks...::Around (master branch) 

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -291,13 +291,11 @@ module ActiveSupport
 
             if !halted && user_conditions.all? { |c| c.call(target, value) }
               user_callback.call(target, value) {
-                env = run.call env
-                env.value
+                run.call.value
               }
-
               env
             else
-              run.call env
+              run.call
             end
           end
         end
@@ -309,11 +307,10 @@ module ActiveSupport
             value  = env.value
 
             if env.halted
-              run.call env
+              run.call
             else
               user_callback.call(target, value) {
-                env = run.call env
-                env.value
+                run.call.value
               }
               env
             end
@@ -328,12 +325,11 @@ module ActiveSupport
 
             if user_conditions.all? { |c| c.call(target, value) }
               user_callback.call(target, value) {
-                env = run.call env
-                env.value
+                run.call.value
               }
               env
             else
-              run.call env
+              run.call
             end
           end
         end
@@ -342,8 +338,7 @@ module ActiveSupport
         def self.simple(callback_sequence, user_callback)
           callback_sequence.around do |env, &run|
             user_callback.call(env.target, env.value) {
-              env = run.call env
-              env.value
+              run.call.value
             }
             env
           end


### PR DESCRIPTION
It's re-submit pull request to master branch.

Take "env = run.call env" in Around.simple for example.
It seems (1) 'env' is never changed; (2) block 'run' doesn't expect any parameter.
So unnecessary assignment/parameter passing could be removed.
