### PR TITLE
remove warning from integer ext test

### DIFF
--- a/activesupport/test/core_ext/integer_ext_test.rb
+++ b/activesupport/test/core_ext/integer_ext_test.rb
@@ -31,11 +31,11 @@ class IntegerExtTest < ActiveSupport::TestCase
   def test_positive
     assert 1.positive?
     assert_not 0.positive?
-    assert_not -1.positive?
+    assert_not(-1.positive?)
   end
 
   def test_negative
-    assert -1.negative?
+    assert(-1.negative?)
     assert_not 0.negative?
     assert_not 1.negative?
   end


### PR DESCRIPTION
this removes the following warning:

```
test/core_ext/integer_ext_test.rb:34: warning: ambiguous first argument; put parentheses or a space even after `-' operator
test/core_ext/integer_ext_test.rb:38: warning: ambiguous first argument; put parentheses or a space even after `-' operator
```
