### PR TITLE
Ignore bad input in group by

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -286,7 +286,7 @@ module ActiveRecord
     def group!(*args) # :nodoc:
       args.flatten!
 
-      self.group_values += args
+      self.group_values += args.select(&:present?)
       self
     end
 


### PR DESCRIPTION
Currently if you use only one group clause with nil parameter it ignores that bad input.
The error here is using multiple group clauses with at least one bad input.
If the behaviour of group method with nil parameter is ignoring that input so it should ignore that bad input with multiple group clauses too.
Related issue is #19873 
