### PR TITLE
update security guide, HttpOnly feature default available since Rails 3....

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -710,7 +710,7 @@ The log files on www.attacker.com will read like this:
 GET http://www.attacker.com/_app_session=836c1c25278e5b321d6bea4f19cb57e2
 ```
 
-You can mitigate these attacks (in the obvious way) by adding the [httpOnly](http://dev.rubyonrails.org/ticket/8895) flag to cookies, so that document.cookie may not be read by JavaScript. Http only cookies can be used from IE v6.SP1, Firefox v2.0.0.5 and Opera 9.5. Safari is still considering, it ignores the option. But other, older browsers (such as WebTV and IE 5.5 on Mac) can actually cause the page to fail to load. Be warned that cookies [will still be visible using Ajax](http://ha.ckers.org/blog/20070719/firefox-implements-httponly-and-is-vulnerable-to-xmlhttprequest/), though.
+You can mitigate these attacks (in the obvious way) by adding the httpOnly flag to cookies, so that document.cookie may not be read by JavaScript. Don't bother about this now, as it's taken care by default in Rails 3 and above.
 
 ##### Defacement
 


### PR DESCRIPTION
...x  updated doc for issue https://github.com/rails/rails/pull/19450 @matthewd 
