### PR TITLE
Raise ArgumentError when find_by receives no arguments

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -77,16 +77,16 @@ module ActiveRecord
     #
     #   Post.find_by name: 'Spartacus', rating: 4
     #   Post.find_by "published_at < ?", 2.weeks.ago
-    def find_by(*args)
-      where(*args).take
+    def find_by(arg, *args)
+      where(arg, *args).take
     rescue RangeError
       nil
     end
 
     # Like <tt>find_by</tt>, except that if no record is found, raises
     # an <tt>ActiveRecord::RecordNotFound</tt> error.
-    def find_by!(*args)
-      where(*args).take!
+    def find_by!(arg, *args)
+      where(arg, *args).take!
     rescue RangeError
       raise RecordNotFound, "Couldn't find #{@klass.name} with an out of range value"
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1657,6 +1657,10 @@ class RelationTest < ActiveRecord::TestCase
     assert_sql(/^((?!ORDER).)*$/) { Post.all.find_by(author_id: 2) }
   end
 
+  test "find_by requires at least one argument" do
+    assert_raises(ArgumentError) { Post.all.find_by }
+  end
+
   test "find_by! with hash conditions returns the first matching record" do
     assert_equal posts(:eager_other), Post.order(:id).find_by!(author_id: 2)
   end
@@ -1677,6 +1681,10 @@ class RelationTest < ActiveRecord::TestCase
     assert_raises(ActiveRecord::RecordNotFound) do
       Post.all.find_by!("1 = 0")
     end
+  end
+
+  test "find_by! requires at least one argument" do
+    assert_raises(ArgumentError) { Post.all.find_by! }
   end
 
   test "loaded relations cannot be mutated by multi value methods" do


### PR DESCRIPTION
It fixes the strange error saying undefined method `take'.

```
RelationTest#test_find_by_without_arg_behaves_same_with_find_by({}):
NoMethodError: undefined method `take' for #<ActiveRecord::QueryMethods::WhereChain:0x007f9c55db1d68>
```
