### PR TITLE
Fixed behaviour, when block wasn't passed to link_to from link_to_if(condition = true) method

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -410,7 +410,7 @@ module ActionView
       #   # => <a href="/accounts/show/3">my_username</a>
       def link_to_if(condition, name, options = {}, html_options = {}, &block)
         if condition
-          link_to(name, options, html_options)
+          link_to(name, options, html_options, &block)
         else
           if block_given?
             block.arity <= 1 ? capture(name, &block) : capture(name, options, html_options, &block)


### PR DESCRIPTION
Seems like `&block` was missing in argument list, so `link_to_if` didn't pass `&block'  to`link_to` method
