### PR TITLE
Example updated [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/atom_feed_helper.rb
+++ b/actionview/lib/action_view/helpers/atom_feed_helper.rb
@@ -16,7 +16,7 @@ module ActionView
       #     end
       #
       #   app/controllers/posts_controller.rb:
-      #     class PostsController < ApplicationController::Base
+      #     class PostsController < ApplicationController
       #       # GET /posts.html
       #       # GET /posts.atom
       #       def index


### PR DESCRIPTION
Should be `ApplicationController` not `ApplicationController::Base`
