### PR TITLE
Raise an ArgumentError when `include_blank` is false for a required select field

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Raise an ArgumentError when a false value for `include_blank` is passed to a
+    required select field (to comply with the HTML5 spec).
+
+    *Grey Baker*
+
 *   Do not put partial name to `local_assigns` when rendering without
     an object or a collection.
 

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -120,7 +120,12 @@ module ActionView
         def select_content_tag(option_tags, options, html_options)
           html_options = html_options.stringify_keys
           add_default_name_and_id(html_options)
-          options[:include_blank] ||= true unless options[:prompt] || select_not_required?(html_options)
+
+          if placeholder_required?(html_options)
+            raise ArgumentError, "include_blank cannot be false for a required field." if options[:include_blank] == false
+            options[:include_blank] ||= true unless options[:prompt]
+          end
+
           value = options.fetch(:selected) { value(object) }
           select = content_tag("select", add_options(option_tags, options, value), html_options)
 
@@ -131,8 +136,9 @@ module ActionView
           end
         end
 
-        def select_not_required?(html_options)
-          !html_options["required"] || html_options["multiple"] || html_options["size"].to_i > 1
+        def placeholder_required?(html_options)
+          # See https://html.spec.whatwg.org/multipage/forms.html#attr-select-required
+          html_options["required"] && !html_options["multiple"] && html_options.fetch("size", 1).to_i == 1
         end
 
         def add_options(option_tags, options, value = nil)

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -645,6 +645,13 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_with_include_blank_false_and_required
+    @post = Post.new
+    @post.category = "<mus>"
+    e = assert_raises(ArgumentError) { select("post", "category", %w( abe <mus> hest), { include_blank: false }, required: 'required') }
+    assert_match(/include_blank cannot be false for a required field./, e.message)
+  end
+
   def test_select_with_blank_as_string
     @post = Post.new
     @post.category = "<mus>"


### PR DESCRIPTION
Previously, passing a falsey value to `include_blank` would be ignored if the field was required because an `||=` was being used incorrectly. This meant the following would still include a blank value:

`select("post", "category", %w(no blank value please), { include_blank: false }, required: 'required')`

This PR fixes that by checking for the presence for the `include_blank` key, rather than checking whether it's truthy.
