### PR TITLE
Require yaml for time_with_zone isolation test

### DIFF
--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -2,6 +2,7 @@ require 'abstract_unit'
 require 'active_support/time'
 require 'time_zone_test_helpers'
 require 'active_support/core_ext/string/strip'
+require 'yaml'
 
 class TimeWithZoneTest < ActiveSupport::TestCase
   include TimeZoneTestHelpers


### PR DESCRIPTION
Same fix as 109e71d2bb6d2305a091fe7ea96d4f6e9c7cd52d but after mocha got removed in 2f28e5b6417fd4e5d6060983b36262737558b613.
