### PR TITLE
Fix `current_page?` not comparing against the original path info.

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -44,13 +44,14 @@ module ActionDispatch
 
     def initialize(env)
       super
-      @method            = nil
-      @request_method    = nil
-      @remote_ip         = nil
-      @original_fullpath = nil
-      @fullpath          = nil
-      @ip                = nil
-      @request_id        = nil
+      @method             = nil
+      @request_method     = nil
+      @remote_ip          = nil
+      @original_fullpath  = nil
+      @original_path_info = nil
+      @fullpath           = nil
+      @ip                 = nil
+      @request_id         = nil
     end
 
     def check_path_parameters!
@@ -111,6 +112,10 @@ module ActionDispatch
 
     def original_script_name # :nodoc:
       env['ORIGINAL_SCRIPT_NAME'.freeze]
+    end
+
+    def original_path # :nodoc:
+      @original_path_info ||= "#{script_name}#{(env['ORIGINAL_PATH_INFO'] || path_info)}"
     end
 
     def engine_script_name(_routes) # :nodoc:

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -410,6 +410,13 @@ class RequestPath < BaseRequestTest
     path = request.original_fullpath
     assert_equal "/foo?bar", path
   end
+
+  test "original_path returns path using ORIGINAL_PATH_INFO" do
+    request = stub_request('ORIGINAL_PATH_INFO' => '/posts/',
+                           'PATH_INFO' => '/posts')
+
+    assert_equal '/posts/', request.original_path
+  end
 end
 
 class RequestHost < BaseRequestTest

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -529,7 +529,7 @@ module ActionView
         # We ignore any extra parameters in the request_uri if the
         # submitted url doesn't have any either. This lets the function
         # work with things like ?order=asc
-        request_uri = url_string.index("?") ? request.fullpath : request.path
+        request_uri = url_string.index("?") ? request.original_fullpath : request.original_path
         request_uri = URI.parser.unescape(request_uri).force_encoding(Encoding::BINARY)
 
         if url_string =~ /^\w+:\/\//

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -423,11 +423,9 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_current_page_with_escaped_params_with_different_encoding
-    @request = request_for_url("/")
-    @request.stub(:path, "/category/administra%c3%a7%c3%a3o".force_encoding(Encoding::ASCII_8BIT)) do
-      assert current_page?(:controller => 'foo', :action => 'category', category: 'administração')
-      assert current_page?("http://www.example.com/category/administra%c3%a7%c3%a3o")
-    end
+    @request = request_for_url("/category/administra%c3%a7%c3%a3o".force_encoding(Encoding::ASCII_8BIT))
+    assert current_page?(:controller => 'foo', :action => 'category', category: 'administração')
+    assert current_page?("http://www.example.com/category/administra%c3%a7%c3%a3o")
   end
 
   def test_current_page_with_double_escaped_params

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -161,6 +161,7 @@ module Rails
     def call(env)
       req = ActionDispatch::Request.new env
       env["ORIGINAL_FULLPATH"] = req.fullpath
+      env["ORIGINAL_PATH_INFO"] = req.path_info
       env["ORIGINAL_SCRIPT_NAME"] = req.script_name
       super(env)
     end


### PR DESCRIPTION
Fixes: https://github.com/rails/rails/issues/19472.

The trailing slash is being removed in [`ActionDispatch::Static` middleware](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/static.rb#L108).
