### PR TITLE
Add explicit base class for ActiveJob jobs

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -77,4 +77,8 @@
 
     *Isaac Seymour*
 
+*   A generated job now inherents from `app/job/application_job.rb` by default.
+
+    *Jeroen van Baarsen*
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activejob/CHANGELOG.md) for previous changes.

--- a/activejob/lib/rails/generators/job/job_generator.rb
+++ b/activejob/lib/rails/generators/job/job_generator.rb
@@ -18,7 +18,6 @@ module Rails
       def create_job_file
         template 'job.rb', File.join('app/jobs', class_path, "#{file_name}_job.rb")
       end
-
     end
   end
 end

--- a/activejob/lib/rails/generators/job/templates/job.rb
+++ b/activejob/lib/rails/generators/job/templates/job.rb
@@ -1,5 +1,5 @@
 <% module_namespacing do -%>
-class <%= class_name %>Job < ActiveJob::Base
+class <%= class_name %>Job < ApplicationJob
   queue_as :<%= options[:queue] %>
 
   def perform(*args)

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -75,6 +75,21 @@ warning by adding the following configuration to your `config/application.rb`:
 
 See [#17227](https://github.com/rails/rails/pull/17227) for more details.
 
+### ActiveJob jobs now inherent from ApplicationJob by default
+
+In Rails 4.2 an ActiveJob inherents from `ActiveJob::Base`. In Rails 5.0 this
+behaviour has changed to now inherent from `ApplicationJob`.
+
+When upgrading from Rails 4.2 to Rails 5.0 you need to create a file
+`application_job.rb` in `app/jobs/` and add the following content:
+
+```
+class ApplicationJob < ActiveJob::Base
+end
+```
+
+See [#19034](https://github.com/rails/rails/pull/19034) for more details
+
 Upgrading from Rails 4.1 to Rails 4.2
 -------------------------------------
 

--- a/railties/lib/rails/generators/rails/app/templates/app/jobs/application_job.rb
+++ b/railties/lib/rails/generators/rails/app/templates/app/jobs/application_job.rb
@@ -1,0 +1,3 @@
+class ApplicationJob < ActiveJob::Base
+
+end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -99,7 +99,7 @@ module ApplicationTests
     end
 
     def test_code_statistics_sanity
-      assert_match "Code LOC: 5     Test LOC: 0     Code to Test Ratio: 1:0.0",
+      assert_match "Code LOC: 7     Test LOC: 0     Code to Test Ratio: 1:0.0",
         Dir.chdir(app_path){ `rake stats` }
     end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -18,6 +18,7 @@ DEFAULT_APP_FILES = %w(
   app/mailers
   app/models
   app/models/concerns
+  app/jobs
   app/views/layouts
   bin/bundle
   bin/rails
@@ -65,6 +66,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file("app/views/layouts/application.html.erb", /javascript_include_tag\s+'application', 'data-turbolinks-track' => true/)
     assert_file("app/assets/stylesheets/application.css")
     assert_file("app/assets/javascripts/application.js")
+  end
+
+  def test_application_job_file_present
+    run_generator
+    assert_file("app/jobs/application_job.rb")
   end
 
   def test_invalid_application_name_raises_an_error

--- a/railties/test/generators/job_generator_test.rb
+++ b/railties/test/generators/job_generator_test.rb
@@ -7,14 +7,14 @@ class JobGeneratorTest < Rails::Generators::TestCase
   def test_job_skeleton_is_created
     run_generator ["refresh_counters"]
     assert_file "app/jobs/refresh_counters_job.rb" do |job|
-      assert_match(/class RefreshCountersJob < ActiveJob::Base/, job)
+      assert_match(/class RefreshCountersJob < ApplicationJob/, job)
     end
   end
 
   def test_job_queue_param
     run_generator ["refresh_counters", "--queue", "important"]
     assert_file "app/jobs/refresh_counters_job.rb" do |job|
-      assert_match(/class RefreshCountersJob < ActiveJob::Base/, job)
+      assert_match(/class RefreshCountersJob < ApplicationJob/, job)
       assert_match(/queue_as :important/, job)
     end
   end
@@ -22,7 +22,7 @@ class JobGeneratorTest < Rails::Generators::TestCase
   def test_job_namespace
     run_generator ["admin/refresh_counters", "--queue", "admin"]
     assert_file "app/jobs/admin/refresh_counters_job.rb" do |job|
-      assert_match(/class Admin::RefreshCountersJob < ActiveJob::Base/, job)
+      assert_match(/class Admin::RefreshCountersJob < ApplicationJob/, job)
       assert_match(/queue_as :admin/, job)
     end
   end


### PR DESCRIPTION
- Jobs generated should inherent from ApplicationJob
- ApplicationJob inherents from ActiveJob::Base

Fixes  #16976

/cc @tamird @rafaelfranca 
