### PR TITLE
allow the fixture_path to glob directories

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -904,7 +904,15 @@ module ActiveRecord
       def fixtures(*fixture_set_names)
         if fixture_set_names.first == :all
           fixture_set_names = Dir["#{fixture_path}/{**,*}/*.{yml}"]
-          fixture_set_names.map! { |f| f[(fixture_path.to_s.size + 1)..-5] }
+          fixture_path_globs = Dir[fixture_path].sort_by!(&:length).reverse!
+          if fixture_path_globs.length > 1
+            open, close = '(?:', ')'
+          else
+            open, close = '', ''
+          end
+          globs_as_regex = "#{open}#{fixture_path_globs.map { |g| Regexp.escape(g) }.join("|")}#{close}"
+          replace = /\A#{globs_as_regex}\/(.+?)\.yml\z/
+          fixture_set_names.map! { |f| f.sub!(replace, "\\1") }
         else
           fixture_set_names = fixture_set_names.flatten.map(&:to_s)
         end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -705,6 +705,15 @@ class LoadAllFixturesWithPathnameTest < ActiveRecord::TestCase
   end
 end
 
+class LoadAllFixturesWithGlobTest < ActiveRecord::TestCase
+  def test_it_loads
+    self.class.fixture_path = FIXTURES_ROOT + '/{to_be_linked,categories}'
+    self.class.fixtures :all
+
+    assert_equal %w(accounts special_categories subsubdir/arbitrary_filename users), fixture_table_names.sort
+  end
+end
+
 class FasterFixturesTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
   fixtures :categories, :authors


### PR DESCRIPTION
Currently fixture initialization does not correctly strip the prefix when `ActiveSupport::TestCase.fixture_path` is a glob, causing fixtures not to be loaded.

As an alternative, I can re-write this to work with an array of `fixture_path`s, which allows more generality than a single glob. This raises questions of filename conflict.

My use case is a project with plugins whose tests get run alongside the main application. Some plugins introduce new models and so need to define fixtures.

The use of `SOME_PATH/../SOME_OTHER_PATH` is likely broken.
