### PR TITLE
simplify send_file

### DIFF
--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -65,7 +65,7 @@ module ActionController #:nodoc:
       # http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
       # for the Cache-Control header spec.
       def send_file(path, options = {}) #:doc:
-        raise MissingFile, "Cannot read file #{path}" unless File.file?(path) and File.readable?(path)
+        raise MissingFile, "Cannot read file #{path}" unless File.readable?(path)
 
         options[:filename] ||= File.basename(path) unless options[:url_based_filename]
         send_file_headers! options


### PR DESCRIPTION
`File.readable?` return false for not existing files. This change make this line 2x faster.
