### PR TITLE
fix missing "if" in API docs for ActionController::Parameters#permit

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -268,7 +268,7 @@ module ActionController
     #
     #   params.permit(:name)
     #
-    # +:name+ passes it is a key of +params+ whose associated value is of type
+    # +:name+ passes if it is a key of +params+ whose associated value is of type
     # +String+, +Symbol+, +NilClass+, +Numeric+, +TrueClass+, +FalseClass+,
     # +Date+, +Time+, +DateTime+, +StringIO+, +IO+,
     # +ActionDispatch::Http::UploadedFile+ or +Rack::Test::UploadedFile+.


### PR DESCRIPTION
Should the docs for this read `:name+` passes **if** it is a key of +params+ whose associated value is...?
