### PR TITLE
Work around for upstream Ruby bug #10685

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -113,7 +113,9 @@ module ActionDispatch # :nodoc:
     # The underlying body, as a streamable object.
     attr_reader :stream
 
-    def initialize(status = 200, header = {}, body = [], default_headers: self.class.default_headers)
+    # Ruby 2.2 bug https://bugs.ruby-lang.org/issues/10685 prevents
+    # default_headers from being a keyword argument.
+    def initialize(status = 200, header = {}, body = [], default_headers = self.class.default_headers)
       super()
 
       header = merge_default_headers(header, default_headers)

--- a/actionpack/lib/action_dispatch/testing/test_response.rb
+++ b/actionpack/lib/action_dispatch/testing/test_response.rb
@@ -7,7 +7,7 @@ module ActionDispatch
   # See Response for more information on controller response objects.
   class TestResponse < Response
     def self.from_response(response)
-      new response.status, response.headers, response.body, default_headers: nil
+      new response.status, response.headers, response.body, nil
     end
 
     # Was the response successful?

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -172,7 +172,7 @@ class ResponseTest < ActiveSupport::TestCase
     original = ActionDispatch::Response.default_charset
     begin
       ActionDispatch::Response.default_charset = 'utf-16'
-      resp = ActionDispatch::Response.new(200, { "Content-Type" => "text/xml" }, default_headers: nil)
+      resp = ActionDispatch::Response.new(200, { "Content-Type" => "text/xml" })
       assert_equal('utf-16', resp.charset)
     ensure
       ActionDispatch::Response.default_charset = original


### PR DESCRIPTION
In f6e293ec54f02f83cdb37502bea117f66f87bcae we avoided a segfault in the
tests, however I think we should try to avoid the crash, as it may
happen in user code as well.

Here is what I distiled the bug down to:

``` ruby
# Rails case - works on 2.0, 2.1; crashes on 2.2
require 'action_dispatch'

ActionDispatch::Response.new(200, "Content-Type" => "text/xml")

# General case - works on 2.0, 2.1; crashes on 2.2
def foo(optional = {}, default_argument: nil)
end

foo('quux' => 'bar')
```

Pinging @jeremy and @eileencodes.
