### PR TITLE
Uncomment byebug in framework Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :test do
 
   platforms :mri do
     gem 'stackprof'
-    # gem 'byebug'
+    gem 'byebug'
   end
 
   gem 'benchmark-ips'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,8 @@ GEM
     builder (3.2.2)
     bunny (1.1.9)
       amq-protocol (>= 1.9.2)
+    byebug (4.0.5)
+      columnize (= 0.9.0)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     coffee-rails (4.1.0)
@@ -115,6 +117,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.0)
+    columnize (0.9.0)
     connection_pool (2.1.1)
     dalli (2.7.2)
     dante (0.1.5)
@@ -258,6 +261,7 @@ DEPENDENCIES
   backburner
   bcrypt (~> 3.1.10)
   benchmark-ips
+  byebug
   coffee-rails (~> 4.1.0)
   dalli (>= 2.2.1)
   delayed_job


### PR DESCRIPTION
History:
1. `debugger` was there until d2ed433b where it was commented out, and I
   couldn't figure out why
2. Since then we inherited that when switching to `byebug` in 93559da4

Reasons:
1. It's nice to have a debugger when working on framework bugs
2. It's an uncommented dependency in app Gemfiles since Rails 4.2 (see fbe38c9e)

@rafaelfranca do you know anything about this?
