### PR TITLE
linkify the active_support/core_ext guide

### DIFF
--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -3,16 +3,19 @@ namespace :guides do
   desc 'Generate guides (for authors), use ONLY=foo to process just "foo.md"'
   task :generate => 'generate:html'
 
+
+  
   namespace :generate do
 
+
     desc "Generate HTML guides"
-    task :html do
+    task :html => 'md_files' do
       ENV["WARN_BROKEN_LINKS"] = "1" # authors can't disable this
       ruby "rails_guides.rb"
     end
 
     desc "Generate .mobi file. The kindlegen executable must be in your PATH. You can get it for free from http://www.amazon.com/gp/feature.html?docId=1000765211"
-    task :kindle do
+    task :kindle => 'md_files' do
       unless `kindlerb -v 2> /dev/null` =~ /kindlerb 0.1.1/
         abort "Please `gem install kindlerb` and make sure you have `kindlegen` in your PATH"
       end
@@ -22,6 +25,12 @@ namespace :guides do
       ENV['KINDLE'] = '1'
       Rake::Task['guides:generate:html'].invoke
     end
+
+    rule '.md' => '.md.erb' do |t|
+      sh "erb -T- #{t.source} > #{t.name}"
+    end
+    desc "Generate md files from md.erb files inside the source directory"
+    task 'md_files' => FileList.new('source/*.md.erb').ext('')
   end
 
   # Validate guides -------------------------------------------------------------------------
@@ -42,7 +51,7 @@ You can generate HTML, Kindle or both formats using the `guides:generate` task.
 
 All of these processes are handled via rake tasks, here's a full list of them:
 
-#{%x[rake -T]}
+    #{%x[rake -T]}
 Some arguments may be passed via environment variables:
 
   WARNINGS=1
@@ -74,6 +83,7 @@ Examples:
   $ rake guides:generate GUIDES_LANGUAGE=es
     help
   end
+
 end
 
-task :default => 'guides:help'
+task :default => [ 'guides:help' ]

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -66,7 +66,7 @@ module RailsGuides
   class Generator
     attr_reader :guides_dir, :source_dir, :output_dir, :edge, :warnings, :all
 
-    GUIDES_RE = /\.(?:erb|md)\z/
+    GUIDES_RE = /\.(?:html\.erb|md)\z/
 
     def initialize(output=nil)
       set_flags_from_environment

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -37,7 +37,7 @@ The most lightweight way to get `blank?` is to cherry-pick the file that defines
 
 For every single method defined as a core extension this guide has a note that says where such a method is defined. In the case of `blank?` the note reads:
 
-NOTE: Defined in `active_support/core_ext/object/blank.rb`.
+NOTE: Defined in [active_support/core_ext/object/blank.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/blank.rb).
 
 That means that you can require it like this:
 
@@ -121,7 +121,7 @@ def set_conditional_cache_control!
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/object/blank.rb`.
+NOTE: Defined in [active_support/core_ext/object/blank.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/blank.rb).
 
 ### `presence`
 
@@ -131,7 +131,7 @@ The `presence` method returns its receiver if `present?`, and `nil` otherwise. I
 host = config[:host].presence || 'localhost'
 ```
 
-NOTE: Defined in `active_support/core_ext/object/blank.rb`.
+NOTE: Defined in [active_support/core_ext/object/blank.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/blank.rb).
 
 ### `duplicable?`
 
@@ -168,7 +168,7 @@ By definition all objects are `duplicable?` except `nil`, `false`, `true`, symbo
 
 WARNING: Any class can disallow duplication by removing `dup` and `clone` or raising exceptions from them. Thus only `rescue` can tell whether a given arbitrary object is duplicable. `duplicable?` depends on the hard-coded list above, but it is much faster than `rescue`. Use it only if you know the hard-coded list is enough in your use case.
 
-NOTE: Defined in `active_support/core_ext/object/duplicable.rb`.
+NOTE: Defined in [active_support/core_ext/object/duplicable.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/duplicable.rb).
 
 ### `deep_dup`
 
@@ -213,7 +213,7 @@ duplicate = number.deep_dup
 number.object_id == duplicate.object_id   # => true
 ```
 
-NOTE: Defined in `active_support/core_ext/object/deep_dup.rb`.
+NOTE: Defined in [active_support/core_ext/object/deep_dup.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/deep_dup.rb).
 
 ### `try`
 
@@ -248,7 +248,7 @@ end
 @person.try { |p| "#{p.first_name} #{p.last_name}" }
 ```
 
-NOTE: Defined in `active_support/core_ext/object/try.rb`.
+NOTE: Defined in [active_support/core_ext/object/try.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/try.rb).
 
 ### `class_eval(*args, &block)`
 
@@ -269,7 +269,7 @@ class Proc
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/kernel/singleton_class.rb`.
+NOTE: Defined in [active_support/core_ext/kernel/singleton_class.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/kernel/singleton_class.rb).
 
 ### `acts_like?(duck)`
 
@@ -288,7 +288,7 @@ some_klass.acts_like?(:string)
 
 Rails has classes that act like `Date` or `Time` and follow this contract.
 
-NOTE: Defined in `active_support/core_ext/object/acts_like.rb`.
+NOTE: Defined in [active_support/core_ext/object/acts_like.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/acts_like.rb).
 
 ### `to_param`
 
@@ -332,7 +332,7 @@ user_path(@user) # => "/users/357-john-smith"
 
 WARNING. Controllers need to be aware of any redefinition of `to_param` because when a request like that comes in "357-john-smith" is the value of `params[:id]`.
 
-NOTE: Defined in `active_support/core_ext/object/to_param.rb`.
+NOTE: Defined in [active_support/core_ext/object/to_param.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/to_param.rb).
 
 ### `to_query`
 
@@ -381,7 +381,7 @@ The method `Hash#to_query` accepts an optional namespace for the keys:
 # => "user%5Bid%5D=89&user%5Bname%5D=John+Smith"
 ```
 
-NOTE: Defined in `active_support/core_ext/object/to_query.rb`.
+NOTE: Defined in [active_support/core_ext/object/to_query.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/to_query.rb).
 
 ### `with_options`
 
@@ -422,13 +422,13 @@ end
 
 TIP: Since `with_options` forwards calls to its receiver they can be nested. Each nesting level will merge inherited defaults in addition to their own.
 
-NOTE: Defined in `active_support/core_ext/object/with_options.rb`.
+NOTE: Defined in [active_support/core_ext/object/with_options.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/with_options.rb).
 
 ### JSON support
 
 Active Support provides a better implementation of `to_json` than the `json` gem ordinarily provides for Ruby objects. This is because some classes, like `Hash`, `OrderedHash` and `Process::Status` need special handling in order to provide a proper JSON representation.
 
-NOTE: Defined in `active_support/core_ext/object/json.rb`.
+NOTE: Defined in [active_support/core_ext/object/json.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/json.rb).
 
 ### Instance Variables
 
@@ -449,7 +449,7 @@ end
 C.new(0, 1).instance_values # => {"x" => 0, "y" => 1}
 ```
 
-NOTE: Defined in `active_support/core_ext/object/instance_variables.rb`.
+NOTE: Defined in [active_support/core_ext/object/instance_variables.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/instance_variables.rb).
 
 #### `instance_variable_names`
 
@@ -465,7 +465,7 @@ end
 C.new(0, 1).instance_variable_names # => ["@x", "@y"]
 ```
 
-NOTE: Defined in `active_support/core_ext/object/instance_variables.rb`.
+NOTE: Defined in [active_support/core_ext/object/instance_variables.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/instance_variables.rb).
 
 ### Silencing Warnings and Exceptions
 
@@ -484,7 +484,7 @@ suppress(ActiveRecord::StaleObjectError) do
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/kernel/reporting.rb`.
+NOTE: Defined in [active_support/core_ext/kernel/reporting.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/kernel/reporting.rb).
 
 ### `in?`
 
@@ -499,7 +499,7 @@ Examples of `in?`:
 1.in?(1)            # => ArgumentError
 ```
 
-NOTE: Defined in `active_support/core_ext/object/inclusion.rb`.
+NOTE: Defined in [active_support/core_ext/object/inclusion.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/inclusion.rb).
 
 Extensions to `Module`
 ----------------------
@@ -552,7 +552,7 @@ end
 
 Rails uses `alias_method_chain` all over the code base. For example validations are added to `ActiveRecord::Base#save` by wrapping the method that way in a separate module specialized in validations.
 
-NOTE: Defined in `active_support/core_ext/module/aliasing.rb`.
+NOTE: Defined in [active_support/core_ext/module/aliasing.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/aliasing.rb).
 
 ### Attributes
 
@@ -568,7 +568,7 @@ class User < ActiveRecord::Base
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/module/aliasing.rb`.
+NOTE: Defined in [active_support/core_ext/module/aliasing.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/aliasing.rb).
 
 #### Internal Attributes
 
@@ -606,7 +606,7 @@ module ActionView
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/module/attr_internal.rb`.
+NOTE: Defined in [active_support/core_ext/module/attr_internal.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/attr_internal.rb).
 
 #### Module Attributes
 
@@ -633,7 +633,7 @@ module ActiveSupport
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/module/attribute_accessors.rb`.
+NOTE: Defined in [active_support/core_ext/module/attribute_accessors.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb).
 
 ### Parents
 
@@ -658,7 +658,7 @@ If the module is anonymous or belongs to the top-level, `parent` returns `Object
 
 WARNING: Note that in that case `parent_name` returns `nil`.
 
-NOTE: Defined in `active_support/core_ext/module/introspection.rb`.
+NOTE: Defined in [active_support/core_ext/module/introspection.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/introspection.rb).
 
 #### `parent_name`
 
@@ -681,7 +681,7 @@ For top-level or anonymous modules `parent_name` returns `nil`.
 
 WARNING: Note that in that case `parent` returns `Object`.
 
-NOTE: Defined in `active_support/core_ext/module/introspection.rb`.
+NOTE: Defined in [active_support/core_ext/module/introspection.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/introspection.rb).
 
 #### `parents`
 
