### PR TITLE
Add ability to create custom formats for Array#to_s

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add ability to create custom formats for `Array#to_s`
+
+    *Anton Davydov*
+
 *   Fixed a problem where String#truncate_words would get stuck with a complex
     string.
 

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -70,11 +70,20 @@ class ToSTest < ActiveSupport::TestCase
     end
   end
 
+  Array::ARRAY_FORMATS[:separated] = ->(array) { array.join ' | ' }
+
   def test_to_s_db
     collection = [TestDB.new, TestDB.new, TestDB.new]
 
     assert_equal "null", [].to_s(:db)
     assert_equal "1,2,3", collection.to_s(:db)
+  end
+
+  def test_to_s_separated
+    collection = [1, 2, 3]
+
+    assert_equal "", [].to_s(:separated)
+    assert_equal "1 | 2 | 3", collection.to_s(:separated)
   end
 end
 


### PR DESCRIPTION
Hello,
I add ability to create custom formats for `Array#to_s` like this now implemented in the [`Range#to_s`](https://github.com/rails/rails/blob/032d279268f73a012679294560b2da3232710434/activesupport/lib/active_support/core_ext/range/conversions.rb#L6-L30) and [`Date#to_s`](https://github.com/rails/rails/blob/afc98eadb892b735a9e40fbd2a9166f15822c569/activesupport/lib/active_support/core_ext/date/conversions.rb#L28-L61)
