### PR TITLE
Raise an error if loading pg structure file fails

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -67,7 +67,7 @@ module ActiveRecord
 
       def structure_load(filename)
         set_psql_env
-        Kernel.system("psql -X -q -f #{Shellwords.escape(filename)} #{configuration['database']}")
+        raise 'Error loading database' unless Kernel.system("psql -X -q -f #{Shellwords.escape(filename)} #{configuration['database']}")
       end
 
       private


### PR DESCRIPTION
Hi all. When dumping the db structure file for PG we raise an error if the shelled out command fails, but we don't raise an error when loading the file. I added a consistent exception for this case.

I was pulling my hair out trying to figure out why my tables were not loaded despite a 0 exit code from the task. Turns out I didn't have the postgresql client tools installed.

xoxo Nick
