### PR TITLE
Fix #16479

### DIFF
--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -9,6 +9,7 @@ require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/array/extract_options'
 
 require 'rails/application'
+require 'rails/env'
 require 'rails/version'
 
 require 'active_support/railtie'
@@ -54,22 +55,6 @@ module Rails
 
     def root
       application && application.config.root
-    end
-
-    # Returns the current Rails environment.
-    #
-    #   Rails.env # => "development"
-    #   Rails.env.development? # => true
-    #   Rails.env.production? # => false
-    def env
-      @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development")
-    end
-
-    # Sets the Rails environment.
-    #
-    #   Rails.env = "staging" # => "staging"
-    def env=(environment)
-      @_env = ActiveSupport::StringInquirer.new(environment)
     end
 
     # Returns all rails groups for loading based on:

--- a/railties/lib/rails/commands/commands_tasks.rb
+++ b/railties/lib/rails/commands/commands_tasks.rb
@@ -1,3 +1,5 @@
+require 'rails/env'
+
 module Rails
   # This is a class which takes in a rails command and initiates the appropriate
   # initiation sequence.
@@ -59,7 +61,7 @@ EOT
       options = Rails::Console.parse_arguments(argv)
 
       # RAILS_ENV needs to be set before config/application is required
-      ENV['RAILS_ENV'] = options[:environment] if options[:environment]
+      Rails.env = options[:environment]
 
       # shift ARGV so IRB doesn't freak
       shift_argv!

--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -1,6 +1,7 @@
 require 'optparse'
 require 'irb'
 require 'irb/completion'
+require 'rails/env'
 
 module Rails
   class Console
@@ -57,7 +58,7 @@ module Rails
     end
 
     def environment
-      options[:environment] ||= ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+      options[:environment] ||= Rails.env
     end
 
     def environment?

--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -1,6 +1,7 @@
 require 'erb'
 require 'yaml'
 require 'optparse'
+require 'rails/env'
 
 module Rails
   class DBConsole
@@ -16,7 +17,7 @@ module Rails
 
     def start
       options = parse_arguments(arguments)
-      ENV['RAILS_ENV'] = options[:environment] || environment
+      Rails.env = options[:environment]
 
       case config["adapter"]
       when /^(jdbc)?mysql/
@@ -104,11 +105,7 @@ module Rails
     end
 
     def environment
-      if Rails.respond_to?(:env)
-        Rails.env
-      else
-        ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
-      end
+      Rails.env
     end
 
     protected

--- a/railties/lib/rails/commands/runner.rb
+++ b/railties/lib/rails/commands/runner.rb
@@ -1,6 +1,7 @@
 require 'optparse'
+require 'rails/env'
 
-options = { environment: (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || "development").dup }
+options = { environment: Rails.env.to_s }
 code_or_file = nil
 
 if ARGV.first.nil?
@@ -45,7 +46,7 @@ end
 
 ARGV.delete(code_or_file)
 
-ENV["RAILS_ENV"] = options[:environment]
+Rails.env = options[:environment]
 
 require APP_PATH
 Rails.application.require_environment!

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -60,7 +60,7 @@ module Rails
     end
 
     def set_environment
-      ENV["RAILS_ENV"] ||= options[:environment]
+      Rails.env = options[:environment]
     end
 
     def start
@@ -95,7 +95,7 @@ module Rails
       super.merge({
         Port:               3000,
         DoNotReverseLookup: true,
-        environment:        (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || "development").dup,
+        environment:        Rails.env.to_s,
         daemonize:          false,
         pid:                File.expand_path("tmp/pids/server.pid"),
         config:             File.expand_path("config.ru")

--- a/railties/lib/rails/env.rb
+++ b/railties/lib/rails/env.rb
@@ -1,0 +1,32 @@
+require 'active_support'
+
+module Rails
+  class << self
+    # Returns the current Rails environment.
+    #
+    #   Rails.env # => 'development'
+    #   Rails.env.development? # => true
+    #   Rails.env.production? # => false
+    def env
+      @_env ||= env_factory
+    end
+
+    # Sets the Rails environment and synchronizes RAILS_ENV.
+    #
+    #   Rails.env = 'staging' # => 'staging'
+    def env=(environment)
+      if @_env != environment
+        ENV['RAILS_ENV'] = @_env = env_factory(environment)
+      end
+      @_env
+    end
+
+    private
+
+    def env_factory(environment = nil)
+      ActiveSupport::StringInquirer.new(environment || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || DEFAULT_ENV)
+    end
+
+    DEFAULT_ENV = 'development'.freeze
+  end
+end

--- a/railties/lib/rails/env.rb
+++ b/railties/lib/rails/env.rb
@@ -15,9 +15,8 @@ module Rails
     #
     #   Rails.env = 'staging' # => 'staging'
     def env=(environment)
-      if @_env != environment
-        ENV['RAILS_ENV'] = @_env = env_factory(environment)
-      end
+      @_env = env_factory(environment) if @_env != environment
+      ENV['RAILS_ENV'] ||= @_env
       @_env
     end
 


### PR DESCRIPTION
Set `Rails.env` much earlier when loading `rails console` with a command-line specified environment so that initializers run in the specified environment rather than `RAILS_ENV` or `development`.
