### PR TITLE
Fix uniqueness validation with out of range value.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Uniqueness validation with out of range value fixed
+
+    *Andrey Voronkov*
+
 *   Foreign key related methods in the migration DSL respect
     `ActiveRecord::Base.pluralize_table_names = false`.
 

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -35,6 +35,12 @@ class Employee < ActiveRecord::Base
   validates_uniqueness_of :nicknames
 end
 
+class BigIntTest < ActiveRecord::Base
+  PG_MAX_INTEGER = 2147483647
+  self.table_name = 'postgresql_4byte_ints'
+  validates :number, uniqueness: true, inclusion: { in: 0..PG_MAX_INTEGER }
+end
+
 class TopicWithUniqEvent < Topic
   belongs_to :event, foreign_key: :parent_id
   validates :event, uniqueness: true
@@ -388,6 +394,12 @@ class UniquenessValidationTest < ActiveRecord::TestCase
       assert e2.errors[:nicknames].any?, "Should have errors for nicknames"
       assert_equal ["has already been taken"], e2.errors[:nicknames], "Should have uniqueness message for nicknames"
     end
+
+    def test_validate_uniqueness_integer_out_of_range
+      entry = BigIntTest.create(number: (BigIntTest::PG_MAX_INTEGER + 1))
+      assert entry.errors[:number] , ['is not included in the list']
+    end
+
   end
 
   def test_validate_uniqueness_on_existing_relation

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -1,6 +1,6 @@
 ActiveRecord::Schema.define do
 
-  %w(postgresql_tsvectors postgresql_hstores postgresql_arrays postgresql_moneys postgresql_numbers postgresql_times
+  %w(postgresql_tsvectors postgresql_hstores postgresql_arrays postgresql_4byte_ints postgresql_moneys postgresql_numbers postgresql_times
       postgresql_network_addresses postgresql_uuids postgresql_ltrees postgresql_oids postgresql_xml_data_type defaults
       geometrics postgresql_timestamp_with_zones postgresql_partitioned_table postgresql_partitioned_table_parent
       postgresql_citext).each do |table_name|
@@ -65,6 +65,13 @@ _SQL
     id SERIAL PRIMARY KEY,
     commission_by_quarter INTEGER[],
     nicknames TEXT[]
+  );
+_SQL
+
+  execute <<_SQL
+  CREATE TABLE postgresql_4byte_ints (
+    id SERIAL PRIMARY KEY,
+    number integer
   );
 _SQL
 


### PR DESCRIPTION
Let's say you have both uniqueness and range validation for PostgreSQL 4 byte integer column:

``` ruby
class A < ActiveRecord::Base
  PG_MAX_INT = 2147483647
  validates :number, uniqueness: true, inclusion: { 0..PG_MAX_INT }
end

a = A.create(number: (A::PG_MAX_INT + 1))
```

Before it will raise this:

``` ruby
RangeError: 2147483648 is out of range for ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer with limit 4
```

Now:

``` ruby
a.errors[:number] =>
['is not included in the list'] 
```
