### PR TITLE
Enhance documentation: Replace pluck(:id) with pluck(:name) in favor of ids()

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -150,6 +150,8 @@ module ActiveRecord
     #   # SELECT DATEDIFF(updated_at, created_at) FROM people
     #   # => ['0', '27761', '173']
     #
+    # See also +ids+.
+    #
     def pluck(*column_names)
       column_names.map! do |column_name|
         if column_name.is_a?(Symbol) && attribute_alias?(column_name)

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -133,6 +133,7 @@ module ActiveRecord
     #   Person.pluck(:id)
     #   # SELECT people.id FROM people
     #   # => [1, 2, 3]
+    #   # Use Person.ids if only ids needed.
     #
     #   Person.pluck(:id, :name)
     #   # SELECT people.id, people.name FROM people

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -130,10 +130,9 @@ module ActiveRecord
     # the plucked column names, if they can be deduced. Plucking an SQL fragment
     # returns String values by default.
     #
-    #   Person.pluck(:id)
-    #   # SELECT people.id FROM people
-    #   # => [1, 2, 3]
-    #   # Use Person.ids if only ids needed.
+    #   Person.pluck(:name)
+    #   # SELECT people.name FROM people
+    #   # => ['David', 'Jeremy', 'Jose']
     #
     #   Person.pluck(:id, :name)
     #   # SELECT people.id, people.name FROM people


### PR DESCRIPTION
Documentation is giving an example that can be replaced by a more dry command.
Give a hint that ids can be used instead of pluck(:id).
