### PR TITLE
Handle raise flag in translate when both main and default translation is missing.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `translate` should handle `raise` flag correctly in case of both main and default
+    translation is missing.
+
+    Fixes #19967
+
+    *Bernard Potocki*
+
 *   Load the `default_form_builder` from the controller on initialization, which overrides
     the global config if it is present.
 

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -62,10 +62,10 @@ module ActionView
         # Note: `raise_error` refers to us re-raising the error in this method. I18n is forced to raise by default.
         if options[:raise] == false || (options.key?(:rescue_format) && options[:rescue_format].nil?)
           raise_error = false
-          options[:raise] = false
+          i18n_raise = false
         else
           raise_error = options[:raise] || options[:rescue_format] || ActionView::Base.raise_on_missing_translations
-          options[:raise] = true
+          i18n_raise = true
         end
 
         if html_safe_translation_key?(key)
@@ -75,11 +75,11 @@ module ActionView
               html_safe_options[name] = ERB::Util.html_escape(value.to_s)
             end
           end
-          translation = I18n.translate(scope_key_by_partial(key), html_safe_options)
+          translation = I18n.translate(scope_key_by_partial(key), html_safe_options.merge(raise: i18n_raise))
 
           translation.respond_to?(:html_safe) ? translation.html_safe : translation
         else
-          I18n.translate(scope_key_by_partial(key), options)
+          I18n.translate(scope_key_by_partial(key), options.merge(raise: i18n_raise))
         end
       rescue I18n::MissingTranslationData => e
         if remaining_defaults.present?

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -157,6 +157,19 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal true, translation.html_safe?
   end
 
+  def test_translate_with_missing_default
+    translation = translate(:'translations.missing', :default => :'translations.missing_html')
+    expected = '<span class="translation_missing" title="translation missing: en.translations.missing_html">Missing Html</span>'
+    assert_equal expected, translation
+    assert_equal true, translation.html_safe?
+  end
+
+  def test_translate_with_missing_default_and_raise_option
+    assert_raise(I18n::MissingTranslationData) do
+      translate(:'translations.missing', :default => :'translations.missing_html', :raise => true)
+    end
+  end
+
   def test_translate_with_two_defaults_named_html
     translation = translate(:'translations.missing', :default => [:'translations.missing_html', :'translations.hello_html'])
     assert_equal '<a>Hello World</a>', translation


### PR DESCRIPTION
Fixes #19967.

Quick explanation of what was happening:

[Basing on options](https://github.com/rails/rails/blob/87f876d0d32ea3e59c1c7752b6008f5ab236887f/actionview/lib/action_view/helpers/translation_helper.rb#L63-L69) `raise_error` flag is set, but unless explicit `options[:raise] = false` was provided it will be changed to `true` in first iteration (this is required for proper I18n handling). The problem is that this option is later passed to `default` call, so it's always `true` raising exception (see #19967).

This pull request changes this behavior so it will only raise exception in case of setting `options[:raise] == true` or `ActionView::Base.raise_on_missing_translations`.
