### PR TITLE
Allow an array to be a default translation value

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   `translate` now allows `default: [[]]` again for a default value of `[]`.
+
+    Fixes a regression introduced in 4.2.1.
+
+    See #19640 and the fix in #19641.
+
+    *Adam Prescott*
+
 *   `translate` should accept nils as members of the `:default`
     parameter without raising a translation missing error.  Fixes a
     regression introduced 362557e.

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -41,7 +41,7 @@ module ActionView
         remaining_defaults = Array(options.delete(:default)).compact
 
         if has_default && !remaining_defaults.first.kind_of?(Symbol)
-          options[:default] = remaining_defaults.shift
+          options[:default] = remaining_defaults
         end
 
         # If the user has explicitly decided to NOT raise errors, pass that option to I18n.

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -195,6 +195,11 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal 'A Generic String', translation
   end
 
+  def test_translate_with_array_of_array_default
+    translation = translate(:'translations.missing', default: [[]])
+    assert_equal [], translation
+  end
+
   def test_translate_does_not_change_options
     options = {}
     translate(:'translations.missing', options)


### PR DESCRIPTION
4.2.1 introduced a change to the way `translate`/`t` works with an option of `default: [[]]`. In 4.2.0, this would give a default value of `[]`, but in 4.2.1, it leads to a missing translation.

`default: [[]]` is again allowed for cases where a default of `[]` is needed.

This should address #19640.
