### PR TITLE
Added ActiveSupport::TimeZone#strptime.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+* Added `ActiveSupport::TimeZone#strptime` to allow parsing times as if from
+  a given timezone.
+
+    *Paul A Jungwirth*
+
 *   Added `ActiveSupport::ArrayInquirer`.
 
     Wrapping an array in an `ArrayInquirer` gives a friendlier way to check its

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -368,6 +368,26 @@ module ActiveSupport
       end
     end
 
+    # Parses +str+ according to +spec+ and returns an ActiveSupport::TimeWithZone.
+    #
+    # Assumes that +str+ is a time in the time zone +self+,
+    # unless +spec+ includes an explicit time zone.
+    # (This is the same behavior as +parse+.)
+    # In either case, the returned TimeWithZone has the timezone of +self+.
+    # 
+    #   Time.zone = 'Hawaii'                   # => "Hawaii"
+    #   Time.zone.strptime('1999-12-31 14:00:00', '%Y-%m-%d %H:%M:%S') # => Fri, 31 Dec 1999 14:00:00 HST -10:00
+    # 
+    def strptime(str, spec)
+      case spec
+      when /(^|[^%](%%)*)%(Z|:{0,3}z)/
+        DateTime.strptime(str, spec).in_time_zone(self)
+      else
+        t = DateTime.strptime(str, spec)
+        local(t.year, t.month, t.mday, t.hour, t.min, t.sec, t.usec)
+      end
+    end
+
     # Returns an ActiveSupport::TimeWithZone instance representing the current
     # time in the time zone represented by +self+.
     #

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -311,6 +311,71 @@ class TimeZoneTest < ActiveSupport::TestCase
     end
   end
 
+  def test_strptime
+    zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
+    twz = zone.strptime('1999-12-31 12:00:00', '%Y-%m-%d %H:%M:%S')
+    assert_equal Time.utc(1999,12,31,17), twz
+    assert_equal Time.utc(1999,12,31,12), twz.time
+    assert_equal Time.utc(1999,12,31,17), twz.utc
+    assert_equal zone, twz.time_zone
+  end
+
+  def test_strptime_with_nondefault_time_zone
+    with_tz_default ActiveSupport::TimeZone['Pacific Time (US & Canada)'] do
+      zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
+      twz = zone.strptime('1999-12-31 12:00:00', '%Y-%m-%d %H:%M:%S')
+      assert_equal Time.utc(1999,12,31,17), twz
+      assert_equal Time.utc(1999,12,31,12), twz.time
+      assert_equal Time.utc(1999,12,31,17), twz.utc
+      assert_equal zone, twz.time_zone
+    end
+  end
+
+  def test_strptime_with_explicit_time_zone_as_abbrev
+    zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
+    twz = zone.strptime('1999-12-31 12:00:00 PST', '%Y-%m-%d %H:%M:%S %Z')
+    assert_equal Time.utc(1999,12,31,20), twz
+    assert_equal Time.utc(1999,12,31,15), twz.time
+    assert_equal Time.utc(1999,12,31,20), twz.utc
+    assert_equal zone, twz.time_zone
+  end
+
+  def test_strptime_with_explicit_time_zone_as_h_offset
+    zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
+    twz = zone.strptime('1999-12-31 12:00:00 -08', '%Y-%m-%d %H:%M:%S %:::z')
+    assert_equal Time.utc(1999,12,31,20), twz
+    assert_equal Time.utc(1999,12,31,15), twz.time
+    assert_equal Time.utc(1999,12,31,20), twz.utc
+    assert_equal zone, twz.time_zone
+  end
+
+  def test_strptime_with_explicit_time_zone_as_hm_offset
+    zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
+    twz = zone.strptime('1999-12-31 12:00:00 -08:00', '%Y-%m-%d %H:%M:%S %:z')
+    assert_equal Time.utc(1999,12,31,20), twz
+    assert_equal Time.utc(1999,12,31,15), twz.time
+    assert_equal Time.utc(1999,12,31,20), twz.utc
+    assert_equal zone, twz.time_zone
+  end
+
+  def test_strptime_with_explicit_time_zone_as_hms_offset
+    zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
+    twz = zone.strptime('1999-12-31 12:00:00 -08:00:00', '%Y-%m-%d %H:%M:%S %::z')
+    assert_equal Time.utc(1999,12,31,20), twz
+    assert_equal Time.utc(1999,12,31,15), twz.time
+    assert_equal Time.utc(1999,12,31,20), twz.utc
+    assert_equal zone, twz.time_zone
+  end
+
+  def test_strptime_with_almost_explicit_time_zone
+    zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
+    twz = zone.strptime('1999-12-31 12:00:00 %Z', '%Y-%m-%d %H:%M:%S %%Z')
+    assert_equal Time.utc(1999,12,31,17), twz
+    assert_equal Time.utc(1999,12,31,12), twz.time
+    assert_equal Time.utc(1999,12,31,17), twz.utc
+    assert_equal zone, twz.time_zone
+  end
+
   def test_utc_offset_lazy_loaded_from_tzinfo_when_not_passed_in_to_initialize
     tzinfo = TZInfo::Timezone.get('America/New_York')
     zone = ActiveSupport::TimeZone.create(tzinfo.name, nil, tzinfo)


### PR DESCRIPTION
In Rails there is no easy way to parse a user-submitted date/time string,
interpreting it as from a given time zone (for instance from the user's preference).
This seems like a natural and common thing to do, and there are several StackOverflow questions about it (with flaky and/or wrong answers):

http://stackoverflow.com/questions/4262550/how-do-i-get-ruby-to-parse-time-as-if-it-were-in-a-different-time-zone

http://stackoverflow.com/questions/6615463/how-can-i-use-ruby-to-parse-a-time-as-though-it-is-in-a-time-zone-i-specify-wit

http://stackoverflow.com/questions/5074238/how-to-get-rails-to-interpret-a-time-as-being-in-a-specific-time-zone

First, some attempted answers. Suppose the user entered the string `2010-02-05 13:00:01` and has a time zone of `Eastern Time (US & Canada)`. This first attempt comes from StackOverflow, and can also be found suggested frequently elsewhere:

```
str = '2010-02-05 13:00:01'
tz = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
ActiveSupport::TimeZone['UTC'].parse(str).in_time_zone(tz)
```

This fails because `in_time_zone` does not change the "instant" the time represents,
but the perspective on that instant.
In other words, the result is not 13:00:01 EST, but 8:00:01 EST
(which on Feb 5 is the same instant as 13:00:01 UTC).

Another suggestion is to append a time zone to the user-submitted string before parsing it,
e.g. `str += " PDT"`. But this is not great, because:
- You may not know whether or not the string already has a timezone abbreviation.
- The correct abbreviation may vary depending on time of year, e.g. PDT vs PST, and that requires first parsing the string.

One more suggestion is to say `Time.use_zone(tz) { Time.strptime(str, spec) }`,
but that is not effective because `use_zone` does not change the behavior of `Time.strptime`.

A final solution is to use `tz.parse` instead of `strptime`,
but you may not want a heuristic-based approach
and might need to parse the string according to a given format,
which requires `strptime`.

So this patch adds a `strptime` method to `TimeZone` objects,
which parses the given string as though it comes from the time zone
represented by the method receiver.
In other words `tz.strptime("1:00", "%H:%M")` means 1:00 in the timezone `tz`.
If the arguments contain an explicit timezone, e.g. with `%Z`,
then that is used instead,
and then the time is converted to the time zone of `tz`.
This is the same behavior as `TimeZone#parse`.
