### PR TITLE
respect `pluralize_table_names` when generate fixture file. fixes #19519

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Respect `pluralize_table_names` when generate fixture file.
+
+    Fixes #19519.
+
+    *Yuji Yaginuma*
+
 *   Add a new-line to the end of route method generated code.
 
     We need to add a `\n`, because we cannot have two routes

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -141,6 +141,10 @@ module Rails
           @plural_file_name ||= file_name.pluralize
         end
 
+        def fixture_file_name
+          @fixture_file_name ||= (pluralize_table_names? ? plural_file_name : file_name)
+        end
+
         def route_url
           @route_url ||= class_path.collect {|dname| "/" + dname }.join + "/" + plural_file_name
         end

--- a/railties/lib/rails/generators/test_unit/model/model_generator.rb
+++ b/railties/lib/rails/generators/test_unit/model/model_generator.rb
@@ -19,7 +19,7 @@ module TestUnit # :nodoc:
 
       def create_fixture_file
         if options[:fixture] && options[:fixture_replacement].nil?
-          template 'fixtures.yml', File.join('test/fixtures', class_path, "#{plural_file_name}.yml")
+          template 'fixtures.yml', File.join('test/fixtures', class_path, "#{fixture_file_name}.yml")
         end
       end
 

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -319,6 +319,16 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_no_file "test/fixtures/accounts.yml"
   end
 
+  def test_fixture_without_pluralization
+    original_pluralize_table_name = ActiveRecord::Base.pluralize_table_names
+    ActiveRecord::Base.pluralize_table_names = false
+    run_generator
+    assert_generated_fixture("test/fixtures/account.yml",
+                             {"one"=>{"name"=>"MyString", "age"=>1}, "two"=>{"name"=>"MyString", "age"=>1}})
+  ensure
+    ActiveRecord::Base.pluralize_table_names = original_pluralize_table_name
+  end
+
   def test_check_class_collision
     content = capture(:stderr){ run_generator ["object"] }
     assert_match(/The name 'Object' is either already used in your application or reserved/, content)


### PR DESCRIPTION
Closes #19519
