### PR TITLE
thrown ActiveRecord::AssociationTypeMismatch when assigning a wrong value for a namespaced association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Correctly thrown `ActiveRecord::AssociationTypeMismatch` when assigning
+    a wrong value to a namespaced association.
+
+    Fixes #20545
+
+    *Diego Carrion*
+
 *   `validates_absence_of` respects `marked_for_destruction?`.
 
     Fixes #20449.

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -211,9 +211,12 @@ module ActiveRecord
         # the kind of the class of the associated objects. Meant to be used as
         # a sanity check when you are about to assign an associated record.
         def raise_on_type_mismatch!(record)
-          unless record.is_a?(reflection.klass) || record.is_a?(reflection.class_name.constantize)
-            message = "#{reflection.class_name}(##{reflection.klass.object_id}) expected, got #{record.class}(##{record.class.object_id})"
-            raise ActiveRecord::AssociationTypeMismatch, message
+          unless record.is_a?(reflection.klass)
+            fresh_class = reflection.class_name.safe_constantize
+            unless fresh_class && record.is_a?(fresh_class)
+              message = "#{reflection.class_name}(##{reflection.klass.object_id}) expected, got #{record.class}(##{record.class.object_id})"
+              raise ActiveRecord::AssociationTypeMismatch, message
+            end
           end
         end
 


### PR DESCRIPTION
fixes #20541
