### PR TITLE
Move multi-parameter attributes from ActiveRecord to ActiveModel

### DIFF
--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -51,6 +51,8 @@ module ActiveModel
     autoload :Errors
     autoload :StrictValidationFailed, 'active_model/errors'
     autoload :UnknownAttributeError, 'active_model/errors'
+    autoload :AttributeAssignmentError, 'active_model/attribute_assignment'
+    autoload :MultiparameterAssignmentErrors, 'active_model/attribute_assignment'
   end
 
   module Serializers

--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -2,7 +2,14 @@ require 'active_support/core_ext/hash/keys'
 
 module ActiveModel
   module AttributeAssignment
+    extend ActiveSupport::Concern
+
     include ActiveModel::ForbiddenAttributesProtection
+
+    # Alias for `assign_attributes`.
+    def attributes=(attributes)
+      assign_attributes(attributes)
+    end
 
     # Allows you to set all the attributes by passing in a hash of attributes with
     # keys matching the attribute names.
@@ -30,10 +37,91 @@ module ActiveModel
       return if new_attributes.blank?
 
       attributes = new_attributes.stringify_keys
+
+      multi_parameter_attributes = {}
+
+      attributes.each do |k, v|
+        if k.include?("(")
+          multi_parameter_attributes[k] = attributes.delete(k)
+        end
+      end
       _assign_attributes(sanitize_for_mass_assignment(attributes))
+
+      assign_multiparameter_attributes(multi_parameter_attributes) unless multi_parameter_attributes.empty?
+    end
+
+    module ClassMethods
+      mattr_accessor :typecasted
+
+      def typecast_attribute(attribute, klass)
+        self.typecasted ||= {}
+        typecasted[attribute] = klass
+      end
     end
 
     private
+
+    # Instantiates objects for all attribute classes that needs more than one constructor parameter. This is done
+    # by calling new on the column type or aggregation type (through composed_of) object with these parameters.
+    # So having the pairs written_on(1) = "2004", written_on(2) = "6", written_on(3) = "24", will instantiate
+    # written_on (a date type) with Date.new("2004", "6", "24"). You can also specify a typecast character in the
+    # parentheses to have the parameters typecasted before they're used in the constructor. Use i for Fixnum and
+    # f for Float. If all the values for a given attribute are empty, the attribute will be set to +nil+.
+    def assign_multiparameter_attributes(pairs)
+      execute_callstack_for_multiparameter_attributes(
+        extract_callstack_for_multiparameter_attributes(pairs)
+      )
+    end
+
+    def execute_callstack_for_multiparameter_attributes(callstack)
+      errors = []
+      callstack.each do |name, values_with_empty_parameters|
+        begin
+          if values_with_empty_parameters.each_value.all?(&:nil?)
+            values = nil
+          else
+            values = values_with_empty_parameters
+          end
+          _assign_attribute(name, values)
+        rescue => ex
+          errors << attribute_assignment_error_klass.new("error on assignment #{values_with_empty_parameters.values.inspect} to #{name} (#{ex.message})", ex, name)
+        end
+      end
+      unless errors.empty?
+        error_descriptions = errors.map(&:message).join(",")
+        raise multiparameter_assignment_errors_klass.new(errors), "#{errors.size} error(s) on assignment of multiparameter attributes [#{error_descriptions}]"
+      end
+    end
+
+    def extract_callstack_for_multiparameter_attributes(pairs)
+      attributes = {}
+
+      pairs.each do |(multiparameter_name, value)|
+        attribute_name = multiparameter_name.split("(").first
+        attributes[attribute_name] ||= {}
+
+        parameter_value = value.empty? ? nil : type_cast_attribute_value(multiparameter_name, value)
+        attributes[attribute_name][find_parameter_position(multiparameter_name)] ||= parameter_value
+      end
+
+      attributes
+    end
+
+    def type_cast_attribute_value(multiparameter_name, value)
+      multiparameter_name =~ /\([0-9]*([if])\)/ ? value.send("to_" + $1) : value
+    end
+
+    def find_parameter_position(multiparameter_name)
+      multiparameter_name.scan(/\(([0-9]*).*\)/).first.first.to_i
+    end
+
+    def attribute_assignment_error_klass
+      ActiveModel::AttributeAssignmentError
+    end
+
+    def multiparameter_assignment_errors_klass
+      ActiveModel::MultiparameterAssignmentErrors
+    end
 
     def _assign_attributes(attributes)
       attributes.each do |k, v|
