### PR TITLE
use our own runner for Rails framework components `bin/test`

### DIFF
--- a/actionmailer/bin/test
+++ b/actionmailer/bin/test
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+COMPONENT_ROOT = File.expand_path("../../", __FILE__)
+require File.expand_path("../tools/test", COMPONENT_ROOT)

--- a/actionmailer/bin/test
+++ b/actionmailer/bin/test
@@ -1,3 +1,4 @@
 #!/usr/bin/env ruby
 COMPONENT_ROOT = File.expand_path("../../", __FILE__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)
+exit Minitest.run(ARGV)

--- a/actionpack/bin/test
+++ b/actionpack/bin/test
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+COMPONENT_ROOT = File.expand_path("../../", __FILE__)
+require File.expand_path("../tools/test", COMPONENT_ROOT)

--- a/actionpack/bin/test
+++ b/actionpack/bin/test
@@ -1,3 +1,4 @@
 #!/usr/bin/env ruby
 COMPONENT_ROOT = File.expand_path("../../", __FILE__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)
+exit Minitest.run(ARGV)

--- a/actionview/bin/test
+++ b/actionview/bin/test
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+COMPONENT_ROOT = File.expand_path("../../", __FILE__)
+require File.expand_path("../tools/test", COMPONENT_ROOT)

--- a/actionview/bin/test
+++ b/actionview/bin/test
@@ -1,3 +1,4 @@
 #!/usr/bin/env ruby
 COMPONENT_ROOT = File.expand_path("../../", __FILE__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)
+exit Minitest.run(ARGV)

--- a/activemodel/bin/test
+++ b/activemodel/bin/test
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+COMPONENT_ROOT = File.expand_path("../../", __FILE__)
+require File.expand_path("../tools/test", COMPONENT_ROOT)

--- a/activemodel/bin/test
+++ b/activemodel/bin/test
@@ -1,3 +1,4 @@
 #!/usr/bin/env ruby
 COMPONENT_ROOT = File.expand_path("../../", __FILE__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)
+exit Minitest.run(ARGV)

--- a/activerecord/bin/test
+++ b/activerecord/bin/test
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+COMPONENT_ROOT = File.expand_path("../../", __FILE__)
+require File.expand_path("../tools/test", COMPONENT_ROOT)

--- a/activerecord/bin/test
+++ b/activerecord/bin/test
@@ -1,3 +1,19 @@
 #!/usr/bin/env ruby
 COMPONENT_ROOT = File.expand_path("../../", __FILE__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)
+module Minitest
+  def self.plugin_active_record_options(opts, options)
+    opts.separator ""
+    opts.separator "Active Record options:"
+    opts.on("-a", "--adapter [ADAPTER]",
+            "Run tests using a specific adapter (sqlite3, sqlite3_mem, mysql, mysql2, postgresql)") do |adapter|
+      ENV["ARCONN"] = adapter.strip
+    end
+
+    opts
+  end
+end
+
+Minitest.extensions.unshift 'active_record'
+
+exit Minitest.run(ARGV)

--- a/activerecord/test/cases/adapters/mysql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/active_schema_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/connection_helper'
 
-class ActiveSchemaTest < ActiveRecord::TestCase
+class MysqlActiveSchemaTest < ActiveRecord::MysqlTestCase
   include ConnectionHelper
 
   def setup

--- a/activerecord/test/cases/adapters/mysql/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql/case_sensitivity_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class MysqlCaseSensitivityTest < ActiveRecord::TestCase
+class MysqlCaseSensitivityTest < ActiveRecord::MysqlTestCase
   class CollationTest < ActiveRecord::Base
   end
 

--- a/activerecord/test/cases/adapters/mysql/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/mysql/charset_collation_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/schema_dumping_helper'
 
-class CharsetCollationTest < ActiveRecord::TestCase
+class MysqlCharsetCollationTest < ActiveRecord::MysqlTestCase
   include SchemaDumpingHelper
   self.use_transactional_tests = false
 

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require 'support/connection_helper'
 require 'support/ddl_helper'
 
-class MysqlConnectionTest < ActiveRecord::TestCase
+class MysqlConnectionTest < ActiveRecord::MysqlTestCase
   include ConnectionHelper
   include DdlHelper
 

--- a/activerecord/test/cases/adapters/mysql/consistency_test.rb
+++ b/activerecord/test/cases/adapters/mysql/consistency_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class MysqlConsistencyTest < ActiveRecord::TestCase
+class MysqlConsistencyTest < ActiveRecord::MysqlTestCase
   self.use_transactional_tests = false
 
   class Consistency < ActiveRecord::Base

--- a/activerecord/test/cases/adapters/mysql/enum_test.rb
+++ b/activerecord/test/cases/adapters/mysql/enum_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class MysqlEnumTest < ActiveRecord::TestCase
+class MysqlEnumTest < ActiveRecord::MysqlTestCase
   class EnumTest < ActiveRecord::Base
   end
 

--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -4,7 +4,7 @@ require 'support/ddl_helper'
 
 module ActiveRecord
   module ConnectionAdapters
-    class MysqlAdapterTest < ActiveRecord::TestCase
+    class MysqlAdapterTest < ActiveRecord::MysqlTestCase
       include DdlHelper
 
       def setup

--- a/activerecord/test/cases/adapters/mysql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql/quoting_test.rb
@@ -1,21 +1,15 @@
 require "cases/helper"
 
-module ActiveRecord
-  module ConnectionAdapters
-    class MysqlAdapter
-      class QuotingTest < ActiveRecord::TestCase
-        def setup
-          @conn = ActiveRecord::Base.connection
-        end
+class MysqlQuotingTest < ActiveRecord::MysqlTestCase
+  def setup
+    @conn = ActiveRecord::Base.connection
+  end
 
