### PR TITLE
MRI compatible code for ActiveSupport::Testing::Isolation::Subprocess

### DIFF
--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -69,17 +69,17 @@ module ActiveSupport
           else
             Tempfile.open("isolation") do |tmpfile|
               env = {
-                ISOLATION_TEST: self.class.name,
-                ISOLATION_OUTPUT: tmpfile.path
+                'ISOLATION_TEST' => self.class.name,
+                'ISOLATION_OUTPUT' => tmpfile.path
               }
 
               load_paths = $-I.map {|p| "-I\"#{File.expand_path(p)}\"" }.join(" ")
               orig_args = ORIG_ARGV.join(" ")
               test_opts = "-n#{self.class.name}##{self.name}"
-              command = "#{Gem.ruby} #{load_paths} #{$0} #{orig_args} #{test_opts}"
+              command = "#{Gem.ruby} #{load_paths} #{$0} '#{orig_args}' #{test_opts}"
 
               # IO.popen lets us pass env in a cross-platform way
-              child = IO.popen([env, command])
+              child = IO.popen(env, command)
 
               begin
                 Process.wait(child.pid)


### PR DESCRIPTION
As discussed in https://github.com/rails/rails/issues/19777 this PR will make code in ActiveSupport::Testing::Isolation::Subprocess working on MRI Ruby 2.2.2.

/cc @rafaelfranca 
