### PR TITLE
put dynamic matchers on GeneratedAssociationMethods instead of model

### DIFF
--- a/activerecord/lib/active_record/dynamic_matchers.rb
+++ b/activerecord/lib/active_record/dynamic_matchers.rb
@@ -16,7 +16,7 @@ module ActiveRecord
 
       if match && match.valid?
         match.define
-        send(name, *arguments, &block)
+        generated_association_methods.send(name, *arguments, &block)
       else
         super
       end
@@ -60,7 +60,7 @@ module ActiveRecord
       end
 
       def define
-        model.class_eval <<-CODE, __FILE__, __LINE__ + 1
+        model.generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
           def self.#{name}(#{signature})
             #{body}
           end
@@ -70,7 +70,7 @@ module ActiveRecord
       private
 
       def body
-        "#{finder}(#{attributes_hash})"
+        "#{model}.#{finder}(#{attributes_hash})"
       end
 
       # The parameters in the signature may have reserved Ruby words, in order

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -17,6 +17,7 @@ require 'models/matey'
 require 'models/dog'
 require 'models/car'
 require 'models/tyre'
+require 'models/electron'
 
 class FinderTest < ActiveRecord::TestCase
   fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :customers, :categories, :categorizations, :cars
@@ -797,6 +798,18 @@ class FinderTest < ActiveRecord::TestCase
   def test_find_by_one_attribute
     assert_equal topics(:first), Topic.find_by_title("The First Topic")
     assert_nil Topic.find_by_title("The First Topic!")
+  end
+
+  def test_find_by_does_not_overwrite_method_on_class
+    Electron.create(name: 'First Electron')
+
+    assert_equal 0, Electron.times_called_find_by_name
+
+    Electron.find_by_name('First Electron')
+    assert_equal 1, Electron.times_called_find_by_name
+
+    Electron.find_by_name('Some Other Electron')
+    assert_equal 2, Electron.times_called_find_by_name
   end
 
   def test_find_by_one_attribute_bang

--- a/activerecord/test/models/electron.rb
+++ b/activerecord/test/models/electron.rb
@@ -2,4 +2,12 @@ class Electron < ActiveRecord::Base
   belongs_to :molecule
 
   validates_presence_of :name
+
+  cattr_reader :times_called_find_by_name
+  @@times_called_find_by_name = 0
+
+  def self.find_by_name(name)
+    @@times_called_find_by_name += 1
+    super(name)
+  end
 end


### PR DESCRIPTION
This is one possible fix to this issue https://github.com/rails/rails/issues/15288

It defines the dynamically created `find_by_xxx` methods in the same anonymous module as the association methods (`Klass::GeneratedAssociationMethods`).

Pros:
- reuses the anonymous module that is there
- avoids the unexpected behavior of having a method in a model blown away after the first call

Cons:
- weird delegation of `Klass.find_by(attrs)`
- will be slightly less performant as future calls will still have to hit `method_missing` on the model before being found in the module

If this is accepted it might make sense to change the module name to something that is not association-specific (GeneratedModelMethods?)
