### PR TITLE
Add default title to link_to

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -1,4 +1,5 @@
 require 'action_view/helpers/javascript_helper'
+require 'action_view/helpers/sanitize_helper'
 require 'active_support/core_ext/array/access'
 require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/string/output_safety'
@@ -20,6 +21,7 @@ module ActionView
       extend ActiveSupport::Concern
 
       include TagHelper
+      include SanitizeHelper
 
       module ClassMethods
         def _url_for_modules
@@ -182,9 +184,11 @@ module ActionView
         options ||= {}
 
         html_options = convert_options_to_data_attributes(options, html_options)
+        striped_name = name.respond_to?(:call) ? strip_tags(name.call) : strip_tags(name)
 
         url = url_for(options)
         html_options['href'] ||= url
+        html_options['title'] ||= striped_name if striped_name.present?
 
         content_tag(:a, name || url, html_options, &block)
       end

--- a/actionview/test/template/test_test.rb
+++ b/actionview/test/template/test_test.rb
@@ -51,7 +51,7 @@ class PeopleHelperTest < ActionView::TestCase
           "/people/1"
         }
       }
-      assert_equal '<a href="/people/1">David</a>', link_to_person(person)
+      assert_equal '<a href="/people/1" title="David">David</a>', link_to_person(person)
       assert_equal person, the_model
     end
   end

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -116,7 +116,7 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_truncate_with_link_options
-    assert_equal "Here is a long test and ...<a href=\"#\">Continue</a>",
+    assert_equal "Here is a long test and ...<a href=\"#\" title=\"Continue\">Continue</a>",
     truncate("Here is a long test and I need a continue to read link", :length => 27) { link_to 'Continue', '#' }
   end
 
@@ -143,12 +143,12 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_truncate_with_block_should_escape_the_input
-    assert_equal "&lt;script&gt;code!&lt;/script&gt;He...<a href=\"#\">Continue</a>",
+    assert_equal "&lt;script&gt;code!&lt;/script&gt;He...<a href=\"#\" title=\"Continue\">Continue</a>",
       truncate("<script>code!</script>Here's a long test and I need a continue to read link", :length => 27) { link_to 'Continue', '#' }
   end
 
   def test_truncate_with_block_should_not_escape_the_input_with_escape_false
-    assert_equal "<script>code!</script>He...<a href=\"#\">Continue</a>",
+    assert_equal "<script>code!</script>He...<a href=\"#\" title=\"Continue\">Continue</a>",
       truncate("<script>code!</script>Here's a long test and I need a continue to read link", :length => 27, :escape => false) { link_to 'Continue', '#' }
   end
 

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -175,21 +175,28 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_link_tag_with_straight_url
-    assert_dom_equal %{<a href="http://www.example.com">Hello</a>}, link_to("Hello", "http://www.example.com")
+    expected = %{<a href="http://www.example.com" title="Hello">Hello</a>}
+    assert_dom_equal expected, link_to("Hello", "http://www.example.com")
+  end
+
+  def test_link_tag_with_custom_title
+    expected = %{<a href="http://www.example.com" title="Hey you!">Hello</a>}
+    assert_dom_equal expected, link_to("Hello", "http://www.example.com", title: 'Hey you!')
   end
 
   def test_link_tag_without_host_option
-    assert_dom_equal(%{<a href="/">Test Link</a>}, link_to('Test Link', url_hash))
+    expected = %{<a href="/" title="Test Link">Test Link</a>}
+    assert_dom_equal(expected, link_to('Test Link', url_hash))
   end
 
   def test_link_tag_with_host_option
     hash = hash_for(host: "www.example.com")
-    expected = %{<a href="http://www.example.com/">Test Link</a>}
+    expected = %{<a href="http://www.example.com/" title="Test Link">Test Link</a>}
     assert_dom_equal(expected, link_to('Test Link', hash))
   end
 
   def test_link_tag_with_query
