### PR TITLE
Add Deserialization section on guides at ActiveJob Exception

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -330,6 +330,13 @@ class GuestsCleanupJob < ActiveJob::Base
 end
 ```
 
+### Deserialization
+
+GlobalID allows serializing full Active Record objects passed to `#perform`.
+
+If a passed record is deleted after the job is enqueued but before the `#perform`
+method is called Active Job will raise an `ActiveJob::DeserializationError`
+exception.
 
 Job Testing
 --------------


### PR DESCRIPTION
When using [Sidekiq without Active Job is a common practice](https://github.com/mperham/sidekiq/wiki/Active-Job#limitations) do something like: 

``` ruby
def perform(user_id)
  user = User.find_by(id: user_id)

  if user
    user.send_welcome_email!
  else
    # handle a deleted user record
  end
end
```

To handle a record that is deleted after the job is enqueued but before the perform. Active Job raises a custom exception that we can handle and [have the same behavior](https://github.com/rails/rails/blob/master/activejob/lib/active_job/arguments.rb#L7-L17).

I think it is a common case when we are dealing with jobs handle this case.
