### PR TITLE
Use memoization while accessing request headers for minimizing memory usage

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -181,7 +181,7 @@ module ActionDispatch
     #
     #   request.headers["Content-Type"] # => "text/plain"
     def headers
-      Http::Headers.new(@env)
+      @headers ||= Http::Headers.new(@env)
     end
 
     # Returns a +String+ with the last requested path including their params.


### PR DESCRIPTION
By this way accessing multiple times to `request.headers` will not create unnecessary objects
