### PR TITLE
Accept lambda as child_index option in #fields_for method

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Accept lambda as `child_index` option in `fields_for` method.
+
+    *Karol Galanciak*
+
 *   `translate` allows `default: [[]]` again for a default value of `[]`.
 
     Fixes #19640.

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1928,7 +1928,11 @@ module ActionView
             explicit_child_index = options[:child_index]
             output = ActiveSupport::SafeBuffer.new
             association.each do |child|
-              options[:child_index] = nested_child_index(name) unless explicit_child_index
+              if explicit_child_index
+                options[:child_index] = explicit_child_index.call if explicit_child_index.respond_to?(:call)
+              else
+                options[:child_index] = nested_child_index(name)
+              end
               output << fields_for_nested_model("#{name}[#{options[:child_index]}]", child, options, block)
             end
             output

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2878,6 +2878,23 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_nested_fields_for_with_child_index_as_lambda_option_override_on_a_nested_attributes_collection_association
+    @post.comments = []
+
+    form_for(@post) do |f|
+      concat f.fields_for(:comments, Comment.new(321), child_index: -> { 'abc' } ) { |cf|
+        concat cf.text_field(:name)
+      }
+    end
+
+    expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', method: 'patch') do
+      '<input id="post_comments_attributes_abc_name" name="post[comments_attributes][abc][name]" type="text" value="comment #321" />' +
+      '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" />'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   class FakeAssociationProxy
     def to_ary
       [1, 2, 3]


### PR DESCRIPTION
Having lambda for `child_index` may be pretty useful when you want to add several nested fields at one time, eg. with ajax by rendering partial with fields. Currently I made a workaround using `each.with_index` to ensure the indexes won't be duplicated with the already existing ones:

```
<% collection.each.with_index(some_index) do |element, idx| %>
  <%= f.fields_for :relation, element, child_index: idx do |nested_form| %>
     # more fields here
  <% end %>
<% end %>
```

but I think it's not commonly known that you can iterate from specified index and using lambda with number generator feels more natural.
