### PR TITLE
Fix the message verifier encoding issue

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -44,7 +44,7 @@ module ActiveSupport
     #   tampered_message = signed_message.chop # editing the message invalidates the signature
     #   verifier.valid_message?(tampered_message) # => false
     def valid_message?(signed_message)
-      return if signed_message.blank?
+      return if signed_message.nil? || !signed_message.valid_encoding? || signed_message.blank?
 
       data, digest = signed_message.split("--")
       data.present? && digest.present? && ActiveSupport::SecurityUtils.secure_compare(digest, generate_digest(data))

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -24,6 +24,7 @@ class MessageVerifierTest < ActiveSupport::TestCase
     data, hash = @verifier.generate(@data).split("--")
     assert !@verifier.valid_message?(nil)
     assert !@verifier.valid_message?("")
+    assert !@verifier.valid_message?("\xff") # invalid encoding
     assert !@verifier.valid_message?("#{data.reverse}--#{hash}")
     assert !@verifier.valid_message?("#{data}--#{hash.reverse}")
     assert !@verifier.valid_message?("purejunk")


### PR DESCRIPTION
Fixes #20416 

``` ruby
verifier = ActiveSupport::MessageVerifier.new('secret')
verifier.verify("\xff") # => ArgumentError: invalid byte sequence in UTF-8
```
