### PR TITLE
AtiveRecord::Enum supports string type column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 	Example:
 
-		class Book < ActiveRecord::Base
-		  enum status: [:proposed, :written]
-		  enum format: [:paperback, :ebook]
+        class Book < ActiveRecord::Base
+          enum status: [:proposed, :written]
+          enum format: [:paperback, :ebook]
         end
 
         # status is integer column,
-	    Book.statuses # => { :proposed => 0, :written => 1 }
+        Book.statuses # => { :proposed => 0, :written => 1 }
 
         # format is string column,
-		Book.formats  # => { :paperback => "paperback", :ebook => "ebook" }
+        Book.formats  # => { :paperback => "paperback", :ebook => "ebook" }
 
     *Jaehyun Shin*
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Add `ActiveRecord::Enum` supports string type column. When column type is string, database values are same as enum values.
+
+	Example:
+
+		class Book < ActiveRecord::Base
+		  enum status: [:proposed, :written]
+		  enum format: [:paperback, :ebook]
+        end
+
+        # status is integer column,
+	    Book.statuses # => { :proposed => 0, :written => 1 }
+
+        # format is string column,
+		Book.formats  # => { :paperback => "paperback", :ebook => "ebook" }
+
+    *Jaehyun Shin*
+
 *   Correctly dump `serial` and `bigserial`.
 
     *Ryuta Kamizono*

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -10,6 +10,7 @@ class Book < ActiveRecord::Base
   enum status: [:proposed, :written, :published]
   enum read_status: {unread: 0, reading: 2, read: 3}
   enum nullable_status: [:single, :married]
+  enum format: [:hardcover, :paperback, :ebook]
 
   def published!
     super


### PR DESCRIPTION
I like actions of `ActiveRecord::Enum` like queries, build, update and so on.
But It is difficult to change the order of enum items after I declare enum with array like `enum status: [:proposed, :written, :published]`. they are automatically assigned by the order. Even if I use hash for declaring, a revision of the list of enum items is difficult too. I must struggle to avoid integer values that were used before (though they are not currently used).

A list of enum items like statuses is so easy to change that it can be added or removed frequently.
I think using integer type of enum is harder than string type.

I prefer string type for that sort of data. I hope rails enum supports string type column. It means that I want to insert just enum string(symbol) values to database.

It makes it easy to maintain, migrate and refactoring. Also it is easy to recognize the meaning of value when struggling with just datas.
