### PR TITLE
mysql structure dump should use --routines

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -59,6 +59,7 @@ module ActiveRecord
         args = prepare_command_options('mysqldump')
         args.concat(["--result-file", "#{filename}"])
         args.concat(["--no-data"])
+        args.concat(["--routines"])
         args.concat(["#{configuration['database']}"])
         unless Kernel.system(*args)
           $stderr.puts "Could not dump the database structure. "\


### PR DESCRIPTION
While I understand it is not entirely common to use functions/stored procedures within active record, a rake db:structure:dump should include them in the structure.sql.

Adding the "--routines" option will include them in the structure.sql.
