### PR TITLE
Add job priorities to ActiveJob (for 4.2.1)

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add job priorities to Active Job.
+
+    *wvengen*
+
 *   Allow keyword arguments to be used with Active Job.
 
     Fixes #18741.

--- a/activejob/lib/active_job/base.rb
+++ b/activejob/lib/active_job/base.rb
@@ -1,6 +1,7 @@
 require 'active_job/core'
 require 'active_job/queue_adapter'
 require 'active_job/queue_name'
+require 'active_job/queue_priority'
 require 'active_job/enqueuing'
 require 'active_job/execution'
 require 'active_job/callbacks'
@@ -56,6 +57,7 @@ module ActiveJob #:nodoc:
     include Core
     include QueueAdapter
     include QueueName
+    include QueuePriority
     include Enqueuing
     include Execution
     include Callbacks

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -15,6 +15,9 @@ module ActiveJob
 
       # Queue in which the job will reside.
       attr_writer :queue_name
+
+      # Priority that the job will have (lower is more priority).
+      attr_writer :priority
     end
 
     # These methods will be included into any Active Job object, adding
@@ -25,6 +28,7 @@ module ActiveJob
         job                      = job_data['job_class'].constantize.new
         job.job_id               = job_data['job_id']
         job.queue_name           = job_data['queue_name']
+        job.priority             = job_data['priority']
         job.serialized_arguments = job_data['arguments']
         job
       end
@@ -37,6 +41,7 @@ module ActiveJob
       # * <tt>:wait</tt> - Enqueues the job with the specified delay
       # * <tt>:wait_until</tt> - Enqueues the job at the time specified
       # * <tt>:queue</tt> - Enqueues the job on the specified queue
+      # * <tt>:priority</tt> - Enqueues the job with the specified priority
       #
       # ==== Examples
       #
@@ -45,6 +50,7 @@ module ActiveJob
       #    VideoJob.set(wait_until: Time.now.tomorrow).perform_later(Video.last)
       #    VideoJob.set(queue: :some_queue, wait: 5.minutes).perform_later(Video.last)
       #    VideoJob.set(queue: :some_queue, wait_until: Time.now.tomorrow).perform_later(Video.last)
+      #    VideoJob.set(queue: :some_queue, wait: 5.minutes, priority: 10).perform_later(Video.last)
       def set(options={})
         ConfiguredJob.new(self, options)
       end
@@ -56,6 +62,7 @@ module ActiveJob
       @arguments  = arguments
       @job_id     = SecureRandom.uuid
       @queue_name = self.class.queue_name
+      @priority   = self.class.priority
     end
 
     # Returns a hash with the job data that can safely be passed to the
@@ -65,6 +72,7 @@ module ActiveJob
         'job_class'  => self.class.name,
         'job_id'     => job_id,
         'queue_name' => queue_name,
+        'priority'   => priority,
         'arguments'  => serialize_arguments(arguments)
       }
     end

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -31,6 +31,7 @@ module ActiveJob
     # * <tt>:wait</tt> - Enqueues the job with the specified delay
     # * <tt>:wait_until</tt> - Enqueues the job at the time specified
     # * <tt>:queue</tt> - Enqueues the job on the specified queue
+    # * <tt>:priority</tt> - Enqueues the job with the specified priority
     #
     # ==== Examples
     #
@@ -53,6 +54,7 @@ module ActiveJob
     # * <tt>:wait</tt> - Enqueues the job with the specified delay
     # * <tt>:wait_until</tt> - Enqueues the job at the time specified
     # * <tt>:queue</tt> - Enqueues the job on the specified queue
+    # * <tt>:priority</tt> - Enqueues the job with the specified priority
     #
     # ==== Examples
     #
@@ -60,10 +62,12 @@ module ActiveJob
     #    my_job_instance.enqueue wait: 5.minutes
     #    my_job_instance.enqueue queue: :important
     #    my_job_instance.enqueue wait_until: Date.tomorrow.midnight
+    #    my_job_instance.enqueue priority: 10
     def enqueue(options={})
       self.scheduled_at = options[:wait].seconds.from_now.to_f if options[:wait]
       self.scheduled_at = options[:wait_until].to_f if options[:wait_until]
       self.queue_name   = self.class.queue_name_from_part(options[:queue]) if options[:queue]
+      self.priority     = options[:priority].to_i if options[:priority]
       run_callbacks :enqueue do
         if self.scheduled_at
           self.class.queue_adapter.enqueue_at self, self.scheduled_at

--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -15,11 +15,15 @@ module ActiveJob
     class DelayedJobAdapter
       class << self
         def enqueue(job) #:nodoc:
-          Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name)
+          enqueue_at(job, nil)
         end
 
         def enqueue_at(job, timestamp) #:nodoc:
-          Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name, run_at: Time.at(timestamp))
+          options = {}
+          options[:queue]    = job.queue_name
+          options[:priority] = job.priority if job.priority
+          options[:run_at]   = Time.at(timestamp) if timestamp
+          Delayed::Job.enqueue(JobWrapper.new(job.serialize), options)
         end
       end
 

--- a/activejob/lib/active_job/queue_adapters/que_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/que_adapter.rb
@@ -17,11 +17,15 @@ module ActiveJob
     class QueAdapter
       class << self
         def enqueue(job) #:nodoc:
