### PR TITLE
Prevent duplicating `where` clauses

### DIFF
--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -100,6 +100,7 @@ module ActiveRecord
         end
 
         def build_default_scope(base_rel = relation) # :nodoc:
+          return if abstract_class?
           if !Base.is_a?(method(:default_scope).owner)
             # The user has defined their own default scope method, so call that
             evaluate_default_scope { default_scope }

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -3,6 +3,7 @@ require 'models/post'
 require 'models/comment'
 require 'models/developer'
 require 'models/computer'
+require 'models/vehicle'
 
 class DefaultScopingTest < ActiveRecord::TestCase
   fixtures :developers, :posts, :comments
@@ -440,5 +441,10 @@ class DefaultScopingTest < ActiveRecord::TestCase
     scope = DeveloperCalledJamis.david2
     assert_equal 1, scope.where_clause.ast.children.length
     assert_equal Developer.where(name: "David"), scope
+  end
+
+  def test_with_abstract_class_where_clause_should_not_be_duplicated
+    scope = Bus.all
+    assert_equal scope.where_clause.ast.children.length, 1
   end
 end

--- a/activerecord/test/models/vehicle.rb
+++ b/activerecord/test/models/vehicle.rb
@@ -1,0 +1,7 @@
+class Vehicle < ActiveRecord::Base
+  self.abstract_class = true
+  default_scope -> { where("tires_count IS NOT NULL") }
+end
+
+class Bus < Vehicle
+end


### PR DESCRIPTION
Prevent duplicating `where` clauses when model is extended from an abstract class

Fixes #19528
