### PR TITLE
Avoid violating key constraints in fixture HABTM associations

### DIFF
--- a/activerecord/lib/active_record/fixture_set/table_rows.rb
+++ b/activerecord/lib/active_record/fixture_set/table_rows.rb
@@ -45,6 +45,9 @@ module ActiveRecord
         # track any join tables we need to insert later
         @tables = Hash.new { |h, table| h[table] = [] }
 
+        # ensure this table is loaded before any HABTM associations
+        @tables[table_name] = nil
+
         build_table_rows_from(fixtures, config)
       end
 

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -619,6 +619,10 @@ class HasManyThroughFixture < ActiveRecord::TestCase
     assert_equal load_has_and_belongs_to_many["parrots_treasures"], rows["parrot_treasures"]
   end
 
+  def test_has_and_belongs_to_many_order
+    assert_equal ["parrots", "parrots_treasures"], load_has_and_belongs_to_many.keys
+  end
+
   def load_has_and_belongs_to_many
     parrot = make_model "Parrot"
     parrot.has_and_belongs_to_many :treasures


### PR DESCRIPTION
When loading fixtures, Ruby 1.9's hash key ordering means that HABTM
join table rows are always loaded before the parent table rows,
violating foreign key constraints that may be in place. This very
simple change ensures that the parent table's key appears first in the
hash. Violations may still occur if fixtures are loaded in the wrong
order but those instances can be avoided unlike this one.
