### PR TITLE
fix ActionView::Template::Error when using Streaming with capture.

### DIFF
--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -195,7 +195,9 @@ module ActionView
       def with_output_buffer(buf = nil) #:nodoc:
         unless buf
           buf = ActionView::OutputBuffer.new
-          buf.force_encoding(output_buffer.encoding) if output_buffer
+          if output_buffer && output_buffer.respond_to?(:encoding)
+            buf.force_encoding(output_buffer.encoding)
+          end
         end
         self.output_buffer, old_buffer = buf, output_buffer
         yield

--- a/actionview/test/fixtures/layouts/streaming_with_capture.erb
+++ b/actionview/test/fixtures/layouts/streaming_with_capture.erb
@@ -1,0 +1,6 @@
+<%= yield :header -%>
+<%= capture do %>
+ this works
+<% end %>
+<%= yield :footer -%>
+<%= yield(:unknown).presence || "." -%>

--- a/actionview/test/template/streaming_render_test.rb
+++ b/actionview/test/template/streaming_render_test.rb
@@ -104,4 +104,8 @@ class FiberedTest < ActiveSupport::TestCase
       buffered_render(:template => "test/nested_streaming", :layout => "layouts/streaming")
   end
 
+  def test_render_with_streaming_and_capture
+    assert_equal "Yes, \n this works\n like a charm.",
+      buffered_render(template: "test/streaming", layout: "layouts/streaming_with_capture")
+  end
 end


### PR DESCRIPTION
can't acquire a encoding from StreamingBuffer. fixes #12001
