### PR TITLE
Fix `undefined method uncached` for polymorphic belongs_to #20426

### DIFF
--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     class SingularAssociation < Association #:nodoc:
       # Implements the reader method, e.g. foo.bar for Foo.has_one :bar
       def reader(force_reload = false)
-        if force_reload
+        if force_reload && klass
           klass.uncached { reload }
         elsif !loaded? || stale_target?
           reload

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -288,6 +288,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   def test_polymorphic_association_class
     sponsor = Sponsor.new
     assert_nil sponsor.association(:sponsorable).send(:klass)
+    assert_nil sponsor.sponsorable(force_reload: true)
 
     sponsor.sponsorable_type = '' # the column doesn't have to be declared NOT NULL
     assert_nil sponsor.association(:sponsorable).send(:klass)


### PR DESCRIPTION
Closes #20426

Unitialized polymorphic `belongs_to` associations raise an error while attempting to reload, as they attempt to make an uncached reload, but don't have a klass to fetch uncachedly.

As best I can tell, this is the only case where `klass` might be `nil` [here](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/singular_association.rb#L7), and in this case there's no cache to bypass. It's unclear to me whether it's better to fall through to `reload` here (which _is_ safe - it [notices it doesn't have a key](https://github.com/rails/rails/blob/3e36db4406beea32772b1db1e9a16cc1e8aea14c/activerecord/lib/active_record/associations/association.rb#L176), and doesn't make a query) or not.

Feedback or logic check 100% welcome. First Rails PR here, so be gentle.
