### PR TITLE
Fix the wrong documentation about config.autoload_paths [ci skip]

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -466,9 +466,7 @@ by adding this to `config/application.rb`:
 config.autoload_paths << "#{Rails.root}/lib"
 ```
 
-`config.autoload_paths` is accessible from environment-specific configuration
-files, but any changes made to it outside `config/application.rb` don't have any
-effect.
+`config.autoload_paths` is not changeable from environment-specific configuration files.
 
 The value of `autoload_paths` can be inspected. In a just generated application
 it is (edited):


### PR DESCRIPTION
config.autoload_paths is not changeable from environment specific configuration files.
