### PR TITLE
Make remove_foreign_key reversible

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Make remove_foreign_key invertible. Any foreign key options must be
+    specified, similar to remove_column.
+
+    *Aster Ryan*
+
 *   Correctly handle decimal arrays with defaults in the schema dumper.
 
     Fixes #20515.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -777,7 +777,10 @@ module ActiveRecord
         execute schema_creation.accept(at)
       end
 
-      # Removes the given foreign key from the table.
+      # Removes the given foreign key from the table. Any options parameters provided
+      # will be used to re-add the foreign key in case of a migration reversion.
+      # It is recommended that you provide any options used when creating the foreign
+      # key so that the migration can be reverted properly.
       #
       # Removes the foreign key on +accounts.branch_id+.
       #
@@ -791,6 +794,8 @@ module ActiveRecord
       #
       #   remove_foreign_key :accounts, name: :special_fk_name
       #
+      # The +options+ hash can include all keys that can be used in add_foreign_key.
+      # Please refer to the add_foreign_key documentation for a full list
       def remove_foreign_key(from_table, options_or_to_table = {})
         return unless supports_foreign_keys?
 

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -184,6 +184,16 @@ module ActiveRecord
         [:remove_foreign_key, [from_table, options]]
       end
 
+      def invert_remove_foreign_key(args)
+        from_table, to_table, remove_options = args
+        raise ActiveRecord::IrreversibleMigration, "remove_foreign_key is only reversible if given a second table" if to_table.nil? || to_table.is_a?(Hash)
+
+        reversed_args = [from_table, to_table]
+        reversed_args << remove_options if remove_options
+
+        [:add_foreign_key, reversed_args]
+      end
+
       # Forwards any missing method call to the \target.
       def method_missing(method, *args, &block)
         if @delegate.respond_to?(method)

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -281,9 +281,19 @@ module ActiveRecord
         assert_equal [:remove_foreign_key, [:dogs, :people]], enable
       end
 
+      def test_invert_remove_foreign_key
+        enable = @recorder.inverse_of :remove_foreign_key, [:dogs, :people]
+        assert_equal [:add_foreign_key, [:dogs, :people]], enable
+      end
+
       def test_invert_add_foreign_key_with_column
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people, column: "owner_id"]
         assert_equal [:remove_foreign_key, [:dogs, column: "owner_id"]], enable
+      end
+
+      def test_invert_remove_foreign_key_with_column
+        enable = @recorder.inverse_of :remove_foreign_key, [:dogs, :people, column: "owner_id"]
+        assert_equal [:add_foreign_key, [:dogs, :people, column: "owner_id"]], enable
       end
 
       def test_invert_add_foreign_key_with_column_and_name
@@ -291,13 +301,32 @@ module ActiveRecord
         assert_equal [:remove_foreign_key, [:dogs, name: "fk"]], enable
       end
 
-      def test_remove_foreign_key_is_irreversible
+      def test_invert_remove_foreign_key_with_column_and_name
+        enable = @recorder.inverse_of :remove_foreign_key, [:dogs, :people, column: "owner_id", name: "fk"]
+        assert_equal [:add_foreign_key, [:dogs, :people, column: "owner_id", name: "fk"]], enable
+      end
+
+      def test_invert_remove_foreign_key_with_primary_key
+        enable = @recorder.inverse_of :remove_foreign_key, [:dogs, :people, primary_key: "person_id"]
+        assert_equal [:add_foreign_key, [:dogs, :people, primary_key: "person_id"]], enable
+      end
+
+      def test_invert_remove_foreign_key_with_on_delete_on_update
+        enable = @recorder.inverse_of :remove_foreign_key, [:dogs, :people, on_delete: :nullify, on_update: :cascade]
+        assert_equal [:add_foreign_key, [:dogs, :people, on_delete: :nullify, on_update: :cascade]], enable
+      end
+
+      def test_invert_remove_foreign_key_is_irreversible_without_to_table
         assert_raises ActiveRecord::IrreversibleMigration do
           @recorder.inverse_of :remove_foreign_key, [:dogs, column: "owner_id"]
         end
 
         assert_raises ActiveRecord::IrreversibleMigration do
           @recorder.inverse_of :remove_foreign_key, [:dogs, name: "fk"]
+        end
+
+        assert_raises ActiveRecord::IrreversibleMigration do
+          @recorder.inverse_of :remove_foreign_key, [:dogs]
         end
       end
     end


### PR DESCRIPTION
Obviously remove_foreign_key is irreversible if a to_table is not passed, but this should remove the necessity to do

``` ruby
reversible do |dir|
  dir.up do
    remove_foreign_key :dogs, :people
  end
  dir.down do
    add_foreign_key :dogs, :people
  end
end
```

I'm open to DRYing this up if necessary. I dug through the history to find out why remove_foreign_key is explicitly irreversible and couldn't quite find a solid answer, so if this has been discussed and decided somewhere already please let me know.

Will update changelog if approved.
