### PR TITLE
Fix incorrect description for `assert_nothing_raised`.

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -73,7 +73,7 @@ module ActiveSupport
     alias :assert_not_respond_to :refute_respond_to
     alias :assert_not_same :refute_same
 
-    # Fails if the block raises an exception.
+    # Reveals the intention that the block should not raise any exception.
     #
     #   assert_nothing_raised do
     #     ...


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/19478.
