### PR TITLE
Raise ArgumentError if an unrecognised callback is skipped

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -62,9 +62,9 @@ module AbstractController
       #   using #skip_action_callback
       def skip_action_callback(*names)
         ActiveSupport::Deprecation.warn('`skip_action_callback` is deprecated and will be removed in the next major version of Rails. Please use skip_before_action, skip_after_action or skip_around_action instead.')
-        skip_before_action(*names)
-        skip_after_action(*names)
-        skip_around_action(*names)
+        skip_before_action(*names, raise: false)
+        skip_after_action(*names, raise: false)
+        skip_around_action(*names, raise: false)
       end
 
       def skip_filter(*names)

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `ActiveSupport::Callbacks#skip_callback` now raises an `ArgumentError` if
+    an unrecognized callback is removed.
+
+    *Iain Beeston*
+
 *   Added `ActiveSupport::ArrayInquirer` and `Array#inquiry`.
 
     Wrapping an array in an `ArrayInquirer` gives a friendlier way to check its

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -691,19 +691,27 @@ module ActiveSupport
       #   class Writer < Person
       #      skip_callback :validate, :before, :check_membership, if: -> { self.age > 18 }
       #   end
+      #
+      # An <tt>ArgumentError</tt> will be raised if the callback has not
+      # already been set (unless the <tt>:raise</tt> option is set to <tt>false</tt>).
       def skip_callback(name, *filter_list, &block)
         type, filters, options = normalize_callback_params(filter_list, block)
+        options[:raise] = true unless options.key?(:raise)
 
         __update_callbacks(name) do |target, chain|
           filters.each do |filter|
-            filter = chain.find {|c| c.matches?(type, filter) }
+            callback = chain.find {|c| c.matches?(type, filter) }
 
-            if filter && options.any?
-              new_filter = filter.merge_conditional_options(chain, if_option: options[:if], unless_option: options[:unless])
-              chain.insert(chain.index(filter), new_filter)
+            if !callback && options[:raise]
+              raise ArgumentError, "#{type.to_s.capitalize} #{name} callback #{filter.inspect} has not been defined"
             end
 
-            chain.delete(filter)
+            if callback && (options.key?(:if) || options.key?(:unless))
+              new_callback = callback.merge_conditional_options(chain, if_option: options[:if], unless_option: options[:unless])
+              chain.insert(chain.index(callback), new_callback)
+            end
+
+            chain.delete(callback)
           end
           target.set_callbacks name, chain
         end


### PR DESCRIPTION
At present, if you skip a callback that hasn't been defined, activesupport callbacks silently does nothing. However, it's easy to mistype the name of a callback and mistakenly think that it's being skipped, when it is not.

This problem even exists in the current test suite. CallbacksTest::SkipCallbacksTest#test_skip_person attempts to skip callbacks that were never set up.

This PR amends the current behavior by printing a warning if a callback is skipped without having been defined first.

There is one catch to this, which is that `AbstractController::Callbacks#skip_action_callback` (which attempts to skip all before, around and after actions with the specified name) will always show a warning when used (unless the same callback is configured for before, around and after). If this PR is accepted I'd suggest that `skip_action_callback` is deprecated, or modified to check whether a callback exists before removing it (I'd go for the former option).
