### PR TITLE
Avoid duping the String class when deep-duping

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -76,6 +76,16 @@ class Numeric
   end
 end
 
+class String
+  class << self
+    # Rubinius will throw a TypeError if you attempt to dup the
+    # String class (and only the String class has this behavior).
+    def duplicable?
+      false
+    end
+  end
+end
+
 require 'bigdecimal'
 class BigDecimal
   def duplicable?

--- a/activesupport/test/core_ext/object/deep_dup_test.rb
+++ b/activesupport/test/core_ext/object/deep_dup_test.rb
@@ -56,4 +56,9 @@ class DeepDupTest < ActiveSupport::TestCase
     assert_equal 1, dup.keys.length
   end
 
+  def test_deep_dup_skips_string_class
+    hash = { foo: String }
+    dup = hash.deep_dup
+    assert_equal hash, dup
+  end
 end


### PR DESCRIPTION
On Rubinius, deep_dup'ing any structure containing the String class will explode with a `TypeError`; e.g.,

```
irb(main):004:0> { :foo => String }.deep_dup
TypeError: Unable to clone/dup String class
        from kernel/common/string.rb:39:in `dup (clone)'
        from /home/robert/Sandbox/ruby/rails/activesupport/lib/active_support/core_ext/object/deep_dup.rb:14:in `deep_dup'
        from /home/robert/Sandbox/ruby/rails/activesupport/lib/active_support/core_ext/object/deep_dup.rb:44:in `deep_dup'
        from kernel/common/enumerable.rb:83:in `each_with_object'
        from kernel/common/hash.rb:342:in `each'
        from kernel/common/enumerable.rb:81:in `each_with_object'
        from /home/robert/Sandbox/ruby/rails/activesupport/lib/active_support/core_ext/object/deep_dup.rb:42:in `deep_dup'
        from (irb):4
```

The cause of this is that `String.dup` cannot work in Rubinius, due to [this code](https://github.com/rubinius/rubinius/blame/60cfdadf0149ca0efebf2b924a0482e4cfa1b404/kernel/common/string.rb#L39). Per [a discussion with Rubinius' maintainer](https://github.com/intridea/grape/issues/873#issuecomment-113364626), that behavior is unlikely to change.

This patch fixes the issue by simply not dup-ing the String class (which could be made Rubinius-specific, if desired). To be honest, I'd rather we re-visit #20008, since dup-ing classes seems pretty pointless and produces unexpected results:

```
irb(main):004:0> NewString = String.dup
=> NewString
irb(main):005:0> v = NewString.new("test")
=> "test"
irb(main):006:0> v.is_a?(String)
=> false
```

Anyway, I've proposed this same change just for Grape in [intridea/grape#1038](https://github.com/intridea/grape/pull/1038), but it seemed like the type of thing to push upstream. Feedback welcome!
