### PR TITLE
primary_key opt for add_foreign_key should be a symbol too

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -705,7 +705,7 @@ module ActiveRecord
       #
       # ====== Creating a foreign key on a specific column
       #
-      #   add_foreign_key :articles, :users, column: :author_id, primary_key: "lng_id"
+      #   add_foreign_key :articles, :users, column: :author_id, primary_key: :lng_id
       #
       # generates:
       #


### PR DESCRIPTION
The `primary_key` option should be consistent with the other options and arguments in this documentation for `add_foreign_key`.
