### PR TITLE
Add support for Set to Relation#where

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for Set to `#where`.
+
+    *Yuki Nishijima*
+
 *   Fixed a bug where uniqueness validations would error on out of range values,
     even if an validation should have prevented it from hitting the database.
 

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -20,6 +20,7 @@ module ActiveRecord
       register_handler(Range, RangeHandler.new(self))
       register_handler(Relation, RelationHandler.new)
       register_handler(Array, ArrayHandler.new(self))
+      register_handler(Set, ArrayHandler.new(self))
       register_handler(AssociationQueryValue, AssociationQueryHandler.new(self))
     end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -848,6 +848,17 @@ class RelationTest < ActiveRecord::TestCase
     }
   end
 
+  def test_find_all_using_where_with_a_set
+    david = authors(:david)
+    mary  = authors(:mary)
+    set   = Set.new([david.id, mary.id])
+
+    assert_queries(1) {
+      relation = Author.where(:id => set)
+      assert_equal [david, mary], relation
+    }
+  end
+
   def test_exists
     davids = Author.where(:name => 'David')
     assert davids.exists?


### PR DESCRIPTION
Right now `#where` treats `Set`objects as nil:

``` ruby
set = Set.new([1, 2])
Author.where(:id => set)
# => SELECT "authors".* FROM "authors" WHERE "authors"."id" = NULL
```

I believe It should treat them as an array:

``` ruby
set = Set.new([1, 2])
Author.where(:id => set)
# => SELECT "authors".* FROM "authors" WHERE "authors"."id" IN (1, 2)
```
