### PR TITLE
config.static_index configures directory Index "index.html" filename

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   `FileHandler` and `Static` middleware initializers accept `index` argument
+    to configure the directory index file name. Defaults to `index` (as in
+    `index.html`).
+
+    See #20017.
+
+    *Eliot Sykes*
+
 *   Fix `rake routes` not showing the right format when
     nesting multiple routes.
 

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -57,6 +57,7 @@ module StaticTests
 
   def test_serves_static_index_file_in_directory
     assert_html "/foo/index.html", get("/foo/index.html")
+    assert_html "/foo/index.html", get("/foo/index")
     assert_html "/foo/index.html", get("/foo/")
     assert_html "/foo/index.html", get("/foo")
   end
@@ -260,6 +261,19 @@ class StaticTest < ActiveSupport::TestCase
     }
     assert_equal(DummyApp.call(nil), @app.call(env))
   end
+
+  def test_non_default_static_index
+    @app = ActionDispatch::Static.new(DummyApp, @root, "public, max-age=60", "other-index")
+    assert_html "/other-index.html", get("/other-index.html")
+    assert_html "/other-index.html", get("/other-index")
+    assert_html "/other-index.html", get("/")
+    assert_html "/other-index.html", get("")
+    assert_html "/foo/other-index.html", get("/foo/other-index.html")
+    assert_html "/foo/other-index.html", get("/foo/other-index")
+    assert_html "/foo/other-index.html", get("/foo/")
+    assert_html "/foo/other-index.html", get("/foo")
+  end
+
 end
 
 class StaticEncodingTest < StaticTest

--- a/actionpack/test/fixtures/public/foo/other-index.html
+++ b/actionpack/test/fixtures/public/foo/other-index.html
@@ -1,0 +1,1 @@
+/foo/other-index.html

--- a/actionpack/test/fixtures/public/other-index.html
+++ b/actionpack/test/fixtures/public/other-index.html
@@ -1,0 +1,1 @@
+/other-index.html

--- a/actionpack/test/fixtures/公共/foo/other-index.html
+++ b/actionpack/test/fixtures/公共/foo/other-index.html
@@ -1,0 +1,1 @@
+/foo/other-index.html

--- a/actionpack/test/fixtures/公共/other-index.html
+++ b/actionpack/test/fixtures/公共/other-index.html
@@ -1,0 +1,1 @@
+/other-index.html

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -202,7 +202,7 @@ The full set of methods that can be used in this block are as follows:
 Every Rails application comes with a standard set of middleware which it uses in this order in the development environment:
 
 * `ActionDispatch::SSL` forces every request to be under HTTPS protocol. Will be available if `config.force_ssl` is set to `true`. Options passed to this can be configured by using `config.ssl_options`.
-* `ActionDispatch::Static` is used to serve static assets. Disabled if `config.serve_static_files` is `false`.
+* `ActionDispatch::Static` is used to serve static assets. Disabled if `config.serve_static_files` is `false`. Set `config.static_index` if you need to serve a static directory index file that is not named `index`. For example, to serve `main.html` instead of `index.html` for directory requests, set `config.static_index` to `"main"`.
 * `Rack::Lock` wraps the app in mutex so it can only be called by a single thread at a time. Only enabled when `config.cache_classes` is `false`.
 * `ActiveSupport::Cache::Strategy::LocalCache` serves as a basic memory backed cache. This cache is not thread safe and is intended only for serving as a temporary memory cache for a single thread.
 * `Rack::Runtime` sets an `X-Runtime` header, containing the time (in seconds) taken to execute the request.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   `config.static_index` configures directory `index.html` filename
+
+    Set `config.static_index` to serve a static directory index file not named
+    `index`. E.g. to serve `main.html` instead of `index.html` for directory
+    requests, set `config.static_index` to `"main"`.
+
+    *Eliot Sykes*
+
 *   `bin/setup` uses built-in rake tasks (`log:clear`, `tmp:clear`).
 
     *Mohnish Thallavajhula*

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -11,8 +11,8 @@ module Rails
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters,
                     :force_ssl, :helpers_paths, :logger, :log_formatter, :log_tags,
                     :railties_order, :relative_url_root, :secret_key_base, :secret_token,
-                    :serve_static_files, :ssl_options, :static_cache_control, :session_options,
-                    :time_zone, :reload_classes_only_on_change,
+                    :serve_static_files, :ssl_options, :static_cache_control, :static_index,
+                    :session_options, :time_zone, :reload_classes_only_on_change,
                     :beginning_of_week, :filter_redirect, :x
 
       attr_writer :log_level
@@ -28,6 +28,7 @@ module Rails
         @helpers_paths                 = []
         @serve_static_files            = true
         @static_cache_control          = nil
+        @static_index                  = "index"
         @force_ssl                     = false
         @ssl_options                   = {}
         @session_store                 = :cookie_store

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -18,7 +18,7 @@ module Rails
           middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header
 
           if config.serve_static_files
-            middleware.use ::ActionDispatch::Static, paths["public"].first, config.static_cache_control
+            middleware.use ::ActionDispatch::Static, paths["public"].first, config.static_cache_control, config.static_index
           end
 
           if rack_cache = load_rack_cache

--- a/railties/test/application/middleware/static_test.rb
+++ b/railties/test/application/middleware/static_test.rb
@@ -26,5 +26,26 @@ module ApplicationTests
 
       assert_not last_response.headers.has_key?('Cache-Control'), "Cache-Control should not be set"
     end
+
+    test "static_index defaults to 'index'" do
+      app_file "public/index.html", "/index.html"
+      
+      require "#{app_path}/config/environment"
+
+      get '/'
+      
+      assert_equal "/index.html\n", last_response.body
+    end
+
+    test "static_index configurable" do
+      app_file "public/other-index.html", "/other-index.html"
+      add_to_config "config.static_index = 'other-index'"
+      
+      require "#{app_path}/config/environment"
+
+      get '/'
+
+      assert_equal "/other-index.html\n", last_response.body
+    end
   end
 end


### PR DESCRIPTION
Set `config.static_index` to serve a static directory index file not
named `index`. For example, to serve `main.html` instead of `index.html`
for directory requests, set `config.static_index` to `"main"`.
