### PR TITLE
Avoid E constant clashing with Minitest defined version.

### DIFF
--- a/activesupport/test/autoloading_fixtures/a/c/e/f.rb
+++ b/activesupport/test/autoloading_fixtures/a/c/e/f.rb
@@ -1,2 +1,0 @@
-class A::C::E::F
-end

--- a/activesupport/test/autoloading_fixtures/a/c/em/f.rb
+++ b/activesupport/test/autoloading_fixtures/a/c/em/f.rb
@@ -1,0 +1,2 @@
+class A::C::EM::F
+end

--- a/activesupport/test/autoloading_fixtures/d.rb
+++ b/activesupport/test/autoloading_fixtures/d.rb
@@ -1,0 +1,2 @@
+class D
+end

--- a/activesupport/test/autoloading_fixtures/e.rb
+++ b/activesupport/test/autoloading_fixtures/e.rb
@@ -1,2 +1,0 @@
-class E
-end

--- a/activesupport/test/autoloading_fixtures/em.rb
+++ b/activesupport/test/autoloading_fixtures/em.rb
@@ -1,0 +1,2 @@
+class EM
+end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -636,37 +636,37 @@ module AutoloadingCacheBehavior
   include DependenciesTestHelpers
   def test_simple_autoloading
     with_autoloading_fixtures do
-      @cache.write('foo', E.new)
+      @cache.write('foo', EM.new)
     end
 
-    remove_constants(:E)
+    remove_constants(:EM)
     ActiveSupport::Dependencies.clear
 
     with_autoloading_fixtures do
-      assert_kind_of E, @cache.read('foo')
+      assert_kind_of EM, @cache.read('foo')
     end
 
-    remove_constants(:E)
+    remove_constants(:EM)
     ActiveSupport::Dependencies.clear
   end
 
   def test_two_classes_autoloading
     with_autoloading_fixtures do
-      @cache.write('foo', [E.new, ClassFolder.new])
+      @cache.write('foo', [EM.new, ClassFolder.new])
     end
 
-    remove_constants(:E, :ClassFolder)
+    remove_constants(:EM, :ClassFolder)
     ActiveSupport::Dependencies.clear
 
     with_autoloading_fixtures do
       loaded = @cache.read('foo')
       assert_kind_of Array, loaded
       assert_equal 2, loaded.size
-      assert_kind_of E, loaded[0]
+      assert_kind_of EM, loaded[0]
       assert_kind_of ClassFolder, loaded[1]
     end
 
-    remove_constants(:E, :ClassFolder)
+    remove_constants(:EM, :ClassFolder)
     ActiveSupport::Dependencies.clear
   end
 end

--- a/activesupport/test/core_ext/marshal_test.rb
+++ b/activesupport/test/core_ext/marshal_test.rb
@@ -8,7 +8,7 @@ class MarshalTest < ActiveSupport::TestCase
 
   def teardown
     ActiveSupport::Dependencies.clear
-    remove_constants(:E, :ClassFolder)
+    remove_constants(:EM, :ClassFolder)
   end
 
   test "that Marshal#load still works" do
@@ -22,14 +22,14 @@ class MarshalTest < ActiveSupport::TestCase
   test "that a missing class is autoloaded from string" do
     dumped = nil
     with_autoloading_fixtures do
-      dumped = Marshal.dump(E.new)
+      dumped = Marshal.dump(EM.new)
     end
 
-    remove_constants(:E)
+    remove_constants(:EM)
     ActiveSupport::Dependencies.clear
 
     with_autoloading_fixtures do
-      assert_kind_of E, Marshal.load(dumped)
+      assert_kind_of EM, Marshal.load(dumped)
     end
   end
 
@@ -50,16 +50,16 @@ class MarshalTest < ActiveSupport::TestCase
   test "that more than one missing class is autoloaded" do
     dumped = nil
     with_autoloading_fixtures do
-      dumped = Marshal.dump([E.new, ClassFolder.new])
+      dumped = Marshal.dump([EM.new, ClassFolder.new])
     end
 
-    remove_constants(:E, :ClassFolder)
+    remove_constants(:EM, :ClassFolder)
     ActiveSupport::Dependencies.clear
 
     with_autoloading_fixtures do
       loaded = Marshal.load(dumped)
       assert_equal 2, loaded.size
-      assert_kind_of E, loaded[0]
+      assert_kind_of EM, loaded[0]
       assert_kind_of ClassFolder, loaded[1]
     end
   end
@@ -67,10 +67,10 @@ class MarshalTest < ActiveSupport::TestCase
   test "that a real missing class is causing an exception" do
     dumped = nil
     with_autoloading_fixtures do
-      dumped = Marshal.dump(E.new)
+      dumped = Marshal.dump(EM.new)
     end
 
