### PR TITLE
Add preload (associations) instance method to ActiveRecord object

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -169,6 +169,11 @@ module ActiveRecord
       super
     end
 
+    # Preload associations for object instance
+    def preload(associations_hash) # :nodoc:
+      Preloader.new.preload(self, associations_hash)
+    end
+
     def reload(*) # :nodoc:
       clear_association_cache
       super


### PR DESCRIPTION
Sometimes there is a need to preload associations for an already instantiated ActiveRecord object. For example, conditionally (`if attribute == xxx`) for some performance reasons. This can be achieved by using `ActiveRecord::Associations::Preloader` class, for example:

Rails 3:
    ActiveRecord::Associations::Preloader.new(object, { association1: [:nested_association1, :nested_association2] }).run

Rails 4:
    ActiveRecord::Associations::Preloader.new.preload(object, { association1: [:nested_association1, :nested_association2] })

As we can see, API for this changed between Rails 3 and 4 and it might change in the future, so I think that it'd be better to take the need to update the code from developers shoulders and handle it internally, in the preload method definition.

Let's discuss.
