### PR TITLE
fix NoMethodError that occurs when generating scaffold inside full mode engine

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix NoMethodError that occurs when generating scaffold inside full mode engine.
+
+    *Yuji Yaginuma*
+
 *   Adding support for passing a block to the `add_source` action of a custom generator
 
     *Mike Dalton*, *Hirofumi Wakasugi*

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -183,6 +183,10 @@ module Rails
           !defined?(ActiveRecord::Base) || ActiveRecord::Base.pluralize_table_names
         end
 
+        def mountable_engine?
+          defined?(ENGINE_ROOT) && namespaced?
+        end
+
         # Add a class collisions name to be checked on class initialization. You
         # can supply a hash with a :prefix or :suffix to be tested.
         #

--- a/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 <% module_namespacing do -%>
 class <%= class_name %>ControllerTest < ActionController::TestCase
-<% if defined?(ENGINE_ROOT) -%>
+<% if mountable_engine? -%>
   setup do
     @routes = Engine.routes
   end

--- a/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
@@ -21,7 +21,7 @@ module TestUnit # :nodoc:
 
       def fixture_name
         @fixture_name ||=
-          if defined?(ENGINE_ROOT)
+          if mountable_engine?
             "%s_%s" % [namespaced_path, table_name]
           else
             table_name

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class <%= controller_class_name %>ControllerTest < ActionController::TestCase
   setup do
     @<%= singular_table_name %> = <%= fixture_name %>(:one)
-<% if defined?(ENGINE_ROOT) -%>
+<% if mountable_engine? -%>
     @routes = Engine.routes
 <% end -%>
   end

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -186,6 +186,17 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_controller_tests_pass_by_default_inside_full_engine
+    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --full` }
+
+    engine_path = File.join(destination_root, "bukkits")
+
+    Dir.chdir(engine_path) do
+      quietly { `bin/rails g controller dashboard foo` }
+      assert_match(/2 runs, 2 assertions, 0 failures, 0 errors/, `bundle exec rake test 2>&1`)
+    end
+  end
+
   def test_api_only_generates_a_proper_api_controller
     run_generator ["User", "--api"]
 

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -491,4 +491,18 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert_match(/8 runs, 13 assertions, 0 failures, 0 errors/, `bundle exec rake test 2>&1`)
     end
   end
+
+  def test_scaffold_tests_pass_by_default_inside_full_engine
+    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --full` }
+
+    engine_path = File.join(destination_root, "bukkits")
+
+    Dir.chdir(engine_path) do
+      quietly do
+        `bin/rails g scaffold User name:string age:integer;
+        bundle exec rake db:migrate`
+      end
+      assert_match(/8 runs, 13 assertions, 0 failures, 0 errors/, `bundle exec rake test 2>&1`)
+    end
+  end
 end


### PR DESCRIPTION
Currently, it is an error to generate the scaffold inside full mode engine. 

``` console
$ ./bin/rails -v  
Rails 4.2.3 

$ bin/rails g scaffold User name:string
      invoke  active_record
      create    db/migrate/20150628034727_create_users.rb
      create    app/models/user.rb
      invoke    test_unit
      create      test/models/user_test.rb
      create      test/fixtures/users.yml
      invoke  resource_route
       route    resources :users
      invoke  scaffold_controller
      create    app/controllers/users_controller.rb
      invoke    erb
      create      app/views/users
      create      app/views/users/index.html.erb
      create      app/views/users/edit.html.erb
      create      app/views/users/show.html.erb
      create      app/views/users/new.html.erb
      create      app/views/users/_form.html.erb
      invoke    test_unit
      create      test/controllers/users_controller_test.rb
/home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/railties-4.2.3/lib/rails/generators/named_base.rb:98:in `namespaced_path': undefined method `name' for nil:NilClass (NoMethodError)
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/railties-4.2.3/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb:21:in `fixture_name'
    from (erb):6:in `block in template'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/file_manipulation.rb:305:in `call'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/file_manipulation.rb:305:in `block in capture'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/file_manipulation.rb:310:in `with_output_buffer'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/file_manipulation.rb:305:in `capture'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/railties-4.2.3/lib/rails/generators/named_base.rb:43:in `module_namespacing'
    from (erb):3:in `template'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/2.2.0/erb.rb:863:in `eval'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/2.2.0/erb.rb:863:in `result'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/file_manipulation.rb:116:in `block in template'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/create_file.rb:53:in `call'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/create_file.rb:53:in `render'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/create_file.rb:62:in `block (2 levels) in invoke!'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/create_file.rb:62:in `open'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/create_file.rb:62:in `block in invoke!'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/empty_directory.rb:116:in `call'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/empty_directory.rb:116:in `invoke_with_conflict_check'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/create_file.rb:60:in `invoke!'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions.rb:94:in `action'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/create_file.rb:25:in `create_file'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/actions/file_manipulation.rb:115:in `template'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/railties-4.2.3/lib/rails/generators/named_base.rb:26:in `block in template'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/railties-4.2.3/lib/rails/generators/named_base.rb:60:in `inside_template'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/railties-4.2.3/lib/rails/generators/named_base.rb:25:in `template'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/railties-4.2.3/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb:14:in `create_test_files'
    from /home/yaginuma/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run' 
```

This bug was introduced in #20387.  It was my fault, sorry about this. 

This commit fixes error, and adds a test for generated test files.
