### PR TITLE
Add new param to simple_format helper method

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Added `spare_tags` option to `simple_format` helper method.
+    This option prevents wrapping block level elements (like `<h1></h1>`) 
+    in your text, which could lead to empty `<p></p>` tags.
+
+    *Noémien Kocher*
+
 *   `translate` should accept nils as members of the `:default`
     parameter without raising a translation missing error.  Fixes a
     regression introduced 362557e.

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,5 +1,5 @@
 *   Added `spare_tags` option to `simple_format` helper method.
-    This option prevents wrapping block level elements (like `<h1></h1>`) 
+    This option prevents wrapping html elements (like `<h1></h1>`) 
     in your text, which could lead to empty `<p></p>` tags.
 
     *Noémien Kocher*

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -289,13 +289,18 @@ module ActionView
         wrapper_tag = options.fetch(:wrapper_tag, :p)
 
         text = sanitize(text) if options.fetch(:sanitize, true)
+        text.gsub!(/[\r\n]*(<([A-Z][A-Z0-9]*)\b[^>]*>.*<\/\2>)[\r\n]*/i, "\n\n#{'\1'}\n\n") if options.fetch(:spare_tags, false)
         paragraphs = split_paragraphs(text)
 
         if paragraphs.empty?
           content_tag(wrapper_tag, nil, html_options)
         else
           paragraphs.map! { |paragraph|
-            content_tag(wrapper_tag, raw(paragraph), html_options)
+            if options.fetch(:spare_tags, false) && paragraph.match(/<([A-Z][A-Z0-9]*)\b[^>]*>.*<\/\1>/i)
+              paragraph
+            else
+              content_tag(wrapper_tag, raw(paragraph), html_options)
+            end
           }.join("\n\n").html_safe
         end
       end

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -262,6 +262,7 @@ module ActionView
       # ==== Options
       # * <tt>:sanitize</tt> - If +false+, does not sanitize +text+.
       # * <tt>:wrapper_tag</tt> - String representing the wrapper tag, defaults to <tt>"p"</tt>
+      # * <tt>:spare_tags</tt> - If +true+, does not wrap html tag, defaults to <tt>"false"</tt>
       #
       # ==== Examples
       #   my_text = "Here is some basic text...\n...with a line break."
@@ -285,6 +286,9 @@ module ActionView
       #
       #   simple_format("<blink>Blinkable!</blink> It's true.", {}, sanitize: false)
       #   # => "<p><blink>Blinkable!</blink> It's true.</p>"
+      #
+      #   simple_format("<blink>Blinkable!</blink> It's true.", {}, sanitize: false, spare_tags: true)
+      #   # => "<blink>Blinkable!</blink><p>It's true.</p>"
       def simple_format(text, html_options = {}, options = {})
         wrapper_tag = options.fetch(:wrapper_tag, :p)
 

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -55,6 +55,14 @@ class TextHelperTest < ActionView::TestCase
     assert_equal "<p><b> test with unsafe string </b><script>code!</script></p>", simple_format("<b> test with unsafe string </b><script>code!</script>", {}, :sanitize => false)
   end
 
+  def test_simple_format_should_not_spare_tag_when_spare_tag_option_is_false
+    assert_equal "<p>This is a classy test</p>\n\n<p><h3>Title</h3></p>", simple_format("This is a classy test\n\n<h3>Title</h3>", {}, spare_tags: false)
+  end
+
+  def test_simple_format_should_spare_tag_when_spare_tag_option_is_true
+    assert_equal "<p>This is a classy test</p>\n\n<h3>Title</h3>", simple_format("This is a classy test\n\n<h3>Title</h3>", {}, spare_tags: true)
+  end
+
   def test_simple_format_with_custom_wrapper
     assert_equal "<div></div>", simple_format(nil, {}, :wrapper_tag => "div")
   end


### PR DESCRIPTION
Added `spare_tags` option to `simple_format` helper method.
This option prevents wrapping html elements (like `<h1></h1>`) 
in your text, which could sometimes lead to empty `<p></p>` tags.
Note that it depends on the browser you use.

Given the text

```
I like bananas
<h2>Title</h2>
```

If you give it to simple_format you got (with google chrome)

```
<p>I like bananas<br></p>
<h2>Title</h2>
<p></p>
```

With spare_tags: true, you got

```
<p>I like bananas</p>
<h2>Title</h2>
```
