### PR TITLE
Follow-up to #10776

### DIFF
--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -50,6 +50,7 @@ module ActiveModel
   eager_autoload do
     autoload :Errors
     autoload :StrictValidationFailed, 'active_model/errors'
+    autoload :UnknownAttributeError, 'active_model/errors'
   end
 
   module Serializers

--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -48,16 +48,5 @@ module ActiveModel
         raise UnknownAttributeError.new(self, k)
       end
     end
-
-    # Raised when unknown attributes are supplied via mass assignment.
-    class UnknownAttributeError < NoMethodError
-      attr_reader :record, :attribute
-
-      def initialize(record, attribute)
-        @record = record
-        @attribute = attribute
-        super("unknown attribute '#{attribute}' for #{@record.class}.")
-      end
-    end
   end
 end

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -525,4 +525,15 @@ module ActiveModel
   #   # => ActiveModel::StrictValidationFailed: Name can't be blank
   class StrictValidationFailed < StandardError
   end
+
+  # Raised when unknown attributes are supplied via mass assignment.
+  class UnknownAttributeError < NoMethodError
+    attr_reader :record, :attribute
+
+    def initialize(record, attribute)
+      @record = record
+      @attribute = attribute
+      super("unknown attribute '#{attribute}' for #{@record.class}.")
+    end
+  end
 end

--- a/activemodel/test/cases/attribute_assignment_test.rb
+++ b/activemodel/test/cases/attribute_assignment_test.rb
@@ -49,7 +49,7 @@ class AttributeAssignmentTest < ActiveModel::TestCase
 
   test "assign non-existing attribute" do
     model = Model.new
-    error = assert_raises(ActiveModel::AttributeAssignment::UnknownAttributeError) do
+    error = assert_raises(ActiveModel::UnknownAttributeError) do
       model.assign_attributes(hz: 1)
     end
 
@@ -59,7 +59,7 @@ class AttributeAssignmentTest < ActiveModel::TestCase
 
   test "assign private attribute" do
     model = Model.new
-    assert_raises(ActiveModel::AttributeAssignment::UnknownAttributeError) do
+    assert_raises(ActiveModel::UnknownAttributeError) do
       model.assign_attributes(metadata: { a: 1 })
     end
   end

--- a/activemodel/test/cases/model_test.rb
+++ b/activemodel/test/cases/model_test.rb
@@ -70,7 +70,7 @@ class ModelTest < ActiveModel::TestCase
   end
 
   def test_mixin_initializer_when_args_dont_exist
-    assert_raises(ActiveModel::AttributeAssignment::UnknownAttributeError) do
+    assert_raises(ActiveModel::UnknownAttributeError) do
       SimpleModel.new(hello: 'world')
     end
   end

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -29,6 +29,13 @@ module ActiveRecord
       assign_multiparameter_attributes(multi_parameter_attributes) unless multi_parameter_attributes.empty?
     end
 
+    # Re-raise with the ActiveRecord constant in case of an error
+    def _assign_attribute(k, v) # :nodoc:
+      super
+    rescue ActiveModel::UnknownAttributeError
+      raise UnknownAttributeError.new(self, k)
+    end
+
     # Assign any deferred nested attributes after the base attributes have been set.
     def assign_nested_parameter_attributes(pairs)
       pairs.each { |k, v| _assign_attribute(k, v) }

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -178,10 +178,8 @@ module ActiveRecord
   class DangerousAttributeError < ActiveRecordError
   end
 
-  UnknownAttributeError = ActiveSupport::Deprecation::DeprecatedConstantProxy.new( # :nodoc:
-    'ActiveRecord::UnknownAttributeError', 
-    'ActiveModel::AttributeAssignment::UnknownAttributeError'
-  )
+  # Raised when unknown attributes are supplied via mass assignment.
+  UnknownAttributeError = ActiveModel::UnknownAttributeError
 
   # Raised when an error occurred while doing a mass assignment to an attribute through the
   # +attributes=+ method. The exception has an +attribute+ property that is the name of the

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -276,7 +276,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
   def test_create_with_inexistent_foreign_key_failing
     firm = Firm.create(name: 'GlobalMegaCorp')
 
-    assert_raises(ActiveModel::AttributeAssignment::UnknownAttributeError) do
+    assert_raises(ActiveRecord::UnknownAttributeError) do
       firm.create_account_with_inexistent_foreign_key
     end
   end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -758,12 +758,12 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   def test_bulk_update_respects_access_control
     privatize("title=(value)")
 
-    assert_raise(ActiveModel::AttributeAssignment::UnknownAttributeError) { @target.new(:title => "Rants about pants") }
-    assert_raise(ActiveModel::AttributeAssignment::UnknownAttributeError) { @target.new.attributes = { :title => "Ants in pants" } }
+    assert_raise(ActiveRecord::UnknownAttributeError) { @target.new(:title => "Rants about pants") }
+    assert_raise(ActiveRecord::UnknownAttributeError) { @target.new.attributes = { :title => "Ants in pants" } }
   end
 
   def test_bulk_update_raise_unknown_attribute_error
-    error = assert_raises(ActiveModel::AttributeAssignment::UnknownAttributeError) {
+    error = assert_raises(ActiveRecord::UnknownAttributeError) {
       Topic.new(hello: "world")
     }
     assert_instance_of Topic, error.record

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -58,7 +58,7 @@ module ActiveRecord
       data = OverloadedType.new(non_existent_decimal: 1)
 
       assert_equal BigDecimal.new(1), data.non_existent_decimal
-      assert_raise ActiveModel::AttributeAssignment::UnknownAttributeError do
+      assert_raise ActiveRecord::UnknownAttributeError do
         UnoverloadedType.new(non_existent_decimal: 1)
       end
     end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -672,7 +672,7 @@ module NestedAttributesOnACollectionAssociationTests
   end
 
   def test_should_not_assign_destroy_key_to_a_record
-    assert_nothing_raised ActiveModel::AttributeAssignment::UnknownAttributeError do
+    assert_nothing_raised ActiveRecord::UnknownAttributeError do
       @pirate.send(association_setter, { 'foo' => { '_destroy' => '0' }})
     end
   end


### PR DESCRIPTION
Hello,

This pull request is a follow up to #10776.

The name `ActiveModel::AttributeAssignment::UnknownAttributeError` is too implementation specific so let's move the constant directly under the ActiveModel namespace.

Also since this constant used to be under the ActiveRecord namespace, to make the upgrade path easier, let's avoid raising the former constant when we deal with this error on the Active Record side.

I don't know whether monkey-patching `_assign_attribute` is the right solution to raise the correct constant so let me know if I should change it.

Have a nice day.
