### PR TITLE
Do not overwrite secret token value when already present.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `has_secure_token` does not overwrite value when already present.
+
+        user = User.create(token: "custom-secure-token")
+        user.token # => "custom-secure-token"
+
+    *Wojciech Wnętrzak*
+
 *   Use SQL COUNT and LIMIT 1 queries for `none?` and `one?` methods if no block or limit is given,
     instead of loading the entire collection to memory.
     This applies to relations (e.g. `User.all`) as well as associations (e.g. `account.users`)

--- a/activerecord/lib/active_record/secure_token.rb
+++ b/activerecord/lib/active_record/secure_token.rb
@@ -27,7 +27,7 @@ module ActiveRecord
         # Load securerandom only when has_secure_token is used.
         require 'active_support/core_ext/securerandom'
         define_method("regenerate_#{attribute}") { update! attribute => self.class.generate_unique_secure_token }
-        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token) }
+        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token) unless self.send("#{attribute}?")}
       end
 
       def generate_unique_secure_token
@@ -36,4 +36,3 @@ module ActiveRecord
     end
   end
 end
-

--- a/activerecord/test/cases/secure_token_test.rb
+++ b/activerecord/test/cases/secure_token_test.rb
@@ -22,4 +22,11 @@ class SecureTokenTest < ActiveRecord::TestCase
     assert_not_equal @user.token, old_token
     assert_not_equal @user.auth_token, old_auth_token
   end
+
+  def test_token_value_not_overwritten_when_present
+    @user.token = "custom-secure-token"
+    @user.save
+
+    assert_equal @user.token, "custom-secure-token"
+  end
 end


### PR DESCRIPTION
```
user = User.create(token: "custom-secure-token")
user.token # => "custom-secure-token"
```

I'm aware that `has_secure_token` is a simple method that shouldn't fit in all possible use cases, but this change is very small and adds some flexibility.
Previously it was little unexpected to get `User.create(token: "custom").token #=> "some-random-string"`
