### PR TITLE
make activemodel to conform rails code conventions

### DIFF
--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -35,18 +35,18 @@ module ActiveModel
 
     private
 
-    def _assign_attributes(attributes)
-      attributes.each do |k, v|
-        _assign_attribute(k, v)
+      def _assign_attributes(attributes)
+        attributes.each do |k, v|
+          _assign_attribute(k, v)
+        end
       end
-    end
 
-    def _assign_attribute(k, v)
-      if respond_to?("#{k}=")
-        public_send("#{k}=", v)
-      else
-        raise UnknownAttributeError.new(self, k)
+      def _assign_attribute(k, v)
+        if respond_to?("#{k}=")
+          public_send("#{k}=", v)
+        else
+          raise UnknownAttributeError.new(self, k)
+        end
       end
-    end
   end
 end

--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -121,28 +121,28 @@ module ActiveModel
 
     private
 
-    def _define_before_model_callback(klass, callback) #:nodoc:
-      klass.define_singleton_method("before_#{callback}") do |*args, &block|
-        set_callback(:"#{callback}", :before, *args, &block)
+      def _define_before_model_callback(klass, callback) #:nodoc:
+        klass.define_singleton_method("before_#{callback}") do |*args, &block|
+          set_callback(:"#{callback}", :before, *args, &block)
+        end
       end
-    end
 
-    def _define_around_model_callback(klass, callback) #:nodoc:
-      klass.define_singleton_method("around_#{callback}") do |*args, &block|
-        set_callback(:"#{callback}", :around, *args, &block)
+      def _define_around_model_callback(klass, callback) #:nodoc:
+        klass.define_singleton_method("around_#{callback}") do |*args, &block|
+          set_callback(:"#{callback}", :around, *args, &block)
+        end
       end
-    end
 
-    def _define_after_model_callback(klass, callback) #:nodoc:
-      klass.define_singleton_method("after_#{callback}") do |*args, &block|
-        options = args.extract_options!
-        options[:prepend] = true
-        conditional = ActiveSupport::Callbacks::Conditionals::Value.new { |v|
-          v != false
-        }
-        options[:if] = Array(options[:if]) << conditional
-        set_callback(:"#{callback}", :after, *(args << options), &block)
+      def _define_after_model_callback(klass, callback) #:nodoc:
+        klass.define_singleton_method("after_#{callback}") do |*args, &block|
+          options = args.extract_options!
+          options[:prepend] = true
+          conditional = ActiveSupport::Callbacks::Conditionals::Value.new { |v|
+            v != false
+          }
+          options[:if] = Array(options[:if]) << conditional
+          set_callback(:"#{callback}", :after, *(args << options), &block)
+        end
       end
-    end
   end
 end

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -473,19 +473,19 @@ module ActiveModel
       I18n.translate(key, options)
     end
 
-  private
-    def normalize_message(attribute, message, options)
-      case message
-      when Symbol
-        generate_message(attribute, message, options.except(*CALLBACKS_OPTIONS))
-      else
-        message
+    private
+      def normalize_message(attribute, message, options)
+        case message
+        when Symbol
+          generate_message(attribute, message, options.except(*CALLBACKS_OPTIONS))
+        else
+          message
+        end
       end
-    end
 
-    def normalize_detail(attribute, message, options)
-      { error: message }.merge(options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS))
-    end
+      def normalize_detail(attribute, message, options)
+        { error: message }.merge(options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS))
+      end
   end
 
   # Raised when a validation cannot be corrected by end users and are considered

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -191,9 +191,9 @@ module ActiveModel
 
     private
 
-    def _singularize(string)
-      ActiveSupport::Inflector.underscore(string).tr('/', '_')
-    end
+      def _singularize(string)
+        ActiveSupport::Inflector.underscore(string).tr('/', '_')
+      end
   end
 
   # == Active \Model \Naming

--- a/activemodel/lib/active_model/serializers/xml.rb
+++ b/activemodel/lib/active_model/serializers/xml.rb
@@ -38,15 +38,15 @@ module ActiveModel
             decorations
           end
 
