### PR TITLE
Fix that collection associations were being cached with the current_scope information

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `CollectionProxy` no longer takes on `klass.current_scope`, so it
+    will not cache `scoping` context across `scoping` calls. It
+    instead applies `default_scoped`.
+
+    *Ben Woosley*
+
 *   When calling `first` with a `limit` argument, return directly from the
     `loaded?` records if available.
 

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -82,8 +82,12 @@ module ActiveRecord
         loaded!
       end
 
+      def proxy_scope
+        association_relation.merge!(klass.default_scoped).merge!(association_scope)
+      end
+
       def scope
-        target_scope.merge(association_scope)
+        target_scope.merge!(association_scope)
       end
 
       # The scope for this association.
@@ -121,7 +125,7 @@ module ActiveRecord
       # Can be overridden (i.e. in ThroughAssociation) to merge in other scopes (i.e. the
       # through association's scope)
       def target_scope
-        AssociationRelation.create(klass, klass.arel_table, klass.predicate_builder, self).merge!(klass.all)
+        association_relation.merge!(klass.all)
       end
 
       # Loads the \target if needed and returns it.
@@ -174,6 +178,10 @@ module ActiveRecord
       end
 
       private
+
+        def association_relation
+          AssociationRelation.create(klass, klass.arel_table, klass.predicate_builder, self)
+        end
 
         def find_target?
           !loaded? && (!owner.new_record? || foreign_key_present?) && klass

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -34,7 +34,7 @@ module ActiveRecord
       def initialize(klass, association) #:nodoc:
         @association = association
         super klass, klass.arel_table, klass.predicate_builder
-        merge! association.scope(nullify: false)
+        merge! association.proxy_scope
       end
 
       def target

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -308,6 +308,18 @@ class HasManyScopingTest < ActiveRecord::TestCase
     assert_equal 2, @welcome.comments.search_by_type('Comment').size
   end
 
+  def test_none_scoping
+    Comment.none.scoping do
+      assert_equal 0, @welcome.comments.count
+      assert_equal 'a comment...', @welcome.comments.what_are_you
+    end
+
+    Comment.where('1=1').scoping do
+      assert_equal 2, @welcome.comments.count
+      assert_equal 'a comment...', @welcome.comments.what_are_you
+    end
+  end
+
   def test_nested_scope_finder
     Comment.where('1=0').scoping do
       assert_equal 0, @welcome.comments.count
@@ -347,6 +359,18 @@ class HasAndBelongsToManyScopingTest < ActiveRecord::TestCase
   def test_forwarding_of_static_methods
     assert_equal 'a category...', Category.what_are_you
     assert_equal 'a category...', @welcome.categories.what_are_you
+  end
+
+  def test_none_scoping
+    Category.none.scoping do
+      assert_equal 0, @welcome.categories.count
+      assert_equal 'a category...', @welcome.categories.what_are_you
+    end
+
+    Category.where('1=1').scoping do
+      assert_equal 2, @welcome.categories.count
+      assert_equal 'a category...', @welcome.categories.what_are_you
+    end
   end
 
   def test_nested_scope_finder


### PR DESCRIPTION
This would mean that `.scoping` values would be retained in the association proxy
cache even after exiting the scoping block, because certain modifications would
not be cleared by `#reset` - for example adding modules via `.extending`.

Now the proxy cache maintains a hash where the proxies are cached based on
`owner#new_record?` status and the `klass`'s `current_scope#object_id`. If
there is no active `current_scope`, the default scope will be active - cached
under `nil#object_id`.

An alternative to `#object_id` would have been to use `#to_sql`, which is used
e.g. by `Relation#==`, this would be somewhat more explicit but would incur
extra cost in evaluating the relation at `#reader` time rather than when data
is actually read from the database.
