### PR TITLE
fix regression caused by 52fddc

### DIFF
--- a/activerecord/lib/active_record/type/integer.rb
+++ b/activerecord/lib/active_record/type/integer.rb
@@ -17,7 +17,7 @@ module ActiveRecord
       end
 
       def deserialize(value)
-        cast_value(value)
+        cast_value(value) unless value.nil?
       end
 
       def serialize(value)

--- a/activerecord/lib/active_record/type/integer.rb
+++ b/activerecord/lib/active_record/type/integer.rb
@@ -17,8 +17,7 @@ module ActiveRecord
       end
 
       def deserialize(value)
-        return if value.nil?
-        value.to_i
+        cast_value(value)
       end
 
       def serialize(value)

--- a/activerecord/lib/active_record/type/integer.rb
+++ b/activerecord/lib/active_record/type/integer.rb
@@ -16,10 +16,6 @@ module ActiveRecord
         :integer
       end
 
-      def deserialize(value)
-        cast_value(value) unless value.nil?
-      end
-
       def serialize(value)
         result = cast(value)
         if result

--- a/activerecord/test/cases/type/integer_test.rb
+++ b/activerecord/test/cases/type/integer_test.rb
@@ -47,6 +47,12 @@ module ActiveRecord
         assert_equal 0, type.serialize(false)
       end
 
+      test "casting booleans from database" do
+        type = Type::Integer.new
+        assert_equal 1, type.deserialize(true)
+        assert_equal 0, type.deserialize(false)
+      end
+
       test "changed?" do
         type = Type::Integer.new
 


### PR DESCRIPTION
https://github.com/rails/rails/commit/52fddcc653458456f98b3683dffd781cf00b35fe short circuited the call to value.rb::type_cast_from_database (now value.rb::deserialize). In doing so this reintroduced the issue fixed by https://github.com/rails/rails/commit/3525a9b5ebc87bbc9dca4b613b6d3740899190bb

found when investigating https://github.com/rails/rails/issues/18964
