### PR TITLE
Fixed functionality to include method in params_wrapper.rb

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -108,6 +108,13 @@ module ActionController
             if m.respond_to?(:attribute_names) && m.attribute_names.any?
               self.include = m.attribute_names
             end
+            if m.respond_to?(:nested_attributes_options) && m.nested_attributes_options.any?
+              nested_attributes_names = self.nested_attributes_options.keys.map do |key| 
+                key.to_s.concat('_attributes').to_sym
+              end
+              self.include += nested_attributes_names
+            end
+
           end
         end
       end


### PR DESCRIPTION
to properly wrap all attributes, including those which are nested.

fix for issue #17216

@sxl1092

These param_wrapper methods are not tested in ActiveRecord. We looked through ActiveRecord and found some nested_attributes tests though that runs tests on all of the nested relations. The problem is that these just tests the nested relationships directly, and we need a test that makes sure that our method in param_wrappers returns all of these nested attributes. We are still stuck on how to get a test for this controller method. We cannot do it in ActiveRecord because those don't test controllers, and in ActionPack these controller tests do not interact with any models. We tried looking at method stubs and we are wondering if that might be a potential solution? We are confused about how to run a simple controller test though if we can't get our controller to interact with some model(s). If there are some basic examples in the current tests that do this, or perhaps some general best coding practice that we are not aware of, we would appreciate any advice. 

Our general approach is correct we believe, because we're trying to access both the attribute_names and nested_attributes_options to make sure that our changes correctly return some combination of these, but we're not sure how to grab these attributes and nested_attributes if we cannot access a model from the controller. And if we were in ActiveRecord, we wouldn't know how to use our controller method on the attributes that we have in those files. This crossover between the two might not be necessary at all, but if that's the case we are not sure how we should be trying to test it. 
