### PR TITLE
[ci skip] Remove unacceptable method name

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -652,7 +652,7 @@ module ActiveRecord
       alias :add_belongs_to :add_reference
 
       # Removes the reference(s). Also removes a +type+ column if one exists.
-      # <tt>remove_reference</tt>, <tt>remove_references</tt> and <tt>remove_belongs_to</tt> are acceptable.
+      # <tt>remove_reference</tt> and <tt>remove_belongs_to</tt> are acceptable.
       #
       # ====== Remove the reference
       #


### PR DESCRIPTION
`alias :remove_belongs_to :remove_reference`, `remove_references` is not aliased. So only two methods are acceptable.
