### PR TITLE
Fix regression when passing a value different of String.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixed the translation helper method to accept different default values types
+    besides String.
+
+    *Ulisses Almeida*
+
 *   Collection rendering automatically caches and fetches multiple partials.
 
     Collections rendered as:

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -37,8 +37,12 @@ module ActionView
       # you know what kind of output to expect when you call translate in a template.
       def translate(key, options = {})
         options = options.dup
+        has_default = options.has_key?(:default)
         remaining_defaults = Array(options.delete(:default))
-        options[:default] = remaining_defaults.shift if remaining_defaults.first.kind_of? String
+
+        if has_default && !remaining_defaults.first.kind_of?(Symbol)
+          options[:default] = remaining_defaults.shift
+        end
 
         # If the user has explicitly decided to NOT raise errors, pass that option to I18n.
         # Otherwise, tell I18n to raise an exception, which we rescue further in this method.

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -180,6 +180,11 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal 'A Generic String', translation
   end
 
+  def test_translate_with_object_default
+    translation = translate(:'translations.missing', default: 123)
+    assert_equal 123, translation
+  end
+
   def test_translate_with_array_of_string_defaults
     translation = translate(:'translations.missing', default: ['A Generic String', 'Second generic string'])
     assert_equal 'A Generic String', translation


### PR DESCRIPTION
The previous version of rails(4.2.0) you can pass objects
to the default option of translation helper.

For example:

``` ruby
  t('foo', default: 1)
```

But on rails 4.2.1 version this kind of use stopped to work,
because started only to accept String types.

Now with this fix we can use orther value types on this
helper again.

This PR is related to https://github.com/rails/rails/issues/19100#issuecomment-76225895
