### PR TITLE
Update routing.md

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -807,6 +807,20 @@ As long as `Sprockets` responds to `call` and returns a `[status, headers, body]
 
 NOTE: For the curious, `'articles#index'` actually expands out to `ArticlesController.action(:index)`, which returns a valid Rack application.
 
+If you specify a rack application as the endpoint for a matcher remember that the route will be unchanged in the receiving application. With the following route your rack application should expect the route to be '/admin':
+
+```ruby
+match '/admin', to: AdminApp, via: all
+```
+
+If you would prefer to have your rack application receive requests at the root path instead use mount:
+
+```ruby
+mount AdminApp, at: '/admin'
+```
+
+
+
 ### Using `root`
 
 You can specify what Rails should route `'/'` to with the `root` method:

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -810,7 +810,7 @@ NOTE: For the curious, `'articles#index'` actually expands out to `ArticlesContr
 If you specify a rack application as the endpoint for a matcher remember that the route will be unchanged in the receiving application. With the following route your rack application should expect the route to be '/admin':
 
 ```ruby
-match '/admin', to: AdminApp, via: all
+match '/admin', to: AdminApp, via: :all
 ```
 
 If you would prefer to have your rack application receive requests at the root path instead use mount:

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -819,8 +819,6 @@ If you would prefer to have your rack application receive requests at the root p
 mount AdminApp, at: '/admin'
 ```
 
-
-
 ### Using `root`
 
 You can specify what Rails should route `'/'` to with the `root` method:


### PR DESCRIPTION
This adds instructions for routing to rack applications with mount instead of match.

I just spent an unreasonable amount of time staring at this, hopefully the next person will save some time. It's possible that the docs should simply advise people to use mount and leave out the match method but I don't know enough about the differences in the two approaches to assert that definitively.
