### PR TITLE
Remove redundant 'Rails' from Rails::AppRailsLoader constant

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -53,11 +53,11 @@ require "rails/cli"
 ```
 
 The file `railties/lib/rails/cli` in turn calls
-`Rails::AppRailsLoader.exec_app_rails`.
+`Rails::AppLoader.exec_app`.
 
-### `railties/lib/rails/app_rails_loader.rb`
+### `railties/lib/rails/app_loader.rb`
 
-The primary goal of the function `exec_app_rails` is to execute your app's
+The primary goal of the function `exec_app` is to execute your app's
 `bin/rails`. If the current directory does not have a `bin/rails`, it will
 navigate upwards until it finds a `bin/rails` executable. Thus one can invoke a
 `rails` command from anywhere inside a rails application.

--- a/railties/lib/rails/app_loader.rb
+++ b/railties/lib/rails/app_loader.rb
@@ -2,7 +2,7 @@ require 'pathname'
 require 'rails/version'
 
 module Rails
-  module AppRailsLoader
+  module AppLoader # :nodoc:
     extend self
 
     RUBY = Gem.ruby
@@ -29,7 +29,7 @@ generate it and add it to source control:
 
 EOS
 
-    def exec_app_rails
+    def exec_app
       original_cwd = Dir.pwd
 
       loop do

--- a/railties/lib/rails/cli.rb
+++ b/railties/lib/rails/cli.rb
@@ -2,7 +2,7 @@ require 'rails/app_rails_loader'
 
 # If we are inside a Rails application this method performs an exec and thus
 # the rest of this script is not run.
-Rails::AppRailsLoader.exec_app_rails
+Rails::AppLoader.exec_app
 
 require 'rails/ruby_version_check'
 Signal.trap("INT") { puts; exit(1) }

--- a/railties/test/app_loader_test.rb
+++ b/railties/test/app_loader_test.rb
@@ -2,10 +2,10 @@ require 'tmpdir'
 require 'abstract_unit'
 require 'rails/app_rails_loader'
 
-class AppRailsLoaderTest < ActiveSupport::TestCase
+class AppLoaderTest < ActiveSupport::TestCase
   def loader
     @loader ||= Class.new do
-      extend Rails::AppRailsLoader
+      extend Rails::AppLoader
 
       def self.exec_arguments
         @exec_arguments
@@ -23,7 +23,7 @@ class AppRailsLoaderTest < ActiveSupport::TestCase
   end
 
   def expects_exec(exe)
-    assert_equal [Rails::AppRailsLoader::RUBY, exe], loader.exec_arguments
+    assert_equal [Rails::AppLoader::RUBY, exe], loader.exec_arguments
   end
 
   setup do
@@ -38,20 +38,20 @@ class AppRailsLoaderTest < ActiveSupport::TestCase
     test "is not in a Rails application if #{exe} is not found in the current or parent directories" do
       def loader.find_executables; end
 
-      assert !loader.exec_app_rails
+      assert !loader.exec_app
     end
 
     test "is not in a Rails application if #{exe} exists but is a folder" do
       FileUtils.mkdir_p(exe)
 
-      assert !loader.exec_app_rails
+      assert !loader.exec_app
     end
 
     ['APP_PATH', 'ENGINE_PATH'].each do |keyword|
       test "is in a Rails application if #{exe} exists and contains #{keyword}" do
         write exe, keyword
 
-        loader.exec_app_rails
+        loader.exec_app
 
         expects_exec exe
       end
@@ -59,7 +59,7 @@ class AppRailsLoaderTest < ActiveSupport::TestCase
       test "is not in a Rails application if #{exe} exists but doesn't contain #{keyword}" do
         write exe
 
-        assert !loader.exec_app_rails
+        assert !loader.exec_app
       end
 
       test "is in a Rails application if parent directory has #{exe} containing #{keyword} and chdirs to the root directory" do
@@ -68,7 +68,7 @@ class AppRailsLoaderTest < ActiveSupport::TestCase
 
         Dir.chdir('foo/bar')
 
-        loader.exec_app_rails
+        loader.exec_app
 
         expects_exec exe
 


### PR DESCRIPTION
The `Rails::AppRailsLoader` class is only called as a fully qualified constant. There is no point to having the "Rails" appear twice in the name, since it's obvious from how its being called: it's loading a Rails application. It's also obvious based on its location: within Railties.
