### PR TITLE
Relocate 'swap param' code in ActvieRecord::Associations

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1280,6 +1280,7 @@ module ActiveRecord
       #   has_many :reports, -> { readonly }
       #   has_many :subscribers, through: :subscriptions, source: :user
       def has_many(name, scope = nil, options = {}, &extension)
+        options, scope = scope, nil if scope.is_a?(Hash)
         reflection = Builder::HasMany.build(self, name, scope, options, &extension)
         Reflection.add_reflection self, name, reflection
       end
@@ -1409,6 +1410,7 @@ module ActiveRecord
       #   has_one :primary_address, -> { where primary: true }, through: :addressables, source: :addressable
       #   has_one :credit_card, required: true
       def has_one(name, scope = nil, options = {})
+        options, scope = scope, nil if scope.is_a?(Hash)
         reflection = Builder::HasOne.build(self, name, scope, options)
         Reflection.add_reflection self, name, reflection
       end
@@ -1542,6 +1544,7 @@ module ActiveRecord
       #   belongs_to :company, touch: :employees_last_updated_at
       #   belongs_to :user, optional: true
       def belongs_to(name, scope = nil, options = {})
+        options, scope = scope, nil if scope.is_a?(Hash)
         reflection = Builder::BelongsTo.build(self, name, scope, options)
         Reflection.add_reflection self, name, reflection
       end
@@ -1707,10 +1710,7 @@ module ActiveRecord
       #   has_and_belongs_to_many :categories, join_table: "prods_cats"
       #   has_and_belongs_to_many :categories, -> { readonly }
       def has_and_belongs_to_many(name, scope = nil, options = {}, &extension)
-        if scope.is_a?(Hash)
-          options = scope
-          scope   = nil
-        end
+        options, scope = scope, nil if scope.is_a?(Hash)
 
         habtm_reflection = ActiveRecord::Reflection::HasAndBelongsToManyReflection.new(name, scope, options, self)
 

--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -36,11 +36,6 @@ module ActiveRecord::Associations::Builder
     def self.create_reflection(model, name, scope, options, extension = nil)
       raise ArgumentError, "association names must be a Symbol" unless name.kind_of?(Symbol)
 
-      if scope.is_a?(Hash)
-        options = scope
-        scope   = nil
-      end
-
       validate_options(options)
 
       scope = build_scope(scope, extension)


### PR DESCRIPTION
Isn't it better location?

I think `self.create_reflection` is not suitable location.
