### PR TITLE
Change assert interface to add explicit message

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -24,7 +24,7 @@ module ActionDispatch
 
         if Symbol === type
           if [:success, :missing, :redirect, :error].include?(type)
-            assert @response.send("#{type}?"), message
+            assert @response.send("#{type}?"), message: message
           else
             code = Rack::Utils::SYMBOL_TO_STATUS_CODE[type]
             if code.nil?

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -240,8 +240,8 @@ module ActionController
     tests TestController
 
     def assert_stream_closed
-      assert response.stream.closed?, 'stream should be closed'
-      assert response.sent?, 'stream should be sent'
+      assert response.stream.closed?, message: 'stream should be closed'
+      assert response.sent?, message: 'stream should be sent'
     end
 
     def capture_log_output
@@ -296,7 +296,7 @@ module ActionController
 
       @controller.process :blocking_stream
 
-      assert t.join(3), 'timeout expired before the thread terminated'
+      assert t.join(3), message: 'timeout expired before the thread terminated'
     end
 
     def test_abort_with_full_buffer

--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -16,12 +16,12 @@ module BareMetalTest
       string = ""
 
       body.each do |part|
-        assert part.is_a?(String), "Each part of the body must be a String"
+        assert part.is_a?(String), message: "Each part of the body must be a String"
         string << part
       end
 
       assert_kind_of Hash, headers, "Headers must be a Hash"
-      assert headers["Content-Type"], "Content-Type must exist"
+      assert headers["Content-Type"], message: "Content-Type must exist"
 
       assert_equal "Hello world", string
     end

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -4,7 +4,7 @@ require 'action_controller/metal/strong_parameters'
 
 class ParametersPermitTest < ActiveSupport::TestCase
   def assert_filtered_out(params, key)
-    assert !params.has_key?(key), "key #{key.inspect} has not been filtered out"
+    assert !params.has_key?(key), message: "key #{key.inspect} has not been filtered out"
   end
 
   setup do

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -250,7 +250,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     end
 
     assert_equal 'default', get(URI('http://www.example.org/foo/'))
-    assert scope_called, "scope constraint should be called"
+    assert scope_called, message: "scope constraint should be called"
   end
 
   def test_scoped_lambda_with_get_lambda
@@ -264,7 +264,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     end
 
     assert_equal 'default', get(URI('http://www.example.org/foo/'))
-    assert inner_called, "inner constraint should be called"
+    assert inner_called, message: "inner constraint should be called"
   end
 
   def test_empty_string_match
@@ -535,12 +535,12 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
     # No + to space in URI escaping, only for query params.
     results = rs.recognize_path "/file/hello+world/how+are+you%3F"
-    assert results, "Recognition should have succeeded"
+    assert results, message: "Recognition should have succeeded"
     assert_equal 'hello+world/how+are+you?', results[:path]
 
     # Use %20 for space instead.
     results = rs.recognize_path "/file/hello%20world/how%20are%20you%3F"
-    assert results, "Recognition should have succeeded"
+    assert results, message: "Recognition should have succeeded"
     assert_equal 'hello world/how are you?', results[:path]
   end
 
@@ -1208,14 +1208,14 @@ class RouteSetTest < ActiveSupport::TestCase
   end
 
   def test_routing_traversal_does_not_load_extra_classes
-    assert !Object.const_defined?("Profiler__"), "Profiler should not be loaded"
+    assert !Object.const_defined?("Profiler__"), message: "Profiler should not be loaded"
     set.draw do
       get '/profile' => 'profile#index'
     end
 
     request_path_params("/profile") rescue nil
 
-    assert !Object.const_defined?("Profiler__"), "Profiler should not be loaded"
+    assert !Object.const_defined?("Profiler__"), message: "Profiler should not be loaded"
   end
 
   def test_recognize_with_conditions_and_format

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -822,11 +822,11 @@ XML
         remove_instance_variable "@#{variable}"
         begin
           send(method, :test_remote_addr)
