### PR TITLE
Add Enumerable#map_with to ActiveSupport

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Added `Enumerable#map_with` to simplify pattern of creating a hash from an
+    enumerable with the original entries as keys and some mapping as values
+
+    *Matt Larraz*
+
 *   Patch `Delegator` to work with `#try`.
 
     Fixes #5790.

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -39,6 +39,21 @@ module Enumerable
     end
   end
 
+  # Convert an enumerable to a hash with its elements as keys and the results
+  # of the given block as values
+  #
+  #   (1..10).map_with { |i| i ** 2 }
+  #     => { 1 => 1, 2 => 4, 3 => 9, 4 => 16, 5 => 25, 6 => 36, ...}
+  #   person.instance_variables.map_with { |ivar| person.instance_variable_get(ivar) }
+  #     => { :@first_name => "David", :@last_name => "Heinemeier Hansson", ...}
+  def map_with
+    if block_given?
+      Hash[map { |elem| [elem, yield(elem)] }]
+    else
+      to_enum(:map_to) { size if respond_to?(:size) }
+    end
+  end
+
   # Returns +true+ if the enumerable has more than 1 element. Functionally
   # equivalent to <tt>enum.to_a.size > 1</tt>. Can be called with a block too,
   # much like any?, so <tt>people.many? { |p| p.age > 26 }</tt> returns +true+

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -81,6 +81,14 @@ class EnumerableTests < ActiveSupport::TestCase
                  payments.index_by.each(&:price))
   end
 
+  def test_map_with
+    original = ('a'..'c')
+    hash = original.map_with { |i| "#{i}!".to_sym }
+
+    assert_equal(('a'..'c'), original)
+    assert_equal({'a' => :a!, 'b' => :b!, 'c' => :c!}, hash)
+  end
+
   def test_many
     assert_equal false, GenericEnumerable.new([]         ).many?
     assert_equal false, GenericEnumerable.new([ 1 ]      ).many?


### PR DESCRIPTION
Basically the converse to `Enumerable#group_by`, this simplifies the pattern of mapping an enumerable to a hash using its elements as the keys and a transformation as the values.

Inspired heavily by #15819.

Name can probably be improved upon.
