### PR TITLE
Proposed fix for routing within controller scope

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix automatic url helper generation when :id present.
+
+    Fixes #20312.
+
+    *Yoong Kang Lim*
+
 *   Provide the name of HTTP Status code in assertions.
 
     *Sean Collins*

--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -117,8 +117,8 @@ module ActionDispatch
   #   # In routes.rb
   #   controller :blog do
   #     get 'blog/show'     => :list
-  #     get 'blog/delete'   => :delete
-  #     get 'blog/edit/:id' => :edit
+  #     get 'blog/:id'      => :show
+  #     get 'blog/:id/edit' => :edit
   #   end
   #
   #   # provides named routes for show, delete, and edit

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1652,7 +1652,11 @@ to this:
 
           default_action = options.delete(:action) || @scope[:action]
 
-          if action =~ /^[\w\-\/]+$/
+          if @scope[:controller] && action.include?(":")
+            parts = action.split("/:")
+            action = parts[0].singularize
+            action = "#{default_action.to_s}_#{action}" if parts[1] && parts[1].include?("/")
+          elsif action =~ /^[\w\-\/]+$/
             default_action ||= action.tr('-', '_') unless action.include?("/")
           else
             action = nil

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -138,6 +138,19 @@ module ActionDispatch
         assert_equal '/a/users/1', url_helpers.user_path(1, foo: 'a')
       end
 
+      test "controller routing creates url helpers" do
+        draw do
+          controller :blogs do
+            get 'blogs'          => :list
+            get 'blogs/:id'      => :show
+            get 'blogs/:id/edit' => :edit
+          end
+        end
+        assert_equal '/blogs', url_helpers.blogs_path
+        assert_equal '/blogs/1', url_helpers.blog_path(1)
+        assert_equal '/blogs/1/edit', url_helpers.edit_blog_path(1)
+      end
+
       private
         def draw(&block)
           @set.draw(&block)


### PR DESCRIPTION
See #20312.

This needs some review!

There are two issues I tried to address. I will try my best to describe them.
## Issue 1: Default path helper names

First is the intended behavior for the naming of url helpers for routes defined within a controller block. According to the [docs](http://api.rubyonrails.org/classes/ActionDispatch/Routing.html):

> Note: when using controller, the route is simply named after the method you call on the block parameter rather than map.

``` ruby
# In routes.rb
controller :blog do
  get 'blog/show'     => :list
  get 'blog/delete'   => :delete
  get 'blog/edit/:id' => :edit
end

# provides named routes for show, delete, and edit
link_to @article.title, show_path(id: @article.id)
```

First of all, the docs make little sense here. On one hand it says the route is named after the controller method (BlogController#list in this case) but on the other the default path helper is `show_path`. The path helper also takes an ID parameter, but that isn't reflected in the routes. I am inclined to think that it's intended to be `list_path` as implied by the documentation.

However, this is also problematic, as the path helpers are not namespaced according to the resource name. My belief is this is harmful especially given that we usually have the same method names in different controllers. In this commit, I have changed the default name to (controller_name)_(method_name). For example in this case it will become `blog_list_path`.

If a user wants something that is different from this default, they can pass in an :as parameter.

This particular change caused two other tests to break, which I have also amended.
## Issue 2: The :id thing

In the method `add_route`, the `action` variable (which is the path of the route) is stripped away if an :id parameter is present in the path. So when we pass this action (which is now nil) to the `name_for_action` method we don't get a named url. 

This commit makes a change so that the add_route method uses the `:action` parameter in the `options` hash (as well as the controller from the scope) and uses it to create the action name.
