### PR TITLE
Prevent defining duplicate enum mappings

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Prevent `enum` of accepting duplicate mappings. When two values are mapped
+    to the same integer, raise an error.
+
+    *Vesa Vänskä*
+
 *   Fixed ActiveRecord::Relation#becomes! and changed_attributes issues for type column
 
     Fixes #17139.

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -259,6 +259,20 @@ class EnumTest < ActiveRecord::TestCase
     end
   end
 
+  test "prevent conflicting value pairs" do
+    e = assert_raises(ArgumentError) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum status: {
+          proposed: 10,
+          written: 10,
+          published: 20
+        }
+      end
+    end
+    assert_match(/value \"written\" would map to 10, but it has already been used by value \"proposed\"/, e.message)
+  end
+
   test "overriding enum method should not raise" do
     assert_nothing_raised do
       Class.new(ActiveRecord::Base) do


### PR DESCRIPTION
Previously you could have an enum where two different values would map to the same integer. The last declaration would always override the value which an integer would be mapped to.

This pull request prevents this problem by raising ArgumentError when setting duplicate integer enum mappings.