-          assert false, "expected RuntimeError, got nothing"
+          assert false, message: "expected RuntimeError, got nothing"
         rescue RuntimeError => error
           assert_match(%r{@#{variable} is nil}, error.message)
         rescue => error
-          assert false, "expected RuntimeError, got #{error.class}"
+          assert false, message: "expected RuntimeError, got #{error.class}"
         end
       end
     end
@@ -889,7 +889,7 @@ XML
 
   def test_fixture_file_upload_should_be_able_access_to_tempfile
     file = fixture_file_upload(FILES_DIR + "/mona_lisa.jpg", "image/jpg")
-    assert file.respond_to?(:tempfile), "expected tempfile should respond on fixture file object, got nothing"
+    assert file.respond_to?(:tempfile), message: "expected tempfile should respond on fixture file object, got nothing"
   end
 
   def test_fixture_file_upload

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -110,7 +110,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_raise ActionController::RoutingError do
       get "/pass", headers: { 'action_dispatch.show_exceptions' => true }
     end
-    assert boomer.closed, "Expected to close the response body"
+    assert boomer.closed, message: "Expected to close the response body"
   end
 
   test 'displays routes in a table when a RoutingError occurs' do

--- a/actionpack/test/dispatch/middleware_stack/middleware_test.rb
+++ b/actionpack/test/dispatch/middleware_stack/middleware_test.rb
@@ -35,7 +35,7 @@ module ActionDispatch
         assert_operator mw, :==, k
 
         result = mw != Class.new
-        assert result, 'middleware should not equal other anon class'
+        assert result, message: 'middleware should not equal other anon class'
       end
 
       def test_double_equal_works_with_strings

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -18,9 +18,9 @@ class MimeTypeTest < ActiveSupport::TestCase
       assert_equal Mime::MOBILE, Mime::EXTENSION_LOOKUP['mobile']
 
       Mime::Type.unregister(:mobile)
-      assert !defined?(Mime::MOBILE), "Mime::MOBILE should not be defined"
-      assert !Mime::LOOKUP.has_key?('text/x-mobile'), "Mime::LOOKUP should not have key ['text/x-mobile]"
-      assert !Mime::EXTENSION_LOOKUP.has_key?('mobile'), "Mime::EXTENSION_LOOKUP should not have key ['mobile]"
+      assert !defined?(Mime::MOBILE), message: "Mime::MOBILE should not be defined"
+      assert !Mime::LOOKUP.has_key?('text/x-mobile'), message: "Mime::LOOKUP should not have key ['text/x-mobile]"
+      assert !Mime::EXTENSION_LOOKUP.has_key?('mobile'), message: "Mime::EXTENSION_LOOKUP should not have key ['mobile]"
     ensure
       Mime.module_eval { remove_const :MOBILE if const_defined?(:MOBILE) }
       Mime::LOOKUP.reject!{|key,_| key == 'text/x-mobile'}
@@ -165,17 +165,17 @@ class MimeTypeTest < ActiveSupport::TestCase
 
     types.each do |type|
       mime = Mime.const_get(type.upcase)
-      assert mime.respond_to?("#{type}?"), "#{mime.inspect} does not respond to #{type}?"
+      assert mime.respond_to?("#{type}?"), message: "#{mime.inspect} does not respond to #{type}?"
       assert mime.send("#{type}?"), "#{mime.inspect} is not #{type}?"
       invalid_types = types - [type]
       invalid_types.delete(:html) if Mime::Type.html_types.include?(type)
-      invalid_types.each { |other_type| assert !mime.send("#{other_type}?"), "#{mime.inspect} is #{other_type}?" }
+      invalid_types.each { |other_type| assert !mime.send("#{other_type}?"), message: "#{mime.inspect} is #{other_type}?" }
     end
   end
 
   test "mime all is html" do
-    assert Mime::ALL.all?,  "Mime::ALL is not all?"
-    assert Mime::ALL.html?, "Mime::ALL is not html?"
+    assert Mime::ALL.all?, message:  "Mime::ALL is not all?"
+    assert Mime::ALL.html?, message: "Mime::ALL is not html?"
   end
 
   test "verifiable mime types" do

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3021,8 +3021,8 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       after = has_named_route?(:hello)
     end
 
-    assert !before, "expected to not have named route :hello before route definition"
-    assert after, "expected to have named route :hello after route definition"
+    assert !before, message: "expected to not have named route :hello before route definition"
+    assert after, message: "expected to have named route :hello after route definition"
   end
 
   def test_explicitly_avoiding_the_named_route
@@ -3238,16 +3238,16 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     get '/streams'
-    assert @response.ok?, 'route without trailing slash should work'
+    assert @response.ok?, message: 'route without trailing slash should work'
 
     get '/streams/'
-    assert @response.ok?, 'route with trailing slash should work'
+    assert @response.ok?, message: 'route with trailing slash should work'
 
     get '/streams?foobar'
-    assert @response.ok?, 'route without trailing slash and with QUERY_STRING should work'
+    assert @response.ok?, message: 'route without trailing slash and with QUERY_STRING should work'
 
     get '/streams/?foobar'
-    assert @response.ok?, 'route with trailing slash and with QUERY_STRING should work'
+    assert @response.ok?, message: 'route with trailing slash and with QUERY_STRING should work'
   end
 
   def test_route_with_dashes_in_path

--- a/actionpack/test/dispatch/test_request_test.rb
+++ b/actionpack/test/dispatch/test_request_test.rb
@@ -25,7 +25,7 @@ class TestRequestTest < ActiveSupport::TestCase
     assert_equal true, env.delete("rack.multiprocess")
     assert_equal false, env.delete("rack.run_once")
 
-    assert env.empty?, env.inspect
+    assert env.empty?, message: env.inspect
   end
 
   test "cookie jar" do

--- a/actionpack/test/dispatch/uploaded_file_test.rb
+++ b/actionpack/test/dispatch/uploaded_file_test.rb
@@ -98,8 +98,8 @@ module ActionDispatch
     def test_respond_to?
       tf = Class.new { def read; yield end }
       uf = Http::UploadedFile.new(:tempfile => tf.new)
-      assert uf.respond_to?(:headers), 'responds to headers'
-      assert uf.respond_to?(:read), 'responds to read'
+      assert uf.respond_to?(:headers), message: 'responds to headers'
+      assert uf.respond_to?(:read), message: 'responds to read'
     end
   end
 end

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -78,7 +78,7 @@ module ActionDispatch
           assert_equal({:id => '10'}, params)
         end
 
-        assert klass.called, 'hello should have been called'
+        assert klass.called, message: 'hello should have been called'
         assert_equal env.env, klass.env
       end
 
@@ -98,7 +98,7 @@ module ActionDispatch
           flunk 'route should not be found'
         end
 
-        assert klass.called, 'hello should have been called'
+        assert klass.called, message: 'hello should have been called'
         assert_equal env.env, klass.env
       end
 
@@ -128,7 +128,7 @@ module ActionDispatch
           recognized = true
         end
 
-        assert recognized, "route should have been recognized"
+        assert recognized, message: "route should have been recognized"
       end
 
       def test_regexp_first_precedence

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -285,7 +285,7 @@ class TemplateDigestorTest < ActionView::TestCase
 
       yield
 
-      assert previous_digest != digest(template_name, options), "digest didn't change"
+      assert previous_digest != digest(template_name, options), message: "digest didn't change"
       ActionView::Digestor.cache.clear
     end
 

--- a/actionview/test/template/partial_iteration_test.rb
+++ b/actionview/test/template/partial_iteration_test.rb
@@ -10,24 +10,24 @@ class PartialIterationTest < ActiveSupport::TestCase
 
   def test_first_is_true_when_current_is_at_the_first_index
     iteration = ActionView::PartialIteration.new 3
-    assert iteration.first?, "first when current is 0"
+    assert iteration.first?, message: "first when current is 0"
   end
 
   def test_first_is_false_unless_current_is_at_the_first_index
     iteration = ActionView::PartialIteration.new 3
     iteration.iterate!
-    assert !iteration.first?, "not first when current is 1"
+    assert !iteration.first?, message: "not first when current is 1"
   end
 
   def test_last_is_true_when_current_is_at_the_last_index
     iteration = ActionView::PartialIteration.new 3
     iteration.iterate!
     iteration.iterate!
-    assert iteration.last?, "last when current is 2"
+    assert iteration.last?, message: "last when current is 2"
   end
 
   def test_last_is_false_unless_current_is_at_the_last_index
     iteration = ActionView::PartialIteration.new 3
-    assert !iteration.last?, "not last when current is 0"
+    assert !iteration.last?, message: "not last when current is 0"
   end
 end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -437,7 +437,7 @@ module RenderTestCases
   def test_render_ignores_templates_with_malformed_template_handlers
     ActiveSupport::Deprecation.silence do
       %w(malformed malformed.erb malformed.html.erb malformed.en.html.erb).each do |name|
-        assert File.exist?(File.expand_path("#{FIXTURE_LOAD_PATH}/test/malformed/#{name}~")), "Malformed file (#{name}~) which should be ignored does not exists"
+        assert File.exist?(File.expand_path("#{FIXTURE_LOAD_PATH}/test/malformed/#{name}~")), message: "Malformed file (#{name}~) which should be ignored does not exists"
         assert_raises(ActionView::MissingTemplate) { @view.render(:file => "test/malformed/#{name}") }
       end
     end

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -154,8 +154,8 @@ module ActionView
 
     test "view_assigns excludes internal ivars" do
       INTERNAL_IVARS.each do |ivar|
-        assert defined?(ivar), "expected #{ivar} to be defined"
-        assert !view_assigns.keys.include?(ivar.to_s.tr('@', '').to_sym), "expected #{ivar} to be excluded from view_assigns"
+        assert defined?(ivar), message: "expected #{ivar} to be defined"
+        assert !view_assigns.keys.include?(ivar.to_s.tr('@', '').to_sym), message: "expected #{ivar} to be excluded from view_assigns"
       end
     end
   end

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -236,7 +236,7 @@ module ActiveJob
         matching_job = enqueued_jobs.any? do |job|
           serialized_args.all? { |key, value| value == job[key] }
         end
-        assert matching_job, "No enqueued job found with #{args}"
+        assert matching_job, message: "No enqueued job found with #{args}"
       ensure
         queue_adapter.enqueued_jobs = original_enqueued_jobs + enqueued_jobs
       end
@@ -257,7 +257,7 @@ module ActiveJob
         matching_job = performed_jobs.any? do |job|
           serialized_args.all? { |key, value| value == job[key] }
         end
-        assert matching_job, "No performed job found with #{args}"
+        assert matching_job, message: "No performed job found with #{args}"
       ensure
         queue_adapter.performed_jobs = original_performed_jobs + performed_jobs
       end

--- a/activemodel/lib/active_model/lint.rb
+++ b/activemodel/lib/active_model/lint.rb
@@ -28,9 +28,9 @@ module ActiveModel
       # <tt>to_key</tt> returns an Enumerable of all (primary) key attributes
       # of the model, and is used to a generate unique DOM id for the object.
       def test_to_key
-        assert model.respond_to?(:to_key), "The model should respond to to_key"
+        assert model.respond_to?(:to_key), message: "The model should respond to to_key"
         def model.persisted?() false end
-        assert model.to_key.nil?, "to_key should return nil when `persisted?` returns false"
+        assert model.to_key.nil?, message: "to_key should return nil when `persisted?` returns false"
       end
 
       # Passes if the object's model responds to <tt>to_param</tt> and if
@@ -43,10 +43,10 @@ module ActiveModel
       # tests for this behavior in lint because it doesn't make sense to force
       # any of the possible implementation strategies on the implementer.
       def test_to_param
-        assert model.respond_to?(:to_param), "The model should respond to to_param"
+        assert model.respond_to?(:to_param), message: "The model should respond to to_param"
         def model.to_key() [1] end
         def model.persisted?() false end
-        assert model.to_param.nil?, "to_param should return nil when `persisted?` returns false"
+        assert model.to_param.nil?, message: "to_param should return nil when `persisted?` returns false"
       end
 
       # Passes if the object's model responds to <tt>to_partial_path</tt> and if
@@ -55,7 +55,7 @@ module ActiveModel
       # <tt>to_partial_path</tt> is used for looking up partials. For example,
       # a BlogPost model might return "blog_posts/blog_post".
       def test_to_partial_path
-        assert model.respond_to?(:to_partial_path), "The model should respond to to_partial_path"
+        assert model.respond_to?(:to_partial_path), message: "The model should respond to to_partial_path"
         assert_kind_of String, model.to_partial_path
       end
 
@@ -67,7 +67,7 @@ module ActiveModel
       # will route to the create action. If it is persisted, a form for the
       # object will route to the update action.
       def test_persisted?
-        assert model.respond_to?(:persisted?), "The model should respond to persisted?"
+        assert model.respond_to?(:persisted?), message: "The model should respond to persisted?"
         assert_boolean model.persisted?, "persisted?"
       end
 
@@ -78,14 +78,14 @@ module ActiveModel
       #
       # Check ActiveModel::Naming for more information.
       def test_model_naming
-        assert model.class.respond_to?(:model_name), "The model class should respond to model_name"
+        assert model.class.respond_to?(:model_name), message: "The model class should respond to model_name"
         model_name = model.class.model_name
         assert model_name.respond_to?(:to_str)
         assert model_name.human.respond_to?(:to_str)
         assert model_name.singular.respond_to?(:to_str)
         assert model_name.plural.respond_to?(:to_str)
 
-        assert model.respond_to?(:model_name), "The model instance should respond to model_name"
+        assert model.respond_to?(:model_name), message: "The model instance should respond to model_name"
         assert_equal model.model_name, model.class.model_name
       end
 
@@ -99,18 +99,18 @@ module ActiveModel
       # If localization is used, the strings should be localized for the current
       # locale. If no error is present, the method should return an empty array.
       def test_errors_aref
-        assert model.respond_to?(:errors), "The model should respond to errors"
-        assert model.errors[:hello].is_a?(Array), "errors#[] should return an Array"
+        assert model.respond_to?(:errors), message: "The model should respond to errors"
+        assert model.errors[:hello].is_a?(Array), message: "errors#[] should return an Array"
       end
 
       private
         def model
-          assert @model.respond_to?(:to_model), "The object should respond to to_model"
+          assert @model.respond_to?(:to_model), message: "The object should respond to to_model"
           @model.to_model
         end
 
         def assert_boolean(result, name)
-          assert result == true || result == false, "#{name} should be a boolean"
+          assert result == true || result == false, message: "#{name} should be a boolean"
         end
     end
   end

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -45,7 +45,7 @@ class ErrorsTest < ActiveModel::TestCase
   def test_include?
     errors = ActiveModel::Errors.new(self)
     errors[:foo] << 'omg'
-    assert errors.include?(:foo), 'errors should include :foo'
+    assert errors.include?(:foo), message: 'errors should include :foo'
   end
 
   def test_dup

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -245,8 +245,8 @@ class NamingHelpersTest < ActiveModel::TestCase
   end
 
   def test_uncountable
-    assert uncountable?(@uncountable), "Expected 'sheep' to be uncountable"
-    assert !uncountable?(@klass), "Expected 'contact' to be countable"
+    assert uncountable?(@uncountable), message: "Expected 'sheep' to be uncountable"
+    assert !uncountable?(@klass), message: "Expected 'contact' to be countable"
   end
 
   def test_uncountable_route_key

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -32,29 +32,29 @@ class SecurePasswordTest < ActiveModel::TestCase
     @user.password = 'password'
     @user.password_confirmation = 'password'
 
-    assert @user.valid?(:create), 'user should be valid'
+    assert @user.valid?(:create), message: 'user should be valid'
 
     @user.password = 'a' * 72
     @user.password_confirmation = 'a' * 72
 
-    assert @user.valid?(:create), 'user should be valid'
+    assert @user.valid?(:create), message: 'user should be valid'
   end
 
   test "create a new user with validation and a spaces only password" do
     @user.password = ' ' * 72
-    assert @user.valid?(:create), 'user should be valid'
+    assert @user.valid?(:create), message: 'user should be valid'
   end
 
   test "create a new user with validation and a blank password" do
     @user.password = ''
-    assert !@user.valid?(:create), 'user should be invalid'
+    assert !@user.valid?(:create), message: 'user should be invalid'
     assert_equal 1, @user.errors.count
     assert_equal ["can't be blank"], @user.errors[:password]
   end
 
   test "create a new user with validation and a nil password" do
     @user.password = nil
-    assert !@user.valid?(:create), 'user should be invalid'
+    assert !@user.valid?(:create), message: 'user should be invalid'
     assert_equal 1, @user.errors.count
     assert_equal ["can't be blank"], @user.errors[:password]
   end
@@ -62,7 +62,7 @@ class SecurePasswordTest < ActiveModel::TestCase
   test 'create a new user with validation and password length greater than 72' do
     @user.password = 'a' * 73
     @user.password_confirmation = 'a' * 73
-    assert !@user.valid?(:create), 'user should be invalid'
+    assert !@user.valid?(:create), message: 'user should be invalid'
     assert_equal 1, @user.errors.count
     assert_equal ["is too long (maximum is 72 characters)"], @user.errors[:password]
   end
@@ -70,7 +70,7 @@ class SecurePasswordTest < ActiveModel::TestCase
   test "create a new user with validation and a blank password confirmation" do
     @user.password = 'password'
     @user.password_confirmation = ''
-    assert !@user.valid?(:create), 'user should be invalid'
+    assert !@user.valid?(:create), message: 'user should be invalid'
     assert_equal 1, @user.errors.count
     assert_equal ["doesn't match Password"], @user.errors[:password_confirmation]
   end
@@ -78,52 +78,52 @@ class SecurePasswordTest < ActiveModel::TestCase
   test "create a new user with validation and a nil password confirmation" do
     @user.password = 'password'
     @user.password_confirmation = nil
-    assert @user.valid?(:create), 'user should be valid'
+    assert @user.valid?(:create), message: 'user should be valid'
   end
 
   test "create a new user with validation and an incorrect password confirmation" do
     @user.password = 'password'
     @user.password_confirmation = 'something else'
-    assert !@user.valid?(:create), 'user should be invalid'
+    assert !@user.valid?(:create), message: 'user should be invalid'
     assert_equal 1, @user.errors.count
     assert_equal ["doesn't match Password"], @user.errors[:password_confirmation]
   end
 
   test "update an existing user with validation and no change in password" do
-    assert @existing_user.valid?(:update), 'user should be valid'
+    assert @existing_user.valid?(:update), message: 'user should be valid'
   end
 
   test "update an existing user with validations and valid password/confirmation" do
     @existing_user.password = 'password'
     @existing_user.password_confirmation = 'password'
 
-    assert @existing_user.valid?(:update), 'user should be valid'
+    assert @existing_user.valid?(:update), message: 'user should be valid'
 
     @existing_user.password = 'a' * 72
     @existing_user.password_confirmation = 'a' * 72
 
-    assert @existing_user.valid?(:update), 'user should be valid'
+    assert @existing_user.valid?(:update), message: 'user should be valid'
   end
 
   test "updating an existing user with validation and a blank password" do
     @existing_user.password = ''
-    assert @existing_user.valid?(:update), 'user should be valid'
+    assert @existing_user.valid?(:update), message: 'user should be valid'
   end
 
   test "updating an existing user with validation and a spaces only password" do
     @user.password = ' ' * 72
-    assert @user.valid?(:update), 'user should be valid'
+    assert @user.valid?(:update), message: 'user should be valid'
   end
 
   test "updating an existing user with validation and a blank password and password_confirmation" do
     @existing_user.password = ''
     @existing_user.password_confirmation = ''
-    assert @existing_user.valid?(:update), 'user should be valid'
+    assert @existing_user.valid?(:update), message: 'user should be valid'
   end
 
   test "updating an existing user with validation and a nil password" do
     @existing_user.password = nil
-    assert !@existing_user.valid?(:update), 'user should be invalid'
+    assert !@existing_user.valid?(:update), message: 'user should be invalid'
     assert_equal 1, @existing_user.errors.count
     assert_equal ["can't be blank"], @existing_user.errors[:password]
   end
@@ -131,7 +131,7 @@ class SecurePasswordTest < ActiveModel::TestCase
   test 'updating an existing user with validation and password length greater than 72' do
     @existing_user.password = 'a' * 73
     @existing_user.password_confirmation = 'a' * 73
-    assert !@existing_user.valid?(:update), 'user should be invalid'
+    assert !@existing_user.valid?(:update), message: 'user should be invalid'
     assert_equal 1, @existing_user.errors.count
     assert_equal ["is too long (maximum is 72 characters)"], @existing_user.errors[:password]
   end
@@ -139,7 +139,7 @@ class SecurePasswordTest < ActiveModel::TestCase
   test "updating an existing user with validation and a blank password confirmation" do
     @existing_user.password = 'password'
     @existing_user.password_confirmation = ''
-    assert !@existing_user.valid?(:update), 'user should be invalid'
+    assert !@existing_user.valid?(:update), message: 'user should be invalid'
     assert_equal 1, @existing_user.errors.count
     assert_equal ["doesn't match Password"], @existing_user.errors[:password_confirmation]
   end
@@ -147,27 +147,27 @@ class SecurePasswordTest < ActiveModel::TestCase
   test "updating an existing user with validation and a nil password confirmation" do
     @existing_user.password = 'password'
     @existing_user.password_confirmation = nil
-    assert @existing_user.valid?(:update), 'user should be valid'
+    assert @existing_user.valid?(:update), message: 'user should be valid'
   end
 
   test "updating an existing user with validation and an incorrect password confirmation" do
     @existing_user.password = 'password'
     @existing_user.password_confirmation = 'something else'
-    assert !@existing_user.valid?(:update), 'user should be invalid'
+    assert !@existing_user.valid?(:update), message: 'user should be invalid'
     assert_equal 1, @existing_user.errors.count
     assert_equal ["doesn't match Password"], @existing_user.errors[:password_confirmation]
   end
 
   test "updating an existing user with validation and a blank password digest" do
     @existing_user.password_digest = ''
-    assert !@existing_user.valid?(:update), 'user should be invalid'
+    assert !@existing_user.valid?(:update), message: 'user should be invalid'
     assert_equal 1, @existing_user.errors.count
     assert_equal ["can't be blank"], @existing_user.errors[:password]
   end
 
   test "updating an existing user with validation and a nil password digest" do
     @existing_user.password_digest = nil
-    assert !@existing_user.valid?(:update), 'user should be invalid'
+    assert !@existing_user.valid?(:update), message: 'user should be invalid'
     assert_equal 1, @existing_user.errors.count
     assert_equal ["can't be blank"], @existing_user.errors[:password]
   end

--- a/activemodel/test/cases/validations/conditional_validation_test.rb
+++ b/activemodel/test/cases/validations/conditional_validation_test.rb
@@ -122,17 +122,17 @@ class ConditionalValidationTest < ActiveModel::TestCase
     Topic.validates_presence_of(:author_name, if: "title.to_s.match('important')")
 
     t = Topic.new
-    assert t.invalid?, "A topic without a title should not be valid"
+    assert t.invalid?, message: "A topic without a title should not be valid"
     assert_empty t.errors[:author_name], "A topic without an 'important' title should not require an author"
 
     t.title = "Just a title"
-    assert t.valid?, "A topic with a basic title should be valid"
+    assert t.valid?, message: "A topic with a basic title should be valid"
 
     t.title = "A very important title"
-    assert t.invalid?, "A topic with an important title, but without an author, should not be valid"
-    assert t.errors[:author_name].any?, "A topic with an 'important' title should require an author"
+    assert t.invalid?, message: "A topic with an important title, but without an author, should not be valid"
+    assert t.errors[:author_name].any?, message: "A topic with an 'important' title should require an author"
 
     t.author_name = "Hubert J. Farnsworth"
-    assert t.valid?, "A topic with an important title and author should be valid"
+    assert t.valid?, message: "A topic with an important title and author should be valid"
   end
 end

--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -13,7 +13,7 @@ class PresenceValidationTest < ActiveModel::TestCase
     Topic.validates_format_of(:title, :content, with: /\AValidation\smacros \w+!\z/, message: "is bad data")
 
     t = Topic.new("title" => "i'm incorrect", "content" => "Validation macros rule!")
-    assert t.invalid?, "Shouldn't be valid"
+    assert t.invalid?, message: "Shouldn't be valid"
     assert_equal ["is bad data"], t.errors[:title]
     assert t.errors[:content].empty?
 
@@ -38,22 +38,22 @@ class PresenceValidationTest < ActiveModel::TestCase
     Topic.validates_format_of(:title, :content, with: /\A[1-9][0-9]*\z/, message: "is bad data")
 
     t = Topic.new("title" => "72x", "content" => "6789")
-    assert t.invalid?, "Shouldn't be valid"
+    assert t.invalid?, message: "Shouldn't be valid"
 
     assert_equal ["is bad data"], t.errors[:title]
     assert t.errors[:content].empty?
 
     t.title = "-11"
-    assert t.invalid?, "Shouldn't be valid"
+    assert t.invalid?, message: "Shouldn't be valid"
 
     t.title = "03"
-    assert t.invalid?, "Shouldn't be valid"
+    assert t.invalid?, message: "Shouldn't be valid"
 
     t.title = "z44"
-    assert t.invalid?, "Shouldn't be valid"
+    assert t.invalid?, message: "Shouldn't be valid"
 
     t.title = "5v7"
-    assert t.invalid?, "Shouldn't be valid"
+    assert t.invalid?, message: "Shouldn't be valid"
 
     t.title = "1"
 

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -297,13 +297,13 @@ class LengthValidationTest < ActiveModel::TestCase
     Topic.validates_length_of :title, within: 3..5, allow_nil: true
 
     t = Topic.new(title: "一二三四五")
-    assert t.valid?, t.errors.inspect
+    assert t.valid?, message: t.errors.inspect
 
     t = Topic.new(title: "一二三")
-    assert t.valid?, t.errors.inspect
+    assert t.valid?, message: t.errors.inspect
 
     t.title = nil
-    assert t.valid?, t.errors.inspect
+    assert t.valid?, message: t.errors.inspect
   end
 
   def test_validates_length_of_using_is_utf8

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -188,15 +188,15 @@ class NumericalityValidationTest < ActiveModel::TestCase
 
   def invalid!(values, error = nil)
     with_each_topic_approved_value(values) do |topic, value|
-      assert topic.invalid?, "#{value.inspect} not rejected as a number"
-      assert topic.errors[:approved].any?, "FAILED for #{value.inspect}"
+      assert topic.invalid?, message: "#{value.inspect} not rejected as a number"
+      assert topic.errors[:approved].any?, message: "FAILED for #{value.inspect}"
       assert_equal error, topic.errors[:approved].first if error
     end
   end
 
   def valid!(values)
     with_each_topic_approved_value(values) do |topic, value|
-      assert topic.valid?, "#{value.inspect} not accepted as a number"
+      assert topic.valid?, message: "#{value.inspect} not accepted as a number"
     end
   end
 

--- a/activemodel/test/cases/validations/presence_validation_test.rb
+++ b/activemodel/test/cases/validations/presence_validation_test.rb
@@ -74,33 +74,33 @@ class PresenceValidationTest < ActiveModel::TestCase
     Topic.validates_presence_of(:title, allow_nil: true)
 
     t = Topic.new(title: "something")
-    assert t.valid?, t.errors.full_messages
+    assert t.valid?, message: t.errors.full_messages
 
     t.title = ""
     assert t.invalid?
     assert_equal ["can't be blank"], t.errors[:title]
 
     t.title = "  "
-    assert t.invalid?, t.errors.full_messages
+    assert t.invalid?, message: t.errors.full_messages
     assert_equal ["can't be blank"], t.errors[:title]
 
     t.title = nil
-    assert t.valid?, t.errors.full_messages
+    assert t.valid?, message: t.errors.full_messages
   end
 
   def test_validates_presence_of_with_allow_blank_option
     Topic.validates_presence_of(:title, allow_blank: true)
 
     t = Topic.new(title: "something")
-    assert t.valid?, t.errors.full_messages
+    assert t.valid?, message: t.errors.full_messages
 
     t.title = ""
-    assert t.valid?, t.errors.full_messages
+    assert t.valid?, message: t.errors.full_messages
 
     t.title = "  "
-    assert t.valid?, t.errors.full_messages
+    assert t.valid?, message: t.errors.full_messages
 
     t.title = nil
-    assert t.valid?, t.errors.full_messages
+    assert t.valid?, message: t.errors.full_messages
   end
 end

--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -17,7 +17,7 @@ class ValidatesTest < ActiveModel::TestCase
   def test_validates_with_messages_empty
     Person.validates :title, presence: { message: "" }
     person = Person.new
-    assert !person.valid?, 'person should not be valid.'
+    assert !person.valid?, message: 'person should not be valid.'
   end
 
   def test_validates_with_built_in_validation

--- a/activemodel/test/cases/validations/validations_context_test.rb
+++ b/activemodel/test/cases/validations/validations_context_test.rb
@@ -18,19 +18,19 @@ class ValidationsContextTest < ActiveModel::TestCase
   test "with a class that adds errors on create and validating a new model with no arguments" do
     Topic.validates_with(ValidatorThatAddsErrors, on: :create)
     topic = Topic.new
-    assert topic.valid?, "Validation doesn't run on valid? if 'on' is set to create"
+    assert topic.valid?, message: "Validation doesn't run on valid? if 'on' is set to create"
   end
 
   test "with a class that adds errors on update and validating a new model" do
     Topic.validates_with(ValidatorThatAddsErrors, on: :update)
     topic = Topic.new
-    assert topic.valid?(:create), "Validation doesn't run on create if 'on' is set to update"
+    assert topic.valid?(:create), message: "Validation doesn't run on create if 'on' is set to update"
   end
 
   test "with a class that adds errors on create and validating a new model" do
     Topic.validates_with(ValidatorThatAddsErrors, on: :create)
     topic = Topic.new
-    assert topic.invalid?(:create), "Validation does run on create if 'on' is set to create"
+    assert topic.invalid?(:create), message: "Validation does run on create if 'on' is set to create"
     assert topic.errors[:base].include?(ERROR_MESSAGE)
   end
 
@@ -38,12 +38,12 @@ class ValidationsContextTest < ActiveModel::TestCase
     Topic.validates_with(ValidatorThatAddsErrors, on: [:context1, :context2])
 
     topic = Topic.new
-    assert topic.valid?, "Validation ran with no context given when 'on' is set to context1 and context2"
+    assert topic.valid?, message: "Validation ran with no context given when 'on' is set to context1 and context2"
 
-    assert topic.invalid?(:context1), "Validation did not run on context1 when 'on' is set to context1 and context2"
+    assert topic.invalid?(:context1), message: "Validation did not run on context1 when 'on' is set to context1 and context2"
     assert topic.errors[:base].include?(ERROR_MESSAGE)
 
-    assert topic.invalid?(:context2), "Validation did not run on context2 when 'on' is set to context1 and context2"
+    assert topic.invalid?(:context2), message: "Validation did not run on context2 when 'on' is set to context1 and context2"
     assert topic.errors[:base].include?(ERROR_MESSAGE)
   end
 end

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -51,14 +51,14 @@ class ValidatesWithTest < ActiveModel::TestCase
   test "validation with class that adds errors" do
     Topic.validates_with(ValidatorThatAddsErrors)
     topic = Topic.new
-    assert topic.invalid?, "A class that adds errors causes the record to be invalid"
+    assert topic.invalid?, message: "A class that adds errors causes the record to be invalid"
     assert topic.errors[:base].include?(ERROR_MESSAGE)
   end
 
   test "with a class that returns valid" do
     Topic.validates_with(ValidatorThatDoesNotAddErrors)
     topic = Topic.new
-    assert topic.valid?, "A class that does not add errors does not cause the record to be invalid"
+    assert topic.valid?, message: "A class that does not add errors does not cause the record to be invalid"
   end
 
   test "with multiple classes" do

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -17,19 +17,19 @@ class ValidationsTest < ActiveModel::TestCase
   def test_single_field_validation
     r = Reply.new
     r.title = "There's no content!"
-    assert r.invalid?, "A reply without content should be invalid"
-    assert r.after_validation_performed, "after_validation callback should be called"
+    assert r.invalid?, message: "A reply without content should be invalid"
+    assert r.after_validation_performed, message: "after_validation callback should be called"
 
     r.content = "Messa content!"
-    assert r.valid?, "A reply with content should be valid"
-    assert r.after_validation_performed, "after_validation callback should be called"
+    assert r.valid?, message: "A reply with content should be valid"
+    assert r.after_validation_performed, message: "after_validation callback should be called"
   end
 
   def test_single_attr_validation_and_error_msg
     r = Reply.new
     r.title = "There's no content!"
     assert r.invalid?
-    assert r.errors[:content].any?, "A reply without content should mark that attribute as invalid"
+    assert r.errors[:content].any?, message: "A reply without content should mark that attribute as invalid"
     assert_equal ["is Empty"], r.errors["content"], "A reply without content should contain an error"
     assert_equal 1, r.errors.count
   end
@@ -38,10 +38,10 @@ class ValidationsTest < ActiveModel::TestCase
     r = Reply.new
     assert r.invalid?
 
-    assert r.errors[:title].any?, "A reply without title should mark that attribute as invalid"
+    assert r.errors[:title].any?, message: "A reply without title should mark that attribute as invalid"
     assert_equal ["is Empty"], r.errors["title"], "A reply without title should contain an error"
 
-    assert r.errors[:content].any?, "A reply without content should mark that attribute as invalid"
+    assert r.errors[:content].any?, message: "A reply without content should mark that attribute as invalid"
     assert_equal ["is Empty"], r.errors["content"], "A reply without content should contain an error"
 
     assert_equal 2, r.errors.count

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -123,7 +123,7 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     def test_multi_results
       rows = ActiveRecord::Base.connection.select_rows('CALL ten();')
       assert_equal 10, rows[0][0].to_i, "ten() did not return 10 as expected: #{rows.inspect}"
-      assert @connection.active?, "Bad connection use by 'MysqlAdapter.select_rows'"
+      assert @connection.active?, message: "Bad connection use by 'MysqlAdapter.select_rows'"
     end
   end
 

--- a/activerecord/test/cases/adapters/mysql/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/schema_test.rb
@@ -67,7 +67,7 @@ module ActiveRecord
 
       def test_table_exists?
         name = @omgpost.table_name
-        assert @connection.table_exists?(name), "#{name} table should exist"
+        assert @connection.table_exists?(name), message: "#{name} table should exist"
       end
 
       def test_table_exists_wrong_schema

--- a/activerecord/test/cases/adapters/mysql/sp_test.rb
+++ b/activerecord/test/cases/adapters/mysql/sp_test.rb
@@ -9,7 +9,7 @@ class StoredProcedureTest < ActiveRecord::TestCase
     def test_multi_results_from_find_by_sql
       topics = Topic.find_by_sql 'CALL topics();'
       assert_equal 1, topics.size
-      assert ActiveRecord::Base.connection.active?, "Bad connection use by 'MysqlAdapter.select'"
+      assert ActiveRecord::Base.connection.active?, message: "Bad connection use by 'MysqlAdapter.select'"
     end
   end
 end

--- a/activerecord/test/cases/adapters/mysql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/mysql/statement_pool_test.rb
@@ -15,7 +15,7 @@ module ActiveRecord::ConnectionAdapters
           }
 
           Process.waitpid pid
-          assert $?.success?, 'process should exit successfully'
+          assert $?.success?, message: 'process should exit successfully'
         end
       end
     end

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -29,7 +29,7 @@ module ActiveRecord
 
       def test_table_exists?
         name = @omgpost.table_name
-        assert @connection.table_exists?(name), "#{name} table should exist"
+        assert @connection.table_exists?(name), message: "#{name} table should exist"
       end
 
       def test_table_exists_wrong_schema

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -292,11 +292,11 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
       def self.model_name; ActiveModel::Name.new(PgArray) end
     end
     e1 = klass.create("tags" => ["black", "blue"])
-    assert e1.persisted?, "Saving e1"
+    assert e1.persisted?, message: "Saving e1"
 
     e2 = klass.create("tags" => ["black", "blue"])
-    assert !e2.persisted?, "e2 shouldn't be valid"
-    assert e2.errors[:tags].any?, "Should have errors for tags"
+    assert !e2.persisted?, message: "e2 shouldn't be valid"
+    assert e2.errors[:tags].any?, message: "Should have errors for tags"
     assert_equal ["has already been taken"], e2.errors[:tags], "Should have uniqueness message for tags"
   end
 

--- a/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
@@ -50,7 +50,7 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::TestCase
 
     migrations = [EnableHstore.new(nil, 1)]
     ActiveRecord::Migrator.new(:up, migrations).migrate
-    assert @connection.extension_enabled?("hstore"), "extension hstore should be enabled"
+    assert @connection.extension_enabled?("hstore"), message: "extension hstore should be enabled"
   end
 
   def test_disable_extension_migration_ignores_prefix_and_suffix

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -37,8 +37,8 @@ if ActiveRecord::Base.connection.supports_extensions?
     end
 
     def test_hstore_included_in_extensions
-      assert @connection.respond_to?(:extensions), "connection should have a list of extensions"
-      assert @connection.extensions.include?('hstore'), "extension list should include hstore"
+      assert @connection.respond_to?(:extensions), message: "connection should have a list of extensions"
+      assert @connection.extensions.include?('hstore'), message: "extension list should include hstore"
     end
 
     def test_disable_enable_hstore

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -68,7 +68,7 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::TestCase
       end
       assert_equal 'Should be re-raised', e.message
     end
-    assert warning.blank?, "expected no warnings but got:\n#{warning}"
+    assert warning.blank?, message: "expected no warnings but got:\n#{warning}"
   end
 
   def test_does_not_break_transactions

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -164,7 +164,7 @@ class SchemaTest < ActiveRecord::TestCase
   def test_table_exists?
     [Thing1, Thing2, Thing3, Thing4].each do |klass|
       name = klass.table_name
-      assert @connection.table_exists?(name), "'#{name}' table should exist"
+      assert @connection.table_exists?(name), message: "'#{name}' table should exist"
     end
   end
 

--- a/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
@@ -26,7 +26,7 @@ module ActiveRecord
             }
 
             Process.waitpid pid
