### PR TITLE
Add missing postgresql types for migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Added methods for PostgreSQL geometric data types to use in migrations
+
+    Example:
+
+        create_table :foo do |t|
+          t.line :foo_line
+          t.lseg :foo_lseg
+          t.box :foo_box
+          t.path :foo_path
+          t.polygon :foo_polygon
+          t.circle :foo_circle
+        end
+
+    *Mehmet Emin İNAÇ*
+
 *   Deprecate the PG `:point` type in favor of a new one which will return
     `Point` objects instead of an `Array`
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -103,6 +103,30 @@ module ActiveRecord
           args.each { |name| column(name, :point, options) }
         end
 
+        def line(*args, **options)
+          args.each { |name| column(name, :line, options) }
+        end
+
+        def lseg(*args, **options)
+          args.each { |name| column(name, :lseg, options) }
+        end
+
+        def box(*args, **options)
+          args.each { |name| column(name, :box, options) }
+        end
+
+        def path(*args, **options)
+          args.each { |name| column(name, :path, options) }
+        end
+
+        def polygon(*args, **options)
+          args.each { |name| column(name, :polygon, options) }
+        end
+
+        def circle(*args, **options)
+          args.each { |name| column(name, :circle, options) }
+        end
+
         def serial(*args, **options)
           args.each { |name| column(name, :serial, options) }
         end

--- a/activerecord/test/cases/migration/postgresql_geometric_types_test.rb
+++ b/activerecord/test/cases/migration/postgresql_geometric_types_test.rb
@@ -1,0 +1,93 @@
+require 'cases/helper'
+
+module ActiveRecord
+  class Migration
+    class PostgreSQLGeometricTypesTest < ActiveRecord::TestCase
+      attr_reader :connection, :table_name
+
+      def setup
+        super
+        @connection = ActiveRecord::Base.connection
+        @table_name = :testings
+      end
+
+      if current_adapter?(:PostgreSQLAdapter)
+        def test_creating_column_with_point_type
+          connection.create_table(table_name) do |t|
+            t.point :foo_point
+          end
+          
+          assert_column_exists(:foo_point)
+          assert_type_correct(:foo_point, :point)
+        end
+
+        def test_creating_column_with_line_type
+          connection.create_table(table_name) do |t|
+            t.line :foo_line
+          end
+          
+          assert_column_exists(:foo_line)
+          assert_type_correct(:foo_line, :line)
+        end
+
+        def test_creating_column_with_lseg_type
+          connection.create_table(table_name) do |t|
+            t.lseg :foo_lseg
+          end
+          
+          assert_column_exists(:foo_lseg)
+          assert_type_correct(:foo_lseg, :lseg)
+        end
+
+        def test_creating_column_with_box_type
+          connection.create_table(table_name) do |t|
+            t.box :foo_box
+          end
+          
+          assert_column_exists(:foo_box)
+          assert_type_correct(:foo_box, :box)
+        end
+
+        def test_creating_column_with_path_type
+          connection.create_table(table_name) do |t|
+            t.path :foo_path
+          end
+          
+          assert_column_exists(:foo_path)
+          assert_type_correct(:foo_path, :path)
+        end
+
+        def test_creating_column_with_polygon_type
+          connection.create_table(table_name) do |t|
+            t.polygon :foo_polygon
+          end
+          
+          assert_column_exists(:foo_polygon)
+          assert_type_correct(:foo_polygon, :polygon)
+        end
+
+        def test_creating_column_with_circle_type
+          connection.create_table(table_name) do |t|
+            t.circle :foo_circle
+          end
+          
+          assert_column_exists(:foo_circle)
+          assert_type_correct(:foo_circle, :circle)
+        end
+      end
+
+      private
+        def assert_column_exists(column_name)
+          columns = connection.columns(table_name)
+          assert columns.map(&:name).include?(column_name.to_s)
+        end
+
+        def assert_type_correct(column_name, type)
+          columns = connection.columns(table_name)
+          column = columns.select{ |c| c.name == column_name.to_s }.first
+          assert_equal type.to_s, column.sql_type
+        end
+
+    end
+  end
+end


### PR DESCRIPTION
In one of my projects I'm using PostgreSQL geometric data types. I saw that there is some missing methods for migrations to create necessary data types for PostgreSQL. 
These methods supported since PostgreSQL version 9.0, for more information please see the [link](http://www.postgresql.org/docs/9.0/static/datatype-geometric.html). 
I've created methods for these types.
