### PR TITLE
Changed the AJADAPTER to AJ_ADAPTER

### DIFF
--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -28,7 +28,7 @@ namespace :test do
   end
 
   ACTIVEJOB_ADAPTERS.each do |adapter|
-    task("env:#{adapter}") { ENV['AJADAPTER'] = adapter }
+    task("env:#{adapter}") { ENV['AJ_ADAPTER'] = adapter }
 
     Rake::TestTask.new(adapter => "test:env:#{adapter}") do |t|
       t.description = "Run adapter tests for #{adapter}"

--- a/activejob/test/cases/adapter_test.rb
+++ b/activejob/test/cases/adapter_test.rb
@@ -1,7 +1,7 @@
 require 'helper'
 
 class AdapterTest < ActiveSupport::TestCase
-  test "should load #{ENV['AJADAPTER']} adapter" do
-    assert_equal "active_job/queue_adapters/#{ENV['AJADAPTER']}_adapter".classify, ActiveJob::Base.queue_adapter.name
+  test "should load #{ENV['AJ_ADAPTER']} adapter" do
+    assert_equal "active_job/queue_adapters/#{ENV['AJ_ADAPTER']}_adapter".classify, ActiveJob::Base.queue_adapter.name
   end
 end

--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -5,7 +5,7 @@ require 'support/job_buffer'
 
 GlobalID.app = 'aj'
 
-@adapter  = ENV['AJADAPTER'] || 'inline'
+@adapter  = ENV['AJ_ADAPTER'] || 'inline'
 
 if ENV['AJ_INTEGRATION_TESTS']
   require 'support/integration/helper'

--- a/activejob/test/support/integration/dummy_app_template.rb
+++ b/activejob/test/support/integration/dummy_app_template.rb
@@ -1,4 +1,4 @@
-if ENV['AJADAPTER'] == 'delayed_job'
+if ENV['AJ_ADAPTER'] == 'delayed_job'
   generate "delayed_job:active_record", "--quiet"
   rake("db:migrate")
 end

--- a/activejob/test/support/integration/helper.rb
+++ b/activejob/test/support/integration/helper.rb
@@ -1,4 +1,4 @@
-puts "*** rake aj:integration:#{ENV['AJADAPTER']} ***\n"
+puts "*** rake aj:integration:#{ENV['AJ_ADAPTER']} ***\n"
 
 ENV["RAILS_ENV"] = "test"
 ActiveJob::Base.queue_name_prefix = nil

--- a/activejob/test/support/integration/jobs_manager.rb
+++ b/activejob/test/support/integration/jobs_manager.rb
@@ -3,7 +3,7 @@ class JobsManager
   attr :adapter_name
 
   def self.current_manager
-    @@managers[ENV['AJADAPTER']] ||= new(ENV['AJADAPTER'])
+    @@managers[ENV['AJ_ADAPTER']] ||= new(ENV['AJ_ADAPTER'])
   end
 
   def initialize(adapter_name)


### PR DESCRIPTION
This PR changed the `AJADAPTER` env var used in testing AcitveJob to `AJ_ADAPTER`.
This allows for easier reading, since those are two words, so they should be split by `_`

/cc @rafaelfranca 
