### PR TITLE
Fix indentation warning on active_support ordered_options

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -37,7 +37,7 @@ module ActiveSupport
           fetch(name_string.to_sym).presence || raise(KeyError.new("#{name_string} is blank."))
         else
           self[name_string]
-       end
+        end
       end
     end
 


### PR DESCRIPTION
I know this looks like a cosmetic pull request but it isn't. This will fix the warning while running tests.
Here is the warning message;
`
rails/activesupport/lib/active_support/ordered_options.rb:40: warning: mismatched indentations at 'end' with 'if' at 36`
