### PR TITLE
Enumerable#count by

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -39,6 +39,20 @@ module Enumerable
     end
   end
 
+  # Convert an enumerable to a hash.
+  #
+  #   people.count_by(&:last_name)
+  #     => { "Fowler" => 20, "Hansson" => 1, ...}
+  #   people.count_by { |person| "#{person.age} #{person.gender}" }
+  #     => { "20 F" => 999, "20 M" => 999, ...}
+  def count_by
+    if block_given?
+      Hash[group_by { |elem| yield(elem) }.map { |group, elems| [group, elems.length] }]
+    else
+      to_enum(:count_by) { size if respond_to?(:size) }
+    end
+  end
+
   # Returns +true+ if the enumerable has more than 1 element. Functionally
   # equivalent to <tt>enum.to_a.size > 1</tt>. Can be called with a block too,
   # much like any?, so <tt>people.many? { |p| p.age > 26 }</tt> returns +true+

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -39,7 +39,7 @@ module Enumerable
     end
   end
 
-  # Convert an enumerable to a hash.
+  # Converts an enumerable into grouped counts.
   #
   #   people.count_by(&:last_name)
   #     => { "Fowler" => 20, "Hansson" => 1, ...}

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -81,6 +81,20 @@ class EnumerableTests < ActiveSupport::TestCase
                  payments.index_by.each(&:price))
   end
 
+  def test_count_by
+    payments = GenericEnumerable.new([Payment.new(5), Payment.new(5), Payment.new(10)])
+
+    assert_equal({5 => 2, 10 => 1}, payments.count_by(&:price))
+    assert_equal Enumerator, payments.count_by.class
+    
+    if Enumerator.method_defined? :size
+      assert_equal nil, payments.count_by.size
+      assert_equal 42, (1..42).count_by.size
+    end
+
+    assert_equal({5 => 2, 10 => 1}, payments.count_by.each(&:price))
+  end
+
   def test_many
     assert_equal false, GenericEnumerable.new([]         ).many?
     assert_equal false, GenericEnumerable.new([ 1 ]      ).many?


### PR DESCRIPTION
Adds the `Enumerable#count_by` method.

A common idiom I've seen out and about is trying to get a grouped count of object properties. For instance, we use AWS quite a bit, so we might want to know:

``` ruby
AmazonInstance.where(state: 'running').count_by(&:instance_type)
# => {'m1.xlarge' => 999, 't1.micro' => 999}
```

or in more normal cases you might want some demographics on your users:

``` ruby
User.joins(:address).where(address: {state: 'CA'}).count_by { |user| user.address.zip_code }
```

Admittedly this may be better served in an sql context
