### PR TITLE
Added missing closing brace in sample code of i18n guide

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -707,7 +707,7 @@ you can safely pass the username as set by the user:
 
 ```erb
 <%# This is safe, it is going to be escaped if needed. %>
-<%= t('welcome_html', username: @current_user.username %>
+<%= t('welcome_html', username: @current_user.username) %>
 ```
 
 Safe strings on the other hand are interpolated verbatim.


### PR DESCRIPTION
Noticed a small typo in the i18n docs and fixed it. A closing brace was missing in a call to the `t` view helper.
