### PR TITLE
Add ability to translate rails guides documents.yaml

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -194,7 +194,7 @@ module RailsGuides
       layout = kindle? ? 'kindle/layout' : 'layout'
 
       File.open(output_path, 'w') do |f|
-        view = ActionView::Base.new(source_dir, :edge => @edge, :version => @version, :mobi => "kindle/#{mobi}")
+        view = ActionView::Base.new(source_dir, :edge => @edge, :version => @version, :mobi => "kindle/#{mobi}", :lang => @lang)
         view.extend(Helpers)
 
         if guide =~ /\.(\w+)\.erb$/

--- a/guides/rails_guides/helpers.rb
+++ b/guides/rails_guides/helpers.rb
@@ -15,7 +15,7 @@ module RailsGuides
     end
 
     def documents_by_section
-      @documents_by_section ||= YAML.load_file(File.expand_path('../../source/documents.yaml', __FILE__))
+      @documents_by_section ||= YAML.load_file(File.expand_path("../../source/#@lang/documents.yaml", __FILE__))
     end
 
     def documents_flat

--- a/guides/rails_guides/helpers.rb
+++ b/guides/rails_guides/helpers.rb
@@ -15,7 +15,7 @@ module RailsGuides
     end
 
     def documents_by_section
-      @documents_by_section ||= YAML.load_file(File.expand_path("../../source/#@lang/documents.yaml", __FILE__))
+      @documents_by_section ||= YAML.load_file(File.expand_path("../../source/#{@lang ? @lang + '/' : ''}documents.yaml", __FILE__))
     end
 
     def documents_flat


### PR DESCRIPTION
Some translations of rails guides has their own documents.yaml, for example

Japanese:
https://github.com/yasslab/railsguides.jp/blob/japanese/guides/source/documents.yaml

Traditional Chinese:
https://github.com/docrails-tw/guides/blob/master/rails_guides/helpers.rb#L21,L27
https://github.com/docrails-tw/guides/blob/master/source/documents_zh-TW.yaml

The [Translating Rails Guides](https://github.com/rails/docrails/wiki/translating-rails-guides) says

> Copy the contents of guides/source into your own language directory and translate them.

So that sounds ok to copy guides/source/documents.yaml into language
specific directly and translating them like other markdown files.
