### PR TITLE
Update bundler to v1.10.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,4 +308,4 @@ DEPENDENCIES
   w3c_validators
 
 BUNDLED WITH
-   1.10.3
+   1.10.4


### PR DESCRIPTION
bundler [v1.10.4](https://rubygems.org/gems/bundler/versions/1.10.4) was released yesterday. This PR updates `Gemfile.lock`'s `BUNDLED WITH` section to reflect that.