-        def test_type_cast_true
-          assert_equal 1, @conn.type_cast(true)
-        end
+  def test_type_cast_true
+    assert_equal 1, @conn.type_cast(true)
+  end
 
-        def test_type_cast_false
-          assert_equal 0, @conn.type_cast(false)
-        end
-      end
-    end
+  def test_type_cast_false
+    assert_equal 0, @conn.type_cast(false)
   end
 end

--- a/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql/reserved_word_test.rb
@@ -1,29 +1,29 @@
 require "cases/helper"
 
-class Group < ActiveRecord::Base
-  Group.table_name = 'group'
-  belongs_to :select
-  has_one :values
-end
-
-class Select < ActiveRecord::Base
-  Select.table_name = 'select'
-  has_many :groups
-end
-
-class Values < ActiveRecord::Base
-  Values.table_name = 'values'
-end
-
-class Distinct < ActiveRecord::Base
-  Distinct.table_name = 'distinct'
-  has_and_belongs_to_many :selects
-  has_many :values, :through => :groups
-end
-
 # a suite of tests to ensure the ConnectionAdapters#MysqlAdapter can handle tables with
 # reserved word names (ie: group, order, values, etc...)
-class MysqlReservedWordTest < ActiveRecord::TestCase
+class MysqlReservedWordTest < ActiveRecord::MysqlTestCase
+  class Group < ActiveRecord::Base
+    Group.table_name = 'group'
+    belongs_to :select
+    has_one :values
+  end
+
+  class Select < ActiveRecord::Base
+    Select.table_name = 'select'
+    has_many :groups
+  end
+
+  class Values < ActiveRecord::Base
+    Values.table_name = 'values'
+  end
+
+  class Distinct < ActiveRecord::Base
+    Distinct.table_name = 'distinct'
+    has_and_belongs_to_many :selects
+    has_many :values, :through => :groups
+  end
+
   def setup
     @connection = ActiveRecord::Base.connection
 

--- a/activerecord/test/cases/adapters/mysql/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/schema_test.rb
@@ -4,7 +4,7 @@ require 'models/comment'
 
 module ActiveRecord
   module ConnectionAdapters
-    class MysqlSchemaTest < ActiveRecord::TestCase
+    class MysqlSchemaTest < ActiveRecord::MysqlTestCase
       fixtures :posts
 
       def setup

--- a/activerecord/test/cases/adapters/mysql/sp_test.rb
+++ b/activerecord/test/cases/adapters/mysql/sp_test.rb
@@ -1,11 +1,11 @@
 require "cases/helper"
 require 'models/topic'
 
-class StoredProcedureTest < ActiveRecord::TestCase
+class StoredProcedureTest < ActiveRecord::MysqlTestCase
   fixtures :topics
 
   # Test that MySQL allows multiple results for stored procedures
-  if Mysql.const_defined?(:CLIENT_MULTI_RESULTS)
+  if defined?(Mysql) && Mysql.const_defined?(:CLIENT_MULTI_RESULTS)
     def test_multi_results_from_find_by_sql
       topics = Topic.find_by_sql 'CALL topics();'
       assert_equal 1, topics.size

--- a/activerecord/test/cases/adapters/mysql/sql_types_test.rb
+++ b/activerecord/test/cases/adapters/mysql/sql_types_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class SqlTypesTest < ActiveRecord::TestCase
+class MysqlSqlTypesTest < ActiveRecord::MysqlTestCase
   def test_binary_types
     assert_equal 'varbinary(64)', type_to_sql(:binary, 64)
     assert_equal 'varbinary(4095)', type_to_sql(:binary, 4095)

--- a/activerecord/test/cases/adapters/mysql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/mysql/statement_pool_test.rb
@@ -1,23 +1,19 @@
 require 'cases/helper'
 
-module ActiveRecord::ConnectionAdapters
-  class MysqlAdapter
-    class StatementPoolTest < ActiveRecord::TestCase
-      if Process.respond_to?(:fork)
-        def test_cache_is_per_pid
-          cache = StatementPool.new nil, 10
-          cache['foo'] = 'bar'
-          assert_equal 'bar', cache['foo']
+class MysqlStatementPoolTest < ActiveRecord::MysqlTestCase
+  if Process.respond_to?(:fork)
+    def test_cache_is_per_pid
+      cache = ActiveRecord::ConnectionAdapters::MysqlAdapter::StatementPool.new nil, 10
+      cache['foo'] = 'bar'
+      assert_equal 'bar', cache['foo']
 
-          pid = fork {
-            lookup = cache['foo'];
-            exit!(!lookup)
-          }
+      pid = fork {
+        lookup = cache['foo'];
+        exit!(!lookup)
+      }
 
-          Process.waitpid pid
-          assert $?.success?, 'process should exit successfully'
-        end
-      end
+      Process.waitpid pid
+      assert $?.success?, 'process should exit successfully'
     end
   end
 end

--- a/activerecord/test/cases/adapters/mysql/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql/table_options_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/schema_dumping_helper'
 
-class MysqlTableOptionsTest < ActiveRecord::TestCase
+class MysqlTableOptionsTest < ActiveRecord::MysqlTestCase
   include SchemaDumpingHelper
 
   def setup

--- a/activerecord/test/cases/adapters/mysql/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/mysql/unsigned_type_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class UnsignedTypeTest < ActiveRecord::TestCase
+class MysqlUnsignedTypeTest < ActiveRecord::MysqlTestCase
   self.use_transactional_tests = false
 
   class UnsignedType < ActiveRecord::Base

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/connection_helper'
 
-class ActiveSchemaTest < ActiveRecord::TestCase
+class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
   include ConnectionHelper
 
   def setup

--- a/activerecord/test/cases/adapters/mysql2/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/bind_parameter_test.rb
@@ -4,7 +4,7 @@ require 'models/topic'
 module ActiveRecord
   module ConnectionAdapters
     class Mysql2Adapter
