### PR TITLE
Merge multi_fetch_fragments.

### DIFF
--- a/actionpack/test/fixtures/collection_cache/index.html.erb
+++ b/actionpack/test/fixtures/collection_cache/index.html.erb
@@ -1,0 +1,1 @@
+<%= render @customers %>

--- a/actionpack/test/fixtures/customers/_commented_customer.html.erb
+++ b/actionpack/test/fixtures/customers/_commented_customer.html.erb
@@ -1,0 +1,4 @@
+<%# I'm a comment %>
+<% cache customer do %>
+  <%= customer.name %>, <%= customer.id %>
+<% end %>

--- a/actionpack/test/fixtures/customers/_customer.html.erb
+++ b/actionpack/test/fixtures/customers/_customer.html.erb
@@ -1,0 +1,3 @@
+<% cache customer do %>
+  <%= customer.name %>, <%= customer.id %>
+<% end %>

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -110,6 +110,29 @@ module ActionView
       #   <%= some_helper_method(person) %>
       #
       # Now all you'll have to do is change that timestamp when the helper method changes.
+      #
+      # === Automatic Collection Caching
+      #
+      # When rendering collections such as:
+      #
+      #   <%= render @notifications %>
+      #   <%= render partial: 'notifications/notification', collection: @notifications %>
+      #
+      # If the notifications/_notification partial starts with a cache call like so:
+      #
+      #   <% cache notification do %>
+      #     <%= notification.name %>
+      #   <% end %>
+      #
+      # The collection can then automatically use any cached renders for that
+      # template by reading them at once instead of one by one.
+      #
+      # See ActionView::Template::Handlers::ERB.resource_cache_call_pattern for more
+      # information on what cache calls make a template eligible for this collection caching.
+      #
+      # The automatic cache multi read can be turned off like so:
+      #
+      #   <%= render @notifications, cache: false %>
       def cache(name = {}, options = nil, &block)
         if controller.perform_caching
           safe_concat(fragment_for(cache_fragment_name(name, options), options, &block))

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -161,6 +161,14 @@ module ActionView
         end
       end
 
+      # Given a key (as described in ActionController::Caching::Fragments.expire_fragment),
+      # returns a key suitable for use in reading, writing, or expiring a
+      # cached fragment. All keys are prefixed with <tt>views/</tt> and uses
+      # ActiveSupport::Cache.expand_cache_key for the expansion.
+      def fragment_cache_key(key)
+        ActiveSupport::Cache.expand_cache_key(key.is_a?(Hash) ? url_for(key).split("://").last : key, :views)
+      end
+
     private
 
       def fragment_name_with_digest(name) #:nodoc:

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -36,6 +36,12 @@ module ActionView
       end
     end
 
+    initializer "action_view.collection_caching" do |app|
+      ActiveSupport.on_load(:action_controller) do
+        PartialRenderer.collection_cache = app.config.action_controller.cache_store
+      end
+    end
+
     initializer "action_view.setup_action_pack" do |app|
       ActiveSupport.on_load(:action_controller) do
         ActionView::RoutingUrlFor.include(ActionDispatch::Routing::UrlFor)

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -1,3 +1,4 @@
+require 'action_view/renderer/partial_renderer/collection_caching'
 require 'thread_safe'
 
 module ActionView
@@ -280,6 +281,8 @@ module ActionView
   #     <%- end -%>
   #   <% end %>
   class PartialRenderer < AbstractRenderer
+    include CollectionCaching
+
     PREFIXED_PARTIAL_NAMES = ThreadSafe::Cache.new do |h, k|
       h[k] = ThreadSafe::Cache.new
     end
@@ -321,8 +324,9 @@ module ActionView
         spacer = find_template(@options[:spacer_template], @locals.keys).render(@view, @locals)
       end
 
