### PR TITLE
Tiny optimization of http auth Realm unquoting

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -118,7 +118,7 @@ module ActionController
       end
 
       def authentication_request(controller, realm)
-        controller.headers["WWW-Authenticate"] = %(Basic realm="#{realm.gsub('"'.freeze, "".freeze)}")
+        controller.headers["WWW-Authenticate"] = %(Basic realm="#{realm.tr('"'.freeze, "".freeze)}")
         controller.status = 401
         controller.response_body = "HTTP Basic: Access denied.\n"
       end
@@ -499,7 +499,7 @@ module ActionController
       #
       # Returns nothing.
       def authentication_request(controller, realm)
-        controller.headers["WWW-Authenticate"] = %(Token realm="#{realm.gsub('"'.freeze, "".freeze)}")
+        controller.headers["WWW-Authenticate"] = %(Token realm="#{realm.tr('"'.freeze, "".freeze)}")
         controller.__send__ :render, :text => "HTTP Token: Access denied.\n", :status => :unauthorized
       end
     end


### PR DESCRIPTION
Some tiny optimization for Realm unquoting

``` ruby
Benchmark.ips do |bm|
  bm.report('gsub') { '"My test Realm"'.gsub('"', '') }
  bm.report('tr') { '"My test Realm"'.tr('"', '') }
  bm.compare!
end
```

```
Calculating -------------------------------------
                gsub    25.497k i/100ms
                  tr    66.568k i/100ms
-------------------------------------------------
                gsub    384.830k (± 3.7%) i/s -      1.938M
                  tr      1.278M (± 2.7%) i/s -      6.391M

Comparison:
                  tr:  1278335.1 i/s
                gsub:   384830.3 i/s - 3.32x slower
```
