### PR TITLE
Allow Relation#compact using delegation

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -39,7 +39,7 @@ module ActiveRecord
     BLACKLISTED_ARRAY_METHODS = [
       :compact!, :flatten!, :reject!, :reverse!, :rotate!, :map!,
       :shuffle!, :slice!, :sort!, :sort_by!, :delete_if,
-      :keep_if, :pop, :shift, :delete_at, :compact, :select!
+      :keep_if, :pop, :shift, :delete_at, :select!
     ].to_set # :nodoc:
 
     delegate :to_xml, :to_yaml, :length, :collect, :map, :each, :all?, :include?, :to_ary, :join, to: :to_a


### PR DESCRIPTION
Based on the original PR (https://github.com/rails/rails/pull/13314), this blacklist should only include methods that mutate an array. Because `compact` is the only method in the list that returns a copy, it appears to have been added by mistake.

It seems reasonable to allow it for consistency with the rule: `Relation` no longer has mutator methods.
