### PR TITLE
Use localtime for TimeWithZone#time

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -94,7 +94,7 @@ class Time
     elsif zone
       ::Time.local(new_year, new_month, new_day, new_hour, new_min, new_sec, new_usec)
     else
-      raise ArgumentError, 'argument out of range' if new_usec > 999999
+      raise ArgumentError, 'argument out of range' if new_usec > Rational(999999999, 1000)
       ::Time.new(new_year, new_month, new_day, new_hour, new_min, new_sec + (new_usec.to_r / 1000000), utc_offset)
     end
   end

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -50,7 +50,7 @@ module ActiveSupport
 
     # Returns a Time or DateTime instance that represents the time in +time_zone+.
     def time
-      @time ||= period.to_local(@utc)
+      @time ||= localtime(period.offset.utc_total_offset)
     end
 
     # Returns a Time or DateTime instance that represents the time in UTC.

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -156,11 +156,11 @@ class DurationTest < ActiveSupport::TestCase
       Time.stubs(:now).returns Time.local(2000)
       # since
       assert_instance_of ActiveSupport::TimeWithZone, 5.seconds.since
-      assert_equal Time.utc(2000,1,1,0,0,5), 5.seconds.since.time
+      assert_equal Time.local(2000) + 5.seconds, 5.seconds.since.time
       assert_equal 'Eastern Time (US & Canada)', 5.seconds.since.time_zone.name
       # ago
       assert_instance_of ActiveSupport::TimeWithZone, 5.seconds.ago
-      assert_equal Time.utc(1999,12,31,23,59,55), 5.seconds.ago.time
+      assert_equal Time.local(2000) - 5.seconds, 5.seconds.ago.time
       assert_equal 'Eastern Time (US & Canada)', 5.seconds.ago.time_zone.name
     end
   ensure

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -151,6 +151,15 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_no_error_with_localtime_offset
+    offset = "+09:00"
+    assert_nothing_raised do
+      Time.now.utc.localtime(offset).end_of_day
+      Time.now.utc.localtime(offset).end_of_hour
+      Time.now.utc.localtime(offset).end_of_minute
+    end
+  end
+
   def test_end_of_hour
     assert_equal Time.local(2005,2,4,19,59,59,Rational(999999999, 1000)), Time.local(2005,2,4,19,30,10).end_of_hour
   end


### PR DESCRIPTION
Didn't fix all the tests as there are a lot(all similar to the one I fixed), just want to make sure there wasn't something fundamentally wrong with this change.

Basically TimeWithZone#time was returning a `local time` in `UTC`. That doesn't really work because `UTC` is not a local time and the offset gets lost. So I changed it to only use the offset from the tzinfo guys.
