### PR TITLE
fix position of :nodoc: in metal/head [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -53,8 +53,8 @@ module ActionController
     end
 
     private
-    # :nodoc:
-    def include_content?(status)
+
+    def include_content?(status) # :nodoc:
       case status
       when 100..199
         false


### PR DESCRIPTION
Moved the :nodoc: in the same line of the declared method
