### PR TITLE
Update .pluck documentation on uniq

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -139,7 +139,7 @@ module ActiveRecord
     #   # SELECT people.id, people.name FROM people
     #   # => [[1, 'David'], [2, 'Jeremy'], [3, 'Jose']]
     #
-    #   Person.pluck('DISTINCT role')
+    #   Person.uniq.pluck(:role)
     #   # SELECT DISTINCT role FROM people
     #   # => ['admin', 'member', 'guest']
     #


### PR DESCRIPTION
This is to show users that they can chain `.uniq` and `.pluck` to get the `DISTINCT column` result. They don't have to do `DISTINCT column` themselves.

I'm submitting this as a PR as this changes the way we represent this method to users. I think it's fine, as we already show that this method supports SQL statement [below](https://github.com/rails/rails/pull/20708/files#diff-e0e70620d0897d6819a6bcc2b5ee7a73R150).
