### PR TITLE
Removed duplicate test cases for template execution

### DIFF
--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -86,15 +86,6 @@ module SharedGeneratorTests
     end
   end
 
-  def test_template_is_executed_when_supplied
-    path = "https://gist.github.com/josevalim/103208/raw/"
-    template = %{ say "It works!" }
-    template.instance_eval "def read; self; end" # Make the string respond to read
-
-    generator([destination_root], template: path).expects(:open).with(path, 'Accept' => 'application/x-thor-template').returns(template)
-    quietly { assert_match(/It works!/, capture(:stdout) { generator.invoke_all }) }
-  end
-
   def test_template_is_executed_when_supplied_an_https_path
     path = "https://gist.github.com/josevalim/103208/raw/"
     template = %{ say "It works!" }


### PR DESCRIPTION
Both `test_template_is_executed_when_supplied` and `test_template_is_executed_when_supplied_an_https_path` methods have same test cases. So either we should delete one method or use one for HTTP path.
It was changed by 57b0ae8011ab0502253631bd6fdbc0fc838b593e
