### PR TITLE
Fix typos and improve the documentation

### DIFF
--- a/activerecord/test/cases/connection_management_test.rb
+++ b/activerecord/test/cases/connection_management_test.rb
@@ -110,7 +110,7 @@ module ActiveRecord
         assert ActiveRecord::Base.connection_handler.active_connections?
       end
 
-      test "proxy is polite to it's body and responds to it" do
+      test "proxy is polite to its body and responds to it" do
         body = Class.new(String) { def to_path; "/path"; end }.new
         app = lambda { |_| [200, {}, body] }
         response_body = ConnectionManagement.new(app).call(@env)[2]

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -204,13 +204,13 @@ module ActiveRecord
       end
 
       # The connection pool is "fair" if threads waiting for
-      # connections receive them the order in which they began
+      # connections receive them in the order in which they began
       # waiting.  This ensures that we don't timeout one HTTP request
       # even while well under capacity in a multi-threaded environment
       # such as a Java servlet container.
       #
       # We don't need strict fairness: if two connections become
-      # available at the same time, it's fine of two threads that were
+      # available at the same time, it's fine if two threads that were
       # waiting acquire the connections out of order.
       #
       # Thus this test prepares waiting threads and then trickles in

--- a/activesupport/lib/active_support/core_ext/module/concerning.rb
+++ b/activesupport/lib/active_support/core_ext/module/concerning.rb
@@ -63,10 +63,10 @@ class Module
   #
   # == Mix-in noise exiled to its own file:
   #
-  # Once our chunk of behavior starts pushing the scroll-to-understand it's
+  # Once our chunk of behavior starts pushing the scroll-to-understand-it
   # boundary, we give in and move it to a separate file. At this size, the
-  # overhead feels in good proportion to the size of our extraction, despite
-  # diluting our at-a-glance sense of how things really work.
+  # increased overhead can be a reasonable tradeoff even if it reduces our
+  # at-a-glance perception of how things work.
   #
   #   class Todo
   #     # Other todo implementation

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -424,13 +424,23 @@ encrypted cookies salt value. Defaults to `'signed encrypted cookie'`.
     end
     ```
 
-* `config.action_view.default_form_builder` tells Rails which form builder to use by default. The default is `ActionView::Helpers::FormBuilder`. If you want your form builder class to be loaded after initialization (so it's reloaded on each request in development), you can pass it as a `String`
+* `config.action_view.default_form_builder` tells Rails which form builder to
+  use by default. The default is `ActionView::Helpers::FormBuilder`. If you
+  want your form builder class to be loaded after initialization (so it's
+  reloaded on each request in development), you can pass it as a `String`.
 
 * `config.action_view.logger` accepts a logger conforming to the interface of Log4r or the default Ruby Logger class, which is then used to log information from Action View. Set to `nil` to disable logging.
 
 * `config.action_view.erb_trim_mode` gives the trim mode to be used by ERB. It defaults to `'-'`, which turns on trimming of tail spaces and newline when using `<%= -%>` or `<%= =%>`. See the [Erubis documentation](http://www.kuwata-lab.com/erubis/users-guide.06.html#topics-trimspaces) for more information.
 
-* `config.action_view.embed_authenticity_token_in_remote_forms` allows you to set the default behavior for `authenticity_token` in forms with `:remote => true`. By default it's set to false, which means that remote forms will not include `authenticity_token`, which is helpful when you're fragment-caching the form. Remote forms get the authenticity from the `meta` tag, so embedding is unnecessary unless you support browsers without JavaScript. In such case you can either pass `:authenticity_token => true` as a form option or set this config setting to `true`
+* `config.action_view.embed_authenticity_token_in_remote_forms` allows you to
+  set the default behavior for `authenticity_token` in forms with `remote:
+  true`. By default it's set to false, which means that remote forms will not
+  include `authenticity_token`, which is helpful when you're fragment-caching
+  the form. Remote forms get the authenticity from the `meta` tag, so embedding
+  is unnecessary unless you support browsers without JavaScript. In such case
+  you can either pass `authenticity_token: true` as a form option or set this
+  config setting to `true`.
 
 * `config.action_view.prefix_partial_path_with_controller_namespace` determines whether or not partials are looked up from a subdirectory in templates rendered from namespaced controllers. For example, consider a controller named `Admin::ArticlesController` which renders this template:
 
@@ -440,7 +450,8 @@ encrypted cookies salt value. Defaults to `'signed encrypted cookie'`.
 
     The default setting is `true`, which uses the partial at `/admin/articles/_article.erb`. Setting the value to `false` would render `/articles/_article.erb`, which is the same behavior as rendering from a non-namespaced controller such as `ArticlesController`.
 
-* `config.action_view.raise_on_missing_translations` determines whether an error should be raised for missing translations
+* `config.action_view.raise_on_missing_translations` determines whether an
+  error should be raised for missing translations.
 
 ### Configuring Action Mailer
 
@@ -555,7 +566,7 @@ There are a few configuration options available in Active Support:
 * `config.active_job.queue_name_prefix` allows you to set an optional, non-blank, queue name prefix for all jobs. By default it is blank and not used.
 
     The following configuration would queue the given job on the `production_high_priority` queue when run in production:
-    
+
     ```ruby
     config.active_job.queue_name_prefix = Rails.env
     ```
@@ -1012,7 +1023,8 @@ Below is a comprehensive list of all the initializers found in Rails in the orde
 
 * `active_record.set_dispatch_hooks` Resets all reloadable connections to the database if `config.cache_classes` is set to `false`.
 
-* `active_job.logger` Sets `ActiveJob::Base.logger` - if it's not already set - to `Rails.logger`
+* `active_job.logger` Sets `ActiveJob::Base.logger` - if it's not already set -
+  to `Rails.logger`.
 
 * `active_job.set_configs` Sets up Active Job by using the settings in `config.active_job` by `send`'ing the method names as setters to `ActiveJob::Base` and passing the values through.
 

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -374,7 +374,8 @@ A CHANGELOG entry should summarize what was changed and should end with the auth
     *Your Name*
 ```
 
