### PR TITLE
Remove unused Rails::Server#log_path

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -91,10 +91,6 @@ module Rails
       Hash.new(middlewares)
     end
 
-    def log_path
-      "log/#{options[:environment]}.log"
-    end
-
     def default_options
       super.merge({
         Port:               3000,


### PR DESCRIPTION
With refactors to Rails::Sever from v3 to v4, this method is no longer used and is untested.

Previous usage: https://github.com/rails/rails/blob/3-2-stable/railties/lib/rails/commands/server.rb#L79
Currently set from: https://github.com/rails/rails/blob/7b75551a1a4539876f878f37a2439cd02f89d961/railties/lib/rails/application/configuration.rb#L69
