### PR TITLE
Handle non-string authenticity tokens

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Non-string authenticity tokens do not raise NoMethodError when decoding
+    the masked token.
+
+    *Ville Lautanala*
+
 *   ActionController#translate supports symbols as shortcuts.
     When shortcut is given it also lookups without action name.
 

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -279,7 +279,7 @@ module ActionController #:nodoc:
 
         begin
           masked_token = Base64.strict_decode64(encoded_masked_token)
-        rescue ArgumentError # encoded_masked_token is invalid Base64
+        rescue ArgumentError, NoMethodError # encoded_masked_token is invalid Base64
           return false
         end
 

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -374,6 +374,13 @@ module RequestForgeryProtectionTests
     end
   end
 
+  def test_should_not_raise_error_if_token_is_not_a_string
+    @controller.unstub(:valid_authenticity_token?)
+    assert_blocked do
+      patch :index, params: { custom_authenticity_token: { foo: 'bar' } }
+    end
+  end
+
   def assert_blocked
     session[:something_like_user_id] = 1
     yield


### PR DESCRIPTION
Non-string authenticity tokens raised NoMethodError when decoding the masked authenticity token. For example, if the following document is posted as JSON, an exception is raised:

``` json
{"authenticity_token": {"foo": "bar"}}
```

While CSRF protection is not bypassed, the exception is unexpected.
