### PR TITLE
Adds/Corrects use case for adding an error message

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -452,7 +452,6 @@ module ActiveModel
         defaults = []
       end
 
-      defaults << options.delete(:message)
       defaults << :"#{@base.class.i18n_scope}.errors.messages.#{type}" if @base.class.respond_to?(:i18n_scope)
       defaults << :"errors.attributes.#{attribute}.#{type}"
       defaults << :"errors.messages.#{type}"
@@ -461,6 +460,7 @@ module ActiveModel
       defaults.flatten!
 
       key = defaults.shift
+      defaults = options.delete(:message) if options[:message]
       value = (attribute != :base ? @base.send(:read_attribute_for_validation, attribute) : nil)
 
       options = {

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -149,6 +149,12 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["cannot be blank"], person.errors[:name]
   end
 
+  test "add an error message on a specific attribute with a defined type" do
+    person = Person.new
+    person.errors.add(:name, :blank, message: "cannot be blank")
+    assert_equal ["cannot be blank"], person.errors[:name]
+  end
+
   test "add an error with a symbol" do
     person = Person.new
     person.errors.add(:name, :blank)


### PR DESCRIPTION
I believe this is a use case that was supposed to be supported, and it's
a small fix. If this is not to be supported, then some tests on `add_on_empty` 
and `add_on_blank` could be removed.

I hope the test is self explanatory, but if you need further clarification let me know.
