### PR TITLE
removing unused and already required require's

### DIFF
--- a/railties/test/application/configuration/custom_test.rb
+++ b/railties/test/application/configuration/custom_test.rb
@@ -1,5 +1,4 @@
 require 'isolation/abstract_unit'
-require 'env_helpers'
 
 module ApplicationTests
   module ConfigurationTests

--- a/railties/test/path_generation_test.rb
+++ b/railties/test/path_generation_test.rb
@@ -1,8 +1,6 @@
 require 'abstract_unit'
 require 'active_support/core_ext/object/with_options'
 require 'active_support/core_ext/object/json'
-require 'rails'
-require 'rails/application'
 
 class PathGenerationTest < ActiveSupport::TestCase
   attr_reader :app


### PR DESCRIPTION
_custom test_ - Does not `include EnvHelpers` or helpers from env_helpers and the require is not needed
_path generation test_ - `require abstract_unit` which has `require rails/all`.  It requires rails and corresponding.
