### PR TITLE
[ActiveSupport] Fix for #20489 - ActiveSupport::Concern#class_methods affects parent classes

### DIFF
--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -132,7 +132,7 @@ module ActiveSupport
     end
 
     def class_methods(&class_methods_module_definition)
-      mod = const_defined?(:ClassMethods) ?
+      mod = const_defined?(:ClassMethods, false) ?
         const_get(:ClassMethods) :
         const_set(:ClassMethods, Module.new)
 


### PR DESCRIPTION
This PR includes a test that reproduces the issue described in #20489 and a fix for it. Here's a short explanation of the issue by @ewoutkleinsmann:

> ActiveSupport::Concern's class_methods uses const_defined? without a second argument and therefore also searches its ancestors for a ClassMethods module. This results in concerns included in a child class that add class methods to a parent class.
