### PR TITLE
Reduce object allocation in normalize_path method

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -2,6 +2,11 @@ module ActionDispatch
   module Journey # :nodoc:
     class Router # :nodoc:
       class Utils # :nodoc:
+        SLASH = '/'.freeze
+        EMPTY = ''.freeze
+        TRAILING_SLASHES = /\/+\Z/.freeze
+        URL_ENCODED_CHAR = /(%[a-f0-9]{2})/.freeze
+
         # Normalizes URI path.
         #
         # Strips off trailing slash and ensures there is a leading slash.
@@ -14,10 +19,10 @@ module ActionDispatch
         #   normalize_path("/%ab")  # => "/%AB"
         def self.normalize_path(path)
           path = "/#{path}"
-          path.squeeze!('/')
-          path.sub!(%r{/+\Z}, '')
-          path.gsub!(/(%[a-f0-9]{2})/) { $1.upcase }
-          path = '/' if path == ''
+          path.squeeze!(SLASH)
+          path.sub!(TRAILING_SLASHES, EMPTY)
+          path.gsub!(URL_ENCODED_CHAR) { $1.upcase }
+          path = '/' if path.empty?
           path
         end
 

--- a/actionpack/test/journey/router/utils_test.rb
+++ b/actionpack/test/journey/router/utils_test.rb
@@ -31,6 +31,22 @@ module ActionDispatch
         def test_normalize_path_uppercase
           assert_equal "/foo%AAbar%AAbaz", Utils.normalize_path("/foo%aabar%aabaz")
         end
+
+        def test_normalize_path_trailing_slash
+          assert_equal "/foo/bar", Utils.normalize_path("/foo/bar/")
+        end
+
+        def test_normalize_path_multiple_slashes
+          assert_equal "/foo/bar", Utils.normalize_path("//foo//bar")
+        end
+
+        def test_normalize_path_missing_leading_slash
+          assert_equal "/foo/bar", Utils.normalize_path("foo/bar")
+        end
+
+        def test_normalize_path_empty_string
+          assert_equal "/", Utils.normalize_path("")
+        end
       end
     end
   end


### PR DESCRIPTION
Move stuff to constants & some new tests.

Benchmark results (ruby 2.2.0):

> Comparison:
> new_normalize_path:   207629.7 i/s
> original_normalize_path:   185932.5 i/s - 1.12x slower
