### PR TITLE
[skip ci] Fix typo in actionmailer documentation

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -21,7 +21,7 @@ module ActionMailer
   # the mailer views, options on the mail itself such as the <tt>:from</tt> address, and attachments.
   #
   #   class ApplicationMailer < ActionMailer::Base
-  #     default from: 'from@exmaple.com'
+  #     default from: 'from@example.com'
   #     layout 'mailer'
   #   end
   #


### PR DESCRIPTION
:scream_cat:
