### PR TITLE
Allow Rack::Runtime to be deleted from middleware stack.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   `delete` operations in configurations are run last in order to eliminate
+    'No such middleware' errors when `insert_before` or `insert_after` are added
+    after the `delete` operation for the middleware being deleted.
+
+    Fixes: #16433.
+
+    *Guo Xiang Tan*
+
 *   Newly generated applications get a `README.md` in Markdown.
 
     *Xavier Noria*

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -35,6 +35,7 @@ module Rails
     class MiddlewareStackProxy
       def initialize
         @operations = []
+        @delete_operations = []
       end
 
       def insert_before(*args, &block)
@@ -56,7 +57,7 @@ module Rails
       end
 
       def delete(*args, &block)
-        @operations << [__method__, args, block]
+        @delete_operations << [__method__, args, block]
       end
 
       def unshift(*args, &block)
@@ -64,9 +65,10 @@ module Rails
       end
 
       def merge_into(other) #:nodoc:
-        @operations.each do |operation, args, block|
+        @operations.concat(@delete_operations).each do |operation, args, block|
           other.send(operation, *args, &block)
         end
+
         other
       end
     end

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -125,6 +125,22 @@ module ApplicationTests
       assert !middleware.include?("ActionDispatch::Static")
     end
 
+    test "can delete a middleware from the stack even if insert_before is added after delete" do
+      add_to_config "config.middleware.delete Rack::Runtime"
+      add_to_config "config.middleware.insert_before(Rack::Runtime, Rack::Config)"
+      boot!
+      assert middleware.include?("Rack::Config")
+      assert_not middleware.include?("Rack::Runtime")
+    end
+
+    test "can delete a middleware from the stack even if insert_after is added after delete" do
+      add_to_config "config.middleware.delete Rack::Runtime"
+      add_to_config "config.middleware.insert_after(Rack::Runtime, Rack::Config)"
+      boot!
+      assert middleware.include?("Rack::Config")
+      assert_not middleware.include?("Rack::Runtime")
+    end
+
     test "includes exceptions middlewares even if action_dispatch.show_exceptions is disabled" do
       add_to_config "config.action_dispatch.show_exceptions = false"
       boot!


### PR DESCRIPTION
Fixes: https://github.com/rails/rails/issues/16433.
