### PR TITLE
The doc says CallbackChain is an Array, while it's actually an Enumerabl...

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -467,7 +467,7 @@ module ActiveSupport
       end
     end
 
-    # An Array with a compile method.
+    # An Enumerable with a compile method.
     class CallbackChain #:nodoc:#
       include Enumerable
 


### PR DESCRIPTION
...e

In the old versions, it used to be an Array as in 

```
class CallbackChain < Array
```

Which has now changed to including an `Enumerable`. So, our code used methods like `reject!` that are no longer defined on this object. Updating the documentation to reflect this.
