### PR TITLE
Fix `thoughtbot` capitalization

### DIFF
--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -25,7 +25,7 @@ module ActiveSupport
   # of the backtrace, you can call <tt>BacktraceCleaner#remove_filters!</tt>
   # These two methods will give you a completely untouched backtrace.
   #
-  # Inspired by the Quiet Backtrace gem by Thoughtbot.
+  # Inspired by the Quiet Backtrace gem by thoughtbot.
   class BacktraceCleaner
     def initialize
       @filters, @silencers = [], []


### PR DESCRIPTION
The company name is spelled `thoughtbot` per
https://github.com/thoughtbot/presskit/blob/master/README.md#name
