### PR TITLE
[ci skip] Fix docs and guide about 'Array.wrap'

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/wrap.rb
+++ b/activesupport/lib/active_support/core_ext/array/wrap.rb
@@ -15,12 +15,13 @@ class Array
   #
   # * If the argument responds to +to_ary+ the method is invoked. <tt>Kernel#Array</tt>
   #   moves on to try +to_a+ if the returned value is +nil+, but <tt>Array.wrap</tt> returns
-  #   +nil+ right away.
+  #   an array with the argument as its single element right away.
   # * If the returned value from +to_ary+ is neither +nil+ nor an +Array+ object, <tt>Kernel#Array</tt>
   #   raises an exception, while <tt>Array.wrap</tt> does not, it just returns the value.
-  # * It does not call +to_a+ on the argument, but returns an empty array if argument is +nil+.
+  # * It does not call +to_a+ on the argument, if the argument does not respond to +to_ary+
+  #   it returns an array with the argument as its single element.
   #
-  # The second point is easily explained with some enumerables:
+  # The last point is easily explained with some enumerables:
   #
   #   Array(foo: :bar)      # => [[:foo, :bar]]
   #   Array.wrap(foo: :bar) # => [{:foo=>:bar}]

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2440,9 +2440,9 @@ Array.wrap(0)         # => [0]
 
 This method is similar in purpose to `Kernel#Array`, but there are some differences:
 
-* If the argument responds to `to_ary` the method is invoked. `Kernel#Array` moves on to try `to_a` if the returned value is `nil`, but `Array.wrap` returns `nil` right away.
+* If the argument responds to `to_ary` the method is invoked. `Kernel#Array` moves on to try `to_a` if the returned value is `nil`, but `Array.wrap` returns an array with the argument as its single element right away.
 * If the returned value from `to_ary` is neither `nil` nor an `Array` object, `Kernel#Array` raises an exception, while `Array.wrap` does not, it just returns the value.
-* It does not call `to_a` on the argument, though special-cases `nil` to return an empty array.
+* It does not call `to_a` on the argument, if the argument does not respond to +to_ary+ it returns an array with the argument as its single element.
 
 The last point is particularly worth comparing for some enumerables:
 


### PR DESCRIPTION
`This method returns an empty array if argument is +nil+` is explained [here](https://github.com/rails/rails/blob/349b3effe5a694b53f16b2305ab65a9df09bf021/activesupport/lib/active_support/core_ext/array/wrap.rb#L6). So we can remove this.
And we should explain how this method work when [+to_ary+ is not defined](https://github.com/rails/rails/blob/349b3effe5a694b53f16b2305ab65a9df09bf021/activesupport/lib/active_support/core_ext/array/wrap.rb#L43), because this is different from `Kernel#Array`.
