### PR TITLE
Move the `validate!` method to `ActiveModel::Validations`.

### DIFF
--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -6,6 +6,7 @@ en:
     # The values :model, :attribute and :value are always available for interpolation
     # The value :count is available when applicable. Can be used for pluralization.
     messages:
+      model_invalid: "Validation failed: %{errors}"
       inclusion: "is not included in the list"
       exclusion: "is reserved"
       invalid: "is invalid"

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -371,6 +371,15 @@ module ActiveModel
       !valid?(context)
     end
 
+    # Runs all the validations within the specified context. Returns +true+ if
+    # no errors are found, raises +ValidationError+ otherwise.
+    #
+    # Validations with no <tt>:on</tt> option will run no matter the context. Validations with
+    # some <tt>:on</tt> option will only run in the specified context.
+    def validate!(context = nil)
+      valid?(context) || raise_validation_error
+    end
+
     # Hook method defining how an attribute value should be retrieved. By default
     # this is assumed to be an instance named after the attribute. Override this
     # method in subclasses should you need to retrieve the value for a given
@@ -394,6 +403,30 @@ module ActiveModel
     def run_validations! #:nodoc:
       _run_validate_callbacks
       errors.empty?
+    end
+
+    def raise_validation_error
+      raise(ValidationError.new(self))
+    end
+  end
+
+  # = Active Model ValidationError
+  #
+  # Raised by <tt>validate!</tt> when the model is invalid. Use the
+  # +model+ method to retrieve the record which did not validate.
+  #
+  #   begin
+  #     complex_operation_that_internally_calls_validate!
+  #   rescue ActiveModel::ValidationError => invalid
+  #     puts invalid.model.errors
+  #   end
+  class ValidationError < StandardError
+    attr_reader :model
+
+    def initialize(model)
+      @model = model
+      errors = @model.errors.full_messages.join(", ")
+      super(I18n.t(:"#{@model.class.i18n_scope}.errors.messages.model_invalid", errors: errors, default: :"errors.messages.model_invalid"))
     end
   end
 end

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -351,6 +351,25 @@ class ValidationsTest < ActiveModel::TestCase
     assert_not_empty topic.errors
   end
 
+  def test_validate_with_bang
+    Topic.validates :title, presence: true
+
+    assert_raise(ActiveModel::ValidationError) do
+      Topic.new.validate!
+    end
+  end
+
+  def test_validate_with_bang_and_context
+    Topic.validates :title, presence: true, on: :context
+
+    assert_raise(ActiveModel::ValidationError) do
+      Topic.new.validate!(:context)
+    end
+
+    t = Topic.new(title: "Valid title")
+    assert t.validate!(:context)
+  end
+
   def test_strict_validation_in_validates
     Topic.validates :title, strict: true, presence: true
     assert_raises ActiveModel::StrictValidationFailed do

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -40,7 +40,7 @@ module ActiveRecord
     # Attempts to save the record just like Base#save but will raise a +RecordInvalid+
     # exception instead of returning +false+ if the record is not valid.
     def save!(options={})
-      perform_validations(options) ? super : raise_record_invalid
+      perform_validations(options) ? super : raise_validation_error
     end
 
     # Runs all the validations within the specified context. Returns +true+ if
@@ -61,21 +61,9 @@ module ActiveRecord
 
     alias_method :validate, :valid?
 
-    # Runs all the validations within the specified context. Returns +true+ if
-    # no errors are found, raises +RecordInvalid+ otherwise.
-    #
-    # If the argument is +false+ (default is +nil+), the context is set to <tt>:create</tt> if
-    # <tt>new_record?</tt> is +true+, and to <tt>:update</tt> if it is not.
-    #
-    # Validations with no <tt>:on</tt> option will run no matter the context. Validations with
-    # some <tt>:on</tt> option will only run in the specified context.
-    def validate!(context = nil)
-      valid?(context) || raise_record_invalid
-    end
-
   protected
 
-    def raise_record_invalid
+    def raise_validation_error
       raise(RecordInvalid.new(self))
     end
 


### PR DESCRIPTION
`validate!` is a nice API that can be useful by non ActiveRecord classes. I've moved the related methods to the `ActiveModel::Validations` module and renamed the `raise_record_invalid` to `raise_validation_error`. 

One thing that I'm 100% about is the exception class for `ActiveModel`. I've duplicated the code from `RecordInvalid` to change the use of `record` by `model` (which might make more sense when not using Active Record, but that's open for debate). If it makes more sense to use a single exception class and use `record` all over I can cut out the extra class and simply stick with `ActiveModel::RecordInvalid` and `ActiveRecord::RecordInvalid`.
