### PR TITLE
Drop `references_eager_loaded_tables?` test from `has_include?`

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -182,7 +182,7 @@ module ActiveRecord
     private
 
     def has_include?(column_name)
-      eager_loading? || (includes_values.present? && ((column_name && column_name != :all) || references_eager_loaded_tables?))
+      eager_loading? || (includes_values.present? && column_name && column_name != :all)
     end
 
     def perform_calculation(operation, column_name)


### PR DESCRIPTION
It is redundant with tests in `eager_loading?`, but for the difference
between `includes_values.present?` and `includes_values.any?`, which
is a difference without a distinction because `false` has no meaning
for `includes`.
