### PR TITLE
Added a deprecation warnings to uses_transaction and run_in_transaction?

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -665,4 +665,10 @@
 
     *Yves Senn*
 
+*   Deprecate `ActiveRecord::TestFixtures.uses_transaction` and
+    `ActiveRecord::TestFixtures.uses_transaction?` and
+    `ActiveRecord::TestFixtures#run_in_transaction?`
+
+    *Islam Wazery*
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activerecord/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
Quoting from the [changelog](https://github.com/rails/rails/blob/49618d6f31d453d3cbed8ed2bea6ca491412c272/activerecord/CHANGELOG.md#L344):

> Tests now run after_commit callbacks. You no longer have to declare uses_transaction ‘test name’ to test the results of an after_commit.

The `#uses_transaction`, `#uses_transaction?`, and `#run_in_transaction?` are no longer needed, so I added some deprecation warnings till them get removed.
