### PR TITLE
Test that an empty Array can be serialized on a not null text column

### DIFF
--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -233,6 +233,11 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     assert_equal [], light.long_state
   end
 
+  def test_serialize_empty_array_on_text_column_with_null_false
+    light = TrafficLight.create long_state: []
+    assert_equal [], light.long_state
+  end
+
   def test_serialized_column_should_unserialize_after_update_column
     t = Topic.create(content: "first")
     assert_equal("first", t.content)


### PR DESCRIPTION
This is the next chapter of #9110 and #18169.
With exactly the same DB with #9110,

``` ruby
ActiveRecord::Schema.define(:version => 20130129132556) do
  create_table "bars", :force => true do |t|
    t.text  "array_attr", :null => false
    t.datetime "created_at", :null => false
    t.datetime "updated_at", :null => false
  end
end

class Bar < ActiveRecord::Base
  serialize :array_attr, Array
end
```

AR 4.2+ fails to serialize an empty Array. This used to work on AR <= 4.1, and this works if the column is nullable.

This happens because `AR::AttributeMethods::Dirty#write_attribute` fails to detect a `[]` to be "changed" from the default value, and so the attribute is not included in the partial insert statement.
I assume this was caused by changes around e35221cfd948098c6fabdff5fed3877edb8921d3, 1455c4c22feb24b0ff2cbb191afb0bd98ebf7b06, and 8b96c0b7a3510bc2a3ffe183318b7b6bcdf89ff3, but I have no idea what the correct fix would be.

Attached patch is a failing test case.
