### PR TITLE
Fix before_commit when updating a record on the callback

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -44,11 +44,12 @@ module ActiveRecord
       attr_reader :connection, :state, :records, :savepoint_name
       attr_writer :joinable
 
-      def initialize(connection, options)
+      def initialize(connection, options, run_commit_callbacks: false)
         @connection = connection
         @state = TransactionState.new
         @records = []
         @joinable = options.fetch(:joinable, true)
+        @run_commit_callbacks = run_commit_callbacks
       end
 
       def add_record(record)
@@ -75,18 +76,21 @@ module ActiveRecord
       end
 
       def before_commit_records
-        records.uniq.each(&:before_committed!)
+        records.uniq.each(&:before_committed!) if @run_commit_callbacks
       end
 
       def commit_records
         ite = records.uniq
         while record = ite.shift
-          record.committed!
+          if @run_commit_callbacks
+            record.committed!
+          else
+            # if not running callbacks, only adds the record to the parent transaction
+            record.add_to_transaction
+          end
         end
       ensure
-        ite.each do |i|
-          i.committed!(should_run_callbacks: false)
-        end
+        ite.each { |i| i.committed!(should_run_callbacks: false) }
       end
 
       def full_rollback?; true; end
@@ -97,8 +101,8 @@ module ActiveRecord
 
     class SavepointTransaction < Transaction
 
-      def initialize(connection, savepoint_name, options)
-        super(connection, options)
+      def initialize(connection, savepoint_name, options, *args)
+        super(connection, options, *args)
         if options[:isolation]
           raise ActiveRecord::TransactionIsolationError, "cannot set transaction isolation in a nested transaction"
         end
@@ -120,7 +124,7 @@ module ActiveRecord
 
     class RealTransaction < Transaction
 
-      def initialize(connection, options)
+      def initialize(connection, options, *args)
         super
         if options[:isolation]
           connection.begin_isolated_db_transaction(options[:isolation])
@@ -147,11 +151,13 @@ module ActiveRecord
       end
 
       def begin_transaction(options = {})
+        run_commit_callbacks = !current_transaction.joinable?
         transaction =
           if @stack.empty?
-            RealTransaction.new(@connection, options)
+            RealTransaction.new(@connection, options, run_commit_callbacks: run_commit_callbacks)
           else
-            SavepointTransaction.new(@connection, "active_record_#{@stack.size}", options)
+            SavepointTransaction.new(@connection, "active_record_#{@stack.size}", options,
+                                     run_commit_callbacks: run_commit_callbacks)
           end
 
         @stack.push(transaction)
@@ -159,18 +165,11 @@ module ActiveRecord
       end
 
       def commit_transaction
-        inner_transaction = @stack.pop
-
-        if current_transaction.joinable?
-          inner_transaction.commit
-          inner_transaction.records.each do |r|
-            r.add_to_transaction
-          end
-        else
-          inner_transaction.before_commit_records
-          inner_transaction.commit
-          inner_transaction.commit_records
-        end
+        transaction = @stack.last
+        transaction.before_commit_records
+        @stack.pop
+        transaction.commit
+        transaction.commit_records
       end
 
       def rollback_transaction(transaction = nil)


### PR DESCRIPTION
This is fixing a bug, and refactoring the code a bit.
#### Bug:

`before_commit` was called after the transaction was poped from the stack, that caused any update on that callback to not join that transaction.

I fixed that bug in here, and cleaned up the code on `commit_transaction` , so now, the `commit_records` or `add_to_transaction` decision is on the transaction object, which is the one that holds the records anyways.
I think this implementation is cleaner, so instead of we check the `joinable` flag on the commit, we check when we create a new transaction.
I would like to know what @jeremy things about this tho.

(#19324 is falling because of we need this fix for the `touch` calls)
