### PR TITLE
Remove unused package tasks

### DIFF
--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -1,5 +1,4 @@
 require 'rake/testtask'
-require 'rubygems/package_task'
 
 desc "Default Task"
 task default: [ :test ]
@@ -19,10 +18,4 @@ namespace :test do
       sh(Gem.ruby, '-w', '-Ilib:test', file)
     end or raise "Failures"
   end
-end
-
-spec = eval(File.read('actionmailer.gemspec'))
-
-Gem::PackageTask.new(spec) do |p|
-  p.gem_spec = spec
 end

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -1,5 +1,4 @@
 require 'rake/testtask'
-require 'rubygems/package_task'
 
 test_files = Dir.glob('test/**/*_test.rb')
 
@@ -22,12 +21,6 @@ namespace :test do
       sh(Gem.ruby, '-w', '-Ilib:test', file)
     end or raise "Failures"
   end
-end
-
-spec = eval(File.read('actionpack.gemspec'))
-
-Gem::PackageTask.new(spec) do |p|
-  p.gem_spec = spec
 end
 
 task :lines do

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -1,5 +1,4 @@
 require 'rake/testtask'
-require 'rubygems/package_task'
 
 desc "Default Task"
 task :default => :test
@@ -43,12 +42,6 @@ namespace :test do
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
   end
-end
-
-spec = eval(File.read('actionview.gemspec'))
-
-Gem::PackageTask.new(spec) do |p|
-  p.gem_spec = spec
 end
 
 task :lines do

--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -1,5 +1,4 @@
 require 'rake/testtask'
-require 'rubygems/package_task'
 
 ACTIVEJOB_ADAPTERS = %w(inline delayed_job qu que queue_classic resque sidekiq sneakers sucker_punch backburner test)
 ACTIVEJOB_ADAPTERS -= %w(queue_classic) if defined?(JRUBY_VERSION)
@@ -73,11 +72,4 @@ def run_without_aborting(tasks)
   end
 
   abort "Errors running #{errors.join(', ')}" if errors.any?
-end
-
-
-spec = eval(File.read('activejob.gemspec'))
-
-Gem::PackageTask.new(spec) do |p|
-  p.gem_spec = spec
 end

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -1,6 +1,6 @@
-dir = File.dirname(__FILE__)
-
 require 'rake/testtask'
+
+dir = File.dirname(__FILE__)
 
 task :default => :test
 
@@ -18,12 +18,4 @@ namespace :test do
       sh(Gem.ruby, '-w', "-I#{dir}/lib", "-I#{dir}/test", file)
     end or raise "Failures"
   end
-end
-
-require 'rubygems/package_task'
-
-spec = eval(File.read("#{dir}/activemodel.gemspec"))
-
-Gem::PackageTask.new(spec) do |p|
-  p.gem_spec = spec
 end

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -1,5 +1,4 @@
 require 'rake/testtask'
-require 'rubygems/package_task'
 
 require File.expand_path(File.dirname(__FILE__)) + "/test/config"
 require File.expand_path(File.dirname(__FILE__)) + "/test/support/config"
@@ -150,10 +149,4 @@ task :lines do
   load File.expand_path('..', File.dirname(__FILE__)) + '/tools/line_statistics'
   files = FileList["lib/active_record/**/*.rb"]
   CodeTools::LineStatistics.new(files).print_loc
-end
-
-spec = eval(File.read('activerecord.gemspec'))
-
-Gem::PackageTask.new(spec) do |p|
-  p.gem_spec = spec
 end

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -1,5 +1,4 @@
 require 'rake/testtask'
-require 'rubygems/package_task'
 
 task :default => :test
 Rake::TestTask.new do |t|
@@ -16,10 +15,4 @@ namespace :test do
       sh(Gem.ruby, '-w', '-Ilib:test', file)
     end or raise "Failures"
   end
-end
-
-spec = eval(File.read('activesupport.gemspec'))
-
-Gem::PackageTask.new(spec) do |p|
-  p.gem_spec = spec
 end

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -1,5 +1,4 @@
 require 'rake/testtask'
-require 'rubygems/package_task'
 
 task :default => :test
 
@@ -30,12 +29,4 @@ Rake::TestTask.new('test:regular') do |t|
   t.warning = true
   t.verbose = true
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
-end
-
-# Generate GEM ----------------------------------------------------------------------------
-
-spec = eval(File.read('railties.gemspec'))
-
-Gem::PackageTask.new(spec) do |pkg|
-  pkg.gem_spec = spec
 end


### PR DESCRIPTION
We are using `all:build` now.
