### PR TITLE
Prevent callable route constraints from disabling constraints in scope

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -306,7 +306,7 @@ module ActionDispatch
           def blocks(options_constraints, scope_blocks)
             if options_constraints && !options_constraints.is_a?(Hash)
               verify_callable_constraint(options_constraints)
-              [options_constraints]
+              [*scope_blocks, options_constraints]
             else
               scope_blocks || []
             end

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -255,20 +255,6 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     assert scope_called, "scope constraint should be called"
   end
 
-  def test_scoped_lambda_with_get_lambda
-    inner_called = false
-
-    rs.draw do
-      scope '/foo', :constraints => lambda { |req| flunk "should not be called" } do
-        get '/', :constraints    => lambda { |req| inner_called = true },
-                 :to             => lambda { |env| [200, {}, %w{default}] }
-      end
-    end
-
-    assert_equal 'default', get(URI('http://www.example.org/foo/'))
-    assert inner_called, "inner constraint should be called"
-  end
-
   def test_empty_string_match
     rs.draw do
       get '/:username', :constraints => { :username => /[^\/]+/ },


### PR DESCRIPTION
This PR should make callable route constraints more consistent with hash constraints in that the constraints on a particular route don't simple replace the ones on the parent scope, but instead they are both checked.

Closes #15668 (finally... i was feeling guilty for leaving that one open for so long :sweat: ). As mentioned on that issue, there was a test on `actionpack/test/dispatch/routing_test.rb` that was actually checking that callable constrains on a parent scope don't get called when a nested route has a callable constraint itself, but i think that's an unintuitive behaviour, and maybe the test was simply there to document "what was happening", as that strange behaviour was not documented elsewhere. Said test is removed in this PR, and another one, that would break before applying this small fix, was added.

Cheers!
