### PR TITLE
Change default cache store to MemoryStore

### DIFF
--- a/actionpack/lib/action_controller/caching.rb
+++ b/actionpack/lib/action_controller/caching.rb
@@ -16,7 +16,7 @@ module ActionController
   # All the caching stores from ActiveSupport::Cache are available to be used as backends
   # for Action Controller caching.
   #
-  # Configuration examples (FileStore is the default):
+  # Configuration examples (MemoryStore is the default):
   #
   #   config.action_controller.cache_store = :memory_store
   #   config.action_controller.cache_store = :file_store, '/path/to/cache/directory'

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -235,6 +235,8 @@ config.cache_store = :memory_store, { size: 64.megabytes }
 
 If you're running multiple Ruby on Rails server processes (which is the case if you're using mongrel_cluster or Phusion Passenger), then your Rails server process instances won't be able to share cache data with each other. This cache store is not appropriate for large application deployments, but can work well for small, low traffic sites with only a couple of server processes or for development and test environments.
 
+This is the default cache store implementation.
+
 ### ActiveSupport::Cache::FileStore
 
 This cache store uses the file system to store entries. The path to the directory where the store files will be stored must be specified when initializing the cache.
@@ -246,8 +248,6 @@ config.cache_store = :file_store, "/path/to/cache/directory"
 With this cache store, multiple server processes on the same host can share a cache. Server processes running on different hosts could share a cache by using a shared file system, but that set up would not be ideal and is not recommended. The cache store is appropriate for low to medium traffic sites that are served off one or two hosts.
 
 Note that the cache will grow until the disk is full unless you periodically clear out old entries.
-
-This is the default cache store implementation.
 
 ### ActiveSupport::Cache::MemCacheStore
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -38,7 +38,7 @@ module Rails
         @log_level                     = nil
         @middleware                    = app_middleware
         @generators                    = app_generators
-        @cache_store                   = [ :file_store, "#{root}/tmp/cache/" ]
+        @cache_store                   = [ :memory_store ]
         @railties_order                = [:all]
         @relative_url_root             = ENV["RAILS_RELATIVE_URL_ROOT"]
         @reload_classes_only_on_change = true

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -27,7 +27,6 @@ module ApplicationTests
         "Rack::Sendfile",
         "ActionDispatch::Static",
         "Rack::Lock",
-        "ActiveSupport::Cache::Strategy::LocalCache",
         "Rack::Runtime",
         "Rack::MethodOverride",
         "ActionDispatch::RequestId",
@@ -59,7 +58,6 @@ module ApplicationTests
         "Rack::Sendfile",
         "ActionDispatch::Static",
         "Rack::Lock",
-        "ActiveSupport::Cache::Strategy::LocalCache",
         "Rack::Runtime",
         "ActionDispatch::RequestId",
         "Rails::Rack::Logger", # must come after Rack::MethodOverride to properly log overridden methods
@@ -201,14 +199,14 @@ module ApplicationTests
     end
 
     test "Rails.cache does not respond to middleware" do
-      add_to_config "config.cache_store = :memory_store"
       boot!
       assert_equal "Rack::Runtime", middleware.fourth
     end
 
     test "Rails.cache does respond to middleware" do
+      add_to_config "config.cache_store = :null_store"
       boot!
-      assert_equal "Rack::Runtime", middleware.fifth
+      assert_equal "ActiveSupport::Cache::Strategy::LocalCache", middleware.fourth
     end
 
     test "insert middleware before" do


### PR DESCRIPTION
I propose changing the default cache store from FileStore to MemoryStore.
- FileStore will, by necessity, be slower than MemoryStore. I am preparing benchmarks on this front. In addition, FileStore uses exception-based handling to manage locks, but MemoryStore uses Monitor.
- FileStore adds an additional Rack middleware to the default stack. MemoryStore does not. Less complexity is always good! In addition, the MemoryStore is much shorter and simpler to understand (IMO).
- FileStore and MemoryStore are both appropriate for _roughly_ the same size of application. Any application larger than 2-3 hosts should use Memcache or another external cache store.
- MemoryStore has the disadvantage of not sharing memory across processes. This makes MemoryStore inappropriate for a server that runs more than ~4 processes per host. I do not have metrics on how many people actually do this. However, consider Heroku. Most Rails apps use ~200 MB of memory, limiting processes-per-server on Heroku dynes (at 512 MB) to about 3.
- FileStore is extremely inappropriate in environments where filesystem access is especially slow and penalized (e.g. Heroku). On Heroku, using the filesystem ("swap") can slow processes to a crawl.
- **FileStore does not evict cache entries based on last-accessed time**. MemoryStore does. This makes FileStore incompatible with key-based cache expiration, leading to ballooning caches (since I think FileStore doesn't even start clearing the cache of expired entries until it's using more than 1GB?). I think this is the main reason we shouldn't use FileStore anymore. We're telling developers in our Guides to do key-based expiration (indeed, forcing that they do with cache_digests) and then telling them to use a cache store that's highly incompatible with the technique.

I believe the advantages here (compatibility with key-based expiration) outweigh the disadvantages (1 cache per process) here. 
