### PR TITLE
Make ActionMailer #cache helper a no-op, not an exception

### DIFF
--- a/actionmailer/test/mail_helper_test.rb
+++ b/actionmailer/test/mail_helper_test.rb
@@ -59,6 +59,12 @@ The second
     end
   end
 
+  def use_cache
+    mail_with_defaults do |format|
+      format.html { render(inline: "<% cache(:foo) do %>Greetings from a cache helper block<% end %>") }
+    end
+  end
+
   protected
 
   def mail_with_defaults(&block)
@@ -107,5 +113,11 @@ class MailerHelperTest < ActionMailer::TestCase
     TEXT
     assert_equal expected.gsub("\n", "\r\n"), mail.body.encoded
   end
-end
 
+  def test_use_cache
+    assert_nothing_raised do
+      mail = HelperMailer.use_cache
+      assert_equal "Greetings from a cache helper block", mail.body.encoded
+    end
+  end
+end

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -134,7 +134,7 @@ module ActionView
       #
       #   <%= render @notifications, cache: false %>
       def cache(name = {}, options = nil, &block)
-        if controller.perform_caching
+        if controller.respond_to?(:perform_caching) && controller.perform_caching
           safe_concat(fragment_for(cache_fragment_name(name, options), options, &block))
         else
           yield


### PR DESCRIPTION
ActionView's `cache` helper checks `controller.perform_caching` which is only defined in ActionController so views of an AbstractController (like ActionMailer's) will raise an exception:

```
$ ruby test/mail_helper_test.rb
Run options: --seed 21612

# Running:

.E.....

Finished in 0.217102s, 32.2429 runs/s, 55.2736 assertions/s.

  1) Error:
MailerHelperTest#test_use_cache:
ActionView::Template::Error: undefined method `perform_caching' for #<HelperMailer:0x007fa2cfa2cd20>
    /Users/javan/Code/rails/actionview/lib/action_view/helpers/cache_helper.rb:137:in `cache'
    inline template:1:in `_inline_template___584781172439821615_70168607863040'
```

(also noted in https://github.com/rails/rails/issues/17657)

This change fixes the exception, allowing controller views to be more easily shared with mailers. It doesn't implement mailer caching (a meatier potential change).
