### PR TITLE
Add parentheses around method arg

### DIFF
--- a/actionpack/lib/action_dispatch/journey/visitors.rb
+++ b/actionpack/lib/action_dispatch/journey/visitors.rb
@@ -59,7 +59,7 @@ module ActionDispatch
 
         private
 
-          def visit node
+          def visit(node)
             send(DISPATCH_CACHE[node.type], node)
           end
 


### PR DESCRIPTION
Super trivial syntax fix, just caught it while reading through the code. Let me know if these PRs aren't accepted and I should just close this.
