### PR TITLE
Add midnight? predicate to check if a time is equal to midnight

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `midnight?` predicate to check if a time is equal to midnight
+
+    *Kieran Johnson*
+
 *   Make `benchmark('something', silence: true)` actually work
 
     *DHH*
@@ -6,7 +10,7 @@
 
     `#on_weekday?` returns `true` if the receiving date/time does not fall on a Saturday
     or Sunday.
-    
+
     *Vipul A M*
 
 *   Add `Array#second_to_last` and `Array#third_to_last` methods.

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -36,6 +36,11 @@ module DateAndTime
       to_date == ::Date.current
     end
 
+    # Returns true if time is midnight
+    def midnight?
+      self == midnight
+    end
+
     # Returns true if the date/time is in the past.
     def past?
       self < self.class.current

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -72,6 +72,11 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal 86399,DateTime.civil(2005,1,1,23,59,59).seconds_since_midnight
   end
 
+  def test_midnight?
+    assert Time.now.beginning_of_day.midnight?
+    assert_not Time.now.beginning_of_day.advance(:minutes => 1).midnight?
+  end
+
   def test_seconds_until_end_of_day
     assert_equal 0, DateTime.civil(2005,1,1,23,59,59).seconds_until_end_of_day
     assert_equal 1, DateTime.civil(2005,1,1,23,59,58).seconds_until_end_of_day


### PR DESCRIPTION
Convenience method for checking if a given time is equal to midnight.

Short-hand for

```
time == time.midnight
```
