### PR TITLE
Don't deep_dup Class

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/deep_dup.rb
+++ b/activesupport/lib/active_support/core_ext/object/deep_dup.rb
@@ -11,7 +11,7 @@ class Object
   #   object.instance_variable_defined?(:@a) # => false
   #   dup.instance_variable_defined?(:@a)    # => true
   def deep_dup
-    duplicable? ? dup : self
+    duplicable? && !is_a?(Class) ? dup : self
   end
 end
 

--- a/activesupport/test/core_ext/object/deep_dup_test.rb
+++ b/activesupport/test/core_ext/object/deep_dup_test.rb
@@ -50,4 +50,8 @@ class DeepDupTest < ActiveSupport::TestCase
     assert dup.instance_variable_defined?(:@a)
   end
 
+  def test_class_deep_dup
+    assert_equal Fixnum.deep_dup, Fixnum
+  end
+
 end


### PR DESCRIPTION
In ruby Class.dup works so adding Class into the duplicable.rb and marking it as a unduplicable object is confusing.
For this reason we have to check that self is a Class or not in deep_dup method.
Fixes #19993 
