### PR TITLE
Add options for rake routes task

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `-g` and `-c` (shorts for _grep_ and _controller_ respectively) options
+    for `bin/rake routes` task. This options returns the url `name`, `verb` and
+    `path` field that match the pattern or returns match for specific controller.
+
+    Deprecate `CONTROLLER` env variable in `bin/rake routes`.
+
+    See #18902.
+
+    *Anton Davydov*
+
 *   Catch invalid UTF-8 querystring values and respond with BadRequest
 
     Check querystring params for invalid UTF-8 characters, and raise an

--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -239,7 +239,8 @@ module ActionDispatch
   #
   #   rake routes
   #
-  # Target specific controllers by prefixing the command with <tt>CONTROLLER=x</tt>.
+  # Target specific controllers by prefixing the command with <tt>--controller</tt> option
+  # - or its <tt>-c</tt> shorthand.
   #
   module Routing
     extend ActiveSupport::Autoload

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -59,9 +59,8 @@ module ActionDispatch
         @routes = routes
       end
 
-      def format(formatter, filter = nil)
-        routes_to_display = filter_routes(filter)
-
+      def format(formatter, **options)
+        routes_to_display = filter_routes(options)
         routes = collect_routes(routes_to_display)
 
         if routes.none?
@@ -82,12 +81,16 @@ module ActionDispatch
 
       private
 
-      def filter_routes(filter)
-        if filter
+      def filter_routes(options)
+        filter = options[:filter]
+        filtered_routes = if filter
           @routes.select { |route| route.defaults[:controller] == filter }
         else
           @routes
         end
+
+        pattern = /#{options[:pattern]}/
+        filtered_routes.select { |r| r.defaults.values.join(' '.freeze) =~ pattern }
       end
 
       def collect_routes(routes)

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -17,7 +17,7 @@ module ActionDispatch
       def draw(options = {}, &block)
         @set.draw(&block)
         inspector = ActionDispatch::Routing::RoutesInspector.new(@set.routes)
-        inspector.format(ActionDispatch::Routing::ConsoleFormatter.new, options[:filter]).split("\n")
+        inspector.format(ActionDispatch::Routing::ConsoleFormatter.new, options).split("\n")
       end
 
       def test_displaying_routes_for_engines

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -1134,10 +1134,17 @@ For example, here's a small section of the `rake routes` output for a RESTful ro
 edit_user GET    /users/:id/edit(.:format) users#edit
 ```
 
-You may restrict the listing to the routes that map to a particular controller setting the `CONTROLLER` environment variable:
-
+You may restrict the listing to the routes that map to a particular controller using the `--controller` option — or its `-c` shorthand:
 ```bash
-$ CONTROLLER=users bin/rake routes
+$ bin/rake routes --controller users
+$ bin/rake routes -c users
+$ bin/rake routes -c Users
+$ bin/rake routes -c UsersController
+```
+
+You can grep your routes with `-g`, which filters routes by `name`, `verb` or `path`.
+```bash
+$ bin/rake routes -g users
 ```
 
 TIP: You'll find that the output from `rake routes` is much more readable if you widen your terminal window until the output lines don't wrap.

--- a/railties/lib/rails/tasks/routes.rake
+++ b/railties/lib/rails/tasks/routes.rake
@@ -1,7 +1,33 @@
-desc 'Print out all defined routes in match order, with names. Target specific controller with CONTROLLER=x.'
+require 'active_support/deprecation'
+require 'active_support/core_ext/string/strip' # for strip_heredoc
+require 'optparse'
+
+desc 'Print out all defined routes in match order, with names. Target specific controller with --controller option - or its -c shorthand.'
 task routes: :environment do
   all_routes = Rails.application.routes.routes
   require 'action_dispatch/routing/inspector'
   inspector = ActionDispatch::Routing::RoutesInspector.new(all_routes)
-  puts inspector.format(ActionDispatch::Routing::ConsoleFormatter.new, ENV['CONTROLLER'])
+
+  if ENV['CONTROLLER']
+    ActiveSupport::Deprecation.warn <<-eow.strip_heredoc
+      Passing `CONTROLLER` to `bin/rake routes` is deprecated and will be removed in Rails 5.1.
+      Please use `bin/rake routes -c #{ENV['CONTROLLER']}` instead.
+    eow
+  end
+
+  options = { controller: ENV['CONTROLLER'] }
+
+  OptionParser.new do |opts|
+    opts.banner = "Usage: rake routes [options]"
+    opts.on("-c", "--controller [PATTERN]") do |pattern|
+      options[:filter] = pattern.downcase.sub(/_?controller\z/, '')
+    end
+    opts.on("-g", "--grep [PATTERN]") do |pattern|
+      options[:pattern] = pattern
+    end
+  end.parse!(ARGV.reject { |x| x == "routes" })
+
+  puts inspector.format(ActionDispatch::Routing::ConsoleFormatter.new, options)
+
+  exit 0 # ensure extra arguments aren't interpreted as Rake tasks
 end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -122,7 +122,40 @@ module ApplicationTests
       RUBY
 
       ENV['CONTROLLER'] = 'cart'
+
+      assert_deprecated { Dir.chdir(app_path){ `bin/rake routes` } }
+
       output = Dir.chdir(app_path){ `bin/rake routes` }
+      assert_equal "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n", output
+    end
+
+    def test_rake_routes_with_global_search_key
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get '/cart', to: 'cart#show'
+          get '/basketball', to: 'basketball#index'
+        end
+      RUBY
+
+      output = Dir.chdir(app_path){ `bin/rake routes -g show` }
+      assert_equal "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n", output
+    end
+
+    def test_rake_routes_with_controller_search_key
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get '/cart', to: 'cart#show'
+          get '/basketball', to: 'basketball#index'
+        end
+      RUBY
+
+      output = Dir.chdir(app_path){ `bin/rake routes -c cart` }
+      assert_equal "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n", output
+
+      output = Dir.chdir(app_path){ `bin/rake routes -c Cart` }
+      assert_equal "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n", output
+
+      output = Dir.chdir(app_path){ `bin/rake routes -c CartController` }
       assert_equal "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n", output
     end
 


### PR DESCRIPTION
It's simple realization for #18902. 
`-g` option returns the urls `name`, `verb`, `path` and `reqs` field that match the pattern.
`-c` option returns the urls for specific controller.

For this I use `OptionParser` from ruby standart lib. I do not like to use `--` symbol, but it's necessary for rake. Also I have a question: May be we replace `CONTROLLER` option to key option too?
