### PR TITLE
Apply Active Record suppression to all saves

### DIFF
--- a/activerecord/lib/active_record/suppressor.rb
+++ b/activerecord/lib/active_record/suppressor.rb
@@ -37,8 +37,7 @@ module ActiveRecord
       end
     end
 
-    # Ignore saving events if we're in suppression mode.
-    def save!(*args) # :nodoc:
+    def create_or_update(*args) # :nodoc:
       SuppressorRegistry.suppressed[self.class.name] ? true : super
     end
   end


### PR DESCRIPTION
It was not being applied to creates and updates attempted through the non-bang save methods. I observed the incorrect behavior in the `create_*` methods provided by singular associations, as demonstrated in [this Gist](https://gist.github.com/georgeclaghorn/e6e7ef670262b9c12e5f).

cc @perceptec
