### PR TITLE
Fix referencing wrong aliases while joining tables of has many through association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix referencing wrong table aliases while joining tables of has many through association
+    (only when calling calculation methods).
+
+    Fixes #19276
+
+    *pinglamb*
+
 *   Reuse the `CollectionAssociation#reader` cache when the foreign key is
     available prior to save.
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -378,7 +378,7 @@ module ActiveRecord
     def construct_relation_for_association_calculations
       from = arel.froms.first
       if Arel::Table === from
-        apply_join_dependency(self, construct_join_dependency)
+        apply_join_dependency(self, construct_join_dependency(joins_values))
       else
         # FIXME: as far as I can tell, `from` will always be an Arel::Table.
         # There are no tests that test this branch, but presumably it's

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -11,6 +11,10 @@ require 'models/minivan'
 require 'models/speedometer'
 require 'models/ship_part'
 require 'models/treasure'
+require 'models/developer'
+require 'models/comment'
+require 'models/rating'
+require 'models/post'
 
 class NumericData < ActiveRecord::Base
   self.table_name = 'numeric_data'
@@ -635,5 +639,12 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_calculation_grouped_by_association_doesnt_error_when_no_records_have_association
     Client.update_all(client_of: nil)
     assert_equal({ nil => Client.count }, Client.group(:firm).count)
+  end
+
+  def test_should_reference_correct_aliases_while_joining_tables_of_has_many_through_association
+    assert_nothing_raised ActiveRecord::StatementInvalid do
+      developer = Developer.create!(name: 'developer')
+      developer.ratings.includes(comment: :post).where(posts: { id: 1 }).count
+    end
   end
 end


### PR DESCRIPTION
Fix for Issue #19276.

While joining table of has_many :through association, ActiveRecord will use the actual table name instead of through-join alias. It results with a wrong SQL and exception is raised. This only happens when calculation methods like #count is called.

This bug is affecting Rails 4.1.x and 4.2.x as well.
