### PR TITLE
Improve error message when serializing unsaved records for jobs, Fixes #19861

### DIFF
--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -88,6 +88,13 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     assert_equal "Job with argument: 2", JobBuffer.last_value
   end
 
+  test 'raises a friendly SerializationError for records without ids' do
+    err = assert_raises ActiveJob::SerializationError do
+      ActiveJob::Arguments.serialize [Person.new(nil)]
+    end
+    assert_match 'Unable to serialize Person without an id.', err.message
+  end
+
   private
     def assert_arguments_unchanged(*args)
       assert_arguments_roundtrip args


### PR DESCRIPTION
Note that this PR depends on the next GlobalID release.
