### PR TITLE
Handle array option in `type_to_sql`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -18,6 +18,9 @@ module ActiveRecord
           "ADD #{accept(o)}"
         end
 
+        delegate :quote_column_name, :quote_table_name, :quote_default_expression, :type_to_sql, to: :@conn
+        private :quote_column_name, :quote_table_name, :quote_default_expression, :type_to_sql
+
         private
 
           def visit_AlterTable(o)
@@ -70,18 +73,6 @@ module ActiveRecord
             column_options
           end
 
-          def quote_column_name(name)
-            @conn.quote_column_name name
-          end
-
-          def quote_table_name(name)
-            @conn.quote_table_name name
-          end
-
-          def type_to_sql(type, limit, precision, scale)
-            @conn.type_to_sql type.to_sym, limit, precision, scale
-          end
-
           def add_column_options!(sql, options)
             sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}" if options_include_default?(options)
             # must explicitly check for :null to allow change_column to work on migrations
@@ -95,10 +86,6 @@ module ActiveRecord
               sql << " PRIMARY KEY"
             end
             sql
-          end
-
-          def quote_default_expression(value, column)
-            @conn.quote_default_expression(value, column)
           end
 
           def options_include_default?(options)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -407,12 +407,16 @@ module ActiveRecord
         def change_column(table_name, column_name, type, options = {})
           clear_cache!
           quoted_table_name = quote_table_name(table_name)
+          quoted_column_name = quote_column_name(column_name)
           sql_type = type_to_sql(type, options[:limit], options[:precision], options[:scale])
           sql_type << "[]" if options[:array]
-          sql = "ALTER TABLE #{quoted_table_name} ALTER COLUMN #{quote_column_name(column_name)} TYPE #{sql_type}"
-          sql << " USING #{options[:using]}" if options[:using]
-          if options[:cast_as]
-            sql << " USING CAST(#{quote_column_name(column_name)} AS #{type_to_sql(options[:cast_as], options[:limit], options[:precision], options[:scale])})"
+          sql = "ALTER TABLE #{quoted_table_name} ALTER COLUMN #{quoted_column_name} TYPE #{sql_type}"
+          if options[:using]
+            sql << " USING #{options[:using]}"
+          elsif options[:cast_as]
+            cast_as_type = type_to_sql(options[:cast_as], options[:limit], options[:precision], options[:scale])
+            cast_as_type << "[]" if options[:array]
+            sql << " USING CAST(#{quoted_column_name} AS #{cast_as_type})"
           end
           execute sql
 

--- a/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
@@ -26,6 +26,13 @@ module ActiveRecord
         connection.change_column :strings, :somedate, :timestamp, cast_as: :timestamp
         assert_equal :datetime, connection.columns(:strings).find { |c| c.name == 'somedate' }.type
       end
+
+      def test_change_type_with_array
+        connection.change_column :strings, :somedate, :timestamp, array: true, cast_as: :timestamp
+        column = connection.columns(:strings).find { |c| c.name == 'somedate' }
+        assert_equal :datetime, column.type
+        assert column.array?
+      end
     end
   end
 end


### PR DESCRIPTION
`[]` is a part of `sql_type`, so it is always necessary to respect to
array option when `type_to_sql` is called.
