### PR TITLE
Make collections rendering multiple templates automatically cacheable.

### DIFF
--- a/actionpack/test/fixtures/supreme_customers/_supreme_customer.html.erb
+++ b/actionpack/test/fixtures/supreme_customers/_supreme_customer.html.erb
@@ -1,0 +1,4 @@
+<% cache supreme_customer do %>
+  <% controller.partial_rendered_times += 1 %>
+  <%= supreme_customer.name %>, <%= supreme_customer.id %>
+<% end %>

--- a/actionpack/test/fixtures/uncached_customers/_uncached_customer.html.erb
+++ b/actionpack/test/fixtures/uncached_customers/_uncached_customer.html.erb
@@ -1,0 +1,2 @@
+<% controller.partial_rendered_times += 1 %>
+<%= uncached_customer.name %>, <%= uncached_customer.id %>

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -12,16 +12,27 @@ module ActionView
 
     private
       def cache_collection_render
-        return yield unless cache_collection?
+        @template_eligibility = {}
+        build_collection_by_cache_keys_with_eager_loaded_templates
 
-        keyed_collection = collection_by_cache_keys
-        cached_partials = collection_cache.read_multi(*keyed_collection.keys)
+        return yield unless cache_collection? || @collection_by_cache_keys.empty?
 
-        @collection = keyed_collection.reject { |key, _| cached_partials.key?(key) }.values
-        rendered_partials = @collection.empty? ? [] : yield
+        cached_partials = collection_cache.read_multi(*@collection_by_cache_keys.keys)
+
+        captured_render_indexes = []
+        collection_to_render    = []
+        @collection_by_cache_keys.each_with_index do |(key, object), index|
+          unless cached_partials.key?(key)
+            captured_render_indexes << index
+            collection_to_render << object
+          end
+        end.values
+
+        @collection = collection_to_render
+        rendered_partials = @collection.empty? ? [] : yield(captured_render_indexes)
 
         index = 0
-        keyed_collection.map do |cache_key, _|
+        @collection_by_cache_keys.map do |cache_key, _|
           cached_partials.fetch(cache_key) do
             rendered_partials[index].tap { index += 1 }
           end
@@ -29,33 +40,54 @@ module ActionView
       end
 
       def cache_collection?
-        @options.fetch(:cache, automatic_cache_eligible?)
-      end
-
-      def automatic_cache_eligible?
-        @template && @template.eligible_for_collection_caching?(as: @options[:as])
+        @options[:cache] != false
       end
 
       def callable_cache_key?
         @options[:cache].respond_to?(:call)
       end
 
-      def collection_by_cache_keys
-        seed = callable_cache_key? ? @options[:cache] : ->(i) { i }
+      def eligible_template?(template, path, as = nil)
+        return unless cache_collection?
 
-        @collection.each_with_object({}) do |item, hash|
-          hash[expanded_cache_key(seed.call(item))] = item
+        @template_eligibility.fetch(path) do
+          @template_eligibility[path] = template.eligible_for_collection_caching?(as: as)
         end
       end
 
-      def expanded_cache_key(key)
-        key = @view.fragment_cache_key(@view.cache_fragment_name(key, virtual_path: @template.virtual_path))
+      def build_collection_by_cache_keys_with_eager_loaded_templates
+        @collection_by_cache_keys = {}
+        seed = callable_cache_key? ? @options[:cache] : ->(i) { i }
+
+        if @template
+          if eligible_template?(@template, @path, @options[:as])
+            @collection.each do |item|
+              @collection_by_cache_keys[expanded_cache_key(seed.call(item), @template)] = item
+            end
+          end
+        else
+          @templates = {}
+          keys = @locals.keys
+
+          @collection.each_with_index do |item, index|
+            path, as, counter, _ = @collection_data[index]
+
+            @templates[path] ||= find_template(path, keys + [ as, counter ])
+            template = @templates[path]
+
+            @collection_by_cache_keys[expanded_cache_key(seed.call(item), template)] = item
+          end
+        end
+      end
+
+      def expanded_cache_key(key, template)
+        key = @view.fragment_cache_key(@view.cache_fragment_name(key, virtual_path: template.virtual_path))
         key.frozen? ? key.dup : key # #read_multi & #write may require mutability, Dalli 2.6.0.
       end
 
-      def collection_cache_rendered_partial(rendered_partial, key_by)
+      def collection_cache_rendered_partial(template, key_by, rendered_partial)
         if callable_cache_key?
-          key = expanded_cache_key(@options[:cache].call(key_by))
+          key = expanded_cache_key(@options[:cache].call(key_by), template)
           collection_cache.write(key, rendered_partial, @options[:cache_options])
         end
       end


### PR DESCRIPTION
Followup to #18948.

Before this if you had a collection rendering more than one template, say the templates like `_notification` and `_amazing_notification`, we couldn't automatically cache them.

Now we should be able to do that.

So people who helped out on the first one, @dhh, @rafaelfranca, @jeremy and anybody else interested, pipe in :smile:

(I've also changed `automatic_cache_eligible?` to no longer check if the cache key is callable. We were already making that work elsewhere.)
