### PR TITLE
Add data type support to store_accessor

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -21,6 +21,10 @@ module ActiveRecord
   # the accessor methods. Be aware that these columns use a string keyed hash and do not allow access
   # using a symbol.
   #
+  # You can also declare accessors which support type casting: either providing key-to-type hash along with simple keys
+  # (using +store+ or +store_accessor+) or using +store_attribute+ method (see examples below).
+  # It is especially useful when working with stores/coders like +hstore+ and +json+ which don't have full types support.
+  #
   # NOTE: The default validations with the exception of +uniqueness+ will work.
   # For example, if you want to check for +uniqueness+ with +hstore+ you will
   # need to use a custom validation to handle it.
@@ -43,6 +47,24 @@ module ActiveRecord
   #   class SuperUser < User
   #     store_accessor :settings, :privileges, :servants
   #   end
+  #
+  #   # Provide type for accessors
+  #   class MegaUser < User
+  #     store_accessor :settings, login_at: :date_time
+  #     store_attribute :settings, :ratio, :integer, limit: 1
+  #   end
+  #
+  #   u = MegaUser.new(active: false, login_at: '2015-01-01 00:01', ratio: "63.4608")
+  #
+  #   u.login_at.is_a?(DateTime) # => true
+  #   u.login_at = DateTime.new(2015,1,1,11,0,0)
+  #   u.ratio # => 63
+  #   u.reload
+  #
+  #   # After loading record from db store contains casted data
+  #   u.settings['login_at'] == DateTime.new(2015,1,1,11,0,0) # => true
+  #
+  # For more examples on using custom types, see documentation for ActiveRecord::Attributes.
   #
   # The stored attribute names can be retrieved using {.stored_attributes}[rdoc-ref:rdoc-ref:ClassMethods#stored_attributes].
   #
@@ -77,31 +99,126 @@ module ActiveRecord
     end
 
     module ClassMethods
-      def store(store_attribute, options = {})
-        serialize store_attribute, IndifferentCoder.new(options[:coder])
-        store_accessor(store_attribute, options[:accessors]) if options.has_key? :accessors
+      # Defines store on this model.
+      #
+      # +store_name+ The name of the store.
+      #
+      # ==== Options
+      # The following options are accepted:
+      #
+      # +coder+ The coder of the store.
+      #
+      # +accessors+ An array of the accessors to the store.
+      #
+      # Examples:
+      #
+      #   class User < ActiveRecord::Base
+      #     store :settings, accessors: [:color, :homepage, login_at: :datetime], coder: JSON
+      #   end
+      def store(store_name, options = {})
+        serialize store_name, IndifferentCoder.new(options[:coder])
+        store_accessor(store_name, *options[:accessors]) if options.key?(:accessors)
       end
 
-      def store_accessor(store_attribute, *keys)
+      # Adds additional accessors to an existing store on this model.
+      #
+      # +store_name+ The name of the store.
+      #
+      # +keys+ The array of the accessors to the store.
+      #
+      # +typed_keys+ The key-to-type hash of the accesors with type to the store.
+      #
+      # Examples:
+      #
+      #   class SuperUser < User
+      #     store_accessor :settings, :privileges, login_at: :datetime
+      #   end
+      def store_accessor(store_name, *keys, **typed_keys)
         keys = keys.flatten
+        typed_keys = typed_keys.except(keys)
 
-        _store_accessors_module.module_eval do
-          keys.each do |key|
-            define_method("#{key}=") do |value|
-              write_store_attribute(store_attribute, key, value)
-            end
+        _define_accessors_methods(store_name, *keys)
 
