### PR TITLE
Generate a NullRelation rather than a `WHERE 1=0` query where possible

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Cache `CollectionAssociation#reader` proxy separately when a different
+    current_scope is active. This prevents the reader from retaining `.scoping`
+    information after the `.scoping` block has been exited.
+
+    *Ben Woosley*
+
 *   Renaming `use_transactional_fixtures` to `use_transactional_tests` for clarity.
 
     Fixes #18864.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   In all cases where ActiveRecord would previously generate a query with
+    `WHERE 1=0`, it will instead avoid the query and return a NullRelation,
+    ala `.none`. This covers cases such as `.where('1=0')` and `.where(id: [])`.
+
+    *Ben Woosley*
+
 *   Cache `CollectionAssociation#reader` proxy separately when a different
     current_scope is active. This prevents the reader from retaining `.scoping`
     information after the `.scoping` block has been exited.

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -38,7 +38,10 @@ module ActiveRecord
           # or else a post-save proxy will still lack the id
           @new_record_proxy ||= CollectionProxy.create(klass, self)
         else
-          @proxy ||= CollectionProxy.create(klass, self)
+          # Include the current_scope#object_id so that the association will
+          # not retain .scoping information after leaving a .scoping context.
+          @proxy ||= {}
+          @proxy[klass.current_scope.object_id] ||= CollectionProxy.create(klass, self)
         end
       end
 

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -81,7 +81,7 @@ module ActiveRecord
     attr_reader :table
 
     def expand_from_hash(attributes)
-      return ["1=0"] if attributes.empty?
+      return [Relation::WhereClause::NONE_PREDICATE] if attributes.empty?
 
       attributes.flat_map do |key, value|
         if value.is_a?(Hash)

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -566,7 +566,9 @@ module ActiveRecord
         references!(PredicateBuilder.references(opts))
       end
 
-      self.where_clause += where_clause_factory.build(opts, rest)
+      new_where_clause = where_clause_factory.build(opts, rest)
+      self.extending!(NullRelation) if new_where_clause.none?
+      self.where_clause += new_where_clause
       self
     end
 
@@ -704,11 +706,11 @@ module ActiveRecord
     #   end
     #
     def none
-      where("1=0").extending!(NullRelation)
+      where(Relation::WhereClause::NONE_PREDICATE)
     end
 
     def none! # :nodoc:
-      where!("1=0").extending!(NullRelation)
+      where!(Relation::WhereClause::NONE_PREDICATE)
     end
 
     # Sets readonly attributes for the returned relation. If value is

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -1,6 +1,8 @@
 module ActiveRecord
   class Relation
     class WhereClause # :nodoc:
+      NONE_PREDICATE = '1=0'
+
       attr_reader :binds
 
       delegate :any?, :empty?, to: :predicates
@@ -84,6 +86,10 @@ module ActiveRecord
         new([], [])
       end
 
+      def none?
+        predicates.any? {|predicate| none_predicate?(predicate) }
+      end
+
       protected
 
       attr_reader :predicates
@@ -96,6 +102,14 @@ module ActiveRecord
       end
 
       private
+
+      def none_predicate?(predicate)
+        predicate == NONE_PREDICATE || (
+          Arel::Nodes::In === predicate &&
+            Array === predicate.right &&
+            predicate.right.empty?
+        )
+      end
 
       def predicates_unreferenced_by(other)
         predicates.reject do |n|

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -319,6 +319,34 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal [2, 4, 6, 8, 10], even_ids.sort
   end
 
+  def test_in_empty_is_none
+    assert_no_queries(ignore_none: false) do
+      assert_equal [], Developer.where(id: [])
+      assert_equal [], Developer.all.where(id: [])
+    end
+  end
+
+  def test_in_empty_hash_associations_is_none
+    assert_no_queries(ignore_none: false) do
+      assert_equal [], Developer.where(comments: {})
+      assert_equal [], Developer.all.where(comments: {})
+    end
+  end
+
+  def test_not_in_empty_is_all
+    all = Developer.all.to_a
+    assert_queries(1) do
+      assert_equal all, Developer.where.not(id: [])
+    end
+  end
+
+  def test_in_empty_or_something
+    developer = Developer.first
+    assert_queries(1) do
+      assert_equal [developer], Developer.where(id: []).or(Developer.where(id: developer.id))
+    end
+  end
+
   def test_none
     assert_no_queries(ignore_none: false) do
       assert_equal [], Developer.none

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -308,6 +308,18 @@ class HasManyScopingTest < ActiveRecord::TestCase
     assert_equal 2, @welcome.comments.search_by_type('Comment').size
   end
 
+  def test_none_scoping
+    Comment.none.scoping do
+      assert_equal 0, @welcome.comments.count
+      assert_equal 'a comment...', @welcome.comments.what_are_you
+    end
+
+    Comment.where('1=1').scoping do
+      assert_equal 2, @welcome.comments.count
+      assert_equal 'a comment...', @welcome.comments.what_are_you
+    end
+  end
+
   def test_nested_scope_finder
     Comment.where('1=0').scoping do
       assert_equal 0, @welcome.comments.count
@@ -347,6 +359,18 @@ class HasAndBelongsToManyScopingTest < ActiveRecord::TestCase
   def test_forwarding_of_static_methods
     assert_equal 'a category...', Category.what_are_you
     assert_equal 'a category...', @welcome.categories.what_are_you
+  end
+
+  def test_none_scoping
+    Category.none.scoping do
+      assert_equal 0, @welcome.categories.count
+      assert_equal 'a category...', @welcome.categories.what_are_you
+    end
+
+    Category.where('1=1').scoping do
+      assert_equal 2, @welcome.categories.count
+      assert_equal 'a category...', @welcome.categories.what_are_you
+    end
   end
 
   def test_nested_scope_finder


### PR DESCRIPTION
In all cases where ActiveRecord currently generates a query with
`WHERE 1=0`, it will instead avoid the query and return a NullRelation,
ala `.none`. This covers cases such as `.where('1=0')` and `.where(id: [])`.

This requires and builds on #19349, so I've included it in this pull request,
but should be separately considered.

This patch would be improved if `Arel::Nodes::In` responded to a method
to indicate when it was a none predicate, but I figured I'd get you guys'
opinion on it first.
