### PR TITLE
Backport pull requests #18417 and #18478 (ActiveRecord: On reconnection failure, release only failed connetion)

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -456,6 +456,10 @@ module ActiveRecord
           c.verify!
         end
         c
+      rescue
+        remove c
+        c.disconnect!
+        raise
       end
     end
 


### PR DESCRIPTION
This is a backport of the pull requests #18417 and #18478 (ActiveRecord: On reconnection failure, release only failed connetion). It would be great to see this come back to 4.2 :-)
