### PR TITLE
Fixes some words missing from the contributing guide

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -532,7 +532,7 @@ pull request". The Rails core team will be notified about your submission.
 
 Most pull requests will go through a few iterations before they get merged.
 Different contributors will sometimes have different opinions, and often
-patches will need revised before they can get merged.
+patches will need to be revised before they can get merged.
 
 Some contributors to Rails have email notifications from GitHub turned on, but
 others do not. Furthermore, (almost) everyone who works on Rails is a


### PR DESCRIPTION
As I was thinking about it, I could decide between "will need revising" and "will need to be revised".
Maybe somebody could weigh in on a preference?

[ci skip]

cc: @zzak because of reasons
