### PR TITLE
[ci skip] Use inline Gemfile dependency when reporting bugs

### DIFF
--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -1,15 +1,10 @@
-unless File.exist?('Gemfile')
-  File.write('Gemfile', <<-GEMFILE)
-    source 'https://rubygems.org'
-    gem 'rails', github: 'rails/rails'
-    gem 'arel', github: 'rails/arel'
-  GEMFILE
+require 'bundler/inline'
 
-  system 'bundle'
+gemfile(true) do
+  source 'https://rubygems.org'
+  gem 'rails', github: 'rails/rails'
+  gem 'arel', github: 'rails/arel'
 end
-
-require 'bundler'
-Bundler.setup(:default)
 
 require 'rails'
 require 'action_controller/railtie'

--- a/guides/bug_report_templates/active_record_master.rb
+++ b/guides/bug_report_templates/active_record_master.rb
@@ -1,16 +1,11 @@
-unless File.exist?('Gemfile')
-  File.write('Gemfile', <<-GEMFILE)
-    source 'https://rubygems.org'
-    gem 'rails', github: 'rails/rails'
-    gem 'arel', github: 'rails/arel'
-    gem 'sqlite3'
-  GEMFILE
+require 'bundler/inline'
 
-  system 'bundle'
+gemfile(true) do
+  source 'https://rubygems.org'
+  gem 'rails', github: 'rails/rails'
+  gem 'arel', github: 'rails/arel'
+  gem 'sqlite3'
 end
-
-require 'bundler'
-Bundler.setup(:default)
 
 require 'active_record'
 require 'minitest/autorun'

--- a/guides/bug_report_templates/generic_master.rb
+++ b/guides/bug_report_templates/generic_master.rb
@@ -1,15 +1,10 @@
-unless File.exist?('Gemfile')
-  File.write('Gemfile', <<-GEMFILE)
-    source 'https://rubygems.org'
-    gem 'rails', github: 'rails/rails'
-    gem 'arel', github: 'rails/arel'
-  GEMFILE
+require 'bundler/inline'
 
-  system 'bundle'
+gemfile(true) do
+  source 'https://rubygems.org'
+  gem 'rails', github: 'rails/rails'
+  gem 'arel', github: 'rails/arel'
 end
-
-require 'bundler'
-Bundler.setup(:default)
 
 require 'active_support'
 require 'active_support/core_ext/object/blank'


### PR DESCRIPTION
With Bundler `1.10.3`, it is possible to list the gems inline without the need to create a `Gemfile` if none is found in the current directory.

Since each template contains the list of gems, they should be executed without `bundle exec`, which would use the context of the available `Gemfile`.

Please see https://github.com/bundler/bundler/pull/3440 for more information regarding the Bundler new feature.

Should the Rails `Gemfile.lock` now indicate the Bundler version `1.10.3`?

PS: skipping the CI since I believe there are no tests for templates. Please let me know if the build is needed.
