### PR TITLE
Allow default_render to take a block to customize behavior when there's no template

### DIFF
--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -3,12 +3,27 @@ module ActionController
 
     include BasicImplicitRender
 
+    # Renders the template corresponding to the controller action, if it exists.
+    # The action name, format, and variant are all taken into account.
+    # For example, the "new" action with an HTML format and variant "phone" 
+    # would try to render the <tt>new.html+phone.erb</tt> template.
+    #
+    # If no template is found <tt>ActionController::BasicImplicitRender</tt>'s implementation is called, unless
+    # a block is passed. In that case, it will override the super implementation.
+    #
+    #   default_render do
+    #     head 404 # No template was found
+    #   end
     def default_render(*args)
       if template_exists?(action_name.to_s, _prefixes, variants: request.variant)
         render(*args)
       else
-        logger.info "No template found for #{self.class.name}\##{action_name}, rendering head :no_content" if logger
-        super
+        if block_given?
+          yield(*args)
+        else
+          logger.info "No template found for #{self.class.name}\##{action_name}, rendering head :no_content" if logger
+          super
+        end
       end
     end
 

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -793,3 +793,24 @@ class RespondToControllerTest < ActionController::TestCase
     assert_equal "phone", @response.body
   end
 end
+
+class RespondToWithBlockOnDefaultRenderController < ActionController::Base
+  def show
+    default_render do
+      render text: 'default_render yielded'
+    end
+  end
+end
+
+class RespondToWithBlockOnDefaultRenderControllerTest < ActionController::TestCase
+  def setup
+    super
+    @request.host = "www.example.com"
+  end
+
+  def test_default_render_uses_block_when_no_template_exists
+    get :show
+    assert_equal "default_render yielded", @response.body
+    assert_equal "text/html", @response.content_type
+  end
+end


### PR DESCRIPTION
In 0de4a23 the behavior when there is a missing template was changed to
not raise an error, but instead head :no_content.  This is a breaking
change and some gems rely on this happening.

This adds `raise_on_missing_template` to controllers that, when set to
`true`, enables the old behavior

<hr>
# Previous description for some context

Doing this to have a conversation, so not necessarily proposing this exact patch, but I need help.
## Problem

The patch being reverted here changes `ActionController::Metal::ImplicitRender#default_render` in a way that isn't backwards compatible.  _Before_ this patch, code like this:

``` ruby
# note use of responders gem in here—could be an issue
def create
  user = User.create(params)
  if user.valid?
    redirect_to users_path
  else
    respond_with user # intends to render the `new` template
  end
end
```

Would render the `new` template.  _After_ the patch being reverted here, it does a `HEAD` with no content and error message that the `create` template cannot be found.

So, before, the code was not ever intending to render a `create` template, but the patch being reverted here checks.
## Solution

It seems like the check for the template existing isn't right.  Seems like it should test if something valid would be rendered, and this:

``` ruby
if template_exists?(action_name.to_s, _prefixes, variants: request.variant)
```

doesn't check that.
## Where I need help

What I can't figure out is how `render(*args)` ends up rendering the `new` template, so I can't figure out how to make the `if` statement more consistent with the behavior of `render`.

It could certainly be an issue in the responders gem, but a glance at the definition of `respond_with` ( https://github.com/plataformatec/responders/blob/70bea715bb87c9e7bd402ef88406a72ca327bb12/lib/action_controller/respond_with.rb#L190 ) doesn't lead me to any insights.  In my case https://github.com/plataformatec/responders/blob/70bea715bb87c9e7bd402ef88406a72ca327bb12/lib/action_controller/respond_with.rb#L205 is calling `self.class.responder` which is the default.

Can anyone point me to the right direction?
