### PR TITLE
remove unnecessary loading fixtures from `navigation_test.rb`

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/test/integration/navigation_test.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/integration/navigation_test.rb
@@ -1,10 +1,6 @@
 require 'test_helper'
 
 class NavigationTest < ActionDispatch::IntegrationTest
-<% unless options[:skip_active_record] -%>
-  fixtures :all
-<% end -%>
-
   # test "the truth" do
   #   assert true
   # end


### PR DESCRIPTION
it has been corrected in 0176aef1ebaa9f69001c7045a51727a8ea9b61b8 as for loading of fixtures in `test_helper.rb`,
loading fixtures for each test is unnecessary.