-            assert $?.success?, 'process should exit successfully'
+            assert $?.success?, message: 'process should exit successfully'
           end
         end
 

--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -54,11 +54,11 @@ class TimestampTest < ActiveRecord::TestCase
 
   def test_load_infinity_and_beyond
     d = Developer.find_by_sql("select 'infinity'::timestamp as updated_at")
-    assert d.first.updated_at.infinite?, 'timestamp should be infinite'
+    assert d.first.updated_at.infinite?, message: 'timestamp should be infinite'
 
     d = Developer.find_by_sql("select '-infinity'::timestamp as updated_at")
     time = d.first.updated_at
-    assert time.infinite?, 'timestamp should be infinite'
+    assert time.infinite?, message: 'timestamp should be infinite'
     assert_operator time, :<, 0
   end
 

--- a/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
@@ -28,7 +28,7 @@ class CopyTableTest < ActiveRecord::TestCase
         :rename => {'name' => 'person_name'}) do |from, to, options|
       expected = column_values(from, 'name')
       assert_equal expected, column_values(to, 'person_name')
-      assert expected.any?, "No values in table: #{expected.inspect}"
+      assert expected.any?, message: "No values in table: #{expected.inspect}"
     end
   end
 

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -118,11 +118,11 @@ module ActiveRecord
         conn = Base.sqlite3_connection database: ':memory:',
                                        adapter: 'sqlite3',
                                        timeout: nil
-        assert conn, 'made a connection'
+        assert conn, message: 'made a connection'
       end
 
       def test_connect
-        assert @conn, 'should have connection'
+        assert @conn, message: 'should have connection'
       end
 
       # sqlite3 defaults to UTF-8 encoding
@@ -366,7 +366,7 @@ module ActiveRecord
           index = @conn.indexes('ex').find { |idx| idx.name == 'fun' }
 
           assert_equal 'ex', index.table
-          assert index.unique, 'index is unique'
+          assert index.unique, message: 'index is unique'
           assert_equal ['id'], index.columns
         end
       end

--- a/activerecord/test/cases/adapters/sqlite3/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/statement_pool_test.rb
@@ -16,7 +16,7 @@ module ActiveRecord::ConnectionAdapters
           }
 
           Process.waitpid pid
-          assert $?.success?, 'process should exit successfully'
+          assert $?.success?, message: 'process should exit successfully'
         end
       end
     end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -35,7 +35,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     ActiveRecord::SQLCounter.clear_log
     Client.find(3).firm
   ensure
-    assert ActiveRecord::SQLCounter.log_all.all? { |sql| /order by/i !~ sql }, 'ORDER BY was used in the query'
+    assert ActiveRecord::SQLCounter.log_all.all? { |sql| /order by/i !~ sql }, message: 'ORDER BY was used in the query'
   end
 
   def test_belongs_to_with_primary_key

--- a/activerecord/test/cases/associations/callbacks_test.rb
+++ b/activerecord/test/cases/associations/callbacks_test.rb
@@ -119,7 +119,7 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
     rec.developers_with_callbacks << alice
     assert_equal alice, dev
     assert_not_nil new_dev
-    assert new_dev, "record should not have been saved"
+    assert new_dev, message: "record should not have been saved"
     assert_not alice.new_record?
   end
 

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -901,7 +901,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   def test_redefine_habtm
     child = SubDeveloper.new("name" => "Aredridel")
     child.special_projects << SpecialProject.new("name" => "Special Project")
-    assert child.save, 'child object should be saved'
+    assert child.save, message: 'child object should be saved'
   end
 
   def test_habtm_with_reflection_using_class_name_and_fixtures

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1344,12 +1344,12 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_destroy_all
     force_signal37_to_load_all_clients_of_firm
     clients = companies(:first_firm).clients_of_firm.to_a
-    assert !clients.empty?, "37signals has clients after load"
+    assert !clients.empty?, message: "37signals has clients after load"
     destroyed = companies(:first_firm).clients_of_firm.destroy_all
     assert_equal clients.sort_by(&:id), destroyed.sort_by(&:id)
-    assert destroyed.all?(&:frozen?), "destroyed clients should be frozen"
-    assert companies(:first_firm).clients_of_firm.empty?, "37signals has no clients after destroy all"
-    assert companies(:first_firm).clients_of_firm(true).empty?, "37signals has no clients after destroy all and refresh"
+    assert destroyed.all?(&:frozen?), message: "destroyed clients should be frozen"
+    assert companies(:first_firm).clients_of_firm.empty?, message: "37signals has no clients after destroy all"
+    assert companies(:first_firm).clients_of_firm(true).empty?, message: "37signals has no clients after destroy all and refresh"
   end
 
   def test_dependence
@@ -1459,7 +1459,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_replace_with_less
     firm = Firm.all.merge!(:order => "id").first
     firm.clients = [companies(:first_client)]
-    assert firm.save, "Could not save firm"
+    assert firm.save, message: "Could not save firm"
     firm.reload
     assert_equal 1, firm.clients.length
   end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -144,7 +144,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
     sicp.students.reload
     sicp.students.destroy(*student.all.to_a)
-    assert after_destroy_called, "after destroy should be called"
+    assert after_destroy_called, message: "after destroy should be called"
   end
 
   def make_no_pk_hm_t
@@ -1076,7 +1076,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     person = Person.create!(:first_name => "Gaga")
     person = Person.where(:id => person.id).where('readers.id = 1 or 1=1').references(:readers).includes(:posts).to_a.first
 
-    assert person.posts.loaded?, 'person.posts should be loaded'
+    assert person.posts.loaded?, message: 'person.posts should be loaded'
     assert_equal [], person.posts
   end
 

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -28,7 +28,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     ActiveRecord::SQLCounter.clear_log
     companies(:first_firm).account
   ensure
-    assert ActiveRecord::SQLCounter.log_all.all? { |sql| /order by/i !~ sql }, 'ORDER BY was used in the query'
+    assert ActiveRecord::SQLCounter.log_all.all? { |sql| /order by/i !~ sql }, message: 'ORDER BY was used in the query'
   end
 
   def test_has_one_cache_nils

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -54,25 +54,25 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
   def test_find_with_implicit_inner_joins_without_select_does_not_imply_readonly
     authors = Author.joins(:posts)
     assert_not authors.empty?, "expected authors to be non-empty"
-    assert authors.none?(&:readonly?), "expected no authors to be readonly"
+    assert authors.none?(&:readonly?), message: "expected no authors to be readonly"
   end
 
   def test_find_with_implicit_inner_joins_honors_readonly_with_select
     authors = Author.joins(:posts).select('authors.*').to_a
-    assert !authors.empty?, "expected authors to be non-empty"
-    assert authors.all? {|a| !a.readonly? }, "expected no authors to be readonly"
+    assert !authors.empty?, message: "expected authors to be non-empty"
+    assert authors.all? {|a| !a.readonly? }, message: "expected no authors to be readonly"
   end
 
   def test_find_with_implicit_inner_joins_honors_readonly_false
     authors = Author.joins(:posts).readonly(false).to_a
-    assert !authors.empty?, "expected authors to be non-empty"
-    assert authors.all? {|a| !a.readonly? }, "expected no authors to be readonly"
+    assert !authors.empty?, message: "expected authors to be non-empty"
+    assert authors.all? {|a| !a.readonly? }, message: "expected no authors to be readonly"
   end
 
   def test_find_with_implicit_inner_joins_does_not_set_associations
     authors = Author.joins(:posts).select('authors.*').to_a
-    assert !authors.empty?, "expected authors to be non-empty"
-    assert authors.all? { |a| !a.instance_variable_defined?(:@posts) }, "expected no authors to have the @posts association loaded"
+    assert !authors.empty?, message: "expected authors to be non-empty"
+    assert authors.all? { |a| !a.instance_variable_defined?(:@posts) }, message: "expected no authors to have the @posts association loaded"
   end
 
   def test_count_honors_implicit_inner_joins

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -22,11 +22,11 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     man_reflection = Man.reflect_on_association(:mixed_case_monkey)
 
     assert_respond_to monkey_reflection, :has_inverse?
-    assert monkey_reflection.has_inverse?, "The monkey reflection should have an inverse"
+    assert monkey_reflection.has_inverse?, message: "The monkey reflection should have an inverse"
     assert_equal man_reflection, monkey_reflection.inverse_of, "The monkey reflection's inverse should be the man reflection"
 
     assert_respond_to man_reflection, :has_inverse?
-    assert man_reflection.has_inverse?, "The man reflection should have an inverse"
+    assert man_reflection.has_inverse?, message: "The man reflection should have an inverse"
     assert_equal monkey_reflection, man_reflection.inverse_of, "The man reflection's inverse should be the monkey reflection"
   end
 
@@ -35,7 +35,7 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     user_reflection = Admin::User.reflect_on_association(:account)
 
     assert_respond_to account_reflection, :has_inverse?
-    assert account_reflection.has_inverse?, "The Admin::Account reflection should have an inverse"
+    assert account_reflection.has_inverse?, message: "The Admin::Account reflection should have an inverse"
     assert_equal user_reflection, account_reflection.inverse_of, "The Admin::Account reflection's inverse should be the Admin::User reflection"
   end
 
@@ -44,11 +44,11 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     bulb_reflection = Bulb.reflect_on_association(:car)
 
     assert_respond_to car_reflection, :has_inverse?
-    assert car_reflection.has_inverse?, "The Car reflection should have an inverse"
+    assert car_reflection.has_inverse?, message: "The Car reflection should have an inverse"
     assert_equal bulb_reflection, car_reflection.inverse_of, "The Car reflection's inverse should be the Bulb reflection"
 
     assert_respond_to bulb_reflection, :has_inverse?
-    assert bulb_reflection.has_inverse?, "The Bulb reflection should have an inverse"
+    assert bulb_reflection.has_inverse?, message: "The Bulb reflection should have an inverse"
     assert_equal car_reflection, bulb_reflection.inverse_of, "The Bulb reflection's inverse should be the Car reflection"
   end
 
@@ -57,7 +57,7 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     rating_reflection = Rating.reflect_on_association(:comment)
 
     assert_respond_to comment_reflection, :has_inverse?
-    assert comment_reflection.has_inverse?, "The Comment reflection should have an inverse"
+    assert comment_reflection.has_inverse?, message: "The Comment reflection should have an inverse"
     assert_equal rating_reflection, comment_reflection.inverse_of, "The Comment reflection's inverse should be the Rating reflection"
   end
 
@@ -105,12 +105,12 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     sponsor_reflection = Sponsor.reflect_on_association(:sponsorable)
 
     assert_respond_to sponsor_reflection, :has_inverse?
-    assert !sponsor_reflection.has_inverse?, "A polymorphic association should not find an inverse automatically"
+    assert !sponsor_reflection.has_inverse?, message: "A polymorphic association should not find an inverse automatically"
 
     club_reflection = Club.reflect_on_association(:members)
 
     assert_respond_to club_reflection, :has_inverse?
-    assert !club_reflection.has_inverse?, "A has_many_through association should not find an inverse automatically"
+    assert !club_reflection.has_inverse?, message: "A has_many_through association should not find an inverse automatically"
   end
 
   def test_polymorphic_relationships_should_still_not_have_inverses_when_non_polymorphic_relationship_has_the_same_name
@@ -118,10 +118,10 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     face_reflection = Face.reflect_on_association(:man)
 
     assert_respond_to face_reflection, :has_inverse?
-    assert face_reflection.has_inverse?, "For this test, the non-polymorphic association must have an inverse"
+    assert face_reflection.has_inverse?, message: "For this test, the non-polymorphic association must have an inverse"
 
     assert_respond_to man_reflection, :has_inverse?
-    assert !man_reflection.has_inverse?, "The target of a polymorphic association should not find an inverse automatically"
+    assert !man_reflection.has_inverse?, message: "The target of a polymorphic association should not find an inverse automatically"
   end
 end
 
@@ -357,17 +357,17 @@ class InverseHasManyTests < ActiveRecord::TestCase
   def test_parent_instance_should_be_shared_within_create_block_of_new_child
     man = Man.first
     interest = man.interests.create do |i|
-      assert i.man.equal?(man), "Man of child should be the same instance as a parent"
+      assert i.man.equal?(man), message: "Man of child should be the same instance as a parent"
     end
-    assert interest.man.equal?(man), "Man of the child should still be the same instance as a parent"
+    assert interest.man.equal?(man), message: "Man of the child should still be the same instance as a parent"
   end
 
   def test_parent_instance_should_be_shared_within_build_block_of_new_child
     man = Man.first
     interest = man.interests.build do |i|
-      assert i.man.equal?(man), "Man of child should be the same instance as a parent"
+      assert i.man.equal?(man), message: "Man of child should be the same instance as a parent"
     end
-    assert interest.man.equal?(man), "Man of the child should still be the same instance as a parent"
+    assert interest.man.equal?(man), message: "Man of the child should still be the same instance as a parent"
   end
 
   def test_parent_instance_should_be_shared_with_poked_in_child
@@ -418,18 +418,18 @@ class InverseHasManyTests < ActiveRecord::TestCase
     interest = Interest.create!
     man.interests = [interest]
 
-    assert interest.equal?(man.interests.first), "The inverse association should use the interest already created and held in memory"
-    assert interest.equal?(man.interests.find(interest.id)), "The inverse association should use the interest already created and held in memory"
-    assert man.equal?(man.interests.first.man), "Two inversion should lead back to the same object that was originally held"
-    assert man.equal?(man.interests.find(interest.id).man), "Two inversions should lead back to the same object that was originally held"
+    assert interest.equal?(man.interests.first), message: "The inverse association should use the interest already created and held in memory"
+    assert interest.equal?(man.interests.find(interest.id)), message: "The inverse association should use the interest already created and held in memory"
+    assert man.equal?(man.interests.first.man), message: "Two inversion should lead back to the same object that was originally held"
+    assert man.equal?(man.interests.find(interest.id).man), message: "Two inversions should lead back to the same object that was originally held"
   end
 
   def test_parent_instance_should_find_child_instance_using_child_instance_id_when_created
     man = Man.create!
     interest = Interest.create!(man: man)
 
-    assert man.equal?(man.interests.first.man), "Two inverses should lead back to the same object that was originally held"
-    assert man.equal?(man.interests.find(interest.id).man), "Two inversions should lead back to the same object that was originally held"
+    assert man.equal?(man.interests.first.man), message: "Two inverses should lead back to the same object that was originally held"
+    assert man.equal?(man.interests.find(interest.id).man), message: "Two inversions should lead back to the same object that was originally held"
 
     assert_equal man.name, man.interests.find(interest.id).man.name, "The name of the man should match before the name is changed"
     man.name = "Ben Bitdiddle"

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -84,16 +84,16 @@ class AssociationsTest < ActiveRecord::TestCase
     firm = Firm.new("name" => "A New Firm, Inc")
     firm.save
     firm.clients.each {} # forcing to load all clients
-    assert firm.clients.empty?, "New firm shouldn't have client objects"
+    assert firm.clients.empty?, message: "New firm shouldn't have client objects"
     assert_equal 0, firm.clients.size, "New firm should have 0 clients"
 
     client = Client.new("name" => "TheClient.com", "firm_id" => firm.id)
     client.save
 
-    assert firm.clients.empty?, "New firm should have cached no client objects"
+    assert firm.clients.empty?, message: "New firm should have cached no client objects"
     assert_equal 0, firm.clients.size, "New firm should have cached 0 clients count"
 
-    assert !firm.clients(true).empty?, "New firm should have reloaded client objects"
+    assert !firm.clients(true).empty?, message: "New firm should have reloaded client objects"
     assert_equal 1, firm.clients(true).size, "New firm should have reloaded clients count"
   end
 
@@ -102,9 +102,9 @@ class AssociationsTest < ActiveRecord::TestCase
     belongs_to_reflections = [Tagging.reflect_on_association(:tag), Tagging.reflect_on_association(:super_tag)]
     has_many_reflections = [Tag.reflect_on_association(:taggings), Developer.reflect_on_association(:projects)]
     mixed_reflections = (belongs_to_reflections + has_many_reflections).uniq
