### PR TITLE
bugfix CodeStatics#calculate_directory_statics when dir has source ext

### DIFF
--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -41,11 +41,9 @@ class CodeStatistics #:nodoc:
 
         if File.directory?(path) && (/^\./ !~ file_name)
           stats.add(calculate_directory_statistics(path, pattern))
+        elsif file_name =~ pattern
+          stats.add_by_file_path(path)
         end
-
-        next unless file_name =~ pattern
-
-        stats.add_by_file_path(path)
       end
 
       stats

--- a/railties/test/code_statistics_test.rb
+++ b/railties/test/code_statistics_test.rb
@@ -1,0 +1,20 @@
+require 'abstract_unit'
+require 'rails/code_statistics'
+
+class CodeStatisticsTest < ActiveSupport::TestCase
+  def setup
+    @tmp_path = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', 'tmp'))
+    @dir_js   = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', 'tmp', 'lib.js'))
+    FileUtils.mkdir_p(@dir_js)
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmp_path)
+  end
+
+  test 'ignores directories that happen to have source files extensions' do
+    assert_nothing_raised do
+      @code_statistics = CodeStatistics.new(['tmp dir', @tmp_path])
+    end
+  end
+end


### PR DESCRIPTION
I've recently upgraded a Rails 3.2.x project to 4.0.x and suddenly "rake stats" stopped to work with a Errno::EISDIR exception:

```
Errno::EISDIR: Is a directory - /home/xxx/Projects/yyy/trunk/app/assets/javascripts/morris.js
../railties-4.0.12/lib/rails/code_statistics_calculator.rb:52:in `gets'
../railties-4.0.12/lib/rails/code_statistics_calculator.rb:52:in `add_by_io'
../railties-4.0.12/lib/rails/code_statistics_calculator.rb:43:in `block in add_by_file_path'
../railties-4.0.12/lib/rails/code_statistics_calculator.rb:42:in `open'
../railties-4.0.12/lib/rails/code_statistics_calculator.rb:42:in `add_by_file_path'
../railties-4.0.12/lib/rails/code_statistics.rb:49:in `block in calculate_directory_statistics'
../railties-4.0.12/lib/rails/code_statistics.rb:40:in `foreach'
../railties-4.0.12/lib/rails/code_statistics.rb:40:in `calculate_directory_statistics'
../railties-4.0.12/lib/rails/code_statistics.rb:34:in `block in calculate_statistics'
../railties-4.0.12/lib/rails/code_statistics.rb:34:in `map'
../railties-4.0.12/lib/rails/code_statistics.rb:34:in `calculate_statistics'
../railties-4.0.12/lib/rails/code_statistics.rb:15:in `initialize'
../railties-4.0.12/lib/rails/tasks/statistics.rake:21:in `new'
../railties-4.0.12/lib/rails/tasks/statistics.rake:21:in `block in <top (required)>'
```

After looking into CodeStatics#calculate_directory_statistics it seemed like the logic in the dir loop was wrong when a subdirectory happens to have an ending that also matches a source file pattern (in my case it was something like "app/assets/javascripts/lib.js/..").

I've added a test and fixed it.
