### PR TITLE
Provide flash messages in application layouts by default

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -17,7 +17,7 @@
 </head>
 <body>
   <%% flash.each do |key, message| %>
-    <div class='flash flash-<%%= key %>'><%%= message %>
+    <div class='flash flash-<%%= key %>'><%%= message %></div>
   <%% end %>
 
 <%%= yield %>

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -16,9 +16,9 @@
   <%%= csrf_meta_tags %>
 </head>
 <body>
-  <% flash.each do |key, message| %>
-    <div class='flash flash-<%= key %>'><%= message %>
-  <% end %>
+  <%% flash.each do |key, message| %>
+    <div class='flash flash-<%%= key %>'><%%= message %>
+  <%% end %>
 
 <%%= yield %>
 

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -16,6 +16,9 @@
   <%%= csrf_meta_tags %>
 </head>
 <body>
+  <% flash.each do |key, message| %>
+    <div class='flash flash-<%= key %>'><%= message %>
+  <% end %>
 
 <%%= yield %>
 

--- a/railties/lib/rails/generators/rails/plugin/templates/app/views/layouts/%namespaced_name%/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/app/views/layouts/%namespaced_name%/application.html.erb.tt
@@ -7,9 +7,9 @@
   <%%= csrf_meta_tags %>
 </head>
 <body>
-  <% flash.each do |key, message| %>
-    <div class='flash flash-<%= key %>'><%= message %>
-  <% end %>
+  <%% flash.each do |key, message| %>
+    <div class='flash flash-<%%= key %>'><%%= message %>
+  <%% end %>
 
 <%%= yield %>
 

--- a/railties/lib/rails/generators/rails/plugin/templates/app/views/layouts/%namespaced_name%/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/app/views/layouts/%namespaced_name%/application.html.erb.tt
@@ -8,7 +8,7 @@
 </head>
 <body>
   <%% flash.each do |key, message| %>
-    <div class='flash flash-<%%= key %>'><%%= message %>
+    <div class='flash flash-<%%= key %>'><%%= message %></div>
   <%% end %>
 
 <%%= yield %>

--- a/railties/lib/rails/generators/rails/plugin/templates/app/views/layouts/%namespaced_name%/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/app/views/layouts/%namespaced_name%/application.html.erb.tt
@@ -7,6 +7,9 @@
   <%%= csrf_meta_tags %>
 </head>
 <body>
+  <% flash.each do |key, message| %>
+    <div class='flash flash-<%= key %>'><%= message %>
+  <% end %>
 
 <%%= yield %>
 


### PR DESCRIPTION
One of the first steps when I create a Rails app that I do is to add a flash message to the application layout. I've seen this be the case for many other people too, and so I think rather than doing it myself, Rails should do it for me (and the others).