-      class BindParameterTest < ActiveRecord::TestCase
+      class BindParameterTest < ActiveRecord::Mysql2TestCase
         fixtures :topics
 
         def test_update_question_marks

--- a/activerecord/test/cases/adapters/mysql2/boolean_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/boolean_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class Mysql2BooleanTest < ActiveRecord::TestCase
+class Mysql2BooleanTest < ActiveRecord::Mysql2TestCase
   self.use_transactional_tests = false
 
   class BooleanType < ActiveRecord::Base

--- a/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class Mysql2CaseSensitivityTest < ActiveRecord::TestCase
+class Mysql2CaseSensitivityTest < ActiveRecord::Mysql2TestCase
   class CollationTest < ActiveRecord::Base
   end
 

--- a/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/schema_dumping_helper'
 
-class CharsetCollationTest < ActiveRecord::TestCase
+class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
   include SchemaDumpingHelper
   self.use_transactional_tests = false
 

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/connection_helper'
 
-class MysqlConnectionTest < ActiveRecord::TestCase
+class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   include ConnectionHelper
 
   fixtures :comments

--- a/activerecord/test/cases/adapters/mysql2/enum_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/enum_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class Mysql2EnumTest < ActiveRecord::TestCase
+class Mysql2EnumTest < ActiveRecord::Mysql2TestCase
   class EnumTest < ActiveRecord::Base
   end
 

--- a/activerecord/test/cases/adapters/mysql2/explain_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/explain_test.rb
@@ -5,7 +5,7 @@ require 'models/computer'
 module ActiveRecord
   module ConnectionAdapters
     class Mysql2Adapter
-      class ExplainTest < ActiveRecord::TestCase
+      class ExplainTest < ActiveRecord::Mysql2TestCase
         fixtures :developers
 
         def test_explain_for_one_query

--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -1,29 +1,29 @@
 require "cases/helper"
 
-class Group < ActiveRecord::Base
-  Group.table_name = 'group'
-  belongs_to :select
-  has_one :values
-end
-
-class Select < ActiveRecord::Base
-  Select.table_name = 'select'
-  has_many :groups
-end
-
-class Values < ActiveRecord::Base
-  Values.table_name = 'values'
-end
-
-class Distinct < ActiveRecord::Base
-  Distinct.table_name = 'distinct'
-  has_and_belongs_to_many :selects
-  has_many :values, :through => :groups
-end
-
 # a suite of tests to ensure the ConnectionAdapters#MysqlAdapter can handle tables with
 # reserved word names (ie: group, order, values, etc...)
-class MysqlReservedWordTest < ActiveRecord::TestCase
+class Mysql2ReservedWordTest < ActiveRecord::Mysql2TestCase
+  class Group < ActiveRecord::Base
+    Group.table_name = 'group'
+    belongs_to :select
+    has_one :values
+  end
+
+  class Select < ActiveRecord::Base
+    Select.table_name = 'select'
+    has_many :groups
+  end
+
+  class Values < ActiveRecord::Base
+    Values.table_name = 'values'
+  end
+
+  class Distinct < ActiveRecord::Base
+    Distinct.table_name = 'distinct'
+    has_and_belongs_to_many :selects
+    has_many :values, :through => :groups
+  end
+
   def setup
     @connection = ActiveRecord::Base.connection
 

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -1,47 +1,42 @@
 require "cases/helper"
 
-module ActiveRecord
-  module ConnectionAdapters
-    class AbstractMysqlAdapter
-      class SchemaMigrationsTest < ActiveRecord::TestCase
-        def test_renaming_index_on_foreign_key
-          connection.add_index "engines", "car_id"
-          connection.add_foreign_key :engines, :cars, name: "fk_engines_cars"
+class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
+  def test_renaming_index_on_foreign_key
+    connection.add_index "engines", "car_id"
+    connection.add_foreign_key :engines, :cars, name: "fk_engines_cars"
 
-          connection.rename_index("engines", "index_engines_on_car_id", "idx_renamed")
-          assert_equal ["idx_renamed"], connection.indexes("engines").map(&:name)
-        ensure
-          connection.remove_foreign_key :engines, name: "fk_engines_cars"
-        end
+    connection.rename_index("engines", "index_engines_on_car_id", "idx_renamed")
+    assert_equal ["idx_renamed"], connection.indexes("engines").map(&:name)
+  ensure
+    connection.remove_foreign_key :engines, name: "fk_engines_cars"
+  end
 
-        def test_initializes_schema_migrations_for_encoding_utf8mb4
-          smtn = ActiveRecord::Migrator.schema_migrations_table_name
-          connection.drop_table smtn, if_exists: true
+  def test_initializes_schema_migrations_for_encoding_utf8mb4
+    smtn = ActiveRecord::Migrator.schema_migrations_table_name
+    connection.drop_table smtn, if_exists: true
 
-          database_name = connection.current_database
-          database_info = connection.select_one("SELECT * FROM information_schema.schemata WHERE schema_name = '#{database_name}'")
+    database_name = connection.current_database
+    database_info = connection.select_one("SELECT * FROM information_schema.schemata WHERE schema_name = '#{database_name}'")
 
-          original_charset = database_info["DEFAULT_CHARACTER_SET_NAME"]
-          original_collation = database_info["DEFAULT_COLLATION_NAME"]
+    original_charset = database_info["DEFAULT_CHARACTER_SET_NAME"]
+    original_collation = database_info["DEFAULT_COLLATION_NAME"]
 
-          execute("ALTER DATABASE #{database_name} DEFAULT CHARACTER SET utf8mb4")
+    execute("ALTER DATABASE #{database_name} DEFAULT CHARACTER SET utf8mb4")
 
-          connection.initialize_schema_migrations_table
+    connection.initialize_schema_migrations_table
 
