### PR TITLE
Prefer `drop_table if_exists: true` over raw SQL

### DIFF
--- a/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
@@ -139,7 +139,7 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
   # custom drop table, uses execute on connection to drop a table if it exists. note: escapes table_name
   def drop_tables_directly(table_names, connection = @connection)
     table_names.each do |name|
-      connection.execute("DROP TABLE IF EXISTS `#{name}`")
+      connection.drop_table name, if_exists: true
     end
   end
 

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -138,7 +138,7 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
   # custom drop table, uses execute on connection to drop a table if it exists. note: escapes table_name
   def drop_tables_directly(table_names, connection = @connection)
     table_names.each do |name|
-      connection.execute("DROP TABLE IF EXISTS `#{name}`")
+      connection.drop_table name, if_exists: true
     end
   end
 

--- a/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
@@ -20,7 +20,7 @@ class PostgresqlBitStringTest < ActiveRecord::TestCase
 
   def teardown
     return unless @connection
-    @connection.execute 'DROP TABLE IF EXISTS postgresql_bit_strings'
+    @connection.drop_table 'postgresql_bit_strings', if_exists: true
   end
 
   def test_bit_string_column

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -19,7 +19,7 @@ if ActiveRecord::Base.connection.supports_extensions?
     end
 
     teardown do
-      @connection.execute 'DROP TABLE IF EXISTS citexts;'
+      @connection.drop_table 'citexts', if_exists: true
       disable_extension!('citext', @connection)
     end
 

--- a/activerecord/test/cases/adapters/postgresql/composite_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/composite_test.rb
@@ -29,7 +29,7 @@ module PostgresqlCompositeBehavior
   def teardown
     super
 
-    @connection.execute 'DROP TABLE IF EXISTS postgresql_composites'
+    @connection.drop_table 'postgresql_composites', if_exists: true
     @connection.execute 'DROP TYPE IF EXISTS full_address'
     reset_connection
     PostgresqlComposite.reset_column_information

--- a/activerecord/test/cases/adapters/postgresql/domain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/domain_test.rb
@@ -19,7 +19,7 @@ class PostgresqlDomainTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.execute 'DROP TABLE IF EXISTS postgresql_domains'
+    @connection.drop_table 'postgresql_domains', if_exists: true
     @connection.execute 'DROP DOMAIN IF EXISTS custom_money'
     reset_connection
   end

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -21,7 +21,7 @@ class PostgresqlEnumTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.execute 'DROP TABLE IF EXISTS postgresql_enums'
+    @connection.drop_table 'postgresql_enums', if_exists: true
     @connection.execute 'DROP TYPE IF EXISTS mood'
     reset_connection
   end

--- a/activerecord/test/cases/adapters/postgresql/full_text_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/full_text_test.rb
@@ -13,7 +13,7 @@ class PostgresqlFullTextTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.execute 'DROP TABLE IF EXISTS tsvectors;'
+    @connection.drop_table 'tsvectors', if_exists: true
   end
 
   def test_tsvector_column

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -18,7 +18,7 @@ class PostgresqlPointTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.execute 'DROP TABLE IF EXISTS postgresql_points'
+    @connection.drop_table 'postgresql_points', if_exists: true
   end
 
   def test_column
@@ -84,7 +84,7 @@ class PostgresqlGeometricTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.execute 'DROP TABLE IF EXISTS postgresql_geometrics'
+    @connection.drop_table 'postgresql_geometrics', if_exists: true
   end
 
   def test_geometric_types

--- a/activerecord/test/cases/adapters/postgresql/infinity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/infinity_test.rb
@@ -15,7 +15,7 @@ class PostgresqlInfinityTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.execute("DROP TABLE IF EXISTS postgresql_infinities")
+    @connection.drop_table 'postgresql_infinities', if_exists: true
   end
 
   test "type casting infinity on a float column" do

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -16,7 +16,7 @@ class PostgresqlMoneyTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.execute 'DROP TABLE IF EXISTS postgresql_moneys'
+    @connection.drop_table 'postgresql_moneys', if_exists: true
   end
 
   def test_column

