### PR TITLE
Add 'work in progress' banner on guides undergoing change

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -64,6 +64,7 @@ require 'rails_guides/levenshtein'
 
 module RailsGuides
   class Generator
+    include RailsGuides::Helpers
     attr_reader :guides_dir, :source_dir, :output_dir, :edge, :warnings, :all
 
     GUIDES_RE = /\.(?:erb|md)\z/
@@ -197,13 +198,15 @@ module RailsGuides
         view = ActionView::Base.new(source_dir, :edge => @edge, :version => @version, :mobi => "kindle/#{mobi}")
         view.extend(Helpers)
 
+        result = ""
+        result << "<div class='note'><b>Work in progress</b></div>" if guide_work_in_progress?(output_file)
         if guide =~ /\.(\w+)\.erb$/
           # Generate the special pages like the home.
           # Passing a template handler in the template name is deprecated. So pass the file name without the extension.
-          result = view.render(:layout => layout, :formats => [$1], :file => $`)
+          result += view.render(:layout => layout, :formats => [$1], :file => $`)
         else
           body = File.read(File.join(source_dir, guide))
-          result = RailsGuides::Markdown.new(view, layout).render(body)
+          result += RailsGuides::Markdown.new(view, layout).render(body)
 
           warn_about_broken_links(result) if @warnings
         end
@@ -244,6 +247,10 @@ module RailsGuides
           puts "*** BROKEN LINK: ##{fragment_identifier}, perhaps you meant ##{guess}."
         end
       end
+    end
+
+    def guide_work_in_progress?(file)
+      work_in_progress_guides.include?(file)
     end
   end
 end

--- a/guides/rails_guides/helpers.rb
+++ b/guides/rails_guides/helpers.rb
@@ -49,5 +49,19 @@ module RailsGuides
       c = capture(&block)
       content_tag(:code, c)
     end
+
+    def work_in_progress_guides
+      @work_in_progress_guides ||= find_work_in_progress_guides
+    end
+
+    def find_work_in_progress_guides
+      wip_guides = []
+      documents_by_section.each do |section|
+        section['documents'].each do |document|
+          wip_guides << document['url'] if document['work_in_progress']
+        end
+      end
+      wip_guides
+    end
   end
 end


### PR DESCRIPTION
Some rails guides are marked as 'work in progress' by setting
work_in_progress: true in guides/source/documents.yml.

Using this setting, a 'Work in progress' banner is added at
the top of the files market as WIP.

At this moment, running 'rake guides:generate:html ONLY=testing'
will generate testing.html with the banner.

And running 'rake guides:generate:html ONLY=generators' will
generate generators.html without the banner.
