### PR TITLE
Prefer string patterns for gsub

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -118,7 +118,7 @@ module ActionController
       end
 
       def authentication_request(controller, realm)
-        controller.headers["WWW-Authenticate"] = %(Basic realm="#{realm.gsub('"', "")}")
+        controller.headers["WWW-Authenticate"] = %(Basic realm="#{realm.gsub('"'.freeze, "".freeze)}")
         controller.status = 401
         controller.response_body = "HTTP Basic: Access denied.\n"
       end
@@ -499,7 +499,7 @@ module ActionController
       #
       # Returns nothing.
       def authentication_request(controller, realm)
-        controller.headers["WWW-Authenticate"] = %(Token realm="#{realm.gsub('"', "")}")
+        controller.headers["WWW-Authenticate"] = %(Token realm="#{realm.gsub('"'.freeze, "".freeze)}")
         controller.__send__ :render, :text => "HTTP Token: Access denied.\n", :status => :unauthorized
       end
     end

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -118,7 +118,7 @@ module ActionController
       end
 
       def authentication_request(controller, realm)
-        controller.headers["WWW-Authenticate"] = %(Basic realm="#{realm.gsub(/"/, "")}")
+        controller.headers["WWW-Authenticate"] = %(Basic realm="#{realm.gsub('"', "")}")
         controller.status = 401
         controller.response_body = "HTTP Basic: Access denied.\n"
       end
@@ -499,7 +499,7 @@ module ActionController
       #
       # Returns nothing.
       def authentication_request(controller, realm)
-        controller.headers["WWW-Authenticate"] = %(Token realm="#{realm.gsub(/"/, "")}")
+        controller.headers["WWW-Authenticate"] = %(Token realm="#{realm.gsub('"', "")}")
         controller.__send__ :render, :text => "HTTP Token: Access denied.\n", :status => :unauthorized
       end
     end

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -102,7 +102,7 @@ module ActionController
             end
           end
 
-          message = json.gsub("\n", "\ndata: ")
+          message = json.gsub("\n".freeze, "\ndata: ".freeze)
           @stream.write "data: #{message}\n\n"
         end
     end

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -102,7 +102,7 @@ module ActionController
             end
           end
 
-          message = json.gsub(/\n/, "\ndata: ")
+          message = json.gsub("\n", "\ndata: ")
           @stream.write "data: #{message}\n\n"
         end
     end

--- a/actionview/lib/action_view/template/handlers/raw.rb
+++ b/actionview/lib/action_view/template/handlers/raw.rb
@@ -2,7 +2,7 @@ module ActionView
   module Template::Handlers
     class Raw
       def call(template)
-        escaped = template.source.gsub(':', '\:')
+        escaped = template.source.gsub(':'.freeze, '\:'.freeze)
 
         '%q:' + escaped + ':;'
       end

--- a/actionview/lib/action_view/template/handlers/raw.rb
+++ b/actionview/lib/action_view/template/handlers/raw.rb
@@ -2,7 +2,7 @@ module ActionView
   module Template::Handlers
     class Raw
       def call(template)
-        escaped = template.source.gsub(/:/, '\:')
+        escaped = template.source.gsub(':', '\:')
 
         '%q:' + escaped + ':;'
       end

--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -85,7 +85,7 @@ module ActiveRecord::Associations::Builder
 
     def middle_reflection(join_model)
       middle_name = [lhs_model.name.downcase.pluralize,
-                     association_name].join('_').gsub(/::/, '_').to_sym
+                     association_name].join('_').gsub('::', '_').to_sym
       middle_options = middle_options join_model
 
       HasMany.create_reflection(lhs_model,

--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -85,7 +85,7 @@ module ActiveRecord::Associations::Builder
 
     def middle_reflection(join_model)
       middle_name = [lhs_model.name.downcase.pluralize,
-                     association_name].join('_').gsub('::', '_').to_sym
+                     association_name].join('_'.freeze).gsub('::'.freeze, '_'.freeze).to_sym
       middle_options = middle_options join_model
 
       HasMany.create_reflection(lhs_model,

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -77,7 +77,7 @@ module ActiveRecord
       # Quotes a string, escaping any ' (single quote) and \ (backslash)
       # characters.
       def quote_string(s)
-        s.gsub(/\\/, '\&\&').gsub(/'/, "''") # ' (for ruby-mode)
+        s.gsub('\\', '\&\&').gsub("'", "''") # ' (for ruby-mode)
       end
 
       # Quotes the column name. Defaults to no quoting.

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -77,7 +77,7 @@ module ActiveRecord
       # Quotes a string, escaping any ' (single quote) and \ (backslash)
       # characters.
       def quote_string(s)
-        s.gsub('\\', '\&\&').gsub("'", "''") # ' (for ruby-mode)
+        s.gsub('\\'.freeze, '\&\&'.freeze).gsub("'".freeze, "''".freeze) # ' (for ruby-mode)
       end
 
       # Quotes the column name. Defaults to no quoting.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -568,7 +568,7 @@ module ActiveRecord
           case default
             # Quoted types
             when /\A[\(B]?'(.*)'::/m
-              $1.gsub(/''/, "'")
+              $1.gsub("''", "'")
             # Boolean types
             when 'true', 'false'
               default

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -568,9 +568,9 @@ module ActiveRecord
           case default
             # Quoted types
             when /\A[\(B]?'(.*)'::/m
-              $1.gsub("''", "'")
+              $1.gsub("''".freeze, "'".freeze)
             # Boolean types
-            when 'true', 'false'
+            when 'true'.freeze, 'false'.freeze
               default
             # Numeric types
             when /\A\(?(-?\d+(\.\d*)?)\)?(::bigint)?\z/

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -73,7 +73,7 @@ module ActiveSupport
         string = string.sub(/^(?:#{inflections.acronym_regex}(?=\b|[A-Z_])|\w)/) { $&.downcase }
       end
       string.gsub!(/(?:_|(\/))([a-z\d]*)/i) { "#{$1}#{inflections.acronyms[$2] || $2.capitalize}" }
-      string.gsub!(/\//, '::')
+      string.gsub!('/', '::')
       string
     end
 
@@ -90,7 +90,7 @@ module ActiveSupport
     #   camelize(underscore('SSLError'))  # => "SslError"
     def underscore(camel_cased_word)
       return camel_cased_word unless camel_cased_word =~ /[A-Z-]|::/
-      word = camel_cased_word.to_s.gsub(/::/, '/')
+      word = camel_cased_word.to_s.gsub('::', '/')
       word.gsub!(/(?:(?<=([A-Za-z\d]))|\b)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1 && '_'}#{$2.downcase}" }
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
       word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -73,7 +73,7 @@ module ActiveSupport
         string = string.sub(/^(?:#{inflections.acronym_regex}(?=\b|[A-Z_])|\w)/) { $&.downcase }
       end
       string.gsub!(/(?:_|(\/))([a-z\d]*)/i) { "#{$1}#{inflections.acronyms[$2] || $2.capitalize}" }
-      string.gsub!('/', '::')
+      string.gsub!('/'.freeze, '::'.freeze)
       string
     end
 
@@ -90,7 +90,7 @@ module ActiveSupport
     #   camelize(underscore('SSLError'))  # => "SslError"
     def underscore(camel_cased_word)
       return camel_cased_word unless camel_cased_word =~ /[A-Z-]|::/
-      word = camel_cased_word.to_s.gsub('::', '/')
+      word = camel_cased_word.to_s.gsub('::'.freeze, '/'.freeze)
       word.gsub!(/(?:(?<=([A-Za-z\d]))|\b)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1 && '_'}#{$2.downcase}" }
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
       word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')

--- a/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
@@ -13,7 +13,7 @@ module ActiveSupport
         end
 
         rounded_number = NumberToRoundedConverter.convert(number, options)
-        format.gsub('%n', rounded_number).gsub('%u', options[:unit])
+        format.gsub('%n'.freeze, rounded_number).gsub('%u'.freeze, options[:unit])
       end
 
       private

--- a/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
@@ -13,7 +13,7 @@ module ActiveSupport
         end
 
         rounded_number = NumberToRoundedConverter.convert(number, options)
-        format.gsub(/%n/, rounded_number).gsub(/%u/, options[:unit])
+        format.gsub('%n', rounded_number).gsub('%u', options[:unit])
       end
 
       private

--- a/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
@@ -23,7 +23,7 @@ module ActiveSupport
         unit = determine_unit(units, exponent)
 
         rounded_number = NumberToRoundedConverter.convert(number, options)
-        format.gsub(/%n/, rounded_number).gsub(/%u/, unit).strip
+        format.gsub('%n', rounded_number).gsub('%u', unit).strip
       end
 
       private

--- a/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
@@ -23,7 +23,7 @@ module ActiveSupport
         unit = determine_unit(units, exponent)
 
         rounded_number = NumberToRoundedConverter.convert(number, options)
-        format.gsub('%n', rounded_number).gsub('%u', unit).strip
+        format.gsub('%n'.freeze, rounded_number).gsub('%u'.freeze, unit).strip
       end
 
       private

--- a/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
@@ -20,7 +20,7 @@ module ActiveSupport
           human_size = number / (base ** exponent)
           number_to_format = NumberToRoundedConverter.convert(human_size, options)
         end
-        conversion_format.gsub(/%n/, number_to_format).gsub(/%u/, unit)
+        conversion_format.gsub('%n', number_to_format).gsub('%u', unit)
       end
 
       private

--- a/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
@@ -20,7 +20,7 @@ module ActiveSupport
           human_size = number / (base ** exponent)
           number_to_format = NumberToRoundedConverter.convert(human_size, options)
         end
-        conversion_format.gsub('%n', number_to_format).gsub('%u', unit)
+        conversion_format.gsub('%n'.freeze, number_to_format).gsub('%u'.freeze, unit)
       end
 
       private

--- a/activesupport/lib/active_support/number_helper/number_to_percentage_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_percentage_converter.rb
@@ -5,7 +5,7 @@ module ActiveSupport
 
       def convert
         rounded_number = NumberToRoundedConverter.convert(number, options)
-        options[:format].gsub('%n', rounded_number)
+        options[:format].gsub('%n'.freeze, rounded_number)
       end
     end
   end

--- a/activesupport/lib/active_support/number_helper/number_to_percentage_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_percentage_converter.rb
@@ -5,7 +5,7 @@ module ActiveSupport
 
       def convert
         rounded_number = NumberToRoundedConverter.convert(number, options)
-        options[:format].gsub(/%n/, rounded_number)
+        options[:format].gsub('%n', rounded_number)
       end
     end
   end


### PR DESCRIPTION
First commit essentially reverts #17308 and #17483. These PR's have converted a few string patterns for `gsub` to regexp since it was faster at a time (the reason why regexp was faster is because a string was converted to regexp underneath `gsub` anyway).

But there is a new optimization since ruby 2.2 (ruby/ruby#579). Now string patterns are faster, so they can be used again as intended.

``` ruby
  Benchmark.ips do |bm|
    bm.report('regexp') { 'this is ::a random string'.gsub(/::/, '/') }
    bm.report('string') { 'this is ::a random string'.gsub('::', '/') }
    bm.compare!
  end
  # string: 753724.4 i/s
  # regexp: 501443.1 i/s - 1.50x slower
```

The second commit adds a few `.freeze` calls for static arguments of `gsub` but I can remove this one if we don't care about a few extra allocations in all these places.
