### PR TITLE
Prevent ActionController::Parameters in url_for

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -67,7 +67,6 @@ module ActionController
     # <tt>ActionController::RedirectBackError</tt>.
     def redirect_to(options = {}, response_status = {}) #:doc:
       raise ActionControllerError.new("Cannot redirect to nil!") unless options
-      raise ActionControllerError.new("Cannot redirect to a parameter hash!") if options.is_a?(ActionController::Parameters)
       raise AbstractController::DoubleRenderError if response_body
 
       self.status        = _extract_redirect_to_status(options, response_status)

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -172,8 +172,11 @@ module ActionDispatch
           _routes.url_for(options.symbolize_keys.reverse_merge!(url_options),
                          route_name)
         when ActionController::Parameters
+          unless options.permitted?
+            raise ArgumentError.new("Generating an URL from non sanitized request parameters is insecure!")
+          end
           route_name = options.delete :use_route
-          _routes.url_for(options.to_unsafe_h.symbolize_keys.
+          _routes.url_for(options.to_h.symbolize_keys.
                           reverse_merge!(url_options), route_name)
         when String
           options

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -273,10 +273,10 @@ class RedirectTest < ActionController::TestCase
   end
 
   def test_redirect_to_params
-    error = assert_raise(ActionController::ActionControllerError) do
+    error = assert_raise(ArgumentError) do
       get :redirect_to_params
     end
-    assert_equal "Cannot redirect to a parameter hash!", error.message
+    assert_equal "Generating an URL from non sanitized request parameters is insecure!", error.message
   end
 
   def test_redirect_to_with_block

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -172,7 +172,7 @@ XML
     before_action { @dynamic_opt = 'opt' }
 
     def test_url_options_reset
-      render plain: url_for(params)
+      render plain: url_for
     end
 
     def default_url_options

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -375,6 +375,13 @@ module AbstractController
         assert_equal({'query[person][position][]' => 'prof'        }.to_query, params[3])
       end
 
+      def test_url_action_controller_parameters
+        add_host!
+        assert_raise(ArgumentError) do
+          W.new.url_for(ActionController::Parameters.new(:controller => 'c', :action => 'a', protocol: 'javascript', f: '%0Aeval(name)'))
+        end
+      end
+
       def test_path_generation_for_symbol_parameter_keys
         assert_generates("/image", :controller=> :image)
       end

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -636,10 +636,6 @@ class UrlHelperControllerTest < ActionController::TestCase
       render inline: "<%= url_for controller: 'url_helper_controller_test/url_helper', action: 'show_url_for' %>"
     end
 
-    def show_overridden_url_for
-      render inline: "<%= url_for params.merge(controller: 'url_helper_controller_test/url_helper', action: 'show_url_for') %>"
-    end
-
     def show_named_route
       render inline: "<%= show_named_route_#{params[:kind]} %>"
     end
@@ -670,11 +666,6 @@ class UrlHelperControllerTest < ActionController::TestCase
 
   def test_url_for_shows_only_path
     get :show_url_for
-    assert_equal '/url_helper_controller_test/url_helper/show_url_for', @response.body
-  end
-
-  def test_overridden_url_for_shows_only_path
-    get :show_overridden_url_for
     assert_equal '/url_helper_controller_test/url_helper/show_url_for', @response.body
   end
 


### PR DESCRIPTION
Similar to https://github.com/rails/rails/commit/341698ed40e023898d9f9d1f5c163d4d2cab4832 but generalized at the `url_for` level. Which mean it it will also protect controllers and `link_to`.

My main concern with this is that there is a coupling issue by referencing `ActionController::Parameters` in the middle of ActionDispatch.

@spastorino @rafaelfranca @arthurnn what do you guys think?

cc @EiNSTeiN- 
