### PR TITLE
Refactored the enqueue methods for delayed supporting backends

### DIFF
--- a/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
@@ -14,7 +14,7 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :backburner
     class BackburnerAdapter
       def enqueue(job) #:nodoc:
-        Backburner::Worker.enqueue JobWrapper, [ job.serialize ], queue: job.queue_name
+        enqueue_at(job, Time.now.to_f)
       end
 
       def enqueue_at(job, timestamp) #:nodoc:

--- a/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
@@ -14,12 +14,15 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :backburner
     class BackburnerAdapter
       def enqueue(job) #:nodoc:
-        enqueue_at(job, Time.now.to_f)
+        enqueue_at(job)
       end
 
-      def enqueue_at(job, timestamp) #:nodoc:
-        delay = timestamp - Time.current.to_f
-        Backburner::Worker.enqueue JobWrapper, [ job.serialize ], queue: job.queue_name, delay: delay
+      def enqueue_at(job, timestamp = nil) #:nodoc:
+        options = {}
+        options[:queue] = job.queue_name
+        options[:delay] = timestamp = Time.current.to_f unless timestamp.nil?
+
+        Backburner::Worker.enqueue JobWrapper, [ job.serialize ], options
       end
 
       class JobWrapper #:nodoc:

--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -14,9 +14,7 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :delayed_job
     class DelayedJobAdapter
       def enqueue(job) #:nodoc:
-        delayed_job = Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name)
-        job.provider_job_id = delayed_job.id
-        delayed_job
+        enqueue_at(job, Time.now)
       end
 
       def enqueue_at(job, timestamp) #:nodoc:

--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -14,11 +14,15 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :delayed_job
     class DelayedJobAdapter
       def enqueue(job) #:nodoc:
-        enqueue_at(job, Time.now)
+        enqueue_at(job)
       end
 
-      def enqueue_at(job, timestamp) #:nodoc:
-        delayed_job = Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name, run_at: Time.at(timestamp))
+      def enqueue_at(job, timestamp = nil) #:nodoc:
+        options = {}
+        options[:queue] = job.queue_name
+        options[:run_at] = Time.at(timestamp) unless timestamp.nil?
+        delayed_job = Delayed::Job.enqueue(JobWrapper.new(job.serialize), options)
+
         job.provider_job_id = delayed_job.id
         delayed_job
       end

--- a/activejob/lib/active_job/queue_adapters/que_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/que_adapter.rb
@@ -16,11 +16,14 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :que
     class QueAdapter
       def enqueue(job) #:nodoc:
-        enqueue_at(job, Time.now)
+        enqueue_at(job)
       end
 
-      def enqueue_at(job, timestamp) #:nodoc:
-        que_job = JobWrapper.enqueue job.serialize, run_at: Time.at(timestamp)
+      def enqueue_at(job, timestamp = nil) #:nodoc:
+        options = {}
+        options[:run_at] = Time.at(timestamp) unless timestamp.nil?
+
+        que_job = JobWrapper.enqueue job.serialize, options
         job.provider_job_id = que_job.attrs["job_id"]
         que_job
       end

--- a/activejob/lib/active_job/queue_adapters/que_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/que_adapter.rb
@@ -16,9 +16,7 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :que
     class QueAdapter
       def enqueue(job) #:nodoc:
-        que_job = JobWrapper.enqueue job.serialize
-        job.provider_job_id = que_job.attrs["job_id"]
-        que_job
+        enqueue_at(job, Time.now)
       end
 
       def enqueue_at(job, timestamp) #:nodoc:

--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -16,12 +16,7 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :sidekiq
     class SidekiqAdapter
       def enqueue(job) #:nodoc:
-        #Sidekiq::Client does not support symbols as keys
-        job.provider_job_id = Sidekiq::Client.push \
-          'class'   => JobWrapper,
-          'wrapped' => job.class.to_s,
-          'queue'   => job.queue_name,
-          'args'    => [ job.serialize ]
+        enqueue_at(job, Time.now.to_f)
       end
 
       def enqueue_at(job, timestamp) #:nodoc:

--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -16,16 +16,18 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :sidekiq
     class SidekiqAdapter
       def enqueue(job) #:nodoc:
-        enqueue_at(job, Time.now.to_f)
+        enqueue_at(job)
       end
 
-      def enqueue_at(job, timestamp) #:nodoc:
-        job.provider_job_id = Sidekiq::Client.push \
-          'class'   => JobWrapper,
-          'wrapped' => job.class.to_s,
-          'queue'   => job.queue_name,
-          'args'    => [ job.serialize ],
-          'at'      => timestamp
+      def enqueue_at(job, timestamp = nil) #:nodoc:
+        options = {}
+        options['class'] = JobWrapper
+        options['wrapped'] = job.class.to_s
+        options['queue'] = job.queue_name
+        options['args'] = [ job.serialize]
+        options['at'] = timestamp unless timestamp.nil?
+
+        job.provider_job_id = Sidekiq::Client.push options
       end
 
       class JobWrapper #:nodoc:


### PR DESCRIPTION
The backends that support `enqueue_at` do have a lot of duplication in
behaviour. We can use the `enqueue_at` method in the `enqueue` but with the
current time to make sure the job is directly ran.

@seuros I'm not sure if this falls under the "we merge no cosmetic changes". If so, feel free to close!
