### PR TITLE
Remove unnecessary `dup` from Mapper `add_route`

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1538,7 +1538,7 @@ module ActionDispatch
           path = path_for_action(action, options.delete(:path))
           raise ArgumentError, "path is required" if path.blank?
 
-          action = action.to_s.dup
+          action = action.to_s
 
           if action =~ /^[\w\-\/]+$/
             options[:action] ||= action.tr('-', '_') unless action.include?("/")


### PR DESCRIPTION
The `dup` was introduced by c4106d0c08954b0761726e0015ec601b7bc7ea4b to work around a frozen key. Nowadays, the string is already being duplicated by the `tr` in `options[:action] ||= action.tr('-', '_')`
and later joined into a new string in `name_for_action`.

@pixeltrix Since you fixed #3429, what do you think?
