### PR TITLE
ActionDispatch::SSL should keep original header's behavior

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -22,7 +22,7 @@ module ActionDispatch
 
       if request.ssl?
         status, headers, body = @app.call(env)
-        headers = hsts_headers.merge(headers)
+        headers.reverse_merge!(hsts_headers)
         flag_cookies_as_secure!(headers)
         [status, headers, body]
       else

--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -216,4 +216,15 @@ class SSLTest < ActionDispatch::IntegrationTest
     assert_equal "https://example.co.uk/path?key=value",
       response.headers['Location']
   end
+
+  def test_keeps_original_headers_behavior
+    headers = Rack::Utils::HeaderHash.new(
+      "Content-Type" => "text/html",
+      "Connection" => ["close"]
+    )
+    self.app = ActionDispatch::SSL.new(lambda { |env| [200, headers, ["OK"]] })
+
+    get "https://example.org/"
+    assert_equal "close", response.headers["Connection"]
+  end
 end


### PR DESCRIPTION
`ActionDispatch::SSL` changes headers to `Hash`.
So some headers will be broken if there are some middlewares
on ActionDispatch::SSL and if it uses `Rack::Utils::HeaderHash`.