-          assert connection.column_exists?(smtn, :version, :string, limit: AbstractMysqlAdapter::MAX_INDEX_LENGTH_FOR_CHARSETS_OF_4BYTES_MAXLEN)
-        ensure
-          execute("ALTER DATABASE #{database_name} DEFAULT CHARACTER SET #{original_charset} COLLATE #{original_collation}")
-        end
+    limit = ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::MAX_INDEX_LENGTH_FOR_CHARSETS_OF_4BYTES_MAXLEN
+    assert connection.column_exists?(smtn, :version, :string, limit: limit)
+  ensure
+    execute("ALTER DATABASE #{database_name} DEFAULT CHARACTER SET #{original_charset} COLLATE #{original_collation}")
+  end
 
-        private
-        def connection
-          @connection ||= ActiveRecord::Base.connection
-        end
+  private
+  def connection
+    @connection ||= ActiveRecord::Base.connection
+  end
 
-        def execute(sql)
-          connection.execute(sql)
-        end
-      end
-    end
+  def execute(sql)
+    connection.execute(sql)
   end
 end

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -4,7 +4,7 @@ require 'models/comment'
 
 module ActiveRecord
   module ConnectionAdapters
-    class Mysql2SchemaTest < ActiveRecord::TestCase
+    class Mysql2SchemaTest < ActiveRecord::Mysql2TestCase
       fixtures :posts
 
       def setup

--- a/activerecord/test/cases/adapters/mysql2/sql_types_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/sql_types_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class SqlTypesTest < ActiveRecord::TestCase
+class Mysql2SqlTypesTest < ActiveRecord::Mysql2TestCase
   def test_binary_types
     assert_equal 'varbinary(64)', type_to_sql(:binary, 64)
     assert_equal 'varbinary(4095)', type_to_sql(:binary, 4095)

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/schema_dumping_helper'
 
-class MysqlTableOptionsTest < ActiveRecord::TestCase
+class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
   include SchemaDumpingHelper
 
   def setup

--- a/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class UnsignedTypeTest < ActiveRecord::TestCase
+class Mysql2UnsignedTypeTest < ActiveRecord::Mysql2TestCase
   self.use_transactional_tests = false
 
   class UnsignedType < ActiveRecord::Base

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -1,6 +1,6 @@
 require 'cases/helper'
 
-class PostgresqlActiveSchemaTest < ActiveRecord::TestCase
+class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
   def setup
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
       def execute(sql, name = nil) sql end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -1,10 +1,9 @@
 require "cases/helper"
 require 'support/schema_dumping_helper'
 
-class PostgresqlArrayTest < ActiveRecord::TestCase
+class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
   include InTimeZone
-  OID = ActiveRecord::ConnectionAdapters::PostgreSQL::OID
 
   class PgArray < ActiveRecord::Base
     self.table_name = 'pg_arrays'
@@ -212,8 +211,9 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
 
   def test_quoting_non_standard_delimiters
     strings = ["hello,", "world;"]
-    comma_delim = OID::Array.new(ActiveRecord::Type::String.new, ',')
-    semicolon_delim = OID::Array.new(ActiveRecord::Type::String.new, ';')
+    oid = ActiveRecord::ConnectionAdapters::PostgreSQL::OID
+    comma_delim = oid::Array.new(ActiveRecord::Type::String.new, ',')
+    semicolon_delim = oid::Array.new(ActiveRecord::Type::String.new, ';')
 
     assert_equal %({"hello,",world;}), comma_delim.serialize(strings)
     assert_equal %({hello,;"world;"}), semicolon_delim.serialize(strings)

--- a/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require 'support/connection_helper'
 require 'support/schema_dumping_helper'
 
-class PostgresqlBitStringTest < ActiveRecord::TestCase
+class PostgresqlBitStringTest < ActiveRecord::PostgreSQLTestCase
   include ConnectionHelper
   include SchemaDumpingHelper
 

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class PostgresqlByteaTest < ActiveRecord::TestCase
+class PostgresqlByteaTest < ActiveRecord::PostgreSQLTestCase
   class ByteaDataType < ActiveRecord::Base
     self.table_name = 'bytea_data_type'
   end

--- a/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
@@ -2,7 +2,7 @@ require 'cases/helper'
 
 module ActiveRecord
   class Migration
-    class PGChangeSchemaTest < ActiveRecord::TestCase
+    class PGChangeSchemaTest < ActiveRecord::PostgreSQLTestCase
       attr_reader :connection
 
       def setup

--- a/activerecord/test/cases/adapters/postgresql/cidr_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/cidr_test.rb
@@ -3,8 +3,8 @@ require "ipaddr"
 
 module ActiveRecord
   module ConnectionAdapters
-    class PostgreSQLAdapter
-      class CidrTest < ActiveRecord::TestCase
+    class PostgreSQLAdapter < AbstractAdapter
+      class CidrTest < ActiveRecord::PostgreSQLTestCase
         test "type casting IPAddr for database" do
           type = OID::Cidr.new
           ip = IPAddr.new("255.0.0.0/8")

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -2,7 +2,7 @@ require 'cases/helper'
 require 'support/schema_dumping_helper'
 
 if ActiveRecord::Base.connection.supports_extensions?
-  class PostgresqlCitextTest < ActiveRecord::TestCase
+  class PostgresqlCitextTest < ActiveRecord::PostgreSQLTestCase
     include SchemaDumpingHelper
     class Citext < ActiveRecord::Base
       self.table_name = 'citexts'

--- a/activerecord/test/cases/adapters/postgresql/collation_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/collation_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/schema_dumping_helper'
 
-class PostgresqlCollationTest < ActiveRecord::TestCase
+class PostgresqlCollationTest < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
 
   def setup

