### PR TITLE
raise ActiveModel::MissingAttributeError when trying to access a relationship without the foreign key attribute

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -107,7 +107,7 @@ module ActiveRecord
         end
 
         def stale_state
-          result = owner._read_attribute(reflection.foreign_key)
+          result = owner._read_attribute(reflection.foreign_key) { |n| owner.send(:missing_attribute, n, caller) }
           result && result.to_s
         end
     end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -31,6 +31,10 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal companies(:first_firm).name, firm.name
   end
 
+  def test_missing_attribute_error_is_raised_when_no_foreign_key_attribute
+    assert_raises(ActiveModel::MissingAttributeError) { Client.select(:id).first.firm }
+  end
+
   def test_belongs_to_does_not_use_order_by
     ActiveRecord::SQLCounter.clear_log
     Client.find(3).firm


### PR DESCRIPTION
fixes regression reported on #20253

ActiveRecord::Base#[] was not used cause of 8b95420
