### PR TITLE
Change regexp of RouteSet's `conditions[:request_method]`

### DIFF
--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -163,7 +163,7 @@ module ActionDispatch
       end
 
       def verb
-        %r[^#{verbs.join('|')}$]
+        %r[\A#{verbs.join('|')}\Z]
       end
 
       private

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -17,7 +17,7 @@ module ActionDispatch
       end
 
       def verb
-        super.source.gsub(/[$^]/, '')
+        super.source.gsub(/\\A|\\Z/, '')
       end
 
       def path

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -82,7 +82,7 @@ module ActionDispatch
         end
         assert_equal({:omg=>:awesome, :controller=>"posts", :action=>"index"},
                      fakeset.defaults.first)
-        assert_equal(/^GET$/, fakeset.routes.first.verb)
+        assert_equal(/\AGET\Z/, fakeset.routes.first.verb)
       end
 
       def test_mapping_requirements
@@ -99,7 +99,7 @@ module ActionDispatch
         mapper.scope(via: :put) do
           mapper.match '/', :to => 'posts#index', :as => :main
         end
-        assert_equal(/^PUT$/, fakeset.routes.first.verb)
+        assert_equal(/\APUT\Z/, fakeset.routes.first.verb)
       end
 
       def test_map_slash


### PR DESCRIPTION
RFC2616 defines Request-Line which includes method token
is separated by SP characters.
So we should not match it with multiline anchors.

cf: http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1