-        protected
+          protected
 
-          def compute_type
-            return if value.nil?
-            type = ActiveSupport::XmlMini::TYPE_NAMES[value.class.name]
-            type ||= :string if value.respond_to?(:to_str)
-            type ||= :yaml
-            type
-          end
+            def compute_type
+              return if value.nil?
+              type = ActiveSupport::XmlMini::TYPE_NAMES[value.class.name]
+              type ||= :string if value.respond_to?(:to_str)
+              type ||= :yaml
+              type
+            end
         end
 
         class MethodAttribute < Attribute #:nodoc:
@@ -100,139 +100,139 @@ module ActiveModel
           end
         end
 
-      private
+        private
 
-        def add_extra_behavior
-        end
-
-        def add_attributes_and_methods
-          serializable_collection.each do |attribute|
-            key = ActiveSupport::XmlMini.rename_key(attribute.name, options)
-            ActiveSupport::XmlMini.to_tag(key, attribute.value,
-              options.merge(attribute.decorations))
-          end
-        end
-
-        def add_includes
-          @serializable.send(:serializable_add_includes, options) do |association, records, opts|
-            add_associations(association, records, opts)
-          end
-        end
-
-        # TODO: This can likely be cleaned up to simple use ActiveSupport::XmlMini.to_tag as well.
-        def add_associations(association, records, opts)
-          merged_options = opts.merge(options.slice(:builder, :indent))
-          merged_options[:skip_instruct] = true
-
-          [:skip_types, :dasherize, :camelize].each do |key|
-            merged_options[key] = options[key] if merged_options[key].nil? && !options[key].nil?
+          def add_extra_behavior
           end
 
-          if records.respond_to?(:to_ary)
-            records = records.to_ary
+          def add_attributes_and_methods
+            serializable_collection.each do |attribute|
+              key = ActiveSupport::XmlMini.rename_key(attribute.name, options)
+              ActiveSupport::XmlMini.to_tag(key, attribute.value,
+                options.merge(attribute.decorations))
+            end
+          end
 
-            tag  = ActiveSupport::XmlMini.rename_key(association.to_s, options)
-            type = options[:skip_types] ? { } : { type: "array" }
-            association_name = association.to_s.singularize
-            merged_options[:root] = association_name
+          def add_includes
+            @serializable.send(:serializable_add_includes, options) do |association, records, opts|
+              add_associations(association, records, opts)
+            end
+          end
 
-            if records.empty?
-              @builder.tag!(tag, type)
-            else
-              @builder.tag!(tag, type) do
-                records.each do |record|
-                  if options[:skip_types]
-                    record_type = {}
-                  else
-                    record_class = (record.class.to_s.underscore == association_name) ? nil : record.class.name
-                    record_type = { type: record_class }
+          # TODO: This can likely be cleaned up to simple use ActiveSupport::XmlMini.to_tag as well.
+          def add_associations(association, records, opts)
+            merged_options = opts.merge(options.slice(:builder, :indent))
+            merged_options[:skip_instruct] = true
+
+            [:skip_types, :dasherize, :camelize].each do |key|
+              merged_options[key] = options[key] if merged_options[key].nil? && !options[key].nil?
+            end
+
+            if records.respond_to?(:to_ary)
+              records = records.to_ary
+
+              tag  = ActiveSupport::XmlMini.rename_key(association.to_s, options)
+              type = options[:skip_types] ? { } : { type: "array" }
+              association_name = association.to_s.singularize
+              merged_options[:root] = association_name
+
+              if records.empty?
+                @builder.tag!(tag, type)
+              else
+                @builder.tag!(tag, type) do
+                  records.each do |record|
+                    if options[:skip_types]
+                      record_type = {}
+                    else
+                      record_class = (record.class.to_s.underscore == association_name) ? nil : record.class.name
+                      record_type = { type: record_class }
+                    end
+
+                    record.to_xml merged_options.merge(record_type)
                   end
+                end
+              end
+            else
+              merged_options[:root] = association.to_s
 
