### PR TITLE
Fix for url_helper method definition of routes with parameters

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1530,6 +1530,8 @@ module ActionDispatch
 
           if action =~ /^[\w\-\/]+$/
             options[:action] ||= action.tr('-', '_') unless action.include?("/")
+          elsif action =~ /^[\w\-\/]+\/:[\w\-]+/
+            action.gsub!(/\/:[\w\-]+|\(|\)|\*/, '')
           else
             action = nil
           end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3037,6 +3037,14 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert !respond_to?(:routes_no_collision_path)
   end
 
+  def test_url_helper_should_be_created_for_route_with_parameter
+    draw do
+      get '/foo/:id' => 'foo#show'
+    end
+
+    assert respond_to?(:foo_path)
+  end
+
   def test_controller_name_with_leading_slash_raise_error
     assert_raise(ArgumentError) do
       draw { get '/feeds/:service', :to => '/feeds#show' }


### PR DESCRIPTION
Fix for issue #20312 
