### PR TITLE
Improve definitions of structs

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -73,7 +73,7 @@ module ActionController
 
     require 'mutex_m'
 
-    class Options < Struct.new(:name, :format, :include, :exclude, :klass, :model) # :nodoc:
+    Options = Struct.new(:name, :format, :include, :exclude, :klass, :model) do # :nodoc:
       include Mutex_m
 
       def self.from_hash(hash)

--- a/actionpack/lib/action_dispatch/journey/visitors.rb
+++ b/actionpack/lib/action_dispatch/journey/visitors.rb
@@ -6,7 +6,7 @@ module ActionDispatch
       ESCAPE_PATH    = ->(value) { Router::Utils.escape_path(value) }
       ESCAPE_SEGMENT = ->(value) { Router::Utils.escape_segment(value) }
 
-      class Parameter < Struct.new(:name, :escaper)
+      Parameter = Struct.new(:name, :escaper) do
         def escape(value); escaper.call value; end
       end
 

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 require 'abstract_unit'
 
 module ActionDispatch
@@ -13,7 +13,7 @@ module ActionDispatch
         @formatter = Formatter.new(@routes)
       end
 
-      class FakeRequestFeeler < Struct.new(:env, :called)
+      FakeRequestFeeler = Struct.new(:env, :called) do
         def new env
           self.env = env
           self

--- a/actionpack/test/lib/controller/fake_models.rb
+++ b/actionpack/test/lib/controller/fake_models.rb
@@ -1,6 +1,6 @@
 require "active_model"
 
-class Customer < Struct.new(:name, :id)
+Customer = Struct.new(:name, :id) do
   extend ActiveModel::Naming
   include ActiveModel::Conversion
 
@@ -28,7 +28,7 @@ class Customer < Struct.new(:name, :id)
   end
 end
 
-class Post < Struct.new(:title, :author_name, :body, :secret, :persisted, :written_on, :cost)
+Post = Struct.new(:title, :author_name, :body, :secret, :persisted, :written_on, :cost) do
   extend ActiveModel::Naming
   include ActiveModel::Conversion
   extend ActiveModel::Translation

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   self.view_paths = File.join(FIXTURE_LOAD_PATH, "actionpack")
 end
 
-class Customer < Struct.new(:name, :id)
+Customer = Struct.new(:name, :id) do
   extend ActiveModel::Naming
   include ActiveModel::Conversion
 
@@ -40,7 +40,7 @@ end
 
 module Quiz
   #Models
-  class Question < Struct.new(:name, :id)
+  Question = Struct.new(:name, :id) do
     extend ActiveModel::Naming
     include ActiveModel::Conversion
 

--- a/actionview/test/activerecord/render_partial_with_record_identification_test.rb
+++ b/actionview/test/activerecord/render_partial_with_record_identification_test.rb
@@ -87,7 +87,7 @@ class RenderPartialWithRecordIdentificationTest < ActiveRecordTestCase
   end
 end
 
-class Game < Struct.new(:name, :id)
+Game = Struct.new(:name, :id) do
   extend ActiveModel::Naming
   include ActiveModel::Conversion
   def to_param

--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -1,6 +1,6 @@
 require "active_model"
 
-class Customer < Struct.new(:name, :id)
+Customer = Struct.new(:name, :id) do
   extend ActiveModel::Naming
   include ActiveModel::Conversion
 
@@ -31,7 +31,7 @@ end
 class GoodCustomer < Customer
 end
 
-class Post < Struct.new(:title, :author_name, :body, :secret, :persisted, :written_on, :cost)
+Post = Struct.new(:title, :author_name, :body, :secret, :persisted, :written_on, :cost) do
   extend ActiveModel::Naming
   include ActiveModel::Conversion
   extend ActiveModel::Translation
@@ -164,7 +164,7 @@ module Blog
     true
   end
 
-  class Post < Struct.new(:title, :id)
+  Post = Struct.new(:title, :id) do
     extend ActiveModel::Naming
     include ActiveModel::Conversion
 
@@ -184,8 +184,7 @@ class ArelLike
   end
 end
 
-class Car < Struct.new(:color)
-end
+Car = Struct.new(:color)
 
 class Plane
   attr_reader :to_key

