### PR TITLE
Models in migrations docs, re #14166, re #14208

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -912,7 +912,7 @@ removed from your project, or if you rely on a callback, or generally rely on
 any code in your model because later that code may be removed and therefore your
 migration will fail.
 
-The best appraoch here is to create your own model class within your migration
+The best approach here is to create your own model class within your migration
 namespace (so it won't be affected by the existing model in your project).  Eg.
 
 ```ruby


### PR DESCRIPTION
There are many situations where, even if you use non-callback, non-validating methods, and even if you're working on your own, it's still necessary to include the model definitions in your migrations in order to not run into errors.

I've taken the original section and reworked it to focus on the specific reasons that best practices are to include these model definitions in your migrations, and given the examples of how to do it.
