### PR TITLE
Remove :rescue_format option for translate helper

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Remove `:rescue_format` option for `translate` helper since it's no longer
+    supported by I18n.
+
+    *Bernard Potocki*
+
 *   `translate` should handle `raise` flag correctly in case of both main and default
     translation is missing.
 

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -60,11 +60,11 @@ module ActionView
         # If the user has explicitly decided to NOT raise errors, pass that option to I18n.
         # Otherwise, tell I18n to raise an exception, which we rescue further in this method.
         # Note: `raise_error` refers to us re-raising the error in this method. I18n is forced to raise by default.
-        if options[:raise] == false || (options.key?(:rescue_format) && options[:rescue_format].nil?)
+        if options[:raise] == false
           raise_error = false
           i18n_raise = false
         else
-          raise_error = options[:raise] || options[:rescue_format] || ActionView::Base.raise_on_missing_translations
+          raise_error = options[:raise] || ActionView::Base.raise_on_missing_translations
           i18n_raise = true
         end
 

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -41,8 +41,8 @@ class TranslationHelperTest < ActiveSupport::TestCase
     I18n.backend.reload!
   end
 
-  def test_delegates_to_i18n_setting_the_rescue_format_option_to_html
-    I18n.expects(:translate).with(:foo, :locale => 'en', :raise=>true).returns("")
+  def test_delegates_setting_to_i18n
+    I18n.expects(:translate).with(:foo, :locale => 'en', :raise => true).returns("")
     translate :foo, :locale => 'en'
   end
 
@@ -56,12 +56,6 @@ class TranslationHelperTest < ActiveSupport::TestCase
     expected = '<span class="translation_missing" title="translation missing: en.translations.missing">Missing</span>'
     assert_equal expected, translate(:"translations.missing")
     assert_equal true, translate(:"translations.missing").html_safe?
-  end
-
-  def test_returns_missing_translation_message_using_nil_as_rescue_format
-    expected = 'translation missing: en.translations.missing'
-    assert_equal expected, translate(:"translations.missing", :rescue_format => nil)
-    assert_equal false, translate(:"translations.missing", :rescue_format => nil).html_safe?
   end
 
   def test_raises_missing_translation_message_with_raise_config_option
@@ -94,12 +88,6 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal 'from CustomExceptionHandler', translate(:"translations.missing_html", raise: false)
   ensure
     I18n.exception_handler = old_exception_handler
-  end
-
-  def test_i18n_translate_defaults_to_nil_rescue_format
-    expected = 'translation missing: en.translations.missing'
-    assert_equal expected, I18n.translate(:"translations.missing")
-    assert_equal false, I18n.translate(:"translations.missing").html_safe?
   end
 
   def test_translation_returning_an_array


### PR DESCRIPTION
`:rescue_format` is not documented, it's [not working in I18n](https://github.com/svenfuchs/i18n/blob/master/CHANGELOG.md) and support for it was removed [with Rails 4.1.0](https://github.com/rails/rails/commit/0c7ac34aed1845044cd1911e5a775366d7ca41c1).

This pull request removes leftovers from that time - two tests that were always passing, one old test name and flag that was working in nearly exact the same way as passing `:raise` flag. 

Rails 5.0 is great moment to remove this flag - next time will be probably in two years with 6.x branch since it might be considered as backward-incompatible.
