### PR TITLE
[ci skip] Correct grammar, add docs to ActiveRecord migration generator

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -14,10 +14,9 @@ module ActiveRecord
       protected
       attr_reader :migration_action, :join_tables
 
-      # sets the default migration template that is being used for the generation of the migration
-      # depending on the arguments which would be sent out in the command line, the migration template 
-      # and the table name instance variables are setup.
-
+      # Sets the default migration template that is being used for the generation of the migration.
+      # Depending on command line arguments, the migration template and the table name instance
+      # variables are set up.
       def set_local_assigns!
         @migration_template = "migration.rb"
         case file_name
@@ -56,6 +55,8 @@ module ActiveRecord
           attributes.select { |a| !a.reference? && a.has_index? }
         end
 
+        # A migration file name can only contain underscores (_), lowercase characters,
+        # and numbers 0-9. Any other file name will raise an IllegalMigrationNameError.
         def validate_file_name!
           unless file_name =~ /^[_a-z0-9]+$/
             raise IllegalMigrationNameError.new(file_name)


### PR DESCRIPTION
This PR corrects the grammar of an existing piece of documentation on `ActiveRecord::Generators::MigrationGenerator` (and rewords it for conciseness), and adds documentation regarding valid migration filenames.
