### PR TITLE
[ci skip] Add `bundle exec` to Running a Single Test

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -295,7 +295,7 @@ You can run a single test through ruby. For instance:
 
 ```bash
 $ cd actionmailer
-$ ruby -w -Itest test/mail_layout_test.rb -n test_explicit_class_layout
+$ bundle exec ruby -w -Itest test/mail_layout_test.rb -n test_explicit_class_layout
 ```
 
 The `-n` option allows you to run a single method instead of the whole


### PR DESCRIPTION
BTW should we replace `bundle exec` with `bin/` ?
Ex
- `bundle exec rails` -> `bin/rails`
- `bundle exec rake` -> `bin/rake`
- `bundle exec ruby test` -> `bin/rails test`

if so, I will create another PR :)
