### PR TITLE
Replace deprecated readonly option with scope blocks in docs and guide

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1386,7 +1386,7 @@ module ActiveRecord
       #   has_one :last_comment, -> { order 'posted_on' }, class_name: "Comment"
       #   has_one :project_manager, -> { where role: 'project_manager' }, class_name: "Person"
       #   has_one :attachment, as: :attachable
-      #   has_one :boss, readonly: :true
+      #   has_one :boss, -> { readonly }
       #   has_one :club, through: :membership
       #   has_one :primary_address, -> { where primary: true }, through: :addressables, source: :addressable
       #   has_one :credit_card, required: true
@@ -1514,7 +1514,7 @@ module ActiveRecord
       #   belongs_to :valid_coupon, ->(o) { where "discounts > ?", o.payments_count },
       #                             class_name: "Coupon", foreign_key: "coupon_id"
       #   belongs_to :attachable, polymorphic: true
-      #   belongs_to :project, readonly: true
+      #   belongs_to :project, -> { readonly }
       #   belongs_to :post, counter_cache: true
       #   belongs_to :comment, touch: true
       #   belongs_to :company, touch: :employees_last_updated_at

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1986,8 +1986,8 @@ While Rails uses intelligent defaults that will work well in most situations, th
 
 ```ruby
 class Parts < ActiveRecord::Base
-  has_and_belongs_to_many :assemblies, autosave: true,
-                                       readonly: true
+  has_and_belongs_to_many :assemblies, -> { readonly },
+                                       autosave: true
 end
 ```
 
@@ -1999,7 +1999,6 @@ The `has_and_belongs_to_many` association supports these options:
 * `:foreign_key`
 * `:join_table`
 * `:validate`
-* `:readonly`
 
 ##### `:association_foreign_key`
 


### PR DESCRIPTION
The documentation for the `has_one` and `belongs_to` associations includes some examples with the deprecated use of the `readonly: value` option. 

There is also one occurrence on the  AR associations guide where the same option is listed for  `has_and_belongs_to_many`, along with a provided code sample.

I replaced all these occurrences to use the scope blocks instead.

I also thought about adding a few examples with `-> { readonly(false) }` in the documentation of `associations.rb`, to make the usage of `readonly` more clear. What do you think?
