### PR TITLE
Pass the current locale to Inflector from the pluralize text helper.

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -204,12 +204,12 @@ module ActionView
 
       # Attempts to pluralize the +singular+ word unless +count+ is 1. If
       # +plural+ is supplied, it will use that when count is > 1, otherwise
-      # it will use the Inflector to determine the plural form.
+      # it will use the Inflector to determine the plural form for the given locale,
+      # which defaults to I18n.locale
       #
-      # If passed an optional +locale:+ parameter, the word will be pluralized
-      # using rules defined for that language (you must define your own
-      # inflection rules for languages other than English).  See
-      # ActiveSupport::Inflector.pluralize
+      # The word will be pluralized using rules defined for the locale
+      # (you must define your own inflection rules for languages other than English).
+      # See ActiveSupport::Inflector.pluralize
       #
       #   pluralize(1, 'person')
       #   # => 1 person
@@ -217,7 +217,7 @@ module ActionView
       #   pluralize(2, 'person')
       #   # => 2 people
       #
-      #   pluralize(3, 'person', 'users')
+      #   pluralize(3, 'person', plural: 'users')
       #   # => 3 users
       #
       #   pluralize(0, 'person')
@@ -225,7 +225,14 @@ module ActionView
       #
       #   pluralize(2, 'Person', locale: :de)
       #   # => 2 Personen
-      def pluralize(count, singular, plural = nil, locale: nil)
+      def pluralize(count, singular, deprecated_plural = nil, plural: nil, locale: I18n.locale)
+        if deprecated_plural
+          ActiveSupport::Deprecation.warn("Passing plural as a positional argument " \
+            "is deprecated and will be removed in Rails 5.1. Use e.g. " \
+            "pluralize(1, 'person', plural: 'people') instead.")
+          plural ||= deprecated_plural
+        end
+
         word = if (count == 1 || count =~ /^1(\.0+)?$/)
           singular
         else

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -379,24 +379,36 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("1.25 counts", pluralize('1.25', "count"))
     assert_equal("1.0 count", pluralize('1.0', "count"))
     assert_equal("1.00 count", pluralize('1.00', "count"))
-    assert_equal("2 counters", pluralize(2, "count", "counters"))
-    assert_equal("0 counters", pluralize(nil, "count", "counters"))
+    assert_equal("2 counters", pluralize(2, "count", plural: "counters"))
+    assert_equal("0 counters", pluralize(nil, "count", plural: "counters"))
     assert_equal("2 people", pluralize(2, "person"))
     assert_equal("10 buffaloes", pluralize(10, "buffalo"))
     assert_equal("1 berry", pluralize(1, "berry"))
     assert_equal("12 berries", pluralize(12, "berry"))
   end
 
-  def test_pluralization_with_locale
-    ActiveSupport::Inflector.inflections(:de) do |inflect|
-      inflect.plural(/(person)$/i, '\1en')
-      inflect.singular(/(person)en$/i, '\1')
+  def test_localized_pluralization
+    old_locale = I18n.locale
+
+    begin
+      I18n.locale = :de
+
+      ActiveSupport::Inflector.inflections(:de) do |inflect|
+        inflect.irregular 'region', 'regionen'
+      end
+
+      assert_equal("1 region",   pluralize(1, "region"))
+      assert_equal("2 regionen", pluralize(2, "region"))
+      assert_equal("2 regions",  pluralize(2, "region", locale: :en))
+    ensure
+      I18n.locale = old_locale
     end
+  end
 
-    assert_equal("2 People", pluralize(2, "Person", locale: :en))
-    assert_equal("2 Personen", pluralize(2, "Person", locale: :de))
-
-    ActiveSupport::Inflector.inflections(:de).clear
+  def test_deprecated_plural_as_positional_argument
+    assert_deprecated do
+      pluralize(2, 'count', 'counters')
+    end
   end
 
   def test_cycle_class


### PR DESCRIPTION
The pluralize text helper uses the Inflector to determine the plural form.

The Inflector accepts an optional parameter for the locale, so we can pass it from the text helper to have locale-aware pluralizations on the text helpers level.

We can't do this on Active Support because it would affect the routes and Active Record -- [a similar PR was reverted](https://github.com/rails/rails/commit/d716fe05dfc174af4d840258b52e690ff754c8c3), but I think it's safe to do this on Action View.
