### PR TITLE
make difference more clear between save and save! in doc

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -100,15 +100,15 @@ module ActiveRecord
       !(@new_record || @destroyed)
     end
 
-    # Saves the model.
-    #
-    # If the model is new a record gets created in the database, otherwise
-    # the existing record gets updated.
+    # Attempts to save the model.
     #
     # By default, save always run validations. If any of them fail the action
     # is cancelled and +save+ returns +false+. However, if you supply
     # validate: false, validations are bypassed altogether. See
     # ActiveRecord::Validations for more information.
+    #
+    # If the model is new a record gets created in the database, otherwise
+    # the existing record gets updated.
     #
     # By default, #save also sets the +updated_at+/+updated_on+ attributes to
     # the current time. However, if you supply <tt>touch: false</tt>, these


### PR DESCRIPTION
adapts changes proposed at https://groups.google.com/forum/#!topic/rubyonrails-core/Py9x8rLaxgQ.
related to #20662.

changes the documentation of `save` by adding "attempts" to the first paragraph and setting the paragraph about "validations can abort the action" as the second paragraph.
