### PR TITLE
Run all our tests in random order

### DIFF
--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -42,8 +42,3 @@ def jruby_skip(message = '')
 end
 
 require 'mocha/setup' # FIXME: stop using mocha
-
-# FIXME: we have tests that depend on run order, we should fix that and
-# remove this method call.
-require 'active_support/test_case'
-ActiveSupport::TestCase.test_order = :sorted

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -9,10 +9,7 @@ task :default => :test
 # Run the unit tests
 Rake::TestTask.new do |t|
   t.libs << 'test'
-
-  # make sure we include the tests in alphabetical order as on some systems
-  # this will not happen automatically and the tests (as a whole) will error
-  t.test_files = test_files.sort
+  t.test_files = test_files
 
   t.warning = true
   t.verbose = true

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -18,7 +18,7 @@ namespace :test do
 
   Rake::TestTask.new(:template) do |t|
     t.libs << 'test'
-    t.test_files = Dir.glob('test/template/**/*_test.rb').sort
+    t.test_files = Dir.glob('test/template/**/*_test.rb')
     t.warning = true
     t.verbose = true
     t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -338,8 +338,3 @@ def jruby_skip(message = '')
 end
 
 require 'mocha/setup' # FIXME: stop using mocha
-
-# FIXME: we have tests that depend on run order, we should fix that and
-# remove this method call.
-require 'active_support/test_case'
-ActiveSupport::TestCase.test_order = :sorted

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -6,7 +6,7 @@ task :default => :test
 
 Rake::TestTask.new do |t|
   t.libs << "test"
-  t.test_files = Dir.glob("#{dir}/test/cases/**/*_test.rb").sort
+  t.test_files = Dir.glob("#{dir}/test/cases/**/*_test.rb")
   t.warning = true
   t.verbose = true
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -22,8 +22,3 @@ end
 def jruby_skip(message = '')
   skip message if defined?(JRUBY_VERSION)
 end
-
-# FIXME: we have tests that depend on run order, we should fix that and
-# remove this method call.
-require 'active_support/test_case'
-ActiveSupport::TestCase.test_order = :sorted

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -51,7 +51,7 @@ end
       t.libs << 'test'
       t.test_files = (Dir.glob( "test/cases/**/*_test.rb" ).reject {
         |x| x =~ /\/adapters\//
-      } + Dir.glob("test/cases/adapters/#{adapter_short}/**/*_test.rb")).sort
+      } + Dir.glob("test/cases/adapters/#{adapter_short}/**/*_test.rb"))
 
       t.warning = true
       t.verbose = true

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -203,8 +203,3 @@ module InTimeZone
 end
 
 require 'mocha/setup' # FIXME: stop using mocha
-
-# FIXME: we have tests that depend on run order, we should fix that and
-# remove this method call.
-require 'active_support/test_case'
-ActiveSupport::TestCase.test_order = :sorted

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -38,8 +38,3 @@ def jruby_skip(message = '')
 end
 
 require 'mocha/setup' # FIXME: stop using mocha
-
-# FIXME: we have tests that depend on run order, we should fix that and
-# remove this method call.
-require 'active_support/test_case'
-ActiveSupport::TestCase.test_order = :sorted

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -30,9 +30,4 @@ end
 
 class ActiveSupport::TestCase
   include ActiveSupport::Testing::Stream
-
-  # FIXME: we have tests that depend on run order, we should fix that and
-  # remove this method call.
-  self.test_order = :sorted
-
 end


### PR DESCRIPTION
My recollection is that this was mostly working, but we were seeing just enough failures that we didn't want to leave it enabled while branching for release.

Let's see whether that's (still) true.

See also #19217.

/cc @tgxworld
