### PR TITLE
Loading fixtures without a 'fixture_path' globs `/` for yml

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -878,6 +878,9 @@ module ActiveRecord
 
       def fixtures(*fixture_set_names)
         if fixture_set_names.first == :all
+          unless fixture_path # protect against globbing `/`
+            raise StandardError, "No 'fixture_path' configured'"
+          end
           fixture_set_names = Dir["#{fixture_path}/{**,*}/*.{yml}"]
           fixture_set_names.map! { |f| f[(fixture_path.to_s.size + 1)..-5] }
         else

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -878,7 +878,8 @@ module ActiveRecord
 
       def fixtures(*fixture_set_names)
         if fixture_set_names.first == :all
-          unless fixture_path # protect against globbing `/`
+          # protect against globbing `/`:
+          unless (fixture_path and fixture_path != '') 
             raise StandardError, "No 'fixture_path' configured'"
           end
           fixture_set_names = Dir["#{fixture_path}/{**,*}/*.{yml}"]


### PR DESCRIPTION
1. `ActiveSupport::TestCase.fixture_path` is not guaranteed to be defined (When using a non-default test-suite, in our case rspec)
2. [`active_record/fixtures.rb#fixtures`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/fixtures.rb#L880-L881) does expect it to always be set; it builds a path to glob like this `"#{fixture_path}/{**,*}/*.{yml}"`.
3. So, when loading `fixtures :all`, without a set `fixture_path`, the **filesystem root is scanned for `yml` files** (`/{**,*}/*.yml`).

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/fixtures.rb#L880-L881

A fix would be easy, but I am not sure how to handle this condition. I think not having set the variable in the first place is an error, so it would be simplest to check for it and raise an error when it's missing?
