### PR TITLE
Fix #12537 performance regression when preloading has_many_through association

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -18,7 +18,8 @@ module ActiveRecord
           through_records = owners.map do |owner|
             association = owner.association through_reflection.name
 
-            [owner, Array(association.reader)]
+            center = target_records_from_association(association)
+            [owner, Array(center)]
           end
 
           reset_association owners, through_reflection.name
@@ -49,7 +50,7 @@ module ActiveRecord
               rhs_records = middles.flat_map { |r|
                 association = r.association source_reflection.name
 
-                association.reader
+                target_records_from_association(association)
               }.compact
 
               rhs_records.sort_by { |rhs| record_offset[rhs] }
@@ -88,6 +89,10 @@ module ActiveRecord
           end
 
           scope
+        end
+
+        def target_records_from_association(association)
+          association.loaded? ? association.target : association.reader
         end
       end
     end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1349,4 +1349,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
     post = Post.eager_load(:tags).where('tags.name = ?', 'General').first
     assert_equal posts(:welcome), post
   end
+
+  # CollectionProxy#reader is expensive, so the preloader avoids calling it.
+  test "preloading has_many_through association avoids calling association.reader" do
+    ActiveRecord::Associations::HasManyAssociation.any_instance.expects(:reader).never
+    Author.preload(:readonly_comments).first!
+  end
 end


### PR DESCRIPTION
Fix #12537

I profiled the benchmark code that preloads has_many_through association,
and found that most of time spent by calling `CollectionAssociation#reader` method  in `associated_records_by_owner`.

Here is a result of profiling `associated_records_by_owner` method.
- https://gist.github.com/yuroyoro/b68f673c2ac24f0fe29a
- (dumpfile) https://www.dropbox.com/s/lqsqr86nrfrqvlq/stackprof-cpu-prelading-4.2-2015-03-10-12-40-24.dump?dl=0

`CollectionAssociation#reader` creates new `CollectionProxy` object if it doesn't exists.
But, instantiate `CollectionProxy` is expensive operation.
Because creating the `Relation` object by calling `Association#scope` is expensive,
and merging it into `CollectionProxy` is also.

https://github.com/rails/rails/commit/c86a32d7451c5d901620ac58630460915292f88b#commitcomment-5384529

In this case, the association's records are already loaded by the preloader.
It just read records by `Association#target` that returns loaded records,
instead of `reader` method.

Here are benchmark results.

```
================================================================================
3.2.21 - postgresql
================================================================================

Calculating -------------------------------------
  limit 100 has_many    12.000  i/100ms
limit 100 has_many_through
                         5.000  i/100ms
limit 100 double has_many_through
                         3.000  i/100ms
 limit 1000 has_many     1.000  i/100ms
limit 1000 has_many_through
                         1.000  i/100ms
limit 1000 double has_many_through
                         1.000  i/100ms
-------------------------------------------------
  limit 100 has_many    129.401  (± 3.9%) i/s -    648.000
limit 100 has_many_through
                         53.440  (± 7.5%) i/s -    270.000
limit 100 double has_many_through
                         31.399  (± 6.4%) i/s -    156.000
 limit 1000 has_many     15.410  (± 6.5%) i/s -     77.000
limit 1000 has_many_through
                          6.097  (± 0.0%) i/s -     31.000
limit 1000 double has_many_through
                          3.520  (± 0.0%) i/s -     18.000

================================================================================
5.0.0.alpha - postgresql
================================================================================

Calculating -------------------------------------
  limit 100 has_many     8.000  i/100ms
limit 100 has_many_through
                         1.000  i/100ms
limit 100 double has_many_through
                         1.000  i/100ms
 limit 1000 has_many     1.000  i/100ms
limit 1000 has_many_through
                         1.000  i/100ms
limit 1000 double has_many_through
                         1.000  i/100ms
-------------------------------------------------
  limit 100 has_many     92.615  (± 4.3%) i/s -    464.000
limit 100 has_many_through
                          8.574  (± 0.0%) i/s -     43.000
limit 100 double has_many_through
                          5.300  (± 0.0%) i/s -     27.000
 limit 1000 has_many     12.712  (± 0.0%) i/s -     64.000
limit 1000 has_many_through
                          0.892  (± 0.0%) i/s -      5.000  in   5.610751s
limit 1000 double has_many_through
                          0.516  (± 0.0%) i/s -      3.000  in   5.814872s

================================================================================
5.0.0.alpha (after) - postgresql
================================================================================

Calculating -------------------------------------
  limit 100 has_many     8.000  i/100ms
limit 100 has_many_through
                         3.000  i/100ms
limit 100 double has_many_through
                         1.000  i/100ms
 limit 1000 has_many     1.000  i/100ms
limit 1000 has_many_through
                         1.000  i/100ms
limit 1000 double has_many_through
                         1.000  i/100ms
-------------------------------------------------
  limit 100 has_many     91.012  (± 4.4%) i/s -    456.000
limit 100 has_many_through
                         31.822  (± 3.1%) i/s -    159.000
limit 100 double has_many_through
                         19.298  (± 5.2%) i/s -     97.000
 limit 1000 has_many     10.621  (± 0.0%) i/s -     54.000
limit 1000 has_many_through
                          3.767  (± 0.0%) i/s -     19.000
limit 1000 double has_many_through
                          2.144  (± 0.0%) i/s -     11.000
```

In the benchmark case "limit 1000 double has_many_through", it still slower than 3.2, but faster then master.

This is a benchmarks code that I used.

https://gist.github.com/yuroyoro/89fae1150e285658db45
