### PR TITLE
Use LIMIT sql word in last with order

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -166,7 +166,7 @@ module ActiveRecord
         if order_values.empty? && primary_key
           order(arel_table[primary_key].desc).limit(limit).reverse
         else
-          to_a.last(limit)
+          reverse_order.limit(limit).to_a.reverse
         end
       else
         find_last

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -436,16 +436,16 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal Topic.order("title").to_a.last(2), Topic.order("title").last(2)
   end
 
-  def test_last_with_integer_and_order_should_not_use_sql_limit
+  def test_last_with_integer_and_order_should_use_sql_limit
     query = assert_sql { Topic.order("title").last(5).entries }
     assert_equal 1, query.length
-    assert_no_match(/LIMIT/, query.first)
+    assert_match(/LIMIT 5/, query.first)
   end
 
-  def test_last_with_integer_and_reorder_should_not_use_sql_limit
+  def test_last_with_integer_and_reorder_should_use_sql_limit
     query = assert_sql { Topic.reorder("title").last(5).entries }
     assert_equal 1, query.length
-    assert_no_match(/LIMIT/, query.first)
+    assert_match(/LIMIT 5/, query.first)
   end
 
   def test_take_and_first_and_last_with_integer_should_return_an_array


### PR DESCRIPTION
Related PR: https://github.com/rails/rails/pull/2789

``` ruby
pry(main)> User.order(foo: :asc).last
  User Load (4.6ms)  SELECT `users`.* FROM `users` ORDER BY `users`.`foo` DESC LIMIT 1

pry(main)> User.order(foo: :asc).last(2)
  User Load (2117.3ms)  SELECT `users`.* FROM `users` ORDER BY `users`.`foo` ASC
```

I think this behavior is incosistent and inefficient. I fixed it to:

``` ruby
pry(main)> User.order(foo: :asc).last(2)
  User Load (4.3ms)  SELECT `users`.* FROM `users` ORDER BY `users`.`foo` DESC LIMIT 2
```
