### PR TITLE
Fix the random caching test failure. (Take two)

### DIFF
--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -381,6 +381,7 @@ class AutomaticCollectionCacheTest < ActionController::TestCase
     @controller.perform_caching = true
     @controller.partial_rendered_times = 0
     @controller.cache_store = ActiveSupport::Cache::MemoryStore.new
+    ActionView::PartialRenderer.collection_cache = @controller.cache_store
   end
 
   def test_collection_fetches_cached_views


### PR DESCRIPTION
Fixes #20535.

As @repinel pointed out on #20535 the `collection_cache` and `cache_store` aren't the same. Hopefully this should fix the test flakyness.

cc @matthewd @rafaelfranca
