### PR TITLE
Add capability to render method to avoid nothing: true with status code 204

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Render no content without explicitly setting `:nothing` to true
+    this works like calling `head` method with 204.
+
+        class FooController < ApplicationController
+          def bar
+            render status: 204
+          end
+        end
+
+    *Mehmet Emin İNAÇ*
+
 *   Fix `rake routes` not showing the right format when
     nesting multiple routes.
 

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -78,12 +78,12 @@ module ActionController
         options[:html] = ERB::Util.html_escape(options[:html])
       end
 
-      if options.delete(:nothing)
-        options[:body] = nil
-      end
-
       if options[:status]
         options[:status] = Rack::Utils.status_code(options[:status])
+      end
+
+      if options.delete(:nothing) || options[:status] == 204
+        options[:body] = nil
       end
 
       super

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -120,6 +120,10 @@ class TestController < ActionController::Base
     render :action => 'hello_world'
   end
 
+  def render_no_content
+    render status: 204
+  end
+
   def conditional_hello_with_bangs
     render :action => 'hello_world'
   end
@@ -369,6 +373,12 @@ class LastModifiedRenderTest < ActionController::TestCase
     assert_equal 200, @response.status.to_i
     assert @response.body.present?
     assert_equal @last_modified, @response.headers['Last-Modified']
+  end
+
+  def test_render_status_204_renders_no_content
+    get :render_no_content
+    assert_response 204
+    assert @response.body.blank?
   end
 
   def test_request_with_bang_gets_last_modified


### PR DESCRIPTION
Normally user can render nothing with `render nothing: true` and can
set status code to 204 with `render nothing: true, status: 204`.
But if you try `render status: 204` it tries to render default template.
I believe this is not what we want. Because 204 status code implies that
there is no content to serve. This new feature works like `head 204`.