-    expected = %{<a href="http://www.example.com?q1=v1&amp;q2=v2">Hello</a>}
+    expected = %{<a href="http://www.example.com?q1=v1&amp;q2=v2" title="Hello">Hello</a>}
     assert_dom_equal expected, link_to("Hello", "http://www.example.com?q1=v1&q2=v2")
   end
 
@@ -201,14 +208,14 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_link_tag_with_back
     env = {"HTTP_REFERER" => "http://www.example.com/referer"}
     @controller = Struct.new(:request).new(Struct.new(:env).new(env))
-    expected = %{<a href="#{env["HTTP_REFERER"]}">go back</a>}
+    expected = %{<a href="#{env["HTTP_REFERER"]}" title="go back">go back</a>}
     assert_dom_equal expected, link_to('go back', :back)
   end
 
   def test_link_tag_with_back_and_no_referer
     @controller = Struct.new(:request).new(Struct.new(:env).new({}))
     link = link_to('go back', :back)
-    assert_dom_equal %{<a href="javascript:history.back()">go back</a>}, link
+    assert_dom_equal %{<a href="javascript:history.back()" title="go back">go back</a>}, link
   end
 
   def test_link_tag_with_img
@@ -219,143 +226,143 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_link_with_nil_html_options
     link = link_to("Hello", url_hash, nil)
-    assert_dom_equal %{<a href="/">Hello</a>}, link
+    assert_dom_equal %{<a href="/" title="Hello">Hello</a>}, link
   end
 
   def test_link_tag_with_custom_onclick
     link = link_to("Hello", "http://www.example.com", onclick: "alert('yay!')")
