### PR TITLE
Add rake dev:cache task to enable development mode caching

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -5,7 +5,16 @@
 
     *Naoto Kaneko*
 
-*   Created rake restart task. Restarts your Rails app by touching the 
+*   Make enabling or disabling caching in development mode possible with rake
+    dev:cache
+
+    Running rake dev:cache will create or remove tmp/caching-dev.txt. When this
+    file exists config.action_controller.perform_caching will be set to true in
+    config/environments/development.rb.
+
+    *Jussi Mertanen*
+
+*   Created rake restart task. Restarts your Rails app by touching the
     `tmp/restart.txt`.
 
     Fixes #18876.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -9,11 +9,20 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
-  # Show full error reports and disable caching.
+  # Show full error reports.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
-  <%- unless options.skip_action_mailer? -%>
 
+  # Enable/disable caching. By default caching is disabled.
+  if Rails.root.join('tmp/caching-dev.txt').exist?
+    config.action_controller.perform_caching = true
+    config.static_cache_control = "public, max-age=172800"
+    config.cache_store = :memory_store
+  else
+    config.action_controller.perform_caching = false
+    config.cache_store = :null_store
+  end
+
+  <%- unless options.skip_action_mailer? -%>
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
   <%- end -%>

--- a/railties/lib/rails/tasks.rb
+++ b/railties/lib/rails/tasks.rb
@@ -3,6 +3,7 @@ require 'rake'
 # Load Rails Rakefile extensions
 %w(
   annotations
+  dev
   framework
   initializer
   log

--- a/railties/lib/rails/tasks/dev.rake
+++ b/railties/lib/rails/tasks/dev.rake
@@ -1,0 +1,13 @@
+namespace :dev do
+  task :cache do
+    desc 'Toggle development mode caching on/off'
+    if File.exist? 'tmp/caching-dev.txt'
+      File.delete 'tmp/caching-dev.txt'
+      puts 'Development mode is no longer being cached.'
+    else
+      FileUtils.touch 'tmp/caching-dev.txt'
+      puts 'Development mode is now being cached.'
+    end
+    FileUtils.touch 'tmp/restart.txt'
+  end
+end

--- a/railties/test/application/rake/dev_test.rb
+++ b/railties/test/application/rake/dev_test.rb
@@ -1,0 +1,28 @@
+require 'isolation/abstract_unit'
+
+module ApplicationTests
+  module RakeTests
+    class RakeDevTest < ActiveSupport::TestCase
+
+      def setup
+        build_app
+        boot_rails
+      end
+
+      def teardown
+        teardown_app
+      end
+
+      test 'dev:cache creates and deletes file and outputs message' do
+        Dir.chdir(app_path) do
+          output = `rake dev:cache`
+          assert File.exist?('tmp/caching-dev.txt')
+          assert_match(/Development mode is now being cached/, output)
+          output = `rake dev:cache`
+          assert !File.exist?('tmp/caching-dev.txt')
+          assert_match(/Development mode is no longer being cached/, output)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Running rake dev:cache will create or remove tmp/caching-dev.txt. When this file exists config.action_controller.perform_caching will be set to true in config/environments/development.rb.

Fixes #18875.
