### PR TITLE
Add tzinfo as a dependency for activesupport v3.2

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency('i18n',       '~> 0.6', '>= 0.6.4')
   s.add_dependency('multi_json', '~> 1.0')
+  s.add_dependency('tzinfo',     '~> 0.3.29')
 end


### PR DESCRIPTION
Hi, 
Currently I can't use the latest 3.2 version of `active_support` gem separately from `rails` without adding `tzinfo` to my Gemfile manually. 
Can we add `tzinfo` as a dependency, as it's currently used [here](https://github.com/rails/rails/blob/3-2-stable/activesupport/lib/active_support/core_ext/time/zones.rb#L52-L62)?
