### PR TITLE
Add schema cache to new connection pool after fork

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -933,7 +933,9 @@ module ActiveRecord
             # A connection was established in an ancestor process that must have
             # subsequently forked. We can't reuse the connection, but we can copy
             # the specification and establish a new connection with it.
-            establish_connection owner, ancestor_pool.spec
+            establish_connection(owner, ancestor_pool.spec).tap do |pool|
+              pool.schema_cache = ancestor_pool.schema_cache if ancestor_pool.schema_cache
+            end
           else
             owner_to_pool[owner.name] = nil
           end

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -46,6 +46,52 @@ module ActiveRecord
       def test_connection_pools
         assert_equal([@pool], @handler.connection_pools)
       end
+
+      if Process.respond_to?(:fork)
+        def test_connection_pool_per_pid
+          object_id = ActiveRecord::Base.connection.object_id
+
+          rd, wr = IO.pipe
+          rd.binmode
+          wr.binmode
+
+          pid = fork {
+            rd.close
+            wr.write Marshal.dump ActiveRecord::Base.connection.object_id
+            wr.close
+            exit!
+          }
+
+          wr.close
+
+          Process.waitpid pid
+          assert_not_equal object_id, Marshal.load(rd.read)
+          rd.close
+        end
+
+        def test_retrieve_connection_pool_copies_schema_cache_from_ancestor_pool
+          @pool.schema_cache = @pool.connection.schema_cache
+          @pool.schema_cache.add('posts')
+
+          rd, wr = IO.pipe
+          rd.binmode
+          wr.binmode
+
+          pid = fork {
+            rd.close
+            pool = @handler.retrieve_connection_pool(@klass)
+            wr.write Marshal.dump pool.schema_cache.size
+            wr.close
+            exit!
+          }
+
+          wr.close
+
+          Process.waitpid pid
+          assert_equal @pool.schema_cache.size, Marshal.load(rd.read)
+          rd.close
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/connection_management_test.rb
+++ b/activerecord/test/cases/connection_management_test.rb
@@ -26,29 +26,6 @@ module ActiveRecord
         assert ActiveRecord::Base.connection_handler.active_connections?
       end
 
-      if Process.respond_to?(:fork)
-        def test_connection_pool_per_pid
-          object_id = ActiveRecord::Base.connection.object_id
-
-          rd, wr = IO.pipe
-          rd.binmode
-          wr.binmode
-
-          pid = fork {
-            rd.close
-            wr.write Marshal.dump ActiveRecord::Base.connection.object_id
-            wr.close
-            exit!
-          }
-
-          wr.close
-
-          Process.waitpid pid
-          assert_not_equal object_id, Marshal.load(rd.read)
-          rd.close
-        end
-      end
-
       def test_app_delegation
         manager = ConnectionManagement.new(@app)
 


### PR DESCRIPTION
Followup to #17632.

Active Record detects when the process has forked and automatically creates a new connection pool to avoid sharing file descriptors.

If the existing connection pool had a schema cache associated with it, the new pool should copy it to avoid unnecessarily querying the database for its schema.

The code to detect that the process has forked is in ConnectionHandler, but the existing test for it was in the ConnectionManagement test file. I moved it to the right place while I was writing the new test for this change.
