### PR TITLE
Give authentication methods the ability to customize response message.

### DIFF
--- a/actionpack/test/controller/http_basic_authentication_test.rb
+++ b/actionpack/test/controller/http_basic_authentication_test.rb
@@ -36,7 +36,7 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
       if authenticate_with_http_basic { |username, password| username == 'pretty' && password == 'please' }
         @logged_in = true
       else
-        request_http_basic_authentication("SuperSecret")
+        request_http_basic_authentication("SuperSecret", "Authentication Failed\n")
       end
     end
 
@@ -104,7 +104,7 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     get :display
 
     assert_response :unauthorized
-    assert_equal "HTTP Basic: Access denied.\n", @response.body
+    assert_equal "Authentication Failed\n", @response.body
     assert_equal 'Basic realm="SuperSecret"', @response.headers['WWW-Authenticate']
   end
 
@@ -113,7 +113,7 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     get :display
 
     assert_response :unauthorized
-    assert_equal "HTTP Basic: Access denied.\n", @response.body
+    assert_equal "Authentication Failed\n", @response.body
     assert_equal 'Basic realm="SuperSecret"', @response.headers['WWW-Authenticate']
   end
 

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -30,7 +30,7 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
       if authenticate_with_http_token { |token, options| token == '"quote" pretty' && options[:algorithm] == 'test' }
         @logged_in = true
       else
-        request_http_token_authentication("SuperSecret")
+        request_http_token_authentication("SuperSecret", "Authentication Failed\n")
       end
     end
 
@@ -91,7 +91,7 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     get :display
 
     assert_response :unauthorized
-    assert_equal "HTTP Token: Access denied.\n", @response.body
+    assert_equal "Authentication Failed\n", @response.body
     assert_equal 'Token realm="SuperSecret"', @response.headers['WWW-Authenticate']
   end
 
@@ -100,7 +100,7 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     get :display
 
     assert_response :unauthorized
-    assert_equal "HTTP Token: Access denied.\n", @response.body
+    assert_equal "Authentication Failed\n", @response.body
     assert_equal 'Token realm="SuperSecret"', @response.headers['WWW-Authenticate']
   end
 


### PR DESCRIPTION
Digest allowed the messages to be customized.

Add the same feature to basic and token
