### PR TITLE
[ci skip] Update `current version of Ruby`

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -97,7 +97,7 @@ For more installation methods for most Operating Systems take a look at
 
 ```bash
 $ ruby -v
-ruby 2.0.0p353
+ruby 2.2.2p95
 ```
 
 Many popular UNIX-like OSes ship with an acceptable version of SQLite3.


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2015/04/13/ruby-2-2-2-released/
