### PR TITLE
Ignore unused parameters

### DIFF
--- a/activejob/lib/active_job/queue_adapters/qu_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/qu_adapter.rb
@@ -20,13 +20,13 @@ module ActiveJob
         qu_job = Qu::Payload.new(klass: JobWrapper, args: [job.serialize]).tap do |payload|
           payload.instance_variable_set(:@queue, job.queue_name)
         end.push
-        
+
         # qu_job can be nil depending on the configured backend
         job.provider_job_id = qu_job.id unless qu_job.nil?
         qu_job
       end
 
-      def enqueue_at(job, timestamp, *args) #:nodoc:
+      def enqueue_at(*) #:nodoc:
         raise NotImplementedError, "This queueing backend does not support scheduling jobs. To see what features are supported go to http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html"
       end
 

--- a/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
@@ -27,7 +27,7 @@ module ActiveJob
         end
       end
 
-      def enqueue_at(job, timestamp) #:nodoc:
+      def enqueue_at(*) #:nodoc:
         raise NotImplementedError, "This queueing backend does not support scheduling jobs. To see what features are supported go to http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html"
       end
 


### PR DESCRIPTION
**What does this do?**
Since we don't use the given parameters, we can just use `*` instead of the
parameter names. This makes it more explicit that we don't really care about the
params.