--- a/activerecord/test/cases/adapters/postgresql/composite_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/composite_test.rb
@@ -40,7 +40,7 @@ end
 #   "unknown OID 5653508: failed to recognize type of 'address'. It will be treated as String."
 # To take full advantage of composite types, we suggest you register your own +OID::Type+.
 # See PostgresqlCompositeWithCustomOIDTest
-class PostgresqlCompositeTest < ActiveRecord::TestCase
+class PostgresqlCompositeTest < ActiveRecord::PostgreSQLTestCase
   include PostgresqlCompositeBehavior
 
   def test_column
@@ -77,7 +77,7 @@ class PostgresqlCompositeTest < ActiveRecord::TestCase
   end
 end
 
-class PostgresqlCompositeWithCustomOIDTest < ActiveRecord::TestCase
+class PostgresqlCompositeWithCustomOIDTest < ActiveRecord::PostgreSQLTestCase
   include PostgresqlCompositeBehavior
 
   class FullAddressType < ActiveRecord::Type::Value

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require 'support/connection_helper'
 
 module ActiveRecord
-  class PostgresqlConnectionTest < ActiveRecord::TestCase
+  class PostgresqlConnectionTest < ActiveRecord::PostgreSQLTestCase
     include ConnectionHelper
 
     class NonExistentTable < ActiveRecord::Base

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -11,7 +11,7 @@ end
 class PostgresqlLtree < ActiveRecord::Base
 end
 
-class PostgresqlDataTypeTest < ActiveRecord::TestCase
+class PostgresqlDataTypeTest < ActiveRecord::PostgreSQLTestCase
   self.use_transactional_tests = false
 
   def setup
@@ -69,7 +69,7 @@ class PostgresqlDataTypeTest < ActiveRecord::TestCase
   end
 end
 
-class PostgresqlInternalDataTypeTest < ActiveRecord::TestCase
+class PostgresqlInternalDataTypeTest < ActiveRecord::PostgreSQLTestCase
   include DdlHelper
 
   setup do

--- a/activerecord/test/cases/adapters/postgresql/domain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/domain_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/connection_helper'
 
-class PostgresqlDomainTest < ActiveRecord::TestCase
+class PostgresqlDomainTest < ActiveRecord::PostgreSQLTestCase
   include ConnectionHelper
 
   class PostgresqlDomain < ActiveRecord::Base

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/connection_helper'
 
-class PostgresqlEnumTest < ActiveRecord::TestCase
+class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
   include ConnectionHelper
 
   class PostgresqlEnum < ActiveRecord::Base

--- a/activerecord/test/cases/adapters/postgresql/explain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/explain_test.rb
@@ -2,25 +2,19 @@ require "cases/helper"
 require 'models/developer'
 require 'models/computer'
 
-module ActiveRecord
-  module ConnectionAdapters
-    class PostgreSQLAdapter
-      class ExplainTest < ActiveRecord::TestCase
-        fixtures :developers
+class PostgreSQLExplainTest < ActiveRecord::PostgreSQLTestCase
+  fixtures :developers
 
-        def test_explain_for_one_query
-          explain = Developer.where(:id => 1).explain
-          assert_match %(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = $1), explain
-          assert_match %(QUERY PLAN), explain
-        end
+  def test_explain_for_one_query
+    explain = Developer.where(:id => 1).explain
+    assert_match %(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = $1), explain
+    assert_match %(QUERY PLAN), explain
+  end
 
-        def test_explain_with_eager_loading
-          explain = Developer.where(:id => 1).includes(:audit_logs).explain
-          assert_match %(QUERY PLAN), explain
-          assert_match %(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = $1), explain
-          assert_match %(EXPLAIN for: SELECT "audit_logs".* FROM "audit_logs" WHERE "audit_logs"."developer_id" = 1), explain
-        end
-      end
-    end
+  def test_explain_with_eager_loading
+    explain = Developer.where(:id => 1).includes(:audit_logs).explain
+    assert_match %(QUERY PLAN), explain
+    assert_match %(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = $1), explain
+    assert_match %(EXPLAIN for: SELECT "audit_logs".* FROM "audit_logs" WHERE "audit_logs"."developer_id" = 1), explain
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class PostgresqlExtensionMigrationTest < ActiveRecord::TestCase
+class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
   self.use_transactional_tests = false
 
   class EnableHstore < ActiveRecord::Migration

--- a/activerecord/test/cases/adapters/postgresql/full_text_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/full_text_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/schema_dumping_helper'
 
-class PostgresqlFullTextTest < ActiveRecord::TestCase
+class PostgresqlFullTextTest < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
   class Tsvector < ActiveRecord::Base; end
 

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require 'support/connection_helper'
 require 'support/schema_dumping_helper'
 
-class PostgresqlPointTest < ActiveRecord::TestCase
+class PostgresqlPointTest < ActiveRecord::PostgreSQLTestCase
   include ConnectionHelper
   include SchemaDumpingHelper
 
@@ -166,7 +166,7 @@ class PostgresqlPointTest < ActiveRecord::TestCase
   end
 end
 
-class PostgresqlGeometricTest < ActiveRecord::TestCase
+class PostgresqlGeometricTest < ActiveRecord::PostgreSQLTestCase
   class PostgresqlGeometric < ActiveRecord::Base; end
 
   setup do

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require 'support/schema_dumping_helper'
 
 if ActiveRecord::Base.connection.supports_extensions?
-  class PostgresqlHstoreTest < ActiveRecord::TestCase
+  class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
     include SchemaDumpingHelper
     class Hstore < ActiveRecord::Base
       self.table_name = 'hstores'

--- a/activerecord/test/cases/adapters/postgresql/infinity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/infinity_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class PostgresqlInfinityTest < ActiveRecord::TestCase
+class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
   include InTimeZone
 
   class PostgresqlInfinity < ActiveRecord::Base

