### PR TITLE
set httpOnly flag default true to mitigate session cookie attack

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: <%= "'_#{app_name}_session'" %>
+Rails.application.config.session_store :cookie_store, {key: <%= "'_#{app_name}_session'" %>, httponly: true}

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -482,7 +482,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_new_hash_style
     run_generator
     assert_file "config/initializers/session_store.rb" do |file|
-      assert_match(/config.session_store :cookie_store, key: '_.+_session'/, file)
+      assert_match(/config.session_store :cookie_store, {key: '_.+_session', httponly: true}/, file)
     end
   end
 


### PR DESCRIPTION
As Suggest in Rails Security Guide document.cookie merely read by JavaScript. we need to explictly true the httponly option. Now i try to implement this feature default serve by rails .

cc @tenderlove 
