### PR TITLE
Fix plural form in active_record en locale

### DIFF
--- a/activerecord/lib/active_record/locale/en.yml
+++ b/activerecord/lib/active_record/locale/en.yml
@@ -17,7 +17,7 @@ en:
         record_invalid: "Validation failed: %{errors}"
         restrict_dependent_destroy:
           one: "Cannot delete record because a dependent %{record} exists"
-          many: "Cannot delete record because dependent %{record} exist"
+          other: "Cannot delete record because dependent %{record} exist"
         # Append your own errors here or at the model/attributes scope.
 
       # You can define own errors for models or model attributes.


### PR DESCRIPTION
Just a small fix in a locale file. Correct plural forms for English are "one" and "other" (as set in all other locale files).
