### PR TITLE
updated Inline format at activerecord rdoc

### DIFF
--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -31,8 +31,8 @@ which might look like this:
      PRIMARY KEY  (id)
    );
 
-This would also define the following accessors: `Product#name` and
-`Product#name=(new_name)`.
+This would also define the following accessors: <tt>Product#name</tt> and
+<tt>Product#name=(new_name)</tt>.
 
 
 * Associations between objects defined by simple class methods.


### PR DESCRIPTION
For Inline formats, changed  single backticks ( `)  to <tt> tag at active record rdoc. As single backticks (`) do not work with `.rdoc`. for inline format.
