### PR TITLE
Run ActionPack test cases in random order.

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -483,8 +483,3 @@ if RUBY_ENGINE == "ruby" && PROCESS_COUNT > 0
   # Use N processes (N defaults to 4)
   Minitest.parallel_executor = ForkingExecutor.new(PROCESS_COUNT)
 end
-
-# FIXME: we have tests that depend on run order, we should fix that and
-# remove this method call.
-require 'active_support/test_case'
-ActiveSupport::TestCase.test_order = :sorted


### PR DESCRIPTION
I figured we should start incrementally run the internal test cases in random order. We can't fix/identify tests that modifies global state if we don't run it. Furthermore, most of the ActionPack tests were already fixed in GSoC 2014.

Just in case, I ran the tests on my local machine 'ALOT' of times.
https://gist.github.com/tgxworld/245cb2fada81a514f6ae

cc/ @senny WDYT?
