### PR TITLE
removed erroneous line. Corrected presence validation example.

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -552,7 +552,6 @@ Since `false.blank?` is true, if you want to validate the presence of a boolean
 field you should use one of the following validations:
 
 ```ruby
-validates :boolean_field_name, presence: true
 validates :boolean_field_name, inclusion: { in: [true, false] }
 validates :boolean_field_name, exclusion: { in: [nil] }
 ```


### PR DESCRIPTION
Addresses #20343.
Removes erroneous line of code in the sample codeblock.

:smile: 
