### PR TITLE
Require pg ~> 0.18 to ensure Ruby 2.2 compatibility

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Increase pg gem version requirement to `~> 0.18`. Earlier versions of the
+    pg gem are known to have problems with Ruby 2.2.
+
+    *Matt Brictson*
+
 *   Correctly dump `serial` and `bigserial`.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -12,8 +12,8 @@ require "active_record/connection_adapters/statement_pool"
 
 require 'arel/visitors/bind_visitor'
 
-# Make sure we're using pg high enough for PGResult#values
-gem 'pg', '~> 0.15'
+# Make sure we're using pg high enough for Ruby 2.2+ compatibility
+gem 'pg', '~> 0.18'
 require 'pg'
 
 require 'ipaddr'


### PR DESCRIPTION
Since Rails 5 will require Ruby 2.2+, I think we should bump the pg gem requirement to `~> 0.18`.

There is apparently a nasty bug with earlier pg versions when used with Ruby 2.2. To summarize:  pg < 0.18 when used with Ruby 2.2 has a known bug that causes random bits to be added to the end of strings.

Further explanation here:

> Sorry for the trouble, but you can not use pg < 0.18.0 together with Ruby-2.2 safely.

https://bitbucket.org/ged/ruby-pg/issue/210/crazy-bytes-being-added-to-record
