### PR TITLE
Add cookies.json method

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add JsonCookieJar for easy working with cookies containing objects dumped to JSON.
+
+    Example:
+
+        cookies.json[:user_ids] = [1, 2, 3]
+        cookies.json[:user_ids] # => [1, 2, 3]
+        cookies[:user_ids]      # => "[1, 2, 3]"
+        cookies.json[:user]     # => nil
+
+    *Roman Samoilov*
+
 *   Add http_cache_forever to Action Controller, so we can cache a response that never gets expired.
 
     *arthurnn*


### PR DESCRIPTION
Hi all,

I've added cookies.json method for easy working with cookies that contain JSON data.

We can work with cookies not only from Ruby, but from JS too. And it's typical to have some data in cookies serialized in JavaScript Object Notation.

Without this method, the code can become dirty with a lot of logic like:

```
filters_json = cookies[:filters]
filters = JSON.parse(filters_json) if filters_json
```

which could now be rewritten as:

```
cookies.json[:filters]
```
