### PR TITLE
Return super in ActionController::Parameters.const_missing

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -117,7 +117,7 @@ module ActionController
     self.always_permitted_parameters = %w( controller action )
 
     def self.const_missing(const_name)
-      super unless const_name == :NEVER_UNPERMITTED_PARAMS
+      return super unless const_name == :NEVER_UNPERMITTED_PARAMS
       ActiveSupport::Deprecation.warn(<<-MSG.squish)
         `ActionController::Parameters::NEVER_UNPERMITTED_PARAMS` has been deprecated.
         Use `ActionController::Parameters.always_permitted_parameters` instead.

--- a/actionpack/test/controller/parameters/always_permitted_parameters_test.rb
+++ b/actionpack/test/controller/parameters/always_permitted_parameters_test.rb
@@ -1,5 +1,6 @@
 require 'abstract_unit'
 require 'action_controller/metal/strong_parameters'
+require 'minitest/mock'
 
 class AlwaysPermittedParametersTest < ActiveSupport::TestCase
   def setup
@@ -14,7 +15,13 @@ class AlwaysPermittedParametersTest < ActiveSupport::TestCase
 
   test "shows deprecations warning on NEVER_UNPERMITTED_PARAMS" do
     assert_deprecated do
-       ActionController::Parameters::NEVER_UNPERMITTED_PARAMS
+      ActionController::Parameters::NEVER_UNPERMITTED_PARAMS
+    end
+  end
+
+  test "returns super on missing constant other than NEVER_UNPERMITTED_PARAMS" do
+    ActionController::Parameters.superclass.stub :const_missing, "super" do
+      assert_equal "super", ActionController::Parameters::NON_EXISTING_CONSTANT
     end
   end
 


### PR DESCRIPTION
The current implementation of `ActionController::Parameters.const_missing` returns `ActionController::Parameters.always_permitted_parameters` even if its `super` returns a constant without raising error. This prevents its subclass in a autoloading module/class from taking advantage of
autoloading constants.

``` rb
class SomeController < ActionController::Base
  def create
    SomeParameters.new(some_params).do_something
  end

  class SomeParameters < ActionController::Parameters
    def do_something
      DefinedSomewhere.do_something
    end
  end
end
```

In the code above, `DefinedSomewhere` is to be autoloaded with `SomeController.const_missing` but `ActionController::Parameters.const_missing` returns `always_permitted_parameters` instead of the autoloaded constant.

This pull request fixes the issue respecting `const_missing`'s `super`.
