### PR TITLE
Use `drop_table :table, if_exists: true`

### DIFF
--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -260,7 +260,7 @@ if current_adapter?(:PostgreSQLAdapter, :MysqlAdapter, :Mysql2Adapter)
     end
 
     teardown do
-      @connection.execute("DROP TABLE IF EXISTS widgets")
+      @connection.drop_table "widgets", if_exists: true
     end
 
     test "primary key column type with bigserial" do

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -668,7 +668,7 @@ class TransactionTest < ActiveRecord::TestCase
       end
     end
   ensure
-    connection.execute("DROP TABLE IF EXISTS transaction_without_primary_keys")
+    connection.drop_table "transaction_without_primary_keys", if_exists: true
   end
 
   private


### PR DESCRIPTION
This pull request replace `drop table .. if exists` statement with `drop_table` method `if_exists: true` option since Oracle database does not support `drop table .. if exists` sql statement but `if_exists` option should work.
