### PR TITLE
Fix misleading errors for has_one through relations

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -61,10 +61,16 @@ module ActiveRecord
     end
   end
 
-  class HasManyThroughCantAssociateThroughHasOneOrManyReflection < ActiveRecordError #:nodoc:
+  class ThroughCantAssociateThroughHasOneOrManyReflection < ActiveRecordError #:nodoc:
     def initialize(owner, reflection)
       super("Cannot modify association '#{owner.class.name}##{reflection.name}' because the source reflection class '#{reflection.source_reflection.class_name}' is associated to '#{reflection.through_reflection.class_name}' via :#{reflection.source_reflection.macro}.")
     end
+  end
+
+  class HasManyThroughCantAssociateThroughHasOneOrManyReflection < ThroughCantAssociateThroughHasOneOrManyReflection #:nodoc:
+  end
+
+  class HasOneThroughCantAssociateThroughHasOneOrManyReflection < ThroughCantAssociateThroughHasOneOrManyReflection #:nodoc:
   end
 
   class HasManyThroughCantAssociateNewRecords < ActiveRecordError #:nodoc:
@@ -79,10 +85,16 @@ module ActiveRecord
     end
   end
 
-  class HasManyThroughNestedAssociationsAreReadonly < ActiveRecordError #:nodoc:
+  class ThroughNestedAssociationsAreReadonly < ActiveRecordError #:nodoc:
     def initialize(owner, reflection)
       super("Cannot modify association '#{owner.class.name}##{reflection.name}' because it goes through more than one other association.")
     end
+  end
+
+  class HasManyThroughNestedAssociationsAreReadonly < ThroughNestedAssociationsAreReadonly #:nodoc:
+  end
+
+  class HasOneThroughNestedAssociationsAreReadonly < ThroughNestedAssociationsAreReadonly #:nodoc:
   end
 
   class EagerLoadPolymorphicError < ActiveRecordError #:nodoc:

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -76,13 +76,21 @@ module ActiveRecord
 
         def ensure_mutable
           unless source_reflection.belongs_to?
-            raise HasManyThroughCantAssociateThroughHasOneOrManyReflection.new(owner, reflection)
+            if reflection.has_one?
+              raise HasOneThroughCantAssociateThroughHasOneOrManyReflection.new(owner, reflection)
+            else
+              raise HasManyThroughCantAssociateThroughHasOneOrManyReflection.new(owner, reflection)
+            end
           end
         end
 
         def ensure_not_nested
           if reflection.nested?
-            raise HasManyThroughNestedAssociationsAreReadonly.new(owner, reflection)
+            if reflection.has_one?
+              raise HasOneThroughNestedAssociationsAreReadonly.new(owner, reflection)
+            else
+              raise HasManyThroughNestedAssociationsAreReadonly.new(owner, reflection)
+            end
           end
         end
 

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -352,4 +352,11 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
 
     assert_deprecated { member.club(true) }
   end
+
+  def test_has_one_through_associations_are_mutable_unless_through_belongs_to
+    member_detail = MemberDetail.new(member: @member)
+    assert_raise(ActiveRecord::HasOneThroughCantAssociateThroughHasOneOrManyReflection) do
+      member_detail.membership = Membership.new
+    end
+  end
 end

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -495,7 +495,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
     groucho = members(:groucho)
     founding = member_types(:founding)
 
-    assert_raises(ActiveRecord::HasManyThroughNestedAssociationsAreReadonly) do
+    assert_raises(ActiveRecord::HasOneThroughNestedAssociationsAreReadonly) do
       groucho.nested_member_type = founding
     end
   end

--- a/activerecord/test/models/member_detail.rb
+++ b/activerecord/test/models/member_detail.rb
@@ -1,7 +1,8 @@
 class MemberDetail < ActiveRecord::Base
-  belongs_to :member, :inverse_of => false
+  belongs_to :member, inverse_of: false
   belongs_to :organization
-  has_one :member_type, :through => :member
+  has_one :member_type, through: :member
+  has_one :membership, through: :member
 
-  has_many :organization_member_details, :through => :organization, :source => :member_details
+  has_many :organization_member_details, through: :organization, source: :member_details
 end


### PR DESCRIPTION
has_one though associations can raise `HasManyThroughCantAssociateThroughHasOneOrManyReflection` and `HasManyThroughNestedAssociationsAreReadonly` exceptions. These should be `HasOneThroughCantAssociateThroughHasOneOrManyReflection` and `HasOneThroughNestedAssociationsAreReadonly`. Also I've added a test case which covers changing has_one through association raises exception if association is not goes through belongs_to association.
