### PR TITLE
Add documentation for local_assigns [ci skip]

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -70,6 +70,14 @@ module ActionView #:nodoc:
   #   Headline: <%= headline %>
   #   First name: <%= person.first_name %>
   #
+  # The local variables passed to sub templates can be accessed as a hash using the <tt>local_assigns</tt> hash. This lets you access the
+  # variables as:
+  #
+  #   Headline: <%= local_assigns[:headline] %>
+  #
+  # This is useful in cases where you aren't sure if the local variable has been assigned. Alternately, you could also use
+  # <tt>defined? headline</tt> to first check if the variable has been assigned before using it.
+  #
   # === Template caching
   #
   # By default, Rails will compile each template to a method in order to render it. When you alter a template,


### PR DESCRIPTION
When passing local variables to sub-templates, the variables can be accesses using `local_assigns`. This part of the documentation was removed in the commit 3dfcae6afa24b641bd838b9044c5ce9aa2a1a6db.

In earlier versions, `defined? foo` did not work reliably, so `local_assigns` was the recommended way to check if a local variable has beed defined. Now `defined?` works, and can be used safely, but `local_assigns` is still available and useful in some scenarios, such as:

```
Headline: <%= defined?(headline) ? headline : '' %>
Headline: <%= local_assigns[:headlines] %>
```

This was also brought up by @dhh in another issue today: #18962. It's especially confusing since the only mention of `local_assigns` was removed from the documentation even though the feature is still available. I've written up more about this [here](http://nithinbekal.com/posts/rails-optional-locals/).
