### PR TITLE
Allow the use of symbols or strings to specify enum values in test fixtures

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow the use of symbols or strings to specify enum values in test
+    fixtures:
+
+        awdr:
+          title: "Agile Web Development with Rails"
+          status: :proposed
+
+    *George Claghorn*
+
 *   Include stored procedures and function on the MySQL structure dump.
 
     *Jonathan Worek*

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -644,6 +644,11 @@ module ActiveRecord
             row[primary_key_name] = ActiveRecord::FixtureSet.identify(label, primary_key_type)
           end
 
+          # Resolve enums
+          model_class.defined_enums.each do |name, values|
+            row[name] = values.fetch(row[name], row[name])
+          end
+
           # If STI is used, find the correct subclass for association reflection
           reflection_class =
             if row.include?(inheritance_column_name)

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -9,49 +9,49 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "query state by predicate" do
-    assert @book.proposed?
+    assert @book.published?
     assert_not @book.written?
-    assert_not @book.published?
+    assert_not @book.proposed?
 
-    assert @book.unread?
+    assert @book.read?
   end
 
   test "query state with strings" do
-    assert_equal "proposed", @book.status
-    assert_equal "unread", @book.read_status
+    assert_equal "published", @book.status
+    assert_equal "read", @book.read_status
   end
 
   test "find via scope" do
-    assert_equal @book, Book.proposed.first
-    assert_equal @book, Book.unread.first
+    assert_equal @book, Book.published.first
+    assert_equal @book, Book.read.first
   end
 
   test "find via where with values" do
-    proposed, written = Book.statuses[:proposed], Book.statuses[:written]
+    published, written = Book.statuses[:published], Book.statuses[:written]
 
-    assert_equal @book, Book.where(status: proposed).first
+    assert_equal @book, Book.where(status: published).first
     refute_equal @book, Book.where(status: written).first
-    assert_equal @book, Book.where(status: [proposed]).first
+    assert_equal @book, Book.where(status: [published]).first
     refute_equal @book, Book.where(status: [written]).first
-    refute_equal @book, Book.where("status <> ?", proposed).first
+    refute_equal @book, Book.where("status <> ?", published).first
     assert_equal @book, Book.where("status <> ?", written).first
   end
 
   test "find via where with symbols" do
-    assert_equal @book, Book.where(status: :proposed).first
+    assert_equal @book, Book.where(status: :published).first
     refute_equal @book, Book.where(status: :written).first
-    assert_equal @book, Book.where(status: [:proposed]).first
+    assert_equal @book, Book.where(status: [:published]).first
     refute_equal @book, Book.where(status: [:written]).first
-    refute_equal @book, Book.where.not(status: :proposed).first
+    refute_equal @book, Book.where.not(status: :published).first
     assert_equal @book, Book.where.not(status: :written).first
   end
 
   test "find via where with strings" do
-    assert_equal @book, Book.where(status: "proposed").first
+    assert_equal @book, Book.where(status: "published").first
     refute_equal @book, Book.where(status: "written").first
-    assert_equal @book, Book.where(status: ["proposed"]).first
+    assert_equal @book, Book.where(status: ["published"]).first
     refute_equal @book, Book.where(status: ["written"]).first
-    refute_equal @book, Book.where.not(status: "proposed").first
+    refute_equal @book, Book.where.not(status: "published").first
     assert_equal @book, Book.where.not(status: "written").first
   end
 
@@ -96,14 +96,14 @@ class EnumTest < ActiveRecord::TestCase
 
   test "enum changed attributes" do
     old_status = @book.status
-    @book.status = :published
+    @book.status = :proposed
     assert_equal old_status, @book.changed_attributes[:status]
   end
 
   test "enum changes" do
     old_status = @book.status
-    @book.status = :published
-    assert_equal [old_status, 'published'], @book.changes[:status]
+    @book.status = :proposed
+    assert_equal [old_status, 'proposed'], @book.changes[:status]
   end
 
   test "enum attribute was" do
@@ -113,25 +113,25 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "enum attribute changed" do
-    @book.status = :published
+    @book.status = :proposed
     assert @book.attribute_changed?(:status)
   end
 
   test "enum attribute changed to" do
