### PR TITLE
Do not run rake test tasks with `at_exit`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   For rake test tasks, call `Minitest.run` explicitly instead of using
+    the `at_exit` hook. This executes test tasks at their specified
+    position and not only at the end of the rake run.
+
+    Fixes #17708.
+
+    *Pascal Zumkehr*
+
 *   Add a new-line to the end of route method generated code.
 
     We need to add a `\n`, because we cannot have two routes

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -3,7 +3,9 @@
 abort("Abort testing: Your Rails environment is running in production mode!") if Rails.env.production?
 
 require "rails/test_unit/minitest_plugin"
-require 'active_support/testing/autorun'
+unless $rails_test_runner
+  require 'active_support/testing/autorun'
+end
 require 'active_support/test_case'
 require 'action_controller'
 require 'action_controller/test_case'

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -86,6 +86,7 @@ module Rails
     def run
       $rails_test_runner = self
       ENV["RAILS_ENV"] = @options[:environment]
+      load_tests
       run_tests
     end
 
@@ -114,10 +115,16 @@ module Rails
     end
 
     private
-    def run_tests
+    def load_tests
       test_files.to_a.each do |file|
         require File.expand_path file
       end
+    end
+
+    def run_tests
+      exit_code = Minitest.run ARGV
+      Minitest::Runnable.reset
+      exit exit_code unless exit_code
     end
 
     def test_methods


### PR DESCRIPTION
For rake test tasks, call `Minitest.run` explicitly instead of using the `at_exit` hook. This executes test tasks at their specified position and not only at the end of the rake run.

E.g.

```
rake test:models other:task test:controllers
```

This first runs the model tests, then other:task and finally the controller tests. Before this change, other:task was run first, then the model and controller tests were run in one go.

If a test task fails, rake exits with exit code 1 (same as before) without running the remaining tasks. 

Fixes #17708.
