### PR TITLE
[ci skip] Don't use TrueClass, FalseClass in docs

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -148,9 +148,6 @@ module AbstractController
     #
     # ==== Parameters
     # * <tt>action_name</tt> - The name of an action to be tested
-    #
-    # ==== Returns
-    # * <tt>TrueClass</tt>, <tt>FalseClass</tt>
     def available_action?(action_name)
       _find_action_name(action_name).present?
     end
@@ -170,9 +167,6 @@ module AbstractController
       #
       # ==== Parameters
       # * <tt>name</tt> - The name of an action to be tested
-      #
-      # ==== Returns
-      # * <tt>TrueClass</tt>, <tt>FalseClass</tt>
       #
       # :api: private
       def action_method?(name)


### PR DESCRIPTION
This sort of documentation style comes from 2009, probably due to the merging of merb (see https://github.com/rails/rails/commit/38b608ecab2441cd0c4e75bc08bdf57fcf85dd71#diff-017d9bc9b1d2bdae199b938d72c15488R120).

Rails follows Ruby's convention to define which values are "truthy" or "falsey", so there is no need to specify that the returned value must strictly be a TrueClass or FalseClass. 

/cc @fxn
