### PR TITLE
update_all with binds

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/money.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/money.rb
@@ -14,7 +14,7 @@ module ActiveRecord
           end
 
           def cast_value(value)
-            return value unless ::String === value
+            return super unless ::String === value
 
             # Because money output is formatted according to the locale, there are two
             # cases to consider (note the decimal separators):


### PR DESCRIPTION
(I still need to come up with some tests.)

This addresses the most egregious instance of @keithpitt & @toolmantim's [cache issue](https://twitter.com/keithpitt/status/587296426192961536).

@sgrif does this sound fundamentally sane? Did I end up with the right sort of typecast? :confused:

Beyond this, I think we need a way to tell `connection.update` (& friends) to skip the statement cache for a given query, beyond the current doesn't-have-binds check. (Well, we do already have `unprepared_statement`.)  Pretty much any time the `sanitize_sql_for_*` helpers have gotten involved [and thus presumably embedded values directly into the query text], we should skip it -- even if some other part of the query is nicely constructed with binds.
