### PR TITLE
Dry up assets initializer with #tap

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
@@ -1,11 +1,13 @@
 # Be sure to restart your server when you modify this file.
 
-# Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.tap do |assets|
+  # Version of your assets, change this if you want to expire all your assets.
+  assets.version = '1.0'
 
-# Add additional assets to the asset load path
-# Rails.application.config.assets.paths << Emoji.images_path
+  # Add additional assets to the asset load path
+  # assets.paths << Emoji.images_path
 
-# Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+  # Precompile additional assets.
+  # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
+  # assets.precompile += %w( search.js )
+end


### PR DESCRIPTION
I think the use of `#tap` as a pattern should be encouraged in places like this. It tremendously enhances the usability of the configuration file.

Consider this before and after:

``` ruby
# Before
Rails.application.config.assets.version = '1.0'
Rails.application.config.assets.paths << Emoji.images_path
Rails.application.config.assets.precompile += %w( search.js )

# After
Rails.application.config.assets.tap do |assets|
  assets.version = '1.0'
  assets.paths << Emoji.images_path
  assets.precompile += %w( search.js )
end
```
