### PR TITLE
Add small speed improvement for alias_attribute calls

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -206,7 +206,7 @@ module ActiveModel
       #   person.name_short?     # => true
       #   person.nickname_short? # => true
       def alias_attribute(new_name, old_name)
-        self.attribute_aliases = attribute_aliases.merge(new_name.to_s => old_name.to_s)
+        attribute_aliases.merge!(new_name.to_s => old_name.to_s)
         attribute_method_matchers.each do |matcher|
           matcher_new = matcher.method_name(new_name).to_s
           matcher_old = matcher.method_name(old_name).to_s


### PR DESCRIPTION
  In the benchmarks the change yields about ~24% speedup when
calling alias_attribute and is identical in function to the old code.

The benchmark was done by temporarily adding another implementation of the method that uses the new code. These are the results of running the benchmark:

``` shell
Calculating -------------------------------------
            baseline    15.192k i/100ms
 alias_attribute old     1.631k i/100ms
 alias_attribute new     2.030k i/100ms
-------------------------------------------------
            baseline    217.841k (± 4.8%) i/s -      1.094M
 alias_attribute old     17.596k (± 4.7%) i/s -     88.074k
 alias_attribute new     22.168k (± 4.8%) i/s -    111.650k
```

And this is the code for the benchmark:

``` ruby
require File.expand_path('../load_paths', __FILE__)
require 'active_model'
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report('alias_attribute old') do
    class Person
      include ActiveModel::AttributeMethods

      attr_accessor :name
      alias_attribute :nickname, :name
    end
  end

  x.report('alias_attribute new') do
    class Person
      include ActiveModel::AttributeMethods

      attr_accessor :name
      alias_attribute2 :nickname, :name
    end
  end
end
```

Note that the actual speedup is larger since both executions contain a common part of constructing a class for the test. Therefore, the 24% is actually a lower bound on the percentage speedup. A clean test comparing just alias_attribute executions would be much more complicated and this lower barrier seemed already big enough to justify the change.
