### PR TITLE
Generate a collection_select in scaffold for a 'references' column

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
@@ -21,6 +21,9 @@
   <div class="field">
     <%%= f.label :password_confirmation %><br>
     <%%= f.password_field :password_confirmation %>
+<% elsif attribute.reference? -%>
+    <%%= f.label :<%= attribute.column_name %> %><br>
+    <%%= f.collection_select :<%= attribute.column_name %>, <%= attribute.name.classify %>.all, :id, :id %>
 <% else -%>
     <%%= f.label :<%= attribute.column_name %> %><br>
     <%%= f.<%= attribute.field_type %> :<%= attribute.column_name %> %>

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -433,7 +433,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/views/accounts/_form.html.erb" do |content|
       assert_match(/^\W{4}<%= f\.text_field :name %>/, content)
-      assert_match(/^\W{4}<%= f\.text_field :currency_id %>/, content)
+      assert_match(/^\W{4}<%= f\.collection_select :currency_id, Currency.all, :id, :id %>/, content)
     end
   end
 


### PR DESCRIPTION
Right now, using `rails generate scaffold thing:references` creates a text input for the ID of the associated object. This allow users to type in any integer, which includes invalid ID's for the associated object.

This patch, instead, generates a `collection_select` of the ID's, so users can only select from all existing objects' ID's.

Some potential issues...
#### 1) The `text_method` parameter of [collection select](http://apidock.com/rails/ActionView/Helpers/FormOptionsHelper/collection_select)

**Issue**:
This displays a `<select>` of ID's  (via the last, `text_method` parameter). It'd be great if we could display something nicer but we can't assume that people have a `name` column (for example).

**Potential Solution**:
Display the first user-defined column, via:

 `(MyModel.column_names - ["id", "created_at", "updated_at"]).first.to_sym`

Else, we can assume users will do this themselves.

An upside to this is we could leverage this in `#show` and `#index` to show something better than `#<MyModel:0x007ef17b5a8e30>`
#### 2) primary_key assumed to be `id`

**Issue**:
This patch assumes the associated object's primary_key is `id`.

**Potential Solution**:
Use the `primary_key` method on the model. Something like: 

`name.classify.constantize.primary_key.to_sym`

Since scaffolding is meant to be changed, it might be OK to assume that their primary_key will be `id`.

I tried this but I couldn't get the test to pass. The other model class (Currency) doesn't exist in the test, just the `belongs_to :currency` does. 

I can change to test to use a loaded Model instead. Which leads me to...
#### 3) Degrade if referenced Model doesn't exist

**Issue**:
This will generate a view that has errors if someone generates a scaffold that has `references` to a Model that doesn't exist yet. 

**Potential Solution**:
Check to see if the other Model exists. If it doesn't, then degrade to current behavior of a `text_field`

Thoughts?

Thanks,
Sean