--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -4,7 +4,7 @@ class ActiveModelHelperTest < ActionView::TestCase
   tests ActionView::Helpers::ActiveModelHelper
 
   silence_warnings do
-    class Post < Struct.new(:author_name, :body, :updated_at)
+    Post = Struct.new(:author_name, :body, :updated_at) do
       include ActiveModel::Conversion
       include ActiveModel::Validations
 

--- a/actionview/test/template/atom_feed_helper_test.rb
+++ b/actionview/test/template/atom_feed_helper_test.rb
@@ -1,6 +1,6 @@
 require 'abstract_unit'
 
-class Scroll < Struct.new(:id, :to_param, :title, :body, :updated_at, :created_at)
+Scroll = Struct.new(:id, :to_param, :title, :body, :updated_at, :created_at) do
   extend ActiveModel::Naming
   include ActiveModel::Conversion
 

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -1,7 +1,6 @@
 require 'abstract_unit'
 
-class Category < Struct.new(:id, :name)
-end
+Category = Struct.new(:id, :name)
 
 class FormCollectionsHelperTest < ActionView::TestCase
   def assert_no_select(selector, value = nil)

--- a/activemodel/test/cases/serializers/xml_serialization_test.rb
+++ b/activemodel/test/cases/serializers/xml_serialization_test.rb
@@ -9,8 +9,7 @@ module Admin
   end
 end
 
-class Customer < Struct.new(:name)
-end
+Customer = Struct.new(:name)
 
 class Address
   include ActiveModel::Serializers::Xml

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -32,7 +32,7 @@ module ActiveRecord
           @alias_cache[node][column]
         end
 
-        class Table < Struct.new(:node, :columns)
+        Table = Struct.new(:node, :columns) do
           def table
             Arel::Nodes::TableAlias.new node.table, node.aliased_table_name
           end

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -153,8 +153,7 @@ module ActiveRecord
       # use the type defined by the model class to convert the value to SQL,
       # calling +serialize+ on your type object. For example:
       #
-      #   class Money < Struct.new(:amount, :currency)
-      #   end
+      #   Money = Struct.new(:amount, :currency)
       #
       #   class MoneyType < Type::Value
       #     def initialize(currency_converter)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -3,27 +3,22 @@ module ActiveRecord
     # Abstract representation of an index definition on a table. Instances of
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#indexes
-    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using) #:nodoc:
-    end
+    IndexDefinition = Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using) #:nodoc:
 
     # Abstract representation of a column definition. Instances of this type
     # are typically created by methods in TableDefinition, and added to the
     # +columns+ attribute of said TableDefinition object, in order to be used
     # for generating a number of table creation or table changing SQL statements.
-    class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :auto_increment, :primary_key, :collation, :sql_type) #:nodoc:
+    ColumnDefinition = Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :auto_increment, :primary_key, :collation, :sql_type) do #:nodoc:
 
       def primary_key?
         primary_key || type.to_sym == :primary_key
       end
     end
 
-    class AddColumnDefinition < Struct.new(:column) # :nodoc:
-    end
-
-    class ChangeColumnDefinition < Struct.new(:column, :name) #:nodoc:
-    end
-
-    class ForeignKeyDefinition < Struct.new(:from_table, :to_table, :options) #:nodoc:
+    AddColumnDefinition = Struct.new(:column) # :nodoc:
+    ChangeColumnDefinition = Struct.new(:column, :name) #:nodoc:
+    ForeignKeyDefinition = Struct.new(:from_table, :to_table, :options) do #:nodoc:
       def name
         options[:name]
       end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -488,7 +488,7 @@ module ActiveRecord
       @connection.respond_to?(:reverting) && @connection.reverting
     end
 
-    class ReversibleBlockHelper < Struct.new(:reverting) # :nodoc:
+    ReversibleBlockHelper = Struct.new(:reverting) do # :nodoc:
       def up
         yield unless reverting
       end
@@ -731,8 +731,7 @@ module ActiveRecord
 
   # MigrationProxy is used to defer loading of the actual migration classes
   # until they are needed
-  class MigrationProxy < Struct.new(:name, :version, :filename, :scope)
-
+  MigrationProxy = Struct.new(:name, :version, :filename, :scope) do
     def initialize(name, version, filename, scope)
       super
       @migration = nil
