### PR TITLE
Preserve Array#take(n) behaviour of HasManyAssociation

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -129,11 +129,11 @@ module ActiveRecord
         first_nth_or_last(:last, *args)
       end
 
-      def take
+      def take(n = nil)
         if loaded?
-          target.first
+          n ? target.take(n) : target.first
         else
-          scope.take.tap do |record|
+          scope.take(n).tap do |record|
             set_inverse_instance record if record.is_a? ActiveRecord::Base
           end
         end

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -227,8 +227,8 @@ module ActiveRecord
         @association.last(*args)
       end
 
-      def take
-        @association.take
+      def take(n = nil)
+        @association.take(n)
       end
 
       # Returns a new object of the collection type that has been instantiated

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -478,6 +478,19 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::RecordNotFound) { authors(:bob).posts.take! }
   end
 
+  def test_taking_with_a_number
+    # taking from unloaded Relation
+    bob = Author.find(authors(:bob).id)
+    assert_equal [posts(:misc_by_bob)], bob.posts.take(1)
+    bob = Author.find(authors(:bob).id)
+    assert_equal [posts(:misc_by_bob), posts(:other_by_bob)], bob.posts.take(2)
+
+    # taking from loaded Relation
+    bob.posts.to_a
+    assert_equal [posts(:misc_by_bob)], authors(:bob).posts.take(1)
+    assert_equal [posts(:misc_by_bob), posts(:other_by_bob)], authors(:bob).posts.take(2)
+  end
+
   def test_taking_with_inverse_of
     interests(:woodsmanship).destroy
     interests(:survival).destroy


### PR DESCRIPTION
I'm not sure whether this behaviour change was by design, so let me PR.

`take` method with an argument had been available on HasManyAssociation until 2b63a354a8f5960a8c5ed4563fdc0730fd9b6809. It used to fallback to `Array#take(n)`.
But now `association.take(n)` raises `ArgumentError: wrong number of arguments (1 for 0)`.

This patch retrieves `Array#take(n)` behaviour without breaking the AR version of `take`.

Note that I didn't touch `take!` method because Ruby Array does not have `take!`.
So `take` can take an argument but `take!` can not take an argument after this change.
I think it's acceptable here, but I'd mention that the API would look a little bit inconsistent.
