### PR TITLE
Fix parse to work with Ruby 2.2

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -268,7 +268,7 @@ module ActiveSupport
     #
     #   Time.zone.now                 # => Fri, 31 Dec 1999 14:00:00 HST -10:00
     #   Time.zone.parse('22:30:00')   # => Fri, 31 Dec 1999 22:30:00 HST -10:00
-    def parse(str, now=self.now)
+    def parse(str, now=self.now())
       parts = Date._parse(str, false)
       return if parts.empty?
 


### PR DESCRIPTION
The Timezone parse function is broken with Ruby 2.2.  This is fixed in master branch (https://github.com/rails/rails/commit/e88da370f190cabd1e9750c5b3531735950ab415), but needs to be fixed in 3.2 branch.
