### PR TITLE
Improve Validation Helpers' documentation comments and tests

### DIFF
--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -42,9 +42,10 @@ module ActiveModel
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "must be
       #   accepted").
-      # * <tt>:accept</tt> - Specifies value that is considered accepted.
-      #   The default value is a string "1", which makes it easy to relate to
-      #   an HTML checkbox. This should be set to +true+ if you are validating
+      # * <tt>:accept</tt> - Specifies a value that is considered accepted.
+      #   Also accepts an array of possible values. The default value is
+      #   an array ["1", true], which makes it easy to relate to an HTML
+      #   checkbox. This should be set to, or include, +true+ if you are validating
       #   a database column, since the attribute is typecast from "1" to +true+
       #   before validation.
       #

--- a/activemodel/lib/active_model/validations/exclusion.rb
+++ b/activemodel/lib/active_model/validations/exclusion.rb
@@ -29,7 +29,9 @@ module ActiveModel
       # Configuration options:
       # * <tt>:in</tt> - An enumerable object of items that the value shouldn't
       #   be part of. This can be supplied as a proc, lambda or symbol which returns an
-      #   enumerable. If the enumerable is a range the test is performed with
+      #   enumerable. If the enumerable is a numerical, time or datetime range the test
+      #   is performed with <tt>Range#cover?</tt>, otherwise with <tt>include?</tt>. When
+      #   using a proc or lambda the instance under validation is passed as an argument.
       # * <tt>:within</tt> - A synonym(or alias) for <tt>:in</tt>
       #   <tt>Range#cover?</tt>, otherwise with <tt>include?</tt>.
       # * <tt>:message</tt> - Specifies a custom error message (default is: "is

--- a/activemodel/lib/active_model/validations/inclusion.rb
+++ b/activemodel/lib/active_model/validations/inclusion.rb
@@ -28,9 +28,9 @@ module ActiveModel
       # Configuration options:
       # * <tt>:in</tt> - An enumerable object of available items. This can be
       #   supplied as a proc, lambda or symbol which returns an enumerable. If the
-      #   enumerable is a numerical range the test is performed with <tt>Range#cover?</tt>,
-      #   otherwise with <tt>include?</tt>. When using a proc or lambda the instance
-      #   under validation is passed as an argument.
+      #   enumerable is a numerical, time or datetime range the test is performed
+      #   with <tt>Range#cover?</tt>, otherwise with <tt>include?</tt>. When using
+      #   a proc or lambda the instance under validation is passed as an argument.
       # * <tt>:within</tt> - A synonym(or alias) for <tt>:in</tt>
       # * <tt>:message</tt> - Specifies a custom error message (default is: "is
       #   not included in the list").

--- a/activemodel/test/cases/validations/acceptance_validation_test.rb
+++ b/activemodel/test/cases/validations/acceptance_validation_test.rb
@@ -50,6 +50,20 @@ class AcceptanceValidationTest < ActiveModel::TestCase
     assert t.valid?
   end
 
+  def test_terms_of_service_agreement_with_multiple_accept_values
+    Topic.validates_acceptance_of(:terms_of_service, accept: [1, "I concur."])
+
+    t = Topic.new("title" => "We should be confirmed", "terms_of_service" => "")
+    assert t.invalid?
+    assert_equal ["must be accepted"], t.errors[:terms_of_service]
+
+    t.terms_of_service = 1
+    assert t.valid?
+
+    t.terms_of_service = "I concur."
+    assert t.valid?
+  end
+
   def test_validates_acceptance_of_for_ruby_class
     Person.validates_acceptance_of :karma
 

--- a/activemodel/test/cases/validations/exclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/exclusion_validation_test.rb
@@ -1,4 +1,5 @@
 require 'cases/helper'
+require 'active_support/core_ext/numeric/time'
 
 require 'models/topic'
 require 'models/person'
@@ -62,6 +63,22 @@ class ExclusionValidationTest < ActiveModel::TestCase
 
     t.title = "wasabi"
     assert t.valid?
+  end
+
+  def test_validates_exclusion_of_with_range
+    Topic.validates_exclusion_of :content, in: ("a".."g")
+
+    assert Topic.new(content: 'g').invalid?
+    assert Topic.new(content: 'h').valid?
+  end
+
+  def test_validates_exclusion_of_with_time_range
+    Topic.validates_exclusion_of :created_at, in: 6.days.ago..2.days.ago
+
+    assert Topic.new(created_at: 5.days.ago).invalid?
+    assert Topic.new(created_at: 3.days.ago).invalid?
+    assert Topic.new(created_at: 7.days.ago).valid?
+    assert Topic.new(created_at: 1.day.ago).valid?
   end
 
   def test_validates_inclusion_of_with_symbol


### PR DESCRIPTION
A few of the validation helpers had outdated (or broken)  comments and some missing tests so I went ahead and fixed that.
