### PR TITLE
Check structure command response for errors

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -67,7 +67,12 @@ module ActiveRecord
 
       def structure_load(filename)
         set_psql_env
-        Kernel.system("psql -X -q -f #{Shellwords.escape(filename)} #{configuration['database']}")
+        case Kernel.system("psql -X -q -f #{Shellwords.escape(filename)} #{configuration['database']}")
+        when nil
+          raise "Unable to load structure, is psql installed?"
+        when false
+          raise "Error loading structure, psql exited with status #{$?.exitstatus}"
+        end
       end
 
       private


### PR DESCRIPTION
If `psql` is not installed on the system, `rake db:structure:load` gives no output, implying success.
This commit will raise sensible error messages in the case that `psql` does not exist or the process
returns an exit status other than 0.
