### PR TITLE
Remove last empty line when we don't use Windows or JRuby

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -42,8 +42,8 @@ group :development, :test do
   gem 'method_source'
 <% end -%>
 end
-
 <% if RUBY_PLATFORM.match(/bccwin|cygwin|emx|mingw|mswin|wince|java/) -%>
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 <% end -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile
@@ -41,7 +41,7 @@ end
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 <% end -%>
-
 <% if RUBY_PLATFORM.match(/bccwin|cygwin|emx|mingw|mswin|wince|java/) -%>
+
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 <% end -%>


### PR DESCRIPTION
This reduces the time to remove last empty line of Gemfile for everyone except Windows or JRuby users.