-      result = @template ? collection_with_template : collection_without_template
-      result.join(spacer).html_safe
+      cache_collection_render do
+        @template ? collection_with_template : collection_without_template
+      end.join(spacer).html_safe
     end
 
     def render_partial

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -1,0 +1,57 @@
+require 'active_support/core_ext/object/try'
+
+module ActionView
+  module CollectionCaching # :nodoc:
+    extend ActiveSupport::Concern
+
+    included do
+      # Fallback cache store if Action View is used without Rails.
+      # Otherwise overriden in Railtie to use Rails.cache.
+      mattr_accessor(:collection_cache) { ActiveSupport::Cache::MemoryStore.new }
+    end
+
+    private
+      def cache_collection_render
+        return yield unless cache_collection?
+
+        keyed_collection = collection_by_cache_keys
+        partial_cache = collection_cache.read_multi(*keyed_collection.keys)
+
+        @collection = keyed_collection.reject { |key, _| partial_cache.key?(key) }.values
+        rendered_partials = @collection.any? ? yield.dup : []
+
+        fetch_or_cache_partial(partial_cache, order_by: keyed_collection.each_key) do
+          rendered_partials.shift
+        end
+      end
+
+      def cache_collection?
+        @options[:cache].present?
+      end
+
+      def collection_by_cache_keys
+        seed = @options[:cache].respond_to?(:call) ? @options[:cache] : ->(i) { i }
+
+        @collection.each_with_object({}) do |item, hash|
+          hash[expanded_cache_key(seed.call(item))] = item
+        end
+      end
+
+      def expanded_cache_key(key)
+        key = @view.fragment_cache_key(@view.cache_fragment_name(key))
+        key.frozen? ? key.dup : key # #read_multi & #write may require mutability, Dalli 2.6.0.
+      end
+
+      def fetch_or_cache_partial(cached_partials, order_by:)
+        cache_options = @options[:cache_options] || @locals[:cache_options] || {}
+
+        order_by.map do |key|
+          cached_partials.fetch(key) do
+            yield.tap do |rendered_partial|
+              collection_cache.write(key, rendered_partial, cache_options)
+            end
+          end
+        end
+      end
+  end
+end

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -117,6 +117,7 @@ module ActionView
       @source            = source
       @identifier        = identifier
       @handler           = handler
+      @cache_name        = extract_resource_cache_call_name
       @compiled          = false
       @original_encoding = nil
       @locals            = details[:locals] || []
@@ -150,6 +151,10 @@ module ActionView
 
     def type
       @type ||= Types[@formats.first] if @formats.first
+    end
+
+    def eligible_for_collection_caching?(as: nil)
+      @cache_name == (as || inferred_cache_name).to_s
     end
 
     # Receives a view object and return a template similar to self by using @virtual_path.
@@ -331,6 +336,15 @@ module ActionView
       def instrument(action, &block)
         payload = { virtual_path: @virtual_path, identifier: @identifier }
         ActiveSupport::Notifications.instrument("#{action}.action_view", payload, &block)
+      end
+
+      def extract_resource_cache_call_name
+        $1 if @handler.respond_to?(:resource_cache_call_pattern) &&
+          @source =~ @handler.resource_cache_call_pattern
+      end
+
+      def inferred_cache_name
+        @inferred_cache_name ||= @virtual_path.split('/').last.sub('_', '')
       end
   end
 end

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -123,6 +123,24 @@ module ActionView
           ).src
         end
 