@@ -43,10 +131,111 @@ module ActiveModel
 
     def _assign_attribute(k, v)
       if respond_to?("#{k}=")
+        if v.present? && self.class.typecasted.key?(k.to_sym) && v.class != self.class.typecasted[k.to_sym]
+          v = Typecaster.new(v, self.class.typecasted[k.to_sym]).typecast
+        end
+
         public_send("#{k}=", v)
       else
         raise UnknownAttributeError.new(self, k)
       end
+    end
+  end
+
+  class Typecaster
+    def initialize(values, klass)
+      @values = values
+      @klass = klass
+    end
+
+    def typecast
+      return if @values.values.compact.empty?
+
+      if @klass == Time
+        read_time
+      elsif @klass == Date
+        read_date
+      else
+        read_other
+      end
+    end
+
+    private
+
+    def instantiate_time_object(set_values)
+      Time.zone.local(*set_values)
+    end
+
+    def read_time
+      validate_required_parameters!([1,2,3])
+      return if blank_date_parameter?
+
+      max_position = extract_max_param(6)
+      set_values   = @values.values_at(*(1..max_position))
+      # If Time bits are not there, then default to 0
+      (3..5).each { |i| set_values[i] = set_values[i].presence || 0 }
+      instantiate_time_object(set_values)
+    end
+
+    def read_date
+      return if blank_date_parameter?
+      set_values = @values.values_at(1,2,3)
+      begin
+        Date.new(*set_values)
+      rescue ArgumentError # if Date.new raises an exception on an invalid date instantiate_time_object(set_values).to_date # we instantiate Time object and convert it back to a date thus using Time's logic in handling invalid dates
+      end
+    end
+
+    def read_other
+      max_position = extract_max_param
+      positions    = (1..max_position)
+      validate_required_parameters!(positions)
+
+      set_values = @values.values_at(*positions)
+      @klass.new(*set_values)
+    end
+
+    # Checks whether some blank date parameter exists. Note that this is different
+    # than the validate_required_parameters! method, since it just checks for blank
+    # positions instead of missing ones, and does not raise in case one blank position
+    # exists. The caller is responsible to handle the case of this returning true.
+    def blank_date_parameter?
+      (1..3).any? { |position| @values[position].blank? }
+    end
+
+    # If some position is not provided, it errors out a missing parameter exception.
+    def validate_required_parameters!(positions)
+      if missing_parameter = positions.detect { |position| !@values.key?(position) }
+        raise ArgumentError.new("Missing Parameter - #{name}(#{missing_parameter})")
+      end
+    end
+
+    def extract_max_param(upper_cap = 100)
+      [@values.keys.max, upper_cap].min
+    end
+  end
+
+  # Raised when an error occurred while doing a mass assignment to an attribute through the
+  # +attributes=+ method. The exception has an +attribute+ property that is the name of the
+  # offending attribute.
+  class AttributeAssignmentError < StandardError
+    attr_reader :exception, :attribute
+
+    def initialize(message, exception, attribute)
+      super(message)
+      @exception = exception
+      @attribute = attribute
+    end
+  end
+
+  # Raised when there are multiple errors while doing a mass assignment through the +attributes+
+  # method. The exception has an +errors+ property that contains an array of AttributeAssignmentError
+  # objects, each corresponding to the error while assigning to an attribute.
+  class MultiparameterAssignmentErrors < StandardError
+    attr_reader :errors
+
+    def initialize(errors)
+      @errors = errors
     end
   end
 end

