### PR TITLE
Error message no longer tells you to set the (deprecated) secret_token.

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -511,7 +511,7 @@ module Rails
           "Read the upgrade documentation to learn more about this new config option."
 
         if secrets.secret_token.blank?
-          raise "Missing `secret_token` and `secret_key_base` for '#{Rails.env}' environment, set these values in `config/secrets.yml`"
+          raise "Missing `secret_key_base` for '#{Rails.env}' environment, set this value in `config/secrets.yml`"
         end
       end
     end


### PR DESCRIPTION
I found this error message confusing considering that I did not in fact have to set secret_token anywhere. 
