### PR TITLE
add active job testing section [ci skip]

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -319,3 +319,10 @@ class GuestsCleanupJob < ActiveJob::Base
   end
 end
 ```
+
+
+Job Testing
+--------------
+
+You can find detailed instructions on how to test your jobs in the
+[testing guide](testing.html#testing-jobs).


### PR DESCRIPTION
In the same way of the "Action Mailer Basics" guide, I thought it would be helpful to add a testing section in the "Active Job Basics" guide with a link back to the "A Guide to Testing Rails Applications" doc.
