### PR TITLE
Fix broken IPv6 addresses handling

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -5,7 +5,7 @@ module ActionDispatch
   module Http
     module URL
       IP_HOST_REGEXP  = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
-      HOST_REGEXP     = /(^.*:\/\/)?([^:]+)(?::(\d+$))?/
+      HOST_REGEXP     = /(^.*:\/\/)?(\[[^\]]+\]|[^:]+)(?::(\d+$))?/
       PROTOCOL_REGEXP = /^([^:]+)(:)?(\/\/)?$/
 
       mattr_accessor :tld_length

--- a/actionpack/test/dispatch/routing/ipv6_redirect_test.rb
+++ b/actionpack/test/dispatch/routing/ipv6_redirect_test.rb
@@ -1,0 +1,51 @@
+require 'abstract_unit'
+
+class IPv6IntegrationTest < ActionDispatch::IntegrationTest
+  Routes = ActionDispatch::Routing::RouteSet.new
+  include Routes.url_helpers
+
+  class ::BadRouteRequestController < ActionController::Base
+    include Routes.url_helpers
+    def index
+      render :text => foo_path
+    end
+
+    def foo
+      redirect_to :action => :index
+    end
+  end
+
+  Routes.draw do
+    get "/",    :to => 'bad_route_request#index', :as => :index
+    get "/foo", :to => "bad_route_request#foo", :as => :foo
+  end
+
+  def _routes
+    Routes
+  end
+
+  # Rails 4.1 Stable
+  def app
+    Routes
+  end
+
+  # Rails 4.2 Stable
+  # APP = build_app Routes
+  # def app
+  #   APP
+  # end
+
+  test "bad IPv6 redirection" do
+    #   def test_simple_redirect
+    request_env = {
+      'REMOTE_ADDR' => 'fd07:2fa:6cff:2112:225:90ff:fec7:22aa',
+      'HTTP_HOST'   => '[fd07:2fa:6cff:2112:225:90ff:fec7:22aa]:3000',
+      'SERVER_NAME' => '[fd07:2fa:6cff:2112:225:90ff:fec7:22aa]',
+      'SERVER_PORT' => 3000 }
+
+    get '/foo', nil, request_env
+    assert_response :redirect
+    assert_equal 'http://[fd07:2fa:6cff:2112:225:90ff:fec7:22aa]:3000/', redirect_to_url
+  end
+
+end


### PR DESCRIPTION
IPv6 address handing, especially for redirects, are broken when compared against Rails 3.x. The current code attempts to add support for IPv6 address detection similar to what already exists
for IPv4 dotted decimal addressing.

The change is sufficiently small enough it should be easily ported to 4.2 stable and master.

This is to address issue #19784 
