### PR TITLE
set engine's route in the functional test is generated in the engine

### DIFF
--- a/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb
@@ -2,6 +2,12 @@ require 'test_helper'
 
 <% module_namespacing do -%>
 class <%= class_name %>ControllerTest < ActionController::TestCase
+<% if defined?(ENGINE_ROOT) -%>
+  setup do
+    @routes = Engine.routes
+  end
+
+<% end -%>
 <% if actions.empty? -%>
   # test "the truth" do
   #   assert true

--- a/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
@@ -15,6 +15,15 @@ module TestUnit # :nodoc:
                  File.join("test/controllers", controller_class_path, "#{controller_file_name}_controller_test.rb")
       end
 
+      def fixture_name
+        @fixture_name ||=
+          if defined?(ENGINE_ROOT)
+            namespaced_path + "_" + table_name
+          else
+            table_name
+          end
+      end
+
       private
 
         def attributes_hash

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
@@ -4,6 +4,9 @@ require 'test_helper'
 class <%= controller_class_name %>ControllerTest < ActionController::TestCase
   setup do
     @<%= singular_table_name %> = <%= table_name %>(:one)
+<% if defined?(ENGINE_ROOT) -%>
+    @routes = Engine.routes
+<% end -%>
   end
 
   test "should get index" do

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 <% module_namespacing do -%>
 class <%= controller_class_name %>ControllerTest < ActionController::TestCase
   setup do
-    @<%= singular_table_name %> = <%= table_name %>(:one)
+    @<%= singular_table_name %> = <%= fixture_name %>(:one)
 <% if defined?(ENGINE_ROOT) -%>
     @routes = Engine.routes
 <% end -%>

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -508,6 +508,21 @@ class PluginGeneratorTest < Rails::Generators::TestCase
       assert_match(/namespace :admin/, contents)
       assert_no_match(/namespace :bukkit/, contents)
     end
+    assert_file "test/controllers/bukkits/admin/dashboard_controller_test.rb" do |contents|
+      assert_match(/@routes = Engine.routes/, contents)
+    end
+  end
+
+  def test_generating_scaffold_controller_inside_mountable_engine
+    run_generator [destination_root, "--mountable"]
+
+    capture(:stdout) do
+      `#{destination_root}/bin/rails g scaffold User name:string age:integer`
+    end
+
+    assert_file "test/controllers/bukkits/users_controller_test.rb" do |contents|
+      assert_match(/@routes = Engine.routes/, contents)
+    end
   end
 
   def test_git_name_and_email_in_gemspec_file

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -508,22 +508,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
       assert_match(/namespace :admin/, contents)
       assert_no_match(/namespace :bukkit/, contents)
     end
-    assert_file "test/controllers/bukkits/admin/dashboard_controller_test.rb" do |contents|
-      assert_match(/@routes = Engine.routes/, contents)
-    end
-  end
-
-  def test_generating_scaffold_controller_inside_mountable_engine
-    run_generator [destination_root, "--mountable"]
-
-    capture(:stdout) do
-      `#{destination_root}/bin/rails g scaffold User name:string age:integer`
-    end
-
-    assert_file "test/controllers/bukkits/users_controller_test.rb" do |contents|
-      assert_match(/@user = bukkits_users\(:one\)/, contents)
-      assert_match(/@routes = Engine.routes/, contents)
-    end
   end
 
   def test_git_name_and_email_in_gemspec_file

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -521,6 +521,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "test/controllers/bukkits/users_controller_test.rb" do |contents|
+      assert_match(/@user = bukkits_users\(:one\)/, contents)
       assert_match(/@routes = Engine.routes/, contents)
     end
   end

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -174,4 +174,15 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       end
     end
   end
+
+  def test_controller_tests_pass_by_default_inside_mountable_engine
+    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --mountable` }
+
+    engine_path = File.join(destination_root, "bukkits")
+
+    Dir.chdir(engine_path) do
+      quietly { `bin/rails g controller dashboard foo` }
+      assert_match(/2 runs, 2 assertions, 0 failures, 0 errors/, `bundle exec rake test 2>&1`)
+    end
+  end
 end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -393,4 +393,18 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert_match(/password_digest: <%= BCrypt::Password.create\('secret'\) %>/, content)
     end
   end
+
+  def test_scaffold_tests_pass_by_default_inside_mountable_engine
+    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --mountable` }
+
+    engine_path = File.join(destination_root, "bukkits")
+
+    Dir.chdir(engine_path) do
+      quietly do
+        `bin/rails g scaffold User name:string age:integer;
+        bundle exec rake db:migrate`
+      end
+      assert_match(/8 runs, 13 assertions, 0 failures, 0 errors/, `bundle exec rake test 2>&1`)
+    end
+  end
 end


### PR DESCRIPTION
Currently, functional test is generated in the engine does not work properly.

``` console
$ ./bin/rails g controller Foo index
      create  app/controllers/blorgh/foo_controller.rb
       route  get 'foo/index'
      invoke  erb
      create    app/views/blorgh/foo
      create    app/views/blorgh/foo/index.html.erb
      invoke  test_unit
      create    test/controllers/blorgh/foo_controller_test.rb
      invoke  helper
      create    app/helpers/blorgh/foo_helper.rb
      invoke    test_unit
      invoke  assets
      invoke    js
      create      app/assets/javascripts/blorgh/foo.js
      invoke    css
      create      app/assets/stylesheets/blorgh/foo.css 

$ bundle exec rake
# Running:

E.

Finished in 0.055383s, 36.1122 runs/s, 18.0561 assertions/s.

  1) Error:
Blorgh::FooControllerTest#test_should_get_index:
ActionController::UrlGenerationError: No route matches {:action=>"index", :controller=>"blorgh/foo"}
    /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/actionpack-4.2.1/lib/action_dispatch/journey/formatter.rb:46:in `generate'
    /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/actionpack-4.2.1/lib/action_dispatch/routing/route_set.rb:727:in `generate'
    /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/actionpack-4.2.1/lib/action_dispatch/routing/route_set.rb:758:in `generate'
    /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/actionpack-4.2.1/lib/action_dispatch/routing/route_set.rb:753:in `generate_extras'
    /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/actionpack-4.2.1/lib/action_dispatch/routing/route_set.rb:748:in `extra_keys'
    /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/actionpack-4.2.1/lib/action_controller/test_case.rb:208:in `assign_parameters'
    /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/actionpack-4.2.1/lib/action_controller/test_case.rb:619:in `process'
    /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/actionpack-4.2.1/lib/action_controller/test_case.rb:65:in `process'
    /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/actionpack-4.2.1/lib/action_controller/test_case.rb:508:in `get'
    /home/yaginuma/program/rails/rails_4-2-1_sample/blorgh/test/controllers/blorgh/foo_controller_test.rb:6:in `block in <class:FooControllerTest>'

2 runs, 1 assertions, 0 failures, 1 errors, 0 skips
rake aborted!
Command failed with status (1): [ruby -I"lib:lib:test"  "/home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/**/*_test.rb" ]
```

In order to work properly, need to set the `@routes` instance variable to the engine's route.  

Therefore, I think good to have engine's route in the generated functional test is set.
