### PR TITLE
Fix deprecated message in routing

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -291,7 +291,7 @@ module ActionDispatch
             when String
               ActiveSupport::Deprecation.warn(<<-MSG.squish)
                 Defining a route where `to` is a controller without an action is deprecated.
-                Please change `to: :#{to}` to `controller: :#{to}`.
+                Please change `to: '#{to}'` to `controller: '#{to}'`.
               MSG
 
               [to, nil]


### PR DESCRIPTION
This is a very tiny change. I replaced `to: :admin/users` with `to: 'admin/users'` because symbol doesn't work with `/`.

```
Rails.application.routes.draw do
  resources :users, to: 'admin/users'                                                                                                                                             
end
```

Before

```
DEPRECATION WARNING: Defining a route where `to` is a controller without an action is deprecated. Please change `to: :admin/users` to `controller: :admin/users`
```

After

```
DEPRECATION WARNING: Defining a route where `to` is a controller without an action is deprecated. Please change `to: 'admin/users'` to `controller: 'admin/users'`.
```
