### PR TITLE
Changed mysqldump to include sprocs and functions

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -59,6 +59,7 @@ module ActiveRecord
         args = prepare_command_options('mysqldump')
         args.concat(["--result-file", "#{filename}"])
         args.concat(["--no-data"])
+        args.concat(["--routines"])
         args.concat(["#{configuration['database']}"])
         unless Kernel.system(*args)
           $stderr.puts "Could not dump the database structure. "\

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -265,14 +265,14 @@ module ActiveRecord
 
     def test_structure_dump
       filename = "awesome-file.sql"
-      Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "test-db").returns(true)
+      Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "--routines", "test-db").returns(true)
 
       ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
     end
 
     def test_warn_when_external_structure_dump_fails
       filename = "awesome-file.sql"
-      Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "test-db").returns(false)
+      Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "--routines", "test-db").returns(false)
 
       warnings = capture(:stderr) do
         ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
@@ -283,7 +283,7 @@ module ActiveRecord
 
     def test_structure_dump_with_port_number
       filename = "awesome-file.sql"
-      Kernel.expects(:system).with("mysqldump", "--port=10000", "--result-file", filename, "--no-data", "test-db").returns(true)
+      Kernel.expects(:system).with("mysqldump", "--port=10000", "--result-file", filename, "--no-data", "--routines", "test-db").returns(true)
 
       ActiveRecord::Tasks::DatabaseTasks.structure_dump(
         @configuration.merge('port' => 10000),
@@ -292,7 +292,7 @@ module ActiveRecord
 
     def test_structure_dump_with_ssl
       filename = "awesome-file.sql"
-      Kernel.expects(:system).with("mysqldump", "--ssl-ca=ca.crt", "--result-file", filename, "--no-data", "test-db").returns(true)
+      Kernel.expects(:system).with("mysqldump", "--ssl-ca=ca.crt", "--result-file", filename, "--no-data", "--routines", "test-db").returns(true)
 
       ActiveRecord::Tasks::DatabaseTasks.structure_dump(
         @configuration.merge("sslca" => "ca.crt"),


### PR DESCRIPTION
While I understand it is not entirely common to use functions/stored procedures within active record, a rake db:structure:dump should include them in the structure.sql.

Adding the "--routines" option will include them in the structure.sql.
