### PR TITLE
Adding support for passing a block to the `add_source` action of a custom generator

### DIFF
--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -503,6 +503,14 @@ Adds a specified source to `Gemfile`:
 add_source "http://gems.github.com"
 ```
 
+This method also takes a block:
+
+```ruby
+add_source "http://gems.github.com" do
+  gem "rspec-rails"
+end
+```
+
 ### `inject_into_file`
 
 Injects a block of code into a defined position in your file.

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -45,6 +45,14 @@ class ActionsTest < Rails::Generators::TestCase
     assert_file 'Gemfile', /source 'http:\/\/gems\.github\.com'/
   end
 
+  def test_add_source_with_block_adds_source_to_gemfile_with_gem
+    run_generator
+    action :add_source, 'http://gems.github.com' do
+      gem 'rspec-rails'
+    end
+    assert_file 'Gemfile', /source 'http:\/\/gems\.github\.com' do\n  gem 'rspec-rails'\nend/
+  end
+
   def test_gem_should_put_gem_dependency_in_gemfile
     run_generator
     action :gem, 'will-paginate'


### PR DESCRIPTION
This PR adds support for passing a block to a call to `add_source` in a custom generator.

```
class AddSourceGenerator < Rails::Generators::Base
  def add_source_with_block
    add_source 'https://gems.github.com' do
      gem 'rspec-rails'
    end
  end
end
```

I do have a question about the best way to add the gems to the Gemfile. The `add_source` action uses `prepend_file` instead of `append_file` to place the `source` call at the top of the Gemfile. In order to get the `gem` calls inside the block to also prepend, I needed to change the `gem` method to use `prepend_file` when called from `add_source`. This seems to work OK. My concern with this is that the gems are added in reverse order that they are declared in. If we wanted to preserve the order, I think I would need to change this to append the `source` calls if `add_source` is passed a block.

Let me know if you have a preference on the above or anything else in the PR.
