### PR TITLE
RoutesInspector should show path with relative_url_root

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -21,7 +21,7 @@ module ActionDispatch
       end
 
       def path
-        super.spec.to_s
+        relative_url_root + super.spec.to_s
       end
 
       def name
@@ -51,6 +51,11 @@ module ActionDispatch
       def engine?
         rack_app.respond_to?(:routes)
       end
+
+      private
+        def relative_url_root
+          Rails.application.config.relative_url_root.to_s
+        end
     end
 
     ##

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -305,6 +305,16 @@ module ActionDispatch
                       "          DELETE /posts/:id(.:format)      posts#destroy"], output
       end
 
+      def test_relative_url_root
+        Rails.application.config.stubs(:relative_url_root).returns('/foo')
+        output = draw do
+          resources :posts, only: :index
+        end
+
+        assert_equal ["Prefix Verb URI Pattern          Controller#Action",
+                      " posts GET  /foo/posts(.:format) posts#index"], output
+      end
+
       def test_regression_route_with_controller_regexp
         output = draw do
           get ':controller(/:action)', controller: /api\/[^\/]+/, format: false
@@ -315,11 +325,6 @@ module ActionDispatch
       end
 
       def test_inspect_routes_shows_resources_route_when_assets_disabled
-        @set = ActionDispatch::Routing::RouteSet.new
-        app = ActiveSupport::OrderedOptions.new
-
-        Rails.stubs(:application).returns(app)
-
         output = draw do
           get '/cart', to: 'cart#show'
         end


### PR DESCRIPTION
I saw this problem in a project which my colleague is trying to work in. He was trying to add new route into the `routes.rb` but he couldn't access the page he had added into the routes. We tried to get list of routes with `rake routes` but because of the this bug we couldn't see the correct path of the route.
Finally we figured out to look at the application.rb and saw the `config.relative_url_root` definition.
I believe `rake routes` should write routes with `relative_url_root` otherwise being a part of the new project which set relative_url_root causes headache :smile:.
