### PR TITLE
`assert_emails` in block form use the given number as expected value

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `assert_emails` in block form use the given number as expected value.
+    This makes the error message much easier to understand.
+
+    *Yuji Yaginuma*
+
 *   Add support for inline images in mailer previews by using an interceptor
     class to convert cid: urls in image src attributes to data urls.
 

--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -34,7 +34,7 @@ module ActionMailer
         original_count = ActionMailer::Base.deliveries.size
         yield
         new_count = ActionMailer::Base.deliveries.size
-        assert_equal original_count + number, new_count, "#{number} emails expected, but #{new_count - original_count} were sent"
+        assert_equal number, new_count - original_count, "#{number} emails expected, but #{new_count - original_count} were sent"
       else
         assert_equal number, ActionMailer::Base.deliveries.size
       end

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -112,6 +112,17 @@ class TestHelperMailerTest < ActionMailer::TestCase
     assert_match(/1 .* but 2/, error.message)
   end
 
+  def test_assert_emails_message
+    TestHelperMailer.test.deliver_now
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_emails 2 do
+        TestHelperMailer.test.deliver_now
+      end
+    end
+    assert_match "Expected: 2", error.message
+    assert_match "Actual: 1", error.message
+  end
+
   def test_assert_no_emails_failure
     error = assert_raise ActiveSupport::TestCase::Assertion do
       assert_no_emails do


### PR DESCRIPTION
In `assert_equal` calling in `assert_email`, appoint the value that added original count and number to. However, appoint only number in error message. 

Therefore, when call `deliver_now` before calling `assert_equal`, output is different from `Expected` in error message. 

``` ruby
test "notifier mail" do
  NotifierMailer.welcome.deliver_now
  assert_emails 2 do
    NotifierMailer.welcome.deliver_now
  end
end
```

``` cosole
  1) Failure:
NotifierMailerTest#test_notifier_mail [/home/yaginuma/program/rails/master/test/mailers/notifier_mailer_test.rb:6]:
2 emails expected, but 1 were sent.
Expected: 3
  Actual: 2
```

This patch fixes the argument of `assert_equal`, so it's output as follows.

``` cosole
  1) Failure:
NotifierMailerTest#test_notifier_mail [/home/yaginuma/program/rails/master/test/mailers/notifier_mailer_test.rb:6]:
2 emails expected, but 1 were sent.
Expected: 2
  Actual: 1
```