--- a/activerecord/test/cases/adapters/postgresql/integer_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/integer_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require "active_support/core_ext/numeric/bytes"
 
-class PostgresqlIntegerTest < ActiveRecord::TestCase
+class PostgresqlIntegerTest < ActiveRecord::PostgreSQLTestCase
   class PgInteger < ActiveRecord::Base
   end
 

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -188,7 +188,7 @@ module PostgresqlJSONSharedTestCases
   end
 end
 
-class PostgresqlJSONTest < ActiveRecord::TestCase
+class PostgresqlJSONTest < ActiveRecord::PostgreSQLTestCase
   include PostgresqlJSONSharedTestCases
 
   def column_type
@@ -196,7 +196,7 @@ class PostgresqlJSONTest < ActiveRecord::TestCase
   end
 end
 
-class PostgresqlJSONBTest < ActiveRecord::TestCase
+class PostgresqlJSONBTest < ActiveRecord::PostgreSQLTestCase
   include PostgresqlJSONSharedTestCases
 
   def column_type

--- a/activerecord/test/cases/adapters/postgresql/ltree_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/ltree_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/schema_dumping_helper'
 
-class PostgresqlLtreeTest < ActiveRecord::TestCase
+class PostgresqlLtreeTest < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
   class Ltree < ActiveRecord::Base
     self.table_name = 'ltrees'

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/schema_dumping_helper'
 
-class PostgresqlMoneyTest < ActiveRecord::TestCase
+class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
 
   class PostgresqlMoney < ActiveRecord::Base; end

--- a/activerecord/test/cases/adapters/postgresql/network_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/network_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/schema_dumping_helper'
 
-class PostgresqlNetworkTest < ActiveRecord::TestCase
+class PostgresqlNetworkTest < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
   class PostgresqlNetworkAddress < ActiveRecord::Base; end
 

--- a/activerecord/test/cases/adapters/postgresql/numbers_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/numbers_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class PostgresqlNumberTest < ActiveRecord::TestCase
+class PostgresqlNumberTest < ActiveRecord::PostgreSQLTestCase
   class PostgresqlNumber < ActiveRecord::Base; end
 
   setup do

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -4,7 +4,7 @@ require 'support/connection_helper'
 
 module ActiveRecord
   module ConnectionAdapters
-    class PostgreSQLAdapterTest < ActiveRecord::TestCase
+    class PostgreSQLAdapterTest < ActiveRecord::PostgreSQLTestCase
       include DdlHelper
       include ConnectionHelper
 

--- a/activerecord/test/cases/adapters/postgresql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/quoting_test.rb
@@ -4,7 +4,7 @@ require 'ipaddr'
 module ActiveRecord
   module ConnectionAdapters
     class PostgreSQLAdapter
-      class QuotingTest < ActiveRecord::TestCase
+      class QuotingTest < ActiveRecord::PostgreSQLTestCase
         def setup
           @conn = ActiveRecord::Base.connection
         end

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -1,12 +1,12 @@
 require "cases/helper"
 require 'support/connection_helper'
 
-if ActiveRecord::Base.connection.supports_ranges?
+if ActiveRecord::Base.connection.respond_to?(:supports_ranges?) && ActiveRecord::Base.connection.supports_ranges?
   class PostgresqlRange < ActiveRecord::Base
     self.table_name = "postgresql_ranges"
   end
 
-  class PostgresqlRangeTest < ActiveRecord::TestCase
+  class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
     self.use_transactional_tests = false
     include ConnectionHelper
 

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -1,7 +1,7 @@
 require 'cases/helper'
 require 'support/connection_helper'
 
-class PostgreSQLReferentialIntegrityTest < ActiveRecord::TestCase
+class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
   self.use_transactional_tests = false
 
   include ConnectionHelper

--- a/activerecord/test/cases/adapters/postgresql/rename_table_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/rename_table_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class PostgresqlRenameTableTest < ActiveRecord::TestCase
+class PostgresqlRenameTableTest < ActiveRecord::PostgreSQLTestCase
   def setup
     @connection = ActiveRecord::Base.connection
     @connection.create_table :before_rename, force: true

--- a/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
@@ -3,7 +3,7 @@ require "cases/helper"
 class SchemaThing < ActiveRecord::Base
 end
 
-class SchemaAuthorizationTest < ActiveRecord::TestCase
+class SchemaAuthorizationTest < ActiveRecord::PostgreSQLTestCase
   self.use_transactional_tests = false
 
   TABLE_NAME = 'schema_things'

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -2,7 +2,7 @@ require "cases/helper"
 require 'models/default'
 require 'support/schema_dumping_helper'
 
-class SchemaTest < ActiveRecord::TestCase
+class SchemaTest < ActiveRecord::PostgreSQLTestCase
   self.use_transactional_tests = false
 
   SCHEMA_NAME = 'test_schema'
@@ -441,7 +441,7 @@ class SchemaTest < ActiveRecord::TestCase
     end
 end
 
-class SchemaForeignKeyTest < ActiveRecord::TestCase
+class SchemaForeignKeyTest < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
 
   setup do
@@ -466,7 +466,7 @@ class SchemaForeignKeyTest < ActiveRecord::TestCase
   end
 end
 
-class DefaultsUsingMultipleSchemasAndDomainTest < ActiveSupport::TestCase
+class DefaultsUsingMultipleSchemasAndDomainTest < ActiveRecord::PostgreSQLTestCase
   setup do
     @connection = ActiveRecord::Base.connection
     @connection.execute "DROP SCHEMA IF EXISTS schema_1 CASCADE"

--- a/activerecord/test/cases/adapters/postgresql/serial_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/serial_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/schema_dumping_helper'
 
-class PostgresqlSerialTest < ActiveRecord::TestCase
+class PostgresqlSerialTest < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
 
   class PostgresqlSerial < ActiveRecord::Base; end
