### PR TITLE
Have Bearer be valid as well

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -62,6 +62,16 @@
 
     *Adam Forsyth*
 
+*   Allow `Bearer` as token-keyword in `Authorization-Header`.
+
+    Aditionally to `Token`, the keyword `Bearer` is acceptable as a keyword
+    for the auth-token. The `Bearer` keyword is described in the original
+    OAuth RFC and used in libraries like Angular-JWT.
+
+    See #19094.
+
+    *Peter Schröder*
+
 *   Drop request class from RouteSet constructor.
 
     If you would like to use a custom request class, please subclass and implement

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -397,7 +397,7 @@ module ActionController
     #   RewriteRule ^(.*)$ dispatch.fcgi [E=X-HTTP_AUTHORIZATION:%{HTTP:Authorization},QSA,L]
     module Token
       TOKEN_KEY = 'token='
-      TOKEN_REGEX = /^Token /
+      TOKEN_REGEX = /^(Token|Bearer) /
       AUTHN_PAIR_DELIMITERS = /(?:,|;|\t+)/
       extend self
 

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -87,6 +87,13 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     assert_equal "HTTP Token: Access denied.\n", @response.body, "Authentication header was not properly parsed"
   end
 
+  test "successful authentication request with Bearer instead of Token" do
+    @request.env['HTTP_AUTHORIZATION'] = 'Bearer lifo'
+    get :index
+
+    assert_response :success
+  end
+
   test "authentication request without credential" do
     get :display
 

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -80,7 +80,7 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
   end
 
   test "authentication request with badly formatted header" do
-    @request.env['HTTP_AUTHORIZATION'] = "Token foobar"
+    @request.env['HTTP_AUTHORIZATION'] = 'Token token$"lifo"'
     get :index
 
     assert_response :unauthorized


### PR DESCRIPTION
it would be nice if Rails would allow the Authorization-Header to deal with the keyword `Bearer` as it's described in [the oauth rfc](https://tools.ietf.org/html/rfc6750#section-2.1) and used by libraries such as [angular-jwt](https://github.com/auth0/angular-jwt/blob/6052964ca69885767490db316199c08169ec9597/dist/angular-jwt.js#L19).

while adding a  test i noticed that `test "authentication request with badly formatted header"` actually does not test what it's saying, so i fixed that along the lines.
