### PR TITLE
Let WITH (CTE) queries be explainable

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Let CTE queries (`WITH ...`) be explainable.
+
+    *Vladimir Kochnev*
+
 *   Deprecate `Relation#uniq` use `Relation#distinct` instead.
 
     See #9683.

--- a/activerecord/lib/active_record/explain_subscriber.rb
+++ b/activerecord/lib/active_record/explain_subscriber.rb
@@ -19,7 +19,7 @@ module ActiveRecord
     # On the other hand, we want to monitor the performance of our real database
     # queries, not the performance of the access to the query cache.
     IGNORED_PAYLOADS = %w(SCHEMA EXPLAIN CACHE)
-    EXPLAINED_SQLS = /\A\s*(select|update|delete|insert)\b/i
+    EXPLAINED_SQLS = /\A\s*(with|select|update|delete|insert)\b/i
     def ignore_payload?(payload)
       payload[:exception] || IGNORED_PAYLOADS.include?(payload[:name]) || payload[:sql] !~ EXPLAINED_SQLS
     end

--- a/activerecord/test/cases/explain_subscriber_test.rb
+++ b/activerecord/test/cases/explain_subscriber_test.rb
@@ -48,6 +48,11 @@ if ActiveRecord::Base.connection.supports_explain?
       assert queries.empty?
     end
 
+    def test_collects_cte_queries
+      SUBSCRIBER.finish(nil, nil, name: 'SQL', sql: 'with s as (values(3)) select 1 from s')
+      assert_equal 1, queries.size
+    end
+
     teardown do
       ActiveRecord::ExplainRegistry.reset
     end


### PR DESCRIPTION
When I build CTE queries using arel and adding them using `scope.arel.with(other_arel)` then `scope.explain` returns empty string. This is because `WITH` queries are not whitelisted to use with `explain` but I think they should.

Should I also add a test for this?
