### PR TITLE
Create Adding images in Action Mailer Views on guides

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -533,6 +533,24 @@ url helper.
 NOTE: non-`GET` links require [jQuery UJS](https://github.com/rails/jquery-ujs)
 and won't work in mailer templates. They will result in normal `GET` requests.
 
+### Adding images in Action Mailer Views
+
+Unlike controllers, the mailer instance doesn't have any context about the
+incoming request so you'll need to provide the `:asset_host` parameter yourself.
+
+As the `:asset_host` usually is consistent across the application you can
+configure it globally in config/application.rb:
+
+```ruby
+config.action_mailer.asset_host = 'http://example.com'
+```
+
+Now you can display an image inside your email.
+
+```ruby
+<%= image_tag 'image.jpg' %>
+```
+
 ### Sending Multipart Emails
 
 Action Mailer will automatically send multipart emails if you have different


### PR DESCRIPTION
I think this generates some confusion, maybe we will help some people adding this to the guides. Take a look at [1](http://stackoverflow.com/questions/27748413/why-do-image-tags-work-in-regular-views-but-not-mailer-views), [2](http://stackoverflow.com/questions/4918414/what-is-the-right-way-to-embed-image-into-email-using-rails), [3](http://stackoverflow.com/questions/7810103/rails-3-1-trouble-on-displaying-images-in-mailer-view-files) and the list continues on Stack Overflow.
