### PR TITLE
Make possible to pass proc as group_method in option_groups_from_collection_for_select

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make possible to pass proc as `group_method` in `ActionView::Helpers::FormOptionsHelper#option_groups_from_collection_for_select`.
+
+    *Karol Galanciak*
+
 *   Extracted `ActionView::Helpers::RecordTagHelper` to external gem
     (`record_tag_helper`) and added removal notices.
 

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -409,7 +409,8 @@ module ActionView
       # Parameters:
       # * +collection+ - An array of objects representing the <tt><optgroup></tt> tags.
       # * +group_method+ - The name of a method which, when called on a member of +collection+, returns an
-      #   array of child objects representing the <tt><option></tt> tags.
+      #   array of child objects representing the <tt><option></tt> tags or a proc taking member of +collection+
+      #   as an argument, which returns an array of child objects representing the <tt><option></tt> tags.
       # * group_label_method+ - The name of a method which, when called on a member of +collection+, returns a
       #   string to be used as the +label+ attribute for its <tt><optgroup></tt> tag.
       # * +option_key_method+ - The name of a method which, when called on a child object of a member of
@@ -454,7 +455,7 @@ module ActionView
       def option_groups_from_collection_for_select(collection, group_method, group_label_method, option_key_method, option_value_method, selected_key = nil)
         collection.map do |group|
           option_tags = options_from_collection_for_select(
-            group.send(group_method), option_key_method, option_value_method, selected_key)
+            value_for_collection(group, group_method), option_key_method, option_value_method, selected_key)
 
           content_tag(:optgroup, option_tags, label: group.send(group_label_method))
         end.join.html_safe

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -303,6 +303,14 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_option_groups_from_collection_for_select_with_proc_for_group_method
+    proc_for_group_method = lambda { |continent| continent.countries.select.with_index { |country, idx| idx.odd? } }
+    assert_dom_equal(
+      "<optgroup label=\"&lt;Africa&gt;\"><option value=\"so\">Somalia</option></optgroup><optgroup label=\"Europe\"><option value=\"ie\">Ireland</option></optgroup>",
+      option_groups_from_collection_for_select(dummy_continents, proc_for_group_method, "continent_name", "country_id", "country_name", "dk")
+    )
+  end
+
   def test_option_groups_from_collection_for_select_returns_html_safe_string
     assert option_groups_from_collection_for_select(dummy_continents, "countries", "continent_name", "country_id", "country_name", "dk").html_safe?
   end


### PR DESCRIPTION
I needed to do some filtering of child objects but didn't want to add a method for it in a model so I thought about using lambda in this case. This PR makes it possible to do so.
