### PR TITLE
[ci skip] add to doc that acceptance validator allows `nil` by default

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -283,6 +283,7 @@ class Person < ActiveRecord::Base
 end
 ```
 
+This check is performed only if `terms_of_service` is not `nil`.
 The default error message for this helper is _"must be accepted"_.
 
 It can receive an `:accept` option, which determines the value that will be


### PR DESCRIPTION
The `validates_acceptance_of` API doc has it, but it was missing from the guides.

Came up in #20188
