### PR TITLE
Patch `Delegator` to work with `#try`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Patch `Delegator` to work with `#try`
+
+    Fixes #5790
+
+    *Nate Smith*
+
 *   Add `Integer#positive?` and `Integer#negative?` query methods
     in the vein of `Fixnum#zero?`.
 

--- a/activesupport/test/core_ext/object/try_test.rb
+++ b/activesupport/test/core_ext/object/try_test.rb
@@ -96,4 +96,68 @@ class ObjectTryTest < ActiveSupport::TestCase
 
     assert_nil klass.new.try(:private_method)
   end
+
+  class Decorator < SimpleDelegator
+    def delegator_method
+      'delegator method'
+    end
+
+    def reverse
+      'overridden reverse'
+    end
+
+    private
+
+    def private_delegator_method
+      'private delegator method'
+    end
+  end
+
+  def test_try_with_method_on_delegator
+    assert_equal 'delegator method', Decorator.new(@string).try(:delegator_method)
+  end
+
+  def test_try_with_method_on_delegator_target
+    assert_equal 5, Decorator.new(@string).size
+  end
+
+  def test_try_with_overriden_method_on_delegator
+    assert_equal 'overridden reverse', Decorator.new(@string).reverse
+  end
+
+  def test_try_with_private_method_on_delegator
+    assert_nil Decorator.new(@string).try(:private_delegator_method)
+  end
+
+  def test_try_with_private_method_on_delegator_bang
+    assert_raise(NoMethodError) do
+      Decorator.new(@string).try!(:private_delegator_method)
+    end
+  end
+
+  def test_try_with_private_method_on_delegator_target
+    klass = Class.new do
+      private
+
+      def private_method
+        'private method'
+      end
+    end
+
+    assert_nil Decorator.new(klass.new).try(:private_method)
+  end
+
+  def test_try_with_private_method_on_delegator_target_bang
+    klass = Class.new do
+      private
+
+      def private_method
+        'private method'
+      end
+    end
+
+    assert_raise(NoMethodError) do
+      Decorator.new(klass.new).try!(:private_method)
+    end
+  end
 end


### PR DESCRIPTION
`Delegator` inherits from `BasicObject`, which means that it will not
have `Object#try` defined. It will then delegate the call to the
underlying object, which will not (necessarily) respond to the method
defined in the enclosing `Delegator`.

This patches `Delegator` with the `#try` method to work around the
surprising behaviour.

Fixes #5790 as per @chancancode's recommendation
