### PR TITLE
Upd pg json_test

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -25,6 +25,7 @@ module PostgresqlJSONSharedTestCases
 
   def teardown
     @connection.drop_table :json_data_type, if_exists: true
+    JsonDataType.reset_column_information
   end
 
   def test_column


### PR DESCRIPTION
PostgresQL [json_test] tests both json and jsonb data types using tables with the same name.
I've recently upgraded to PostgresQL 9.4 and I'm using rails dev virtual box. And I've seen the following errors from time to time:

```
1) Error:
PostgresqlJSONBTest#test_rewrite:
ActiveRecord::StatementInvalid: PG::DatatypeMismatch: ERROR:  column "payload" is of type jsonb but expression is of type json at character 41
HINT:  You will need to rewrite or cast the expression.

1) Failure:
PostgresqlJSONBTest#test_column [/vagrant/rails/activerecord/test/cases/adapters/postgresql/json_test.rb:32]:
Expected: :jsonb
  Actual: :json
```

I don't remember whether I saw such errors when were using 9.3. But the patch is simple: use different tables.
