### PR TITLE
change AR clear order in ActionDisplatch::Reloader hook

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -147,8 +147,8 @@ end_warning
       ActiveSupport.on_load(:active_record) do
         ActionDispatch::Reloader.send(hook) do
           if ActiveRecord::Base.connected?
-            ActiveRecord::Base.clear_reloadable_connections!
             ActiveRecord::Base.clear_cache!
+            ActiveRecord::Base.clear_reloadable_connections!
           end
         end
       end


### PR DESCRIPTION
seems it's been there since 4.0 ... the current order is unfortunate since `clear_reloadable_connections!` might release check-in a connection while `clear_cache!` seem to currently always cause a (new) connection check-out.

consider a AR operation in an initializer, `RAILS_ENV=production` the initializer causes the following callbacks : https://gist.github.com/kares/9b45c5eedb603dd487ac

thus if `clear_reloadable_connections!` [causes a connection to be released](https://gist.github.com/kares/9b45c5eedb603dd487ac#file-callbacks_trace-out-L11-L22) ... `clear_cache!` [forces a new one to be opened](https://gist.github.com/kares/9b45c5eedb603dd487ac#file-callbacks_trace-out-L62-L73)
