### PR TITLE
`ActiveModel::Validations::JsonValidator` to validate json field data

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `ActiveModel::Validations::JsonValidator` added to handle json typed fields validation.
+    Using this validator user can validates data of `json` fields
+
+    *Sameer Rahmani*
+
 *   Deprecate `ActiveModel::Errors#add_on_empty` and `ActiveModel::Errors#add_on_blank`
     with no replacement.
 

--- a/activemodel/lib/active_model/validations/json.rb
+++ b/activemodel/lib/active_model/validations/json.rb
@@ -4,6 +4,12 @@ module ActiveModel
       attr_accessor :record, :attribute, :attribute_value
 
       def validate_each(record, attribute, attribute_value)
+
+        # Check for valid atribute values.
+        if !attribute_value.kind_of?(Hash) || !attribute_value.kind_of?(Array)
+          raise TypeError, "JsonValidator can be used by 'json' type only"
+        end
+
         self.record = record
         self.attribute = attribute
         self.attribute_value = attribute_value

--- a/activemodel/lib/active_model/validations/json.rb
+++ b/activemodel/lib/active_model/validations/json.rb
@@ -26,6 +26,23 @@ module ActiveModel
         end
       end
 
+      # Check for formats of a specific keys
+      def format_validator(opts)
+        if opts.kind_of? Hash
+          opts.each do |field, format_opts|
+
+            regexp = format_opts[:with]
+            value  = attribute_value[field].to_s
+
+            unless regexp
+              raise ArgumentError, "'with' argument is missing for 'format'."
+            end
+
+            add_error "'#{field}' is not well formatted." if value !~ regexp
+          end
+        end
+      end
+
       private
 
       def add_error(msg)

--- a/activemodel/lib/active_model/validations/json.rb
+++ b/activemodel/lib/active_model/validations/json.rb
@@ -16,10 +16,10 @@ module ActiveModel
       end
 
       # Check whether that record include each of given fields
-      def include_validator(fields)
+      def include_validator(fields, attr_value = attribute_value)
         if fields.respond_to? :each
           fields.each do |key|
-            if attribute_value.kind_of?(Hash) && !attribute_value.include?(key.to_s)
+            if attr_value.kind_of?(Hash) && !attr_value.include?(key.to_s)
               add_error "'#{attribute}' does not contains '#{key}'"
             end
           end
@@ -27,12 +27,12 @@ module ActiveModel
       end
 
       # Check for formats of a specific keys
-      def format_validator(opts)
-        if opts.kind_of? Hash
+      def format_validator(opts, attr_value = attribute_value)
+        with_hash :format, opts do
           opts.each do |field, format_opts|
 
             regexp = format_opts[:with]
-            value  = attribute_value[field].to_s
+            value  = attr_value[field].to_s
 
             unless regexp
               raise ArgumentError, "'with' argument is missing for 'format'."
@@ -43,7 +43,39 @@ module ActiveModel
         end
       end
 
+      # In case of an Array as json root object, <tt>:each</tt>
+      # Allow to provide validate options for each element in
+      # the given Array.
+      def each_validator(opts)
+        if attribute_value.respond_to? :each
+          attribute_value.each do |json_obj|
+
+            # Skip if current element is not an object
+            next unless json_obj.kind_of? Hash
+
+            # Loop over <tt>:each</tt> options and match them
+            # against current value.
+            with_hash :each, opts do |opt_key, opt_value|
+              if respond_to? "#{opt_key}_validator"
+                send("#{opt_key}_validator", opt_value, json_obj)
+              end
+            end
+
+          end
+        end
+      end
+
       private
+
+      def with_hash(opt_name, opts, &block)
+        if opts.kind_of? Hash
+          opts.each do |key, value|
+            yield key, value
+          end
+        else
+          raise ArgumentError, "'#{opt_name}' needs a Hash as value."
+        end
+      end
 
       def add_error(msg)
         record.errors[attribute] << (options[:message] || msg || 'is invalid')
@@ -65,6 +97,8 @@ module ActiveModel
       # * <tt>:message</tt> - A custom error message. (default is: "is invalid").
       # * <tt>:include</tt> - An array of keys with given <tt>json</tt> data
       # should include.
+      # * <tt>:format</tt> - A hash with json field names as key and a hash
+      # with <tt>FormatValidator</tt> options as value.
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.