-            define_method(key) do
-              read_store_attribute(store_attribute, key)
-            end
-          end
+        _prepare_local_stored_attributes(store_name, *keys)
+
+        typed_keys.each do |key, type|
+          store_attribute(store_name, key, type)
+        end
+      end
+
+      # Adds additional accessors with a type to an existing store on this model.
+      # Type casting occurs every time you write data through accessor or update store itself
+      # and when object is loaded from database.
+      #
+      # Note that if you update store explicitly then value isn't  type casted.
+      #
+      # +store_name+ The name of the store.
+      #
+      # +name+ The name of the accessor to the store.
+      #
+      # +type+ A symbol such as +:string+ or +:integer+, or a type object
+      # to be used for the accessor.
+      #
+      # +options+ A hash of cast type options such as +precision+, +limit+, +scale+.
+      #
+      # Examples:
+      #
+      #   class MegaUser < User
+      #     store_attribute :settings, :ratio, :integer, limit: 1
+      #     store_attribute :settings, :login_at, :datetime
+      #   end
+      #
+      #   u = MegaUser.new(active: false, login_at: '2015-01-01 00:01', ratio: "63.4608")
+      #
+      #   u.login_at.is_a?(DateTime) # => true
+      #   u.login_at = DateTime.new(2015,1,1,11,0,0)
+      #   u.ratio # => 63
+      #   u.reload
+      #
+      #   # After loading record from db store contains casted data
+      #   u.settings['login_at'] == DateTime.new(2015,1,1,11,0,0) # => true
+      #
+      #   # If you update store explicitly then the value returned
+      #   # by accessor isn't type casted
+      #   u.settings['ration'] = "3.141592653"
+      #   u.ratio # => "3.141592653"
+      #
+      #   # On the other hand, writing through accessor set correct data within store
+      #   u.ratio = "3.14.1592653"
+      #   u.ratio # => 3
+      #   u.settings['ratio'] # => 3
+      #
+      # For more examples on using types, see documentation for ActiveRecord::Attributes.
+      def store_attribute(store_name, name, type, **options)
+        _define_accessors_methods(store_name, name)
+
+        decorate_attribute_type(store_name, "typed_accessor_for_#{name}") do |subtype|
+          Type::TypedStore.create_from_type(subtype, name, type, **options)
         end
 
+        _prepare_local_stored_attributes(store_name, name)
+      end
+
+      def _prepare_local_stored_attributes(store_name, *keys) # :nodoc:
         # assign new store attribute and create new hash to ensure that each class in the hierarchy
         # has its own hash of stored attributes.
         self.local_stored_attributes ||= {}
-        self.local_stored_attributes[store_attribute] ||= []
-        self.local_stored_attributes[store_attribute] |= keys
+        self.local_stored_attributes[store_name] ||= []
+        self.local_stored_attributes[store_name] |= keys
+      end
+
+      def _define_accessors_methods(store_name, *keys)
+        _store_accessors_module.module_eval do
+          keys.each do |key|
+            define_method("#{key}=") do |value|
+              write_store_attribute(store_name, key, value)
+            end
+
+            define_method(key) do
+              read_store_attribute(store_name, key)
+            end
+          end
+        end
       end
 
       def _store_accessors_module # :nodoc:
@@ -115,26 +232,26 @@ module ActiveRecord
       def stored_attributes
         parent = superclass.respond_to?(:stored_attributes) ? superclass.stored_attributes : {}
         if self.local_stored_attributes
-          parent.merge!(self.local_stored_attributes) { |k, a, b| a | b }
+          parent.merge!(self.local_stored_attributes) { |_k, a, b| a | b }
         end
         parent
       end
     end
 
     protected
-      def read_store_attribute(store_attribute, key)
-        accessor = store_accessor_for(store_attribute)
-        accessor.read(self, store_attribute, key)
+      def read_store_attribute(store_name, key)
+        accessor = store_accessor_for(store_name)
+        accessor.read(self, store_name, key)
       end
 
-      def write_store_attribute(store_attribute, key, value)
-        accessor = store_accessor_for(store_attribute)
-        accessor.write(self, store_attribute, key, value)
+      def write_store_attribute(store_name, key, value)
+        accessor = store_accessor_for(store_name)
+        accessor.write(self, store_name, key, value)
       end
 
     private
-      def store_accessor_for(store_attribute)
-        type_for_attribute(store_attribute.to_s).accessor
+      def store_accessor_for(store_name)
+        type_for_attribute(store_name.to_s).accessor
       end
 
       class HashAccessor # :nodoc:
@@ -167,11 +284,11 @@ module ActiveRecord
       end
 
       class IndifferentHashAccessor < ActiveRecord::Store::HashAccessor # :nodoc:
-        def self.prepare(object, store_attribute)
-          attribute = object.send(store_attribute)
+        def self.prepare(object, store_name)
+          attribute = object.send(store_name)
           unless attribute.is_a?(ActiveSupport::HashWithIndifferentAccess)
             attribute = IndifferentCoder.as_indifferent_hash(attribute)
