### PR TITLE
correct example output of references migration [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1547,11 +1547,10 @@ class CreateComments < ActiveRecord::Migration
       t.text :body
 
       # this line adds an integer column called `article_id`.
-      t.references :article, index: true
+      t.references :article, index: true, foreign_key: true
 
       t.timestamps null: false
     end
-    add_foreign_key :comments, :articles
   end
 end
 ```
@@ -1571,8 +1570,6 @@ run against the current database, so in this case you will just see:
 ==  CreateComments: migrating =================================================
 -- create_table(:comments)
    -> 0.0115s
--- add_foreign_key(:comments, :articles)
-   -> 0.0000s
 ==  CreateComments: migrated (0.0119s) ========================================
 ```
 


### PR DESCRIPTION
this behavior was changed in 99a6f9e60ea55924b44f894a16f8de0162cf2702
