### PR TITLE
Add PostgreSQL box to supported data types

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid.rb
@@ -1,6 +1,7 @@
 require 'active_record/connection_adapters/postgresql/oid/array'
 require 'active_record/connection_adapters/postgresql/oid/bit'
 require 'active_record/connection_adapters/postgresql/oid/bit_varying'
+require 'active_record/connection_adapters/postgresql/oid/box'
 require 'active_record/connection_adapters/postgresql/oid/bytea'
 require 'active_record/connection_adapters/postgresql/oid/cidr'
 require 'active_record/connection_adapters/postgresql/oid/date_time'

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/box.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/box.rb
@@ -1,0 +1,40 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID # :nodoc:
+        class Box < Type::Value # :nodoc:
+          def type
+            :box
+          end
+
+          def serialize(value)
+            if value.is_a?(::Array)
+              "(#{serialize(value[0])},#{serialize(value[1])})"
+            else
+              value
+            end
+          end
+
+          def cast(value)
+            case value
+            when ::String
+              values = value.tr('()', '').split(',')
+              if values
+                values = values.map{|v| Float(v)}
+                [[values[0], values[1]], [values[2], values[3]]]
+              else
+                value
+              end
+            else
+              value
+            end
+          end
+
+          def changed_in_place?(raw_old_value, new_value)
+            cast(raw_old_value) != new_value
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -47,6 +47,10 @@ module ActiveRecord
           args.each { |name| column(name, :bit_varying, options) }
         end
 
+        def box(*args, **options)
+          args.each { |name| column(name, :box, options) }
+        end
+
         def cidr(*args, **options)
           args.each { |name| column(name, :cidr, options) }
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -108,6 +108,7 @@ module ActiveRecord
         ltree:       { name: "ltree" },
         citext:      { name: "citext" },
         point:       { name: "point" },
+        box:         { name: "box" },
         bit:         { name: "bit" },
         bit_varying: { name: "bit varying" },
         money:       { name: "money" },
@@ -505,6 +506,7 @@ module ActiveRecord
           m.register_type 'money', OID::Money.new
           m.register_type 'bytea', OID::Bytea.new
           m.register_type 'point', OID::Point.new
+          m.register_type 'box', OID::Box.new
           m.register_type 'hstore', OID::Hstore.new
           m.register_type 'json', OID::Json.new
           m.register_type 'jsonb', OID::Jsonb.new
@@ -524,7 +526,6 @@ module ActiveRecord
           m.alias_type 'polygon', 'varchar'
           m.alias_type 'circle', 'varchar'
           m.alias_type 'lseg', 'varchar'
-          m.alias_type 'box', 'varchar'
 
           register_class_with_precision m, 'time', Type::Time
           register_class_with_precision m, 'timestamp', OID::DateTime
@@ -848,6 +849,7 @@ module ActiveRecord
         ActiveRecord::Type.register(:bit, OID::Bit, adapter: :postgresql)
         ActiveRecord::Type.register(:bit_varying, OID::BitVarying, adapter: :postgresql)
         ActiveRecord::Type.register(:binary, OID::Bytea, adapter: :postgresql)
+        ActiveRecord::Type.register(:box, OID::Box, adapter: :postgresql)
         ActiveRecord::Type.register(:cidr, OID::Cidr, adapter: :postgresql)
         ActiveRecord::Type.register(:date_time, OID::DateTime, adapter: :postgresql)
         ActiveRecord::Type.register(:decimal, OID::Decimal, adapter: :postgresql)

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -69,6 +69,77 @@ class PostgresqlPointTest < ActiveRecord::TestCase
   end
 end
 
