### PR TITLE
 Added an example to show how common secrets can be shared across multiple environments in secrets.yml

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/secrets.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/secrets.yml
@@ -10,6 +10,22 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
+# You can also share common secrets in multiple environments
+# using YAML anchor/reference syntax.
+
+# common: &common
+#   api_key:    <%= API_KEY %>
+#   api_secret: <%= API_SECRET %>
+
+# development:
+#   <<: *common
+#
+# test:
+#   <<: *common
+#
+# production:
+#   <<: *common
+
 development:
   secret_key_base: <%= app_secret %>
 


### PR DESCRIPTION
- Earlier, if there were common configurations under all environments then
  they had to be duplicated under each environment in
  `config/secrets.yml`.
- This commit adds a way to specify them under `common` key such that
  they will be loaded in all environments.
- Environment specific configurations will override the common configurations if they
  are present under both sections.
#### Edit

Common secrets is a bit confusing here. I meant to say common configuration options or settings like lets say `default_from_email_address`. It can be `support@example.com` in development, test and in production can be something else.
