### PR TITLE
add support for multiple callback objects

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -783,4 +783,8 @@
 
     *Yves Senn*
 
+*   Add support for define_callback_object to handle multiple callbacks with one declaration.
+
+    *Kevin Deisz*
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -279,6 +279,16 @@ module ActiveRecord
 
     module ClassMethods
       include ActiveModel::Callbacks
+
+      # == Registering a custom callback object
+      #
+      # Define a callback object that will handle multiple callbacks
+      # Any public instance methods defined in this object will become separate callbacks
+      def define_callback_object(object)
+        (object.methods & CALLBACKS).each do |callback_method|
+          send(callback_method, object.dup)
+        end
+      end
     end
 
     included do

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -381,6 +381,14 @@ end
 
 You can declare as many callbacks as you want inside your callback classes.
 
+You can also declare multiple callbacks with one object by using `define_callback_object`. This will define a callback for every allowed callback that is defined inside the given object:
+
+```ruby
+class PictureFile < ActiveRecord::Base
+  define_callback_object PictureFileCallbacks
+end
+```
+
 Transaction Callbacks
 ---------------------
 


### PR DESCRIPTION
First PR so any advice/feedback is appreciated! This PR allows users to define multiple callbacks with one method in AR objects using define_callback_object. This changes this:

after_create Thing.new
after_save Thing.new
before_destroy Thing.new

to this:

define_callback_object Thing.new
