### PR TITLE
Fix cache issue when different partials use the same collection

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Always attach the template digest to the cache key for collection caching
+    even when `virtual_path` is not available from the view context.
+    Which could happen if the rendering was done directly in the controller
+    and not in a template.
+
+    Fixes #20535
+
+    *Roque Pinel*
+
 *   Improve detection of partial templates eligible for collection caching,
     now allowing multi-line comments at the beginning of the template file.
 

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -51,7 +51,7 @@ module ActionView
       end
 
       def expanded_cache_key(key)
-        key = @view.fragment_cache_key(@view.cache_fragment_name(key))
+        key = @view.fragment_cache_key(@view.cache_fragment_name(key, virtual_path: @template.virtual_path))
         key.frozen? ? key.dup : key # #read_multi & #write may require mutability, Dalli 2.6.0.
       end
 


### PR DESCRIPTION
It adds the partial `virtual_path` to the caching key: instead of something like `views/david/1` it will be `views/customers/_customer/david/1`.

@kaspth Would you think this is valid?

Fixes #20535 
