### PR TITLE
Add a new-line to the end of route method generated code.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add a new-line to the end of route method generated code.
+
+    We need to add a `\n`, because we cannot have two routes
+    in the same line.
+
+    *arthurnn*
+
 *   Add `rake initializer`
 
     This task prints out initializers for an application. It is useful to

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -221,7 +221,7 @@ module Rails
         sentinel = /\.routes\.draw do\s*\n/m
 
         in_root do
-          inject_into_file 'config/routes.rb', "  #{routing_code}", { after: sentinel, verbose: false, force: true }
+          inject_into_file 'config/routes.rb', "  #{routing_code}\n", { after: sentinel, verbose: false, force: true }
         end
       end
 

--- a/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
+++ b/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
@@ -29,8 +29,10 @@ module Rails
           write("end", route_length - index)
         end
 
-        # route prepends two spaces onto the front of the string that is passed, this corrects that
-        route route_string[2..-1]
+        # route prepends two spaces onto the front of the string that is passed, this corrects that.
+        # Also it adds a \n to the end of each line, as route already adds that
+        # we need to correct that too.
+        route route_string[2..-2]
       end
 
       private

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -219,6 +219,30 @@ class ActionsTest < Rails::Generators::TestCase
     assert_file 'config/routes.rb', /#{Regexp.escape(route_command)}/
   end
 
+  def test_route_should_add_data_with_an_new_line
+    run_generator
+    action :route, "root 'welcome#index'"
+    route_path = File.expand_path("config/routes.rb", destination_root)
+    content = File.read(route_path)
+
+    # Remove all of the comments and blank lines from the routes file
+    content.gsub!(/^  \#.*\n/, '')
+    content.gsub!(/^\n/, '')
+
+    File.open(route_path, "wb") { |file| file.write(content) }
+    assert_file "config/routes.rb", /\.routes\.draw do\n  root 'welcome#index'\nend\n\z/
+
+    action :route, "resources :product_lines"
+
+    routes = <<-F
+Rails.application.routes.draw do
+  resources :product_lines
+  root 'welcome#index'
+end
+F
+    assert_file "config/routes.rb", routes
+  end
+
   def test_readme
     run_generator
     Rails::Generators::AppGenerator.expects(:source_root).times(2).returns(destination_root)


### PR DESCRIPTION
Fix regression on route method that was added by
bac812a7ef2660a2fe2ab00822e5e66228379822. The regression was that when
calling the `route` method, we were not appending a \n anymore.

[fixes #19316]

review @rafaelfranca @pixeltrix 
