### PR TITLE
Document :tld_length option for cookies.

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -79,6 +79,9 @@ module ActionDispatch
   #     domain: %w(.example.com .example.org) # Allow the cookie
   #                                           # for concrete domain names.
   #
+  # * <tt>:tld_length</tt> - When using <tt>:domain => :all</tt>, this option can be used to explicitly
+  #   set the TLD length when using a short (<= 3 character) domain that is being interpreted as part of a TLD.
+  #   For example, to share cookies between user1.lvh.me and user2.lvh.me, set <tt>:tld_length</tt> to 1.
   # * <tt>:expires</tt> - The time at which this cookie expires, as a \Time object.
   # * <tt>:secure</tt> - Whether this cookie is only transmitted to HTTPS servers.
   #   Default is +false+.


### PR DESCRIPTION
This option is currently undocumented and it took me a long time to figure out why my cookies weren't being shared across subdomains when using the :domain => :all option.
