### PR TITLE
Renaming transactional fixtures to transactional tests

### DIFF
--- a/actionview/test/active_record_unit.rb
+++ b/actionview/test/active_record_unit.rb
@@ -76,7 +76,7 @@ class ActiveRecordTestCase < ActionController::TestCase
   # Set our fixture path
   if ActiveRecordTestConnector.able_to_connect
     self.fixture_path = [FIXTURE_LOAD_PATH]
-    self.use_transactional_fixtures = false
+    self.use_transactional_tests = false
   end
 
   def self.fixtures(*args)

--- a/activejob/test/support/integration/test_case_helpers.rb
+++ b/activejob/test/support/integration/test_case_helpers.rb
@@ -5,7 +5,7 @@ module TestCaseHelpers
   extend ActiveSupport::Concern
 
   included do
-    self.use_transactional_fixtures = false
+    self.use_transactional_tests = false
 
     setup do
       clear_jobs

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Renaming `use_transactional_fixtures` to `use_transactional_tests` for clarity.
+
+    Fixes #18864.
+
+    *Brandon Weiss*
+
 *   Increase pg gem version requirement to `~> 0.18`. Earlier versions of the
     pg gem are known to have problems with Ruby 2.2.
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -226,7 +226,7 @@ module ActiveRecord
   end
 
   class AdapterTestWithoutTransaction < ActiveRecord::TestCase
-    self.use_transactional_fixtures = false
+    self.use_transactional_tests = false
 
     class Klass < ActiveRecord::Base
     end

--- a/activerecord/test/cases/adapters/mysql/consistency_test.rb
+++ b/activerecord/test/cases/adapters/mysql/consistency_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class MysqlConsistencyTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   class Consistency < ActiveRecord::Base
     self.table_name = "mysql_consistency"

--- a/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
@@ -71,7 +71,7 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
 
   #fixtures
   self.use_instantiated_fixtures = true
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   #activerecord model class with reserved-word table name
   def test_activerecord_model

--- a/activerecord/test/cases/adapters/mysql/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/mysql/unsigned_type_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class UnsignedTypeTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   class UnsignedType < ActiveRecord::Base
   end

--- a/activerecord/test/cases/adapters/mysql2/boolean_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/boolean_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class Mysql2BooleanTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   class BooleanType < ActiveRecord::Base
     self.table_name = "mysql_booleans"

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -71,7 +71,7 @@ class MysqlReservedWordTest < ActiveRecord::TestCase
 
   #fixtures
   self.use_instantiated_fixtures = true
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   #activerecord model class with reserved-word table name
   def test_activerecord_model

--- a/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class UnsignedTypeTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   class UnsignedType < ActiveRecord::Base
   end

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -12,7 +12,7 @@ class PostgresqlLtree < ActiveRecord::Base
 end
 
 class PostgresqlDataTypeTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   def setup
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class PostgresqlExtensionMigrationTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   class EnableHstore < ActiveRecord::Migration
     def change

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -7,7 +7,7 @@ if ActiveRecord::Base.connection.supports_ranges?
   end
 
   class PostgresqlRangeTest < ActiveRecord::TestCase
-    self.use_transactional_fixtures = false
+    self.use_transactional_tests = false
     include ConnectionHelper
 
     def setup

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -2,7 +2,7 @@ require 'cases/helper'
 require 'support/connection_helper'
 
 class PostgreSQLReferentialIntegrityTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   include ConnectionHelper
 

