### PR TITLE
Make sure the ID for the Delayed Job AJ test adapter does not get overridden.

### DIFF
--- a/activejob/test/support/delayed_job/delayed/backend/test.rb
+++ b/activejob/test/support/delayed_job/delayed/backend/test.rb
@@ -19,13 +19,13 @@ module Delayed
 
         include Delayed::Backend::Base
 
-        cattr_accessor :id
-        self.id = 0
+        cattr_accessor :local_id
+        self.local_id = 0
 
         def initialize(hash = {})
           self.attempts = 0
           self.priority = 0
-          self.id = (self.class.id += 1)
+          self.id = (self.class.local_id += 1)
           hash.each{|k,v| send(:"#{k}=", v)}
         end
 


### PR DESCRIPTION
When running this adapter in production you should get back an ID. Since the
 cattr_accessor was overriding the ID in testing mode, we did not get back such
 an ID. By renaming the `cattr_accessor :id` to `cattr_accessor :local_id` we
 fix this issue.

This is needed in order to continue work on #18821

/cc @cristianbica @seuros 