-          JobWrapper.enqueue job.serialize, queue: job.queue_name
+          enqueue_at(job, nil)
         end
 
         def enqueue_at(job, timestamp) #:nodoc:
-          JobWrapper.enqueue job.serialize, queue: job.queue_name, run_at: Time.at(timestamp)
+          options = {}
+          options[:queue]    = job.queue_name
+          options[:priority] = job.priority if job.priority
+          options[:run_at]   = Time.at(timestamp) if timestamp
+          JobWrapper.enqueue job.serialize, options
         end
       end
 

--- a/activejob/lib/active_job/queue_priority.rb
+++ b/activejob/lib/active_job/queue_priority.rb
@@ -1,0 +1,44 @@
+module ActiveJob
+  module QueuePriority
+    extend ActiveSupport::Concern
+
+    # Includes the ability to override the default queue priority.
+    module ClassMethods
+      mattr_accessor(:default_priority)
+
+      # Specifies the priority of the queue to create the job with.
+      #
+      #   class PublishToFeedJob < ActiveJob::Base
+      #     queue_with_priority 50
+      #
+      #     def perform(post)
+      #       post.to_feed!
+      #     end
+      #   end
+      #
+      # Specify either an argument or a block.
+      def queue_with_priority(priority=nil, &block)
+        if block_given?
+          self.priority = block
+        else
+          self.priority = priority
+        end
+      end
+    end
+
+    included do
+      class_attribute :priority, instance_accessor: false
+
+      self.priority = default_priority
+    end
+
+    # Returns the priority that the job will be created with
+    def priority
+      if @priority.is_a?(Proc)
+        @priority = instance_exec(&@priority)
+      end
+      @priority
+    end
+
+  end
+end

--- a/activejob/test/cases/queue_priority_test.rb
+++ b/activejob/test/cases/queue_priority_test.rb
@@ -1,0 +1,47 @@
+require 'helper'
+require 'jobs/hello_job'
+
+class QueuePriorityTest < ActiveSupport::TestCase
+  test 'priority unset by default' do
+    assert_equal nil, HelloJob.priority
+  end
+
+  test 'uses given priority' do
+    original_priority = HelloJob.priority
+
+    begin
+      HelloJob.queue_with_priority 90
+      assert_equal 90, HelloJob.new.priority
+    ensure
+      HelloJob.priority = original_priority
+    end
+  end
+
+  test 'evals block given to priority to determine priority' do
+    original_priority = HelloJob.priority
+
+    begin
+      HelloJob.queue_with_priority { 25 }
+      assert_equal 25, HelloJob.new.priority
+    ensure
+      HelloJob.priority = original_priority
+    end
+  end
+
+  test 'can use arguments to determine priority in priority block' do
+    original_priority = HelloJob.priority
+
+    begin
+      HelloJob.queue_with_priority { self.arguments.first=='1' ? 99 : 11 }
+      assert_equal 99, HelloJob.new('1').priority
+      assert_equal 11, HelloJob.new('3').priority
+    ensure
+      HelloJob.priority = original_priority
+    end
+  end
+
+  test 'uses priority passed to #set' do
+    job = HelloJob.set(priority: 123).perform_later
+    assert_equal 123, job.priority
+  end
+end

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -44,4 +44,16 @@ class QueuingTest < ActiveSupport::TestCase
       skip
     end
   end
+
+  test 'should run job with higher priority first' do
+    skip unless adapter_is?(:delayed_job) || adapter_is?(:que)
+
+    wait_until = Time.now + 3.seconds
+    TestJob.set(wait_until: wait_until, priority: 20).perform_later "#{@id}.1"
+    TestJob.set(wait_until: wait_until, priority: 10).perform_later "#{@id}.2"
+    wait_for_jobs_to_finish_for(10.seconds)
+    assert job_executed "#{@id}.1"
+    assert job_executed "#{@id}.2"
+    assert job_executed_at("#{@id}.2") < job_executed_at("#{@id}.1")
+  end
 end

--- a/activejob/test/support/integration/test_case_helpers.rb
+++ b/activejob/test/support/integration/test_case_helpers.rb
@@ -42,7 +42,11 @@ module TestCaseHelpers
       end
     end
 
-    def job_executed
-      Dummy::Application.root.join("tmp/#{@id}").exist?
+    def job_executed(id=@id)
+      Dummy::Application.root.join("tmp/#{id}").exist?
+    end
+
+    def job_executed_at(id=@id)
+      File.new(Dummy::Application.root.join("tmp/#{id}")).ctime
     end
 end


### PR DESCRIPTION
The Active Job documentation [mentions](http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html) that some backends allow setting priority per job. This PR adds support for setting job-level priorites to Active Job.
- Similar to queue_name, the priority can be set on the class level and can be overridden per job.
- This only brings support to job-based priorities, not queue-based priorities. (Though the same syntax could be used, with the backend checking that the same priority is always used per queue.)
- The default priority for delayed_job is 0, for que 100. To keep backward-compatibility, the job priority is unset by default, but this can be overridden by setting default_priority.
- Backends that don't support priorities will silently ignore any priority setting. Perhaps an exception could be thrown (like scheduled jobs with the inline backend), but as most backends will need to do that, I guess some refactoring is needed. Since this is my first contribution, I've kept it with this for now.
- I hope it's ok to use the 4-2-1 branch, I'd be happy to port it to master when merged - but as I started development here it'd be double work to rebase on master and then backport later.
