### PR TITLE
Fix wrong examples of [asset_type]_url methods [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -251,7 +251,7 @@ module ActionView
       # Since +javascript_url+ is based on +asset_url+ method you can set :host options. If :host
       # options is set, it overwrites global +config.action_controller.asset_host+ setting.
       #
-      #   javascript_url "js/xmlhr.js", host: "http://stage.example.com" # => http://stage.example.com/assets/dir/xmlhr.js
+      #   javascript_url "xmlhr.js", host: "http://stage.example.com" # => http://stage.example.com/javascripts/xmlhr.js
       #
       def javascript_url(source, options = {})
         url_to_asset(source, {type: :javascript}.merge!(options))
@@ -278,7 +278,7 @@ module ActionView
       # Since +stylesheet_url+ is based on +asset_url+ method you can set :host options. If :host
       # options is set, it overwrites global +config.action_controller.asset_host+ setting.
       #
-      #   stylesheet_url "css/style.css", host: "http://stage.example.com" # => http://stage.example.com/css/style.css
+      #   stylesheet_url "style.css", host: "http://stage.example.com" # => http://stage.example.com/stylesheets/style.css
       #
       def stylesheet_url(source, options = {})
         url_to_asset(source, {type: :stylesheet}.merge!(options))
@@ -308,7 +308,7 @@ module ActionView
       # Since +image_url+ is based on +asset_url+ method you can set :host options. If :host
       # options is set, it overwrites global +config.action_controller.asset_host+ setting.
       #
-      #   image_url "edit.png", host: "http://stage.example.com" # => http://stage.example.com/edit.png
+      #   image_url "edit.png", host: "http://stage.example.com" # => http://stage.example.com/images/edit.png
       #
       def image_url(source, options = {})
         url_to_asset(source, {type: :image}.merge!(options))
@@ -334,7 +334,7 @@ module ActionView
       # Since +video_url+ is based on +asset_url+ method you can set :host options. If :host
       # options is set, it overwrites global +config.action_controller.asset_host+ setting.
       #
-      #   video_url "hd.avi", host: "http://stage.example.com" # => http://stage.example.com/hd.avi
+      #   video_url "hd.avi", host: "http://stage.example.com" # => http://stage.example.com/videos/hd.avi
       #
       def video_url(source, options = {})
         url_to_asset(source, {type: :video}.merge!(options))
@@ -360,7 +360,7 @@ module ActionView
       # Since +audio_url+ is based on +asset_url+ method you can set :host options. If :host
       # options is set, it overwrites global +config.action_controller.asset_host+ setting.
       #
-      #   audio_url "horse.wav", host: "http://stage.example.com" # => http://stage.example.com/horse.wav
+      #   audio_url "horse.wav", host: "http://stage.example.com" # => http://stage.example.com/audios/horse.wav
       #
       def audio_url(source, options = {})
         url_to_asset(source, {type: :audio}.merge!(options))
@@ -385,7 +385,7 @@ module ActionView
       # Since +font_url+ is based on +asset_url+ method you can set :host options. If :host
       # options is set, it overwrites global +config.action_controller.asset_host+ setting.
       #
-      #   font_url "font.ttf", host: "http://stage.example.com" # => http://stage.example.com/font.ttf
+      #   font_url "font.ttf", host: "http://stage.example.com" # => http://stage.example.com/fonts/font.ttf
       #
       def font_url(source, options = {})
         url_to_asset(source, {type: :font}.merge!(options))


### PR DESCRIPTION
At least as of now, those methods generate URLs with folders which `ActionView::Helpers::AssetUrlHelper::ASSET_PUBLIC_DIRECTORIES` maps each asset type to (e.g. `:audio=>"/audios"`), unless you override the default implementation (that is, `#compute_asset_path`).

rails c

``` ruby
helper.javascript_url "js/xmlhr.js", host: "http://stage.example.com"
=> "http://stage.example.com/javascripts/js/xmlhr.js"
helper.stylesheet_url "css/style.css", host: "http://stage.example.com"
=> "http://stage.example.com/stylesheets/css/style.css"
helper.image_url "edit.png", host: "http://stage.example.com"
=> "http://stage.example.com/images/edit.png"
helper.video_url "hd.avi", host: "http://stage.example.com"
=> "http://stage.example.com/videos/hd.avi"
helper.audio_url "horse.wav", host: "http://stage.example.com"
=> "http://stage.example.com/audios/horse.wav"
helper.font_url "font.ttf", host: "http://stage.example.com"
=> "http://stage.example.com/fonts/font.ttf"
```

I also omit `js/` and `css/` from the file names that the original examples had, since I'm not sure the likes of `/javascripts/js/***.js` is something we really want to provide as an example, even if a real-world
app may sometimes end up like this...
