### PR TITLE
Spike on new transaction callbacks

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -487,7 +487,7 @@ module ActiveRecord
     end
 
     def has_transactional_callbacks? # :nodoc:
-      !_rollback_callbacks.empty? || !_commit_callbacks.empty?
+      !_rollback_callbacks.empty? || !_commit_callbacks.empty? || !_before_commit_callbacks.empty?
     end
 
     # Updates the attributes on this particular ActiveRecord object so that

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -407,7 +407,8 @@ class TransactionEnrollmentCallbacksTest < ActiveRecord::TestCase
   class TopicWithoutTransactionalEnrollmentCallbacks < ActiveRecord::Base
     self.table_name = :topics
 
-    after_commit_without_transaction_enrollment { |r| r.history << :commit }
+    before_commit_without_transaction_enrollment { |r| r.history << :before_commit }
+    after_commit_without_transaction_enrollment { |r| r.history << :after_commit }
     after_rollback_without_transaction_enrollment { |r| r.history << :rollback }
 
     def history
@@ -435,7 +436,7 @@ class TransactionEnrollmentCallbacksTest < ActiveRecord::TestCase
       end
       @topic.class.connection.add_transaction_record(@topic)
     end
-    assert_equal [:commit], @topic.history
+    assert_equal [:before_commit, :after_commit], @topic.history
   end
 
   def test_rollback_dont_enroll_transaction

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -420,7 +420,7 @@ class TransactionEnrollmentCallbacksTest < ActiveRecord::TestCase
     @topic = TopicWithoutTransactionalEnrollmentCallbacks.create!
   end
 
-  def test_commit_dont_enroll_transaction
+  def test_commit_does_not_run_transactions_callbacks_without_enrollment
     @topic.transaction do
       @topic.content = 'foo'
       @topic.save!
@@ -428,7 +428,7 @@ class TransactionEnrollmentCallbacksTest < ActiveRecord::TestCase
     assert @topic.history.empty?
   end
 
-  def test_commit_enrollment_transaction_when_call_add
+  def test_commit_run_transactions_callbacks_with_explicit_enrollment
     @topic.transaction do
       2.times do
         @topic.content = 'foo'
@@ -439,7 +439,7 @@ class TransactionEnrollmentCallbacksTest < ActiveRecord::TestCase
     assert_equal [:before_commit, :after_commit], @topic.history
   end
 
-  def test_rollback_dont_enroll_transaction
+  def test_rollback_does_not_run_transactions_callbacks_without_enrollment
     @topic.transaction do
       @topic.content = 'foo'
       @topic.save!
@@ -448,7 +448,7 @@ class TransactionEnrollmentCallbacksTest < ActiveRecord::TestCase
     assert @topic.history.empty?
   end
 
-  def test_rollback_enrollment_transaction_when_call_add
+  def test_rollback_run_transactions_callbacks_with_explicit_enrollment
     @topic.transaction do
       2.times do
         @topic.content = 'foo'


### PR DESCRIPTION
this fixes #18904 #18903

Adds a `before_commit` callback.
Add `_without_transaction_enrollment` versions for after_commit, after_rollback, before_commit.
Keep in mind all this APIs are private for now, so we can use on #18824, and shape them before making them public.(if even we will)

Thoughts @jeremy before I merge it?
