### PR TITLE
Minor addition to getting started guide for foreign_key description

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1555,8 +1555,8 @@ end
 ```
 
 The `t.references` line creates an integer column called `article_id`, an index
-for it, and a foreign key constraint that points to the `articles` table. Go
-ahead and run the migration:
+for it, and a foreign key constraint that points to the `id` column of the `articles`
+table. Go ahead and run the migration:
 
 ```bash
 $ bin/rake db:migrate


### PR DESCRIPTION
Minor addition to getting started guide for foreign_key description of references migration.
Also I've checked [migration guide about foreign_key](http://guides.rubyonrails.org/active_record_migrations.html#foreign-keys) and it's correct. 
