### PR TITLE
Handle param-parsing errors from Rack that happen low down the stack

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Adds`Rack::Utils::ParameterTypeError` and `Rack::Utils::InvalidParameterError`
+    to the rescue_responses hash in `ExceptionWrapper` (Rack recommends
+    integrators serve 400s for both of these).
+
+    *Grey Baker*
+
 *   Add support for API only apps.
     ActionController::API is added as a replacement of
     ActionController::Base for this kind of applications.

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -17,7 +17,9 @@ module ActionDispatch
       'ActionController::InvalidCrossOriginRequest'   => :unprocessable_entity,
       'ActionDispatch::ParamsParser::ParseError'      => :bad_request,
       'ActionController::BadRequest'                  => :bad_request,
-      'ActionController::ParameterMissing'            => :bad_request
+      'ActionController::ParameterMissing'            => :bad_request,
+      'Rack::Utils::ParameterTypeError'               => :bad_request,
+      'Rack::Utils::InvalidParameterError'            => :bad_request
     )
 
     cattr_accessor :rescue_templates


### PR DESCRIPTION
Move `ActionDispatch::ShowExceptions` and `ActionDispatch::DebugExceptions` lower down the default middleware stack so they can catch Rack errors raised from `Rack::MethodOverride`. Also adds the two errors Rack recommends integrators serve 400s for (`Rack::Utils::ParameterTypeError` and `Rack::Utils::InvalidParameterError`) to the rescue_responses hash in `ExceptionWrapper`.

We've been seeing some `Rack::Utils::InvalidParameterError`s coming from `Rack::MethodOverride` (spec included), and it feels like they should be handled by Rails' exception handling, or by any custom `exception_app`s.
