### PR TITLE
User bundler 1.3.5 or later to generate the guides [ci skip]

### DIFF
--- a/guides/source/ruby_on_rails_guides_guidelines.md
+++ b/guides/source/ruby_on_rails_guides_guidelines.md
@@ -64,7 +64,7 @@ The guides and the API should be coherent and consistent where appropriate. In p
 HTML Guides
 -----------
 
-Before generating the guides, make sure that you have the latest version of Bundler installed on your system. As of this writing, you must install Bundler 1.3.5 on your device.
+Before generating the guides, make sure that you have the latest version of Bundler installed on your system. As of this writing, you must install Bundler 1.3.5 or later on your device.
 
 To install the latest version of Bundler, run `gem install bundler`.
 


### PR DESCRIPTION
\cc @senny 
