### PR TITLE
[ci skip] Remove comments about Rails 3.1

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -8,8 +8,7 @@ module ActionController
   # POST requests without having to specify any root elements.
   #
   # This functionality is enabled in +config/initializers/wrap_parameters.rb+
-  # and can be customized. If you are upgrading to \Rails 3.1, this file will
-  # need to be created for the functionality to be enabled.
+  # and can be customized.
   #
   # You could also turn it on per controller by setting the format array to
   # a non-empty array:

--- a/actionpack/lib/action_controller/metal/streaming.rb
+++ b/actionpack/lib/action_controller/metal/streaming.rb
@@ -110,9 +110,9 @@ module ActionController #:nodoc:
   # This means that, if you have <code>yield :title</code> in your layout
   # and you want to use streaming, you would have to render the whole template
   # (and eventually trigger all queries) before streaming the title and all
-  # assets, which kills the purpose of streaming. For this reason Rails 3.1
-  # introduces a new helper called +provide+ that does the same as +content_for+
-  # but tells the layout to stop searching for other entries and continue rendering.
+  # assets, which kills the purpose of streaming. For this purpose, you can use
+  # a helper called +provide+ that does the same as +content_for+ but tells the
+  # layout to stop searching for other entries and continue rendering.
   #
   # For instance, the template above using +provide+ would be:
   #

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -275,21 +275,6 @@ module ActiveRecord
   # The phrase "Updating salaries..." would then be printed, along with the
   # benchmark for the block when the block completes.
   #
-  # == About the schema_migrations table
-  #
-  # Rails versions 2.0 and prior used to create a table called
-  # <tt>schema_info</tt> when using migrations. This table contained the
-  # version of the schema as of the last applied migration.
-  #
-  # Starting with Rails 2.1, the <tt>schema_info</tt> table is
-  # (automatically) replaced by the <tt>schema_migrations</tt> table, which
-  # contains the version numbers of all the migrations applied.
-  #
-  # As a result, it is now possible to add migration files that are numbered
-  # lower than the current schema version: when migrating up, those
-  # never-applied "interleaved" migrations will be automatically applied, and
-  # when migrating down, never-applied "interleaved" migrations will be skipped.
-  #
   # == Timestamped Migrations
   #
   # By default, Rails generates migrations that look like:

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -46,7 +46,7 @@ module ActiveRecord
     #   # returns the first item or returns a new instance (requires you call .save to persist against the database).
     #
     #   Person.where(name: 'Spartacus', rating: 4).first_or_create
-    #   # returns the first item or creates it and returns it, available since Rails 3.2.1.
+    #   # returns the first item or creates it and returns it.
     #
     # ==== Alternatives for +find+
     #
@@ -57,10 +57,10 @@ module ActiveRecord
     #   # returns a chainable list of instances with only the mentioned fields.
     #
     #   Person.where(name: 'Spartacus', rating: 4).ids
-    #   # returns an Array of ids, available since Rails 3.2.1.
+    #   # returns an Array of ids.
     #
     #   Person.where(name: 'Spartacus', rating: 4).pluck(:field1, :field2)
-    #   # returns an Array of the required fields, available since Rails 3.1.
+    #   # returns an Array of the required fields.
     def find(*args)
       if block_given?
         to_a.find(*args) { |*block_args| yield(*block_args) }

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -7,8 +7,7 @@ require 'active_support/message_verifier'
 require 'rails/engine'
 
 module Rails
-  # In Rails 3.0, a Rails::Application object was introduced which is nothing more than
-  # an Engine but with the responsibility of coordinating the whole boot process.
+  # An Engine with the responsibility of coordinating the whole boot process.
   #
   # == Initialization
   #

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -6,7 +6,7 @@ require 'pathname'
 module Rails
   # <tt>Rails::Engine</tt> allows you to wrap a specific Rails application or subset of
   # functionality and share it with other applications or within a larger packaged application.
-  # Since Rails 3.0, every <tt>Rails::Application</tt> is just an engine, which allows for simple
+  # Every <tt>Rails::Application</tt> is just an engine, which allows for simple
   # feature and application sharing.
   #
   # Any <tt>Rails::Engine</tt> is also a <tt>Rails::Railtie</tt>, so the same
@@ -15,10 +15,9 @@ module Rails
   #
   # == Creating an Engine
   #
-  # In Rails versions prior to 3.0, your gems automatically behaved as engines, however,
-  # this coupled Rails to Rubygems. Since Rails 3.0, if you want a gem to automatically
-  # behave as an engine, you have to specify an +Engine+ for it somewhere inside
-  # your plugin's +lib+ folder (similar to how we specify a +Railtie+):
+  # If you want a gem to behave as an engine, you have to specify an +Engine+
+  # for it somewhere inside your plugin's +lib+ folder (similar to how we
+  # specify a +Railtie+):
   #
   #   # lib/my_engine.rb
   #   module MyEngine
@@ -69,10 +68,9 @@ module Rails
   #
   # == Paths
   #
-  # Since Rails 3.0, applications and engines have more flexible path configuration (as
-  # opposed to the previous hardcoded path configuration). This means that you are not
-  # required to place your controllers at <tt>app/controllers</tt>, but in any place
-  # which you find convenient.
+  # Applications and engines have flexible path configuration, meaning that you
+  # are not required to place your controllers at <tt>app/controllers</tt>, but
+  # in any place which you find convenient.
   #
   # For example, let's suppose you want to place your controllers in <tt>lib/controllers</tt>.
   # You can set that as an option:


### PR DESCRIPTION
Stems from https://github.com/rails/rails/pull/20105#issuecomment-100900939 where @senny said:

> From my point of view, all the docs (guides, API) are version bound.
> They should describe that version and continue to be available when newer versions are released.
> The cross referencing can be done by the interested user.

@senny, merge/reject as you wish… I don't have a strict preference about this.
