### PR TITLE
change REQUEST_URI to PATH_INFO

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -201,7 +201,7 @@ end
 If your application includes a locale switching menu, you would then have something like this in it:
 
 ```ruby
-link_to("Deutsch", "#{APP_CONFIG[:deutsch_website_url]}#{request.env['REQUEST_URI']}")
+link_to("Deutsch", "#{APP_CONFIG[:deutsch_website_url]}#{request.env['PATH_INFO']}")
 ```
 
 assuming you would set `APP_CONFIG[:deutsch_website_url]` to some value like `http://www.application.de`.


### PR DESCRIPTION
request.env['REQUEST_URI'] returns full URI of the resource
request.env['PATH_INFO'] returns only path of the resource
this pr closes issue #19648 
