### PR TITLE
Reduce allocation in AS::Notifications::Instrumenter.

### DIFF
--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -49,7 +49,7 @@ module ActiveSupport
 
       def initialize(name, start, ending, transaction_id, payload)
         @name           = name
-        @payload        = payload.dup
+        @payload        = payload
         @time           = start
         @transaction_id = transaction_id
         @end            = ending


### PR DESCRIPTION
AllocationTracer:

```
["rails/activesupport/lib/active_support/notifications/instrumenter.rb", 52, :T_HASH], [29968, 3, 27880, 0, 8, 4978776]
```

@eileencodes I saw what you did in https://github.com/rails/rails/commit/fcfca5c70023ab01388a87be49a4a33e29d6cd43 so I took a look further down the trace.
