### PR TITLE
Allow creating a save callback for same name with parent association

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -176,7 +176,8 @@ module ActiveRecord
         # check if the save or validation methods have already been defined
         # before actually defining them.
         def add_autosave_association_callbacks(reflection)
-          save_method = :"autosave_associated_records_for_#{reflection.name}"
+          method_suffix = reflection.options[:class_name].try(:underscore)
+          save_method = :"autosave_associated_records_for_#{reflection.name}_#{method_suffix}"
 
           if reflection.collection?
             before_save :before_save_collection_association


### PR DESCRIPTION
Allow creating a save callback for same name with parent association with different class name.
Normally rails let you to define an association with same name as in the parent model. But it does not create new save callback for this new association and this causes problem.
Assume that you have 4 models like below;

``` ruby
class Vehicle < ActiveRecord::Base
  has_one :tire
end

class Car < Vehicle
  self.table_name = "cars"
  has_one :tire, class_name: "WinterTier"
  accepts_nested_attributes_for :tire
end

class Tire < ActiveRecord::Base
  belongs_to :vehicle
end

class WinterTire < Tire
  self.table_name = "winter_tires"
  belongs_to :car
end
```

If you try to update tire of a car object it does not update it.

``` ruby
car = Car.create
winter_tire = WinterTire.create(car: car, brand: "Toyo")

attributes = { tire_attributes: { brand: "Bridgestone" } }
car.update(attributes)
winter_tire.reload.brand # returns Toyo but it should return Bridgestone.
```

This pull request fixes #20120
