### PR TITLE
Enum: add wrapper for `not` statements.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Extend Enum scopes to include a `not_` query which is a wrapper for the
+    `where.not` query.
+
+    *Jelmer Snoeck*
+
 *   Reuse the `CollectionAssociation#reader` cache when the foreign key is
     available prior to save.
 

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -31,6 +31,8 @@ module ActiveRecord
   #
   #   Conversation.active
   #   Conversation.archived
+  #   Conversation.not_active
+  #   Conversation.not_archived
   #
   # Of course, you can also query them directly if the scopes doesn't fit your
   # needs:
@@ -151,6 +153,10 @@ module ActiveRecord
             # scope :active, -> { where status: 0 }
             klass.send(:detect_enum_conflict!, name, value, true)
             klass.scope value, -> { klass.where name => value }
+
+            # scope :not_active, -> { where.not status: 0 }
+            klass.send(:detect_enum_conflict!, name, "not_#{value}", true)
+            klass.scope "not_#{value}", -> { klass.where.not name => value }
           end
         end
         defined_enums[name.to_s] = enum_values

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -26,6 +26,16 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal @book, Book.unread.first
   end
 
+  test "find others via scope" do
+    proposed = Book.proposed.create!
+    written = Book.written.create!
+    published = Book.published.create!
+
+    assert_not Book.not_proposed.include?(proposed)
+    assert_not Book.not_written.include?(written)
+    assert_not Book.not_published.include?(published)
+  end
+
   test "find via where with values" do
     proposed, written = Book.statuses[:proposed], Book.statuses[:written]
 


### PR DESCRIPTION
Have a wrapper method that replaces the `where.not(status: value)` query with
`not_value`.

This makes it more consistent with the other available scopes (`Model.value`).
