### PR TITLE
Rake restart task no longer loads entire Rails environment when run

### DIFF
--- a/railties/lib/rails/tasks/restart.rake
+++ b/railties/lib/rails/tasks/restart.rake
@@ -1,4 +1,4 @@
 desc "Restart app by touching tmp/restart.txt"
-task restart: :environment do
+task :restart do
   FileUtils.touch('tmp/restart.txt')
 end


### PR DESCRIPTION
Fixes #18876. Rake restart touches `tmp/restart.txt` to restart
application on next request. Updated test and documentation accordingly.
