### PR TITLE
[ci skip] Replace `reraised` with `not captured`

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -475,7 +475,7 @@ The methods `silence_warnings` and `enable_warnings` change the value of `$VERBO
 silence_warnings { Object.const_set "RAILS_DEFAULT_LOGGER", logger }
 ```
 
-Silencing exceptions is also possible with `suppress`. This method receives an arbitrary number of exception classes. If an exception is raised during the execution of the block and is `kind_of?` any of the arguments, `suppress` captures it and returns silently. Otherwise the exception is reraised:
+Silencing exceptions is also possible with `suppress`. This method receives an arbitrary number of exception classes. If an exception is raised during the execution of the block and is `kind_of?` any of the arguments, `suppress` captures it and returns silently. Otherwise the exception is not captured:
 
 ```ruby
 # If the user is locked, the increment is lost, no big deal.


### PR DESCRIPTION
[suppress method](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/kernel/reporting.rb#L39) dose not reraise the exception which is not kind_of arguments. But this code only dose not capture the 
exception.

In this code `the exception is reraised`

``` ruby
  def suppress(*exception_classes)
    yield
  rescue => e # once rescue all
    raise unless exception_classes.any {|ex| e.kind_of? ex} # re raise if no exception_classes hit
  end
```
