### PR TITLE
The default collation should not be change

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module Tasks # :nodoc:
     class MySQLDatabaseTasks # :nodoc:
       DEFAULT_CHARSET     = ENV['CHARSET']   || 'utf8'
-      DEFAULT_COLLATION   = ENV['COLLATION'] || 'utf8_unicode_ci'
+      DEFAULT_COLLATION   = ENV['COLLATION'] || 'utf8_general_ci'
       ACCESS_DENIED_ERROR = 1045
 
       delegate :connection, :establish_connection, to: ActiveRecord::Base

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -23,14 +23,14 @@ module ActiveRecord
 
     def test_creates_database_with_default_encoding_and_collation
       @connection.expects(:create_database).
-        with('my-app-db', charset: 'utf8', collation: 'utf8_unicode_ci')
+        with('my-app-db', charset: 'utf8', collation: 'utf8_general_ci')
 
       ActiveRecord::Tasks::DatabaseTasks.create @configuration
     end
 
     def test_creates_database_with_given_encoding_and_default_collation
       @connection.expects(:create_database).
-        with('my-app-db', charset: 'utf8', collation: 'utf8_unicode_ci')
+        with('my-app-db', charset: 'utf8', collation: 'utf8_general_ci')
 
       ActiveRecord::Tasks::DatabaseTasks.create @configuration.merge('encoding' => 'utf8')
     end
@@ -205,7 +205,7 @@ module ActiveRecord
 
     def test_recreates_database_with_the_default_options
       @connection.expects(:recreate_database).
-        with('test-db', charset: 'utf8', collation: 'utf8_unicode_ci')
+        with('test-db', charset: 'utf8', collation: 'utf8_general_ci')
 
       ActiveRecord::Tasks::DatabaseTasks.purge @configuration
     end


### PR DESCRIPTION
This reverts commit f6ca7e4e75408bc42f515fc7206d6c6ff0dce7c6.

The default collation of utf8 in MySQL is the `utf8_general_ci`, and this should not be changed. This is because, the better collation in the all locales is not exists, optimal collation in own application is not known other than themselves.

The `utf8_unicode_ci` is known as Japanese killer in Japan, there are serious impacts in search of Japanese.

MySQL implements the `utf8_unicode_ci` according to the Unicode Collation Algorithm (UCA) described at http://www.unicode.org/reports/tr10/, but the `utf8_unicode_ci` have only partial support for the UCA, only primary level key comparison implemented (also known as L1 (Base characters) comparison).

Because L1 (Base characters) comparison does not distinguish between the presence or absence of the accent, if distinction of the accent is important there is a serious impact (e.g. Japanese).

Example:

```
> SHOW CREATE TABLE `dicts`\G
*************************** 1. row ***************************
       Table: dicts
Create Table: CREATE TABLE `dicts` (
  `word` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
  `meaning` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci
1 row in set (0.00 sec)

> INSERT INTO `dicts` VALUES ('ハハ', 'mother'), ('パパ', 'father');
Query OK, 2 rows affected (0.00 sec)

> SELECT * FROM `dicts` WHERE `word` = 'ハハ';
+--------+---------+
| word   | meaning |
+--------+---------+
| ハハ   | mother  |
| パパ   | father  |
+--------+---------+
2 rows in set (0.00 sec)

> CREATE UNIQUE INDEX `unique_index_word` ON `dicts`(`word`);
ERROR 1062 (23000): Duplicate entry 'ハハ' for key 'unique_index_word'
```
