### PR TITLE
 Removed `assigns` from functional_test templates

### DIFF
--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
@@ -9,7 +9,6 @@ class <%= controller_class_name %>ControllerTest < ActionController::TestCase
   test "should get index" do
     get :index
     assert_response :success
-    assert_not_nil assigns(:<%= table_name %>)
   end
 
   test "should get new" do
@@ -22,7 +21,7 @@ class <%= controller_class_name %>ControllerTest < ActionController::TestCase
       post :create, params: { <%= "#{singular_table_name}: { #{attributes_hash} }" %> }
     end
 
-    assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
+    assert_redirected_to <%= singular_table_name %>_path(<%= class_name %>.last)
   end
 
   test "should show <%= singular_table_name %>" do
@@ -37,7 +36,7 @@ class <%= controller_class_name %>ControllerTest < ActionController::TestCase
 
   test "should update <%= singular_table_name %>" do
     patch :update, params: { id: <%= "@#{singular_table_name}" %>, <%= "#{singular_table_name}: { #{attributes_hash} }" %> }
-    assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
+    assert_redirected_to <%= singular_table_name %>_path(<%= "@#{singular_table_name}" %>)
   end
 
   test "should destroy <%= singular_table_name %>" do

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -190,7 +190,7 @@ module ApplicationTests
          bundle exec rake db:migrate test`
       end
 
-      assert_match(/7 runs, 13 assertions, 0 failures, 0 errors/, output)
+      assert_match(/7 runs, 12 assertions, 0 failures, 0 errors/, output)
       assert_no_match(/Errors running/, output)
     end
 
@@ -203,7 +203,7 @@ module ApplicationTests
          bundle exec rake db:migrate test`
       end
 
-      assert_match(/7 runs, 13 assertions, 0 failures, 0 errors/, output)
+      assert_match(/7 runs, 12 assertions, 0 failures, 0 errors/, output)
       assert_no_match(/Errors running/, output)
     end
 


### PR DESCRIPTION
- Based on DHH's suggestion about deprecating `assigns` in
  https://github.com/rails/rails/pull/18305#issuecomment-68605166.
