### PR TITLE
Backport: fix the Levenshtein distance implementation

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -159,7 +159,7 @@ module Rails
         options     = sorted_groups.map(&:last).flatten
         suggestions = options.sort_by {|suggested| levenshtein_distance(namespace.to_s, suggested) }.first(3)
         msg =  "Could not find generator '#{namespace}'. "
-        msg << "Maybe you meant #{ suggestions.map {|s| "'#{s}'"}.join(" or ") }\n"
+        msg << "Maybe you meant #{ suggestions.map {|s| "'#{s}'"}.to_sentence(last_word_connector: " or ") }\n"
         msg << "Run `rails generate --help` for more options."
         puts msg
       end
@@ -260,11 +260,9 @@ module Rails
         t = str2
         n = s.length
         m = t.length
-        max = n/2
 
         return m if (0 == n)
         return n if (0 == m)
-        return n if (n - m).abs > max
 
         d = (0..m).to_a
         x = nil


### PR DESCRIPTION
This is a backport of #18395. I consider this a bug so I would like to merge this in to **4-2-stable** and **4-2-1**. Also feel tree to close this issue if you prefer to just cherry-pick 98d896e0aede716ecf3918d54dfc78bad80d2878.

cc/ @rafaelfranca @schneems @shunsukeaida
