### PR TITLE
Revert work arounds for upstream Ruby 2.2.0 kwargs bug

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -113,9 +113,7 @@ module ActionDispatch # :nodoc:
     # The underlying body, as a streamable object.
     attr_reader :stream
 
-    # Ruby 2.2 bug https://bugs.ruby-lang.org/issues/10685 prevents
-    # default_headers from being a keyword argument.
-    def initialize(status = 200, header = {}, body = [], default_headers = self.class.default_headers)
+    def initialize(status = 200, header = {}, body = [], default_headers: self.class.default_headers)
       super()
 
       header = merge_default_headers(header, default_headers)

--- a/actionpack/lib/action_dispatch/testing/test_response.rb
+++ b/actionpack/lib/action_dispatch/testing/test_response.rb
@@ -7,7 +7,7 @@ module ActionDispatch
   # See Response for more information on controller response objects.
   class TestResponse < Response
     def self.from_response(response)
-      new response.status, response.headers, response.body, nil
+      new response.status, response.headers, response.body, default_headers: nil
     end
 
     # Was the response successful?

--- a/railties/lib/rails/ruby_version_check.rb
+++ b/railties/lib/rails/ruby_version_check.rb
@@ -1,13 +1,13 @@
-if RUBY_VERSION < '2.2.0' && RUBY_ENGINE == 'ruby'
+if RUBY_VERSION < '2.2.1' && RUBY_ENGINE == 'ruby'
   desc = defined?(RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : "ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE})"
   abort <<-end_message
 
-    Rails 5 requires to run on Ruby 2.2.0 or newer.
+    Rails 5 requires to run on Ruby 2.2.1 or newer.
 
     You're running
       #{desc}
 
-    Please upgrade to Ruby 2.2.0 or newer to continue.
+    Please upgrade to Ruby 2.2.1 or newer to continue.
 
   end_message
 end


### PR DESCRIPTION
The bug caused a segfault and you can find more info about it at:
https://bugs.ruby-lang.org/issues/10685.

We did a couple of work arounds, but 2.2.1 rolled out and those aren't
needed anymore.

Here are the reverted commits:
- Revert "Work around for upstream Ruby bug #10685",
  commit 707a433870e9e06af688f85a4aedc64a90791a64.
- Revert "Fix segmentation fault in ActionPack tests",
  commit 22e0a22d5f98e162290d9820891d8191e720ad3b.

Poking @eileencodes and @jeremy.
