### PR TITLE
On guides, correcting incorrect controller name used on routing.md.

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -229,7 +229,7 @@ or, for a single case:
 resources :articles, path: '/admin/articles'
 ```
 
-In each of these cases, the named routes remain the same as if you did not use `scope`. In the last case, the following paths map to `PostsController`:
+In each of these cases, the named routes remain the same as if you did not use `scope`. In the last case, the following paths map to `ArticlesController`:
 
 | HTTP Verb | Path                     | Controller#Action    | Named Helper           |
 | --------- | ------------------------ | -------------------- | ---------------------- |


### PR DESCRIPTION
This is a change on a particular guide. On "Controller Namespaces and Routing" section of the "Rails Routing from the Outside In" guide , the examples are using "AritclesController" as an example of a controller, to show different organizers. But on the line 232, it incorrectly uses "PostsController" instead of "AritclesController".
