### PR TITLE
Changed 'blank space' to 'blank line'

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -82,7 +82,7 @@ steve:
   profession: guy with keyboard
 ```
 
-Each fixture is given a name followed by an indented list of colon-separated key/value pairs. Records are typically separated by a blank space. You can place comments in a fixture file by using the # character in the first column.
+Each fixture is given a name followed by an indented list of colon-separated key/value pairs. Records are typically separated by a blank line. You can place comments in a fixture file by using the # character in the first column.
 
 If you are working with [associations](/association_basics.html), you can simply
 define a reference node between two different fixtures. Here's an example with


### PR DESCRIPTION
Line 85 stated that fixtures are typically separated by a blank space. I changed the wording to blank line because blank space could be misinterpreted as a non-breaking space character when in reality, each fixture record (in YAML) is separated by a blank line.
