### PR TITLE
Fixed spacing in error message

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -161,7 +161,7 @@ module ActiveRecord
         }
         record = statement.execute([id], self, connection).first
         unless record
-          raise RecordNotFound, "Couldn't find #{name} with '#{primary_key}'=#{id}"
+          raise RecordNotFound, "Couldn't find #{name} with '#{primary_key}' = #{id}"
         end
         record
       rescue RangeError

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1031,7 +1031,7 @@ class FinderTest < ActiveRecord::TestCase
       e = assert_raises(ActiveRecord::RecordNotFound) do
         model.find 'Hello World!'
       end
-      assert_equal %Q{Couldn't find MercedesCar with 'name'=Hello World!}, e.message
+      assert_equal %Q{Couldn't find MercedesCar with 'name' = Hello World!}, e.message
     end
   end
 


### PR DESCRIPTION
Before RecordNotFound error message and query generated to fetch record had different spacing when showing id=somevalue.

Example:

irb(main):001:0> User.find 42
  User Load (0.3ms)  SELECT  `users`.\* FROM `users` WHERE `users`.`id` = 42 LIMIT 1
ActiveRecord::RecordNotFound: Couldn't find User with 'id'=42

Removed spacing inconsistency, so that the message is not confusing anymore.
