### PR TITLE
Move ActionMailer options to an initializer

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -687,8 +687,8 @@ the same generic helpers as you do in Action Controller.
 Action Mailer Configuration
 ---------------------------
 
-The following configuration options are best made in one of the environment
-files (environment.rb, production.rb, etc...)
+The following configuration options are best made in the file
+`config/initializers/action_mailer.rb`.
 
 | Configuration | Description |
 |---------------|-------------|
@@ -707,36 +707,23 @@ our Configuring Rails Applications guide.
 
 ### Example Action Mailer Configuration
 
-An example would be adding the following to your appropriate
-`config/environments/$RAILS_ENV.rb` file:
-
-```ruby
-config.action_mailer.delivery_method = :sendmail
-# Defaults to:
-# config.action_mailer.sendmail_settings = {
-#   location: '/usr/sbin/sendmail',
-#   arguments: '-i -t'
-# }
-config.action_mailer.perform_deliveries = true
-config.action_mailer.raise_delivery_errors = true
-config.action_mailer.default_options = {from: 'no-reply@example.com'}
-```
+An example can be found in `config/initializers/action_mailer.rb`.
 
 ### Action Mailer Configuration for Gmail
 
-As Action Mailer now uses the [Mail gem](https://github.com/mikel/mail), this
-becomes as simple as adding to your `config/environments/$RAILS_ENV.rb` file:
+As Action Mailer uses the [Mail gem](https://github.com/mikel/mail), this
+becomes as simple as editing your `config/initializers/action_mailer.rb` file:
 
 ```ruby
-config.action_mailer.delivery_method = :smtp
-config.action_mailer.smtp_settings = {
+ActionMailer::Base.delivery_method = :smtp
+ActionMailer::Base.smtp_settings = {
   address:              'smtp.gmail.com',
   port:                 587,
-  domain:               'example.com',
   user_name:            '<username>',
   password:             '<password>',
-  authentication:       'plain',
-  enable_starttls_auto: true  }
+  authentication:       :plain,
+  enable_starttls_auto: true
+}
 ```
 
 Mailer Testing

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Move mailer configuration to an initializer.
+
+    *Lucas Caton*
+
 *   Remove sqlite support from `rails dbconsole`.
 
     *Andrew White*

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -263,6 +263,12 @@ module Rails
         end
       end
 
+      def delete_mailer_initializer_skipping_action_mailer
+        if options[:skip_action_mailer]
+          remove_file 'config/initializers/action_mailer.rb'
+        end
+      end
+
       def delete_active_record_initializers_skipping_active_record
         if options[:skip_active_record]
           remove_file 'config/initializers/active_record_belongs_to_required_by_default.rb'

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -14,8 +14,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
   <%- unless options.skip_action_mailer? -%>
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # `config.action_mailer` options have moved to config/initializers/action_mailer.rb
   <%- end -%>
 
   # Print deprecation notices to the Rails logger.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -61,9 +61,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "<%= app_name %>_#{Rails.env}"
   <%- unless options.skip_action_mailer? -%>
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  # `config.action_mailer` options have moved to config/initializers/action_mailer.
   <%- end -%>
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -27,10 +27,7 @@ Rails.application.configure do
   config.action_controller.allow_forgery_protection = false
   <%- unless options.skip_action_mailer? -%>
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
+  # `config.action_mailer` options have moved to config/initializers/action_mailer.
   <%- end -%>
 
   # Randomize the order test cases are executed.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/action_mailer.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/action_mailer.rb.tt
@@ -1,0 +1,36 @@
+# Be sure to restart your server when you modify this file.
+
+# Tell Action Mailer not to deliver emails to the real world.
+# The :test delivery method accumulates sent emails in the ActionMailer::Base.deliveries array.
+# Possible values are :smtp (default), :sendmail, :test, and :file.
+ActionMailer::Base.delivery_method = :test if Rails.env.test?
+
+ActionMailer::Base.smtp_settings = {
+  address:              'smtp.yourserver.com', # Default is 'localhost'
+  port:                 587,                   # Default is 25
+  domain:               'yourserver.com',      # Specify a HELO domain if needed
+  user_name:            'user_name',
+  password:             'password',
+  authentication:       :plain                 # :plain, :login or :cram_md5
+  # enable_starttls_auto: true                 # false if there is a server certificate problem
+}
+
+# Ignore bad email addresses and do not raise email delivery errors.
+# Set this to true and configure the email server for immediate delivery to raise delivery
+# errors or set false if you don't care if the mailer can't send. Default is true.
+# ActionMailer::Base.raise_delivery_errors = !Rails.env.development?
+
+# Generates information on the mailing run if available. Can be set to nil for no logging.
+# Compatible with both Ruby's own Logger and Log4r loggers.
+# ActionMailer::Base.logger = CustomLogger.logger
+
+# Allows you to override options for the :sendmail delivery method.
+# ActionMailer::Base.delivery_method = :sendmail
+# ActionMailer::Base.sendmail_settings = {
+#   location: '/usr/sbin/sendmail', # Sendmail executable
+#   arguments: '-i -t'              # Command line arguments
+# }
+
+# Determines whether emails are actually sent from Action Mailer when you `.deliver` on an email
+# message or on an Action Mailer method. Default is true.
+# ActionMailer::Base.perform_deliveries = true

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -333,15 +333,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_generator_without_skips
     run_generator
     assert_file "config/application.rb", /\s+require\s+["']rails\/all["']/
-    assert_file "config/environments/development.rb" do |content|
-      assert_match(/config\.action_mailer\.raise_delivery_errors = false/, content)
-    end
-    assert_file "config/environments/test.rb" do |content|
-      assert_match(/config\.action_mailer\.delivery_method = :test/, content)
-    end
-    assert_file "config/environments/production.rb" do |content|
-      assert_match(/# config\.action_mailer\.raise_delivery_errors = false/, content)
-    end
+    assert_file "config/initializers/action_mailer.rb"
   end
 
   def test_generator_if_skip_active_record_is_given
@@ -357,15 +349,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_generator_if_skip_action_mailer_is_given
     run_generator [destination_root, "--skip-action-mailer"]
     assert_file "config/application.rb", /#\s+require\s+["']action_mailer\/railtie["']/
-    assert_file "config/environments/development.rb" do |content|
-      assert_no_match(/config\.action_mailer/, content)
-    end
-    assert_file "config/environments/test.rb" do |content|
-      assert_no_match(/config\.action_mailer/, content)
-    end
-    assert_file "config/environments/production.rb" do |content|
-      assert_no_match(/config\.action_mailer/, content)
-    end
+    assert_no_file "config/initializers/action_mailer.rb"
   end
 
   def test_generator_if_skip_sprockets_is_given

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -147,15 +147,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   def test_app_generator_without_skips
     run_generator
     assert_file "test/dummy/config/application.rb", /\s+require\s+["']rails\/all["']/
-    assert_file "test/dummy/config/environments/development.rb" do |content|
-      assert_match(/config\.action_mailer\.raise_delivery_errors = false/, content)
-    end
-    assert_file "test/dummy/config/environments/test.rb" do |content|
-      assert_match(/config\.action_mailer\.delivery_method = :test/, content)
-    end
-    assert_file "test/dummy/config/environments/production.rb" do |content|
-      assert_match(/# config\.action_mailer\.raise_delivery_errors = false/, content)
-    end
+    assert_file "test/dummy/config/initializers/action_mailer.rb"
   end
 
   def test_active_record_is_removed_from_frameworks_if_skip_active_record_is_given
@@ -174,15 +166,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   def test_action_mailer_is_removed_from_frameworks_if_skip_action_mailer_is_given
     run_generator [destination_root, "--skip-action-mailer"]
     assert_file "test/dummy/config/application.rb", /#\s+require\s+["']action_mailer\/railtie["']/
-    assert_file "test/dummy/config/environments/development.rb" do |content|
-      assert_no_match(/config\.action_mailer/, content)
-    end
-    assert_file "test/dummy/config/environments/test.rb" do |content|
-      assert_no_match(/config\.action_mailer/, content)
-    end
-    assert_file "test/dummy/config/environments/production.rb" do |content|
-      assert_no_match(/config\.action_mailer/, content)
-    end
+    assert_no_file "test/dummy/config/initializers/action_mailer.rb"
   end
 
   def test_ensure_that_database_option_is_passed_to_app_generator


### PR DESCRIPTION
This Pull Request moves ActionMailer options to an initializer, which will contain most of the available options.

The goal here is to make the setup of a new app more straight forward.

This follows the way that assets options are now being initialized.