--- a/activemodel/test/cases/multiparameter_attributes_test.rb
+++ b/activemodel/test/cases/multiparameter_attributes_test.rb
@@ -1,0 +1,305 @@
+require 'cases/helper'
+require 'active_support/core_ext/time/zones'
+
+class MultiParameterAttributeTest < ActiveModel::TestCase
+  class Address < Struct.new(:street, :city, :country);end
+
+  class Person
+    include ActiveModel::AttributeAssignment
+    attr_accessor :name, :date_of_birth, :last_slept, :address
+
+    typecast_attribute :date_of_birth, Date
+    typecast_attribute :last_slept, Time
+    typecast_attribute :address, Address
+  end
+
+  def setup
+    Time.zone = 'UTC'
+  end
+
+  def test_multiparameter_attributes_on_date
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "2004",
+      "date_of_birth(2i)" => "6",
+      "date_of_birth(3i)" => "24"
+    }
+    assert_equal Date.new(2004, 6, 24), person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_date_with_empty_year
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "",
+      "date_of_birth(2i)" => "6",
+      "date_of_birth(3i)" => "24"
+    }
+    assert_nil person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_date_with_empty_month
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "2004",
+      "date_of_birth(2i)" => "",
+      "date_of_birth(3i)" => "24"
+    }
+    assert_nil person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_date_with_empty_day
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "2004",
+      "date_of_birth(2i)" => "6",
+      "date_of_birth(3i)" => ""
+    }
+    assert_nil person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_date_with_empty_day_and_year
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "",
+      "date_of_birth(2i)" => "6",
+      "date_of_birth(3i)" => ""
+    }
+    assert_nil person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_date_with_empty_day_and_month
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "2004",
+      "date_of_birth(2i)" => "",
+      "date_of_birth(3i)" => ""
+    }
+    assert_nil person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_date_with_empty_year_and_month
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "",
+      "date_of_birth(2i)" => "",
+      "date_of_birth(3i)" => "24"
+    }
+    assert_nil person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_date_with_all_empty
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "",
+      "date_of_birth(2i)" => "",
+      "date_of_birth(3i)" => ""
+    }
+    assert_nil person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_time
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "2004", "last_slept(2i)" => "6", "last_slept(3i)" => "24",
+      "last_slept(4i)" => "16", "last_slept(5i)" => "24", "last_slept(6i)" => "00"
+    }
+    assert_equal Time.zone.local(2004, 6, 24, 16, 24, 0), person.last_slept
+  end
+
+  def test_multiparameter_attributes_on_time_with_no_date
+    person = Person.new
+    ex = assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      person.attributes = {
+        "last_slept(4i)" => "16",
+        "last_slept(5i)" => "24",
+        "last_slept(6i)" => "00"
+      }
+    end
+    assert_equal("last_slept", ex.errors[0].attribute)
+  end
+
+  def test_multiparameter_attributes_on_time_with_invalid_time_params
+    person = Person.new
+    ex = assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      person.attributes = {
+        "last_slept(1i)" => "2004",
+        "last_slept(2i)" => "6",
+        "last_slept(3i)" => "24",
+        "last_slept(4i)" => "2004",
+        "last_slept(5i)" => "36",
+        "last_slept(6i)" => "64",
+      }
+    end
+    assert_equal("last_slept", ex.errors[0].attribute)
+  end
+
+  def test_multiparameter_attributes_on_time_with_old_date
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "1850",
+      "last_slept(2i)" => "6",
+      "last_slept(3i)" => "24",
+      "last_slept(4i)" => "16",
+      "last_slept(5i)" => "24",
+      "last_slept(6i)" => "00"
+    }
+    assert_equal Time.zone.local(1850, 6, 24, 16, 24, 0), person.last_slept
+  end
+
+  def test_multiparameter_attributes_on_time_will_raise_on_big_time_if_missing_date_parts
+    person = Person.new
+    ex = assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      person.attributes = {
+        "last_slept(4i)" => "16", "last_slept(5i)" => "24"
+      }
+    end
+    assert_equal("last_slept", ex.errors[0].attribute)
+  end
+
+  def test_multiparameter_attributes_on_time_with_raise_on_small_time_if_missing_date_parts
+    person = Person.new
+    ex = assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      person.attributes = {
+        "last_slept(4i)" => "16",
+        "last_slept(5i)" => "12",
+        "last_slept(6i)" => "02"
+      }
+    end
+    assert_equal("last_slept", ex.errors[0].attribute)
+  end
+
+  def test_multiparameter_attributes_on_time_will_ignore_hour_if_missing
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "2004", "last_slept(2i)" => "12", "last_slept(3i)" => "12",
+      "last_slept(5i)" => "12", "last_slept(6i)" => "02"
+    }
+    assert_equal Time.zone.local(2004, 12, 12, 0, 12, 2), person.last_slept
+  end
+
+  def test_multiparameter_attributes_on_time_will_ignore_hour_if_blank
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "", "last_slept(2i)" => "", "last_slept(3i)" => "",
+      "last_slept(4i)" => "", "last_slept(5i)" => "12", "last_slept(6i)" => "02"
+    }
+    assert_nil person.last_slept
+  end
+
+  def test_multiparameter_attributes_on_time_will_ignore_date_if_empty
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "", "last_slept(2i)" => "", "last_slept(3i)" => "",
+      "last_slept(4i)" => "16", "last_slept(5i)" => "24"
+    }
+    assert_nil person.last_slept
+  end
+
+  def test_multiparameter_attributes_on_time_with_seconds_will_ignore_date_if_empty
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "", "last_slept(2i)" => "", "last_slept(3i)" => "",
+      "last_slept(4i)" => "16", "last_slept(5i)" => "12", "last_slept(6i)" => "02"
+    }
+    assert_nil person.last_slept
+  end
+
+  def test_multiparameter_attributes_on_time_with_empty_seconds
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "2004", "last_slept(2i)" => "6", "last_slept(3i)" => "24",
+      "last_slept(4i)" => "16", "last_slept(5i)" => "24", "last_slept(6i)" => ""
+    }
+    assert_equal Time.zone.local(2004, 6, 24, 16, 24, 0), person.last_slept
+  end
+
+  def test_multiparameter_attributes_setting_date_attribute
+    person = Person.new
+    person.attributes = { "last_slept(1i)" => "1952", "last_slept(2i)" => "3", "last_slept(3i)" => "11" }
+    assert_equal 1952, person.last_slept.year
+    assert_equal 3, person.last_slept.month
+    assert_equal 11, person.last_slept.day
+  end
+
+  def test_multiparameter_attributes_setting_date_and_time_attribute
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "1952",
+      "last_slept(2i)" => "3",
+      "last_slept(3i)" => "11",
+      "last_slept(4i)" => "13",
+      "last_slept(5i)" => "55"
+    }
+    assert_equal 1952, person.last_slept.year
+    assert_equal 3, person.last_slept.month
+    assert_equal 11, person.last_slept.day
+    assert_equal 13, person.last_slept.hour
+    assert_equal 55, person.last_slept.min
+  end
+
+  def test_multiparameter_attributes_setting_time_but_not_date_on_date_field
+    person = Person.new
+    assert_raise( ActiveModel::MultiparameterAssignmentErrors ) do
+      person.attributes = { "last_slept(4i)" => "13", "last_slept(5i)" => "55" }
+    end
+  end
+
+  def test_multiparameter_assignment_of_aggregation
+    address = Address.new("The Street", "The City", "The Country")
+    person = Person.new
+    person.attributes = {
+      "address(1)" => address.street,
+      "address(2)" => address.city,
+      "address(3)" => address.country
+    }
+    assert_equal address, person.address
+  end
+
+  def test_muliparameter_assignment_of_aggregation_out_of_order
+    address = Address.new("The Street", "The City", "The Country")
+    person = Person.new
+    person.attributes = {
+      "address(3)" => address.country,
+      "address(2)" => address.city,
+      "address(1)" => address.street
+    }
+    assert_equal address, person.address
+  end
+
+  def test_multiparameter_assignment_of_aggregation_with_missing_values
+    address = Address.new("The Street", "The City", "The Country")
+    person = Person.new
+    ex = assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      person.attributes = {
+        "address(2)" => address.city,
+        "address(3)" => address.country
+      }
+    end
+    assert_equal("address", ex.errors[0].attribute)
+  end
+
+  def test_multiparameter_assignment_of_aggregation_with_blank_values
+    address = Address.new("The Street", "The City", "The Country")
+    person = Person.new
+    person.attributes = {
+      "address(1)" => "",
+      "address(2)" => address.city,
+      "address(3)" => address.country
+    }
+    assert_equal Address.new(nil, "The City", "The Country"), person.address
+  end
+
+  def test_multiparameter_assignment_of_aggregation_with_large_index
+    address = Address.new("The Street", "The City", "The Country")
+    person = Person.new
+    ex = assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      person.attributes = {
+        "address(1)" => "The Street",
+        "address(2)" => address.city,
+        "address(3000)" => address.country
+      }
+    end
+
+    assert_equal("address", ex.errors[0].attribute)
+  end
+end

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -1,39 +1,32 @@
 require 'active_model/forbidden_attributes_protection'
