### PR TITLE
Use Module.prepend instead of alias_method and unify behavior of all Numeric extensions

### DIFF
--- a/activesupport/lib/active_support/core_ext/big_decimal/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/big_decimal/conversions.rb
@@ -1,15 +1,14 @@
 require 'bigdecimal'
 require 'bigdecimal/util'
 
-class BigDecimal
-  DEFAULT_STRING_FORMAT = 'F'
-  alias_method :to_default_s, :to_s
+module ActiveSupport
+  module BigDecimalWithDefaultFormat #:nodoc:
+    DEFAULT_STRING_FORMAT = 'F'
 
-  def to_s(format = nil, options = nil)
-    if format.is_a?(Symbol)
-      to_formatted_s(format, options || {})
-    else
-      to_default_s(format || DEFAULT_STRING_FORMAT)
+    def to_s(format = nil)
+      super(format || DEFAULT_STRING_FORMAT)
     end
   end
 end
+
+BigDecimal.prepend(ActiveSupport::BigDecimalWithDefaultFormat)

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2071,30 +2071,22 @@ Extensions to `BigDecimal`
 --------------------------
 ### `to_s`
 
-The method `to_s` is aliased to `to_formatted_s`. This provides a convenient way to display a BigDecimal value in floating-point notation:
+The method `to_s` provides a default specifier of "F".  This means that a simple call to `to_s` will result in floating point representation instead of engineering notation:
 
 ```ruby
 BigDecimal.new(5.00, 6).to_s  # => "5.0"
 ```
 
-### `to_formatted_s`
-
-Te method `to_formatted_s` provides a default specifier of "F".  This means that a simple call to `to_formatted_s` or `to_s` will result in floating point representation instead of engineering notation:
-
-```ruby
-BigDecimal.new(5.00, 6).to_formatted_s  # => "5.0"
-```
-
 and that symbol specifiers are also supported:
 
 ```ruby
-BigDecimal.new(5.00, 6).to_formatted_s(:db)  # => "5.0"
+BigDecimal.new(5.00, 6).to_s(:db)  # => "5.0"
 ```
 
 Engineering notation is still supported:
 
 ```ruby
-BigDecimal.new(5.00, 6).to_formatted_s("e")  # => "0.5E1"
+BigDecimal.new(5.00, 6).to_s("e")  # => "0.5E1"
 ```
 
 Extensions to `Enumerable`


### PR DESCRIPTION
This is a follow-up pull request to #19434 - now that Ruby 2.2.2 is out we can switch to #prepend.

/cc @rafaelfranca @kirs
