### PR TITLE
 Mark assets pipeline guide as "Work in progress" [ci skip]

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -106,6 +106,7 @@
       description: This guide covers the command line tools and rake tasks provided by Rails.
     -
       name: Asset Pipeline
+      work_in_progress: true
       url: asset_pipeline.html
       description: This guide documents the asset pipeline.
     -


### PR DESCRIPTION
- As per https://github.com/rails/rails/issues/19835#issuecomment-95041261
  assets pipeline guide needs to be rewritten for Sprockets 3.
- So this commit marks the guide as WIP for now.
