### PR TITLE
updated squash docs-section [ci skip]

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -579,8 +579,7 @@ following:
 ```bash
 $ git fetch upstream
 $ git checkout my_pull_request
-$ git rebase upstream/master
-$ git rebase -i
+$ git rebase -i upstream/master
 
 < Choose 'squash' for all of your commits except the first one. >
 < Edit the commit message to make sense, and describe all your changes. >


### PR DESCRIPTION
I happen to squash my couple of commits and when followed steps from guide, I observed that I have to give a commit id after which I want to squash. If I don't provide one it picks last 3 commits, which might not include my commits to squash.
Refer: http://stackoverflow.com/questions/5189560/squash-my-last-x-commits-together-using-git
