### PR TITLE
Update template_renderer.rb

### DIFF
--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -18,7 +18,7 @@ module ActionView
 
     # Determine the template to be rendered using the given options.
     def determine_template(options)
-      keys = options.has_key?(:locals) ? options[:locals].keys : []
+      keys = options[:locals].present? ? options[:locals].keys : []
 
       if options.key?(:body)
         Template::Text.new(options[:body])


### PR DESCRIPTION
previous version sometimes raised "undefined method 'keys' for nil class", because, for example,
{1 => nil}.has_key?(1) returns true.
