### PR TITLE
Fix for accessing nested through association on new object

### DIFF
--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -71,7 +71,15 @@ module ActiveRecord
         end
 
         def foreign_key_present?
-          through_reflection.belongs_to? && !owner[through_reflection.foreign_key].nil?
+          (through_reflection.belongs_to? && !owner[through_reflection.foreign_key].nil?) ||
+            recursive_through_foreign_key_present?(through_reflection.through_reflection)
+        end
+
+        def recursive_through_foreign_key_present?(th_reflection)
+          return false if th_reflection.nil?
+
+          (th_reflection.belongs_to? && !owner[th_reflection.foreign_key].nil?) ||
+            recursive_through_foreign_key_present?(th_reflection.through_reflection)
         end
 
         def ensure_mutable

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -6,6 +6,8 @@ require 'models/reference'
 require 'models/job'
 require 'models/reader'
 require 'models/comment'
+require 'models/comment_reply'
+require 'models/comment_subreply'
 require 'models/tag'
 require 'models/tagging'
 require 'models/subscriber'
@@ -125,6 +127,14 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   # Through: has_one through
   def test_has_many_through_has_one_through_with_has_one_source_reflection
     assert_equal [sponsors(:moustache_club_sponsor_for_groucho)], members(:groucho).nested_sponsors
+  end
+
+  def test_nested_through_associations_on_new_record
+    comment = comments(:greetings)
+    comment_reply = CommentReply.create!(comment: comment)
+    comment_subreply = CommentSubreply.new(comment_reply: comment_reply)
+
+    assert_equal comment.post, comment_subreply.post
   end
 
   def test_has_many_through_has_one_through_with_has_one_source_reflection_preload

--- a/activerecord/test/models/comment_reply.rb
+++ b/activerecord/test/models/comment_reply.rb
@@ -1,0 +1,5 @@
+class CommentReply < ActiveRecord::Base
+  belongs_to :comment
+
+  has_many :comment_subreplies
+end

--- a/activerecord/test/models/comment_subreply.rb
+++ b/activerecord/test/models/comment_subreply.rb
@@ -1,0 +1,6 @@
+class CommentSubreply < ActiveRecord::Base
+  belongs_to :comment_reply
+
+  has_one :comment, through: :comment_reply
+  has_one :post, through: :comment
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -190,6 +190,14 @@ ActiveRecord::Schema.define do
     t.integer :developer_id
   end
 
+  create_table :comment_replies, force: true do |t|
+    t.references :comment
+  end
+
+  create_table :comment_subreplies, force: true do |t|
+    t.references :comment_reply
+  end
+
   create_table :companies, force: true do |t|
     t.string  :type
     t.integer :firm_id


### PR DESCRIPTION
Fix for #20827 
The idea is try to access belongs_to association through `through` associations.
