### PR TITLE
Add missing :hit attribute in instrumentation payload on cache#fetch

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add missing :hit attribute in instrumentation payload on cache#fetch
+    when invoked with a block
+
+    *Vivien Barousse*
+
 ## Rails 4.2.5 (November 12, 2015) ##
 
 *   Fix `TimeWithZone#eql?` to properly handle `TimeWithZone` created from `DateTime`:

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -554,8 +554,12 @@ module ActiveSupport
 
         def find_cached_entry(key, name, options)
           instrument(:read, name, options) do |payload|
-            payload[:super_operation] = :fetch if payload
-            read_entry(key, options)
+            entry = read_entry(key, options)
+            if payload
+              payload[:super_operation] = :fetch
+              payload[:hit] = !!(entry && !entry.expired?)
+            end
+            entry
           end
         end
 


### PR DESCRIPTION
`cache#fetch`, when invoked with a block, doesn't set the `:hit` attribute in the instrumentation payload. This behaviour is different than `cache#read`, and `cache#fetch` when invoked without a block.

The [documentation on `cache_read.active_support` instrumentation](http://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-read-active-support) suggests `:hit` should be set regardless of whether `cache#fetch` is called with or without a block.

The first of those commit adds test cases for `cache#read` and `cache#fetch` without a block. The second commit is an attempt at fixing the missing attribute, and adds test cases for `cache#fetch` when invoked with a block.
