### PR TITLE
Fix typo in version number

### DIFF
--- a/activeresource/CHANGELOG.md
+++ b/activeresource/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Rails 3.2.19 (Jun 16, 2015) ##
+## Rails 3.2.22 (Jun 16, 2015) ##
 
 * No changes.
 


### PR DESCRIPTION
Fixes a simple copy-and-paste mistake by bumping the patch version number in the CHANGELOG from 3.3.19 to 3.2.22.