-Your name can be added directly after the last word if you don't provide any code examples or don't need multiple paragraphs. Otherwise, it's best to make as a new paragraph.
+Your name can be added directly after the last word if there are no code
+examples or multiple paragraphs. Otherwise, it's best to make a new paragraph.
 
 ### Updating the Gemfile.lock
 
@@ -406,13 +407,13 @@ Good commit message should be formatted according to the following example:
 Short summary (ideally 50 characters or less)
 
 More detailed description, if necessary. It should be wrapped to 72
-characters. Try to be as descriptive as you can, even if you think that
-the commit content is obvious, it may not be obvious to others. You
-should add such description also if it's already present in bug tracker,
-it should not be necessary to visit a webpage to check the history.
+characters. Try to be as descriptive as you can; even if you think that the
+commit content is obvious, it may not be obvious to others. Add any description
+that is already present in relevant issues - it should not be necessary to visit
+a webpage to check the history.
 
-Description can have multiple paragraphs and you can use code examples
-inside, just indent it with 4 spaces:
+The description section can have multiple paragraphs. Code examples can be
+embedded by indenting them with 4 spaces:
 
     class ArticlesController
       def index
@@ -428,7 +429,8 @@ You can also add bullet points:
   long to fit in 72 characters
 ```
 
-TIP. Please squash your commits into a single commit when appropriate. This simplifies future cherry picks, and also keeps the git log clean.
+TIP. Please squash your commits into a single commit when appropriate. This
+simplifies future cherry picks and also keeps the git log clean.
 
 ### Update Your Branch
 

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -129,9 +129,14 @@ TIP: By default, each log is created under `Rails.root/log/` and the log file is
 
 ### Log Levels
 
-When something is logged it's printed into the corresponding log if the log level of the message is equal or higher than the configured log level. If you want to know the current log level you can call the `Rails.logger.level` method.
+When something is logged, it's printed into the corresponding log if the log
+level of the message is equal or higher than the configured log level. If you
+want to know the current log level, you can call the `Rails.logger.level`
+method.
 
-The available log levels are: `:debug`, `:info`, `:warn`, `:error`, `:fatal`, and `:unknown`, corresponding to the log level numbers from 0 up to 5 respectively. To change the default log level, use
+The available log levels are: `:debug`, `:info`, `:warn`, `:error`, `:fatal`,
+and `:unknown`, corresponding to the log level numbers from 0 up to 5,
+respectively. To change the default log level, use
 
 ```ruby
 config.log_level = :warn # In any environment initializer, or

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -50,7 +50,7 @@ code while accomplishing more than many other languages and frameworks.
 Experienced Rails developers also report that it makes web application
 development more fun.
 