-    remove_constants(:E)
+    remove_constants(:EM)
     ActiveSupport::Dependencies.clear
 
     assert_raise(NameError) do
@@ -84,10 +84,10 @@ class MarshalTest < ActiveSupport::TestCase
     end
 
     with_autoloading_fixtures do
-      dumped = Marshal.dump([E.new, SomeClass.new])
+      dumped = Marshal.dump([EM.new, SomeClass.new])
     end
 
-    remove_constants(:E)
+    remove_constants(:EM)
     self.class.send(:remove_const, :SomeClass)
     ActiveSupport::Dependencies.clear
 
@@ -96,8 +96,8 @@ class MarshalTest < ActiveSupport::TestCase
         Marshal.load(dumped)
       end
 
-      assert_nothing_raised("E failed to load while we expect only SomeClass to fail loading") do
-        E.new
+      assert_nothing_raised("EM failed to load while we expect only SomeClass to fail loading") do
+        EM.new
       end
 
       assert_raise(NameError, "We expected SomeClass to not be loaded but it is!") do
@@ -109,15 +109,15 @@ class MarshalTest < ActiveSupport::TestCase
   test "loading classes from files trigger autoloading" do
     Tempfile.open("object_serializer_test") do |f|
       with_autoloading_fixtures do
-        Marshal.dump(E.new, f)
+        Marshal.dump(EM.new, f)
       end
 
       f.rewind
-      remove_constants(:E)
+      remove_constants(:EM)
       ActiveSupport::Dependencies.clear
 
       with_autoloading_fixtures do
-        assert_kind_of E, Marshal.load(f)
+        assert_kind_of EM, Marshal.load(f)
       end
     end
   end

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -187,7 +187,7 @@ class DependenciesTest < ActiveSupport::TestCase
       assert_kind_of Module, A
       assert_kind_of Class, A::B
       assert_kind_of Class, A::C::D
-      assert_kind_of Class, A::C::E::F
+      assert_kind_of Class, A::C::EM::F
     end
   end
 
@@ -552,24 +552,24 @@ class DependenciesTest < ActiveSupport::TestCase
   def test_const_missing_in_anonymous_modules_loads_top_level_constants
     with_autoloading_fixtures do
       # class_eval STRING pushes the class to the nesting of the eval'ed code.
-      klass = Class.new.class_eval "E"
-      assert_equal E, klass
+      klass = Class.new.class_eval "EM"
+      assert_equal EM, klass
     end
   ensure
-    remove_constants(:E)
+    remove_constants(:EM)
   end
 
   def test_const_missing_in_anonymous_modules_raises_if_the_constant_belongs_to_Object
     with_autoloading_fixtures do
-      require_dependency 'e'
+      require_dependency 'em'
 
       mod = Module.new
-      e = assert_raise(NameError) { mod::E }
-      assert_equal 'E cannot be autoloaded from an anonymous class or module', e.message
-      assert_equal :E, e.name
+      e = assert_raise(NameError) { mod::EM }
+      assert_equal 'EM cannot be autoloaded from an anonymous class or module', e.message
+      assert_equal :EM, e.name
     end
   ensure
-    remove_constants(:E)
+    remove_constants(:EM)
   end
 
   def test_removal_from_tree_should_be_detected
@@ -664,19 +664,19 @@ class DependenciesTest < ActiveSupport::TestCase
 
   def test_preexisting_constants_are_not_marked_as_autoloaded
     with_autoloading_fixtures do
-      require_dependency 'e'
-      assert ActiveSupport::Dependencies.autoloaded?(:E)
+      require_dependency 'em'
+      assert ActiveSupport::Dependencies.autoloaded?(:EM)
       ActiveSupport::Dependencies.clear
     end
 
-    Object.const_set :E, Class.new
+    Object.const_set :EM, Class.new
     with_autoloading_fixtures do
-      require_dependency 'e'
-      assert ! ActiveSupport::Dependencies.autoloaded?(:E), "E shouldn't be marked autoloaded!"
+      require_dependency 'em'
+      assert ! ActiveSupport::Dependencies.autoloaded?(:EM), "EM shouldn't be marked autoloaded!"
       ActiveSupport::Dependencies.clear
     end
   ensure
-    remove_constants(:E)
+    remove_constants(:EM)
   end
 
   def test_constants_in_capitalized_nesting_marked_as_autoloaded


### PR DESCRIPTION
Fixes issues in Active Support with upgrading to a Minitest version greater than 5.3.3.

Here's an example of the failures this prevents: https://travis-ci.org/rails/rails/jobs/63084379#L394-L446

Minitest sets an `E` constant to an empty string to save GC time: https://github.com/seattlerb/minitest/blob/master/lib/minitest/assertions.rb#L147
This clashes with autoloading tests which define an `E` constant.
