### PR TITLE
require rack/utils in exception_wrapper

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -1,5 +1,6 @@
 require 'action_controller/metal/exceptions'
 require 'active_support/core_ext/module/attribute_accessors'
+require 'rack/utils'
 
 module ActionDispatch
   class ExceptionWrapper


### PR DESCRIPTION
Trying to use this class on it's own throws an error. There's a reference to `Rack::Utils` without a corresponding `require`.

```
require 'action_dispatch/middleware/exception_wrapper'
ActionDispatch::ExceptionWrapper.status_code_for_exception("Exception") #=> NameError: uninitialized constant ActionDispatch::ExceptionWrapper::Rack
```
