### PR TITLE
modify console of app method in that can use the path helpers

### DIFF
--- a/railties/lib/rails/console/app.rb
+++ b/railties/lib/rails/console/app.rb
@@ -18,6 +18,11 @@ module Rails
       app = Rails.application
       session = ActionDispatch::Integration::Session.new(app)
       yield session if block_given?
+
+      # This makes app.url_for and app.foo_path available in the console
+      session.extend(app.routes.url_helpers)
+      session.extend(app.routes.mounted_helpers)
+
       session
     end
 

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -29,6 +29,18 @@ class ConsoleTest < ActiveSupport::TestCase
     assert_instance_of ActionDispatch::Integration::Session, console_session
   end
 
+  def test_app_can_access_path_helper_method
+    app_file 'config/routes.rb', <<-RUBY
+      Rails.application.routes.draw do
+        get 'foo', to: 'foo#index'
+      end
+    RUBY
+
+    load_environment
+    console_session = irb_context.app
+    assert_equal '/foo', console_session.foo_path
+  end
+
   def test_new_session_should_return_integration_session
     load_environment
     session = irb_context.new_session


### PR DESCRIPTION
In `rails console` of `master`,  `app` can not use the url and path helpers.

``` ruby
# config/routes.rb 
Rails.application.routes.draw do
  root 'welcome#index'
end
```

``` console
$ ./bin/rails c
pry(main)> Rails.version 
=> "5.0.0.alpha"
[2] pry(main)> app.root_path
NoMethodError: undefined method `root_path' for #<ActionDispatch::Integration::Session:0x007f63818d3678>
from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/rails-abe199b3899f/actionpack/lib/action_dispatch/testing/assertions/routing.rb:171:in `method_missing'
```

This is a thing by the correspondence of https://github.com/rails/rails/commit/0acd4a57768fc3c7e758f9f4b26563797f43e7ef , but I think that path helper method should be usable in `rails console`, WDYT?
