### PR TITLE
ActionController::Head `head` method should return 204 instead 200

### DIFF
--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -16,9 +16,9 @@ module ActionController
     #   render
     #
     # See Rack::Utils::SYMBOL_TO_STATUS_CODE for a full list of valid +status+ symbols.
-    def head(status, options = {})
+    def head(status = :no_content, options = {})
       options, status = status, nil if status.is_a?(Hash)
-      status ||= options.delete(:status) || :ok
+      status ||= options.delete(:status) || :no_content
       location = options.delete(:location)
       content_type = options.delete(:content_type)
 

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -494,7 +494,7 @@ class HeadRenderTest < ActionController::TestCase
     get :head_with_location_header
     assert @response.body.blank?
     assert_equal "/foo", @response.headers["Location"]
-    assert_response :ok
+    assert_response :no_content
   end
 
   def test_head_with_location_object
@@ -507,7 +507,7 @@ class HeadRenderTest < ActionController::TestCase
       get :head_with_location_object
       assert @response.body.blank?
       assert_equal "http://www.nextangle.com/customers/1", @response.headers["Location"]
-      assert_response :ok
+      assert_response :no_content
     end
   end
 
@@ -515,14 +515,14 @@ class HeadRenderTest < ActionController::TestCase
     get :head_with_custom_header
     assert @response.body.blank?
     assert_equal "something", @response.headers["X-Custom-Header"]
-    assert_response :ok
+    assert_response :no_content
   end
 
   def test_head_with_www_authenticate_header
     get :head_with_www_authenticate_header
     assert @response.body.blank?
     assert_equal "something", @response.headers["WWW-Authenticate"]
-    assert_response :ok
+    assert_response :no_content
   end
 
   def test_head_with_symbolic_status


### PR DESCRIPTION
ActionController::Head `head` method should return 204 instead 200 when status code is not supplied.

This method requires at least one parameter which includes status or not, if you provide a parameter for this method which does not include status code it returns `:ok` by default. But as a definition of http result codes, more convenient code is 204 `:no_content`. And also as a developer i want to call this method with no parameter. In this case it should return 204 `:no_content` for being consistent with w3 standards.
Please see http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
