### PR TITLE
Scopes can be array columns for uniq. validator

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -81,7 +81,13 @@ module ActiveRecord
           else
             scope_value = record.read_attribute(scope_item)
           end
-          relation = relation.and(table[scope_item].eq(scope_value))
+
+          # This is basically emulating an Arel::Nodes::Casted
+          column = record.class.columns_hash[scope_item.to_s]
+          quoted_value = record.class.connection.quote(scope_value, column)
+          node = Arel::Nodes::SqlLiteral.new(quoted_value)
+
+          relation = relation.and(table[scope_item].eq(node))
         end
 
         relation

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -45,6 +45,11 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
   repair_validations(Topic, Reply)
 
+  class ModelWithScopedValidationOnArray < ActiveRecord::Base
+    self.table_name = 'postgresql_arrays'
+    validates_uniqueness_of :name, scope: [:commission_by_quarter]
+  end
+
   def test_validate_uniqueness
     Topic.validates_uniqueness_of(:title)
 
@@ -387,6 +392,15 @@ class UniquenessValidationTest < ActiveRecord::TestCase
       assert !e2.persisted?, "e2 shouldn't be valid"
       assert e2.errors[:nicknames].any?, "Should have errors for nicknames"
       assert_equal ["has already been taken"], e2.errors[:nicknames], "Should have uniqueness message for nicknames"
+    end
+
+    def test_validate_uniqueness_scoped_to_array
+      record = ModelWithScopedValidationOnArray.new(
+        name: "Sheldon Cooper",
+        commission_by_quarter: [1, 2, 3]
+      )
+
+      assert_nothing_raised { record.valid? }
     end
   end
 

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -62,7 +62,8 @@ _SQL
   CREATE TABLE postgresql_arrays (
     id SERIAL PRIMARY KEY,
     commission_by_quarter INTEGER[],
-    nicknames TEXT[]
+    nicknames TEXT[],
+    name TEXT
   );
 _SQL
 


### PR DESCRIPTION
`validates_uniqueness_of` would blow up when used with a scope that was
an array column. The validator must perform a query to determine whether
the record already exists in the database, and uses the scope to do so.
When it constructs the query, it deserializes the value of the scope (an
array). Unfortunately this breaks the query because Postgres is still
expecting that value to be an array. There is a newer version of Arel
that prevents this from happening, but 4.1 is not on that version, so we
have to emulate that code here.
