### PR TITLE
[Feature] params.require accepts array of parameters that should be present or raise error

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -252,7 +252,15 @@ module ActionController
     #
     #   ActionController::Parameters.new(person: {}).require(:person)
     #   # => ActionController::ParameterMissing: param is missing or the value is empty: person
+    #
+    #   ActionController::Parameters.new(first_name: 'Gaurish', title: nil).require([:first_name, :title])
+    #   # => ActionController::ParameterMissing: param is missing or the value is empty: title
+    #
+    #   params = ActionController::Parameters.new(first_name: 'Gaurish', title: Mjallo)
+    #   first_name, title = params.require([:first_name, :title])
+    #
     def require(key)
+      return keys.map { |k| require(k) } if key.is_a?(Array)
       value = self[key]
       if value.present? || value == false
         value

--- a/actionpack/test/controller/required_params_test.rb
+++ b/actionpack/test/controller/required_params_test.rb
@@ -48,4 +48,21 @@ class ParametersRequireTest < ActiveSupport::TestCase
       ActionController::Parameters.new(person: {}).require(:person)
     end
   end
+
+  test "require array of params" do
+    safe_params = ActionController::Parameters.new(person: {first_name: 'Gaurish', title: 'Mjallo'})
+      .require(:person)
+      .require([:first_name, :last_name])
+
+    assert_kind_of Array, safe_params
+    assert_equal ['Gaurish', 'Mjallo'], safe_params
+  end
+
+  test "require array when it contains a nil values" do
+    assert_raises(ActionController::ParameterMissing) do
+      safe_params = ActionController::Parameters.new(person: {first_name: 'Gaurish', title: nil})
+        .require(:person)
+        .require([:first_name, :last_name])
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a method `require_all` which allows you to require multiple values in one method.

for example, in our app. I have a person object which MUST have first_name & last_name. so to do this in current code, I have to write this:

``` ruby
params.require(:person).require(:first_name)
params.require(:person).require(:last_name)
```

Here it will be one line for each params, so say if I require 10params, it will be 10lines of repeated code which is not DRY. So I propose a method which does this in one line:

``` ruby
params.require(:person).require_all(:first_name, :last_name)
```

Comments welcome
