### PR TITLE
Speedup String#squish

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -17,9 +17,8 @@ class String
   #   str.squish!                         # => "foo bar boo"
   #   str                                 # => "foo bar boo"
   def squish!
-    gsub!(/\A[[:space:]]+/, '')
-    gsub!(/[[:space:]]+\z/, '')
     gsub!(/[[:space:]]+/, ' ')
+    strip!
     self
   end
 


### PR DESCRIPTION
[Benchmark](https://gist.github.com/ojab/1e70a0e921f49df9ff00) (Linux, MRI-2.2.1) shows

```
Calculating -------------------------------------
              squish    45.000  i/100ms
          new_squish   106.000  i/100ms
-------------------------------------------------
              squish    445.238  (± 7.4%) i/s -      2.250k
          new_squish      1.094k (± 5.3%) i/s -      5.512k
```

Also benchmark's peak memory usage (according to the `grep VmPeak /proc/$(pgrep ruby)/status`) drops from 98144 kB to 44304 kB [if only old or new version are executed, accordingly].

rbx[-2.5.2] & jruby[-9k.pre1] shows similar results.
