### PR TITLE
Drop tables only when they exist

### DIFF
--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -10,8 +10,8 @@ module ActiveRecord
       end
 
       teardown do
-        @connection.execute("drop table if exists testings")
-        @connection.execute("drop table if exists testing_parents")
+        @connection.drop_table("testings") if @connection.table_exists? "testings"
+        @connection.drop_table("testing_parents") if @connection.table_exists? "testing_parents"
       end
 
       test "foreign keys can be created with the table" do

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -661,7 +661,7 @@ class TransactionTest < ActiveRecord::TestCase
       end
     end
   ensure
-    connection.execute("DROP TABLE IF EXISTS transaction_without_primary_keys")
+    connection.drop_table("transaction_without_primary_keys") if connection.table_exists? "transaction_without_primary_keys"
   end
 
   private


### PR DESCRIPTION
This pull request replace `drop table .. if exists` statement with `drop_table` method to `4-2-stable` branch because `if_exists` option does not exist in `4-2-stable` branch. Without this commit, `rake test_oracle` will hang   with TX enqueue wait.
