### PR TITLE
Change Integer#year to return a Fixnum instead of a Float to improve consistency

### DIFF
--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -629,13 +629,13 @@ class HttpCacheForeverTest < ActionController::TestCase
 
   def test_cache_with_public
     get :cache_me_forever, params: {public: true}
-    assert_equal "max-age=#{100.years.to_i}, public", @response.headers["Cache-Control"]
+    assert_equal "max-age=#{100.years}, public", @response.headers["Cache-Control"]
     assert_not_nil @response.etag
   end
 
   def test_cache_with_private
     get :cache_me_forever
-    assert_equal "max-age=#{100.years.to_i}, private", @response.headers["Cache-Control"]
+    assert_equal "max-age=#{100.years}, private", @response.headers["Cache-Control"]
     assert_not_nil @response.etag
     assert_response :success
   end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Change Integer#year to return a Fixnum instead of a Float to improve
+    consistency.
+
+    Integer#years returned a Float while the rest of the accompanying methods
+    (days, weeks, months, etc.) return a Fixnum.
+
+    Before:
+
+    1.year # => 31557600.0
+
+    After:
+
+    1.year # => 31557600
+
+    *Konstantinos Rousis*
+
 *   Handle invalid UTF-8 strings when HTML escaping
 
     Use `ActiveSupport::Multibyte::Unicode.tidy_bytes` to handle invalid UTF-8

--- a/activesupport/lib/active_support/core_ext/integer/time.rb
+++ b/activesupport/lib/active_support/core_ext/integer/time.rb
@@ -23,7 +23,7 @@ class Integer
   alias :month :months
 
   def years
-    ActiveSupport::Duration.new(self * 365.25.days, [[:years, self]])
+    ActiveSupport::Duration.new(self * 365.25.days.to_i, [[:years, self]])
   end
   alias :year :years
 end


### PR DESCRIPTION
`Integer#years` returns a Float while the rest of the accompanying methods return a `Fixnum`.

This PR converts the constant `365.25.days` to an integer to ensure that `Integer#years` returns a `Fixnum` as well and improve the consistency of the API.

Closes #19320.
