### PR TITLE
Ensure that locking_enabled? returns boolean

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -139,7 +139,7 @@ module ActiveRecord
         # (which it is, by default) and the table includes the
         # +locking_column+ column (defaults to +lock_version+).
         def locking_enabled?
-          lock_optimistically && columns_hash[locking_column]
+          lock_optimistically && columns_hash[locking_column].present?
         end
 
         # Set the column to use for optimistic locking. Defaults to +lock_version+.


### PR DESCRIPTION
`locking_enabled?` doesn't return boolean when the `lock_optimistically` flag is set to true, because `columns_hash[locking_column]` returns not boolean but nil or object.
