### PR TITLE
Replace occurences of alias_method_chain with their Module#prepend counterpart

### DIFF
--- a/activesupport/lib/active_support/core_ext/marshal.rb
+++ b/activesupport/lib/active_support/core_ext/marshal.rb
@@ -1,9 +1,7 @@
-require 'active_support/core_ext/module/aliasing'
-
-module Marshal
-  class << self
-    def load_with_autoloading(source)
-      load_without_autoloading(source)
+module ActiveSupport
+  module MarshalWithAutoloading
+    def load(source)
+      super(source)
     rescue ArgumentError, NameError => exc
       if exc.message.match(%r|undefined class/module (.+)|)
         # try loading the class/module
@@ -15,7 +13,7 @@ module Marshal
         raise exc
       end
     end
-
-    alias_method_chain :load, :autoloading
   end
 end
+
+Marshal.singleton_class.prepend(ActiveSupport::MarshalWithAutoloading)

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -9,7 +9,6 @@ require 'time'
 require 'active_support/core_ext/time/conversions'
 require 'active_support/core_ext/date_time/conversions'
 require 'active_support/core_ext/date/conversions'
-require 'active_support/core_ext/module/aliasing'
 
 # The JSON gem adds a few modules to Ruby core classes containing :to_json definition, overwriting
 # their default behavior. That said, we need to define the basic to_json method in all of them,
@@ -26,20 +25,25 @@ require 'active_support/core_ext/module/aliasing'
 # bypassed completely. This means that as_json won't be invoked and the JSON gem will simply
 # ignore any options it does not natively understand. This also means that ::JSON.{generate,dump}
 # should give exactly the same results with or without active support.
-[Object, Array, FalseClass, Float, Hash, Integer, NilClass, String, TrueClass, Enumerable].each do |klass|
-  klass.class_eval do
-    def to_json_with_active_support_encoder(options = nil)
-      if options.is_a?(::JSON::State)
-        # Called from JSON.{generate,dump}, forward it to JSON gem's to_json
-        self.to_json_without_active_support_encoder(options)
-      else
-        # to_json is being invoked directly, use ActiveSupport's encoder
-        ActiveSupport::JSON.encode(self, options)
+
+module ActiveSupport
+  module CoreExt
+    module ToJsonWithActiveSupportEncoder
+      def to_json(options = nil)
+        if options.is_a?(::JSON::State)
+          # Called from JSON.{generate,dump}, forward it to JSON gem's to_json
+          super(options)
+        else
+          # to_json is being invoked directly, use ActiveSupport's encoder
+          ActiveSupport::JSON.encode(self, options)
+        end
       end
     end
-
-    alias_method_chain :to_json, :active_support_encoder
   end
+end
+
+[Object, Array, FalseClass, Float, Hash, Integer, NilClass, String, TrueClass, Enumerable].reverse_each do |klass|
+  klass.prepend(ActiveSupport::CoreExt::ToJsonWithActiveSupportEncoder)
 end
 
 class Object

--- a/activesupport/test/core_ext/marshal_test.rb
+++ b/activesupport/test/core_ext/marshal_test.rb
@@ -15,7 +15,7 @@ class MarshalTest < ActiveSupport::TestCase
     sanity_data = ["test", [1, 2, 3], {a: [1, 2, 3]}, ActiveSupport::TestCase]
     sanity_data.each do |obj|
       dumped = Marshal.dump(obj)
-      assert_equal Marshal.load_without_autoloading(dumped), Marshal.load(dumped)
+      assert_equal Marshal.method(:load).super_method.call(dumped), Marshal.load(dumped)
     end
   end
 


### PR DESCRIPTION
Earlier @fbernier proposed a cool idea of replacing `alias_method_chain` with `Module#prepend` in #17394.
I guess it's now time to merge it :rocket:
/cc @rafaelfranca 
