### PR TITLE
Document :tld_length option for cookies.

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -79,6 +79,8 @@ module ActionDispatch
   #     domain: %w(.example.com .example.org) # Allow the cookie
   #                                           # for concrete domain names.
   #
+  # * <tt>:tld_length</tt> - When using <tt>:domain => :all</tt>, set this to the appropriate value.
+  #   For example, to share cookies between user1.example.com and user2.example.com set <tt>:tld_length</tt> to 2.
   # * <tt>:expires</tt> - The time at which this cookie expires, as a \Time object.
   # * <tt>:secure</tt> - Whether this cookie is only transmitted to HTTPS servers.
   #   Default is +false+.


### PR DESCRIPTION
This option is currently undocumented and it took me a long time to figure out why my cookies weren't being shared across subdomains when using the `:domain => :all` option.
