### PR TITLE
Require explicit counter_cache option for has_many

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -80,8 +80,15 @@ module ActiveRecord
           [association_scope.limit_value, count].compact.min
         end
 
+
+        # Returns whether a counter cache should be used for this association.
+        #
+        # The counter_cache option must be given on either the owner or inverse
+        # association, and the column must be present on the owner.
         def has_cached_counter?(reflection = reflection())
-          owner.attribute_present?(cached_counter_attribute_name(reflection))
+          if reflection.options[:counter_cache] || (inverse = inverse_which_updates_counter_cache(reflection)) && inverse.options[:counter_cache]
+            owner.attribute_present?(cached_counter_attribute_name(reflection))
+          end
         end
 
         def cached_counter_attribute_name(reflection = reflection())

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -19,6 +19,9 @@ require 'models/invoice'
 require 'models/line_item'
 require 'models/column'
 require 'models/record'
+require 'models/ship'
+require 'models/treasure'
+require 'models/parrot'
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
@@ -309,6 +312,22 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   def test_with_select
     assert_equal 1, Company.find(2).firm_with_select.attributes.size
     assert_equal 1, Company.all.merge!(:includes => :firm_with_select ).find(2).firm_with_select.attributes.size
+  end
+
+  def test_belongs_to_without_counter_cache_option
+    # Ship has a conventionally named `treasures_count` column, but the counter_cache
+    # option is not given on the association.
+    ship = Ship.create(name: 'Countless')
+
+    assert_no_difference lambda { ship.reload.treasures_count }, "treasures_count should not be changed unless counter_cache is given on the relation" do
+      treasure = Treasure.new(name: 'Gold', ship: ship)
+      treasure.save
+    end
+
+    assert_no_difference lambda { ship.reload.treasures_count }, "treasures_count should not be changed unless counter_cache is given on the relation" do
+      treasure = ship.treasures.first
+      treasure.destroy
+    end
   end
 
   def test_belongs_to_counter

--- a/activerecord/test/models/categorization.rb
+++ b/activerecord/test/models/categorization.rb
@@ -1,6 +1,6 @@
 class Categorization < ActiveRecord::Base
   belongs_to :post
-  belongs_to :category
+  belongs_to :category, counter_cache: true
   belongs_to :named_category, :class_name => 'Category', :foreign_key => :named_category_name, :primary_key => :name
   belongs_to :author
 

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -98,11 +98,11 @@ class Post < ActiveRecord::Base
     end
   end
 
-  has_many :taggings_with_delete_all, :class_name => 'Tagging', :as => :taggable, :dependent => :delete_all
-  has_many :taggings_with_destroy, :class_name => 'Tagging', :as => :taggable, :dependent => :destroy
+  has_many :taggings_with_delete_all, :class_name => 'Tagging', :as => :taggable, :dependent => :delete_all, counter_cache: :taggings_with_delete_all_count
+  has_many :taggings_with_destroy, :class_name => 'Tagging', :as => :taggable, :dependent => :destroy, counter_cache: :taggings_with_destroy_count
 
-  has_many :tags_with_destroy, :through => :taggings, :source => :tag, :dependent => :destroy
-  has_many :tags_with_nullify, :through => :taggings, :source => :tag, :dependent => :nullify
+  has_many :tags_with_destroy, :through => :taggings, :source => :tag, :dependent => :destroy, counter_cache: :tags_with_destroy_count
+  has_many :tags_with_nullify, :through => :taggings, :source => :tag, :dependent => :nullify, counter_cache: :tags_with_nullify_count
 
   has_many :misc_tags, -> { where :tags => { :name => 'Misc' } }, :through => :taggings, :source => :tag
   has_many :funky_tags, :through => :taggings, :source => :tag

--- a/activerecord/test/models/treasure.rb
+++ b/activerecord/test/models/treasure.rb
@@ -1,6 +1,7 @@
 class Treasure < ActiveRecord::Base
   has_and_belongs_to_many :parrots
   belongs_to :looter, :polymorphic => true
+  # No counter_cache option given
   belongs_to :ship
 
   has_many :price_estimates, :as => :estimate_of

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -671,6 +671,8 @@ ActiveRecord::Schema.define do
     t.string :name
     t.integer :pirate_id
     t.integer :update_only_pirate_id
+    # Conventionally named column for counter_cache
+    t.integer :treasures_count, default: 0
     t.datetime :created_at
     t.datetime :created_on
     t.datetime :updated_at


### PR DESCRIPTION
Previously has_many associations assumed a counter_cache was to be used
based on the presence of an appropriately named column. This is
inconsistent, since the inverse belongs_to association will not make
this assumption. See issues #19042 #8446.
This commit checks for the presence of the counter_cache key in the
options of either the has_many or belongs_to association as well as
ensuring that the *_count column is present.
