### PR TITLE
Fix regression in #20017 wrong number of arguments error

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -13,7 +13,7 @@ module ActionDispatch
   # located at `public/assets/application.js` if the file exists. If the file
   # does not exist, a 404 "File not Found" response will be returned.
   class FileHandler
-    def initialize(root, cache_control, index)
+    def initialize(root, cache_control, index = 'index')
       @root          = root.chomp('/')
       @compiled_root = /^#{Regexp.escape(root)}/
       headers        = cache_control && { 'Cache-Control' => cache_control }
@@ -105,7 +105,7 @@ module ActionDispatch
   # produce a directory traversal using this middleware. Only 'GET' and 'HEAD'
   # requests will result in a file being returned.
   class Static
-    def initialize(app, path, cache_control=nil, index="index")
+    def initialize(app, path, cache_control = nil, index = 'index')
       @app = app
       @file_handler = FileHandler.new(path, cache_control, index)
     end
@@ -115,7 +115,7 @@ module ActionDispatch
       when 'GET', 'HEAD'
         path = env['PATH_INFO'].chomp('/')
         if match = @file_handler.match?(path)
-          env["PATH_INFO"] = match
+          env['PATH_INFO'] = match
           return @file_handler.call(env)
         end
       end


### PR DESCRIPTION
This fixes a regression I'm encountering since #20017 which changed the
number of arguments to be passed to `ActionDispatch::FileHandler.new`.

When other services try to use it, for instance the Heroku-deflator gem [here](https://github.com/romanbsd/heroku-deflater/blob/master/lib/heroku-deflater/serve_zipped_assets.rb#L15),
it raises `ArgumentError: wrong number of arguments (2 for 3)` and is a breaking change.
