### PR TITLE
[PoC] Stop shadowing parameters named `action`

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -205,9 +205,10 @@ module ActionController
     end
 
     def assign_parameters(routes, controller_path, action, parameters = {})
-      parameters = parameters.symbolize_keys.merge(:controller => controller_path, :action => action)
-      extra_keys = routes.extra_keys(parameters)
+      parameters = parameters.symbolize_keys
+      extra_keys = routes.extra_keys(parameters.merge(:controller => controller_path, :action => action))
       non_path_parameters = get? ? query_parameters : request_parameters
+
       parameters.each do |key, value|
         if value.is_a?(Array) && (value.frozen? || value.any?(&:frozen?))
           value = value.map{ |v| v.duplicable? ? v.dup : v }
@@ -217,7 +218,7 @@ module ActionController
           value = value.dup
         end
 
-        if extra_keys.include?(key)
+        if extra_keys.include?(key) || key == :action || key == :controller
           non_path_parameters[key] = value
         else
           if value.is_a?(Array)
@@ -230,19 +231,16 @@ module ActionController
         end
       end
 
+      path_parameters[:controller] = controller_path
+      path_parameters[:action] = action
+
       # Clear the combined params hash in case it was already referenced.
       @env.delete("action_dispatch.request.parameters")
 
       # Clear the filter cache variables so they're not stale
       @filtered_parameters = @filtered_env = @filtered_path = nil
 
-      params = self.request_parameters.dup
-      %w(controller action only_path).each do |k|
-        params.delete(k)
-        params.delete(k.to_sym)
-      end
-      data = params.to_query
-
+      data = request_parameters.to_query
       @env['CONTENT_LENGTH'] = data.length.to_s
       @env['rack.input'] = StringIO.new(data)
     end
@@ -669,12 +667,10 @@ module ActionController
         @controller.request  = @request
         @controller.response = @response
 
-        build_request_uri(action, parameters)
-
-        name = @request.parameters[:action]
+        build_request_uri(controller_class_name, action, parameters)
 
         @controller.recycle!
-        @controller.process(name)
+        @controller.process(action)
 
         if cookies = @request.env['action_dispatch.cookies']
           unless @response.committed?
@@ -790,10 +786,11 @@ module ActionController
         end
       end
 
-      def build_request_uri(action, parameters)
+      def build_request_uri(controller_class_name, action, parameters)
         unless @request.env["PATH_INFO"]
           options = @controller.respond_to?(:url_options) ? @controller.__send__(:url_options).merge(parameters) : parameters
           options.update(
+            :controller => controller_class_name,
             :action => action,
             :relative_url_root => nil,
             :_recall => @request.path_parameters)

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -48,6 +48,14 @@ class TestCaseTest < ActionController::TestCase
       render text: params.inspect
     end
 
+    def test_query_parameters
+      render text: request.query_parameters.inspect
+    end
+
+    def test_request_parameters
+      render text: request.request_parameters.inspect
+    end
+
     def test_uri
       render text: request.fullpath
     end
@@ -545,6 +553,18 @@ XML
       },
       parsed_params
     )
+  end
+
+  def test_query_param_named_action
+    get :test_query_parameters, params: {action: 'foobar'}
+    parsed_params = eval(@response.body)
+    assert_equal({action: 'foobar'}, parsed_params)
+  end
+
+  def test_request_param_named_action
+    post :test_request_parameters, params: {action: 'foobar'}
+    parsed_params = eval(@response.body)
+    assert_equal({'action' => 'foobar'}, parsed_params)
   end
 
   def test_kwarg_params_passing_with_session_and_flash


### PR DESCRIPTION
NB: This is just a very rough PR to open the discussion.
### What the problem is?

If you have an endpoint that expect a parameter named `action`, you have no way to test it. The test helpers simply don't allow you to pass such parameter.
### Why don't you rename it to something else?

Unfortunately I can't. It come from GitHub webhooks: https://developer.github.com/v3/activity/events/types/#membershipevent . And a little googling indicate that there is other use cases for this: http://stackoverflow.com/questions/6209848/how-to-not-use-rails-action-parameter-in-controller

And in general I can't find any argument for `params[:action]` and `params[:controller]` to exist while there is `action_name` and `controller_name` methods on `ActionController::Base`.

IMO those 2 params are leaky abstractions from the router, they should not be in accessed via `params`, and even less so override legitimate params.

Not sure who to ping @rafaelfranca maybe?

Would such change be accepted for Rails 5? If so I can submit a proper PR.
