### PR TITLE
Add missing NOTE for Time extensions' location

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1936,6 +1936,8 @@ as well as adding or subtracting their results from a Time object. For example:
 (4.months + 5.years).from_now
 ```
 
+NOTE: Defined in `active_support/core_ext/numeric/time.rb`
+
 ### Formatting
 
 Enables the formatting of numbers in a variety of ways.


### PR DESCRIPTION
Every extension has a note showing where the relevant ruby file is located, except for Numeric Time extensions. This adds the missing note.
