### PR TITLE
Activesupport dependencies failing test

### DIFF
--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -374,7 +374,7 @@ class DependenciesTest < ActiveSupport::TestCase
     end
   end
 
-  def failing_test_access_thru_and_upwards_fails
+  def test_access_thru_and_upwards_fails
     with_autoloading_fixtures do
       assert_not defined?(ModuleFolder)
       assert_raise(NameError) { ModuleFolder::Object }

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -378,7 +378,7 @@ class DependenciesTest < ActiveSupport::TestCase
     with_autoloading_fixtures do
       assert_not defined?(ModuleFolder)
       assert_raise(NameError) { ModuleFolder::Object }
-      assert_raise(NameError) { ModuleFolder::NestedClass::Object }
+      assert_raise(NameError) { ModuleFolder::NestedClass::DoesNotExist }
     end
   ensure
     remove_constants(:ModuleFolder)


### PR DESCRIPTION
I found a test case that doesn't start with `test_` in AS/test. So I renamed it, then I found that it's actually not passing.
The test case expects a `NameError` when AS tries to autoload `ModuleFolder::NestedClass::Object`, but in fact it autoloads `ModuleFolder::NestedClass` and returns `::Object` with `warning: toplevel constant Object referenced by ModuleFolder::NestedClass::Object`.
I'm not sure what is the desired fix here. What do you think, @fxn?
