### PR TITLE
Allow `joins` to be unscoped (4-2-stable)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow `joins` to be unscoped.
+
+    Backport of #18109.
+
+    *Takashi Kokubun*, *Andrey Novikov*
+
 *   Fix default `format` value in `ActiveRecord::Tasks::DatabaseTasks#schema_file`.
 
     *James Cox*

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -52,7 +52,17 @@ module ActiveRecord
             end
             scope_chain_index += 1
 
-            scope_chain_items.concat [klass.send(:build_default_scope, ActiveRecord::Relation.create(klass, table))].compact
+            klass_scope =
+                if klass.current_scope
+                  klass.current_scope.clone
+                else
+                  relation = ActiveRecord::Relation.create(
+                      klass,
+                      table,
+                  )
+                  klass.send(:build_default_scope, relation)
+                end
+            scope_chain_items.concat [klass_scope].compact
 
             rel = scope_chain_items.inject(scope_chain_items.shift) do |left, right|
               left.merge right

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -353,6 +353,10 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_equal 10, DeveloperCalledJamis.unscoped { DeveloperCalledJamis.poor }.length
   end
 
+  def test_unscoped_with_joins_should_not_have_default_scope
+    assert_equal FirstPost.unscoped { Comment.joins(:post_with_default_scope).to_a }, Comment.joins(:post).to_a
+  end
+
   def test_default_scope_select_ignored_by_aggregations
     assert_equal DeveloperWithSelect.all.to_a.count, DeveloperWithSelect.count
   end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -14,6 +14,7 @@ class Comment < ActiveRecord::Base
   has_many :ratings
 
   belongs_to :first_post, :foreign_key => :post_id
+  belongs_to :post_with_default_scope, :foreign_key => :post_id
 
   has_many :children, :class_name => 'Comment', :foreign_key => :parent_id
   belongs_to :parent, :class_name => 'Comment', :counter_cache => :children_count


### PR DESCRIPTION
Backport of #18109 by @kokubun for 4.2.x

Fixes the code like

``` ruby
FirstPost.unscoped do
  Comment.joins(:post_with_default_scope) # Here all the posts should be loaded, not only scope ones
end
```

Will make people from #13775 happy before the 5.0 release (and me too!)