@@ -30,7 +30,7 @@ class PostgresqlSerialTest < ActiveRecord::TestCase
   end
 end
 
-class PostgresqlBigSerialTest < ActiveRecord::TestCase
+class PostgresqlBigSerialTest < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
 
   class PostgresqlBigSerial < ActiveRecord::Base; end

--- a/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         end
       end
 
-      class StatementPoolTest < ActiveRecord::TestCase
+      class StatementPoolTest < ActiveRecord::PostgreSQLTestCase
         if Process.respond_to?(:fork)
           def test_cache_is_per_pid
             cache = StatementPool.new nil, 10

--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -2,7 +2,7 @@ require 'cases/helper'
 require 'models/developer'
 require 'models/topic'
 
-class PostgresqlTimestampTest < ActiveRecord::TestCase
+class PostgresqlTimestampTest < ActiveRecord::PostgreSQLTestCase
   class PostgresqlTimestampWithZone < ActiveRecord::Base; end
 
   self.use_transactional_tests = false
@@ -43,7 +43,7 @@ class PostgresqlTimestampTest < ActiveRecord::TestCase
   end
 end
 
-class TimestampTest < ActiveRecord::TestCase
+class PostgresqlTimestampFixtureTest < ActiveRecord::PostgreSQLTestCase
   fixtures :topics
 
   def test_group_by_date

--- a/activerecord/test/cases/adapters/postgresql/type_lookup_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/type_lookup_test.rb
@@ -1,6 +1,6 @@
 require 'cases/helper'
 
-class PostgresqlTypeLookupTest < ActiveRecord::TestCase
+class PostgresqlTypeLookupTest < ActiveRecord::PostgreSQLTestCase
   setup do
     @connection = ActiveRecord::Base.connection
   end

--- a/activerecord/test/cases/adapters/postgresql/utils_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/utils_test.rb
@@ -1,6 +1,7 @@
 require 'cases/helper'
+require 'active_record/connection_adapters/postgresql/utils'
 
-class PostgreSQLUtilsTest < ActiveSupport::TestCase
+class PostgreSQLUtilsTest < ActiveRecord::PostgreSQLTestCase
   Name = ActiveRecord::ConnectionAdapters::PostgreSQL::Name
   include ActiveRecord::ConnectionAdapters::PostgreSQL::Utils
 
@@ -20,7 +21,7 @@ class PostgreSQLUtilsTest < ActiveSupport::TestCase
   end
 end
 
-class PostgreSQLNameTest < ActiveSupport::TestCase
+class PostgreSQLNameTest < ActiveRecord::PostgreSQLTestCase
   Name = ActiveRecord::ConnectionAdapters::PostgreSQL::Name
 
   test "represents itself as schema.name" do

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -11,7 +11,7 @@ module PostgresqlUUIDHelper
   end
 end
 
-class PostgresqlUUIDTest < ActiveRecord::TestCase
+class PostgresqlUUIDTest < ActiveRecord::PostgreSQLTestCase
   include PostgresqlUUIDHelper
   include SchemaDumpingHelper
 
@@ -135,7 +135,7 @@ class PostgresqlUUIDTest < ActiveRecord::TestCase
   end
 end
 
-class PostgresqlUUIDGenerationTest < ActiveRecord::TestCase
+class PostgresqlUUIDGenerationTest < ActiveRecord::PostgreSQLTestCase
   include PostgresqlUUIDHelper
   include SchemaDumpingHelper
 
@@ -210,7 +210,7 @@ class PostgresqlUUIDGenerationTest < ActiveRecord::TestCase
   end
 end
 
-class PostgresqlUUIDTestNilDefault < ActiveRecord::TestCase
+class PostgresqlUUIDTestNilDefault < ActiveRecord::PostgreSQLTestCase
   include PostgresqlUUIDHelper
   include SchemaDumpingHelper
 
@@ -244,7 +244,7 @@ class PostgresqlUUIDTestNilDefault < ActiveRecord::TestCase
   end
 end
 
-class PostgresqlUUIDTestInverseOf < ActiveRecord::TestCase
+class PostgresqlUUIDTestInverseOf < ActiveRecord::PostgreSQLTestCase
   include PostgresqlUUIDHelper
 
   class UuidPost < ActiveRecord::Base

--- a/activerecord/test/cases/adapters/postgresql/view_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/view_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require "cases/view_test"
 
-class UpdateableViewTest < ActiveRecord::TestCase
+class UpdateableViewTest < ActiveRecord::PostgreSQLTestCase
   fixtures :books
 
   class PrintedBook < ActiveRecord::Base
@@ -46,8 +46,9 @@ class UpdateableViewTest < ActiveRecord::TestCase
   end
 end
 
-if ActiveRecord::Base.connection.supports_materialized_views?
-class MaterializedViewTest < ActiveRecord::TestCase
+if ActiveRecord::Base.connection.respond_to?(:supports_materialized_views?) &&
+    ActiveRecord::Base.connection.supports_materialized_views?
+class MaterializedViewTest < ActiveRecord::PostgreSQLTestCase
   include ViewBehavior
 
   private

--- a/activerecord/test/cases/adapters/postgresql/xml_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/xml_test.rb
@@ -1,7 +1,7 @@
 require 'cases/helper'
 require 'support/schema_dumping_helper'
 
-class PostgresqlXMLTest < ActiveRecord::TestCase
+class PostgresqlXMLTest < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
   class XmlDataType < ActiveRecord::Base
     self.table_name = 'xml_data_type'

--- a/activerecord/test/cases/adapters/sqlite3/collation_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/collation_test.rb
@@ -1,7 +1,7 @@
 require "cases/helper"
 require 'support/schema_dumping_helper'
 
