### PR TITLE
use `messages` instead of deprecated `ActiveModel::Errors#[]=` method [ci skip]

### DIFF
--- a/activemodel/README.rdoc
+++ b/activemodel/README.rdoc
@@ -219,7 +219,7 @@ behavior out of the box:
   
     class HasNameValidator < ActiveModel::Validator
       def validate(record)
-        record.errors[:name] = "must exist" if record.name.blank?
+        record.errors.messages[:name] << "must exist" if record.name.blank?
       end
     end
 

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -15,7 +15,7 @@ module ActiveModel
   #   class MyValidator < ActiveModel::Validator
   #     def validate(record)
   #       if some_complex_logic
-  #         record.errors[:base] = "This record is invalid"
+  #         record.errors.messages[:base] << "This record is invalid"
   #       end
   #     end
   #

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -1078,7 +1078,7 @@ Another way to do this is using `[]=` setter
 ```ruby
   class Person < ActiveRecord::Base
     def a_method_used_for_validation_purposes
-      errors[:name] = "cannot contain the characters !@#%*()_-+="
+      errors.messages[:name] << "cannot contain the characters !@#%*()_-+="
     end
   end
 


### PR DESCRIPTION
refs: https://github.com/rails/rails/commit/3c750c4c6c4d3c2e67865bc43a99010fa8b6c7a6
