### PR TITLE
Ensure input to distance_of_time_in_words is not nil

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,1 +1,6 @@
+*   Update distance_of_time_in_words helper to display better error messages
+    for bad input.
+
+    *Jay Hayes*
+
 Please check [5-1-stable](https://github.com/rails/rails/blob/5-1-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -95,8 +95,8 @@ module ActionView
           scope: :'datetime.distance_in_words'
         }.merge!(options)
 
-        from_time = from_time.to_time if from_time.respond_to?(:to_time)
-        to_time = to_time.to_time if to_time.respond_to?(:to_time)
+        from_time = normalize_distance_of_time_argument_to_time(from_time)
+        to_time = normalize_distance_of_time_argument_to_time(to_time)
         from_time, to_time = to_time, from_time if from_time > to_time
         distance_in_minutes = ((to_time - from_time) / 60.0).round
         distance_in_seconds = (to_time - from_time).round
@@ -130,22 +130,18 @@ module ActionView
             # 60 days up to 365 days
           when 86400...525600   then locale.t :x_months,       count: (distance_in_minutes.to_f / 43200.0).round
             else
-            if from_time.acts_like?(:time) && to_time.acts_like?(:time)
-              fyear = from_time.year
-              fyear += 1 if from_time.month >= 3
-              tyear = to_time.year
-              tyear -= 1 if to_time.month < 3
-              leap_years = (fyear > tyear) ? 0 : (fyear..tyear).count { |x| Date.leap?(x) }
-              minute_offset_for_leap_year = leap_years * 1440
-              # Discount the leap year days when calculating year distance.
-              # e.g. if there are 20 leap year days between 2 dates having the same day
-              # and month then the based on 365 days calculation
-              # the distance in years will come out to over 80 years when in written
-              # English it would read better as about 80 years.
-              minutes_with_offset = distance_in_minutes - minute_offset_for_leap_year
-            else
-              minutes_with_offset = distance_in_minutes
-            end
+            from_year = from_time.year
+            from_year += 1 if from_time.month >= 3
+            to_year = to_time.year
+            to_year -= 1 if to_time.month < 3
+            leap_years = (from_year > to_year) ? 0 : (from_year..to_year).count { |x| Date.leap?(x) }
+            minute_offset_for_leap_year = leap_years * 1440
+            # Discount the leap year days when calculating year distance.
+            # e.g. if there are 20 leap year days between 2 dates having the same day
+            # and month then the based on 365 days calculation
+            # the distance in years will come out to over 80 years when in written
+            # English it would read better as about 80 years.
+            minutes_with_offset = distance_in_minutes - minute_offset_for_leap_year
             remainder                   = (minutes_with_offset % MINUTES_IN_YEAR)
             distance_in_years           = (minutes_with_offset.div MINUTES_IN_YEAR)
             if remainder < MINUTES_IN_QUARTER_YEAR
@@ -687,6 +683,18 @@ module ActionView
 
         content_tag("time".freeze, content, options.reverse_merge(datetime: datetime), &block)
       end
+
+      private
+
+        def normalize_distance_of_time_argument_to_time(value)
+          if value.is_a?(Numeric)
+            Time.at(value)
+          elsif value.respond_to?(:to_time)
+            value.to_time
+          else
+            raise ArgumentError, "#{value.inspect} can't be converted to a Time value"
+          end
+        end
     end
 
     class DateTimeSelector #:nodoc:

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -128,6 +128,16 @@ class DateHelperTest < ActionView::TestCase
     assert_distance_of_time_in_words(from)
   end
 
+  def test_distance_in_words_with_nil_input
+    assert_raises(ArgumentError) { distance_of_time_in_words(nil) }
+    assert_raises(ArgumentError) { distance_of_time_in_words(0, nil) }
+  end
+
+  def test_distance_in_words_with_mixed_argument_types
+    assert_equal "1 minute", distance_of_time_in_words(0, Time.at(60))
+    assert_equal "10 minutes", distance_of_time_in_words(Time.at(600), 0)
+  end
+
   def test_distance_in_words_with_mathn_required
     # test we avoid Integer#/ (redefined by mathn)
     silence_warnings { require "mathn" }


### PR DESCRIPTION
## Problem

The error message for bad input to the `distance_of_time_in_words` and related methods is cryptic. For example, if `nil` is provided as an argument to `time_ago_in_words`, this is the error:

``` ruby
irb> helper.time_ago_in_words(nil)
NoMethodError: undefined method `>' for nil:NilClass
```

I believe a more palatable result in this case would be to raise an `ArgumentError` for invalid input.
## (Proposed) Solution

The provided implementation is a bit naive in that it only checks for `nil` arguments. While investigating the problem, I realized there are several different ways in which the input may be "bad".
1. Argument is `nil`
2. The `from_time` and `to_time` arguments are incompatible with one another. e.g.
   
   ``` ruby
   irb> helper.distance_of_time_in_words(Date.current, 0)
   ArgumentError: comparison of Time with 0 failed
   
   ```
3. moar?

Generally it seems like the interface requires either two numeric arguments, or two `to_time` convertible arguments.

To that end, it felt like this issue may benefit from the input of parties more familiar with the code. I would be honored and willing to help with the solution. If I am able to come up with a more "elegant" solution to the type situation, I will gladly post it back here.

Thank you! :dizzy:

---
### TODO
- [ ] settle on solution
- [ ] update docs (if needed)
- [x] update changelog
