### PR TITLE
ActiveJob: Stop using Que's named queues.

### DIFF
--- a/activejob/lib/active_job/queue_adapters/que_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/que_adapter.rb
@@ -16,11 +16,11 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :que
     class QueAdapter
       def enqueue(job) #:nodoc:
-        JobWrapper.enqueue job.serialize, queue: job.queue_name
+        JobWrapper.enqueue job.serialize
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
-        JobWrapper.enqueue job.serialize, queue: job.queue_name, run_at: Time.at(timestamp)
+        JobWrapper.enqueue job.serialize, run_at: Time.at(timestamp)
       end
 
       class JobWrapper < Que::Job #:nodoc:

--- a/activejob/test/support/que/inline.rb
+++ b/activejob/test/support/que/inline.rb
@@ -3,7 +3,11 @@ require 'que'
 Que::Job.class_eval do
   class << self; alias_method :original_enqueue, :enqueue; end
   def self.enqueue(*args)
-    args.pop if args.last.is_a?(Hash)
+    if args.last.is_a?(Hash)
+      options = args.pop
+      options.delete(:run_at)
+      args << options unless options.empty?
+    end
     self.run(*args)
   end
 end


### PR DESCRIPTION
(I'm the author of Que)

This patch stops the ActiveJob adapter for Que from using Que's named queues feature. Named queues were added to Que specifically for the (rare) use case wherein multiple codebases need to use the same database, and need to scope their job lock queries as such. They weren't intended for use as a priority system, which is how ActiveJob seems to treat them (we have a separate priority system for that), and the current setup has some users hacking into things to get the same worker pool working jobs from multiple queues, which is not what the worker pool or the job locking system were designed for.

The plan is for named queues to be removed entirely from Que for 1.0 anyway (in favor of supporting multiple job queues in the same DB), so it'd be good for ActiveJob to stop depending on their existence.
