### PR TITLE
improve autoload_paths logic

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -406,6 +406,11 @@ module ActiveSupport #:nodoc:
       autoload_paths.each do |root|
         path = File.join(root, path_suffix)
         return path if File.file? path
+        module_path = path_suffix.split('/').first
+        if module_path && root.to_s =~ /#{module_path}$/
+          path = File.join(root.sub(/#{module_path}$/, ''), path_suffix)
+          return path if File.file? path
+        end
       end
       nil # Gee, I sure wish we had first_match ;-)
     end
@@ -416,6 +421,10 @@ module ActiveSupport #:nodoc:
     def autoloadable_module?(path_suffix)
       autoload_paths.each do |load_path|
         return load_path if File.directory? File.join(load_path, path_suffix)
+        if load_path.to_s =~ /#{path_suffix}$/
+          m_dir = File.join(load_path.sub(/\/#{path_suffix}$/, ''), path_suffix)
+          return load_path if File.directory? m_dir
+        end
       end
       nil
     end

--- a/activesupport/test/dependencies/foo/bar.rb
+++ b/activesupport/test/dependencies/foo/bar.rb
@@ -1,0 +1,4 @@
+module Foo
+  class Bar
+  end
+end

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -510,6 +510,20 @@ class DependenciesTest < ActiveSupport::TestCase
     end
   end
 
+  def test_file_search_exact_path
+    with_loading 'dependencies/foo' do
+      root = ActiveSupport::Dependencies.autoload_paths.first
+      assert_equal "#{root}/bar.rb", ActiveSupport::Dependencies.search_for_file('foo/bar')
+    end
+  end
+
+  def test_autoloadable_module
+    with_loading 'dependencies/foo' do
+      root = ActiveSupport::Dependencies.autoload_paths.first
+      assert_equal  "#{root}", ActiveSupport::Dependencies.autoloadable_module?('foo')
+    end
+  end
+
   def test_file_search_uses_first_in_load_path
     with_loading 'dependencies', 'autoloading_fixtures' do
       deps, autoload = ActiveSupport::Dependencies.autoload_paths


### PR DESCRIPTION
Normally in rails if you want to add a directory to autoload_paths which is under of the lib directory you have to add whole lib directory to autoload_paths. With this commit we can add only necessary directory into the autoload_paths.
In current behaviour if you add the directory into the autoload_paths like below;

``` ruby
  config.autoload_paths << "#{config.root}/lib/foo"
```

rails can't load the files under the foo directory but now It can.
