### PR TITLE
Passing nil to image_tag

### DIFF
--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -121,6 +121,8 @@ module ActionView
       #   asset_path "application", type: :stylesheet     # => /assets/application.css
       #   asset_path "http://www.example.com/js/xmlhr.js" # => http://www.example.com/js/xmlhr.js
       def asset_path(source, options = {})
+        raise ArgumentError, "Cannot pass nil as asset source" if source.nil?
+
         source = source.to_s
         return "" unless source.present?
         return source if source =~ URI_REGEXP

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -310,6 +310,11 @@ class AssetTagHelperTest < ActionView::TestCase
     AssetPathToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
 
+  def test_asset_path_tag_raises_an_error_for_nil_source
+    exception = assert_raise(ArgumentError) { asset_path(nil) }
+    assert_equal("Cannot pass nil as asset source", exception.message)
+  end
+
   def test_asset_path_tag_to_not_create_duplicate_slashes
     @controller.config.asset_host = "host/"
     assert_dom_equal('http://host/foo', asset_path("foo"))


### PR DESCRIPTION
When I pass `nil` to `image_tag` it's generate image with empty src.
I do not think that is correct behavior.

I don't see a case, when someone had to pass `nil` to `image_tag` directly. It's likely to be a string, or an object (like here - #16911).

When `nil` passed to `image_tag` - it's happens probably by mistake (something with `find` method, or another one which can return `nil` as result). So I would like to get an error in that case instead of blank image.

What do you think?
