### PR TITLE
not needed require's

### DIFF
--- a/actionmailer/test/delivery_methods_test.rb
+++ b/actionmailer/test/delivery_methods_test.rb
@@ -1,5 +1,4 @@
 require 'abstract_unit'
-require 'mail'
 
 class MyCustomDelivery
 end

--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -2,7 +2,6 @@ require 'abstract_unit'
 require 'active_job'
 require 'minitest/mock'
 require 'mailers/delayed_mailer'
-require 'active_support/core_ext/numeric/time'
 
 class MessageDeliveryTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper


### PR DESCRIPTION
- `as/core_ext` is not used and test pass locally without it
- `mail` is [already required](https://github.com/rails/rails/blob/master/actionmailer/test/abstract_unit.rb#L14) in abstract_unit.
