### PR TITLE
Compare content_type with Mime::XML instead of regexp

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions.rb
@@ -12,7 +12,7 @@ module ActionDispatch
     include Rails::Dom::Testing::Assertions
 
     def html_document
-      @html_document ||= if @response.content_type =~ /xml$/
+      @html_document ||= if @response.content_type === Mime::XML
         Nokogiri::XML::Document.parse(@response.body)
       else
         Nokogiri::HTML::Document.parse(@response.body)

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -363,6 +363,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       respond_to do |format|
         format.html { render :text => "OK", :status => 200 }
         format.js { render :text => "JS OK", :status => 200 }
+        format.xml { render :xml => "<root></root>", :status => 200 }
       end
     end
 
@@ -415,6 +416,22 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       assert_equal "OK", body
       assert_equal "OK", response.body
       assert_kind_of Nokogiri::HTML::Document, html_document
+      assert_equal 1, request_count
+    end
+  end
+
+  def test_get_xml
+    with_test_route_set do
+      get "/get", {}, {"HTTP_ACCEPT" => "application/xml"}
+      assert_equal 200, status
+      assert_equal "OK", status_message
+      assert_response 200
+      assert_response :success
+      assert_response :ok
+      assert_equal({}, cookies.to_hash)
+      assert_equal "<root></root>", body
+      assert_equal "<root></root>", response.body
+      assert_instance_of Nokogiri::XML::Document, html_document
       assert_equal 1, request_count
     end
   end


### PR DESCRIPTION
Regexp is broken for both content types including charsets and for
integration tests, where the content_type is a Mime::Type and not String
