### PR TITLE
Removes unnecessary comments from i18n validations tests [ci skip]

### DIFF
--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -55,8 +55,6 @@ class I18nValidationTest < ActiveModel::TestCase
     [ "given option that is not reserved", { format: "jpg" },             { format: "jpg" }]
   ]
 
-  # validates_confirmation_of w/ mocks
-
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_confirmation_of on generated message #{name}" do
       Person.validates_confirmation_of :title, validation_options
@@ -68,8 +66,6 @@ class I18nValidationTest < ActiveModel::TestCase
     end
   end
 
-  # validates_acceptance_of w/ mocks
-
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_acceptance_of on generated message #{name}" do
       Person.validates_acceptance_of :title, validation_options.merge(allow_nil: false)
@@ -79,8 +75,6 @@ class I18nValidationTest < ActiveModel::TestCase
       end
     end
   end
-
-  # validates_presence_of w/ mocks
 
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_presence_of on generated message #{name}" do
@@ -92,8 +86,6 @@ class I18nValidationTest < ActiveModel::TestCase
     end
   end
 
-  # validates_length_of :within too short w/ mocks
-
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_length_of for :within on generated message when too short #{name}" do
       Person.validates_length_of :title, validation_options.merge(within: 3..5)
@@ -103,8 +95,6 @@ class I18nValidationTest < ActiveModel::TestCase
       end
     end
   end
-
-  # validates_length_of :within too long w/ mocks
 
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_length_of for :too_long generated message #{name}" do
@@ -117,8 +107,6 @@ class I18nValidationTest < ActiveModel::TestCase
     end
   end
 
-  # validates_length_of :is w/ mocks
-
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_length_of for :is on generated message #{name}" do
       Person.validates_length_of :title, validation_options.merge(is: 5)
@@ -128,8 +116,6 @@ class I18nValidationTest < ActiveModel::TestCase
       end
     end
   end
-
-  # validates_format_of w/ mocks
 
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_format_of on generated message #{name}" do
@@ -142,8 +128,6 @@ class I18nValidationTest < ActiveModel::TestCase
     end
   end
 
-  # validates_inclusion_of w/ mocks
-
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_inclusion_of on generated message #{name}" do
       Person.validates_inclusion_of :title, validation_options.merge(in: %w(a b c))
@@ -154,8 +138,6 @@ class I18nValidationTest < ActiveModel::TestCase
       end
     end
   end
-
-  # validates_inclusion_of using :within w/ mocks
 
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_inclusion_of using :within on generated message #{name}" do
@@ -168,8 +150,6 @@ class I18nValidationTest < ActiveModel::TestCase
     end
   end
 
-  # validates_exclusion_of w/ mocks
-
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_exclusion_of generated message #{name}" do
       Person.validates_exclusion_of :title, validation_options.merge(in: %w(a b c))
@@ -180,8 +160,6 @@ class I18nValidationTest < ActiveModel::TestCase
       end
     end
   end
-
-  # validates_exclusion_of using :within w/ mocks
 
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_exclusion_of using :within generated message #{name}" do
@@ -194,8 +172,6 @@ class I18nValidationTest < ActiveModel::TestCase
     end
   end
 
-  # validates_numericality_of without :only_integer w/ mocks
-
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_numericality_of generated message #{name}" do
       Person.validates_numericality_of :title, validation_options
@@ -206,8 +182,6 @@ class I18nValidationTest < ActiveModel::TestCase
       end
     end
   end
-
-  # validates_numericality_of with :only_integer w/ mocks
 
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_numericality_of for :only_integer on generated message #{name}" do
@@ -220,8 +194,6 @@ class I18nValidationTest < ActiveModel::TestCase
     end
   end
 
-  # validates_numericality_of :odd w/ mocks
-
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_numericality_of for :odd on generated message #{name}" do
       Person.validates_numericality_of :title, validation_options.merge(only_integer: true, odd: true)
@@ -232,8 +204,6 @@ class I18nValidationTest < ActiveModel::TestCase
       end
     end
   end
-
-  # validates_numericality_of :less_than w/ mocks
 
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_numericality_of for :less_than on generated message #{name}" do
@@ -246,15 +216,14 @@ class I18nValidationTest < ActiveModel::TestCase
     end
   end
 
-
-  # To make things DRY this macro is defined to define 3 tests for every validation case.
+  # To make things DRY this macro is created to define 3 tests for every validation case.
   def self.set_expectations_for_validation(validation, error_type, &block_that_sets_validation)
     if error_type == :confirmation
       attribute = :title_confirmation
     else
       attribute = :title
     end
-    # test "validates_confirmation_of finds custom model key translation when blank"
+
     test "#{validation} finds custom model key translation when #{error_type}" do
       I18n.backend.store_translations 'en', activemodel: { errors: { models: { person: { attributes: { attribute => { error_type => 'custom message' } } } } } }
       I18n.backend.store_translations 'en', errors: { messages: { error_type => 'global message'}}
