### PR TITLE
Enum prefix

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Added :enum_prefix, :enum_postfix option to `ActiveRecord::Base.enum`
+
+    Fixes: #17511
+
+    Example:
+
+        class Book < ActiveRecord::Base
+          enum author_visibility: [:visible, :invisible], enum_prefix: 'for_author'
+          enum illustrator_visibility: [:visible, :invisible], enum_prefix: 'for_illustrator'
+        end
+
+    *Pascal Betz*
+
 *   Deprecate the PG `:point` type in favor of a new one which will return
     `Point` objects instead of an `Array`
 

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -5,7 +5,7 @@ module ActiveRecord
   # but can be queried by name. Example:
   #
   #   class Conversation < ActiveRecord::Base
-  #     enum status: [:active, :archived]
+  #     enum status: [ :active, :archived ]
   #   end
   #
   #   # conversation.update! status: 0
@@ -50,7 +50,7 @@ module ActiveRecord
   #   # book.update! author_visibility: 0
   #   book.visible_for_author!
   #   book.visible_for_author? # => true
-  #   book.author_visibility  # => "visisble"
+  #   book.author_visibility  # => "visible"
   #
   # Note that :enum_prefix/:enum_postfix are reserved keywords and can not be used as an enum name.
   #

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -5,7 +5,7 @@ module ActiveRecord
   # but can be queried by name. Example:
   #
   #   class Conversation < ActiveRecord::Base
-  #     enum status: [ :active, :archived ]
+  #     enum status: [:active, :archived]
   #   end
   #
   #   # conversation.update! status: 0
@@ -38,6 +38,22 @@ module ActiveRecord
   #   Conversation.where(status: [:active, :archived])
   #   Conversation.where.not(status: :active)
   #
+  # If you have multiple enums and they share values then you can use
+  # <tt>:enum_prefix</tt> and <tt>:enum_postfix</tt> to avoid naming clashes for the generated
+  # methods. Example:
+  #
+  #   class Book < ActiveRecord::Base
+  #     enum(author_visibility: [:visible, :invisible], enum_postfix: 'for_author')
+  #     enum(illustrator_visibility: [:visible, :invisible], enum_postfix: 'for_illustrator')
+  #   end
+  #
+  #   # book.update! author_visibility: 0
+  #   book.visible_for_author!
+  #   book.visible_for_author? # => true
+  #   book.author_visibility  # => "visisble"
+  #
+  # Note that :enum_prefix/:enum_postfix are reserved keywords and can not be used as an enum name.
+  #
   # You can set the default value from the database declaration, like:
   #
   #   create_table :conversations do |t|
@@ -62,6 +78,7 @@ module ActiveRecord
   # Therefore, once a value is added to the enum array, its position in the array must
   # be maintained, and new values should only be added to the end of the array. To
   # remove unused values, the explicit +Hash+ syntax should be used.
+  #
   #
   # In rare circumstances you might need to access the mapping directly.
   # The mappings are exposed through a class method with the pluralized attribute
@@ -120,7 +137,11 @@ module ActiveRecord
     end
 
     def enum(definitions)
+      enum_prefix = definitions.delete(:enum_prefix)
+      enum_postfix = definitions.delete(:enum_postfix)
+
       klass = self
+
       definitions.each do |name, values|
         # statuses = { }
         enum_values = ActiveSupport::HashWithIndifferentAccess.new
@@ -139,18 +160,19 @@ module ActiveRecord
           pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
           pairs.each do |value, i|
             enum_values[value] = i
-
+            # base name for generated methods including pre and postfix
+            pre_postfixed_value = [enum_prefix, value, enum_postfix].compact.join('_')
             # def active?() status == 0 end
-            klass.send(:detect_enum_conflict!, name, "#{value}?")
-            define_method("#{value}?") { self[name] == value.to_s }
+            klass.send(:detect_enum_conflict!, name, "#{pre_postfixed_value}?")
+            define_method("#{pre_postfixed_value}?") { self[name] == value.to_s }
 
             # def active!() update! status: :active end
-            klass.send(:detect_enum_conflict!, name, "#{value}!")
-            define_method("#{value}!") { update! name => value }
+            klass.send(:detect_enum_conflict!, name, "#{pre_postfixed_value}!")
+            define_method("#{pre_postfixed_value}!") { update! name => value }
 
             # scope :active, -> { where status: 0 }
