### PR TITLE
Modify redirect_to to halt further execution.

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -9,7 +9,7 @@ module AbstractController
 
     included do
       define_callbacks :process_action,
-                       terminator: ->(controller, result_lambda) { result_lambda.call if result_lambda.is_a?(Proc); controller.response_body },
+                       terminator: _callback_terminator,
                        skip_after_callbacks_if_terminated: true
     end
 
@@ -17,7 +17,9 @@ module AbstractController
     # process_action callbacks around the normal behavior.
     def process_action(*args)
       run_callbacks(:process_action) do
-        super
+        action_return = nil
+        catch(:halt_action) { action_return = super }
+        action_return
       end
     end
 
@@ -90,6 +92,18 @@ module AbstractController
         callbacks.push(block) if block
         callbacks.each do |callback|
           yield callback, options
+        end
+      end
+
+      # Return a proc that is used to determine if callbacks should continue
+      # executing. The condition for aborting execution is based on whether
+      # or not the controller response has a body.
+      def _callback_terminator
+        Proc.new do |controller, result_lambda|
+          catch(:halt_action) do
+            result_lambda.call if result_lambda.is_a?(Proc)
+          end
+          controller.response_body
         end
       end
 

--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -61,9 +61,15 @@ module ActionController
 
     def redirect_to(*args)
       ActiveSupport::Notifications.instrument("redirect_to.action_controller") do |payload|
-        result = super
+        caught = true
+        result = nil
+        catch(:halt_action) do
+          result = super
+          caught = false
+        end
         payload[:status]   = response.status
         payload[:location] = response.filtered_location
+        throw :halt_action if caught
         result
       end
     end

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -74,6 +74,7 @@ module ActionController
       self.status        = _extract_redirect_to_status(options, response_status)
       self.location      = _compute_redirect_to_location(request, options)
       self.response_body = "<html><body>You are being <a href=\"#{ERB::Util.unwrapped_html_escape(location)}\">redirected</a>.</body></html>"
+      throw :halt_action
     end
 
     def _compute_redirect_to_location(request, options) #:nodoc:

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -66,8 +66,8 @@ class FlashTest < ActionController::TestCase
 
     def halt_and_redir
       flash["foo"] = "bar"
-      redirect_to :action => "std_action"
       @flash_copy = {}.update(flash)
+      redirect_to :action => "std_action"
     end
 
     def redirect_with_alert

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -115,6 +115,16 @@ class RedirectController < ActionController::Base
     redirect_to "\000/lol\r\nwat"
   end
 
+  def execute_after_redirect
+    redirect_to action: "hello_world"
+    raise 'test_failure'
+  end
+
+  def execute_after_redirect_handle_in_controller
+    catch(:halt_action) { redirect_to action: "hello_world" }
+    raise 'expected_error'
+  end
+
   def rescue_errors(e) raise e end
 
   protected
@@ -313,6 +323,18 @@ class RedirectTest < ActionController::TestCase
 
       assert_response :redirect
       assert_redirected_to "http://test.host/redirect/hello_world"
+    end
+  end
+
+  def test_execute_after_redirect
+    get :execute_after_redirect
+    assert_response :redirect
+    assert_equal "http://test.host/redirect/hello_world", redirect_to_url
+  end
+
+  def test_execute_after_redirect_handle_in_controller
+    assert_raise RuntimeError do
+      get :execute_after_redirect_handle_in_controller
     end
   end
 end

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -414,7 +414,7 @@ class TestController < ApplicationController
   end
 
   def double_redirect
-    redirect_to :action => "double_render"
+    catch(:halt_action) { redirect_to :action => "double_render" }
     redirect_to :action => "double_render"
   end
 


### PR DESCRIPTION
This PR is a work in progress as there are still some tests that are not passing. I am submitting the PR in hope to receive some feedback about this change and what other additions would be necessary to get it in. I realize this is a breaking change, and perhaps this change could be introduced in a similar route as #17227 where the continuing of execution is only deprecated until a version increase. Alternatively, I spoke with @tenderlove at RailsConf earlier today who brought up the concern about potential failures with transactions as this exception should _not_ result in transaction failures. I'm not sure the best way to handle that concern. In our very brief conversation, @tenderlove also was more comfortable with the separate notion of introducing a `redirect_to!` method that results in the halting of action code. However, my prior (dated) [research](http://adamdoupe.com/publications/fear-the-ear-ccs2011.pdf) suggests that the majority of uses of `redirect_to` do not require execution after redirect. Hence I would prefer to not add an additional method.

Assuming this works as planned, I think similar changes could be made to `head` and `render` as they also seldom require execution after their respective calls.

---

The purpose of this addition is to prevent possible execution after redirect exceptions in rails. While the suggested method of handling control flow is to utilize a `before_filter` to prevent code in a controller from executing, there are cases were rails developers will legitimately use `redirect_to` in their controllers.

With that in mind, there is zero reason for any code, save for ensure blocks, to execute after a `redirect_to` is issued. Anywhere someone intentionally executes code following a redirect, it can be restructured to occur prior to the `redirect_to` exception. If modifying the redirect response body is desired feature, then `redirect_to` should be extended to take a custom response body as a parameter.

This is a reimplementation of my friend and colleague Adam Doupé's prior work:
adamdoupe@78c6550

---

Updated to use throw/catch rather than raise/rescue. Previous commit:
e4953d3
