### PR TITLE
Add code example for include option of AM::Serialization#serializable_hash

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -72,10 +72,20 @@ module ActiveModel
   module Serialization
     # Returns a serialized hash of your object.
     #
+    #   class Address
+    #     include ActiveModel::Serialization
+    #
+    #     attr_accessor :city, :street
+    #
+    #     def attributes
+    #       {'city' => nil, 'street' => nil}
+    #     end
+    #   end
+    #
     #   class Person
     #     include ActiveModel::Serialization
     #
-    #     attr_accessor :name, :age
+    #     attr_accessor :name, :age, :address
     #
     #     def attributes
     #       {'name' => nil, 'age' => nil}
@@ -89,6 +99,9 @@ module ActiveModel
     #   person = Person.new
     #   person.name = 'bob'
     #   person.age  = 22
+    #   person.address = Address.new
+    #   person.address.city = 'New York'
+    #   person.address.street = 'Main St'
     #   person.serializable_hash                # => {"name"=>"bob", "age"=>22}
     #   person.serializable_hash(only: :name)   # => {"name"=>"bob"}
     #   person.serializable_hash(except: :name) # => {"age"=>22}


### PR DESCRIPTION
ActiveModel::Serialization#serializable_hash code examples were not showcasing the `include`option at all so I extended the current example to include it.
