### PR TITLE
Patch for issue #19439, ActiveJob::Logger should check that logger formatter responds to `current_tags`

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -77,4 +77,15 @@
 
     *Isaac Seymour*
 
+*   `ActiveJob::Logging` checks the log formatter responds to `current_tags`
+     
+    When checking to see if the ActiveJob tag should be added to the logger, we need
+    to retrieve the current list of tags. If the log formatter does not respond
+    to the method `current_tags`, then we should assume the tag has already been added
+
+    Fixes #19439
+
+    *Rob Di Marco*
+  
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activejob/CHANGELOG.md) for previous changes.

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -47,7 +47,13 @@ module ActiveJob
       end
 
       def logger_tagged_by_active_job?
-        logger.formatter.current_tags.include?("ActiveJob")
+        if logger.formatter.respond_to?(:current_tags)
+          logger.formatter.current_tags.include?("ActiveJob")
+        else
+          # Return true because if we cannot figure out what the current tags
+          # are, we do not want to keep adding the ActiveJob tag
+          true
+        end
       end
 
     class LogSubscriber < ActiveSupport::LogSubscriber #:nodoc:

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -47,13 +47,7 @@ module ActiveJob
       end
 
       def logger_tagged_by_active_job?
-        if logger.formatter.respond_to?(:current_tags)
-          logger.current_tags.include?("ActiveJob")
-        else
-          # Return true because if we cannot figure out what the current tags
-          # are, we do not want to keep adding the ActiveJob tag
-          true
-        end
+        logger.current_tags.include?("ActiveJob")
       end
 
     class LogSubscriber < ActiveSupport::LogSubscriber #:nodoc:

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -38,7 +38,7 @@ module ActiveJob
 
     private
       def tag_logger(*tags)
-        if logger.respond_to?(:tagged)
+        if logger.respond_to?(:tagged) && logger.respond_to?(:current_tags)
           tags.unshift "ActiveJob" unless logger_tagged_by_active_job?
           ActiveJob::Base.logger.tagged(*tags){ yield }
         else
@@ -48,7 +48,7 @@ module ActiveJob
 
       def logger_tagged_by_active_job?
         if logger.formatter.respond_to?(:current_tags)
-          logger.formatter.current_tags.include?("ActiveJob")
+          logger.current_tags.include?("ActiveJob")
         else
           # Return true because if we cannot figure out what the current tags
           # are, we do not want to keep adding the ActiveJob tag

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -64,7 +64,7 @@ module ActiveSupport
       logger.extend(self)
     end
 
-    delegate :push_tags, :pop_tags, :clear_tags!, to: :formatter
+    delegate :push_tags, :pop_tags, :clear_tags!, :current_tags, to: :formatter
 
     def tagged(*tags)
       formatter.tagged(*tags) { yield self }


### PR DESCRIPTION
When checking to see if the ActiveJob tag should be added to the logger, we need to retrieve the current list of tags. If the log formatter does not respond to the method `current_tags`, then we should assume the tag has already been added.

This addresses issue #19439