-                  record.to_xml merged_options.merge(record_type)
+              unless records.class.to_s.underscore == association.to_s
+                merged_options[:type] = records.class.name
+              end
+
+              records.to_xml merged_options
+            end
+          end
+
+          def add_procs
+            if procs = options.delete(:procs)
+              Array(procs).each do |proc|
+                if proc.arity == 1
+                  proc.call(options)
+                else
+                  proc.call(options, @serializable)
                 end
               end
             end
-          else
-            merged_options[:root] = association.to_s
-
-            unless records.class.to_s.underscore == association.to_s
-              merged_options[:type] = records.class.name
-            end
-
-            records.to_xml merged_options
           end
         end
 
-        def add_procs
-          if procs = options.delete(:procs)
-            Array(procs).each do |proc|
-              if proc.arity == 1
-                proc.call(options)
-              else
-                proc.call(options, @serializable)
-              end
-            end
-          end
+        # Returns XML representing the model. Configuration can be
+        # passed through +options+.
+        #
+        # Without any +options+, the returned XML string will include all the
+        # model's attributes.
+        #
+        #   user = User.find(1)
+        #   user.to_xml
+        #
+        #   <?xml version="1.0" encoding="UTF-8"?>
+        #   <user>
+        #     <id type="integer">1</id>
+        #     <name>David</name>
+        #     <age type="integer">16</age>
+        #     <created-at type="dateTime">2011-01-30T22:29:23Z</created-at>
+        #   </user>
+        #
+        # The <tt>:only</tt> and <tt>:except</tt> options can be used to limit the
+        # attributes included, and work similar to the +attributes+ method.
+        #
+        # To include the result of some method calls on the model use <tt>:methods</tt>.
+        #
+        # To include associations use <tt>:include</tt>.
+        #
+        # For further documentation, see <tt>ActiveRecord::Serialization#to_xml</tt>
+        def to_xml(options = {}, &block)
+          Serializer.new(self, options).serialize(&block)
         end
-      end
 
-      # Returns XML representing the model. Configuration can be
-      # passed through +options+.
-      #
-      # Without any +options+, the returned XML string will include all the
-      # model's attributes.
-      #
-      #   user = User.find(1)
-      #   user.to_xml
-      #
-      #   <?xml version="1.0" encoding="UTF-8"?>
-      #   <user>
-      #     <id type="integer">1</id>
-      #     <name>David</name>
-      #     <age type="integer">16</age>
-      #     <created-at type="dateTime">2011-01-30T22:29:23Z</created-at>
-      #   </user>
-      #
-      # The <tt>:only</tt> and <tt>:except</tt> options can be used to limit the
-      # attributes included, and work similar to the +attributes+ method.
-      #
-      # To include the result of some method calls on the model use <tt>:methods</tt>.
-      #
-      # To include associations use <tt>:include</tt>.
-      #
-      # For further documentation, see <tt>ActiveRecord::Serialization#to_xml</tt>
-      def to_xml(options = {}, &block)
-        Serializer.new(self, options).serialize(&block)
-      end
-
-      # Sets the model +attributes+ from an XML string. Returns +self+.
-      #
-      #   class Person
-      #     include ActiveModel::Serializers::Xml
-      #
-      #     attr_accessor :name, :age, :awesome
-      #
-      #     def attributes=(hash)
-      #       hash.each do |key, value|
-      #         instance_variable_set("@#{key}", value)
-      #       end
-      #     end
-      #
-      #     def attributes
-      #       instance_values
-      #     end
-      #   end
-      #
-      #   xml = { name: 'bob', age: 22, awesome:true }.to_xml
-      #   person = Person.new
-      #   person.from_xml(xml) # => #<Person:0x007fec5e3b3c40 @age=22, @awesome=true, @name="bob">
-      #   person.name          # => "bob"
-      #   person.age           # => 22
-      #   person.awesome       # => true
-      def from_xml(xml)
-        self.attributes = Hash.from_xml(xml).values.first
-        self
-      end
+        # Sets the model +attributes+ from an XML string. Returns +self+.
+        #
+        #   class Person
+        #     include ActiveModel::Serializers::Xml
+        #
+        #     attr_accessor :name, :age, :awesome
+        #
+        #     def attributes=(hash)
+        #       hash.each do |key, value|
+        #         instance_variable_set("@#{key}", value)
+        #       end
+        #     end
+        #
+        #     def attributes
+        #       instance_values
+        #     end
+        #   end
+        #
+        #   xml = { name: 'bob', age: 22, awesome:true }.to_xml
+        #   person = Person.new
+        #   person.from_xml(xml) # => #<Person:0x007fec5e3b3c40 @age=22, @awesome=true, @name="bob">
+        #   person.name          # => "bob"
+        #   person.age           # => 22
+        #   person.awesome       # => true
+        def from_xml(xml)
+          self.attributes = Hash.from_xml(xml).values.first
+          self
+        end
     end
   end
 end

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -398,16 +398,16 @@ module ActiveModel
     #   end
     alias :read_attribute_for_validation :send
 
