### PR TITLE
Add missing :html option in determine_template error message.

### DIFF
--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -40,7 +40,7 @@ module ActionView
           find_template(options[:template], options[:prefixes], false, keys, @details)
         end
       else
-        raise ArgumentError, "You invoked render but did not give any of :partial, :template, :inline, :file, :plain, :text or :body option."
+        raise ArgumentError, "You invoked render but did not give any of :partial, :template, :inline, :file, :plain, :html, :text or :body option."
       end
     end
 


### PR DESCRIPTION
The code below checks `:html` option, but did not mention it in the error message. This Pull Request fixes it.

``` ruby
if options.key?(:body)
  Template::Text.new(options[:body])
elsif options.key?(:text)
  Template::Text.new(options[:text], formats.first)
elsif options.key?(:plain)
  Template::Text.new(options[:plain])
elsif options.key?(:html)
  Template::HTML.new(options[:html], formats.first)
elsif options.key?(:file)
  with_fallbacks { find_template(options[:file], nil, false, keys, @details) }
elsif options.key?(:inline)
  handler = Template.handler_for_extension(options[:type] || "erb")
  Template.new(options[:inline], "inline template", handler, :locals => keys)
elsif options.key?(:template)
  if options[:template].respond_to?(:render)
    options[:template]
  else
    find_template(options[:template], options[:prefixes], false, keys, @details)
  end
else
  raise ArgumentError, "You invoked render but did not give any of :partial, :template, :inline, :file, :plain, :text or :body option."
end
```
