### PR TITLE
Let WITH (CTE) queries be explainable

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Let CTE queries (`WITH ...`) be explainable.
+
+    *Vladimir Kochnev*
+
 *   SQLite: `:collation` support for string and text columns.
 
     Example:

--- a/activerecord/lib/active_record/explain_subscriber.rb
+++ b/activerecord/lib/active_record/explain_subscriber.rb
@@ -19,7 +19,7 @@ module ActiveRecord
     # On the other hand, we want to monitor the performance of our real database
     # queries, not the performance of the access to the query cache.
     IGNORED_PAYLOADS = %w(SCHEMA EXPLAIN CACHE)
-    EXPLAINED_SQLS = /\A\s*(select|update|delete|insert)\b/i
+    EXPLAINED_SQLS = /\A\s*(with|select|update|delete|insert)\b/i
     def ignore_payload?(payload)
       payload[:exception] || IGNORED_PAYLOADS.include?(payload[:name]) || payload[:sql] !~ EXPLAINED_SQLS
     end

--- a/activerecord/test/cases/explain_subscriber_test.rb
+++ b/activerecord/test/cases/explain_subscriber_test.rb
@@ -48,6 +48,11 @@ if ActiveRecord::Base.connection.supports_explain?
       assert queries.empty?
     end
 
+    def test_collects_cte_queries
+      SUBSCRIBER.finish(nil, nil, name: 'SQL', sql: 'with s as (values(3)) select 1 from s')
+      assert_equal 1, queries.size
+    end
+
     teardown do
       ActiveRecord::ExplainRegistry.reset
     end


### PR DESCRIPTION
Reopened #19843  — squashed in one commit and with changelog entry.
