### PR TITLE
Remove reference to workingwithrails.com since it is being retired

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -1093,11 +1093,8 @@ Resources
 Authors
 -------
 
-* [Sven Fuchs](http://www.workingwithrails.com/person/9963-sven-fuchs) (initial author)
-* [Karel Minařík](http://www.workingwithrails.com/person/7476-karel-mina-k)
-
-If you found this guide useful, please consider recommending its authors on [workingwithrails](http://www.workingwithrails.com).
-
+* [Sven Fuchs](http://svenfuchs.com) (initial author)
+* [Karel Minařík](http://www.karmi.cz)
 
 Footnotes
 ---------


### PR DESCRIPTION
I was reading the I18n guides and came across the following sentence:

```
If you found this guide useful, please consider recommending its authors on workingwithrails.
```

Intrigued, I followed the link and found out that the website the link leads to is "being retired". The author links also lead to this website. I removed the sentence and replaced the author URLs with URLs of the personal websites of the authors.
