### PR TITLE
dry'in up, moving assert_filtered_out to custom assertions

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../load_paths', __FILE__)
 
 $:.unshift(File.dirname(__FILE__) + '/lib')
+$:.unshift(File.dirname(__FILE__) + '/controller/support')
 $:.unshift(File.dirname(__FILE__) + '/fixtures/helpers')
 $:.unshift(File.dirname(__FILE__) + '/fixtures/alternate_helpers')
 
@@ -229,6 +230,7 @@ class Rack::TestCase < ActionDispatch::IntegrationTest
   def assert_header(name, value)
     assert_equal value, response.headers[name]
   end
+
 end
 
 module ActionController

--- a/actionpack/test/controller/parameters/multi_parameter_attributes_test.rb
+++ b/actionpack/test/controller/parameters/multi_parameter_attributes_test.rb
@@ -1,4 +1,5 @@
 require 'abstract_unit'
+require 'custom_assertions'
 require 'action_controller/metal/strong_parameters'
 
 class MultiParameterAttributesTest < ActiveSupport::TestCase
@@ -34,5 +35,7 @@ class MultiParameterAttributesTest < ActiveSupport::TestCase
     assert_nil permitted[:book]["published_at(1i)"]
     assert_nil permitted[:book]["published_at(2i)"]
     assert_nil permitted[:book]["published_at(3i)"]
+
+    assert_filtered_out permitted,:published_at
   end
 end

--- a/actionpack/test/controller/parameters/nested_parameters_test.rb
+++ b/actionpack/test/controller/parameters/nested_parameters_test.rb
@@ -1,11 +1,8 @@
 require 'abstract_unit'
+require 'custom_assertions'
 require 'action_controller/metal/strong_parameters'
 
 class NestedParametersTest < ActiveSupport::TestCase
-  def assert_filtered_out(params, key)
-    assert !params.has_key?(key), "key #{key.inspect} has not been filtered out"
-  end
-
   test "permitted nested parameters" do
     params = ActionController::Parameters.new({
       book: {

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -1,12 +1,9 @@
 require 'abstract_unit'
+require 'custom_assertions'
 require 'action_dispatch/http/upload'
 require 'action_controller/metal/strong_parameters'
 
 class ParametersPermitTest < ActiveSupport::TestCase
-  def assert_filtered_out(params, key)
-    assert !params.has_key?(key), "key #{key.inspect} has not been filtered out"
-  end
-
   setup do
     @params = ActionController::Parameters.new(
       person: {

--- a/actionpack/test/controller/support/custom_assertions.rb
+++ b/actionpack/test/controller/support/custom_assertions.rb
@@ -1,0 +1,3 @@
+def assert_filtered_out(params, key)
+  assert !params.has_key?(key), "key #{key.inspect} has not been filtered out"
+end


### PR DESCRIPTION
Moving it into custom_assertions and also adding `assert_filtered_out` to MultiParameterAttributesTest
