### PR TITLE
Fix undesired type lookup with `SET` in MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -789,13 +789,18 @@ module ActiveRecord
         register_integer_type m, %r(^tinyint)i,   limit: 1
 
         m.alias_type %r(tinyint\(1\))i,  'boolean' if emulate_booleans
-        m.alias_type %r(set)i,           'varchar'
         m.alias_type %r(year)i,          'integer'
         m.alias_type %r(bit)i,           'binary'
 
         m.register_type(%r(enum)i) do |sql_type|
           limit = sql_type[/^enum\((.+)\)/i, 1]
             .split(',').map{|enum| enum.strip.length - 2}.max
+          MysqlString.new(limit: limit)
+        end
+
+        m.register_type(%r(^set)i) do |sql_type|
+          limit = sql_type[/^set\((.+)\)/i, 1]
+            .split(',').map{|set| set.strip.length - 1}.sum - 1
           MysqlString.new(limit: limit)
         end
       end

--- a/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
@@ -22,6 +22,10 @@ module ActiveRecord
         assert_lookup_type :string, "SET('one', 'two', 'three')"
       end
 
+      def test_set_type_with_value_matching_other_type
+        assert_lookup_type :string, "SET('unicode', '8bit', 'none', 'time')"
+      end
+
       def test_enum_type_with_value_matching_other_type
         assert_lookup_type :string, "ENUM('unicode', '8bit', 'none')"
       end


### PR DESCRIPTION
Fixes #20566.

This PR fixes the following problems:
- cause infinit type lookup loop when `SET` includes aliased types
  - For example:  
    when `SET('set')` includes aliased type `set`,  
    then aliased `varchar('set')` by type lookup,  
    but type lookup infinit matching same rule.
- cause type lookup miss when `SET` includes registered types
  - For example:  
    when `SET('time')` includes registered type `time`,  
    then aliased `varchar('time')` by type lookup,  
    then matching `time` type.
