### PR TITLE
created :time option for touch

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `:time` option added for `#touch`
+    Fixes #18905.
+
+    *Hyonjee Joo*
+
 *   Deprecated passing of `start` value to `find_in_batches` and `find_each`
     in favour of `begin_at` value.
 

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -73,6 +73,15 @@ class TimestampTest < ActiveRecord::TestCase
     assert_equal @previously_updated_at, @developer.updated_at
   end
 
+  def test_touching_updates_timestamp_with_given_time
+    previously_updated_at = @developer.updated_at 
+    new_time = Time.utc(2015, 2, 16, 0, 0, 0) 
+    @developer.touch(time: new_time) 
+
+    assert_not_equal previously_updated_at, @developer.updated_at 
+    assert_equal new_time, @developer.updated_at 
+  end
+
   def test_touching_an_attribute_updates_timestamp
     previously_created_at = @developer.created_at
     @developer.touch(:created_at)
@@ -89,6 +98,18 @@ class TimestampTest < ActiveRecord::TestCase
     task.touch(:ending)
     assert_not_equal previous_value, task.ending
     assert_in_delta Time.now, task.ending, 1
+  end
+
+  def test_touching_an_attribute_updates_timestamp_with_given_time
+    previously_updated_at = @developer.updated_at 
+    previously_created_at = @developer.created_at
+    new_time = Time.utc(2015, 2, 16, 4, 54, 0) 
+    @developer.touch(:created_at, time: new_time)
+
+    assert_not_equal previously_created_at, @developer.created_at
+    assert_not_equal previously_updated_at, @developer.updated_at
+    assert_equal new_time, @developer.created_at
+    assert_equal new_time, @developer.updated_at
   end
 
   def test_touching_many_attributes_updates_them


### PR DESCRIPTION
Created a ':time' option for '#touch' to address issue #18905. Not sure if there is a better method for implementing optional arguments. 
