### PR TITLE
Restore collection proxy `#compact` in 4.1

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -40,7 +40,7 @@ module ActiveRecord
     BLACKLISTED_ARRAY_METHODS = [
       :compact!, :flatten!, :reject!, :reverse!, :rotate!, :map!,
       :shuffle!, :slice!, :sort!, :sort_by!, :delete_if,
-      :keep_if, :pop, :shift, :delete_at, :compact, :select!
+      :keep_if, :pop, :shift, :delete_at, :select!
     ].to_set # :nodoc:
 
     delegate :to_xml, :to_yaml, :length, :collect, :map, :each, :all?, :include?, :to_ary, :join, to: :to_a

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -28,7 +28,7 @@ module ActiveRecord
   module DelegationWhitelistBlacklistTests
     ARRAY_DELEGATES = [
       :+, :-, :|, :&, :[],
-      :all?, :collect, :detect, :each, :each_cons, :each_with_index,
+      :all?, :collect, :compact, :detect, :each, :each_cons, :each_with_index,
       :exclude?, :find_all, :flat_map, :group_by, :include?, :length,
       :map, :none?, :one?, :partition, :reject, :reverse,
       :sample, :second, :sort, :sort_by, :third,


### PR DESCRIPTION
Just following up on https://github.com/rails/rails/pull/19836 This seems like a regression, so can we get it backported to 4.1?
