### PR TITLE
[skip ci] Update information about #link_to attributes

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -173,11 +173,10 @@ module ActionView
       #   link_to "Visit Other Site", "http://www.rubyonrails.org/", data: { confirm: "Are you sure?" }
       #   # => <a href="http://www.rubyonrails.org/" data-confirm="Are you sure?">Visit Other Site</a>
       #
-      # Also you can set target attribute with <tt>target</tt> options:
+      # Also you can set any link attributes such as <tt>target</tt>, <tt>rel</tt>, <tt>type</tt>:
       #
-      #   link_to "External link", "http://www.rubyonrails.org/", target: "_blank"
-      #   # => <a href="http://www.rubyonrails.org/" target="_blank">External link</a>
-      #
+      #   link_to "External link", "http://www.rubyonrails.org/", target: "_blank", rel: "nofollow"
+      #   # => <a href="http://www.rubyonrails.org/" target="_blank" rel="nofollow">External link</a>
       def link_to(name = nil, options = nil, html_options = nil, &block)
         html_options, options, name = options, name, block if block_given?
         options ||= {}


### PR DESCRIPTION
Yesterday I created PR with updating documentation for `link_to` method (#19609). However, as it turned out, I hurried and added information only about `target` attribute. I'm sorry :cold_sweat:
