### PR TITLE
pass params to mailer preview

### DIFF
--- a/actionmailer/lib/action_mailer/preview.rb
+++ b/actionmailer/lib/action_mailer/preview.rb
@@ -61,8 +61,9 @@ module ActionMailer
       # Returns the mail object for the given email name. The registered preview
       # interceptors will be informed so that they can transform the message
       # as they would if the mail was actually being delivered.
-      def call(email)
+      def call(email, params)
         preview = self.new
+        preview.params = params
         message = preview.public_send(email)
         inform_preview_interceptors(message)
         message
@@ -114,5 +115,7 @@ module ActionMailer
           end
         end
     end
+
+    attr_accessor :params
   end
 end

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -851,35 +851,39 @@ class BasePreviewInterceptorsTest < ActiveSupport::TestCase
   end
 
   test "you can register a preview interceptor to the mail object that gets passed the mail object before previewing" do
+    params = {}
     ActionMailer::Base.register_preview_interceptor(MyInterceptor)
     mail = BaseMailer.welcome
     BaseMailerPreview.any_instance.stubs(:welcome).returns(mail)
     MyInterceptor.expects(:previewing_email).with(mail)
-    BaseMailerPreview.call(:welcome)
+    BaseMailerPreview.call(:welcome, params)
   end
 
   test "you can register a preview interceptor using its stringified name to the mail object that gets passed the mail object before previewing" do
+    params = {}
     ActionMailer::Base.register_preview_interceptor("BasePreviewInterceptorsTest::MyInterceptor")
     mail = BaseMailer.welcome
     BaseMailerPreview.any_instance.stubs(:welcome).returns(mail)
     MyInterceptor.expects(:previewing_email).with(mail)
-    BaseMailerPreview.call(:welcome)
+    BaseMailerPreview.call(:welcome, params)
   end
 
   test "you can register an interceptor using its symbolized underscored name to the mail object that gets passed the mail object before previewing" do
+    params = {}
     ActionMailer::Base.register_preview_interceptor(:"base_preview_interceptors_test/my_interceptor")
     mail = BaseMailer.welcome
     BaseMailerPreview.any_instance.stubs(:welcome).returns(mail)
     MyInterceptor.expects(:previewing_email).with(mail)
-    BaseMailerPreview.call(:welcome)
+    BaseMailerPreview.call(:welcome, params)
   end
 
   test "you can register multiple preview interceptors to the mail object that both get passed the mail object before previewing" do
+    params = {}
     ActionMailer::Base.register_preview_interceptors("BasePreviewInterceptorsTest::MyInterceptor", MySecondInterceptor)
     mail = BaseMailer.welcome
     BaseMailerPreview.any_instance.stubs(:welcome).returns(mail)
     MyInterceptor.expects(:previewing_email).with(mail)
     MySecondInterceptor.expects(:previewing_email).with(mail)
-    BaseMailerPreview.call(:welcome)
+    BaseMailerPreview.call(:welcome, params)
   end
 end

--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -19,7 +19,7 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
       @email_action = File.basename(params[:path])
 
       if @preview.email_exists?(@email_action)
-        @email = @preview.call(@email_action)
+        @email = @preview.call(@email_action, params)
 
         if params[:part]
           part_type = Mime::Type.lookup(params[:part])

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -407,6 +407,36 @@ module ApplicationTests
       assert_match "David Heinemeier Hansson &lt;david@heinemeierhansson.com&gt;", last_response.body
     end
 
+    test "mailer preview has access to params" do
+      mailer 'notifier', <<-RUBY
+        class Notifier < ActionMailer::Base
+          default from: "from@example.com"
+
+          def foo(user_name)
+            mail to: "\#{user_name}@example.org"
+          end
+        end
+      RUBY
+
+      text_template 'notifier/foo', <<-RUBY
+        Hello, World!
+      RUBY
+
+      mailer_preview 'notifier', <<-RUBY
+        class NotifierPreview < ActionMailer::Preview
+          def foo
+            Notifier.foo(params.fetch('user_name'))
+          end
+        end
+      RUBY
+
+      app('development')
+
+      get "/rails/mailers/notifier/foo?user_name=barcar"
+      assert_equal 200, last_response.status
+      assert_match "barcar@example.org", last_response.body
+    end
+
     test "part menu selects correct option" do
       mailer 'notifier', <<-RUBY
         class Notifier < ActionMailer::Base


### PR DESCRIPTION
ability to pass `Rails::MailersControlle` `params` to  `ActionMailer::Preview` instances (e.g. `MyMailerPreview`)   

...sounds stupid but hear me out

Imagine you need create a feature where you need to preview different email types for different clients, which has some different states. you don't want to replicate my `MyMailerPreview` in several classes (`MyMailerPreviewClientTypeA`, `MyMailerPreviewClientTypeB`, ...) you want it to be dynamic:

``` ruby
class MyMailerPreview < ActionMailer::Preview 

   def good_news
     MyMailer.good_news(client)
   end

   def bad news
     MyMailer.bad_news(client)
   end

   private

     def client
        Client.find(params['client_id']) || Client.find_by email: 'default@client.test'
     end
end
```
