### PR TITLE
Store queries for PostgresQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/relation/query_methods.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/relation/query_methods.rb
@@ -1,0 +1,58 @@
+module ActiveRecord
+  module QueryMethods
+    class StoreChain
+      def initialize(scope, store_name)
+        @scope = scope
+        @store_name = store_name
+      end
+
+      def key(key)
+        update_scope "#{@store_name} ? :key", key: key.to_s
+      end
+
+      def keys(*keys)
+        update_scope "#{@store_name} ?& ARRAY[:keys]", keys: keys.map(&:to_s)
+      end
+
+      def any(*keys)
+        update_scope "#{@store_name} ?| ARRAY[:keys]", keys: keys.map(&:to_s)
+      end
+
+      def contain(opts)
+        update_scope "#{@store_name} @> :data", data: @scope.table.type_cast_for_database(@store_name, opts)
+      end
+
+      def contained(opts)
+        update_scope "#{@store_name} <@ :data", data: @scope.table.type_cast_for_database(@store_name, opts)
+      end
+
+      private
+
+      def update_scope(*opts)
+        where_clause = @scope.send(:where_clause_factory).build(opts, {})
+        @scope.where_clause += where_clause
+        @scope
+      end
+    end
+
+    class WhereChain
+      def store(store_name, opts = nil)
+        # TODO: validate that store is queryable
+        if opts.nil?
+          # We want to use store-specific operator
+          StoreChain.new(@scope, store_name.to_s)
+        else
+          # We want to query by store key value
+          opts.each do |k,v|
+            where_clause = @scope.send(:where_clause_factory).build(
+              ["#{store_name}->:key = :val", key: k, val: v.to_s],
+              {}
+            )
+            @scope.where_clause += where_clause
+          end
+          @scope
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -8,8 +8,8 @@ require "active_record/connection_adapters/postgresql/schema_definitions"
 require "active_record/connection_adapters/postgresql/schema_statements"
 require "active_record/connection_adapters/postgresql/type_metadata"
 require "active_record/connection_adapters/postgresql/utils"
+require "active_record/connection_adapters/postgresql/relation/query_methods"
 require "active_record/connection_adapters/statement_pool"
-
 require 'arel/visitors/bind_visitor'
 
 # Make sure we're using pg high enough for PGResult#values

--- a/activerecord/test/cases/adapters/postgresql/store_chain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/store_chain_test.rb
@@ -1,0 +1,89 @@
+require "cases/helper"
+require 'support/schema_dumping_helper'
+
+if ActiveRecord::Base.connection.supports_extensions?
+  class PostgresqlStoreChainTest < ActiveRecord::TestCase
+    class Hstore < ActiveRecord::Base
+      self.table_name = 'hstores2'
+    end
+
+    def setup
+      @connection = ActiveRecord::Base.connection
+
+      unless @connection.extension_enabled?('hstore')
+        @connection.enable_extension 'hstore'
+        @connection.commit_db_transaction
+      end
+
+      @connection.reconnect!
+
+      @connection.transaction do
+        @connection.create_table('hstores2') do |t|
+          t.string :name
+          t.hstore :data
+        end
+      end
+
+      Hstore.create!(name: 'a', data: { a: 1, b: 2, f: true })
+      Hstore.create!(name: 'b', data: { a: 2 })
+      Hstore.create!(name: 'c', data: { f: true })
+      Hstore.create!(name: 'd', data: { f: false })
+      Hstore.create!(name: 'e', data: { a: 2, c: 'x' })
+    end
+
+    teardown do
+      @connection.drop_table 'hstores2', if_exists: true
+    end
+
+    def test_query_by_key_val
+      assert_equal 'a', Hstore.where.store(:data, a: 1, b: 2).first.name
+      assert_equal 'e', Hstore.where.store(:data, a: 2, c: 'x').first.name
+      assert_equal 'd', Hstore.where.store(:data, f: false).first.name
+    end
+
+    def test_key_clause
+      records = Hstore.where.store(:data).key(:a)
+      assert_equal 3, records.size
+
+      records = Hstore.where.store(:data).key(:b)
+      assert_equal 1, records.size
+      assert_equal 'a', records.first.name
+    end
+
+    def test_keys_clause
+      records = Hstore.where.store(:data).keys('a', 'f')
+      assert_equal 1, records.size
+      assert_equal 'a', records.first.name
+
+      records = Hstore.where.store(:data).keys(:a, :c)
+      assert_equal 1, records.size
+      assert_equal 'e', records.first.name
+    end
+
+    def test_any_clause
+      records = Hstore.where.store(:data).any('b', 'f')
+      assert_equal 3, records.size
+
+      records = Hstore.where.store(:data).any(:c, :b)
+      assert_equal 2, records.size
+    end
+
+    def test_contain_clause
+      records = Hstore.where.store(:data).contain(f: true)
+      assert_equal 2, records.size
+
+      records = Hstore.where.store(:data).contain(a: 2, c: 'x')
+      assert_equal 1, records.size
+      assert_equal 'e', records.first.name
+    end
+
+    def test_contained_clause
+      records = Hstore.where.store(:data).contained(a: 2, b: 2, f: true)
+      assert_equal 2, records.size
+
+      records = Hstore.where.store(:data).contained(c: 'x', f: false)
+      assert_equal 1, records.size
+      assert_equal 'd', records.first.name
+    end
+  end
+end


### PR DESCRIPTION
PostgresQL has a great support for querying store-like data (hstore, jsonb). But AR don't, so you have to write plain old SQL. Sometimes it leads to [confusion](https://github.com/rails/rails/issues/17589).

We can enhance query methods with store-specific ones and write more _ORM-friendly_ code.

Examples:

``` ruby

# Key exists
# before
Model.where("json ? :something", something: "some_key") 
# after
Model.where.store(:json).key(:some_key)

# Keys exist
# before
Model.where("h ?& ARRAY[:keys]", keys: vals.map(&:to_s))
# after
Model.where.store(:h).keys(vals)

# Query by key value
# before
Model.where("hstore->'a' = :v", v: val.to_s)
# after
Model.where.store(:hstore, a: val) # we don't care here about the value type

# and so on, see more in the provided test case
```

The above (and proposed) implementation uses `WhereChain` as an entry point and translate store operators to usual where clauses. Thus there is no need of extending Arel with new types of nodes. 

I think, it's also possible to avoid using additional `store` method:

``` ruby
Model.where(:store).keys(:a,:b)

Model.where(:store, a: val)
```

It is shorter, but, maybe, a little bit more confusing.

Currently, it's not working with complex values, such as arrays or ranges, when querying by store key value.
To handle different value types it's reasonable to pass Hash to `WhereClauseFactory#build`.

``` ruby
Model.where.store(:hstore, a: [1,2]) 
# it calls
where_clause_factory.build {"hstore->'a'" => ['1','2']}, {}
# which produces
%q(
select ... where "models"."hstore->'a'" in ('1',\ '2')' 
)
# which is incorrect due to quotes around hstore->'a'
```

But there is a possible fix: use `Arel::Nodes::SqlLiteral` instead of simple `String` as a key.
In order it to work we should add `Arel::Nodes::SqlLiteral#to_s` to return `self`, because now it returns `String`. 

What do you think about this feature, does it make sense? (I think yes)

/cc @rafaelfranca @sgrif 
