### PR TITLE
Do not require open-uri to Actions generator

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -1,4 +1,3 @@
-require 'open-uri'
 require 'rbconfig'
 
 module Rails


### PR DESCRIPTION
It seems like it is not used in this generator.
