### PR TITLE
Fix size and empty methods in relations with group and order

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -272,7 +272,7 @@ module ActiveRecord
 
     # Returns size of the records.
     def size
-      loaded? ? @records.length : count(:all)
+      loaded? ? @records.length : except(:order).count(:all)
     end
 
     # Returns true if there are no records.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -282,7 +282,7 @@ module ActiveRecord
       if limit_value == 0
         true
       else
-        c = count(:all)
+        c = except(:order).count(:all)
         c.respond_to?(:zero?) ? c.zero? : c.empty?
       end
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1166,6 +1166,15 @@ class RelationTest < ActiveRecord::TestCase
     assert_no_queries { assert_equal 0, posts.size }
   end
 
+  def test_size_with_group_and_order
+    posts = Post.select("author_id")
+              .group("author_id")
+              .order("author_count DESC")
+
+    expected = { 0 => 1, 1 => 5, 2 => 3, 3 => 2 }
+    assert_queries(1) { assert_equal expected, posts.size }
+  end
+
   def test_empty_with_zero_limit
     posts = Post.limit(0)
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1206,6 +1206,17 @@ class RelationTest < ActiveRecord::TestCase
     assert ! no_posts.loaded?
   end
 
+  def test_empty_complex_chained_relations_with_group_order_and_count
+    posts = Post.select("author_id, count(author_id) AS author_count")
+      .order("author_count DESC")
+      .group("author_id")
+
+    assert_queries(1) { assert_equal false, posts.empty? }
+
+    no_posts = posts.where(title: "")
+    assert_queries(1) { assert_equal true, no_posts.empty? }
+  end
+
   def test_any
     posts = Post.all
 


### PR DESCRIPTION
Fix the problem mentioned in this issue https://github.com/rails/rails/issues/20508

The idea is to prevent invalid SQL count queries created on the `empty?` and `size` methods by excluding the order clause. The issue is happening when the order clause depends on an expression using the SQL count function because this part is changed by AR at the moment of creating the SQL count query.
After all, removing the order clause in a SQL count query does not alter the result. 
