### PR TITLE
make activejob to conform rails code conventions

### DIFF
--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -28,34 +28,34 @@ module ActiveJob
 
       private
 
-      def interpret_adapter(name_or_adapter_or_class)
-        case name_or_adapter_or_class
-        when Symbol, String
-          ActiveJob::QueueAdapters.lookup(name_or_adapter_or_class).new
-        else
-          if queue_adapter?(name_or_adapter_or_class)
-            name_or_adapter_or_class
-          elsif queue_adapter_class?(name_or_adapter_or_class)
-            ActiveSupport::Deprecation.warn "Passing an adapter class is deprecated " \
-              "and will be removed in Rails 5.1. Please pass an adapter name " \
-              "(.queue_adapter = :#{name_or_adapter_or_class.name.demodulize.remove('Adapter').underscore}) " \
-              "or an instance (.queue_adapter = #{name_or_adapter_or_class.name}.new) instead."
-              name_or_adapter_or_class.new
+        def interpret_adapter(name_or_adapter_or_class)
+          case name_or_adapter_or_class
+          when Symbol, String
+            ActiveJob::QueueAdapters.lookup(name_or_adapter_or_class).new
           else
-            raise ArgumentError
+            if queue_adapter?(name_or_adapter_or_class)
+              name_or_adapter_or_class
+            elsif queue_adapter_class?(name_or_adapter_or_class)
+              ActiveSupport::Deprecation.warn "Passing an adapter class is deprecated " \
+                "and will be removed in Rails 5.1. Please pass an adapter name " \
+                "(.queue_adapter = :#{name_or_adapter_or_class.name.demodulize.remove('Adapter').underscore}) " \
+                "or an instance (.queue_adapter = #{name_or_adapter_or_class.name}.new) instead."
+                name_or_adapter_or_class.new
+            else
+              raise ArgumentError
+            end
           end
         end
-      end
 
-      QUEUE_ADAPTER_METHODS = [:enqueue, :enqueue_at].freeze
+        QUEUE_ADAPTER_METHODS = [:enqueue, :enqueue_at].freeze
 
-      def queue_adapter?(object)
-        QUEUE_ADAPTER_METHODS.all? { |meth| object.respond_to?(meth) }
-      end
+        def queue_adapter?(object)
+          QUEUE_ADAPTER_METHODS.all? { |meth| object.respond_to?(meth) }
+        end
 
-      def queue_adapter_class?(object)
-        object.is_a?(Class) && QUEUE_ADAPTER_METHODS.all? { |meth| object.public_method_defined?(meth) }
-      end
+        def queue_adapter_class?(object)
+          object.is_a?(Class) && QUEUE_ADAPTER_METHODS.all? { |meth| object.public_method_defined?(meth) }
+        end
     end
   end
 end

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -39,22 +39,22 @@ module ActiveJob
 
       private
 
-      def job_to_hash(job, extras = {})
-        { job: job.class, args: job.serialize.fetch('arguments'), queue: job.queue_name }.merge!(extras)
-      end
-
-      def enqueue_or_perform(perform, job, job_data)
-        if perform
-          performed_jobs << job_data
-          Base.execute job.serialize
-        else
-          enqueued_jobs << job_data
+        def job_to_hash(job, extras = {})
+          { job: job.class, args: job.serialize.fetch('arguments'), queue: job.queue_name }.merge!(extras)
         end
-      end
 
-      def filtered?(job)
-        filter && !Array(filter).include?(job.class)
-      end
+        def enqueue_or_perform(perform, job, job_data)
+          if perform
+            performed_jobs << job_data
+            Base.execute job.serialize
+          else
+            enqueued_jobs << job_data
+          end
+        end
+
+        def filtered?(job)
+          filter && !Array(filter).include?(job.class)
+        end
     end
   end
 end


### PR DESCRIPTION
rails code style guide is clear about the indentation rules of private and protected methods.
this commit fixes unindented private and protected methods for activejob.
