### PR TITLE
Materialize subqueries by adding `DISTINCT` to suport MySQL 5.7.6 and later

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -785,7 +785,9 @@ module ActiveRecord
 
         subselect = Arel::SelectManager.new(select.engine)
         subselect.project Arel.sql(key.name)
-        subselect.from subsubselect.as('__active_record_temp')
+        # Materialized subquery by adding distinct
+        # to work with MySQL 5.7.6 which sets optimizer_switch='derived_merge=on'
+        subselect.from subsubselect.distinct.as('__active_record_temp')
       end
 
       def add_index_length(option_strings, column_names, options = {})


### PR DESCRIPTION
This pull request addresses #19281 when mysql and mysql2 adapters tested with MySQL 5.7.6 whose default  value is `optimizer_switch='derived_merge=on'` by adding `distinct` in the sub-subquery as suggested in http://bugs.mysql.com/bug.php?id=76259
- Testcase which got errors without this commit

``` shell
for i in mysql mysql2
do 
echo $i
ARCONN=$i ruby -Itest test/cases/scoping/relation_scoping_test.rb -n test_delete_all_default_scope_filters_on_joins
done
```
- SQL statement without this commit which causes `:Error: You can't specify target table` error

``` sql
 SQL (0.8ms)  DELETE FROM `developers` WHERE `developers`.`id` IN (SELECT id FROM (SELECT `developers`.`id` FROM `developers` INNER JOIN `developers_projects` ON `developers_projects`.`developer_id` = `developers`.`id` INNER JOIN `projects` ON `projects`.`id` = `developers_projects`.`project_id` WHERE `projects`.`name` = ?) __active_record_temp)  [["name", "Active Controller"]]
```
- SQL statement with this commit you can see `DISTINCT` in the sub-subquery

``` sql
  SQL (1.0ms)  DELETE FROM `developers` WHERE `developers`.`id` IN (SELECT id FROM (SELECT DISTINCT `developers`.`id` FROM `developers` INNER JOIN `developers_projects` ON `developers_projects`.`developer_id` = `developers`.`id` INNER JOIN `projects` ON `projects`.`id` = `developers_projects`.`project_id` WHERE `projects`.`name` = ?) __active_record_temp)  [["name", "Active Controller"]]
```

I think adding DISTINCT in the sub-subquery will not change the result expected.
