### PR TITLE
Avoid loading user's psqlrc when loading test structure

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -67,7 +67,7 @@ module ActiveRecord
 
       def structure_load(filename)
         set_psql_env
-        Kernel.system("psql -q -f #{Shellwords.escape(filename)} #{configuration['database']}")
+        Kernel.system("psql -X -q -f #{Shellwords.escape(filename)} #{configuration['database']}")
       end
 
       private


### PR DESCRIPTION
This avoids user configuration from interfering with loading of test structure.

In my case, I have `\timing` in my `~/.psqlrc` which, when enabled, results in thousands of `Time: 0.124 ms` lines being outputted every time I run `rake db:test:prepare`. 