--- a/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
@@ -4,7 +4,7 @@ class SchemaThing < ActiveRecord::Base
 end
 
 class SchemaAuthorizationTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   TABLE_NAME = 'schema_things'
   COLUMNS = [

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -3,7 +3,7 @@ require 'models/default'
 require 'support/schema_dumping_helper'
 
 class SchemaTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   SCHEMA_NAME = 'test_schema'
   SCHEMA2_NAME = 'test_schema2'

--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -5,7 +5,7 @@ require 'models/topic'
 class PostgresqlTimestampTest < ActiveRecord::TestCase
   class PostgresqlTimestampWithZone < ActiveRecord::Base; end
 
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   setup do
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     class SQLite3AdapterTest < ActiveRecord::TestCase
       include DdlHelper
 
-      self.use_transactional_fixtures = false
+      self.use_transactional_tests = false
 
       class DualEncoding < ActiveRecord::Base
       end

--- a/activerecord/test/cases/ar_schema_test.rb
+++ b/activerecord/test/cases/ar_schema_test.rb
@@ -3,7 +3,7 @@ require "cases/helper"
 if ActiveRecord::Base.connection.supports_migrations?
 
   class ActiveRecordSchemaTest < ActiveRecord::TestCase
-    self.use_transactional_fixtures = false
+    self.use_transactional_tests = false
 
     setup do
       @original_verbose = ActiveRecord::Migration.verbose

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -12,7 +12,7 @@ require 'models/image'
 require 'models/post'
 
 class HasOneAssociationsTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
   fixtures :accounts, :companies, :developers, :projects, :developers_projects, :ships, :pirates
 
   def setup

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -17,7 +17,7 @@ require 'models/engine'
 require 'models/car'
 
 class AssociationsJoinModelTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
 
   fixtures :posts, :authors, :categories, :categorizations, :comments, :tags, :taggings, :author_favorites, :vertices, :items, :books,
     # Reload edges table from fixtures as otherwise repeated test was failing

--- a/activerecord/test/cases/associations/required_test.rb
+++ b/activerecord/test/cases/associations/required_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class RequiredAssociationsTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   class Parent < ActiveRecord::Base
   end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -629,7 +629,7 @@ class TestDefaultAutosaveAssociationOnNewRecord < ActiveRecord::TestCase
 end
 
 class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   setup do
     @pirate = Pirate.create(:catchphrase => "Don' botharrr talkin' like one, savvy?")
@@ -637,7 +637,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
   end
 
   teardown do
-    # We are running without transactional fixtures and need to cleanup.
+    # We are running without transactional tests and need to cleanup.
     Bird.delete_all
     Parrot.delete_all
     @ship.delete
@@ -1009,7 +1009,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
 end
 
 class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
 
   def setup
     super
@@ -1145,7 +1145,7 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
 end
 
 class TestAutosaveAssociationOnAHasOneThroughAssociation < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
 
   def setup
     super
@@ -1166,7 +1166,7 @@ class TestAutosaveAssociationOnAHasOneThroughAssociation < ActiveRecord::TestCas
 end
 
 class TestAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
 
   def setup
     super
@@ -1414,7 +1414,7 @@ module AutosaveAssociationOnACollectionAssociationTests
 end
 
 class TestAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
 
   def setup
     super
@@ -1430,7 +1430,7 @@ class TestAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCase
 end
 
 class TestAutosaveAssociationOnAHasAndBelongsToManyAssociation < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
 
   def setup
     super
@@ -1447,7 +1447,7 @@ class TestAutosaveAssociationOnAHasAndBelongsToManyAssociation < ActiveRecord::T
 end
 
 class TestAutosaveAssociationOnAHasAndBelongsToManyAssociationWithAcceptsNestedAttributes < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
 
   def setup
     super
@@ -1464,7 +1464,7 @@ class TestAutosaveAssociationOnAHasAndBelongsToManyAssociationWithAcceptsNestedA
 end
 
 class TestAutosaveAssociationValidationsOnAHasManyAssociation < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
 
   def setup
     super
@@ -1481,7 +1481,7 @@ class TestAutosaveAssociationValidationsOnAHasManyAssociation < ActiveRecord::Te
 end
 
 class TestAutosaveAssociationValidationsOnAHasOneAssociation < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
 
   def setup
     super
@@ -1504,7 +1504,7 @@ class TestAutosaveAssociationValidationsOnAHasOneAssociation < ActiveRecord::Tes
 end
 
 class TestAutosaveAssociationValidationsOnABelongsToAssociation < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
 
   def setup
     super
@@ -1525,7 +1525,7 @@ class TestAutosaveAssociationValidationsOnABelongsToAssociation < ActiveRecord::
 end
 
 class TestAutosaveAssociationValidationsOnAHABTMAssociation < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
 
   def setup
     super
@@ -1548,7 +1548,7 @@ class TestAutosaveAssociationValidationsOnAHABTMAssociation < ActiveRecord::Test
 end
 
 class TestAutosaveAssociationValidationMethodsGeneration < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
 
   def setup
     super

--- a/activerecord/test/cases/date_time_precision_test.rb
+++ b/activerecord/test/cases/date_time_precision_test.rb
@@ -4,7 +4,7 @@ require 'support/schema_dumping_helper'
 if ActiveRecord::Base.connection.supports_datetime_with_precision?
 class DateTimePrecisionTest < ActiveRecord::TestCase
   include SchemaDumpingHelper
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   class Foo < ActiveRecord::Base; end
 

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -90,14 +90,14 @@ end
 if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
   class DefaultsTestWithoutTransactionalFixtures < ActiveRecord::TestCase
     # ActiveRecord::Base#create! (and #save and other related methods) will
-    # open a new transaction. When in transactional fixtures mode, this will
+    # open a new transaction. When in transactional tests mode, this will
     # cause Active Record to create a new savepoint. However, since MySQL doesn't
     # support DDL transactions, creating a table will result in any created
     # savepoints to be automatically released. This in turn causes the savepoint
     # release code in AbstractAdapter#transaction to fail.
     #
-    # We don't want that to happen, so we disable transactional fixtures here.
-    self.use_transactional_fixtures = false
+    # We don't want that to happen, so we disable transactional tests here.
+    self.use_transactional_tests = false
 
     def using_strict(strict)
       connection = ActiveRecord::Base.remove_connection

--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -4,7 +4,7 @@ class TestRecord < ActiveRecord::Base
 end
 
 class TestDisconnectedAdapter < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   def setup
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -28,7 +28,7 @@ require 'tempfile'
 
 class FixturesTest < ActiveRecord::TestCase
   self.use_instantiated_fixtures = true
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   # other_topics fixture should not be included here
   fixtures :topics, :developers, :accounts, :tasks, :categories, :funny_jokes, :binaries, :traffic_lights
@@ -419,7 +419,7 @@ end
 
 class TransactionalFixturesTest < ActiveRecord::TestCase
   self.use_instantiated_fixtures = true
-  self.use_transactional_fixtures = true
+  self.use_transactional_tests = true
 
   fixtures :topics
 
@@ -511,7 +511,7 @@ class CheckSetTableNameFixturesTest < ActiveRecord::TestCase
   fixtures :funny_jokes
   # Set to false to blow away fixtures cache and ensure our fixtures are loaded
   # and thus takes into account our set_fixture_class
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   def test_table_method
     assert_kind_of Joke, funny_jokes(:a_joke)
@@ -523,7 +523,7 @@ class FixtureNameIsNotTableNameFixturesTest < ActiveRecord::TestCase
   fixtures :items
   # Set to false to blow away fixtures cache and ensure our fixtures are loaded
   # and thus takes into account our set_fixture_class
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   def test_named_accessor
     assert_kind_of Book, items(:dvd)
@@ -535,7 +535,7 @@ class FixtureNameIsNotTableNameMultipleFixturesTest < ActiveRecord::TestCase
   fixtures :items, :funny_jokes
   # Set to false to blow away fixtures cache and ensure our fixtures are loaded
   # and thus takes into account our set_fixture_class
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   def test_named_accessor_of_differently_named_fixture
     assert_kind_of Book, items(:dvd)
@@ -549,7 +549,7 @@ end
 class CustomConnectionFixturesTest < ActiveRecord::TestCase
   set_fixture_class :courses => Course
   fixtures :courses
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   def test_leaky_destroy
     assert_nothing_raised { courses(:ruby) }
@@ -564,7 +564,7 @@ end
 class TransactionalFixturesOnCustomConnectionTest < ActiveRecord::TestCase
   set_fixture_class :courses => Course
   fixtures :courses
-  self.use_transactional_fixtures = true
+  self.use_transactional_tests = true
 
   def test_leaky_destroy
     assert_nothing_raised { courses(:ruby) }
@@ -580,7 +580,7 @@ class InvalidTableNameFixturesTest < ActiveRecord::TestCase
   fixtures :funny_jokes
   # Set to false to blow away fixtures cache and ensure our fixtures are loaded
   # and thus takes into account our lack of set_fixture_class
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   def test_raises_error
     assert_raise ActiveRecord::FixtureClassNotFound do
@@ -594,7 +594,7 @@ class CheckEscapedYamlFixturesTest < ActiveRecord::TestCase
   fixtures :funny_jokes
   # Set to false to blow away fixtures cache and ensure our fixtures are loaded
   # and thus takes into account our set_fixture_class
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   def test_proper_escaped_fixture
     assert_equal "The \\n Aristocrats\nAte the candy\n", funny_jokes(:another_joke).name
@@ -664,7 +664,7 @@ class LoadAllFixturesWithPathnameTest < ActiveRecord::TestCase
 end
 
 class FasterFixturesTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
   fixtures :categories, :authors
 
   def load_extra_fixture(name)

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -143,7 +143,7 @@ class ActiveSupport::TestCase
 
   self.fixture_path = FIXTURES_ROOT
   self.use_instantiated_fixtures  = false
-  self.use_transactional_fixtures = true
+  self.use_transactional_tests = true
 
   def create_fixtures(*fixture_set_names, &block)
     ActiveRecord::FixtureSet.create_fixtures(ActiveSupport::TestCase.fixture_path, fixture_set_names, fixture_class_names, &block)

--- a/activerecord/test/cases/hot_compatibility_test.rb
+++ b/activerecord/test/cases/hot_compatibility_test.rb
@@ -1,7 +1,7 @@
 require 'cases/helper'
 
 class HotCompatibilityTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   setup do
     @klass = Class.new(ActiveRecord::Base) do

--- a/activerecord/test/cases/invalid_connection_test.rb
+++ b/activerecord/test/cases/invalid_connection_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 
 class TestAdapterWithInvalidConnection < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   class Bird < ActiveRecord::Base
   end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -285,10 +285,10 @@ end
 class OptimisticLockingWithSchemaChangeTest < ActiveRecord::TestCase
   fixtures :people, :legacy_things, :references
 
-  # need to disable transactional fixtures, because otherwise the sqlite3
+  # need to disable transactional tests, because otherwise the sqlite3
   # adapter (at least) chokes when we try and change the schema in the middle
   # of a test (see test_increment_counter_*).
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   { :lock_version => Person, :custom_lock_version => LegacyThing }.each do |name, model|
     define_method("test_increment_counter_updates_#{name}") do
@@ -365,7 +365,7 @@ end
 # (See exec vs. async_exec in the PostgreSQL adapter.)
 unless in_memory_db?
   class PessimisticLockingTest < ActiveRecord::TestCase
-    self.use_transactional_fixtures = false
+    self.use_transactional_tests = false
     fixtures :people, :readers
 
     def setup

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -426,7 +426,7 @@ module ActiveRecord
 
     if ActiveRecord::Base.connection.supports_foreign_keys?
       class ChangeSchemaWithDependentObjectsTest < ActiveRecord::TestCase
-        self.use_transactional_fixtures = false
+        self.use_transactional_tests = false
 
         setup do
           @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     class ColumnAttributesTest < ActiveRecord::TestCase
       include ActiveRecord::Migration::TestHelper
 
-      self.use_transactional_fixtures = false
+      self.use_transactional_tests = false
 
       def test_add_column_newline_default
         string = "foo\nbar"

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     class ColumnsTest < ActiveRecord::TestCase
       include ActiveRecord::Migration::TestHelper
 
-      self.use_transactional_fixtures = false
+      self.use_transactional_tests = false
 
       # FIXME: this is more of an integration test with AR::Base and the
       # schema modifications.  Maybe we should move this?

--- a/activerecord/test/cases/migration/logger_test.rb
+++ b/activerecord/test/cases/migration/logger_test.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   class Migration
     class LoggerTest < ActiveRecord::TestCase
       # MySQL can't roll back ddl changes
-      self.use_transactional_fixtures = false
+      self.use_transactional_tests = false
 
       Migration = Struct.new(:name, :version) do
         def disable_ddl_transaction; false end

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     class ReferencesStatementsTest < ActiveRecord::TestCase
       include ActiveRecord::Migration::TestHelper
 
-      self.use_transactional_fixtures = false
+      self.use_transactional_tests = false
 
       def setup
         super

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     class RenameTableTest < ActiveRecord::TestCase
       include ActiveRecord::Migration::TestHelper
 
-      self.use_transactional_fixtures = false
+      self.use_transactional_tests = false
 
       def setup
         super

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -24,7 +24,7 @@ class Reminder < ActiveRecord::Base; end
 class Thing < ActiveRecord::Base; end
 
 class MigrationTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   fixtures :people
 

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require "cases/migration/helper"
 
 class MigratorTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   # Use this class to sense if migrations have gone
   # up or down.

--- a/activerecord/test/cases/multiple_db_test.rb
+++ b/activerecord/test/cases/multiple_db_test.rb
@@ -4,7 +4,7 @@ require 'models/bird'
 require 'models/course'
 
 class MultipleDbTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   def setup
     @courses  = create_fixtures("courses") { Course.retrieve_connection }

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -943,7 +943,7 @@ class TestNestedAttributesWithNonStandardPrimaryKeys < ActiveRecord::TestCase
 end
 
 class TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
 
   def setup
     @pirate = Pirate.create!(:catchphrase => "My baby takes tha mornin' train!")
@@ -983,7 +983,7 @@ class TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations < ActiveRe
 end
 
 class TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false unless supports_savepoints?
+  self.use_transactional_tests = false unless supports_savepoints?
 
   def setup
     @ship = Ship.create!(:name => "The good ship Dollypop")

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -898,7 +898,7 @@ class PersistenceTest < ActiveRecord::TestCase
   end
 
   class SaveTest < ActiveRecord::TestCase
-    self.use_transactional_fixtures = false
+    self.use_transactional_tests = false
 
     def test_save_touch_false
       widget = Class.new(ActiveRecord::Base) do

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -3,7 +3,7 @@ require "models/project"
 require "timeout"
 
 class PooledConnectionsTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   def setup
     @per_test_teardown = []

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -178,7 +178,7 @@ class PrimaryKeysTest < ActiveRecord::TestCase
 end
 
 class PrimaryKeyWithNoConnectionTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   unless in_memory_db?
     def test_set_primary_key_with_no_connection
@@ -199,7 +199,7 @@ end
 class PrimaryKeyAnyTypeTest < ActiveRecord::TestCase
   include SchemaDumpingHelper
 
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   class Barcode < ActiveRecord::Base
   end
@@ -229,7 +229,7 @@ end
 
 if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
   class PrimaryKeyWithAnsiQuotesTest < ActiveRecord::TestCase
-    self.use_transactional_fixtures = false
+    self.use_transactional_tests = false
 
     def test_primary_key_method_with_ansi_quotes
       con = ActiveRecord::Base.connection
@@ -245,7 +245,7 @@ if current_adapter?(:PostgreSQLAdapter, :MysqlAdapter, :Mysql2Adapter)
   class PrimaryKeyBigSerialTest < ActiveRecord::TestCase
     include SchemaDumpingHelper
 
-    self.use_transactional_fixtures = false
+    self.use_transactional_tests = false
 
     class Widget < ActiveRecord::Base
     end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -3,7 +3,7 @@ require 'support/schema_dumping_helper'
 
 class SchemaDumperTest < ActiveRecord::TestCase
   include SchemaDumpingHelper
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   setup do
     ActiveRecord::SchemaMigration.create_table

--- a/activerecord/test/cases/test_fixtures_test.rb
+++ b/activerecord/test/cases/test_fixtures_test.rb
@@ -1,0 +1,36 @@
+require 'cases/helper'
+
+class TestFixturesTest < ActiveRecord::TestCase
+  setup do
+    @klass = Class.new
+    @klass.send(:include, ActiveRecord::TestFixtures)
+  end
+
+  def test_deprecated_use_transactional_fixtures=
+    assert_deprecated 'use use_transactional_tests= instead' do
+      @klass.use_transactional_fixtures = true
+    end
+  end
+
+  def test_use_transactional_tests_prefers_use_transactional_fixtures
+    ActiveSupport::Deprecation.silence do
+      @klass.use_transactional_fixtures = false
+    end
+
+    assert_equal false, @klass.use_transactional_tests
+  end
+
+  def test_use_transactional_tests_defaults_to_true
+    ActiveSupport::Deprecation.silence do
+      @klass.use_transactional_fixtures = nil
+    end
+
+    assert_equal true, @klass.use_transactional_tests
+  end
+
+  def test_use_transactional_tests_can_be_overriden
+    @klass.use_transactional_tests = "foobar"
+
+    assert_equal "foobar", @klass.use_transactional_tests
+  end
+end

--- a/activerecord/test/cases/time_precision_test.rb
+++ b/activerecord/test/cases/time_precision_test.rb
@@ -4,7 +4,7 @@ require 'support/schema_dumping_helper'
 if ActiveRecord::Base.connection.supports_datetime_with_precision?
 class TimePrecisionTest < ActiveRecord::TestCase
   include SchemaDumpingHelper
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   class Foo < ActiveRecord::Base; end
 

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -450,7 +450,7 @@ end
 
 class TimestampsWithoutTransactionTest < ActiveRecord::TestCase
   include DdlHelper
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   class TimestampAttributePost < ActiveRecord::Base
     attr_accessor :created_at, :updated_at

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -367,7 +367,7 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
 end
 
 class CallbacksOnMultipleActionsTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   class TopicWithCallbacksOnMultipleActions < ActiveRecord::Base
     self.table_name = :topics

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -2,7 +2,7 @@ require 'cases/helper'
 
 unless ActiveRecord::Base.connection.supports_transaction_isolation?
   class TransactionIsolationUnsupportedTest < ActiveRecord::TestCase
-    self.use_transactional_fixtures = false
+    self.use_transactional_tests = false
 
     class Tag < ActiveRecord::Base
     end
@@ -17,7 +17,7 @@ end
 
 if ActiveRecord::Base.connection.supports_transaction_isolation?
   class TransactionIsolationTest < ActiveRecord::TestCase
-    self.use_transactional_fixtures = false
+    self.use_transactional_tests = false
 
     class Tag < ActiveRecord::Base
       self.table_name = 'tags'

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -9,7 +9,7 @@ require 'models/post'
 require 'models/movie'
 
 class TransactionTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
   fixtures :topics, :developers, :authors, :posts
 
   def setup
@@ -703,7 +703,7 @@ class TransactionTest < ActiveRecord::TestCase
 end
 
 class TransactionsWithTransactionalFixturesTest < ActiveRecord::TestCase
-  self.use_transactional_fixtures = true
+  self.use_transactional_tests = true
   fixtures :topics
 
   def test_automatic_savepoint_in_outer_transaction

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -4,7 +4,7 @@ class TestRecord < ActiveRecord::Base
 end
 
 class TestUnconnectedAdapter < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   def setup
     @underlying = ActiveRecord::Base.connection


### PR DESCRIPTION
I think the name "transactional fixtures" is a little misleading and confusing, because (as far as I can tell) it doesn't really have anything to do with fixtures.

This is pretty embarrassing, but I've been using Rails almost since 1.0 and I had no idea that transactional fixtures were running on my tests. I don't use fixtures so I just erroneously assumed that feature didn't work for me. I've been using Database Cleaner unnecessarily for like the last four years. I know, it seems ridiculous, but I talked to a few other fairly savvy Rails users and they had no idea either. I'm beginning to think my misunderstanding is fairly common.

To make the feature less confusing and its intent clearer I've renamed "transactional fixtures" to "transactional tests". I deprecated the old usage and made it backwards-compatible so either will work but the new one will be preferred.

Let me know what you think!
