### PR TITLE
Speed-up comparison of 2 ActiveSupport::TimeWithZone objects.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Speed-up comparison of 2 ActiveSupport::TimeWithZone objects.
+
+    *Ivan Schneider*
+
 *   Encoding ActiveSupport::TimeWithZone to YAML now preserves the timezone information.
 
     Fixes #9183.

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -220,7 +220,11 @@ module ActiveSupport
 
     # Use the time in UTC for comparisons.
     def <=>(other)
-      utc <=> other
+      if other.class == self.class
+        to_i <=> other.to_i
+      else
+        utc <=> other
+      end
     end
 
     # Returns true if the current object's time is within the specified


### PR DESCRIPTION
Avoids creating a copy of the `utc` Time instance variable on each comparison of 2 ActiveSupport::TimeWithZone objects (`to_time` is called in https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/time/calculations.rb#L253).
I've seen a 2.5x performance improvement in a real life application on requests involving a lot of TimeWithZone comparisons.
