### PR TITLE
PostgreSQL: `:collation` support for string and text columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   PostgreSQL: `:collation` support for string and text columns.
+
+    Example:
+
+        create_table :foos do |t|
+          t.string :string_en, collation: 'en_US.UTF-8'
+          t.text   :text_ja,   collation: 'ja_JP.UTF-8'
+        end
+
+    *Ryuta Kamizono*
+
 *   Make `unscope` aware of "less than" and "greater than" conditions.
 
     *TAKAHASHI Kazuaki*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -70,6 +70,7 @@ module ActiveRecord
             column_options[:after] = o.after
             column_options[:auto_increment] = o.auto_increment
             column_options[:primary_key] = o.primary_key
+            column_options[:collation] = o.collation
             column_options
           end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -15,7 +15,7 @@ module ActiveRecord
     # are typically created by methods in TableDefinition, and added to the
     # +columns+ attribute of said TableDefinition object, in order to be used
     # for generating a number of table creation or table changing SQL statements.
-    class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :auto_increment, :primary_key, :sql_type) #:nodoc:
+    class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :auto_increment, :primary_key, :collation, :sql_type) #:nodoc:
 
       def primary_key?
         primary_key || type.to_sym == :primary_key
@@ -434,6 +434,7 @@ module ActiveRecord
         column.after       = options[:after]
         column.auto_increment = options[:auto_increment]
         column.primary_key = type == :primary_key || options[:primary_key]
+        column.collation   = options[:collation]
         column
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -35,12 +35,16 @@ module ActiveRecord
         default = schema_default(column) if column.has_default?
         spec[:default]   = default unless default.nil?
 
+        if collation = schema_collation(column)
+          spec[:collation] = collation
+        end
+
         spec
       end
 
       # Lists the valid migration options
       def migration_keys
-        [:name, :limit, :precision, :scale, :default, :null]
+        [:name, :limit, :precision, :scale, :default, :null, :collation]
       end
 
       private
@@ -55,6 +59,10 @@ module ActiveRecord
         unless default.nil?
           type.type_cast_for_schema(default)
         end
+      end
+
+      def schema_collation(column)
+        column.collation.inspect if column.collation
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -387,8 +387,8 @@ module ActiveRecord
         end
       end
 
-      def new_column(name, default, sql_type_metadata = nil, null = true)
-        Column.new(name, default, sql_type_metadata, null)
+      def new_column(name, default, sql_type_metadata = nil, null = true, default_function = nil, collation = nil)
+        Column.new(name, default, sql_type_metadata, null, default_function, collation)
       end
 
       def lookup_cast_type(sql_type) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -12,7 +12,7 @@ module ActiveRecord
         ISO_DATETIME = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(\.\d+)?\z/
       end
 
-      attr_reader :name, :null, :sql_type_metadata, :default, :default_function
+      attr_reader :name, :null, :sql_type_metadata, :default, :default_function, :collation
 
       delegate :precision, :scale, :limit, :type, :sql_type, to: :sql_type_metadata, allow_nil: true
 
@@ -22,12 +22,13 @@ module ActiveRecord
       # +default+ is the type-casted default value, such as +new+ in <tt>sales_stage varchar(20) default 'new'</tt>.
       # +sql_type_metadata+ is various information about the type of the column
       # +null+ determines if this column allows +NULL+ values.
-      def initialize(name, default, sql_type_metadata = nil, null = true, default_function = nil)
+      def initialize(name, default, sql_type_metadata = nil, null = true, default_function = nil, collation = nil)
         @name = name
         @sql_type_metadata = sql_type_metadata
         @null = null
         @default = default
         @default_function = default_function
+        @collation = collation
         @table_name = nil
       end
 
@@ -60,7 +61,7 @@ module ActiveRecord
       protected
 
       def attributes_for_hash
-        [self.class, name, default, sql_type_metadata, null, default_function]
+        [self.class, name, default, sql_type_metadata, null, default_function, collation]
       end
     end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -8,6 +8,13 @@ module ActiveRecord
           o.sql_type = type_to_sql(o.type, o.limit, o.precision, o.scale, o.array)
           super
         end
+
+        def add_column_options!(sql, options)
+          if options[:collation]
+            sql << " COLLATE \"#{options[:collation]}\""
+          end
+          super
+        end
       end
 
       module SchemaStatements
@@ -159,13 +166,13 @@ module ActiveRecord
         # Returns the list of all column definitions for a table.
         def columns(table_name)
           # Limit, precision, and scale are all handled by the superclass.