+        # Returns Regexp to extract a cached resource's name from a cache call at the
+        # first line of a template.
+        # The extracted cache name is expected in $1.
+        #
+        #   <% cache notification do %> # => notification
+        #
+        # The pattern should support templates with a beginning comment:
+        #
+        #   <%# Still extractable even though there's a comment %>
+        #   <% cache notification do %> # => notification
+        #
+        # But fail to extract a name if a resource association is cached.
+        #
+        #   <% cache notification.event do %> # => nil
+        def resource_cache_call_pattern
+          /\A(?:<%#.*%>\n?)?<% cache\(?\s*(\w+\.?)/
+        end
+
       private
 
         def valid_encoding(string, encoding)

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -31,6 +31,10 @@ class Customer < Struct.new(:name, :id)
   def persisted?
     id.present?
   end
+
+  def cache_key
+    name.to_s
+  end
 end
 
 module Quiz

--- a/actionview/test/fixtures/test/_cached_customer.erb
+++ b/actionview/test/fixtures/test/_cached_customer.erb
@@ -1,0 +1,3 @@
+<% cache cached_customer do %>
+  Hello: <%= cached_customer.name %>
+<% end %>

--- a/actionview/test/fixtures/test/_cached_customer_as.erb
+++ b/actionview/test/fixtures/test/_cached_customer_as.erb
@@ -1,0 +1,3 @@
+<% cache buyer do %>
+  <%= greeting %>: <%= customer.name %>
+<% end %>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -599,6 +599,12 @@ class LazyViewRenderTest < ActiveSupport::TestCase
 end
 
 class CachedCollectionViewRenderTest < CachedViewRenderTest
+  class CachedCustomer < Customer; end
+
+  teardown do
+    ActionView::PartialRenderer.collection_cache.clear
+  end
+
   test "with custom key" do
     customer = Customer.new("david")
     key = ActionController::Base.new.fragment_cache_key([customer, 'key'])
@@ -607,7 +613,25 @@ class CachedCollectionViewRenderTest < CachedViewRenderTest
 
     assert_equal "Hello",
       @view.render(partial: "test/customer", collection: [customer], cache: ->(item) { [item, 'key'] })
+  end
 
-    ActionView::PartialRenderer.collection_cache.clear
+  test "automatic caching with inferred cache name" do
+    customer = CachedCustomer.new("david")
+    key = ActionController::Base.new.fragment_cache_key(customer)
+
+    ActionView::PartialRenderer.collection_cache.write(key, 'Cached')
+
+    assert_equal "Cached",
+      @view.render(partial: "test/cached_customer", collection: [customer])
+  end
+
+  test "automatic caching with as name" do
+    customer = CachedCustomer.new("david")
+    key = ActionController::Base.new.fragment_cache_key(customer)
+
+    ActionView::PartialRenderer.collection_cache.write(key, 'Cached')
+
+    assert_equal "Cached",
+      @view.render(partial: "test/cached_customer_as", collection: [customer], as: :buyer)
   end
 end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -597,3 +597,17 @@ class LazyViewRenderTest < ActiveSupport::TestCase
     silence_warnings { Encoding.default_external = old }
   end
 end
+
+class CachedCollectionViewRenderTest < CachedViewRenderTest
+  test "with custom key" do
+    customer = Customer.new("david")
+    key = ActionController::Base.new.fragment_cache_key([customer, 'key'])
+
+    ActionView::PartialRenderer.collection_cache.write(key, 'Hello')
+
+    assert_equal "Hello",
+      @view.render(partial: "test/customer", collection: [customer], cache: ->(item) { [item, 'key'] })
+
+    ActionView::PartialRenderer.collection_cache.clear
+  end
+end

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -66,14 +66,17 @@ module ActiveSupport
       def read_multi(*names)
         options = names.extract_options!
         options = merged_options(options)
-        keys_to_names = Hash[names.map{|name| [escape_key(namespaced_key(name, options)), name]}]
-        raw_values = @data.get_multi(keys_to_names.keys, :raw => true)
-        values = {}
-        raw_values.each do |key, value|
-          entry = deserialize_entry(value)
-          values[keys_to_names[key]] = entry.value unless entry.expired?
+
+        instrument_multi(:read, names, options) do
+          keys_to_names = Hash[names.map{|name| [escape_key(namespaced_key(name, options)), name]}]
+          raw_values = @data.get_multi(keys_to_names.keys, :raw => true)
+          values = {}
+          raw_values.each do |key, value|
+            entry = deserialize_entry(value)
+            values[keys_to_names[key]] = entry.value unless entry.expired?
+          end
+          values
         end
-        values
       end
 
       # Increment a cached value. This method uses the memcached incr atomic

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -1021,6 +1021,15 @@ class CacheStoreLoggerTest < ActiveSupport::TestCase
     @cache.mute { @cache.fetch('foo') { 'bar' } }
     assert @buffer.string.blank?
   end
+
+  def test_multi_read_loggin
+    @cache.write 'hello', 'goodbye'
+    @cache.write 'world', 'earth'
+
+    @cache.read_multi('hello', 'world')
+
+    assert_match "Caches multi read:\n- hello\n- world", @buffer.string.tap { |l| p l }
+  end
 end
 
 class CacheEntryTest < ActiveSupport::TestCase


### PR DESCRIPTION
Fixes #18900.

Makes caching a collection of template partials faster using `read_multi`
on the Rails cache store.

Some caching implementations have optimized `read_multi` so we don't have
to check in the cache store for every template.

@dhh, I will be tackling automatic caching next. This is just so my approach and choices, so far, can be reviewed.
