### PR TITLE
Add descriptions to testing rake tasks

### DIFF
--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -21,22 +21,26 @@ namespace :test do
   task :db => %w[db:test:prepare test]
 
   ["models", "helpers", "controllers", "mailers", "integration", "jobs"].each do |name|
+    desc "Runs all the #{name.singularize} tests from test/#{name}"
     task name => "test:prepare" do
       $: << "test"
       Rails::TestRunner.run(["test/#{name}"])
     end
   end
 
+  desc "Runs all the generator tests from test/lib/generators"
   task :generators => "test:prepare" do
     $: << "test"
     Rails::TestRunner.run(["test/lib/generators"])
   end
 
+  desc "Runs all the unit tests from test/models, test/helpers, and test/unit"
   task :units => "test:prepare" do
     $: << "test"
     Rails::TestRunner.run(["test/models", "test/helpers", "test/unit"])
   end
 
+  desc "Runs all the functional tests from test/controllers, test/mailers, and test/functional"
   task :functionals => "test:prepare" do
     $: << "test"
     Rails::TestRunner.run(["test/controllers", "test/mailers", "test/functional"])


### PR DESCRIPTION
Rake tasks are only listed via `rake -D` or `rake -T` when they have a
description. I found it confusing that these tasks were not listed.

I've based the descriptions on [this table](http://guides.rubyonrails.org/testing.html#rake-tasks-for-running-your-tests) in the Rails Guides. After the
changes in this commit the output of `rake -T` is as follows:

```
rake test              # Runs all tests in test folder
rake test:controllers  # Runs all the controller tests from test/controllers
rake test:db           # Run tests quickly, but also reset db
rake test:functionals  # Runs all the functional tests from test/controllers, test/mailers, and test/functional
rake test:generators   # Runs all the generator tests from test/lib/generators
rake test:helpers      # Runs all the helper tests from test/helpers
rake test:integration  # Runs all the integration tests from test/integration
rake test:jobs         # Runs all the job tests from test/jobs
rake test:mailers      # Runs all the mailer tests from test/mailers
rake test:models       # Runs all the model tests from test/models
rake test:units        # Runs all the unit tests from test/models, test/helpers, and test/unit
```

I can see from [this commit](09d2623783183c0e9c22d92b52c64b05980c3b7e) that these testing rake tasks are on their way
out, but I'm willing to back-port this change to relevant branches if that's of
any interest.
