### PR TITLE
Spelling/typo/grammatical fixes

### DIFF
--- a/activejob/test/cases/test_case_test.rb
+++ b/activejob/test/cases/test_case_test.rb
@@ -5,7 +5,7 @@ require 'jobs/nested_job'
 
 class ActiveJobTestCaseTest < ActiveJob::TestCase
   # this tests that this job class doesn't get its adapter set.
-  # that's the correct behaviour since we don't want to break
+  # that's the correct behavior since we don't want to break
   # the `class_attribute` inheritence
   class TestClassAttributeInheritenceJob < ActiveJob::Base
     def self.queue_adapter=(*)

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -182,7 +182,7 @@ module ActiveRecord
         assert !@pool.active_connection?
       end
 
-      def test_checkout_behaviour
+      def test_checkout_behavior
         pool = ConnectionPool.new ActiveRecord::Base.connection_pool.spec
         connection = pool.connection
         assert_not_nil connection

--- a/activerecord/test/cases/finder_respond_to_test.rb
+++ b/activerecord/test/cases/finder_respond_to_test.rb
@@ -5,19 +5,19 @@ class FinderRespondToTest < ActiveRecord::TestCase
 
   fixtures :topics
 
-  def test_should_preserve_normal_respond_to_behaviour_on_base
+  def test_should_preserve_normal_respond_to_behavior_on_base
     assert_respond_to ActiveRecord::Base, :new
     assert !ActiveRecord::Base.respond_to?(:find_by_something)
   end
 
-  def test_should_preserve_normal_respond_to_behaviour_and_respond_to_newly_added_method
+  def test_should_preserve_normal_respond_to_behavior_and_respond_to_newly_added_method
     class << Topic; self; end.send(:define_method, :method_added_for_finder_respond_to_test) { }
     assert_respond_to Topic, :method_added_for_finder_respond_to_test
   ensure
     class << Topic; self; end.send(:remove_method, :method_added_for_finder_respond_to_test)
   end
 
-  def test_should_preserve_normal_respond_to_behaviour_and_respond_to_standard_object_method
+  def test_should_preserve_normal_respond_to_behavior_and_respond_to_standard_object_method
     assert_respond_to Topic, :to_s
   end
 

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -101,7 +101,7 @@ class DeprecationTest < ActiveSupport::TestCase
     assert_match(/foo=nil/, @b)
   end
 
-  def test_raise_behaviour
+  def test_raise_behavior
     ActiveSupport::Deprecation.behavior = :raise
 
     message   = 'Revise this deprecated stuff now!'


### PR DESCRIPTION
As Rails documentation standard is American English.