-    assert using_limitable_reflections.call(belongs_to_reflections), "Belong to associations are limitable"
-    assert !using_limitable_reflections.call(has_many_reflections), "All has many style associations are not limitable"
-    assert !using_limitable_reflections.call(mixed_reflections), "No collection associations (has many style) should pass"
+    assert using_limitable_reflections.call(belongs_to_reflections), message: "Belong to associations are limitable"
+    assert !using_limitable_reflections.call(has_many_reflections), message: "All has many style associations are not limitable"
+    assert !using_limitable_reflections.call(mixed_reflections), message: "No collection associations (has many style) should pass"
   end
 
   def test_force_reload_is_uncached

--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -46,7 +46,7 @@ module ActiveRecord
         @klass.define_attribute_methods
 
         @klass.attribute_names.each do |name|
-          assert instance.methods.map(&:to_s).include?(name), "#{name} is not defined"
+          assert instance.methods.map(&:to_s).include?(name), message: "#{name} is not defined"
         end
       end
 

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -320,32 +320,32 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   def test_read_attribute_when_false
     topic = topics(:first)
     topic.approved = false
-    assert !topic.approved?, "approved should be false"
+    assert !topic.approved?, message: "approved should be false"
     topic.approved = "false"
-    assert !topic.approved?, "approved should be false"
+    assert !topic.approved?, message: "approved should be false"
   end
 
   def test_read_attribute_when_true
     topic = topics(:first)
     topic.approved = true
-    assert topic.approved?, "approved should be true"
+    assert topic.approved?, message: "approved should be true"
     topic.approved = "true"
-    assert topic.approved?, "approved should be true"
+    assert topic.approved?, message: "approved should be true"
   end
 
   def test_read_write_boolean_attribute
     topic = Topic.new
     topic.approved = "false"
-    assert !topic.approved?, "approved should be false"
+    assert !topic.approved?, message: "approved should be false"
 
     topic.approved = "false"
-    assert !topic.approved?, "approved should be false"
+    assert !topic.approved?, message: "approved should be false"
 
     topic.approved = "true"
-    assert topic.approved?, "approved should be true"
+    assert topic.approved?, message: "approved should be true"
 
     topic.approved = "true"
-    assert topic.approved?, "approved should be true"
+    assert topic.approved?, message: "approved should be true"
   end
 
   def test_overridden_write_attribute
@@ -815,12 +815,12 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     instance = subklass.new
     instance.id = 5
     assert_equal 5, instance.id
-    assert subklass.method_defined?(:id), "subklass is missing id method"
+    assert subklass.method_defined?(:id), message: "subklass is missing id method"
 
     Topic.undefine_attribute_methods
 
     assert_equal 5, instance.id
-    assert subklass.method_defined?(:id), "subklass is missing id method"
+    assert subklass.method_defined?(:id), message: "subklass is missing id method"
   end
 
   def test_read_attribute_with_nil_should_not_asplode

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -553,8 +553,8 @@ class BasicsTest < ActiveRecord::TestCase
     car.bulbs.build
     car.save
 
-    assert car.bulbs == Bulb.where(car_id: car.id), 'CollectionProxy should be comparable with Relation'
-    assert Bulb.where(car_id: car.id) == car.bulbs, 'Relation should be comparable with CollectionProxy'
+    assert car.bulbs == Bulb.where(car_id: car.id), message: 'CollectionProxy should be comparable with Relation'
+    assert Bulb.where(car_id: car.id) == car.bulbs, message: 'Relation should be comparable with CollectionProxy'
   end
 
   def test_equality_of_relation_and_array
@@ -562,7 +562,7 @@ class BasicsTest < ActiveRecord::TestCase
     car.bulbs.build
     car.save
 
-    assert Bulb.where(car_id: car.id) == car.bulbs.to_a, 'Relation should be comparable with Array'
+    assert Bulb.where(car_id: car.id) == car.bulbs.to_a, message: 'Relation should be comparable with Array'
   end
 
   def test_equality_of_relation_and_association_relation
@@ -1337,7 +1337,7 @@ class BasicsTest < ActiveRecord::TestCase
     marshalled = Marshal.dump(Post.new)
     post       = Marshal.load(marshalled)
 
-    assert post.new_record?, "should be a new record"
+    assert post.new_record?, message: "should be a new record"
   end
 
   def test_marshalling_with_associations
@@ -1387,7 +1387,7 @@ class BasicsTest < ActiveRecord::TestCase
 
     post = Marshal.load(Marshal.dump(post))
 
-    assert post.new_record?, "should be a new record"
+    assert post.new_record?, message: "should be a new record"
   end
 
   def test_attribute_names

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -52,7 +52,7 @@ module ActiveRecord
       def test_find_one_uses_binds
         Topic.find(1)
         message = @subscriber.calls.find { |args| args[4][:binds].any? { |attr| attr.value == 1 } }
-        assert message, 'expected a message with binds'
+        assert message, message: 'expected a message with binds'
       end
 
       def test_logs_bind_vars_after_type_cast

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -71,14 +71,14 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_should_group_by_field
     c = Account.group(:firm_id).sum(:credit_limit)
     [1,6,2].each do |firm_id|
-      assert c.keys.include?(firm_id), "Group #{c.inspect} does not contain firm_id #{firm_id}"
+      assert c.keys.include?(firm_id), message: "Group #{c.inspect} does not contain firm_id #{firm_id}"
     end
   end
 
   def test_should_group_by_arel_attribute
     c = Account.group(Account.arel_table[:firm_id]).sum(:credit_limit)
     [1,6,2].each do |firm_id|
-      assert c.keys.include?(firm_id), "Group #{c.inspect} does not contain firm_id #{firm_id}"
+      assert c.keys.include?(firm_id), message: "Group #{c.inspect} does not contain firm_id #{firm_id}"
     end
   end
 

--- a/activerecord/test/cases/clone_test.rb
+++ b/activerecord/test/cases/clone_test.rb
@@ -8,9 +8,9 @@ module ActiveRecord
     def test_persisted
       topic = Topic.first
       cloned = topic.clone
-      assert topic.persisted?, 'topic persisted'
-      assert cloned.persisted?, 'topic persisted'
-      assert !cloned.new_record?, 'topic is not new'
+      assert topic.persisted?, message: 'topic persisted'
+      assert cloned.persisted?, message: 'topic persisted'
+      assert !cloned.new_record?, message: 'topic is not new'
     end
 
     def test_stays_frozen
@@ -18,9 +18,9 @@ module ActiveRecord
       topic.freeze
 
       cloned = topic.clone
-      assert cloned.persisted?, 'topic persisted'
-      assert !cloned.new_record?, 'topic is not new'
-      assert cloned.frozen?, 'topic should be frozen'
+      assert cloned.persisted?, message: 'topic persisted'
+      assert !cloned.new_record?, message: 'topic is not new'
+      assert cloned.frozen?, message: 'topic should be frozen'
     end
 
     def test_shallow

--- a/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
+++ b/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
@@ -18,20 +18,20 @@ module ActiveRecord
 
       def test_in_use?
         assert_not @adapter.in_use?, 'adapter is not in use'
-        assert @adapter.lease, 'lease adapter'
-        assert @adapter.in_use?, 'adapter is in use'
+        assert @adapter.lease, message: 'lease adapter'
+        assert @adapter.in_use?, message: 'adapter is in use'
       end
 
       def test_lease_twice
-        assert @adapter.lease, 'should lease adapter'
+        assert @adapter.lease, message: 'should lease adapter'
         assert_raises(ActiveRecordError) do
           @adapter.lease
         end
       end
 
       def test_expire_mutates_in_use
-        assert @adapter.lease, 'lease adapter'
-        assert @adapter.in_use?, 'adapter is in use'
+        assert @adapter.lease, message: 'lease adapter'
+        assert @adapter.in_use?, message: 'adapter is in use'
         @adapter.expire
         assert_not @adapter.in_use?, 'adapter is in use'
       end

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -13,7 +13,7 @@ class DefaultTest < ActiveRecord::TestCase
 
     column_defaults.each do |name, default|
       column = Entrant.columns_hash[name]
-      assert !column.null, "#{name} column should be NOT NULL"
+      assert !column.null, message: "#{name} column should be NOT NULL"
       assert_equal default, column.default, "#{name} column should be DEFAULT #{default.inspect}"
     end
   end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -587,7 +587,7 @@ class DirtyTest < ActiveRecord::TestCase
       topic = target.create(:written_on => written_on)
       topic.written_on += 0.3
 
-      assert topic.written_on_changed?, 'Fractional second update not detected'
+      assert topic.written_on_changed?, message: 'Fractional second update not detected'
     end
   end
 

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -14,7 +14,7 @@ module ActiveRecord
       topic = Topic.first
 
       duped = topic.dup
-      assert !duped.readonly?, 'should not be readonly'
+      assert !duped.readonly?, message: 'should not be readonly'
     end
 
     def test_is_readonly
@@ -22,15 +22,15 @@ module ActiveRecord
       topic.readonly!
 
       duped = topic.dup
-      assert duped.readonly?, 'should be readonly'
+      assert duped.readonly?, message: 'should be readonly'
     end
 
     def test_dup_not_persisted
       topic = Topic.first
       duped = topic.dup
 
-      assert !duped.persisted?, 'topic not persisted'
-      assert duped.new_record?, 'topic is new'
+      assert !duped.persisted?, message: 'topic not persisted'
+      assert duped.new_record?, message: 'topic is new'
     end
 
     def test_dup_not_destroyed
@@ -137,7 +137,7 @@ module ActiveRecord
       prev_default_scopes = Topic.default_scopes
       Topic.default_scopes = [proc { Topic.where(:approved => true) }]
       topic = Topic.new(:approved => false)
-      assert !topic.dup.approved?, "should not be overridden by default scopes"
+      assert !topic.dup.approved?, message: "should not be overridden by default scopes"
     ensure
       Topic.default_scopes = prev_default_scopes
     end

--- a/activerecord/test/cases/fixture_set/file_test.rb
+++ b/activerecord/test/cases/fixture_set/file_test.rb
@@ -15,7 +15,7 @@ module ActiveRecord
           called = true
           assert_equal 6, fh.to_a.length
         end
-        assert called, 'block called'
+        assert called, message: 'block called'
       end
 
       def test_names

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -69,8 +69,8 @@ class FixturesTest < ActiveRecord::TestCase
 
   def test_create_fixtures
     fixtures = ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, "parrots")
-    assert Parrot.find_by_name('Curious George'), 'George is not in the database'
-    assert fixtures.detect { |f| f.name == 'parrots' }, "no fixtures named 'parrots' in #{fixtures.map(&:name).inspect}"
+    assert Parrot.find_by_name('Curious George'), message: 'George is not in the database'
+    assert fixtures.detect { |f| f.name == 'parrots' }, message: "no fixtures named 'parrots' in #{fixtures.map(&:name).inspect}"
   end
 
   def test_multiple_clean_fixtures
@@ -83,8 +83,8 @@ class FixturesTest < ActiveRecord::TestCase
   def test_create_symbol_fixtures
     fixtures = ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, :collections, :collections => Course) { Course.connection }
 
-    assert Course.find_by_name('Collection'), 'course is not in the database'
-    assert fixtures.detect { |f| f.name == 'collections' }, "no fixtures named 'collections' in #{fixtures.map(&:name).inspect}"
+    assert Course.find_by_name('Collection'), message: 'course is not in the database'
+    assert fixtures.detect { |f| f.name == 'collections' }, message: "no fixtures named 'collections' in #{fixtures.map(&:name).inspect}"
   end
 
   def test_attributes
@@ -263,7 +263,7 @@ class FixturesTest < ActiveRecord::TestCase
 
     result = test_case.new(:test_fixtures).run
 
-    assert result.passed?, "Expected #{result.name} to pass:\n#{result}"
+    assert result.passed?, message: "Expected #{result.name} to pass:\n#{result}"
   ensure
     ENV['DATABASE_URL'] = db_url_tmp
   end
@@ -414,7 +414,7 @@ class FixturesWithoutInstanceInstantiationTest < ActiveRecord::TestCase
   fixtures :topics, :developers, :accounts
 
   def test_without_instance_instantiation
-    assert !defined?(@first), "@first is not defined"
+    assert !defined?(@first), message: "@first is not defined"
   end
 end
 

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -79,9 +79,9 @@ class InheritanceTest < ActiveRecord::TestCase
 
   def test_company_descends_from_active_record
     assert !ActiveRecord::Base.descends_from_active_record?
-    assert AbstractCompany.descends_from_active_record?, 'AbstractCompany should descend from ActiveRecord::Base'
-    assert Company.descends_from_active_record?, 'Company should descend from ActiveRecord::Base'
-    assert !Class.new(Company).descends_from_active_record?, 'Company subclass should not descend from ActiveRecord::Base'
+    assert AbstractCompany.descends_from_active_record?, message: 'AbstractCompany should descend from ActiveRecord::Base'
+    assert Company.descends_from_active_record?, message: 'Company should descend from ActiveRecord::Base'
+    assert !Class.new(Company).descends_from_active_record?, message: 'Company subclass should not descend from ActiveRecord::Base'
   end
 
   def test_inheritance_base_class
@@ -327,12 +327,12 @@ class InheritanceTest < ActiveRecord::TestCase
 
   def test_eager_load_belongs_to_something_inherited
     account = Account.all.merge!(:includes => :firm).find(1)
-    assert account.association(:firm).loaded?, "association was not eager loaded"
+    assert account.association(:firm).loaded?, message: "association was not eager loaded"
   end
 
   def test_alt_eager_loading
     cabbage = RedCabbage.all.merge!(:includes => :seller).find(4)
-    assert cabbage.association(:seller).loaded?, "association was not eager loaded"
+    assert cabbage.association(:seller).loaded?, message: "association was not eager loaded"
   end
 
   def test_eager_load_belongs_to_primary_key_quoting

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -156,7 +156,7 @@ module ActiveRecord
     def test_migrate_up
       migration = InvertibleMigration.new
       migration.migrate(:up)
-      assert migration.connection.table_exists?("horses"), "horses should exist"
+      assert migration.connection.table_exists?("horses"), message: "horses should exist"
     end
 
     def test_migrate_down
@@ -245,24 +245,24 @@ module ActiveRecord
 
     def test_legacy_up
       LegacyMigration.migrate :up
-      assert ActiveRecord::Base.connection.table_exists?("horses"), "horses should exist"
+      assert ActiveRecord::Base.connection.table_exists?("horses"), message: "horses should exist"
     end
 
     def test_legacy_down
       LegacyMigration.migrate :up
       LegacyMigration.migrate :down
-      assert !ActiveRecord::Base.connection.table_exists?("horses"), "horses should not exist"
+      assert !ActiveRecord::Base.connection.table_exists?("horses"), message: "horses should not exist"
     end
 
     def test_up
       LegacyMigration.up
-      assert ActiveRecord::Base.connection.table_exists?("horses"), "horses should exist"
+      assert ActiveRecord::Base.connection.table_exists?("horses"), message: "horses should exist"
     end
 
     def test_down
       LegacyMigration.up
       LegacyMigration.down
-      assert !ActiveRecord::Base.connection.table_exists?("horses"), "horses should not exist"
+      assert !ActiveRecord::Base.connection.table_exists?("horses"), message: "horses should not exist"
     end
 
     def test_migrate_down_with_table_name_prefix
@@ -271,7 +271,7 @@ module ActiveRecord
       migration = InvertibleMigration.new
       migration.migrate(:up)
       assert_nothing_raised { migration.migrate(:down) }
-      assert !ActiveRecord::Base.connection.table_exists?("p_horses_s"), "p_horses_s should not exist"
+      assert !ActiveRecord::Base.connection.table_exists?("p_horses_s"), message: "p_horses_s should not exist"
     ensure
       ActiveRecord::Base.table_name_prefix = ActiveRecord::Base.table_name_suffix = ''
     end
@@ -285,9 +285,9 @@ module ActiveRecord
 
         connection = ActiveRecord::Base.connection
         assert connection.index_exists?(:horses, :content),
-               "index on content should exist"
+               message: "index on content should exist"
         assert !connection.index_exists?(:horses, :content, name: "horses_index_named"),
-              "horses_index_named index should not exist"
+              message: "horses_index_named index should not exist"
       end
     end
 

--- a/activerecord/test/cases/json_serialization_test.rb
+++ b/activerecord/test/cases/json_serialization_test.rb
@@ -275,7 +275,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
 
     ['"name":"David"', '"posts":[', '{"id":1}', '{"id":2}', '{"id":4}',
      '{"id":5}', '{"id":6}', '"name":"Mary"', '"posts":[', '{"id":7}', '{"id":9}'].each do |fragment|
-      assert json.include?(fragment), json
+      assert json.include?(fragment), message: json
      end
   end
 

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -167,7 +167,7 @@ module ActiveRecord
 
       def test_change_column_nullability
         add_column "test_models", "funny", :boolean
-        assert TestModel.columns_hash["funny"].null, "Column 'funny' must initially allow nulls"
+        assert TestModel.columns_hash["funny"].null, message: "Column 'funny' must initially allow nulls"
 
         change_column "test_models", "funny", :boolean, :null => false, :default => true
 
@@ -176,7 +176,7 @@ module ActiveRecord
 
         change_column "test_models", "funny", :boolean, :null => true
         TestModel.reset_column_information
-        assert TestModel.columns_hash["funny"].null, "Column 'funny' must allow nulls again at this point"
+        assert TestModel.columns_hash["funny"].null, message: "Column 'funny' must allow nulls again at this point"
       end
 
       def test_change_column

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         recorder = CommandRecorder.new(Class.new {
           def create_table(name); end
         }.new)
-        assert recorder.respond_to?(:create_table), 'respond_to? create_table'
+        assert recorder.respond_to?(:create_table), message: 'respond_to? create_table'
         recorder.send(:create_table, :horses)
         assert_equal [[:create_table, [:horses], nil]], recorder.commands
       end

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -126,7 +126,7 @@ module ActiveRecord
           assert_includes connection.tables, 'audio_artists_musics'
 
           connection.drop_join_table 'audio_artists', 'audio_musics'
-          assert !connection.tables.include?('audio_artists_musics'), "Should have dropped join table, but didn't"
+          assert !connection.tables.include?('audio_artists_musics'), message: "Should have dropped join table, but didn't"
         end
       end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -251,22 +251,22 @@ class MigrationTest < ActiveRecord::TestCase
 
   def test_instance_based_migration_up
     migration = MockMigration.new
-    assert !migration.went_up, 'have not gone up'
-    assert !migration.went_down, 'have not gone down'
+    assert !migration.went_up, message: 'have not gone up'
+    assert !migration.went_down, message: 'have not gone down'
 
     migration.migrate :up
-    assert migration.went_up, 'have gone up'
-    assert !migration.went_down, 'have not gone down'
+    assert migration.went_up, message: 'have gone up'
+    assert !migration.went_down, message: 'have not gone down'
   end
 
   def test_instance_based_migration_down
     migration = MockMigration.new
-    assert !migration.went_up, 'have not gone up'
-    assert !migration.went_down, 'have not gone down'
+    assert !migration.went_up, message: 'have not gone up'
+    assert !migration.went_down, message: 'have not gone down'
 
     migration.migrate :down
