### PR TITLE
[ci skip] Document running a rake command as a rails command

### DIFF
--- a/railties/lib/rails/commands/commands_tasks.rb
+++ b/railties/lib/rails/commands/commands_tasks.rb
@@ -151,6 +151,17 @@ EOT
         puts HELP_MESSAGE
       end
 
+      # Output an error message stating that the attempted command is not a valid rails command.
+      # Run the attempted command as a rake command with the --dry-run flag. If successful, suggest
+      # to the user that they possibly meant to run the given rails command as a rake command.
+      # Append the help message.
+      #
+      #   Example:
+      #   $ rails db:migrate
+      #   Error: Command 'db:migrate' not recognized
+      #   Did you mean: `$ rake db:migrate` ?
+      #   (Help message output)
+      #
       def write_error_message(command)
         puts "Error: Command '#{command}' not recognized"
         if %x{rake #{command} --dry-run 2>&1 } && $?.success?


### PR DESCRIPTION
Add documentation to `Rails::CommandsTasks` regarding running a command through the cli as a `rails` command that is actually a `rake` command (e.g., `rails db:migrate`).
