### PR TITLE
Add a "generic" bug report template

### DIFF
--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -1,0 +1,15 @@
+# Activate the gems you are reporting the issue against.
+gem 'activesupport', '4.2.0'
+require 'active_support'
+require 'active_support/core_ext/object/blank'
+require 'minitest/autorun'
+
+# Ensure backward compatibility with Minitest 4
+Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
+
+class BugTest < Minitest::Test
+  def test_stuff
+    assert "zomg".present?
+    refute "".present?
+  end
+end

--- a/guides/bug_report_templates/generic_master.rb
+++ b/guides/bug_report_templates/generic_master.rb
@@ -1,0 +1,26 @@
+unless File.exist?('Gemfile')
+  File.write('Gemfile', <<-GEMFILE)
+    source 'https://rubygems.org'
+    gem 'rails', github: 'rails/rails'
+    gem 'arel', github: 'rails/arel'
+  GEMFILE
+
+  system 'bundle'
+end
+
+require 'bundler'
+Bundler.setup(:default)
+
+require 'active_support'
+require 'active_support/core_ext/object/blank'
+require 'minitest/autorun'
+
+# Ensure backward compatibility with Minitest 4
+Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
+
+class BugTest < Minitest::Test
+  def test_stuff
+    assert "zomg".present?
+    refute "".present?
+  end
+end


### PR DESCRIPTION
This template gives contributors a starting point to use when reporting bugs that does not involve Active Record or Action Pack.

If the naming and template content is good enough, I can backport this to all the supported branches.

cc @rafaelfranca @eileencodes @fxn @matthewd 
