### PR TITLE
Dead blog/site links [ci skip]

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1033,4 +1033,4 @@ The security landscape shifts and it is important to keep up to date, because mi
 
 * Subscribe to the Rails security [mailing list](http://groups.google.com/group/rubyonrails-security)
 * [Keep up to date on the other application layers](http://secunia.com/) (they have a weekly newsletter, too)
-* A [good security blog](http://ha.ckers.org/blog/) including the [Cross-Site scripting Cheat Sheet](http://ha.ckers.org/xss.html)
+


### PR DESCRIPTION
The 2 links (http://ha.ckers.org/blog & http://ha.ckers.org/xss.html)  are dead.  Does anyone know thr new place or any preference on what can be placed as alternative?

I removed bullet at the moment but would like to add alternative link for them.

cc / @senny @rafaelfranca 
