### PR TITLE
#20710 parse RSS/ATOM responses as XML, not HTML

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions.rb
@@ -12,7 +12,7 @@ module ActionDispatch
     include Rails::Dom::Testing::Assertions
 
     def html_document
-      @html_document ||= if @response.content_type === Mime::XML
+      @html_document ||= if @response.content_type.to_s =~ /xml$/
         Nokogiri::XML::Document.parse(@response.body)
       else
         Nokogiri::HTML::Document.parse(@response.body)

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -247,6 +247,8 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
         format.html { render :text => "OK", :status => 200 }
         format.js { render :text => "JS OK", :status => 200 }
         format.xml { render :xml => "<root></root>", :status => 200 }
+        format.rss { render :xml => "<root></root>", :status => 200 }
+        format.atom { render :xml => "<root></root>", :status => 200 }
       end
     end
 
@@ -303,19 +305,21 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def test_get_xml
-    with_test_route_set do
-      get "/get", {}, {"HTTP_ACCEPT" => "application/xml"}
-      assert_equal 200, status
-      assert_equal "OK", status_message
-      assert_response 200
-      assert_response :success
-      assert_response :ok
-      assert_equal({}, cookies.to_hash)
-      assert_equal "<root></root>", body
-      assert_equal "<root></root>", response.body
-      assert_instance_of Nokogiri::XML::Document, html_document
-      assert_equal 1, request_count
+  def test_get_xml_rss_atom
+    %w[ application/xml application/rss+xml application/atom+xml ].each do |mime_string|
+      with_test_route_set do
+        get "/get", {}, {"HTTP_ACCEPT" => mime_string}
+        assert_equal 200, status
+        assert_equal "OK", status_message
+        assert_response 200
+        assert_response :success
+        assert_response :ok
+        assert_equal({}, cookies.to_hash)
+        assert_equal "<root></root>", body
+        assert_equal "<root></root>", response.body
+        assert_instance_of Nokogiri::XML::Document, html_document
+        assert_equal 1, request_count
+      end
     end
   end
 


### PR DESCRIPTION
Addresses #20710
@rafaelfranca @tomhughes 
