### PR TITLE
Improve definitions of structs

### DIFF
--- a/actionpack/lib/action_dispatch/journey/visitors.rb
+++ b/actionpack/lib/action_dispatch/journey/visitors.rb
@@ -6,7 +6,7 @@ module ActionDispatch
       ESCAPE_PATH    = ->(value) { Router::Utils.escape_path(value) }
       ESCAPE_SEGMENT = ->(value) { Router::Utils.escape_segment(value) }
 
-      class Parameter < Struct.new(:name, :escaper)
+      Parameter = Struct.new(:name, :escaper) do
         def escape(value); escaper.call value; end
       end
 

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -1,7 +1,6 @@
 require 'abstract_unit'
 
-class Category < Struct.new(:id, :name)
-end
+Category = Struct.new(:id, :name)
 
 class FormCollectionsHelperTest < ActionView::TestCase
   def assert_no_select(selector, value = nil)

--- a/activemodel/test/cases/serializers/xml_serialization_test.rb
+++ b/activemodel/test/cases/serializers/xml_serialization_test.rb
@@ -9,8 +9,7 @@ module Admin
   end
 end
 
-class Customer < Struct.new(:name)
-end
+Customer = Struct.new(:name)
 
 class Address
   include ActiveModel::Serializers::Xml

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -32,7 +32,7 @@ module ActiveRecord
           @alias_cache[node][column]
         end
 
-        class Table < Struct.new(:node, :columns)
+        Table = Struct.new(:node, :columns) do
           def table
             Arel::Nodes::TableAlias.new node.table, node.aliased_table_name
           end

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -153,8 +153,7 @@ module ActiveRecord
       # use the type defined by the model class to convert the value to SQL,
       # calling +serialize+ on your type object. For example:
       #
-      #   class Money < Struct.new(:amount, :currency)
-      #   end
+      #   Money = Struct.new(:amount, :currency)
       #
       #   class MoneyType < Type::Value
       #     def initialize(currency_converter)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -3,27 +3,22 @@ module ActiveRecord
     # Abstract representation of an index definition on a table. Instances of
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#indexes
-    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using) #:nodoc:
-    end
+    IndexDefinition = Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using) #:nodoc:
 
     # Abstract representation of a column definition. Instances of this type
     # are typically created by methods in TableDefinition, and added to the
     # +columns+ attribute of said TableDefinition object, in order to be used
     # for generating a number of table creation or table changing SQL statements.
-    class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :auto_increment, :primary_key, :collation, :sql_type) #:nodoc:
+    ColumnDefinition = Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :auto_increment, :primary_key, :collation, :sql_type) do #:nodoc:
 
       def primary_key?
         primary_key || type.to_sym == :primary_key
       end
     end
 
-    class AddColumnDefinition < Struct.new(:column) # :nodoc:
-    end
-
-    class ChangeColumnDefinition < Struct.new(:column, :name) #:nodoc:
-    end
-
-    class ForeignKeyDefinition < Struct.new(:from_table, :to_table, :options) #:nodoc:
+    AddColumnDefinition = Struct.new(:column) # :nodoc:
+    ChangeColumnDefinition = Struct.new(:column, :name) #:nodoc:
+    ForeignKeyDefinition = Struct.new(:from_table, :to_table, :options) do #:nodoc:
       def name
         options[:name]
       end

--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -4,7 +4,7 @@ require 'thread'
 module ActiveRecord
   module AttributeMethods
     class ReadTest < ActiveRecord::TestCase
-      class FakeColumn < Struct.new(:name)
+      FakeColumn = Struct.new(:name) do
         def type; :integer; end
       end
 


### PR DESCRIPTION
Subclassing an anonymous struct creates an extra
anonymous class that will never be used.

Example

``` ruby
$ pry
[1] pry(main)> A = Struct.new(:a, :b)
=> A
[2] pry(main)> class B < Struct.new(:a, :b); end
=> nil
[3] pry(main)> A.ancestors
=> [A, Struct, Enumerable, Object, PP::ObjectMixin, Kernel, BasicObject]
[4] pry(main)> B.ancestors
=> [B,
 #<Class:0x007f04b65db3f0>,
 Struct,
 Enumerable,
 Object,
 PP::ObjectMixin,
 Kernel,
 BasicObject]
```

https://github.com/bbatsov/ruby-style-guide#no-extend-struct-new
