### PR TITLE
Return truthy value from head method

### DIFF
--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -38,6 +38,8 @@ module ActionController
         headers.delete('Content-Type')
         headers.delete('Content-Length')
       end
+      
+      true
     end
 
     private

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -173,6 +173,11 @@ class TestController < ActionController::Base
     head :forbidden, :x_custom_header => "something"
   end
 
+  def head_and_return
+    head :ok and return
+    raise 'should not reach this line'
+  end
+
   def head_with_no_content
     # Fill in the headers with dummy data to make
     # sure they get removed during the testing
@@ -559,6 +564,12 @@ class HeadRenderTest < ActionController::TestCase
     assert_equal "Forbidden", @response.message
     assert_equal "something", @response.headers["X-Custom-Header"]
     assert_response :forbidden
+  end
+
+  def test_head_returns_truthy_value
+    assert_nothing_raised do
+      get :head_and_return
+    end
   end
 end
 


### PR DESCRIPTION
It was returning false in normal circumstances.
This broke the `head :ok and return if` construct.
