### PR TITLE
Remove warning for setting eager_load

### DIFF
--- a/railties/test/application/multiple_applications_test.rb
+++ b/railties/test/application/multiple_applications_test.rb
@@ -118,7 +118,7 @@ module ApplicationTests
       assert_equal 0, run_count, "Without loading the initializers, the count should be 0"
 
       # Set config.eager_load to false so that an eager_load warning doesn't pop up
-      AppTemplate::Application.new { config.eager_load = false }.initialize!
+      AppTemplate::Application.create { config.eager_load = false }.initialize!
 
       assert_equal 3, run_count, "There should have been three initializers that incremented the count"
     end


### PR DESCRIPTION
AppTemplate::Application.new does not run load hooks.

To load this configuration we need to use create which will 
run load hooks to load this configuration.
