### PR TITLE
Clearify that alias_method_chain is deprecated

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/aliasing.rb
+++ b/activesupport/lib/active_support/core_ext/module/aliasing.rb
@@ -1,4 +1,7 @@
 class Module
+  # NOTE: This method is deprecated. Please use <tt>Module#prepend</tt> that
+  # comes with Ruby 2.0 or newer instead.
+  #
   # Encapsulates the common pattern of:
   #
   #   alias_method :foo_without_feature, :foo


### PR DESCRIPTION
This was not clear on the API documentation that the method was deprecated in a982a42d766169c2170d7f100c2a5ceb5430efb1.
