### PR TITLE
Persist default values declared with Attributes API

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -135,6 +135,18 @@ module ActiveRecord
         changed & self.class.column_names
       end
 
+      def attributes_for_create(attributes)
+        if new_record?
+          attributes.push(*keys_with_default_values)
+        end
+
+        attributes
+      end
+
+      def keys_with_default_values
+        self.class._default_attributes.values_before_type_cast.delete_if { |k, v| v.blank? }.keys
+      end
+
       def _field_changed?(attr, old_value)
         @attributes[attr].changed_from?(old_value)
       end

--- a/activerecord/test/cases/default_values_test.rb
+++ b/activerecord/test/cases/default_values_test.rb
@@ -1,0 +1,31 @@
+require 'cases/helper'
+
+module ActiveRecord
+  class Company < ActiveRecord::Base;end
+
+  class DefaultValuesTest < ActiveRecord::TestCase
+    test "persists default user value to database" do
+      UniverseCompany = Class.new(Company) do
+        attribute :rating, :integer, default: 42
+      end
+
+      record = UniverseCompany.create!
+
+      assert_equal 42, record.rating
+
+      record.reload
+      assert_equal 42, record.rating
+
+      assert_equal 42, UniverseCompany.last.rating
+    end
+
+    test "persists default column value to database" do
+      data = Company.create!
+
+      assert_equal 1, data.rating
+
+      data.reload
+      assert_equal 1, data.rating
+    end
+  end
+end


### PR DESCRIPTION
We have kind of bug in Attributes API now, because it doesn't persist default value into database.

Now:

``` ruby
class Account < ActiveRecord::Base
  attribute :name, :string, default: "my default"
end

Account.create!
puts Account.last.name.inspect
# => nil
```

After the patch:

``` ruby
class Account < ActiveRecord::Base
  attribute :name, :string, default: "my default"
end

Account.create!
puts Account.last.name.inspect
# => “my default”
```

@sgrif 
