### PR TITLE
Let strip_tags leave HTML escaping to Rails.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ gem 'rake', '>= 10.3'
 # ensure correct loading order
 gem 'mocha', '~> 0.14', require: false
 
+gem 'rails-html-sanitizer', '~> 1.0.2', github: 'rails/rails-html-sanitizer'
+
 gem 'rack-cache', '~> 1.2'
 gem 'jquery-rails', github: 'rails/jquery-rails', branch: 'master'
 gem 'coffee-rails', '~> 4.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,13 @@ GIT
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
 
+GIT
+  remote: git://github.com/rails/rails-html-sanitizer.git
+  revision: 4f0f7810fce6c8aa63de07a40d69d6027a30acaf
+  specs:
+    rails-html-sanitizer (1.0.2)
+      loofah (~> 2.0)
+
 PATH
   remote: .
   specs:
@@ -50,13 +57,13 @@ PATH
       rack (~> 1.6)
       rack-test (~> 0.6.3)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.1)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
     actionview (5.0.0.alpha)
       activesupport (= 5.0.0.alpha)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.1)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
     activejob (5.0.0.alpha)
       activesupport (= 5.0.0.alpha)
       globalid (>= 0.3.0)
@@ -165,8 +172,6 @@ GEM
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6.0)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.1)
-      loofah (~> 2.0)
     rake (10.4.2)
     rdoc (4.2.0)
     redcarpet (3.2.2)
@@ -274,6 +279,7 @@ DEPENDENCIES
   racc (>= 1.4.6)
   rack-cache (~> 1.2)
   rails!
+  rails-html-sanitizer (~> 1.0.2)!
   rake (>= 10.3)
   redcarpet (~> 3.2.2)
   resque

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rack',      '~> 1.6'
   s.add_dependency 'rack-test', '~> 0.6.3'
-  s.add_dependency 'rails-html-sanitizer', '~> 1.0', '>= 1.0.1'
+  s.add_dependency 'rails-html-sanitizer', '~> 1.0', '>= 1.0.2'
   s.add_dependency 'rails-dom-testing', '~> 1.0', '>= 1.0.5'
   s.add_dependency 'actionview', version
 

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'builder',       '~> 3.1'
   s.add_dependency 'erubis',        '~> 2.7.0'
-  s.add_dependency 'rails-html-sanitizer', '~> 1.0', '>= 1.0.1'
+  s.add_dependency 'rails-html-sanitizer', '~> 1.0', '>= 1.0.2'
   s.add_dependency 'rails-dom-testing', '~> 1.0', '>= 1.0.5'
 
   s.add_development_dependency 'actionpack',  version

--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -99,7 +99,7 @@ module ActionView
       #   strip_tags("<div id='top-bar'>Welcome to my website!</div>")
       #   # => Welcome to my website!
       def strip_tags(html)
-        self.class.full_sanitizer.sanitize(html)
+        self.class.full_sanitizer.sanitize(html, encode_special_chars: false)
       end
 
       # Strips all link tags from +html+ leaving just the link text.

--- a/actionview/test/template/sanitize_helper_test.rb
+++ b/actionview/test/template/sanitize_helper_test.rb
@@ -29,6 +29,10 @@ class SanitizeHelperTest < ActionView::TestCase
     assert_equal "", strip_tags("<script>")
   end
 
+  def test_strip_tags_will_not_encode_special_characters
+    assert_equal "test\r\n\r\ntest", strip_tags("test\r\n\r\ntest")
+  end
+
   def test_sanitize_is_marked_safe
     assert sanitize("<html><script></script></html>").html_safe?
   end


### PR DESCRIPTION
Prevents double escaping errors, such as "&amp;" becoming "&amp;amp;".

This needs a release of Rails Html Sanitizer 1.0.2. Then I'll bundle again and update this PR.

cc @rafaelfranca
