### PR TITLE
If TZInfo-data is not present in windows, let the user know.

### DIFF
--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -23,6 +23,11 @@ module ActiveSupport
     # Sets the default value for Time.zone
     # If assigned value cannot be matched to a TimeZone, an exception will be raised.
     initializer "active_support.initialize_time_zone" do |app|
+      begin
+        TZInfo::DataSource.get
+      rescue TZInfo::DataSourceNotFound => e
+        raise e.exception "tzinfo-data is not present. Please add gem 'tzinfo-data' to your Gemfile and run bundle install"
+      end
       require 'active_support/core_ext/time/zones'
       zone_default = Time.find_zone!(app.config.time_zone)
 


### PR DESCRIPTION
Fixes #19175.
Rails tries calling TZInfo::DataSource.get. If it gets a  DataSourceNotFound error then it prints out 

```
Gem 'tzinfo-data' is not present. Please add gem 'tzinfo-data' to your Gemfile and run bundle install
```
