### PR TITLE
Add wrapped class to Sidekiq payload

### DIFF
--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -18,17 +18,19 @@ module ActiveJob
       def enqueue(job) #:nodoc:
         #Sidekiq::Client does not support symbols as keys
         Sidekiq::Client.push \
-          'class' => JobWrapper,
-          'queue' => job.queue_name,
-          'args'  => [ job.serialize ]
+          'class'   => JobWrapper,
+          'queue'   => job.queue_name,
+          'wrapped' => job.class.to_s,
+          'args'    => [ job.serialize ]
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
         Sidekiq::Client.push \
-          'class' => JobWrapper,
-          'queue' => job.queue_name,
-          'args'  => [ job.serialize ],
-          'at'    => timestamp
+          'class'   => JobWrapper,
+          'queue'   => job.queue_name,
+          'wrapped' => job.class.to_s,
+          'args'    => [ job.serialize ],
+          'at'      => timestamp
       end
 
       class JobWrapper #:nodoc:


### PR DESCRIPTION
This will allow Sidekiq to show the underlying job class when logging.  Currently the job class is serialized within the job payload so Sidekiq does not know about it.

Will help fix mperham/sidekiq#2248
