### PR TITLE
[ci skip] Check a result of `valid?` instead of `create`

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -69,7 +69,8 @@ module ActionView
     # controller gets a nested hash <tt>params[:person]</tt> with the person attributes
     # set in the form. That hash is ready to be passed to <tt>Person.create</tt>:
     #
-    #   if @person = Person.create(params[:person])
+    #   @person = Person.create(params[:person])
+    #   if @person.valid?
     #     # success
     #   else
     #     # error handling


### PR DESCRIPTION
`Person.create` returns `person` object even if `person` is invalid.
So check  a result of `valid?`.
