### PR TITLE
Allow variants to be set through the URL (updated)

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,13 @@
+*   Allow variants to be set through the URL
+
+    request.variant can be set from url. For example, accessing
+    http://example.com/posts.html+partial set `request.variant = [:partial]`
+    automatically. `:variant` is tied to `:format` like `(.:format(+:variant))`.
+
+    *Hong ChulJu*
+
 *   Drop request class from RouteSet constructor.
- 
+
     If you would like to use a custom request class, please subclass and implemet
     the `request_class` method.
 

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -10,8 +10,6 @@ module ActionDispatch
         self.ignore_accept_header = false
       end
 
-      attr_reader :variant
-
       # The MIME type of the HTTP request, such as Mime::XML.
       #
       # For backward compatibility, the post \format is extracted from the
@@ -71,6 +69,10 @@ module ActionDispatch
             [Mime::HTML]
           end
         end
+      end
+
+      def variant
+        @variant ||= send(:variant=, parameters[:variant].try(:to_sym))
       end
 
       # Sets the \variant for template.

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -97,7 +97,6 @@ module ActionDispatch
 
           options = normalize_options!(options, formatted, path_params, ast, scope[:module])
 
-
           split_constraints(path_params, scope[:constraints]) if scope[:constraints]
           constraints = constraints(options, path_params)
 
@@ -114,7 +113,7 @@ module ActionDispatch
             end
           end
 
-          normalize_format!(formatted)
+          normalize_format!(formatted || optional_format?(path, formatted))
 
           @conditions[:path_info] = path
           @conditions[:parsed_path_info] = ast
@@ -133,9 +132,9 @@ module ActionDispatch
             path = Mapper.normalize_path(path)
 
             if format == true
-              "#{path}.:format"
+              "#{path}.:format(+:variant)"
             elsif optional_format?(path, format)
-              "#{path}(.:format)"
+              "#{path}(.:format(+:variant))"
             else
               path
             end
@@ -190,7 +189,7 @@ module ActionDispatch
 
           def normalize_format!(formatted)
             if formatted == true
-              @requirements[:format] ||= /.+/
+              @requirements[:format] ||= /[^\+]+/
             elsif Regexp === formatted
               @requirements[:format] = formatted
               @defaults[:format] = nil

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -256,9 +256,9 @@ module ActionDispatch
 
           def handle_positional_args(controller_options, inner_options, args, result, path_params)
             if args.size > 0
-              # take format into account
+              # take format into account (variant is tied to formats)
               if path_params.include?(:format)
-                path_params_size = path_params.size - 1
+                path_params_size = path_params.size - 2
               else
                 path_params_size = path_params.size
               end

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -781,4 +781,11 @@ class RespondToControllerTest < ActionController::TestCase
     assert_equal "text/html", @response.content_type
     assert_equal "phone", @response.body
   end
+
+  def test_variant_from_variant_parameter
+    get :format_any_variant_any, params: { format: "js", variant: "tablet" }
+    assert_equal "text/javascript", @response.content_type
+    assert_equal "tablet", @response.body
+  end
+
 end

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -117,7 +117,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     @app = DevelopmentApp
     get "/pass", headers: { 'action_dispatch.show_exceptions' => true }
     routing_table = body[/route_table.*<.table>/m]
-    assert_match '/:controller(/:action)(.:format)', routing_table
+    assert_match '/:controller(/:action)(.:format(+:variant))', routing_table
     assert_match ':controller#:action', routing_table
     assert_no_match '&lt;|&gt;', routing_table, "there should not be escaped html in the output"
   end

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -56,14 +56,14 @@ module ActionDispatch
 
         # FIXME: is this a desired behavior?
         mapper.get '/one/two/', :to => 'posts#index', :as => :main
-        assert_equal '/one/two(.:format)', fakeset.conditions.first[:path_info]
+        assert_equal '/one/two(.:format(+:variant))', fakeset.conditions.first[:path_info]
       end
 
       def test_map_wildcard
         fakeset = FakeSet.new
         mapper = Mapper.new fakeset
         mapper.get '/*path', :to => 'pages#show'