-Rails is opinionated software. It makes the assumption that there is the "best"
+Rails is opinionated software. It makes the assumption that there is a "best"
 way to do things, and it's designed to encourage that way - and in some cases to
 discourage alternatives. If you learn "The Rails Way" you'll probably discover a
 tremendous increase in productivity. If you persist in bringing old habits from

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -489,7 +489,9 @@ NOTE: The default locale loading mechanism in Rails does not load locale files i
 Overview of the I18n API Features
 ---------------------------------
 
-You should have good understanding of using the i18n library now, knowing all necessary aspects of internationalizing a basic Rails application. In the following chapters, we'll cover it's features in more depth.
+You should have a good understanding of using the i18n library now and know how
+to internationalize a basic Rails application. In the following chapters, we'll
+cover its features in more depth.
 
 These chapters will show examples using both the `I18n.translate` method as well as the [`translate` view helper method](http://api.rubyonrails.org/classes/ActionView/Helpers/TranslationHelper.html#method-i-translate) (noting the additional feature provide by the view helper method).
 

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -1073,9 +1073,14 @@ One way to use partials is to treat them as the equivalent of subroutines: as a 
 <%= render "shared/footer" %>
 ```
 
-Here, the `_ad_banner.html.erb` and `_footer.html.erb` partials could contain content that is shared among many pages in your application. You don't need to see the details of these sections when you're concentrating on a particular page.
+Here, the `_ad_banner.html.erb` and `_footer.html.erb` partials could contain
+content that is shared by many pages in your application. You don't need to see
+the details of these sections when you're concentrating on a particular page.
 
-As you already could see from the previous sections of this guide, `yield` is a very powerful tool for cleaning up your layouts. Keep in mind that it's pure ruby, so you can use it almost everywhere. For example, we can use it to DRY form layout definition for several similar resources:
+As seen in the previous sections of this guide, `yield` is a very powerful tool
+for cleaning up your layouts. Keep in mind that it's pure Ruby, so you can use
+it almost everywhere. For example, we can use it to DRY up form layout
+definitions for several similar resources:
 
 * `users/index.html.erb`
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -298,7 +298,7 @@ end
 The migration DSL has been expanded to support foreign key definitions. If
 you've been using the Foreigner gem, you might want to consider removing it.
 Note that the foreign key support of Rails is a subset of Foreigner. This means
-that not every Foreigner definition can be fully replaced by it's Rails
+that not every Foreigner definition can be fully replaced by its Rails
 migration DSL counterpart.
 
 The migration procedure is as follows:

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -2,7 +2,7 @@
 
     *Islam Wazery*
 
-*   Print `bundle install` output in `rails new` as soon as it's available
+*   Print `bundle install` output in `rails new` as soon as it's available.
 
     Running `rails new` will now print the output of `bundle install` as
     it is available, instead of waiting until all gems finish installing.


### PR DESCRIPTION
Mostly minor, random things I’ve come across lately that individually
did not seem worth making a PR for, so I saved them up for one commit.

One common error is using “it’s” (which is an abbreviation of “it is”)
when the possessive “its” should be used for indicating possession.
