### PR TITLE
[WIP] Aliased foreign keys in association definitions

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -88,7 +88,13 @@ module ActiveRecord
         end
 
         def foreign_key_present?
-          owner._read_attribute(reflection.foreign_key)
+          key = owner._read_attribute(reflection.foreign_key)
+          unless key
+            real_key = owner.class.attribute_alias(reflection.foreign_key)
+            key = owner._read_attribute(real_key) if real_key
+          end
+
+          key
         end
 
         # NOTE - for now, we're only supporting inverse setting from belongs_to back onto

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -612,7 +612,14 @@ module ActiveRecord
       end
 
       def join_id_for(owner) # :nodoc:
-        owner[foreign_key]
+        id = owner[foreign_key]
+
+        unless id
+          real_key = owner.class.attribute_alias(foreign_key)
+          id = owner[real_key] if real_key
+        end
+
+        id
       end
     end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -19,11 +19,13 @@ require 'models/invoice'
 require 'models/line_item'
 require 'models/column'
 require 'models/record'
+require 'models/pet'
+require 'models/owner'
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
            :developers_projects, :computers, :authors, :author_addresses,
-           :posts, :tags, :taggings, :comments, :sponsors, :members
+           :posts, :tags, :taggings, :comments, :sponsors, :members, :pets, :owners
 
   def test_belongs_to
     firm = Client.find(3).firm
@@ -110,6 +112,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal [{error: :blank}], account.errors.details[:company]
   ensure
     ActiveRecord::Base.belongs_to_required_by_default = original_value
+  end
+
+  def test_belongs_to_with_aliased_foreign_key
+    owner = Pet.find(1).aliased_owner
+    assert_not_nil owner
+    assert_equal owners(:blackbeard).name, owner.name
   end
 
   def test_default_scope_on_relations_is_not_cached

--- a/activerecord/test/models/pet.rb
+++ b/activerecord/test/models/pet.rb
@@ -2,8 +2,11 @@ class Pet < ActiveRecord::Base
   attr_accessor :current_user
 
   self.primary_key = :pet_id
+  alias_attribute :OwnerId, :owner_id
   belongs_to :owner, :touch => true
+  belongs_to :aliased_owner, foreign_key: :OwnerId, class_name: 'Owner'
   has_many :toys
+  has_many :aliased_toys, foreign_key: :PetId
 
   class << self
     attr_accessor :after_destroy_output

--- a/activerecord/test/models/toy.rb
+++ b/activerecord/test/models/toy.rb
@@ -2,5 +2,8 @@ class Toy < ActiveRecord::Base
   self.primary_key = :toy_id
   belongs_to :pet
 
+  alias_attribute :PetId, :pet_id
+  belongs_to :aliased_pet, foreign_key: :PetId
+
   scope :with_pet, -> { joins(:pet) }
 end


### PR DESCRIPTION
Hello,

this is first step in a feature I'd like to implement. My post on the rails-core mailing list is here https://groups.google.com/forum/?fromgroups#!topic/rubyonrails-core/PQCBPn_fK-w

This PR is intentionally not done because it is still not clear if this is a change that is consider warranted for the problem it solves. I've implemented only support for `belongs_to` to get a grasp on the change and how it affects performance
## Problem

When using an aliased attribute as the foreign key for a association rails does not behave as expected.
### Example

``` ruby
class Pet < ActiveRecord::Base
  alias_attribute :owner_id :OwnerID

  belongs_to :owner # This association will not work
end
```
## Suggested fix

Places where the value of the foreign key in the owner is determined use `_read_attribute` or `ActiveRecord::Base.[]` this bypasses aliased attributes completely. To combat this I suggest that an explicit check or fallback is added to consider aliased attributes
### Performance

Doing the extra work to figure out wether the foreign_key is aliased will take some extra time. Depending on how it is implemented the work could be a small constant slowdown or a heavier slowdown in edge cases, but with a very small effect on the most common case. The following examples uses `active_record/lib/active_record/associations/belongs_to_association.rb#foreign_key_present?` to illustrate the change and it's impact on performance.
### Edge case slowdown

``` ruby
def foreign_key_present?
  key = owner._read_attribute(reflection.foreign_key)
  # Extra check if the foreign key is aliased or the value is nil
  unless key
    real_key = owner.class.attribute_alias(reflection.foreign_key)
    key = owner._read_attribute(real_key) if real_key
  end

   key
end
```
### Constant slowdown

``` ruby
def foreign_key_present?
  aliased_key = owner.class.attribute_alias(reflection.foreign_key)
  real_key = aliased_key ? aliased_key : foreign_key

  key = owner._read_attribute(real_key)
end
```
