### PR TITLE
Refactor `quote_default_expression`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -102,6 +102,11 @@ module ActiveRecord
         quote_table_name("#{table}.#{attr}")
       end
 
+      def quote_default_expression(value, column) #:nodoc:
+        value = lookup_cast_type(column.sql_type).type_cast_for_database(value)
+        quote(value)
+      end
+
       def quoted_true
         "'t'"
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -98,8 +98,7 @@ module ActiveRecord
           end
 
           def quote_default_expression(value, column)
-            value = type_for_column(column).type_cast_for_database(value)
-            @conn.quote(value)
+            @conn.quote_default_expression(value, column)
           end
 
           def options_include_default?(options)
@@ -117,10 +116,6 @@ module ActiveRecord
                 Supported values are: :nullify, :cascade, :restrict
               MSG
             end
-          end
-
-          def type_for_column(column)
-            @conn.lookup_cast_type(column.sql_type)
           end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -52,12 +52,14 @@ module ActiveRecord
         end
 
         # Does not quote function default values for UUID columns
-        def quote_default_value(value, column) #:nodoc:
+        def quote_default_expression(value, column) #:nodoc:
           if column.type == :uuid && value =~ /\(\)/
             value
-          else
+          elsif column.respond_to?(:array?)
             value = type_cast_from_column(column, value)
             quote(value)
+          else
+            super
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -9,14 +9,6 @@ module ActiveRecord
           o.sql_type << '[]' if o.array
           super
         end
-
-        def quote_default_expression(value, column)
-          if column.type == :uuid && value =~ /\(\)/
-            value
-          else
-            super
-          end
-        end
       end
 
       module SchemaStatements
@@ -440,7 +432,7 @@ module ActiveRecord
             # cast the default to the columns type, which leaves us with a default like "default NULL::character varying".
             execute alter_column_query % "DROP DEFAULT"
           else
-            execute alter_column_query % "SET DEFAULT #{quote_default_value(default, column)}"
+            execute alter_column_query % "SET DEFAULT #{quote_default_expression(default, column)}"
           end
         end
 
@@ -448,7 +440,7 @@ module ActiveRecord
           clear_cache!
           unless null || default.nil?
             column = column_for(table_name, column_name)
-            execute("UPDATE #{quote_table_name(table_name)} SET #{quote_column_name(column_name)}=#{quote_default_value(default, column)} WHERE #{quote_column_name(column_name)} IS NULL") if column
+            execute("UPDATE #{quote_table_name(table_name)} SET #{quote_column_name(column_name)}=#{quote_default_expression(default, column)} WHERE #{quote_column_name(column_name)} IS NULL") if column
           end
           execute("ALTER TABLE #{quote_table_name(table_name)} ALTER #{quote_column_name(column_name)} #{null ? 'DROP' : 'SET'} NOT NULL")
         end


### PR DESCRIPTION
`quote_default_expression` and `quote_default_value` are almost the same
handling for do not quote default function of `:uuid` columns. Rename
`quote_default_value` to `quote_default_expression`, and remove
duplicate code.
