### PR TITLE
`:nodoc:` postgresql's change_column

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -403,8 +403,7 @@ module ActiveRecord
           super
         end
 
-        # Changes the column of a table.
-        def change_column(table_name, column_name, type, options = {})
+        def change_column(table_name, column_name, type, options = {}) #:nodoc:
           clear_cache!
           quoted_table_name = quote_table_name(table_name)
           quoted_column_name = quote_column_name(column_name)


### PR DESCRIPTION
Its nodoc'ed for the other implementations, and doc'ed in the base
class, just like the other change_column\* methods.
