### PR TITLE
Improve the Rubinius build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'jquery-rails', github: 'rails/jquery-rails', branch: 'master'
 gem 'coffee-rails', '~> 4.1.0'
 gem 'turbolinks'
 gem 'arel', github: 'rails/arel', branch: 'master'
+gem 'mail', github: 'mikel/mail'
 
 # require: false so bcrypt is loaded only when has_secure_password is used.
 # This is to avoid ActiveModel (and by extension the entire framework)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,13 @@ GIT
       redis-namespace
 
 GIT
+  remote: git://github.com/mikel/mail.git
+  revision: b159e0a542962fdd5e292a48cfffa560d7cf412e
+  specs:
+    mail (2.6.3.edge)
+      mime-types (>= 1.16, < 3)
+
+GIT
   remote: git://github.com/rails/arel.git
   revision: aac9da257f291ad8d2d4f914528881c240848bb2
   branch: master
@@ -123,8 +130,6 @@ GEM
       nokogiri
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
-    mail (2.6.3)
-      mime-types (>= 1.16, < 3)
     metaclass (0.0.4)
     mime-types (2.4.3)
     mini_portile (0.6.2)
@@ -250,6 +255,7 @@ DEPENDENCIES
   jquery-rails!
   json
   kindlerb (= 0.1.1)
+  mail!
   minitest (< 5.3.4)
   mocha (~> 0.14)
   mysql (>= 2.9.0)

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -95,7 +95,7 @@ end
 module ActiveSupport
   class TestCase
     include ActionDispatch::DrawOnce
-    if ActiveSupport::Testing::Isolation.forking_env? && PROCESS_COUNT > 0
+    if RUBY_ENGINE == "ruby" && PROCESS_COUNT > 0
       parallelize_me!
     end
   end
@@ -479,7 +479,7 @@ class ForkingExecutor
   end
 end
 
-if ActiveSupport::Testing::Isolation.forking_env? && PROCESS_COUNT > 0
+if RUBY_ENGINE == "ruby" && PROCESS_COUNT > 0
   # Use N processes (N defaults to 4)
   Minitest.parallel_executor = ForkingExecutor.new(PROCESS_COUNT)
 end

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -276,6 +276,8 @@ module ActionController
     end
 
     def test_async_stream
+      rubinius_skip "https://github.com/rubinius/rubinius/issues/2934"
+
       @controller.latch = ActiveSupport::Concurrency::Latch.new
       parts             = ['hello', 'world']
 

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -305,7 +305,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
 
     assert_response 500
     assert_select '#Application-Trace' do
-      assert_select 'pre code', /\(eval\):1: syntax error, unexpected/
+      assert_select 'pre code', /syntax error, unexpected/
     end
   end
 
@@ -332,7 +332,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
 
     assert_response 500
     assert_select '#Application-Trace' do
-      assert_select 'pre code', /\(eval\):1: syntax error, unexpected/
+      assert_select 'pre code', /syntax error, unexpected/
     end
   end
 

--- a/actionview/test/activerecord/polymorphic_routes_test.rb
+++ b/actionview/test/activerecord/polymorphic_routes_test.rb
@@ -208,7 +208,7 @@ class PolymorphicRoutesTest < ActionController::TestCase
         @series.save
         polymorphic_url([nil, @series])
       end
-      assert_match(/undefined method `series_url' for/, exception.message)
+      assert_match(/undefined method `series_url'/, exception.message)
     end
   end
 

--- a/activemodel/test/cases/attribute_assignment_test.rb
+++ b/activemodel/test/cases/attribute_assignment_test.rb
@@ -58,6 +58,8 @@ class AttributeAssignmentTest < ActiveModel::TestCase
   end
 
   test "assign private attribute" do
+    rubinius_skip "https://github.com/rubinius/rubinius/issues/3328"
+
     model = Model.new
     assert_raises(ActiveModel::AttributeAssignment::UnknownAttributeError) do
       model.assign_attributes(metadata: { a: 1 })

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -14,6 +14,15 @@ require 'active_support/testing/autorun'
 
 require 'mocha/setup' # FIXME: stop using mocha
 
+# Skips the current run on Rubinius using Minitest::Assertions#skip
+def rubinius_skip(message = '')
+  skip message if RUBY_ENGINE == 'rbx'
+end
+# Skips the current run on JRuby using Minitest::Assertions#skip
+def jruby_skip(message = '')
+  skip message if defined?(JRUBY_VERSION)
+end
+
 # FIXME: we have tests that depend on run order, we should fix that and
 # remove this method call.
 require 'active_support/test_case'

--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -100,7 +100,7 @@ module ActiveSupport
         # a string, otherwise a NameError will be raised by the interpreter
         # itself when rescue_from CONSTANT is executed.
         klass = self.class.const_get(klass_name) rescue nil
-        klass ||= klass_name.constantize rescue nil
+        klass ||= (klass_name.constantize rescue nil)
         klass === exception if klass
       end
 

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -9,6 +9,9 @@ class DuplicableTest < ActiveSupport::TestCase
   ALLOW_DUP << BigDecimal.new('4.56')
 
   def test_duplicable
+    rubinius_skip "* Method#dup is allowed at the moment on Rubinius\n" \
+                  "* https://github.com/rubinius/rubinius/issues/3089"
+
     RAISE_DUP.each do |v|
       assert !v.duplicable?
       assert_raises(TypeError, v.class.name) { v.dup }

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -130,6 +130,8 @@ class TestJSONEncoding < ActiveSupport::TestCase
   end
 
   def test_process_status
+    rubinius_skip "https://github.com/rubinius/rubinius/issues/3334"
+
     # There doesn't seem to be a good way to get a handle on a Process::Status object without actually
     # creating a child process, hence this to populate $?
     system("not_a_real_program_#{SecureRandom.hex}")

--- a/railties/lib/rails/ruby_version_check.rb
+++ b/railties/lib/rails/ruby_version_check.rb
@@ -1,4 +1,4 @@
-if RUBY_VERSION < '2.2.0'
+if RUBY_VERSION < '2.2.0' && RUBY_ENGINE == 'ruby'
   desc = defined?(RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : "ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE})"
   abort <<-end_message
 


### PR DESCRIPTION
Hello,

This is just a tiny pull request that improves the build on Rubinius skipping the tests that are failing at the moment with the attached ticket on the upstream tracker. There are also a few other changes that avoid a plethora of failures in the suite and that doesn't affect the build on other implementations.

Finally, the most important change here is that we are testing against the mail gem's master branch in order to incorporate mikel/mail#782 that makes the Action Mailer's test suite green on Ruby.

I've split the patch into several commits to ease the review and future blames but feel free to ask me to squash some of them together.

Have a nice day.
