### PR TITLE
remove `web-console` from API app generated Gemfile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -36,13 +36,15 @@ group :development, :test do
 end
 
 group :development do
+<%- unless options.api? -%>
   # Access an IRB console on exception pages or by using <%%= console %> in views
   <%- if options.dev? || options.edge? -%>
   gem 'web-console', github: 'rails/web-console'
   <%- else -%>
   gem 'web-console', '~> 2.0'
   <%- end -%>
-<%- if spring_install? %>
+<%- end -%>
+<% if spring_install? -%>
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 <% end -%>

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -38,6 +38,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
       assert_no_match(/gem 'jquery-rails'/, content)
       assert_no_match(/gem 'sass-rails'/, content)
       assert_no_match(/gem 'jbuilder'/, content)
+      assert_no_match(/gem 'web-console'/, content)
       assert_match(/gem 'active_model_serializers'/, content)
     end
 


### PR DESCRIPTION
Since there is no views in the API-only application, `web-console` I think unnecessary.
