### PR TITLE
Fix handling of empty X_FORWARDED_HOST header.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix handling of empty X_FORWARDED_HOST header in raw_host_with_port
+
+    Previously, an empty X_FORWARDED_HOST header would cause
+    Actiondispatch::Http:URL.raw_host_with_port to return nil, causing
+    Actiondispatch::Http:URL.host to raise a NoMethodError.
+
+    *Adam Forsyth*
+
 *   Drop request class from RouteSet constructor.
  
     If you would like to use a custom request class, please subclass and implement

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -229,7 +229,7 @@ module ActionDispatch
       #   req = Request.new 'HTTP_HOST' => 'example.com:8080'
       #   req.raw_host_with_port # => "example.com:8080"
       def raw_host_with_port
-        if forwarded = env["HTTP_X_FORWARDED_HOST"]
+        if forwarded = env["HTTP_X_FORWARDED_HOST"].presence
           forwarded.split(/,\s?/).last
         else
           env['HTTP_HOST'] || "#{env['SERVER_NAME'] || env['SERVER_ADDR']}:#{env['SERVER_PORT']}"

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -435,6 +435,9 @@ class RequestHost < BaseRequestTest
 
     request = stub_request 'HTTP_X_FORWARDED_HOST' => "www.firsthost.org, www.secondhost.org"
     assert_equal "www.secondhost.org", request.host
+
+    request = stub_request 'HTTP_X_FORWARDED_HOST' => "", 'HTTP_HOST' => "rubyonrails.org"
+    assert_equal "rubyonrails.org", request.host
   end
 
   test "http host with default port overrides server port" do


### PR DESCRIPTION
Previously, an empty X_FORWARDED_HOST header would cause
Actiondispatch::Http:URL.raw_host_with_port to return nil, causing
Actiondispatch::Http:URL.host to raise a NoMethodError.

I ran into this bug on 3.2, so it might make sense to backport this to `-stable` branches.
