### PR TITLE
Added index option to the add_column migration method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added `index` option to add_column migration.
+
+    *Mehmet Emin İNAÇ*
+
 *   Include the `Enumerable` module in `ActiveRecord::Relation`
 
     *Sean Griffin & bogdan*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -416,7 +416,12 @@ module ActiveRecord
       def add_column(table_name, column_name, type, options = {})
         at = create_alter_table table_name
         at.add_column(column_name, type, options)
-        execute schema_creation.accept at
+        result = execute schema_creation.accept at
+        if(options[:index])
+          index_options = options[:index].is_a?(Hash) ? options[:index] : {}
+          add_index(table_name, column_name, index_options)
+        end
+        result
       end
 
       # Removes the given columns from the table definition.

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -198,6 +198,11 @@ module ActiveRecord
         end
       end
 
+      def test_add_column_with_index_option
+        connection.add_column :testings, :index_column, :string, index: true
+        assert_equal 1, connection.indexes(:testings).size
+      end
+
       private
         def good_index_name
           'x' * connection.allowed_index_name_length


### PR DESCRIPTION
As a developer I want to add index to the column with add_column migration.
So far this was too confusing for developers because there was no document about add_column does not support index option but it supports now :smile: 
There are lots of issues about this problem, one can found [here](https://github.com/rails/rails/issues/20400).
