### PR TITLE
Remove unused variable in activerecord reflection_test.

### DIFF
--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -282,7 +282,7 @@ class ReflectionTest < ActiveRecord::TestCase
     hotel = Hotel.create!
     department = hotel.departments.create!
     drink = department.chefs.create!(employable: DrinkDesigner.create!)
-    recipe = Recipe.create!(chef_id: drink.id, hotel_id: hotel.id)
+    Recipe.create!(chef_id: drink.id, hotel_id: hotel.id)
 
     hotel.drink_designers.to_a
     assert_sql(/^(?!.*employable_type).*$/) { hotel.recipes.to_a }


### PR DESCRIPTION
Remove this unused `recipe`. :smile: Found when ran tests:

```
/Users/Juan/dev/rails/activerecord/test/cases/reflection_test.rb:285: warning: assigned but unused variable - recipe
```