-    expected = %{<a href="http://www.example.com" onclick="alert(&#39;yay!&#39;)">Hello</a>}
+    expected = %{<a onclick="alert(&#39;yay!&#39;)" href="http://www.example.com" title="Hello">Hello</a>}
     assert_dom_equal expected, link
   end
 
   def test_link_tag_with_javascript_confirm
     assert_dom_equal(
-      %{<a href="http://www.example.com" data-confirm="Are you sure?">Hello</a>},
+      %{<a data-confirm="Are you sure?" href="http://www.example.com" title="Hello">Hello</a>},
       link_to("Hello", "http://www.example.com", data: { confirm: "Are you sure?" })
     )
     assert_dom_equal(
-      %{<a href="http://www.example.com" data-confirm="You cant possibly be sure, can you?">Hello</a>},
+      %{<a data-confirm="You cant possibly be sure, can you?" href="http://www.example.com" title="Hello">Hello</a>},
       link_to("Hello", "http://www.example.com", data: { confirm: "You cant possibly be sure, can you?" })
     )
     assert_dom_equal(
-      %{<a href="http://www.example.com" data-confirm="You cant possibly be sure,\n can you?">Hello</a>},
+      %{<a data-confirm="You cant possibly be sure,\n can you?" href="http://www.example.com" title="Hello">Hello</a>},
       link_to("Hello", "http://www.example.com", data: { confirm: "You cant possibly be sure,\n can you?" })
     )
   end
 
   def test_link_to_with_remote
     assert_dom_equal(
-      %{<a href="http://www.example.com" data-remote="true">Hello</a>},
+      %{<a href="http://www.example.com" data-remote="true" title="Hello">Hello</a>},
       link_to("Hello", "http://www.example.com", remote: true)
     )
   end
 
   def test_link_to_with_remote_false
     assert_dom_equal(
-      %{<a href="http://www.example.com">Hello</a>},
+      %{<a href="http://www.example.com" title="Hello">Hello</a>},
       link_to("Hello", "http://www.example.com", remote: false)
     )
   end
 
   def test_link_to_with_symbolic_remote_in_non_html_options
     assert_dom_equal(
-      %{<a href="/" data-remote="true">Hello</a>},
+      %{<a href="/" data-remote="true" title="Hello">Hello</a>},
       link_to("Hello", hash_for(remote: true), {})
     )
   end
 
   def test_link_to_with_string_remote_in_non_html_options
     assert_dom_equal(
-      %{<a href="/" data-remote="true">Hello</a>},
+      %{<a href="/" data-remote="true" title="Hello">Hello</a>},
       link_to("Hello", hash_for('remote' => true), {})
     )
   end
 
   def test_link_tag_using_post_javascript
     assert_dom_equal(
-      %{<a href="http://www.example.com" data-method="post" rel="nofollow">Hello</a>},
+      %{<a href="http://www.example.com" data-method="post" rel="nofollow" title="Hello">Hello</a>},
       link_to("Hello", "http://www.example.com", method: :post)
     )
   end
 
   def test_link_tag_using_delete_javascript
     assert_dom_equal(
-      %{<a href="http://www.example.com" rel="nofollow" data-method="delete">Destroy</a>},
+      %{<a href="http://www.example.com" rel="nofollow" data-method="delete" title="Destroy">Destroy</a>},
       link_to("Destroy", "http://www.example.com", method: :delete)
     )
   end
 
   def test_link_tag_using_delete_javascript_and_href
     assert_dom_equal(
-      %{<a href="\#" rel="nofollow" data-method="delete">Destroy</a>},
+      %{<a href="\#" rel="nofollow" data-method="delete" title="Destroy">Destroy</a>},
       link_to("Destroy", "http://www.example.com", method: :delete, href: '#')
     )
   end
 
   def test_link_tag_using_post_javascript_and_rel
     assert_dom_equal(
-      %{<a href="http://www.example.com" data-method="post" rel="example nofollow">Hello</a>},
+      %{<a href="http://www.example.com" data-method="post" rel="example nofollow" title="Hello">Hello</a>},
       link_to("Hello", "http://www.example.com", method: :post, rel: 'example')
     )
   end
 
   def test_link_tag_using_post_javascript_and_confirm
     assert_dom_equal(
-      %{<a href="http://www.example.com" data-method="post" rel="nofollow" data-confirm="Are you serious?">Hello</a>},
+      %{<a href="http://www.example.com" data-method="post" rel="nofollow" data-confirm="Are you serious?" title="Hello">Hello</a>},
       link_to("Hello", "http://www.example.com", method: :post, data: { confirm: "Are you serious?" })
     )
   end
 
   def test_link_tag_using_delete_javascript_and_href_and_confirm
     assert_dom_equal(
-      %{<a href="\#" rel="nofollow" data-confirm="Are you serious?" data-method="delete">Destroy</a>},
+      %{<a href="\#" rel="nofollow" data-confirm="Are you serious?" data-method="delete" title="Destroy">Destroy</a>},
       link_to("Destroy", "http://www.example.com", method: :delete, href: '#', data: { confirm: "Are you serious?" })
     )
   end
 
   def test_link_tag_with_block
-    assert_dom_equal %{<a href="/"><span>Example site</span></a>},
+    assert_dom_equal %{<a href="/" title="Example site"><span>Example site</span></a>},
       link_to('/') { content_tag(:span, 'Example site') }
   end
 
   def test_link_tag_with_block_and_html_options
-    assert_dom_equal %{<a class="special" href="/"><span>Example site</span></a>},
+    assert_dom_equal %{<a class="special" href="/" title="Example site"><span>Example site</span></a>},
       link_to('/', class: "special") { content_tag(:span, 'Example site') }
   end
 
   def test_link_tag_using_block_and_hash
     assert_dom_equal(
-      %{<a href="/"><span>Example site</span></a>},
+      %{<a href="/" title="Example site"><span>Example site</span></a>},
       link_to(url_hash) { content_tag(:span, 'Example site') }
     )
   end
 
   def test_link_tag_using_block_in_erb
     out = render_erb %{<%= link_to('/') do %>Example site<% end %>}
-    assert_equal '<a href="/">Example site</a>', out
+    assert_equal '<a href="/" title="Example site">Example site</a>', out
   end
 
   def test_link_tag_with_html_safe_string
     assert_dom_equal(
-      %{<a href="/article/Gerd_M%C3%BCller">Gerd Müller</a>},
+      %{<a href="/article/Gerd_M%C3%BCller" title="Gerd Müller">Gerd Müller</a>},
       link_to("Gerd Müller", article_path("Gerd_Müller".html_safe))
     )
   end
 
   def test_link_tag_escapes_content
