### PR TITLE
Map :bigint as NUMBER(19) sql_type by using `:limit => 19` for Oracle

### DIFF
--- a/activerecord/test/cases/connection_adapters/type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/type_lookup_test.rb
@@ -81,7 +81,11 @@ module ActiveRecord
 
       def test_bigint_limit
         cast_type = @connection.type_map.lookup("bigint")
-        assert_equal 8, cast_type.limit
+        if current_adapter?(:OracleAdapter)
+          assert_equal 19, cast_type.limit
+        else
+          assert_equal 8, cast_type.limit
+        end
       end
 
       def test_decimal_without_scale

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -105,7 +105,7 @@ module ActiveRecord
         eight   = columns.detect { |c| c.name == "eight_int"   }
 
         if current_adapter?(:OracleAdapter)
-          assert_equal 'NUMBER(8)', eight.sql_type
+          assert_equal 'NUMBER(19)', eight.sql_type
         elsif current_adapter?(:SQLite3Adapter)
           assert_equal 'bigint', eight.sql_type
         else


### PR DESCRIPTION
since NUMBER(8) is not enough to store the maximum number of bigint.
Oracle NUMBER(p,0) as handled as integer
because there is no dedicated integer sql data type exist in Oracle database.

Also NUMBER(p,s) precision can take up to 38. p means the number of digits, not the byte length.
bigint type needs 19 digits as follows.

``` ruby
    $ irb
    2.2.2 :001 > limit = 8
     => 8
    2.2.2 :002 > maxvalue_of_bigint = 1 << ( limit * 8 - 1)
     => 9223372036854775808
    2.2.2 :003 > puts maxvalue_of_bigint.to_s.length
    19
     => nil
    2.2.2 :004 >
```

Also this pull request addresses following failures. Actually Oracle enhanced adapter is still trying to
support Rails 4.2. Then these tests are done in 4-2-stable branch. but I wanted to include this pull request in master branch first. Then I tested in 4-2-stable branch and cherry-pick it to the master branch.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/connection_adapters/type_lookup_test.rb -n test_bigint_limit
Using oracle
Run options: -n test_bigint_limit --seed 46517

# Running:

F

Finished in 0.005952s, 168.0172 runs/s, 168.0172 assertions/s.

  1) Failure:
ActiveRecord::ConnectionAdapters::TypeLookupTest#test_bigint_limit [test/cases/connection_adapters/type_lookup_test.rb:84]:
Expected: 8
  Actual: 19

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/migration/change_schema_test.rb -n test_create_table_with_bigint

Using oracle
Run options: -n test_create_table_with_bigint --seed 57162

# Running:

F

Finished in 0.054332s, 18.4054 runs/s, 18.4054 assertions/s.

  1) Failure:
ActiveRecord::Migration::ChangeSchemaTest#test_create_table_with_bigint [test/cases/migration/change_schema_test.rb:108]:
Expected: "NUMBER(8)"
  Actual: "NUMBER(19)"

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```
