### PR TITLE
Fix activejob integration test

### DIFF
--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -1,6 +1,17 @@
 require 'sidekiq/cli'
 require 'sidekiq/api'
 
+module Sidekiq
+  class CLI
+    def boot_system_with_rescue
+      boot_system_without_rescue
+    rescue => e
+      raise unless /Application has been already initialized./ =~ e.message
+    end
+    alias_method_chain :boot_system, :rescue
+  end
+end
+
 module SidekiqJobsManager
 
   def setup

--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -1,16 +1,4 @@
-require 'sidekiq/cli'
 require 'sidekiq/api'
-
-module Sidekiq
-  class CLI
-    def boot_system_with_rescue
-      boot_system_without_rescue
-    rescue => e
-      raise unless /Application has been already initialized./ =~ e.message
-    end
-    alias_method_chain :boot_system, :rescue
-  end
-end
 
 module SidekiqJobsManager
 
@@ -29,23 +17,45 @@ module SidekiqJobsManager
 
   def start_workers
     fork do
-      sidekiq = Sidekiq::CLI.instance
       logfile = Rails.root.join("log/sidekiq.log").to_s
       pidfile = Rails.root.join("tmp/sidekiq.pid").to_s
-      sidekiq.parse([ "--require", Rails.root.to_s,
-                      "--queue",   "integration_tests",
-                      "--logfile", logfile,
-                      "--pidfile", pidfile,
-                      "--environment", "test",
-                      "--concurrency", "1",
-                      "--timeout", "1",
-                      "--daemon",
-                      ])
+      ::Process.daemon(true, true)
+      [$stdout, $stderr].each do |io|
+        File.open(logfile, 'ab') do |f|
+          io.reopen(f)
+        end
+        io.sync = true
+      end
+      $stdin.reopen('/dev/null')
+      Sidekiq::Logging.initialize_logger(logfile)
+      File.open(File.expand_path(pidfile), 'w') do |f|
+        f.puts ::Process.pid
+      end
+
+      self_read, self_write = IO.pipe
+      trap "TERM" do
+        self_write.puts("TERM")
+      end
+
       require 'celluloid'
-      require 'sidekiq/scheduled'
+      require 'sidekiq/launcher'
+      sidekiq = Sidekiq::Launcher.new({queues: ["integration_tests"],
+                                       environment: "test",
+                                       concurrency: 1,
+                                       timeout: 1,
+                                      })
       Sidekiq.poll_interval = 0.5
       Sidekiq::Scheduled.const_set :INITIAL_WAIT, 1
-      sidekiq.run
+      begin
+        sidekiq.run
+        while readable_io = IO.select([self_read])
+          signal = readable_io.first[0].gets.strip
+          raise Interrupt if signal == "TERM"
+        end
+      rescue Interrupt
+        sidekiq.stop
+        exit(0)
+      end
     end
     sleep 1
   end

--- a/activejob/test/support/integration/dummy_app_template.rb
+++ b/activejob/test/support/integration/dummy_app_template.rb
@@ -5,7 +5,9 @@ end
 
 initializer 'activejob.rb', <<-CODE
 require "#{File.expand_path("../jobs_manager.rb",  __FILE__)}"
-JobsManager.current_manager.setup
+Rails.application.config.after_initialize do
+  JobsManager.current_manager.setup
+end
 CODE
 
 file 'app/jobs/test_job.rb', <<-CODE


### PR DESCRIPTION
- fix activejob integration test's queue_adapter initialization.
- avoid double initialization error caused to sidekiq
