### PR TITLE
update find_or_create/initialize_by behavior when given block

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `find_or_initialize_by` and `find_or_create_by` now yield to a block
+    regardlesss of whether or not the record is new or not.
+
+    *Logan Hasson*
+
 *   Make `unscope` aware of "less than" and "greater than" conditions.
 
     *TAKAHASHI Kazuaki*

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -219,12 +219,23 @@ module ActiveRecord
     # Like <tt>find_or_create_by</tt>, but calls <tt>create!</tt> so an exception
     # is raised if the created record is invalid.
     def find_or_create_by!(attributes, &block)
-      find_by(attributes) || create!(attributes, &block)
+      find_by_with_block(attributes, &block) || create!(attributes, &block)
     end
 
     # Like <tt>find_or_create_by</tt>, but calls <tt>new</tt> instead of <tt>create</tt>.
     def find_or_initialize_by(attributes, &block)
-      find_by(attributes) || new(attributes, &block)
+      find_by_with_block(attributes, &block) || new(attributes, &block)
+    end
+
+    # Like <tt>find_by</tt>, but takes a block
+    def find_by_with_block(attributes, &block)
+      found = find_by(attributes)
+
+      if found && block_given?
+        found.tap(&block)
+      else
+        found
+      end
     end
 
     # Runs EXPLAIN on the query or queries triggered by this relation and


### PR DESCRIPTION
find_or_create_by and find_or_initialize_by now behave the same when
given a block, regardless of whether or not the record is new or already
persisted.
