### PR TITLE
Testing Guide: Change 'girlfriend' to 'partner'

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -138,7 +138,7 @@ users(:david)
 users(:david).id
 
 # one can also access methods available on the User class
-email(david.girlfriend.email, david.location_tonight)
+email(david.partner.email, david.location_tonight)
 ```
 
 ### Rake Tasks for Running your Tests


### PR DESCRIPTION
Right now the testing guide says `david.girlfriend`

Instead, I think we should prefer a more inclusive term like `david.partner`, since `david.girlfriend` is [heteronormative](https://en.wikipedia.org/wiki/Heteronormativity). 

And besides, David is married now.
