### PR TITLE
Add normalized message to errors detail

### DIFF
--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -366,19 +366,19 @@ class ErrorsTest < ActiveModel::TestCase
   test "details returns added error detail" do
     person = Person.new
     person.errors.add(:name, :invalid)
-    assert_equal({ name: [{ error: :invalid }] }, person.errors.details)
+    assert_equal({ name: [{ error: :invalid, message: 'is invalid' }] }, person.errors.details)
   end
 
   test "details returns added error detail with custom option" do
     person = Person.new
     person.errors.add(:name, :greater_than, count: 5)
-    assert_equal({ name: [{ error: :greater_than, count: 5 }] }, person.errors.details)
+    assert_equal({ name: [{ error: :greater_than, message: 'must be greater than 5', count: 5 }] }, person.errors.details)
   end
 
   test "details do not include message option" do
     person = Person.new
     person.errors.add(:name, :invalid, message: "is bad")
-    assert_equal({ name: [{ error: :invalid }] }, person.errors.details)
+    assert_equal({ name: [{ error: :invalid, message: 'is bad' }] }, person.errors.details)
   end
 
   test "dup duplicates details" do

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -93,8 +93,8 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     end
 
     account = model.new
-    assert_not account.valid?
-    assert_equal [{error: :blank}], account.errors.details[:company]
+    refute account.valid?
+    assert_equal [{error: :blank, message: 'must exist'}], account.errors.details[:company]
   ensure
     ActiveRecord::Base.belongs_to_required_by_default = original_value
   end
@@ -111,7 +111,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
     account = model.new
     assert_not account.valid?
-    assert_equal [{error: :blank}], account.errors.details[:company]
+    assert_equal [{error: :blank, message: 'must exist'}], account.errors.details[:company]
   ensure
     ActiveRecord::Base.belongs_to_required_by_default = original_value
   end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -443,7 +443,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
     assert_not invalid_electron.valid?
     assert valid_electron.valid?
     assert_not molecule.valid?
-    assert_equal [{error: :blank}], molecule.errors.details["electrons.name"]
+    assert_equal [{error: :blank, message: "can't be blank"}], molecule.errors.details["electrons.name"]
   end
 
   def test_errors_details_should_be_indexed_when_passed_as_array
@@ -457,7 +457,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
     assert_not tuning_peg_invalid.valid?
     assert tuning_peg_valid.valid?
     assert_not guitar.valid?
-    assert_equal [{error: :not_a_number, value: nil}] , guitar.errors.details["tuning_pegs[1].pitch"]
+    assert_equal [{error: :not_a_number, message: "is not a number", value: nil}] , guitar.errors.details["tuning_pegs[1].pitch"]
     assert_equal [], guitar.errors.details["tuning_pegs.pitch"]
   end
 
@@ -474,7 +474,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
     assert_not invalid_electron.valid?
     assert valid_electron.valid?
     assert_not molecule.valid?
-    assert_equal [{error: :blank}], molecule.errors.details["electrons[1].name"]
+    assert_equal [{error: :blank, message: "can't be blank"}], molecule.errors.details["electrons[1].name"]
     assert_equal [], molecule.errors.details["electrons.name"]
   ensure
     ActiveRecord::Base.index_nested_attribute_errors = old_attribute_config


### PR DESCRIPTION
Adding generated message to ActiveModel::Errors details.
Provide more convenience for customize errors display, rather than zipping messages and details or call generate_message again.

Also considering remove the duplication on messages and details, merging messages and details to a single hash. But that will probably drop the support for directly manipulate messages, like `person.errors.messages[:base] << 'another error message'.`
But since directly add message does not work with details, maybe that is a direction we can consider?
