### PR TITLE
Make config.active_job.default_queue_name configurable

### DIFF
--- a/activejob/lib/active_job/queue_name.rb
+++ b/activejob/lib/active_job/queue_name.rb
@@ -24,18 +24,22 @@ module ActiveJob
         end
       end
 
+      def queue_name
+        class_variable_get(:@@queue_name) || queue_name_from_part(nil)
+      end
+
       def queue_name_from_part(part_name) #:nodoc:
         queue_name = part_name || default_queue_name
         name_parts = [queue_name_prefix.presence, queue_name]
         name_parts.compact.join(queue_name_delimiter)
       end
+
     end
 
     included do
-      class_attribute :queue_name, instance_accessor: false
+      cattr_writer :queue_name, instance_writer: false
       class_attribute :queue_name_delimiter, instance_accessor: false
 
-      self.queue_name = default_queue_name
       self.queue_name_delimiter = '_' # set default delimiter to '_'
     end
 

--- a/activejob/test/cases/queue_naming_test.rb
+++ b/activejob/test/cases/queue_naming_test.rb
@@ -4,6 +4,11 @@ require 'jobs/logging_job'
 require 'jobs/nested_job'
 
 class QueueNamingTest < ActiveSupport::TestCase
+
+  setup do
+    HelloJob.queue_name = nil
+  end
+
   test 'name derived from base' do
     assert_equal "default", HelloJob.queue_name
   end
@@ -92,6 +97,30 @@ class QueueNamingTest < ActiveSupport::TestCase
       ActiveJob::Base.queue_name_prefix = original_queue_name_prefix
       ActiveJob::Base.queue_name_delimiter = original_queue_name_delimiter
       HelloJob.queue_name = original_queue_name
+    end
+  end
+
+  test 'queue_name_prefix prepended to default_queue_name' do
+    original_queue_name_prefix = ActiveJob::Base.queue_name_prefix
+
+    begin
+      ActiveJob::Base.queue_name_prefix = "aj"
+      assert_equal "aj_default", HelloJob.queue_name
+      assert_equal "aj_default", HelloJob.new.queue_name
+    ensure
+      ActiveJob::Base.queue_name_prefix = original_queue_name_prefix
+    end
+  end
+
+  test 'default_queue_name is configurable' do
+    original_default_queue_name = ActiveJob::Base.default_queue_name
+
+    begin
+      ActiveJob::Base.default_queue_name = "odd_jobs"
+      assert_equal "odd_jobs", HelloJob.queue_name
+      assert_equal "odd_jobs", HelloJob.new.queue_name
+    ensure
+      ActiveJob::Base.default_queue_name = original_default_queue_name
     end
   end
 


### PR DESCRIPTION
Setting the `default_queue_name` in `application.rb` or an initializer seems not to be working in Rails 4.2.0, 4.2.1, and current edge.

The problem seems to stem from the `queue_name` class attribute being initialized to `default_queue_name` (value: `"default"`) once at startup, before a custom config in `application.rb` or initializer can be used.

This change delays evaluating and using the `default_queue_name`.

I'm not sure if this proposed change is the right way to go about fixing it.

(Note to self: If this is accepted, remember to ask about submitting a patch for 4-2-stable if needed.)