+class PostgresqlBoxTest < ActiveRecord::TestCase
+  include ConnectionHelper
+  include SchemaDumpingHelper
+
+  class PostgresqlBox < ActiveRecord::Base; end
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table('postgresql_boxes') do |t|
+      t.box :x
+      t.box :y, default: [[11.1, 14.4], [13.3, 12.2]]
+      t.box :z, default: "((21.1,22.2),(23.3,24.4))"
+    end
+  end
+
+  teardown do
+    @connection.drop_table 'postgresql_boxes', if_exists: true
+  end
+
+  def test_column
+    column = PostgresqlBox.columns_hash["x"]
+    assert_equal :box, column.type
+    assert_equal "box", column.sql_type
+    assert_not column.array?
+
+    type = PostgresqlBox.type_for_attribute("x")
+    assert_not type.binary?
+  end
+
+  def test_default
+    # reordered to store upper right corner then bottom left corner:
+    assert_equal [[13.3, 14.4], [11.1, 12.2]], PostgresqlBox.column_defaults['y']
+    assert_equal [[13.3, 14.4], [11.1, 12.2]], PostgresqlBox.new.y
+
+    # reordered to store upper right corner then bottom left corner:
+    assert_equal [[23.3, 24.4], [21.1, 22.2]], PostgresqlBox.column_defaults['z']
+    assert_equal [[23.3, 24.4], [21.1, 22.2]], PostgresqlBox.new.z
+  end
+
+  def test_schema_dumping
+    output = dump_table_schema("postgresql_boxes")
+    assert_match %r{t\.box\s+"x"$}, output
+    assert_match %r{t\.box\s+"y",\s+default: \[\[13\.3, 14\.4\], \[11\.1, 12\.2\]\]$}, output
+    assert_match %r{t\.box\s+"z",\s+default: \[\[23\.3, 24\.4\], \[21\.1, 22\.2\]\]$}, output
+  end
+
+  def test_roundtrip
+    PostgresqlBox.create! x: [[11, 12.2], [13.3, 14]]
+    record = PostgresqlBox.first
+    assert_equal [[13.3, 14], [11, 12.2]], record.x
+
+    record.x = [[1.1, 2.2], [3.3, 4.4]]
+    record.save!
+    assert record.reload
+    assert_equal [[3.3, 4.4], [1.1, 2.2]], record.x
+  end
+
+  def test_mutation
+    PostgresqlBox.create! x: [[10, 20], [31.1, 32.2]]
+    record = PostgresqlBox.first
+
+    record.x[0] = [31.5, 32.5]
+    record.x[1][0] = 11
+    record.save!
+    record.reload
+
+    assert_equal [[31.5, 32.5], [11.0, 20.0]], record.x
+    assert_not record.changed?
+  end
+end
+
 class PostgresqlGeometricTest < ActiveRecord::TestCase
   class PostgresqlGeometric < ActiveRecord::Base; end
 
@@ -76,7 +147,6 @@ class PostgresqlGeometricTest < ActiveRecord::TestCase
     @connection = ActiveRecord::Base.connection
     @connection.create_table("postgresql_geometrics") do |t|
       t.column :a_line_segment, :lseg
-      t.column :a_box, :box
       t.column :a_path, :path
       t.column :a_polygon, :polygon
       t.column :a_circle, :circle
@@ -90,7 +160,6 @@ class PostgresqlGeometricTest < ActiveRecord::TestCase
   def test_geometric_types
     g = PostgresqlGeometric.new(
       :a_line_segment => '(2.0, 3), (5.5, 7.0)',
-      :a_box          => '2.0, 3, 5.5, 7.0',
       :a_path         => '[(2.0, 3), (5.5, 7.0), (8.5, 11.0)]',
       :a_polygon      => '((2.0, 3), (5.5, 7.0), (8.5, 11.0))',
       :a_circle       => '<(5.3, 10.4), 2>'
@@ -101,7 +170,6 @@ class PostgresqlGeometricTest < ActiveRecord::TestCase
     h = PostgresqlGeometric.find(g.id)
 
     assert_equal '[(2,3),(5.5,7)]', h.a_line_segment
-    assert_equal '(5.5,7),(2,3)', h.a_box # reordered to store upper right corner then bottom left corner
     assert_equal '[(2,3),(5.5,7),(8.5,11)]', h.a_path
     assert_equal '((2,3),(5.5,7),(8.5,11))', h.a_polygon
     assert_equal '<(5.3,10.4),2>', h.a_circle
@@ -110,7 +178,6 @@ class PostgresqlGeometricTest < ActiveRecord::TestCase
   def test_alternative_format
     g = PostgresqlGeometric.new(
       :a_line_segment => '((2.0, 3), (5.5, 7.0))',
-      :a_box          => '(2.0, 3), (5.5, 7.0)',
       :a_path         => '((2.0, 3), (5.5, 7.0), (8.5, 11.0))',
       :a_polygon      => '2.0, 3, 5.5, 7.0, 8.5, 11.0',
       :a_circle       => '((5.3, 10.4), 2)'
@@ -120,7 +187,6 @@ class PostgresqlGeometricTest < ActiveRecord::TestCase
 
     h = PostgresqlGeometric.find(g.id)
     assert_equal '[(2,3),(5.5,7)]', h.a_line_segment
-    assert_equal '(5.5,7),(2,3)', h.a_box   # reordered to store upper right corner then bottom left corner
     assert_equal '((2,3),(5.5,7),(8.5,11))', h.a_path
     assert_equal '((2,3),(5.5,7),(8.5,11))', h.a_polygon
     assert_equal '<(5.3,10.4),2>', h.a_circle


### PR DESCRIPTION
Support box data type (http://www.postgresql.org/docs/9.4/static/datatype-geometric.html#AEN6814). Cast to nested array: `[[x1, y1], [x2, y2]]`
