### PR TITLE
Removed use of mocha in ActiveSupport

### DIFF
--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -15,6 +15,7 @@ silence_warnings do
 end
 
 require 'active_support/testing/autorun'
+require 'active_support/testing/method_call_assertions'
 
 ENV['NO_RELOAD'] = '1'
 require 'active_support'
@@ -38,4 +39,7 @@ def jruby_skip(message = '')
 end
 
 require 'minitest/mock'
-require 'mocha/setup' # FIXME: stop using mocha
+
+class ActiveSupport::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -961,10 +961,11 @@ class HashExtTest < ActiveSupport::TestCase
     assert_raise(RuntimeError) { original.except!(:a) }
   end
 
-  def test_except_with_mocha_expectation_on_original
+  def test_except_does_not_delete_values_in_original
     original = { :a => 'x', :b => 'y' }
-    original.expects(:delete).never
-    original.except(:a)
+    assert_not_called(original, :delete) do
+      original.except(:a)
+    end
   end
 
   def test_compact

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -482,22 +482,24 @@ class TimeWithZoneTest < ActiveSupport::TestCase
   end
 
   def test_method_missing_with_non_time_return_value
-    @twz.time.expects(:foo).returns('bar')
+    time = @twz.time
+    def time.foo; 'bar'; end
     assert_equal 'bar', @twz.foo
   end
 
   def test_date_part_value_methods
     twz = ActiveSupport::TimeWithZone.new(Time.utc(1999,12,31,19,18,17,500), @time_zone)
-    twz.expects(:method_missing).never
-    assert_equal 1999, twz.year
-    assert_equal 12, twz.month
-    assert_equal 31, twz.day
-    assert_equal 14, twz.hour
-    assert_equal 18, twz.min
-    assert_equal 17, twz.sec
-    assert_equal 500, twz.usec
-    assert_equal 5, twz.wday
-    assert_equal 365, twz.yday
+    assert_not_called(twz, :method_missing) do
+      assert_equal 1999, twz.year
+      assert_equal 12, twz.month
+      assert_equal 31, twz.day
+      assert_equal 14, twz.hour
+      assert_equal 18, twz.min
+      assert_equal 17, twz.sec
+      assert_equal 500, twz.usec
+      assert_equal 5, twz.wday
+      assert_equal 365, twz.yday
+    end
   end
 
   def test_usec_returns_0_when_datetime_is_wrapped

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -721,12 +721,13 @@ class DependenciesTest < ActiveSupport::TestCase
   end
 
   def test_unloadable_constants_should_receive_callback
-    Object.const_set :C, Class.new
+    Object.const_set :C, Class.new { def self.before_remove_const; end }
     C.unloadable
-    C.expects(:before_remove_const).once
-    assert C.respond_to?(:before_remove_const)
-    ActiveSupport::Dependencies.clear
-    assert !defined?(C)
+    assert_called(C, :before_remove_const, times: 1) do
+      assert C.respond_to?(:before_remove_const)
+      ActiveSupport::Dependencies.clear
+      assert !defined?(C)
+    end
   ensure
     remove_constants(:C)
   end

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -256,17 +256,17 @@ class DeprecationTest < ActiveSupport::TestCase
   end
 
   def test_deprecate_with_custom_deprecator
-    custom_deprecator = mock('Deprecator') do
-      expects(:deprecation_warning)
-    end
+    custom_deprecator = Struct.new(:deprecation_warning).new
 
-    klass = Class.new do
-      def method
+    assert_called_with(custom_deprecator, :deprecation_warning, [:method, nil]) do
+      klass = Class.new do
+        def method
+        end
+        deprecate :method, deprecator: custom_deprecator
       end
-      deprecate :method, deprecator: custom_deprecator
-    end
 
-    klass.new.method
+      klass.new.method
+    end
   end
 
   def test_deprecated_constant_with_deprecator_given

--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -82,10 +82,11 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
 
   def test_does_not_send_the_event_if_logger_is_nil
     ActiveSupport::LogSubscriber.logger = nil
-    @log_subscriber.expects(:some_event).never
-    ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
-    instrument "some_event.my_log_subscriber"
-    wait
+    assert_not_called(@log_subscriber, :some_event) do
+      ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
+      instrument "some_event.my_log_subscriber"
+      wait
+    end
   end
 
   def test_does_not_fail_with_non_namespaced_events

--- a/activesupport/test/multibyte_unicode_database_test.rb
+++ b/activesupport/test/multibyte_unicode_database_test.rb
@@ -11,8 +11,9 @@ class MultibyteUnicodeDatabaseTest < ActiveSupport::TestCase
 
   UnicodeDatabase::ATTRIBUTES.each do |attribute|
     define_method "test_lazy_loading_on_attribute_access_of_#{attribute}" do
-      @ucd.expects(:load)
-      @ucd.send(attribute)
+      assert_called(@ucd, :load) do
+        @ucd.send(attribute)
+      end
     end
   end
 


### PR DESCRIPTION
caching_test.rb have some tweaks , I'm not sure how to handle them with minitest.
Also I replaced `never` expectation with 

``` ruby
assert_equal "expected call() => nil, got []", assert_raises(MockExpectationError) { mock.verify }.message 
```

not sure if it's the right way to do this
