### PR TITLE
[docs fix] Indexing a polymorphic assoc adds index on type and id

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -460,7 +460,7 @@ class CreatePictures < ActiveRecord::Migration
       t.timestamps null: false
     end
 
-    add_index :pictures, :imageable_id
+    add_index :pictures, [:imageable_id, :imageable_type]
   end
 end
 ```


### PR DESCRIPTION
The simplified way of creating a polymorphic association in a migration is:

```
t.references :imageable, polymorphic: true, index: true
```

This will create an index on `[:imageable_id, :imageable_type]`. 

The docs show how you can manually create the association instead of using `t.references`, but only show adding an index on `:imageable_id`.
