### PR TITLE
[regression] AR 4.2+ RangeError when querying with a very big (or small) Fixnum

### DIFF
--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -81,6 +81,7 @@ class FinderTest < ActiveRecord::TestCase
 
     assert_equal false, Topic.exists?(45)
     assert_equal false, Topic.exists?(Topic.new.id)
+    assert_equal false, Topic.exists?(2147483648)  # ActiveRecord::Type::Integer#max_value
 
     assert_raise(NoMethodError) { Topic.exists?([1,2]) }
   end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -47,6 +47,10 @@ module ActiveRecord
       assert_equal [chef], chefs.to_a
     end
 
+    def test_where_with_out_of_range_integer
+      assert_nothing_raised { Post.where(id: 2147483648).to_sql }  # ActiveRecord::Type::Integer#max_value
+    end
+
     def test_rewhere_on_root
       assert_equal posts(:welcome), Post.rewhere(title: 'Welcome to the weblog').first
     end


### PR DESCRIPTION
AR 4.2+ raises a weird RangeError when querying with a very big (GTE 2 *\* 31) or very small (LTE - 2 *\* 31 - 1) Fixnum value against an integer column.

4.1

```
% rails r 'p User.exists? 2147483647'
false

% rails r 'p User.exists? 2147483648'
false

% rails r 'puts User.where(age: -2147483649).to_sql'
 "users".* FROM "users"  WHERE "users"."age" = -2147483649
```

4.2

```
% rails r 'p User.exists? 2147483647'
false

% rails r 'p User.exists? 2147483648'
.../gems/activerecord-4.2.1/lib/active_record/type/integer.rb:45:in `ensure_in_range': 2147483648 is out of range for ActiveRecord::Type::Integer with limit 4 (RangeError)
    from .../gems/activerecord-4.2.1/lib/active_record/type/integer.rb:23:in `type_cast_for_database'
    from .../gems/activerecord-4.2.1/lib/active_record/connection_adapters/abstract/quoting.rb:28:in `type_cast'
    from .../gems/activerecord-4.2.1/lib/active_record/connection_adapters/sqlite3_adapter.rb:290:in `block in exec_query'
    from .../gems/activerecord-4.2.1/lib/active_record/connection_adapters/sqlite3_adapter.rb:289:in `map'
    from .../gems/activerecord-4.2.1/lib/active_record/connection_adapters/sqlite3_adapter.rb:289:in `exec_query'
    from .../gems/activerecord-4.2.1/lib/active_record/connection_adapters/abstract/database_statements.rb:347:in `select'
    from .../gems/activerecord-4.2.1/lib/active_record/connection_adapters/abstract/database_statements.rb:32:in `select_all'
    from .../gems/activerecord-4.2.1/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
    from .../gems/activerecord-4.2.1/lib/active_record/connection_adapters/abstract/database_statements.rb:38:in `select_one'
    from .../gems/activerecord-4.2.1/lib/active_record/connection_adapters/abstract/database_statements.rb:43:in `select_value'
    from .../gems/activerecord-4.2.1/lib/active_record/relation/finder_methods.rb:314:in `exists?'
    from .../gems/activerecord-4.2.1/lib/active_record/querying.rb:3:in `exists?'
  ...

% rails r 'puts User.where(age: -2147483649).to_sql'
.../gems/activerecord-4.2.1/lib/active_record/type/integer.rb:45:in `ensure_in_range': -2147483649 is out of range for ActiveRecord::Type::Integer with limit 4 (RangeError)
    from .../gems/activerecord-4.2.1/lib/active_record/type/integer.rb:23:in `type_cast_for_database'
    from .../gems/activerecord-4.2.1/lib/active_record/connection_adapters/abstract/quoting.rb:13:in `quote'
    from .../gems/activerecord-4.2.1/lib/active_record/relation.rb:549:in `block in to_sql'
    from .../gems/activerecord-4.2.1/lib/active_record/relation.rb:549:in `map!'
    from .../gems/activerecord-4.2.1/lib/active_record/relation.rb:549:in `to_sql'
  ...
```

Attached is a reproducing test.
