### PR TITLE
Bugfix: Modified body method of request to always return the same StringIO

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -52,6 +52,7 @@ module ActionDispatch
       @original_fullpath = nil
       @fullpath          = nil
       @ip                = nil
+      @body              = nil
     end
 
     def check_path_parameters!
@@ -252,8 +253,13 @@ module ActionDispatch
     # variable is already set, wrap it in a StringIO.
     def body
       if raw_post = @env['RAW_POST_DATA']
-        raw_post.force_encoding(Encoding::BINARY)
-        StringIO.new(raw_post)
+        raw_post_binary = raw_post.dup
+        raw_post_binary.force_encoding(Encoding::BINARY)
+        if @body.nil?
+          @body = StringIO.new(raw_post_binary)
+        else
+          @body
+        end
       else
         @env['rack.input']
       end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -570,6 +570,22 @@ class RequestParamsParsing < BaseRequestTest
   end
 end
 
+class RequestStingIO < BaseRequestTest
+  test "request body returns StringIO with raw post data" do
+    env = {'RAW_POST_DATA' => 'text1 text2'}
+    request = stub_request(env)
+    assert_equal "text1 text2", request.body.read
+  end
+
+  test "request body always returns same StringIO object" do
+    env = {'RAW_POST_DATA' => 'text1 text2'}
+    request = stub_request(env)
+    b1 = request.body
+    b2 = request.body
+    assert_equal b1, b2
+  end
+end
+
 class RequestRewind < BaseRequestTest
   test "body should be rewound" do
     data = 'rewind'


### PR DESCRIPTION
The body method of request returns a new StringIO containing the raw post data. This causes a apparent rewind each time request.body.read(n) is called. Modified to store in an instance variable to prevent the apparent rewind.

A workaround is to call request.body once and assign this to a variable which is used to call read(n), however, it is not apparent that this is required, and not doing so causes a difference in behavior depending on whether the raw post data or rack input is being returned.

The proposed modification ensures that this function behaves consistently in either case.
