### PR TITLE
Fix dependency tracker bug

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixed a dependency tracker bug that caused template dependencies not
+    count layouts as dependencies for partials.
+
+    *Juho Leinonen*
+
 *   Extracted `ActionView::Helpers::RecordTagHelper` to external gem
     (`record_tag_helper`) and added removal notices.
 

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -60,7 +60,6 @@ class ERBTrackerTest < Minitest::Test
   end
 
   def test_dependency_of_template_partial_with_layout
-    skip # FIXME: Needs to be fixed properly, right now we can only match one dependency per line. Need multiple!
     template = FakeTemplate.new("<%# render partial: 'messages/show', layout: 'messages/layout' %>", :erb)
     tracker = make_tracker("multiple/_dependencies", template)
 


### PR DESCRIPTION
Fixed a dependency tracker bug that caused template dependencies not count layouts as dependencies for partials.
