### PR TITLE
[ci skip] Fix a typo for PostgreSQL text limit, GB instead of Gb.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -514,14 +514,14 @@ module ActiveRecord
           sql = case type.to_s
           when 'binary'
             # PostgreSQL doesn't support limits on binary (bytea) columns.
-            # The hard limit is 1Gb, because of a 32-bit size field, and TOAST.
+            # The hard limit is 1GB, because of a 32-bit size field, and TOAST.
             case limit
             when nil, 0..0x3fffffff; super(type)
             else raise(ActiveRecordError, "No binary type has byte size #{limit}.")
             end
           when 'text'
             # PostgreSQL doesn't support limits on text columns.
-            # The hard limit is 1Gb, according to section 8.3 in the manual.
+            # The hard limit is 1GB, according to section 8.3 in the manual.
             case limit
             when nil, 0..0x3fffffff; super(type)
             else raise(ActiveRecordError, "The limit on text can be at most 1GB - 1byte.")


### PR DESCRIPTION
:smile:
