### PR TITLE
Force ActionDispatch::Request#xhr? to return true or false

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -230,7 +230,7 @@ module ActionDispatch
     # (case-insensitive), which may need to be manually added depending on the
     # choice of JavaScript libraries and frameworks.
     def xml_http_request?
-      @env['HTTP_X_REQUESTED_WITH'] =~ /XMLHttpRequest/i
+      /XMLHttpRequest/i === @env['HTTP_X_REQUESTED_WITH']
     end
     alias :xhr? :xml_http_request?
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -767,7 +767,7 @@ class RequestFormat < BaseRequestTest
       'HTTP_ACCEPT' => [Mime::JS, Mime::HTML, Mime::XML, "text/xml", Mime::ALL].join(",")
     )
     request.expects(:parameters).at_least_once.returns({})
-    assert request.xhr?
+    assert_equal request.xhr?, true
     assert_equal Mime::JS, request.format
   end
 


### PR DESCRIPTION
The `ActionDispatch::Request#xhr?` comment lines say "Return true if ...", but in fact it returns 0 instead of `true`. This is because `String#=~` returns Fixnum or `nil`. I think it should always return `true` or `false` only, so I replaced it with `Regexp#===`.
