### PR TITLE
AUTH PLAIN is Base64 encoded [ci skip]

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -379,8 +379,8 @@ module ActionMailer
   #   * <tt>:password</tt> - If your mail server requires authentication, set the password in this setting.
   #   * <tt>:authentication</tt> - If your mail server requires authentication, you need to specify the
   #     authentication type here.
-  #     This is a symbol and one of <tt>:plain</tt> (will send the password in the clear), <tt>:login</tt> (will
-  #     send password Base64 encoded) or <tt>:cram_md5</tt> (combines a Challenge/Response mechanism to exchange
+  #     This is a symbol and one of <tt>:plain</tt> (will send the password Base64 encoded), <tt>:login</tt> (will
+  #     send the password Base64 encoded) or <tt>:cram_md5</tt> (combines a Challenge/Response mechanism to exchange
   #     information and a cryptographic Message Digest 5 algorithm to hash important information)
   #   * <tt>:enable_starttls_auto</tt> - Detects if STARTTLS is enabled in your SMTP server and starts
   #     to use it. Defaults to <tt>true</tt>.


### PR DESCRIPTION
Contrary to what the name suggests, PLAIN SMTP authentication is not
sent in plain text but is Base64 encoded like the LOGIN method. Their
difference is described in the third link below.
- https://tools.ietf.org/html/rfc4954
- https://en.wikipedia.org/wiki/SMTP_Authentication
- http://www.samlogic.net/articles/smtp-commands-reference-auth.htm
