### PR TITLE
`ActiveJob::QueueAdapters::TestAdapter` is now a singleton

### DIFF
--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -17,8 +17,6 @@ module ActiveJob
       def queue_adapter=(name_or_adapter)
         @@queue_adapter = \
           case name_or_adapter
-          when :test
-            ActiveJob::QueueAdapters::TestAdapter.new
           when Symbol, String
             load_adapter(name_or_adapter)
           else

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -10,40 +10,39 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :test
     class TestAdapter
-      delegate :name, to: :class
-      attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter)
-      attr_writer(:enqueued_jobs, :performed_jobs)
+      class << self
+        attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter)
+        attr_writer(:enqueued_jobs, :performed_jobs)
 
-      def initialize
-        self.perform_enqueued_jobs = false
-        self.perform_enqueued_at_jobs = false
-      end
+        # Provides a store of all the enqueued jobs with the TestAdapter so you can check them.
+        def enqueued_jobs
+          @enqueued_jobs ||= []
+        end
 
-      # Provides a store of all the enqueued jobs with the TestAdapter so you can check them.
-      def enqueued_jobs
-        @enqueued_jobs ||= []
-      end
+        # Provides a store of all the performed jobs with the TestAdapter so you can check them.
+        def performed_jobs
+          @performed_jobs ||= []
+        end
 
-      # Provides a store of all the performed jobs with the TestAdapter so you can check them.
-      def performed_jobs
-        @performed_jobs ||= []
-      end
+        def enqueue(job) #:nodoc:
+          return if filtered?(job)
 
-      def enqueue(job) #:nodoc:
-        return if filtered?(job)
+          job_data = job_to_hash(job)
+          enqueue_or_perform(perform_enqueued_jobs, job, job_data)
+        end
 
-        job_data = { job: job.class, args: job.serialize['arguments'], queue: job.queue_name }
-        enqueue_or_perform(perform_enqueued_jobs, job, job_data)
-      end
+        def enqueue_at(job, timestamp) #:nodoc:
+          return if filtered?(job)
 
-      def enqueue_at(job, timestamp) #:nodoc:
-        return if filtered?(job)
+          job_data = job_to_hash(job, at: timestamp)
+          enqueue_or_perform(perform_enqueued_at_jobs, job, job_data)
+        end
 
-        job_data = { job: job.class, args: job.serialize['arguments'], queue: job.queue_name, at: timestamp }
-        enqueue_or_perform(perform_enqueued_at_jobs, job, job_data)
-      end
+        private
 
-      private
+        def job_to_hash(job, extras = {})
+          { job: job.class, args: job.serialize.fetch('arguments'), queue: job.queue_name }.merge(extras)
+        end
 
         def enqueue_or_perform(perform, job, job_data)
           if perform
@@ -57,6 +56,7 @@ module ActiveJob
         def filtered?(job)
           filter && !Array(filter).include?(job.class)
         end
+      end
     end
   end
 end

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -7,10 +7,12 @@ module ActiveJob
 
     included do
       def before_setup
-        @old_queue_adapter  = queue_adapter
+        @old_queue_adapter = queue_adapter
         ActiveJob::Base.queue_adapter = :test
         clear_enqueued_jobs
         clear_performed_jobs
+        queue_adapter.perform_enqueued_jobs = false
+        queue_adapter.perform_enqueued_at_jobs = false
         super
       end
 
@@ -281,7 +283,7 @@ module ActiveJob
 
         def enqueued_jobs_size(only: nil)
           if only
-            enqueued_jobs.select { |job| job[:job] == only }.size
+            enqueued_jobs.select { |job| job.fetch(:job) == only }.size
           else
             enqueued_jobs.size
           end

--- a/activejob/test/cases/test_case_test.rb
+++ b/activejob/test/cases/test_case_test.rb
@@ -9,6 +9,6 @@ class ActiveJobTestCaseTest < ActiveJob::TestCase
   end
 
   def test_set_test_adapter
-    assert_instance_of ActiveJob::QueueAdapters::TestAdapter, self.queue_adapter
+    assert_equal ActiveJob::QueueAdapters::TestAdapter, self.queue_adapter
   end
 end


### PR DESCRIPTION
Since `ActiveJob::TestHelper` globally sets
`ActiveJob::Base.queue_adapter` on setup, there is no benefit in
instantiating a new `TestAdapter` per tests. The original rationale was
to allow parallel tests to run without interference, but since they'd
all mutate the global `ActiveJob::Base.queue_adapter`, that was never
realized.

@cristianbica @jeremy @dhh 
