### PR TITLE
updating the security links, they were removed in cc30f5f9 [ci skip]

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1033,4 +1033,5 @@ The security landscape shifts and it is important to keep up to date, because mi
 
 * Subscribe to the Rails security [mailing list](http://groups.google.com/group/rubyonrails-security)
 * [Keep up to date on the other application layers](http://secunia.com/) (they have a weekly newsletter, too)
+* A [good security blog](https://www.owasp.org) including the [Cross-Site scripting Cheat Sheet](https://www.owasp.org/index.php/DOM_based_XSS_Prevention_Cheat_Sheet)
 


### PR DESCRIPTION
The links were removed in cc30f5f9 . New links as per pull request [#20160_comment](https://github.com/rails/rails/pull/20160#issuecomment-102218231)  (OWASP guides)
