### PR TITLE
Fix method signature of `parse_query` to match rack

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -340,7 +340,7 @@ module ActionDispatch
     end
 
     protected
-      def parse_query(qs)
+      def parse_query(*)
         Utils.deep_munge(super)
       end
 


### PR DESCRIPTION
Recently rack was changed to have a second argument on the `parse_query`
method (in rack/rack#781). Rails relies on this and it's `parse_query`
method was missing the second argument. I've bumped rack in the gemspec
until it can be released so that tests between Rails master and Rack
master pass.

Sending as a PR because I'm not sure if it's ok to change Rails to point to the unreleased Rack.
