### PR TITLE
Added before_dependent_destroy

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -137,7 +137,11 @@ module ActiveRecord::Associations::Builder
 
     def self.add_destroy_callbacks(model, reflection)
       name = reflection.name
-      model.before_destroy lambda { |o| o.association(name).handle_dependency }
+      model.before_destroy(lambda do |o|
+        run_callbacks(:dependent_destroy) do
+          o.association(name).handle_dependency
+        end
+      end)
     end
   end
 end

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -78,6 +78,42 @@ class ImmutableDeveloper < ActiveRecord::Base
     end
 end
 
+class RelatedProject < ActiveRecord::Base
+  self.table_name = 'projects'
+end
+
+class RelatedDeveloper < ActiveRecord::Base
+  self.table_name = 'developers'
+end
+
+class RelatedDeveloperProject < ActiveRecord::Base
+  self.table_name = 'developers_projects'
+
+  belongs_to :developer, :class => RelatedProject, :foreign_key => 'developer_id'
+  belongs_to :project, :class => RelatedDeveloper, :foreign_key => 'project_id'
+end
+
+class RelatedProject < ActiveRecord::Base
+  has_many :developers_projects, :class => RelatedDeveloperProject, :foreign_key => 'project_id'
+  has_many :developers, :class => RelatedDeveloper, :through => :developers_projects
+end
+
+class RelatedDeveloper < ActiveRecord::Base
+  has_many :developers_projects, :class => RelatedDeveloperProject, :foreign_key => 'developer_id'
+  has_many :projects, :class => RelatedProject, :through => :developers_projects, :dependent => :destroy
+
+  before_dependent_destroy :store_projects_in_memory
+
+  attr_reader :projects_in_memory
+
+  private
+    def store_projects_in_memory
+      @projects_in_memory = self.projects.map do |project|
+        RelatedProject.find_by_id(project.id)
+      end
+    end
+end
+
 class DeveloperWithCanceledCallbacks < ActiveRecord::Base
   self.table_name = 'developers'
 
@@ -174,6 +210,8 @@ end
 
 class CallbacksTest < ActiveRecord::TestCase
   fixtures :developers
+  fixtures :projects
+  fixtures :developers_projects
 
   def test_initialize
     david = CallbackDeveloper.new
@@ -466,6 +504,15 @@ class CallbacksTest < ActiveRecord::TestCase
       assert !someone.save
     end
     assert_save_callbacks_not_called(someone)
+  end
+
+  #TODO handle delete_all and nullify as well. Also, handle around hook
+  def test_before_dependent_destroy_happens_before_dependent_destroy_regardless_of_order
+    andy = RelatedDeveloper.find(1)
+    projects = andy.projects.map(&:clone)
+    assert !projects.empty?
+    andy.destroy!
+    assert_equal projects, andy.projects_in_memory
   end
 
   def test_deprecated_before_create_returning_false


### PR DESCRIPTION
As per my comment on this issue:
https://github.com/rails/rails/issues/670#issuecomment-111306103

I realize there are existing alternatives, such as prepend: true, but please hear me out and put yourself in the shoe of a Rails framework consumer who sees Rails as a black box during business development, and rightly so as that is part of what made Rails so successful.

On a recent Android/Rails project, we got surprised by the default sequencing of events for dependent: :destroy vs a before_destroy added below it in an activerecord. From a Rails framework consumer point of view, the thought process assumes dependent: :destroy behavior to be part of #destroy. So, we expected before_destroy to happen before any kind of destruction on the active record and all its dependent destroy active records. That wasn't the case because from a Rails framework developer point of view, dependent: :destroy relies on before_destroy hooks in its implementation (something a consumer would not know intuitively without reading and digging). One hour and a half of troubleshooting later, I discovered the cause of our project problem. 

Still, I think we can save many Rails developers trouble in the future by having this adhere to the principle of least surprise (aka, before_destroy happens before any kind of destruction on the main active record or dependent ones). Given there is already a prepend:true option and we don't want to break older Rails applications, one friendly alternative is to simply support a more intuitive before_dependent_destroy, and that is what i implemented in this Pull Request and added documentation for. It would help make things absolutely clear with regards to the ordering of events when a developer learns of it alongside before_destroy.

This is a first cut implementation of before_dependent_destroy that I did last night test-first (activerecord/test/cases/callbacks_test.rb). Your feedback is greatly appreciated. I just noticed I am missing tests for after_dependent_destroy and around_dependent_destroy, so I'm adding soon (please bare with me).

Thanks. I've been a happy camper with Rails and appreciate the Rails folks continually striving to meet developer needs. I hope this solution pleases the happiness standards you conceive of for the Rails community.

Regards,

Andy Maleh
