### PR TITLE
docs for updating nested attributes while creating parent record

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -166,6 +166,11 @@ module ActiveRecord
     #   member.posts.first.title # => '[UPDATED] An, as of yet, undisclosed awesome Ruby documentation browser!'
     #   member.posts.second.title # => '[UPDATED] other post'
     #
+    # However, the above applies if the parent model is being updated as well.
+    # For example, If you wanted to create a +member+ named _joe_ and wanted to
+    # update the +posts+ at the same time, that would give an
+    # ActiveRecord::RecordNotFound error.
+    #
     # By default the associated records are protected from being destroyed. If
     # you want to destroy any of the associated records through the attributes
     # hash, you have to enable it first using the <tt>:allow_destroy</tt>


### PR DESCRIPTION
This references an issue that I had while trying to update a nested attribute while trying to create a new record in the parent model at the same time with `accepts_nested_attributes_for`. 

I think the reason that Rails doesn't allow this is because of a security issue, so I thought it would be good for every one else to know
