### PR TITLE
Refine AS i18n pessimistic version constraint

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.rdoc_options.concat ['--encoding',  'UTF-8']
 
-  s.add_dependency('i18n',       '~> 0.6', '>= 0.6.4')
+  s.add_dependency('i18n',       '~> 0.6.4')
   s.add_dependency('multi_json', '~> 1.0')
 end


### PR DESCRIPTION
Because `~> 0.6` would go all the way up to 0.7 or newer and i18n 0.7 does not support Ruby < 1.9.3

[Fixes #18967]
