### PR TITLE
Prevent duplicating `where` clauses

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Prevent duplicating `where` clauses
+
+    Fixes #19528
+
 *   Add `config.active_record.warn_on_records_fetched_greater_than` option
 
     When set to an integer, a warning will be logged whenever a result set

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -67,7 +67,7 @@ module ActiveRecord
       end
 
       def ast
-        Arel::Nodes::And.new(predicates_with_wrapped_sql_literals)
+        Arel::Nodes::And.new(predicates_with_wrapped_sql_literals.uniq)
       end
 
       def ==(other)


### PR DESCRIPTION
This might look like small or not important change, but after small investigation
it looks like it's deeper problem. In several situations (i.e. STI, especially with
abstract class) Rails will automatically duplicate (sometimes multiple times) default
scope. In case of simple scopes that's not a problem, but for complex ones it might
quickly get out of hand.

Fixes #19528
