### PR TITLE
Remove unnecessary reference to example Blog app in initialization guides

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -557,9 +557,8 @@ I18n and Rails configuration are all being defined here.
 The rest of `config/application.rb` defines the configuration for the
 `Rails::Application` which will be used once the application is fully
 initialized. When `config/application.rb` has finished loading Rails and defined
-the application namespace, we go back to `config/environment.rb`,
-where the application is initialized. For example, if the application was called
-`Blog`, here we would find `Rails.application.initialize!`, which is
+the application namespace, we go back to `config/environment.rb`. Here, the
+application is initialized with `Rails.application.initialize!`, which is
 defined in `rails/application.rb`.
 
 ### `railties/lib/rails/application.rb`


### PR DESCRIPTION
https://github.com/rails/rails/commit/2ddbe87e7acc324ce7e0a4784c4d10b79cc49a40 changed `Blog::Application.initialize!` to `Rails.application.initialize!` and thus we no longer need to say "if the application was called `Blog`." This PR cleans up the phrasing of this sentence by removing the reference to `Blog`, as it is no longer relevant and is not mentioned anywhere else in this guide.

This is my first Rails PR. I read the "Contributing to the Rails Documentation" guide but please let me know if I should be doing something differently, either with the changes or the PR formatting. Thanks!
