### PR TITLE
Raise StaleObjectError if touched object is stale and locking is enabled

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -477,11 +477,23 @@ module ActiveRecord
           changes[column] = write_attribute(column, time)
         end
 
-        changes[self.class.locking_column] = increment_lock if locking_enabled?
-
         clear_attribute_changes(changes.keys)
         primary_key = self.class.primary_key
-        self.class.unscoped.where(primary_key => self[primary_key]).update_all(changes) == 1
+        scope = self.class.unscoped.where(primary_key => id)
+
+        if locking_enabled?
+          locking_column = self.class.locking_column
+          scope = scope.where(locking_column => _read_attribute(locking_column))
+          changes[locking_column] = increment_lock
+        end
+
+        result = scope.update_all(changes) == 1
+
+        if !result && locking_enabled?
+          raise ActiveRecord::StaleObjectError.new(self, "touch")
+        end
+
+        result
       else
         true
       end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -177,6 +177,16 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     assert_equal 1, p1.lock_version
   end
 
+  def test_touch_stale_object
+    person = Person.create!(first_name: 'Mehmet Emin')
+    stale_person = Person.find(person.id)
+    person.update_attribute(:gender, 'M')
+
+    assert_raises(ActiveRecord::StaleObjectError) do
+      stale_person.touch
+    end
+  end
+
   def test_lock_column_name_existing
     t1 = LegacyThing.find(1)
     t2 = LegacyThing.find(1)


### PR DESCRIPTION
Fixes #19776
