### PR TITLE
Move casting values to Boolean from ActiveRecord to ActiveSupport.

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -1,3 +1,5 @@
+using Truthiness
+
 module ActiveRecord
   module AttributeMethods
     module Query
@@ -19,7 +21,7 @@ module ActiveRecord
             if Numeric === value || value !~ /[^0-9]/
               !value.to_i.zero?
             else
-              return false if ActiveRecord::ConnectionAdapters::Column::FALSE_VALUES.include?(value)
+              return false if value.falsey?
               !value.blank?
             end
           elsif value.respond_to?(:zero?)

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -5,7 +5,7 @@ module ActiveRecord
   module ConnectionAdapters
     # An abstract definition of a column in a table.
     class Column
-      FALSE_VALUES = [false, 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF'].to_set
+      FALSE_VALUES = Truthiness::FALSE_VALUES
 
       module Format
         ISO_DATE = /\A(\d{4})-(\d\d)-(\d\d)\z/

--- a/activerecord/lib/active_record/type/boolean.rb
+++ b/activerecord/lib/active_record/type/boolean.rb
@@ -1,3 +1,7 @@
+require 'active_support/core_ext/object/truthiness'
+
+using Truthiness
+
 module ActiveRecord
   module Type
     class Boolean < Value # :nodoc:
@@ -8,11 +12,9 @@ module ActiveRecord
       private
 
       def cast_value(value)
-        if value == ''
-          nil
-        else
-          !ConnectionAdapters::Column::FALSE_VALUES.include?(value)
-        end
+        return nil if value == ''
+
+        value.truthy?
       end
     end
   end

--- a/activesupport/lib/active_support/core_ext/object.rb
+++ b/activesupport/lib/active_support/core_ext/object.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/object/duplicable'
 require 'active_support/core_ext/object/deep_dup'
 require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/object/inclusion'
+require 'active_support/core_ext/object/truthiness'
 
 require 'active_support/core_ext/object/conversions'
 require 'active_support/core_ext/object/instance_variables'

--- a/activesupport/lib/active_support/core_ext/object/truthiness.rb
+++ b/activesupport/lib/active_support/core_ext/object/truthiness.rb
@@ -1,0 +1,13 @@
+module Truthiness
+  refine Object do
+    FALSE_VALUES = ['0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF', false, 0, nil].to_set
+
+    def falsey?
+      FALSE_VALUES.include? self
+    end
+
+    def truthy?
+      ! falsey?
+    end
+  end
+end

--- a/activesupport/test/core_ext/object/truthiness_test.rb
+++ b/activesupport/test/core_ext/object/truthiness_test.rb
@@ -1,0 +1,22 @@
+require 'active_support/core_ext/object'
+
+using Truthiness
+
+class TruthinessTest < ActiveSupport::TestCase
+  def test_true_values_are_truthy
+    assert 1.truthy?
+    assert true.truthy?
+    assert 'true'.truthy?
+    assert '1'.truthy?
+    assert 't'.truthy?
+  end
+
+  def test_false_values_are_falsey
+    assert 0.falsey?
+    assert false.falsey?
+    assert 'false'.falsey?
+    assert '0'.falsey?
+    assert 'f'.falsey?
+    assert nil.falsey?
+  end
+end


### PR DESCRIPTION
This creates a refinement on Object and moves the existing code in
ActiveRecord::ConnectionAdapters::Column and a few other places
that determines if a value being cast to bool is true/false, and
puts it into ActiveSupport. The existing code is changed to use
this new refinement.

The existing location of this behavior is in scattered and somewhat 
counterintuitive. ActiveRecord already depends on ActiveSupport,and 
projects could use this behavior without importing ActiveRecord.
