### PR TITLE
MemCache Store increment decrement bug for not initalized key

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -86,7 +86,7 @@ module ActiveSupport
       def increment(name, amount = 1, options = nil) # :nodoc:
         options = merged_options(options)
         instrument(:increment, name, :amount => amount) do
-          @data.incr(escape_key(namespaced_key(name, options)), amount)
+          @data.incr(escape_key(namespaced_key(name, options)), amount, nil, 0)
         end
       rescue Dalli::DalliError => e
         logger.error("DalliError (#{e}): #{e.message}") if logger
@@ -100,7 +100,7 @@ module ActiveSupport
       def decrement(name, amount = 1, options = nil) # :nodoc:
         options = merged_options(options)
         instrument(:decrement, name, :amount => amount) do
-          @data.decr(escape_key(namespaced_key(name, options)), amount)
+          @data.decr(escape_key(namespaced_key(name, options)), amount, nil, 0)
         end
       rescue Dalli::DalliError => e
         logger.error("DalliError (#{e}): #{e.message}") if logger


### PR DESCRIPTION
In dalli client it says
If default is nil, the counter must already exist or the operation
will fail and will return nil.  Otherwise this method will return
the new value for the counter.
Fix for issue #19803 
