### PR TITLE
Fixes Inflector#titleize to work with SafeBuffer

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixed a problem with ActiveSupport::SafeBuffer.titleize calling capitalize
+    on nil.
+
+    *Brian McManus*
+    
 *   Added `#without` on `Enumerable` and `Array` to return a copy of an
     enumerable without the specified elements.
 

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -153,7 +153,9 @@ module ActiveSupport
     #   titleize('TheManWithoutAPast')       # => "The Man Without A Past"
     #   titleize('raiders_of_the_lost_ark')  # => "Raiders Of The Lost Ark"
     def titleize(word)
-      humanize(underscore(word)).gsub(/\b(?<!['’`])[a-z]/) { $&.capitalize }
+      humanize(underscore(word)).gsub(/\b(?<!['’`])[a-z]/) do |match|
+        match.capitalize
+      end
     end
 
     # Creates the name of a table like Rails does for models to table names.

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -237,7 +237,8 @@ module InflectorTestCases
     "maybe you'll be there" => "Maybe You'll Be There",
     "¿por qué?"             => '¿Por Qué?',
     "Fred’s"                => "Fred’s",
-    "Fred`s"                => "Fred`s"
+    "Fred`s"                => "Fred`s",
+    ActiveSupport::SafeBuffer.new("confirmation num") => "Confirmation Num"
   }
 
   OrdinalNumbers = {


### PR DESCRIPTION
The way Inflector#titleize was implemented did not work properly when
called on a SafeBuffer object. Using the global `$&` variable in the
gsub resulted in calling capitalize on a nil object for reasons I still
do not fully understand. Removing the UNSAFE_STRING_METHODS override for
the gsub method in SafeBuffer "fixed" the bug but is obviously
unacceptable.

An example of this is very easy to see in rails console:

```
ActiveSupport::SafeBuffer.new("my test").titleize
> NoMethodError: undefined method `capitalize' for nil:NilClass
```

Using the non global version of gsub with a |match| arg passed to the
block fixes the problem. Again I do not quite understand why. I noticed
that other parts of Inflector were already using the standard block arg
version of gsub so I don't think it should be a problem to convert this
method to using it as well.
