### PR TITLE
Remove call to sanitize_sql_hash_for_conditions

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -11,10 +11,9 @@ module ActiveRecord
 
       protected
 
-      # Accepts an array, hash, or string of SQL conditions and sanitizes
+      # Accepts an array or string of SQL conditions and sanitizes
       # them into a valid SQL fragment for a WHERE clause.
       #   ["name='%s' and group_id='%s'", "foo'bar", 4]  returns  "name='foo''bar' and group_id='4'"
-      #   { name: "foo'bar", group_id: 4 }  returns "name='foo''bar' and group_id='4'"
       #   "name='foo''bar' and group_id='4'" returns "name='foo''bar' and group_id='4'"
       def sanitize_sql_for_conditions(condition, table_name = self.table_name)
         return nil if condition.blank?

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -21,7 +21,6 @@ module ActiveRecord
 
         case condition
         when Array; sanitize_sql_array(condition)
-        when Hash;  sanitize_sql_hash_for_conditions(condition, table_name)
         else        condition
         end
       end


### PR DESCRIPTION
This method has already been removed as of https://github.com/rails/rails/commit/3a59dd212315ebb9bae8338b98af259ac00bbef3

But the call is still there when `Hash` params are sent.

I don't know if desired functionality is to `raise` or just let it pass through.
But at a minimum, it should probably avoid calling a non-existent method.
