### PR TITLE
Add method_source dependency to activesupport

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ PATH
       concurrent-ruby (~> 0.9.0)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
+      method_source
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'minitest',   '~> 5.1'
   s.add_dependency 'thread_safe','~> 0.3', '>= 0.3.4'
   s.add_dependency 'concurrent-ruby', '~> 0.9.0'
+  s.add_dependency 'method_source'
 end


### PR DESCRIPTION
method_source is required in https://github.com/rails/rails/blob/master/activesupport/lib/active_support/testing/composite_filter.rb#L1 but is not currently a dependency of the activesupport gem
