### PR TITLE
Update dbconsole to enable Redshift

### DIFF
--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -43,7 +43,7 @@ module Rails
 
         find_cmd_and_exec(['mysql', 'mysql5'], *args)
 
-      when /^postgres|^postgis/
+      when /^postgres|^postgis|^redshift/
         ENV['PGUSER']     = config["username"] if config["username"]
         ENV['PGHOST']     = config["host"] if config["host"]
         ENV['PGPORT']     = config["port"].to_s if config["port"]


### PR DESCRIPTION
Redshift is based on an old version of postgres, so can be accessed in the same way.

I realize that redshift is not officially supported elsewhere, but this is a very simple and easy fix to at least give it some support, especially given that the dbconsole is difficult to patch with a database adapter.
