### PR TITLE
deprecation warning clarifies which field value is invalid

### DIFF
--- a/activerecord/lib/active_record/type/boolean.rb
+++ b/activerecord/lib/active_record/type/boolean.rb
@@ -16,6 +16,7 @@ module ActiveRecord
           if !ConnectionAdapters::Column::FALSE_VALUES.include?(value)
             ActiveSupport::Deprecation.warn(<<-MSG.squish)
               You attempted to assign a value which is not explicitly `true` or `false`
+              (#{value.inspect})
               to a boolean column. Currently this value casts to `false`. This will
               change to match Ruby's semantics, and will cast to `true` in Rails 5.
               If you would like to maintain the current behavior, you should


### PR DESCRIPTION
This deprecation warning currently says "You attempted to assign a value which is not explicitly `true` or `false` to a boolean column" but doesn't say _which_ column or value is the culprit. This patch makes it easier to track down mistakes and correct them by clearly saying what value was not found in the list of acceptable TRUE and FALSE values. 

(Unfortunately it doesn't know which _field_ was being set, just what _value_, but it's much better than it was.)
