### PR TITLE
Schema creation doesn't load the app

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -286,7 +286,7 @@ db_namespace = namespace :db do
     end
 
     desc "Recreate the databases from the structure.sql file"
-    task :load => [:environment, :load_config] do
+    task :load => [:load_config] do
       ActiveRecord::Tasks::DatabaseTasks.load_schema_current(:sql, ENV['SCHEMA'])
     end
 


### PR DESCRIPTION
@senny to answer your question, the app doesn't need to know the schema type - it is specified by the task name.
