### PR TITLE
schema.rb breaking when an array column is used with a default decimal 

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -45,6 +45,10 @@ module ActiveRecord
               delimiter == other.delimiter
           end
 
+          def type_cast_for_schema(value)
+            value.map { |val| BigDecimal === val ? val.to_s : val }.inspect
+          end
+
           private
 
           def type_cast_array(value, method)

--- a/activerecord/lib/active_record/type/decimal.rb
+++ b/activerecord/lib/active_record/type/decimal.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       end
 
       def type_cast_for_schema(value)
-        value.to_s
+        value.to_s.inspect
       end
 
       private

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -98,6 +98,12 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert_equal([nil], @type.deserialize('{NULL}'))
   end
 
+  def test_type_cast_for_schema_with_decimals
+    type = OID::Array.new(ActiveRecord::Type::Decimal.new)
+    assert_equal "[\"0.33\"]", type.type_cast_for_schema([BigDecimal.new("0.33")])
+    assert_equal "[\"0.123456789123456789\"]", type.type_cast_for_schema([BigDecimal.new("0.123456789123456789")])
+  end
+
   def test_type_cast_integers
     x = PgArray.new(ratings: ['1', '2'])
 

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -56,7 +56,7 @@ class PostgresqlMoneyTest < ActiveRecord::TestCase
   def test_schema_dumping
     output = dump_table_schema("postgresql_moneys")
     assert_match %r{t\.money\s+"wealth",\s+scale: 2$}, output
-    assert_match %r{t\.money\s+"depth",\s+scale: 2,\s+default: 150\.55$}, output
+    assert_match %r{t\.money\s+"depth",\s+scale: 2,\s+default: "150\.55"$}, output
   end
 
   def test_create_and_update_money

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -239,7 +239,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
   def test_schema_dump_includes_decimal_options
     output = dump_all_table_schema([/^[^n]/])
-    assert_match %r{precision: 3,[[:space:]]+scale: 2,[[:space:]]+default: 2\.78}, output
+    assert_match %r{precision: 3,[[:space:]]+scale: 2,[[:space:]]+default: "2\.78"}, output
   end
 
   if current_adapter?(:PostgreSQLAdapter)

--- a/activerecord/test/cases/type/decimal_test.rb
+++ b/activerecord/test/cases/type/decimal_test.rb
@@ -30,6 +30,12 @@ module ActiveRecord
         assert_equal BigDecimal("0.333333333333333333E0"), type.cast(Rational(1, 3))
       end
 
+      def test_type_cast_for_schema
+        type = Decimal.new
+        assert_equal "\"0.33\"", type.type_cast_for_schema(BigDecimal.new("0.33"))
+        assert_equal "\"0.123456789123456789\"", type.type_cast_for_schema(BigDecimal.new("0.123456789123456789"))
+      end
+
       def test_type_cast_decimal_from_object_responding_to_d
         value = Object.new
         def value.to_d

--- a/activerecord/test/cases/type/string_test.rb
+++ b/activerecord/test/cases/type/string_test.rb
@@ -9,6 +9,11 @@ module ActiveRecord
       assert_equal "123", type.cast(123)
     end
 
+    test "type_cast_for_schema" do
+      type = Type::String.new
+      assert_equal "\"value\"", type.type_cast_for_schema("value")
+    end
+
     test "values are duped coming out" do
       s = "foo"
       type = Type::String.new


### PR DESCRIPTION
Let's say I make a brand new app using pg for the database
And in it I create a model called Thing
And that model has 3 columns like so:

``` ruby
create_table :things do |t|
  t.string :features, array: true, default: ['base']
  t.decimal :prices, array: true, default: [9.99]
  t.decimal :default_price, default: 9.99

  t.timestamps null: false
end
```

And I run `rake db:migrate`
Then I would expect this in db/schema:

``` ruby
create_table "things", force: :cascade do |t|
  t.string   "features",      default: ["base"],              array: true
  t.decimal  "prices",        default: [9.99],                array: true
  t.decimal  "default_price", default: 9.99
  t.datetime "created_at",                       null: false
  t.datetime "updated_at",                       null: false
end
```

BUT alas I get this instead:

``` ruby
create_table "things", force: :cascade do |t|
  t.string   "features",      default: ["base"],                                                   array: true
  t.decimal  "prices",        default: [#<BigDecimal:7fe6171cb560,'0.999E1',18(18)>],              array: true
  t.decimal  "default_price", default: 9.99
  t.datetime "created_at",                                                            null: false
  t.datetime "updated_at",                                                            null: false
end
```

WAT.
On a scale of 1..major problem... it causes a **syntax error** in the schema file! So when I run `rake db:schema:load` or `rake db:test:prepare` it breaks, rendering the entire schema.rb file useless!

The proper output should be 

``` ruby
t.decimal  "prices",        default: [9.99],                array: true
```

Community! Let me know what you think. I can definitely work on a patch.
