### PR TITLE
Pass connection rather than connection ID

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -88,11 +88,7 @@ module ActiveRecord
     end
 
     def connection_id
-      ActiveRecord::RuntimeRegistry.connection_id ||= Thread.current.object_id
-    end
-
-    def connection_id=(connection_id)
-      ActiveRecord::RuntimeRegistry.connection_id = connection_id
+      Thread.current.object_id
     end
 
     # Returns the configuration of the associated connection as a hash:

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -30,26 +30,24 @@ module ActiveRecord
     def call(env)
       connection    = ActiveRecord::Base.connection
       enabled       = connection.query_cache_enabled
-      connection_id = ActiveRecord::Base.connection_id
       connection.enable_query_cache!
 
       response = @app.call(env)
       response[2] = Rack::BodyProxy.new(response[2]) do
-        restore_query_cache_settings(connection_id, enabled)
+        restore_query_cache_settings(connection, enabled)
       end
 
       response
     rescue Exception => e
-      restore_query_cache_settings(connection_id, enabled)
+      restore_query_cache_settings(connection, enabled)
       raise e
     end
 
     private
 
-    def restore_query_cache_settings(connection_id, enabled)
-      ActiveRecord::Base.connection_id = connection_id
-      ActiveRecord::Base.connection.clear_query_cache
-      ActiveRecord::Base.connection.disable_query_cache! unless enabled
+    def restore_query_cache_settings(connection, enabled)
+      connection.clear_query_cache
+      connection.disable_query_cache! unless enabled
     end
 
   end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -43,7 +43,7 @@ class QueryCacheTest < ActiveRecord::TestCase
     connection_id = ActiveRecord::Base.connection_id
 
     mw = ActiveRecord::QueryCache.new lambda { |env|
-      ActiveRecord::Base.connection_id = self.object_id
+      ActiveRecord::RuntimeRegistry.connection_id = self.object_id
       raise "lol borked"
     }
     assert_raises(RuntimeError) { mw.call({}) }


### PR DESCRIPTION
`connection_id` shouldn't be changed so we don't need to explicitly pass
it around. If you want to change the `connection_id` then `#with_connection`
should be used instead. Changing the `connection_id` directly could
result in issues with ActiveRecord connections.

This change allows the connection to be cached through the stack by
passing `connection` rather than `connection_id`.

I'm sending this as a PR instead of pushing it directly because @tenderlove and I are unsure about this change. Tests pass but you never know :wink:
