### PR TITLE
deep_dup method, remove old key from duplicated hash

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/deep_dup.rb
+++ b/activesupport/lib/active_support/core_ext/object/deep_dup.rb
@@ -40,6 +40,7 @@ class Hash
   #   dup[:a][:c]  # => "c"
   def deep_dup
     each_with_object(dup) do |(key, value), hash|
+      hash.delete(key)
       hash[key.deep_dup] = value.deep_dup
     end
   end

--- a/activesupport/test/core_ext/object/deep_dup_test.rb
+++ b/activesupport/test/core_ext/object/deep_dup_test.rb
@@ -50,4 +50,10 @@ class DeepDupTest < ActiveSupport::TestCase
     assert dup.instance_variable_defined?(:@a)
   end
 
+  def test_deep_dup_with_hash_class_key
+    hash = { Fixnum => 1 }
+    dup = hash.deep_dup
+    assert_equal dup.keys.length, 1
+  end
+
 end


### PR DESCRIPTION
remove old key from duplicated hash to avoid unnecessary pairs,
Also I've tried with inject but it does not work because in some cases you need to make operation on duplicated hash.
Fixes #19993 
