### PR TITLE
Don't error when passing an empty array to a polymorphic association (rails 4.1.10 regression)

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -61,8 +61,11 @@ module ActiveRecord
         end
 
         column = reflection.foreign_key
-        primary_key = reflection.association_primary_key(base_class)
-        value = convert_value_to_association_ids(value, primary_key)
+
+        if base_class
+          primary_key = reflection.association_primary_key(base_class)
+          value = convert_value_to_association_ids(value, primary_key)
+        end
       end
 
       queries << build(table[column], value)

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -96,6 +96,18 @@ module ActiveRecord
       assert_equal expected.to_sql, actual.to_sql
     end
 
+    def test_polymorphic_empty_array_where
+      treasure = Treasure.new
+      treasure.id = 1
+      hidden = HiddenTreasure.new
+      hidden.id = 2
+
+      expected = PriceEstimate.where("1=0")
+      actual   = PriceEstimate.where(estimate_of: [])
+
+      assert_equal expected.to_a, actual.to_a
+    end
+
     def test_polymorphic_nested_relation_where
       expected = PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: Treasure.where(id: [1,2]))
       actual   = PriceEstimate.where(estimate_of: Treasure.where(id: [1,2]))


### PR DESCRIPTION
We're seeing an issue similar to #19087 on spree builds running rails 4.1.10. Applying that patch to 4-1-stable fixes the issue.

sorry we didn't catch this earlier guys ..
