### PR TITLE
ActionMailer::MessageDelivery respects current I18n.locale

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `deliver_later` now respects the current locale.
+
+    Fixes #20774.
+
+    *Johannes Opper*
+
 *   Add `config.action_mailer.deliver_later_queue_name` configuration to set the
     mailer queue name.
 

--- a/actionmailer/lib/action_mailer/delivery_job.rb
+++ b/actionmailer/lib/action_mailer/delivery_job.rb
@@ -6,8 +6,10 @@ module ActionMailer
   class DeliveryJob < ActiveJob::Base # :nodoc:
     queue_as { ActionMailer::Base.deliver_later_queue_name }
 
-    def perform(mailer, mail_method, delivery_method, *args) #:nodoc:
-      mailer.constantize.public_send(mail_method, *args).send(delivery_method)
+    def perform(mailer, mail_method, delivery_method, locale, *args) #:nodoc:
+      I18n.with_locale(locale) do
+        mailer.constantize.public_send(mail_method, *args).send(delivery_method)
+      end
     end
   end
 end

--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -87,7 +87,7 @@ module ActionMailer
     private
 
       def enqueue_delivery(delivery_method, options={})
-        args = @mailer.name, @mail_method.to_s, delivery_method.to_s, *@args
+        args = @mailer.name, @mail_method.to_s, delivery_method.to_s, I18n.locale.to_s, *@args
         ActionMailer::DeliveryJob.set(options).perform_later(*args)
       end
   end

--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -57,20 +57,20 @@ class MessageDeliveryTest < ActiveSupport::TestCase
   end
 
   test 'should enqueue the email with :deliver_now delivery method' do
-    assert_performed_with(job: ActionMailer::DeliveryJob, args: ['DelayedMailer', 'test_message', 'deliver_now', 1, 2, 3]) do
+    assert_performed_with(job: ActionMailer::DeliveryJob, args: ['DelayedMailer', 'test_message', 'deliver_now', 'en', 1, 2, 3]) do
       @mail.deliver_later
     end
   end
 
   test 'should enqueue the email with :deliver_now! delivery method' do
-    assert_performed_with(job: ActionMailer::DeliveryJob, args: ['DelayedMailer', 'test_message', 'deliver_now!', 1, 2, 3]) do
+    assert_performed_with(job: ActionMailer::DeliveryJob, args: ['DelayedMailer', 'test_message', 'deliver_now!', 'en', 1, 2, 3]) do
       @mail.deliver_later!
     end
   end
 
   test 'should enqueue a delivery with a delay' do
     travel_to Time.new(2004, 11, 24, 01, 04, 44) do
-      assert_performed_with(job: ActionMailer::DeliveryJob, at: Time.current.to_f+600.seconds, args: ['DelayedMailer', 'test_message', 'deliver_now', 1, 2, 3]) do
+      assert_performed_with(job: ActionMailer::DeliveryJob, at: Time.current.to_f+600.seconds, args: ['DelayedMailer', 'test_message', 'deliver_now', 'en', 1, 2, 3]) do
         @mail.deliver_later wait: 600.seconds
       end
     end
@@ -78,20 +78,28 @@ class MessageDeliveryTest < ActiveSupport::TestCase
 
   test 'should enqueue a delivery at a specific time' do
     later_time = Time.now.to_f + 3600
-    assert_performed_with(job: ActionMailer::DeliveryJob, at: later_time, args: ['DelayedMailer', 'test_message', 'deliver_now', 1, 2, 3]) do
+    assert_performed_with(job: ActionMailer::DeliveryJob, at: later_time, args: ['DelayedMailer', 'test_message', 'deliver_now', 'en', 1, 2, 3]) do
       @mail.deliver_later wait_until: later_time
     end
   end
 
   test 'should enqueue the job on the correct queue' do
-    assert_performed_with(job: ActionMailer::DeliveryJob, args: ['DelayedMailer', 'test_message', 'deliver_now', 1, 2, 3], queue: "test_queue") do
+    assert_performed_with(job: ActionMailer::DeliveryJob, args: ['DelayedMailer', 'test_message', 'deliver_now', 'en', 1, 2, 3], queue: "test_queue") do
       @mail.deliver_later
     end
   end
 
   test 'can override the queue when enqueuing mail' do
-    assert_performed_with(job: ActionMailer::DeliveryJob, args: ['DelayedMailer', 'test_message', 'deliver_now', 1, 2, 3], queue: "another_queue") do
+    assert_performed_with(job: ActionMailer::DeliveryJob, args: ['DelayedMailer', 'test_message', 'deliver_now', 'en', 1, 2, 3], queue: "another_queue") do
       @mail.deliver_later(queue: :another_queue)
+    end
+  end
+
+  test 'should enqueue a delivery with the correct locale' do
+    I18n.with_locale('de') do
+      assert_performed_with(job: ActionMailer::DeliveryJob, args: ['DelayedMailer', 'test_message', 'deliver_now', 'de', 1, 2, 3]) do
+        @mail.deliver_later
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #20774

When #deliver_now is called all translations within the
generated email will be looked up for the current I18n
locale.

```
I18n.locale = ‘de’
mail.deliver_now # Generates german email, correct
```

In #enqueue_delivery the locale was not considered and
the resulting job uses the default locale.

```
I18n.locale = ‘de’
mail.deliver_later # Generate english email, incorrect
```

In order to achieve a consistent behaviour the current locale
is now always passed to `ActionMailer::DeliveryJob`.
