### PR TITLE
Do not put partial name to local_assigns when rendering without an object

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Do not put partial name to local_assigns when rendering without an object or a collection.
+
+    *Henrik Nygren*
+
 *   Remove `:rescue_format` option for `translate` helper since it's no longer
     supported by I18n.
 

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -338,7 +338,7 @@ module ActionView
       end
 
       object ||= locals[as]
-      locals[as] = object
+      locals[as] = object if @has_object
 
       content = @template.render(view, locals) do |*name|
         view._layout_for(*name, &block)

--- a/actionview/test/fixtures/test/_partial_name_in_local_assigns.erb
+++ b/actionview/test/fixtures/test/_partial_name_in_local_assigns.erb
@@ -1,0 +1,1 @@
+<%= local_assigns.has_key?(:partial_name_in_local_assigns) %>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -277,6 +277,14 @@ module RenderTestCases
     assert_nil @view.render(:partial => "test/customer", :collection => nil)
   end
 
+  def test_render_partial_without_object_does_not_put_partial_name_to_local_assigns
+    assert_equal 'false', @view.render(partial: 'test/partial_name_in_local_assigns')
+  end
+
+  def test_render_partial_with_nil_object_puts_partial_name_to_local_assigns
+    assert_equal 'true', @view.render(partial: 'test/partial_name_in_local_assigns', object: nil)
+  end
+
   def test_render_partial_with_nil_values_in_collection
     assert_equal "Hello: davidHello: Anonymous", @view.render(:partial => "test/customer", :collection => [ Customer.new("david"), nil ])
   end


### PR DESCRIPTION
When one was rendering a partial template without specifying an object or a collection (e.g. `<%= render partial: 'partial_name' %>`), Rails would make an object called `:partial_name` available in `local_assigns`. I don't think this was the intended behavior, since no local variable called `partial_name` gets defined in the view.

/cc @matthewd 
