### PR TITLE
Update documentation for QueueAdapters::lookup

### DIFF
--- a/activejob/lib/active_job/queue_adapters.rb
+++ b/activejob/lib/active_job/queue_adapters.rb
@@ -116,6 +116,10 @@ module ActiveJob
     private_constant :ADAPTER
 
     class << self
+      # Returns adapter for specified name.
+      #
+      #   ActiveJob::QueueAdapters.lookup(:sidekiq)
+      #   # => ActiveJob::QueueAdapters::SidekiqAdapter
       def lookup(name)
         const_get(name.to_s.camelize << ADAPTER)
       end


### PR DESCRIPTION
I added simple documentation for method and also added `:nodoc:` because this method called only in private [`QueueAdapter::interpret_adapter`](https://github.com/rails/rails/blob/17c10038c5c34b3050628b7ea20d59e16dc00dbc/activejob/lib/active_job/queue_adapter.rb#L34).

/cc @kaspth 
