### PR TITLE
Add suffix option support to Module#delegate

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added `suffix` option support to `Module#delegate`.
+
+    * Pavel Pravosud *
+
 *   Added `ActiveSupport::ArrayInquirer` and `Array#inquiry`.
 
     Wrapping an array in an `ArrayInquirer` gives a friendlier way to check its

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -153,12 +153,8 @@ class Module
       raise ArgumentError, 'Can only automatically set the delegation prefix when delegating to a method.'
     end
 
-    method_prefix = \
-      if prefix
-        "#{prefix == true ? to : prefix}_"
-      else
-        ''
-      end
+    prefix = to if prefix == true
+    prefix = prefix ? "#{prefix}_" : ""
 
     file, line = caller(1, 1).first.split(':', 2)
     line = line.to_i
@@ -180,7 +176,7 @@ class Module
       # be doing one call.
       if allow_nil
         method_def = [
-          "def #{method_prefix}#{method}(#{definition})",
+          "def #{prefix}#{method}(#{definition})",
           "_ = #{to}",
           "if !_.nil? || nil.respond_to?(:#{method})",
           "  _.#{method}(#{definition})",
@@ -188,10 +184,10 @@ class Module
         "end"
         ].join ';'
       else
-        exception = %(raise DelegationError, "#{self}##{method_prefix}#{method} delegated to #{to}.#{method}, but #{to} is nil: \#{self.inspect}")
+        exception = %(raise DelegationError, "#{self}##{prefix}#{method} delegated to #{to}.#{method}, but #{to} is nil: \#{self.inspect}")
 
         method_def = [
-          "def #{method_prefix}#{method}(#{definition})",
+          "def #{prefix}#{method}(#{definition})",
           " _ = #{to}",
           "  _.#{method}(#{definition})",
           "rescue NoMethodError => e",

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -148,14 +148,7 @@ class Module
   #
   # The target method must be public, otherwise it will raise +NoMethodError+.
   #
-  def delegate(*methods)
-    options = methods.pop
-    unless options.is_a?(Hash) && to = options[:to]
-      raise ArgumentError, 'Delegation needs a target. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter).'
-    end
-
-    prefix, allow_nil = options.values_at(:prefix, :allow_nil)
-
+  def delegate(*methods, to:, prefix: nil, allow_nil: false)
     if prefix == true && to =~ /^[^a-z_]/
       raise ArgumentError, 'Can only automatically set the delegation prefix when delegating to a method.'
     end

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -30,6 +30,9 @@ class Someone < Struct.new(:name, :place)
   delegate :upcase, :to => "place.city"
   delegate :table_name, :to => :class
   delegate :table_name, :to => :class, :prefix => true
+  delegate :downcase, :paulina?, to: :street, suffix: :street
+  delegate :upcase!, to: :street, suffix: true
+  delegate :name=, to: :place, suffix: :of_the_place
 
   def self.table_name
     'some_table'
@@ -191,6 +194,37 @@ class ModuleTest < ActiveSupport::TestCase
         delegate :name, :address, :to => :@client, :prefix => true
       end
     end
+  end
+
+  def test_delegation_suffix_with_instance_variable
+    assert_raise ArgumentError do
+      Class.new do
+        def initialize(client)
+          @client = client
+        end
+        delegate :name, :address, to: :@client, suffix: true
+      end
+    end
+  end
+
+  def test_delegation_suffix
+    assert_equal "paulina", @david.downcase_street
+  end
+
+  def test_delegation_suffix_predicate
+    street = @david.street
+    def street.paulina?; true; end
+    assert @david.paulina_street?
+  end
+
+  def test_delegation_suffix_bang
+    @david.upcase_street!
+    assert_equal "PAULINA", @david.street
+  end
+
+  def test_delegation_suffix_setter
+    @david.name_of_the_place = "David's Home"
+    assert_equal "David's Home", @david.place.name
   end
 
   def test_delegation_with_allow_nil


### PR DESCRIPTION
This PR adds `suffix` option support to `Module#delegate`.

``` ruby
class User
  def name
    @name ||= "joe"
  end

  delegate :capitalize!, to: :name, suffix: true
end

user = User.new
user.name # => "joe"
user.capitalize_name! # => "Joe"
user.name # => "Joe"
```
