### PR TITLE
Use request.session.id instead of request.session_options[:id]

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -201,7 +201,7 @@ module ActionController
       super
 
       self.session = TestSession.new
-      self.session_options = TestSession::DEFAULT_OPTIONS.merge(:id => SecureRandom.hex(16))
+      self.session_options = TestSession::DEFAULT_OPTIONS
     end
 
     def assign_parameters(routes, controller_path, action, parameters = {})

--- a/actionpack/test/controller/request/test_request_test.rb
+++ b/actionpack/test/controller/request/test_request_test.rb
@@ -24,12 +24,4 @@ class ActionController::TestRequestTest < ActiveSupport::TestCase
     end
   end
 
-  def test_session_id_exists_by_default
-    assert_not_nil(@request.session_options[:id])
-  end
-
-  def test_session_id_different_on_each_call
-    assert_not_equal(@request.session_options[:id], ActionController::TestRequest.new.session_options[:id])
-  end
-
 end

--- a/actionpack/test/dispatch/session/cache_store_test.rb
+++ b/actionpack/test/dispatch/session/cache_store_test.rb
@@ -22,7 +22,7 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
     end
 
     def get_session_id
-      render :text => "#{request.session_options[:id]}"
+      render :text => "#{request.session.id}"
     end
 
     def call_reset_session

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -29,7 +29,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
     end
 
     def get_session_id
-      render :text => "id: #{request.session_options[:id]}"
+      render :text => "id: #{request.session.id}"
     end
 
     def get_class_after_reset_session
@@ -53,7 +53,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
     end
 
     def change_session_id
-      request.session_options[:id] = nil
+      request.session.options[:id] = nil
       get_session_id
     end
 

--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -23,7 +23,7 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
     end
 
     def get_session_id
-      render :text => "#{request.session_options[:id]}"
+      render :text => "#{request.session.id}"
     end
 
     def call_reset_session


### PR DESCRIPTION
As of the upgrade to Rack 1.5, request.session_options[:id] is no longer populated. Reflect this change in the tests by using request.session.id instead.

Related change in Rack:
https://github.com/rack/rack/commit/83a270d6
