### PR TITLE
Fixes reference for schema_format to AR::Base from AS::Base

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -212,7 +212,7 @@ module ActiveRecord
         load_schema(*args)
       end
 
-      def schema_file(format = ActiveSupport::Base.schema_format)
+      def schema_file(format = ActiveRecord::Base.schema_format)
         case format
         when :ruby
           File.join(db_dir, "schema.rb")

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -377,4 +377,20 @@ module ActiveRecord
       ActiveRecord::Tasks::DatabaseTasks.check_schema_file("awesome-file.sql")
     end
   end
+
+  class DatabaseTasksCheckSchemaFileDefaultsTest < ActiveRecord::TestCase
+    def test_check_schema_file_defaults
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:db_dir).returns('/tmp')
+      assert_equal '/tmp/schema.rb', ActiveRecord::Tasks::DatabaseTasks.schema_file
+    end
+  end
+
+  class DatabaseTasksCheckSchemaFileSpecifiedFormatsTest < ActiveRecord::TestCase
+    {ruby: 'schema.rb', sql: 'structure.sql'}.each_pair do |fmt, filename|
+      define_method("test_check_schema_file_for_#{fmt}_format") do
+        ActiveRecord::Tasks::DatabaseTasks.stubs(:db_dir).returns('/tmp')
+        assert_equal "/tmp/#{filename}", ActiveRecord::Tasks::DatabaseTasks.schema_file(fmt)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hey-

this is a simple fix, but i think it should also get backported to the relevant stable branches in the 4.x series. I don't think it is relevant for 3.x.
