### PR TITLE
Deprecate `AbstractController::Callbacks#skip_action_callback`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecate AbstractController#skip_action_callback in favor of individual skip_callback methods
+    (which can be made to raise an error if no callback was removed).
+
+    *Iain Beeston*
+
 *   Non-string authenticity tokens do not raise NoMethodError when decoding
     the masked token.
 

--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -50,6 +50,7 @@ module AbstractController
       #   impossible to skip a callback defined using an anonymous proc
       #   using #skip_action_callback
       def skip_action_callback(*names)
+        ActiveSupport::Deprecation.warn('`skip_action_callback` is deprecated and will be removed in the next major version of Rails. Please use skip_before_action, skip_after_action or skip_around_action instead.')
         skip_before_action(*names)
         skip_after_action(*names)
         skip_around_action(*names)

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -951,8 +951,15 @@ class ControllerWithAllTypesOfFilters < PostsController
 end
 
 class ControllerWithTwoLessFilters < ControllerWithAllTypesOfFilters
-  skip_action_callback :around_again
-  skip_action_callback :after
+  skip_around_action :around_again
+  skip_after_action :after
+end
+
+class SkipFilterUsingSkipActionCallback < ControllerWithAllTypesOfFilters
+  ActiveSupport::Deprecation.silence do
+    skip_action_callback :around_again
+    skip_action_callback :after
+  end
 end
 
 class YieldingAroundFiltersTest < ActionController::TestCase
@@ -1037,6 +1044,19 @@ class YieldingAroundFiltersTest < ActionController::TestCase
     response = test_process(controller, 'fail_3')
     assert_equal '', response.body
     assert_equal 3, controller.instance_variable_get(:@try)
+  end
+
+  def test_skipping_with_skip_action_callback
+    test_process(SkipFilterUsingSkipActionCallback,'no_raise')
+    assert_equal 'before around (before yield) around (after yield)', assigns['ran_filter'].join(' ')
+  end
+
+  def test_deprecated_skip_action_callback
+    assert_deprecated do
+      Class.new(TestController) do
+        skip_action_callback :clean_up
+      end
+    end
   end
 
   protected


### PR DESCRIPTION
As part of #19029, in future `skip_before_action`, `skip_after_action` and `skip_around_action` will raise an ArgumentError if the specified callback does not exist. `skip_action_callback` calls all three of these methods and will almost certainly result in an ArgumentError. If anyone wants to remove all three callbacks then they can still call the three individual methods. Therefore let's deprecate `skip_action_callback` now and remove it when #19029 is merged.

I hope it's ok that I've targeted this pull request at the 4.2 branch (rather than master/5.0)
