### PR TITLE
Expand the default watch list for Spring

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -78,6 +78,7 @@ module Rails
         template "routes.rb"
         template "application.rb"
         template "environment.rb"
+        template "spring.rb"
         template "secrets.yml"
 
         directory "environments"

--- a/railties/lib/rails/generators/rails/app/templates/config/spring.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/spring.rb
@@ -1,0 +1,4 @@
+%w(
+  .ruby-version .rbenv-vars
+  tmp/caching.txt tmp/restart.txt
+).each { |path| Spring.watch path }


### PR DESCRIPTION
Implements #18874. Due to issues with the spring-watcher-listen gem, it is not possible to use Spring.watch_method = :listen. Spring only begins watching the files listed if they already exist so it may make sense to generate them by default with a new rails app.
