### PR TITLE
AR: translate_exception_class() no longer logs error.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -478,7 +478,6 @@ module ActiveRecord
           message = "#{e.class.name}: #{e.message.force_encoding sql.encoding}: #{sql}"
         end
 
-        @logger.error message if @logger
         exception = translate_exception(e, message)
         exception.set_backtrace e.backtrace
         exception


### PR DESCRIPTION
`ActiveRecord::ConnectionAdapters::AbstractAdapter#translate_exception_class(e, sql)` is expected to take an error and wrap it in another error; logging the error is an unexpected (and often unwanted) side effect.

This error logging occurs even when the error is explicitly rescued by a caller. For example, this method idempotently creates a uniquely named Widget:

``` ruby
def ensure_widget_exists(name)
  Widget.create!(name: name)
rescue ActiveRecord::RecordNotUnique
end
```

The logging side effect in `translate_exception_class` causes a database error to be added to the Rails log despite the RecordNotUnique condition being correctly handled. When using `Mysql2`, the error in the log looks like:

```
Mysql2::Error: Duplicate entry '123' for key 'index_name': INSERT INTO `table` (…) VALUES (…)
```

If the error is not rescued, it will continue to a global error handler or be an uncaught exception — either way it will be exposed through the regular error handling channels, and doesn't need to be logged.
