### PR TITLE
Stop skipping a test that now works on Rubinius

### DIFF
--- a/activemodel/test/cases/attribute_assignment_test.rb
+++ b/activemodel/test/cases/attribute_assignment_test.rb
@@ -58,8 +58,6 @@ class AttributeAssignmentTest < ActiveModel::TestCase
   end
 
   test "assign private attribute" do
-    rubinius_skip "https://github.com/rubinius/rubinius/issues/3328"
-
     model = Model.new
     assert_raises(ActiveModel::UnknownAttributeError) do
       model.assign_attributes(metadata: { a: 1 })


### PR DESCRIPTION
The test was skipped because of an issue that, in the meantime, has been fixed: https://github.com/rubinius/rubinius/issues/3328.

Using the latest Rubinius (the one currently on Travis CI), this is the result:

``` sh
$ ruby --version
rubinius 2.5.3 (2.1.0 2482b093 2015-05-10 3.5.1 JI) [x86_64-darwin14.3.0]
```

**Before this PR**

``` sh
$ ruby -Itest test/cases/attribute_assignment_test.rb
Run options: --seed 58569

.....S...

Finished in 0.048278s, 186.4203 runs/s, 269.2738 assertions/s.

9 runs, 13 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
```

**After this PR**

``` sh
$ ruby -Itest test/cases/attribute_assignment_test.rb
Run options: --seed 35720

.........

Finished in 0.029441s, 305.6961 runs/s, 475.5273 assertions/s.

9 runs, 14 assertions, 0 failures, 0 errors, 0 skips
```
