### PR TITLE
 Nodoc validate_index_length! method

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1049,7 +1049,7 @@ module ActiveRecord
         end
       end
 
-      def validate_index_length!(table_name, new_name)
+      def validate_index_length!(table_name, new_name) # :nodoc:
         if new_name.length > allowed_index_name_length
           raise ArgumentError, "Index name '#{new_name}' on table '#{table_name}' is too long; the limit is #{allowed_index_name_length} characters"
         end


### PR DESCRIPTION
- This method is used only by adapters to validate length of new index names.