-  protected
+    protected
 
-    def run_validations! #:nodoc:
-      _run_validate_callbacks
-      errors.empty?
-    end
+      def run_validations! #:nodoc:
+        _run_validate_callbacks
+        errors.empty?
+      end
 
-    def raise_validation_error
-      raise(ValidationError.new(self))
-    end
+      def raise_validation_error
+        raise(ValidationError.new(self))
+      end
   end
 
   # = Active Model ValidationError

--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -14,16 +14,16 @@ module ActiveModel
       end
 
       private
-      def setup!(klass)
-        attr_readers = attributes.reject { |name| klass.attribute_method?(name) }
-        attr_writers = attributes.reject { |name| klass.attribute_method?("#{name}=") }
-        klass.send(:attr_reader, *attr_readers)
-        klass.send(:attr_writer, *attr_writers)
-      end
+        def setup!(klass)
+          attr_readers = attributes.reject { |name| klass.attribute_method?(name) }
+          attr_writers = attributes.reject { |name| klass.attribute_method?("#{name}=") }
+          klass.send(:attr_reader, *attr_readers)
+          klass.send(:attr_writer, *attr_writers)
+        end
 
-      def acceptable_option?(value)
-        Array(options[:accept]).include?(value)
-      end
+        def acceptable_option?(value)
+          Array(options[:accept]).include?(value)
+        end
     end
 
     module HelperMethods

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -105,12 +105,12 @@ module ActiveModel
         end
       end
 
-    protected
+      protected
 
-      # Overwrite run validations to include callbacks.
-      def run_validations! #:nodoc:
-        _run_validation_callbacks { super }
-      end
+        # Overwrite run validations to include callbacks.
+        def run_validations! #:nodoc:
+          _run_validation_callbacks { super }
+        end
     end
   end
 end

--- a/activemodel/lib/active_model/validations/clusivity.rb
+++ b/activemodel/lib/active_model/validations/clusivity.rb
@@ -12,40 +12,40 @@ module ActiveModel
         end
       end
 
-    private
+      private
 
-      def include?(record, value)
-        members = if delimiter.respond_to?(:call)
-                    delimiter.call(record)
-                  elsif delimiter.respond_to?(:to_sym)
-                    record.send(delimiter)
-                  else
-                    delimiter
-                  end
+        def include?(record, value)
+          members = if delimiter.respond_to?(:call)
+                      delimiter.call(record)
+                    elsif delimiter.respond_to?(:to_sym)
+                      record.send(delimiter)
+                    else
+                      delimiter
+                    end
 
-        members.send(inclusion_method(members), value)
-      end
+          members.send(inclusion_method(members), value)
+        end
 
-      def delimiter
-        @delimiter ||= options[:in] || options[:within]
-      end
+        def delimiter
+          @delimiter ||= options[:in] || options[:within]
+        end
 
