### PR TITLE
improve tests file system case sensitiveness validation to avoid breaking on some setups

### DIFF
--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -680,11 +680,7 @@ class RenderTest < ActionController::TestCase
   end
 
   def case_sensitive_file_system?
-    fname = '.case_sensitive_file_system_test'
-    FileUtils.touch(fname)
-    !File.exist?(fname.upcase)
-  ensure
-    FileUtils.rm_f(fname)
+    File.fnmatch('FILENAME', 'filename', File::FNM_EXTGLOB)
   end
 
   # :ported:


### PR DESCRIPTION
I'm not sure if this is zsh or [yadr](https://github.com/skwp/dotfiles) related or even a Ruby bug, but my filesystem is case insensitive and still `File.fnmatch` cares about the case. For example:

```
File.exist? 'gemfile'
 => true
File.fnmatch 'Gemfile', 'gemfile'
=> false
```

The consequence of this is that this [test](https://github.com/rails/rails/blob/10d0c43c7937f65b2fc6fb87a87b1023bbd85674/actionview/test/actionpack/controller/render_test.rb#L755) breaks on my setup because the test case validates case sensitiveness in a way (`File.exist?`) and the [implementation](https://github.com/rails/rails/blob/10d0c43c7937f65b2fc6fb87a87b1023bbd85674/actionview/test/actionpack/controller/render_test.rb#L755) in another way (`File.fnmatch`).

This pull request fixes this problem and as a bonus avoids the creation and removal of a file.
