### PR TITLE
Use kwargs in the options of `benchmark`

### DIFF
--- a/activesupport/lib/active_support/benchmarkable.rb
+++ b/activesupport/lib/active_support/benchmarkable.rb
@@ -32,14 +32,11 @@ module ActiveSupport
     #  <% benchmark 'Process data files', level: :info, silence: true do %>
     #    <%= expensive_and_chatty_files_operation %>
     #  <% end %>
-    def benchmark(message = "Benchmarking", options = {})
+    def benchmark(message = "Benchmarking", level: :info, silence: false)
       if logger
-        options.assert_valid_keys(:level, :silence)
-        options[:level] ||= :info
-
         result = nil
-        ms = Benchmark.ms { result = options[:silence] ? silence { yield } : yield }
-        logger.send(options[:level], '%s (%.1fms)' % [ message, ms ])
+        ms = Benchmark.ms { result = silence ? silence { yield } : yield }
+        logger.send(level, '%s (%.1fms)' % [ message, ms ])
         result
       else
         yield


### PR DESCRIPTION
This commit only changes the syntax for the expected options of the `benchmark` method in ActiveSupport::Benchmarkable.

Rails core team: are you interested in this commit and in more commits of this type?

On one hand, kwargs provide clarity. On the other, this change might be seen as cosmetic only. 

Let me know!
