### PR TITLE
[ci skip] Fix `transaction` code example

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -898,7 +898,7 @@ For example:
 Item.transaction do
   i = Item.lock.first
   i.name = 'Jones'
-  i.save
+  i.save!
 end
 ```
 


### PR DESCRIPTION
To raise an exception, use `save!` instead of `save`.
