### PR TITLE
Use base model class when app is generated

### DIFF
--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -44,7 +44,18 @@ module ActiveRecord
 
         # Used by the migration template to determine the parent name of the model
         def parent_class_name
-          options[:parent] || "ActiveRecord::Base"
+          options[:parent] || default_parent_class_name
+        end
+
+        def default_parent_class_name
+          begin
+            # Check if Model is defined and serve as base class
+            if Model.superclass == ActiveRecord::Base && Model.abstract_class?
+              return 'Model'
+            end
+          rescue NameError
+          end
+          'ActiveRecord::Base'
         end
 
     end

--- a/railties/lib/rails/generators/rails/app/templates/app/models/model.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/models/model.rb.tt
@@ -1,0 +1,4 @@
+class Model < ActiveRecord::Base
+  self.abstract_class = true
+  # A place for code shared accross all models
+end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1,5 +1,6 @@
 require 'generators/generators_test_helper'
 require 'rails/generators/rails/app/app_generator'
+require "rails/generators/rails/model/model_generator"
 require 'generators/shared_generator_tests'
 require 'mocha/setup' # FIXME: stop using mocha
 
@@ -65,6 +66,23 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file("app/views/layouts/application.html.erb", /javascript_include_tag\s+'application', 'data-turbolinks-track' => true/)
     assert_file("app/assets/stylesheets/application.css")
     assert_file("app/assets/javascripts/application.js")
+    assert_file("app/models/model.rb")
+  end
+
+  def test_model_inherit_model_generated_by_app
+    run_generator
+    Object.const_set(
+      "Model", 
+      Class.new(ActiveRecord::Base) do
+        self.abstract_class = true
+      end
+    )
+    capture(:stdout) do
+      Rails::Generators::ModelGenerator.start(["account"], destination_root: destination_root)
+    end
+    assert_file("app/models/account.rb", /class Account < Model/)
+  ensure
+    Object.send(:remove_const, "Model") rescue NameError
   end
 
   def test_invalid_application_name_raises_an_error


### PR DESCRIPTION
I think there is a need to have a base model class just like `ApplicationController` for controllers
to store code that is shared across all models.

I end up doing it for every project I work on.

So, this patch adds `Model` to generated app uses it as base class when new model is generated.
