### PR TITLE
Review app server mention in Gemfile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -15,8 +15,8 @@ source 'https://rubygems.org'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
-# Use Unicorn as the app server
-# gem 'unicorn'
+# Use Puma as the app server
+# gem 'puma'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development


### PR DESCRIPTION
Unicorn has been the app server mentioned in the Gemfile since 2010,
previously it was Mongrel [0].

In January 2015, Heroku posted Unicorn is susceptible to slow client attacks,
and moved their recommendation to Puma, asking that apps using Unicorn be
migrated to Puma [1].

This changes the app server mentioned in the Gemfile to Puma, though please
also consider other app servers.

[0] https://github.com/rails/rails/commit/aa758b93889ea879f084948c71dcd47c0275fb30
[1] https://devcenter.heroku.com/changelog-items/594
