### PR TITLE
Track Gemfile.lock at the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ debug.log
 .Gemfile
 /.bundle
 /.ruby-version
-/Gemfile.lock
 pkg
 /dist
 /doc/rdoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 script: 'ci/travis.rb'
 before_install:
   - gem install bundler
+  - "rm ${BUNDLE_GEMFILE}.lock"
 before_script:
   - bundle update
 cache: bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,281 @@
+GIT
+  remote: git://github.com/bkeepers/qu.git
+  revision: d098e2657c92e89a6413bebd9c033930759c061f
+  branch: master
+  specs:
+    qu (0.2.0)
+    qu-rails (0.2.0)
+      qu (= 0.2.0)
+      railties (>= 3.2, < 5)
+    qu-redis (0.2.0)
+      qu (= 0.2.0)
+      redis-namespace
+
+GIT
+  remote: git://github.com/rails/arel.git
+  revision: aac9da257f291ad8d2d4f914528881c240848bb2
+  branch: master
+  specs:
+    arel (7.0.0.alpha)
+
+GIT
+  remote: git://github.com/rails/jquery-rails.git
+  revision: 272abdd319bb3381b23182b928b25320590096b0
+  branch: master
+  specs:
+    jquery-rails (4.0.3)
+      rails-dom-testing (~> 1.0)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
+
+PATH
+  remote: .
+  specs:
+    actionmailer (5.0.0.alpha)
+      actionpack (= 5.0.0.alpha)
+      actionview (= 5.0.0.alpha)
+      activejob (= 5.0.0.alpha)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+    actionpack (5.0.0.alpha)
+      actionview (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      rack (~> 1.6)
+      rack-test (~> 0.6.2)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.1)
+    actionview (5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.1)
+    activejob (5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      globalid (>= 0.3.0)
+    activemodel (5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      builder (~> 3.1)
+    activerecord (5.0.0.alpha)
+      activemodel (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      arel (= 7.0.0.alpha)
+    activesupport (5.0.0.alpha)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    rails (5.0.0.alpha)
+      actionmailer (= 5.0.0.alpha)
+      actionpack (= 5.0.0.alpha)
+      actionview (= 5.0.0.alpha)
+      activejob (= 5.0.0.alpha)
+      activemodel (= 5.0.0.alpha)
+      activerecord (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      bundler (>= 1.3.0, < 2.0)
+      railties (= 5.0.0.alpha)
+      sprockets-rails
+    railties (5.0.0.alpha)
+      actionpack (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    amq-protocol (1.9.2)
+    backburner (0.4.6)
+      beaneater (~> 0.3.1)
+      dante (~> 0.1.5)
+    bcrypt (3.1.10)
+    beaneater (0.3.3)
+    benchmark-ips (2.1.1)
+    builder (3.2.2)
+    bunny (1.1.9)
+      amq-protocol (>= 1.9.2)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
+    coffee-rails (4.1.0)
+      coffee-script (>= 2.2.0)
+      railties (>= 4.0.0, < 5.0)
+    coffee-script (2.3.0)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.9.0)
+    connection_pool (2.1.1)
+    dalli (2.7.2)
+    dante (0.1.5)
+    delayed_job (4.0.6)
+      activesupport (>= 3.0, < 5.0)
+    erubis (2.7.0)
+    execjs (2.3.0)
+    globalid (0.3.3)
+      activesupport (>= 4.1.0)
+    hike (1.2.3)
+    hitimes (1.2.2)
+    i18n (0.7.0)
+    json (1.8.2)
+    kindlerb (0.1.1)
+      mustache
+      nokogiri
+    loofah (2.0.1)
+      nokogiri (>= 1.5.9)
+    mail (2.6.3)
+      mime-types (>= 1.16, < 3)
+    metaclass (0.0.4)
+    mime-types (2.4.3)
+    mini_portile (0.6.2)
+    minitest (5.3.3)
+    mocha (0.14.0)
+      metaclass (~> 0.0.1)
+    mono_logger (1.1.0)
+    multi_json (1.10.1)
+    mustache (1.0.0)
+    mysql (2.9.1)
+    mysql2 (0.3.18)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    pg (0.18.1)
+    psych (2.0.13)
+    que (0.9.2)
+    queue_classic (3.1.0)
+      pg (>= 0.17, < 0.19)
+    racc (1.4.12)
+    rack (1.6.0)
+    rack-cache (1.2)
+      rack (>= 0.4)
+    rack-protection (1.5.3)
+      rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rails-deprecated_sanitizer (1.0.3)
+      activesupport (>= 4.2.0.alpha)
+    rails-dom-testing (1.0.5)
+      activesupport (>= 4.2.0.beta, < 5.0)
+      nokogiri (~> 1.6.0)
+      rails-deprecated_sanitizer (>= 1.0.1)
+    rails-html-sanitizer (1.0.1)
+      loofah (~> 2.0)
+    rake (10.4.2)
+    rdoc (4.2.0)
+    redcarpet (3.2.2)
+    redis (3.2.1)
+    redis-namespace (1.5.1)
+      redis (~> 3.0, >= 3.0.4)
+    resque (1.25.2)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.3)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
+    resque-scheduler (4.0.0)
+      mono_logger (~> 1.0)
+      redis (~> 3.0)
+      resque (~> 1.25)
+      rufus-scheduler (~> 3.0)
+    ruby-prof (0.11.3)
+    rufus-scheduler (3.0.9)
+      tzinfo
+    sdoc (0.4.1)
+      json (~> 1.7, >= 1.7.7)
+      rdoc (~> 4.0)
+    sequel (4.19.0)
+    serverengine (1.5.10)
+      sigdump (~> 0.2.2)
+    sidekiq (3.3.2)
+      celluloid (>= 0.16.0)
+      connection_pool (>= 2.1.1)
+      json
+      redis (>= 3.0.6)
+      redis-namespace (>= 1.3.1)
+    sigdump (0.2.2)
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    sneakers (0.1.1.pre)
+      bunny (~> 1.1.3)
+      serverengine
+      thor
+      thread
+    sprockets (2.12.3)
+      hike (~> 1.2)
+      multi_json (~> 1.0)
+      rack (~> 1.0)
+      tilt (~> 1.1, != 1.3.0)
+    sprockets-rails (2.2.4)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      sprockets (>= 2.8, < 4.0)
+    sqlite3 (1.3.10)
+    stackprof (0.2.7)
+    sucker_punch (1.3.2)
+      celluloid (~> 0.16.0)
+    thor (0.19.1)
+    thread (0.1.5)
+    thread_safe (0.3.4)
+    tilt (1.4.1)
+    timers (4.0.1)
+      hitimes
+    turbolinks (2.5.3)
+      coffee-rails
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    uglifier (2.7.0)
+      execjs (>= 0.3.0)
+      json (>= 1.8.0)
+    vegas (0.1.11)
+      rack (>= 1.0.0)
+    w3c_validators (1.2)
+      json
+      nokogiri
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord-jdbcmysql-adapter (>= 1.3.0)
+  activerecord-jdbcpostgresql-adapter (>= 1.3.0)
+  activerecord-jdbcsqlite3-adapter (>= 1.3.0)
+  arel!
+  backburner
+  bcrypt (~> 3.1.7)
+  benchmark-ips
+  coffee-rails (~> 4.1.0)
+  dalli (>= 2.2.1)
+  delayed_job
+  jquery-rails!
+  json
+  kindlerb (= 0.1.1)
+  minitest (< 5.3.4)
+  mocha (~> 0.14)
+  mysql (>= 2.9.0)
+  mysql2 (>= 0.3.13)
+  nokogiri (>= 1.4.5)
+  pg (>= 0.18.0)
+  psych (~> 2.0)
+  qu-rails!
+  qu-redis
+  que
+  queue_classic
+  racc (>= 1.4.6)
+  rack-cache (~> 1.2)
+  rails!
+  rake (>= 10.3)
+  redcarpet (~> 3.2.2)
+  resque
+  resque-scheduler
+  ruby-prof (~> 0.11.2)
+  sdoc (~> 0.4.0)
+  sequel
+  sidekiq
+  sneakers (= 0.1.1.pre)
+  sqlite3 (~> 1.3.6)
+  stackprof
+  sucker_punch
+  turbolinks
+  uglifier (>= 1.3.0)
+  w3c_validators


### PR DESCRIPTION
The main reason is to make bisect easier.

In some points, we have a lot of git dependencies. Since we don't have
the information of which commit we are referring to, bundler get the
latest commit of the master branch of the dependency. This sometimes
returns a version that is not compatible with Rails anymore, making the
tests fail and the harder to identify the commit that introduced a bug.

Also this will make sure that a contributor will always get a set of
dependencies that are passing with our tests.

In our CI server we delete the lock file to make sure we are always
testing against the newest release of our dependencies.
