### PR TITLE
[skip ci] Minor edits for clarity in the test fixture guide.

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -59,9 +59,9 @@ You can find comprehensive documentation in the [Fixtures API documentation](htt
 
 #### What Are Fixtures?
 
-_Fixtures_ is a fancy word for sample data. Fixtures allow you to populate your testing database with predefined data before your tests run. Fixtures are database independent written in YAML. There is one file per model.
+_Fixtures_ is a fancy word for sample data. Fixtures allow you to populate your testing database with predefined data before your tests run. Fixtures are database independent and written in YAML. There is one file per model.
 
-You'll find fixtures under your `test/fixtures` directory. When you run `rails generate model` to create a new model fixture stubs will be automatically created and placed in this directory.
+You'll find fixtures under your `test/fixtures` directory. When you run `rails generate model` to create a new model, Rails automatically creates fixture stubs in this directory.
 
 #### YAML
 


### PR DESCRIPTION
Minor edits for clarity in two places in the test fixture guide.  Mostly to make reading more smooth, using "and" and a comma to pace reading and separate clauses.
