### PR TITLE
Fix typo in the Testing Your Mailers docs

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1083,7 +1083,7 @@ Testing mailer classes requires some specific tools to do a thorough job.
 
 ### Keeping the Postman in Check
 
-Your mailer classes - like every other part of your Rails application - should be tested to ensure that it is working as expected.
+Your mailer classes - like every other part of your Rails application - should be tested to ensure that they are working as expected.
 
 The goals of testing your mailer classes are to ensure that:
 


### PR DESCRIPTION
> Your mailer classes […] should be tested to ensure that _they are_ working as expected.