+require 'active_model/attribute_assignment'
 
 module ActiveRecord
   module AttributeAssignment
     extend ActiveSupport::Concern
     include ActiveModel::AttributeAssignment
 
-    # Alias for `assign_attributes`. See +ActiveModel::AttributeAssignment+.
-    def attributes=(attributes)
-      assign_attributes(attributes)
-    end
-
     private
 
     def _assign_attributes(attributes) # :nodoc:
-      multi_parameter_attributes  = {}
       nested_parameter_attributes = {}
 
       attributes.each do |k, v|
-        if k.include?("(")
-          multi_parameter_attributes[k] = attributes.delete(k)
-        elsif v.is_a?(Hash)
+        if v.is_a?(Hash)
           nested_parameter_attributes[k] = attributes.delete(k)
         end
       end
       super(attributes)
 
       assign_nested_parameter_attributes(nested_parameter_attributes) unless nested_parameter_attributes.empty?
-      assign_multiparameter_attributes(multi_parameter_attributes) unless multi_parameter_attributes.empty?
     end
 
-    # Re-raise with the ActiveRecord constant in case of an error
-    def _assign_attribute(k, v) # :nodoc:
-      super
-    rescue ActiveModel::UnknownAttributeError
-      raise UnknownAttributeError.new(self, k)
+    def _assign_attribute(k, v)
+      if respond_to?("#{k}=")
+        public_send("#{k}=", v)
+      else
+        raise UnknownAttributeError.new(self, k)
+      end
     end
 
     # Assign any deferred nested attributes after the base attributes have been set.
