### PR TITLE
Combine complementary AR #find doc lines

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     ONE_AS_ONE = '1 AS one'
 
     # Find by id - This can either be a specific id (1), a list of ids (1, 5, 6), or an array of ids ([5, 6, 10]).
-    # If no record can be found for all of the listed ids, then RecordNotFound will be raised. If the primary key
+    # If one or more records can not be found for the requested ids, then RecordNotFound will be raised. If the primary key
     # is an integer, find by id coerces its arguments using +to_i+.
     #
     #   Person.find(1)          # returns the object for ID = 1
@@ -15,8 +15,6 @@ module ActiveRecord
     #   Person.find([7, 17])    # returns an array for objects with IDs in (7, 17)
     #   Person.find([1])        # returns an array for the object with ID = 1
     #   Person.where("administrator = 1").order("created_on DESC").find(1)
-    #
-    # <tt>ActiveRecord::RecordNotFound</tt> will be raised if one or more ids are not found.
     #
     # NOTE: The returned records may not be in the same order as the ids you
     # provide since database rows are unordered. You'd need to provide an explicit <tt>order</tt>


### PR DESCRIPTION
Someone reading the docs for the ActiveRecord #find method will likely encounter the first line, but could miss the second statement (as my co-worker did). I think we can improve this by including all cases in the same sentence.
