### PR TITLE
Removed not needed includes, As record_tag_helper is moved to a gem we..

### DIFF
--- a/actionview/test/template/record_tag_helper_test.rb
+++ b/actionview/test/template/record_tag_helper_test.rb
@@ -2,7 +2,7 @@ require 'abstract_unit'
 
 class RecordTagPost
   extend ActiveModel::Naming
-  include ActiveModel::Conversion
+
   attr_accessor :id, :body
 
   def initialize
@@ -14,7 +14,6 @@ class RecordTagPost
 end
 
 class RecordTagHelperTest < ActionView::TestCase
-  include RenderERBUtils
 
   tests ActionView::Helpers::RecordTagHelper
 


### PR DESCRIPTION
are not testing it completely here now. `RenderErbUtils` and `AM::Conversion` are not used.
