### PR TITLE
testing.md job testing example incomplete

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1155,6 +1155,8 @@ within a model:
 require 'test_helper'
 
 class ProductTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   test 'billing job scheduling' do
     assert_enqueued_with(job: BillingJob) do
       product.charge(account)


### PR DESCRIPTION
The section for "Testing Jobs Inside Other Components" contains an example that is missing "include ActiveJob::TestHelper".
