### PR TITLE
Fix ActionDispatch::PublicExceptions returning string rack status

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
@@ -17,10 +17,10 @@ module ActionDispatch
     end
 
     def call(env)
-      status       = env["PATH_INFO"][1..-1]
+      status       = env["PATH_INFO"][1..-1].to_i
       request      = ActionDispatch::Request.new(env)
       content_type = request.formats.first
-      body         = { :status => status, :error => Rack::Utils::HTTP_STATUS_CODES.fetch(status.to_i, Rack::Utils::HTTP_STATUS_CODES[500]) }
+      body         = { :status => status, :error => Rack::Utils::HTTP_STATUS_CODES.fetch(status, Rack::Utils::HTTP_STATUS_CODES[500]) }
 
       render(status, content_type, body)
     end


### PR DESCRIPTION
ActionDispatch::PublicExceptions returns a rack `[status, headers, body]` array with a string status, which can cause problems with middleware that assume the status will be a Fixnum. This likely never surfaced because other middleware to_i the status returned from downstream apps before passing it on.

/cc @charliesome
