### PR TITLE
Remove explicit queue usage from ActionMailer job

### DIFF
--- a/actionmailer/lib/action_mailer/delivery_job.rb
+++ b/actionmailer/lib/action_mailer/delivery_job.rb
@@ -4,7 +4,6 @@ module ActionMailer
   # The <tt>ActionMailer::DeliveryJob</tt> class is used when you
   # want to send emails outside of the request-response cycle.
   class DeliveryJob < ActiveJob::Base # :nodoc:
-    queue_as :mailers
 
     def perform(mailer, mail_method, delivery_method, *args) #:nodoc:
       mailer.constantize.public_send(mail_method, *args).send(delivery_method)


### PR DESCRIPTION
I've gotten many of the exact same bug report from Rails 4.2 users, developers trying to send emails with Sidekiq and ActiveJob and spending hours debugging why it's not working, e.g.:

http://stackoverflow.com/questions/28796293/rails-4-2-sidekiq-not-sending-emails-in-development

The issue is that ActionMailer uses an explicit `mailers` queue for its jobs, rather than letting the user configure it or letting the queue adapter use the default queue.  I would like future Rails versions to let the job system route the job by default.  This ensures mails will work out of the box without the user having to customize their background job system.
