### PR TITLE
Virtual option added into the create_table migration for sqlite3

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add virtual table option to the create_table migration for sqlite3
+
+    *Mehmet Emin İNAÇ*
+
 *   Include the `Enumerable` module in `ActiveRecord::Relation`
 
     *Sean Griffin & bogdan*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -208,6 +208,9 @@ module ActiveRecord
       #
       # See also TableDefinition#column for details on how to create columns.
       def create_table(table_name, options = {})
+        if options[:virtual]
+          options[:options] = options.fetch(:options, {}).merge(virtual: options[:virtual])
+        end
         td = create_table_definition table_name, options[:temporary], options[:options], options[:as]
 
         if options[:id] != false && !options[:as]

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_creation.rb
@@ -3,6 +3,21 @@ module ActiveRecord
     module SQLite3
       class SchemaCreation < AbstractAdapter::SchemaCreation
         private
+          def visit_TableDefinition(o)
+            table_name = quote_table_name(o.name)
+            create_sql = if o.temporary
+                "CREATE TEMPORARY TABLE #{table_name} "
+              elsif o.virtual
+                "CREATE VIRTUAL TABLE #{table_name} USING #{o.virtual} "
+              else
+                "CREATE TABLE #{table_name} "
+              end
+            create_sql << "(#{o.columns.map { |c| accept c }.join(', ')}) " unless o.as
+            create_sql << "#{o.options}"
+            create_sql << " AS #{@conn.to_sql(o.as)}" if o.as
+            create_sql
+          end
+
           def add_column_options!(sql, options)
             if options[:collation]
               sql << " COLLATE \"#{options[:collation]}\""

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/table_definition.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/table_definition.rb
@@ -1,0 +1,16 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+
+        attr_reader :virtual
+
+        def initialize(types, name, temporary, virtual, options, as = nil)
+          super(types, name, temporary, options, as)
+          @virtual = virtual
+        end
+
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -1,6 +1,7 @@
 require 'active_record/connection_adapters/abstract_adapter'
 require 'active_record/connection_adapters/statement_pool'
 require 'active_record/connection_adapters/sqlite3/schema_creation'
+require 'active_record/connection_adapters/sqlite3/table_definition'
 
 gem 'sqlite3', '~> 1.3.6'
 require 'sqlite3'
@@ -599,6 +600,12 @@ module ActiveRecord
           else
             basic_structure.to_hash
           end
+        end
+
+        def create_table_definition(name, temporary = false, options = nil, as = nil) # :nodoc:
+          virtual = options ? options.delete(:virtual).to_s.upcase : nil
+          options = nil if options.blank?
+          SQLite3::TableDefinition.new(native_database_types, name, temporary, virtual, options, as)
         end
     end
   end

--- a/activerecord/test/cases/adapters/sqlite3/virtual_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/virtual_table_test.rb
@@ -1,0 +1,31 @@
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class SQLite3Adapter
+      class VirtualTableTest < ActiveRecord::SQLite3TestCase
+
+        def setup
+          @connection = Base.sqlite3_connection :database => ':memory:',
+                  :adapter => 'sqlite3',
+                  :timeout => 100
+        end
+
+        def test_virtual_table_with_symbol
+          @connection.create_table(:foo, virtual: :fts3, id: false) do |t|
+            t.string :body
+          end
+          sql = (@connection.execute <<-SQL
+            SELECT sql
+            FROM sqlite_master
+            WHERE name = 'foo'
+          SQL
+          ).first["sql"]
+
+          assert @connection.table_exists?(:foo)
+          assert_equal 'CREATE VIRTUAL TABLE "foo" USING FTS3 ("body" varchar)', sql
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For detailed information about the virtual tables you can see the [link](http://www.sqlite.org/vtab.html).
