### PR TITLE
Use single quote in Railties generators Gemfile [ci skip]

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -38,7 +38,7 @@ end
 group :development do
   # Access an IRB console on exception pages or by using <%%= console %> in views
   <%- if options.dev? || options.edge? -%>
-  gem 'web-console', github: "rails/web-console"
+  gem 'web-console', github: 'rails/web-console'
   <%- else -%>
   gem 'web-console', '~> 2.0'
   <%- end -%>


### PR DESCRIPTION
I know this looks like a cosmetic change but I believe it's not. We are using single quote every where in Gemfile so it should be compatible with the others.