-    assert !migration.went_up, 'have gone up'
-    assert migration.went_down, 'have not gone down'
+    assert !migration.went_up, message: 'have gone up'
+    assert migration.went_down, message: 'have not gone down'
   end
 
   if ActiveRecord::Base.connection.supports_ddl_transactions?

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -111,7 +111,7 @@ class MigratorTest < ActiveRecord::TestCase
     migration_proxy = list.find { |item|
       item.name == 'ValidPeopleHaveLastNames'
     }
-    assert migration_proxy, 'should find pending migration'
+    assert migration_proxy, message: 'should find pending migration'
   end
 
   def test_finds_pending_migrations

--- a/activerecord/test/cases/modules_test.rb
+++ b/activerecord/test/cases/modules_test.rb
@@ -30,7 +30,7 @@ class ModulesTest < ActiveRecord::TestCase
 
   def test_module_spanning_associations
     firm = MyApplication::Business::Firm.first
-    assert !firm.clients.empty?, "Firm should have clients"
+    assert !firm.clients.empty?, message: "Firm should have clients"
     assert_nil firm.class.table_name.match('::'), "Firm shouldn't have the module appear in its table name"
   end
 
@@ -153,7 +153,7 @@ class ModulesTest < ActiveRecord::TestCase
     ActiveRecord::Base.store_full_sti_class = true
 
     collection = Shop::Collection.first
-    assert !collection.products.empty?, "Collection should have products"
+    assert !collection.products.empty?, message: "Collection should have products"
     assert_nothing_raised { collection.destroy }
   ensure
     ActiveRecord::Base.store_full_sti_class = old
@@ -164,7 +164,7 @@ class ModulesTest < ActiveRecord::TestCase
     ActiveRecord::Base.store_full_sti_class = true
 
     product = Shop::Product.first
-    assert !product.variants.empty?, "Product should have variants"
+    assert !product.variants.empty?, message: "Product should have variants"
     assert_nothing_raised { product.destroy }
   ensure
     ActiveRecord::Base.store_full_sti_class = old

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -127,7 +127,7 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_difference('Topic.count', -topics_by_mary.size) do
       destroyed = Topic.destroy_all(conditions).sort_by(&:id)
       assert_equal topics_by_mary, destroyed
-      assert destroyed.all?(&:frozen?), "destroyed topics should be frozen"
+      assert destroyed.all?(&:frozen?), message: "destroyed topics should be frozen"
     end
   end
 
@@ -137,7 +137,7 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_difference('Client.count', -2) do
       destroyed = Client.destroy([2, 3]).sort_by(&:id)
       assert_equal clients, destroyed
-      assert destroyed.all?(&:frozen?), "destroyed clients should be frozen"
+      assert destroyed.all?(&:frozen?), message: "destroyed clients should be frozen"
     end
   end
 
@@ -375,7 +375,7 @@ class PersistenceTest < ActiveRecord::TestCase
   def test_delete
     topic = Topic.find(1)
     assert_equal topic, topic.delete, 'topic.delete did not return self'
-    assert topic.frozen?, 'topic not frozen after delete'
+    assert topic.frozen?, message: 'topic not frozen after delete'
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(topic.id) }
   end
 
@@ -387,14 +387,14 @@ class PersistenceTest < ActiveRecord::TestCase
   def test_destroy
     topic = Topic.find(1)
     assert_equal topic, topic.destroy, 'topic.destroy did not return self'
-    assert topic.frozen?, 'topic not frozen after destroy'
+    assert topic.frozen?, message: 'topic not frozen after destroy'
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(topic.id) }
   end
 
   def test_destroy!
     topic = Topic.find(1)
     assert_equal topic, topic.destroy!, 'topic.destroy! did not return self'
-    assert topic.frozen?, 'topic not frozen after destroy!'
+    assert topic.frozen?, message: 'topic not frozen after destroy!'
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(topic.id) }
   end
 
@@ -475,8 +475,8 @@ class PersistenceTest < ActiveRecord::TestCase
     t = Topic.first
     t.update_attribute(:title, 'super_title')
     assert_equal 'super_title', t.title
-    assert !t.changed?, "topic should not have changed"
-    assert !t.title_changed?, "title should not have changed"
+    assert !t.changed?, message: "topic should not have changed"
+    assert !t.title_changed?, message: "title should not have changed"
     assert_nil t.title_change, 'title change should be nil'
 
     t.reload
@@ -575,8 +575,8 @@ class PersistenceTest < ActiveRecord::TestCase
     t.update_column(:title, 'super_title')
     assert_equal 'John', t.author_name
     assert_equal 'super_title', t.title
-    assert t.changed?, "topic should have changed"
-    assert t.author_name_changed?, "author_name should have changed"
+    assert t.changed?, message: "topic should have changed"
+    assert t.author_name_changed?, message: "author_name should have changed"
 
     t.reload
     assert_equal author_name, t.author_name
@@ -588,7 +588,7 @@ class PersistenceTest < ActiveRecord::TestCase
     developer.name = 'John'
     developer.save!
 
-    assert developer.update_column(:name, 'Will'), 'did not update record due to default scope'
+    assert developer.update_column(:name, 'Will'), message: 'did not update record due to default scope'
   end
 
   def test_update_columns
@@ -674,8 +674,8 @@ class PersistenceTest < ActiveRecord::TestCase
     t.update_columns(title: 'super_title')
     assert_equal 'John', t.author_name
     assert_equal 'super_title', t.title
-    assert t.changed?, "topic should have changed"
-    assert t.author_name_changed?, "author_name should have changed"
+    assert t.changed?, message: "topic should have changed"
+    assert t.author_name_changed?, message: "author_name should have changed"
 
     t.reload
     assert_equal author_name, t.author_name
@@ -700,7 +700,7 @@ class PersistenceTest < ActiveRecord::TestCase
     developer.name = 'John'
     developer.save!
 
-    assert developer.update_columns(name: 'Will'), 'did not update record due to default scope'
+    assert developer.update_columns(name: 'Will'), message: 'did not update record due to default scope'
   end
 
   def test_update
@@ -900,7 +900,7 @@ class PersistenceTest < ActiveRecord::TestCase
   def test_reload_via_querycache
     ActiveRecord::Base.connection.enable_query_cache!
     ActiveRecord::Base.connection.clear_query_cache
-    assert ActiveRecord::Base.connection.query_cache_enabled, 'cache should be on'
+    assert ActiveRecord::Base.connection.query_cache_enabled, message: 'cache should be on'
     parrot = Parrot.create(:name => 'Shane')
 
     # populate the cache with the SELECT result

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -14,7 +14,7 @@ class QueryCacheTest < ActiveRecord::TestCase
   end
 
   def test_exceptional_middleware_clears_and_disables_cache_on_error
-    assert !ActiveRecord::Base.connection.query_cache_enabled, 'cache off'
+    assert !ActiveRecord::Base.connection.query_cache_enabled, message: 'cache off'
 
     mw = ActiveRecord::QueryCache.new lambda { |env|
       Task.find 1
@@ -25,7 +25,7 @@ class QueryCacheTest < ActiveRecord::TestCase
     assert_raises(RuntimeError) { mw.call({}) }
 
     assert_equal 0, ActiveRecord::Base.connection.query_cache.length
-    assert !ActiveRecord::Base.connection.query_cache_enabled, 'cache off'
+    assert !ActiveRecord::Base.connection.query_cache_enabled, message: 'cache off'
   end
 
   def test_exceptional_middleware_leaves_enabled_cache_alone
@@ -36,7 +36,7 @@ class QueryCacheTest < ActiveRecord::TestCase
     }
     assert_raises(RuntimeError) { mw.call({}) }
 
-    assert ActiveRecord::Base.connection.query_cache_enabled, 'cache on'
+    assert ActiveRecord::Base.connection.query_cache_enabled, message: 'cache on'
   end
 
   def test_exceptional_middleware_assigns_original_connection_id_on_error
@@ -58,7 +58,7 @@ class QueryCacheTest < ActiveRecord::TestCase
       [200, {}, nil]
     }
     mw.call({})
-    assert called, 'middleware should delegate'
+    assert called, message: 'middleware should delegate'
   end
 
   def test_middleware_caches
@@ -72,10 +72,10 @@ class QueryCacheTest < ActiveRecord::TestCase
   end
 
   def test_cache_enabled_during_call
-    assert !ActiveRecord::Base.connection.query_cache_enabled, 'cache off'
+    assert !ActiveRecord::Base.connection.query_cache_enabled, message: 'cache off'
 
     mw = ActiveRecord::QueryCache.new lambda { |env|
-      assert ActiveRecord::Base.connection.query_cache_enabled, 'cache on'
+      assert ActiveRecord::Base.connection.query_cache_enabled, message: 'cache on'
       [200, {}, nil]
     }
     mw.call({})
@@ -92,18 +92,18 @@ class QueryCacheTest < ActiveRecord::TestCase
       [200, {}, streaming.new]
     }
     body = mw.call({}).last
-    body.each { |x| assert x, 'cache should be on' }
+    body.each { |x| assert x, message: 'cache should be on' }
     body.close
-    assert !ActiveRecord::Base.connection.query_cache_enabled, 'cache disabled'
+    assert !ActiveRecord::Base.connection.query_cache_enabled, message: 'cache disabled'
   end
 
   def test_cache_off_after_close
     mw = ActiveRecord::QueryCache.new lambda { |env| [200, {}, nil] }
     body = mw.call({}).last
 
-    assert ActiveRecord::Base.connection.query_cache_enabled, 'cache enabled'
+    assert ActiveRecord::Base.connection.query_cache_enabled, message: 'cache enabled'
     body.close
-    assert !ActiveRecord::Base.connection.query_cache_enabled, 'cache disabled'
+    assert !ActiveRecord::Base.connection.query_cache_enabled, message: 'cache disabled'
   end
 
   def test_cache_clear_after_close
@@ -113,9 +113,9 @@ class QueryCacheTest < ActiveRecord::TestCase
     }
     body = mw.call({}).last
 
-    assert !ActiveRecord::Base.connection.query_cache.empty?, 'cache not empty'
+    assert !ActiveRecord::Base.connection.query_cache.empty?, message: 'cache not empty'
     body.close
-    assert ActiveRecord::Base.connection.query_cache.empty?, 'cache should be empty'
+    assert ActiveRecord::Base.connection.query_cache.empty?, message: 'cache should be empty'
   end
 
   def test_cache_passing_a_relation

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -222,7 +222,7 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_reflections_should_return_keys_as_strings
-    assert Category.reflections.keys.all? { |key| key.is_a? String }, "Model.reflections is expected to return string for keys"
+    assert Category.reflections.keys.all? { |key| key.is_a? String }, message: "Model.reflections is expected to return string for keys"
   end
 
   def test_has_and_belongs_to_many_reflection

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -26,7 +26,7 @@ module ActiveRecord
       relation = Relation.new(FakeKlass, :b, nil)
       assert_equal FakeKlass, relation.klass
       assert_equal :b, relation.table
-      assert !relation.loaded, 'relation is not loaded'
+      assert !relation.loaded, message: 'relation is not loaded'
     end
 
     def test_responds_to_model_and_returns_klass

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -53,7 +53,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_dynamic_finder
     x = Post.where('author_id = ?', 1)
-    assert x.klass.respond_to?(:find_by_id), '@klass should handle dynamic finders'
+    assert x.klass.respond_to?(:find_by_id), message: '@klass should handle dynamic finders'
   end
 
   def test_multivalue_where

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -101,7 +101,7 @@ class NamedScopingTest < ActiveRecord::TestCase
   def test_scope_with_object
     objects = Topic.with_object
     assert_operator objects.length, :>, 0
-    assert objects.all?(&:approved?), 'all objects should be approved'
+    assert objects.all?(&:approved?), message: 'all objects should be approved'
   end
 
   def test_has_many_associations_have_access_to_scopes
@@ -500,7 +500,7 @@ class NamedScopingTest < ActiveRecord::TestCase
     [:destroy_all, :reset, :delete_all].each do |method|
       before = post.comments.containing_the_letter_e
       post.association(:comments).send(method)
-      assert before.object_id != post.comments.containing_the_letter_e.object_id, "CollectionAssociation##{method} should reset the named scopes cache"
+      assert before.object_id != post.comments.containing_the_letter_e.object_id, message: "CollectionAssociation##{method} should reset the named scopes cache"
     end
   end
 

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -29,7 +29,7 @@ module ActiveRecord
       patterns_to_match.each do |pattern|
         failed_patterns << pattern unless SQLCounter.log_all.any?{ |sql| pattern === sql }
       end
-      assert failed_patterns.empty?, "Query pattern(s) #{failed_patterns.map(&:inspect).join(', ')} not found.#{SQLCounter.log.size == 0 ? '' : "\nQueries:\n#{SQLCounter.log.join("\n")}"}"
+      assert failed_patterns.empty?, message: "Query pattern(s) #{failed_patterns.map(&:inspect).join(', ')} not found.#{SQLCounter.log.size == 0 ? '' : "\nQueries:\n#{SQLCounter.log.join("\n")}"}"
     end
 
     def assert_queries(num = 1, options = {})
@@ -52,7 +52,7 @@ module ActiveRecord
     end
 
     def assert_column(model, column_name, msg=nil)
-      assert has_column?(model, column_name), msg
+      assert has_column?(model, column_name), message: msg
     end
 
     def assert_no_column(model, column_name, msg=nil)

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -38,8 +38,8 @@ class TimestampTest < ActiveRecord::TestCase
 
     assert_not_equal @previously_updated_at, @developer.updated_at
     assert_equal previous_salary + 10000, @developer.salary
-    assert @developer.salary_changed?, 'developer salary should have changed'
-    assert @developer.changed?, 'developer should be marked as changed'
+    assert @developer.salary_changed?, message: 'developer salary should have changed'
+    assert @developer.changed?, message: 'developer should be marked as changed'
     @developer.reload
     assert_equal previous_salary, @developer.salary
   end
@@ -74,20 +74,20 @@ class TimestampTest < ActiveRecord::TestCase
   end
 
   def test_touching_updates_timestamp_with_given_time
-    previously_updated_at = @developer.updated_at 
-    new_time = Time.utc(2015, 2, 16, 0, 0, 0) 
-    @developer.touch(time: new_time) 
+    previously_updated_at = @developer.updated_at
+    new_time = Time.utc(2015, 2, 16, 0, 0, 0)
+    @developer.touch(time: new_time)
 
-    assert_not_equal previously_updated_at, @developer.updated_at 
-    assert_equal new_time, @developer.updated_at 
+    assert_not_equal previously_updated_at, @developer.updated_at
+    assert_equal new_time, @developer.updated_at
   end
 
   def test_touching_an_attribute_updates_timestamp
     previously_created_at = @developer.created_at
     @developer.touch(:created_at)
 
-    assert !@developer.created_at_changed? , 'created_at should not be changed'
-    assert !@developer.changed?, 'record should not be changed'
+    assert !@developer.created_at_changed? , message: 'created_at should not be changed'
+    assert !@developer.changed?, message: 'record should not be changed'
     assert_not_equal previously_created_at, @developer.created_at
     assert_not_equal @previously_updated_at, @developer.updated_at
   end
@@ -101,9 +101,9 @@ class TimestampTest < ActiveRecord::TestCase
   end
 
   def test_touching_an_attribute_updates_timestamp_with_given_time
-    previously_updated_at = @developer.updated_at 
+    previously_updated_at = @developer.updated_at
     previously_created_at = @developer.created_at
-    new_time = Time.utc(2015, 2, 16, 4, 54, 0) 
+    new_time = Time.utc(2015, 2, 16, 4, 54, 0)
     @developer.touch(:created_at, time: new_time)
 
     assert_not_equal previously_created_at, @developer.created_at

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -44,8 +44,8 @@ class TransactionTest < ActiveRecord::TestCase
       @second.save
     end
 
-    assert Topic.find(1).approved?, "First should have been approved"
-    assert !Topic.find(2).approved?, "Second should have been unapproved"
+    assert Topic.find(1).approved?, message: "First should have been approved"
+    assert !Topic.find(2).approved?, message: "Second should have been unapproved"
   end
 
   def transaction_with_return
@@ -72,8 +72,8 @@ class TransactionTest < ActiveRecord::TestCase
     transaction_with_return
     assert committed
 
-    assert Topic.find(1).approved?, "First should have been approved"
-    assert !Topic.find(2).approved?, "Second should have been unapproved"
+    assert Topic.find(1).approved?, message: "First should have been approved"
+    assert !Topic.find(2).approved?, message: "Second should have been unapproved"
   ensure
     Topic.connection.class_eval do
       remove_method :commit_db_transaction
@@ -113,8 +113,8 @@ class TransactionTest < ActiveRecord::TestCase
       @second.save
     end
 
-    assert Topic.find(1).approved?, "First should have been approved"
-    assert !Topic.find(2).approved?, "Second should have been unapproved"
+    assert Topic.find(1).approved?, message: "First should have been approved"
+    assert !Topic.find(2).approved?, message: "Second should have been unapproved"
   end
 
   def test_failing_on_exception
@@ -130,11 +130,11 @@ class TransactionTest < ActiveRecord::TestCase
       # caught it
     end
 
-    assert @first.approved?, "First should still be changed in the objects"
-    assert !@second.approved?, "Second should still be changed in the objects"
+    assert @first.approved?, message: "First should still be changed in the objects"
+    assert !@second.approved?, message: "Second should still be changed in the objects"
 
-    assert !Topic.find(1).approved?, "First shouldn't have been approved"
-    assert Topic.find(2).approved?, "Second should still be approved"
+    assert !Topic.find(1).approved?, message: "First shouldn't have been approved"
+    assert Topic.find(2).approved?, message: "Second should still be approved"
   end
 
   def test_raising_exception_in_callback_rollbacks_in_save
@@ -158,7 +158,7 @@ class TransactionTest < ActiveRecord::TestCase
       @first.approved  = true
       @first.save!
     end
-    assert !Topic.find(@first.id).approved?, "Should not commit the approved flag"
+    assert !Topic.find(@first.id).approved?, message: "Should not commit the approved flag"
   end
 
   def test_raising_exception_in_nested_transaction_restore_state_in_save
@@ -172,7 +172,7 @@ class TransactionTest < ActiveRecord::TestCase
       Topic.transaction { topic.save }
     end
 
-    assert topic.new_record?, "#{topic.inspect} should be new record"
+    assert topic.new_record?, message: "#{topic.inspect} should be new record"
   end
 
   def test_update_should_rollback_on_failure
@@ -280,7 +280,7 @@ class TransactionTest < ActiveRecord::TestCase
     }
 
     new_topic = topic.create(:title => "A new topic")
-    assert !new_topic.persisted?, "The topic should not be persisted"
+    assert !new_topic.persisted?, message: "The topic should not be persisted"
     assert_nil new_topic.id, "The topic should not have an ID"
   end
 
@@ -294,8 +294,8 @@ class TransactionTest < ActiveRecord::TestCase
       end
     end
 
-    assert Topic.find(1).approved?, "First should have been approved"
-    assert !Topic.find(2).approved?, "Second should have been unapproved"
+    assert Topic.find(1).approved?, message: "First should have been approved"
+    assert !Topic.find(2).approved?, message: "Second should have been unapproved"
   end
 
   def test_manually_rolling_back_a_transaction
@@ -308,11 +308,11 @@ class TransactionTest < ActiveRecord::TestCase
       raise ActiveRecord::Rollback
     end
 
