### PR TITLE
Reduce allocated memory for ActiveJob#perform_later

### DIFF
--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -54,7 +54,7 @@ module ActiveJob
       def enqueue(event)
         info do
           job = event.payload[:job]
-          "Enqueued #{job.class.name} (Job ID: #{job.job_id}) to #{queue_name(event)}" + args_info(job)
+          "Enqueued #{job.class.name} (Job ID: #{job.job_id}) to #{queue_name(event)} #{args_info(job)}"
         end
       end
 
@@ -81,7 +81,8 @@ module ActiveJob
 
       private
         def queue_name(event)
-          event.payload[:adapter].class.name.demodulize.remove('Adapter') + "(#{event.payload[:job].queue_name})"
+          adapter = event.payload[:adapter].class.name.demodulize.tr('Adapter'.freeze, ''.freeze)
+          "#{adapter}(#{event.payload[:job].queue_name})"
         end
 
         def args_info(job)


### PR DESCRIPTION
Hello,
I used [memory_profiler](https://github.com/SamSaffron/memory_profiler) gem and checked allocated memory for `perform_later` method:

``` ruby
MemoryProfiler.report{ 100.times { GuestsCleanupJob.perform_later } }.pretty_print
```
#### Results for master branch:

```
Total allocated 50197
Total retained 635

allocated memory by gem
-----------------------------------
   1471258  activesupport/lib
    567765  activejob/lib
```
#### My branch:

```
Total allocated 45730
Total retained 635

allocated memory by gem
-----------------------------------
   1269694  activesupport/lib
    485165  activejob/lib
```
