### PR TITLE
Some enum improvements

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -98,8 +98,6 @@ module ActiveRecord
 
         if mapping.has_key?(value)
           value.to_s
-        elsif mapping.has_value?(value)
-          mapping.key(value)
         else
           raise ArgumentError, "'#{value}' is not a valid #{name}"
         end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -61,8 +61,6 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "build from where" do
-    assert Book.where(status: Book.statuses[:written]).build.written?
-    refute Book.where(status: Book.statuses[:written]).build.proposed?
     assert Book.where(status: :written).build.written?
     refute Book.where(status: :written).build.proposed?
     assert Book.where(status: "written").build.written?


### PR DESCRIPTION
I would like to discuss two separate things (probably should open two PRs for it but I was too lazy!):
1. Do we actually care about making `Book.where(status:1).build` work? (the first commit)
   
   That "assign the mapped value" thing always gave me a weird feeling, and I'd always wanted to get rid of it. The reason for adding the hack in 788bb40 no longer applies, and removing it doesn't break anything except the two tests that I added a few hours ago.
   
   So that got me thinking, for the long term, do we actually care about making `Book.where(status: <some raw sql value>)` work? I suppose this is a question that needs to be answered for not just enums but more broadly for the "non-standard" types. If this _should_ work across the board, should it be implemented somewhere else? 
   
    (Perhaps we can always do a to/from_database round trip in `populate_with_current_scope_attributes` or something...)
2. Should enum be type-agnostic? (second commit)
   
   There has always been this undocumented secret feature that you can use strings for the enum type. It never quite got the official status so there were no tests around it. 933decc "broke" this, so I attempted to fix it in the second commit.
   
   Are we comfortable enough supporting that for the long term? If so, perhaps it is time to add test/docs for it. With Sean's refactor, it appears that we can maintain this feature at a pretty reasonable cost and pretty low risk. This would also open up the possibility of backing AR enums with real enums in databases that supports it.
   
   The implementation is probably not rock solid yet, but it should at least unbreak the strings case. @sgrif can probably tell us what else needs to be done if we are committed down.

cc @sgrif @rafaelfranca @senny @dhh @matthewd 
