### PR TITLE
Don't re-raise ActionController::BadRequest when rendering an exception.

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -313,7 +313,11 @@ module ActionDispatch
     def GET
       @env["action_dispatch.request.query_parameters"] ||= Utils.deep_munge(normalize_encode_params(super || {}))
     rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e
-      raise ActionController::BadRequest.new(:query, e)
+      if @env["action_dispatch.exception"].present?
+        @env["action_dispatch.request.query_parameters"] = {}
+      else
+        raise ActionController::BadRequest.new(:query, e)
+      end
     end
     alias :query_parameters :GET
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -951,6 +951,14 @@ class RequestParameters < BaseRequestTest
     end
   end
 
+  test "does not re-raise rack parse error of invalid UTF8 character when rendering the exception" do
+    request = stub_request("QUERY_STRING" => "foo%81E=1", "action_dispatch.exception" => ActionController::BadRequest.new)
+
+    2.times do
+      request.parameters
+    end
+  end
+
   test "parameters not accessible after rack parse error 1" do
     request = stub_request(
       'REQUEST_METHOD' => 'POST',


### PR DESCRIPTION
When an ActionController::BadRequest error is triggered due to malformed query params (e.g. localhost:3000?width=80%&height=80%) and `config.exceptions_app = self.routes`, the fail-safe in the ShowExceptions middleware is triggered due to a second attempt to parse the query parameters. This causes the Rails fail-safe 500 page to render, instead of the 400 error page we want.

This error has been documented around the web in the issue trackers of various levels of the stack:

http://trac.nginx.org/nginx/ticket/374
https://code.google.com/p/phusion-passenger/issues/detail?id=831
https://github.com/rack/rack/issues/337
