### PR TITLE
maintain_test_schema!: initialize migrations_paths from Rails application

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -394,6 +394,8 @@ module ActiveRecord
       end
 
       def load_schema_if_pending!
+        ActiveRecord::Migrator.migrations_paths = Rails.application.config.paths['db/migrate']
+
         if ActiveRecord::Migrator.needs_migration? || !ActiveRecord::Migrator.any_migrations?
           # Roundtrip to Rake to allow plugins to hook into database initialization.
           FileUtils.cd Rails.root do


### PR DESCRIPTION
When migrations are included in engines and maintain_test_schema! is used, those migrations may not trigger a call to db:test:prepare. Suggestions for testing welcome.
