### PR TITLE
Extract precision from datetime and time columns

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -328,8 +328,8 @@ module ActiveRecord
 
       def initialize_type_map(m) # :nodoc:
         super
-        m.register_type %r(datetime)i, Fields::DateTime.new
-        m.register_type %r(time)i,     Fields::Time.new
+        register_class_with_precision m, %r(datetime)i, Fields::DateTime
+        register_class_with_precision m, %r(time)i,     Fields::Time
       end
 
       def exec_without_stmt(sql, name = 'SQL') # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -477,7 +477,6 @@ module ActiveRecord
           register_class_with_limit m, 'varbit', OID::BitVarying
           m.alias_type 'timestamptz', 'timestamp'
           m.register_type 'date', Type::Date.new
-          m.register_type 'time', Type::Time.new
 
           m.register_type 'money', OID::Money.new
           m.register_type 'bytea', OID::Bytea.new
@@ -503,10 +502,8 @@ module ActiveRecord
           m.alias_type 'lseg', 'varchar'
           m.alias_type 'box', 'varchar'
 
-          m.register_type 'timestamp' do |_, _, sql_type|
-            precision = extract_precision(sql_type)
-            OID::DateTime.new(precision: precision)
-          end
+          register_class_with_precision m, 'time', Type::Time
+          register_class_with_precision m, 'timestamp', OID::DateTime
 
           m.register_type 'numeric' do |_, fmod, sql_type|
             precision = extract_precision(sql_type)

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -46,7 +46,7 @@ def in_memory_db?
 end
 
 def mysql_56?
-  current_adapter?(:Mysql2Adapter) &&
+  current_adapter?(:MysqlAdapter, :Mysql2Adapter) &&
     ActiveRecord::Base.connection.send(:version).join(".") >= "5.6.0"
 end
 


### PR DESCRIPTION
The cause by which the test suite for the mysql adapter broke in 1502cae
(reverted 89ba5bb) is because the precision was not extracted.

It is extracted in abstract adapter already. [abstract_adapter.rb#L405-L406](https://github.com/rails/rails/blob/af59f6d5309782e94364430bd49059b93f519381/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L405-L406)

The rounding problem in mysql adapter has not been fixed, but `mysql_56`
helper tested only mysql2 adapter, its behavior was not apparent.
