### PR TITLE
Do not include column limit in schema.rb if it matches the default

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -61,8 +61,8 @@ module ActiveRecord
       end
 
       def schema_limit(column)
-        limit = column.limit || native_database_types[column.type][:limit]
-        limit.inspect if limit
+        limit = column.limit
+        limit.inspect if limit && limit != native_database_types[column.type][:limit]
       end
 
       def schema_precision(column)

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -118,7 +118,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
       assert_match %r{c_int_4.*}, output
       assert_no_match %r{c_int_4.*limit:}, output
     elsif current_adapter?(:MysqlAdapter, :Mysql2Adapter)
-      assert_match %r{c_int_without_limit.*limit: 4}, output
+      assert_match %r{c_int_without_limit"$}, output
 
       assert_match %r{c_int_1.*limit: 1}, output
       assert_match %r{c_int_2.*limit: 2}, output


### PR DESCRIPTION
When working on engines that supports multiple databases, it's
very annoying to have a different schema.rb output based on which
database you use. MySQL being the primary offender.

This patch should reduce the disparities a bit.

Next on the list could be `using: :btree` for mysql indexes.

cc @rafaelfranca 
