### PR TITLE
removing require object/blank 

### DIFF
--- a/railties/lib/rails/generators/rails/resource/resource_generator.rb
+++ b/railties/lib/rails/generators/rails/resource/resource_generator.rb
@@ -1,6 +1,5 @@
 require 'rails/generators/resource_helpers'
 require 'rails/generators/rails/model/model_generator'
-require 'active_support/core_ext/object/blank'
 
 module Rails
   module Generators


### PR DESCRIPTION
the current class is not using the blank?, present? as well as other inheriting, the test suite also passes on local without it.
