### PR TITLE
Remove reference to Numeric#from_now, as it is no longer supported

### DIFF
--- a/activesupport/lib/active_support/core_ext/integer/time.rb
+++ b/activesupport/lib/active_support/core_ext/integer/time.rb
@@ -17,21 +17,6 @@ class Integer
   #
   #   # equivalent to Time.now.advance(months: 4, years: 5)
   #   (4.months + 5.years).from_now
-  #
-  # While these methods provide precise calculation when used as in the examples
-  # above, care should be taken to note that this is not true if the result of
-  # +months+, +years+, etc is converted before use:
-  #
-  #   # equivalent to 30.days.to_i.from_now
-  #   1.month.to_i.from_now
-  #
-  #   # equivalent to 365.25.days.to_f.from_now
-  #   1.year.to_f.from_now
-  #
-  # In such cases, Ruby's core
-  # Date[http://ruby-doc.org/stdlib/libdoc/date/rdoc/Date.html] and
-  # Time[http://ruby-doc.org/stdlib/libdoc/time/rdoc/Time.html] should be used for precision
-  # date and time arithmetic.
   def months
     ActiveSupport::Duration.new(self * 30.days, [[:months, self]])
   end

--- a/activesupport/lib/active_support/core_ext/numeric/time.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/time.rb
@@ -18,21 +18,6 @@ class Numeric
   #
   #   # equivalent to Time.current.advance(months: 4, years: 5)
   #   (4.months + 5.years).from_now
-  #
-  # While these methods provide precise calculation when used as in the examples above, care
-  # should be taken to note that this is not true if the result of `months', `years', etc is
-  # converted before use:
-  #
-  #   # equivalent to 30.days.to_i.from_now
-  #   1.month.to_i.from_now
-  #
-  #   # equivalent to 365.25.days.to_f.from_now
-  #   1.year.to_f.from_now
-  #
-  # In such cases, Ruby's core
-  # Date[http://ruby-doc.org/stdlib/libdoc/date/rdoc/Date.html] and
-  # Time[http://ruby-doc.org/stdlib/libdoc/time/rdoc/Time.html] should be used for precision
-  # date and time arithmetic.
   def seconds
     ActiveSupport::Duration.new(self, [[:seconds, self]])
   end


### PR DESCRIPTION
Follow up to #17892

Introduced by #12389 and https://github.com/rails/rails/commit/f1eddea1e3f6faf93581c43651348f48b2b7d8bb
