### PR TITLE
removes documentation that is no longer relevant

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -88,8 +88,6 @@ application. Accepts a valid week day symbol (e.g. `:monday`).
     end
     ```
 
-* `config.dependency_loading` is a flag that allows you to disable constant autoloading setting it to false. It only has effect if `config.cache_classes` is true, which it is by default in production mode.
-
 * `config.eager_load` when true, eager loads all registered `config.eager_load_namespaces`. This includes your application, engines, Rails frameworks and any other registered namespace.
 
 * `config.eager_load_namespaces` registers namespaces that are eager loaded when `config.eager_load` is true. All namespaces in the list must respond to the `eager_load!` method.
@@ -996,8 +994,6 @@ Below is a comprehensive list of all the initializers found in Rails in the orde
 * `finisher_hook` Provides a hook for after the initialization of process of the application is complete, as well as running all the `config.after_initialize` blocks for the application, railties and engines.
 
 * `set_routes_reloader` Configures Action Dispatch to reload the routes file using `ActionDispatch::Callbacks.to_prepare`.
-
-* `disable_dependency_loading` Disables the automatic dependency loading if the `config.eager_load` is set to true.
 
 Database pooling
 ----------------


### PR DESCRIPTION
It would appear that these config/initializer options have been removed - a8bf12979e5fa15282b39c8cfa315e663f613539
