### PR TITLE
304 response should not include Content-Type header

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -47,10 +47,11 @@ module ActionDispatch
       if gzip_path && gzip_encoding_accepted?(env)
         env['PATH_INFO']            = gzip_path
         status, headers, body       = @file_server.call(env)
-        headers['Content-Encoding'] = 'gzip'
-        if status != 304
-          headers['Content-Type']   = content_type(path)
+        if status == 304
+          return [status, headers, body]
         end
+        headers['Content-Encoding'] = 'gzip'
+        headers['Content-Type']     = content_type(path)
       else
         status, headers, body = @file_server.call(env)
       end

--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -48,7 +48,9 @@ module ActionDispatch
         env['PATH_INFO']            = gzip_path
         status, headers, body       = @file_server.call(env)
         headers['Content-Encoding'] = 'gzip'
-        headers['Content-Type']     = content_type(path)
+        if status != 304
+          headers['Content-Type']   = content_type(path)
+        end
       else
         status, headers, body = @file_server.call(env)
       end

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -149,7 +149,8 @@ module StaticTests
     response = get(file_name, 'HTTP_ACCEPT_ENCODING' => 'gzip', 'HTTP_IF_MODIFIED_SINCE' => last_modified.httpdate)
     assert_equal 304, response.status
     assert_equal nil, response.headers['Content-Type']
-    assert_equal 'gzip', response.headers['Content-Encoding']
+    assert_equal nil, response.headers['Content-Encoding']
+    assert_equal nil, response.headers['Vary']
   end
 
   # Windows doesn't allow \ / : * ? " < > | in filenames

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -143,6 +143,15 @@ module StaticTests
     assert_equal default_response.headers['Content-Type'], response.headers['Content-Type']
   end
 
+  def test_serves_gzip_files_with_not_modified
+    file_name = "/gzip/application-a71b3024f80aea3181c09774ca17e712.js"
+    last_modified = File.mtime(File.join(@root, "#{file_name}.gz"))
+    response = get(file_name, 'HTTP_ACCEPT_ENCODING' => 'gzip', 'HTTP_IF_MODIFIED_SINCE' => last_modified.httpdate)
+    assert_equal 304, response.status
+    assert_equal nil, response.headers['Content-Type']
+    assert_equal 'gzip', response.headers['Content-Encoding']
+  end
+
   # Windows doesn't allow \ / : * ? " < > | in filenames
   unless RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
     def test_serves_static_file_with_colon


### PR DESCRIPTION
Rack::Lint raises an error saying "Content-Type header found in 304
response, not allowed".
