### PR TITLE
[ci skip] Don’t encourage `sudo gem install`

### DIFF
--- a/actionmailer/README.rdoc
+++ b/actionmailer/README.rdoc
@@ -146,7 +146,7 @@ The Base class has the full list of configuration options. Here's an example:
 
 The latest version of Action Mailer can be installed with RubyGems:
 
-  % [sudo] gem install actionmailer
+  % gem install actionmailer
 
 Source code can be downloaded as part of the Rails project on GitHub
 

--- a/actionpack/README.rdoc
+++ b/actionpack/README.rdoc
@@ -28,7 +28,7 @@ can be used outside of Rails.
 
 The latest version of Action Pack can be installed with RubyGems:
 
-  % [sudo] gem install actionpack
+  % gem install actionpack
 
 Source code can be downloaded as part of the Rails project on GitHub
 

--- a/actionview/README.rdoc
+++ b/actionview/README.rdoc
@@ -9,7 +9,7 @@ used to inline short Ruby snippets inside HTML), and XML Builder.
 
 The latest version of Action View can be installed with RubyGems:
 
-  % [sudo] gem install actionview
+  % gem install actionview
 
 Source code can be downloaded as part of the Rails project on GitHub
 

--- a/activejob/README.md
+++ b/activejob/README.md
@@ -102,7 +102,7 @@ see the API Documentation for [ActiveJob::QueueAdapters](http://api.rubyonrails.
 The latest version of Active Job can be installed with RubyGems:
 
 ```
-  % [sudo] gem install activejob
+  % gem install activejob
 ```
 
 Source code can be downloaded as part of the Rails project on GitHub

--- a/activemodel/README.rdoc
+++ b/activemodel/README.rdoc
@@ -242,7 +242,7 @@ behavior out of the box:
 
 The latest version of Active Model can be installed with RubyGems:
 
-  % [sudo] gem install activemodel
+  % gem install activemodel
 
 Source code can be downloaded as part of the Rails project on GitHub
 

--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -188,7 +188,7 @@ Admit the Database:
 
 The latest version of Active Record can be installed with RubyGems:
 
-  % [sudo] gem install activerecord
+  % gem install activerecord
 
 Source code can be downloaded as part of the Rails project on GitHub:
 

--- a/activesupport/README.rdoc
+++ b/activesupport/README.rdoc
@@ -10,7 +10,7 @@ outside of Rails.
 
 The latest version of Active Support can be installed with RubyGems:
 
-  % [sudo] gem install activesupport
+  % gem install activesupport
 
 Source code can be downloaded as part of the Rails project on GitHub:
 


### PR DESCRIPTION
I think we are better off leaving `sudo` outside of the documented way of installing gems (`activerecord`, `actionpack`, …).

We don’t want newbies to think that `sudo` is required or, even worse, than they actually have to type `[sudo] gem install`.

In most scenarios, `sudo` is not needed to install gems, and people who do need it, probably already know about it.

What do you think? :grin:
