### PR TITLE
Added `#else` method on `Enumerable`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Added `#else` on `Enumerable` as a shortcut to perform an action if the 
+    enumerable is empty:
+
+        people.each do |person|
+          puts "Hello #{person.name}"
+        end.else
+          puts "No person in your contact list"
+        end
+
+    *Francesco Boffa*
+
 *   Added `#without` on `Enumerable` and `Array` to return a copy of an
     enumerable without the specified elements.
 

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -71,6 +71,12 @@ module Enumerable
   def without(*elements)
     reject { |element| elements.include?(element) }
   end
+
+  # Calls the given block if the enumerable does not contain any element.
+  def else
+    yield unless count > 0
+    self
+  end
 end
 
 class Range #:nodoc:

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -110,4 +110,24 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal [1, 2, 4], (1..5).to_set.without(3, 5)
     assert_equal({foo: 1, baz: 3}, {foo: 1, bar: 2, baz: 3}.without(:bar))
   end
+
+  def test_else
+    empty = false
+    result = [1, 2, 3].else { empty = true }
+    assert_equal [1, 2, 3], result
+    assert_equal false, empty
+
+    result = [].else { empty = true }
+    assert_equal [], result
+    assert_equal true, empty
+
+    empty = false
+    result = (1..5).else { empty = true }
+    assert_equal (1..5), result
+    assert_equal false, empty
+
+    result = (0...0).else { empty = true }
+    assert_equal (0...0), result
+    assert_equal true, empty
+  end
 end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2193,6 +2193,21 @@ people.without("Aaron", "Todd")
 
 NOTE: Defined in `active_support/core_ext/enumerable.rb`.
 
+### `else`
+
+The method `else` calls the given block if the enumerable is empty and returns
+the enumerable itself:
+
+```ruby
+people.each do |name|
+  puts name
+end.else do
+  puts "No person in your array"
+end
+```
+
+NOTE: Defined in `active_support/core_ext/enumerable.rb`.
+
 Extensions to `Array`
 ---------------------
 


### PR DESCRIPTION
This method allows you to perform an action if the enumerable is empty. I use this core extension in some of my projects to shorten views from:

``` erb
<% if @people.any? %>
  <% @people.each do |person| %>
    <div><%= person.name %></div>
  <% end %>
<% else %>
  <div class="error">No person in your contacts list</div>
<% end %>
```

To:

``` erb
<% @people.each do |person| %>
  <div><%= person.name %></div>
<% end.else do %>
  <div class="error">No person in your contacts list</div>
<% end %>
```

Or, if you prefer haml:

``` haml
- if @people.any?
  - @people.each do |person|
    %div=person.name
- else
  .error No person in your contacts list
```

To:

``` haml
- @people.each do |person|
  %div=person.name
- end.else do
  .error No person in your contacts list
```
