### PR TITLE
activemodel: make .model_name json encodable

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -130,7 +130,7 @@ module ActiveModel
     #
     # Equivalent to +to_s+.
     delegate :==, :===, :<=>, :=~, :"!~", :eql?, :to_s,
-             :to_str, to: :name
+             :to_str, :as_json, to: :name
 
     # Returns a new ActiveModel::Name instance. By default, the +namespace+
     # and +name+ option will take the namespace and name of the given class

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -195,4 +195,8 @@ class JsonSerializationTest < ActiveModel::TestCase
     assert_no_match %r{"awesome":}, json
     assert_no_match %r{"preferences":}, json
   end
+
+  test "Class.model_name should be json encodable" do
+    assert_match %r{"Contact"}, Contact.model_name.to_json
+  end
 end


### PR DESCRIPTION
Previously. calling `User.model_name.to_json` would result in an infinite recursion as `.model_name` did not respond to the `.to_json`. This patch fixesthat unexpected behavior by delegating `.to_json` to the correct handler.

resolves https://github.com/rails/rails/issues/19050
