### PR TITLE
Regex fix for mattr_accessor validation

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
@@ -53,7 +53,7 @@ class Module
   def mattr_reader(*syms)
     options = syms.extract_options!
     syms.each do |sym|
-      raise NameError.new("invalid attribute name: #{sym}") unless sym =~ /^[_A-Za-z]\w*$/
+      raise NameError.new("invalid attribute name: #{sym}") unless sym =~ /\A[_A-Za-z]\w*\z/
       class_eval(<<-EOS, __FILE__, __LINE__ + 1)
         @@#{sym} = nil unless defined? @@#{sym}
 
@@ -119,7 +119,7 @@ class Module
   def mattr_writer(*syms)
     options = syms.extract_options!
     syms.each do |sym|
-      raise NameError.new("invalid attribute name: #{sym}") unless sym =~ /^[_A-Za-z]\w*$/
+      raise NameError.new("invalid attribute name: #{sym}") unless sym =~ /\A[_A-Za-z]\w*\z/
       class_eval(<<-EOS, __FILE__, __LINE__ + 1)
         @@#{sym} = nil unless defined? @@#{sym}
 

--- a/activesupport/test/core_ext/module/attribute_accessor_test.rb
+++ b/activesupport/test/core_ext/module/attribute_accessor_test.rb
@@ -69,6 +69,20 @@ class ModuleAttributeAccessorTest < ActiveSupport::TestCase
       end
     end
     assert_equal "invalid attribute name: 1nvalid", exception.message
+
+    exception = assert_raises NameError do
+      Class.new do
+        mattr_reader "valid_part\ninvalid_part"
+      end
+    end
+    assert_equal "invalid attribute name: valid_part\ninvalid_part", exception.message
+
+    exception = assert_raises NameError do
+      Class.new do
+        mattr_writer "valid_part\ninvalid_part"
+      end
+    end
+    assert_equal "invalid attribute name: valid_part\ninvalid_part", exception.message
   end
 
   def test_should_use_default_value_if_block_passed


### PR DESCRIPTION
Hi!

This patch changes `^` and `$` operators in regex that validates arguments passed to `mattr_reader/writer` methods to `\A` and `\z` appropriately. 

Using `^` and `$` allows arguments such as `valid\nwhatever_text` that definitely not valid and even more they would be executed in context of `class_eval` after.

So it could lead to the syntax errors or potential code injections if the arguments was created somehow dynamically.

Does it make sense or I miss something?

Thanks and have a good day! :sunny: 