@@ -700,7 +700,7 @@ X::Y::Z.parents # => [X::Y, X, Object]
 M.parents       # => [X::Y, X, Object]
 ```
 
-NOTE: Defined in `active_support/core_ext/module/introspection.rb`.
+NOTE: Defined in [active_support/core_ext/module/introspection.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/introspection.rb).
 
 ### Constants
 
@@ -723,7 +723,7 @@ X::Y.local_constants # => [:Y1, :X1]
 
 The names are returned as symbols.
 
-NOTE: Defined in `active_support/core_ext/module/introspection.rb`.
+NOTE: Defined in [active_support/core_ext/module/introspection.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/introspection.rb).
 
 #### Qualified Constant Names
 
@@ -781,7 +781,7 @@ as in `const_defined?`.
 For coherence with the built-in methods only relative paths are accepted.
 Absolute qualified constant names like `::Math::PI` raise `NameError`.
 
-NOTE: Defined in `active_support/core_ext/module/qualified_const.rb`.
+NOTE: Defined in [active_support/core_ext/module/qualified_const.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/qualified_const.rb).
 
 ### Reachable
 
@@ -819,7 +819,7 @@ end
 orphan.reachable? # => false
 ```
 
-NOTE: Defined in `active_support/core_ext/module/reachable.rb`.
+NOTE: Defined in [active_support/core_ext/module/reachable.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/reachable.rb).
 
 ### Anonymous
 
@@ -860,7 +860,7 @@ m.anonymous? # => false
 
 though an anonymous module is unreachable by definition.
 
-NOTE: Defined in `active_support/core_ext/module/anonymous.rb`.
+NOTE: Defined in [active_support/core_ext/module/anonymous.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/anonymous.rb).
 
 ### Method Delegation
 
@@ -944,7 +944,7 @@ delegate :size, to: :attachment, prefix: :avatar
 
 In the previous example the macro generates `avatar_size` rather than `size`.
 
-NOTE: Defined in `active_support/core_ext/module/delegation.rb`
+NOTE: Defined in [active_support/core_ext/module/delegation.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/delegation.rb)
 
 ### Redefining Methods
 
@@ -952,7 +952,7 @@ There are cases where you need to define a method with `define_method`, but don'
 
 The method `redefine_method` prevents such a potential warning, removing the existing method before if needed.
 
-NOTE: Defined in `active_support/core_ext/module/remove_method.rb`
+NOTE: Defined in [active_support/core_ext/module/remove_method.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/remove_method.rb)
 
 Extensions to `Class`
 ---------------------
@@ -1039,7 +1039,7 @@ When `:instance_reader` is `false`, the instance predicate returns a `NoMethodEr
 
 If you do not want the instance predicate, pass `instance_predicate: false` and it will not be defined.
 
-NOTE: Defined in `active_support/core_ext/class/attribute.rb`
+NOTE: Defined in [active_support/core_ext/class/attribute.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/class/attribute.rb)
 
 #### `cattr_reader`, `cattr_writer`, and `cattr_accessor`
 
@@ -1092,7 +1092,7 @@ end
 
 A model may find it useful to set `:instance_accessor` to `false` as a way to prevent mass-assignment from setting the attribute.
 
-NOTE: Defined in `active_support/core_ext/module/attribute_accessors.rb`.
+NOTE: Defined in [active_support/core_ext/module/attribute_accessors.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb).
 
 ### Subclasses & Descendants
 
@@ -1116,7 +1116,7 @@ C.subclasses # => [B, D]
 
 The order in which these classes are returned is unspecified.
 
-NOTE: Defined in `active_support/core_ext/class/subclasses.rb`.
+NOTE: Defined in [active_support/core_ext/class/subclasses.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/class/subclasses.rb).
 
 #### `descendants`
 
@@ -1138,7 +1138,7 @@ C.descendants # => [B, A, D]
 
 The order in which these classes are returned is unspecified.
 
-NOTE: Defined in `active_support/core_ext/class/subclasses.rb`.
+NOTE: Defined in [active_support/core_ext/class/subclasses.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/class/subclasses.rb).
 
 Extensions to `String`
 ----------------------
@@ -1214,7 +1214,7 @@ def raw(stringish)
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/string/output_safety.rb`.
+NOTE: Defined in [active_support/core_ext/string/output_safety.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/output_safety.rb).
 
 #### Transformation
 
@@ -1242,7 +1242,7 @@ The method `remove` will remove all occurrences of the pattern:
 
 There's also the destructive version `String#remove!`.
 
-NOTE: Defined in `active_support/core_ext/string/filters.rb`.
+NOTE: Defined in [active_support/core_ext/string/filters.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/filters.rb).
 
 ### `squish`
 
@@ -1256,7 +1256,7 @@ There's also the destructive version `String#squish!`.
 
 Note that it handles both ASCII and Unicode whitespace.
 
-NOTE: Defined in `active_support/core_ext/string/filters.rb`.
+NOTE: Defined in [active_support/core_ext/string/filters.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/filters.rb).
 
 ### `truncate`
 
@@ -1294,7 +1294,7 @@ The option `:separator` can be a regexp:
 
 In above examples "dear" gets cut first, but then `:separator` prevents it.
 
-NOTE: Defined in `active_support/core_ext/string/filters.rb`.
+NOTE: Defined in [active_support/core_ext/string/filters.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/filters.rb).
 
 ### `truncate_words`
 
@@ -1326,7 +1326,7 @@ The option `:separator` can be a regexp:
 # => "Oh dear! Oh dear!..."
 ```
 
-NOTE: Defined in `active_support/core_ext/string/filters.rb`.
+NOTE: Defined in [active_support/core_ext/string/filters.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/filters.rb).
 
 ### `inquiry`
 
@@ -1346,7 +1346,7 @@ Active Support defines 3rd person aliases of `String#start_with?` and `String#en
 "foo".ends_with?("o")   # => true
 ```
 
-NOTE: Defined in `active_support/core_ext/string/starts_ends_with.rb`.
+NOTE: Defined in [active_support/core_ext/string/starts_ends_with.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/starts_ends_with.rb).
 
 ### `strip_heredoc`
 
@@ -1371,7 +1371,7 @@ the user would see the usage message aligned against the left margin.
 Technically, it looks for the least indented line in the whole string, and removes
 that amount of leading whitespace.
 
-NOTE: Defined in `active_support/core_ext/string/strip.rb`.
+NOTE: Defined in [active_support/core_ext/string/strip.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/strip.rb).
 
 ### `indent`
 
@@ -1408,7 +1408,7 @@ The third argument, `indent_empty_lines`, is a flag that says whether empty line
 
 The `indent!` method performs indentation in-place.
 
-NOTE: Defined in `active_support/core_ext/string/indent.rb`.
+NOTE: Defined in [active_support/core_ext/string/indent.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/indent.rb).
 
 ### Access
 
@@ -1423,7 +1423,7 @@ Returns the character of the string at position `position`:
 "hello".at(10) # => nil
 ```
 
-NOTE: Defined in `active_support/core_ext/string/access.rb`.
+NOTE: Defined in [active_support/core_ext/string/access.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/access.rb).
 
 #### `from(position)`
 
@@ -1436,7 +1436,7 @@ Returns the substring of the string starting at position `position`:
 "hello".from(10) # => nil
 ```
 
-NOTE: Defined in `active_support/core_ext/string/access.rb`.
+NOTE: Defined in [active_support/core_ext/string/access.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/access.rb).
 
 #### `to(position)`
 
@@ -1449,19 +1449,19 @@ Returns the substring of the string up to position `position`:
 "hello".to(10) # => "hello"
 ```
 
-NOTE: Defined in `active_support/core_ext/string/access.rb`.
+NOTE: Defined in [active_support/core_ext/string/access.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/access.rb).
 
 #### `first(limit = 1)`
 
 The call `str.first(n)` is equivalent to `str.to(n-1)` if `n` > 0, and returns an empty string for `n` == 0.
 
-NOTE: Defined in `active_support/core_ext/string/access.rb`.
+NOTE: Defined in [active_support/core_ext/string/access.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/access.rb).
 
 #### `last(limit = 1)`
 
 The call `str.last(n)` is equivalent to `str.from(-n)` if `n` > 0, and returns an empty string for `n` == 0.
 
-NOTE: Defined in `active_support/core_ext/string/access.rb`.
+NOTE: Defined in [active_support/core_ext/string/access.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/access.rb).
 
 ### Inflections
 
@@ -1495,7 +1495,7 @@ def undecorated_table_name(class_name = base_class.name)
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
 
 #### `singularize`
 
@@ -1518,7 +1518,7 @@ def derive_class_name
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
 
 #### `camelize`
 
@@ -1566,7 +1566,7 @@ end
 
 `camelize` is aliased to `camelcase`.
 
-NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
 
 #### `underscore`
 
@@ -1605,7 +1605,7 @@ end
 
 INFO: As a rule of thumb you can think of `underscore` as the inverse of `camelize`, though there are cases where that does not hold. For example, `"SSLError".underscore.camelize` gives back `"SslError"`.
 
-NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
 
 #### `titleize`
 
@@ -1618,7 +1618,7 @@ The method `titleize` capitalizes the words in the receiver:
 
 `titleize` is aliased to `titlecase`.
 
-NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
 
 #### `dasherize`
 
@@ -1639,7 +1639,7 @@ def reformat_name(name)
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
 
 #### `demodulize`
 
@@ -1667,7 +1667,7 @@ def counter_cache_column
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
 
 #### `deconstantize`
 
@@ -1692,7 +1692,7 @@ def qualified_const_set(path, value)
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
 
 #### `parameterize`
 
@@ -1705,7 +1705,7 @@ The method `parameterize` normalizes its receiver in a way that can be used in p
 
 In fact, the result string is wrapped in an instance of `ActiveSupport::Multibyte::Chars`.
 
-NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
 
 #### `tableize`
 
@@ -1719,7 +1719,7 @@ The method `tableize` is `underscore` followed by `pluralize`.
 
 As a rule of thumb, `tableize` returns the table name that corresponds to a given model for simple cases. The actual implementation in Active Record is not straight `tableize` indeed, because it also demodulizes the class name and checks a few options that may affect the returned string.
 
-NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
 
 #### `classify`
 
@@ -1739,7 +1739,7 @@ The method understands qualified table names:
 
 Note that `classify` returns a class name as a string. You can get the actual class object invoking `constantize` on it, explained next.
 
-NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
 
 #### `constantize`
 
@@ -1782,7 +1782,7 @@ rescue NameError => e
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
 
 #### `humanize`
 
@@ -1830,7 +1830,7 @@ def full_message
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
 
 #### `foreign_key`
 
@@ -1855,7 +1855,7 @@ Associations use this method to infer foreign keys, for example `has_one` and `h
 foreign_key = options[:foreign_key] || reflection.active_record.name.foreign_key
 ```
 
-NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
 
 ### Conversions
 
