### PR TITLE
Get provider_job_id from DelayedJob

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Allow `DelayedJob` to report id back to `ActiveJob::Base` as
+    `provider_job_id`.
+
+    Fixes #18821.
+
+    *Kevin Deisz*
+
 *   `assert_enqueued_jobs` and `assert_performed_jobs` in block form use the
     given number as expected value. This makes the error message much easier to
     understand.

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -17,6 +17,9 @@ module ActiveJob
 
       # Queue in which the job will reside.
       attr_writer :queue_name
+
+      # ID optionally provided by adapter
+      attr_accessor :provider_job_id
     end
 
     # These methods will be included into any Active Job object, adding

--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -14,11 +14,15 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :delayed_job
     class DelayedJobAdapter
       def enqueue(job) #:nodoc:
-        Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name)
+        delayed_job = Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name)
+        job.provider_job_id = delayed_job.id
+        delayed_job
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
-        Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name, run_at: Time.at(timestamp))
+        delayed_job = Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name, run_at: Time.at(timestamp))
+        job.provider_job_id = delayed_job.id
+        delayed_job
       end
 
       class JobWrapper #:nodoc:

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -55,4 +55,10 @@ class QueuingTest < ActiveSupport::TestCase
       skip
     end
   end
+
+  test 'should supply a provider_job_id to DelayedJob' do
+    skip unless adapter_is?(:delayed_job)
+    test_job = TestJob.perform_later @id
+    assert_kind_of Fixnum, test_job.provider_job_id
+  end
 end


### PR DESCRIPTION
When queueing with DelayedJob, get the id of the job instance and report
it back to ActiveJob as provider_job_id.
