### PR TITLE
Activemode::Dirty attributes query methods consistency before and after saving.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `ActiveModel::Dirty#[attr_name]_previously_changed?` and
+    `ActiveModel::Dirty#[attr_name]_previous_change` to improve access
+    to recorded changes after the model has been saved.
+
+    It makes the dirty-attributes query methods consistent before and after
+    saving.
+
+    *Fernando Tapia Rico*
+
 *   Deprecate the `:tokenizer` option for `validates_length_of`, in favor of
     plain Ruby.
 

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -137,6 +137,19 @@ class DirtyTest < ActiveModel::TestCase
     assert_equal [nil, "Jericho Cane"], @model.previous_changes['name']
   end
 
+  test "setting new attributes should not affect previous changes" do
+    @model.name = "Jericho Cane"
+    @model.save
+    @model.name = "DudeFella ManGuy"
+    assert_equal [nil, "Jericho Cane"], @model.name_previous_change
+  end
+
+  test "saving should preserve model's previous changed status" do
+    @model.name = "Jericho Cane"
+    @model.save
+    assert @model.name_previously_changed?
+  end
+
   test "previous value is preserved when changed after save" do
     assert_equal({}, @model.changed_attributes)
     @model.name = "Paul"


### PR DESCRIPTION
Provides `ActiveModel::Dirty#[attr_name]_previously_changed?` and `ActiveModel::Dirty#[attr_name]_previous_change` to improve access to recorded changes after the model has been saved.

It makes the dirty-attributes query methods consistent before and after saving. It comes handy when attribute changes are inspected in controllers, services objects and so on.
