### PR TITLE
Fix mutliline anchor test in format validations for edge case

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix that regexes in format-validation which end with an escaped backslash before a line-end anchor
+    actually raise an ArgumentError:
+
+        Topic.validates_format_of(:title, with: /Valid Title\\$/)
+        # ArgumentError: The provided regular expression is using multiline anchors (^ or $), which may present a
+        # security risk. Did you mean to use \A and \z, or forgot to add the :multiline => true option?
+
+    *Jan Lelis*
+
 *   Raise FrozenError when trying to write attributes that aren't backed by the database on an object that is frozen:
 
         class Animal

--- a/activemodel/lib/active_model/validations/format.rb
+++ b/activemodel/lib/active_model/validations/format.rb
@@ -48,7 +48,9 @@ module ActiveModel
 
         def regexp_using_multiline_anchors?(regexp)
           source = regexp.source
-          source.start_with?("^") || (source.end_with?("$") && !source.end_with?("\\$"))
+          # We cannot rely on end_with? for $, because it would also catch escaped dollars. At the same time,
+          # we need the extra check for pairs of backslashes to prevent false positives like /example\\$/
+          source.start_with?("^") || source =~ /(?<!\\)(?:\\{2})*\$\z/
         end
     end
 

--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -70,7 +70,17 @@ class FormatValidationTest < ActiveModel::TestCase
   end
 
   def test_validate_format_of_with_multiline_regexp_should_raise_error
-    assert_raise(ArgumentError) { Topic.validates_format_of(:title, with: /^Valid Title$/) }
+    assert_raise(ArgumentError) { Topic.validates_format_of(:title, with: /Valid Title$/) }
+  end
+
+  def test_validate_format_of_with_multiline_regexp_with_escaped_dollar
+    assert_nothing_raised do
+      Topic.validates_format_of(:title, with: /Valid Title\$/)
+    end
+  end
+
+  def test_validate_format_of_with_multiline_regexp_with_escaped_backslash_should_raise_error
+    assert_raise(ArgumentError) { Topic.validates_format_of(:title, with: /Valid Title\\$/) }
   end
 
   def test_validate_format_of_with_multiline_regexp_and_option


### PR DESCRIPTION
The bug occurs, when someone tries to use a regex in a format validation, which ends with a line-end anchor (`$`) AND has an escaped backslash just before the dollar sign. The old code behavior was to only check for the existence of a single backslash, which ignores the case when there are actually more backslashes before that one (like an escaped backslash)

``` ruby
/...$/ # => line-end anchor -- properly caught before bugfix
/...\$/ # => escaped dollar sign -- properly caught before bugfix, because of extra-check
/...\\$/ # => line-end anchor -- falsely let through
```
