### PR TITLE
Add Gemfile.lock to plugin's gitignore template

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/gitignore
+++ b/railties/lib/rails/generators/rails/plugin/templates/gitignore
@@ -1,6 +1,7 @@
 .bundle/
 log/*.log
 pkg/
+Gemfile.lock
 <% unless options[:skip_test] && options[:dummy_path] == 'test/dummy' -%>
 <%= dummy_path %>/db/*.sqlite3
 <%= dummy_path %>/db/*.sqlite3-journal


### PR DESCRIPTION
When building a gem, Gemfile.lock should be ignored by default.
