### PR TITLE
Fix a regression introduced by removing unnecessary db call when replacing

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -370,6 +370,8 @@ module ActiveRecord
           replace_common_records_in_memory(other_array, original_target)
           if other_array != original_target
             transaction { replace_records(other_array, original_target) }
+          else
+            other_array
           end
         end
       end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1503,6 +1503,8 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_queries(0, ignore_none: true) do
       firm.clients = []
     end
+
+    assert_equal [], firm.send('clients=', [])
   end
 
   def test_transactions_when_replacing_on_persisted


### PR DESCRIPTION
When replacing a has_many association with the same one, there is nothing to do with database but a setter method should still return the substituted value for backward compatibility.

rails 4.2.10

``` ruby
firm.clients = []
firm.clients = []          #=> []
firm.send('clients=', [])  #=> []
```

edge rails

``` ruby
firm.clients = []
firm.clients = []          #=> []
firm.send('clients=', [])  #=> nil
```

`firm.clients = []` returns `[]` just because ruby implicitly returns the substituted value
when substitution-formed method call, but `send('clients=', [])` doesn't. This behavior is possibly a regression, and not good for metaprogramming.
