### PR TITLE
Use ActiveSupport::SafeBuffer when flushing content_for

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Create a new `ActiveSupport::SafeBuffer` instance when `content_for` is flushed.
+
+    Fixes #19890
+
+    *Yoong Kang Lim*
+    
 *   Do not put partial name to `local_assigns` when rendering without
     an object or a collection.
 

--- a/actionview/lib/action_view/flows.rb
+++ b/actionview/lib/action_view/flows.rb
@@ -15,7 +15,7 @@ module ActionView
 
     # Called by each renderer object to set the layout contents.
     def set(key, value)
-      @content[key] = value
+      @content[key] = ActiveSupport::SafeBuffer.new(value)
     end
 
     # Called by content_for

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -148,6 +148,19 @@ class CaptureHelperTest < ActionView::TestCase
     assert ! content_for?(:something_else)
   end
 
+  def test_content_for_should_be_html_safe_after_flush_empty
+    assert ! content_for?(:title)
+    content_for :title do
+      content_tag(:p, 'title')
+    end
+    assert content_for(:title).html_safe?
+    content_for :title, "", flush: true
+    content_for(:title) do
+      content_tag(:p, 'title')
+    end
+    assert content_for(:title).html_safe?
+  end
+
   def test_provide
     assert !content_for?(:title)
     provide :title, "hi"


### PR DESCRIPTION
This addresses issue #19890.

Previously, when content_for is flushed, the content
was replaced directly by a new value in
ActionView::OutputFlow#set. The problem is this new
value passed to the method may not be an instance of
ActiveSupport::SafeBuffer.

This change forces the value to be set to a new
instance of ActiveSupport::SafeBuffer.
