### PR TITLE
[ci skip] Update 4.2 Release notes with more assert_select information.

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -302,6 +302,30 @@ application is using any of these spellings, you will need to update them:
     assert_select('p', 'AT&amp;T')  # => false
     ```
 
+Furthermore substitutions have changed syntax.
+
+Now you have to use a `:match` CSS-like selector:
+
+```ruby
+assert_select ":match('id', ?)", 'comment_1'
+```
+
+Additionally Regexp substitutions look different when the assertion fails.
+Notice how `/hello/` here:
+
+```ruby
+assert_select(":match('id', ?)", /hello/)
+```
+
+becomes `"(?-mix:hello)"`:
+
+```
+Expected at least 1 element matching "div:match('id', "(?-mix:hello)")", found 0..
+Expected 0 to be >= 1.
+```
+
+See the [Rails Dom Testing](https://github.com/rails/rails-dom-testing/tree/8798b9349fb9540ad8cb9a0ce6cb88d1384a210b) documentation for more on `assert_select`.
+
 
 Railties
 --------


### PR DESCRIPTION
Adds documentation for substitutions and why Regexp substitions look different
when assertion fails.

As promised a while ago here: https://github.com/rails/rails/issues/19098#issuecomment-76277810

(@rafaelfranca said I could handle the 4.2 backport)
