### PR TITLE
American English Spelling fixes [ci skip]

### DIFF
--- a/activejob/test/cases/test_case_test.rb
+++ b/activejob/test/cases/test_case_test.rb
@@ -5,7 +5,7 @@ require 'jobs/nested_job'
 
 class ActiveJobTestCaseTest < ActiveJob::TestCase
   # this tests that this job class doesn't get its adapter set.
-  # that's the correct behaviour since we don't want to break
+  # that's the correct behavior since we don't want to break
   # the `class_attribute` inheritence
   class TestClassAttributeInheritenceJob < ActiveJob::Base
     def self.queue_adapter=(*)


### PR DESCRIPTION
As Rails documentation standard is American English.
