### PR TITLE
Take UTC offset into account when assigning string value to time attributes.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Take into account UTC offset when assigning string representation of
+    timestamp with offset specified to attribute of time type.
+
+    *Andrey Novikov*
+
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
 *   Validate multiple contexts on `valid?` and `invalid?` at once.

--- a/activemodel/lib/active_model/type/time.rb
+++ b/activemodel/lib/active_model/type/time.rb
@@ -38,7 +38,7 @@ module ActiveModel
         fast_string_to_time(dummy_time_value) || begin
           time_hash = ::Date._parse(dummy_time_value)
           return if time_hash[:hour].nil?
-          new_time(*time_hash.values_at(:year, :mon, :mday, :hour, :min, :sec, :sec_fraction))
+          new_time(*time_hash.values_at(:year, :mon, :mday, :hour, :min, :sec, :sec_fraction, :offset))
         end
       end
     end

--- a/activemodel/test/cases/types_test.rb
+++ b/activemodel/test/cases/types_test.rb
@@ -64,6 +64,9 @@ module ActiveModel
 
       time_string = Time.now.utc.strftime("%T")
       assert_equal time_string, type.cast(time_string).strftime("%T")
+
+      assert_equal ::Time.utc(2000,  1,  1, 16, 45, 54), type.cast('2015-06-13T19:45:54+03:00')
+      assert_equal ::Time.utc(1999, 12, 31, 21,  7,  8), type.cast('06:07:08+09:00')
     end
 
     def test_type_cast_datetime_and_timestamp


### PR DESCRIPTION
This is a fix for bug when you try assign a string representation of time with UTC offset specified to ActiveRecord's object attribute of `time` type.

Example:

``` ruby
Schedule.arrival = '12:00:00+03:00'
Schedule.arrival # returns 2000-01-01 12:00:00 UTC but it should be 2000-01-01 09:00:00 UTC
```

Gist to reproduce: https://gist.github.com/Envek/3cd94d76f1ccd84b0253

Discovered on 4.2.0, so please also backport it.
