### PR TITLE
Test proving that accepts_nested_attributes_for is secure against ID tampering attacks

### DIFF
--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -658,6 +658,16 @@ module NestedAttributesOnACollectionAssociationTests
     assert_equal "Couldn't find #{@child_1.class.name} with ID=1234567890 for Pirate with ID=#{@pirate.id}", exception.message
   end
 
+  def test_should_raise_RecordNotFound_if_an_id_belonging_to_a_different_record_is_given
+    other_pirate = Pirate.create! catchphrase: 'Ahoy!'
+    other_child = other_pirate.send(@association_name).create! name: 'Buccaneers Servant'
+
+    exception = assert_raise ActiveRecord::RecordNotFound do
+      @pirate.attributes = { association_getter => [{ id: other_child.id }] }
+    end
+    assert_equal "Couldn't find #{@child_1.class.name} with ID=#{other_child.id} for Pirate with ID=#{@pirate.id}", exception.message
+  end
+
   def test_should_automatically_build_new_associated_models_for_each_entry_in_a_hash_where_the_id_is_missing
     @pirate.send(@association_name).destroy_all
     @pirate.reload.attributes = {


### PR DESCRIPTION
When using `accepts_nested_attributes_for`, I was worried that the implementation would do the naive thing and look up record by the `id` field when provided. I was worried that attackers could take advantage of that and edit record that they're not supposed to.

I looked at the implementation in `activerecord/lib/active_record/nested_attributes.rb` and saw that my worries were unfounded. I also looked at the tests, and couldn't find a test that checks for this specific misuse case.

This change adds such a test. Given the current implementation, the test is redundant with the one above it. However, I think it's a valuable addition to the codebase, as it provides a safety net in case the `accepts_nested_attributes_for` implementation changes. I'd sleep better at night knowing that this test is watching my back.

So, will you please consider merging this into the test suite?

Thank you very much!
