### PR TITLE
Implement eager loading view templates

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Implement eager loading of view templates on server startup.
+
+    This adds an option to cache and compile all possible view templates when
+    the server starts.
+
+    Set 'config.action_view.eager_load_templates' to true to enable this.
+
+    *Juho Leinonen*, *Qian Zhou*, *Henrik Nygren*, *Jussi Mertanen*
+
 *   `translate` should accept nils as members of the `:default`
     parameter without raising a translation missing error.  Fixes a
     regression introduced 362557e.

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -44,6 +44,7 @@ module ActionView
     autoload :RoutingUrlFor
     autoload :Template
     autoload :ViewPaths
+    autoload :TemplateEagerLoader
 
     autoload_under "renderer" do
       autoload :Renderer

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -175,6 +175,10 @@ module ActionView #:nodoc:
         ActionView::Resolver.caching = value
       end
 
+      def eager_load_templates=(value)
+        ActionView::TemplateEagerLoader.eager_load_templates = value
+      end
+
       def xss_safe? #:nodoc:
         true
       end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -48,6 +48,14 @@ module ActionView
       end
     end
 
+    initializer "cache_templates" do
+      ActiveSupport.on_load(:action_controller) do
+        if Rails.env.production? && app.config.eager_load_templates
+          ActionView::TemplateEagerLoader.new(_view_paths).cache_templates
+        end
+      end
+    end
+
     rake_tasks do
       load "action_view/tasks/dependencies.rake"
     end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -48,10 +48,11 @@ module ActionView
       end
     end
 
-    initializer "cache_templates" do
-      ActiveSupport.on_load(:action_controller) do
-        if Rails.env.production? && app.config.eager_load_templates
-          ActionView::TemplateEagerLoader.new(_view_paths).cache_templates
+    initializer "action_view.eager_load_templates" do |app|
+      if app.config.action_view.eager_load_templates
+        raise "To eager load view templates config.eager_load should be true" unless app.config.eager_load
+        ActiveSupport.on_load(:action_controller) do
+          ActionView::TemplateEagerLoader.new(_view_paths).eager_load
         end
       end
     end

--- a/actionview/lib/action_view/template_eager_loader.rb
+++ b/actionview/lib/action_view/template_eager_loader.rb
@@ -1,17 +1,27 @@
 module ActionView
-  # Does stuff.
-  class TemplateEagerLoader
+  # = Action View Template Eager Loader
+  class TemplateEagerLoader # :nodoc:
+    # ActionView::TemplateEagerLoader finds and caches all
+    # view templates and then compiles them.
+    #
+    # If this is done on server startup,
+    # the first request will be faster.
 
     def initialize(resolver)
       @resolver = resolver
     end
 
+    # Compiles and caches all templates 
     def eager_load
       each_template(&:compile!)
     end
 
     private
 
+    # Determines all possible template parameters and then
+    # delegates finding and caching to the Resolver.
+    # After finding and caching the templates, it will
+    # yield them to the block.
     def each_template(&block)
       prefixes.each do |prefix|
         path_names(prefix).each do |name|

--- a/actionview/lib/action_view/template_eager_loader.rb
+++ b/actionview/lib/action_view/template_eager_loader.rb
@@ -1,0 +1,50 @@
+module ActionView
+  class TemplateEagerLoader
+    def self.do(o)
+      partial = false
+      locals = []
+
+      prefixes = Dir.glob('app/views/*').map { |name| name.split('/').last }
+      prefixes.each do |prefix|
+
+        path_names = Dir.glob("app/views/#{prefix}/*").map { |name| File.basename name }
+        path_names.each do |name|
+          locales.each do |locale|
+            pieces = name.split('.')
+            keyh = {
+              locale: locale,
+              formats: Mime::SET.collect(&:symbol),
+              variants: variants(pieces),
+              handlers: ActionView::Template::Handlers.extensions
+            }
+            key = ActionView::LookupContext::DetailsKey.get(keyh)
+            o._view_paths.paths.first.instance_variable_get(:@cache).cache(key, pieces.first, prefix, partial, locals) do
+              o._view_paths.paths.first.find_all(pieces.first, prefix, partial, keyh, locals)
+            end
+          end
+        end
+      end
+    end
+
+    def self.variants(pieces)
+      separator = ActionView::PathResolver::EXTENSIONS[:variants]
+      pieces.pop
+      parts = pieces.last.split(separator)
+      parts.length > 1 ? [parts.last] : []
+    end
+
+    # All possible locale combinations
+    def self.locales
+      locales = [[:en]]
+      available = I18n.available_locales - [:en]
+      available.each do |locale|
+        locales << [locale, :en]
+        available.each do |default|
+          next if locale == default
+          locales << [locale, :en, default]
+        end
+      end
+      locales
+    end
+  end
+end

