### PR TITLE
keep using lookup context prefixes if path includes slash

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -179,7 +179,15 @@ module ActionView
         return name, prefixes || [""] if parts.empty?
 
         parts    = parts.join('/')
-        prefixes = prefixes ? prefixes.map { |p| "#{p}/#{parts}" } : [parts]
+
+        if prefixes
+          prefixes = prefixes.map do |p|
+            p.blank? ? parts : "#{p}/#{parts}"
+          end
+        else
+          prefixes = [parts]
+        end
+
 
         return name, prefixes
       end

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -418,7 +418,7 @@ module ActionView
     end
 
     def find_template(path, locals)
-      prefixes = path.include?(?/) ? [] : @lookup_context.prefixes
+      prefixes = path.include?(?/) ? [''] + @lookup_context.prefixes : @lookup_context.prefixes
       @lookup_context.find_template(path, prefixes, true, locals, @details)
     end
 


### PR DESCRIPTION
The idea comes from #19834 
