### PR TITLE
Use `select_value` for avoid `ActiveRecord::Result` instance creating

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -770,7 +770,7 @@ module ActiveRecord
         #  - format_type includes the column size constraint, e.g. varchar(50)
         #  - ::regclass is a function that gives the id for a table name
         def column_definitions(table_name) # :nodoc:
-          exec_query(<<-end_sql, 'SCHEMA').rows
+          query(<<-end_sql, 'SCHEMA')
               SELECT a.attname, format_type(a.atttypid, a.atttypmod),
                      pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
              (SELECT c.collname FROM pg_collation c, pg_type t


### PR DESCRIPTION
`exec_query` create `ActiveRecord::Result` instance. It is better to use
`select_value` instead of `exec_query` for performance.