@@ -1882,7 +1882,7 @@ Please refer to the documentation of `Date._parse` for further details.
 
 INFO: The three of them return `nil` for blank receivers.
 
-NOTE: Defined in `active_support/core_ext/string/conversions.rb`.
+NOTE: Defined in [active_support/core_ext/string/conversions.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/conversions.rb).
 
 Extensions to `Numeric`
 -----------------------
@@ -1916,7 +1916,7 @@ Singular forms are aliased so you are able to say:
 1.megabyte # => 1048576
 ```
 
-NOTE: Defined in `active_support/core_ext/numeric/bytes.rb`.
+NOTE: Defined in [active_support/core_ext/numeric/bytes.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/numeric/bytes.rb).
 
 ### Time
 
@@ -2021,7 +2021,7 @@ Produce a string representation of a number in human-readable words:
 1234567890123456.to_s(:human)  # => "1.23 Quadrillion"
 ```
 
-NOTE: Defined in `active_support/core_ext/numeric/conversions.rb`.
+NOTE: Defined in [active_support/core_ext/numeric/conversions.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/numeric/conversions.rb).
 
 Extensions to `Integer`
 -----------------------
@@ -2035,7 +2035,7 @@ The method `multiple_of?` tests whether an integer is multiple of the argument:
 1.multiple_of?(2) # => false
 ```
 
-NOTE: Defined in `active_support/core_ext/integer/multiple.rb`.
+NOTE: Defined in [active_support/core_ext/integer/multiple.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/integer/multiple.rb).
 
 ### `ordinal`
 
@@ -2050,7 +2050,7 @@ The method `ordinal` returns the ordinal suffix string corresponding to the rece
 -134.ordinal # => "th"
 ```
 
-NOTE: Defined in `active_support/core_ext/integer/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/integer/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/integer/inflections.rb).
 
 ### `ordinalize`
 
@@ -2065,7 +2065,7 @@ The method `ordinalize` returns the ordinal string corresponding to the receiver
 -134.ordinalize # => "-134th"
 ```
 
-NOTE: Defined in `active_support/core_ext/integer/inflections.rb`.
+NOTE: Defined in [active_support/core_ext/integer/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/integer/inflections.rb).
 
 Extensions to `BigDecimal`
 --------------------------
@@ -2137,7 +2137,7 @@ The sum of an empty receiver can be customized in this form as well:
 [].sum(1) {|n| n**3} # => 1
 ```
 
-NOTE: Defined in `active_support/core_ext/enumerable.rb`.
+NOTE: Defined in [active_support/core_ext/enumerable.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/enumerable.rb).
 
 ### `index_by`
 
@@ -2152,7 +2152,7 @@ invoices.index_by(&:number)
 
 WARNING. Keys should normally be unique. If the block returns the same value for different elements no collection is built for that key. The last item will win.
 
-NOTE: Defined in `active_support/core_ext/enumerable.rb`.
+NOTE: Defined in [active_support/core_ext/enumerable.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/enumerable.rb).
 
 ### `many?`
 
@@ -2170,7 +2170,7 @@ If an optional block is given, `many?` only takes into account those elements th
 @see_more = videos.many? {|video| video.category == params[:category]}
 ```
 
-NOTE: Defined in `active_support/core_ext/enumerable.rb`.
+NOTE: Defined in [active_support/core_ext/enumerable.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/enumerable.rb).
 
 ### `exclude?`
 
@@ -2180,7 +2180,7 @@ The predicate `exclude?` tests whether a given object does **not** belong to the
 to_visit << node if visited.exclude?(node)
 ```
 
-NOTE: Defined in `active_support/core_ext/enumerable.rb`.
+NOTE: Defined in [active_support/core_ext/enumerable.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/enumerable.rb).
 
 ### `without`
 
@@ -2191,7 +2191,7 @@ removed:
 people.without("Aaron", "Todd")
 ```
 
-NOTE: Defined in `active_support/core_ext/enumerable.rb`.
+NOTE: Defined in [active_support/core_ext/enumerable.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/enumerable.rb).
 
 Extensions to `Array`
 ---------------------
@@ -2220,7 +2220,7 @@ The methods `second`, `third`, `fourth`, and `fifth` return the corresponding el
 %w(a b c d).fifth # => nil
 ```
 
-NOTE: Defined in `active_support/core_ext/array/access.rb`.
+NOTE: Defined in [active_support/core_ext/array/access.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/access.rb).
 
 ### Adding Elements
 
@@ -2233,7 +2233,7 @@ This method is an alias of `Array#unshift`.
 [].prepend(10)            # => [10]
 ```
 
-NOTE: Defined in `active_support/core_ext/array/prepend_and_append.rb`.
+NOTE: Defined in [active_support/core_ext/array/prepend_and_append.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/prepend_and_append.rb).
 
 #### `append`
 
@@ -2244,7 +2244,7 @@ This method is an alias of `Array#<<`.
 [].append([1,2])         # => [[1,2]]
 ```
 
-NOTE: Defined in `active_support/core_ext/array/prepend_and_append.rb`.
+NOTE: Defined in [active_support/core_ext/array/prepend_and_append.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/prepend_and_append.rb).
 
 ### Options Extraction
 
@@ -2272,7 +2272,7 @@ end
 
 This method receives an arbitrary number of action names, and an optional hash of options as last argument. With the call to `extract_options!` you obtain the options hash and remove it from `actions` in a simple and explicit way.
 
-NOTE: Defined in `active_support/core_ext/array/extract_options.rb`.
+NOTE: Defined in [active_support/core_ext/array/extract_options.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/extract_options.rb).
 
 ### Conversions
 
@@ -2301,7 +2301,7 @@ The defaults for these options can be localized, their keys are:
 | `:words_connector`     | `support.array.words_connector`     |
 | `:last_word_connector` | `support.array.last_word_connector` |
 
-NOTE: Defined in `active_support/core_ext/array/conversions.rb`.
+NOTE: Defined in [active_support/core_ext/array/conversions.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/conversions.rb).
 
 #### `to_formatted_s`
 
@@ -2319,7 +2319,7 @@ invoice.lines.to_formatted_s(:db) # => "23,567,556,12"
 
 Integers in the example above are supposed to come from the respective calls to `id`.
 
-NOTE: Defined in `active_support/core_ext/array/conversions.rb`.
+NOTE: Defined in [active_support/core_ext/array/conversions.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/conversions.rb).
 
 #### `to_xml`
 
@@ -2420,7 +2420,7 @@ Contributor.limit(2).order(:rank).to_xml(skip_types: true)
 # </contributors>
 ```
 
-NOTE: Defined in `active_support/core_ext/array/conversions.rb`.
+NOTE: Defined in [active_support/core_ext/array/conversions.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/conversions.rb).
 
 ### Wrapping
 
@@ -2461,7 +2461,7 @@ which in Ruby 1.8 returns `[nil]` for `nil`, and calls to `Array(object)` otherw
 
 Thus, in this case the behavior is different for `nil`, and the differences with `Kernel#Array` explained above apply to the rest of `object`s.
 
-NOTE: Defined in `active_support/core_ext/array/wrap.rb`.
+NOTE: Defined in [active_support/core_ext/array/wrap.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/wrap.rb).
 
 ### Duplicating
 
@@ -2475,7 +2475,7 @@ dup[1][2] = 4
 array[1][2] == nil   # => true
 ```
 
-NOTE: Defined in `active_support/core_ext/object/deep_dup.rb`.
+NOTE: Defined in [active_support/core_ext/object/deep_dup.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/deep_dup.rb).
 
 ### Grouping
 
@@ -2513,7 +2513,7 @@ And you can tell the method not to fill the last group passing `false`:
 
 As a consequence `false` can't be a used as a padding value.
 
-NOTE: Defined in `active_support/core_ext/array/grouping.rb`.
+NOTE: Defined in [active_support/core_ext/array/grouping.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/grouping.rb).
 
 #### `in_groups(number, fill_with = nil)`
 
@@ -2551,7 +2551,7 @@ And you can tell the method not to fill the smaller groups passing `false`:
 
 As a consequence `false` can't be a used as a padding value.
 
-NOTE: Defined in `active_support/core_ext/array/grouping.rb`.
+NOTE: Defined in [active_support/core_ext/array/grouping.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/grouping.rb).
 
 #### `split(value = nil)`
 
@@ -2573,7 +2573,7 @@ Otherwise, the value received as argument, which defaults to `nil`, is the separ
 
 TIP: Observe in the previous example that consecutive separators result in empty arrays.
 
-NOTE: Defined in `active_support/core_ext/array/grouping.rb`.
+NOTE: Defined in [active_support/core_ext/array/grouping.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/grouping.rb).
 
 Extensions to `Hash`
 --------------------
@@ -2625,7 +2625,7 @@ By default the root node is "hash", but that's configurable via the `:root` opti
 
 The default XML builder is a fresh instance of `Builder::XmlMarkup`. You can configure your own builder with the `:builder` option. The method also accepts options like `:dasherize` and friends, they are forwarded to the builder.
 
-NOTE: Defined in `active_support/core_ext/hash/conversions.rb`.
+NOTE: Defined in [active_support/core_ext/hash/conversions.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/conversions.rb).
 
 ### Merging
 
@@ -2660,7 +2660,7 @@ options.reverse_merge!(length: 30, omission: "...")
 
 WARNING. Take into account that `reverse_merge!` may change the hash in the caller, which may or may not be a good idea.
 
-NOTE: Defined in `active_support/core_ext/hash/reverse_merge.rb`.
+NOTE: Defined in [active_support/core_ext/hash/reverse_merge.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb).
 
 #### `reverse_update`
 
@@ -2668,7 +2668,7 @@ The method `reverse_update` is an alias for `reverse_merge!`, explained above.
 
 WARNING. Note that `reverse_update` has no bang.
 
-NOTE: Defined in `active_support/core_ext/hash/reverse_merge.rb`.
+NOTE: Defined in [active_support/core_ext/hash/reverse_merge.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb).
 
 #### `deep_merge` and `deep_merge!`
 
@@ -2683,7 +2683,7 @@ Active Support defines `Hash#deep_merge`. In a deep merge, if a key is found in 
 
 The method `deep_merge!` performs a deep merge in place.
 
-NOTE: Defined in `active_support/core_ext/hash/deep_merge.rb`.
+NOTE: Defined in [active_support/core_ext/hash/deep_merge.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/deep_merge.rb).
 
 ### Deep duplicating
 
