### PR TITLE
Fix ActiveModel::Errors deprecation messages failing when used on its own

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/array/conversions'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/object/deep_dup'
+require 'active_support/core_ext/string/filters'
 
 module ActiveModel
   # == Active \Model \Errors


### PR DESCRIPTION
  Deprecation messages in ActiveModel::Errors are using String#squish
from ActiveSupport but were not explicitly requiring it, causing failures
when used outside rails.

The minimal file for reproducing it is ("when run from rails repository root"):

``` ruby
require File.expand_path('../load_paths', __FILE__)
require 'active_model'

class Person
  def initialize
    @errors = ActiveModel::Errors.new(self)
  end

  attr_accessor :name
  attr_reader :errors
end

Person.new.errors.get(:name)
```

It fails with:

``` bash
/vagrant/rails/activemodel/lib/active_model/errors.rb:116:in `get': undefined method `squish' for #<String:0x8f592ec> (NoMethodError)
```
