### PR TITLE
Remove config.assets.raise_runtime_errors from development.rb into 4-2-stable

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -33,11 +33,6 @@ Rails.application.configure do
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
   config.assets.digest = true
-
-  # Adds additional error checking when serving assets at runtime.
-  # Checks for improperly declared sprockets dependencies.
-  # Raises helpful error messages.
-  config.assets.raise_runtime_errors = true
   <%- end -%>
 
   # Raises error for missing translations


### PR DESCRIPTION
config.assets.raise_runtime_errors = true by default started with sprockets-rails 3.0.beta1
https://github.com/rails/sprockets-rails/commit/655b93bffc6f51b96a7cc097f9010942693bfaae