--- a/activemodel/lib/active_model/validations/json.rb
+++ b/activemodel/lib/active_model/validations/json.rb
@@ -1,0 +1,61 @@
+module ActiveModel
+  module Validations
+    class JsonValidator < ActiveModel::EachValidator
+      attr_accessor :record, :attribute, :attribute_value
+
+      def validate_each(record, attribute, attribute_value)
+        self.record = record
+        self.attribute = attribute
+        self.attribute_value = attribute_value
+
+        options.each do |key, value|
+          # Find and execute the sub validator methods
+          # for each key in the <tt>options</tt> hash.
+          send("#{key}_validator", value) if respond_to? "#{key}_validator"
+        end
+      end
+
+      # Check whether that record include each of given fields
+      def include_validator(fields)
+        if fields.respond_to? :each
+          fields.each do |key|
+            if attribute_value.kind_of?(Hash) && !attribute_value.include?(key.to_s)
+              add_error "'#{attribute}' does not contains '#{key}'"
+            end
+          end
+        end
+      end
+
+      private
+
+      def add_error(msg)
+        record.errors[attribute] << (options[:message] || msg || 'is invalid')
+      end
+    end
+
+    module HelperMethods
+      # Validate whether the given <tt>json</tt> field meets specified
+      # standard or not. For example:
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_json_of :contact, include: [:phone_number]
+      #   end
+      #
+      # The above example will ensure that <tt>contact</tt> field contains
+      # a <tt>phone_number</tt> key.
+      #
+      # Configuration options:
+      # * <tt>:message</tt> - A custom error message. (default is: "is invalid").
+      # * <tt>:include</tt> - An array of keys with given <tt>json</tt> data
+      # should include.
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # See <tt>ActiveModel::Validation#validates</tt> for more information
+      def validates_json_of(*attr_names)
+        validates_with JsonValidator, _merge_attributes(attr_names)
+      end
+    end
+
+  end
+end

--- a/activemodel/test/cases/validations/json_test.rb
+++ b/activemodel/test/cases/validations/json_test.rb
@@ -1,0 +1,76 @@
+require 'cases/helper'
+
+require 'models/person'
+
+class JsonValidationTest < ActiveModel::TestCase
+
+  def teardown
+    Person.clear_validators!
+  end
+
+  def test_json_validation_on_non_json_data
+    Person.validates_json_of(:details, include: [:address])
+
+    person = Person.new
+    person.details = 'not_json'
+
+    assert_raise TypeError do
+      assert person.invalid?
+    end
+  end
+
+  def test_json_validation_on_json_data
+    Person.validates_json_of(:details, include: [:address])
+
+    person = Person.new
+    person.details = { 'address' => 'funny street' }
+
+    assert person.valid?
+  end
+
+  def test_include_option
+    Person.validates_json_of(:details, include: [:address])
+
+    person1 = Person.new
+    person2 = Person.new
+
+    person1.details = { 'address' => 'funny street' }
+    person2.details = { 'phone_number' => '+13435564534' }
+
+    assert person1.valid?
+    assert person2.invalid?
+  end
+
+  def test_format_option
+    Person.validates_json_of(:details,
+                             format: { phone_number: { with: /\+[0-9]+/ },
+                                       name: { with: /[a-zA-Z]+\s[a-zA-Z]+/ } })
+
+    person1 = Person.new
+    person2 = Person.new
+    person3 = Person.new
+
+    person1.details = { 'name' => 'Roronoa Zoro', 'phone_number' => '324234' }
+    person2.details = { 'phone_number' => '+13435564534', 'name' => 'Luffy' }
+    person3.details = { 'name' => 'Nico Robin',
+                        'phone_number' => '+35345345' }
+
+    assert person1.invalid?
+    assert person2.invalid?
+    assert person3.valid?
+  end
+
+  def test_each_option
+    Person.validates_json_of(:details, each: { include: [:name] })
+
+    person1 = Person.new
+    person2 = Person.new
+
+    person1.details = [{ name: 'Zoro' }, { name: 'Luffy' }]
+    person2.details = [{ name: 'Zoro' }, { age: 20 }]
+
+
+    assert person1.valid?
+    assert person2.invalid?
+  end
+end

--- a/activemodel/test/models/person.rb
+++ b/activemodel/test/models/person.rb
@@ -2,7 +2,7 @@ class Person
   include ActiveModel::Validations
   extend  ActiveModel::Translation
 
-  attr_accessor :title, :karma, :salary, :gender
+  attr_accessor :title, :karma, :salary, :gender, :details
 
   def condition_is_true
     true


### PR DESCRIPTION
This validator provides data validation for model fields with json format. ( For example Postgres `json` data type ). Here is some examples:

``` ruby
class Person
  include ActiveModel::Validations
  extend  ActiveModel::Translation

  attr_accessor :title, :details

  validates_json_of :details, include: [:age, :salery]

  # or

  validates_json_of :details, format: { age: { with: /\d{2}/ } }

  # or

  validates_json_of :details, each: { include: [:name] }
end
```

Or any combination of above options.
