### PR TITLE
Foreign key creation fails when a table prefix or suffix is used

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fixed a bug when adding a foreign key and having a prefix or suffix set
+
+    *Brian Malinconico*
+
 *   Rename `:class` to `:anonymous_class` in association options.
 
     Fixes #19659.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -796,7 +796,7 @@ module ActiveRecord
       end
 
       def foreign_key_column_for(table_name) # :nodoc:
-        "#{table_name.to_s.singularize}_id"
+        "#{remove_prefix_and_suffix(table_name).to_s.singularize}_id"
       end
 
       def dump_schema_information #:nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -385,6 +385,28 @@ module ActiveRecord
         visitor.accept(node, collector).value
       end
 
+      def table_name_options(config = ActiveRecord::Base)
+        {
+          table_name_prefix: config.table_name_prefix,
+          table_name_suffix: config.table_name_suffix
+        }
+      end
+
+      # Finds the correct table name given an Active Record object.
+      # Uses the Active Record object's own table_name, or pre/suffix from the
+      # options passed in.
+      def proper_table_name(name, options = table_name_options)
+        if name.respond_to?(:table_name)
+          name.table_name
+        else
+          "#{options[:table_name_prefix]}#{name}#{options[:table_name_suffix]}"
+        end
+      end
+
+      def remove_prefix_and_suffix(table)
+        table.to_s.gsub(/^(#{table_name_options[:table_name_prefix]})(.+)(#{table_name_options[:table_name_suffix]})$/,  "\\2")
+      end
+
       protected
 
       def initialize_type_map(m) # :nodoc:

--- a/activerecord/test/cases/connection_adapters/abstract_adapter_test.rb
+++ b/activerecord/test/cases/connection_adapters/abstract_adapter_test.rb
@@ -1,0 +1,56 @@
+# encoding: utf-8
+require "cases/helper"
+require 'support/ddl_helper'
+require 'support/connection_helper'
+
+module ActiveRecord
+  module ConnectionAdapters
+    class AbstractAdapterTest < ActiveRecord::TestCase
+      include ConnectionHelper
+
+      class Reminder < ActiveRecord::Base; end
+      teardown do
+        ActiveRecord::Base.table_name_prefix = ""
+        ActiveRecord::Base.table_name_suffix = ""
+      end
+
+      def test_proper_table_name_on_abstract_adapter
+        reminder_class = new_isolated_reminder_class
+        abstract_adapter = ActiveRecord::ConnectionAdapters::AbstractAdapter.new({})
+        assert_equal "table", abstract_adapter.proper_table_name('table')
+        assert_equal "table", abstract_adapter.proper_table_name(:table)
+        assert_equal "reminders", abstract_adapter.proper_table_name(reminder_class)
+        reminder_class.reset_table_name
+        assert_equal reminder_class.table_name, abstract_adapter.proper_table_name(reminder_class)
+    
+        # Use the model's own prefix/suffix if a model is given
+        ActiveRecord::Base.table_name_prefix = "ARprefix_"
+        ActiveRecord::Base.table_name_suffix = "_ARsuffix"
+        reminder_class.table_name_prefix = 'prefix_'
+        reminder_class.table_name_suffix = '_suffix'
+        reminder_class.reset_table_name
+        assert_equal "prefix_reminders_suffix", abstract_adapter.proper_table_name(reminder_class)
+        reminder_class.table_name_prefix = ''
+        reminder_class.table_name_suffix = ''
+        reminder_class.reset_table_name
+    
+        # Use AR::Base's prefix/suffix if string or symbol is given
+        ActiveRecord::Base.table_name_prefix = "prefix_"
+        ActiveRecord::Base.table_name_suffix = "_suffix"
+        reminder_class.reset_table_name
+        assert_equal "prefix_table_suffix", abstract_adapter.proper_table_name('table', abstract_adapter.table_name_options)
+        assert_equal "prefix_table_suffix", abstract_adapter.proper_table_name(:table, abstract_adapter.table_name_options)
+      end
+
+    protected
+      # This is needed to isolate class_attribute assignments like `table_name_prefix`
+      # for each test case.
+      def new_isolated_reminder_class
+        Class.new(Reminder) {
+          def self.name; "Reminder"; end
+          def self.base_class; self; end
+        }
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -11,7 +11,6 @@ require MIGRATIONS_ROOT + "/valid/2_we_need_reminders"
 require MIGRATIONS_ROOT + "/rename/1_we_need_things"
 require MIGRATIONS_ROOT + "/rename/2_rename_things"
 require MIGRATIONS_ROOT + "/decimal/1_give_me_big_numbers"
-
 class BigNumber < ActiveRecord::Base
   unless current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter)
     attribute :value_of_e, Type::Integer.new
@@ -360,34 +359,6 @@ class MigrationTest < ActiveRecord::TestCase
   ensure
     ActiveRecord::Base.schema_migrations_table_name = original_schema_migrations_table_name
     Reminder.reset_table_name
-  end
-
-  def test_proper_table_name_on_migration
-    reminder_class = new_isolated_reminder_class
-    migration = ActiveRecord::Migration.new
-    assert_equal "table", migration.proper_table_name('table')
-    assert_equal "table", migration.proper_table_name(:table)
-    assert_equal "reminders", migration.proper_table_name(reminder_class)
-    reminder_class.reset_table_name
-    assert_equal reminder_class.table_name, migration.proper_table_name(reminder_class)
-
-    # Use the model's own prefix/suffix if a model is given
-    ActiveRecord::Base.table_name_prefix = "ARprefix_"
-    ActiveRecord::Base.table_name_suffix = "_ARsuffix"
-    reminder_class.table_name_prefix = 'prefix_'
-    reminder_class.table_name_suffix = '_suffix'
-    reminder_class.reset_table_name
-    assert_equal "prefix_reminders_suffix", migration.proper_table_name(reminder_class)
-    reminder_class.table_name_prefix = ''
-    reminder_class.table_name_suffix = ''
-    reminder_class.reset_table_name
-
-    # Use AR::Base's prefix/suffix if string or symbol is given
-    ActiveRecord::Base.table_name_prefix = "prefix_"
-    ActiveRecord::Base.table_name_suffix = "_suffix"
-    reminder_class.reset_table_name
-    assert_equal "prefix_table_suffix", migration.proper_table_name('table', migration.table_name_options)
-    assert_equal "prefix_table_suffix", migration.proper_table_name(:table, migration.table_name_options)
   end
 
   def test_rename_table_with_prefix_and_suffix


### PR DESCRIPTION
Simply using a prefix, or suffix:

``` ruby
  config.active_record.table_name_prefix = 'test_'
```

will break the addition of a foreign key with the following migration:

``` ruby
class Test < ActiveRecord::Migration
  def change
    create_table :posts do |t|
      t.timestamps
    end

    create_table :comments do |t|
      t.integer :post_id
      t.timestamps
    end
    add_foreign_key :comments, :posts
  end
end
```

This migration attempts to add a foreign key referencing the test_post_id column. If you specify the column the migration will run correctly.

In order to correct this I extracted the proper_table_name and the remove_prefix_and_suffix function to the abstract connector since it is needed in multiple contexts (SchemaStatments and Migrations)
