### PR TITLE
[docs fix] Composite index is actually [:imageable_type, :imageable_id]

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -460,7 +460,7 @@ class CreatePictures < ActiveRecord::Migration
       t.timestamps null: false
     end
 
-    add_index :pictures, [:imageable_id, :imageable_type]
+    add_index :pictures, [:imageable_type, :imageable_id]
   end
 end
 ```


### PR DESCRIPTION
As pointed out by @egilburg in https://github.com/rails/rails/pull/19153
