### PR TITLE
Move comment about microseconds [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -123,6 +123,8 @@ module ActiveRecord
         'f'
       end
 
+      # Quote date/time values for use in SQL input. Includes microseconds
+      # if the value is a Time responding to usec.
       def quoted_date(value)
         if value.acts_like?(:time)
           zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -40,8 +40,7 @@ module ActiveRecord
           PGconn.quote_ident(name.to_s)
         end
 
-        # Quote date/time values for use in SQL input. Includes microseconds
-        # if the value is a Time responding to usec.
+        # Quote date/time values for use in SQL input.
         def quoted_date(value) #:nodoc:
           if value.year <= 0
             bce_year = format("%04d", -value.year + 1)


### PR DESCRIPTION
The microseconds handling was already moved to `Quoting#quoted_date`.
