### PR TITLE
Adding max_retry to ActiveJob

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Add `max_retry` to change default adapter max retry on failures.
+    For now only Sidekiq and DelayedJob get max_retry working but
+    if max_retry is not set, adapters get default value
+
+    Example:
+
+        class HelloJob < ActiveJob::Base
+
+            max_retry 3
+
+            def perform(greeter = "David")
+                JobBuffer.add("#{greeter} says hello")
+            end
+        end
+
+    *Claudio Fiorini*
+
 *   Allow `DelayedJob`, `Sidekiq`, `qu`, and `que` to report the job id back to
     `ActiveJob::Base` as `provider_job_id`.
 

--- a/activejob/lib/active_job/base.rb
+++ b/activejob/lib/active_job/base.rb
@@ -1,6 +1,7 @@
 require 'active_job/core'
 require 'active_job/queue_adapter'
 require 'active_job/queue_name'
+require 'active_job/max_retry'
 require 'active_job/enqueuing'
 require 'active_job/execution'
 require 'active_job/callbacks'
@@ -56,6 +57,7 @@ module ActiveJob #:nodoc:
     include Core
     include QueueAdapter
     include QueueName
+    include MaxRetry
     include Enqueuing
     include Execution
     include Callbacks

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -18,6 +18,9 @@ module ActiveJob
       # Queue in which the job will reside.
       attr_writer :queue_name
 
+      # max retry for adapters that have supports retry
+      attr_writer :max_retry
+
       # ID optionally provided by adapter
       attr_accessor :provider_job_id
     end
@@ -25,6 +28,7 @@ module ActiveJob
     # These methods will be included into any Active Job object, adding
     # helpers for de/serialization and creation of job instances.
     module ClassMethods
+
       # Creates a new job instance from a hash created with +serialize+
       def deserialize(job_data)
         job = job_data['job_class'].constantize.new
@@ -59,6 +63,7 @@ module ActiveJob
       @arguments  = arguments
       @job_id     = SecureRandom.uuid
       @queue_name = self.class.queue_name
+      @max_retry  = self.class.max_retry
     end
 
     # Returns a hash with the job data that can safely be passed to the
@@ -68,6 +73,7 @@ module ActiveJob
         'job_class'  => self.class.name,
         'job_id'     => job_id,
         'queue_name' => queue_name,
+        'max_retry'  => max_retry,
         'arguments'  => serialize_arguments(arguments)
       }
     end
@@ -95,6 +101,7 @@ module ActiveJob
     def deserialize(job_data)
       self.job_id               = job_data['job_id']
       self.queue_name           = job_data['queue_name']
+      self.max_retry            = job_data['max_retry']
       self.serialized_arguments = job_data['arguments']
     end
 

--- a/activejob/lib/active_job/max_retry.rb
+++ b/activejob/lib/active_job/max_retry.rb
@@ -1,0 +1,52 @@
+module ActiveJob
+  module MaxRetry
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+
+      mattr_accessor(:default_max_retry) { nil }
+
+      def max_retry_from_part(max_retries) #:nodoc:
+        ( "#{max_retries}".to_i > 0 ? "#{max_retries}".to_i : default_max_retry )
+      end
+
+    end
+
+    included do
+      # Specifies the max retry for the job.
+      #
+      #   class PublishToFeedJob < ActiveJob::Base
+      #     max_retry 2
+      #
+      #     def perform(post)
+      #       post.to_feed!
+      #     end
+      #   end
+      def self.max_retry(max_retries=nil, &block)
+        if block_given?
+          @max_retry = block
+        else
+          if max_retries.nil?
+            @max_retry
+          else
+            @max_retry = max_retry_from_part(max_retries)
+          end
+        end
+      end
+
+      def self.max_retry=(max_retries = nil)
+        @max_retry = max_retry_from_part(max_retries)
+      end
+    end
+
+    # Returns the max retry of current job
+    def max_retry
+      if @max_retry.is_a?(Proc)
+        @max_retry = self.class.max_retry_from_part(instance_exec(&@max_retry))
+      end
+      @max_retry
+    end
+
+  end
+end
+

--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -14,13 +14,13 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :delayed_job
     class DelayedJobAdapter
       def enqueue(job) #:nodoc:
-        delayed_job = Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name)
+        delayed_job = Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name, attempts: job.max_retry || 3)
         job.provider_job_id = delayed_job.id
         delayed_job
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
-        delayed_job = Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name, run_at: Time.at(timestamp))
+        delayed_job = Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name, attempts: job.max_retry || 3, run_at: Time.at(timestamp))
         job.provider_job_id = delayed_job.id
         delayed_job
       end

--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -21,6 +21,7 @@ module ActiveJob
           'class'   => JobWrapper,
           'wrapped' => job.class.to_s,
           'queue'   => job.queue_name,
+          'retry'   => job.max_retry || true,
           'args'    => [ job.serialize ]
       end
 
@@ -29,6 +30,7 @@ module ActiveJob
           'class'   => JobWrapper,
           'wrapped' => job.class.to_s,
           'queue'   => job.queue_name,
+          'retry'   => job.max_retry || true,
           'args'    => [ job.serialize ],
           'at'      => timestamp
       end

--- a/activejob/test/cases/max_retry_test.rb
+++ b/activejob/test/cases/max_retry_test.rb
@@ -1,0 +1,67 @@
+require 'helper'
+require 'jobs/hello_job'
+require 'jobs/logging_job'
+require 'jobs/nested_job'
+
+class MaxRetryTest < ActiveSupport::TestCase
+  test 'max retry from base' do
+    assert_equal nil, HelloJob.max_retry
+  end
+
+  test 'uses given max retry job' do
+    original_max_retry = HelloJob.max_retry
+
+    begin
+      HelloJob.max_retry 5
+      assert_equal 5, HelloJob.new.max_retry
+    ensure
+      HelloJob.max_retry = original_max_retry
+    end
+  end
+
+  test 'not allows a blank max_retry' do
+    original_max_retry = HelloJob.max_retry
+
+    begin
+      HelloJob.max_retry ''
+      assert_equal nil, HelloJob.max_retry
+    ensure
+      HelloJob.max_retry = original_max_retry
+    end
+  end
+
+  test 'uses given string for max retry job' do
+    original_max_retry = HelloJob.max_retry
+
+    begin
+      HelloJob.max_retry '5'
+      assert_equal 5, HelloJob.new.max_retry
+    ensure
+      HelloJob.max_retry = original_max_retry
+    end
+  end
+
+  test 'evals block given to max_retry to determine max retries' do
+    original_max_retry = HelloJob.max_retry
+
+    begin
+      HelloJob.max_retry { 2 }
+      assert_equal 2, HelloJob.new.max_retry
+    ensure
+      HelloJob.max_retry = original_max_retry
+    end
+  end
+
+  test 'can use arguments to determine max retry in max_retry block' do
+    original_max_retry = HelloJob.max_retry
+
+    begin
+      HelloJob.max_retry { self.arguments.first=='a' ? 1 : 3 }
+      assert_equal 1, HelloJob.new('a').max_retry
+      assert_equal 3, HelloJob.new('b').max_retry
+    ensure
+      HelloJob.max_retry = original_max_retry
+    end
+  end
+
+end


### PR DESCRIPTION
The possibility to change max attempts can be very useful if you want a job to die on first failure.
For now only Sidekiq and DelayedJob allow to set max attempts when adding a job to the queue.
max_retry accept a value or a block.