-    assert @first.approved?, "First should still be changed in the objects"
-    assert !@second.approved?, "Second should still be changed in the objects"
+    assert @first.approved?, message: "First should still be changed in the objects"
+    assert !@second.approved?, message: "Second should still be changed in the objects"
 
-    assert !Topic.find(1).approved?, "First shouldn't have been approved"
-    assert Topic.find(2).approved?, "Second should still be approved"
+    assert !Topic.find(1).approved?, message: "First shouldn't have been approved"
+    assert Topic.find(2).approved?, message: "Second should still be approved"
   end
 
   def test_invalid_keys_for_transaction
@@ -498,9 +498,9 @@ class TransactionTest < ActiveRecord::TestCase
     assert_match(/frozen/i, e.message) # Not good enough, but we can't do much
                                        # about it since there is no specific error
                                        # for frozen objects.
-    assert !topic.persisted?, 'not persisted'
+    assert !topic.persisted?, message: 'not persisted'
     assert_nil topic.id
-    assert topic.frozen?, 'not frozen'
+    assert topic.frozen?, message: 'not frozen'
   end
 
   def test_rollback_when_thread_killed
@@ -524,11 +524,11 @@ class TransactionTest < ActiveRecord::TestCase
     thread.kill
     thread.join
 
-    assert @first.approved?, "First should still be changed in the objects"
-    assert !@second.approved?, "Second should still be changed in the objects"
+    assert @first.approved?, message: "First should still be changed in the objects"
+    assert !@second.approved?, message: "Second should still be changed in the objects"
 
-    assert !Topic.find(1).approved?, "First shouldn't have been approved"
-    assert Topic.find(2).approved?, "Second should still be approved"
+    assert !Topic.find(1).approved?, message: "First shouldn't have been approved"
+    assert Topic.find(2).approved?, message: "Second should still be approved"
   end
 
   def test_restore_active_record_state_for_all_records_in_a_transaction
@@ -546,27 +546,27 @@ class TransactionTest < ActiveRecord::TestCase
       assert topic_3.save
       @first.save
       @second.destroy
-      assert topic_1.persisted?, 'persisted'
+      assert topic_1.persisted?, message: 'persisted'
       assert_not_nil topic_1.id
-      assert topic_2.persisted?, 'persisted'
+      assert topic_2.persisted?, message: 'persisted'
       assert_not_nil topic_2.id
-      assert topic_3.persisted?, 'persisted'
+      assert topic_3.persisted?, message: 'persisted'
       assert_not_nil topic_3.id
-      assert @first.persisted?, 'persisted'
+      assert @first.persisted?, message: 'persisted'
       assert_not_nil @first.id
-      assert @second.destroyed?, 'destroyed'
+      assert @second.destroyed?, message: 'destroyed'
       raise ActiveRecord::Rollback
     end
 
-    assert !topic_1.persisted?, 'not persisted'
+    assert !topic_1.persisted?, message: 'not persisted'
     assert_nil topic_1.id
-    assert !topic_2.persisted?, 'not persisted'
+    assert !topic_2.persisted?, message: 'not persisted'
     assert_nil topic_2.id
-    assert !topic_3.persisted?, 'not persisted'
+    assert !topic_3.persisted?, message: 'not persisted'
     assert_nil topic_3.id
-    assert @first.persisted?, 'persisted'
+    assert @first.persisted?, message: 'persisted'
     assert_not_nil @first.id
-    assert !@second.destroyed?, 'not destroyed'
+    assert !@second.destroyed?, message: 'not destroyed'
   end
 
   def test_restore_frozen_state_after_double_destroy
@@ -590,7 +590,7 @@ class TransactionTest < ActiveRecord::TestCase
       topic.destroy
       raise ActiveRecord::Rollback
     end
-    assert topic.frozen?, 'frozen'
+    assert topic.frozen?, message: 'frozen'
   end
 
   def test_rollback_for_freshly_persisted_records
@@ -599,7 +599,7 @@ class TransactionTest < ActiveRecord::TestCase
       topic.destroy
       raise ActiveRecord::Rollback
     end
-    assert topic.persisted?, 'persisted'
+    assert topic.persisted?, message: 'persisted'
   end
 
   def test_sqlite_add_column_in_transaction

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -28,6 +28,6 @@ class TestUnconnectedAdapter < ActiveRecord::TestCase
   end
 
   def test_underlying_adapter_no_longer_active
-    assert !@underlying.active?, "Removed adapter should no longer be active"
+    assert !@underlying.active?, message: "Removed adapter should no longer be active"
   end
 end

--- a/activerecord/test/cases/validations/association_validation_test.rb
+++ b/activerecord/test/cases/validations/association_validation_test.rb
@@ -70,7 +70,7 @@ class AssociationValidationTest < ActiveRecord::TestCase
       Interest.validates_presence_of(:man)
       man = Man.new(:name => 'John')
       interest = man.interests.build(:topic => 'Airplanes')
-      assert interest.valid?, "Expected interest to be valid, but was not. Interest should have a man object associated"
+      assert interest.valid?, message: "Expected interest to be valid, but was not. Interest should have a man object associated"
     end
   end
 
@@ -79,7 +79,7 @@ class AssociationValidationTest < ActiveRecord::TestCase
       Interest.validates_presence_of(:man)
       man = Man.create!(:name => 'John')
       interest = man.interests.build(:topic => 'Airplanes')
-      assert interest.valid?, "Expected interest to be valid, but was not. Interest should have a man object associated"
+      assert interest.valid?, message: "Expected interest to be valid, but was not. Interest should have a man object associated"
     end
   end
 end

--- a/activerecord/test/cases/validations/presence_validation_test.rb
+++ b/activerecord/test/cases/validations/presence_validation_test.rb
@@ -22,7 +22,7 @@ class PresenceValidationTest < ActiveRecord::TestCase
   def test_validates_presence_of_has_one
     Boy.validates_presence_of(:face)
     b = Boy.new
-    assert b.invalid?, "should not be valid if has_one association missing"
+    assert b.invalid?, message: "should not be valid if has_one association missing"
     assert_equal 1, b.errors[:face].size, "validates_presence_of should only add one error"
   end
 

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -58,18 +58,18 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     Topic.validates_uniqueness_of(:title)
 
     t = Topic.new("title" => "I'm uniqué!")
-    assert t.save, "Should save t as unique"
+    assert t.save, message: "Should save t as unique"
 
     t.content = "Remaining unique"
-    assert t.save, "Should still save t as unique"
+    assert t.save, message: "Should still save t as unique"
 
     t2 = Topic.new("title" => "I'm uniqué!")
-    assert !t2.valid?, "Shouldn't be valid"
-    assert !t2.save, "Shouldn't save t2 as unique"
+    assert !t2.valid?, message: "Shouldn't be valid"
+    assert !t2.save, message: "Shouldn't save t2 as unique"
     assert_equal ["has already been taken"], t2.errors[:title]
 
     t2.title = "Now I am really also unique"
-    assert t2.save, "Should now save t2 as unique"
+    assert t2.save, message: "Should now save t2 as unique"
   end
 
   def test_validate_uniqueness_with_alias_attribute
@@ -84,11 +84,11 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     Topic.validates_uniqueness_of(:title)
 
     t = Topic.new("title" => nil)
-    assert t.save, "Should save t as unique"
+    assert t.save, message: "Should save t as unique"
 
     t2 = Topic.new("title" => nil)
-    assert !t2.valid?, "Shouldn't be valid"
-    assert !t2.save, "Shouldn't save t2 as unique"
+    assert !t2.valid?, message: "Shouldn't be valid"
+    assert !t2.save, message: "Shouldn't save t2 as unique"
     assert_equal ["has already been taken"], t2.errors[:title]
   end
 
@@ -115,7 +115,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     Topic.validates_uniqueness_of(:title, :case_sensitive => false)
 
     t = Topic.new("title" => "new\nline")
-    assert t.save, "Should save t as unique"
+    assert t.save, message: "Should save t as unique"
   end
 
   def test_validate_uniqueness_with_scope
@@ -124,17 +124,17 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     t = Topic.create("title" => "I'm unique!")
 
     r1 = t.replies.create "title" => "r1", "content" => "hello world"
-    assert r1.valid?, "Saving r1"
+    assert r1.valid?, message: "Saving r1"
 
     r2 = t.replies.create "title" => "r2", "content" => "hello world"
-    assert !r2.valid?, "Saving r2 first time"
+    assert !r2.valid?, message: "Saving r2 first time"
 
     r2.content = "something else"
-    assert r2.save, "Saving r2 second time"
+    assert r2.save, message: "Saving r2 second time"
 
     t2 = Topic.create("title" => "I'm unique too!")
     r3 = t2.replies.create "title" => "r3", "content" => "hello world"
-    assert r3.valid?, "Saving r3"
+    assert r3.valid?, message: "Saving r3"
   end
 
   def test_validate_uniqueness_with_object_scope
@@ -143,18 +143,18 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     t = Topic.create("title" => "I'm unique!")
 
     r1 = t.replies.create "title" => "r1", "content" => "hello world"
-    assert r1.valid?, "Saving r1"
+    assert r1.valid?, message: "Saving r1"
 
     r2 = t.replies.create "title" => "r2", "content" => "hello world"
-    assert !r2.valid?, "Saving r2 first time"
+    assert !r2.valid?, message: "Saving r2 first time"
   end
 
   def test_validate_uniqueness_with_composed_attribute_scope
     r1 = ReplyWithTitleObject.create "title" => "r1", "content" => "hello world"
-    assert r1.valid?, "Saving r1"
+    assert r1.valid?, message: "Saving r1"
 
     r2 = ReplyWithTitleObject.create "title" => "r1", "content" => "hello world"
-    assert !r2.valid?, "Saving r2 first time"
+    assert !r2.valid?, message: "Saving r2 first time"
   end
 
   def test_validate_uniqueness_with_object_arg
@@ -163,25 +163,25 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     t = Topic.create("title" => "I'm unique!")
 
     r1 = t.replies.create "title" => "r1", "content" => "hello world"
-    assert r1.valid?, "Saving r1"
+    assert r1.valid?, message: "Saving r1"
 
     r2 = t.replies.create "title" => "r2", "content" => "hello world"
-    assert !r2.valid?, "Saving r2 first time"
+    assert !r2.valid?, message: "Saving r2 first time"
   end
 
   def test_validate_uniqueness_scoped_to_defining_class
     t = Topic.create("title" => "What, me worry?")
 
     r1 = t.unique_replies.create "title" => "r1", "content" => "a barrel of fun"
-    assert r1.valid?, "Saving r1"
+    assert r1.valid?, message: "Saving r1"
 
     r2 = t.silly_unique_replies.create "title" => "r2", "content" => "a barrel of fun"
-    assert !r2.valid?, "Saving r2"
+    assert !r2.valid?, message: "Saving r2"
 
     # Should succeed as validates_uniqueness_of only applies to
     # UniqueReply and its subclasses
     r3 = t.replies.create "title" => "r2", "content" => "a barrel of fun"
-    assert r3.valid?, "Saving r3"
+    assert r3.valid?, message: "Saving r3"
   end
 
   def test_validate_uniqueness_with_scope_array
@@ -190,62 +190,62 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     t = Topic.create("title" => "The earth is actually flat!")
 
     r1 = t.replies.create "author_name" => "jeremy", "author_email_address" => "jeremy@rubyonrails.com", "title" => "You're crazy!", "content" => "Crazy reply"
-    assert r1.valid?, "Saving r1"
+    assert r1.valid?, message: "Saving r1"
 
     r2 = t.replies.create "author_name" => "jeremy", "author_email_address" => "jeremy@rubyonrails.com", "title" => "You're crazy!", "content" => "Crazy reply again..."
-    assert !r2.valid?, "Saving r2. Double reply by same author."
+    assert !r2.valid?, message: "Saving r2. Double reply by same author."
 
     r2.author_email_address = "jeremy_alt_email@rubyonrails.com"
-    assert r2.save, "Saving r2 the second time."
+    assert r2.save, message: "Saving r2 the second time."
 
     r3 = t.replies.create "author_name" => "jeremy", "author_email_address" => "jeremy_alt_email@rubyonrails.com", "title" => "You're wrong", "content" => "It's cubic"
-    assert !r3.valid?, "Saving r3"
+    assert !r3.valid?, message: "Saving r3"
 
     r3.author_name = "jj"
-    assert r3.save, "Saving r3 the second time."
+    assert r3.save, message: "Saving r3 the second time."
 
     r3.author_name = "jeremy"
-    assert !r3.save, "Saving r3 the third time."
+    assert !r3.save, message: "Saving r3 the third time."
   end
 
   def test_validate_case_insensitive_uniqueness
     Topic.validates_uniqueness_of(:title, :parent_id, :case_sensitive => false, :allow_nil => true)
 
     t = Topic.new("title" => "I'm unique!", :parent_id => 2)
-    assert t.save, "Should save t as unique"
+    assert t.save, message: "Should save t as unique"
 
     t.content = "Remaining unique"
-    assert t.save, "Should still save t as unique"
+    assert t.save, message: "Should still save t as unique"
 
     t2 = Topic.new("title" => "I'm UNIQUE!", :parent_id => 1)
-    assert !t2.valid?, "Shouldn't be valid"
-    assert !t2.save, "Shouldn't save t2 as unique"
+    assert !t2.valid?, message: "Shouldn't be valid"
+    assert !t2.save, message: "Shouldn't save t2 as unique"
     assert t2.errors[:title].any?
     assert t2.errors[:parent_id].any?
     assert_equal ["has already been taken"], t2.errors[:title]
 
     t2.title = "I'm truly UNIQUE!"
-    assert !t2.valid?, "Shouldn't be valid"
-    assert !t2.save, "Shouldn't save t2 as unique"
+    assert !t2.valid?, message: "Shouldn't be valid"
+    assert !t2.save, message: "Shouldn't save t2 as unique"
     assert t2.errors[:title].empty?
     assert t2.errors[:parent_id].any?
 
     t2.parent_id = 4
-    assert t2.save, "Should now save t2 as unique"
+    assert t2.save, message: "Should now save t2 as unique"
 
     t2.parent_id = nil
     t2.title = nil
-    assert t2.valid?, "should validate with nil"
-    assert t2.save, "should save with nil"
+    assert t2.valid?, message: "should validate with nil"
+    assert t2.save, message: "should save with nil"
 
     t_utf8 = Topic.new("title" => "Я тоже уникальный!")
-    assert t_utf8.save, "Should save t_utf8 as unique"
+    assert t_utf8.save, message: "Should save t_utf8 as unique"
 
     # If database hasn't UTF-8 character set, this test fails
     if Topic.all.merge!(:select => 'LOWER(title) AS title').find(t_utf8.id).title == "я тоже уникальный!"
       t2_utf8 = Topic.new("title" => "я тоже УНИКАЛЬНЫЙ!")
-      assert !t2_utf8.valid?, "Shouldn't be valid"
-      assert !t2_utf8.save, "Shouldn't save t2_utf8 as unique"
+      assert !t2_utf8.valid?, message: "Shouldn't be valid"
+      assert !t2_utf8.save, message: "Shouldn't save t2_utf8 as unique"
     end
   end
 
@@ -253,47 +253,47 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     Topic.validates_uniqueness_of(:title, :case_sensitive => true)
 
     t = Topic.new("title" => "I'm unique!")
-    assert t.save, "Should save t as unique"
+    assert t.save, message: "Should save t as unique"
 
     t2 = Topic.new("title" => "I'm %")
-    assert t2.save, "Should save t2 as unique"
+    assert t2.save, message: "Should save t2 as unique"
 
     t3 = Topic.new("title" => "I'm uniqu_!")
-    assert t3.save, "Should save t3 as unique"
+    assert t3.save, message: "Should save t3 as unique"
   end
 
   def test_validate_case_insensitive_uniqueness_with_special_sql_like_chars
     Topic.validates_uniqueness_of(:title, :case_sensitive => false)
 
     t = Topic.new("title" => "I'm unique!")
-    assert t.save, "Should save t as unique"
+    assert t.save, message: "Should save t as unique"
 
     t2 = Topic.new("title" => "I'm %")
-    assert t2.save, "Should save t2 as unique"
+    assert t2.save, message: "Should save t2 as unique"
 
     t3 = Topic.new("title" => "I'm uniqu_!")
-    assert t3.save, "Should save t3 as unique"
+    assert t3.save, message: "Should save t3 as unique"
   end
 
   def test_validate_case_sensitive_uniqueness
     Topic.validates_uniqueness_of(:title, :case_sensitive => true, :allow_nil => true)
 
     t = Topic.new("title" => "I'm unique!")
-    assert t.save, "Should save t as unique"
+    assert t.save, message: "Should save t as unique"
 
     t.content = "Remaining unique"
-    assert t.save, "Should still save t as unique"
+    assert t.save, message: "Should still save t as unique"
 
     t2 = Topic.new("title" => "I'M UNIQUE!")
-    assert t2.valid?, "Should be valid"
-    assert t2.save, "Should save t2 as unique"
+    assert t2.valid?, message: "Should be valid"
+    assert t2.save, message: "Should save t2 as unique"
     assert t2.errors[:title].empty?
     assert t2.errors[:parent_id].empty?
     assert_not_equal ["has already been taken"], t2.errors[:title]
 
     t3 = Topic.new("title" => "I'M uNiQUe!")
-    assert t3.valid?, "Should be valid"
-    assert t3.save, "Should save t2 as unique"
+    assert t3.valid?, message: "Should be valid"
+    assert t3.save, message: "Should save t2 as unique"
     assert t3.errors[:title].empty?
     assert t3.errors[:parent_id].empty?
     assert_not_equal ["has already been taken"], t3.errors[:title]
@@ -310,8 +310,8 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
   def test_validate_uniqueness_with_non_standard_table_names
     i1 = WarehouseThing.create(:value => 1000)
-    assert !i1.valid?, "i1 should not be valid"
-    assert i1.errors[:value].any?, "Should not be empty"
+    assert !i1.valid?, message: "i1 should not be valid"
+    assert i1.errors[:value].any?, message: "Should not be empty"
   end
 
   def test_validates_uniqueness_inside_scoping
@@ -337,45 +337,45 @@ class UniquenessValidationTest < ActiveRecord::TestCase
   def test_validate_uniqueness_with_limit
     # Event.title is limited to 5 characters
     e1 = Event.create(:title => "abcde")
-    assert e1.valid?, "Could not create an event with a unique, 5 character title"
+    assert e1.valid?, message: "Could not create an event with a unique, 5 character title"
     e2 = Event.create(:title => "abcdefgh")
-    assert !e2.valid?, "Created an event whose title, with limit taken into account, is not unique"
+    assert !e2.valid?, message: "Created an event whose title, with limit taken into account, is not unique"
   end
 
   def test_validate_uniqueness_with_limit_and_utf8
     # Event.title is limited to 5 characters
     e1 = Event.create(:title => "一二三四五")
-    assert e1.valid?, "Could not create an event with a unique, 5 character title"
+    assert e1.valid?, message: "Could not create an event with a unique, 5 character title"
     e2 = Event.create(:title => "一二三四五六七八")
-    assert !e2.valid?, "Created an event whose title, with limit taken into account, is not unique"
+    assert !e2.valid?, message: "Created an event whose title, with limit taken into account, is not unique"
   end
 
   def test_validate_straight_inheritance_uniqueness
     w1 = IneptWizard.create(:name => "Rincewind", :city => "Ankh-Morpork")
