### PR TITLE
Print the migration file of current schema version number.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add `rake db:version:number` and `rake db:version:file` rake tasks.
+
+    - `rake db:version:number`
+
+      Prints the current schema version number.
+
+    - `rake db:version:file`
+
+      Prints the current schema's migration file path. If the current schema
+      version is ahead of the current branch an error will be raised.
+
+    *Juanito Fatas*
+
 *   Add `config.active_record.warn_on_records_fetched_greater_than` option
 
     When set to an integer, a warning will be logged whenever a result set

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -158,6 +158,22 @@ db_namespace = namespace :db do
     puts "Current version: #{ActiveRecord::Migrator.current_version}"
   end
 
+  namespace :version do
+    desc 'Prints the current schema version number'
+    task :number => [:environment, :load_config] do
+      puts ActiveRecord::Migrator.current_version
+    end
+
+    desc "Prints the file path of current schema's migration"
+    task :file => [:environment, :load_config] do
+      if migration_file = Dir.glob("#{ActiveRecord::Migrator.migrations_path}/#{ActiveRecord::Migrator.current_version}*.rb").first
+        puts migration_file
+      else
+        raise "Current migration is ahead of working branch."
+      end
+    end
+  end
+
   # desc "Raises an error if there are pending migrations"
   task :abort_if_pending_migrations => :environment do
     pending_migrations = ActiveRecord::Migrator.open(ActiveRecord::Migrator.migrations_paths).pending_migrations


### PR DESCRIPTION
Hello there,

I use `rake db:version` to debug migration error. And the current behaviour is to print the version number of schema: 

``` Shell
$ rake db:version
Current version: 20150316153147
```

Then I use this number to find the migration file and fix the migration error.

This pull request will print the migration file path, then one can click on Terminal or copy this path to quickly open the migration file.

```
$ rake db:version
Current version: /Users/Juan/dev/rails-4-2/db/migrate/20150316153147_rename_columns_of_users.rb.
```

Hope this make  `rake db:version` a little bit better.
