### PR TITLE
[ci skip] fix guides example on arbitrary SQL execution

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -501,7 +501,7 @@ If the helpers provided by Active Record aren't enough you can use the `execute`
 method to execute arbitrary SQL:
 
 ```ruby
-Product.connection.execute('UPDATE `products` SET `price`=`free` WHERE 1')
+Product.connection.execute("UPDATE products SET price = 'free' WHERE 1=1")
 ```
 
 For more details and examples of individual methods, check the API documentation.


### PR DESCRIPTION
The existing SQL example is invalid (use of backticks, wrong use of quotes, `WHERE 1` is not supported by PostgreSQL). This PR fixes that.
