### PR TITLE
Compare content_type with Mime::XML

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions.rb
@@ -12,7 +12,7 @@ module ActionDispatch
     include Rails::Dom::Testing::Assertions
 
     def html_document
-      @html_document ||= if @response.content_type =~ /xml$/
+      @html_document ||= if @response.content_type === Mime::XML
         Nokogiri::XML::Document.parse(@response.body)
       else
         Nokogiri::HTML::Document.parse(@response.body)


### PR DESCRIPTION
Based on actionpack/test/dispatch/response_test.rb, the correct response for Integration Tests (ONLY) is Mime::XML.

The problem is that ActionDispatch::Assertions tests against /xml$/
This isn't correct even in the case of "application/xml; charset=utf-8", which I received when trying to use the "Action Controller template for gems" from the guides site.

Replacing the regexp with === Mime::XML seems to fix this for all cases.

The bug is especially visible trying to test XML with CDATA-encoded parts, where the HTML parser fails entirely.

Example test:

```
class FeedsControllerTest < ActionDispatch::IntegrationTest
  test "feed works right" do
    get '/feeds/example_feed', :format => :xml # or post, or xhr(:post)
    assert_select 'plain', 'text'
    assert_select 'encoded', 'also text', response.body
  end
end
```

example_feed.xml.builder:

```
xml.root do
  xml.plain 'text'
  xml.encoded { xml.cdata! 'also text' }
end
```
