### PR TITLE
Guard against finder options or invalid-type column names in Relation#count

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   ActiveRecord::Relation#count: raise an ArgumentError when finder options
+    are specified or an ActiveRecord::StatementInvalid when an invalid type
+    is provided for a column name (e.g. a Hash).
+
+    Fixes #20434
+
+    *Konstantinos Rousis*
+
 *   Fix regression when loading fixture files with symbol keys.
 
     Closes #22584.

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -36,9 +36,15 @@ module ActiveRecord
     # Note: not all valid +select+ expressions are valid +count+ expressions. The specifics differ
     # between databases. In invalid cases, an error from the database is thrown.
     def count(column_name = nil, options = {})
+      if options.present? && !ActiveRecord.const_defined?(:DeprecatedFinders)
+        raise ArgumentError, "Relation#count does not support finder options anymore. " \
+                             "Please build a scope and then call count on it or use the " \
+                             "activerecord-deprecated_finders gem to enable this functionality."
+
+      end
+
       # TODO: Remove options argument as soon we remove support to
       # activerecord-deprecated_finders.
-      column_name, options = nil, column_name if column_name.is_a?(Hash)
       calculate(:count, column_name, options)
     end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -389,6 +389,14 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_raise(ArgumentError) { Account.count(1, 2, 3) }
   end
 
+  def test_count_with_a_single_hash_parameter_raises
+    assert_raise(ActiveRecord::StatementInvalid) { Account.count({}) }
+  end
+
+  def test_count_with_finder_options_raises
+    assert_raise(ArgumentError) { Account.count(:firm_name, { conditions: {} }) }
+  end
+
   def test_count_with_order
     assert_equal 6, Account.order(:credit_limit).count
   end


### PR DESCRIPTION
This is what I came up with regarding #20434 . Keep in mind that the current implementation of `count` in 4.1 and 4.2 has two related but distinct issues:
1. When both a column name and an options hash are provided, the options are silently ignored.
2. When a Hash (with finder options or otherwise) is provided as the sole argument, it is silently ignored and a `count(:all)` is performed.

I introduced an explicit check for the first case, raising an `ArgumentError` whenever an options hash is specified. When the `activerecord-deprecated_finders` gem is present we can safely let that handle the finder options.

I handle the second issue by passing the argument to the DB directly and letting that to eventually raise an error. This is consistent with the approach taken in the current `master` when provided with an invalid type for a column name. 
### Providing both a column name and an options hash

These are the results of running `User.count(:id, conditions: { username: 'rousis' })`:

| 4-1-stable and 4-2-stable | 4-1 and 4-2 with deprecated_finders | master | 4-2-stable with thtis PR |
| --- | --- | --- | --- |
| SELECT COUNT("users"."id") FROM "users" | SELECT COUNT("users"."id") FROM "users" WHERE "users"."username" = $1  [["username", "rousis"]](plus deprecation warning) | ArgumentError: wrong number of arguments (2 for 0..1) | ArgumentError: Relation#count does not support finder options anymore. Please build a scope and then call count on it or use the activerecord-deprecated_finders gem to enable this functionality. |
### Providing a single hash argument

And these are the results of running `User.count({ username: 'rousis' })`:

| 4-1-stable and 4-2-stable | 4-1 and 4-2 with deprecated_finders | master | 4-2-stable with thtis PR |
| --- | --- | --- | --- |
| SELECT COUNT(*) FROM "users" | SELECT COUNT(*) FROM "users" WHERE "users"."username" = 'rousis' (plus deprecation warning) | ActiveRecord:: StatementInvalid | ActiveRecord:: StatementInvalid |

This PR targets `4-2-stable` but it might be a useful addition to `4-1-stable` as well.

Any feedback on the concept or the implementation would be greatly appreciated.
