### PR TITLE
Fixing error thrown when active job started with no args

### DIFF
--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -85,7 +85,7 @@ module ActiveJob
         end
 
         def args_info(job)
-          if job.arguments.any?
+          if job.arguments and job.arguments.any?
             ' with arguments: ' +
               job.arguments.map { |arg| arg.try(:to_global_id).try(:to_s) || arg.inspect }.join(', ')
           else

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -85,7 +85,7 @@ module ActiveJob
         end
 
         def args_info(job)
-          if job.arguments and job.arguments.any?
+          if job.arguments && job.arguments.any?
             ' with arguments: ' +
               job.arguments.map { |arg| arg.try(:to_global_id).try(:to_s) || arg.inspect }.join(', ')
           else


### PR DESCRIPTION
Upon calling a job in a unit test I got this error 

```
E, [2015-06-16T17:56:47.329082 #32337] ERROR -- : Could not log "perform_start.active_job" event. NoMethodError: undefined method `any?' for nil:NilClass ["/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activejob-4.2.1/lib/active_job/logging.rb:88:in `args_info'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activejob-4.2.1/lib/active_job/logging.rb:71:in `block in perform_start'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/2.2.0/logger.rb:372:in `add'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/2.2.0/logger.rb:434:in `info'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/log_subscriber.rb:93:in `info'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activejob-4.2.1/lib/active_job/logging.rb:69:in `perform_start'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/subscriber.rb:100:in `finish'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/log_subscriber.rb:83:in `finish'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/notifications/fanout.rb:102:in `finish'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/notifications/fanout.rb:46:in `block in finish'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/notifications/fanout.rb:46:in `each'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/notifications/fanout.rb:46:in `finish'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/notifications/instrumenter.rb:36:in `finish'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/notifications/instrumenter.rb:25:in `instrument'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/notifications.rb:164:in `instrument'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activejob-4.2.1/lib/active_job/logging.rb:21:in `block (3 levels) in <module:Logging>'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activejob-4.2.1/lib/active_job/logging.rb:45:in `tag_logger'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activejob-4.2.1/lib/active_job/logging.rb:19:in `block (2 levels) in <module:Logging>'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/callbacks.rb:441:in `instance_exec'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/callbacks.rb:441:in `block in make_lambda'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/callbacks.rb:342:in `call'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/callbacks.rb:342:in `block in simple'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/callbacks.rb:497:in `call'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/callbacks.rb:497:in `block in around'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/callbacks.rb:505:in `call'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/callbacks.rb:505:in `call'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/callbacks.rb:92:in `_run_callbacks'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/callbacks.rb:776:in `_run_perform_callbacks'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/callbacks.rb:81:in `run_callbacks'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activejob-4.2.1/lib/active_job/execution.rb:31:in `perform_now'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activejob-4.2.1/lib/active_job/execution.rb:16:in `perform_now'", "test/jobs/crawl_newsfeed_job_test.rb:10:in `block in <class:CrawlNewsfeedJobTest>'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest/test.rb:108:in `block (3 levels) in run'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest/test.rb:205:in `capture_exceptions'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest/test.rb:105:in `block (2 levels) in run'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest/test.rb:256:in `time_it'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest/test.rb:104:in `block in run'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest.rb:332:in `on_signal'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest/test.rb:276:in `with_info_handler'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest/test.rb:103:in `run'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-reporters-1.0.5/lib/minitest/reporters.rb:42:in `run_with_hooks'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest.rb:779:in `run_one_method'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest.rb:306:in `run_one_method'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest.rb:294:in `block (2 levels) in run'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest.rb:293:in `each'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest.rb:293:in `block in run'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest.rb:332:in `on_signal'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest.rb:319:in `with_info_handler'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest.rb:292:in `run'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest.rb:155:in `block in __run'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest.rb:155:in `map'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest.rb:155:in `__run'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest.rb:129:in `run'", "/home/da/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/minitest-5.6.1/lib/minitest.rb:56:in `block in autorun'"]
```
