### PR TITLE
Explicitly exit with status "1" for create and drop failures

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Exit with non-zero status for failed database rake tasks.
+
+    *Jay Hayes*
+
 *   Add ability to default to `uuid` as primary key when generating database migrations
 
     Set `Rails.application.config.active_record.primary_key = :uuid`

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -94,8 +94,9 @@ module ActiveRecord
       rescue DatabaseAlreadyExists
         $stderr.puts "#{configuration['database']} already exists"
       rescue Exception => error
-        $stderr.puts error, *(error.backtrace)
+        $stderr.puts error
         $stderr.puts "Couldn't create database for #{configuration.inspect}"
+        raise
       end
 
       def create_all

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -116,8 +116,9 @@ module ActiveRecord
       rescue ActiveRecord::NoDatabaseError
         $stderr.puts "Database '#{configuration['database']}' does not exist"
       rescue Exception => error
-        $stderr.puts error, *(error.backtrace)
+        $stderr.puts error
         $stderr.puts "Couldn't drop #{configuration['database']}"
+        raise
       end
 
       def drop_all

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -19,11 +19,15 @@ module ActiveRecord
         path = Pathname.new configuration['database']
         file = path.absolute? ? path.to_s : File.join(root, path)
 
-        FileUtils.rm(file) if File.exist?(file)
+        FileUtils.rm(file)
+      rescue Errno::ENOENT => error
+        raise NoDatabaseError.new(error.message, error)
       end
 
       def purge
         drop
+      rescue NoDatabaseError
+      ensure
         create
       end
 

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -60,7 +60,7 @@ module ActiveRecord
       $stderr.expects(:puts).
         with("Couldn't create database for #{@configuration.inspect}")
 
-      ActiveRecord::Tasks::DatabaseTasks.create @configuration
+      assert_raises(Exception) { ActiveRecord::Tasks::DatabaseTasks.create @configuration }
     end
 
     def test_create_when_database_exists_outputs_info_to_stderr

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -53,7 +53,7 @@ module ActiveRecord
       $stderr.expects(:puts).
         with("Couldn't create database for #{@configuration.inspect}")
 
-      ActiveRecord::Tasks::DatabaseTasks.create @configuration, '/rails/root'
+      assert_raises(Exception) { ActiveRecord::Tasks::DatabaseTasks.create @configuration, '/rails/root' }
     end
   end
 

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -69,10 +69,7 @@ module ApplicationTests
       test 'db:drop failure because database does not exist' do
         Dir.chdir(app_path) do
           output = `bin/rake db:drop 2>&1`
-          # This assertion should work, but it does not. The SQLite3 adapter
-          # does not raise an error when nothing exists to drop.
-          # https://github.com/rails/rails/blob/f00554a8226b9529c38be1f3e61b6b1888682fb4/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L34-L37
-          # assert_match /does not exist/, output
+          assert_match /does not exist/, output
           assert_equal 0, $?.exitstatus
         end
       end

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -91,6 +91,16 @@ module ApplicationTests
         end
       end
 
+      test 'db:drop failure because bad permissions' do
+        with_database_existing do
+          with_bad_permissions do
+            output = `bin/rake db:drop 2>&1`
+            assert_match /Couldn't drop/, output
+            assert_equal 1, $?.exitstatus
+          end
+        end
+      end
+
       def db_migrate_and_status(expected_database)
         Dir.chdir(app_path) do
           `bin/rails generate model book title:string;

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -66,6 +66,23 @@ module ApplicationTests
         end
       end
 
+      def with_bad_permissions
+        Dir.chdir(app_path) do
+          set_database_url
+          FileUtils.chmod("-w", "db")
+          yield
+          FileUtils.chmod("+w", "db")
+        end
+      end
+
+      test 'db:create failure because bad permissions' do
+        with_bad_permissions do
+          output = `bin/rake db:create 2>&1`
+          assert_match /Couldn't create database/, output
+          assert_equal 1, $?.exitstatus
+        end
+      end
+
       test 'db:drop failure because database does not exist' do
         Dir.chdir(app_path) do
           output = `bin/rake db:drop 2>&1`

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -49,6 +49,34 @@ module ApplicationTests
         db_create_and_drop database_url_db_name
       end
 
+      def with_database_existing
+        Dir.chdir(app_path) do
+          set_database_url
+          `bin/rake db:create`
+          yield
+          `bin/rake db:drop`
+        end
+      end
+
+      test 'db:create failure because database exists' do
+        with_database_existing do
+          output = `bin/rake db:create 2>&1`
+          assert_match /already exists/, output
+          assert_equal 0, $?.exitstatus
+        end
+      end
+
+      test 'db:drop failure because database does not exist' do
+        Dir.chdir(app_path) do
+          output = `bin/rake db:drop 2>&1`
+          # This assertion should work, but it does not. The SQLite3 adapter
+          # does not raise an error when nothing exists to drop.
+          # https://github.com/rails/rails/blob/f00554a8226b9529c38be1f3e61b6b1888682fb4/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L34-L37
+          # assert_match /does not exist/, output
+          assert_equal 0, $?.exitstatus
+        end
+      end
+
       def db_migrate_and_status(expected_database)
         Dir.chdir(app_path) do
           `bin/rails generate model book title:string;


### PR DESCRIPTION
## History

I've attempted this a couple times now. Originally in #12531 and then in #12956. After speaking with @sgrif at RailsConf, I thought to give it another shot.
## TL;DR

Failed database tasks should exit with a non-zero status. You can run the updated tests with:

``` bash
# from cloned rails repo
$ cd railties/
$ ruby -Itest test/application/rake/dbs_test.rb
```
## Summary

Failed database tasks should exit with a non-zero status. This follows the standard that command line programs that fail generally exit with a non-zero status. Doing so allows additional commands to be chained along with a database task with `&&`.

For example:

``` bash
bin/rake db:setup && bin/rspec
```
## Problem

Currently failed database tasks exit with status `0`. This happens because errors [are rescued](https://github.com/rails/rails/blob/72d4d47216de66c8db391dcb88650fe4d76900d3/activerecord/lib/active_record/tasks/database_tasks.rb#L94-L98).

The above example would attempt to run `rspec` without a test database in the case that `db:setup` failed (e.g. db server unavailable).
## Solution

The solution here is to explicitly exit with non-zero status for errors during the creation or dropping of a database.

Additionally, you notice that in the cases:
- db already exists for create task
- db doesn't exit for drop task

no special exit status is specified. This is because these should be recoverable situations. Namely, "if the db is already created, the task is effectively done".
## Changes in Behavior
- [ ] The behavior of the SQLite3 `drop` task has been changed to raise an error when the database file does not exist. Check here if the change in behavior is :ok_hand: 
- [ ] The behavior of failing of db:create and db:drop has changed to not always print a backtrace. It instead now only prints the error message. You may still see a backtrace after the task fails by using the `--trace` option with `rake`. Check here if the change in behavior is :ok_hand: 
- [ ] The behavior has changed for the `create` and `drop` methods that back the corresponding rake tasks. They now re-raise errors triggered during the task. Check here if the change in behavior is :ok_hand: 
