### PR TITLE
Raise AR::IrreversibleOrderError when #reverse_order can not do it's job

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   `ActiveRecord::Relation#reverse_order` throws `ActiveRecord::IrreversibleOrderError`
+    when the order can not be reversed using current trivial algorithm.
+    Also raises the same error when `#reverse_order` is called on
+    relation without any order and table has no primary key:
+
+        Topic.order("concat(author_name, title)").reverse_order
+          # Before: SELECT `topics`.* FROM `topics` ORDER BY concat(author_name DESC, title) DESC
+          # After: raises ActiveRecord::IrreversibleOrderError
+        Edge.all.reverse_order
+          # Before: SELECT `edges`.* FROM `edges` ORDER BY `edges`.`` DESC
+          # After: raises ActiveRecord::IrreversibleOrderError
+
+    *Bogdan Gusiev*
+
 *   Improve schema_migrations insertion performance by inserting all versions
     in one INSERT SQL.
 

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -275,4 +275,9 @@ module ActiveRecord
   # The mysql2 and postgresql adapters support setting the transaction isolation level.
   class TransactionIsolationError < ActiveRecordError
   end
+
+  # IrreversibleOrderError is raised when a relation's order is too complex for
+  # +reverse_order+ to automatically reverse.
+  class IrreversibleOrderError < ActiveRecordError
+  end
 end


### PR DESCRIPTION
Current `#reverse_order` algorithm is very simple and doesn't try to
handle complicated cases of reversing order given as string.
This patch makes AR to raise exception instead of generating invalid SQL
inside `#reverse_order`.

Fixes #8225, #11571

This patch is alternative to #16779 and #18754.
