### PR TITLE
Dump indexes in `create_table` instead of `add_index`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Dump indexes in `create_table` instead of `add_index`.
+
+    If the adapter supports indexes in create table, generated SQL is
+    slightly more efficient.
+
+    *Ryuta Kamizono*
+
 *   Make `unscope` aware of "less than" and "greater than" conditions.
 
     *TAKAHASHI Kazuaki*

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -168,10 +168,10 @@ HEADER
             tbl.puts
           end
 
+          indexes(table, tbl)
+
           tbl.puts "  end"
           tbl.puts
-
-          indexes(table, tbl)
 
           tbl.rewind
           stream.print tbl.read
@@ -188,8 +188,7 @@ HEADER
         if (indexes = @connection.indexes(table)).any?
           add_index_statements = indexes.map do |index|
             statement_parts = [
-              "add_index #{remove_prefix_and_suffix(index.table).inspect}",
-              index.columns.inspect,
+              "t.index #{index.columns.inspect}",
               "name: #{index.name.inspect}",
             ]
             statement_parts << 'unique: true' if index.unique
@@ -203,11 +202,10 @@ HEADER
             statement_parts << "using: #{index.using.inspect}" if index.using
             statement_parts << "type: #{index.type.inspect}" if index.type
 
-            "  #{statement_parts.join(', ')}"
+            "    #{statement_parts.join(', ')}"
           end
 
           stream.puts add_index_statements.sort.join("\n")
-          stream.puts
         end
       end
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -168,24 +168,24 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   def test_schema_dumps_index_columns_in_right_order
-    index_definition = standard_dump.split(/\n/).grep(/add_index.*companies/).first.strip
+    index_definition = standard_dump.split(/\n/).grep(/t\.index.*company_index/).first.strip
     if current_adapter?(:MysqlAdapter, :Mysql2Adapter, :PostgreSQLAdapter)
-      assert_equal 'add_index "companies", ["firm_id", "type", "rating"], name: "company_index", using: :btree', index_definition
+      assert_equal 't.index ["firm_id", "type", "rating"], name: "company_index", using: :btree', index_definition
     else
-      assert_equal 'add_index "companies", ["firm_id", "type", "rating"], name: "company_index"', index_definition
+      assert_equal 't.index ["firm_id", "type", "rating"], name: "company_index"', index_definition
     end
   end
 
   def test_schema_dumps_partial_indices
-    index_definition = standard_dump.split(/\n/).grep(/add_index.*company_partial_index/).first.strip
+    index_definition = standard_dump.split(/\n/).grep(/t\.index.*company_partial_index/).first.strip
     if current_adapter?(:PostgreSQLAdapter)
-      assert_equal 'add_index "companies", ["firm_id", "type"], name: "company_partial_index", where: "(rating > 10)", using: :btree', index_definition
+      assert_equal 't.index ["firm_id", "type"], name: "company_partial_index", where: "(rating > 10)", using: :btree', index_definition
     elsif current_adapter?(:MysqlAdapter, :Mysql2Adapter)
-      assert_equal 'add_index "companies", ["firm_id", "type"], name: "company_partial_index", using: :btree', index_definition
+      assert_equal 't.index ["firm_id", "type"], name: "company_partial_index", using: :btree', index_definition
     elsif current_adapter?(:SQLite3Adapter) && ActiveRecord::Base.connection.supports_partial_index?
-      assert_equal 'add_index "companies", ["firm_id", "type"], name: "company_partial_index", where: "rating > 10"', index_definition
+      assert_equal 't.index ["firm_id", "type"], name: "company_partial_index", where: "rating > 10"', index_definition
     else
-      assert_equal 'add_index "companies", ["firm_id", "type"], name: "company_partial_index"', index_definition
+      assert_equal 't.index ["firm_id", "type"], name: "company_partial_index"', index_definition
     end
   end
 
@@ -232,8 +232,8 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
     def test_schema_dumps_index_type
       output = standard_dump
-      assert_match %r{add_index "key_tests", \["awesome"\], name: "index_key_tests_on_awesome", type: :fulltext}, output
-      assert_match %r{add_index "key_tests", \["pizza"\], name: "index_key_tests_on_pizza", using: :btree}, output
+      assert_match %r{t\.index \["awesome"\], name: "index_key_tests_on_awesome", type: :fulltext}, output
+      assert_match %r{t\.index \["pizza"\], name: "index_key_tests_on_pizza", using: :btree}, output
     end
   end
 


### PR DESCRIPTION
If the adapter supports indexes in create table, generated SQL is
slightly more efficient.
