### PR TITLE
More granular console SQL coloration

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -47,18 +47,21 @@ module ActiveRecord
         binds = "  " + payload[:binds].map { |attr| render_bind(attr) }.inspect
       end
 
-      if odd?
-        name = color(name, CYAN, true)
-        sql  = color(sql, nil, true)
-      else
-        name = color(name, MAGENTA, true)
-      end
+      name = color(name, nil, true)
+      sql  = color(sql, sql_color(sql), true)
 
       debug "  #{name}  #{sql}#{binds}"
     end
 
-    def odd?
-      @odd = !@odd
+    def sql_color(sql)
+      case sql
+        when /\s*\Ainsert/i      then GREEN
+        when /\s*\Aselect/i      then BLUE
+        when /\s*\Aupdate/i      then YELLOW
+        when /\s*\Adelete/i      then RED
+        when /transaction\s*\Z/i then CYAN
+        else MAGENTA
+      end
     end
 
     def logger


### PR DESCRIPTION
This new coloration approach makes it easier to scan the rails console
for specific types of activity with more fine-grained visual cues.

Virtual terminal ANSI color escape codes are used when displaying SQL
statements in the rails console. The former implementation alternates
line prefix information (including the statement name and execution
latency) between CYAN and MAGENTA. This visually differentiates any SQL
statements in the log and is useful for quickly scanning for database
activity.

While a great idea and a solid foundation, alternating between just two
colors on an even/odd basis (much like striping an HTML table) can be
improved upon.

This patch replaces the even/odd striping with a more comprehensive
scheme that applies coloration based on the type of statement being
run. Every statement logged has its prefix (name and latency) colored
white (as the statement body was previously). The statement body is now
colored according to the nature of the statement:
- INSERT statements are GREEN (symbolic of creation or genesis)
- SELECT statements are BLUE (typically used for informational
  displays, as SELECT statements do not normally have side-effects)
- DELETE statements are RED (commonly used to indicate the danger of
  a destructive action)
- UPDATE statements are YELLOW (it's like a less extreme RED :P)
- TRANSACTION statements are CYAN (arbitrary)
- and any other statements are MAGENTA (again, arbitrary)