--- a/actionview/lib/action_view/template_eager_loader.rb
+++ b/actionview/lib/action_view/template_eager_loader.rb
@@ -14,7 +14,9 @@ module ActionView
             action = pieces.first
             partial, locals = partial_and_locals(action)
             action = action[1..-1] if action[0] == '_'
-            @resolver.find_all(action, prefix, partial, details, key, locals)
+            locals.each do |locals_array|
+              templates(action, prefix, partial, details, key, locals_array).each(&:compile!)
+            end
           end
         end
       end

--- a/actionview/lib/action_view/template_eager_loader.rb
+++ b/actionview/lib/action_view/template_eager_loader.rb
@@ -77,5 +77,11 @@ module ActionView
       format = name.split('.')[-2].to_sym
       all_formats.include?(format) ? [format] : [:html]
     end
+
+    cattr_accessor :eager_load_templates
+
+    class << self
+      alias :eager_load_templates? :eager_load_templates
+    end
   end
 end

--- a/actionview/lib/action_view/template_eager_loader.rb
+++ b/actionview/lib/action_view/template_eager_loader.rb
@@ -71,7 +71,7 @@ module ActionView
     end
 
     def view_paths
-      Dir.glob('app/views/**/*.*')
+      @view_paths ||= Dir.glob('app/views/**/*.*')
     end
 
     def path_names(prefix)
@@ -79,7 +79,7 @@ module ActionView
     end
 
     def view_paths_for(prefix)
