### PR TITLE
Fix requiring 'active_support/core_ext' by itself

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fixed requiring `active_support/core_ext` by itself.
+
+    *David Verhasselt*
+
 *   Added `ActiveSupport::ArrayInquirer`.
 
     Wrapping an array in an `ArrayInquirer` gives a friendlier way to check its

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -1,3 +1,5 @@
+require 'active_support/dependencies/autoload'
+
 module ActiveSupport
   module NumberHelper
     extend ActiveSupport::Autoload


### PR DESCRIPTION
This is a fix for a bug that's in 4.2 stable and beyond. I'm unable to do this:

``` ruby
require 'active_support/core_ext'
```

To just use the `core_ext` code. It would throw this error:

```
activesupport/lib/active_support/number_helper.rb:3:in `<module:NumberHelper>': uninitialized constant ActiveSupport::Autoload (NameError)
```

This fix also requires [this commit](https://github.com/rails/rails/commit/dd7bd8c023696657a600ee5dba16bfe5def876bf) made on `4-2-stable` but not yet added to `master`.

Test case:

``` ruby
require 'rubygems'
require 'bundler/setup'

require 'active_support/core_ext'
```
