### PR TITLE
ActionController::RoutingError exception raises when a undefined method exists in a controller

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -59,6 +59,7 @@ module ActionDispatch
             controller_reference(controller_param)
           end
         rescue NameError => e
+          raise if e.message.include?("undefined local variable or method")
           raise ActionController::RoutingError, e.message, e.backtrace if default_controller
         end
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -58,16 +58,15 @@ module ActionDispatch
             controller_param = params[:controller]
             controller_reference(controller_param)
           end
-        rescue NameError => e
-          raise if e.message.include?("undefined local variable or method")
-          raise ActionController::RoutingError, e.message, e.backtrace if default_controller
+        rescue ActionController::RoutingError
+          raise if default_controller
         end
 
       private
 
         def controller_reference(controller_param)
           const_name = @controller_class_names[controller_param] ||= "#{controller_param.camelize}Controller"
-          ActiveSupport::Dependencies.constantize(const_name)
+          ActiveSupport::Dependencies.safe_constantize(const_name) || raise(ActionController::RoutingError, "uninitialized constant #{const_name}")
         end
 
         def dispatch(controller, action, env)

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -337,6 +337,10 @@ module RoutingTestHelpers
     TestSet.new ->(c) { tc.controller = c }, strict
   end
 
+  def make_bad_set
+    TestBadSet.new -> {}
+  end
+
   class TestSet < ActionDispatch::Routing::RouteSet
     attr_reader :strict
 
@@ -371,6 +375,18 @@ module RoutingTestHelpers
 
     def dispatcher defaults
       TestSet::Dispatcher.new defaults, self, @block
+    end
+  end
+
+  class TestBadSet < TestSet
+    class Dispatcher < TestSet::Dispatcher
+      def controller_reference(controller_param)
+        raise NameError, "undefined local variable or method `dummy_method' for #<Class:0x0>"
+      end
+    end
+
+    def dispatcher defaults
+      TestBadSet::Dispatcher.new defaults, self, @block
     end
   end
 end

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -562,6 +562,14 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     assert_raise(ActionController::RoutingError) { rs.recognize_path("/not_a/show/10") }
   end
 
+  def test_no_hide_undefined_method_error
+    set = make_bad_set
+    set.draw do
+      get ':controller/:action'
+    end
+    assert_raise(NameError) { set.recognize_path("/bad/ok") }
+  end
+
   def test_should_list_options_diff_when_routing_constraints_dont_match
     rs.draw do
       get 'post/:id' => 'post#show', :constraints => { :id => /\d+/ }, :as => 'post'


### PR DESCRIPTION
For example,

config/routes.rb

```
Rails.application.routes.draw do
  ...
  get ':controller/:action'
  ...
end
```

app/controllers/articles_controller.rb

```
class ArticlesController < ApplicationController
  tsukasa # undefined method

  def ok
    ...
  end
end
```

ActionController::RoutingError exception(No route matches) occurs when you access to '/article/ok'.
Its correct exception is NameError exception(undefined method).
There are two reasons that NameError exception occurs.
One is undefined variable or method. Another is uninitialized constant.
ActionController::RoutingError exception is correct when uninitialized constant raises, but its not correct when undefined method raises.
