### PR TITLE
Support polymorphic and index reference with utf8mb4 charset on MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -128,7 +128,14 @@ module ActiveRecord
       def columns
         result = [["#{name}_id", type, options]]
         if polymorphic
-          result.unshift(["#{name}_type", :string, polymorphic_options])
+          options = polymorphic_options
+          if index
+            indexable_string_limit = Base.connection.max_indexable_string_limit
+            if indexable_string_limit
+              options = options.merge(limit: indexable_string_limit)
+            end
+          end
+          result.unshift(["#{name}_type", :string, options])
         end
         result
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -171,6 +171,13 @@ module ActiveRecord
         self.class::ADAPTER_NAME
       end
 
+      # Returns the max indexable limit for string type column if the
+      # backend has limitation. Returns nil if the backend doesn't have
+      # limitation.
+      def max_indexable_string_limit
+        nil
+      end
+
       # Does this adapter support migrations?
       def supports_migrations?
         false


### PR DESCRIPTION
Here is a script that reproduces this problem:

```
require 'active_record'

ActiveRecord::Base.establish_connection(adapter: 'mysql2',
                                        username: 'rails',
                                        encoding: 'utf8mb4',
                                        database: 'activerecord_unittest')

ActiveRecord::Schema.define do
  create_table :articles, force: true, options: 'DEFAULT CHARSET=utf8mb4' do |t|
    t.references :taggable, polymorphic: true, index: true
  end
end
```

It raises the following exception:

```
-- create_table(:articles, {:force=>true, :options=>"DEFAULT CHARSET=utf8mb4"})
/home/kou/work/ruby/rails.kou/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:392:in `query': Mysql2::Error: Specified key was too long; max key length is 767 bytes: CREATE TABLE `articles` (`id` int(11) AUTO_INCREMENT PRIMARY KEY, `taggable_type` varchar(255), `taggable_id` int(11),  INDEX `index_articles_on_taggable_type_and_taggable_id`  (`taggable_type`, `taggable_id`) ) DEFAULT CHARSET=utf8mb4 (ActiveRecord::StatementInvalid)
        from /home/kou/work/ruby/rails.kou/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:392:in `block in execute'
        from /home/kou/work/ruby/rails.kou/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:500:in `block in log'
        from /home/kou/work/ruby/rails.kou/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
        from /home/kou/work/ruby/rails.kou/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:494:in `log'
        from /home/kou/work/ruby/rails.kou/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:392:in `execute'
        from /home/kou/work/ruby/rails.kou/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb:214:in `execute'
        from /home/kou/work/ruby/rails.kou/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:208:in `create_table'
        from /home/kou/work/ruby/rails.kou/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:555:in `create_table'
        from /home/kou/work/ruby/rails.kou/activerecord/lib/active_record/migration.rb:662:in `block in method_missing'
        from /home/kou/work/ruby/rails.kou/activerecord/lib/active_record/migration.rb:632:in `block in say_with_time'
        from /tmp/local/lib/ruby/2.3.0/benchmark.rb:288:in `measure'
        from /home/kou/work/ruby/rails.kou/activerecord/lib/active_record/migration.rb:632:in `say_with_time'
        from /home/kou/work/ruby/rails.kou/activerecord/lib/active_record/migration.rb:652:in `method_missing'
        from /tmp/a.rb:9:in `block in <main>'
        from /home/kou/work/ruby/rails.kou/activerecord/lib/active_record/schema.rb:41:in `instance_eval'
        from /home/kou/work/ruby/rails.kou/activerecord/lib/active_record/schema.rb:41:in `define'
        from /home/kou/work/ruby/rails.kou/activerecord/lib/active_record/schema.rb:61:in `define'
        from /tmp/a.rb:8:in `<main>'
```

The following is the important error message:

```
Specified key was too long; max key length is 767 bytes
```

"utf8mb4" charset allocates 4 bytes for one character. mysql2 adapter
creates `varchar(255)` column for string type column (`taggable_type`
column) that is created internally. 4 \* 255 = 1020. It is greater than
767 that is the max key length in MySQL.

This change reduces the max number of characters to 191 when "utf8mb4"
charset is used. 4 \* 191 = 764. It is less than 767 that is the max key
length in MySQL.

FYI1:
"utf8" charset allocates 3 bytes for one character. 3 \* 255 = 765.
It is less than 767 that is the max key length in MySQL.

FYI2:
`ActiveRecord::Migration::ReferencesIndexTest#test_creates_polymorphic_index`
is the test for the case.
