### PR TITLE
 Updated documentation of CollectionProxy#clear [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -976,6 +976,9 @@ module ActiveRecord
       # Equivalent to +delete_all+. The difference is that returns +self+, instead
       # of an array with the deleted objects, so methods can be chained. See
       # +delete_all+ for more information.
+      # Note that because +delete_all+ removes records by directly
+      # running an SQL query into the database, the +updated_at+ column of
+      # the object is not changed.
       def clear
         delete_all
         self


### PR DESCRIPTION
- CollectionProxy#clear method calls delete_all so the SQL is directly
  run into the database.
- So the updated_at column of the object on which its run is not
  updated.
- Closes #17161
