### PR TITLE
docs: syncing with the code, adding aj [ci skip]

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -533,6 +533,7 @@ require "rails"
   action_controller
   action_view
   action_mailer
+  active_job
   rails/test_unit
   sprockets
 ).each do |framework|


### PR DESCRIPTION
syncing this will the code, adding aj

```
require "rails"

%w(
  active_record
  action_controller
  action_view
  action_mailer
  active_job
  rails/test_unit
  sprockets
).each do |framework|
  begin
    require "#{framework}/railtie"
  rescue LoadError
  end
end

```
