### PR TITLE
Catch InvalidURIError on bad paths on redirect.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Handle InvalidURIError on bad paths on redirect route.
+
+    *arthurnn*
+
 *   Deprecate passing first parameter as `Hash` and default status code for `head` method.
 
     *Mehmet Emin İNAÇ*

--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -23,8 +23,12 @@ module ActionDispatch
 
       def serve(req)
         req.check_path_parameters!
-        uri = URI.parse(path(req.path_parameters, req))
-        
+        begin
+          uri = URI.parse(path(req.path_parameters, req))
+        rescue URI::InvalidURIError
+          return [ 400, {}, ['Invalid path.'] ]
+        end
+
         unless uri.host
           if relative_path?(uri.path)
             uri.path = "#{req.script_name}/#{uri.path}"
@@ -32,7 +36,7 @@ module ActionDispatch
             uri.path = req.script_name.empty? ? "/" : req.script_name
           end
         end
-          
+
         uri.scheme ||= req.scheme
         uri.host   ||= req.host
         uri.port   ||= req.port unless req.standard_port?
@@ -124,7 +128,7 @@ module ActionDispatch
             url_options[:script_name] = request.script_name
           end
         end
-        
+
         ActionDispatch::Http::URL.url_for url_options
       end
 

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -219,6 +219,13 @@ module ActionDispatch
         assert_equal 404, resp.first
       end
 
+      def test_invalid_url_path
+        routes = Class.new { include ActionDispatch::Routing::Redirection }.new
+        route = routes.redirect("/foo/bar/%{id}")
+        resp = route.serve(rails_env({ 'REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/foo/(function(){})' }))
+        assert_equal 400, resp.first
+      end
+
       def test_clear_trailing_slash_from_script_name_on_root_unanchored_routes
         route_set = Routing::RouteSet.new
         mapper = Routing::Mapper.new route_set


### PR DESCRIPTION
Handle `URI::InvalidURIError` errors on the redirect route method, so it
wont raise a 500 if a bad path is given.

We started seeing errors like `URI::InvalidURIError: bad URI(is not URI?):` on a redirect endpoint. We can easily catch that error and return a bad request instead of a 500.

review @rafaelfranca 
