### PR TITLE
Require Module#delegate core ext in ActiveModel::Naming

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -1,6 +1,7 @@
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/module/introspection'
 require 'active_support/core_ext/module/remove_method'
+require 'active_support/core_ext/module/delegation'
 
 module ActiveModel
   class Name


### PR DESCRIPTION
Steps to reproduce:
- Rails 4.2.1

```
require 'active_model/naming'
```
### Expected behaviour

Require happens without error.
### Actual behaviour

```
NoMethodError: undefined method `delegate' for ActiveModel::Name:Class
    from /Users/ryanbigg/.gem/ruby/2.1.5/gems/activemodel-4.2.1/lib/active_model/naming.rb:132:in `<class:Name>'
    from /Users/ryanbigg/.gem/ruby/2.1.5/gems/activemodel-4.2.1/lib/active_model/naming.rb:6:in `<module:ActiveModel>'
    from /Users/ryanbigg/.gem/ruby/2.1.5/gems/activemodel-4.2.1/lib/active_model/naming.rb:5:in `<top (required)>'
    from /Users/ryanbigg/.rubies/ruby-2.1.5/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:69:in `require'
    from /Users/ryanbigg/.rubies/ruby-2.1.5/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:69:in `require'
    from (irb):2
    from /Users/ryanbigg/.rubies/ruby-2.1.5/bin/irb:11:in `<main>'
```
