### PR TITLE
Avoid branching in abstract_mysql_adapter when calling type_to_sql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -695,13 +695,8 @@ module ActiveRecord
 
       # Maps logical Rails types to MySQL-specific data types.
       def type_to_sql(type, limit = nil, precision = nil, scale = nil)
-        case type.to_s
-        when 'binary'
-          binary_to_sql(limit)
-        when 'integer'
-          integer_to_sql(limit)
-        when 'text'
-          text_to_sql(limit)
+        if (["binary", "integer", "text"].include?(type.to_s))
+          send("#{type.to_s}_to_sql", limit)
         else
           super
         end


### PR DESCRIPTION
In this commit d88f6e79ccf8480f349e985d7418d86b8f68cdda, we created separate the calls into individual methods but the case statement still persists. We should avoid branching in the code as much as we can and should use send method to call the methods dynamically.
