### PR TITLE
Move back `new_column_definition` into `TableDefinition`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -11,6 +11,10 @@ module ActiveRecord
           options[:auto_increment] = true if type == :bigint
           super
         end
+      end
+
+      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+        include ColumnMethods
 
         def new_column_definition(name, type, options) # :nodoc:
           column = super
@@ -21,10 +25,6 @@ module ActiveRecord
           end
           column
         end
-      end
-
-      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
-        include ColumnMethods
       end
 
       class Table < ActiveRecord::ConnectionAdapters::Table


### PR DESCRIPTION
Only `primary_key` should be extracted by d47357e in #19030, but
`new_coclumn_definition` was also extracted because #17631 is merged
previously, then #19030 is auto merged without conflicts.

This PR is for move back `new_column_definition` into `TableDefinition`.
