### PR TITLE
Ensure that microsecond precision is only used for versions of mysql that support it.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -107,6 +107,18 @@ module ActiveRecord
         @prepared_statements = false
       end
 
+      class Version
+        include Comparable
+
+        def initialize(version_string)
+          @version = version_string.split('.').map(&:to_i)
+        end
+
+        def <=>(version_string)
+          @version <=> version_string.split('.').map(&:to_i)
+        end
+      end
+
       class BindCollector < Arel::Collectors::Bind
         def compile(bvs, conn)
           casted_binds = conn.prepare_binds_for_database(bvs)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -307,7 +307,7 @@ module ActiveRecord
       #
       # http://bugs.mysql.com/bug.php?id=39170
       def supports_transaction_isolation?
-        version[0] >= 5
+        version >= '5.0.0'
       end
 
       def supports_indexes_in_create?
@@ -319,11 +319,11 @@ module ActiveRecord
       end
 
       def supports_views?
-        version[0] >= 5
+        version >= '5.0.0'
       end
 
       def supports_datetime_with_precision?
-        (version[0] == 5 && version[1] >= 6) || version[0] >= 6
+        version >= '5.6.4'
       end
 
       def native_database_types
@@ -384,6 +384,14 @@ module ActiveRecord
 
       def unquoted_false
         0
+      end
+
+      def quoted_date(value)
+        if supports_datetime_with_precision?
+          super
+        else
+          super.sub(/\.\d{6}\z/, '')
+        end
       end
 
       # REFERENTIAL INTEGRITY ====================================
@@ -938,7 +946,7 @@ module ActiveRecord
       end
 
       def version
-        @version ||= full_version.scan(/^(\d+)\.(\d+)\.(\d+)/).flatten.map(&:to_i)
+        @version ||= Version.new(full_version.match(/^\d+\.\d+\.\d+/)[0])
       end
 
       def mariadb?
@@ -946,7 +954,7 @@ module ActiveRecord
       end
 
       def supports_rename_index?
-        mariadb? ? false : (version[0] == 5 && version[1] >= 7) || version[0] >= 6
+        mariadb? ? false : version >= '5.7.6'
       end
 
       def configure_connection

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -65,18 +65,6 @@ module ActiveRecord
         boolean:      { name: "boolean" }
       }
 
-      class Version
-        include Comparable
-
-        def initialize(version_string)
-          @version = version_string.split('.').map(&:to_i)
-        end
-
-        def <=>(version_string)
-          @version <=> version_string.split('.').map(&:to_i)
-        end
-      end
-
       class StatementPool < ConnectionAdapters::StatementPool
         private
 

--- a/activerecord/test/cases/adapters/mysql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql/quoting_test.rb
@@ -12,4 +12,18 @@ class MysqlQuotingTest < ActiveRecord::MysqlTestCase
   def test_type_cast_false
     assert_equal 0, @conn.type_cast(false)
   end
+
+  def test_quoted_date_precision_for_gte_564
+    @conn.stubs(:full_version).returns('5.6.4')
+    @conn.remove_instance_variable(:@version)
+    t = Time.now.change(usec: 1)
+    assert_match(/\.000001\z/, @conn.quoted_date(t))
+  end
+
+  def test_quoted_date_precision_for_lt_564
+    @conn.stubs(:full_version).returns('5.6.3')
+    @conn.remove_instance_variable(:@version)
+    t = Time.now.change(usec: 1)
+    refute_match(/\.000001\z/, @conn.quoted_date(t))
+  end
 end

--- a/activerecord/test/cases/adapters/mysql2/quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/quoting_test.rb
@@ -1,0 +1,21 @@
+require "cases/helper"
+
+class Mysql2QuotingTest < ActiveRecord::Mysql2TestCase
+  setup do
+    @connection = ActiveRecord::Base.connection
+  end
+
+  test 'quoted date precision for gte 5.6.4' do
+    @connection.stubs(:full_version).returns('5.6.4')
+    @connection.remove_instance_variable(:@version)
+    t = Time.now.change(usec: 1)
+    assert_match(/\.000001\z/, @connection.quoted_date(t))
+  end
+
+  test 'quoted date precision for lt 5.6.4' do
+    @connection.stubs(:full_version).returns('5.6.3')
+    @connection.remove_instance_variable(:@version)
+    t = Time.now.change(usec: 1)
+    refute_match(/\.000001\z/, @connection.quoted_date(t))
+  end
+end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -47,7 +47,8 @@ end
 
 def mysql_56?
   current_adapter?(:MysqlAdapter, :Mysql2Adapter) &&
-    ActiveRecord::Base.connection.send(:version).join(".") >= "5.6.0"
+    ActiveRecord::Base.connection.send(:version) >= '5.6.0' &&
+    ActiveRecord::Base.connection.send(:version) < '5.7.0'
 end
 
 def mysql_enforcing_gtid_consistency?


### PR DESCRIPTION
Fixes #19711. By default, the quoting module returns datetimes with usec precision. This breaks quoted queries in mysql < 5.6.4 which lack support for usec precision.
