### PR TITLE
Let Sidekiq and Que set provider_job_id

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Allow `Sidekiq` to report the job id back to `ActiveJob::Base` as
+    `provider_job_id`
+
+    *Jeroen van Baarsen*
+
 *   Allow `DelayedJob` to report id back to `ActiveJob::Base` as
     `provider_job_id`.
 

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,14 +1,9 @@
-*   Allow `Sidekiq` to report the job id back to `ActiveJob::Base` as
-    `provider_job_id`
-
-    *Jeroen van Baarsen*
-
-*   Allow `DelayedJob` to report id back to `ActiveJob::Base` as
-    `provider_job_id`.
+*   Allow `DelayedJob`, `Sidekiq` and `que` to report the job id back to
+    `ActiveJob::Base` as `provider_job_id`.
 
     Fixes #18821.
 
-    *Kevin Deisz*
+    *Kevin Deisz* And *Jeroen van Baarsen*
 
 *   `assert_enqueued_jobs` and `assert_performed_jobs` in block form use the
     given number as expected value. This makes the error message much easier to

--- a/activejob/lib/active_job/queue_adapters/que_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/que_adapter.rb
@@ -16,11 +16,15 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :que
     class QueAdapter
       def enqueue(job) #:nodoc:
-        JobWrapper.enqueue job.serialize
+        que_job = JobWrapper.enqueue job.serialize
+        job.provider_job_id = que_job.attrs["job_id"]
+        que_job
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
-        JobWrapper.enqueue job.serialize, run_at: Time.at(timestamp)
+        que_job = JobWrapper.enqueue job.serialize, run_at: Time.at(timestamp)
+        job.provider_job_id = que_job.attrs["job_id"]
+        que_job
       end
 
       class JobWrapper < Que::Job #:nodoc:

--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -17,20 +17,24 @@ module ActiveJob
     class SidekiqAdapter
       def enqueue(job) #:nodoc:
         #Sidekiq::Client does not support symbols as keys
-        Sidekiq::Client.push \
+        sidekiq_job_id = Sidekiq::Client.push \
           'class'   => JobWrapper,
           'wrapped' => job.class.to_s,
           'queue'   => job.queue_name,
           'args'    => [ job.serialize ]
+        job.provider_job_id = sidekiq_job_id
+        sidekiq_job_id
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
-        Sidekiq::Client.push \
+        sidekiq_job_id = Sidekiq::Client.push \
           'class'   => JobWrapper,
           'wrapped' => job.class.to_s,
           'queue'   => job.queue_name,
           'args'    => [ job.serialize ],
           'at'      => timestamp
+        job.provider_job_id = sidekiq_job_id
+        sidekiq_job_id
       end
 
       class JobWrapper #:nodoc:

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -61,4 +61,14 @@ class QueuingTest < ActiveSupport::TestCase
     test_job = TestJob.perform_later @id
     assert_kind_of Fixnum, test_job.provider_job_id
   end
+
+  test 'should supply a provider_job_id to Sidekiq' do
+    skip unless adapter_is?(:sidekiq)
+    test_job = TestJob.perform_later @id
+    refute test_job.provider_job_id.nil?, "Provider job id should be set by Sidekiq"
+
+    delayed_test_job = TestJob.set(wait: 1.minute).perform_later @id
+    refute delayed_test_job.provider_job_id.nil?,
+      "Provider job id should by set for delayed jobs by sidekiq"
+  end
 end

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -56,19 +56,13 @@ class QueuingTest < ActiveSupport::TestCase
     end
   end
 
-  test 'should supply a provider_job_id to DelayedJob' do
-    skip unless adapter_is?(:delayed_job)
+  test 'should supply a provider_job_id when available' do
+    skip unless adapter_is?(:sidekiq) || adapter_is?(:que) || adapter_is?(:delayed_job)
     test_job = TestJob.perform_later @id
-    assert_kind_of Fixnum, test_job.provider_job_id
-  end
-
-  test 'should supply a provider_job_id to Sidekiq' do
-    skip unless adapter_is?(:sidekiq)
-    test_job = TestJob.perform_later @id
-    refute test_job.provider_job_id.nil?, "Provider job id should be set by Sidekiq"
+    refute test_job.provider_job_id.nil?, "Provider job id should be set by provider"
 
     delayed_test_job = TestJob.set(wait: 1.minute).perform_later @id
     refute delayed_test_job.provider_job_id.nil?,
-      "Provider job id should by set for delayed jobs by sidekiq"
+      "Provider job id should by set for delayed jobs by provider"
   end
 end


### PR DESCRIPTION
When a job is added to Sidekiq or Que by ActiveJob, make sure we still can get the
original job_id provider by Sidekiq or Que. We do this by adding the Sidekiq jid or Que job_id to
provider_job_id field on the job object.

Partly fixes #18821

This PR is an extension on the PR submitted by @kddeisz : https://github.com/rails/rails/pull/19910
