### PR TITLE
Remove `config.assets.version` from Configuring Rails Application Guide

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -161,8 +161,6 @@ pipeline is enabled. It is set to true by default.
 
 * `config.assets.cache_store` defines the cache store that Sprockets will use. The default is the Rails file store.
 
-* `config.assets.version` is an option string that is used in MD5 hash generation. This can be changed to force all files to be recompiled.
-
 * `config.assets.compile` is a boolean that can be used to turn on live Sprockets compilation in production.
 
 * `config.assets.logger` accepts a logger conforming to the interface of Log4r or the default Ruby `Logger` class. Defaults to the same configured at `config.logger`. Setting `config.assets.logger` to false will turn off served assets logging.


### PR DESCRIPTION
Sprockets no longer reference Environment#version when generating asset digests. Let's drop this from the guide since the option no longer has any tangible effect.
