### PR TITLE
Fix AS::Callbacks raising an error when `:run` callback is defined.

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -401,7 +401,7 @@ module ActiveModel
   protected
 
     def run_validations! #:nodoc:
-      _run_validate_callbacks
+      run_callbacks :validate
       errors.empty?
     end
 

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -109,7 +109,7 @@ module ActiveModel
 
       # Overwrite run validations to include callbacks.
       def run_validations! #:nodoc:
-        _run_validation_callbacks { super }
+        run_callbacks(:validation) { super }
       end
     end
   end

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -135,7 +135,7 @@ module ActiveRecord
             if scope.klass.primary_key
               count = scope.destroy_all.length
             else
-              scope.each(&:_run_destroy_callbacks)
+              scope.each { |record| record.run_callbacks :destroy }
 
               arel = scope.arel
 

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -289,25 +289,24 @@ module ActiveRecord
     end
 
     def destroy #:nodoc:
-      _run_destroy_callbacks { super }
+      run_callbacks(:destroy) { super }
     end
 
     def touch(*) #:nodoc:
-      _run_touch_callbacks { super }
+      run_callbacks(:touch) { super }
     end
 
   private
-
     def create_or_update(*) #:nodoc:
-      _run_save_callbacks { super }
+      run_callbacks(:save) { super }
     end
 
     def _create_record #:nodoc:
-      _run_create_callbacks { super }
+      run_callbacks(:create) { super }
     end
 
     def _update_record(*) #:nodoc:
-      _run_update_callbacks { super }
+      run_callbacks(:update) { super }
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -358,7 +358,7 @@ module ActiveRecord
         synchronize do
           owner = conn.owner
 
-          conn._run_checkin_callbacks do
+          conn.run_callbacks :checkin do
             conn.expire
           end
 
@@ -449,7 +449,7 @@ module ActiveRecord
       end
 
       def checkout_and_verify(c)
-        c._run_checkout_callbacks do
+        c.run_callbacks :checkout do
           c.verify!
         end
         c

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -293,7 +293,7 @@ module ActiveRecord
       assign_attributes(attributes) if attributes
 
       yield self if block_given?
-      _run_initialize_callbacks
+      run_callbacks :initialize
     end
 
     # Initialize an empty model object from +coder+. +coder+ must contain
@@ -316,8 +316,8 @@ module ActiveRecord
 
       self.class.define_attribute_methods
 
-      _run_find_callbacks
-      _run_initialize_callbacks
+      run_callbacks :find
+      run_callbacks :initialize
 
       self
     end
@@ -353,7 +353,7 @@ module ActiveRecord
       @attributes = @attributes.dup
       @attributes.reset(self.class.primary_key)
 
-      _run_initialize_callbacks
+      run_callbacks(:initialize)
 
       @new_record  = true
       @destroyed   = false

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -319,8 +319,8 @@ module ActiveRecord
     end
 
     def before_committed! # :nodoc:
-      _run_before_commit_without_transaction_enrollment_callbacks
-      _run_before_commit_callbacks
+      run_callbacks :before_commit_without_transaction_enrollment
+      run_callbacks :before_commit
     end
 
     # Call the +after_commit+ callbacks.
@@ -329,8 +329,8 @@ module ActiveRecord
     # but call it after the commit of a destroyed object.
     def committed!(should_run_callbacks: true) #:nodoc:
       if should_run_callbacks && destroyed? || persisted?
-        _run_commit_without_transaction_enrollment_callbacks
-        _run_commit_callbacks
+        run_callbacks :commit_without_transaction_enrollment
+        run_callbacks :commit
       end
     ensure
       force_clear_transaction_record_state
@@ -340,8 +340,8 @@ module ActiveRecord
     # state should be rolled back to the beginning or just to the last savepoint.
     def rolledback!(force_restore_state: false, should_run_callbacks: true) #:nodoc:
       if should_run_callbacks
-        _run_rollback_without_transaction_enrollment_callbacks
-        _run_rollback_callbacks
+        run_callbacks :rollback
+        run_callbacks :rollback_without_transaction_enrollment
       end
     ensure
       restore_transaction_record_state(force_restore_state)

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -79,20 +79,18 @@ module ActiveSupport
     #     save
     #   end
     def run_callbacks(kind, &block)
-      send "_run_#{kind}_callbacks", &block
-    end
+      callbacks = send("_#{kind}_callbacks")
 
-    private
-
-    def _run_callbacks(callbacks, &block)
       if callbacks.empty?
-        block.call if block
+        yield if block_given?
       else
         runner = callbacks.compile
         e = Filters::Environment.new(self, false, nil, block)
         runner.call(e).value
       end
     end
+
+    private
 
     # A hook invoked every time a before callback is halted.
     # This can be overridden in AS::Callback implementors in order
@@ -797,12 +795,6 @@ module ActiveSupport
         names.each do |name|
           class_attribute "_#{name}_callbacks"
           set_callbacks name, CallbackChain.new(name, options)
-
-          module_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def _run_#{name}_callbacks(&block)
-              _run_callbacks(_#{name}_callbacks, &block)
-            end
-          RUBY
         end
       end
 


### PR DESCRIPTION
Fixes: https://github.com/rails/rails/issues/19405.

Based on the reverted commit, I ran the [script](https://github.com/rails/rails/pull/17093) that was checking for object allocations but didn't see any difference even after reverting the commit.

``` bash
rails (fix_activesupport_callbacks_clash_on_run) $ ruby /home/guoxiang/work/rails-dev-box/rails/ob.rb > after.txt
rails (fix_activesupport_callbacks_clash_on_run) $ git co master
Switched to branch 'master'
Your branch is ahead of 'origin/master' by 1732 commits.
  (use "git push" to publish your local commits)
rails (master) $ ruby /home/guoxiang/work/rails-dev-box/rails/ob.rb > before.txt
rails (master) $ git diff before.txt after.txt
```

Similarly there isn't any significant difference in performance as well based on the [benchmarks](https://gist.github.com/phiggins/e46e51dcc7edb45b5f98) used in the reverted commit. 

``` bash
Calculating -------------------------------------
                find     1.729k i/100ms
          initialize     9.850k i/100ms
              create   295.000  i/100ms
-------------------------------------------------
                find     20.690k (± 0.8%) i/s -    620.711k
          initialize    157.055k (± 1.7%) i/s -      4.708M
              create      3.059k (± 0.7%) i/s -     91.745k
guoxiang@guoxiang-GS60-2PC-Ghost rails (fix_activesupport_callbacks_clash_on_run) $ git co master
Switched to branch 'master'
Your branch is ahead of 'origin/master' by 1732 commits.
  (use "git push" to publish your local commits)
guoxiang@guoxiang-GS60-2PC-Ghost rails (master) $ ruby /home/guoxiang/work/rails-dev-box/rails/bench.rb
Calculating -------------------------------------
                find     1.735k i/100ms
          initialize    10.451k i/100ms
              create   296.000  i/100ms
-------------------------------------------------
                find     20.264k (± 1.0%) i/s -    608.985k
          initialize    152.585k (± 1.7%) i/s -      4.578M
              create      3.057k (± 0.8%) i/s -     91.760k
```

cc/ @phiggins @tenderlove @rafaelfranca 
