### PR TITLE
Fix that collection associations are being cached with the current_scope information

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Cache `CollectionAssociation#reader` proxy separately when a different
+    current_scope is active. This prevents the reader from retaining `.scoping`
+    information after the `.scoping` block has been exited.
+
+    *Ben Woosley*
+
 *   Increase pg gem version requirement to `~> 0.18`. Earlier versions of the
     pg gem are known to have problems with Ruby 2.2.
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -33,13 +33,14 @@ module ActiveRecord
           reload
         end
 
-        if owner.new_record?
-          # Cache the proxy separately before the owner has an id
-          # or else a post-save proxy will still lack the id
-          @new_record_proxy ||= CollectionProxy.create(klass, self)
-        else
-          @proxy ||= CollectionProxy.create(klass, self)
-        end
+        # Cache the proxy separately before the owner has an id or else a
+        # post-save proxy will still lack the id
+        #
+        # Include the current_scope#object_id so that the association will
+        # operate correctly under different .scoping contexts
+        @proxy ||= {}
+        @proxy[[owner.new_record?, klass.current_scope.object_id]] ||=
+          CollectionProxy.create(klass, self)
       end
 
       # Implements the writer method, e.g. foo.items= for Foo.has_many :items

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -308,6 +308,18 @@ class HasManyScopingTest < ActiveRecord::TestCase
     assert_equal 2, @welcome.comments.search_by_type('Comment').size
   end
 
+  def test_none_scoping
+    Comment.none.scoping do
+      assert_equal 0, @welcome.comments.count
+      assert_equal 'a comment...', @welcome.comments.what_are_you
+    end
+
+    Comment.where('1=1').scoping do
+      assert_equal 2, @welcome.comments.count
+      assert_equal 'a comment...', @welcome.comments.what_are_you
+    end
+  end
+
   def test_nested_scope_finder
     Comment.where('1=0').scoping do
       assert_equal 0, @welcome.comments.count
@@ -347,6 +359,18 @@ class HasAndBelongsToManyScopingTest < ActiveRecord::TestCase
   def test_forwarding_of_static_methods
     assert_equal 'a category...', Category.what_are_you
     assert_equal 'a category...', @welcome.categories.what_are_you
+  end
+
+  def test_none_scoping
+    Category.none.scoping do
+      assert_equal 0, @welcome.categories.count
+      assert_equal 'a category...', @welcome.categories.what_are_you
+    end
+
+    Category.where('1=1').scoping do
+      assert_equal 2, @welcome.categories.count
+      assert_equal 'a category...', @welcome.categories.what_are_you
+    end
   end
 
   def test_nested_scope_finder


### PR DESCRIPTION
This means that `.scoping` values are currently retained in the association proxy
cache even after exiting the `.scoping` block. With this change the proxy cache maintains a hash
where the proxies are cached based on `owner#new_record?` status and the `klass`'s
`current_scope#object_id`.

If there is no active `current_scope`, the default scope will be active - cached
under `nil#object_id`.

An alternative to `#object_id` would have been to use `#to_sql`, which is used
e.g. by `Relation#==`, this would be somewhat more explicit but would incur
extra cost in evaluating the relation at `#reader` time rather than when data
is actually read from the database.

This is somewhat related to my earlier PR https://github.com/rails/rails/pull/11694