-    assert w1.valid?, "Saving w1"
+    assert w1.valid?, message: "Saving w1"
 
     # Should use validation from base class (which is abstract)
     w2 = IneptWizard.new(:name => "Rincewind", :city => "Quirm")
-    assert !w2.valid?, "w2 shouldn't be valid"
-    assert w2.errors[:name].any?, "Should have errors for name"
+    assert !w2.valid?, message: "w2 shouldn't be valid"
+    assert w2.errors[:name].any?, message: "Should have errors for name"
     assert_equal ["has already been taken"], w2.errors[:name], "Should have uniqueness message for name"
 
     w3 = Conjurer.new(:name => "Rincewind", :city => "Quirm")
-    assert !w3.valid?, "w3 shouldn't be valid"
-    assert w3.errors[:name].any?, "Should have errors for name"
+    assert !w3.valid?, message: "w3 shouldn't be valid"
+    assert w3.errors[:name].any?, message: "Should have errors for name"
     assert_equal ["has already been taken"], w3.errors[:name], "Should have uniqueness message for name"
 
     w4 = Conjurer.create(:name => "The Amazing Bonko", :city => "Quirm")
-    assert w4.valid?, "Saving w4"
+    assert w4.valid?, message: "Saving w4"
 
     w5 = Thaumaturgist.new(:name => "The Amazing Bonko", :city => "Lancre")
-    assert !w5.valid?, "w5 shouldn't be valid"
-    assert w5.errors[:name].any?, "Should have errors for name"
+    assert !w5.valid?, message: "w5 shouldn't be valid"
+    assert w5.errors[:name].any?, message: "Should have errors for name"
     assert_equal ["has already been taken"], w5.errors[:name], "Should have uniqueness message for name"
 
     w6 = Thaumaturgist.new(:name => "Mustrum Ridcully", :city => "Quirm")
-    assert !w6.valid?, "w6 shouldn't be valid"
-    assert w6.errors[:city].any?, "Should have errors for city"
+    assert !w6.valid?, message: "w6 shouldn't be valid"
+    assert w6.errors[:city].any?, message: "Should have errors for city"
     assert_equal ["has already been taken"], w6.errors[:city], "Should have uniqueness message for city"
   end
 
@@ -385,10 +385,10 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     Topic.create("title" => "I'm an unapproved topic", "approved" => false)
 
     t3 = Topic.new("title" => "I'm a topic", "approved" => true)
-    assert !t3.valid?, "t3 shouldn't be valid"
+    assert !t3.valid?, message: "t3 shouldn't be valid"
 
     t4 = Topic.new("title" => "I'm an unapproved topic", "approved" => false)
-    assert t4.valid?, "t4 should be valid"
+    assert t4.valid?, message: "t4 should be valid"
   end
 
   def test_validate_uniqueness_with_non_callable_conditions_is_not_supported

--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -18,7 +18,7 @@ class ValidationsTest < ActiveRecord::TestCase
     r = WrongReply.new
     r.title = "Wrong Create"
     assert_not r.valid?
-    assert r.errors[:title].any?, "A reply with a bad title should mark that attribute as invalid"
+    assert r.errors[:title].any?, message: "A reply with a bad title should mark that attribute as invalid"
     assert_equal ["is Wrong Create"], r.errors[:title], "A reply with a bad content should contain an error"
   end
 
@@ -26,12 +26,12 @@ class ValidationsTest < ActiveRecord::TestCase
     r = WrongReply.new
     r.title = "Bad"
     r.content = "Good"
-    assert r.save, "First validation should be successful"
+    assert r.save, message: "First validation should be successful"
 
     r.title = "Wrong Update"
     assert_not r.valid?, "Second validation should fail"
 
-    assert r.errors[:title].any?, "A reply with a bad title should mark that attribute as invalid"
+    assert r.errors[:title].any?, message: "A reply with a bad title should mark that attribute as invalid"
     assert_equal ["is Wrong Update"], r.errors[:title], "A reply with a bad content should contain an error"
   end
 

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -33,7 +33,7 @@ module ViewBehavior
 
   def test_table_exists
     view_name = Ebook.table_name
-    assert @connection.table_exists?(view_name), "'#{view_name}' table should exist"
+    assert @connection.table_exists?(view_name), message: "'#{view_name}' table should exist"
   end
 
   def test_column_definitions
@@ -93,7 +93,7 @@ class ViewWithoutPrimaryKeyTest < ActiveRecord::TestCase
 
   def test_table_exists
     view_name = Paperback.table_name
-    assert @connection.table_exists?(view_name), "'#{view_name}' table should exist"
+    assert @connection.table_exists?(view_name), message: "'#{view_name}' table should exist"
   end
 
   def test_column_definitions

--- a/activerecord/test/cases/xml_serialization_test.rb
+++ b/activerecord/test/cases/xml_serialization_test.rb
@@ -417,7 +417,7 @@ class DatabaseConnectedXmlSerializationTest < ActiveRecord::TestCase
   def test_should_support_aliased_attributes
     xml = Author.select("name as firstname").to_xml
     Author.all.each do |author|
