### PR TITLE
Reduce String allocations in ActionController::Parameters#permitted_scal...

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -537,7 +537,10 @@ module ActionController
           params[key] = self[key]
         end
 
-        keys.grep(/\A#{Regexp.escape(key)}\(\d+[if]?\)\z/) do |k|
+        @@permitted_scalar_filter_regexps ||= ThreadSafe::Cache.new
+        @@permitted_scalar_filter_regexps[key] ||= /\A#{Regexp.escape(key)}\(\d+[if]?\)\z/
+
+        keys.grep(@@permitted_scalar_filter_regexps[key]) do |k|
           if permitted_scalar?(self[k])
             params[k] = self[k]
           end

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -533,12 +533,8 @@ module ActionController
       end
 
       def permitted_scalar_filter(params, key)
-        if has_key?(key) && permitted_scalar?(self[key])
-          params[key] = self[key]
-        end
-
         @@permitted_scalar_filter_regexps ||= ThreadSafe::Cache.new
-        @@permitted_scalar_filter_regexps[key] ||= /\A#{Regexp.escape(key)}\(\d+[if]?\)\z/
+        @@permitted_scalar_filter_regexps[key] ||= /\A#{Regexp.escape(key)}(?:\(\d+[if]?\))?\z/
 
         keys.grep(@@permitted_scalar_filter_regexps[key]) do |k|
           if permitted_scalar?(self[k])


### PR DESCRIPTION
...ar_filter.

Script used: https://github.com/eileencodes/integration_performance_test/blob/master/test/integration/documents_allocations_create_test.rb.

Before:

```
[["rails/actionpack/lib/action_controller/metal/strong_parameters.rb", 540, :T_STRING], [52820, 0, 52406, 0, 2, 5676390]]
[["rails/actionpack/lib/action_controller/metal/strong_parameters.rb", 540, :T_NODE], [17448, 0, 17318, 0, 2, 675600]]
[["rails/actionpack/lib/action_controller/metal/strong_parameters.rb", 540, :T_ARRAY], [17448, 0, 17321, 0, 2, 675600]]
[["rails/actionpack/lib/action_controller/metal/strong_parameters.rb", 540, :T_REGEXP], [5816, 0, 5774, 0, 2, 3777730]]
```

After:

```
[["rails/actionpack/lib/action_controller/metal/strong_parameters.rb", 543, :T_NODE], [18006, 0, 17503, 0, 2, 696240]]
[["rails/actionpack/lib/action_controller/metal/strong_parameters.rb", 543, :T_ARRAY], [12004, 0, 11670, 0, 2, 464160]]
```

cc/ @eileencodes @tenderlove 
