### PR TITLE
Add info on default layout functionality 3.2 >> 4.0 upgrade

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -940,6 +940,8 @@ Please read [Pull Request #9978](https://github.com/rails/rails/pull/9978) for d
 
 * Rails 4.0 has removed the XML parameters parser. You will need to add the `actionpack-xml_parser` gem if you require this feature.
 
+* Rails 4.0 changes the default `layout` lookup set using symbols or procs that return nil. To get the "no layout" behavior, return false instead of nil. 
+
 * Rails 4.0 changes the default memcached client from `memcache-client` to `dalli`. To upgrade, simply add `gem 'dalli'` to your `Gemfile`.
 
 * Rails 4.0 deprecates the `dom_id` and `dom_class` methods in controllers (they are fine in views). You will need to include the `ActionView::RecordIdentifier` module in controllers requiring this feature.


### PR DESCRIPTION
This adds a quick note to the 3.2 to 4.0 upgrade guide regarding the default `layout` lookup behavioral change from `nil` to `false` in the Rails 4.0. Taken from the [actionpack 4.0 changelog](https://github.com/rails/rails/blob/4-0-stable/actionpack/CHANGELOG.md#rails-400-june-25-2013).
