### PR TITLE
Use #prepend rather than using 2 aliases

### DIFF
--- a/activesupport/lib/active_support/core_ext/range/each.rb
+++ b/activesupport/lib/active_support/core_ext/range/each.rb
@@ -1,27 +1,21 @@
-class Range #:nodoc:
-
-  def each_with_time_with_zone(&block)
-    ensure_iteration_allowed
-    each_without_time_with_zone(&block)
-  end
-  # TODO: change to Module#prepend as soon as the fix is backported to MRI 2.2:
-  # https://bugs.ruby-lang.org/issues/10847
-  alias_method :each_without_time_with_zone, :each
-  alias_method :each, :each_with_time_with_zone
-
-  def step_with_time_with_zone(n = 1, &block)
-    ensure_iteration_allowed
-    step_without_time_with_zone(n, &block)
-  end
-  # TODO: change to Module#prepend as soon as the fix is backported to MRI 2.2:
-  # https://bugs.ruby-lang.org/issues/10847
-  alias_method :step_without_time_with_zone, :step
-  alias_method :step, :step_with_time_with_zone
-
-  private
-  def ensure_iteration_allowed
-    if first.is_a?(Time)
-      raise TypeError, "can't iterate from #{first.class}"
+module ActiveSupport
+  module EachTimeWithZone #:nodoc:
+    def each(&block)
+      ensure_iteration_allowed
+      super
     end
+
+    def step(n = 1, &block)
+      ensure_iteration_allowed
+      super
+    end
+
+    private
+
+      def ensure_iteration_allowed
+        raise TypeError, "can't iterate from #{first.class}" if first.is_a?(Time)
+      end
   end
 end
+
+Range.prepend(ActiveSupport::EachTimeWithZone)

--- a/activesupport/lib/active_support/core_ext/range/include_range.rb
+++ b/activesupport/lib/active_support/core_ext/range/include_range.rb
@@ -1,23 +1,23 @@
-class Range
-  # Extends the default Range#include? to support range comparisons.
-  #  (1..5).include?(1..5) # => true
-  #  (1..5).include?(2..3) # => true
-  #  (1..5).include?(2..6) # => false
-  #
-  # The native Range#include? behavior is untouched.
-  #  ('a'..'f').include?('c') # => true
-  #  (5..9).include?(11) # => false
-  def include_with_range?(value)
-    if value.is_a?(::Range)
-      # 1...10 includes 1..9 but it does not include 1..10.
-      operator = exclude_end? && !value.exclude_end? ? :< : :<=
-      include_without_range?(value.first) && value.last.send(operator, last)
-    else
-      include_without_range?(value)
+module ActiveSupport
+  module IncludeWithRange #:nodoc:
+    # Extends the default Range#include? to support range comparisons.
+    #  (1..5).include?(1..5) # => true
+    #  (1..5).include?(2..3) # => true
+    #  (1..5).include?(2..6) # => false
+    #
+    # The native Range#include? behavior is untouched.
+    #  ('a'..'f').include?('c') # => true
+    #  (5..9).include?(11) # => false
+    def include?(value)
+      if value.is_a?(::Range)
+        # 1...10 includes 1..9 but it does not include 1..10.
+        operator = exclude_end? && !value.exclude_end? ? :< : :<=
+        super(value.first) && value.last.send(operator, last)
+      else
+        super
+      end
     end
   end
-  # TODO: change to Module#prepend as soon as the fix is backported to MRI 2.2:
-  # https://bugs.ruby-lang.org/issues/10847
-  alias_method :include_without_range?, :include?
-  alias_method :include?, :include_with_range?
 end
+
+Range.prepend(ActiveSupport::IncludeWithRange)


### PR DESCRIPTION
This is a follow-up pull request to #19434. Now that Ruby 2.2.2 is out and we can use `#prepend` anywhere.

cc/ @rafaelfranca @kirs
