### PR TITLE
Address silent failure issue when no counters provided.

### DIFF
--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -19,7 +19,7 @@ module ActiveRecord
       #   Post.reset_counters(1, :comments)
       def reset_counters(id, *counters)
         object = find(id)
-        raise ArgumentError, "Must specify at least one association" unless counters.any?
+        raise ArgumentError, "Must specify at least one association" unless counters && counters.any?
         counters.each do |counter_association|
           has_many_association = _reflect_on_association(counter_association)
           unless has_many_association

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -19,7 +19,7 @@ module ActiveRecord
       #   Post.reset_counters(1, :comments)
       def reset_counters(id, *counters)
         object = find(id)
-        raise ArgumentError, "Must specify at least one association" unless counters && counters.any?
+        raise ArgumentError, "Must specify at least one association" if counters.empty?
         counters.each do |counter_association|
           has_many_association = _reflect_on_association(counter_association)
           unless has_many_association

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -19,6 +19,7 @@ module ActiveRecord
       #   Post.reset_counters(1, :comments)
       def reset_counters(id, *counters)
         object = find(id)
+        raise ArgumentError, "Must specify at least one association" unless counters.any?
         counters.each do |counter_association|
           has_many_association = _reflect_on_association(counter_association)
           unless has_many_association


### PR DESCRIPTION
reset_counters(id, *counters) silently fails (returns true) if no counters are passed:

reset_counters(some_id, [])
reset_counters(some_id)

Both appear to succeed, even though they will do nothing.  No spec coverage added, can do so if needed.
