### PR TITLE
Check if default is a hash rather than checking if it responds to merge

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -321,7 +321,7 @@ module ActionDispatch # :nodoc:
     end
 
     def merge_default_headers(original, default)
-      default.respond_to?(:merge) ? default.merge(original) : original
+      default.is_a?(Hash) ? default.merge(original) : original
     end
 
     def build_buffer(response, body)


### PR DESCRIPTION
This fixes scenarios where objects (such as nil) have the 'merge' method defined for other reasons. In this situation, the CanCan gem had defined merge: https://github.com/CanCanCommunity/cancancan/issues/229. It is debatable whether cancan or rails is 'at fault' here, but checking if default is a hash feels more correct based on my understanding of the intended behavior.

If you'd like for a test to be added just let me know.

This fixes https://github.com/rails/rails/issues/20837
