### PR TITLE
Check references for eager loading stricter

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -687,7 +687,7 @@ module ActiveRecord
       # always convert table names to downcase as in Oracle quoted table names are in uppercase
       joined_tables = joined_tables.flatten.compact.map(&:downcase).uniq
 
-      (references_values - joined_tables).any?
+      (includes_values.map(&:to_s) & references_values - joined_tables).any?
     end
 
     def tables_in_string(string)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1538,6 +1538,12 @@ class RelationTest < ActiveRecord::TestCase
     assert scope.references(:comments).eager_loading?
   end
 
+  def test_references_does_not_trigger_eager_loading
+    scope = Post.includes(:comments)
+    assert !scope.eager_loading?
+    assert !scope.references(:foo).eager_loading?
+  end
+
   def test_references_doesnt_trigger_eager_loading_if_reference_not_included
     scope = Post.references(:comments)
     assert !scope.eager_loading?


### PR DESCRIPTION
Currently I can call `references` method with any argument I want. And it will use `eager_loading?`, like:

``` ruby
Post.includes(:comments).references(:foo)
```

I guess it's better to check the arguments and use eager loading only when references match. 
