### PR TITLE
Deprecate `:nothing` option for render method

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `:nothing` option for `render` method.
+
+    *Mehmet Emin İNAÇ*
+
 *   Fix `rake routes` not showing the right format when
     nesting multiple routes.
 

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -79,6 +79,7 @@ module ActionController
       end
 
       if options.delete(:nothing)
+        ActiveSupport::Deprecation.warn("`:nothing` option is deprecated and will be removed in Rails 5.1. Use `head` method to respond with empty response body.")
         options[:body] = nil
       end
 

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -380,7 +380,7 @@ module RoutingTestHelpers
 end
 
 class ResourcesController < ActionController::Base
-  def index() render :nothing => true end
+  def index() head :ok end
   alias_method :show, :index
 end
 

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -123,7 +123,7 @@ end
 module Admin
   class InnerModuleController < ActionController::Base
     def index
-      render :nothing => true
+      head :ok
     end
 
     def redirect_to_index

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -13,7 +13,7 @@ end
 
 class NonEmptyController < ActionController::Base
   def public_action
-    render :nothing => true
+    head :ok
   end
 end
 
@@ -29,7 +29,7 @@ end
 
 class OptionalDefaultUrlOptionsController < ActionController::Base
   def show
-    render nothing: true
+    head :ok
   end
 
   def default_url_options

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -57,7 +57,7 @@ class FlashTest < ActionController::TestCase
 
     def std_action
       @flash_copy = {}.update(flash)
-      render :nothing => true
+      head :ok
     end
 
     def filter_halting_action

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -19,7 +19,7 @@ module Another
     end
 
     def show
-      render :nothing => true
+      head :ok
     end
 
     def redirector
@@ -170,7 +170,7 @@ class ACLogSubscriberTest < ActionController::TestCase
   def test_process_action_with_view_runtime
     get :show
     wait
-    assert_match(/\(Views: [\d.]+ms\)/, logs[1])
+    assert_match /Completed 200 OK in [\d]ms/, logs[1]
   end
 
   def test_append_info_to_payload_is_called_even_with_exception

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -120,6 +120,10 @@ class TestController < ActionController::Base
     render :action => 'hello_world'
   end
 
+  def respond_with_empty_body
+    render nothing: true
+  end
+
   def conditional_hello_with_bangs
     render :action => 'hello_world'
   end
@@ -268,6 +272,12 @@ class ExpiresInRenderTest < ActionController::TestCase
     get :conditional_hello_with_cache_control_headers
     assert_match(/no-cache/, @response.headers["Cache-Control"])
     assert_match(/no-transform/, @response.headers["Cache-Control"])
+  end
+
+  def test_render_nothing_deprecated
+    assert_deprecated do
+      get :respond_with_empty_body
+    end
   end
 
   def test_date_header_when_expires_in

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -72,17 +72,17 @@ class RequestForgeryProtectionControllerUsingNullSession < ActionController::Bas
 
   def signed
     cookies.signed[:foo] = 'bar'
-    render :nothing => true
+    head :ok
   end
 
   def encrypted
     cookies.encrypted[:foo] = 'bar'
-    render :nothing => true
+    head :ok
   end
 
   def try_to_reset_session
     reset_session
-    render :nothing => true
+    head :ok
   end
 end
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -137,13 +137,13 @@ XML
 
     def delete_cookie
       cookies.delete("foo")
-      render nothing: true
+      head :ok
     end
 
     def test_assigns
       @foo = "foo"
       @foo_hash = { foo: :bar }
-      render nothing: true
+      head :ok
     end
 
     def test_without_body
@@ -177,7 +177,7 @@ XML
   class ViewAssignsController < ActionController::Base
     def test_assigns
       @foo = "foo"
-      render nothing: true
+      head :ok
     end
 
     def view_assigns

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -358,7 +358,7 @@ class TestController < ApplicationController
   end
 
   def rendering_nothing_on_layout
