### PR TITLE
Fix unscope for less than

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -135,7 +135,7 @@ module ActiveRecord
       def predicates_except(columns)
         predicates.reject do |node|
           case node
-          when Arel::Nodes::Between, Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality, Arel::Nodes::NotEqual, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThanOrEqual
+          when Arel::Nodes::Between, Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality, Arel::Nodes::NotEqual, Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual
             subrelation = (node.left.kind_of?(Arel::Attributes::Attribute) ? node.left : node.right)
             columns.include?(subrelation.name.to_s)
           end

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -153,6 +153,18 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_equal expected_7, received_7
   end
 
+  def test_unscope_comparison_where_clauses
+    # unscoped for WHERE (`developers`.`id` <= 2)
+    expected = Developer.order('salary DESC').collect(&:name)
+    received = DeveloperOrderedBySalary.where(id: -Float::INFINITY..2).unscope(where: :id).collect { |dev| dev.name }
+    assert_equal expected, received
+
+    # unscoped for WHERE (`developers`.`id` < 2)
+    expected = Developer.order('salary DESC').collect(&:name)
+    received = DeveloperOrderedBySalary.where(id: -Float::INFINITY...2).unscope(where: :id).collect { |dev| dev.name }
+    assert_equal expected, received
+  end
+
   def test_unscope_multiple_where_clauses
     expected = Developer.order('salary DESC').collect(&:name)
     received = DeveloperOrderedBySalary.where(name: 'Jamis').where(id: 1).unscope(where: [:name, :id]).collect(&:name)


### PR DESCRIPTION
Code such as the following will be corrected.

```
Developer.where(id: -Float::INFINITY...2).unscope(where: :id)
```

See also: #19518
