### PR TITLE
Fix confirmation validation error attribute.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Confirmation validation error is now attached to the attribute itself - not to it's #{attribute}_confirmation twin.
+    For example in case of "Password Confirmation" the error message looks foolish (and semantically untrue):
+    Password Confirmation doesn't match confirmation.
+
+    *Andrey Voronkov*
+
 *   Deprecate the `:tokenizer` option for `validates_length_of`, in favor of
     plain Ruby.
 

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -8,22 +8,23 @@ module ActiveModel
       end
 
       def validate_each(record, attribute, value)
-        if (confirmed = record.send("#{attribute}_confirmation")) && (value != confirmed)
+        if (confirmed = record.public_send("#{attribute}_confirmation")) && (value != confirmed)
           human_attribute_name = record.class.human_attribute_name(attribute)
-          record.errors.add(:"#{attribute}_confirmation", :confirmation, options.merge(attribute: human_attribute_name))
+          record.errors.add(attribute.to_sym, :confirmation, options.merge(attribute: human_attribute_name))
         end
       end
 
       private
-      def setup!(klass)
-        klass.send(:attr_reader, *attributes.map do |attribute|
-          :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation")
-        end.compact)
 
-        klass.send(:attr_writer, *attributes.map do |attribute|
-          :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation=")
-        end.compact)
-      end
+        def setup!(klass)
+          klass.send(:attr_reader, *attributes.map do |attribute|
+            :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation")
+          end.compact)
+
+          klass.send(:attr_writer, *attributes.map do |attribute|
+            :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation=")
+          end.compact)
+        end
     end
 
     module HelperMethods


### PR DESCRIPTION
Confirmation validation error should be attached to the attribute itself - not to it's #{attribute}_confirmation twin.  For example in case of "Password Confirmation" the error message looks foolish (and semantically untrue): Password Confirmation doesn't match confirmation.

To be discussed. My point is:

``` ruby
validates :password, confirmation: true
```

assumes you have error on `:password` attribute itself.
