### PR TITLE
More accurate example of what .pluck replaces

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -125,7 +125,7 @@ module ActiveRecord
     #
     # instead of
     #
-    #   Person.all.map(&:name)
+    #   Person.select(:name).map(&:name)
     #
     # Pluck returns an <tt>Array</tt> of attribute values type-casted to match
     # the plucked column names, if they can be deduced. Plucking an SQL fragment


### PR DESCRIPTION
This is hardly the most important thing in the world, in fact I only bothered because I am procrastinating a feature, but I thought it was a little more representative of what `.pluck` it's actually doing. 

`User.all.map(&:id)` = `SELECT "users".* FROM "users"`

`User.select(:id).map(&:id)` = `SELECT "users"."id" FROM "users"`

Enjoy the never-ending wealth and prosperity that comes with the merging of this PR.
