### PR TITLE
Fix default params for quote value on Rails 4.1

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def quote_value(value, column) #:nodoc:
+      def quote_value(value, column = nil) #:nodoc:
         connection.quote(value, column)
       end
 


### PR DESCRIPTION
### sanitization.rb

While gems like `acts-as-taggable-on` heavily use `quote_value` in many cases, this will fix some problems for gems using the method without specifying a default value for `column`. 

This should improve the compatibility of overall usage of ActiveRecord's sanitization methods across all the Rails developers.

Since `connection.quote(value, column)` has already supports (1..2) params, I can't see why the `quote_value` is strictly needed for 2 parameters for the function to work.
