### PR TITLE
Fix #has_secure_token documentation

### DIFF
--- a/activerecord/lib/active_record/secure_token.rb
+++ b/activerecord/lib/active_record/secure_token.rb
@@ -21,8 +21,8 @@ module ActiveRecord
       # SecureRandom::base58 is used to generate the 24-character unique token, so collisions are highly unlikely.
       #
       # Note that it's still possible to generate a race condition in the database in the same way that
-      # validates_presence_of can. You're encouraged to add a unique index in the database to deal with
-      # this even more unlikely scenario.
+      # <tt>validates_uniqueness_of</tt> can. You're encouraged to add a unique index in the database to deal
+      # with this even more unlikely scenario.
       def has_secure_token(attribute = :token)
         # Load securerandom only when has_secure_token is used.
         require 'active_support/core_ext/securerandom'


### PR DESCRIPTION
The documentation for `has_secure_token` states that `validates_presence_of` could generate a race condition in the database, but actually `validates_uniqueness_of` is the validation that could generate a race condition.
