### PR TITLE
Rails 5.0 needs ruby 2.2.1 or higher

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -20,7 +20,7 @@ The best way to be sure that your application still works after upgrading is to 
 
 Rails generally stays close to the latest released Ruby version when it's released:
 
-* Rails 5 requires Ruby 2.2 or newer.
+* Rails 5 requires Ruby 2.2.1 or newer.
 * Rails 4 prefers Ruby 2.0 and requires 1.9.3 or newer.
 * Rails 3.2.x is the last branch to support Ruby 1.8.7.
 * Rails 3 and above require Ruby 1.8.7 or higher. Support for all of the previous Ruby versions has been dropped officially. You should upgrade as early as possible.


### PR DESCRIPTION
Since there was a bug in 2.2.0, the minimum ruby requirement is 2.2.1. 
See https://github.com/rails/rails/commit/8ed0b89b
