### PR TITLE
Add `rake initializer`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `rake initializer`
+
+    This task prints out initializers for an application. It is useful to
+    develop a rubygem which involves the initialization process.
+
+    *Naoto Kaneko*
+
 *   Created rake restart task. Restarts your Rails app by touching the 
     `tmp/restart.txt`.
 

--- a/railties/lib/rails/tasks.rb
+++ b/railties/lib/rails/tasks.rb
@@ -4,6 +4,7 @@ require 'rake'
 %w(
   annotations
   framework
+  initializer
   log
   middleware
   misc

--- a/railties/lib/rails/tasks/initializer.rake
+++ b/railties/lib/rails/tasks/initializer.rake
@@ -1,0 +1,6 @@
+desc "Prints out initializers for your application"
+task initializer: :environment do
+  Rails.application.initializers.tsort_each do |initializer|
+    puts initializer.name
+  end
+end


### PR DESCRIPTION
This task prints out initializers for an application. It is useful to
develop a rubygem which involves the initialization process.
