### PR TITLE
Add method call assertions for internal use.

### DIFF
--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -1,0 +1,30 @@
+module ActiveSupport
+  module Testing
+    module MethodCallAssertions # :nodoc:
+      private
+        def assert_called(object, method_name, message = nil, times: 1)
+          times_called = 0
+
+          object.stub(method_name, -> { times_called += 1 }) { yield }
+
+          error = "Expected #{method_name} to be called #{times} times, " \
+            "but was called #{times_called} times"
+          error = "#{message}.\n#{error}" if message
+          assert_equal times, times_called, error
+        end
+
+        def assert_called_with(object, method_name, args = [], returns: nil)
+          mock = Minitest::Mock.new
+          mock.expect(:call, returns, args)
+
+          object.stub(method_name, mock) { yield }
+
+          mock.verify
+        end
+
+        def assert_not_called(object, method_name, message = nil, &block)
+          assert_called(object, method_name, message, times: 0, &block)
+        end
+    end
+  end
+end

--- a/activesupport/test/testing/method_call_assertions_test.rb
+++ b/activesupport/test/testing/method_call_assertions_test.rb
@@ -1,0 +1,91 @@
+require 'abstract_unit'
+require 'active_support/testing/method_call_assertions'
+
+class MethodCallAssertionsTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+
+  class Level
+    def increment; 1; end
+    def decrement; end
+    def <<(arg); end
+  end
+
+  setup do
+    @object = Level.new
+  end
+
+  def test_assert_called_with_defaults_to_expect_once
+    assert_called @object, :increment do
+      @object.increment
+    end
+  end
+
+  def test_assert_called_more_than_once
+    assert_called(@object, :increment, times: 2) do
+      @object.increment
+      @object.increment
+    end
+  end
+
+  def test_assert_called_failure
+    error = assert_raises(Minitest::Assertion) do
+      assert_called(@object, :increment) do
+        # Call nothing...
+      end
+    end
+
+    assert_equal "Expected increment to be called 1 times, but was called 0 times.\nExpected: 1\n  Actual: 0", error.message
+  end
+
+  def test_assert_called_with_message
+    error = assert_raises(Minitest::Assertion) do
+      assert_called(@object, :increment, 'dang it') do
+        # Call nothing...
+      end
+    end
+
+    assert_match(/dang it.\nExpected increment/, error.message)
+  end
+
+  def test_assert_called_with
+    assert_called_with(@object, :increment) do
+      @object.increment
+    end
+  end
+
+  def test_assert_called_with_arguments
+    assert_called_with(@object, :<<, [ 2 ]) do
+      @object << 2
+    end
+  end
+
+  def test_assert_called_with_failure
+    assert_raises(MockExpectationError) do
+      assert_called_with(@object, :<<, [ 4567 ]) do
+        @object << 2
+      end
+    end
+  end
+
+  def test_assert_called_with_returns
+    assert_called_with(@object, :increment, returns: 1) do
+      @object.increment
+    end
+  end
+
+  def test_assert_not_called
+    assert_not_called(@object, :decrement) do
+      @object.increment
+    end
+  end
+
+  def test_assert_not_called_failure
+    error = assert_raises(Minitest::Assertion) do
+      assert_not_called(@object, :increment) do
+        @object.increment
+      end
+    end
+
+    assert_equal "Expected increment to be called 0 times, but was called 1 times.\nExpected: 0\n  Actual: 1", error.message
+  end
+end


### PR DESCRIPTION
Prompted by the discussion in https://github.com/rails/rails/pull/20457.

We're trying to remove the use of Mocha in Rails and finding some cases where going with a stub and mock yields hard to read code. Here's an example from #20457:

``` ruby
mock = Minitest::Mock.new
mock.expect(:call, nil, [])
original.stub(:delete, mock) do
  original.except(:a)
end
assert_equal "expected call() => nil, got []", assert_raises(MockExpectationError) { mock.verify }.message
```

Instead I've added `assert_called` and `assert_not_called` to boil down the boilerplate we need to write
to assert methods are called a certain number of times.

``` ruby
assert_not_called(original, :delete) { original.except(:a) }
```

As we generally want people to use shy away from behavior testing when contributing I've marked these as `:nodoc:`.

cc @matthewd @ronakjangir47 @andycroll
