### PR TITLE
Refactoring translate helper & fix regression #19967.

### DIFF
--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -64,6 +64,13 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal false, translate(:"translations.missing", :rescue_format => nil).html_safe?
   end
 
+  # I don't know whether this is intended behavior.
+  def test_rescue_format_non_nil
+    assert_raise(I18n::MissingTranslationData) do
+      translate(:"translations.missing", :rescue_format => :something)
+    end
+  end
+
   def test_raises_missing_translation_message_with_raise_config_option
     ActionView::Base.raise_on_missing_translations = true
 
@@ -154,6 +161,13 @@ class TranslationHelperTest < ActiveSupport::TestCase
   def test_translate_with_default_named_html
     translation = translate(:'translations.missing', :default => :'translations.hello_html')
     assert_equal '<a>Hello World</a>', translation
+    assert_equal true, translation.html_safe?
+  end
+
+  def test_translate_with_missing_default
+    translation = translate(:'translations.missing', :default => :'translations.missing_html')
+    expected = '<span class="translation_missing" title="translation missing: en.translations.missing_html">Missing Html</span>'
+    assert_equal expected, translation
     assert_equal true, translation.html_safe?
   end
 


### PR DESCRIPTION
See #19967, #19998

I did a refactoring so that both the helper method `translate` and `I18n.translate` don't rely on the same `:raise` option for different purposes. Instead, I now use two distinctive variables: re_raise (which we use in rescue) and i18n_raise (which we pass to I18n.translate). The original option `:raise` is passed as-is recursively to `translate` helper. I’ve also separated the deprecated `:rescue_format` option from the rest so it is easier to understand.

@rafaelfranca @imanel @matthewd 
What do you think?
