### PR TITLE
Removed AJAX example with poor convention adherence

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -191,30 +191,6 @@ $(document).ready ->
 Obviously, you'll want to be a bit more sophisticated than that, but it's a
 start. You can see more about the events [in the jquery-ujs wiki](https://github.com/rails/jquery-ujs/wiki/ajax).
 
-Another possibility is returning javascript directly from the server side on
-remote calls:
-
-```ruby
-# articles_controller
-def create
-  respond_to do |format|
-    if @article.save
-      format.html { ... }
-      format.js do
-        render js: <<-endjs
-          alert('Article saved successfully!');
-          window.location = '#{article_path(@article)}';
-        endjs
-      end
-    else
-      format.html { ... }
-      format.js do
-        render js: "alert('There are empty fields in the form!');"
-      end
-    end
-  end
-end
-```
 
 NOTE: If javascript is disabled in the user browser, `format.html { ... }`
 block should be executed as fallback.


### PR DESCRIPTION
The removed section promotes putting JS code directly inside the controller, this is not in line with convention.
