### PR TITLE
Use kwargs in Module#delegate

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -148,14 +148,7 @@ class Module
   #
   # The target method must be public, otherwise it will raise +NoMethodError+.
   #
-  def delegate(*methods)
-    options = methods.pop
-    unless options.is_a?(Hash) && to = options[:to]
-      raise ArgumentError, 'Delegation needs a target. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter).'
-    end
-
-    prefix, allow_nil = options.values_at(:prefix, :allow_nil)
-
+  def delegate(*methods, to:, prefix: nil, allow_nil: false)
     if prefix == true && to =~ /^[^a-z_]/
       raise ArgumentError, 'Can only automatically set the delegation prefix when delegating to a method.'
     end


### PR DESCRIPTION
Since we started converting methods to use kwargs, I think that
`Module#delegate` can benefit from the treatment.

Now, we do lose a good message, IMO.

``` ruby
>> module A
>>  delegate :foo
>> end
```

Used to produce:

```
ArgumentError: Delegation needs a target. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter).
```

With this change the error is:

```
ArgumentError: missing keyword: to
```

However, I do think with time people will start using more and more
kwargs, the error will be quite familiar to most of the devs.
