### PR TITLE
Fix warnings in multiple application tests

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -75,11 +75,15 @@ class Class
     instance_predicate = options.fetch(:instance_predicate, true)
 
     attrs.each do |name|
+      remove_possible_singleton_method(name)
       define_singleton_method(name) { nil }
+
+      remove_possible_singleton_method("#{name}?")
       define_singleton_method("#{name}?") { !!public_send(name) } if instance_predicate
 
       ivar = "@#{name}"
 
+      remove_possible_singleton_method("#{name}=")
       define_singleton_method("#{name}=") do |val|
         singleton_class.class_eval do
           remove_possible_method(name)
@@ -110,10 +114,15 @@ class Class
             self.class.public_send name
           end
         end
+
+        remove_possible_method "#{name}?"
         define_method("#{name}?") { !!public_send(name) } if instance_predicate
       end
 
-      attr_writer name if instance_writer
+      if instance_writer
+        remove_possible_method "#{name}="
+        attr_writer name
+      end
     end
   end
 end

--- a/activesupport/lib/active_support/core_ext/module/remove_method.rb
+++ b/activesupport/lib/active_support/core_ext/module/remove_method.rb
@@ -6,6 +6,13 @@ class Module
     end
   end
 
+  # Removes the named singleton method, if it exists.
+  def remove_possible_singleton_method(method)
+    singleton_class.instance_eval do
+      remove_possible_method(method)
+    end
+  end
+
   # Replaces the existing method definition, if there is one, with the passed
   # block as its body.
   def redefine_method(method, &block)

--- a/activesupport/test/core_ext/module/remove_method_test.rb
+++ b/activesupport/test/core_ext/module/remove_method_test.rb
@@ -6,19 +6,31 @@ module RemoveMethodTests
     def do_something
       return 1
     end
-    
+
+    class << self
+      def do_something_else
+        return 2
+      end
+    end
   end
 end
 
 class RemoveMethodTest < ActiveSupport::TestCase
-  
+
   def test_remove_method_from_an_object
     RemoveMethodTests::A.class_eval{
       self.remove_possible_method(:do_something)
     }
     assert !RemoveMethodTests::A.new.respond_to?(:do_something)
   end
-  
+
+  def test_remove_singleton_method_from_an_object
+    RemoveMethodTests::A.class_eval{
+      self.remove_possible_singleton_method(:do_something_else)
+    }
+    assert !RemoveMethodTests::A.respond_to?(:do_something_else)
+  end
+
   def test_redefine_method_in_an_object
     RemoveMethodTests::A.class_eval{
       self.redefine_method(:do_something) { return 100 }


### PR DESCRIPTION
This is primarily to fix warnings in this test:

https://github.com/rails/rails/blob/d687881/railties/test/application/multiple_applications_test.rb#L102-L124

but I wanted to get feedback on a couple of things:
1. We call `remove_possible_method` for some of the methods defined in `class_attribute` but not the singleton methods - before merging this I want to make sure that it's not because of something I'm missing like a memory leak, etc.
2. Since 2296989 any block passed to a second application's initialize method isn't called because `run_load_hooks!` is only called via the singleton `instance` method so the block isn't evaluated. Is this intentional? That question specifically goes to @tenderlove :smile:

I'm not sure what the expected behaviour is with respect to multiple applications - not really seen any use of them in the wild.

/cc @rafaelfranca @matthewd @carlosantoniodasilva 
