### PR TITLE
[ci skip] Fix dead link

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -20,7 +20,7 @@ After reading this guide, you will know:
 What is Active Record?
 ----------------------
 
-Active Record is the M in [MVC](getting_started.html#the-mvc-architecture) - the
+Active Record is the M in [MVC](http://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller) - the
 model - which is the layer of the system responsible for representing business
 data and logic. Active Record facilitates the creation and use of business
 objects whose data requires persistent storage to a database. It is an


### PR DESCRIPTION
getting_started.html#the-mvc-architecture is lost by this commit
2f06c94e38a116fdfa43d7b7117e6bf911a0bff5 (Mar 14 2012 !).

So replace it with wikipedia link.
