### PR TITLE
do not show "Failed tests" message when a failed test is not

### DIFF
--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -7,7 +7,7 @@ module Rails
     self.executable = "bin/rails test"
 
     def report
-      return if results.empty?
+      return if filtered_results.empty?
       io.puts
       io.puts "Failed tests:"
       io.puts
@@ -15,12 +15,18 @@ module Rails
     end
 
     def aggregated_results # :nodoc:
-      filtered_results = results.dup
-      filtered_results.reject!(&:skipped?) unless options[:verbose]
       filtered_results.map do |result|
         location, line = result.method(result.name).source_location
         "#{self.executable} #{relative_path_for(location)}:#{line}"
       end.join "\n"
+    end
+
+    def filtered_results
+      if options[:verbose]
+        results
+      else
+        results.reject(&:skipped?)
+      end
     end
 
     def relative_path_for(file)

--- a/railties/test/test_unit/reporter_test.rb
+++ b/railties/test/test_unit/reporter_test.rb
@@ -32,6 +32,7 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     @reporter.record(passing_test)
     @reporter.record(skipped_test)
     @reporter.report
+    assert_no_match 'Failed tests:', @output.string
     assert_rerun_snippet_count 0
   end
 


### PR DESCRIPTION
Currently, are not considerations of skipped test in `report` method.
Therefore, if there is no skipped test case and failed there was a test, and `Failed tests
` message has got is displayed.

``` console
$ ./bin/rails t
Run options: --seed 21347

# Running:

........S.....

Finished in 0.440309s, 31.7958 runs/s, 47.6938 assertions/s.

14 runs, 21 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.

Failed tests:

```

This patch, it does not appear to `Failed tests` message in such a case.
