### PR TITLE
Use block variable instead of global

### DIFF
--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -12,7 +12,7 @@ unless str == parser.unescape(parser.escape(str))
       # YK: My initial experiments say yes, but let's be sure please
       enc = str.encoding
       enc = Encoding::UTF_8 if enc == Encoding::US_ASCII
-      str.gsub(escaped) { [$&[1, 2].hex].pack('C') }.force_encoding(enc)
+      str.gsub(escaped) { |match| [match[1, 2].hex].pack('C') }.force_encoding(enc)
     end
   end
 end


### PR DESCRIPTION
Similar to #20410

``` ruby
Benchmark.ips do |x|
  x.report("$&") {
    "foo".gsub(/f/) { $&.hex }
  }
  x.report("block var") {
    "foo".gsub(/f/) { |match| match.hex }
  }
end
```

```
Calculating -------------------------------------
                  $&    23.271k i/100ms
           block var    24.804k i/100ms
-------------------------------------------------
                  $&    321.981k (± 7.4%) i/s -      1.606M
           block var    324.949k (± 9.2%) i/s -      1.612M
```