-            object.send :"#{store_attribute}=", attribute
+            object.send :"#{store_name}=", attribute
           end
           attribute
         end

--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -6,6 +6,7 @@ require 'active_record/type/internal/timezone'
 require 'active_record/type/date'
 require 'active_record/type/date_time'
 require 'active_record/type/time'
+require 'active_record/type/typed_store'
 
 require 'active_record/type/serialized'
 require 'active_record/type/adapter_specific_registry'

--- a/activerecord/lib/active_record/type/typed_store.rb
+++ b/activerecord/lib/active_record/type/typed_store.rb
@@ -1,6 +1,6 @@
 module ActiveRecord
   module Type
-    class TypedStore < DelegateClass(Type::Value) # :nodoc:
+    class TypedStore < DelegateClass(ActiveModel::Type::Value) # :nodoc:
       # Creates +TypedStore+ type instance and specifies type caster
       # for key.
       def self.create_from_type(basetype, key, type, **options)

--- a/activerecord/lib/active_record/type/typed_store.rb
+++ b/activerecord/lib/active_record/type/typed_store.rb
@@ -1,0 +1,81 @@
+module ActiveRecord
+  module Type
+    class TypedStore < DelegateClass(Type::Value) # :nodoc:
+      # Creates +TypedStore+ type instance and specifies type caster
+      # for key.
+      def self.create_from_type(basetype, key, type, **options)
+        typed_store = new(basetype)
+        typed_store.add_typed_key(key, type, **options)
+        typed_store
+      end
+
+      def initialize(subtype)
+        @accessor_types = {}
+        @store_accessor = subtype.accessor
+        super(subtype)
+      end
+
+      def add_typed_key(key, type, **options)
+        if type.is_a?(Symbol)
+          type = ActiveRecord::Type.lookup(type, options)
+        end
+        @accessor_types[key.to_s] = type
+      end
+
+      def deserialize(value)
+        hash = super
+        cast(hash)
+      end
+
+      def serialize(value)
+        if value
+          accessor_types.each do |key, type|
+            k = key_to_cast(value, key)
+            value[k] = type.serialize(value[k]) unless k.nil?
+          end
+        end
+        super(value)
+      end
+
+      def cast(value)
+        hash = super
+        if hash
+          accessor_types.each do |key, type|
+            hash[key] = type.cast(hash[key]) if hash.key?(key)
+          end
+        end
+        hash
+      end
+
+      def accessor
+        self
+      end
+
+      def write(object, attribute, key, value)
+        if typed?(key)
+          value = type_for(key).cast(value)
+        end
+        store_accessor.write(object, attribute, key, value)
+      end
+
+      delegate :read, :prepare, to: :store_accessor
+
+      protected
+        # We cannot rely on string keys 'cause user input can contain symbol keys
+        def key_to_cast(val, key)
+          return key if val.key?(key)
+          return key.to_sym if val.key?(key.to_sym)
+        end
+
+        def typed?(key)
+          accessor_types.key?(key.to_s)
+        end
+
+        def type_for(key)
+          accessor_types.fetch(key.to_s)
+        end
+
+        attr_reader :accessor_types, :store_accessor
+    end
+  end
+end

