### PR TITLE
Allow AS::Cache::FileStore#clear without cache directory

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -29,6 +29,7 @@ module ActiveSupport
       def clear(options = nil)
         root_dirs = Dir.entries(cache_path).reject {|f| (EXCLUDED_DIRS + [".gitkeep"]).include?(f)}
         FileUtils.rm_r(root_dirs.collect{|f| File.join(cache_path, f)})
+      rescue Errno::ENOENT
       end
 
       # Preemptively iterates through all stored keys and removes the ones which have expired.

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -684,6 +684,7 @@ class FileStoreTest < ActiveSupport::TestCase
 
   def teardown
     FileUtils.rm_r(cache_dir)
+  rescue Errno::ENOENT
   end
 
   def cache_dir
@@ -701,6 +702,11 @@ class FileStoreTest < ActiveSupport::TestCase
     FileUtils.touch(filepath)
     @cache.clear
     assert File.exist?(filepath)
+  end
+
+  def test_clear_without_cache_dir
+    FileUtils.rm_r(cache_dir)
+    @cache.clear
   end
 
   def test_long_keys


### PR DESCRIPTION
Currently `Rails.cache.clear` raises Errno::ENOENT if it's run just
after cloning a new Rails project. It should succeed without removing
files or directories.
