### PR TITLE
rails new: parallelize bundle install

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -537,7 +537,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_spring_binstubs
     jruby_skip "spring doesn't run on JRuby"
-    generator.stubs(:bundle_command).with('install')
+    generator.stubs(:bundle_command).with { |val| val.match(/^install -j\d+/) }
     generator.expects(:bundle_command).with('exec spring binstub --all').once
     quietly { generator.invoke_all }
   end
@@ -627,7 +627,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     generator([destination_root], template: path).expects(:open).with(path, 'Accept' => 'application/x-thor-template').returns(template)
 
     bundler_first = sequence('bundle, binstubs, after_bundle')
-    generator.expects(:bundle_command).with('install').once.in_sequence(bundler_first)
+    generator.expects(:bundle_command).with { |val| val.match(/^install -j\d+/) }.once.in_sequence(bundler_first)
     generator.expects(:bundle_command).with('exec spring binstub --all').in_sequence(bundler_first)
     generator.expects(:run).with('echo ran after_bundle').in_sequence(bundler_first)
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -28,7 +28,7 @@ module SharedGeneratorTests
 
   def assert_generates_with_bundler(options = {})
     generator([destination_root], options)
-    generator.expects(:bundle_command).with('install').once
+    generator.expects(:bundle_command).with { |val| val.match(/^install -j\d+/) }.once
     generator.stubs(:bundle_command).with('exec spring binstub --all')
     quietly { generator.invoke_all }
   end


### PR DESCRIPTION
It's 2015; we have CPUs; bundler supports multiple jobs... Let's speed up bundle install in `rails new ...` by running some tasks in parallel.

For a moment I thought about putting the logic for detecting the number of CPUs in ActiveSupport, but then thought that dir probably doesn't need any extra noise. Thoughts? Also, I did not include windows because I do not have the ability to test it. So if someone wants that added, let me know and I'll slide that in.

:heartbeat:
