### PR TITLE
[ci skip] fixing 'cancelling after_* callback' doc

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -199,7 +199,7 @@ module ActiveRecord
   # == Canceling callbacks
   #
   # If a <tt>before_*</tt> callback returns +false+, all the later callbacks and the associated action are
-  # cancelled. If an <tt>after_*</tt> callback returns +false+, all the later callbacks are cancelled.
+  # cancelled.
   # Callbacks are generally run in the order they are defined, with the exception of callbacks defined as
   # methods on the model, which are called last.
   #


### PR DESCRIPTION
Returning `false` in any of after_\* callbacks will not halt callback chain, thus documentation needs to be updated. As discussed in the issue https://github.com/rails/rails/issues/20422.
