### PR TITLE
Allow custom schema dumpers

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -59,6 +59,7 @@ module ActiveRecord
   autoload :Sanitization
   autoload :Schema
   autoload :SchemaDumper
+  autoload :SchemaManager
   autoload :SchemaMigration
   autoload :Scoping
   autoload :Serialization

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -97,6 +97,14 @@ module ActiveRecord
 
       ##
       # :singleton-method:
+      # Specifies the class the ActiveRecord will use to dump the schema. If
+      # the value is :default, it will use the built-in dumper. Otherwise it will
+      # use the class specified.
+      mattr_accessor :schema_dumper, instance_writer: false
+      self.schema_dumper = :default
+
+      ##
+      # :singleton-method:
       # Specify a threshold for the size of query result sets. If the number of
       # records in the set exceeds the threshold, a warning is logged. This can
       # be used to identify queries which load thousands of records and

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -234,7 +234,7 @@ db_namespace = namespace :db do
       require 'active_record/schema_dumper'
       filename = ENV['SCHEMA'] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, 'schema.rb')
       File.open(filename, "w:utf-8") do |file|
-        ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, file)
+        ActiveRecord::SchemaManager.dump(ActiveRecord::Base.connection, file)
       end
       db_namespace['schema:dump'].reenable
     end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -3,10 +3,8 @@ require 'stringio'
 module ActiveRecord
   # = Active Record Schema Dumper
   #
-  # This class is used to dump the database schema for some connection to some
-  # output format (i.e., ActiveRecord::Schema).
+  # This class is used as the default schema dumper for ActiveRecord.
   class SchemaDumper #:nodoc:
-    private_class_method :new
 
     ##
     # :singleton-method:
@@ -16,19 +14,10 @@ module ActiveRecord
     cattr_accessor :ignore_tables
     @@ignore_tables = []
 
-    class << self
-      def dump(connection=ActiveRecord::Base.connection, stream=STDOUT, config = ActiveRecord::Base)
-        new(connection, generate_options(config)).dump(stream)
-        stream
-      end
-
-      private
-        def generate_options(config)
-          {
-            table_name_prefix: config.table_name_prefix,
-            table_name_suffix: config.table_name_suffix
-          }
-        end
+    def initialize(connection, options = {})
+      @connection = connection
+      @version = Migrator::current_version rescue nil
+      @options = options
     end
 
     def dump(stream)
@@ -40,12 +29,6 @@ module ActiveRecord
     end
 
     private
-
-      def initialize(connection, options = {})
-        @connection = connection
-        @version = Migrator::current_version rescue nil
-        @options = options
-      end
 
       def header(stream)
         define_params = @version ? "version: #{@version}" : ""

--- a/activerecord/lib/active_record/schema_manager.rb
+++ b/activerecord/lib/active_record/schema_manager.rb
@@ -1,0 +1,28 @@
+require 'stringio'
+
+module ActiveRecord
+  # = Active Record Schema Manager
+  #
+  # This class is used to dump the database schema for some connection to some
+  # output format (i.e., ActiveRecord::Schema).
+  class SchemaManager #:nodoc:
+    class << self
+      def dump(connection = ActiveRecord::Base.connection, stream = STDOUT, config = ActiveRecord::Base)
+        dumper_klass = ActiveRecord::Base.schema_dumper
+        dumper_klass = SchemaDumper if dumper_klass == :default
+
+        dumper_klass.new(connection, generate_options(config)).dump(stream)
+        stream
+      end
+
+      private
+
+        def generate_options(config)
+          {
+            table_name_prefix: config.table_name_prefix,
+            table_name_suffix: config.table_name_suffix
+          }
+        end
+    end
+  end
+end

--- a/activerecord/test/cases/schema_manager_test.rb
+++ b/activerecord/test/cases/schema_manager_test.rb
@@ -1,0 +1,23 @@
+require 'cases/helper'
+require 'support/schema_dumping_helper'
+
+class FakeSchemaDumper
+  def initialize(connection, options = {})
+  end
+
+  def dump(stream)
+    stream.print 'Fake Schema Dump'
+  end
+end
+
+class SchemaManagerTest < ActiveRecord::TestCase
+  include SchemaDumpingHelper
+
+  def test_schema_dumper_config
+    previous_schema_dumper = ActiveRecord::Base.schema_dumper
+    ActiveRecord::Base.schema_dumper = FakeSchemaDumper
+
+    assert_equal dump_all_table_schema([]), 'Fake Schema Dump'
+    ActiveRecord::Base.schema_dumper = previous_schema_dumper
+  end
+end

--- a/activerecord/test/support/schema_dumping_helper.rb
+++ b/activerecord/test/support/schema_dumping_helper.rb
@@ -3,7 +3,7 @@ module SchemaDumpingHelper
     old_ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
     ActiveRecord::SchemaDumper.ignore_tables = connection.tables - [table]
     stream = StringIO.new
-    ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
+    ActiveRecord::SchemaManager.dump(ActiveRecord::Base.connection, stream)
     stream.string
   ensure
     ActiveRecord::SchemaDumper.ignore_tables = old_ignore_tables
@@ -12,7 +12,7 @@ module SchemaDumpingHelper
   def dump_all_table_schema(ignore_tables)
     old_ignore_tables, ActiveRecord::SchemaDumper.ignore_tables = ActiveRecord::SchemaDumper.ignore_tables, ignore_tables
     stream = StringIO.new
-    ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
+    ActiveRecord::SchemaManager.dump(ActiveRecord::Base.connection, stream)
     stream.string
   ensure
     ActiveRecord::SchemaDumper.ignore_tables = old_ignore_tables


### PR DESCRIPTION
Per this conversation: https://groups.google.com/forum/#!topic/rubyonrails-core/h6q8nGFzGKs, allows for setting a class that responds to #dump to allow for customizing the schema dump.
