### PR TITLE
Fixed multibyte-chars slice! behavior to return nil for out-of-bound parameters

### DIFF
--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -95,7 +95,8 @@ module ActiveSupport #:nodoc:
       #   string.mb_chars.slice!(0..3) # => #<ActiveSupport::Multibyte::Chars:0x00000002eb80a0 @wrapped_string="Welo">
       #   string # => 'me'
       def slice!(*args)
-        chars(@wrapped_string.slice!(*args))
+        string_sliced = @wrapped_string.slice!(*args)
+        string_sliced ? chars(string_sliced) : nil
       end
 
       # Reverses all characters in the string.

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -413,6 +413,10 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
     assert_equal 'にち', @chars.slice!(1..2)
   end
 
+  def test_slice_bang_returns_nil_on_out_of_bound_arguments
+    assert_equal nil, @chars.mb_chars.slice!(9..10)
+  end
+
   def test_slice_bang_removes_the_slice_from_the_receiver
     chars = 'úüù'.mb_chars
     chars.slice!(0,2)


### PR DESCRIPTION
Expected behavior: 
If string is length 5 and I try to `slice!(7..10)` characters, it should return `nil`

Actual behavior:
I get an error

```
NoMethodError: undefined method `force_encoding' for nil:NilClass
/home/ubuntu/workspace/activesupport/lib/active_support/multibyte/chars.rb:55:in `initialize'
/home/ubuntu/workspace/activesupport/lib/active_support/multibyte/chars.rb:229:in `new'
/home/ubuntu/workspace/activesupport/lib/active_support/multibyte/chars.rb:229:in `chars'
/home/ubuntu/workspace/activesupport/lib/active_support/multibyte/chars.rb:102:in `slice!'
test/multibyte_chars_test.rb:417:in `test_slice_bang_returns_nil_on_out_of_bound_arguments'
```
