### PR TITLE
Handle multiple actions on namespaced routes better.

### DIFF
--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -12,10 +12,7 @@ module Rails
 
       def add_routes
         unless options[:skip_routes]
-          actions.reverse_each do |action|
-            # route prepends two spaces onto the front of the string that is passed, this corrects that.
-            route generate_routing_code(action)[2..-1]
-          end
+          route generate_routing_code(actions)
         end
       end
 
@@ -24,10 +21,11 @@ module Rails
       private
 
         # This method creates nested route entry for namespaced resources.
-        # For eg. rails g controller foo/bar/baz index
+        # For eg. rails g controller foo/bar/baz index show
         # Will generate -
         # namespace :foo do
         #   namespace :bar do
+        #     get 'baz/show'
         #     get 'baz/index'
         #   end
         # end
@@ -40,9 +38,13 @@ module Rails
             indent("  namespace :#{ns} do\n", i * 2)
           end.join
 
-          # Create route
+
+          # Create routes
+          #     get 'baz/show'
           #     get 'baz/index'
-          route = indent(%{  get '#{file_name}/#{action}'\n}, depth * 2)
+          route = actions.reverse_each.map do |action|
+            indent(%{  get '#{file_name}/#{action}'\n}, depth * 2)
+          end.join
 
           # Create `end` ladder
           #   end
@@ -52,7 +54,8 @@ module Rails
           end.join
 
           # Combine the 3 parts to generate complete route entry
-          namespace_ladder + route + end_ladder
+          # route prepends two spaces onto the front of the string that is passed, this corrects that.
+          (namespace_ladder + route + end_ladder)[2..-1]
         end
     end
   end

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -100,4 +100,11 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
       assert_match(/^  namespace :admin do\n    get 'dashboard\/index'\n  end$/, route)
     end
   end
+
+  def test_namespaced_routes_with_multiple_actions_are_created_in_routes
+    run_generator ["admin/dashboard", "index", "show"]
+    assert_file "config/routes.rb" do |route|
+      assert_match(/^  namespace :admin do\n    get 'dashboard\/show'\n    get 'dashboard\/index'\n  end$/, route)
+    end
+  end
 end


### PR DESCRIPTION
generate_routing_code is refactored to be able receive array of actions and correctly handle it. That is made to avoid multiplication of namespace nesting in routes.rb.
Before:

``` ruby
$ rails g controller admin/infobar index edit update show

namespace :admin do
  get 'infobar/index'
end

namespace :admin do
  get 'infobar/edit'
end

namespace :admin do
  get 'infobar/update'
end

namespace :admin do
  get 'infobar/show'
end
```

After:

``` ruby
namespace :admin do
 get 'infobar/show'
  get 'infobar/update'
  get 'infobar/edit'
  get 'infobar/index'
end
```

EDIT: fixed identation
