### PR TITLE
[ci skip] correct for ActiveRecord::Associations::Preloader

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -10,7 +10,8 @@ module ActiveRecord
     #   end
     #
     #   class Book < ActiveRecord::Base
-    #     # columns: title, sales
+    #     # columns: title, sales, :author_id
+    #     belongs_to :author
     #   end
     #
     # When you load an author with all associated books Active Record will make


### PR DESCRIPTION
I saw [this](http://apidock.com/rails/ActiveRecord/Associations/Preloader) example and something doesn't seemed right.
