### PR TITLE
Fix uniqueness validation with out of range value

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Uniqueness validation with out of range value fixed
+
+    *Andrey Voronkov*
+
 *   MySQL: `:charset` and `:collation` support for string and text columns.
 
     Example:

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -76,6 +76,8 @@ module ActiveRecord
           klass.connection.case_sensitive_comparison(table, attribute, column, value)
         end
         klass.unscoped.where(comparison)
+      rescue RangeError
+        klass.none
       end
 
       def scope_relation(record, table, relation)


### PR DESCRIPTION
Let's say you have both uniqueness and range validation for PostgreSQL 4 byte integer column:

``` ruby
class A < ActiveRecord::Base
  PG_MAX_INT = 2147483647
  validates :number, uniqueness: true, inclusion: { 0..PG_MAX_INT }
end

a = A.create(number: (A::PG_MAX_INT + 1))
```

Before it will raise this:

``` ruby
RangeError: 2147483648 is out of range for ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer with limit 4
```

Now:

``` ruby
a.errors[:number] =>
['is not included in the list'] 
```
