### PR TITLE
Avoid crashing when minitest-rails is loaded.

### DIFF
--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -34,14 +34,14 @@ module Minitest
 
     ENV["RAILS_ENV"] = options[:environment] || "test"
 
-    Rails::TestRequirer.require_files options[:patterns] unless run_with_autorun
+    ::Rails::TestRequirer.require_files options[:patterns] unless run_with_autorun
 
     unless options[:full_backtrace] || ENV["BACKTRACE"]
       # Plugin can run without Rails loaded, check before filtering.
-      Minitest.backtrace_filter = Rails.backtrace_cleaner if Rails.respond_to?(:backtrace_cleaner)
+      Minitest.backtrace_filter = ::Rails.backtrace_cleaner if ::Rails.respond_to?(:backtrace_cleaner)
     end
 
-    self.reporter << Rails::TestUnitReporter.new(options[:io], options)
+    self.reporter << ::Rails::TestUnitReporter.new(options[:io], options)
   end
 
   mattr_accessor(:run_with_autorun)         { false }


### PR DESCRIPTION
The improvments to the test runner's integration with minitest in commit b6fc8e25a10cc4abdd03018798b180270d6c5d7f add methods to the Minitest module that refer to the Rails module. Unfortunately, when the minitest-rails gem is loaded, the reference is incorrectly resolved to the Minitest::Rails module.

I fixed this by switching those references to absolute references. I'm not sure how to add tests for this change, but I tested it manually and it works with the `rails5` branch of [minitest-rails](https://github.com/blowmage/minitest-rails).