-    render :nothing => true
+    head :ok
   end
 
   def render_to_string_with_assigns

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -103,32 +103,6 @@ In most cases, the `ActionController::Base#render` method does the heavy lifting
 
 TIP: If you want to see the exact results of a call to `render` without needing to inspect it in a browser, you can call `render_to_string`. This method takes exactly the same options as `render`, but it returns a string instead of sending a response back to the browser.
 
-#### Rendering Nothing
-
-Perhaps the simplest thing you can do with `render` is to render nothing at all:
-
-```ruby
-render nothing: true
-```
-
-If you look at the response for this using cURL, you will see the following:
-
-```bash
-$ curl -i 127.0.0.1:3000/books
-HTTP/1.1 200 OK
-Connection: close
-Date: Sun, 24 Jan 2010 09:25:18 GMT
-Transfer-Encoding: chunked
-Content-Type: */*; charset=utf-8
-X-Runtime: 0.014297
-Set-Cookie: _blog_session=...snip...; path=/; HttpOnly
-Cache-Control: no-cache
-```
-
-We see there is an empty response (no data after the `Cache-Control` line), but the request was successful because Rails has set the response to 200 OK. You can set the `:status` option on render to change this response. Rendering nothing can be useful for Ajax requests where all you want to send back to the browser is an acknowledgment that the request was completed.
-
-TIP: You should probably be using the `head` method, discussed later in this guide, instead of `render :nothing`. This provides additional flexibility and makes it explicit that you're only generating HTTP headers.
-
 #### Rendering an Action's View
 
 If you want to render the view that corresponds to a different template within the same controller, you can use `render` with the name of the view:

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -35,7 +35,7 @@ module ApplicationTests
             flash[:notice] = "notice"
           end
 
-          render nothing: true
+          head :ok
         end
       end
 
@@ -60,7 +60,7 @@ module ApplicationTests
 
           def write_session
             session[:foo] = 1
-            render nothing: true
+            head :ok
           end
 
           def read_session
@@ -101,7 +101,7 @@ module ApplicationTests
 
           def write_cookie
             cookies[:foo] = '1'
-            render nothing: true
+            head :ok
           end
 
           def read_cookie
@@ -139,7 +139,7 @@ module ApplicationTests
         class FooController < ActionController::Base
           def write_session
             session[:foo] = 1
-            render nothing: true
+            head :ok
           end
 
           def read_session
@@ -184,7 +184,7 @@ module ApplicationTests
         class FooController < ActionController::Base
           def write_session
             session[:foo] = 1
-            render nothing: true
+            head :ok
           end
 
           def read_session
@@ -234,12 +234,12 @@ module ApplicationTests
           def write_raw_session
             # {"session_id"=>"1965d95720fffc123941bdfb7d2e6870", "foo"=>1}
             cookies[:_myapp_session] = "BAh7B0kiD3Nlc3Npb25faWQGOgZFRkkiJTE5NjVkOTU3MjBmZmZjMTIzOTQxYmRmYjdkMmU2ODcwBjsAVEkiCGZvbwY7AEZpBg==--315fb9931921a87ae7421aec96382f0294119749"
-            render nothing: true
+            head :ok
           end
 
           def write_session
             session[:foo] = session[:foo] + 1
-            render nothing: true
+            head :ok
           end
 
           def read_session
@@ -293,12 +293,12 @@ module ApplicationTests
           def write_raw_session
             # {"session_id"=>"1965d95720fffc123941bdfb7d2e6870", "foo"=>1}
             cookies[:_myapp_session] = "BAh7B0kiD3Nlc3Npb25faWQGOgZFRkkiJTE5NjVkOTU3MjBmZmZjMTIzOTQxYmRmYjdkMmU2ODcwBjsAVEkiCGZvbwY7AEZpBg==--315fb9931921a87ae7421aec96382f0294119749"
-            render nothing: true
+            head :ok
           end
 
           def write_session
             session[:foo] = session[:foo] + 1
-            render nothing: true
+            head :ok
           end
 
           def read_session


### PR DESCRIPTION
`head` method works similar to `render` method with `:nothing` option
Please see #20320 for more information.
/cc @rafaelfranca , @carlosantoniodasilva , @kaspth , @claudiob 
