### PR TITLE
Print `bundle install` output in `rails new` as soon as it's available

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Print `bundle install` output in `rails new` as soon as it's available
+
+    Running `rails new` will now print the output of `bundle install` as
+    it is available, instead of waiting until all gems finish installing.
+
+    *Max Holder*
+
 *   Add a new-line to the end of route method generated code.
 
     We need to add a `\n`, because we cannot have two routes

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -315,10 +315,6 @@ module Rails
         # its own vendored Thor, which could be a different version. Running both
         # things in the same process is a recipe for a night with paracetamol.
         #
-        # We use backticks and #print here instead of vanilla #system because it
-        # is easier to silence stdout in the existing test suite this way. The
-        # end-user gets the bundler commands called anyway, so no big deal.
-        #
         # We unset temporary bundler variables to load proper bundler and Gemfile.
         #
         # Thanks to James Tucker for the Gem tricks involved in this call.
@@ -326,8 +322,12 @@ module Rails
 
         require 'bundler'
         Bundler.with_clean_env do
-          output = `"#{Gem.ruby}" "#{_bundle_command}" #{command}`
-          print output unless options[:quiet]
+          full_command = %Q["#{Gem.ruby}" "#{_bundle_command}" #{command}]
+          if options[:quiet]
+            system(full_command, out: File::NULL)
+          else
+            system(full_command)
+          end
         end
       end
 


### PR DESCRIPTION
Previously, running `rails new` would not print any of the output from
`bundle install` until all the gems had finished installing. This made
it look like the generator was hanging at the `bundle install` step.

This is arguably a minor issue, but it can be confusing for new people.

This PR changes how we call the bundle command from using backticks
to using `Open3.popen2e`, allowing us to read each line of the output as
bundler produces it.

This has the added benefit of including output bundler produces on
standard error, which the previous code ignored since backticks only
capture standard out. This is not a big deal right now since bundler
does not currently print errors to standard error, but that may change
in the future (see: bundler/bundler/issues/3353).

The one downside here is that since we're using `Open3.popen2e`, we are
merging standard error and standard out, and outputting them both to
standard out. This is not ideal, but it removes the possibility for a
deadlock that could occur if we used `Open3.popen3` instead.
