### PR TITLE
Support proc as default value for Attributes API

### DIFF
--- a/activerecord/lib/active_record/attribute.rb
+++ b/activerecord/lib/active_record/attribute.rb
@@ -114,6 +114,10 @@ module ActiveRecord
 
     class FromUser < Attribute # :nodoc:
       def type_cast(value)
+        if value.is_a?(Proc)
+          value = value.call
+        end
+
         type.cast(value)
       end
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -912,6 +912,7 @@ ActiveRecord::Schema.define do
     t.float :unoverloaded_float
     t.string :overloaded_string_with_limit, limit: 255
     t.string :string_with_default, default: 'the original default'
+    t.string :string_with_default_proc
   end
 
   create_table :users, force: true do |t|


### PR DESCRIPTION
Example:

```
attribute :year, :integer, default: -> { Time.now.year }
```

/cc @sgrif 
