### PR TITLE
Silence ambiguous first argument warning

### DIFF
--- a/actionpack/test/journey/route_test.rb
+++ b/actionpack/test/journey/route_test.rb
@@ -30,7 +30,7 @@ module ActionDispatch
         path      = Path::Pattern.new strexp
         defaults  = { name: 'tender' }
         route     = Route.new('name', nil, path, nil, defaults)
-        assert_equal /love/, route.requirements[:name]
+        assert_equal(/love/, route.requirements[:name])
       end
 
       def test_ip_address


### PR DESCRIPTION
This silences:

```
actionpack/test/journey/route_test.rb:33: warning: ambiguous first argument; put parentheses or a space even after `/' operator
```
