### PR TITLE
Allow to pass extra tag attributes to auto_discovery_link_tag helper.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow to pass extra tag attributes to `auto_discovery_link_tag` helper
+
+    *Max Trubetskoy*
+
 *   `translate` should accept nils as members of the `:default`
     parameter without raising a translation missing error.  Fixes a
     regression introduced 362557e.

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -128,18 +128,23 @@ module ActionView
       #   # => <link rel="alternate" type="application/rss+xml" title="RSS" href="http://www.currenthost.com/news/feed" />
       #   auto_discovery_link_tag(:rss, "http://www.example.com/feed.rss", {title: "Example RSS"})
       #   # => <link rel="alternate" type="application/rss+xml" title="Example RSS" href="http://www.example.com/feed" />
+      #   auto_discovery_link_tag(:atom, {controller: "news", action: "feed"}, {data: {'turbolinks-track' => true}})
+      #   # => <link rel="alternate" type="application/atom+xml" title="ATOM" href="http://www.currenthost.com/news/feed" data-turbolinks-track="true" />
       def auto_discovery_link_tag(type = :rss, url_options = {}, tag_options = {})
         if !(type == :rss || type == :atom) && tag_options[:type].blank?
           raise ArgumentError.new("You should pass :type tag_option key explicitly, because you have passed #{type} type other than :rss or :atom.")
         end
 
-        tag(
-          "link",
+        tag_options = tag_options.with_indifferent_access
+        default_tag_options = {
           "rel"   => tag_options[:rel] || "alternate",
           "type"  => tag_options[:type] || Mime::Type.lookup_by_extension(type.to_s).to_s,
           "title" => tag_options[:title] || type.to_s.upcase,
           "href"  => url_options.is_a?(Hash) ? url_for(url_options.merge(:only_path => false)) : url_options
-        )
+        }
+        tag_options = default_tag_options.reverse_merge tag_options
+
+        tag("link", tag_options)
       end
 
       # Returns a link tag for a favicon managed by the asset pipeline.

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -60,6 +60,8 @@ class AssetTagHelperTest < ActionView::TestCase
     %(auto_discovery_link_tag(nil, {}, {:title => "No stream.. really", :type => "text/html"})) => %(<link href="http://www.example.com" rel="alternate" title="No stream.. really" type="text/html" />),
     %(auto_discovery_link_tag(:rss, {}, {:title => "My RSS", :type => "text/html"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="text/html" />),
     %(auto_discovery_link_tag(:atom, {}, {:rel => "Not so alternate"})) => %(<link href="http://www.example.com" rel="Not so alternate" title="ATOM" type="application/atom+xml" />),
+    %(auto_discovery_link_tag(:atom, {}, {:data => {'turbolinks-track' => false}})) => %(<link href="http://www.example.com" rel="alternate" title="ATOM" type="application/atom+xml" data-turbolinks-track="false" />),
+    %(auto_discovery_link_tag(:atom, {}, {'rel' => "Not so alternate", :data => {'turbolinks-track' => false}})) => %(<link href="http://www.example.com" rel="Not so alternate" title="ATOM" type="application/atom+xml" data-turbolinks-track="false" />),
   }
 
   JavascriptPathToTag = {


### PR DESCRIPTION
auto_discovery_link_tag should accept extra options (data attributes) to work properly with turbolinks.

I've faced an issue with `auto_diskovery_link_tag` and turbolinks.  
When I come to a specific page with a feed link, generated by auto_discovery_link_tag, the feed link doesn't appear until I refresh the page manually. Or I see the feed for the last visited page on every page.
Setting the data attribute for turbolinks fixes the issue.
