### PR TITLE
Adds more clarity on how to use custom rake tasks with arguments passed to it

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -526,8 +526,8 @@ end
 To pass arguments to your custom rake task:
 
 ```ruby
-task :task_name, [:arg_1] => [:pre_1, :pre_2] do |t, args|
-  # You can use args from here
+task :task_name, [:arg_1] => [:prerequisite_1, :prerequisite_2] do |task, args|
+  argument_1 = args.arg_1
 end
 ```
 


### PR DESCRIPTION
##### Summary of things this PR makes an attempt to address
- The current guide to create [custom rake tasks](http://guides.rubyonrails.org/command_line.html#custom-rake-tasks) doesn't explain how exactly a user can access the command line arguments passed to it. This PR makes that more clear with an example.
- This PR also makes it more clear that `t` actually stands for `task` and similarly `pre` stands for `prerequisite`.
