### PR TITLE
Fix confirmation validation error attribute.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Confirmation validation error is now attached to the attribute itself - not to its #{attribute}_confirmation twin.
+    For example in case of "Password Confirmation" the error message looks foolish (and semantically untrue):
+    Password Confirmation doesn't match confirmation.
+
+    *Andrey Voronkov*
+
 *   Deprecate the `:tokenizer` option for `validates_length_of`, in favor of
     plain Ruby.
 

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -8,22 +8,22 @@ module ActiveModel
       end
 
       def validate_each(record, attribute, value)
-        if (confirmed = record.send("#{attribute}_confirmation")) && (value != confirmed)
-          human_attribute_name = record.class.human_attribute_name(attribute)
-          record.errors.add(:"#{attribute}_confirmation", :confirmation, options.merge(attribute: human_attribute_name))
+        if (confirmed = record.public_send("#{attribute}_confirmation")) && (value != confirmed)
+          record.errors.add(attribute.to_sym, :confirmation, options)
         end
       end
 
       private
-      def setup!(klass)
-        klass.send(:attr_reader, *attributes.map do |attribute|
-          :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation")
-        end.compact)
 
-        klass.send(:attr_writer, *attributes.map do |attribute|
-          :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation=")
-        end.compact)
-      end
+        def setup!(klass)
+          klass.send(:attr_reader, *attributes.map do |attribute|
+            :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation")
+          end.compact)
+
+          klass.send(:attr_writer, *attributes.map do |attribute|
+            :"#{attribute}_confirmation" unless klass.method_defined?(:"#{attribute}_confirmation=")
+          end.compact)
+        end
     end
 
     module HelperMethods

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -72,7 +72,7 @@ class SecurePasswordTest < ActiveModel::TestCase
     @user.password_confirmation = ''
     assert !@user.valid?(:create), 'user should be invalid'
     assert_equal 1, @user.errors.count
-    assert_equal ["doesn't match Password"], @user.errors[:password_confirmation]
+    assert_equal ["doesn't match Password"], @user.errors[:password]
   end
 
   test "create a new user with validation and a nil password confirmation" do
@@ -86,7 +86,7 @@ class SecurePasswordTest < ActiveModel::TestCase
     @user.password_confirmation = 'something else'
     assert !@user.valid?(:create), 'user should be invalid'
     assert_equal 1, @user.errors.count
-    assert_equal ["doesn't match Password"], @user.errors[:password_confirmation]
+    assert_equal ["doesn't match Password"], @user.errors[:password]
   end
 
   test "update an existing user with validation and no change in password" do
@@ -141,7 +141,7 @@ class SecurePasswordTest < ActiveModel::TestCase
     @existing_user.password_confirmation = ''
     assert !@existing_user.valid?(:update), 'user should be invalid'
     assert_equal 1, @existing_user.errors.count
-    assert_equal ["doesn't match Password"], @existing_user.errors[:password_confirmation]
+    assert_equal ["doesn't match Password"], @existing_user.errors[:password]
   end
 
   test "updating an existing user with validation and a nil password confirmation" do
@@ -155,7 +155,7 @@ class SecurePasswordTest < ActiveModel::TestCase
     @existing_user.password_confirmation = 'something else'
     assert !@existing_user.valid?(:update), 'user should be invalid'
     assert_equal 1, @existing_user.errors.count
-    assert_equal ["doesn't match Password"], @existing_user.errors[:password_confirmation]
+    assert_equal ["doesn't match Password"], @existing_user.errors[:password]
   end
 
   test "updating an existing user with validation and a blank password digest" do

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -12,27 +12,27 @@ class ConfirmationValidationTest < ActiveModel::TestCase
   def test_no_title_confirmation
     Topic.validates_confirmation_of(:title)
 
-    t = Topic.new(author_name: "Plutarch")
+    t = Topic.new(author_name: 'Plutarch')
     assert t.valid?
 
-    t.title_confirmation = "Parallel Lives"
+    t.title_confirmation = 'Parallel Lives'
     assert t.invalid?
 
     t.title_confirmation = nil
-    t.title = "Parallel Lives"
+    t.title = 'Parallel Lives'
     assert t.valid?
 
-    t.title_confirmation = "Parallel Lives"
+    t.title_confirmation = 'Parallel Lives'
     assert t.valid?
   end
 
   def test_title_confirmation
     Topic.validates_confirmation_of(:title)
 
-    t = Topic.new("title" => "We should be confirmed","title_confirmation" => "")
+    t = Topic.new(title: 'We should be confirmed', title_confirmation: '')
     assert t.invalid?
 
-    t.title_confirmation = "We should be confirmed"
+    t.title_confirmation = 'We should be confirmed'
     assert t.valid?
   end
 
@@ -40,12 +40,12 @@ class ConfirmationValidationTest < ActiveModel::TestCase
     Person.validates_confirmation_of :karma
 
     p = Person.new
-    p.karma_confirmation = "None"
+    p.karma_confirmation = 'None'
     assert p.invalid?
 
-    assert_equal ["doesn't match Karma"], p.errors[:karma_confirmation]
+    assert_equal ["doesn't match Karma"], p.errors[:karma]
 
-    p.karma = "None"
+    p.karma = 'None'
     assert p.valid?
   ensure
     Person.clear_validators!
@@ -63,9 +63,9 @@ class ConfirmationValidationTest < ActiveModel::TestCase
 
       Topic.validates_confirmation_of(:title)
 
-      t = Topic.new("title" => "We should be confirmed","title_confirmation" => "")
+      t = Topic.new(title: 'We should be confirmed', title_confirmation: '')
       assert t.invalid?
