### PR TITLE
Silence warning from requiring mathn

### DIFF
--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -130,7 +130,7 @@ class DateHelperTest < ActionView::TestCase
 
   def test_distance_in_words_with_mathn_required
     # test we avoid Integer#/ (redefined by mathn)
-    require 'mathn'
+    silence_warnings { require "mathn" }
     from = Time.utc(2004, 6, 6, 21, 45, 0)
     assert_distance_of_time_in_words(from)
   end


### PR DESCRIPTION
Running Action View test case currently printing out this warning:

```
lib/mathn.rb is deprecated
```

(For example: https://travis-ci.org/rails/rails/jobs/59573388#L401)

This should silence the warning since we really want to require this
file in this test.
