### PR TITLE
Ensure that quoted times do not deviate from the default db time format

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -134,12 +134,7 @@ module ActiveRecord
           end
         end
 
-        result = value.to_s(:db)
-        if value.respond_to?(:usec) && value.usec > 0
-          "#{result}.#{sprintf("%06d", value.usec)}"
-        else
-          result
-        end
+        value.to_s(:db)
       end
 
       def prepare_binds_for_database(binds) # :nodoc:

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -44,6 +44,13 @@ module ActiveRecord
         assert_equal t.to_s(:db), @quoter.quoted_date(t)
       end
 
+      def test_quoted_time_with_usec
+        with_timezone_config default: :utc do
+          t = Time.now.change(usec: 1)
+          assert_equal t.getutc.to_s(:db), @quoter.quoted_date(t)
+        end
+      end
+
       def test_quoted_time_utc
         with_timezone_config default: :utc do
           t = Time.now.change(usec: 0)


### PR DESCRIPTION
This removes some code from the Quoting module in activerecord that would modify returned timestamps in such a way that they no longer followed the default to_s(:db) format. This caused some queries to break in versions of mysql that don't support microsecond precision. Test case that failed under the previous version included. Fixes #19711
