### PR TITLE
Clarify view tests

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -898,7 +898,7 @@ For more information on routing assertions available in Rails, see the API docum
 Testing Views
 -------------
 
-Testing the response to your request by asserting the presence of key HTML elements and their content is a common way to test the views of your application. The `assert_select` method allows you to query HTML elements of the response by using a simple yet powerful syntax.
+Testing the response to your request by asserting the presence of key HTML elements and their content is a common way to test the views of your application. Like route tests, view tests reside in `test/controllers/` or are part of controller tests. The `assert_select` method allows you to query HTML elements of the response by using a simple yet powerful syntax.
 
 There are two forms of `assert_select`:
 


### PR DESCRIPTION
In http://edgeguides.rubyonrails.org/testing.html#testing-views the assertions for testing views are explained. In http://edgeguides.rubyonrails.org/testing.html#testing-routes the file path and the test case which the test class should extend from are given.

However view testing is a seperate chapter (6) like route testing. But unlike in the route testing chapter no hint is given that the view testing is also part of the controller tests, therefore a new rails user could be confused where those view tests would live.

Thanks :heart: :heart:
