### PR TITLE
Bug fix, has_many restrict_with_error translation should be set on parent

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix a bug where translation for `restrict_with_error` has to be set on child 
+    instead of parent.
+
+    Fixes #17003
+
+    *Alex Handley*
+
 *   Add `quoted_time` for truncating the date part of a TIME column value.
     This fixes queries on TIME column on MariaDB, as it doesn't ignore the 
     date part of the string when it coerces to time.

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -15,7 +15,7 @@ module ActiveRecord
 
         when :restrict_with_error
           unless empty?
-            record = owner.class.human_attribute_name(reflection.name).downcase
+            record = reflection.active_record.human_attribute_name(reflection.name).downcase
             message = owner.errors.generate_message(:base, :'restrict_dependent_destroy.many', record: record, raise: true) rescue nil
             if message
               ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1526,6 +1526,32 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     I18n.backend.reload!
   end
 
+  def test_restrict_with_error_and_translation
+    translation = { activerecord: {
+                      attributes: {
+                        restricted_with_error_firm: { companies: "public company name" }
+                      }
+                    }
+                  }
+    I18n.backend.store_translations("en", translation)
+
+    firm = RestrictedWithErrorFirm.create!(name: "restrict")
+    firm.companies.create!(name: "child")
+    firm.destroy
+
+    expected_message = "Cannot delete record because dependent public company name exist"
+    assert_equal expected_message, firm.errors[:base].first
+
+  ensure
+    translation = { activerecord: {
+                      attributes: {
+                        restricted_with_error_firm: { companies: nil }
+                      }
+                    }
+                  }
+    I18n.backend.store_translations("en", translation)
+  end
+
   def test_included_in_collection
     assert_equal true, companies(:first_firm).clients.include?(Client.find(2))
   end


### PR DESCRIPTION
When you want to set a translation on a has_many relation with its dependent set to restrict_with_error you have to set it on the child instead of the parent e.g

```
en.activerecord.attributes.company.companies
```

When it should be 

```
en.activerecord.attributes.restricted_with_error_firm.companies
```

This was also reported in #17003
