### PR TITLE
Use `use_transactional_tests` in Active Record

### DIFF
--- a/activerecord/test/cases/adapters/mysql/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/mysql/charset_collation_test.rb
@@ -3,7 +3,7 @@ require 'support/schema_dumping_helper'
 
 class CharsetCollationTest < ActiveRecord::TestCase
   include SchemaDumpingHelper
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   setup do
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
@@ -3,7 +3,7 @@ require 'support/schema_dumping_helper'
 
 class CharsetCollationTest < ActiveRecord::TestCase
   include SchemaDumpingHelper
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false
 
   setup do
     @connection = ActiveRecord::Base.connection


### PR DESCRIPTION
`use_transactional_fixtures` was deprecated in favor of `use_transactional_tests` in Rails 5.0. This removes one warning while running test suite.
