### PR TITLE
fix a mysql column type registration bug

### DIFF
--- a/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
@@ -22,6 +22,10 @@ module ActiveRecord
         assert_lookup_type :string, "SET('one', 'two', 'three')"
       end
 
+      def test_set_type_with_value_matching_other_type
+        assert_lookup_type :string, "SET('one_time', 'unicode', '8bit', 'none')"
+      end
+
       def test_enum_type_with_value_matching_other_type
         assert_lookup_type :string, "ENUM('unicode', '8bit', 'none')"
       end


### PR DESCRIPTION
if the mysql "set" type includes other type name strings, column type registration failed.

```
set('hogehoge', 'fugafuga_time')
```

↓↓↓↓

```
ActiveRecord::Type::Time
```
