### PR TITLE
 Fix documentation of url_for module [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/url_for.rb
+++ b/actionpack/lib/action_controller/metal/url_for.rb
@@ -4,7 +4,10 @@ module ActionController
   #
   # In addition to <tt>AbstractController::UrlFor</tt>, this module accesses the HTTP layer to define
   # url options like the +host+. In order to do so, this module requires the host class
-  # to implement +env+ and +request+, which need to be a Rack-compatible.
+  # to implement +env+ which needs to be Rack-compatible and +request+
+  # which is either instance of +ActionDispatch::Request+ or an object
+  # that responds to <tt>host</tt>, <tt>optional_port</tt>, <tt>protocol</tt> and
+  # <tt>symbolized_path_parameter</tt> methods.
   #
   #   class RootUrl
   #     include ActionController::UrlFor


### PR DESCRIPTION
- The request needs to be instance of ActionDispatch::Request or should
  respond to host, optional_port, protocol and
  symbolized_path_parameter.
- This documentation was correctly added in
  https://github.com/rails/rails/commit/e3b3f416b57f5642ea25078485f7e9394ad04526
  but was changed to
  https://github.com/rails/rails/commit/e1ceae576e3911f3e6708b5d19a0e3ef63769eb7.
- Fixes #16160.
