### PR TITLE
Fix error in 'Action Mailer Basics' guide. [ci-skip]

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -35,7 +35,7 @@ views.
 #### Create the Mailer
 
 ```bash
-$ bin/rails generate mailer UserMailer
+$ rails generate mailer UserMailer
 create  app/mailers/user_mailer.rb
 create  app/mailers/application_mailer.rb
 invoke  erb


### PR DESCRIPTION
In the 'Action Mailer Basics' guide, '/bin/rails generate ...' should be 'rails generate ...'.
