### PR TITLE
marking serialization class in Readme

### DIFF
--- a/activemodel/README.rdoc
+++ b/activemodel/README.rdoc
@@ -154,7 +154,7 @@ behavior out of the box:
 
 * Making objects serializable
 
-  ActiveModel::Serialization provides a standard interface for your object
+  <tt>ActiveModel::Serialization</tt> provides a standard interface for your object
   to provide +to_json+ or +to_xml+ serialization.
 
     class SerialPerson


### PR DESCRIPTION
Displaying the `ActiveModel::Serialization` similar as we are displaying other ActiveModel classes in the readme.
