### PR TITLE
ActiveSupport::HashWithIndifferentAccess select and reject should return enumerator if called without block

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   ActiveSupport::HashWithIndifferentAccess `select` and `reject` will now return
+    enumerator if called without block.
+
+    Fixes #20095
+
+    *Bernard Potocki*
+
 *   Add a bang version to `ActiveSupport::OrderedOptions` get methods which will raise
     an `KeyError` if the value is `.blank?`
 

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -238,10 +238,12 @@ module ActiveSupport
     def to_options!; self end
 
     def select(*args, &block)
+      return to_enum(:select) unless block_given?
       dup.tap { |hash| hash.select!(*args, &block) }
     end
 
     def reject(*args, &block)
+      return to_enum(:reject) unless block_given?
       dup.tap { |hash| hash.reject!(*args, &block) }
     end
 

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -547,6 +547,11 @@ class HashExtTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
   end
 
+  def test_indifferent_select_returns_enumerator
+    enum = ActiveSupport::HashWithIndifferentAccess.new(@strings).select
+    assert_instance_of Enumerator, enum
+  end
+
   def test_indifferent_select_returns_a_hash_when_unchanged
     hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).select {|k,v| true}
 
@@ -566,6 +571,11 @@ class HashExtTest < ActiveSupport::TestCase
 
     assert_equal({ 'a' => 1 }, hash)
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
+  def test_indifferent_reject_returns_enumerator
+    enum = ActiveSupport::HashWithIndifferentAccess.new(@strings).reject
+    assert_instance_of Enumerator, enum
   end
 
   def test_indifferent_reject_bang


### PR DESCRIPTION
[According to Ruby spec](http://ruby-doc.org/core-2.2.0/Hash.html#method-i-select) `select` and `reject` should return enumerator if called without block. Until now if no block was given `HashWithIndifferentAccess` returned `self` instead of enumerator - this commit fixes such behavior.

Fixes #20095
