### PR TITLE
fix indent in routes when using namespaced controllers

### DIFF
--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -13,7 +13,8 @@ module Rails
       def add_routes
         unless options[:skip_routes]
           actions.reverse_each do |action|
-            route generate_routing_code(action)
+            # route prepends two spaces onto the front of the string that is passed, this corrects that.
+            route generate_routing_code(action)[2..-1]
           end
         end
       end
@@ -36,12 +37,12 @@ module Rails
           # namespace :foo do
           #   namespace :bar do
           namespace_ladder = regular_class_path.each_with_index.map do |ns, i|
-            indent("namespace :#{ns} do\n", i * 2)
+            indent("  namespace :#{ns} do\n", i * 2)
           end.join
 
           # Create route
           #     get 'baz/index'
-          route = indent(%{get '#{file_name}/#{action}'\n}, depth * 2)
+          route = indent(%{  get '#{file_name}/#{action}'\n}, depth * 2)
 
           # Create `end` ladder
           #   end

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -96,6 +96,8 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
 
   def test_namespaced_routes_are_created_in_routes
     run_generator ["admin/dashboard", "index"]
-    assert_file "config/routes.rb", /namespace :admin do\n\s+get 'dashboard\/index'\n/
+    assert_file "config/routes.rb" do |route|
+      assert_match(/^  namespace :admin do\n    get 'dashboard\/index'\n  end$/, route)
+    end
   end
 end


### PR DESCRIPTION
Currently, running `bin/rails g controller foo/bar/baz index` gives the following:

``` ruby
Rails.application.routes.draw do
  namespace :foo do
  namespace :bar do
    get 'baz/index'
    end
  end
end 
```

This patch fixes the indent, so it's generated as follows:

``` ruby
Rails.application.routes.draw do
  namespace :foo do
    namespace :bar do
      get 'baz/index'
    end
  end
end
```
