### PR TITLE
Fix doc: set_callback also accepts an array of if:

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -663,10 +663,12 @@ module ActiveSupport
       #
       # ===== Options
       #
-      # * <tt>:if</tt> - A symbol naming an instance method or a proc; the
-      #   callback will be called only when it returns a +true+ value.
-      # * <tt>:unless</tt> - A symbol naming an instance method or a proc; the
-      #   callback will be called only when it returns a +false+ value.
+      # * <tt>:if</tt> - A symbol, a string or an array of symbols and strings,
+      #   each naming an instance method or a proc; the callback will be called
+      #   only when they all return a true value.
+      # * <tt>:unless</tt> - A symbol, a string or an array of symbols and
+      #   strings, each naming an instance method or a proc; the callback will
+      #   be called only when they all return a false value.
       # * <tt>:prepend</tt> - If +true+, the callback will be prepended to the
       #   existing chain rather than appended.
       def set_callback(name, *filter_list, &block)


### PR DESCRIPTION
When Active Record calls `set_callback` inside `after_commit`, [these lines of code](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/transactions.rb#L276) pass an **array** of methods as the `:if` condition:

``` ruby
options[:if] = Array(options[:if])
options[:if] << "transaction_include_any_action?(#{fire_on})"
```

That made me realize that anyone could pass an **array** of `:if` and `:unless` conditions to `set_callback`, since Active Support transforms these conditions into an array anyways in [these lines of code](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/callbacks.rb#L365):

``` ruby
@if      = Array(options[:if])
@unless  = Array(options[:unless])
```

Long story short, this commit updates the documentation of the `set_callback` method to explain that arrays are also accepted.

It also replaces `+false+` and `+true+` with `false` and `true`, since any _falsey_ or _truthy_ value will work.

[ci skip]