-          column_definitions(table_name).map do |column_name, type, default, notnull, oid, fmod|
+          column_definitions(table_name).map do |column_name, type, default, notnull, oid, fmod, collation|
             oid = oid.to_i
             fmod = fmod.to_i
             type_metadata = fetch_type_metadata(column_name, type, oid, fmod)
             default_value = extract_value_from_default(default)
             default_function = extract_default_function(default_value, default)
-            new_column(column_name, default_value, type_metadata, !notnull, default_function)
+            new_column(column_name, default_value, type_metadata, !notnull, default_function, collation)
           end
         end
 
@@ -409,6 +416,9 @@ module ActiveRecord
           quoted_column_name = quote_column_name(column_name)
           sql_type = type_to_sql(type, options[:limit], options[:precision], options[:scale], options[:array])
           sql = "ALTER TABLE #{quoted_table_name} ALTER COLUMN #{quoted_column_name} TYPE #{sql_type}"
+          if options[:collation]
+            sql << " COLLATE \"#{options[:collation]}\""
+          end
           if options[:using]
             sql << " USING #{options[:using]}"
           elsif options[:cast_as]

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -169,8 +169,8 @@ module ActiveRecord
           end
         end
 
-        def new_column(name, default, sql_type_metadata = nil, null = true, default_function = nil) # :nodoc:
-          PostgreSQLColumn.new(name, default, sql_type_metadata, null, default_function)
+        def new_column(name, default, sql_type_metadata = nil, null = true, default_function = nil, collation = nil) # :nodoc:
+          PostgreSQLColumn.new(name, default, sql_type_metadata, null, default_function, collation)
         end
 
         # Returns the current database name.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -772,7 +772,9 @@ module ActiveRecord
         def column_definitions(table_name) # :nodoc:
           exec_query(<<-end_sql, 'SCHEMA').rows
               SELECT a.attname, format_type(a.atttypid, a.atttypmod),
-                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
+                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
+             (SELECT c.collname FROM pg_collation c, pg_type t
+               WHERE c.oid = a.attcollation AND t.oid = a.atttypid AND a.attcollation <> t.typcollation)
                 FROM pg_attribute a LEFT JOIN pg_attrdef d
                   ON a.attrelid = d.adrelid AND a.attnum = d.adnum
                WHERE a.attrelid = '#{quote_table_name(table_name)}'::regclass

--- a/activerecord/test/cases/adapters/postgresql/collation_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/collation_test.rb
@@ -1,0 +1,53 @@
+require "cases/helper"
+require 'support/schema_dumping_helper'
+
+class PostgresqlCollationTest < ActiveRecord::TestCase
+  include SchemaDumpingHelper
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table :postgresql_collations, force: true do |t|
+      t.string :string_c, collation: 'C'
+      t.text :text_posix, collation: 'POSIX'
+    end
+  end
+
+  def teardown
+    @connection.drop_table :postgresql_collations, if_exists: true
+  end
+
+  test "string column with collation" do
+    column = @connection.columns(:postgresql_collations).find { |c| c.name == 'string_c' }
+    assert_equal :string, column.type
+    assert_equal 'C', column.collation
+  end
+
+  test "text column with collation" do
+    column = @connection.columns(:postgresql_collations).find { |c| c.name == 'text_posix' }
+    assert_equal :text, column.type
+    assert_equal 'POSIX', column.collation
+  end
+
+  test "add column with collation" do
+    @connection.add_column :postgresql_collations, :title, :string, collation: 'C'
+
+    column = @connection.columns(:postgresql_collations).find { |c| c.name == 'title' }
+    assert_equal :string, column.type
+    assert_equal 'C', column.collation
+  end
+
+  test "change column with collation" do
+    @connection.add_column :postgresql_collations, :description, :string
+    @connection.change_column :postgresql_collations, :description, :text, collation: 'POSIX'
+
+    column = @connection.columns(:postgresql_collations).find { |c| c.name == 'description' }
+    assert_equal :text, column.type
+    assert_equal 'POSIX', column.collation
+  end
+
+  test "schema dump includes collation" do
+    output = dump_table_schema("postgresql_collations")
+    assert_match %r{t.string\s+"string_c",\s+collation: "C"$}, output
+    assert_match %r{t.text\s+"text_posix",\s+collation: "POSIX"$}, output
+  end
+end


### PR DESCRIPTION
A part of the collation support for any adapters.

Related with #19549.

Example:

``` ruby
    create_table :foos do |t|
      t.string :string_en, collation: 'en_US.UTF-8'
      t.text   :text_ja,   collation: 'ja_JP.UTF-8'
    end
```
