### PR TITLE
Checking the missing object inside test_template_objects_missing

### DIFF
--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -269,13 +269,15 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
 
   def test_template_objects_exist
     process :assign_this
-    assert !@controller.instance_variable_defined?(:"@hi")
-    assert @controller.instance_variable_get(:"@howdy")
+    assert @controller.instance_variable_get(:@howdy)
   end
 
   def test_template_objects_missing
     process :nothing
     assert !@controller.instance_variable_defined?(:@howdy)
+
+    process :assign_this
+    assert !@controller.instance_variable_defined?(:@hi)
   end
 
   def test_empty_flash


### PR DESCRIPTION
The instance variable @hi was getting asserted under test_template_objects_exist.  We already have a test_template_objects_missing which is checking for nothing, since we need it so putting it under the definition of missing_objects. Also as a second thought do we need that assertion for @hi as we are doing same for nothing .
