### PR TITLE
Remove alias for `i_suck_and_my_tests_are_order_dependent`.

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -45,8 +45,6 @@ module ActiveSupport
 
         test_order
       end
-
-      alias :my_tests_are_order_dependent! :i_suck_and_my_tests_are_order_dependent!
     end
 
     alias_method :method_name, :name

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -205,15 +205,4 @@ class TestOrderTest < ActiveSupport::TestCase
     assert_equal :random, self.class.test_order
     assert_equal :random, Class.new(ActiveSupport::TestCase).test_order
   end
-
-  def test_i_suck_and_my_tests_are_order_dependent!
-    ActiveSupport::TestCase.test_order = :random
-
-    klass = Class.new(ActiveSupport::TestCase) do
-      i_suck_and_my_tests_are_order_dependent!
-    end
-
-    assert_equal :alpha, klass.test_order
-    assert_equal :random, ActiveSupport::TestCase.test_order
-  end
 end


### PR DESCRIPTION
This alias is no longer required for Rails internal tests after https://github.com/rails/rails/pull/19221.
