### PR TITLE
Small refactor on db:reset

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -134,10 +134,7 @@ db_namespace = namespace :db do
   end
 
   # desc 'Drops and recreates the database from db/schema.rb for the current environment and loads the seeds.'
-  task :reset => [:environment, :load_config] do
-    db_namespace["drop"].invoke
-    db_namespace["setup"].invoke
-  end
+  task :reset => [ 'db:drop', 'db:setup' ]
 
   # desc "Retrieves the charset for the current environment's database"
   task :charset => [:environment, :load_config] do


### PR DESCRIPTION
db:reset should not prematurely load the environment, so, for instance,
if there is any initializer that touches th DB, it will not touch that
before droping it.

Also this makes the code simpler.

This changed was made back in
https://github.com/rails/rails/commit/15fb4302b6ff16e641b6279a3530eb8ed97f2899
, not sure why. But I am pretty much sure we should do it like this, as
drop and setup should load its dependencies tasks if necessary.

review @rafaelfranca  @senny 
