### PR TITLE
Deprecate `ActiveModel::Errors` `add_on_empty` and `add_on_blank` methods

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecate `ActiveModel::Errors#add_on_empty` and `ActiveModel::Errors#add_on_blank`
+    with no replacement.
+
+    *Wojciech Wnętrzak*
+
 *   Deprecate `ActiveModel::Errors#get`, `ActiveModel::Errors#set` and
     `ActiveModel::Errors#[]=` methods that have inconsistent behaviour.
 

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -347,6 +347,13 @@ module ActiveModel
     #   person.errors.messages
     #   # => {:name=>["can't be empty"]}
     def add_on_empty(attributes, options = {})
+      ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)
+        ActiveModel::Errors#add_on_empty is deprecated and will be removed in Rails 5.1
+
+        To achieve the same write
+        errors.add(attribute, :empty, options) if value.nil? || value.empty?
+      MESSAGE
+
       Array(attributes).each do |attribute|
         value = @base.send(:read_attribute_for_validation, attribute)
         is_empty = value.respond_to?(:empty?) ? value.empty? : false
@@ -361,6 +368,13 @@ module ActiveModel
     #   person.errors.messages
     #   # => {:name=>["can't be blank"]}
     def add_on_blank(attributes, options = {})
+      ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)
+        ActiveModel::Errors#add_on_blank is deprecated and will be removed in Rails 5.1
+
+        To achieve the same write
+        errors.add(attribute, :empty, options) if value.blank?
+      MESSAGE
+
       Array(attributes).each do |attribute|
         value = @base.send(:read_attribute_for_validation, attribute)
         add(attribute, :blank, options) if value.blank?

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -288,46 +288,60 @@ class ErrorsTest < ActiveModel::TestCase
   test "add_on_empty generates message" do
     person = Person.new
     person.errors.expects(:generate_message).with(:name, :empty, {})
-    person.errors.add_on_empty :name
+    assert_deprecated do
+      person.errors.add_on_empty :name
+    end
   end
 
   test "add_on_empty generates message for multiple attributes" do
     person = Person.new
     person.errors.expects(:generate_message).with(:name, :empty, {})
     person.errors.expects(:generate_message).with(:age, :empty, {})
-    person.errors.add_on_empty [:name, :age]
+    assert_deprecated do
+      person.errors.add_on_empty [:name, :age]
+    end
   end
 
   test "add_on_empty generates message with custom default message" do
     person = Person.new
     person.errors.expects(:generate_message).with(:name, :empty, { message: 'custom' })
-    person.errors.add_on_empty :name, message: 'custom'
+    assert_deprecated do
+      person.errors.add_on_empty :name, message: 'custom'
+    end
   end
 
   test "add_on_empty generates message with empty string value" do
     person = Person.new
     person.name = ''
     person.errors.expects(:generate_message).with(:name, :empty, {})
-    person.errors.add_on_empty :name
+    assert_deprecated do
+      person.errors.add_on_empty :name
+    end
   end
 
   test "add_on_blank generates message" do
     person = Person.new
     person.errors.expects(:generate_message).with(:name, :blank, {})
-    person.errors.add_on_blank :name
+    assert_deprecated do
+      person.errors.add_on_blank :name
+    end
   end
 
   test "add_on_blank generates message for multiple attributes" do
     person = Person.new
     person.errors.expects(:generate_message).with(:name, :blank, {})
     person.errors.expects(:generate_message).with(:age, :blank, {})
-    person.errors.add_on_blank [:name, :age]
+    assert_deprecated do
+      person.errors.add_on_blank [:name, :age]
+    end
   end
 
   test "add_on_blank generates message with custom default message" do
     person = Person.new
     person.errors.expects(:generate_message).with(:name, :blank, { message: 'custom' })
-    person.errors.add_on_blank :name, message: 'custom'
+    assert_deprecated do
+      person.errors.add_on_blank :name, message: 'custom'
+    end
   end
 
   test "details returns added error detail" do

--- a/activemodel/test/cases/validations/i18n_generate_message_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_generate_message_validation_test.rb
@@ -62,7 +62,7 @@ class I18nGenerateMessageValidationTest < ActiveModel::TestCase
     assert_equal 'custom message', @person.errors.generate_message(:title, :empty, message: 'custom message')
   end
 
-  # add_on_blank: generate_message(attr, :blank, message: custom_message)
+  # validates_presence_of: generate_message(attr, :blank, message: custom_message)
   def test_generate_message_blank_with_default_message
     assert_equal "can't be blank", @person.errors.generate_message(:title, :blank)
   end

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -214,7 +214,7 @@ class Account < ActiveRecord::Base
   protected
 
   def check_empty_credit_limit
-    errors.add_on_empty "credit_limit"
+    errors.add("credit_limit", :blank) if credit_limit.blank?
   end
 
   private

--- a/activerecord/test/models/company_in_module.rb
+++ b/activerecord/test/models/company_in_module.rb
@@ -91,7 +91,7 @@ module MyApplication
       protected
 
       def check_empty_credit_limit
-        errors.add_on_empty "credit_limit"
+        errors.add("credit_card", :blank) if credit_card.blank?
       end
     end
   end


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/18634#issuecomment-74946516