-    assert_dom_equal %{<a href="/">Malicious &lt;script&gt;content&lt;/script&gt;</a>},
+    assert_dom_equal %{<a href="/" title="Malicious ">Malicious &lt;script&gt;content&lt;/script&gt;</a>},
       link_to("Malicious <script>content</script>", "/")
   end
 
   def test_link_tag_does_not_escape_html_safe_content
-    assert_dom_equal %{<a href="/">Malicious <script>content</script></a>},
+    assert_dom_equal %{<a href="/" title="Malicious ">Malicious <script>content</script></a>},
       link_to("Malicious <script>content</script>".html_safe, "/")
   end
 
   def test_link_to_unless
     assert_equal "Showing", link_to_unless(true, "Showing", url_hash)
 
-    assert_dom_equal %{<a href="/">Listing</a>},
+    assert_dom_equal %{<a href="/" title="Listing">Listing</a>},
       link_to_unless(false, "Listing", url_hash)
 
     assert_equal "<strong>Showing</strong>",
@@ -369,19 +376,19 @@ class UrlHelperTest < ActiveSupport::TestCase
       }
 
     assert_equal %{&lt;b&gt;Showing&lt;/b&gt;}, link_to_unless(true, "<b>Showing</b>", url_hash)
-    assert_equal %{<a href="/">&lt;b&gt;Showing&lt;/b&gt;</a>}, link_to_unless(false, "<b>Showing</b>", url_hash)
+    assert_equal %{<a href="/" title="Showing">&lt;b&gt;Showing&lt;/b&gt;</a>}, link_to_unless(false, "<b>Showing</b>", url_hash)
     assert_equal %{<b>Showing</b>}, link_to_unless(true, "<b>Showing</b>".html_safe, url_hash)
-    assert_equal %{<a href="/"><b>Showing</b></a>}, link_to_unless(false, "<b>Showing</b>".html_safe, url_hash)
+    assert_equal %{<a href="/" title="Showing"><b>Showing</b></a>}, link_to_unless(false, "<b>Showing</b>".html_safe, url_hash)
   end
 
   def test_link_to_if
     assert_equal "Showing", link_to_if(false, "Showing", url_hash)
-    assert_dom_equal %{<a href="/">Listing</a>}, link_to_if(true, "Listing", url_hash)
+    assert_dom_equal %{<a href="/" title="Listing">Listing</a>}, link_to_if(true, "Listing", url_hash)
   end
 
   def test_link_to_if_with_block
     assert_equal "Fallback", link_to_if(false, "Showing", url_hash) { "Fallback" }
-    assert_dom_equal %{<a href="/">Listing</a>}, link_to_if(true, "Listing", url_hash) { "Fallback" }
+    assert_dom_equal %{<a href="/" title="Listing">Listing</a>}, link_to_if(true, "Listing", url_hash) { "Fallback" }
   end
 
   def request_for_url(url, opts = {})
@@ -465,27 +472,27 @@ class UrlHelperTest < ActiveSupport::TestCase
 
     @request = request_for_url("/?order=desc")
 
-    assert_equal %{<a href="/?order=asc">Showing</a>},
+    assert_equal %{<a href="/?order=asc" title="Showing">Showing</a>},
       link_to_unless_current("Showing", hash_for(order: :asc))
-    assert_equal %{<a href="http://www.example.com/?order=asc">Showing</a>},
+    assert_equal %{<a href="http://www.example.com/?order=asc" title="Showing">Showing</a>},
       link_to_unless_current("Showing", "http://www.example.com/?order=asc")
 
     @request = request_for_url("/?order=desc")
