### PR TITLE
Fix cache_helper comment ERB typo

### DIFF
--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -122,7 +122,7 @@ module ActionView
 
       # Cache fragments of a view if +condition+ is true
       #
-      #   <%= cache_if admin?, project do %>
+      #   <% cache_if admin?, project do %>
       #     <b>All the topics on this project</b>
       #     <%= render project.topics %>
       #   <% end %>
@@ -138,7 +138,7 @@ module ActionView
 
       # Cache fragments of a view unless +condition+ is true
       #
-      #   <%= cache_unless admin?, project do %>
+      #   <% cache_unless admin?, project do %>
       #     <b>All the topics on this project</b>
       #     <%= render project.topics %>
       #   <% end %>


### PR DESCRIPTION
`cache` calls should be wrapped in `<% ... %>`, not `<%= ... %>`.

This confuses some of the younger devs that I work with, so I decided to fix it.
