### PR TITLE
Match HashWithIndifferentAccess#default & Hash#default

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Match `HashWithIndifferentAccess#default`'s behaviour with `Hash#default`
+
+    *David Cornu*
+
 *   Adds `:exception_object` key to `ActiveSupport::Notifications::Instrumenter` payload when an exception is raised.
 
     Adds new key/value pair to payload when an exception is raised: e.g. `:exception_object => #<RuntimeError: FAIL>`.

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -68,12 +68,10 @@ module ActiveSupport
       end
     end
 
-    def default(key = nil)
-      if key.is_a?(Symbol) && include?(key = key.to_s)
-        self[key]
-      else
-        super
-      end
+    def default(*args)
+      key = args.first
+      args[0] = key.to_s if key.is_a?(Symbol)
+      super(*args)
     end
 
     def self.new_from_hash_copying_default(hash)
@@ -158,6 +156,20 @@ module ActiveSupport
     alias_method :include?, :key?
     alias_method :has_key?, :key?
     alias_method :member?, :key?
+
+
+    # Same as <tt>Hash#[]</tt> where the key passed as argument can be
+    # either a string or a symbol:
+    #
+    #   counters = ActiveSupport::HashWithIndifferentAccess.new
+    #   counters[:foo] = 1
+    #
+    #   counters['foo'] # => 1
+    #   counters[:foo]  # => 1
+    #   counters[:zoo]  # => nil
+    def [](key)
+      super(convert_key(key))
+    end
 
     # Same as <tt>Hash#fetch</tt> where the key passed as argument can be
     # either a string or a symbol:

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1587,9 +1587,9 @@ class HashToXmlTest < ActiveSupport::TestCase
     assert_equal 3, hash_wia[:new_key]
   end
 
-  def test_should_use_default_proc_if_no_key_is_supplied
+  def test_should_return_nil_if_no_key_is_supplied
     hash_wia = HashWithIndifferentAccess.new { 1 +  2 }
-    assert_equal 3, hash_wia.default
+    assert_equal nil, hash_wia.default
   end
 
   def test_should_use_default_value_for_unknown_key


### PR DESCRIPTION
The behaviour for Ruby's `Hash#default` is as follows

``` ruby
default_value = Hash.new(:default)
default_value[:foo] = :bar
default_value.default # => :default
default_value.default(:foo) # => :default
default_value # => {:foo=>:bar}

default_proc = Hash.new { |h, k| h[k] = [] }
default_proc[:foo] = :bar
default_proc.default # => nil
default_proc.default(:foo) # => []
default_proc # => {:foo=>[]}
```

whereas with `HashWithIndifferentAccess`

``` ruby
default_value = HashWithIndifferentAccess.new(:default)
default_value[:foo] = :bar
default_value.default # => :default
default_value.default(:foo) # => :bar
default_value # => {"foo"=>:bar}

default_proc = HashWithIndifferentAccess.new { |h, k| h[k] = [] }
default_proc[:foo] = :bar
default_proc.default # => []
default_proc.default(:foo) # => :bar
default_proc # => {"foo"=>:bar, nil=>[]}
```

`HashWithIndifferentAccess` relies on this behaviour to overwrite all getters which means respecting Ruby's behaviour requires defining `[]` and `fetch` explicitly.
