### PR TITLE
Add ActiveSupport::Duration#range_from and #range_until.

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -503,7 +503,7 @@ module ActiveRecord
     #    User.where({ name: ["Alice", "Bob"]})
     #    # SELECT * FROM users WHERE name IN ('Alice', 'Bob')
     #
-    #    User.where({ created_at: (Time.now.midnight - 1.day)..Time.now.midnight })
+    #    User.where({ created_at: 1.day.range_until(Time.now.midnight) })
     #    # SELECT * FROM users WHERE (created_at BETWEEN '2012-06-09 07:00:00.000000' AND '2012-06-10 07:00:00.000000')
     #
     # In the case of a belongs_to relationship, an association key can be used

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add methods `ActiveSupport::Duration#range_from` and 
+    `ActiveSupport::Duration#range_until` with corresponding aliases
+    ending in `_now`. 
+    
+        User.where(created_at: 1.week.range_until_now)
+        User.where(created_at: 1.week.range_until(3.days.ago))
+        
+        User.where(birthday: 3.months.range_from_now)
+        User.where(birthday: 3.months.range_from(1.month.ago))
+        
+    *Volodymyr Shatsky*
+    
 *   Fix a range of values for parameters of the Time#change
 
     *Nikolay Kondratyev*

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -114,6 +114,28 @@ module ActiveSupport
     end
     alias :until :ago
 
+    # Creates a new Time or Date range
+    # that starts at +time+
+    # and has a duration specified in the method receiver.
+    #
+    #   1.month.range_from(3.months.ago) # equivalent to 3.months.ago..2.months.ago
+    #   1.month.range_from_now # equivalent to Time.current..1.month.from_now
+    def range_from(time = ::Time.current)
+      time..since(time)
+    end
+    alias :range_from_now :range_from
+
+    # Creates a new Time or Date range
+    # that has a duration specified in the method receiver
+    # and ends at +time+.
+    #
+    #   3.months.range_until(1.month.ago) # equivalent to 4.months.ago..1.month.ago
+    #   1.month.range_until_now # equivalent to 1.month.ago..Time.current
+    def range_until(time = ::Time.current)
+      ago(time)..time
+    end
+    alias :range_until_now :range_until
+
     def inspect #:nodoc:
       parts.
         reduce(::Hash.new(0)) { |h,(l,r)| h[l] += r; h }.

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -167,6 +167,36 @@ class DurationTest < ActiveSupport::TestCase
     Time.zone = nil
   end
 
+  def test_range_from_with_now
+    now = Time.current
+    assert_equal 1.month.range_from(now), now..1.month.since(now)
+  end
+
+  def test_range_from_with_future_date
+    date = Date.tomorrow
+    assert_equal 3.weeks.range_from(date), date..3.weeks.since(date)
+  end
+
+  def test_range_from_with_past_time
+    time = 1.hour.ago
+    assert_equal 2.hours.range_from(time), time..2.hours.since(time)
+  end
+
+  def test_range_until_with_now
+    now = Time.current
+    assert_equal 1.month.range_until(now), 1.month.until(now)..now
+  end
+
+  def test_range_until_with_future_date
+    date = 3.days.from_now
+    assert_equal 1.day.range_until(date), 1.day.until(date)..date
+  end
+
+  def test_range_until_with_past_date
+    date = 3.days.ago
+    assert_equal 1.day.range_until(date), 1.day.until(date)..date
+  end
+
   def test_adding_hours_across_dst_boundary
     with_env_tz 'CET' do
       assert_equal Time.local(2009,3,29,0,0,0) + 24.hours, Time.local(2009,3,30,1,0,0)

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -457,7 +457,7 @@ NOTE: The values cannot be symbols. For example, you cannot do `Client.where(sta
 #### Range Conditions
 
 ```ruby
-Client.where(created_at: (Time.now.midnight - 1.day)..Time.now.midnight)
+Client.where(created_at: 1.day.range_until(Time.now.midnight))
 ```
 
 This will find all clients created yesterday by using a `BETWEEN` SQL statement:
@@ -1053,15 +1053,13 @@ SELECT categories.* FROM categories
 You can specify conditions on the joined tables using the regular [Array](#array-conditions) and [String](#pure-string-conditions) conditions. [Hash conditions](#hash-conditions) provides a special syntax for specifying conditions for the joined tables:
 
 ```ruby
-time_range = (Time.now.midnight - 1.day)..Time.now.midnight
-Client.joins(:orders).where('orders.created_at' => time_range)
+Client.joins(:orders).where('orders.created_at' => 1.day.range_until(Time.now.midnight))
 ```
 
 An alternative and cleaner syntax is to nest the hash conditions:
 
 ```ruby
-time_range = (Time.now.midnight - 1.day)..Time.now.midnight
-Client.joins(:orders).where(orders: { created_at: time_range })
+Client.joins(:orders).where(orders: { created_at: 1.day.range_until(Time.now.midnight) })
 ```
 
 This will find all clients who have orders that were created yesterday, again using a `BETWEEN` SQL expression.


### PR DESCRIPTION
It often happens that we need to select database records for, say, last week. Currently the right way to do it is 

``` ruby
User.where(created_at: 1.week.ago..Time.current)
```

It gets a bit worse when the range ends at a different point of time; now we need to introduce a local variable:

``` ruby
end_time = 1.day.ago
User.where(created_at: 1.week.until(end_time)..end_time))
```

This PR proposes two obvious, and, in my humble opinion, rather useful methods, which simplify this kind of queries. Now you can do 

``` ruby
User.where(created_at: 1.week.range_until_now)
User.where(created_at: 1.week.range_until(3.days.ago))

User.where(birthday: 3.months.range_from_now)
User.where(birthday: 3.months.range_from(1.month.ago)
```

I'm not sure it's obvious that `3.months.range_until(1.month.ago)` is `4.months.ago..1.month.ago`, and not `3.months.ago..1.month.ago`. What do you think?
