### PR TITLE
Added "constraint" in a few places for clarity.

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -469,12 +469,12 @@ While it's not required you might want to add foreign key constraints to
 add_foreign_key :articles, :authors
 ```
 
-This adds a new foreign key to the `author_id` column of the `articles`
+This adds a new foreign key constraint to the `author_id` column of the `articles`
 table. The key references the `id` column of the `authors` table. If the
 column names can not be derived from the table names, you can use the
 `:column` and `:primary_key` options.
 
-Rails will generate a name for every foreign key starting with
+Rails will generate a name for every foreign key constraint starting with
 `fk_rails_` followed by 10 random characters.
 There is a `:name` option to specify a different name if needed.
 
@@ -482,7 +482,7 @@ NOTE: Active Record only supports single column foreign keys. `execute` and
 `structure.sql` are required to use composite foreign keys. See
 [Schema Dumping and You](#schema-dumping-and-you).
 
-Removing a foreign key is easy as well:
+Removing a constraint is easy as well:
 
 ```ruby
 # let Active Record figure out the column name


### PR DESCRIPTION
Making it clear that `add_foreign_key` creates _constraints_ on _pre-existing_ columns. 

Because: I was genuinely confused when reading this to learn what `add_foreign_key` does. The text referred to "foreign keys" being created. But I believe that "foreign key" usually means the column itself, not the constraint. And since Rails _does_ sometimes automatically create columns for some migrations, I thought this might be the case here.

This language is in line with how e.g. the [PostgreSQL docs](http://www.postgresql.org/docs/current/static/ddl-constraints.html#DDL-CONSTRAINTS-FK) discusses foreign keys and constraints.
