### PR TITLE
[Skip ci] Add information about :host options

### DIFF
--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -248,6 +248,11 @@ module ActionView
 
       # Computes the full URL to a JavaScript asset in the public javascripts directory.
       # This will use +javascript_path+ internally, so most of their behaviors will be the same.
+      # Since +javascript_url+ is based on +asser_url+ method you can set :host options. If :host
+      # options is set, it overwrites global +config.action_controller.asset_host+ setting.
+      #
+      #   javascript_url "js/xmlhr.js", host: "http://stage.example.com" # => http://stage.example.com/assets/dir/xmlhr.js
+      #
       def javascript_url(source, options = {})
         url_to_asset(source, {type: :javascript}.merge!(options))
       end
@@ -270,6 +275,11 @@ module ActionView
 
       # Computes the full URL to a stylesheet asset in the public stylesheets directory.
       # This will use +stylesheet_path+ internally, so most of their behaviors will be the same.
+      # Since +stylesheet_url+ is based on +asser_url+ method you can set :host options. If :host
+      # options is set, it overwrites global +config.action_controller.asset_host+ setting.
+      #
+      #   stylesheet_url "css/style.css", host: "http://stage.example.com" # => http://stage.example.com/css/style.css
+      #
       def stylesheet_url(source, options = {})
         url_to_asset(source, {type: :stylesheet}.merge!(options))
       end
@@ -295,6 +305,11 @@ module ActionView
 
       # Computes the full URL to an image asset.
       # This will use +image_path+ internally, so most of their behaviors will be the same.
+      # Since +image_url+ is based on +asser_url+ method you can set :host options. If :host
+      # options is set, it overwrites global +config.action_controller.asset_host+ setting.
+      #
+      #   image_url "edit.png", host: "http://stage.example.com" # => http://stage.example.com/edit.png
+      #
       def image_url(source, options = {})
         url_to_asset(source, {type: :image}.merge!(options))
       end
@@ -316,6 +331,11 @@ module ActionView
 
       # Computes the full URL to a video asset in the public videos directory.
       # This will use +video_path+ internally, so most of their behaviors will be the same.
+      # Since +video_url+ is based on +asser_url+ method you can set :host options. If :host
+      # options is set, it overwrites global +config.action_controller.asset_host+ setting.
+      #
+      #   video_url "hd.avi", host: "http://stage.example.com" # => http://stage.example.com/hd.avi
+      #
       def video_url(source, options = {})
         url_to_asset(source, {type: :video}.merge!(options))
       end
@@ -337,6 +357,11 @@ module ActionView
 
       # Computes the full URL to an audio asset in the public audios directory.
       # This will use +audio_path+ internally, so most of their behaviors will be the same.
+      # Since +audio_url+ is based on +asser_url+ method you can set :host options. If :host
+      # options is set, it overwrites global +config.action_controller.asset_host+ setting.
+      #
+      #   audio_url "horse.wav", host: "http://stage.example.com" # => http://stage.example.com/horse.wav
+      #
       def audio_url(source, options = {})
         url_to_asset(source, {type: :audio}.merge!(options))
       end
@@ -357,6 +382,11 @@ module ActionView
 
       # Computes the full URL to a font asset.
       # This will use +font_path+ internally, so most of their behaviors will be the same.
+      # Since +font_url+ is based on +asser_url+ method you can set :host options. If :host
+      # options is set, it overwrites global +config.action_controller.asset_host+ setting.
+      #
+      #   font_url "font.ttf", host: "http://stage.example.com" # => http://stage.example.com/font.ttf
+      #
       def font_url(source, options = {})
         url_to_asset(source, {type: :font}.merge!(options))
       end


### PR DESCRIPTION
Added informations about `:host` options for each url helper (`#javascript_url`, `#video_url`, `#stylesheet_url`, etc) based on `#asser_url` method.
