### PR TITLE
Raise argument error if user tries to pass nil as argument to query methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Raise argument error if user tries to pass nil as argument to query methods.
+
+    Fixes #19873.
+
+    *Mehmet Emin İNAÇ*
+
 *   Properly allow uniqueness validations on primary keys.
 
     Fixes #20966.

--- a/activerecord/lib/active_record/associations/preloader/collection_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/collection_association.rb
@@ -6,7 +6,8 @@ module ActiveRecord
         private
 
         def build_scope
-          super.order(preload_scope.values[:order] || reflection_scope.values[:order])
+          order = preload_scope.values[:order] || reflection_scope.values[:order]
+          order ? super.order(order) : super
         end
 
         def preload(preloader)

--- a/activerecord/lib/active_record/associations/preloader/has_one.rb
+++ b/activerecord/lib/active_record/associations/preloader/has_one.rb
@@ -14,7 +14,8 @@ module ActiveRecord
         private
 
         def build_scope
-          super.order(preload_scope.values[:order] || reflection_scope.values[:order])
+          order = preload_scope.values[:order] || reflection_scope.values[:order]
+          order ? super.order(order) : super
         end
 
       end

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -84,7 +84,9 @@ module ActiveRecord
             end
 
             scope.references! reflection_scope.values[:references]
-            scope = scope.order reflection_scope.values[:order] if scope.eager_loading?
+            if scope.eager_loading? && reflection_scope.values[:order]
+              scope = scope.order(reflection_scope.values[:order])
+            end
           end
 
           scope

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1073,13 +1073,14 @@ module ActiveRecord
     end
 
     # Checks to make sure that the arguments are not blank. Note that if some
-    # blank-like object were initially passed into the query method, then this
-    # method will not raise an error.
+    # blank-like not nil object were initially passed into the query method,
+    # then this method will not raise an error.
     #
     # Example:
     #
-    #    Post.references()   # => raises an error
-    #    Post.references([]) # => does not raise an error
+    #    Post.references()    # => raises an error
+    #    Post.references(nil) # => raises an error
+    #    Post.references([])  # => does not raise an error
     #
     # This particular method should be called with a method_name and the args
     # passed into that method as an input. For example:
@@ -1089,7 +1090,7 @@ module ActiveRecord
     #   ...
     # end
     def check_if_method_has_arguments!(method_name, args)
-      if args.blank?
+      if args.blank? || (method_name != :reorder && args.compact.blank?)
         raise ArgumentError, "The method .#{method_name}() must contain arguments."
       end
     end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1199,7 +1199,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_join_eager_with_nil_order_should_generate_valid_sql
     assert_nothing_raised(ActiveRecord::StatementInvalid) do
-      Post.includes(:comments).order(nil).where(:comments => {:body => "Thank you for the welcome"}).first
+      Post.includes(:comments).where(:comments => {:body => "Thank you for the welcome"}).first
     end
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -437,7 +437,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_joins_with_nil_argument
-    assert_nothing_raised { DependentFirm.joins(nil).first }
+    assert_raise(ArgumentError) { DependentFirm.joins(nil).first }
   end
 
   def test_finding_with_hash_conditions_on_joined_table


### PR DESCRIPTION
Please read the discussion in #19873 
Also we can raise argument error with another message for nil attribute case(any advise? :smile:).
