### PR TITLE
Set max-age=0 instead of no-cache in expires_now

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -209,10 +209,10 @@ module ActionController
       response.date = Time.now unless response.date?
     end
 
-    # Sets a HTTP 1.1 Cache-Control header of <tt>no-cache</tt> so no caching should
+    # Sets a HTTP 1.1 Cache-Control header of <tt>max-age=0</tt> so no caching should
     # occur by the browser or intermediate caches (like caching proxy servers).
     def expires_now
-      response.cache_control.replace(:no_cache => true)
+      response.cache_control.replace(:max_age => 0)
     end
 
     # Cache or yield the block. The cache is supposed to never expire.

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -261,12 +261,12 @@ class ExpiresInRenderTest < ActionController::TestCase
 
   def test_expires_now
     get :conditional_hello_with_expires_now
-    assert_equal "no-cache", @response.headers["Cache-Control"]
+    assert_match(/max-age=0/, @response.headers["Cache-Control"])
   end
 
   def test_expires_now_with_cache_control_headers
     get :conditional_hello_with_cache_control_headers
-    assert_match(/no-cache/, @response.headers["Cache-Control"])
+    assert_match(/max-age=0/, @response.headers["Cache-Control"])
     assert_match(/no-transform/, @response.headers["Cache-Control"])
   end
 


### PR DESCRIPTION
This is not meant to be directly pulled into rails, more as a beginning point of a discussion.

As I understand expires_now is used purely to prevent browsers and caching proxies from serving a cached response. The no-cache setting does not actually enforce this, it just instructs the caching-proxy to validate if any cached value it has stored can still be used. There are two things possibly problematic with this:
1. In some circumstance (I don't believe Rails actually supports this at the moment) the application might actually respond to the validation request with 'not modified', as the result might not have changed (i.e. the etags are identical), no expiration is actually enforced by this setting explicitly.
2. The user might expect expires_now to enforce that proxies will not store sensitive information. The no-cache setting does not enforce this, but very explicitly no-store would. Whether max-age=0 enforces this is questionable.

Note that I am not an expert on the HTTP specs at all, so there might be legacy or other reasons for Rails to use no-cache instead of no-store or max-age=0. If there are, perhaps they should be documented.

Alternatively, I would sort of expect that expires_now would simply invoke expires_in(0). But expires_in does a whole lot more that I'm not familiar with.
