### PR TITLE
Change the `index` arg of `ActionDispatch::Static#new` to a kwarg

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -13,14 +13,13 @@ module ActionDispatch
   # located at `public/assets/application.js` if the file exists. If the file
   # does not exist, a 404 "File not Found" response will be returned.
   class FileHandler
-    def initialize(root, cache_control, index = 'index')
+    def initialize(root, cache_control, index: 'index')
       @root          = root.chomp('/')
       @compiled_root = /^#{Regexp.escape(root)}/
       headers        = cache_control && { 'Cache-Control' => cache_control }
       @file_server = ::Rack::File.new(@root, headers)
       @index = index
     end
-
 
     # Takes a path to a file. If the file is found, has valid encoding, and has
     # correct read permissions, the return value is a URI-escaped string
@@ -105,9 +104,9 @@ module ActionDispatch
   # produce a directory traversal using this middleware. Only 'GET' and 'HEAD'
   # requests will result in a file being returned.
   class Static
-    def initialize(app, path, cache_control = nil, index = 'index')
+    def initialize(app, path, cache_control = nil, index: 'index')
       @app = app
-      @file_handler = FileHandler.new(path, cache_control, index)
+      @file_handler = FileHandler.new(path, cache_control, index: index)
     end
 
     def call(env)

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -263,7 +263,7 @@ class StaticTest < ActiveSupport::TestCase
   end
 
   def test_non_default_static_index
-    @app = ActionDispatch::Static.new(DummyApp, @root, "public, max-age=60", "other-index")
+    @app = ActionDispatch::Static.new(DummyApp, @root, "public, max-age=60", index: "other-index")
     assert_html "/other-index.html", get("/other-index.html")
     assert_html "/other-index.html", get("/other-index")
     assert_html "/other-index.html", get("/")

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -18,7 +18,7 @@ module Rails
           middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header
 
           if config.serve_static_files
-            middleware.use ::ActionDispatch::Static, paths["public"].first, config.static_cache_control, config.static_index
+            middleware.use ::ActionDispatch::Static, paths["public"].first, config.static_cache_control, index: config.static_index
           end
 
           if rack_cache = load_rack_cache


### PR DESCRIPTION
This makes it easier to add new args to `ActionDispatch::Static` (e.g. https://github.com/rails/rails/pull/19135) since we no longer have to take account of the order of the args.

cc/ @eliotsykes @jonatack
