### PR TITLE
Add missing require for String#strip_heredoc

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -2,6 +2,7 @@ require 'stringio'
 require 'uri'
 require 'active_support/core_ext/kernel/singleton_class'
 require 'active_support/core_ext/object/try'
+require 'active_support/core_ext/string/strip'
 require 'rack/test'
 require 'minitest'
 


### PR DESCRIPTION
This method is being used in `#xml_http_request`, but was not properly required. This causes `NoMethodError` on projects that are doing integration test.

![screen shot 2015-04-17 at 3 23 32 pm](https://cloud.githubusercontent.com/assets/4912/7209327/bc36b404-e515-11e4-9cf8-cb1adab9323e.png)
