### PR TITLE
Doc fix [ci skip]

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -43,7 +43,7 @@ module ActiveSupport
       end
 
       def current_tags
-        # We use our object ID here to void conflicting with other instances
+        # We use our object ID here to avoid conflicting with other instances
         thread_key = @thread_key ||= "activesupport_tagged_logging_tags:#{object_id}".freeze
         Thread.current[thread_key] ||= []
       end


### PR DESCRIPTION
I think 

 We use our object ID here to **void**

should be 

 We use our object ID here to **avoid**
