### PR TITLE
Using relative includes

### DIFF
--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -14,7 +14,7 @@ module Rails
 
     class Base < Thor::Group
       include Thor::Actions
-      include Rails::Generators::Actions
+      include Actions
 
       add_runtime_options!
       strict_args_position!

--- a/railties/lib/rails/generators/rails/model/model_generator.rb
+++ b/railties/lib/rails/generators/rails/model/model_generator.rb
@@ -3,7 +3,7 @@ require 'rails/generators/model_helpers'
 module Rails
   module Generators
     class ModelGenerator < NamedBase # :nodoc:
-      include Rails::Generators::ModelHelpers
+      include ModelHelpers
 
       argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
       hook_for :orm, required: true, desc: "ORM to be invoked"


### PR DESCRIPTION
We are already inside `Rails::Generators` namespace, no need for absolute include.  Little benchmarking on absolute vs relative includes

```
require 'benchmark'
module A
  module B
    module C

    def test
      "this is good"
    end

    def test1
      "this is good"
    end

    def test2
      "this is good"
    end

    def test3
      "this is good"
    end

    def test4
      "this is good"
    end
  end
  end
end



module A
  module B
    class AB
      include A::B::C #Absolute include
    end
  end
end


module A
  module B
    class CD
      include C #Relative include
    end
  end
end


Benchmark.bm do |x|
  x.report("Absolute: ") { A::B::AB.new }
  x.report("Relative: ") { A::B::CD.new }
end

```

**Report**

```
Ankits-MacBook-Pro:tests ankitgupta$ ruby module.rb 
       user     system      total        real
Absolute:   0.000000   0.000000   0.000000 (  0.000005)
Relative:   0.000000   0.000000   0.000000 (  0.000004)
Ankits-MacBook-Pro:tests ankitgupta$ 

```
