### PR TITLE
Add common secret names to filter parameters defaults.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add common secret names to filter parameters defaults.
+
+    *Xavier Shay*
+
 *   Rename `railties/bin` to `railties/exe` to match the new Bundler executables convention.
 
     *Islam Wazery*

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -23,7 +23,7 @@ module Rails
         self.encoding = "utf-8"
         @allow_concurrency             = nil
         @consider_all_requests_local   = false
-        @filter_parameters             = []
+        @filter_parameters             = [:session, :secret, :salt, :cookie, :csrf]
         @filter_redirect               = []
         @helpers_paths                 = []
         @serve_static_files            = true

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -241,7 +241,11 @@ module ApplicationTests
 
       require "#{app_path}/config/environment"
 
-      assert_equal [:password, :foo, 'bar'], Rails.application.env_config['action_dispatch.parameter_filter']
+      filters = Rails.application.env_config['action_dispatch.parameter_filter']
+
+      assert_includes filters, :password
+      assert_includes filters, :foo
+      assert_includes filters, 'bar'
     end
 
     test "config.to_prepare is forwarded to ActionDispatch" do


### PR DESCRIPTION
This configuration is often used by extensions for filtering of Rails
session and environment data, for example:
- https://github.com/smartinez87/exception_notification/issues/182
- https://github.com/bugsnag/bugsnag-ruby/commit/7d40acbcc50a90a951d1e1662d57030fd172a64e

As a result, they tend to be insecure until they are explicitly patched.
In the event of exception notification, this has not happened even after
the insecure defaults being present for many years.

The risk of these names being used for non-secret values is very low,
compared to the high and demonstrated risk of secrets leaking via a
common extension pattern.