-        assert_equal '/*path(.:format)', fakeset.conditions.first[:path_info]
+        assert_equal '/*path(.:format(+:variant))', fakeset.conditions.first[:path_info]
         assert_equal(/.+?/, fakeset.requirements.first[:path])
       end
 
@@ -71,7 +71,7 @@ module ActionDispatch
         fakeset = FakeSet.new
         mapper = Mapper.new fakeset
         mapper.get '/*path/foo/:bar', :to => 'pages#show'
-        assert_equal '/*path/foo/:bar(.:format)', fakeset.conditions.first[:path_info]
+        assert_equal '/*path/foo/:bar(.:format(+:variant))', fakeset.conditions.first[:path_info]
         assert_equal(/.+?/, fakeset.requirements.first[:path])
       end
 
@@ -79,7 +79,7 @@ module ActionDispatch
         fakeset = FakeSet.new
         mapper = Mapper.new fakeset
         mapper.get '/*foo/*bar', :to => 'pages#show'
-        assert_equal '/*foo/*bar(.:format)', fakeset.conditions.first[:path_info]
+        assert_equal '/*foo/*bar(.:format(+:variant))', fakeset.conditions.first[:path_info]
         assert_equal(/.+?/, fakeset.requirements.first[:foo])
         assert_equal(/.+?/, fakeset.requirements.first[:bar])
       end
@@ -96,7 +96,7 @@ module ActionDispatch
         fakeset = FakeSet.new
         mapper = Mapper.new fakeset
         mapper.get '/*path', :to => 'pages#show', :format => true
-        assert_equal '/*path.:format', fakeset.conditions.first[:path_info]
+        assert_equal '/*path.:format(+:variant)', fakeset.conditions.first[:path_info]
       end
 
       def test_raising_helpful_error_on_invalid_arguments

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -42,12 +42,12 @@ module ActionDispatch
         end
 
         assert_equal [
-          "       Prefix Verb URI Pattern              Controller#Action",
-          "custom_assets GET  /custom/assets(.:format) custom_assets#show",
-          "         blog      /blog                    Blog::Engine",
+          "       Prefix Verb URI Pattern                         Controller#Action",
+          "custom_assets GET  /custom/assets(.:format(+:variant)) custom_assets#show",
+          "         blog      /blog                               Blog::Engine",
           "",
           "Routes for Blog::Engine:",
-          "  cart GET  /cart(.:format) cart#show"
+          "  cart GET  /cart(.:format(+:variant)) cart#show"
         ], output
       end
 
@@ -78,8 +78,8 @@ module ActionDispatch
         end
 
         assert_equal [
-          "Prefix Verb URI Pattern     Controller#Action",
-          "  cart GET  /cart(.:format) cart#show"
+          "Prefix Verb URI Pattern                Controller#Action",
+          "  cart GET  /cart(.:format(+:variant)) cart#show"
         ], output
       end
 
@@ -89,8 +89,8 @@ module ActionDispatch
         end
 
         assert_equal [
-          "       Prefix Verb URI Pattern              Controller#Action",
-          "custom_assets GET  /custom/assets(.:format) custom_assets#show"
+          "       Prefix Verb URI Pattern                         Controller#Action",
+          "custom_assets GET  /custom/assets(.:format(+:variant)) custom_assets#show"
         ], output
       end
 
@@ -100,15 +100,15 @@ module ActionDispatch
         end
 
         assert_equal [
-          "      Prefix Verb   URI Pattern                  Controller#Action",
-          "    articles GET    /articles(.:format)          articles#index",
-          "             POST   /articles(.:format)          articles#create",
-          " new_article GET    /articles/new(.:format)      articles#new",
-          "edit_article GET    /articles/:id/edit(.:format) articles#edit",
-          "     article GET    /articles/:id(.:format)      articles#show",
-          "             PATCH  /articles/:id(.:format)      articles#update",
-          "             PUT    /articles/:id(.:format)      articles#update",
-          "             DELETE /articles/:id(.:format)      articles#destroy"
+          "      Prefix Verb   URI Pattern                             Controller#Action",
+          "    articles GET    /articles(.:format(+:variant))          articles#index",
+          "             POST   /articles(.:format(+:variant))          articles#create",
+          " new_article GET    /articles/new(.:format(+:variant))      articles#new",
+          "edit_article GET    /articles/:id/edit(.:format(+:variant)) articles#edit",
+          "     article GET    /articles/:id(.:format(+:variant))      articles#show",
+          "             PATCH  /articles/:id(.:format(+:variant))      articles#update",
+          "             PUT    /articles/:id(.:format(+:variant))      articles#update",
+          "             DELETE /articles/:id(.:format(+:variant))      articles#destroy"
         ], output
       end
 
