### PR TITLE
Previews when `mail` wasn't called (NullMail instances).

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Mailer previews no longer crash when the `mail` method wasn't called
+    (`NullMail`).
+
+    Fixes #19849.
+
+    *Yves Senn*
+
 *   Make sure labels and values line up in mailer previews.
 
     *Yves Senn*

--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make sure labels and values line up in mailer previews.
+
+    *Yves Senn*
+
 *   Add `assert_enqueued_emails` and `assert_no_enqueued_emails`.
 
     Example:

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -596,6 +596,7 @@ module ActionMailer
 
     class NullMail #:nodoc:
       def body; '' end
+      def header; {} end
 
       def respond_to?(string, include_all=false)
         true

--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -16,10 +16,10 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
       @page_title = "Mailer Previews for #{@preview.preview_name}"
       render action: 'mailer'
     else
-      email = File.basename(params[:path])
+      @email_action = File.basename(params[:path])
 
-      if @preview.email_exists?(email)
-        @email = @preview.call(email)
+      if @preview.email_exists?(@email_action)
+        @email = @preview.call(@email_action)
 
         if params[:part]
           part_type = Mime::Type.lookup(params[:part])
@@ -28,14 +28,14 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
             response.content_type = part_type
             render text: part.respond_to?(:decoded) ? part.decoded : part
           else
-            raise AbstractController::ActionNotFound, "Email part '#{part_type}' not found in #{@preview.name}##{email}"
+            raise AbstractController::ActionNotFound, "Email part '#{part_type}' not found in #{@preview.name}##{@email_action}"
           end
         else
           @part = find_preferred_part(request.format, Mime::HTML, Mime::TEXT)
           render action: 'email', layout: false, formats: %w[html]
         end
       else
-        raise AbstractController::ActionNotFound, "Email '#{email}' not found in #{@preview.name}"
+        raise AbstractController::ActionNotFound, "Email '#{@email_action}' not found in #{@preview.name}"
       end
     end
   end

--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -39,6 +39,10 @@
     padding: 1px;
   }
 
+  dd:empty:before {
+    content: "\00a0"; // &nbsp;
+  }
+
   iframe {
     border: 0;
     width: 100%;

--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -103,7 +103,14 @@
   </dl>
 </header>
 
-<iframe seamless name="messageBody" src="?part=<%= Rack::Utils.escape(@part.mime_type) %>"></iframe>
+<% if @part.mime_type %>
+  <iframe seamless name="messageBody" src="?part=<%= Rack::Utils.escape(@part.mime_type) %>"></iframe>
+<% else %>
+  <p>
+    You are trying to preview an email that does not have any content.
+    This is probably because the <em>mail</em> method has not been called in <em><%= @preview.preview_name %>#<%= @email_action %></em>.
+  </p>
+<% end %>
 
 </body>
 </html>

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -327,6 +327,32 @@ module ApplicationTests
       assert_match "Email &#39;bar&#39; not found in NotifierPreview", last_response.body
     end
 
+    test "mailer preview NullMail" do
+      mailer 'notifier', <<-RUBY
+        class Notifier < ActionMailer::Base
+          default from: "from@example.com"
+
+          def foo
+            # does not call +mail+
+          end
+        end
+      RUBY
+
+      mailer_preview 'notifier', <<-RUBY
+        class NotifierPreview < ActionMailer::Preview
+          def foo
+            Notifier.foo
+          end
+        end
+      RUBY
+
+      app('development')
+
+      get "/rails/mailers/notifier/foo"
+      assert_match "You are trying to preview an email that does not have any content.", last_response.body
+      assert_match "notifier#foo", last_response.body
+    end
+
     test "mailer preview email part not found" do
       mailer 'notifier', <<-RUBY
         class Notifier < ActionMailer::Base


### PR DESCRIPTION
Closes #19849

This patch makes it possible to preview `NullMail` instances. It reuses the same template to keep a consistent output but replaces the body iframe with help and debug output:

![screen shot 2015-04-27 at 10 15 31](https://cloud.githubusercontent.com/assets/5402/7343847/af400d28-ecc6-11e4-944e-6808e881a738.png)

It was also necessary to get the definition list to align properly when blank values are involved:

**Before:**
![screen shot 2015-04-27 at 09 36 51](https://cloud.githubusercontent.com/assets/5402/7343856/c3c73c9e-ecc6-11e4-9c08-c664a2c14b7f.png)

**After:**
![screen shot 2015-04-27 at 09 37 04](https://cloud.githubusercontent.com/assets/5402/7343857/c793bef6-ecc6-11e4-8433-c87541eeb4b2.png)
