### PR TITLE
option_for_select with proc

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -351,18 +351,19 @@ module ActionView
         return container if String === container
 
         selected, disabled = extract_selected_and_disabled(selected).map do |r|
+          next r if r.is_a?(Proc)
           Array(r).map(&:to_s)
         end
 
         container.map do |element|
           html_attributes = option_html_attributes(element)
-          text, value = option_text_and_value(element).map(&:to_s)
+          text, value = option_text_and_value(element)
 
           html_attributes[:selected] ||= option_value_selected?(value, selected)
           html_attributes[:disabled] ||= disabled && option_value_selected?(value, disabled)
-          html_attributes[:value] = value
+          html_attributes[:value] = value.to_s
 
-          content_tag_string(:option, text, html_attributes)
+          content_tag_string(:option, text.to_s, html_attributes)
         end.join("\n").html_safe
       end
 
@@ -731,7 +732,11 @@ module ActionView
         end
 
         def option_value_selected?(value, selected)
-          Array(selected).include? value
+          if selected.is_a?(Proc)
+            selected.call(value)
+          else
+            Array(selected).include? value.to_s
+          end
         end
 
         def extract_selected_and_disabled(selected)

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -153,6 +153,13 @@ class FormOptionsHelperTest < ActionView::TestCase
       )
   end
 
+  def test_array_options_for_select_with_selection_proc
+      assert_dom_equal(
+        "<option value=\"Denmark\">Denmark</option>\n<option value=\"&lt;USA&gt;\" selected=\"selected\">&lt;USA&gt;</option>\n<option value=\"Sweden\" selected=\"selected\">Sweden</option>",
+        options_for_select([ "Denmark", "<USA>", "Sweden" ], ->(value) { [ "<USA>", "Sweden" ].include? value })
+      )
+  end
+
   def test_array_options_for_select_with_disabled_value
     assert_dom_equal(
       "<option value=\"Denmark\">Denmark</option>\n<option value=\"&lt;USA&gt;\" disabled=\"disabled\">&lt;USA&gt;</option>\n<option value=\"Sweden\">Sweden</option>",
@@ -164,6 +171,13 @@ class FormOptionsHelperTest < ActionView::TestCase
     assert_dom_equal(
       "<option value=\"Denmark\">Denmark</option>\n<option value=\"&lt;USA&gt;\" disabled=\"disabled\">&lt;USA&gt;</option>\n<option value=\"Sweden\" disabled=\"disabled\">Sweden</option>",
       options_for_select([ "Denmark", "<USA>", "Sweden" ], :disabled => ["<USA>", "Sweden"])
+    )
+  end
+
+  def test_array_options_for_select_with_disabled_proc
+    assert_dom_equal(
+      "<option value=\"Denmark\">Denmark</option>\n<option value=\"&lt;USA&gt;\" disabled=\"disabled\">&lt;USA&gt;</option>\n<option value=\"Sweden\" disabled=\"disabled\">Sweden</option>",
+      options_for_select([ "Denmark", "<USA>", "Sweden" ], :disabled => ->(value) { ["<USA>", "Sweden"].include? value })
     )
   end
 


### PR DESCRIPTION
This patch allow to use proc  to 'select_for_option'.
 I would like to use proc when select 'selected' or 'disabled'.

now:

```
stores = [store1, store2, store3]
selected_stores = options.detect {|store| store.has_item?(item) }

options_for_select stores, selected_stores.to_s
```

after:

```
stores = [store1, store2, store3]

options_for_select stores, ->(store) { store.has_item?(item) }
```

And, this path support 'selected' and 'disable' option.

```
stores = [store1, store2, store3]

options_for_select stores, disabled: ->(store) { !store.has_item?(item) }
```
