### PR TITLE
minor rdoc syntax fix [ci skip]

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -102,10 +102,10 @@ module ActiveModel
   #   person.changes # => {"name" => ["Bill", "Bob"]}
   #
   # If an attribute is modified in-place then make use of
-  # +[attribute_name]_will_change!+ to mark that the attribute is changing.
+  # <tt>[attribute_name]_will_change!</tt> to mark that the attribute is changing.
   # Otherwise \Active \Model can't track changes to in-place attributes. Note
   # that Active Record can detect in-place modifications automatically. You do
-  # not need to call +[attribute_name]_will_change!+ on Active Record models.
+  # not need to call <tt>[attribute_name]_will_change!</tt> on Active Record models.
   #
   #   person.name_will_change!
   #   person.name_change # => ["Bill", "Bill"]


### PR DESCRIPTION
Without this syntax '+' sign show up on document: http://api.rubyonrails.org/classes/ActiveModel/Dirty.html
