### PR TITLE
Only coerce time when comparing if necessary

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -246,8 +246,10 @@ class Time
   # Layers additional behavior on Time#<=> so that DateTime and ActiveSupport::TimeWithZone instances
   # can be chronologically compared with a Time
   def compare_with_coercion(other)
-    # we're avoiding Time#to_datetime cause it's expensive
-    if other.is_a?(Time)
+    # we're avoiding Time#to_datetime and Time#to_time because they're expensive
+    if other.class == Time
+      compare_without_coercion(other)
+    elsif other.is_a?(Time)
       compare_without_coercion(other.to_time)
     else
       to_datetime <=> other


### PR DESCRIPTION
This results in a ~100ms savings per request in development on my Late 2013 MBP on a medium sized project.

In dev, `ActiveSupport::FileUpdateChecker#max_mtime` triggers many time comparisons. `Time#to_time` is quite a bit slower than not doing it, so we should avoid it if possible.
## Before:
### curl

```
------------------------
Total time (ms): 6513.18
Repetitions    : 10
Sample mode    : 600 (3 ocurrences)
Median time    : 614.169
Avg time       : 651.318
Std dev.       : 92.3848
Minimum        : 592.293
Maximum        : 911.171
95% conf.int.  : [470.247, 832.389]  e = 181.071
99% conf.int.  : [413.35, 889.285]  e = 237.968
EstimatedAvg95%: [594.058, 708.577]  e = 57.2597
EstimatedAvg99%: [576.066, 726.57]  e = 75.252
```
### Benchmark in `#max_mtime`

```
  0.020000   0.080000   0.100000 (  0.104686)
  0.050000   0.080000   0.130000 (  0.126047)
  0.010000   0.080000   0.090000 (  0.103902)
  0.020000   0.080000   0.100000 (  0.103445)
```
## After:
### curl

```
------------------------
Total time (ms): 5211.29
Repetitions    : 10
Sample mode    : 500 (5 ocurrences)
Median time    : 504.944
Avg time       : 521.129
Std dev.       : 36.3683
Minimum        : 494.416
Maximum        : 619.499
95% conf.int.  : [449.849, 592.41]  e = 71.2806
99% conf.int.  : [427.451, 614.808]  e = 93.6786
EstimatedAvg95%: [498.588, 543.67]  e = 22.5409
EstimatedAvg99%: [491.506, 550.753]  e = 29.6238
```
### Benchmark in `#max_mtime`

```
  0.000000   0.000000   0.000000 (  0.000092)
  0.000000   0.000000   0.000000 (  0.004499)
  0.000000   0.000000   0.000000 (  0.005431)
  0.000000   0.000000   0.000000 (  0.000048)
```
