### PR TITLE
persist empty serialized attributes #20478

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -118,6 +118,8 @@ module ActiveRecord
       def old_attribute_value(attr)
         if attribute_changed?(attr)
           changed_attributes[attr]
+        elsif @attributes[attr].value_before_type_cast.nil?
+          nil
         else
           clone_attribute_value(:_read_attribute, attr)
         end

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -20,10 +20,7 @@ module ActiveRecord
       end
 
       def serialize(value)
-        return if value.nil?
-        unless default_value?(value)
-          super coder.dump(value)
-        end
+        super(coder.dump(value)) unless value.nil?
       end
 
       def inspect

--- a/activerecord/lib/active_record/type/string.rb
+++ b/activerecord/lib/active_record/type/string.rb
@@ -21,6 +21,10 @@ module ActiveRecord
         end
       end
 
+      def changed?(old_value, new_value, _new_value_before_type_cast)
+        old_value != _new_value_before_type_cast
+      end
+
       private
 
       def cast_value(value)

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -274,4 +274,11 @@ class SerializedAttributeTest < ActiveRecord::TestCase
 
     assert_equal({}, topic.content)
   end
+
+  def test_persists_an_empty_hash_on_a_not_null_field
+    College.serialize(:name, Hash)
+    college = College.new(name: {})
+
+    assert college.save
+  end
 end


### PR DESCRIPTION
When an attribute is defined as serialised and the value is explicitly defined as empty, the empty serialised attribute is persisted.

This commit is a solution for the problem described in the issue #20478 
