### PR TITLE
Rake task to restart spring

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Restart task added to railties rake tasks in order to
+    address #18876 and #18874 issues without expanding spring
+    watchlist.
+
+    *Sameer Rahmani*
+    
 *   Newly generated applications get a `README.md` in Markdown.
 
     *Xavier Noria*

--- a/railties/lib/rails/tasks/restart.rake
+++ b/railties/lib/rails/tasks/restart.rake
@@ -1,0 +1,9 @@
+require 'spring/client'
+
+desc "Restart Rails and Spring"
+task :restart do
+  puts "Restarting Spring . . ."
+  Spring::Client::Stop.call([])
+  # Quick hack to run spring.
+  Spring::Client::Run.call(["rake", "-e" "'puts'"])
+end


### PR DESCRIPTION
Restart task added to railties rake tasks in order to address #18876 , #18874 and #18878 issues without expanding spring watchlist.
