### PR TITLE
use singular table name if pluralize_table_names is setted as false whil...

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -138,7 +138,7 @@ module ActiveRecord
       end
 
       def foreign_table_name
-        name.to_s.pluralize
+        Base.pluralize_table_names ? name.to_s.pluralize : name
       end
     end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -667,7 +667,10 @@ module ActiveRecord
       #   remove_reference(:products, :user, index: true, foreign_key: true)
       #
       def remove_reference(table_name, ref_name, options = {})
-        remove_foreign_key table_name, ref_name.to_s.pluralize if options[:foreign_key]
+        if options[:foreign_key]
+          reference_name = Base.pluralize_table_names ? ref_name.to_s.pluralize : ref_name
+          remove_foreign_key(table_name, reference_name)
+        end
 
         remove_column(table_name, "#{ref_name}_id")
         remove_column(table_name, "#{ref_name}_type") if options[:polymorphic]


### PR DESCRIPTION
use singular table name if pluralize_table_names is setted as false while creating foreign key

Closes #19643
