### PR TITLE
 Escape README in Plugin builder API documentation

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -8,7 +8,7 @@ module Rails
   # generator.
   #
   # This allows you to override entire operations, like the creation of the
-  # Gemfile, README, or JavaScript files, without needing to know exactly
+  # Gemfile, \README, or JavaScript files, without needing to know exactly
   # what those operations do so you can create another template action.
   class PluginBuilder
     def rakefile


### PR DESCRIPTION
- So that RDoc will not generate link for README.
  [ci skip]
