### PR TITLE
Fix formatting of scaffold css

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold/templates/scaffold.css
+++ b/railties/lib/rails/generators/rails/scaffold/templates/scaffold.css
@@ -1,8 +1,11 @@
-body { background-color: #fff; color: #333; }
+body {
+  background-color: #fff;
+  color: #333;
+}
 
 body, p, ol, ul, td {
   font-family: verdana, arial, helvetica, sans-serif;
-  font-size:   13px;
+  font-size: 13px;
   line-height: 18px;
   margin: 33px;
 }
@@ -13,9 +16,18 @@ pre {
   font-size: 11px;
 }
 
-a { color: #000; }
-a:visited { color: #666; }
-a:hover { color: #fff; background-color:#000; }
+a {
+  color: #000;
+}
+
+a:visited {
+  color: #666;
+}
+
+a:hover {
+  color: #fff;
+  background-color: #000;
+}
 
 th {
   padding-bottom: 5px;
@@ -27,7 +39,8 @@ td {
   padding-right: 5px;
 }
 
-div.field, div.actions {
+div.field,
+div.actions {
   margin-bottom: 10px;
 }
 
@@ -56,7 +69,7 @@ div.field, div.actions {
   padding: 5px 5px 5px 15px;
   font-size: 12px;
   margin: -7px;
-  margin-bottom: 0px;
+  margin-bottom: 0;
   background-color: #c00;
   color: #fff;
 }


### PR DESCRIPTION
This commit standardizes the formatting of `scaffold.css`.

This commit:
- makes a number of whitespace changes
- changes the `div.field` and `div.actions` to just `.field` and `.actions`
- changes margin from `0px` to just `0`, since that's sufficient and the best practice.
