### PR TITLE
Check subtype limit before using the default limit

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -698,4 +698,10 @@
 
     *Yves Senn*
 
+*   Fixes #19420. When generating schema.rb using Postgres BigInt[] data type
+    the limit: 8 was not coming through. This caused it to become Int[] data type
+    after doing a rebuild off of schema.rb.
+
+    *Jake Waller*
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -18,7 +18,7 @@ module ActiveRecord
           end
 
           attr_reader :subtype, :delimiter
-          delegate :type, :user_input_in_time_zone, to: :subtype
+          delegate :type, :user_input_in_time_zone, :limit, to: :subtype
 
           def initialize(subtype, delimiter = ',')
             @subtype = subtype

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -248,6 +248,11 @@ class SchemaDumperTest < ActiveRecord::TestCase
       assert_match %r{t\.integer\s+"bigint_default",\s+limit: 8,\s+default: 0}, output
     end
 
+    def test_schema_dump_includes_limit_on_array_type
+      output = standard_dump
+      assert_match %r{t\.integer\s+"big_int_data_points\",\s+limit: 8,\s+array: true}, output
+    end
+
     if ActiveRecord::Base.connection.supports_extensions?
       def test_schema_dump_includes_extensions
         connection = ActiveRecord::Base.connection

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -93,4 +93,8 @@ _SQL
     t.binary :binary, limit: 100_000
     t.text :text, limit: 100_000
   end
+
+  create_table :bigint_array, force: true do |t|
+    t.integer :big_int_data_points, limit: 8, array: true
+  end
 end


### PR DESCRIPTION
As described here https://github.com/rails/rails/issues/19420. When using the Postgres BigInt[] field type the big int value was not being translated into schema.rb. This caused the field to become just a regular integer field when building off of schema.rb. This fix will addrees this by checking the subtype's limit first and if not found then defaulting to the limit. As in this case the subtype limit is correct.

https://github.com/rails/rails/issues/19420
