### PR TITLE
Fix none.or!

### DIFF
--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -84,7 +84,7 @@ module ActiveRecord
       false
     end
 
-    def or(other)
+    def or!(other)
       other.spawn
     end
   end

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -20,9 +20,19 @@ module ActiveRecord
       assert_equal expected, Post.none.or(Post.where('id = 1')).to_a
     end
 
+    def test_or_with_null_left_mutated
+      expected = Post.where('id = 1').to_a
+      assert_equal expected, Post.none.or!(Post.where('id = 1')).to_a
+    end
+
     def test_or_with_null_right
       expected = Post.where('id = 1').to_a
       assert_equal expected, Post.where('id = 1').or(Post.none).to_a
+    end
+
+    def test_or_with_null_right_mutated
+      expected = Post.where('id = 1').to_a
+      assert_equal expected, Post.where('id = 1').or!(Post.none).to_a
     end
 
     def test_or_with_bind_params


### PR DESCRIPTION
I was trying to do the following

``` ruby
def a_or_b
  scope = none
  scope.or!(a)
  scope.or!(b)
  scope
end
```

But it seems to be a bug, as this returns no results.

The non-mutative form works fine

``` ruby
def a_or_b
  scope = none
  scope = scope.or(a)
  scope = scope.or(b)
  scope
end
```

This patch fixes that, and tests the mutative `or!` for null relations on either side

`none.or!(other)` and `other.or!(none)`
