### PR TITLE
Add the bug report templates to the Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
     - "GEM=ar:sqlite3"
     - "GEM=ar:postgresql"
     - "GEM=aj:integration"
+    - "GEM=guides"
 rvm:
   - 2.2.2
   - ruby-head

--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -1,7 +1,11 @@
-# Activate the gem you are reporting the issue against.
-gem 'rails', '4.2.0'
+require 'bundler/inline'
 
-require 'rails'
+gemfile(true) do
+  source 'https://rubygems.org'
+  # Activate the gem you are reporting the issue against.
+  gem 'rails', '4.2.0'
+end
+
 require 'rack/test'
 require 'action_controller/railtie'
 

--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -6,7 +6,6 @@ gemfile(true) do
   gem 'arel', github: 'rails/arel'
 end
 
-require 'rails'
 require 'action_controller/railtie'
 
 class TestApp < Rails::Application

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -1,5 +1,12 @@
-# Activate the gem you are reporting the issue against.
-gem 'activerecord', '4.2.0'
+require 'bundler/inline'
+
+gemfile(true) do
+  source 'https://rubygems.org'
+  # Activate the gem you are reporting the issue against.
+  gem 'activerecord', '4.2.0'
+  gem 'sqlite3'
+end
+
 require 'active_record'
 require 'minitest/autorun'
 require 'logger'

--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -1,6 +1,11 @@
-# Activate the gems you are reporting the issue against.
-gem 'activesupport', '4.2.0'
-require 'active_support'
+require 'bundler/inline'
+
+gemfile(true) do
+  source 'https://rubygems.org'
+  # Activate the gem you are reporting the issue against.
+  gem 'activesupport', '4.2.0'
+end
+
 require 'active_support/core_ext/object/blank'
 require 'minitest/autorun'
 


### PR DESCRIPTION
Continuing the work from #20429. The bug report templates are now executed from the `ci/travis.rb` when `GEM` contains `guides`.

I started by creating a `test` task in `guides/Rakefile` to handle this, but since inline `gemfile` must not be executed with `bundle exec`, that rake task would not be consistent with others. So I went back by executing them directly from `Build`.

/cc @rafaelfranca 
