### PR TITLE
[ci skip] Fix comment of `ActiveRecord::Associations#association_inst…

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -185,7 +185,7 @@ module ActiveRecord
         super
       end
 
-      # Returns the specified association instance if it responds to :loaded?, nil otherwise.
+      # Returns the specified association instance if it exists, nil otherwise.
       def association_instance_get(name)
         @association_cache[name]
       end


### PR DESCRIPTION
…ance_get`

`@association_cache`  is simple Hash, so this method returns association instance if it exists.
