### PR TITLE
Fixes incorrect wording of test description

### DIFF
--- a/activesupport/test/xml_mini_test.rb
+++ b/activesupport/test/xml_mini_test.rb
@@ -11,7 +11,7 @@ module XmlMiniTest
       assert_equal "my-key", ActiveSupport::XmlMini.rename_key("my_key")
     end
 
-    def test_rename_key_does_nothing_with_dasherize_true
+    def test_rename_key_dasherizes_with_dasherize_true
       assert_equal "my-key", ActiveSupport::XmlMini.rename_key("my_key", :dasherize => true)
     end
 


### PR DESCRIPTION
- Clarifies test description, as `rename_key` actually does dasherize.

@arthurnn :green_heart: :smile: 
