### PR TITLE
Added ActionDispatch::Journey::Routes#empty?

### DIFF
--- a/actionpack/lib/action_dispatch/journey/routes.rb
+++ b/actionpack/lib/action_dispatch/journey/routes.rb
@@ -15,6 +15,10 @@ module ActionDispatch
         @custom_routes      = []
         @simulator          = nil
       end
+      
+      def empty?
+        routes.empty?
+      end
 
       def length
         routes.length

--- a/actionpack/lib/action_dispatch/journey/routes.rb
+++ b/actionpack/lib/action_dispatch/journey/routes.rb
@@ -15,7 +15,7 @@ module ActionDispatch
         @custom_routes      = []
         @simulator          = nil
       end
-      
+
       def empty?
         routes.empty?
       end

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -17,6 +17,16 @@ module ActionDispatch
         @set = RouteSet.new
       end
 
+      test "not being empty when route is added" do
+        assert empty?
+
+        draw do
+          get 'foo', to: SimpleApp.new('foo#index')
+        end
+
+        refute empty?
+      end
+
       test "url helpers are added when route is added" do
         draw do
           get 'foo', to: SimpleApp.new('foo#index')
@@ -135,6 +145,10 @@ module ActionDispatch
 
         def url_helpers
           @set.url_helpers
+        end
+
+        def empty?
+          @set.empty?
         end
     end
   end

--- a/actionpack/test/journey/routes_test.rb
+++ b/actionpack/test/journey/routes_test.rb
@@ -14,9 +14,11 @@ module ActionDispatch
         requirements = { :hello => /world/ }
 
         routes.add_route nil, path, requirements, {:id => nil}, {}
+        refute routes.empty?
         assert_equal 1, routes.length
 
         routes.clear
+        assert routes.empty?
         assert_equal 0, routes.length
       end
 


### PR DESCRIPTION
ActionDispatch::Routing::RouteSet has method "empty?", which is delegating to an instance of ActionDispatch::Journey::Routes, but latter has not this method. So the following code raises NoMethodError.

```
Rails.application.routes.empty?
```