-            klass.send(:detect_enum_conflict!, name, value, true)
-            klass.scope value, -> { klass.where name => value }
+            klass.send(:detect_enum_conflict!, name, pre_postfixed_value, true)
+            klass.scope pre_postfixed_value, -> { klass.where name => value }
           end
         end
         defined_enums[name.to_s] = enum_values

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -355,4 +355,44 @@ class EnumTest < ActiveRecord::TestCase
     book2 = klass.single.create!
     assert book2.single?
   end
+
+  test "enum with prefix" do
+    book = Book.new
+    assert book.about_ruby?
+    assert_equal 'ruby', book.topic
+    book.about_rails!
+    assert book.about_rails?
+    refute book.about_ruby?
+  end
+
+  test "enum with postfix" do
+    book = Book.new
+    assert book.visible_for_author?
+    assert_equal 'visible', book.author_visibility
+    book.invisible_for_author!
+    assert book.invisible_for_author?
+    refute book.visible_for_author?
+  end
+
+  test "enum with prefix and postfix" do
+    book = Book.new
+    assert book.available_in_small_font?
+    assert_equal 'small', book.font_size
+    book.available_in_large_font!
+    assert book.available_in_large_font?
+    refute book.available_in_small_font?
+  end
+
+  test "scopes for enum with prefixes/postfixes" do
+    assert_equal 2, Book.available_in_small_font.size
+    assert_equal 1, Book.available_in_medium_font.size
+    assert_equal 0, Book.available_in_large_font.size
+  end
+
+  test "multiple enum can share values if the are prefixed/postfixed" do
+    assert_equal Book.author_visibilities, {'visible' => 0, 'invisible' => 1}
+    assert_equal Book.illustrator_visibilities, {'visible' => 0, 'invisible' => 1}
+  end
+
+
 end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -383,13 +383,13 @@ class EnumTest < ActiveRecord::TestCase
     refute book.available_in_small_font?
   end
 
-  test "scopes for enum with prefixes/postfixes" do
+  test "scopes for enum with prefix and postfix" do
     assert_equal 2, Book.available_in_small_font.size
     assert_equal 1, Book.available_in_medium_font.size
     assert_equal 0, Book.available_in_large_font.size
   end
 
-  test "multiple enum can share values if the are prefixed/postfixed" do
+  test "multiple enums can share values if they have a prefix and/or postfix" do
     assert_equal Book.author_visibilities, {'visible' => 0, 'invisible' => 1}
     assert_equal Book.illustrator_visibilities, {'visible' => 0, 'invisible' => 1}
   end

--- a/activerecord/test/fixtures/books.yml
+++ b/activerecord/test/fixtures/books.yml
@@ -5,6 +5,7 @@ awdr:
   format: "paperback"
   status: :published
   read_status: :read
+  font_size: small
 
 rfr:
   author_id: 1
@@ -13,6 +14,7 @@ rfr:
   format: "ebook"
   status: "proposed"
   read_status: "reading"
+  font_size: small
 
 ddd:
   author_id: 1
@@ -20,3 +22,4 @@ ddd:
   name: "Domain-Driven Design"
   format: "hardcover"
   status: 2
+  font_size: medium

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -11,6 +11,11 @@ class Book < ActiveRecord::Base
   enum read_status: {unread: 0, reading: 2, read: 3}
   enum nullable_status: [:single, :married]
 
+  enum(font_size: [:small, :medium, :large], enum_prefix: 'available_in', enum_postfix: 'font')
+  enum(topic: [:ruby, :rails], enum_prefix: 'about')
+  enum(author_visibility: [:visible, :invisible], enum_postfix: 'for_author')
+  enum(illustrator_visibility: [:visible, :invisible], enum_postfix: 'for_illustrator')
+
   def published!
     super
     "do publish work..."

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -100,6 +100,10 @@ ActiveRecord::Schema.define do
     t.column :status, :integer, default: 0
     t.column :read_status, :integer, default: 0
     t.column :nullable_status, :integer
+    t.column :font_size, :integer, default: 0
+    t.column :author_visibility, :integer, default: 0
+    t.column :illustrator_visibility, :integer, default: 0
+    t.column :topic, :integer, default: 0
   end
 
   create_table :booleans, force: true do |t|


### PR DESCRIPTION
Added :enum_prefix, :enum_postfix option to `ActiveRecord::Base.enum`
Fixes: #17511
