### PR TITLE
Fix undefined method error on exception

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -23,7 +23,7 @@ module ActiveRecord
         end
       rescue error_class => error
         if error.respond_to?(:errno) && error.errno == ACCESS_DENIED_ERROR
-          $stdout.print error.error
+          $stdout.print error.message
           establish_connection root_configuration_without_database
           connection.create_database configuration['database'], creation_options
           if configuration['username'] != 'root'


### PR DESCRIPTION
The `error` method is not defined, in general, for exceptions. Instead,
print the exception message. This error was hiding actual meaningful DB
configuration errors. See http://stackoverflow.com/questions/18774463.
