### PR TITLE
Prevent broken `Content-Type` from raising exceptions

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -9,11 +9,7 @@ module ActionDispatch
       # Returns both GET and POST \parameters in a single hash.
       def parameters
         @env["action_dispatch.request.parameters"] ||= begin
-          params = begin
-            request_parameters.merge(query_parameters)
-          rescue EOFError
-            query_parameters.dup
-          end
+          params = request_parameters.merge(query_parameters)
           params.merge!(path_parameters)
         end
       end

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -318,7 +318,11 @@ module ActionDispatch
     # Override Rack's POST method to support indifferent access
     def POST
       @env["action_dispatch.request.request_parameters"] ||= Utils.deep_munge(normalize_encode_params(super || {}))
-    rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e
+    rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError, EOFError => e
+      if e.is_a?(EOFError) && get?
+        return {}
+      end
+
       raise ActionController::BadRequest.new(:request, e)
     end
     alias :request_parameters :POST

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -17,6 +17,10 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
       head :ok
     end
 
+    def parse_broken_multipart
+      render text: request.request_parameters
+    end
+
     def read
       render :text => "File: #{params[:uploaded_data].read}"
     end
@@ -154,6 +158,18 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
       headers = { "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x" }
       get "/parse", headers: headers
       assert_response :ok
+    end
+  end
+
+  test "does not raise EOFError on POST request with broken content-type" do
+    with_routing do |set|
+      set.draw do
+        post ':action', controller: 'multipart_params_parsing_test/test'
+      end
+      headers = { "CONTENT_TYPE" => "multipart/form-data; boundary=---------------------------41184676334" }
+      post "/parse_broken_multipart", headers: headers
+
+      assert_equal 400, response.status
     end
   end
 


### PR DESCRIPTION
My app gets requests from bots like this one:

```
{
  "REQUEST_METHOD" => "POST",
  "REQUEST_PATH" => "/index.php",
  "REQUEST_URI" => "/index.php?option=com_jce&task=plugin&plugin=imgmanager&file=imgmanager&method=form&cid=20&6bc427c8a7981f4fe1f5ac65c1246b5f=cf6dd3cf1923c950586d0dd595c8e20b",
  "SERVER_PROTOCOL" => "HTTP/1.0",
  "HTTP_VERSION" => "HTTP/1.0",
  "HTTP_HOST" => "example.com",
  "HTTP_X_SENDFILE_TYPE" => "X-Accel-Redirect",
  "HTTP_CONNECTION" => "close",
  "CONTENT_LENGTH" => "2286",
  "HTTP_X_FORWARDED_PROTO" => "http",
  "HTTP_USER_AGENT" => "BOT/0.1 (BOT for JCE)",
  "CONTENT_TYPE" => "multipart/form-data; boundary=---------------------------41184676334",
  "SERVER_NAME" => "example.com",
  "SERVER_PORT" => "80",
  "SERVER_SOFTWARE" => "Unicorn 4.8.3",
  "ORIGINAL_FULLPATH" => "/index.php?option=com_jce&task=plugin&plugin=imgmanager&file=imgmanager&method=form&cid=20&6bc427c8a7981f4fe1f5ac65c1246b5f=cf6dd3cf1923c950586d0dd595c8e20b"
}
```

This requests contents broken `CONTENT_TYPE` value, which leads to uncaught `EOFError` in production thrown by Rack parser.
I guess we should avoid such uncaught exceptions.

Similar with https://github.com/rails/rails/commit/bc254cc23558f016c3697ecd5d39e58f46908018
