### PR TITLE
Add newlines between divs in form scaffolding

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
@@ -17,6 +17,7 @@
     <%%= f.label :password %><br>
     <%%= f.password_field :password %>
   </div>
+
   <div class="field">
     <%%= f.label :password_confirmation %><br>
     <%%= f.password_field :password_confirmation %>
@@ -25,6 +26,7 @@
     <%%= f.<%= attribute.field_type %> :<%= attribute.column_name %> %>
 <% end -%>
   </div>
+
 <% end -%>
   <div class="actions">
     <%%= f.submit %>


### PR DESCRIPTION
Right now, the fields in scaffolding's `_form.html.erb` are generated to look like this:

```
<div class="field">
  <%= f.label :name %><br /> 
  <%= f.text_field :name %>
</div>  
<div class="field">
  <%= f.label :comment %><br /> 
  <%= f.text_field :comment %>
</div>  
<div class="field">
  <%= f.label :author %><br /> 
  <%= f.text_field :author %>
</div>   
```

whereas, with this patch, they would look like

```
<div class="field">
  <%= f.label :name %><br /> 
  <%= f.text_field :name %>
</div>  

<div class="field">
  <%= f.label :comment %><br /> 
  <%= f.text_field :comment %>
</div>  

<div class="field">
  <%= f.label :author %><br /> 
  <%= f.text_field :author %>
</div>   
```

This is consistent with how we generate the scaffolding for [show.html.erb](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/erb/scaffold/templates/show.html.erb), i.e. with a trailing new line.