-    assert_equal %{<a href="/?order=desc&amp;page=2\">Showing</a>},
+    assert_equal %{<a href="/?order=desc&amp;page=2\" title="Showing">Showing</a>},
       link_to_unless_current("Showing", hash_for(order: "desc", page: 2))
-    assert_equal %{<a href="http://www.example.com/?order=desc&amp;page=2">Showing</a>},
+    assert_equal %{<a href="http://www.example.com/?order=desc&amp;page=2" title="Showing">Showing</a>},
       link_to_unless_current("Showing", "http://www.example.com/?order=desc&page=2")
 
     @request = request_for_url("/show")
 
-    assert_equal %{<a href="/">Listing</a>},
+    assert_equal %{<a href="/" title="Listing">Listing</a>},
       link_to_unless_current("Listing", url_hash)
-    assert_equal %{<a href="http://www.example.com/">Listing</a>},
+    assert_equal %{<a href="http://www.example.com/" title="Listing">Listing</a>},
       link_to_unless_current("Listing", "http://www.example.com/")
   end
 
   def test_link_to_unless_with_block
-    assert_dom_equal %{<a href="/">Showing</a>}, link_to_unless(false, "Showing", url_hash) { "Fallback" }
+    assert_dom_equal %{<a href="/" title="Showing">Showing</a>}, link_to_unless(false, "Showing", url_hash) { "Fallback" }
     assert_equal "Fallback", link_to_unless(true, "Listing", url_hash) { "Fallback" }
   end
 
@@ -719,8 +726,8 @@ class LinkToUnlessCurrentWithControllerTest < ActionController::TestCase
 
   def test_link_to_unless_current_shows_link
     get :show, params: { id: 1 }
-    assert_equal %{<a href="/tasks">tasks</a>\n} +
-      %{<a href="#{@request.protocol}#{@request.host_with_port}/tasks">tasks</a>},
+    assert_equal %{<a href="/tasks" title="tasks">tasks</a>\n} +
+      %{<a href="#{@request.protocol}#{@request.host_with_port}/tasks" title="tasks">tasks</a>},
       @response.body
   end
 end
@@ -786,27 +793,27 @@ class PolymorphicControllerTest < ActionController::TestCase
     @controller = WorkshopsController.new
 
     get :index
-    assert_equal %{/workshops\n<a href="/workshops">Workshop</a>}, @response.body
+    assert_equal %{/workshops\n<a href="/workshops" title="Workshop">Workshop</a>}, @response.body
   end
 
   def test_existing_resource
     @controller = WorkshopsController.new
 
     get :show, params: { id: 1 }
-    assert_equal %{/workshops/1\n<a href="/workshops/1">Workshop</a>}, @response.body
+    assert_equal %{/workshops/1\n<a href="/workshops/1" title="Workshop">Workshop</a>}, @response.body
   end
 
   def test_new_nested_resource
     @controller = SessionsController.new
 
     get :index, params: { workshop_id: 1 }
-    assert_equal %{/workshops/1/sessions\n<a href="/workshops/1/sessions">Session</a>}, @response.body
+    assert_equal %{/workshops/1/sessions\n<a href="/workshops/1/sessions" title="Session">Session</a>}, @response.body
   end
 
   def test_existing_nested_resource
     @controller = SessionsController.new
 
     get :show, params: { workshop_id: 1, id: 1 }
-    assert_equal %{/workshops/1/sessions/1\n<a href="/workshops/1/sessions/1">Session</a>}, @response.body
+    assert_equal %{/workshops/1/sessions/1\n<a href="/workshops/1/sessions/1" title="Session">Session</a>}, @response.body
   end
 end


### PR DESCRIPTION
Hey guys,

what you think about define a default [title attribute](https://tools.ietf.org/html/rfc1866#section-5.7.3) on `link_to` based on the name of the link?

Today we already do something like that on the `image_tag` defining the [alt](https://tools.ietf.org/html/rfc1866#section-5.10) attribute.

I started the code to [expose the idea and gather some feedback](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#what-about-feature-requests-questionmark). If you guys agree with this I can continue on it, add docs etc.

Thanks 
