### PR TITLE
Support for foreign keys in create table

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -15,9 +15,9 @@ module ActiveRecord
         end
 
         delegate :quote_column_name, :quote_table_name, :quote_default_expression, :type_to_sql,
-          :options_include_default?, :supports_indexes_in_create?, to: :@conn
+          :options_include_default?, :supports_indexes_in_create?, :supports_foreign_keys?, :foreign_key_options, to: :@conn
         private :quote_column_name, :quote_table_name, :quote_default_expression, :type_to_sql,
-          :options_include_default?, :supports_indexes_in_create?
+          :options_include_default?, :supports_indexes_in_create?, :supports_foreign_keys?, :foreign_key_options
 
         private
 
@@ -49,6 +49,10 @@ module ActiveRecord
               statements.concat(o.indexes.map { |column_name, options| index_in_create(o.name, column_name, options) })
             end
 
+            if supports_foreign_keys?
+              statements.concat(o.foreign_keys.map { |to_table, options| foreign_key_in_create(o.name, to_table, options) })
+            end
+
             create_sql << "(#{statements.join(', ')}) " if statements.present?
             create_sql << "#{o.options}"
             create_sql << " AS #{@conn.to_sql(o.as)}" if o.as
@@ -59,15 +63,19 @@ module ActiveRecord
             "PRIMARY KEY (#{o.name.join(', ')})"
           end
 
-          def visit_AddForeignKey(o)
+          def visit_ForeignKeyDefinition(o)
             sql = <<-SQL.strip_heredoc
-              ADD CONSTRAINT #{quote_column_name(o.name)}
+              CONSTRAINT #{quote_column_name(o.name)}
               FOREIGN KEY (#{quote_column_name(o.column)})
                 REFERENCES #{quote_table_name(o.to_table)} (#{quote_column_name(o.primary_key)})
             SQL
             sql << " #{action_sql('DELETE', o.on_delete)}" if o.on_delete
             sql << " #{action_sql('UPDATE', o.on_update)}" if o.on_update
             sql
+          end
+
+          def visit_AddForeignKey(o)
+            "ADD #{accept(o)}"
           end
 
           def visit_DropForeignKey(name)
@@ -100,6 +108,11 @@ module ActiveRecord
               sql << " PRIMARY KEY"
             end
             sql
+          end
+
+          def foreign_key_in_create(from_table, to_table, options)
+            options = foreign_key_options(from_table, to_table, options)
+            accept ForeignKeyDefinition.new(from_table, to_table, options)
           end
 
           def action_sql(action, dependency)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -260,10 +260,6 @@ module ActiveRecord
           end
         end
 
-        td.foreign_keys.each_pair do |other_table_name, foreign_key_options|
-          add_foreign_key(table_name, other_table_name, foreign_key_options)
-        end
-
         result
       end
 
@@ -792,15 +788,7 @@ module ActiveRecord
       def add_foreign_key(from_table, to_table, options = {})
         return unless supports_foreign_keys?
 
-        options[:column] ||= foreign_key_column_for(to_table)
-
-        options = {
-          column: options[:column],
-          primary_key: options[:primary_key],
-          name: foreign_key_name(from_table, options),
-          on_delete: options[:on_delete],
-          on_update: options[:on_update]
-        }
+        options = foreign_key_options(from_table, to_table, options)
         at = create_alter_table from_table
         at.add_foreign_key to_table, options
 
@@ -866,6 +854,13 @@ module ActiveRecord
         suffix = Base.table_name_suffix
         name = table_name.to_s =~ /#{prefix}(.+)#{suffix}/ ? $1 : table_name.to_s
         "#{name.singularize}_id"
+      end
+
+      def foreign_key_options(from_table, to_table, options) # :nodoc:
+        options = options.dup
+        options[:column] ||= foreign_key_column_for(to_table)
+        options[:name]   ||= foreign_key_name(from_table, options)
+        options
       end
 
       def dump_schema_information #:nodoc:

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -32,6 +32,14 @@ module ActiveRecord
         assert_equal [], @connection.foreign_keys("testings")
       end
 
+      test "foreign keys can be created in one query" do
+        assert_queries(1) do
+          @connection.create_table :testings do |t|
+            t.references :testing_parent, foreign_key: true
+          end
+        end
+      end
+
       test "options hash can be passed" do
         @connection.change_table :testing_parents do |t|
           t.integer :other_id


### PR DESCRIPTION
If foreign keys specified in create table, generated SQL is slightly more efficient.

Definition:

``` ruby
create_table :testings do |t|
  t.references :testing_parent, foreign_key: true
end
```

Before:

``` sql
CREATE TABLE "testings" ("id" serial primary key, "testing_parent_id" integer);
ALTER TABLE "testings" ADD CONSTRAINT "fk_rails_a196c353b2" FOREIGN KEY ("testing_parent_id") REFERENCES "testing_parents" ("id");
```

After:

``` sql
CREATE TABLE "testings" ("id" serial primary key, "testing_parent_id" integer, CONSTRAINT "fk_rails_a196c353b2" FOREIGN KEY ("testing_parent_id") REFERENCES "testing_parents" ("id"));
```
