### PR TITLE
Undo `lookup_cast_type` visibility to protected

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -391,15 +391,15 @@ module ActiveRecord
         Column.new(name, default, sql_type_metadata, null)
       end
 
-      def lookup_cast_type(sql_type) # :nodoc:
-        type_map.lookup(sql_type)
-      end
-
       def column_name_for_operation(operation, node) # :nodoc:
         visitor.accept(node, collector).value
       end
 
       protected
+
+      def lookup_cast_type(sql_type) # :nodoc:
+        type_map.lookup(sql_type)
+      end
 
       def initialize_type_map(m) # :nodoc:
         register_class_with_limit m, %r(boolean)i,       Type::Boolean

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -410,11 +410,6 @@ module ActiveRecord
         PostgreSQL::Table.new(table_name, base)
       end
 
-      def lookup_cast_type(sql_type) # :nodoc:
-        oid = execute("SELECT #{quote(sql_type)}::regtype::oid", "SCHEMA").first['oid'].to_i
-        super(oid)
-      end
-
       def column_name_for_operation(operation, node) # :nodoc:
         OPERATION_ALIASES.fetch(operation) { operation.downcase }
       end
@@ -462,6 +457,11 @@ module ActiveRecord
               type_map.register_type(oid, cast_type)
             end
           }
+        end
+
+        def lookup_cast_type(sql_type) # :nodoc:
+          oid = execute("SELECT #{quote(sql_type)}::regtype::oid", "SCHEMA").first['oid'].to_i
+          super(oid)
         end
 
         def initialize_type_map(m) # :nodoc:


### PR DESCRIPTION
`lookup_cast_type` is internal API but the visibility was changed to
public to call directly from `SchemaCreation` by b404613. Currently,
it is not already call from `SchemaCreation`.
