### PR TITLE
Enumerable#index_by speedup without intermediate array

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -33,7 +33,11 @@ module Enumerable
   #     => { "Chade- Fowlersburg-e" => <Person ...>, "David Heinemeier Hansson" => <Person ...>, ...}
   def index_by
     if block_given?
-      Hash[map { |elem| [yield(elem), elem] }]
+      hash = {}
+      each do |elem|
+        hash[yield(elem)] = elem
+      end
+      hash
     else
       to_enum(:index_by) { size if respond_to?(:size) }
     end


### PR DESCRIPTION
Using Hash[map ...] is convenient for constructing an entire hash at once, but it is a bit needless. The intermediate array created by map is immediately discarded by the GC. My patch changes `index_by` to simply create a hash and then iterate over the enumerable, adding keys to it, which is a bit faster (about 20%) and just as readable.

Below is a benchmark you can use to compare:

``` ruby
require 'benchmark/ips'

module Enumerable
  def rails_index_by
    if block_given?
      Hash[map { |elem| [yield(elem), elem] }]
    else
      to_enum(:index_by) { size if respond_to?(:size) }
    end
  end

  def new_index_by
    if block_given?
      hash = {}
      each do |elem|
        hash[yield(elem)] = elem
      end
      hash
    else
      to_enum(:index_by) { size if respond_to?(:size) }
    end
  end
end

arr = (1..10000).to_a.shuffle

Benchmark.ips do |x|
  x.report("rails:")   { arr.rails_index_by &:itself }
  x.report("new:")     { arr.new_index_by   &:itself }
end
```

And sample output on my macbook air:

```
Calculating -------------------------------------
              rails:    21.000  i/100ms
                new:    22.000  i/100ms
-------------------------------------------------
              rails:    218.382  (± 5.5%) i/s -      1.092k
                new:    271.432  (±36.1%) i/s -      1.100k
```

cc my hero, @samsaffron
