### PR TITLE
Remove unused gsub_app_file method from Bukkit.

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -277,12 +277,6 @@ module TestHelpers
       end
     end
 
-    def gsub_app_file(path, regexp, *args, &block)
-      path = "#{app_path}/#{path}"
-      content = File.read(path).gsub(regexp, *args, &block)
-      File.open(path, 'wb') { |f| f.write(content) }
-    end
-
     def remove_file(path)
       FileUtils.rm_rf "#{app_path}/#{path}"
     end


### PR DESCRIPTION
It was introduced in https://github.com/rails/rails/commit/a2ca04bb3ac178bbe1503ac65dc88f5f3f8cb37f#diff-6b400e02467a1f4e0c2c60863c87b927R246, used once in https://github.com/rails/rails/commit/a2ca04bb3ac178bbe1503ac65dc88f5f3f8cb37f#diff-3655bb3c262815dffb850d9adbeb6328R18 and that usage was removed in https://github.com/rails/rails/commit/1385ae138d701174916a3c44d8bc8b92f3dd3aeb#diff-3655bb3c262815dffb850d9adbeb6328L18.
