### PR TITLE
Fix documentation for find_or_create_by

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -205,7 +205,9 @@ module ActiveRecord
     # constraint an exception may be raised, just retry:
     #
     #  begin
-    #    CreditAccount.find_or_create_by(user_id: user.id)
+    #    CreditAccount.transaction(requires_new: true) do
+    #      CreditAccount.find_or_create_by(user_id: user.id)
+    #    end
     #  rescue ActiveRecord::RecordNotUnique
     #    retry
     #  end


### PR DESCRIPTION
The code in the comment fails on concurrent inserts if done inside a transaction. 

The fix is to force a savepoint to run so that if the database raises an unique violation exception, the next query can run. Otherwise, you'll get errors like:

```
   (0.3ms)  BEGIN
  Cart Load (0.5ms)  SELECT  "carts".* FROM "carts"  WHERE "carts"."uuid" = '12345' LIMIT 1

# Another process inserts a cart with uuid of '12345' right now

  SQL (4371.7ms)  INSERT INTO "carts" ("created_at", "updated_at", "uuid") VALUES ('2015-03-21 01:05:07.833231', '2015-03-21 01:05:07.833231', '12345') RETURNING "id"  [["created_at", Sat, 21 Mar 2015 01:05:07 PDT -07:00], ["updated_at", Sat, 21 Mar 2015 01:05:07 PDT -07:00], ["uuid", "12345"]]
PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "carts_uuid_idx1"
DETAIL:  Key (uuid)=(12345) already exists.
: INSERT INTO "carts" ("created_at", "updated_at", "uuid") VALUES ('2015-03-21 01:05:07.833231', '2015-03-21 01:05:07.833231', '12345') RETURNING "id"

# Retrying the find

  Cart Load (0.8ms)  SELECT  "carts".* FROM "carts"  WHERE "carts"."uuid" = '12345' LIMIT 1
PG::InFailedSqlTransaction: ERROR:  current transaction is aborted, commands ignored until end of transaction block
: SELECT  "carts".* FROM "carts"  WHERE "carts"."uuid" = '12345' LIMIT 1
   (0.1ms)  ROLLBACK
ActiveRecord::StatementInvalid: PG::InFailedSqlTransaction: ERROR:  current transaction is aborted, commands ignored until end of transaction block
: SELECT  "carts".* FROM "carts"  WHERE "carts"."uuid" = '12345' LIMIT 1
```
