### PR TITLE
Fix for irregular inflection inconsistency

### DIFF
--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -113,6 +113,14 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal 'PluralIrregular', reflection.class_name
   end
 
+  def test_irregular_reflection_class_name_with_camel
+    ActiveSupport::Inflector.inflections do |inflect|
+      inflect.irregular 'ProtocolSpecies', 'ProtocolSpecies'
+    end
+    reflection = ActiveRecord::Reflection.create(:has_many, 'protocol_species', nil, {}, ActiveRecord::Base)
+    assert_equal 'ProtocolSpecies', reflection.class_name
+  end
+
   def test_aggregation_reflection
     reflection_for_address = AggregateReflection.new(
       :address, nil, { :mapping => [ %w(address_street street), %w(address_city city), %w(address_country country) ] }, Customer

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   `ActiveSupport::Inflector::Inflection#irregular` is now done for both camel
+    and snake case. This is to address a previous problem with irregular nouns 
+    in camel case when used by `AR::Reflection`. 
+
+    Fixes #17546.
+
+    *Yoong Kang Lim*
+
 *   Patch `Delegator` to work with `#try`.
 
     Fixes #5790.

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -66,15 +66,7 @@ module ActiveSupport
     #
     #   camelize(underscore('SSLError'))        # => "SslError"
     def camelize(term, uppercase_first_letter = true)
-      string = term.to_s
-      if uppercase_first_letter
-        string = string.sub(/^[a-z\d]*/) { inflections.acronyms[$&] || $&.capitalize }
-      else
-        string = string.sub(/^(?:#{inflections.acronym_regex}(?=\b|[A-Z_])|\w)/) { $&.downcase }
-      end
-      string.gsub!(/(?:_|(\/))([a-z\d]*)/i) { "#{$1}#{inflections.acronyms[$2] || $2.capitalize}" }
-      string.gsub!('/'.freeze, '::'.freeze)
-      string
+      inflections.camelize(term, uppercase_first_letter)
     end
 
     # Makes an underscored, lowercase form from the expression in the string.
@@ -89,14 +81,7 @@ module ActiveSupport
     #
     #   camelize(underscore('SSLError'))  # => "SslError"
     def underscore(camel_cased_word)
-      return camel_cased_word unless camel_cased_word =~ /[A-Z-]|::/
-      word = camel_cased_word.to_s.gsub('::'.freeze, '/'.freeze)
-      word.gsub!(/(?:(?<=([A-Za-z\d]))|\b)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1 && '_'}#{$2.downcase}" }
-      word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
-      word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
-      word.tr!("-", "_")
-      word.downcase!
-      word
+      inflections.underscore(camel_cased_word)
     end
 
     # Tweaks an attribute name for display to end users.


### PR DESCRIPTION
Hi, this is one of my first patches. This is to address issue #17546 which is a regression due to inconsistencies in irregular inflections between snake and camelcase.

I tried making a fix without breaking the API, but I still moved some things around. Basically, I changed ActiveSupport::Inflector::Inflection#irregular to create an irregular inflection in both camel and snake case.

I'm not sure if this is the best way to do this, but would certainly appreciate a review.

Thanks :heart::heart:
