### PR TITLE
fix documentation for SchemaStatements#add_foreign_key

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -690,8 +690,8 @@ module ActiveRecord
       # +to_table+ contains the referenced primary key.
       #
       # The foreign key will be named after the following pattern: <tt>fk_rails_<identifier></tt>.
-      # +identifier+ is a 10 character long random string. A custom name can be specified with
-      # the <tt>:name</tt> option.
+      # +identifier+ is a 10 character long string which is deterministically generated from the
+      # +from_table+ and +column+. A custom name can be specified with the <tt>:name</tt> option.
       #
       # ====== Creating a simple foreign key
       #


### PR DESCRIPTION
The implementation of the generation of the foreign key name was changed
between Rails 4.2.0 and 4.2.1 from a random to a deterministic behavior,
however the documentation still describes the old randomized behavior.
