### PR TITLE
Add `find_if_id` method to ActiveRecord::FinderMethods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `find_if_id` method to find a record if given an ID or
+    if given an AR object return the object.
+
+    Example:
+
+        Person.find_if_id(3) # return Person.find(3)
+        Person.find_if_id(@person) # returns @person
+
+    *Benjamin Sullivan*
+
 *   Add `config.active_record.warn_on_records_fetched_greater_than` option
 
     When set to an integer, a warning will be logged whenever a result set

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -93,6 +93,19 @@ module ActiveRecord
       raise RecordNotFound, "Couldn't find #{@klass.name} with an out of range value"
     end
 
+    # Like <tt>find</tt>, except that if a record is passed instead of an id,
+    # it returns the record.
+    #
+    #   Person.find_if_id(5) # returns record where id=5
+    #   Person.find_if_id(@person) # returns @person
+    def find_if_id(*args)
+      if ActiveRecord::Base === args[0]
+        args.size == 1 ? args[0] : args
+      else
+        find(*args)
+      end
+    end
+
     # Gives a record (or N records if a parameter is supplied) without any implied
     # order. The order will depend on the database implementation.
     # If an order is supplied it will be respected.

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -701,6 +701,20 @@ class RelationTest < ActiveRecord::TestCase
     assert_raises(ActiveRecord::RecordNotFound) { authors.find(['42', 43]) }
   end
 
+  def test_find_if_id_with_id
+    authors = Author.all
+
+    david = authors.find_if_id(authors(:david).id)
+    assert_equal 'David', david.name
+  end
+
+  def test_find_if_id_with_ar_object
+    authors = Author.all
+
+    david = authors.find_if_id(authors(:david))
+    assert_equal 'David', david.name
+  end
+
   def test_find_in_empty_array
     authors = Author.all.where(:id => [])
     assert authors.to_a.blank?


### PR DESCRIPTION
This would be useful for cases where a method accepts either an AR instance or an id.
