### PR TITLE
Remove broken and unused release task

### DIFF
--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -26,10 +26,3 @@ spec = eval(File.read('actionmailer.gemspec'))
 Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
-
-desc "Release to rubygems"
-task release: :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
-end

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -30,13 +30,6 @@ Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
 
-desc "Release to rubygems"
-task :release => :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
-end
-
 task :lines do
   load File.expand_path('..', File.dirname(__FILE__)) + '/tools/line_statistics'
   files = FileList["lib/**/*.rb"]

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -51,13 +51,6 @@ Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
 
-desc "Release to rubygems"
-task :release => :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
-end
-
 task :lines do
   lines, codelines, total_lines, total_codelines = 0, 0, 0, 0
 

--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -81,10 +81,3 @@ spec = eval(File.read('activejob.gemspec'))
 Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
-
-desc 'Release to rubygems'
-task release: :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
-end

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -27,10 +27,3 @@ spec = eval(File.read("#{dir}/activemodel.gemspec"))
 Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
-
-desc "Release to rubygems"
-task :release => :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
-end

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -157,12 +157,3 @@ spec = eval(File.read('activerecord.gemspec'))
 Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
-
-# Publishing ------------------------------------------------------
-
-desc "Release to rubygems"
-task :release => :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
-end

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -23,10 +23,3 @@ spec = eval(File.read('activesupport.gemspec'))
 Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
 end
-
-desc "Release to rubygems"
-task :release => :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
-end

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -39,12 +39,3 @@ spec = eval(File.read('railties.gemspec'))
 Gem::PackageTask.new(spec) do |pkg|
   pkg.gem_spec = spec
 end
-
-# Publishing -------------------------------------------------------
-
-desc "Release to rubygems"
-task :release => :package do
-  require 'rake/gemcutter'
-  Rake::Gemcutter::Tasks.new(spec).define
-  Rake::Task['gem:push'].invoke
-end


### PR DESCRIPTION
- We do release with release.rb
- There is no `rake/gemcutter`

I have kept `rake package` task if we want to see and package a gem. Should we remove that as well?
