### PR TITLE
 Add redirection path in the error message of assert_response if response is :redirect

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -27,6 +27,8 @@ module ActionDispatch
       #   # Asserts that the response code was status code 401 (unauthorized)
       #   assert_response 401
       def assert_response(type, message = nil)
+        message ||= generate_response_message(type)
+
         if Symbol === type
           if [:success, :missing, :redirect, :error].include?(type)
             assert_predicate @response, RESPONSE_PREDICATES[type], message
@@ -81,6 +83,19 @@ module ActionDispatch
             handle = @controller || ActionController::Redirecting
             handle._compute_redirect_to_location(@request, fragment)
           end
+        end
+
+        def generate_response_message(type)
+          message = "Expected response to be a <#{type}>, but was"
+
+          if @response.redirection?
+            redirect_is = normalize_argument_to_redirection(@response.location)
+            message << " a redirect to <#{redirect_is}>"
+          else
+            message << " <#{@response.response_code}>"
+          end
+
+          message
         end
     end
   end


### PR DESCRIPTION
- If the assert_response is checking for any non-redirect response like
  :success and actual response is :redirect then, the error message displayed was -
  
  ```
   Expected response to be a <success>, but was <302>
  ```
- This commit adds the redirect path to the error message of
  assert_response if the response is :redirect. So above message is changed to -
  
  ```
  Expected response to be a <success>, but was a redirect to <http://test.host/posts/lol>
  ```
