### PR TITLE
Write log with level :error when an exception got raised when trying to deliver an email.

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Write log with level :error when an exception got raised when trying to deliver an email.
+
+    *Ignatius Reza Lesmana*
+
 *   Allow Action Mailer classes to configure their delivery job.
 
         class MyMailer < ApplicationMailer


### PR DESCRIPTION
Before:

>  "Sent mail to [recipients]" got written even when we fail to deliver.

After:

>  "[exception_class] was raised when sending mail to [recipients]" will be written

This changes helps in understanding which emails got delivered and which emails does not when parsing hundreds of lines of mailer logs. Current behavior is misleading, because "Sent mail to" gives of the sense that emails got successfully sent, even when it's not.
