### PR TITLE
Make sure Array#to_sentence always returns a String

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -74,7 +74,7 @@ class Array
     when 0
       ''
     when 1
-      self[0].to_s.dup
+      "#{self[0]}"
     when 2
       "#{self[0]}#{options[:two_words_connector]}#{self[1]}"
     else

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -60,6 +60,12 @@ class ToSentenceTest < ActiveSupport::TestCase
 
     assert_equal exception.message, "Unknown key: :passing. Valid keys are: :words_connector, :two_words_connector, :last_word_connector, :locale"
   end
+
+  def test_always_returns_string
+    assert_instance_of String, [ActiveSupport::SafeBuffer.new('one')].to_sentence
+    assert_instance_of String, [ActiveSupport::SafeBuffer.new('one'), 'two'].to_sentence
+    assert_instance_of String, [ActiveSupport::SafeBuffer.new('one'), 'two', 'three'].to_sentence
+  end
 end
 
 class ToSTest < ActiveSupport::TestCase


### PR DESCRIPTION
Ensures a consistent behaviour of `Array#to_sentence` when used with string-like objects.

``` ruby
[ActiveSupport::SafeBuffer.new("foo")].to_sentence.class # => ActiveSupport::SafeBuffer
[ActiveSupport::SafeBuffer.new("foo"), "bar"].to_sentence.class # => String
```