@@ -2701,7 +2701,7 @@ hash[:b][:e] == nil      # => true
 hash[:b][:d] == [3, 4]   # => true
 ```
 
-NOTE: Defined in `active_support/core_ext/object/deep_dup.rb`.
+NOTE: Defined in [active_support/core_ext/object/deep_dup.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/deep_dup.rb).
 
 ### Working with Keys
 
@@ -2722,7 +2722,7 @@ If the receiver responds to `convert_key`, the method is called on each of the a
 
 There's also the bang variant `except!` that removes keys in the very receiver.
 
-NOTE: Defined in `active_support/core_ext/hash/except.rb`.
+NOTE: Defined in [active_support/core_ext/hash/except.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/except.rb).
 
 #### `transform_keys` and `transform_keys!`
 
@@ -2764,7 +2764,7 @@ Besides that, one can use `deep_transform_keys` and `deep_transform_keys!` to pe
 # => {""=>nil, "1"=>1, "NESTED"=>{"A"=>3, "5"=>5}}
 ```
 
-NOTE: Defined in `active_support/core_ext/hash/keys.rb`.
+NOTE: Defined in [active_support/core_ext/hash/keys.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/keys.rb).
 
 #### `stringify_keys` and `stringify_keys!`
 
@@ -2806,7 +2806,7 @@ Besides that, one can use `deep_stringify_keys` and `deep_stringify_keys!` to st
 # => {""=>nil, "1"=>1, "nested"=>{"a"=>3, "5"=>5}}
 ```
 
-NOTE: Defined in `active_support/core_ext/hash/keys.rb`.
+NOTE: Defined in [active_support/core_ext/hash/keys.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/keys.rb).
 
 #### `symbolize_keys` and `symbolize_keys!`
 
@@ -2850,13 +2850,13 @@ Besides that, one can use `deep_symbolize_keys` and `deep_symbolize_keys!` to sy
 # => {nil=>nil, 1=>1, nested:{a:3, 5=>5}}
 ```
 
-NOTE: Defined in `active_support/core_ext/hash/keys.rb`.
+NOTE: Defined in [active_support/core_ext/hash/keys.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/keys.rb).
 
 #### `to_options` and `to_options!`
 
 The methods `to_options` and `to_options!` are respectively aliases of `symbolize_keys` and `symbolize_keys!`.
 
-NOTE: Defined in `active_support/core_ext/hash/keys.rb`.
+NOTE: Defined in [active_support/core_ext/hash/keys.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/keys.rb).
 
 #### `assert_valid_keys`
 
@@ -2869,7 +2869,7 @@ The method `assert_valid_keys` receives an arbitrary number of arguments, and ch
 
 Active Record does not accept unknown options when building associations, for example. It implements that control via `assert_valid_keys`.
 
-NOTE: Defined in `active_support/core_ext/hash/keys.rb`.
+NOTE: Defined in [active_support/core_ext/hash/keys.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/keys.rb).
 
 ### Working with Values
 
@@ -2883,7 +2883,7 @@ The method `transform_values` accepts a block and returns a hash that has applie
 ```
 There's also the bang variant `transform_values!` that applies the block operations to values in the very receiver.
 
-NOTE: Defined in `active_support/core_text/hash/transform_values.rb`.
+NOTE: Defined in [active_support/core_text/hash/transform_values.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_text/hash/transform_values.rb).
 
 ### Slicing
 
@@ -2914,7 +2914,7 @@ rest = hash.slice!(:a) # => {:b=>2}
 hash                   # => {:a=>1}
 ```
 
-NOTE: Defined in `active_support/core_ext/hash/slice.rb`.
+NOTE: Defined in [active_support/core_ext/hash/slice.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/slice.rb).
 
 ### Extracting
 
@@ -2934,7 +2934,7 @@ rest = hash.extract!(:a).class
 # => ActiveSupport::HashWithIndifferentAccess
 ```
 
-NOTE: Defined in `active_support/core_ext/hash/slice.rb`.
+NOTE: Defined in [active_support/core_ext/hash/slice.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/slice.rb).
 
 ### Indifferent Access
 
@@ -2944,7 +2944,7 @@ The method `with_indifferent_access` returns an `ActiveSupport::HashWithIndiffer
 {a: 1}.with_indifferent_access["a"] # => 1
 ```
 
-NOTE: Defined in `active_support/core_ext/hash/indifferent_access.rb`.
+NOTE: Defined in [active_support/core_ext/hash/indifferent_access.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb).
 
 ### Compacting
 
@@ -2954,7 +2954,7 @@ The methods `compact` and `compact!` return a Hash without items with `nil` valu
 {a: 1, b: 2, c: nil}.compact # => {a: 1, b: 2}
 ```
 
-NOTE: Defined in `active_support/core_ext/hash/compact.rb`.
+NOTE: Defined in [active_support/core_ext/hash/compact.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/compact.rb).
 
 Extensions to `Regexp`
 ----------------------
@@ -2983,7 +2983,7 @@ def assign_route_options(segments, defaults, requirements)
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/regexp.rb`.
+NOTE: Defined in [active_support/core_ext/regexp.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/regexp.rb).
 
 Extensions to `Range`
 ---------------------
@@ -3002,7 +3002,7 @@ Active Support extends the method `Range#to_s` so that it understands an optiona
 
 As the example depicts, the `:db` format generates a `BETWEEN` SQL clause. That is used by Active Record in its support for range values in conditions.
 
-NOTE: Defined in `active_support/core_ext/range/conversions.rb`.
+NOTE: Defined in [active_support/core_ext/range/conversions.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/range/conversions.rb).
 
 ### `include?`
 
@@ -3026,7 +3026,7 @@ Active Support extends these methods so that the argument may be another range i
 (1...9) === (3..9)  # => false
 ```
 
-NOTE: Defined in `active_support/core_ext/range/include_range.rb`.
+NOTE: Defined in [active_support/core_ext/range/include_range.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/range/include_range.rb).
 
 ### `overlaps?`
 
@@ -3038,7 +3038,7 @@ The method `Range#overlaps?` says whether any two given ranges have non-void int
 (1..10).overlaps?(11..27) # => false
 ```
 
-NOTE: Defined in `active_support/core_ext/range/overlaps.rb`.
+NOTE: Defined in [active_support/core_ext/range/overlaps.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/range/overlaps.rb).
 
 Extensions to `Proc`
 --------------------
@@ -3085,7 +3085,7 @@ def handler_for_rescue(exception)
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/proc.rb`.
+NOTE: Defined in [active_support/core_ext/proc.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/proc.rb).
 
 Extensions to `Date`
 --------------------
@@ -3787,7 +3787,7 @@ WARNING. Note you can't append with `atomic_write`.
 
 The auxiliary file is written in a standard directory for temporary files, but you can pass a directory of your choice as second argument.
 
-NOTE: Defined in `active_support/core_ext/file/atomic.rb`.
+NOTE: Defined in [active_support/core_ext/file/atomic.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/file/atomic.rb).
 
 Extensions to `Marshal`
 -----------------------
@@ -3806,7 +3806,7 @@ If the cached data refers to a constant that is unknown at that point, the autol
 
 WARNING. If the argument is an `IO` it needs to respond to `rewind` to be able to retry. Regular files respond to `rewind`.
 
-NOTE: Defined in `active_support/core_ext/marshal.rb`.
+NOTE: Defined in [active_support/core_ext/marshal.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/marshal.rb).
 
 Extensions to `NameError`
 -------------------------
@@ -3831,7 +3831,7 @@ rescue NameError => e
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/name_error.rb`.
+NOTE: Defined in [active_support/core_ext/name_error.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/name_error.rb).
 
 Extensions to `LoadError`
 -------------------------
@@ -3854,4 +3854,4 @@ rescue NameError => e
 end
 ```
 
-NOTE: Defined in `active_support/core_ext/load_error.rb`.
+NOTE: Defined in [active_support/core_ext/load_error.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/load_error.rb).

--- a/guides/source/active_support_core_extensions.md.erb
+++ b/guides/source/active_support_core_extensions.md.erb
@@ -1,3 +1,24 @@
+<%
+MAPPING = {
+  "active_support" => "activesupport",
+  "action_view" => "actionview",
+  "action_controller" => "actionpack",
+  "abstract_controller" => "actionpack",
+  "action_pack" => "actionpack",
+  "action_dispatch" => "actionpack",
+  "active_job" => "activejob",
+  "active_model" => "activemodel",
+  "action_mailer" => "actionmailer",
+  "active_record" => "activerecord",
+}
+RAILS_VERSION = ENV['RAILS_VERSION'] || File.read(File.join(`git rev-parse --show-cdup`.chomp,'RAILS_VERSION')).chomp
+PREFIX = "https://github.com/rails/rails/tree/#{RAILS_VERSION}"
+
+def source_ref(require_path)
+    root = require_path.partition("/").first
+    return "[#{require_path}](#{PREFIX}/#{MAPPING[root]}/lib/#{$2})#{$3}"
+end
+-%>
 **DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON http://guides.rubyonrails.org.**
 
 Active Support Core Extensions
@@ -37,7 +58,7 @@ The most lightweight way to get `blank?` is to cherry-pick the file that defines
 
 For every single method defined as a core extension this guide has a note that says where such a method is defined. In the case of `blank?` the note reads:
 
