### PR TITLE
Add ActiveSupport::TimeZone.country_zones helper

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `ActiveSupport::TimeZone.country_zones` helper to retrieve time zones
+    for every country that tzdata knows about.
+
+    Make `ActiveSupport::TimeZone.us_zones` helper use it.
+
+    *Andrey Novikov*
+
 *   `Array#sum` compat with Ruby 2.4's native method.
 
     Ruby 2.4 introduces `Array#sum`, but it only supports numeric elements,

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -184,6 +184,7 @@ module ActiveSupport
     UTC_OFFSET_WITHOUT_COLON = UTC_OFFSET_WITH_COLON.tr(':', '')
 
     @lazy_zones_map = Concurrent::Map.new
+    @country_zones  = Concurrent::Map.new
 
     class << self
       # Assumes self represents an offset from UTC in seconds (as returned from
@@ -242,7 +243,18 @@ module ActiveSupport
       # A convenience method for returning a collection of TimeZone objects
       # for time zones in the USA.
       def us_zones
-        @us_zones ||= all.find_all { |z| z.name =~ /US|Arizona|Indiana|Hawaii|Alaska/ }
+        country_zones(:us)
+      end
+
+      # A convenience method for returning a collection of TimeZone objects
+      # for time zones in the country specified by its ISO 3166-1 Alpha2 code.
+      def country_zones(country_code)
+        code = country_code.to_s.upcase
+        @country_zones[code] ||=
+          TZInfo::Country.get(code).zone_identifiers.map do |tz_id|
+            name = MAPPING.key(tz_id)
+            name && self[name]
+          end.compact.sort!
       end
 
       private

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -491,6 +491,11 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert !ActiveSupport::TimeZone.us_zones.include?(ActiveSupport::TimeZone["Kuala Lumpur"])
   end
 
+  def test_country_zones
+    assert ActiveSupport::TimeZone.country_zones("ru").include?(ActiveSupport::TimeZone["Moscow"])
+    assert !ActiveSupport::TimeZone.country_zones(:ru).include?(ActiveSupport::TimeZone["Kuala Lumpur"])
+  end
+
   def test_to_yaml
     assert_equal("--- !ruby/object:ActiveSupport::TimeZone\nname: Pacific/Honolulu\n", ActiveSupport::TimeZone["Hawaii"].to_yaml)
     assert_equal("--- !ruby/object:ActiveSupport::TimeZone\nname: Europe/London\n", ActiveSupport::TimeZone["Europe/London"].to_yaml)


### PR DESCRIPTION
I always wondered why there is a method to retrieve all time zones for US, but no such methods for another countries until I discovered that tzdata is already knows about all countries and their timezones and tzinfo gem even have an API for that.

Live example:

```
2.3.0 :001 > puts ActiveSupport::TimeZone.country_zones('us').map(&:to_s)
(GMT-10:00) Hawaii
(GMT-09:00) Alaska
(GMT-08:00) Pacific Time (US & Canada)
(GMT-07:00) Arizona
(GMT-07:00) Mountain Time (US & Canada)
(GMT-06:00) Central Time (US & Canada)
(GMT-05:00) Eastern Time (US & Canada)
(GMT-05:00) Indiana (East)
2.3.0 :002 > puts ActiveSupport::TimeZone.country_zones('ru').map(&:to_s)
(GMT+02:00) Kaliningrad
(GMT+03:00) Moscow
(GMT+03:00) Volgograd
(GMT+04:00) Samara
(GMT+05:00) Ekaterinburg
(GMT+06:00) Novosibirsk
(GMT+07:00) Krasnoyarsk
(GMT+08:00) Irkutsk
(GMT+09:00) Yakutsk
(GMT+10:00) Magadan
(GMT+10:00) Vladivostok
(GMT+11:00) Srednekolymsk
(GMT+12:00) Kamchatka
2.3.0 :003 > puts ActiveSupport::TimeZone.country_zones('fr').map(&:to_s)
(GMT+01:00) Paris
```

UPDATE: Method `ActiveSupport::TimeZone.us_zones` reimplemented with `ActiveSupport::TimeZone.country_zones('us')`

P.S> This PR is a good addition to my [talk](http://devconf.ru/ru/offers/offer/40) about working with timezones in Rails apps at [DevConf](http://devconf.ru/ru)