--- a/activerecord/test/cases/type/typed_store_test.rb
+++ b/activerecord/test/cases/type/typed_store_test.rb
@@ -1,0 +1,69 @@
+require "cases/helper"
+
+module ActiveRecord
+  module Type
+    class TypedStoreTest < ActiveRecord::TestCase
+      setup do
+        @store_type = Serialized.new(Text.new, Coders::JSON)
+        @yaml_type = Serialized.new(
+          Text.new,
+          Store::IndifferentCoder.new(Coders::YAMLColumn.new(Hash))
+        )
+      end
+
+      def test_without_key_types
+        type = TypedStore.new(@store_type)
+        assert_equal [1, 2], type.cast([1, 2])
+        assert_equal({ 'a' => 'b' }, type.cast('a' => 'b'))
+        assert_equal [1, 2], type.deserialize('[1,2]')
+        assert_equal({ 'a' => 'b' }, type.deserialize('{"a":"b"}'))
+        assert_equal '[1,2]', type.serialize([1, 2])
+        assert_equal '{"a":"b"}', type.serialize('a' => 'b')
+      end
+
+      def test_with_key_types
+        type = TypedStore.new(@store_type)
+        type.add_typed_key('date', :date)
+
+        date = ::Date.new(2015, 3, 8)
+
+        assert_equal({ 'date' => date }, type.cast(date: '2015-03-08'))
+        assert_equal({ 'date' => date }, type.deserialize('{"date":"2015-03-08"}'))
+        assert_equal '{"date":"2015-03-08"}', type.serialize(date: date)
+      end
+
+      def test_key_type_with_options
+        type = TypedStore.new(@store_type)
+        type.add_typed_key('val', :integer, limit: 1)
+
+        assert_raises(::RangeError) do
+          type.serialize(val: 1024)
+        end
+      end
+
+      def test_create_from_type
+        type = TypedStore.create_from_type(@store_type, 'date', :date)
+        new_type = TypedStore.create_from_type(type, 'val', :integer)
+
+        date = ::Date.new(2015, 3, 8)
+
+        assert_equal({ 'date' => date, 'val' => '1.2' }, type.cast(date: '2015-03-08', val: '1.2'))
+        assert_equal({ 'date' => date, 'val' => 1 }, new_type.cast(date: '2015-03-08', val: '1.2'))
+      end
+
+      def test_with_yaml_coder
+        type = TypedStore.new(@yaml_type)
+        type.add_typed_key('date', :date)
+
+        date = ::Date.new(2015, 3, 8)
+
+        assert_equal({ 'date' => date }, type.cast(date: '2015-03-08'))
+        assert_equal({ 'date' => date }, type.cast('date' => '2015-03-08'))
+        assert_equal({ 'date' => date }, type.deserialize("---\n:date: 2015-03-08\n"))
+        assert_equal({ 'date' => date }, type.deserialize("---\ndate: 2015-03-08\n"))
+        assert_equal "--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess\ndate: 2015-03-08\n", type.serialize(date: date)
+        assert_equal "--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess\ndate: 2015-03-08\n", type.serialize('date' => date)
+      end
+    end
+  end
+end

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -18,8 +18,9 @@ class Admin::User < ActiveRecord::Base
   store :settings, :accessors => [ :color, :homepage ]
   store_accessor :settings, :favorite_food
   store :preferences, :accessors => [ :remember_login ]
-  store :json_data, :accessors => [ :height, :weight ], :coder => Coder.new
+  store :json_data, :accessors => [ :height, :weight, active: :boolean, salary: :integer, birthday: :date ], :coder => Coder.new
   store :json_data_empty, :accessors => [ :is_a_good_guy ], :coder => Coder.new
+  store_attribute :json_data, :progress, :integer, limit: 1
 
   def phone_number
     read_store_attribute(:settings, :phone_number).gsub(/(\d{3})(\d{3})(\d{4})/,'(\1) \2-\3')


### PR DESCRIPTION
Add type casting for store_accessors. First, example:

``` ruby
class TypedUser < User
  store_accessor :settings, login_at: :date_time
end

u = TypedUser.new(active: false, login_at: '2015-01-01 00:01')   
u.login_at.is_a?(DateTime) #=> true 
u.login_at = DateTime.new(2015,1,1,11,0,0)
u.reload

# after loading record from db store contains raw data
u.settings['login_at'] #=> '2015-01-01 11:00:00'
# but accessor returns type casted value
u.login_at == DateTime.new(2015,1,1,11,0,0) #=> true
```

This feature is the most efficient when working with Postresql hstore, because hstore stores all values as strings. Example:

``` ruby
# without typed accessors
class User < ActiveRecord::User
  # suppose we store some counter within hstore 'settings'
  store_accessor :settings, :counter

  # we have to override getter to get value as integer
  def counter
    super.to_i  
  end
end

# with typed accessor
class User < ActiveRecord::User
  store_accessor :settings, counter: :integer
end
```

This makes code depend less on store type. 

Another feature is data normalization:

``` ruby
class User < ActiveRecord::User
  store_accessor :settings, birthday: :date
end

User.new(birthday: '01/01/2010') #=> stores 'birthday' as '2010-01-01' 
User.new(birthday: '2010-01-01') #=> stores 'birthday' as '2010-01-01'  too
```

Custom types are also supported (they must inherits from `ActiveRecord::Type::Value`):

``` ruby
class User < ActiveRecord::User
  # provide class or instance itself
  store_accessor :settings, birthday: BirthdayValue, money: MoneyValue.new
end
```