-NOTE: Defined in [active_support/core_ext/object/blank.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/blank.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/blank.rb' %>.
 
 That means that you can require it like this:
 
@@ -121,7 +142,7 @@ def set_conditional_cache_control!
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/object/blank.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/blank.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/blank.rb' %>.
 
 ### `presence`
 
@@ -131,7 +152,7 @@ The `presence` method returns its receiver if `present?`, and `nil` otherwise. I
 host = config[:host].presence || 'localhost'
 ```
 
-NOTE: Defined in [active_support/core_ext/object/blank.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/blank.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/blank.rb' %>.
 
 ### `duplicable?`
 
@@ -168,7 +189,7 @@ By definition all objects are `duplicable?` except `nil`, `false`, `true`, symbo
 
 WARNING: Any class can disallow duplication by removing `dup` and `clone` or raising exceptions from them. Thus only `rescue` can tell whether a given arbitrary object is duplicable. `duplicable?` depends on the hard-coded list above, but it is much faster than `rescue`. Use it only if you know the hard-coded list is enough in your use case.
 
-NOTE: Defined in [active_support/core_ext/object/duplicable.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/duplicable.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/duplicable.rb' %>.
 
 ### `deep_dup`
 
@@ -213,7 +234,7 @@ duplicate = number.deep_dup
 number.object_id == duplicate.object_id   # => true
 ```
 
-NOTE: Defined in [active_support/core_ext/object/deep_dup.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/deep_dup.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/deep_dup.rb' %>.
 
 ### `try`
 
@@ -236,7 +257,7 @@ Another example is this code from `ActiveRecord::ConnectionAdapters::AbstractAda
 ```ruby
 def log_info(sql, name, ms)
   if @logger.try(:debug?)
-    name = '%s (%.1fms)' % [name || 'SQL', ms]
+    name = '%%s (%%.1fms)' %% [name || 'SQL', ms]
     @logger.debug(format_log_entry(name, sql.squeeze(' ')))
   end
 end
@@ -248,7 +269,7 @@ end
 @person.try { |p| "#{p.first_name} #{p.last_name}" }
 ```
 
-NOTE: Defined in [active_support/core_ext/object/try.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/try.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/try.rb' %>.
 
 ### `class_eval(*args, &block)`
 
@@ -269,7 +290,7 @@ class Proc
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/kernel/singleton_class.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/kernel/singleton_class.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/kernel/singleton_class.rb' %>.
 
 ### `acts_like?(duck)`
 
@@ -288,7 +309,7 @@ some_klass.acts_like?(:string)
 
 Rails has classes that act like `Date` or `Time` and follow this contract.
 
-NOTE: Defined in [active_support/core_ext/object/acts_like.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/acts_like.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/acts_like.rb' %>.
 
 ### `to_param`
 
@@ -332,7 +353,7 @@ user_path(@user) # => "/users/357-john-smith"
 
 WARNING. Controllers need to be aware of any redefinition of `to_param` because when a request like that comes in "357-john-smith" is the value of `params[:id]`.
 
-NOTE: Defined in [active_support/core_ext/object/to_param.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/to_param.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/to_param.rb' %>.
 
 ### `to_query`
 
@@ -356,7 +377,7 @@ This method escapes whatever is needed, both for the key and the value:
 
 ```ruby
 account.to_query('company[name]')
-# => "company%5Bname%5D=Johnson+%26+Johnson"
+# => "company%%5Bname%%5D=Johnson+%%26+Johnson"
 ```
 
 so its output is ready to be used in a query string.
@@ -365,7 +386,7 @@ Arrays return the result of applying `to_query` to each element with `_key_[]` a
 
 ```ruby
 [3.4, -45.6].to_query('sample')
-# => "sample%5B%5D=3.4&sample%5B%5D=-45.6"
+# => "sample%%5B%%5D=3.4&sample%%5B%%5D=-45.6"
 ```
 
 Hashes also respond to `to_query` but with a different signature. If no argument is passed a call generates a sorted series of key/value assignments calling `to_query(key)` on its values. Then it joins the result with "&":
@@ -378,10 +399,10 @@ The method `Hash#to_query` accepts an optional namespace for the keys:
 
 ```ruby
 {id: 89, name: "John Smith"}.to_query('user')
-# => "user%5Bid%5D=89&user%5Bname%5D=John+Smith"
+# => "user%%5Bid%%5D=89&user%%5Bname%%5D=John+Smith"
 ```
 
-NOTE: Defined in [active_support/core_ext/object/to_query.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/to_query.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/to_query.rb' %>.
 
 ### `with_options`
 
@@ -422,13 +443,13 @@ end
 
 TIP: Since `with_options` forwards calls to its receiver they can be nested. Each nesting level will merge inherited defaults in addition to their own.
 
-NOTE: Defined in [active_support/core_ext/object/with_options.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/with_options.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/with_options.rb' %>.
 
 ### JSON support
 
 Active Support provides a better implementation of `to_json` than the `json` gem ordinarily provides for Ruby objects. This is because some classes, like `Hash`, `OrderedHash` and `Process::Status` need special handling in order to provide a proper JSON representation.
 
-NOTE: Defined in [active_support/core_ext/object/json.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/json.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/json.rb' %>.
 
 ### Instance Variables
 
@@ -449,7 +470,7 @@ end
 C.new(0, 1).instance_values # => {"x" => 0, "y" => 1}
 ```
 
-NOTE: Defined in [active_support/core_ext/object/instance_variables.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/instance_variables.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/instance_variables.rb' %>.
 
 #### `instance_variable_names`
 
@@ -465,7 +486,7 @@ end
 C.new(0, 1).instance_variable_names # => ["@x", "@y"]
 ```
 
-NOTE: Defined in [active_support/core_ext/object/instance_variables.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/instance_variables.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/instance_variables.rb' %>.
 
 ### Silencing Warnings and Exceptions
 
@@ -484,7 +505,7 @@ suppress(ActiveRecord::StaleObjectError) do
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/kernel/reporting.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/kernel/reporting.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/kernel/reporting.rb' %>.
 
 ### `in?`
 
@@ -499,7 +520,7 @@ Examples of `in?`:
 1.in?(1)            # => ArgumentError
 ```
 
-NOTE: Defined in [active_support/core_ext/object/inclusion.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/inclusion.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/inclusion.rb' %>.
 
 Extensions to `Module`
 ----------------------
@@ -552,7 +573,7 @@ end
 
 Rails uses `alias_method_chain` all over the code base. For example validations are added to `ActiveRecord::Base#save` by wrapping the method that way in a separate module specialized in validations.
 
-NOTE: Defined in [active_support/core_ext/module/aliasing.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/aliasing.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/module/aliasing.rb' %>.
 
 ### Attributes
 
@@ -568,7 +589,7 @@ class User < ActiveRecord::Base
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/module/aliasing.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/aliasing.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/module/aliasing.rb' %>.
 
 #### Internal Attributes
 
@@ -592,7 +613,7 @@ end
 
 In the previous example it could be the case that `:log_level` does not belong to the public interface of the library and it is only used for development. The client code, unaware of the potential conflict, subclasses and defines its own `:log_level`. Thanks to `attr_internal` there's no collision.
 
-By default the internal instance variable is named with a leading underscore, `@_log_level` in the example above. That's configurable via `Module.attr_internal_naming_format` though, you can pass any `sprintf`-like format string with a leading `@` and a `%s` somewhere, which is where the name will be placed. The default is `"@_%s"`.
+By default the internal instance variable is named with a leading underscore, `@_log_level` in the example above. That's configurable via `Module.attr_internal_naming_format` though, you can pass any `sprintf`-like format string with a leading `@` and a `%%s` somewhere, which is where the name will be placed. The default is `"@_%%s"`.
 
 Rails uses internal attributes in a few spots, for examples for views:
 
@@ -606,7 +627,7 @@ module ActionView
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/module/attr_internal.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/attr_internal.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/module/attr_internal.rb' %>.
 
 #### Module Attributes
 
@@ -633,7 +654,7 @@ module ActiveSupport
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/module/attribute_accessors.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/module/attribute_accessors.rb' %>.
 
 ### Parents
 
@@ -658,7 +679,7 @@ If the module is anonymous or belongs to the top-level, `parent` returns `Object
 
 WARNING: Note that in that case `parent_name` returns `nil`.
 
-NOTE: Defined in [active_support/core_ext/module/introspection.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/introspection.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/module/introspection.rb' %>.
 
 #### `parent_name`
 
@@ -681,7 +702,7 @@ For top-level or anonymous modules `parent_name` returns `nil`.
 
 WARNING: Note that in that case `parent` returns `Object`.
 
-NOTE: Defined in [active_support/core_ext/module/introspection.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/introspection.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/module/introspection.rb' %>.
 
 #### `parents`
 
@@ -700,7 +721,7 @@ X::Y::Z.parents # => [X::Y, X, Object]
 M.parents       # => [X::Y, X, Object]
 ```
 
-NOTE: Defined in [active_support/core_ext/module/introspection.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/introspection.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/module/introspection.rb' %>.
 
 ### Constants
 
@@ -723,7 +744,7 @@ X::Y.local_constants # => [:Y1, :X1]
 
 The names are returned as symbols.
 
-NOTE: Defined in [active_support/core_ext/module/introspection.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/introspection.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/module/introspection.rb' %>.
 
 #### Qualified Constant Names
 
@@ -781,7 +802,7 @@ as in `const_defined?`.
 For coherence with the built-in methods only relative paths are accepted.
 Absolute qualified constant names like `::Math::PI` raise `NameError`.
 
-NOTE: Defined in [active_support/core_ext/module/qualified_const.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/qualified_const.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/module/qualified_const.rb' %>.
 
 ### Reachable
 
@@ -819,7 +840,7 @@ end
 orphan.reachable? # => false
 ```
 
-NOTE: Defined in [active_support/core_ext/module/reachable.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/reachable.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/module/reachable.rb' %>.
 
 ### Anonymous
 
@@ -860,7 +881,7 @@ m.anonymous? # => false
 
 though an anonymous module is unreachable by definition.
 
-NOTE: Defined in [active_support/core_ext/module/anonymous.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/anonymous.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/module/anonymous.rb' %>.
 
 ### Method Delegation
 
@@ -944,7 +965,7 @@ delegate :size, to: :attachment, prefix: :avatar
 
 In the previous example the macro generates `avatar_size` rather than `size`.
 
-NOTE: Defined in [active_support/core_ext/module/delegation.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/delegation.rb)
+NOTE: Defined in <%= source_ref 'active_support/core_ext/module/delegation.rb' %>
 
 ### Redefining Methods
 
@@ -952,7 +973,7 @@ There are cases where you need to define a method with `define_method`, but don'
 
 The method `redefine_method` prevents such a potential warning, removing the existing method before if needed.
 
-NOTE: Defined in [active_support/core_ext/module/remove_method.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/remove_method.rb)
+NOTE: Defined in <%= source_ref 'active_support/core_ext/module/remove_method.rb' %>
 
 Extensions to `Class`
 ---------------------
@@ -1039,7 +1060,7 @@ When `:instance_reader` is `false`, the instance predicate returns a `NoMethodEr
 
 If you do not want the instance predicate, pass `instance_predicate: false` and it will not be defined.
 
-NOTE: Defined in [active_support/core_ext/class/attribute.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/class/attribute.rb)
+NOTE: Defined in <%= source_ref 'active_support/core_ext/class/attribute.rb' %>
 
 #### `cattr_reader`, `cattr_writer`, and `cattr_accessor`
 
@@ -1092,7 +1113,7 @@ end
 
 A model may find it useful to set `:instance_accessor` to `false` as a way to prevent mass-assignment from setting the attribute.
 
-NOTE: Defined in [active_support/core_ext/module/attribute_accessors.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/module/attribute_accessors.rb' %>.
 
 ### Subclasses & Descendants
 
@@ -1116,7 +1137,7 @@ C.subclasses # => [B, D]
 
 The order in which these classes are returned is unspecified.
 
-NOTE: Defined in [active_support/core_ext/class/subclasses.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/class/subclasses.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/class/subclasses.rb' %>.
 
 #### `descendants`
 
@@ -1138,7 +1159,7 @@ C.descendants # => [B, A, D]
 
 The order in which these classes are returned is unspecified.
 
-NOTE: Defined in [active_support/core_ext/class/subclasses.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/class/subclasses.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/class/subclasses.rb' %>.
 
 Extensions to `String`
 ----------------------
@@ -1191,19 +1212,19 @@ Safe arguments are directly appended:
 These methods should not be used in ordinary views. Unsafe values are automatically escaped:
 
 ```erb
-<%= @review.title %> <%# fine, escaped if needed %>
+<%%= @review.title %%> <%%# fine, escaped if needed %%>
 ```
 
 To insert something verbatim use the `raw` helper rather than calling `html_safe`:
 
 ```erb
-<%= raw @cms.current_template %> <%# inserts @cms.current_template as is %>
+<%%= raw @cms.current_template %%> <%%# inserts @cms.current_template as is %%>
 ```
 
-or, equivalently, use `<%==`:
+or, equivalently, use `<%%==`:
 
 ```erb
-<%== @cms.current_template %> <%# inserts @cms.current_template as is %>
+<%%== @cms.current_template %%> <%%# inserts @cms.current_template as is %%>
 ```
 
 The `raw` helper calls `html_safe` for you:
@@ -1214,7 +1235,7 @@ def raw(stringish)
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/string/output_safety.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/output_safety.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/output_safety.rb' %>.
 
 #### Transformation
 
@@ -1242,7 +1263,7 @@ The method `remove` will remove all occurrences of the pattern:
 
 There's also the destructive version `String#remove!`.
 
-NOTE: Defined in [active_support/core_ext/string/filters.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/filters.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/filters.rb' %>.
 
 ### `squish`
 
@@ -1256,7 +1277,7 @@ There's also the destructive version `String#squish!`.
 
 Note that it handles both ASCII and Unicode whitespace.
 
-NOTE: Defined in [active_support/core_ext/string/filters.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/filters.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/filters.rb' %>.
 
 ### `truncate`
 
@@ -1294,7 +1315,7 @@ The option `:separator` can be a regexp:
 
 In above examples "dear" gets cut first, but then `:separator` prevents it.
 
-NOTE: Defined in [active_support/core_ext/string/filters.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/filters.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/filters.rb' %>.
 
 ### `truncate_words`
 
@@ -1326,7 +1347,7 @@ The option `:separator` can be a regexp:
 # => "Oh dear! Oh dear!..."
 ```
 
-NOTE: Defined in [active_support/core_ext/string/filters.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/filters.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/filters.rb' %>.
 
 ### `inquiry`
 
@@ -1346,7 +1367,7 @@ Active Support defines 3rd person aliases of `String#start_with?` and `String#en
 "foo".ends_with?("o")   # => true
 ```
 
-NOTE: Defined in [active_support/core_ext/string/starts_ends_with.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/starts_ends_with.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/starts_ends_with.rb' %>.
 
 ### `strip_heredoc`
 
@@ -1371,7 +1392,7 @@ the user would see the usage message aligned against the left margin.
 Technically, it looks for the least indented line in the whole string, and removes
 that amount of leading whitespace.
 
-NOTE: Defined in [active_support/core_ext/string/strip.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/strip.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/strip.rb' %>.
 
 ### `indent`
 
@@ -1408,7 +1429,7 @@ The third argument, `indent_empty_lines`, is a flag that says whether empty line
 
 The `indent!` method performs indentation in-place.
 
-NOTE: Defined in [active_support/core_ext/string/indent.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/indent.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/indent.rb' %>.
 
 ### Access
 
@@ -1423,7 +1444,7 @@ Returns the character of the string at position `position`:
 "hello".at(10) # => nil
 ```
 
-NOTE: Defined in [active_support/core_ext/string/access.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/access.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/access.rb' %>.
 
 #### `from(position)`
 
@@ -1436,7 +1457,7 @@ Returns the substring of the string starting at position `position`:
 "hello".from(10) # => nil
 ```
 
-NOTE: Defined in [active_support/core_ext/string/access.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/access.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/access.rb' %>.
 
 #### `to(position)`
 
@@ -1449,19 +1470,19 @@ Returns the substring of the string up to position `position`:
 "hello".to(10) # => "hello"
 ```
 
-NOTE: Defined in [active_support/core_ext/string/access.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/access.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/access.rb' %>.
 
 #### `first(limit = 1)`
 
 The call `str.first(n)` is equivalent to `str.to(n-1)` if `n` > 0, and returns an empty string for `n` == 0.
 
-NOTE: Defined in [active_support/core_ext/string/access.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/access.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/access.rb' %>.
 
 #### `last(limit = 1)`
 
 The call `str.last(n)` is equivalent to `str.from(-n)` if `n` > 0, and returns an empty string for `n` == 0.
 
-NOTE: Defined in [active_support/core_ext/string/access.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/access.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/access.rb' %>.
 
 ### Inflections
 
@@ -1495,7 +1516,7 @@ def undecorated_table_name(class_name = base_class.name)
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/inflections.rb' %>.
 
 #### `singularize`
 
@@ -1518,7 +1539,7 @@ def derive_class_name
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/inflections.rb' %>.
 
 #### `camelize`
 
@@ -1566,7 +1587,7 @@ end
 
 `camelize` is aliased to `camelcase`.
 
-NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/inflections.rb' %>.
 
 #### `underscore`
 
@@ -1605,7 +1626,7 @@ end
 
 INFO: As a rule of thumb you can think of `underscore` as the inverse of `camelize`, though there are cases where that does not hold. For example, `"SSLError".underscore.camelize` gives back `"SslError"`.
 
-NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/inflections.rb' %>.
 
 #### `titleize`
 
@@ -1618,7 +1639,7 @@ The method `titleize` capitalizes the words in the receiver:
 
 `titleize` is aliased to `titlecase`.
 
-NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/inflections.rb' %>.
 
 #### `dasherize`
 
@@ -1639,7 +1660,7 @@ def reformat_name(name)
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/inflections.rb' %>.
 
 #### `demodulize`
 
@@ -1667,7 +1688,7 @@ def counter_cache_column
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/inflections.rb' %>.
 
 #### `deconstantize`
 
@@ -1692,7 +1713,7 @@ def qualified_const_set(path, value)
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/inflections.rb' %>.
 
 #### `parameterize`
 
@@ -1705,7 +1726,7 @@ The method `parameterize` normalizes its receiver in a way that can be used in p
 
 In fact, the result string is wrapped in an instance of `ActiveSupport::Multibyte::Chars`.
 
-NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/inflections.rb' %>.
 
 #### `tableize`
 
@@ -1719,7 +1740,7 @@ The method `tableize` is `underscore` followed by `pluralize`.
 
 As a rule of thumb, `tableize` returns the table name that corresponds to a given model for simple cases. The actual implementation in Active Record is not straight `tableize` indeed, because it also demodulizes the class name and checks a few options that may affect the returned string.
 
-NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/inflections.rb' %>.
 
 #### `classify`
 
@@ -1739,7 +1760,7 @@ The method understands qualified table names:
 
 Note that `classify` returns a class name as a string. You can get the actual class object invoking `constantize` on it, explained next.
 
-NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/inflections.rb' %>.
 
 #### `constantize`
 
@@ -1782,7 +1803,7 @@ rescue NameError => e
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/inflections.rb' %>.
 
 #### `humanize`
 
@@ -1830,7 +1851,7 @@ def full_message
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/inflections.rb' %>.
 
 #### `foreign_key`
 
@@ -1855,7 +1876,7 @@ Associations use this method to infer foreign keys, for example `has_one` and `h
 foreign_key = options[:foreign_key] || reflection.active_record.name.foreign_key
 ```
 
-NOTE: Defined in [active_support/core_ext/string/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/inflections.rb' %>.
 
 ### Conversions
 
@@ -1882,7 +1903,7 @@ Please refer to the documentation of `Date._parse` for further details.
 
 INFO: The three of them return `nil` for blank receivers.
 
-NOTE: Defined in [active_support/core_ext/string/conversions.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/string/conversions.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/string/conversions.rb' %>.
 
 Extensions to `Numeric`
 -----------------------
@@ -1916,7 +1937,7 @@ Singular forms are aliased so you are able to say:
 1.megabyte # => 1048576
 ```
 
-NOTE: Defined in [active_support/core_ext/numeric/bytes.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/numeric/bytes.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/numeric/bytes.rb' %>.
 
 ### Time
 
@@ -1969,13 +1990,13 @@ Produce a string representation of a number as a percentage:
 
 ```ruby
 100.to_s(:percentage)
-# => 100.000%
+# => 100.000%%
 100.to_s(:percentage, precision: 0)
-# => 100%
+# => 100%%
 1000.to_s(:percentage, delimiter: '.', separator: ',')
-# => 1.000,000%
+# => 1.000,000%%
 302.24398923423.to_s(:percentage, precision: 5)
-# => 302.24399%
+# => 302.24399%%
 ```
 
 Produce a string representation of a number in delimited form:
@@ -2021,7 +2042,7 @@ Produce a string representation of a number in human-readable words:
 1234567890123456.to_s(:human)  # => "1.23 Quadrillion"
 ```
 
-NOTE: Defined in [active_support/core_ext/numeric/conversions.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/numeric/conversions.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/numeric/conversions.rb' %>.
 
 Extensions to `Integer`
 -----------------------
@@ -2035,7 +2056,7 @@ The method `multiple_of?` tests whether an integer is multiple of the argument:
 1.multiple_of?(2) # => false
 ```
 
-NOTE: Defined in [active_support/core_ext/integer/multiple.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/integer/multiple.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/integer/multiple.rb' %>.
 
 ### `ordinal`
 
@@ -2050,7 +2071,7 @@ The method `ordinal` returns the ordinal suffix string corresponding to the rece
 -134.ordinal # => "th"
 ```
 
-NOTE: Defined in [active_support/core_ext/integer/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/integer/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/integer/inflections.rb' %>.
 
 ### `ordinalize`
 
@@ -2065,7 +2086,7 @@ The method `ordinalize` returns the ordinal string corresponding to the receiver
 -134.ordinalize # => "-134th"
 ```
 
-NOTE: Defined in [active_support/core_ext/integer/inflections.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/integer/inflections.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/integer/inflections.rb' %>.
 
 Extensions to `BigDecimal`
 --------------------------
@@ -2113,7 +2134,7 @@ Addition only assumes the elements respond to `+`:
 
 ```ruby
 [[1, 2], [2, 3], [3, 4]].sum    # => [1, 2, 2, 3, 3, 4]
-%w(foo bar baz).sum             # => "foobarbaz"
+%%w(foo bar baz).sum             # => "foobarbaz"
 {a: 1, b: 2, c: 3}.sum # => [:b, 2, :c, 3, :a, 1]
 ```
 
@@ -2137,7 +2158,7 @@ The sum of an empty receiver can be customized in this form as well:
 [].sum(1) {|n| n**3} # => 1
 ```
 
-NOTE: Defined in [active_support/core_ext/enumerable.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/enumerable.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/enumerable.rb' %>.
 
 ### `index_by`
 
@@ -2152,16 +2173,16 @@ invoices.index_by(&:number)
 
 WARNING. Keys should normally be unique. If the block returns the same value for different elements no collection is built for that key. The last item will win.
 
-NOTE: Defined in [active_support/core_ext/enumerable.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/enumerable.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/enumerable.rb' %>.
 
 ### `many?`
 
 The method `many?` is shorthand for `collection.size > 1`:
 
 ```erb
-<% if pages.many? %>
-  <%= pagination_links %>
-<% end %>
+<%% if pages.many? %%>
+  <%%= pagination_links %%>
+<%% end %%>
 ```
 
 If an optional block is given, `many?` only takes into account those elements that return true:
@@ -2170,7 +2191,7 @@ If an optional block is given, `many?` only takes into account those elements th
 @see_more = videos.many? {|video| video.category == params[:category]}
 ```
 
-NOTE: Defined in [active_support/core_ext/enumerable.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/enumerable.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/enumerable.rb' %>.
 
 ### `exclude?`
 
@@ -2180,7 +2201,7 @@ The predicate `exclude?` tests whether a given object does **not** belong to the
 to_visit << node if visited.exclude?(node)
 ```
 
-NOTE: Defined in [active_support/core_ext/enumerable.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/enumerable.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/enumerable.rb' %>.
 
 ### `without`
 
@@ -2191,7 +2212,7 @@ removed:
 people.without("Aaron", "Todd")
 ```
 
-NOTE: Defined in [active_support/core_ext/enumerable.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/enumerable.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/enumerable.rb' %>.
 
 Extensions to `Array`
 ---------------------
@@ -2201,26 +2222,26 @@ Extensions to `Array`
 Active Support augments the API of arrays to ease certain ways of accessing them. For example, `to` returns the subarray of elements up to the one at the passed index:
 
 ```ruby
-%w(a b c d).to(2) # => %w(a b c)
+%%w(a b c d).to(2) # => %%w(a b c)
 [].to(7)          # => []
 ```
 
 Similarly, `from` returns the tail from the element at the passed index to the end. If the index is greater than the length of the array, it returns an empty array.
 
 ```ruby
-%w(a b c d).from(2)  # => %w(c d)
-%w(a b c d).from(10) # => []
+%%w(a b c d).from(2)  # => %%w(c d)
+%%w(a b c d).from(10) # => []
 [].from(0)           # => []
 ```
 
 The methods `second`, `third`, `fourth`, and `fifth` return the corresponding element (`first` is built-in). Thanks to social wisdom and positive constructiveness all around, `forty_two` is also available.
 
 ```ruby
-%w(a b c d).third # => c
-%w(a b c d).fifth # => nil
+%%w(a b c d).third # => c
+%%w(a b c d).fifth # => nil
 ```
 
-NOTE: Defined in [active_support/core_ext/array/access.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/access.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/array/access.rb' %>.
 
 ### Adding Elements
 
@@ -2229,22 +2250,22 @@ NOTE: Defined in [active_support/core_ext/array/access.rb](https://github.com/ra
 This method is an alias of `Array#unshift`.
 
 ```ruby
-%w(a b c d).prepend('e')  # => %w(e a b c d)
+%%w(a b c d).prepend('e')  # => %%w(e a b c d)
 [].prepend(10)            # => [10]
 ```
 
-NOTE: Defined in [active_support/core_ext/array/prepend_and_append.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/prepend_and_append.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/array/prepend_and_append.rb' %>.
 
 #### `append`
 
 This method is an alias of `Array#<<`.
 
 ```ruby
-%w(a b c d).append('e')  # => %w(a b c d e)
+%%w(a b c d).append('e')  # => %%w(a b c d e)
 [].append([1,2])         # => [[1,2]]
 ```
 
-NOTE: Defined in [active_support/core_ext/array/prepend_and_append.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/prepend_and_append.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/array/prepend_and_append.rb' %>.
 
 ### Options Extraction
 
@@ -2272,7 +2293,7 @@ end
 
 This method receives an arbitrary number of action names, and an optional hash of options as last argument. With the call to `extract_options!` you obtain the options hash and remove it from `actions` in a simple and explicit way.
 
-NOTE: Defined in [active_support/core_ext/array/extract_options.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/extract_options.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/array/extract_options.rb' %>.
 
 ### Conversions
 
@@ -2281,10 +2302,10 @@ NOTE: Defined in [active_support/core_ext/array/extract_options.rb](https://gith
 The method `to_sentence` turns an array into a string containing a sentence that enumerates its items:
 
 ```ruby
-%w().to_sentence                # => ""
-%w(Earth).to_sentence           # => "Earth"
-%w(Earth Wind).to_sentence      # => "Earth and Wind"
-%w(Earth Wind Fire).to_sentence # => "Earth, Wind, and Fire"
+%%w().to_sentence                # => ""
+%%w(Earth).to_sentence           # => "Earth"
+%%w(Earth Wind).to_sentence      # => "Earth and Wind"
+%%w(Earth Wind Fire).to_sentence # => "Earth, Wind, and Fire"
 ```
 
 This method accepts three options:
@@ -2301,7 +2322,7 @@ The defaults for these options can be localized, their keys are:
 | `:words_connector`     | `support.array.words_connector`     |
 | `:last_word_connector` | `support.array.last_word_connector` |
 
-NOTE: Defined in [active_support/core_ext/array/conversions.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/conversions.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/array/conversions.rb' %>.
 
 #### `to_formatted_s`
 
@@ -2319,7 +2340,7 @@ invoice.lines.to_formatted_s(:db) # => "23,567,556,12"
 
 Integers in the example above are supposed to come from the respective calls to `id`.
 
-NOTE: Defined in [active_support/core_ext/array/conversions.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/conversions.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/array/conversions.rb' %>.
 
 #### `to_xml`
 
@@ -2420,7 +2441,7 @@ Contributor.limit(2).order(:rank).to_xml(skip_types: true)
 # </contributors>
 ```
 
-NOTE: Defined in [active_support/core_ext/array/conversions.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/conversions.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/array/conversions.rb' %>.
 
 ### Wrapping
 
@@ -2461,7 +2482,7 @@ which in Ruby 1.8 returns `[nil]` for `nil`, and calls to `Array(object)` otherw
 
 Thus, in this case the behavior is different for `nil`, and the differences with `Kernel#Array` explained above apply to the rest of `object`s.
 
-NOTE: Defined in [active_support/core_ext/array/wrap.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/wrap.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/array/wrap.rb' %>.
 
 ### Duplicating
 
@@ -2475,7 +2496,7 @@ dup[1][2] = 4
 array[1][2] == nil   # => true
 ```
 
-NOTE: Defined in [active_support/core_ext/object/deep_dup.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/deep_dup.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/deep_dup.rb' %>.
 
 ### Grouping
 
@@ -2490,13 +2511,13 @@ The method `in_groups_of` splits an array into consecutive groups of a certain s
 or yields them in turn if a block is passed:
 
 ```html+erb
-<% sample.in_groups_of(3) do |a, b, c| %>
+<%% sample.in_groups_of(3) do |a, b, c| %%>
   <tr>
-    <td><%= a %></td>
-    <td><%= b %></td>
-    <td><%= c %></td>
+    <td><%%= a %%></td>
+    <td><%%= b %%></td>
+    <td><%%= c %%></td>
   </tr>
-<% end %>
+<%% end %%>
 ```
 
 The first example shows `in_groups_of` fills the last group with as many `nil` elements as needed to have the requested size. You can change this padding value using the second optional argument:
@@ -2513,21 +2534,21 @@ And you can tell the method not to fill the last group passing `false`:
 
 As a consequence `false` can't be a used as a padding value.
 
-NOTE: Defined in [active_support/core_ext/array/grouping.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/grouping.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/array/grouping.rb' %>.
 
 #### `in_groups(number, fill_with = nil)`
 
 The method `in_groups` splits an array into a certain number of groups. The method returns an array with the groups:
 
 ```ruby
-%w(1 2 3 4 5 6 7).in_groups(3)
+%%w(1 2 3 4 5 6 7).in_groups(3)
 # => [["1", "2", "3"], ["4", "5", nil], ["6", "7", nil]]
 ```
 
 or yields them in turn if a block is passed:
 
 ```ruby
-%w(1 2 3 4 5 6 7).in_groups(3) {|group| p group}
+%%w(1 2 3 4 5 6 7).in_groups(3) {|group| p group}
 ["1", "2", "3"]
 ["4", "5", nil]
 ["6", "7", nil]
@@ -2538,20 +2559,20 @@ The examples above show that `in_groups` fills some groups with a trailing `nil`
 You can change this padding value using the second optional argument:
 
 ```ruby
-%w(1 2 3 4 5 6 7).in_groups(3, "0")
+%%w(1 2 3 4 5 6 7).in_groups(3, "0")
 # => [["1", "2", "3"], ["4", "5", "0"], ["6", "7", "0"]]
 ```
 
 And you can tell the method not to fill the smaller groups passing `false`:
 
 ```ruby
-%w(1 2 3 4 5 6 7).in_groups(3, false)
+%%w(1 2 3 4 5 6 7).in_groups(3, false)
 # => [["1", "2", "3"], ["4", "5"], ["6", "7"]]
 ```
 
 As a consequence `false` can't be a used as a padding value.
 
-NOTE: Defined in [active_support/core_ext/array/grouping.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/grouping.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/array/grouping.rb' %>.
 
 #### `split(value = nil)`
 
@@ -2573,7 +2594,7 @@ Otherwise, the value received as argument, which defaults to `nil`, is the separ
 
 TIP: Observe in the previous example that consecutive separators result in empty arrays.
 
-NOTE: Defined in [active_support/core_ext/array/grouping.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/array/grouping.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/array/grouping.rb' %>.
 
 Extensions to `Hash`
 --------------------
@@ -2625,7 +2646,7 @@ By default the root node is "hash", but that's configurable via the `:root` opti
 
 The default XML builder is a fresh instance of `Builder::XmlMarkup`. You can configure your own builder with the `:builder` option. The method also accepts options like `:dasherize` and friends, they are forwarded to the builder.
 
-NOTE: Defined in [active_support/core_ext/hash/conversions.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/conversions.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/hash/conversions.rb' %>.
 
 ### Merging
 
@@ -2660,7 +2681,7 @@ options.reverse_merge!(length: 30, omission: "...")
 
 WARNING. Take into account that `reverse_merge!` may change the hash in the caller, which may or may not be a good idea.
 
-NOTE: Defined in [active_support/core_ext/hash/reverse_merge.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/hash/reverse_merge.rb' %>.
 
 #### `reverse_update`
 
@@ -2668,7 +2689,7 @@ The method `reverse_update` is an alias for `reverse_merge!`, explained above.
 
 WARNING. Note that `reverse_update` has no bang.
 
-NOTE: Defined in [active_support/core_ext/hash/reverse_merge.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/hash/reverse_merge.rb' %>.
 
 #### `deep_merge` and `deep_merge!`
 
@@ -2683,7 +2704,7 @@ Active Support defines `Hash#deep_merge`. In a deep merge, if a key is found in 
 
 The method `deep_merge!` performs a deep merge in place.
 
-NOTE: Defined in [active_support/core_ext/hash/deep_merge.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/deep_merge.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/hash/deep_merge.rb' %>.
 
 ### Deep duplicating
 
@@ -2701,7 +2722,7 @@ hash[:b][:e] == nil      # => true
 hash[:b][:d] == [3, 4]   # => true
 ```
 
-NOTE: Defined in [active_support/core_ext/object/deep_dup.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/object/deep_dup.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/object/deep_dup.rb' %>.
 
 ### Working with Keys
 
@@ -2722,7 +2743,7 @@ If the receiver responds to `convert_key`, the method is called on each of the a
 
 There's also the bang variant `except!` that removes keys in the very receiver.
 
-NOTE: Defined in [active_support/core_ext/hash/except.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/except.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/hash/except.rb' %>.
 
 #### `transform_keys` and `transform_keys!`
 
@@ -2764,7 +2785,7 @@ Besides that, one can use `deep_transform_keys` and `deep_transform_keys!` to pe
 # => {""=>nil, "1"=>1, "NESTED"=>{"A"=>3, "5"=>5}}
 ```
 
-NOTE: Defined in [active_support/core_ext/hash/keys.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/keys.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/hash/keys.rb' %>.
 
 #### `stringify_keys` and `stringify_keys!`
 
@@ -2806,7 +2827,7 @@ Besides that, one can use `deep_stringify_keys` and `deep_stringify_keys!` to st
 # => {""=>nil, "1"=>1, "nested"=>{"a"=>3, "5"=>5}}
 ```
 
-NOTE: Defined in [active_support/core_ext/hash/keys.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/keys.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/hash/keys.rb' %>.
 
 #### `symbolize_keys` and `symbolize_keys!`
 
@@ -2850,13 +2871,13 @@ Besides that, one can use `deep_symbolize_keys` and `deep_symbolize_keys!` to sy
 # => {nil=>nil, 1=>1, nested:{a:3, 5=>5}}
 ```
 
-NOTE: Defined in [active_support/core_ext/hash/keys.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/keys.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/hash/keys.rb' %>.
 
 #### `to_options` and `to_options!`
 
 The methods `to_options` and `to_options!` are respectively aliases of `symbolize_keys` and `symbolize_keys!`.
 
-NOTE: Defined in [active_support/core_ext/hash/keys.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/keys.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/hash/keys.rb' %>.
 
 #### `assert_valid_keys`
 
@@ -2869,7 +2890,7 @@ The method `assert_valid_keys` receives an arbitrary number of arguments, and ch
 
 Active Record does not accept unknown options when building associations, for example. It implements that control via `assert_valid_keys`.
 
-NOTE: Defined in [active_support/core_ext/hash/keys.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/keys.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/hash/keys.rb' %>.
 
 ### Working with Values
 
@@ -2883,7 +2904,7 @@ The method `transform_values` accepts a block and returns a hash that has applie
 ```
 There's also the bang variant `transform_values!` that applies the block operations to values in the very receiver.
 
-NOTE: Defined in [active_support/core_text/hash/transform_values.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_text/hash/transform_values.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_text/hash/transform_values.rb' %>.
 
 ### Slicing
 
@@ -2914,7 +2935,7 @@ rest = hash.slice!(:a) # => {:b=>2}
 hash                   # => {:a=>1}
 ```
 
-NOTE: Defined in [active_support/core_ext/hash/slice.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/slice.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/hash/slice.rb' %>.
 
 ### Extracting
 
@@ -2934,7 +2955,7 @@ rest = hash.extract!(:a).class
 # => ActiveSupport::HashWithIndifferentAccess
 ```
 
-NOTE: Defined in [active_support/core_ext/hash/slice.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/slice.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/hash/slice.rb' %>.
 
 ### Indifferent Access
 
@@ -2944,7 +2965,7 @@ The method `with_indifferent_access` returns an `ActiveSupport::HashWithIndiffer
 {a: 1}.with_indifferent_access["a"] # => 1
 ```
 
-NOTE: Defined in [active_support/core_ext/hash/indifferent_access.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/hash/indifferent_access.rb' %>.
 
 ### Compacting
 
@@ -2954,7 +2975,7 @@ The methods `compact` and `compact!` return a Hash without items with `nil` valu
 {a: 1, b: 2, c: nil}.compact # => {a: 1, b: 2}
 ```
 
-NOTE: Defined in [active_support/core_ext/hash/compact.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/hash/compact.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/hash/compact.rb' %>.
 
 Extensions to `Regexp`
 ----------------------
@@ -2964,8 +2985,8 @@ Extensions to `Regexp`
 The method `multiline?` says whether a regexp has the `/m` flag set, that is, whether the dot matches newlines.
 
 ```ruby
-%r{.}.multiline?  # => false
-%r{.}m.multiline? # => true
+%%r{.}.multiline?  # => false
+%%r{.}m.multiline? # => true
 
 Regexp.new('.').multiline?                    # => false
 Regexp.new('.', Regexp::MULTILINE).multiline? # => true
@@ -2983,7 +3004,7 @@ def assign_route_options(segments, defaults, requirements)
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/regexp.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/regexp.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/regexp.rb' %>.
 
 Extensions to `Range`
 ---------------------
@@ -3002,7 +3023,7 @@ Active Support extends the method `Range#to_s` so that it understands an optiona
 
 As the example depicts, the `:db` format generates a `BETWEEN` SQL clause. That is used by Active Record in its support for range values in conditions.
 
-NOTE: Defined in [active_support/core_ext/range/conversions.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/range/conversions.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/range/conversions.rb' %>.
 
 ### `include?`
 
@@ -3026,7 +3047,7 @@ Active Support extends these methods so that the argument may be another range i
 (1...9) === (3..9)  # => false
 ```
 
-NOTE: Defined in [active_support/core_ext/range/include_range.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/range/include_range.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/range/include_range.rb' %>.
 
 ### `overlaps?`
 
@@ -3038,7 +3059,7 @@ The method `Range#overlaps?` says whether any two given ranges have non-void int
 (1..10).overlaps?(11..27) # => false
 ```
 
-NOTE: Defined in [active_support/core_ext/range/overlaps.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/range/overlaps.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/range/overlaps.rb' %>.
 
 Extensions to `Proc`
 --------------------
@@ -3085,7 +3106,7 @@ def handler_for_rescue(exception)
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/proc.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/proc.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/proc.rb' %>.
 
 Extensions to `Date`
 --------------------
@@ -3787,7 +3808,7 @@ WARNING. Note you can't append with `atomic_write`.
 
 The auxiliary file is written in a standard directory for temporary files, but you can pass a directory of your choice as second argument.
 
-NOTE: Defined in [active_support/core_ext/file/atomic.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/file/atomic.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/file/atomic.rb' %>.
 
 Extensions to `Marshal`
 -----------------------
@@ -3806,7 +3827,7 @@ If the cached data refers to a constant that is unknown at that point, the autol
 
 WARNING. If the argument is an `IO` it needs to respond to `rewind` to be able to retry. Regular files respond to `rewind`.
 
-NOTE: Defined in [active_support/core_ext/marshal.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/marshal.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/marshal.rb' %>.
 
 Extensions to `NameError`
 -------------------------
@@ -3831,7 +3852,7 @@ rescue NameError => e
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/name_error.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/name_error.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/name_error.rb' %>.
 
 Extensions to `LoadError`
 -------------------------
@@ -3854,4 +3875,4 @@ rescue NameError => e
 end
 ```
 
-NOTE: Defined in [active_support/core_ext/load_error.rb](https://github.com/rails/rails/tree/master/activesupport/lib/active_support/core_ext/load_error.rb).
+NOTE: Defined in <%= source_ref 'active_support/core_ext/load_error.rb' %>.


### PR DESCRIPTION
This makes it more useful, IMO.

(
Linkified with:

``` ruby
#!/usr/bin/env ruby
# -*- coding: utf-8 -*-

regexp = /^(\s*NOTE:\s+Defined\s+in\s+)`([^`]*)`(.*)$/
mapping = {
  "active_support" => "activesupport",
  "action_view" => "actionview",
  "action_controller" => "actionpack",
  "abstract_controller" => "actionpack",
  "action_pack" => "actionpack",
  "action_dispatch" => "actionpack",
  "active_job" => "activejob",
  "active_model" => "activemodel",
  "action_mailer" => "actionmailer",
  "active_record" => "activerecord",
}
prefix = "https://github.com/rails/rails/tree/#{ENV['RAILS_VERSION'] || 'master'}"

while $_ = gets
  $_.chomp!
  if $_ =~ regexp
    root = $2.partition("/").first
    puts "#{$1}[#{$2}](#{prefix}/#{mapping[root]}/lib/#{$2})#{$3}"
  else
    puts $_
  end
end
```

The hash is gotten through a command also. This should e more generally applicable, but I've only found these `Defined in` notes in the core_ext guide.
)
