### PR TITLE
[ci skip] Fix the dynamic fixtures example

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -110,7 +110,7 @@ module ActiveRecord
   #   <% 1.upto(1000) do |i| %>
   #   fix_<%= i %>:
   #     id: <%= i %>
-  #     name: guy_<%= 1 %>
+  #     name: guy_<%= i %>
   #   <% end %>
   #
   # This will create 1000 very simple fixtures.


### PR DESCRIPTION
My impression of the code sample is that the intent is to assign guy_1, guy_2, etc. The code as it stood would have assigned guy_1, guy_1, etc.

This simply replaces the 1 with the iterator variable i.
