### PR TITLE
Fix for ticket #4260.  Where a constraint was not reading any request parameters.  I passed into constraint.matches? the parameters generated in routing mapper.  Included in the pull request is an appropriate unit test.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -23,8 +23,12 @@ module ActionDispatch
           @app, @constraints, @request = app, constraints, request
         end
 
-        def matches?(env)
+        def matches?(env, params = {})
           req = @request.new(env)
+
+          params.each do |key, value|
+            req.params[key] = value
+          end
 
           @constraints.each { |constraint|
             if constraint.respond_to?(:matches?) && !constraint.matches?(req)

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -629,7 +629,7 @@ module ActionDispatch
           end
 
           dispatcher = route.app
-          while dispatcher.is_a?(Mapper::Constraints) && dispatcher.matches?(env) do
+          while dispatcher.is_a?(Mapper::Constraints) && dispatcher.matches?(env, params) do
             dispatcher = dispatcher.app
           end
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1462,6 +1462,20 @@ class RouteSetTest < ActiveSupport::TestCase
     end
   end
 
+  def test_route_with_constraint_class_that_checks_parameters
+    foo_constraint = Class.new {
+      def matches? request
+        request.params[:foo] == 'bar'
+      end
+    }
+
+    set.draw do
+      match '/:foo' => 'foo#index', :constraints => foo_constraint.new
+    end
+
+    assert_equal({:controller => 'foo', :action => 'index', :foo => 'bar'}, set.recognize_path('/bar'))
+  end
+
   def test_route_requirement_recognize_with_ignore_case
     set.draw do
       match 'page/:name' => 'pages#show',


### PR DESCRIPTION
Fix for ticket #4260.  Where a constraint was not reading any request parameters.  I passed into constraint.matches? the parameters generated in routing mapper.  Included in the pull request is an appropriate unit test.
