### PR TITLE
Fix eager loading association using default_scope for finder methods.

### DIFF
--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -35,7 +35,7 @@ module ActiveRecord
 
         # Are there attributes associated with this scope?
         def scope_attributes? # :nodoc:
-          super || default_scopes.any?
+          super || default_scopes.any? || respond_to?(:default_scope)
         end
 
         def before_remove_const #:nodoc:

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -759,6 +759,23 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_eager_with_default_scope_as_class_method_using_find_method
+    david = developers(:david)
+    developer = EagerDeveloperWithClassMethodDefaultScope.find(david.id)
+    projects = Project.order(:id).to_a
+    assert_no_queries do
+      assert_equal(projects, developer.projects)
+    end
+  end
+
+  def test_eager_with_default_scope_as_class_method_using_find_by_method
+    developer = EagerDeveloperWithClassMethodDefaultScope.find_by(name: 'David')
+    projects = Project.order(:id).to_a
+    assert_no_queries do
+      assert_equal(projects, developer.projects)
+    end
+  end
+
   def test_eager_with_default_scope_as_lambda
     developer = EagerDeveloperWithLambdaDefaultScope.where(:name => 'David').first
     projects = Project.order(:id).to_a


### PR DESCRIPTION
- Eager loading was not working for the default_scope (class method)
  for 'find' & 'find_by' methods.
- Fixed these by adding a new check 'respond_to?(:default_scope)'.