@@ -129,8 +129,8 @@ module ActionDispatch
         end
 
         assert_equal [
-          "Prefix Verb URI Pattern            Controller#Action",
-          "       GET  /api/:action(.:format) api#:action"
+          "Prefix Verb URI Pattern                       Controller#Action",
+          "       GET  /api/:action(.:format(+:variant)) api#:action"
         ], output
       end
 
@@ -140,8 +140,8 @@ module ActionDispatch
         end
 
         assert_equal [
-          "Prefix Verb URI Pattern                    Controller#Action",
-          "       GET  /:controller/:action(.:format) :controller#:action"
+          "Prefix Verb URI Pattern                               Controller#Action",
+          "       GET  /:controller/:action(.:format(+:variant)) :controller#:action"
         ], output
       end
 
@@ -151,8 +151,8 @@ module ActionDispatch
         end
 
         assert_equal [
-          "Prefix Verb URI Pattern                            Controller#Action",
-          "       GET  /:controller(/:action(/:id))(.:format) :controller#:action {:id=>/\\d+/}"
+          "Prefix Verb URI Pattern                                       Controller#Action",
+          "       GET  /:controller(/:action(/:id))(.:format(+:variant)) :controller#:action {:id=>/\\d+/}"
         ], output
       end
 
@@ -162,8 +162,8 @@ module ActionDispatch
         end
 
         assert_equal [
-          "Prefix Verb URI Pattern           Controller#Action",
-          %Q[       GET  /photos/:id(.:format) photos#show {:format=>"jpg"}]
+          "Prefix Verb URI Pattern                      Controller#Action",
+          %Q[       GET  /photos/:id(.:format(+:variant)) photos#show {:format=>\"jpg\"}]
         ], output
       end
 
@@ -173,8 +173,8 @@ module ActionDispatch
         end
 
         assert_equal [
-          "Prefix Verb URI Pattern           Controller#Action",
-          "       GET  /photos/:id(.:format) photos#show {:id=>/[A-Z]\\d{5}/}"
+          "Prefix Verb URI Pattern                      Controller#Action",
+          "       GET  /photos/:id(.:format(+:variant)) photos#show {:id=>/[A-Z]\\d{5}/}"
         ], output
       end
 
@@ -191,13 +191,13 @@ module ActionDispatch
         end
 
         assert_equal [
-          "               Prefix Verb URI Pattern                              Controller#Action",
-          "             about_us GET  /about-us(.:format)                      pages#about_us",
-          "      our_work_latest GET  /our-work/latest(.:format)               our_work#latest",
-          "user_favorites_photos GET  /photos/user-favorites(.:format)         photos#user_favorites",
-          "  preview_photo_photo GET  /photos/:id/preview-photo(.:format)      photos#preview_photo",
-          "   photo_summary_text GET  /photos/:photo_id/summary-text(.:format) photos#summary_text",
-          "                photo GET  /photos/:id(.:format)                    photos#show"
+          "               Prefix Verb URI Pattern                                         Controller#Action",
+          "             about_us GET  /about-us(.:format(+:variant))                      pages#about_us",
+          "      our_work_latest GET  /our-work/latest(.:format(+:variant))               our_work#latest",
+          "user_favorites_photos GET  /photos/user-favorites(.:format(+:variant))         photos#user_favorites",
+          "  preview_photo_photo GET  /photos/:id/preview-photo(.:format(+:variant))      photos#preview_photo",
+          "   photo_summary_text GET  /photos/:photo_id/summary-text(.:format(+:variant)) photos#summary_text",
+          "                photo GET  /photos/:id(.:format(+:variant))                    photos#show"
         ], output
       end
 
@@ -207,8 +207,8 @@ module ActionDispatch
         end
 
         assert_equal [
-          "Prefix Verb URI Pattern        Controller#Action",
-          "       GET  /foo/:id(.:format) MountedRackApp {:id=>/[A-Z]\\d{5}/}"
+          "Prefix Verb URI Pattern                   Controller#Action",
+          "       GET  /foo/:id(.:format(+:variant)) MountedRackApp {:id=>/[A-Z]\\d{5}/}"
         ], output
       end
 
@@ -268,8 +268,8 @@ module ActionDispatch
           end
         end
         assert_equal [
-          "Prefix Verb URI Pattern              Controller#Action",
-          "   foo GET  /sprockets/foo(.:format) foo#bar"
+          "Prefix Verb URI Pattern                         Controller#Action",
+          "   foo GET  /sprockets/foo(.:format(+:variant)) foo#bar"
         ], output
       end
 
@@ -281,10 +281,10 @@ module ActionDispatch
         end
 
         assert_equal [
-          "Prefix Verb URI Pattern       Controller#Action",
-          "   foo GET  /foo(.:format)    redirect(301, /foo/bar) {:subdomain=>\"admin\"}",
-          "   bar GET  /bar(.:format)    redirect(307, path: /foo/bar)",
-          "foobar GET  /foobar(.:format) redirect(301)"
+          "Prefix Verb URI Pattern                  Controller#Action",
+          "   foo GET  /foo(.:format(+:variant))    redirect(301, /foo/bar) {:subdomain=>\"admin\"}",
+          "   bar GET  /bar(.:format(+:variant))    redirect(307, path: /foo/bar)",
+          "foobar GET  /foobar(.:format(+:variant)) redirect(301)"
         ], output
       end
 
@@ -294,15 +294,17 @@ module ActionDispatch
           resources :posts
         end
 
-        assert_equal ["   Prefix Verb   URI Pattern               Controller#Action",
-                      "    posts GET    /posts(.:format)          posts#index",
-                      "          POST   /posts(.:format)          posts#create",
-                      " new_post GET    /posts/new(.:format)      posts#new",
-                      "edit_post GET    /posts/:id/edit(.:format) posts#edit",
-                      "     post GET    /posts/:id(.:format)      posts#show",
-                      "          PATCH  /posts/:id(.:format)      posts#update",
-                      "          PUT    /posts/:id(.:format)      posts#update",
-                      "          DELETE /posts/:id(.:format)      posts#destroy"], output
+        assert_equal [
+          "   Prefix Verb   URI Pattern                          Controller#Action",
+          "    posts GET    /posts(.:format(+:variant))          posts#index",
+          "          POST   /posts(.:format(+:variant))          posts#create",
+          " new_post GET    /posts/new(.:format(+:variant))      posts#new",
+          "edit_post GET    /posts/:id/edit(.:format(+:variant)) posts#edit",
+          "     post GET    /posts/:id(.:format(+:variant))      posts#show",
+          "          PATCH  /posts/:id(.:format(+:variant))      posts#update",
+          "          PUT    /posts/:id(.:format(+:variant))      posts#update",
+          "          DELETE /posts/:id(.:format(+:variant))      posts#destroy"
+          ], output
       end
 
       def test_regression_route_with_controller_regexp


### PR DESCRIPTION
Related issue : #18818 
Related PR : #18865 

`:variant` is tied to `:format` like (.:format(+:variant)), and constraints of :format is set to `[^\+]+` rather than `.+`. `request.variant` is set to `:variant` parameter default. For example, accessing http://example.com/posts.html+partial set `request.variant = [:partial]` automatically if route is `posts(.:format(+:variant))`.

I've tried 
1. Hooking :format and extract variants from it. (I may be hooking at wrong level) (#18865)
2. Add `+` to default separators (https://github.com/FeGs/rails/commit/f33342b930431e68a377573b213f1233b8921580)
3. Tie `:variant` to `:format` like `(.:format(+:variant))`, and just add constraints for format `/^[\+]/` rather than `/.+/`. (This PR)

I don't know this approach is good, but it's simpler than 2. If this approach is passed, I should modify (.:format) to (.:format(+:variant)) in a lot of documents and tests.
