### PR TITLE
Remove already defined methods in super class of ActionDispatch::Request class

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -141,42 +141,6 @@ module ActionDispatch
       HTTP_METHOD_LOOKUP[method]
     end
 
-    # Is this a GET (or HEAD) request?
-    # Equivalent to <tt>request.request_method_symbol == :get</tt>.
-    def get?
-      HTTP_METHOD_LOOKUP[request_method] == :get
-    end
-
-    # Is this a POST request?
-    # Equivalent to <tt>request.request_method_symbol == :post</tt>.
-    def post?
-      HTTP_METHOD_LOOKUP[request_method] == :post
-    end
-
-    # Is this a PATCH request?
-    # Equivalent to <tt>request.request_method == :patch</tt>.
-    def patch?
-      HTTP_METHOD_LOOKUP[request_method] == :patch
-    end
-
-    # Is this a PUT request?
-    # Equivalent to <tt>request.request_method_symbol == :put</tt>.
-    def put?
-      HTTP_METHOD_LOOKUP[request_method] == :put
-    end
-
-    # Is this a DELETE request?
-    # Equivalent to <tt>request.request_method_symbol == :delete</tt>.
-    def delete?
-      HTTP_METHOD_LOOKUP[request_method] == :delete
-    end
-
-    # Is this a HEAD request?
-    # Equivalent to <tt>request.request_method_symbol == :head</tt>.
-    def head?
-      HTTP_METHOD_LOOKUP[request_method] == :head
-    end
-
     # Provides access to the request's HTTP headers, for example:
     #
     #   request.headers["Content-Type"] # => "text/plain"


### PR DESCRIPTION
These methods had defined in 2004 by dhh in initial commit and `ActionDispatch::Request`
class has been inherited from `Rack::Request` class in 2009 by josh.
In 2014 these methods and more of them defined in `Rack::Request` class
so we don't need them anymore in rails codebase.

[Here](https://github.com/rails/rails/pull/20316#issuecomment-106074576) is the comment about this idea.

/cc @rafaelfranca 
