### PR TITLE
Document that partial indexes are only supported by Postgres and SQLite.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add note that partial indexes are only supported by Postgres and SQLite.
+
+    Fixes #18106
+
+    *Grey Baker*
+
 *   Fixed a bug where uniqueness validations would error on out of range values,
     even if an validation should have prevented it from hitting the database.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -537,6 +537,8 @@ module ActiveRecord
       #
       #   CREATE UNIQUE INDEX index_accounts_on_branch_id_and_party_id ON accounts(branch_id, party_id) WHERE active
       #
+      # Note: Partial indexes are only supported for PostgreSQL and SQLite 3.8.0+.
+      #
       # ====== Creating an index with a specific method
       #
       #   add_index(:developers, :name, using: 'btree')


### PR DESCRIPTION
Noticed this whilst working on a Statesman [issue](https://github.com/gocardless/statesman/issues/157) and subsequently came across #18106.

It would be nice to raise an `ArgumentError` when invalid options (e.g., a `where`) are passed to databases that don't support them, but that should probably wait until we have versioning for these migrations. In the meantime, improving the docs to mention that partial indexes are only supported for PostgreSQL and SQLite 3.8.0+ (the only adapters that set `supports_partial_index?` to `true`) seems like it might help people out.