-    @book.status = :published
-    assert @book.attribute_changed?(:status, to: 'published')
+    @book.status = :proposed
+    assert @book.attribute_changed?(:status, to: 'proposed')
   end
 
   test "enum attribute changed from" do
     old_status = @book.status
-    @book.status = :published
+    @book.status = :proposed
     assert @book.attribute_changed?(:status, from: old_status)
   end
 
   test "enum attribute changed from old status to new status" do
     old_status = @book.status
-    @book.status = :published
-    assert @book.attribute_changed?(:status, from: old_status, to: 'published')
+    @book.status = :proposed
+    assert @book.attribute_changed?(:status, from: old_status, to: 'proposed')
   end
 
   test "enum didn't change" do
@@ -141,7 +141,7 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "persist changes that are dirty" do
-    @book.status = :published
+    @book.status = :proposed
     assert @book.attribute_changed?(:status)
     @book.status = :written
     assert @book.attribute_changed?(:status)
@@ -149,7 +149,7 @@ class EnumTest < ActiveRecord::TestCase
 
   test "reverted changes that are not dirty" do
     old_status = @book.status
-    @book.status = :published
+    @book.status = :proposed
     assert @book.attribute_changed?(:status)
     @book.status = old_status
     assert_not @book.attribute_changed?(:status)
@@ -210,9 +210,9 @@ class EnumTest < ActiveRecord::TestCase
 
   test "_before_type_cast returns the enum label (required for form fields)" do
     if @book.status_came_from_user?
-      assert_equal "proposed", @book.status_before_type_cast
+      assert_equal "published", @book.status_before_type_cast
     else
-      assert_equal "proposed", @book.status
+      assert_equal "published", @book.status
     end
   end
 

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -691,7 +691,7 @@ end
 
 class FoxyFixturesTest < ActiveRecord::TestCase
   fixtures :parrots, :parrots_pirates, :pirates, :treasures, :mateys, :ships, :computers,
-           :developers, :"admin/accounts", :"admin/users", :live_parrots, :dead_parrots
+           :developers, :"admin/accounts", :"admin/users", :live_parrots, :dead_parrots, :books
 
   if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
     require 'models/uuid_parent'
@@ -840,6 +840,13 @@ class FoxyFixturesTest < ActiveRecord::TestCase
   def test_namespaced_models
     assert admin_accounts(:signals37).users.include?(admin_users(:david))
     assert_equal 2, admin_accounts(:signals37).users.size
+  end
+
+  def test_resolves_enums
+    assert books(:awdr).published?
+    assert books(:awdr).read?
+    assert books(:rfr).proposed?
+    assert books(:ddd).published?
   end
 end
 

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -102,7 +102,7 @@ class ViewWithoutPrimaryKeyTest < ActiveRecord::TestCase
   end
 
   def test_attributes
-    assert_equal({"name" => "Agile Web Development with Rails", "status" => 0},
+    assert_equal({"name" => "Agile Web Development with Rails", "status" => 2},
                  Paperback.first.attributes)
   end
 

--- a/activerecord/test/fixtures/books.yml
+++ b/activerecord/test/fixtures/books.yml
@@ -3,9 +3,20 @@ awdr:
   id: 1
   name: "Agile Web Development with Rails"
   format: "paperback"
+  status: :published
+  read_status: :read
 
 rfr:
   author_id: 1
   id: 2
   name: "Ruby for Rails"
   format: "ebook"
+  status: "proposed"
+  read_status: "reading"
+
+ddd:
+  author_id: 1
+  id: 3
+  name: "Domain-Driven Design"
+  format: "hardcover"
+  status: 2


### PR DESCRIPTION
Currently, values for columns backing Active Record enums must be specified as integers in test fixtures:

``` yaml
awdr:
  title: "Agile Web Development with Rails"
  status: 2

rfr:
  title: "Ruby for Rails"
  status: <%= Book.statuses[:proposed] %>
```

This is potentially confusing, since enum values are typically specified as symbols or strings in application code. To resolve the confusion, this change permits the use of symbols or strings to specify enum values:

``` yaml
awdr:
  status: :published
```

It is compatible with fixtures that specify enum values as integers.
