### PR TITLE
[ci skip] Add mising parenthesis in a method definition

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -96,7 +96,7 @@ module ActionDispatch
           simulator.memos(path) { [] }
         end
 
-        def find_routes req
+        def find_routes(req)
           routes = filter_routes(req.path_info).concat custom_routes.find_all { |r|
             r.path.match(req.path_info)
           }


### PR DESCRIPTION
Just for consistency of method definitions.
