### PR TITLE
Respect routing precedence for HEAD requests

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -121,7 +121,8 @@ module ActionDispatch
         end
 
         def match_head_routes(routes, req)
-          head_routes = match_routes(routes, req)
+          verb_specific_routes = routes.reject { |route| route.verb == // }
+          head_routes = match_routes(verb_specific_routes, req)
 
           if head_routes.empty?
             begin

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3492,12 +3492,11 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       mount lambda { |env| [200, {}, [env['REQUEST_METHOD']]] }, at: '/'
     end
 
-    # TODO: HEAD request should match `get /home` rather than the
+    # HEAD request should match `get /home` rather than the
     # lower-precedence Rack app mounted at `/`.
     head '/home'
     assert_response :ok
-    #assert_equal 'test#index', @response.body
-    assert_equal 'HEAD', @response.body
+    assert_equal 'test#index', @response.body
 
     # But the Rack app can still respond to its own HEAD requests.
     head '/foobar'


### PR DESCRIPTION
Fixes the issue described in #18764 - prevents Rack middleware from swallowing up HEAD requests that should have been matched by a higher-precedence `get` route, but still allows Rack middleware to
respond to HEAD requests.

Also needs to be backported to 4.2 and 4.1.

An alternative solution, described by @jeremy [here](https://github.com/rails/rails/pull/18764#issuecomment-75864412) would be making `get` routes match GET & HEAD requests, rather than just GET. This could be done by adding `HEAD` into the `via` array [here](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing/mapper.rb#L91), but changes the output of `rake routes` to show `GET|HEAD` for `get` routes.

If there's a preference for the alternative solution, I'm happy to switch over to that.
