### PR TITLE
Raises the right exception when declares a has many through association with missing source

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Raises the right exception when declares a has many through
+    association with missing source.
+
+    *Mauro George*
+
 *   Revert behavior of `db:schema:load` back to loading the full
     environment. This ensures that initializers are run.
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -534,7 +534,9 @@ module ActiveRecord
       #   # => <ActiveRecord::Reflection::AssociationReflection: @macro=:belongs_to, @name=:tag, @active_record=Tagging, @plural_name="tags">
       #
       def source_reflection
-        through_reflection.klass._reflect_on_association(source_reflection_name)
+        if source_reflection_name
+          through_reflection.klass._reflect_on_association(source_reflection_name)
+        end
       end
 
       # Returns the AssociationReflection object specified in the <tt>:through</tt> option

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -386,6 +386,12 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_should_raise_exception_for_association_not_found
+    assert_raise(ActiveRecord::HasManyThroughSourceAssociationNotFoundError) do
+      posts(:welcome).author_toys
+    end
+  end
+
   def test_delete_through_belongs_to_with_dependent_nullify
     Reference.make_comments = true
 

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -63,6 +63,7 @@ class Post < ActiveRecord::Base
   has_many :comments_with_extend_2, extend: [NamedExtension, NamedExtension2], class_name: "Comment", foreign_key: "post_id"
 
   has_many :author_favorites, :through => :author
+  has_many :author_toys, :through => :author
   has_many :author_categorizations, :through => :author, :source => :categorizations
   has_many :author_addresses, :through => :author
   has_many :author_address_extra_with_address,


### PR DESCRIPTION
Hi guys, 

this PR solves the following problem:  On rails 4.0 and 4.2 the following association raises a `ActiveRecord::HasManyThroughSourceAssociationNotFoundError` but on the rails 4.1 raises a `#<NoMethodError: undefined method `to_sym' for nil:NilClass>`.

``` ruby
class Child < ActiveRecord::Base
end

class Conception < ActiveRecord::Base
end

class Parent < ActiveRecord::Base
  has_many :conceptions
  has_many :children, through: :conceptions
end
```

The exception is raised because the `Conception` model does not define the right associations.

I really don't know if this is the best approach, I don't know too much about the codebase I take a look on [4.1](https://github.com/rails/rails/blob/4-0-stable/activerecord/lib/active_record/reflection.rb#L419-L421) and [4.2](https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/reflection.rb#L660-L662) and they are so different, because of that I take my own road, all tests are green on sqlite let see if this does not broken other stuffs on Travis.

I wait for you feedback.

Thanks
