### PR TITLE
Use the post-type-cast version of the attribute to validate numericality

### DIFF
--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -71,11 +71,25 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!([11])
   end
 
+  def test_validates_numericality_with_greater_than_using_differing_numeric_types
+    Topic.validates_numericality_of :approved, greater_than: BigDecimal.new('97.18')
+
+    invalid!([-97.18, BigDecimal.new('97.18'), BigDecimal('-97.18')], 'must be greater than 97.18')
+    valid!([97.18, 98, BigDecimal.new('98')]) # Notice the 97.18 as a float is greater than 97.18 as a BigDecimal due to floating point precision
+  end
+
   def test_validates_numericality_with_greater_than_or_equal
     Topic.validates_numericality_of :approved, greater_than_or_equal_to: 10
 
     invalid!([-9, 9], 'must be greater than or equal to 10')
     valid!([10])
+  end
+
+  def test_validates_numericality_with_greater_than_or_equal_using_differing_numeric_types
+    Topic.validates_numericality_of :approved, greater_than_or_equal_to: BigDecimal.new('97.18') 
+
+    invalid!([-97.18, 97.17, 97, BigDecimal.new('97.17'), BigDecimal.new('-97.18')], 'must be greater than or equal to 97.18')
+    valid!([97.18, 98, BigDecimal.new('97.19')])
   end
 
   def test_validates_numericality_with_equal_to
@@ -85,6 +99,13 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!([10])
   end
 
+  def test_validates_numericality_with_equal_to_using_differing_numeric_types
+    Topic.validates_numericality_of :approved, equal_to: BigDecimal.new('97.18')
+
+    invalid!([-97.18, 97.18], 'must be equal to 97.18')
+    valid!([BigDecimal.new('97.18')])
+  end
+
   def test_validates_numericality_with_less_than
     Topic.validates_numericality_of :approved, less_than: 10
 
@@ -92,11 +113,25 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!([-9, 9])
   end
 
+  def test_validates_numericality_with_less_than_using_differing_numeric_types
+    Topic.validates_numericality_of :approved, less_than: BigDecimal.new('97.18')
+
+    invalid!([97.18, BigDecimal.new('97.18')], 'must be less than 97.18')
+    valid!([-97.0, 97.0, -97, 97, BigDecimal.new('-97'), BigDecimal.new('97')])
+  end
+
   def test_validates_numericality_with_less_than_or_equal_to
     Topic.validates_numericality_of :approved, less_than_or_equal_to: 10
 
     invalid!([11], 'must be less than or equal to 10')
     valid!([-10, 10])
+  end
+
+  def test_validates_numericality_with_less_than_or_equal_to_using_differing_numeric_types
+    Topic.validates_numericality_of :approved, less_than_or_equal_to: BigDecimal.new('97.18')
+
+    invalid!([97.18, 98], 'must be less than or equal to 97.18')
+    valid!([-97.18, BigDecimal.new('-97.18'), BigDecimal.new('97.18')])
   end
 
   def test_validates_numericality_with_odd
@@ -196,7 +231,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
 
   def valid!(values)
     with_each_topic_approved_value(values) do |topic, value|
-      assert topic.valid?, "#{value.inspect} not accepted as a number"
+      assert topic.valid?, "#{value.inspect} not accepted as a number with validation error: #{topic.errors[:approved].first}"
     end
   end
 


### PR DESCRIPTION
This should fix the issue #12134 as started by @trev in #18617 and with the changed indicated by @sgrif.

When validating numeric attributes, the actual value was not being used since the validator was parsing it internally to `float`.
