### PR TITLE
Add bang version to OrderedOptions

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*  Add a bang version to `ActiveSupport::OrderedOptions` get methods which will raise an `KeyError` if the value is `.blank?`
+    Before:
+
+        if (slack_url = Rails.application.secrets.slack_url).present?)
+          // Do something worthwhile
+        else
+          // Raise hell as important secret password is not specified
+        end
+
+    After:
+
+        slack_url = Rails.application.secrets.slack_url!
+
+    *Aditya Sanghi*, *Gaurish Sharma*
+
 *   Patch `Delegator` to work with `#try`.
 
     Fixes #5790.

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -31,7 +31,12 @@ module ActiveSupport
       if name_string.chomp!('=')
         self[name_string] = args.first
       else
-        self[name]
+        bangs = name_string.chomp!('!')
+        if bangs
+          fetch(name_string.to_sym).presence || raise(KeyError.new("#{name_string} is nil or undefined"))
+        else
+         self[name_string]
+       end
       end
     end
 

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -85,4 +85,19 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     assert_equal 42, a.method(:blah=).call(42)
     assert_equal 42, a.method(:blah).call
   end
+
+  def test_raises_with_bang
+    a = ActiveSupport::OrderedOptions.new
+    a[:foo] = :bar
+    assert a.respond_to?(:foo!)
+
+    assert_nothing_raised { a.foo! }
+    assert_equal a.foo, a.foo!
+
+    assert_raises(KeyError) do
+      a.foo = nil
+      a.foo!
+    end
+    assert_raises(KeyError){ a.non_existing_key! }
+  end
 end


### PR DESCRIPTION
Every method should have a bang counter-part. if someone uses a bang version & its not defined. it will raise an ArgumentError. 

example(normal version)
`Rails.application.secrets.big_query`

bang version
`Rails.application.secrets.big_query!`

By:
Aditya Sanghi(@asanghi)
Gaurish Sharma(@gaurish)