-      assert xml.include?(%(<firstname>#{author.name}</firstname>)), xml
+      assert xml.include?(%(<firstname>#{author.name}</firstname>)), message: xml
     end
   end
 
@@ -428,8 +428,8 @@ class DatabaseConnectedXmlSerializationTest < ActiveRecord::TestCase
 
   def test_array_to_xml_including_methods
     xml = [ topics(:first), topics(:second) ].to_xml(:indent => 0, :skip_instruct => true, :methods => [ :topic_id ])
-    assert xml.include?(%(<topic-id type="integer">#{topics(:first).topic_id}</topic-id>)), xml
-    assert xml.include?(%(<topic-id type="integer">#{topics(:second).topic_id}</topic-id>)), xml
+    assert xml.include?(%(<topic-id type="integer">#{topics(:first).topic_id}</topic-id>)), message: xml
+    assert xml.include?(%(<topic-id type="integer">#{topics(:second).topic_id}</topic-id>)), message: xml
   end
 
   def test_array_to_xml_including_has_one_association

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -59,8 +59,8 @@ class YamlSerializationTest < ActiveRecord::TestCase
   def test_new_records_remain_new_after_round_trip
     topic = Topic.new
 
-    assert topic.new_record?, "Sanity check that new records are new"
-    assert YAML.load(YAML.dump(topic)).new_record?, "Record should be new after deserialization"
+    assert topic.new_record?, message: "Sanity check that new records are new"
+    assert YAML.load(YAML.dump(topic)).new_record?, message: "Record should be new after deserialization"
 
     topic.save!
 

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -84,5 +84,12 @@ module ActiveSupport
     def assert_nothing_raised(*args)
       yield
     end
+
+    def assert(predicate, message_or_equal = nil, message: nil)
+      if message_or_equal.present? && !caller_locations.first.base_label.match(/^(assert|refute|flunk)/)
+        raise ArgumentError, "Use the kwarg message instead of the positional one, unless you meant assert_equal?"
+      end
+      super(predicate, message || message_or_equal)
+    end
   end
 end

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -16,7 +16,7 @@ module ActiveSupport
       #   assert_not foo, 'foo should be false'
       def assert_not(object, message = nil)
         message ||= "Expected #{mu_pp(object)} to be nil or false"
-        assert !object, message
+        assert !object, message: message
       end
 
       # Test numeric difference between the return value of an expression as a

--- a/activesupport/lib/active_support/testing/deprecation.rb
+++ b/activesupport/lib/active_support/testing/deprecation.rb
@@ -5,17 +5,17 @@ module ActiveSupport
     module Deprecation #:nodoc:
       def assert_deprecated(match = nil, &block)
         result, warnings = collect_deprecations(&block)
-        assert !warnings.empty?, "Expected a deprecation warning within the block but received none"
+        assert !warnings.empty?, message: "Expected a deprecation warning within the block but received none"
         if match
           match = Regexp.new(Regexp.escape(match)) unless match.is_a?(Regexp)
-          assert warnings.any? { |w| w =~ match }, "No deprecation warning matched #{match}: #{warnings.join(', ')}"
+          assert warnings.any? { |w| w =~ match }, message: "No deprecation warning matched #{match}: #{warnings.join(', ')}"
         end
         result
       end
 
       def assert_not_deprecated(&block)
         result, deprecations = collect_deprecations(&block)
-        assert deprecations.empty?, "Expected no deprecation warning within the block but received #{deprecations.size}: \n  #{deprecations * "\n  "}"
+        assert deprecations.empty?, message: "Expected no deprecation warning within the block but received #{deprecations.size}: \n  #{deprecations * "\n  "}"
         result
       end
 

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -18,8 +18,8 @@ module ActiveSupport
 
     def test_close
       logger.close
-      assert log1.closed, 'should be closed'
-      assert log2.closed, 'should be closed'
+      assert log1.closed, message: 'should be closed'
+      assert log2.closed, message: 'should be closed'
     end
 
     def test_chevrons

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -12,13 +12,13 @@ module ActiveSupport
             key = "super awesome key"
             assert_nil LocalCacheRegistry.cache_for key
             middleware = Middleware.new('<3', key).new(->(env) {
-              assert LocalCacheRegistry.cache_for(key), 'should have a cache'
+              assert LocalCacheRegistry.cache_for(key), message: 'should have a cache'
               [200, {}, []]
             })
             _, _, body = middleware.call({})
-            assert LocalCacheRegistry.cache_for(key), 'should still have a cache'
+            assert LocalCacheRegistry.cache_for(key), message: 'should still have a cache'
             body.each { }
-            assert LocalCacheRegistry.cache_for(key), 'should still have a cache'
+            assert LocalCacheRegistry.cache_for(key), message: 'should still have a cache'
             body.close
             assert_nil LocalCacheRegistry.cache_for(key)
           end
@@ -27,7 +27,7 @@ module ActiveSupport
             key = "super awesome key"
             assert_nil LocalCacheRegistry.cache_for key
             middleware = Middleware.new('<3', key).new(->(env) {
-              assert LocalCacheRegistry.cache_for(key), 'should have a cache'
+              assert LocalCacheRegistry.cache_for(key), message: 'should have a cache'
               raise
             })
             assert_raises(RuntimeError) { middleware.call({}) }
@@ -740,7 +740,7 @@ class FileStoreTest < ActiveSupport::TestCase
     key = "#{'A' * ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}"
     path = @cache.send(:key_file_path, key)
     Dir::Tmpname.create(path) do |tmpname, n, opts|
-      assert File.basename(tmpname+'.lock').length <= 255, "Temp filename too long: #{File.basename(tmpname+'.lock').length}"
+      assert File.basename(tmpname+'.lock').length <= 255, message: "Temp filename too long: #{File.basename(tmpname+'.lock').length}"
     end
   end
 
@@ -768,8 +768,8 @@ class FileStoreTest < ActiveSupport::TestCase
       assert sub_cache_store.write('foo', 'bar')
       assert sub_cache_store.delete('foo')
     end
-    assert File.exist?(cache_dir), "Parent of top level cache dir was deleted!"
-    assert File.exist?(sub_cache_dir), "Top level cache dir was deleted!"
+    assert File.exist?(cache_dir), message: "Parent of top level cache dir was deleted!"
+    assert File.exist?(sub_cache_dir), message: "Top level cache dir was deleted!"
     assert Dir.entries(sub_cache_dir).reject {|f| ActiveSupport::Cache::FileStore::EXCLUDED_DIRS.include?(f)}.empty?
   end
 
@@ -821,9 +821,9 @@ class MemoryStoreTest < ActiveSupport::TestCase
     @cache.prune(@record_size * 3)
     assert @cache.exist?(5)
     assert @cache.exist?(4)
-    assert !@cache.exist?(3), "no entry"
+    assert !@cache.exist?(3), message: "no entry"
     assert @cache.exist?(2)
-    assert !@cache.exist?(1), "no entry"
+    assert !@cache.exist?(1), message: "no entry"
   end
 
   def test_prune_size_on_write
@@ -845,12 +845,12 @@ class MemoryStoreTest < ActiveSupport::TestCase
     assert @cache.exist?(9)
     assert @cache.exist?(8)
     assert @cache.exist?(7)
-    assert !@cache.exist?(6), "no entry"
-    assert !@cache.exist?(5), "no entry"
+    assert !@cache.exist?(6), message: "no entry"
+    assert !@cache.exist?(5), message: "no entry"
     assert @cache.exist?(4)
-    assert !@cache.exist?(3), "no entry"
+    assert !@cache.exist?(3), message: "no entry"
     assert @cache.exist?(2)
-    assert !@cache.exist?(1), "no entry"
+    assert !@cache.exist?(1), message: "no entry"
   end
 
   def test_prune_size_on_write_based_on_key_length
@@ -870,11 +870,11 @@ class MemoryStoreTest < ActiveSupport::TestCase
     assert @cache.exist?(8)
     assert @cache.exist?(7)
     assert @cache.exist?(6)
-    assert !@cache.exist?(5), "no entry"
-    assert !@cache.exist?(4), "no entry"
-    assert !@cache.exist?(3), "no entry"
-    assert !@cache.exist?(2), "no entry"
-    assert !@cache.exist?(1), "no entry"
+    assert !@cache.exist?(5), message: "no entry"
+    assert !@cache.exist?(4), message: "no entry"
+    assert !@cache.exist?(3), message: "no entry"
+    assert !@cache.exist?(2), message: "no entry"
+    assert !@cache.exist?(1), message: "no entry"
   end
 
   def test_pruning_is_capped_at_a_max_time
@@ -1028,7 +1028,7 @@ class NullStoreTest < ActiveSupport::TestCase
   end
 
   def test_setting_nil_cache_store
-    assert ActiveSupport::Cache.lookup_store.class.name, ActiveSupport::Cache::NullStore.name
+    assert_equal ActiveSupport::Cache.lookup_store.class.name, ActiveSupport::Cache::NullStore.name
   end
 end
 
@@ -1063,11 +1063,11 @@ end
 class CacheEntryTest < ActiveSupport::TestCase
   def test_expired
     entry = ActiveSupport::Cache::Entry.new("value")
-    assert !entry.expired?, 'entry not expired'
+    assert !entry.expired?, message: 'entry not expired'
     entry = ActiveSupport::Cache::Entry.new("value", :expires_in => 60)
-    assert !entry.expired?, 'entry not expired'
+    assert !entry.expired?, message: 'entry not expired'
     Time.stub(:now, Time.now + 61) do
-      assert entry.expired?, 'entry is expired'
+      assert entry.expired?, message: 'entry is expired'
     end
   end
 
@@ -1075,7 +1075,7 @@ class CacheEntryTest < ActiveSupport::TestCase
     value = "value" * 100
     entry = ActiveSupport::Cache::Entry.new(value, :compress => true, :compress_threshold => 1)
     assert_equal value, entry.value
-    assert(value.bytesize > entry.size, "value is compressed")
+    assert(value.bytesize > entry.size, message: "value is compressed")
   end
 
   def test_non_compress_values

--- a/activesupport/test/configurable_test.rb
+++ b/activesupport/test/configurable_test.rb
@@ -121,11 +121,11 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
 
   def assert_method_defined(object, method)
     methods = object.public_methods.map(&:to_s)
-    assert methods.include?(method.to_s), "Expected #{methods.inspect} to include #{method.to_s.inspect}"
+    assert methods.include?(method.to_s), message: "Expected #{methods.inspect} to include #{method.to_s.inspect}"
   end
 
   def assert_method_not_defined(object, method)
     methods = object.public_methods.map(&:to_s)
-    assert !methods.include?(method.to_s), "Expected #{methods.inspect} to not include #{method.to_s.inspect}"
+    assert !methods.include?(method.to_s), message: "Expected #{methods.inspect} to not include #{method.to_s.inspect}"
   end
 end

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -92,28 +92,28 @@ class ToXmlTest < ActiveSupport::TestCase
     ].to_xml(skip_instruct: true, indent: 0)
 
     assert_equal '<objects type="array"><object>', xml.first(30)
-    assert xml.include?(%(<age type="integer">26</age>)), xml
-    assert xml.include?(%(<age-in-millis type="integer">820497600000</age-in-millis>)), xml
-    assert xml.include?(%(<name>David</name>)), xml
-    assert xml.include?(%(<age type="integer">31</age>)), xml
-    assert xml.include?(%(<age-in-millis type="decimal">1.0</age-in-millis>)), xml
-    assert xml.include?(%(<name>Jason</name>)), xml
+    assert xml.include?(%(<age type="integer">26</age>)), message: xml
+    assert xml.include?(%(<age-in-millis type="integer">820497600000</age-in-millis>)), message: xml
+    assert xml.include?(%(<name>David</name>)), message: xml
+    assert xml.include?(%(<age type="integer">31</age>)), message: xml
+    assert xml.include?(%(<age-in-millis type="decimal">1.0</age-in-millis>)), message: xml
+    assert xml.include?(%(<name>Jason</name>)), message: xml
   end
 
   def test_to_xml_with_non_hash_elements
     xml = [1, 2, 3].to_xml(skip_instruct: true, indent: 0)
 
     assert_equal '<fixnums type="array"><fixnum', xml.first(29)
-    assert xml.include?(%(<fixnum type="integer">2</fixnum>)), xml
+    assert xml.include?(%(<fixnum type="integer">2</fixnum>)), message: xml
   end
 
   def test_to_xml_with_non_hash_different_type_elements
     xml = [1, 2.0, '3'].to_xml(skip_instruct: true, indent: 0)
 
     assert_equal '<objects type="array"><object', xml.first(29)
-    assert xml.include?(%(<object type="integer">1</object>)), xml
-    assert xml.include?(%(<object type="float">2.0</object>)), xml
-    assert xml.include?(%(object>3</object>)), xml
+    assert xml.include?(%(<object type="integer">1</object>)), message: xml
+    assert xml.include?(%(<object type="float">2.0</object>)), message: xml
+    assert xml.include?(%(object>3</object>)), message: xml
   end
 
   def test_to_xml_with_dedicated_name
@@ -186,7 +186,7 @@ class ToXmlTest < ActiveSupport::TestCase
       builder.count 2
     end
 
-    assert xml.include?(%(<count>2</count>)), xml
+    assert xml.include?(%(<count>2</count>)), message: xml
   end
 
   def test_to_xml_with_empty

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -723,7 +723,7 @@ class HashExtTest < ActiveSupport::TestCase
   def test_assorted_keys_not_stringified
     original = {Object.new => 2, 1 => 2, [] => true}
     indiff = original.with_indifferent_access
-    assert(!indiff.keys.any? {|k| k.kind_of? String}, "A key was converted to a string!")
+    assert(!indiff.keys.any? {|k| k.kind_of? String}, message: "A key was converted to a string!")
   end
 
   def test_deep_merge

--- a/activesupport/test/core_ext/module/concerning_test.rb
+++ b/activesupport/test/core_ext/module/concerning_test.rb
@@ -4,7 +4,7 @@ require 'active_support/core_ext/module/concerning'
 class ModuleConcerningTest < ActiveSupport::TestCase
   def test_concerning_declares_a_concern_and_includes_it_immediately
     klass = Class.new { concerning(:Foo) { } }
-    assert klass.ancestors.include?(klass::Foo), klass.ancestors.inspect
+    assert klass.ancestors.include?(klass::Foo), message: klass.ancestors.inspect
   end
 end
 
@@ -21,7 +21,7 @@ class ModuleConcernTest < ActiveSupport::TestCase
     assert klass.const_defined?(:Baz, false)
     assert !ModuleConcernTest.const_defined?(:Baz)
     assert_kind_of ActiveSupport::Concern, klass::Baz
-    assert !klass.ancestors.include?(klass::Baz), klass.ancestors.inspect
+    assert !klass.ancestors.include?(klass::Baz), message: klass.ancestors.inspect
 
     # Public method visibility by default
     assert klass::Baz.public_instance_methods.map(&:to_s).include?('should_be_public')

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -268,7 +268,7 @@ class ModuleTest < ActiveSupport::TestCase
     file_and_line = "#{__FILE__}:#{Someone::FAILED_DELEGATE_LINE}"
     # We can't simply check the first line of the backtrace, because JRuby reports the call to __send__ in the backtrace.
     assert e.backtrace.any?{|a| a.include?(file_and_line)},
-           "[#{e.backtrace.inspect}] did not include [#{file_and_line}]"
+           message: "[#{e.backtrace.inspect}] did not include [#{file_and_line}]"
   end
 
   def test_delegation_exception_backtrace_with_allow_nil
@@ -278,7 +278,7 @@ class ModuleTest < ActiveSupport::TestCase
     file_and_line = "#{__FILE__}:#{Someone::FAILED_DELEGATE_LINE_2}"
     # We can't simply check the first line of the backtrace, because JRuby reports the call to __send__ in the backtrace.
     assert e.backtrace.any?{|a| a.include?(file_and_line)},
-           "[#{e.backtrace.inspect}] did not include [#{file_and_line}]"
+           message: "[#{e.backtrace.inspect}] did not include [#{file_and_line}]"
   end
 
   def test_delegation_invokes_the_target_exactly_once

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -18,7 +18,7 @@ class DuplicableTest < ActiveSupport::TestCase
     end
 
     ALLOW_DUP.each do |v|
-      assert v.duplicable?, "#{ v.class } should be duplicable"
+      assert v.duplicable?, message: "#{ v.class } should be duplicable"
       assert_nothing_raised { v.dup }
     end
   end

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -898,8 +898,8 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < ActiveSupport::TestCase
 
   def test_nil_time_zone
     Time.use_zone nil do
-      assert !@t.in_time_zone.respond_to?(:period), 'no period method'
-      assert !@dt.in_time_zone.respond_to?(:period), 'no period method'
+      assert !@t.in_time_zone.respond_to?(:period), message: 'no period method'
+      assert !@dt.in_time_zone.respond_to?(:period), message: 'no period method'
     end
   end
 
@@ -987,8 +987,8 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < ActiveSupport::TestCase
     Time.use_zone 'Paris' do
       t1 = Thread.new { Time.zone = 'Alaska' }.join
       t2 = Thread.new { Time.zone = 'Hawaii' }.join
-      assert t1.stop?, "Thread 1 did not finish running"
-      assert t2.stop?, "Thread 2 did not finish running"
+      assert t1.stop?, message: "Thread 1 did not finish running"
+      assert t2.stop?, message: "Thread 2 did not finish running"
       assert_equal ActiveSupport::TimeZone['Paris'], Time.zone
       assert_equal ActiveSupport::TimeZone['Alaska'], t1[:time_zone]
       assert_equal ActiveSupport::TimeZone['Hawaii'], t2[:time_zone]
@@ -1087,7 +1087,7 @@ class TimeWithZoneMethodsForDate < ActiveSupport::TestCase
 
   def test_nil_time_zone
     with_tz_default nil do
-      assert !@d.in_time_zone.respond_to?(:period), 'no period method'
+      assert !@d.in_time_zone.respond_to?(:period), message: 'no period method'
     end
   end
 
@@ -1136,9 +1136,9 @@ class TimeWithZoneMethodsForString < ActiveSupport::TestCase
 
   def test_nil_time_zone
     with_tz_default nil do
-      assert !@s.in_time_zone.respond_to?(:period), 'no period method'
-      assert !@u.in_time_zone.respond_to?(:period), 'no period method'
-      assert !@z.in_time_zone.respond_to?(:period), 'no period method'
+      assert !@s.in_time_zone.respond_to?(:period), message: 'no period method'
+      assert !@u.in_time_zone.respond_to?(:period), message: 'no period method'
+      assert !@z.in_time_zone.respond_to?(:period), message: 'no period method'
     end
   end
 

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -672,7 +672,7 @@ class DependenciesTest < ActiveSupport::TestCase
     Object.const_set :EM, Class.new
     with_autoloading_fixtures do
       require_dependency 'em'
-      assert ! ActiveSupport::Dependencies.autoloaded?(:EM), "EM shouldn't be marked autoloaded!"
+      assert ! ActiveSupport::Dependencies.autoloaded?(:EM), message: "EM shouldn't be marked autoloaded!"
       ActiveSupport::Dependencies.clear
     end
   ensure
@@ -699,7 +699,7 @@ class DependenciesTest < ActiveSupport::TestCase
 
       Object.const_set :M, Module.new
       ActiveSupport::Dependencies.clear
-      assert ! defined?(M), "Dependencies should unload unloadable constants each time"
+      assert ! defined?(M), message: "Dependencies should unload unloadable constants each time"
     end
   end
 
@@ -896,10 +896,10 @@ class DependenciesTest < ActiveSupport::TestCase
 
   def test_autoload_doesnt_shadow_no_method_error_with_relative_constant
     with_autoloading_fixtures do
-      assert !defined?(::RaisesNoMethodError), "::RaisesNoMethodError is defined but it hasn't been referenced yet!"
+      assert !defined?(::RaisesNoMethodError), message: "::RaisesNoMethodError is defined but it hasn't been referenced yet!"
       2.times do
         assert_raise(NoMethodError) { RaisesNoMethodError }
-        assert !defined?(::RaisesNoMethodError), "::RaisesNoMethodError is defined but it should have failed!"
+        assert !defined?(::RaisesNoMethodError), message: "::RaisesNoMethodError is defined but it should have failed!"
       end
     end
   ensure
@@ -908,10 +908,10 @@ class DependenciesTest < ActiveSupport::TestCase
 
   def test_autoload_doesnt_shadow_no_method_error_with_absolute_constant
     with_autoloading_fixtures do
-      assert !defined?(::RaisesNoMethodError), "::RaisesNoMethodError is defined but it hasn't been referenced yet!"
+      assert !defined?(::RaisesNoMethodError), message: "::RaisesNoMethodError is defined but it hasn't been referenced yet!"
       2.times do
         assert_raise(NoMethodError) { ::RaisesNoMethodError }
-        assert !defined?(::RaisesNoMethodError), "::RaisesNoMethodError is defined but it should have failed!"
+        assert !defined?(::RaisesNoMethodError), message: "::RaisesNoMethodError is defined but it should have failed!"
       end
     end
   ensure
@@ -936,13 +936,13 @@ class DependenciesTest < ActiveSupport::TestCase
           ::RaisesNameError::FooBarBaz.object_id
         end
         assert_equal 'uninitialized constant RaisesNameError::FooBarBaz', e.message
-        assert !defined?(::RaisesNameError), "::RaisesNameError is defined but it should have failed!"
+        assert !defined?(::RaisesNameError), message: "::RaisesNameError is defined but it should have failed!"
       end
 
       assert !defined?(::RaisesNameError)
       2.times do
         assert_raise(NameError) { ::RaisesNameError }
-        assert !defined?(::RaisesNameError), "::RaisesNameError is defined but it should have failed!"
+        assert !defined?(::RaisesNameError), message: "::RaisesNameError is defined but it should have failed!"
       end
     end
   ensure
@@ -1021,10 +1021,10 @@ class DependenciesTest < ActiveSupport::TestCase
       assert_nothing_raised { CrossSiteDepender.nil? }
       assert defined?(CrossSiteDependency)
       assert_not ActiveSupport::Dependencies.autoloaded?(CrossSiteDependency),
-        "CrossSiteDependency shouldn't be marked as autoloaded!"
+        message: "CrossSiteDependency shouldn't be marked as autoloaded!"
       ActiveSupport::Dependencies.clear
       assert defined?(CrossSiteDependency),
-        "CrossSiteDependency shouldn't have been unloaded!"
+        message: "CrossSiteDependency shouldn't have been unloaded!"
     end
   ensure
     ActiveSupport::Dependencies.autoload_once_paths = old_path

--- a/activesupport/test/gzip_test.rb
+++ b/activesupport/test/gzip_test.rb
@@ -16,7 +16,7 @@ class GzipTest < ActiveSupport::TestCase
     compressed = ActiveSupport::Gzip.compress('')
 
     assert_equal Encoding.find('binary'), compressed.encoding
-    assert !compressed.blank?, "a compressed blank string should not be blank"
+    assert !compressed.blank?, message: "a compressed blank string should not be blank"
   end
 
   def test_compress_should_return_gzipped_string_by_compression_level

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -369,7 +369,7 @@ class InflectorTest < ActiveSupport::TestCase
       def test_clear_#{inflection_type}
         with_dup do
           ActiveSupport::Inflector.inflections.clear :#{inflection_type}
-          assert ActiveSupport::Inflector.inflections.#{inflection_type}.empty?, \"#{inflection_type} inflections should be empty after clear :#{inflection_type}\"
+          assert ActiveSupport::Inflector.inflections.#{inflection_type}.empty?, message: \"#{inflection_type} inflections should be empty after clear :#{inflection_type}\"
         end
       end
     RUBY

--- a/activesupport/test/load_paths_test.rb
+++ b/activesupport/test/load_paths_test.rb
@@ -11,6 +11,6 @@ class LoadPathsTest < ActiveSupport::TestCase
     load_paths_count[File.expand_path('../../lib', __FILE__)] -= 1
 
     load_paths_count.select! { |k, v| v > 1 }
-    assert load_paths_count.empty?, load_paths_count.inspect
+    assert load_paths_count.empty?, message: load_paths_count.inspect
   end
 end

--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -108,7 +108,7 @@ class LoggerTest < ActiveSupport::TestCase
     Logger::Severity.constants.each do |level|
       next if level.to_s == 'UNKNOWN'
       @logger.level = Logger::Severity.const_get(level) - 1
-      assert @logger.send("#{level.downcase}?"), "didn't know if it was #{level.downcase}? or below"
+      assert @logger.send("#{level.downcase}?"), message: "didn't know if it was #{level.downcase}? or below"
     end
   end
 
@@ -120,13 +120,13 @@ class LoggerTest < ActiveSupport::TestCase
     byte_string.force_encoding("ASCII-8BIT")
     assert byte_string.include?(BYTE_STRING)
   end
-  
+
   def test_silencing_everything_but_errors
     @logger.silence do
       @logger.debug "NOT THERE"
       @logger.error "THIS IS HERE"
     end
-    
+
     assert !@output.string.include?("NOT THERE")
     assert @output.string.include?("THIS IS HERE")
   end

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -132,20 +132,20 @@ class SafeBufferTest < ActiveSupport::TestCase
   test "Should be safe when sliced if original value was safe" do
     new_buffer = @buffer[0,0]
     assert_not_nil new_buffer
-    assert new_buffer.html_safe?, "should be safe"
+    assert new_buffer.html_safe?, message: "should be safe"
   end
 
   test "Should continue unsafe on slice" do
     x = 'foo'.html_safe.gsub!('f', '<script>alert("lolpwnd");</script>')
 
     # calling gsub! makes the dirty flag true
-    assert !x.html_safe?, "should not be safe"
+    assert !x.html_safe?, message: "should not be safe"
 
     # getting a slice of it
     y = x[0..-1]
 
     # should still be unsafe
-    assert !y.html_safe?, "should not be safe"
+    assert !y.html_safe?, message: "should not be safe"
   end
 
   test 'Should work with interpolation (array argument)' do
@@ -170,7 +170,7 @@ class SafeBufferTest < ActiveSupport::TestCase
 
   test 'Should interpolate to a safe string' do
     x = 'foo %{x} bar'.html_safe % { x: 'qux' }
-    assert x.html_safe?, 'should be safe'
+    assert x.html_safe?, message: 'should be safe'
   end
 
   test 'Should not affect frozen objects when accessing characters' do

--- a/railties/lib/rails/generators/testing/assertions.rb
+++ b/railties/lib/rails/generators/testing/assertions.rb
@@ -24,7 +24,7 @@ module Rails
         #   end
         def assert_file(relative, *contents)
           absolute = File.expand_path(relative, destination_root).shellescape
-          assert File.exist?(absolute), "Expected file #{relative.inspect} to exist, but does not"
+          assert File.exist?(absolute), message: "Expected file #{relative.inspect} to exist, but does not"
 
           read = File.read(absolute) if block_given? || !contents.empty?
           yield read if block_given?
@@ -46,7 +46,7 @@ module Rails
         #   assert_no_file "config/random.rb"
         def assert_no_file(relative)
           absolute = File.expand_path(relative, destination_root)
-          assert !File.exist?(absolute), "Expected file #{relative.inspect} to not exist, but does"
+          assert !File.exist?(absolute), message: "Expected file #{relative.inspect} to not exist, but does"
         end
         alias :assert_no_directory :assert_no_file
 
@@ -98,7 +98,7 @@ module Rails
         #     end
         #   end
         def assert_instance_method(method, content)
-          assert content =~ /(\s+)def #{method}(\(.+\))?(.*?)\n\1end/m, "Expected to have method #{method}"
+          assert content =~ /(\s+)def #{method}(\(.+\))?(.*?)\n\1end/m, message: "Expected to have method #{method}"
           yield $3.strip if block_given?
         end
         alias :assert_method :assert_instance_method

--- a/railties/test/application/asset_debugging_test.rb
+++ b/railties/test/application/asset_debugging_test.rb
@@ -37,7 +37,7 @@ module ApplicationTests
       # config.assets.debug and config.assets.compile are false for production environment
       ENV["RAILS_ENV"] = "production"
       output = Dir.chdir(app_path){ `bundle exec rake assets:precompile --trace 2>&1` }
-      assert $?.success?, output
+      assert $?.success?, message: output
       require "#{app_path}/config/environment"
 
       class ::PostsController < ActionController::Base ; end

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -32,11 +32,11 @@ module ApplicationTests
     end
 
     def assert_file_exists(filename)
-      assert Dir[filename].first, "missing #{filename}"
+      assert Dir[filename].first, message: "missing #{filename}"
     end
 
     def assert_no_file_exists(filename)
-      assert !File.exist?(filename), "#{filename} does exist"
+      assert !File.exist?(filename), message: "#{filename} does exist"
     end
 
     test "assets routes have higher priority" do

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -128,7 +128,7 @@ class FullStackConsoleTest < ActiveSupport::TestCase
       end
     end
 
-    assert output.include?(expected), "#{expected.inspect} expected, but got:\n\n#{output}"
+    assert output.include?(expected), message: "#{expected.inspect} expected, but got:\n\n#{output}"
   end
 
   def write_prompt(command, expected_output = nil)

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -23,7 +23,7 @@ module ApplicationTests
     test "config.force_ssl sets cookie to secure only" do
       add_to_config "config.force_ssl = true"
       require "#{app_path}/config/environment"
-      assert app.config.session_options[:secure], "Expected session to be marked as secure"
+      assert app.config.session_options[:secure], message: "Expected session to be marked as secure"
     end
 
     test "session is not loaded if it's not used" do

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -53,7 +53,7 @@ module ApplicationTests
     test "Rack::Cache is not included by default" do
       boot!
 
-      assert !middleware.include?("Rack::Cache"), "Rack::Cache is not included in the default stack unless you set config.action_dispatch.rack_cache"
+      assert !middleware.include?("Rack::Cache"), message: "Rack::Cache is not included in the default stack unless you set config.action_dispatch.rack_cache"
     end
 
     test "Rack::Cache is present when action_dispatch.rack_cache is set" do

--- a/railties/test/application/paths_test.rb
+++ b/railties/test/application/paths_test.rb
@@ -32,11 +32,11 @@ module ApplicationTests
     end
 
     def assert_in_load_path(*path)
-      assert $:.any? { |p| File.expand_path(p) == root(*path) }, "Load path does not include '#{root(*path)}'. They are:\n-----\n #{$:.join("\n")}\n-----"
+      assert $:.any? { |p| File.expand_path(p) == root(*path) }, message: "Load path does not include '#{root(*path)}'. They are:\n-----\n #{$:.join("\n")}\n-----"
     end
 
     def assert_not_in_load_path(*path)
-      assert !$:.any? { |p| File.expand_path(p) == root(*path) }, "Load path includes '#{root(*path)}'. They are:\n-----\n #{$:.join("\n")}\n-----"
+      assert !$:.any? { |p| File.expand_path(p) == root(*path) }, message: "Load path includes '#{root(*path)}'. They are:\n-----\n #{$:.join("\n")}\n-----"
     end
 
     test "booting up Rails yields a valid paths object" do

--- a/railties/test/rails_info_controller_test.rb
+++ b/railties/test/rails_info_controller_test.rb
@@ -57,25 +57,25 @@ class InfoControllerTest < ActionController::TestCase
     exact_count = -> { JSON(response.body)['exact'].size }
 
     get :routes, params: { path: 'rails/info/route' }
-    assert exact_count.call == 0, 'should not match incomplete routes'
+    assert exact_count.call == 0, message: 'should not match incomplete routes'
 
     get :routes, params: { path: 'rails/info/routes' }
-    assert exact_count.call == 1, 'should match complete routes'
+    assert exact_count.call == 1, message: 'should match complete routes'
 
     get :routes, params: { path: 'rails/info/routes.html' }
-    assert exact_count.call == 1, 'should match complete routes with optional parts'
+    assert exact_count.call == 1, message: 'should match complete routes with optional parts'
   end
 
   test "info controller returns fuzzy matches" do
     fuzzy_count = -> { JSON(response.body)['fuzzy'].size }
 
     get :routes, params: { path: 'rails/info' }
-    assert fuzzy_count.call == 2, 'should match incomplete routes'
+    assert fuzzy_count.call == 2, message: 'should match incomplete routes'
 
     get :routes, params: { path: 'rails/info/routes' }
-    assert fuzzy_count.call == 1, 'should match complete routes'
+    assert fuzzy_count.call == 1, message: 'should match complete routes'
 
     get :routes, params: { path: 'rails/info/routes.html' }
-    assert fuzzy_count.call == 0, 'should match optional parts of route literally'
+    assert fuzzy_count.call == 0, message: 'should match optional parts of route literally'
   end
 end


### PR DESCRIPTION
This PR is probably unfinished. I just want to know if this is something that would be considered. 
I think that the `assert predicate, message` interface is less than ideal, for the very simple reason that it's the same interface as `assert_equal x, y`. I believe that interfaces should be designed to prevent programmers from making mistakes, especially as easy to oversee as these. 

This is a backport of a patch we made in our codebase on the [`assert`](https://github.com/rails/rails/compare/master...gmalette:add-message-to-assert#diff-cbef10f252bdfb6975e32c5b9c32a84bR88) method.  It replaces the 2nd parameter by an explicit `message` kwarg. When I applied the patch in our codebase, I found a lot `assert` that really wanted to be `assert_equal`, many of which caused failing tests. 

Rails fared better, and only had a [single occurence](https://github.com/rails/rails/compare/master...gmalette:add-message-to-assert#diff-f88fb76eaf514ad473e66c250b95b6c4R1031) of `assert` wanting to be an `assert_equal`. Well, I'm not sure if it was supposed to be or not; the test name isn't descriptive, and changing it to an `assert_equal` makes the test fail. 
