### PR TITLE
Remove ActiveSupport.test_order

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -72,8 +72,6 @@ module ActiveSupport
     NumberHelper.eager_load!
   end
 
-  cattr_accessor :test_order # :nodoc:
-
   def self.halt_callback_chains_on_return_false
     Callbacks::CallbackChain.halt_and_display_warning_on_return_false
   end

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -26,7 +26,7 @@ module ActiveSupport
       # * +:sorted+   (to run tests alphabetically by method name)
       # * +:alpha+    (equivalent to +:sorted+)
       def test_order=(new_order)
-        ActiveSupport.test_order = new_order
+        @test_order = new_order
       end
 
       # Returns the order in which test cases are run.
@@ -36,7 +36,7 @@ module ActiveSupport
       # Possible values are +:random+, +:parallel+, +:alpha+, +:sorted+.
       # Defaults to +:random+.
       def test_order
-        ActiveSupport.test_order ||= :random
+        @test_order ||= :random
       end
     end
 

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -186,23 +186,5 @@ class TestOrderTest < ActiveSupport::TestCase
     ActiveSupport::TestCase.test_order = nil
 
     assert_equal :random, ActiveSupport::TestCase.test_order
-
-    assert_equal :random, ActiveSupport.test_order
-  end
-
-  def test_test_order_is_global
-    ActiveSupport::TestCase.test_order = :sorted
-
-    assert_equal :sorted, ActiveSupport.test_order
-    assert_equal :sorted, ActiveSupport::TestCase.test_order
-    assert_equal :sorted, self.class.test_order
-    assert_equal :sorted, Class.new(ActiveSupport::TestCase).test_order
-
-    ActiveSupport.test_order = :random
-
-    assert_equal :random, ActiveSupport.test_order
-    assert_equal :random, ActiveSupport::TestCase.test_order
-    assert_equal :random, self.class.test_order
-    assert_equal :random, Class.new(ActiveSupport::TestCase).test_order
   end
 end


### PR DESCRIPTION
I am writing a ruby tool and use Active Support for unit testing, especially for the `test "test name"` syntax and the additional matchers.

When I `require 'active_support/test_case'`, I must `require 'active_support'`, too.
Since these lines of code, I get error if I do not `require 'active_support'` itself.

``` ruby
def test_order
  ActiveSupport.test_order ||= :random
end
```

It's not good design pattern, testing features should go into test case instead of the whole module.

After the removing, just use 

``` ruby
ActiveSupport::TestCase.test_order = :random
```
