### PR TITLE
Allow AssetUrlHelper#asset_url to be used in mailers

### DIFF
--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -159,7 +159,7 @@ module ActionView
       #   asset_url "application.js", host: "http://cdn.example.com" # => http://cdn.example.com/assets/application.js
       #
       def asset_url(source, options = {})
-        path_to_asset(source, options.merge(:protocol => :request))
+        path_to_asset(source, options.merge(:protocol => respond_to?(:request) ? :request : config.default_asset_host_protocol || :relative))
       end
       alias_method :url_to_asset, :asset_url # aliased to avoid conflicts with an asset_url named route
 


### PR DESCRIPTION
Mailer templates need to provide a complete path to their asset including protocol so that all all mail client can display them properly.

As of now, asset_url sets protocol as :request. But inside mailers, request doesn't exist and it ends up throwing an exception when it tries to access request.protocol.

So instead of forcing the protocol type to be request, let us guess intelligently what should apply in the current situation.

Also, I believe whoever wrote AssetUrlHelper#compute_asset_host meant for option[:protocol] to be an actual web protocol instead of :request/:relative values, but that is besides the point.
