### PR TITLE
Isolate access to .default_scopes in ActiveRecord::Scoping::Default

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -432,8 +432,7 @@ module ActiveRecord
       def get_records
         if reflection.scope_chain.any?(&:any?) ||
           scope.eager_loading? ||
-          klass.current_scope ||
-          klass.default_scopes.any?
+          klass.scope_attributes?
 
           return scope.to_a
         end

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -41,8 +41,7 @@ module ActiveRecord
         def get_records
           if reflection.scope_chain.any?(&:any?) ||
               scope.eager_loading? ||
-              klass.current_scope ||
-              klass.default_scopes.any?
+              klass.scope_attributes?
 
             return scope.limit(1).to_a
           end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -123,8 +123,7 @@ module ActiveRecord
         return super unless ids.length == 1
         return super if block_given? ||
                         primary_key.nil? ||
-                        default_scopes.any? ||
-                        current_scope ||
+                        scope_attributes? ||
                         columns_hash.include?(inheritance_column) ||
                         ids.first.kind_of?(Array)
 
@@ -152,8 +151,7 @@ module ActiveRecord
       end
 
       def find_by(*args) # :nodoc:
-        return super if current_scope || !(Hash === args.first) || reflect_on_all_aggregations.any?
-        return super if default_scopes.any?
+        return super if scope_attributes? || !(Hash === args.first) || reflect_on_all_aggregations.any?
 
         hash = args.first
 

--- a/activerecord/lib/active_record/scoping.rb
+++ b/activerecord/lib/active_record/scoping.rb
@@ -17,6 +17,17 @@ module ActiveRecord
       def current_scope=(scope) #:nodoc:
         ScopeRegistry.set_value_for(:current_scope, self.to_s, scope)
       end
+
+      # Collects attributes from scopes that should be applied when creating
+      # an AR instance for the particular class this is called on.
+      def scope_attributes # :nodoc:
+        all.scope_for_create
+      end
+
+      # Are there attributes associated with this scope?
+      def scope_attributes? # :nodoc:
+        current_scope
+      end
     end
 
     def populate_with_current_scope_attributes

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -33,6 +33,11 @@ module ActiveRecord
           block_given? ? relation.scoping { yield } : relation
         end
 
+        # Are there attributes associated with this scope?
+        def scope_attributes? # :nodoc:
+          super || default_scopes.any?
+        end
+
         def before_remove_const #:nodoc:
           self.current_scope = nil
         end

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -39,17 +39,6 @@ module ActiveRecord
           end
         end
 
-        # Collects attributes from scopes that should be applied when creating
-        # an AR instance for the particular class this is called on.
-        def scope_attributes # :nodoc:
-          all.scope_for_create
-        end
-
-        # Are there default attributes associated with this scope?
-        def scope_attributes? # :nodoc:
-          current_scope || default_scopes.any?
-        end
-
         # Adds a class method for retrieving and querying objects. A \scope
         # represents a narrowing of a database query, such as
         # <tt>where(color: :red).select('shirts.*').includes(:washing_instructions)</tt>.


### PR DESCRIPTION
Instead use .scope_attributes? consistently in ActiveRecord to check whether
there are attributes currently associated with the scope.

Move the implementation of .scope_attributes? and .scope_attributes to
ActiveRecord::Scoping because they don't particularly have to do specifically
with Named scopes and their only dependency, in the case of
.scope_attributes?, and only caller, in the case of .scope_attributes is
contained in Scoping.