@@ -41,58 +34,12 @@ module ActiveRecord
       pairs.each { |k, v| _assign_attribute(k, v) }
     end
 
-    # Instantiates objects for all attribute classes that needs more than one constructor parameter. This is done
-    # by calling new on the column type or aggregation type (through composed_of) object with these parameters.
-    # So having the pairs written_on(1) = "2004", written_on(2) = "6", written_on(3) = "24", will instantiate
-    # written_on (a date type) with Date.new("2004", "6", "24"). You can also specify a typecast character in the
-    # parentheses to have the parameters typecasted before they're used in the constructor. Use i for Fixnum and
-    # f for Float. If all the values for a given attribute are empty, the attribute will be set to +nil+.
-    def assign_multiparameter_attributes(pairs)
-      execute_callstack_for_multiparameter_attributes(
-        extract_callstack_for_multiparameter_attributes(pairs)
-      )
+    def attribute_assignment_error_klass
+      ::ActiveRecord::AttributeAssignmentError
     end
 
-    def execute_callstack_for_multiparameter_attributes(callstack)
-      errors = []
-      callstack.each do |name, values_with_empty_parameters|
-        begin
-          if values_with_empty_parameters.each_value.all?(&:nil?)
-            values = nil
-          else
-            values = values_with_empty_parameters
-          end
-          send("#{name}=", values)
-        rescue => ex
-          errors << AttributeAssignmentError.new("error on assignment #{values_with_empty_parameters.values.inspect} to #{name} (#{ex.message})", ex, name)
-        end
-      end
-      unless errors.empty?
-        error_descriptions = errors.map(&:message).join(",")
-        raise MultiparameterAssignmentErrors.new(errors), "#{errors.size} error(s) on assignment of multiparameter attributes [#{error_descriptions}]"
-      end
-    end
-
-    def extract_callstack_for_multiparameter_attributes(pairs)
-      attributes = {}
-
-      pairs.each do |(multiparameter_name, value)|
-        attribute_name = multiparameter_name.split("(").first
-        attributes[attribute_name] ||= {}
-
-        parameter_value = value.empty? ? nil : type_cast_attribute_value(multiparameter_name, value)
-        attributes[attribute_name][find_parameter_position(multiparameter_name)] ||= parameter_value
-      end
-
-      attributes
-    end
-
-    def type_cast_attribute_value(multiparameter_name, value)
-      multiparameter_name =~ /\([0-9]*([if])\)/ ? value.send("to_" + $1) : value
-    end
-
-    def find_parameter_position(multiparameter_name)
-      multiparameter_name.scan(/\(([0-9]*).*\)/).first.first.to_i
+    def multiparameter_assignment_errors_klass
+      ::ActiveRecord::MultiparameterAssignmentErrors
     end
   end
 end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -184,26 +184,12 @@ module ActiveRecord
   # Raised when an error occurred while doing a mass assignment to an attribute through the
   # +attributes=+ method. The exception has an +attribute+ property that is the name of the
   # offending attribute.