-class SQLite3CollationTest < ActiveRecord::TestCase
+class SQLite3CollationTest < ActiveRecord::SQLite3TestCase
   include SchemaDumpingHelper
 
   def setup

--- a/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
@@ -1,6 +1,6 @@
 require "cases/helper"
 
-class CopyTableTest < ActiveRecord::TestCase
+class CopyTableTest < ActiveRecord::SQLite3TestCase
   fixtures :customers
 
   def setup

--- a/activerecord/test/cases/adapters/sqlite3/explain_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/explain_test.rb
@@ -5,7 +5,7 @@ require 'models/computer'
 module ActiveRecord
   module ConnectionAdapters
     class SQLite3Adapter
-      class ExplainTest < ActiveRecord::TestCase
+      class ExplainTest < ActiveRecord::SQLite3TestCase
         fixtures :developers
 
         def test_explain_for_one_query

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -6,7 +6,7 @@ require 'securerandom'
 module ActiveRecord
   module ConnectionAdapters
     class SQLite3Adapter
-      class QuotingTest < ActiveRecord::TestCase
+      class QuotingTest < ActiveRecord::SQLite3TestCase
         def setup
           @conn = Base.sqlite3_connection :database => ':memory:',
             :adapter => 'sqlite3',

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -5,7 +5,7 @@ require 'support/ddl_helper'
 
 module ActiveRecord
   module ConnectionAdapters
-    class SQLite3AdapterTest < ActiveRecord::TestCase
+    class SQLite3AdapterTest < ActiveRecord::SQLite3TestCase
       include DdlHelper
 
       self.use_transactional_tests = false

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_create_folder_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_create_folder_test.rb
@@ -3,7 +3,7 @@ require 'models/owner'
 
 module ActiveRecord
   module ConnectionAdapters
-    class SQLite3CreateFolder < ActiveRecord::TestCase
+    class SQLite3CreateFolder < ActiveRecord::SQLite3TestCase
       def test_sqlite_creates_directory
         Dir.mktmpdir do |dir|
           dir = Pathname.new(dir)

--- a/activerecord/test/cases/adapters/sqlite3/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/statement_pool_test.rb
@@ -2,7 +2,7 @@ require 'cases/helper'
 
 module ActiveRecord::ConnectionAdapters
   class SQLite3Adapter
-    class StatementPoolTest < ActiveRecord::TestCase
+    class StatementPoolTest < ActiveRecord::SQLite3TestCase
       if Process.respond_to?(:fork)
         def test_cache_is_per_pid
 
@@ -22,4 +22,3 @@ module ActiveRecord::ConnectionAdapters
     end
   end
 end
-

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -65,6 +65,30 @@ module ActiveRecord
     end
   end
 
+  class PostgreSQLTestCase < TestCase
+    def self.run(*args)
+      super if current_adapter?(:PostgreSQLAdapter)
+    end
+  end
+
+  class Mysql2TestCase < TestCase
+    def self.run(*args)
+      super if current_adapter?(:Mysql2Adapter)
+    end
+  end
+
+  class MysqlTestCase < TestCase
+    def self.run(*args)
+      super if current_adapter?(:MysqlAdapter)
+    end
+  end
+
+  class SQLite3TestCase < TestCase
+    def self.run(*args)
+      super if current_adapter?(:SQLite3Adapter)
+    end
+  end
+
   class SQLCounter
     class << self
       attr_accessor :ignored_sql, :log, :log_all

--- a/activesupport/bin/test
+++ b/activesupport/bin/test
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+COMPONENT_ROOT = File.expand_path("../../", __FILE__)
+require File.expand_path("../tools/test", COMPONENT_ROOT)

--- a/activesupport/bin/test
+++ b/activesupport/bin/test
@@ -1,3 +1,4 @@
 #!/usr/bin/env ruby
 COMPONENT_ROOT = File.expand_path("../../", __FILE__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)
+exit Minitest.run(ARGV)

--- a/activesupport/lib/active_support/testing/autorun.rb
+++ b/activesupport/lib/active_support/testing/autorun.rb
@@ -2,4 +2,11 @@ gem 'minitest'
 
 require 'minitest'
 
-Minitest.autorun
+if Minitest.respond_to?(:run_with_rails_extension)
+  unless Minitest.run_with_rails_extension
+    Minitest.run_with_autorun = true
+    Minitest.autorun
+  end
+else
+  Minitest.autorun
+end

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -9,10 +9,7 @@ require 'action_controller/test_case'
 require 'action_dispatch/testing/integration'
 require 'rails/generators/test_case'
 
-unless Minitest.run_with_rails_extension
-  Minitest.run_with_autorun = true
-  require 'active_support/testing/autorun'
-end
+require 'active_support/testing/autorun'
 
 if defined?(ActiveRecord::Base)
   ActiveRecord::Migration.maintain_test_schema!

--- a/tools/test.rb
+++ b/tools/test.rb
@@ -8,5 +8,3 @@ module Rails
     @root ||= Pathname.new(COMPONENT_ROOT)
   end
 end
-
-exit Minitest.run(ARGV)

--- a/tools/test.rb
+++ b/tools/test.rb
@@ -1,0 +1,12 @@
+$: << File.expand_path("test", COMPONENT_ROOT)
+require File.expand_path("../../load_paths", __FILE__)
+require "rails/test_unit/minitest_plugin"
+
+module Rails
+  # Necessary to get rerun-snippts working.
+  def self.root
+    @root ||= Pathname.new(COMPONENT_ROOT)
+  end
+end
+
+exit Minitest.run(ARGV)


### PR DESCRIPTION
The minitest plugin for Rails 5 has some fantastic improvements. Would be nice to have it's features available in Rails itself.

This is a quick proof of concept to integrate the runner. The components Active Record, Railties and Active Job have been skipped for now because they rely on additional setup performed in the Rake tasks.

Interested to hear your thoughts.
