### PR TITLE
Don't fallback to RACK_ENV when RAILS_ENV is not present

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -36,7 +36,7 @@ require 'pp' # require 'pp' early to prevent hidden_methods from not picking up 
 module Rails
   class << self
     def env
-      @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "test")
+      @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"] || "test")
     end
   end
 end

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -28,7 +28,7 @@ require 'pp' # require 'pp' early to prevent hidden_methods from not picking up 
 module Rails
   class << self
     def env
-      @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "test")
+      @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"] || "test")
     end
   end
 end

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -1,6 +1,6 @@
 module ActiveRecord
   module ConnectionHandling
-    RAILS_ENV   = -> { (Rails.env if defined?(Rails.env)) || ENV["RAILS_ENV"] || ENV["RACK_ENV"] }
+    RAILS_ENV   = -> { (Rails.env if defined?(Rails.env)) || ENV["RAILS_ENV"] }
     DEFAULT_ENV = -> { RAILS_ENV.call || "default_env" }
 
     # Establishes the connection to the database. Accepts a hash as input where

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -5,13 +5,11 @@ module ActiveRecord
     class MergeAndResolveDefaultUrlConfigTest < ActiveRecord::TestCase
       def setup
         @previous_database_url = ENV.delete("DATABASE_URL")
-        @previous_rack_env = ENV.delete("RACK_ENV")
         @previous_rails_env = ENV.delete("RAILS_ENV")
       end
 
       teardown do
         ENV["DATABASE_URL"] = @previous_database_url
-        ENV["RACK_ENV"] = @previous_rack_env
         ENV["RAILS_ENV"] = @previous_rails_env
       end
 
@@ -34,16 +32,6 @@ module ActiveRecord
       def test_resolver_with_database_uri_and_current_env_symbol_key_and_rails_env
         ENV['DATABASE_URL'] = "postgres://localhost/foo"
         ENV['RAILS_ENV']    = "foo"
-
-        config   = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
-        actual   = resolve_spec(:foo, config)
-        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost" }
-        assert_equal expected, actual
-      end
-
-      def test_resolver_with_database_uri_and_current_env_symbol_key_and_rack_env
-        ENV['DATABASE_URL'] = "postgres://localhost/foo"
-        ENV['RACK_ENV']     = "foo"
 
         config   = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
         actual   = resolve_spec(:foo, config)
@@ -153,28 +141,6 @@ module ActiveRecord
 
       def test_blank_with_database_url_with_rails_env
         ENV['RAILS_ENV'] = "not_production"
-        ENV['DATABASE_URL'] = "postgres://localhost/foo"
-
-        config   = {}
-        actual   = resolve_config(config)
-        expected = { "adapter"  => "postgresql",
-                     "database" => "foo",
-                     "host"     => "localhost" }
-
-        assert_equal expected, actual["not_production"]
-        assert_equal nil,      actual["production"]
-        assert_equal nil,      actual["default_env"]
-        assert_equal nil,      actual["development"]
-        assert_equal nil,      actual["test"]
-        assert_equal nil,      actual[:default_env]
-        assert_equal nil,      actual[:not_production]
-        assert_equal nil,      actual[:production]
-        assert_equal nil,      actual[:development]
-        assert_equal nil,      actual[:test]
-      end
-
-      def test_blank_with_database_url_with_rack_env
-        ENV['RACK_ENV'] = "not_production"
         ENV['DATABASE_URL'] = "postgres://localhost/foo"
 
         config   = {}

--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -278,7 +278,7 @@ def parse_options(args)
 
   options.merge! opt_parser.parse!(args)
   options[:config] = ::File.expand_path(options[:config])
-  ENV["RACK_ENV"] = options[:environment]
+  ENV["RAILS_ENV"] = options[:environment]
   options
 end
 ```
@@ -287,7 +287,7 @@ With the `default_options` set to this:
 
 ```ruby
 def default_options
