### PR TITLE
fix 'kB' with lowercase 'k' in en.yml locale

### DIFF
--- a/activesupport/lib/active_support/locale/en.yml
+++ b/activesupport/lib/active_support/locale/en.yml
@@ -102,7 +102,7 @@ en:
           byte:
             one:   "Byte"
             other: "Bytes"
-          kb: "KB"
+          kb: "kB"
           mb: "MB"
           gb: "GB"
           tb: "TB"


### PR DESCRIPTION
This PR replaces the non-standard conform KB-values with those standardized (kB) see: 
https://en.wikipedia.org/wiki/Byte#Unit_symbol
This will allow standard conform parsing of those values.

This PR references svenfuchs/rails-i18n#558
