### PR TITLE
Use keyword arguments for Module#delegate

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -148,14 +148,7 @@ class Module
   #
   # The target method must be public, otherwise it will raise +NoMethodError+.
   #
-  def delegate(*methods)
-    options = methods.pop
-    unless options.is_a?(Hash) && to = options[:to]
-      raise ArgumentError, 'Delegation needs a target. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter).'
-    end
-
-    prefix, allow_nil = options.values_at(:prefix, :allow_nil)
-
+  def delegate(*methods, to:, prefix: false, allow_nil: false)
     if prefix == true && to =~ /^[^a-z_]/
       raise ArgumentError, 'Can only automatically set the delegation prefix when delegating to a method.'
     end


### PR DESCRIPTION
Hi,

Since Rails 5.0 is targeting Ruby 2.2.x, it seems sensible to migrate existing uses of options hash to keyword arguments using Module#delegate as a proof of concept.

The potential downside in this particular case is losing the error message when delegation target is missing, however, this is covered by the required keyword argument.

This is my first PR to Rails. I'd love some feedback on this and look forward to helping Rails more!
