### PR TITLE
Update documentation for ActiveRecord::Migration#remove_index

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -138,8 +138,8 @@ module ActiveRecord
   #   <tt>:name</tt>, <tt>:unique</tt> (e.g.
   #   <tt>{ name: 'users_name_index', unique: true }</tt>) and <tt>:order</tt>
   #   (e.g. <tt>{ order: { name: :desc } }</tt>).
-  # * <tt>remove_index(table_name, column: column_name)</tt>: Removes the index
-  #   specified by +column_name+.
+  # * <tt>remove_index(table_name, column: column_names)</tt>: Removes the index
+  #   specified by +column_names+.
   # * <tt>remove_index(table_name, name: index_name)</tt>: Removes the index
   #   specified by +index_name+.
   #


### PR DESCRIPTION
`remove_index` works with multiple column names as `add_index`
