### PR TITLE
Allow `pluralize` helper to take a locale.

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -206,6 +206,11 @@ module ActionView
       # +plural+ is supplied, it will use that when count is > 1, otherwise
       # it will use the Inflector to determine the plural form.
       #
+      # If passed an optional +locale:+ parameter, the word will be pluralized
+      # using rules defined for that language (you must define your own
+      # inflection rules for languages other than English).  See
+      # ActiveSupport::Inflector.pluralize
+      #
       #   pluralize(1, 'person')
       #   # => 1 person
       #
@@ -217,11 +222,14 @@ module ActionView
       #
       #   pluralize(0, 'person')
       #   # => 0 people
-      def pluralize(count, singular, plural = nil)
+      #
+      #   pluralize(2, 'Person', locale: :de)
+      #   # => 2 Personen
+      def pluralize(count, singular, plural = nil, locale: nil)
         word = if (count == 1 || count =~ /^1(\.0+)?$/)
           singular
         else
-          plural || singular.pluralize
+          plural || singular.pluralize(locale)
         end
 
         "#{count || 0} #{word}"

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -383,6 +383,18 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("12 berries", pluralize(12, "berry"))
   end
 
+  def test_pluralization_with_locale
+    ActiveSupport::Inflector.inflections(:de) do |inflect|
+      inflect.plural(/(person)$/i, '\1en')
+      inflect.singular(/(person)en$/i, '\1')
+    end
+
+    assert_equal("2 People", pluralize(2, "Person", locale: :en))
+    assert_equal("2 Personen", pluralize(2, "Person", locale: :de))
+
+    ActiveSupport::Inflector.inflections(:de).clear
+  end
+
   def test_cycle_class
     value = Cycle.new("one", 2, "3")
     assert_equal("one", value.to_s)


### PR DESCRIPTION
This is already supported in `ActiveSupport::Inflector#pluralize` and `String#pluralize`, so we just forward the locale.
