### PR TITLE
Pass block to Relation#distinct and Relation#uniq

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Allow passing of block to `distinct` or `uniq` which builds an array of objects
+    that are iterated through using `Array#uniq`.
+
+    *Harry Whelchel*
+
 *   Allow single table inheritance instantiation to work when storing
     demodulized class names.
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -776,7 +776,16 @@ module ActiveRecord
       self
     end
 
-    # Specifies whether the records should be unique or not. For example:
+    # Works in two unique ways.
+    #
+    # First: takes a block so it can be used like Array#uniq.
+    #
+    #   Model.all.distinct { |m| m.field == value }
+    #
+    # This will build an array of objects from the database for the scope,
+    # convert them into an array and iterate through them using Array#uniq.
+    #
+    # Second: Specifies whether the records should be unique or not. For example:
     #
     #   User.select(:name)
     #   # => Might return two records with the same name
@@ -787,7 +796,11 @@ module ActiveRecord
     #   User.select(:name).distinct.distinct(false)
     #   # => You can also remove the uniqueness
     def distinct(value = true)
-      spawn.distinct!(value)
+      if block_given?
+        spawn.to_a.uniq { |*block_args| yield(*block_args) }
+      else
+        spawn.distinct!(value)
+      end
     end
     alias uniq distinct
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1503,6 +1503,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal ['Foo', 'Foo'], query.uniq(true).uniq(false).map(&:name)
   end
 
+  def test_distinct_with_block
+    distinct_ids = Developer.all.distinct {|d| d.salary }.map(&:id)
+    assert_equal [1, 2, 3, 11], distinct_ids.sort
+  end
+
   def test_doesnt_add_having_values_if_options_are_blank
     scope = Post.having('')
     assert scope.having_clause.empty?

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -563,7 +563,10 @@ ActiveModel::MissingAttributeError: missing attribute: <attribute>
 
 Where `<attribute>` is the attribute you asked for. The `id` method will not raise the `ActiveRecord::MissingAttributeError`, so just be careful when working with associations because they need the `id` method to function properly.
 
-If you would like to only grab a single record per unique value in a certain field, you can use `distinct`:
+Selecting Distinct Records
+--------------------------
+
+If you would like to grab a single record per unique value in a field, you can use `distinct`:
 
 ```ruby
 Client.select(:name).distinct
@@ -575,11 +578,21 @@ This would generate SQL like:
 SELECT DISTINCT name FROM clients
 ```
 
-You can also remove the uniqueness constraint:
+You can remove the uniqueness constraint:
 
 ```ruby
 query = Client.select(:name).distinct
 # => Returns unique names
+
+query.distinct(false)
+# => Returns all names, even if there are duplicates
+```
+
+You also can pass distinct a block, whose return value is used to determine uniqueness:
+
+```ruby
+query = Client.all.distinct { |client| "#{client.name}:#{client.city}" }
+# => Returns clients whose name and city combination are unique.
 
 query.distinct(false)
 # => Returns all names, even if there are duplicates
@@ -998,7 +1011,7 @@ SELECT categories.* FROM categories
   INNER JOIN articles ON articles.category_id = categories.id
 ```
 
-Or, in English: "return a Category object for all categories with articles". Note that you will see duplicate categories if more than one article has the same category. If you want unique categories, you can use `Category.joins(:articles).uniq`.
+Or, in English: "return a Category object for all categories with articles". Note that you will see duplicate categories if more than one article has the same category. If you want unique categories, you can use `Category.joins(:articles).distinct`.
 
 #### Joining Multiple Associations
 


### PR DESCRIPTION
Observes `Array#uniq` semantics when passing a block to `distinct` or `uniq`. Loads an array of the relation and then uses the return value of the block to determine uniqueness.

See: https://github.com/rails/rails/issues/20189