--- a/activerecord/test/cases/adapters/postgresql/network_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/network_test.rb
@@ -15,7 +15,7 @@ class PostgresqlNetworkTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.execute 'DROP TABLE IF EXISTS postgresql_network_addresses'
+    @connection.drop_table 'postgresql_network_addresses', if_exists: true
   end
 
   def test_cidr_column

--- a/activerecord/test/cases/adapters/postgresql/numbers_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/numbers_test.rb
@@ -12,7 +12,7 @@ class PostgresqlNumberTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.execute 'DROP TABLE IF EXISTS postgresql_numbers'
+    @connection.drop_table 'postgresql_numbers', if_exists: true
   end
 
   def test_data_type

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -227,8 +227,8 @@ module ActiveRecord
           "DELETE FROM pg_depend WHERE objid = 'ex2_id_seq'::regclass AND refobjid = 'ex'::regclass AND deptype = 'a'"
         )
       ensure
-        @connection.exec_query('DROP TABLE IF EXISTS ex')
-        @connection.exec_query('DROP TABLE IF EXISTS ex2')
+        @connection.drop_table 'ex', if_exists: true
+        @connection.drop_table 'ex2', if_exists: true
       end
 
       def test_exec_insert_number

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -91,7 +91,7 @@ _SQL
     end
 
     teardown do
-      @connection.execute 'DROP TABLE IF EXISTS postgresql_ranges'
+      @connection.drop_table 'postgresql_ranges', if_exists: true
       @connection.execute 'DROP TYPE IF EXISTS floatrange'
       reset_connection
     end

--- a/activerecord/test/cases/adapters/postgresql/rename_table_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/rename_table_test.rb
@@ -7,8 +7,8 @@ class PostgresqlRenameTableTest < ActiveRecord::TestCase
   end
 
   def teardown
-    @connection.execute 'DROP TABLE IF EXISTS "before_rename"'
-    @connection.execute 'DROP TABLE IF EXISTS "after_rename"'
+    @connection.drop_table "before_rename", if_exists: true
+    @connection.drop_table "after_rename", if_exists: true
   end
 
   test "renaming a table also renames the primary key index" do

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -460,8 +460,8 @@ class SchemaForeignKeyTest < ActiveRecord::TestCase
     output = dump_table_schema "wagons"
     assert_match %r{\s+add_foreign_key "wagons", "my_schema\.trains", column: "train_id"$}, output
   ensure
-    @connection.execute "DROP TABLE IF EXISTS wagons"
-    @connection.execute "DROP TABLE IF EXISTS my_schema.trains"
+    @connection.drop_table "wagons", if_exists: true
+    @connection.drop_table "my_schema.trains", if_exists: true
     @connection.execute "DROP SCHEMA IF EXISTS my_schema"
   end
 end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -191,7 +191,7 @@ module ActiveRecord
         binary.save!
         assert_equal str, binary.data
       ensure
-        DualEncoding.connection.execute('DROP TABLE IF EXISTS dual_encodings')
+        DualEncoding.connection.drop_table 'dual_encodings', if_exists: true
       end
 
       def test_type_cast_should_not_mutate_encoding

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -260,7 +260,7 @@ if current_adapter?(:PostgreSQLAdapter, :MysqlAdapter, :Mysql2Adapter)
     end
 
     teardown do
-      @connection.execute("DROP TABLE IF EXISTS widgets")
+      @connection.drop_table 'widgets', if_exists: true
     end
 
     test "primary key column type with bigserial" do

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -362,7 +362,7 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
 
   teardown do
     return unless @connection
-    @connection.execute 'DROP TABLE defaults' if @connection.table_exists? 'defaults'
+    @connection.drop_table 'defaults', if_exists: true
   end
 
   def test_schema_dump_defaults_with_universally_supported_types

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -2,7 +2,7 @@ ActiveRecord::Schema.define do
 
   %w(postgresql_times postgresql_oids defaults postgresql_timestamp_with_zones
       postgresql_partitioned_table postgresql_partitioned_table_parent).each do |table_name|
-    execute "DROP TABLE IF EXISTS #{quote_table_name table_name}"
+    drop_table table_name, if_exists: true
   end
 
   execute 'DROP SEQUENCE IF EXISTS companies_nonstd_seq CASCADE'


### PR DESCRIPTION
Lowercase raw SQL has been replaced by 07b659c already.
This PR replaces everything else of raw SQL.