-      # In Ruby 1.9 <tt>Range#include?</tt> on non-number-or-time-ish ranges checks all
-      # possible values in the range for equality, which is slower but more accurate.
-      # <tt>Range#cover?</tt> uses the previous logic of comparing a value with the range
-      # endpoints, which is fast but is only accurate on Numeric, Time, or DateTime ranges.
-      def inclusion_method(enumerable)
-        if enumerable.is_a? Range
-          case enumerable.first
-          when Numeric, Time, DateTime
-            :cover?
+        # In Ruby 1.9 <tt>Range#include?</tt> on non-number-or-time-ish ranges checks all
+        # possible values in the range for equality, which is slower but more accurate.
+        # <tt>Range#cover?</tt> uses the previous logic of comparing a value with the range
+        # endpoints, which is fast but is only accurate on Numeric, Time, or DateTime ranges.
+        def inclusion_method(enumerable)
+          if enumerable.is_a? Range
+            case enumerable.first
+            when Numeric, Time, DateTime
+              :cover?
+            else
+              :include?
+            end
           else
             :include?
           end
-        else
-          :include?
         end
-      end
     end
   end
 end

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -15,15 +15,15 @@ module ActiveModel
       end
 
       private
-      def setup!(klass)
-        klass.send(:attr_reader, *attributes.map do |attribute|
-          :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation")
-        end.compact)
+        def setup!(klass)
+          klass.send(:attr_reader, *attributes.map do |attribute|
+            :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation")
+          end.compact)
 
-        klass.send(:attr_writer, *attributes.map do |attribute|
-          :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation=")
-        end.compact)
-      end
+          klass.send(:attr_writer, *attributes.map do |attribute|
+            :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation=")
+          end.compact)
+        end
     end
 
     module HelperMethods

--- a/activemodel/lib/active_model/validations/format.rb
+++ b/activemodel/lib/active_model/validations/format.rb
@@ -23,33 +23,33 @@ module ActiveModel
 
       private
 
-      def option_call(record, name)
-        option = options[name]
-        option.respond_to?(:call) ? option.call(record) : option
-      end
+        def option_call(record, name)
+          option = options[name]
+          option.respond_to?(:call) ? option.call(record) : option
+        end
 
-      def record_error(record, attribute, name, value)
-        record.errors.add(attribute, :invalid, options.except(name).merge!(value: value))
-      end
+        def record_error(record, attribute, name, value)
+          record.errors.add(attribute, :invalid, options.except(name).merge!(value: value))
+        end
 
-      def check_options_validity(name)
-        if option = options[name]
-          if option.is_a?(Regexp)
-            if options[:multiline] != true && regexp_using_multiline_anchors?(option)
-              raise ArgumentError, "The provided regular expression is using multiline anchors (^ or $), " \
-              "which may present a security risk. Did you mean to use \\A and \\z, or forgot to add the " \
-              ":multiline => true option?"
+        def check_options_validity(name)
+          if option = options[name]
+            if option.is_a?(Regexp)
+              if options[:multiline] != true && regexp_using_multiline_anchors?(option)
+                raise ArgumentError, "The provided regular expression is using multiline anchors (^ or $), " \
+                "which may present a security risk. Did you mean to use \\A and \\z, or forgot to add the " \
+                ":multiline => true option?"
+              end
+            elsif !option.respond_to?(:call)
+              raise ArgumentError, "A regular expression or a proc or lambda must be supplied as :#{name}"
             end
-          elsif !option.respond_to?(:call)
-            raise ArgumentError, "A regular expression or a proc or lambda must be supplied as :#{name}"
           end
         end
-      end
 
-      def regexp_using_multiline_anchors?(regexp)
-        source = regexp.source
-        source.start_with?("^") || (source.end_with?("$") && !source.end_with?("\\$"))
-      end
+        def regexp_using_multiline_anchors?(regexp)
+          source = regexp.source
+          source.start_with?("^") || (source.end_with?("$") && !source.end_with?("\\$"))
+        end
     end
 
     module HelperMethods

--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -82,20 +82,20 @@ module ActiveModel
       end
 
       private