-      assert_equal ["doesn't match Test Title"], t.errors[:title_confirmation]
+      assert_equal ["doesn't match Test Title"], t.errors[:title]
     ensure
       I18n.load_path.replace @old_load_path
       I18n.backend = @old_backend
@@ -73,35 +73,43 @@ class ConfirmationValidationTest < ActiveModel::TestCase
     end
   end
 
-  test "does not override confirmation reader if present" do
+  def test_error_is_attached_to_attribute_itself_and_not_its_confirmation_twin
+    Topic.validates_confirmation_of(:title)
+    t = Topic.new(title: 'Sometitle', title_confirmation: 'NotThatTitle')
+    assert t.invalid?
+    assert_not_empty t.errors[:title]
+    assert_empty t.errors[:title_confirmation]
+  end
+
+  def test_does_not_override_confirmation_reader_if_present
     klass = Class.new do
       include ActiveModel::Validations
 
       def title_confirmation
-        "expected title"
+        'expected title'
       end
 
       validates_confirmation_of :title
     end
 
-    assert_equal "expected title", klass.new.title_confirmation,
-     "confirmation validation should not override the reader"
+    assert_equal 'expected title', klass.new.title_confirmation,
+     'confirmation validation should not override the reader'
   end
 
-  test "does not override confirmation writer if present" do
+  def test_does_not_override_confirmation_writer_if_present
     klass = Class.new do
       include ActiveModel::Validations
 
       def title_confirmation=(value)
-        @title_confirmation = "expected title"
+        @title_confirmation = 'expected title'
       end
 
       validates_confirmation_of :title
     end
 
     model = klass.new
-    model.title_confirmation = "new title"
-    assert_equal "expected title", model.title_confirmation,
-     "confirmation validation should not override the writer"
+    model.title_confirmation = 'new title'
+    assert_equal 'expected title', model.title_confirmation,
+     'confirmation validation should not override the writer'
   end
 end

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -60,7 +60,7 @@ class I18nValidationTest < ActiveModel::TestCase
     test "validates_confirmation_of on generated message #{name}" do
       Person.validates_confirmation_of :title, validation_options
       @person.title_confirmation = 'foo'
-      @person.errors.expects(:generate_message).with(:title_confirmation, :confirmation, generate_message_options.merge(attribute: 'Title'))
+      @person.errors.expects(:generate_message).with(:title, :confirmation, generate_message_options)
       @person.valid?
     end
   end
@@ -218,29 +218,24 @@ class I18nValidationTest < ActiveModel::TestCase
 
   # To make things DRY this macro is defined to define 3 tests for every validation case.
   def self.set_expectations_for_validation(validation, error_type, &block_that_sets_validation)
-    if error_type == :confirmation
-      attribute = :title_confirmation
-    else
-      attribute = :title
-    end
     # test "validates_confirmation_of finds custom model key translation when blank"
     test "#{validation} finds custom model key translation when #{error_type}" do
-      I18n.backend.store_translations 'en', activemodel: { errors: { models: { person: { attributes: { attribute => { error_type => 'custom message' } } } } } }
+      I18n.backend.store_translations 'en', activemodel: { errors: { models: { person: { attributes: { title: { error_type => 'custom message' } } } } } }
       I18n.backend.store_translations 'en', errors: { messages: { error_type => 'global message'}}
 
       yield(@person, {})
       @person.valid?
-      assert_equal ['custom message'], @person.errors[attribute]
+      assert_equal ['custom message'], @person.errors[:title]
     end
 
     # test "validates_confirmation_of finds custom model key translation with interpolation when blank"
     test "#{validation} finds custom model key translation with interpolation when #{error_type}" do
-      I18n.backend.store_translations 'en', activemodel: { errors: { models: { person: { attributes: { attribute => { error_type => 'custom message with %{extra}' } } } } } }
+      I18n.backend.store_translations 'en', activemodel: { errors: { models: { person: { attributes: { title: { error_type => 'custom message with %{extra}' } } } } } }
       I18n.backend.store_translations 'en', errors: { messages: {error_type => 'global message'} }
 
       yield(@person, { extra: "extra information" })
       @person.valid?
-      assert_equal ['custom message with extra information'], @person.errors[attribute]
+      assert_equal ['custom message with extra information'], @person.errors[:title]
     end
 
     # test "validates_confirmation_of finds global default key translation when blank"
@@ -249,7 +244,7 @@ class I18nValidationTest < ActiveModel::TestCase
 
       yield(@person, {})
       @person.valid?
-      assert_equal ['global message'], @person.errors[attribute]
+      assert_equal ['global message'], @person.errors[:title]
     end
   end
 

--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -152,6 +152,6 @@ class ValidatesTest < ActiveModel::TestCase
     topic.title = "What's happening"
     topic.title_confirmation = "Not this"
     assert !topic.valid?
-    assert_equal ['Y U NO CONFIRM'], topic.errors[:title_confirmation]
+    assert_equal ['Y U NO CONFIRM'], topic.errors[:title]
   end
 end


### PR DESCRIPTION
Confirmation validation error should be attached to the attribute itself - not to it's #{attribute}_confirmation twin.  For example in case of "Password Confirmation" the error message looks foolish (and semantically untrue): Password Confirmation doesn't match confirmation.

To be discussed. My point is:

``` ruby
validates :password, confirmation: true
```

assumes you have error on `:password` attribute itself.

To be more concrete when you do an i18n of password and password confirmation attributes it is better to get validation error on password itself about it doesn't match the confirmation OR the confirmation doesn't match the attribute but not like it was before.
