### PR TITLE
Call destroy not destroy! on dependent children

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Calling `destroy` on an object with `has_many dependent: :destroy` relations
+    will now call `destroy` and not `destroy!` on the related objects. If a
+    `.replace` call fails due to a `before_destroy`, it will now raise
+    `ActiveRecord::RecordNotSaved`.
+
+    Fixes #19761
+
+    *Nate Collings*
+
 *   Added a configuration option to have active record raise an ArgumentError
     if the order or limit is ignored in a batch query, rather than logging a
     warning message.

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -117,7 +117,7 @@ module ActiveRecord
         # Deletes the records according to the <tt>:dependent</tt> option.
         def delete_records(records, method)
           if method == :destroy
-            records.each(&:destroy!)
+            records.each(&:destroy)
             update_counter(-records.length) unless reflection.inverse_updates_counter_cache?
           else
             scope = self.scope.where(reflection.klass.primary_key => records)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2236,12 +2236,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     car = Car.create!
     original_child = FailedBulb.create!(car: car)
 
-    error = assert_raise(ActiveRecord::RecordNotDestroyed) do
+    error = assert_raise(ActiveRecord::RecordNotSaved) do
       car.failed_bulbs = [FailedBulb.create!]
     end
 
     assert_equal [original_child], car.reload.failed_bulbs
     assert_equal "Failed to destroy the record", error.message
+  end
+
+  test 'before_destroy gets called on the parent if a dependent child fails to destroy' do
+    car = IndestructibleCar.create! failed_bulbs: [FailedBulb.create!]
+    car.destroy
+    assert_equal car.errors.messages, {:base => ['I cannot be destroyed']}
   end
 
   test 'updates counter cache when default scope is given' do

--- a/activerecord/test/models/bulb.rb
+++ b/activerecord/test/models/bulb.rb
@@ -41,7 +41,7 @@ end
 
 class FunkyBulb < Bulb
   before_destroy do
-    raise "before_destroy was called"
+    throw(:abort)
   end
 end
 

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -27,3 +27,12 @@ end
 class FastCar < Car
   default_scope { order('name desc') }
 end
+
+class IndestructibleCar < Car
+  before_destroy :cannot_destroy
+
+  def cannot_destroy
+    errors.add(:base, 'I cannot be destroyed')
+    throw(:abort)
+  end
+end


### PR DESCRIPTION
This should fix #19761 while still resolving the issue in #12812. This reverts back to calling `destroy` and not `destroy!` on a parent's `has_many dependent: :destroy` children when you call `destroy` on the parent.

In my opinion, this change is important because of the expectation that `destroy` should not raise an exception (which is the case in Rails 3, and in Rails 4 before #13042). This was causing various bugs for us until we discovered that it was because `destroy!` was now getting called on the related objects.

This retains the fix from #13042 by only raising an exception if the necessary objects are not destroyed when doing a replace.

The one difference is that when the replace fails it now raises `ActiveRecord::RecordNotSaved` instead of `ActiveRecord::RecordNotDestroyed`. I think this is a better exception to raise, because I think it's a bit clearer to somebody when they try to save some new objects and they get `RecordNotSaved` instead of `RecordNotDestroyed`. But that might be a breaking change if people are already handling `RecordNotDestroyed` exceptions for those cases, so I could change it back if needed.
