### PR TITLE
Use notification to ensure that lazy-loaded model classes have transactions

### DIFF
--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -341,6 +341,18 @@ module ActiveRecord
         end
       end
 
+      def test_connection_notification_is_called
+        payloads = []
+        subscription = ActiveSupport::Notifications.subscribe('!connection.active_record') do |name, started, finished, unique_id, payload|
+          payloads << payload
+        end
+        ActiveRecord::Base.establish_connection :arunit
+        assert_equal [:class_name, :config, :connection_id], payloads[0].keys.sort
+        assert_equal 'primary', payloads[0][:class_name]
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscription) if subscription
+      end
+
       def test_pool_sets_connection_schema_cache
         connection = pool.checkout
         schema_cache = SchemaCache.new connection


### PR DESCRIPTION
See #17776

In Rails 4 `config.eager_load` was changed to `false` in the test environment. This
means that model classes that connect to alternate databases with
`establish_connection` are not loaded at start up. If `use_transactional_fixtures`
is enabled for tests, transactions are wrapped around the connections that have been
established _only at the start of the test suite_. So model classes loaded later
don't have transactions, causing data created in the alternate database not to
be removed.

This change resolves that by creating a new `!connection.active_record`
notification that gets fired whenever a connection is established. I then added
a subscriber after we set up transactions in the test environment to listen for
additional connections and wrap those in transactions as well.