-      Dir.glob("app/views/#{prefix}/*.*")
+      view_paths.select { |i| i.match(%r{\Aapp/views/#{prefix}/[^/]+\.+[^/]+\z}) }
     end
 
     def variants(pieces)

--- a/actionview/test/template/template_eager_loader_test.rb
+++ b/actionview/test/template/template_eager_loader_test.rb
@@ -26,13 +26,13 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
     end
 
     def test_cache_templates_calls_find_all
-      resolver.expects(:find_all)
+      resolver.expects(:find_all).returns([])
       subject.eager_load
     end
 
     def test_compile_called
       template = mock
-      subject.stubs(:templates).returns([template])
+      resolver.stubs(:find_all).returns([template])
       template.expects(:compile!)
       subject.eager_load
     end
@@ -40,7 +40,7 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
     def test_multiple_templates
       template1 = mock
       template2 = mock
-      subject.stubs(:templates).returns([template1, template2])
+      resolver.stubs(:find_all).returns([template1, template2])
       template1.expects(:compile!)
       template2.expects(:compile!)
       subject.eager_load
@@ -77,48 +77,48 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
       end
 
       def test_cache_templates_parses_partial_names
-        resolver.expects(:find_all).with('partial', anything, anything, anything, anything, anything).at_least_once
+        resolver.expects(:find_all).with('partial', anything, anything, anything, anything, anything).returns([]).at_least_once
         subject.eager_load
       end
 
       def test_cache_templates_passes_right_locals_with_partial
-        resolver.expects(:find_all).with('partial', anything, anything, anything, anything, %w(partial partial_counter partial_iteration))
-        resolver.expects(:find_all).with('partial', anything, anything, anything, anything, [])
+        resolver.expects(:find_all).with('partial', anything, anything, anything, anything, %w(partial partial_counter partial_iteration)).returns([])
+        resolver.expects(:find_all).with('partial', anything, anything, anything, anything, []).returns([])
         subject.eager_load
       end
     end
 
     def test_partials_and_locals_correct_when_not_a_partial
-      resolver.expects(:find_all).with(anything, anything, false, anything, anything, [])
+      resolver.expects(:find_all).with(anything, anything, false, anything, anything, []).returns([])
       subject.eager_load
     end
 
     def test_not_being_partial_does_not_lead_into_multiple_caching_attemps
-      resolver.expects(:find_all).at_most_once
+      resolver.expects(:find_all).returns([]).at_most_once
       subject.eager_load
     end
 
     def test_details_have_correct_formats
-      resolver.expects(:find_all).with(anything, anything, anything, has_entry(formats: [:html]), anything, anything)
+      resolver.expects(:find_all).with(anything, anything, anything, has_entry(formats: [:html]), anything, anything).returns([])
       subject.eager_load
     end
 
     def test_formats_work_without_the_extension_in_filename
       subject.stubs(:path_names).with(anything).returns(['index.haml'])
-      resolver.expects(:find_all).with(anything, anything, anything, has_entry(formats: [:html]), anything, anything)
+      resolver.expects(:find_all).with(anything, anything, anything, has_entry(formats: [:html]), anything, anything).returns([])
       subject.eager_load
     end
 
     def test_details_locale_defaults_to_english
-      resolver.expects(:find_all).with(anything, anything, anything, has_entry(locale: [:en]), anything, anything)
+      resolver.expects(:find_all).with(anything, anything, anything, has_entry(locale: [:en]), anything, anything).returns([])
       subject.eager_load
     end
 
-    def test_details_locale_works_with_other_default_than_english
+    def test_details_with_other_default_than_english
       I18n.stubs(:available_locales).returns([:other, :en])
       I18n.stubs(:default_locale).returns([:other])
-      resolver.stubs(:find_all)
-      resolver.expects(:find_all).with(anything, anything, anything, has_entry(locale: [:other, :en]), anything, anything)
+      resolver.stubs(:find_all).returns([])
+      resolver.expects(:find_all).with(anything, anything, anything, has_entry(locale: [:other, :en]), anything, anything).returns([])
       subject.eager_load
     end
 
@@ -126,30 +126,30 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
       I18n.stubs(:available_locales).returns([:fi, :en, :cn])
       I18n.stubs(:default_locale).returns([:cn])
       I18n.stubs(:locale).returns([:fi])
-      resolver.stubs(:find_all)
-      resolver.expects(:find_all).with(anything, anything, anything, has_entry(locale: [:fi, :en, :cn]), anything, anything)
+      resolver.stubs(:find_all).returns([])
+      resolver.expects(:find_all).with(anything, anything, anything, has_entry(locale: [:fi, :en, :cn]), anything, anything).returns([])
       subject.eager_load
     end
 
 
     def test_details_variants_is_not_set_when_view_is_not_a_variant
-      resolver.expects(:find_all).with(anything, anything, anything, has_entry(variants: []), anything, anything)
+      resolver.expects(:find_all).with(anything, anything, anything, has_entry(variants: []), anything, anything).returns([])
       subject.eager_load
     end
 
     def test_details_variants_get_set_correctly
       subject.stubs(:path_names).with(anything).returns(['index.html+variant.erb'])
-      resolver.expects(:find_all).with(anything, anything, anything, has_entry(variants: ['variant']), anything, anything)
+      resolver.expects(:find_all).with(anything, anything, anything, has_entry(variants: ['variant']), anything, anything).returns([])
       subject.eager_load
     end
 
     def test_cache_templates_action
-      resolver.expects(:find_all).with('index', anything, anything, anything, anything, anything)
+      resolver.expects(:find_all).with('index', anything, anything, anything, anything, anything).returns([])
       subject.eager_load
     end
 
     def test_cache_templates_prefix
-      resolver.expects(:find_all).with(anything, 'people', anything, anything, anything, anything)
+      resolver.expects(:find_all).with(anything, 'people', anything, anything, anything, anything).returns([])
       subject.eager_load
     end
   end
@@ -159,7 +159,7 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
       super
       subject.stubs(:path_names).with('people/assets').returns(['index.html.erb'])
       subject.stubs(:view_paths).returns(['app/views/people/assets/index.html.erb'])
-      resolver.stubs(:find_all)
+      resolver.stubs(:find_all).returns([])
     end
 
     def test_two_layer_nested_prefixes_calls_view_paths
@@ -168,7 +168,7 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
     end
 
     def test_two_layer_nested_prefixes_returns_desired_results
-      resolver.expects(:find_all).with(anything,'people/assets', anything, anything, anything, anything)
+      resolver.expects(:find_all).with(anything,'people/assets', anything, anything, anything, anything).returns([])
       subject.eager_load
     end
   end
@@ -176,7 +176,7 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
   class Prefixes < TemplateEagerLoaderTest
     def setup
       super
-      resolver.stubs(:find_all)
+      resolver.stubs(:find_all).returns([])
     end
 
     def test_prefixes_calls_view_paths
@@ -185,7 +185,7 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
     end
 
     def test_prefixes_returns_desired_results
-      resolver.expects(:find_all).with(anything,'people', anything, anything, anything, anything)
+      resolver.expects(:find_all).with(anything,'people', anything, anything, anything, anything).returns([])
       subject.eager_load
     end
 
@@ -193,8 +193,8 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
       subject.stubs(:prefixes).returns(['prefix1', 'prefix2'])
       subject.stubs(:path_names).with('prefix1').returns(['index.html.erb'])
       subject.stubs(:path_names).with('prefix2').returns(['index.html.erb'])
-      resolver.expects(:find_all).with(anything, 'prefix1', anything, anything, anything, anything)
-      resolver.expects(:find_all).with(anything, 'prefix2', anything, anything, anything, anything)
+      resolver.expects(:find_all).with(anything, 'prefix1', anything, anything, anything, anything).returns([])
+      resolver.expects(:find_all).with(anything, 'prefix2', anything, anything, anything, anything).returns([])
       subject.eager_load
     end
   end

--- a/actionview/test/template/template_eager_loader_test.rb
+++ b/actionview/test/template/template_eager_loader_test.rb
@@ -14,15 +14,10 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
 
   include TemplateEagerLoaderTestHelper
 
-  def setup
-    subject.stubs(:path_names).with('people').returns(['index.html.erb'])
-    subject.stubs(:view_paths).returns(['app/views/people/index.html.erb'])
-  end
-
-  class PrefixesReturnsPeople < TemplateEagerLoaderTest
+  class BasicViewsTests < TemplateEagerLoaderTest
     def setup
       super
-      subject.stubs(:prefixes).returns(['people'])
+      subject.stubs(:views).returns([['people', 'index.html.erb']])
     end
 
     def test_cache_templates_calls_find_all
@@ -73,7 +68,7 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
     class PartialTests < TemplateEagerLoaderTest
       def setup
         super
-        subject.stubs(:path_names).with(anything).returns(['_partial.html.erb'])
+        subject.stubs(:views).with(anything).returns([['prefix', '_partial.html.erb']])
       end
 
       def test_cache_templates_parses_partial_names
@@ -104,7 +99,7 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
     end
 
     def test_formats_work_without_the_extension_in_filename
-      subject.stubs(:path_names).with(anything).returns(['index.haml'])
+      subject.stubs(:views).with(anything).returns([['prefix', 'index.haml']])
       resolver.expects(:find_all).with(anything, anything, anything, has_entry(formats: [:html]), anything, anything).returns([])
       subject.eager_load
     end
@@ -138,7 +133,7 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
     end
 
     def test_details_variants_get_set_correctly
-      subject.stubs(:path_names).with(anything).returns(['index.html+variant.erb'])
+      subject.stubs(:views).with(anything).returns([['people', 'new.html+variant.erb']])
       resolver.expects(:find_all).with(anything, anything, anything, has_entry(variants: ['variant']), anything, anything).returns([])
       subject.eager_load
     end
@@ -154,17 +149,11 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
     end
   end
 
-  class NestedPrefixes < TemplateEagerLoaderTest
+  class NestedPrefixesTests < TemplateEagerLoaderTest
     def setup
       super
-      subject.stubs(:path_names).with('people/assets').returns(['index.html.erb'])
-      subject.stubs(:view_paths).returns(['app/views/people/assets/index.html.erb'])
+      subject.stubs(:views).returns([['people/assets', 'index.html.erb']])
       resolver.stubs(:find_all).returns([])
-    end
-
-    def test_two_layer_nested_prefixes_calls_view_paths
-      subject.expects(:view_paths).returns(['app/views/people/assets/index.html.erb'])
-      subject.eager_load
     end
 
     def test_two_layer_nested_prefixes_returns_desired_results
@@ -179,20 +168,14 @@ class TemplateEagerLoaderTest < ActiveSupport::TestCase
       resolver.stubs(:find_all).returns([])
     end
 
-    def test_prefixes_calls_view_paths
-      subject.expects(:view_paths).returns(['app/views/people/index.html.erb'])
-      subject.eager_load
-    end
-
     def test_prefixes_returns_desired_results
+      subject.stubs(:view_paths).returns(['people/index.html.erb'])
       resolver.expects(:find_all).with(anything,'people', anything, anything, anything, anything).returns([])
       subject.eager_load
     end
 
     def test_cache_templates_multiple_prefixes
-      subject.stubs(:prefixes).returns(['prefix1', 'prefix2'])
-      subject.stubs(:path_names).with('prefix1').returns(['index.html.erb'])
-      subject.stubs(:path_names).with('prefix2').returns(['index.html.erb'])
+      subject.stubs(:views).returns([['prefix1', 'index.html.erb'], ['prefix2', 'index.html.erb']])
       resolver.expects(:find_all).with(anything, 'prefix1', anything, anything, anything, anything).returns([])
       resolver.expects(:find_all).with(anything, 'prefix2', anything, anything, anything, anything).returns([])
       subject.eager_load

--- a/actionview/test/template/template_eager_loader_test.rb
+++ b/actionview/test/template/template_eager_loader_test.rb
@@ -1,0 +1,161 @@
+require 'abstract_unit'
+require 'mocha/setup' # FIXME: stop using mocha
+
+class TemplateEagerLoaderTest < ActiveSupport::TestCase
+  module TemplateEagerLoaderTestHelper
+    def subject
+      @subject ||= ActionView::TemplateEagerLoader.new(resolver)
+    end
+
+    def resolver
+      @resolver ||= mock
+    end
+  end
+
+  include TemplateEagerLoaderTestHelper
+
+  def setup
+    subject.stubs(:path_names).with('people').returns(['index.html.erb'])
+    subject.stubs(:view_paths).returns(['app/views/people/index.html.erb'])
+  end
+
+  class PrefixesReturnsPeople < TemplateEagerLoaderTest
+    def setup
+      super
+      subject.stubs(:prefixes).returns(['people'])
+    end
+
+    def test_cache_templates_calls_find_all
+      resolver.expects(:find_all)
+      subject.eager_load
+    end
+
+    class PartialTests < TemplateEagerLoaderTest
+      def setup
+        super
+        subject.stubs(:path_names).with(anything).returns(['_partial.html.erb'])
+      end
+
+      def test_cache_templates_parses_partial_names
+        resolver.expects(:find_all).with('partial', anything, anything, anything, anything, anything).at_least_once
+        subject.eager_load
+      end
+
+      def test_cache_templates_passes_right_locals_with_partial
+        resolver.expects(:find_all).with('partial', anything, anything, anything, anything, %w(partial partial_counter partial_iteration))
+        resolver.expects(:find_all).with('partial', anything, anything, anything, anything, [])
+        subject.eager_load
+      end
+    end
+
+    def test_partials_and_locals_correct_when_not_a_partial
+      resolver.expects(:find_all).with(anything, anything, false, anything, anything, [])
+      subject.eager_load
+    end
+
+    def test_not_being_partial_does_not_lead_into_multiple_caching_attemps
+      resolver.expects(:find_all).at_most_once
+      subject.eager_load
+    end
+
+    def test_details_have_correct_formats
+      resolver.expects(:find_all).with(anything, anything, anything, has_entry(formats: [:html]), anything, anything)
+      subject.eager_load
+    end
+
+    def test_formats_work_without_the_extension_in_filename
+      subject.stubs(:path_names).with(anything).returns(['index.haml'])
+      resolver.expects(:find_all).with(anything, anything, anything, has_entry(formats: [:html]), anything, anything)
+      subject.eager_load
+    end
+
+    def test_details_locale_defaults_to_english
+      resolver.expects(:find_all).with(anything, anything, anything, has_entry(locale: [:en]), anything, anything)
+      subject.eager_load
+    end
+
+    def test_details_locale_works_with_other_default_than_english
+      I18n.stubs(:available_locales).returns([:other, :en])
+      I18n.stubs(:default_locale).returns([:other])
+      resolver.stubs(:find_all)
+      resolver.expects(:find_all).with(anything, anything, anything, has_entry(locale: [:other, :en]), anything, anything)
+      subject.eager_load
+    end
+
+    def test_details_locale_works_with_default_and_set_locale
+      I18n.stubs(:available_locales).returns([:fi, :en, :cn])
+      I18n.stubs(:default_locale).returns([:cn])
+      I18n.stubs(:locale).returns([:fi])
+      resolver.stubs(:find_all)
+      resolver.expects(:find_all).with(anything, anything, anything, has_entry(locale: [:fi, :en, :cn]), anything, anything)
+      subject.eager_load
+    end
+
+
+    def test_details_variants_is_not_set_when_view_is_not_a_variant
+      resolver.expects(:find_all).with(anything, anything, anything, has_entry(variants: []), anything, anything)
+      subject.eager_load
+    end
+
+    def test_details_variants_get_set_correctly
+      subject.stubs(:path_names).with(anything).returns(['index.html+variant.erb'])
+      resolver.expects(:find_all).with(anything, anything, anything, has_entry(variants: ['variant']), anything, anything)
+      subject.eager_load
+    end
+
+    def test_cache_templates_action
+      resolver.expects(:find_all).with('index', anything, anything, anything, anything, anything)
+      subject.eager_load
+    end
+
+    def test_cache_templates_prefix
+      resolver.expects(:find_all).with(anything, 'people', anything, anything, anything, anything)
+      subject.eager_load
+    end
+  end
+
+  class NestedPrefixes < TemplateEagerLoaderTest
+    def setup
+      super
+      subject.stubs(:path_names).with('people/assets').returns(['index.html.erb'])
+      subject.stubs(:view_paths).returns(['app/views/people/assets/index.html.erb'])
+      resolver.stubs(:find_all)
+    end
+
+    def test_two_layer_nested_prefixes_calls_view_paths
+      subject.expects(:view_paths).returns(['app/views/people/assets/index.html.erb'])
+      subject.eager_load
+    end
+
+    def test_two_layer_nested_prefixes_returns_desired_results
+      resolver.expects(:find_all).with(anything,'people/assets', anything, anything, anything, anything)
+      subject.eager_load
+    end
+  end
+
+  class Prefixes < TemplateEagerLoaderTest
+    def setup
+      super
+      resolver.stubs(:find_all)
+    end
+
+    def test_prefixes_calls_view_paths
+      subject.expects(:view_paths).returns(['app/views/people/index.html.erb'])
+      subject.eager_load
+    end
+
+    def test_prefixes_returns_desired_results
+      resolver.expects(:find_all).with(anything,'people', anything, anything, anything, anything)
+      subject.eager_load
+    end
+
+    def test_cache_templates_multiple_prefixes
+      subject.stubs(:prefixes).returns(['prefix1', 'prefix2'])
+      subject.stubs(:path_names).with('prefix1').returns(['index.html.erb'])
+      subject.stubs(:path_names).with('prefix2').returns(['index.html.erb'])
+      resolver.expects(:find_all).with(anything, 'prefix1', anything, anything, anything, anything)
+      resolver.expects(:find_all).with(anything, 'prefix2', anything, anything, anything, anything)
+      subject.eager_load
+    end
+  end
+end

--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add documentation for `config.action_view.eager_load_templates`
+
+    *Juho Leinonen*, *Qian Zhou*, *Henrik Nygren*, *Jussi Mertanen*
+
 *   New section in Active Record Association Basics: Single Table Inheritance
 
     *Andrey Nering*

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -68,6 +68,8 @@ These configuration methods are to be called on a `Rails::Railtie` object, such 
 
 * `config.action_view.cache_template_loading` controls whether or not templates should be reloaded on each request. Defaults to whatever is set for `config.cache_classes`.
 
+* `config.action_view.eager_load_templates` controls whether or not templates should be cached and compiled on server startup.
+
 * `config.beginning_of_week` sets the default beginning of week for the
 application. Accepts a valid week day symbol (e.g. `:monday`).
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -444,7 +444,10 @@ module Rails
       super
       require "rails/tasks"
       task :environment do
-        ActiveSupport.on_load(:before_initialize) { config.eager_load = false }
+        ActiveSupport.on_load(:before_initialize) do
+          config.eager_load = false
+          config.action_view.eager_load_templates = false
+        end
 
         require_environment!
       end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -10,6 +10,9 @@ Rails.application.configure do
   # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
 
+  # Eager load view templates on boot. Ignored by rake tasks.
+  config.action_view.eager_load_templates = true
+
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true


### PR DESCRIPTION
Implement eager loading of view templates on server startup. This adds an option to cache and compile all possible view templates when the server starts. Set 'config.action_view.eager_load_templates' to true to enable this.

cc @tenderlove  @matthewd 