-      def tokenize(record, value)
-        tokenizer = options[:tokenizer]
-        if tokenizer && value.kind_of?(String)
-          if tokenizer.kind_of?(Proc)
-            tokenizer.call(value)
-          elsif record.respond_to?(tokenizer)
-            record.send(tokenizer, value)
-          end
-        end || value
-      end
+        def tokenize(record, value)
+          tokenizer = options[:tokenizer]
+          if tokenizer && value.kind_of?(String)
+            if tokenizer.kind_of?(Proc)
+              tokenizer.call(value)
+            elsif record.respond_to?(tokenizer)
+              record.send(tokenizer, value)
+            end
+          end || value
+        end
 
-      def skip_nil_check?(key)
-        key == :maximum && options[:allow_nil].nil? && options[:allow_blank].nil?
-      end
+        def skip_nil_check?(key)
+          key == :maximum && options[:allow_nil].nil? && options[:allow_blank].nil?
+        end
     end
 
     module HelperMethods

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -62,41 +62,41 @@ module ActiveModel
         end
       end
 
-    protected
+      protected
 
-      def parse_raw_value_as_a_number(raw_value)
-        Kernel.Float(raw_value) if raw_value !~ /\A0[xX]/
-      rescue ArgumentError, TypeError
-        nil
-      end
-
-      def parse_raw_value_as_an_integer(raw_value)
-        raw_value.to_i if raw_value.to_s =~ /\A[+-]?\d+\z/
-      end
-
-      def filtered_options(value)
-        filtered = options.except(*RESERVED_OPTIONS)
-        filtered[:value] = value
-        filtered
-      end
-
-      def allow_only_integer?(record)
-        case options[:only_integer]
-        when Symbol
-          record.send(options[:only_integer])
-        when Proc
-          options[:only_integer].call(record)
-        else
-          options[:only_integer]
+        def parse_raw_value_as_a_number(raw_value)
+          Kernel.Float(raw_value) if raw_value !~ /\A0[xX]/
+        rescue ArgumentError, TypeError
+          nil
         end
-      end
+
+        def parse_raw_value_as_an_integer(raw_value)
+          raw_value.to_i if raw_value.to_s =~ /\A[+-]?\d+\z/
+        end
+
+        def filtered_options(value)
+          filtered = options.except(*RESERVED_OPTIONS)
+          filtered[:value] = value
+          filtered
+        end
+
+        def allow_only_integer?(record)
+          case options[:only_integer]
+          when Symbol
+            record.send(options[:only_integer])
+          when Proc
+            options[:only_integer].call(record)
+          else
+            options[:only_integer]
+          end
+        end
 
       private
 
-      def record_attribute_changed_in_place?(record, attr_name)
-        record.respond_to?(:attribute_changed_in_place?) &&
-          record.attribute_changed_in_place?(attr_name.to_s)
-      end
+        def record_attribute_changed_in_place?(record, attr_name)
+          record.respond_to?(:attribute_changed_in_place?) &&
+            record.attribute_changed_in_place?(attr_name.to_s)
+        end
     end
 
     module HelperMethods

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -148,26 +148,26 @@ module ActiveModel
         validates(*(attributes << options))
       end
 
-    protected
+      protected
 
-      # When creating custom validators, it might be useful to be able to specify
-      # additional default keys. This can be done by overwriting this method.
-      def _validates_default_keys # :nodoc:
-        [:if, :unless, :on, :allow_blank, :allow_nil , :strict]
-      end
-
-      def _parse_validates_options(options) # :nodoc:
-        case options
-        when TrueClass
-          {}
-        when Hash
-          options
-        when Range, Array
-          { in: options }
-        else
-          { with: options }
+        # When creating custom validators, it might be useful to be able to specify
+        # additional default keys. This can be done by overwriting this method.
+        def _validates_default_keys # :nodoc:
+          [:if, :unless, :on, :allow_blank, :allow_nil , :strict]
         end
-      end
+
+        def _parse_validates_options(options) # :nodoc:
+          case options
+          when TrueClass
+            {}
+          when Hash
+            options
+          when Range, Array
+            { in: options }
+          else
+            { with: options }
+          end
+        end
     end
   end
 end


### PR DESCRIPTION
rails code style guide is clear about the indentation rules of private and protected methods.
this commit fixes unindented private and protected methods for activemodel.
