### PR TITLE
FileStore: Long cache keys may result in too long paths due to encoding

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -119,11 +119,12 @@ module ActiveSupport
 
         # Translate a key into a file path.
         def key_file_path(key)
-          if key.size > FILEPATH_MAX_SIZE
-            key = Digest::MD5.hexdigest(key)
+          fname = URI.encode_www_form_component(key)
+
+          if fname.size > FILEPATH_MAX_SIZE
+            fname = Digest::MD5.hexdigest(key)
           end
 
-          fname = URI.encode_www_form_component(key)
           hash = Zlib.adler32(fname)
           hash, dir_1 = hash.divmod(0x1000)
           dir_2 = hash.modulo(0x1000)

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -714,6 +714,11 @@ class FileStoreTest < ActiveSupport::TestCase
     assert_equal 1, @cache.read("a"*10000)
   end
 
+  def test_long_uri_encoded_keys
+    @cache.write("%"*870, 1)
+    assert_equal 1, @cache.read("%"*870)
+  end
+
   def test_key_transformation
     key = @cache.send(:key_file_path, "views/index?id=1")
     assert_equal "views/index?id=1", @cache.send(:file_path_key, key)


### PR DESCRIPTION
Currently it is ensured that a cache key is not bigger than the max path length of the system before it is URI encoded. As URI encoding is adding additional chars, a long cache key containing some chars that get encoded may still result in too long paths. This lead to an exception in our application.

This PR changes this by checking the length after the cache key was encoded and using the hexdigested value of the cache key instead.
This solution will only change the cache keys for a small subset: All keys that are not longer than 900 chars but are longer than 900 when URI encoded.
#15688 tackles a similar problem and would also solve mine as far as I can tell.