-  class AttributeAssignmentError < ActiveRecordError
-    attr_reader :exception, :attribute
-
-    def initialize(message, exception, attribute)
-      super(message)
-      @exception = exception
-      @attribute = attribute
-    end
-  end
+  AttributeAssignmentError = ActiveModel::AttributeAssignmentError
 
   # Raised when there are multiple errors while doing a mass assignment through the +attributes+
   # method. The exception has an +errors+ property that contains an array of AttributeAssignmentError
   # objects, each corresponding to the error while assigning to an attribute.
-  class MultiparameterAssignmentErrors < ActiveRecordError
-    attr_reader :errors
-
-    def initialize(errors)
-      @errors = errors
-    end
-  end
+  MultiparameterAssignmentErrors = ActiveModel::MultiparameterAssignmentErrors
 
   # Raised when a primary key is needed, but not specified in the schema or model.
   class UnknownPrimaryKey < ActiveRecordError


### PR DESCRIPTION
Here is my attempt to move multi-parameters to ActiveModel.
It was [discussed in Basecamp](https://basecamp.com/1755757/projects/6741427/messages/35654189) with @dhh and we really [need it in ActiveForm](https://github.com/rails/actionform/pull/33#issuecomment-68600577). I also believe there are developers who'd like to use `time_select` helpers in their ActiveModel forms.

The first attempt by @georgebrock is in https://github.com/rails/rails/pull/8189 but it can't be applied anymore because typecasting in AR was completely refactored.

I had to implement dirty prototype of typecasting in ActiveModel too, because using multi parameters with Date and Time requires some kind of typecast.

The initial API is:

``` ruby
class Person
  include ActiveModel::Model
  include ActiveModel::AttributeAssignment

  attr_accessor :name, birthdate

  typecast_attribute :birthdate, Date
  # another possible API is attr_typecasted :birthdate, Date
end
```

cc @carlosantoniodasilva @kaspth 
