### PR TITLE
Count results with custom `from` breaks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixed a bug where using `count` on a combination of `from` with a `String`,
+    `joins`, `includes` and `where` results in an unexpected `NoMethodError`.
+
+    *Finn Glöe*
+
 *   Ensure that the Suppressor runs before validations.
 
     This moves the suppressor up to be run before validations rather than after

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -405,7 +405,7 @@ module ActiveRecord
         # FIXME: as far as I can tell, `from` will always be an Arel::Table.
         # There are no tests that test this branch, but presumably it's
         # possible for `from` to be a list?
-        apply_join_dependency(self, construct_join_dependency(from))
+        apply_join_dependency(self, construct_join_dependency(Array.wrap(from)))
       end
     end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1156,6 +1156,14 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal tyre2, zyke.tyres.custom_find_by(id: tyre2.id)
   end
 
+  test "count on a plain SqlLiteral with association does not fail" do
+    car = cars(:honda)
+    car.tyres.create!
+    sql = "(SELECT * FROM #{Tyre.table_name}) #{Tyre.table_name}"
+
+    assert_equal 1, Tyre.from(sql).joins(:car).includes(:car).where(car_id: car.id).count
+  end
+
   protected
     def table_with_custom_primary_key
       yield(Class.new(Toy) do


### PR DESCRIPTION
Today I came across a bug when requesting a special resources count in our software. We use the `from` method of ActiveRecord to replace the real table of a model by a custom sub query using recursion.

Combining this with joins, includes and where will always result in a `NoMethodError`:

> undefined method `map' for Arel::Nodes::SqlLiteral

Here's the Gist that demonstrates the problem: https://gist.github.com/AmShaegar13/bb7dc2352588226ec0f4

I think the root cause is an untested - as the comment states - branch of code. The method `construct_join_dependency` expects its argument to be an Array. You can derive that from the arguments default value. See here: https://github.com/rails/rails/blob/7f60bedd7aca0c62d59e6f7971e73e214c2fb9db/activerecord/lib/active_record/relation/finder_methods.rb#L359

This is the reason why `map` fails. The `Arel::Nodes::SqlLiteral` should have been wrapped in an Array.

Although this neither fully answers the question of the author nor fixes the underlying problem of untested code, I would highly appreciate if this fix could to be merged. I don't see a chance to fix it on our end.
