### PR TITLE
Cause ActiveRecord::Base::reload to also ignore the QueryCache.

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -380,7 +380,7 @@ module ActiveRecord
     #   # => #<Account id: 1, email: 'account@example.com'>
     #
     # Attributes are reloaded from the database, and caches busted, in
-    # particular the associations cache.
+    # particular the associations cache and the QueryCache.
     #
     # If the record no longer exists in the database <tt>ActiveRecord::RecordNotFound</tt>
     # is raised. Otherwise, in addition to the in-place modification the method
@@ -416,6 +416,8 @@ module ActiveRecord
     #   end
     #
     def reload(options = nil)
+      self.class.connection.clear_query_cache
+
       fresh_object =
         if options && options[:lock]
           self.class.unscoped { self.class.lock(options[:lock]).find(id) }

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -897,6 +897,33 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_not post.new_record?
   end
 
+  def test_reload_via_querycache
+    ActiveRecord::Base.connection.enable_query_cache!
+    ActiveRecord::Base.connection.clear_query_cache
+    assert ActiveRecord::Base.connection.query_cache_enabled, 'cache should be on'
+    parrot = Parrot.create(:name => 'Shane')
+
+    # populate the cache with the SELECT result
+    found_parrot = Parrot.find(parrot.id)
+    assert_equal parrot.id, found_parrot.id
+
+    # Manually update the 'name' attribute in the DB directly
+    assert_equal 1, ActiveRecord::Base.connection.query_cache.length
+    ActiveRecord::Base.uncached do
+      found_parrot.name = 'Mary'
+      found_parrot.save
+    end
+
+    # Now reload, and verify that it gets the DB version, and not the querycache version
+    found_parrot.reload
+    assert_equal 'Mary', found_parrot.name
+
+    found_parrot = Parrot.find(parrot.id)
+    assert_equal 'Mary', found_parrot.name
+  ensure
+    ActiveRecord::Base.connection.disable_query_cache!
+  end
+
   class SaveTest < ActiveRecord::TestCase
     self.use_transactional_tests = false
 


### PR DESCRIPTION
This pull request gives a suggested implementation for causing the ActiveRecord::Base::reload method to not only ignore association and aggregation caches, but also to ignore the query cache.

The main use case here is that an external process updates a row in the DB, and the developer is expecting 'reload' to also pull those new changes in.

```
user = User.find(1) # -> { id: 1, name: 'shane' }
# ... other thread/process updates User's name to 'mary'
user.reload # { id: 1, name: 'shane' }
```

I recreated this PR from #17140 as I had screwed up the squashing/rebasing.
