### PR TITLE
add error log that notify 'file not found' when using cache_digest dependency rake

### DIFF
--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -70,7 +70,8 @@ module ActionView
     def dependencies
       DependencyTracker.find_dependencies(name, template)
     rescue ActionView::MissingTemplate
-      [] # File doesn't exist, so no dependencies
+      logger.try :error, "  '#{name}' file doesn't exist, so no dependencies"
+      []
     end
 
     def nested_dependencies

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -111,6 +111,18 @@ class TemplateDigestorTest < ActionView::TestCase
     end
   end
 
+  def test_logging_of_missing_template_for_dependencies
+    assert_logged "'messages/something_missing' file doesn't exist, so no dependencies" do
+      dependencies("messages/something_missing")
+    end
+  end
+
+  def test_logging_of_missing_template_for_nested_dependencies
+    assert_logged "'messages/something_missing' file doesn't exist, so no dependencies" do
+      nested_dependencies("messages/something_missing")
+    end
+  end
+
   def test_nested_template_directory
     assert_digest_difference("messages/show") do
       change_template("messages/actions/_move")
@@ -296,6 +308,14 @@ class TemplateDigestorTest < ActionView::TestCase
       finder.variants = options.delete(:variants) || []
 
       ActionView::Digestor.digest({ name: template_name, finder: finder }.merge(options))
+    end
+
+    def dependencies(template_name)
+      ActionView::Digestor.new({ name: template_name, finder: finder }).dependencies
+    end
+
+    def nested_dependencies(template_name)
+      ActionView::Digestor.new({ name: template_name, finder: finder }).nested_dependencies
     end
 
     def finder


### PR DESCRIPTION
fixed #19968 
