### PR TITLE
refactor ActiveRecord's #become by removing not needed code

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -211,8 +211,7 @@ module ActiveRecord
     def becomes(klass)
       became = klass.new
       became.instance_variable_set("@attributes", @attributes)
-      changed_attributes = @changed_attributes if defined?(@changed_attributes)
-      became.instance_variable_set("@changed_attributes", changed_attributes || {})
+      became.instance_variable_set("@changed_attributes", attributes_changed_by_setter)
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became.instance_variable_set("@errors", errors)


### PR DESCRIPTION
This refactor throw some warnings when running the tests:

```
warning: instance variable @changed_attributes not initialized
```

If this is a problem, I can change the line to be like this:

```
  became.instance_variable_set("@changed_attributes", @changed_attributes) if defined?(@changed_attributes)
```
