### PR TITLE
Move expectation to instance level.

### DIFF
--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -352,6 +352,8 @@ class ViewCacheDependencyTest < ActionController::TestCase
 end
 
 class CollectionCacheController < ActionController::Base
+  attr_accessor :partial_rendered_times
+
   def index
     @customers = [Customer.new('david', params[:id] || 1)]
   end
@@ -377,14 +379,15 @@ class AutomaticCollectionCacheTest < ActionController::TestCase
     super
     @controller = CollectionCacheController.new
     @controller.perform_caching = true
-    @controller.cache_store = ActiveSupport::Cache::MemoryStore.new
+    @controller.partial_rendered_times = 0
   end
 
   def test_collection_fetches_cached_views
     get :index
+    assert_equal 1, @controller.partial_rendered_times
 
-    ActionView::PartialRenderer.expects(:collection_with_template).never
     get :index
+    assert_equal 1, @controller.partial_rendered_times
   end
 
   def test_preserves_order_when_reading_from_cache_plus_rendering
@@ -402,8 +405,9 @@ class AutomaticCollectionCacheTest < ActionController::TestCase
 
   def test_caching_works_with_beginning_comment
     get :index_with_comment
+    assert_equal 1, @controller.partial_rendered_times
 
-    ActionView::PartialRenderer.expects(:collection_with_template).never
     get :index_with_comment
+    assert_equal 1, @controller.partial_rendered_times
   end
 end

--- a/actionpack/test/fixtures/customers/_commented_customer.html.erb
+++ b/actionpack/test/fixtures/customers/_commented_customer.html.erb
@@ -1,4 +1,5 @@
 <%# I'm a comment %>
 <% cache customer do %>
+  <% controller.partial_rendered_times += 1 %>
   <%= customer.name %>, <%= customer.id %>
 <% end %>

--- a/actionpack/test/fixtures/customers/_customer.html.erb
+++ b/actionpack/test/fixtures/customers/_customer.html.erb
@@ -1,3 +1,4 @@
 <% cache customer do %>
+  <% controller.partial_rendered_times += 1 %>
   <%= customer.name %>, <%= customer.id %>
 <% end %>


### PR DESCRIPTION
As noted by @dubek here: https://github.com/kaspth/rails/commit/11644fd0ceb99f3f0529323df5ad625c596b3f21#commitcomment-11337785

The tests would still pass if the cache call in the rendered templates were removed.
