### PR TITLE
Show an error message if bundler 1.10.x is not installed when reporting bugs

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -1,4 +1,9 @@
-require 'bundler/inline'
+begin
+  require 'bundler/inline'
+rescue LoadError => e
+  $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
+  raise e
+end
 
 gemfile(true) do
   source 'https://rubygems.org'

--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -1,4 +1,9 @@
-require 'bundler/inline'
+begin
+  require 'bundler/inline'
+rescue LoadError => e
+  $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
+  raise e
+end
 
 gemfile(true) do
   source 'https://rubygems.org'

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -1,4 +1,9 @@
-require 'bundler/inline'
+begin
+  require 'bundler/inline'
+rescue LoadError => e
+  $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
+  raise e
+end
 
 gemfile(true) do
   source 'https://rubygems.org'

--- a/guides/bug_report_templates/active_record_master.rb
+++ b/guides/bug_report_templates/active_record_master.rb
@@ -1,4 +1,9 @@
-require 'bundler/inline'
+begin
+  require 'bundler/inline'
+rescue LoadError => e
+  $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
+  raise e
+end
 
 gemfile(true) do
   source 'https://rubygems.org'

--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -1,4 +1,9 @@
-require 'bundler/inline'
+begin
+  require 'bundler/inline'
+rescue LoadError => e
+  $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
+  raise e
+end
 
 gemfile(true) do
   source 'https://rubygems.org'

--- a/guides/bug_report_templates/generic_master.rb
+++ b/guides/bug_report_templates/generic_master.rb
@@ -1,4 +1,9 @@
-require 'bundler/inline'
+begin
+  require 'bundler/inline'
+rescue LoadError => e
+  $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
+  raise e
+end
 
 gemfile(true) do
   source 'https://rubygems.org'


### PR DESCRIPTION
Now bundler 1.10.x is required when reporting bugs.

I think it would be better to output an error message and raise an error if bundler 1.10.x is not installed than to just show `cannot load such file -- bundler/inline (LoadError)`.
