### PR TITLE
[ci skip] Unify the code comment in ActionView::Renderer#render_template...

### DIFF
--- a/actionview/lib/action_view/renderer/renderer.rb
+++ b/actionview/lib/action_view/renderer/renderer.rb
@@ -37,7 +37,7 @@ module ActionView
       end
     end
 
-    # Direct accessor to template rendering.
+    # Direct access to template rendering.
     def render_template(context, options) #:nodoc:
       TemplateRenderer.new(@lookup_context).render(context, options)
     end


### PR DESCRIPTION
After this Pull Request, comments of `render_template` and `render_partial` are symmetry.

``` ruby
# Direct access to template rendering.
def render_template(context, options) #:nodoc:
  TemplateRenderer.new(@lookup_context).render(context, options)
end

# Direct access to partial rendering.
def render_partial(context, options, &block) #:nodoc:
  PartialRenderer.new(@lookup_context).render(context, options, block)
end
```
