### PR TITLE
[skip ci] Update docs for adding a remote repo

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -468,7 +468,7 @@ Navigate to the Rails [GitHub repository](https://github.com/rails/rails) and pr
 Add the new remote to your local repository on your local machine:
 
 ```bash
-$ git remote add mine git@github.com:<your user name>/rails.git
+$ git remote add mine https://github.com/<your user name>/rails.git
 ```
 
 Push to your remote:


### PR DESCRIPTION
Github no longer seems to allow pushing to remotes set according to the current
Contributing Guide using `git@github.com:<your user name>/rails.git`

This PR updates the guide to the recommended `https` format which allows
`git push`. The `https` format is also used further down in the guide for
`git remote add upstream https://github.com/rails/rails.git`.

The other two git remote add examples in the Guide use
`git remote add rails git://github.com/rails/rails.git`.
They function because they are used with `git pull` or `git fetch` only.

All four examples could arguably be simplified to the same `https` format;
for now this PR is the minimum needed change.
