### PR TITLE
Update cache_timestamp_format default value in guides

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -286,7 +286,7 @@ All these configuration options are delegated to the `I18n` library.
 
 * `config.active_record.lock_optimistically` controls whether Active Record will use optimistic locking and is true by default.
 
-* `config.active_record.cache_timestamp_format` controls the format of the timestamp value in the cache key. Default is `:number`.
+* `config.active_record.cache_timestamp_format` controls the format of the timestamp value in the cache key. Default is `:nsec`.
 
 * `config.active_record.record_timestamps` is a boolean value which controls whether or not timestamping of `create` and `update` operations on a model occur. The default value is `true`.
 


### PR DESCRIPTION
Default is `:nsec`, not `:number`.

See https://github.com/rails/rails/blob/33ae6344834fdf71b93e0b6db899b58e017a7655/activerecord/lib/active_record/integration.rb#L13-L15