@@ -264,7 +233,6 @@ class I18nValidationTest < ActiveModel::TestCase
       assert_equal ['custom message'], @person.errors[attribute]
     end
 
-    # test "validates_confirmation_of finds custom model key translation with interpolation when blank"
     test "#{validation} finds custom model key translation with interpolation when #{error_type}" do
       I18n.backend.store_translations 'en', activemodel: { errors: { models: { person: { attributes: { attribute => { error_type => 'custom message with %{extra}' } } } } } }
       I18n.backend.store_translations 'en', errors: { messages: {error_type => 'global message'} }
@@ -274,7 +242,6 @@ class I18nValidationTest < ActiveModel::TestCase
       assert_equal ['custom message with extra information'], @person.errors[attribute]
     end
 
-    # test "validates_confirmation_of finds global default key translation when blank"
     test "#{validation} finds global default key translation when #{error_type}" do
       I18n.backend.store_translations 'en', errors: { messages: {error_type => 'global message'} }
 
@@ -284,26 +251,18 @@ class I18nValidationTest < ActiveModel::TestCase
     end
   end
 
-  # validates_confirmation_of w/o mocks
-
   set_expectations_for_validation "validates_confirmation_of", :confirmation do |person, options_to_merge|
     Person.validates_confirmation_of :title, options_to_merge
     person.title_confirmation = 'foo'
   end
 
-  # validates_acceptance_of w/o mocks
-
   set_expectations_for_validation "validates_acceptance_of", :accepted do |person, options_to_merge|
     Person.validates_acceptance_of :title, options_to_merge.merge(allow_nil: false)
   end
 
-  # validates_presence_of w/o mocks
-
   set_expectations_for_validation "validates_presence_of", :blank do |person, options_to_merge|
     Person.validates_presence_of :title, options_to_merge
   end
-
-  # validates_length_of :within w/o mocks
 
   set_expectations_for_validation "validates_length_of", :too_short do |person, options_to_merge|
     Person.validates_length_of :title, options_to_merge.merge(within: 3..5)
@@ -314,60 +273,42 @@ class I18nValidationTest < ActiveModel::TestCase
     person.title = "too long"
   end
 
-  # validates_length_of :is w/o mocks
-
   set_expectations_for_validation "validates_length_of", :wrong_length do |person, options_to_merge|
     Person.validates_length_of :title, options_to_merge.merge(is: 5)
   end
-
-  # validates_format_of w/o mocks
 
   set_expectations_for_validation "validates_format_of", :invalid do |person, options_to_merge|
     Person.validates_format_of :title, options_to_merge.merge(with: /\A[1-9][0-9]*\z/)
   end
 
-  # validates_inclusion_of w/o mocks
-
   set_expectations_for_validation "validates_inclusion_of", :inclusion do |person, options_to_merge|
     Person.validates_inclusion_of :title, options_to_merge.merge(in: %w(a b c))
   end
-
-  # validates_exclusion_of w/o mocks
 
   set_expectations_for_validation "validates_exclusion_of", :exclusion do |person, options_to_merge|
     Person.validates_exclusion_of :title, options_to_merge.merge(in: %w(a b c))
     person.title = 'a'
   end
 
-  # validates_numericality_of without :only_integer w/o mocks
-
   set_expectations_for_validation "validates_numericality_of", :not_a_number do |person, options_to_merge|
     Person.validates_numericality_of :title, options_to_merge
     person.title = 'a'
   end
-
-  # validates_numericality_of with :only_integer w/o mocks
 
   set_expectations_for_validation "validates_numericality_of", :not_an_integer do |person, options_to_merge|
     Person.validates_numericality_of :title, options_to_merge.merge(only_integer: true)
     person.title = '1.0'
   end
 
-  # validates_numericality_of :odd w/o mocks
-
   set_expectations_for_validation "validates_numericality_of", :odd do |person, options_to_merge|
     Person.validates_numericality_of :title, options_to_merge.merge(only_integer: true, odd: true)
     person.title = 0
   end
 
-  # validates_numericality_of :less_than w/o mocks
-
   set_expectations_for_validation "validates_numericality_of", :less_than do |person, options_to_merge|
     Person.validates_numericality_of :title, options_to_merge.merge(only_integer: true, less_than: 0)
     person.title = 1
   end
-
-  # test with validates_with
 
   def test_validations_with_message_symbol_must_translate
     I18n.backend.store_translations 'en', errors: { messages: { custom_error: "I am a custom error" } }


### PR DESCRIPTION
These comments do not add a lot to the readability, grepability or
overall understanding of the tests, therefore I believe they can be
safely removed.
