### PR TITLE
[AR] Underscore class names for visitor pattern methods

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -45,11 +45,11 @@ module ActiveRecord
       class SchemaCreation < AbstractAdapter::SchemaCreation
         private
 
-        def visit_DropForeignKey(name)
+        def visit_drop_foreign_key(name)
           "DROP FOREIGN KEY #{name}"
         end
 
-        def visit_TableDefinition(o)
+        def visit_table_definition(o)
           name = o.name
           create_sql = "CREATE#{' TEMPORARY' if o.temporary} TABLE #{quote_table_name(name)} "
 
@@ -62,11 +62,11 @@ module ActiveRecord
           create_sql
         end
 
-        def visit_AddColumnDefinition(o)
+        def visit_add_column_definition(o)
           add_column_position!(super, column_options(o.column))
         end
 
-        def visit_ChangeColumnDefinition(o)
+        def visit_change_column_definition(o)
           change_column_sql = "CHANGE #{quote_column_name(o.name)} #{accept(o.column)}"
           add_column_position!(change_column_sql, column_options(o.column))
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       class SchemaCreation < AbstractAdapter::SchemaCreation
         private
 
-        def visit_ColumnDefinition(o)
+        def visit_column_definition(o)
           o.sql_type = type_to_sql(o.type, o.limit, o.precision, o.scale, o.array)
           super
         end


### PR DESCRIPTION
I believe underscoring the class names for the visitor pattern methods
reads better, as it aligns with Ruby's convention for method names.

Also, I think it isn't harder to understand that this is the visitor
pattern (the visit_ prefix gives it away). I don't know if there is any 
convention to camel case visitor patterns methods, but I don't think so.

I might be completely missing some reason as to why this was camel
cased, but this was something that confused me while reading the 
code and thus wanted the next person not to feel the same.
