### PR TITLE
add_source in Application Template should take a block for gem entries

### DIFF
--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -503,6 +503,14 @@ Adds a specified source to `Gemfile`:
 add_source "http://gems.github.com"
 ```
 
+This method also takes a block:
+
+```ruby
+add_source "http://gems.github.com" do
+  gem "rspec-rails"
+end
+```
+
 ### `inject_into_file`
 
 Injects a block of code into a defined position in your file.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Adding support for passing a block to the `add_source` action of a custom generator
+
+    *Mike Dalton*, *Hirofumi Wakasugi*
+
 *   `assert_file` understands paths with special characters
     (eg. `v0.1.4~alpha+nightly`).
 

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -63,12 +63,26 @@ module Rails
 
       # Add the given source to +Gemfile+
       #
+      # If block is given, gem entries in block are wrapped into the source group.
+      #
       #   add_source "http://gems.github.com/"
-      def add_source(source, options={})
+      #
+      #   add_source "http://gems.github.com/" do
+      #     gem "rspec-rails"
+      #   end
+      def add_source(source, options={}, &block)
         log :source, source
 
         in_root do
-          prepend_file "Gemfile", "source #{quote(source)}\n", verbose: false
+          if block
+            append_file "Gemfile", "source #{quote(source)} do", force: true
+            @in_group = true
+            instance_eval(&block)
+            @in_group = false
+            append_file "Gemfile", "\nend\n", force: true
+          else
+            prepend_file "Gemfile", "source #{quote(source)}\n", verbose: false
+          end
         end
       end
 

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -47,6 +47,14 @@ class ActionsTest < Rails::Generators::TestCase
     assert_file 'Gemfile', /source 'http:\/\/gems\.github\.com'/
   end
 
+  def test_add_source_with_block_adds_source_to_gemfile_with_gem
+    run_generator
+    action :add_source, 'http://gems.github.com' do
+      gem 'rspec-rails'
+    end
+    assert_file 'Gemfile', /source 'http:\/\/gems\.github\.com' do\n  gem 'rspec-rails'\nend/
+  end
+
   def test_gem_should_put_gem_dependency_in_gemfile
     run_generator
     action :gem, 'will-paginate'


### PR DESCRIPTION
Since newer versions of Bundler complain when you have multiple `source` in Gemfile without specifying a block for gem entries group from that source, Application Template generator's `add_source` method should also take a block.