-  environment  = ENV['RACK_ENV'] || 'development'
+  environment  = ENV['RAILS_ENV'] || 'development'
   default_host = environment == 'development' ? 'localhost' : '0.0.0.0'
 
   {
@@ -669,7 +669,7 @@ def self.run(app, options = {})
   end
 
   if options[:environment]
-    ENV['RACK_ENV'] = options[:environment].to_s
+    ENV['RAILS_ENV'] = options[:environment].to_s
   end
 
   server   = ::Puma::Server.new(app)
@@ -677,7 +677,7 @@ def self.run(app, options = {})
 
   puts "Puma #{::Puma::Const::PUMA_VERSION} starting..."
   puts "* Min threads: #{min}, max threads: #{max}"
-  puts "* Environment: #{ENV['RACK_ENV']}"
+  puts "* Environment: #{ENV['RAILS_ENV']}"
   puts "* Listening on tcp://#{options[:Host]}:#{options[:Port]}"
 
   server.add_tcp_listener options[:Host], options[:Port]

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -62,7 +62,7 @@ module Rails
     #   Rails.env.development? # => true
     #   Rails.env.production? # => false
     def env
-      @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development")
+      @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"] || "development")
     end
 
     # Sets the Rails environment.

--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -57,7 +57,7 @@ module Rails
     end
 
     def environment
-      options[:environment] ||= ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+      options[:environment] ||= ENV['RAILS_ENV'] || 'development'
     end
 
     def environment?

--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -107,7 +107,7 @@ module Rails
       if Rails.respond_to?(:env)
         Rails.env
       else
-        ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
+        ENV["RAILS_ENV"] || "development"
       end
     end
 

--- a/railties/lib/rails/commands/runner.rb
+++ b/railties/lib/rails/commands/runner.rb
@@ -1,6 +1,6 @@
 require 'optparse'
 
-options = { environment: (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || "development").dup }
+options = { environment: (ENV['RAILS_ENV'] || "development").dup }
 code_or_file = nil
 
 if ARGV.first.nil?

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -95,7 +95,7 @@ module Rails
       super.merge({
         Port:               3000,
         DoNotReverseLookup: true,
-        environment:        (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || "development").dup,
+        environment:        (ENV['RAILS_ENV'] || "development").dup,
         daemonize:          false,
         pid:                File.expand_path("tmp/pids/server.pid"),
         config:             File.expand_path("config.ru")

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -203,9 +203,7 @@ module ApplicationTests
       test 'db:setup loads schema and seeds database' do
         begin
           @old_rails_env = ENV["RAILS_ENV"]
-          @old_rack_env = ENV["RACK_ENV"]
           ENV.delete "RAILS_ENV"
-          ENV.delete "RACK_ENV"
 
           app_file 'db/schema.rb', <<-RUBY
             ActiveRecord::Schema.define(version: "1") do
@@ -225,7 +223,6 @@ module ApplicationTests
           end
         ensure
           ENV["RAILS_ENV"] = @old_rails_env
-          ENV["RACK_ENV"] = @old_rack_env
         end
       end
     end

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -79,11 +79,5 @@ module ApplicationTests
         assert_match "production", Dir.chdir(app_path) { `bundle exec rails runner "puts Rails.env"` }
       end
     end
-
-    def test_environment_with_rack_env
-      with_rack_env "production" do
-        assert_match "production", Dir.chdir(app_path) { `bundle exec rails runner "puts Rails.env"` }
-      end
-    end
   end
 end

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -70,13 +70,6 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     end
   end
 
-  def test_default_environment_with_rack_env
-    with_rack_env 'production' do
-      start
-      assert_match(/\sproduction\s/, output)
-    end
-  end
-
   def test_e_option
     start ['-e', 'special-production']
     assert_match(/\sspecial-production\s/, output)

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -82,20 +82,15 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     assert_equal "test", Rails::DBConsole.new.environment
 
     ENV['RAILS_ENV'] = nil
-    ENV['RACK_ENV'] = nil
 
     Rails.stub(:respond_to?, false) do
       assert_equal "development", Rails::DBConsole.new.environment
-
-      ENV['RACK_ENV'] = "rack_env"
-      assert_equal "rack_env", Rails::DBConsole.new.environment
 
       ENV['RAILS_ENV'] = "rails_env"
       assert_equal "rails_env", Rails::DBConsole.new.environment
     end
   ensure
     ENV['RAILS_ENV'] = "test"
-    ENV['RACK_ENV'] = nil
   end
 
   def test_rails_env_is_development_when_argument_is_dev

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -27,61 +27,36 @@ class Rails::ServerTest < ActiveSupport::TestCase
   end
 
   def test_environment_with_rails_env
-    with_rack_env nil do
-      with_rails_env 'production' do
-        server = Rails::Server.new
-        assert_equal 'production', server.options[:environment]
-      end
-    end
-  end
-
-  def test_environment_with_rack_env
-    with_rails_env nil do
-      with_rack_env 'production' do
-        server = Rails::Server.new
-        assert_equal 'production', server.options[:environment]
-      end
+    with_rails_env 'production' do
+      server = Rails::Server.new
+      assert_equal 'production', server.options[:environment]
     end
   end
 
   def test_log_stdout
-    with_rack_env nil do
-      with_rails_env nil do
+    with_rails_env nil do
+      args    = []
+      options = Rails::Server::Options.new.parse!(args)
+      assert_equal true, options[:log_stdout]
+
+      args    = ["-e", "development"]
+      options = Rails::Server::Options.new.parse!(args)
+      assert_equal true, options[:log_stdout]
+
+      args    = ["-e", "production"]
+      options = Rails::Server::Options.new.parse!(args)
+      assert_equal false, options[:log_stdout]
+
+      with_rails_env 'development' do
         args    = []
         options = Rails::Server::Options.new.parse!(args)
         assert_equal true, options[:log_stdout]
+      end
 
-        args    = ["-e", "development"]
-        options = Rails::Server::Options.new.parse!(args)
-        assert_equal true, options[:log_stdout]
-
-        args    = ["-e", "production"]
+      with_rails_env 'production' do
+        args    = []
         options = Rails::Server::Options.new.parse!(args)
         assert_equal false, options[:log_stdout]
-
-        with_rack_env 'development' do
-          args    = []
-          options = Rails::Server::Options.new.parse!(args)
-          assert_equal true, options[:log_stdout]
-        end
-
-        with_rack_env 'production' do
-          args    = []
-          options = Rails::Server::Options.new.parse!(args)
-          assert_equal false, options[:log_stdout]
-        end
-
-        with_rails_env 'development' do
-          args    = []
-          options = Rails::Server::Options.new.parse!(args)
-          assert_equal true, options[:log_stdout]
-        end
-
-        with_rails_env 'production' do
-          args    = []
-          options = Rails::Server::Options.new.parse!(args)
-          assert_equal false, options[:log_stdout]
-        end
       end
     end
   end

--- a/railties/test/env_helpers.rb
+++ b/railties/test/env_helpers.rb
@@ -12,15 +12,6 @@ module EnvHelpers
     end
   end
 
-  def with_rack_env(env)
-    Rails.instance_variable_set :@_env, nil
-    switch_env 'RACK_ENV', env do
-      switch_env 'RAILS_ENV', nil do
-        yield
-      end
-    end
-  end
-
   def switch_env(key, value)
     old, ENV[key] = ENV[key], value
     yield


### PR DESCRIPTION
`RACK_ENV` is _not_ the same as `RAILS_ENV`, and can't serve as a fallback when the later isn't present.

See http://www.hezmatt.org/~mpalmer/blog/2013/10/13/rack_env-its-not-for-you.html

In fact, it can even cause some issues if your app is using unicorn, as they're including internal rack middlewares relying on `RACK_ENV` to have the `deployment` value.
See https://github.com/defunkt/unicorn/blob/master/lib/unicorn.rb#L56-L79

Rack itself does that too.
https://github.com/rack/rack/blob/4e4ab39b0508aa3e59f5d7e53696ef6ae7c220ed/lib/rack/server.rb#L228

This removes support for falling back to RACK_ENV when RAILS_ENV is not available.
