### PR TITLE
Fix crash when loading fixture with belongs_to association defined in abstract base class

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -659,7 +659,7 @@ module ActiveRecord
                   row[association.foreign_type] = $1
                 end
 
-                fk_type = association.active_record.columns_hash[fk_name].type
+                fk_type = model_class.columns_hash[fk_name].type
                 row[fk_name] = ActiveRecord::FixtureSet.identify(value, fk_type)
               end
             when :has_many

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -16,6 +16,7 @@ require 'models/joke'
 require 'models/matey'
 require 'models/parrot'
 require 'models/pirate'
+require 'models/doubloon'
 require 'models/post'
 require 'models/randomly_named_c1'
 require 'models/reply'
@@ -883,5 +884,14 @@ class FixturesWithDefaultScopeTest < ActiveRecord::TestCase
 
   test "allows access to fixtures excluded by a default scope" do
     assert_equal "special", bulbs(:special).name
+  end
+end
+
+class FixturesWithAbstractBelongsTo < ActiveRecord::TestCase
+  fixtures :pirates, :doubloons
+
+  test "creates fixtures with belongs_to associations defined in abstract base classes" do
+    assert_not_nil doubloons(:blackbeards_doubloon)
+    assert_equal pirates(:blackbeard), doubloons(:blackbeards_doubloon).pirate
   end
 end

--- a/activerecord/test/fixtures/doubloons.yml
+++ b/activerecord/test/fixtures/doubloons.yml
@@ -1,0 +1,3 @@
+blackbeards_doubloon:
+  pirate: blackbeard
+  weight: 2

--- a/activerecord/test/models/doubloon.rb
+++ b/activerecord/test/models/doubloon.rb
@@ -1,0 +1,12 @@
+class AbstractDoubloon < ActiveRecord::Base
+  # This has functionality that might be shared by multiple classes.
+
+  self.abstract_class = true
+  belongs_to :pirate
+end
+
+class Doubloon < AbstractDoubloon
+  # This uses an abstract class that defines attributes and associations.
+
+  self.table_name = 'doubloons'
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -281,6 +281,11 @@ ActiveRecord::Schema.define do
     t.string  :alias
   end
 
+  create_table :doubloons, force: true do |t|
+    t.integer :pirate_id
+    t.integer :weight
+  end
+
   create_table :edges, force: true, id: false do |t|
     t.column :source_id, :integer, null: false
     t.column :sink_id,   :integer, null: false


### PR DESCRIPTION
This fixes #20436 for the 4.2 line of releases.

I'm looking forward to your feedback. :heart: 
