### PR TITLE
Pass wrapped class name to Sidekiq for logging purposes

### DIFF
--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -18,17 +18,19 @@ module ActiveJob
       def enqueue(job) #:nodoc:
         #Sidekiq::Client does not support symbols as keys
         Sidekiq::Client.push \
-          'class' => JobWrapper,
-          'queue' => job.queue_name,
-          'args'  => [ job.serialize ]
+          'class'   => JobWrapper,
+          'wrapped' => job.class.to_s,
+          'queue'   => job.queue_name,
+          'args'    => [ job.serialize ]
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
         Sidekiq::Client.push \
-          'class' => JobWrapper,
-          'queue' => job.queue_name,
-          'args'  => [ job.serialize ],
-          'at'    => timestamp
+          'class'   => JobWrapper,
+          'wrapped' => job.class.to_s,
+          'queue'   => job.queue_name,
+          'args'    => [ job.serialize ],
+          'at'      => timestamp
       end
 
       class JobWrapper #:nodoc:

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -1,5 +1,6 @@
 require 'helper'
 require 'jobs/logging_job'
+require 'jobs/hello_job'
 require 'active_support/core_ext/numeric/time'
 
 class QueuingTest < ActiveSupport::TestCase
@@ -20,6 +21,18 @@ class QueuingTest < ActiveSupport::TestCase
       assert_not job_executed
     ensure
       TestJob.queue_name = old_queue
+    end
+  end
+
+  test 'should supply a wrapped class name to Sidekiq' do
+    skip unless adapter_is?(:sidekiq)
+    require 'sidekiq/testing'
+
+    Sidekiq::Testing.fake! do
+      ::HelloJob.perform_later
+      hash = ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper.jobs.first
+      assert_equal "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper", hash['class']
+      assert_equal "HelloJob", hash['wrapped']
     end
   end
 


### PR DESCRIPTION
Sidekiq logs the name of the job class being performed.  Because
ActiveJob wraps the class, this means currently every job logs as an AJ::JobWrapper
instead of the actual job name.

Will help fix mperham/sidekiq#2248
