### PR TITLE
Add support for PostgreSQL operator classes to add_index

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add support for PostgreSQL operator classes to `add_index`.
+
+    Example:
+
+        add_index :users, :name, using: :gist, opclass: name: :gist_trgm_ops
+
+    *Greg Navis*
+
 *   Don't allow scopes to be defined which conflict with instance methods on `Relation`.
 
     Fixes #31120.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
     class IndexDefinition # :nodoc:
-      attr_reader :table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using, :comment
+      attr_reader :table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using, :opclass, :comment
 
       def initialize(
         table, name,
@@ -17,6 +17,7 @@ module ActiveRecord
         where: nil,
         type: nil,
         using: nil,
+        opclass: {},
         comment: nil
       )
         @table = table
@@ -28,6 +29,7 @@ module ActiveRecord
         @where = where
         @type = type
         @using = using
+        @opclass = opclass
         @comment = comment
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -388,6 +388,23 @@ module ActiveRecord
 
       private
 
+        def add_index_opclass(column_names, options = {})
+          opclass =
+            if options[:opclass].is_a?(Hash)
+              options[:opclass].symbolize_keys
+            else
+              Hash.new { |hash, column| hash[column] = options[:opclass].to_s }
+            end
+          column_names.each do |name, column|
+            column << " #{opclass[name]}" if opclass[name].present?
+          end
+        end
+
+        def add_options_for_index_columns(quoted_columns, **options)
+          quoted_columns = add_index_opclass(quoted_columns, options)
+          super
+        end
+
         # See https://www.postgresql.org/docs/current/static/errcodes-appendix.html
         VALUE_LIMIT_VIOLATION = "22001"
         NUMERIC_VALUE_OUT_OF_RANGE = "22003"

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -189,6 +189,7 @@ HEADER
         index_parts << "where: #{index.where.inspect}" if index.where
         index_parts << "using: #{index.using.inspect}" if !@connection.default_index_type?(index)
         index_parts << "type: #{index.type.inspect}" if index.type
+        index_parts << "opclass: #{index.opclass.inspect}" if index.opclass.present?
         index_parts << "comment: #{index.comment.inspect}" if index.comment
         index_parts
       end

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -59,6 +59,9 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
       assert_equal expected, add_index(:people, "lower(last_name)", using: type, unique: true)
     end
 
+    expected = %(CREATE  INDEX  "index_people_on_last_name" ON "people" USING gist ("last_name" bpchar_pattern_ops))
+    assert_equal expected, add_index(:people, :last_name, using: :gist, opclass: { last_name: :bpchar_pattern_ops })
+
     assert_raise ArgumentError do
       add_index(:people, :last_name, algorithm: :copy)
     end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -248,12 +248,12 @@ module ActiveRecord
 
       def test_index_with_opclass
         with_example_table do
-          @connection.add_index "ex", "data varchar_pattern_ops"
-          index = @connection.indexes("ex").find { |idx| idx.name == "index_ex_on_data_varchar_pattern_ops" }
-          assert_equal "data varchar_pattern_ops", index.columns
+          @connection.add_index "ex", "data", opclass: "varchar_pattern_ops"
+          index = @connection.indexes("ex").find { |idx| idx.name == "index_ex_on_data" }
+          assert_equal ["data"], index.columns
 
-          @connection.remove_index "ex", "data varchar_pattern_ops"
-          assert_not @connection.indexes("ex").find { |idx| idx.name == "index_ex_on_data_varchar_pattern_ops" }
+          @connection.remove_index "ex", "data"
+          assert_not @connection.indexes("ex").find { |idx| idx.name == "index_ex_on_data" }
         end
       end
 


### PR DESCRIPTION
# Use case

I needed to use trigrams when `SELECT`-ing from a table. I want to use `schema.rb`. Unfortunately this wasn't possible to create an appropriate index. The required query is:

``` sql
CREATE INDEX users_name ON users USING gist (name gist_trgm_ops);
```

The `gist_trgm_ops` after `name` is the [operator class](http://www.postgresql.org/docs/current/static/indexes-opclass.html) to use when using the index. Currently it's possible to specify `... USING gist (name)` but there's no way of adding the operator class after `name`.

PostgreSQL is the _only_ affected database. Other databases are not affected.
# Solution

Operator classes can be explicitly specified in `add_index` as:

``` ruby
add_index :users, :name, using: :gist, opclass: :gist_trgm_ops
```
# Changes
- added `opclass` to `IndexDefinition` and made it a valid `add_index` option
- added support for `opclass` to `SchemaDumper`
- test cases for the changes above
# Issues

Below are issues I run into. I present my decision and a rationale for it. Any feedback is welcome! Hopefully some improvement is possible.
## Syntax

I wasn't sure what's the best syntax. I considered

``` ruby
add_index :users, {name: :gist_trgm_ops}, using: :gist
```

but it places PostgreSQL-specific data where the user might not expect it.

I decided to use a new option as this makes the implementation _very_ simple and makes the opclasses used explicit. The tradeoff is that the column names must be specified twice.
## Extraneous whitespace (resolved)

~There's always a space after a column name used in the index even when no operator class is specified. For example `... USING gist (name)` is turned into `... USING gist (name )`. I decided that this makes the code simpler at the expense of a tiny ugliness in the test suite. Additionally multiple spaces already appear in some statements, e.g. `CREATE  INDEX` when `UNIQE` is _not_ present.~
