### PR TITLE
Check first argument passed to form_for does not contain nil

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -428,8 +428,13 @@ module ActionView
           object_name = record
           object      = nil
         else
-          object      = record.is_a?(Array) ? record.last : record
-          raise ArgumentError, "First argument in form cannot contain nil or be empty" unless object
+          record_is_array = record.is_a?(Array)
+          object = record_is_array ? record.last : record
+
+          if record_is_array && record.any?(&:nil?) || object.nil?
+            raise ArgumentError, "First argument in form cannot contain nil or be empty"
+          end
+
           object_name = options[:as] || model_name_from_record_or_class(object).param_key
           apply_form_for_options!(record, object, options)
         end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1558,6 +1558,14 @@ class FormHelperTest < ActionView::TestCase
     assert_equal "First argument in form cannot contain nil or be empty", error.message
   end
 
+  def test_form_for_requires_all_non_nil_arguments
+    error = assert_raises(ArgumentError) do
+      form_for([nil, @comment], html: { id: 'create-post' }) do
+      end
+    end
+    assert_equal "First argument in form cannot contain nil or be empty", error.message
+  end
+
   def test_form_for
     form_for(@post, html: { id: 'create-post' }) do |f|
       concat f.label(:title) { "The Title" }


### PR DESCRIPTION
This PR updates the error handling in `ActionView.form_for` to raise an
`ArgumentError` if the passed object or any element (if it's an array) is `nil`.

Currently, the following will raise an error because the last argument in the
passed array is `nil`:

`form_for([nil, nil], html: { id: 'create-post' })`

but the following will not raise an error because the error handling checks
only the last argument of the array:

`form_for([nil, @comment], html: { id: 'create-post' }`

Given the error message is:

`"First argument in form cannot contain nil or be empty"`

it seems reasonable that all the elements in the passed array should be checked.
