### PR TITLE
Improve integration_tool documentation

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -185,7 +185,7 @@ The full set of methods that can be used in this block are as follows:
 * `assets` allows to create assets on generating a scaffold. Defaults to `true`.
 * `force_plural` allows pluralized model names. Defaults to `false`.
 * `helper` defines whether or not to generate helpers. Defaults to `true`.
-* `integration_tool` defines which integration tool to use. Defaults to `nil`.
+* `integration_tool` defines which integration tool to use to generate integration tests. Defaults to `:test_unit`.
 * `javascripts` turns on the hook for JavaScript files in generators. Used in Rails for when the `scaffold` generator is run. Defaults to `true`.
 * `javascript_engine` configures the engine to be used (for eg. coffee) when generating assets. Defaults to `nil`.
 * `orm` defines which orm to use. Defaults to `false` and will use Active Record by default.


### PR DESCRIPTION
As per railties/lib/rails/test_unit/railtie.rb, where it sets it explicitly.

This can be confirmed by starting a new Rails console session in a new app and running this code:

Rails.application.config.app_generators.rails[:integration_tool]

I also beefed up the documentation slightly to be more explicit about what this configuration setting does.
