### PR TITLE
Ensure HashWithIndifferentAccess#select is consistent with Hash.select

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -238,7 +238,8 @@ module ActiveSupport
     def to_options!; self end
 
     def select(*args, &block)
-      dup.tap { |hash| hash.select!(*args, &block) }
+      copy = dup
+      copy.select!(*args, &block) || copy
     end
 
     def reject(*args, &block)

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -8,4 +8,13 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_equal :old_value, hash[:key]
   end
 
+  def test_select_with_block
+    hash = HashWithIndifferentAccess.new({ a: 1, b: 2, c: 3 })
+    assert_equal hash.select { |k, v| true }, hash
+  end
+
+  def test_select_without_block
+    hash = HashWithIndifferentAccess.new({ a: 1, b: 2, c: 3 })
+    assert_instance_of Enumerator, hash.select
+  end
 end


### PR DESCRIPTION
- Ensure HashWithIndifferentAccess#select is consistent with Hash.select
  with or without block

This will ensure HashWithIndifferentAccess#select is consistent with Hash.select
with or without block.
