### PR TITLE
Update RDoc for ActionController::TestCase for kwargs.

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -165,7 +165,7 @@ module ActionController
   #   class BooksControllerTest < ActionController::TestCase
   #     def test_create
   #       # Simulate a POST response with the given HTTP parameters.
-  #       post(:create, book: { title: "Love Hina" })
+  #       post(:create, params: { book: { title: "Love Hina" }})
   #
   #       # Assert that the controller tried to redirect us to
   #       # the created book's URI.


### PR DESCRIPTION
Looks like an RDoc example was overlooked when switching requests to kwargs.
