### PR TITLE
[ci skip] Fix series will receive severe security fix.

### DIFF
--- a/guides/source/maintenance_policy.md
+++ b/guides/source/maintenance_policy.md
@@ -68,7 +68,7 @@ For severe security issues we will provide new versions as above, and also the
 last major release series will receive patches and new versions. The
 classification of the security issue is judged by the core team.
 
-**Currently included series:** `4.2.Z`, `4.1.Z`, `3.2.Z`.
+**Currently included series:** `4.2.Z`, `4.1.Z`, `4.0.Z`.
 
 Unsupported Release Series
 --------------------------


### PR DESCRIPTION
Last change of this line: https://github.com/rails/rails/commit/867bc258c76d33c1c07056b915e52ea1dd7c54bd

I think `3.2.Z` forgot to change to `4.0.Z`. Or `3.2.Z` will still receive severe security fix?

/cc @rafaelfranca 

Thanks.
