### PR TITLE
Prevent the silent destruction of user input

### DIFF
--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -400,8 +400,7 @@ module ActionView
 
     def collection_from_options
       if @options.key?(:collection)
-        collection = @options[:collection]
-        collection.respond_to?(:to_ary) ? collection.to_ary : []
+        collection = @options[:collection].to_ary
       end
     end
 


### PR DESCRIPTION
Rather than silently changing what was specified to be the collection for this partial,
this will call `to_ary` on whatever is passed.  This has a few benefits for the developer:
- Knowledge that the collection should implement `to_ary` if it doesn't.
- Principle of least surprise as, rather than the partial not being rendered at all, an exception gets raised.

I'm hoping with this to open a dialogue, so if this patch isn't 100% right for the case that I'm trying to solve then please let me know how we could improve this.

Thanks! :heart: :blue_heart: :yellow_heart: :green_heart: :purple_heart: 
