### PR TITLE
Fix circular import warning on build

### DIFF
--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -1,6 +1,5 @@
 require 'active_record/scoping/default'
 require 'active_record/scoping/named'
-require 'active_record/base'
 
 module ActiveRecord
   class SchemaMigration < ActiveRecord::Base


### PR DESCRIPTION
An unnecessary require was causing a "circular import" warning in the build.
