### PR TITLE
rename `widgets` table to `new_widgets`

### DIFF
--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -924,7 +924,8 @@ class PersistenceTest < ActiveRecord::TestCase
       assert_equal instance.created_at, created_at
       assert_equal instance.updated_at, updated_at
     ensure
-      ActiveRecord::Base.connection.drop_table :widgets
+      ActiveRecord::Base.connection.drop_table widget.table_name
+      widget.reset_column_information
     end
   end
 end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -260,7 +260,8 @@ if current_adapter?(:PostgreSQLAdapter, :MysqlAdapter, :Mysql2Adapter)
     end
 
     teardown do
-      @connection.drop_table 'widgets', if_exists: true
+      @connection.drop_table :widgets, if_exists: true
+      Widget.reset_column_information
     end
 
     test "primary key column type with bigserial" do


### PR DESCRIPTION
`widgets` table is being created in [primary_keys_test.rb](https://github.com/rails/rails/blob/master/activerecord/test/cases/primary_keys_test.rb#L256-L258) for PostgreSQLAdapter, MysqlAdapter, Mysql2Adapter only and it makes test to fail for these adapters irrespective of how many times I execute the test suite.

Before:
  `bundle exec rake mysql2:test`

```
Finished in 127.287669s, 35.5258 runs/s, 97.8885 assertions/s.

  1) Error:
PersistenceTest::SaveTest#test_save_touch_false:
ActiveModel::UnknownAttributeError: unknown attribute 'name' for #<Class:0x0000000a7d6ef0>.
    /home/kd/projects/kd-rails/activerecord/lib/active_record/attribute_assignment.rb:36:in `rescue in _assign_attribute'
    /home/kd/projects/kd-rails/activerecord/lib/active_record/attribute_assignment.rb:34:in `_assign_attribute'
    /home/kd/projects/kd-rails/activemodel/lib/active_model/attribute_assignment.rb:40:in `block in _assign_attributes'
    /home/kd/projects/kd-rails/activemodel/lib/active_model/attribute_assignment.rb:39:in `each'
    /home/kd/projects/kd-rails/activemodel/lib/active_model/attribute_assignment.rb:39:in `_assign_attributes'
    /home/kd/projects/kd-rails/activerecord/lib/active_record/attribute_assignment.rb:26:in `_assign_attributes'
    /home/kd/projects/kd-rails/activemodel/lib/active_model/attribute_assignment.rb:33:in `assign_attributes'
    /home/kd/projects/kd-rails/activerecord/lib/active_record/core.rb:293:in `initialize'
    /home/kd/projects/kd-rails/activerecord/lib/active_record/inheritance.rb:61:in `new'
    /home/kd/projects/kd-rails/activerecord/lib/active_record/inheritance.rb:61:in `new'
    /home/kd/projects/kd-rails/activerecord/lib/active_record/persistence.rb:50:in `create!'
    /home/kd/projects/kd-rails/activerecord/test/cases/persistence_test.rb:913:in `test_save_touch_false'

4522 runs, 12460 assertions, 0 failures, 1 errors, 4 skips
```

After:
  `bundle exec rake mysql2:test`

```
   Finished in 135.785086s, 33.3026 runs/s, 91.7774 assertions/s.

   4522 runs, 12462 assertions, 0 failures, 0 errors, 4 skips
```

P.S. I don't know how Travis is so lucky every time.
