### PR TITLE
Add `ActiveSupport::TimeZone#from_offset`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `ActiveSupport::TimeZone#from_offset`
+
+    When given a specific offset, use the first result found where the
+    total current offset (including any periodic deviations such as DST)
+    from UTC is equal. Takes a time to use as context, or defaults to
+    the current local time.
+
+    *Yasyf Mohamedali*
+
 *   `Date.to_s` doesn't produce too many spaces. For example, `to_s(:short)`
     will now produce `01 Feb` instead of ` 1 Feb`.
 

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -942,6 +942,14 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < ActiveSupport::TestCase
     end
   end
 
+  def test_in_time_zone_with_dst
+    travel_to Time.utc(2014, 5, 20, 4, 59, 59) do
+      zone = ActiveSupport::TimeZone.from_offset -4
+      time = Time.now.in_time_zone zone
+      assert_equal -4.hours, time.time_zone.utc_total_offset
+    end
+  end
+
   def test_in_time_zone_with_invalid_argument
     assert_raise(ArgumentError) {  @t.in_time_zone("No such timezone exists") }
     assert_raise(ArgumentError) { @dt.in_time_zone("No such timezone exists") }


### PR DESCRIPTION
When given a specific offset, use the first result found where the
total current offset (including any periodic deviations such as DST)
from UTC is equal. Takes a time to use as context, or defaults to
the current local time.
