### PR TITLE
Require active_support/duration.

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -1,3 +1,4 @@
+require 'active_support/duration'
 require 'active_support/values/time_zone'
 require 'active_support/core_ext/object/acts_like'
 


### PR DESCRIPTION
`ActiveSupport::TimeWithZone` references `ActiveSupport::Duration` but does not require it, which can result in a `LoadError` when required directly (without requiring a component less granular like `active_support/time`, where the autoload for `ActiveSupport::Duration` is set up).
