### PR TITLE
Rack changed their status codes to IETF RFC 7231

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -227,6 +227,17 @@ restore the old behavior.
 If you do this, be sure to configure your firewall properly such that only
 trusted machines on your network can access your development server.
 
+### Changed status option symbols for `render`
+
+Due to a [change in Rack](https://github.com/rack/rack/commit/be28c6a2ac152fe4adfbef71f3db9f4200df89e8), the symbols that the `render` method accepts for the `:status` option have changed:
+
+- 306: `:reserved` has been removed.
+- 413: `:request_entity_too_large` has been renamed to `:payload_too_large`.
+- 414: `:request_uri_too_long` has been renamed to `:uri_too_long`.
+- 416: `:requested_range_not_satisfiable` has been renamed to `:range_not_satisfiable`.
+
+Keep in mind that if calling `render` with an unknown symbol, the response status will default to 500.
+
 ### HTML Sanitizer
 
 The HTML sanitizer has been replaced with a new, more robust, implementation

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -360,7 +360,6 @@ Rails understands both numeric status codes and the corresponding symbols shown 
 |                     | 303              | :see_other                       |
 |                     | 304              | :not_modified                    |
 |                     | 305              | :use_proxy                       |
-|                     | 306              | :reserved                        |
 |                     | 307              | :temporary_redirect              |
 |                     | 308              | :permanent_redirect              |
 | **Client Error**    | 400              | :bad_request                     |
@@ -376,10 +375,10 @@ Rails understands both numeric status codes and the corresponding symbols shown 
 |                     | 410              | :gone                            |
 |                     | 411              | :length_required                 |
 |                     | 412              | :precondition_failed             |
-|                     | 413              | :request_entity_too_large        |
-|                     | 414              | :request_uri_too_long            |
+|                     | 413              | :payload_too_large               |
+|                     | 414              | :uri_too_long                    |
 |                     | 415              | :unsupported_media_type          |
-|                     | 416              | :requested_range_not_satisfiable |
+|                     | 416              | :range_not_satisfiable           |
 |                     | 417              | :expectation_failed              |
 |                     | 422              | :unprocessable_entity            |
 |                     | 423              | :locked                          |


### PR DESCRIPTION
Rails is calling the `Rack::Utils.status_code` method in several places, and calling that method with an unknown symbol will return the integer 500.

The valid symbols are defined by the names in `Rack::Utils::HTTP_STATUS_CODES`. And they changed in in rack/rack#754, released in Rack v1.6.0 (see also https://github.com/rack/rack/blob/master/HISTORY.md). This PR changes Rails’ documentation to match the new valid status symbols.

Here’s the relevant diff from that Rack PR:

``` diff
     HTTP_STATUS_CODES = {
       100 => 'Continue',
       101 => 'Switching Protocols',
 @@ -590,7 +590,6 @@ def to_params_hash
       303 => 'See Other',
       304 => 'Not Modified',
       305 => 'Use Proxy',
-      306 => 'Reserved',
       307 => 'Temporary Redirect',
       308 => 'Permanent Redirect',
       400 => 'Bad Request',
 @@ -606,12 +605,11 @@ def to_params_hash
       410 => 'Gone',
       411 => 'Length Required',
       412 => 'Precondition Failed',
-      413 => 'Request Entity Too Large',
-      414 => 'Request-URI Too Long',
+      413 => 'Payload Too Large',
+      414 => 'URI Too Long',
       415 => 'Unsupported Media Type',
-      416 => 'Requested Range Not Satisfiable',
+      416 => 'Range Not Satisfiable',
       417 => 'Expectation Failed',
-      418 => 'I\'m a teapot',
       422 => 'Unprocessable Entity',
       423 => 'Locked',
       424 => 'Failed Dependency',
 @@ -625,7 +623,7 @@ def to_params_hash
       503 => 'Service Unavailable',
       504 => 'Gateway Timeout',
       505 => 'HTTP Version Not Supported',
-      506 => 'Variant Also Negotiates (Experimental)',
+      506 => 'Variant Also Negotiates',
       507 => 'Insufficient Storage',
       508 => 'Loop Detected',
       510 => 'Not Extended',
```