@@ -758,7 +757,6 @@ module ActiveRecord
         require(File.expand_path(filename))
         name.constantize.new(name, version)
       end
-
   end
 
   class NullMigration < MigrationProxy #:nodoc:

--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -4,7 +4,7 @@ require 'thread'
 module ActiveRecord
   module AttributeMethods
     class ReadTest < ActiveRecord::TestCase
-      class FakeColumn < Struct.new(:name)
+      FakeColumn = Struct.new(:name) do
         def type; :integer; end
       end
 

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -3,7 +3,7 @@ require 'models/post'
 
 module ActiveRecord
   class RelationMutationTest < ActiveSupport::TestCase
-    class FakeKlass < Struct.new(:table_name, :name)
+    FakeKlass = Struct.new(:table_name, :name) do
       extend ActiveRecord::Delegation::DelegateCache
       inherited self
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -8,7 +8,7 @@ module ActiveRecord
   class RelationTest < ActiveRecord::TestCase
     fixtures :posts, :comments, :authors
 
-    class FakeKlass < Struct.new(:table_name, :name)
+    FakeKlass = Struct.new(:table_name, :name) do
       extend ActiveRecord::Delegation::DelegateCache
 
       inherited self

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -89,7 +89,7 @@ class Module
   #
   #   Person = Struct.new(:name, :address)
   #
-  #   class Invoice < Struct.new(:client)
+  #   Invoice = Struct.new(:client) do
   #     delegate :name, :address, to: :client, prefix: true
   #   end
   #
@@ -100,7 +100,7 @@ class Module
   #
   # It is also possible to supply a custom prefix.
   #
-  #   class Invoice < Struct.new(:client)
+  #   Invoice = Struct.new(:client) do
   #     delegate :name, :address, to: :client, prefix: :customer
   #   end
   #

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -24,7 +24,7 @@ Somewhere = Struct.new(:street, :city) do
   attr_accessor :name
 end
 
-class Someone < Struct.new(:name, :place)
+Someone = Struct.new(:name, :place) do
   delegate :street, :city, :to_f, :to => :place
   delegate :name=, :to => :place, :prefix => true
   delegate :upcase, :to => "place.city"

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -182,7 +182,7 @@ module Rails
         !options[:skip_active_record] && options[:database] == 'sqlite3'
       end
 
-      class GemfileEntry < Struct.new(:name, :version, :comment, :options, :commented_out)
+      GemfileEntry = Struct.new(:name, :version, :comment, :options, :commented_out) do
         def initialize(name, version, comment, options = {}, commented_out = false)
           super
         end

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -13,7 +13,7 @@
 # start with the tag optionally followed by a colon. Everything up to the end
 # of the line (or closing ERB comment tag) is considered to be their text.
 class SourceAnnotationExtractor
-  class Annotation < Struct.new(:line, :tag, :text)
+  Annotation = Struct.new(:line, :tag, :text) do
     def self.directories
       @@directories ||= %w(app config db lib test) + (ENV['SOURCE_ANNOTATION_DIRECTORIES'] || '').split(',')
     end

--- a/railties/test/rack_logger_test.rb
+++ b/railties/test/rack_logger_test.rb
@@ -20,7 +20,7 @@ module Rails
         def development?; false; end
       end
 
-      class Subscriber < Struct.new(:starts, :finishes)
+      Subscriber = Struct.new(:starts, :finishes) do
         def initialize(starts = [], finishes = [])
           super
         end


### PR DESCRIPTION
https://github.com/bbatsov/ruby-style-guide#no-extend-struct-new

> Extending `Struct.new` introduces a superfluous class level and
> may also introduce weird errors if the file is required multiple times

Example

``` ruby
$ pry
[1] pry(main)> A = Struct.new(:a, :b)
=> A
[2] pry(main)> class B < Struct.new(:a, :b); end
=> nil
[3] pry(main)> A.ancestors
=> [A, Struct, Enumerable, Object, PP::ObjectMixin, Kernel, BasicObject]
[4] pry(main)> B.ancestors
=> [B,
 #<Class:0x007f04b65db3f0>,
 Struct,
 Enumerable,
 Object,
 PP::ObjectMixin,
 Kernel,
 BasicObject]
```
