### PR TITLE
Silence warning from MySQL::Error object in test

### DIFF
--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -21,7 +21,9 @@ class TestDisconnectedAdapter < ActiveRecord::TestCase
       @connection.execute "SELECT count(*) from products"
       @connection.disconnect!
       assert_raises(ActiveRecord::StatementInvalid) do
-        @connection.execute "SELECT count(*) from products"
+        silence_warnings do
+          @connection.execute "SELECT count(*) from products"
+        end
       end
     end
   end


### PR DESCRIPTION
When running Active Record MySQL test, this warning is printed in the console:

```
warning: instance variable errno not initialized
```

It turns out that this is a warning from `mysql` gem in MySQL::Error object. However, since the `mysql` gem is no longer maintained, and there won't be a newer version, it make sense for us to just silence
this warning to make the output cleaner.

(See example at https://travis-ci.org/rails/rails/jobs/59788681#L364)
