### PR TITLE
[ci skip] Replace `query methods` with `a predicate`

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/aliasing.rb
+++ b/activesupport/lib/active_support/core_ext/module/aliasing.rb
@@ -45,7 +45,7 @@ class Module
   end
 
   # Allows you to make aliases for attributes, which includes
-  # getter, setter, and query methods.
+  # getter, setter, and a predicate.
   #
   #   class Content < ActiveRecord::Base
   #     # has a title attribute


### PR DESCRIPTION
`e.subject?` is predicate and matching [rails guide](https://github.com/rails/rails/blob/master/guides/source/active_support_core_extensions.md#alias_attribute).
