### PR TITLE
Give Sessions Indifferent Access

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Update session to have indifferent access across multiple requests
+
+        session[:deep][:hash] = "Magic"
+
+        session[:deep][:hash] == "Magic"
+        session[:deep]["hash"] == "Magic"
+
+    *Tom Prats*
+
 *   Response etags to always be weak: Prefixes 'W/' to value returned by
    `ActionDispatch::Http::Cache::Response#etag=`, such that etags set in
    `fresh_when` and `stale?` are weak.

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -165,7 +165,7 @@ module ActionController
     def initialize(session = {})
       super(nil, nil)
       @id = SecureRandom.hex(16)
-      @data = stringify_keys(session)
+      @data = session.with_indifferent_access
       @loaded = true
     end
 

--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -9,7 +9,7 @@ module ActionDispatch
 
       # Singleton object used to determine if an optional param wasn't specified
       Unspecified = Object.new
-      
+
       # Creates a session hash, merging the properties of the previous session if any
       def self.create(store, req, default_options)
         session_was = find req
@@ -61,7 +61,7 @@ module ActionDispatch
       def initialize(by, req)
         @by       = by
         @req      = req
-        @delegate = {}
+        @delegate = {}.with_indifferent_access
         @loaded   = false
         @exists   = nil # we haven't checked yet
       end

--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -88,13 +88,13 @@ module ActionDispatch
       # nil if the given key is not found in the session.
       def [](key)
         load_for_read!
-        @delegate[key.to_s]
+        @delegate[key]
       end
 
       # Returns true if the session has the given key or false.
       def has_key?(key)
         load_for_read!
-        @delegate.key?(key.to_s)
+        @delegate.key?(key)
       end
       alias :key? :has_key?
       alias :include? :has_key?
@@ -112,7 +112,7 @@ module ActionDispatch
       # Writes given value to given key of the session.
       def []=(key, value)
         load_for_write!
-        @delegate[key.to_s] = value
+        @delegate[key] = value
       end
 
       # Clears the session.
@@ -139,13 +139,13 @@ module ActionDispatch
       #   # => {"session_id"=>"e29b9ea315edf98aad94cc78c34cc9b2", "foo" => "bar"}
       def update(hash)
         load_for_write!
-        @delegate.update stringify_keys(hash)
+        @delegate.update hash
       end
 
       # Deletes given key from the session.
       def delete(key)
         load_for_write!
-        @delegate.delete key.to_s
+        @delegate.delete key
       end
 
       # Returns value of the given key from the session, or raises +KeyError+
@@ -165,9 +165,9 @@ module ActionDispatch
       def fetch(key, default=Unspecified, &block)
         load_for_read!
         if default == Unspecified
-          @delegate.fetch(key.to_s, &block)
+          @delegate.fetch(key, &block)
         else
-          @delegate.fetch(key.to_s, default, &block)
+          @delegate.fetch(key, default, &block)
         end
       end
 
@@ -211,14 +211,8 @@ module ActionDispatch
       def load!
         id, session = @by.load_session @req
         options[:id] = id
-        @delegate.replace(stringify_keys(session))
+        @delegate.replace(session)
         @loaded = true
-      end
-
-      def stringify_keys(other)
-        other.each_with_object({}) { |(key, value), hash|
-          hash[key.to_s] = value
-        }
       end
     end
   end

--- a/actionpack/test/dispatch/request/session_test.rb
+++ b/actionpack/test/dispatch/request/session_test.rb
@@ -105,6 +105,16 @@ module ActionDispatch
         end
       end
 
+      def test_with_indifferent_access
+        s = Session.create(store, req, {})
+
+        s[:one] = { test: "deep" }
+        s[:two] = { "test" => "deep" }
+
+        assert_equal 'deep', s[:one]["test"]
+        assert_equal 'deep', s[:two][:test]
+      end
+
       private
       def store
         Class.new {

--- a/actionpack/test/dispatch/request/session_test.rb
+++ b/actionpack/test/dispatch/request/session_test.rb
@@ -105,7 +105,7 @@ module ActionDispatch
         end
       end
 
-      def test_with_indifferent_access
+      def test_indifferent_access
         s = Session.create(store, req, {})
 
         s[:one] = { test: "deep" }

--- a/actionpack/test/dispatch/session/abstract_store_test.rb
+++ b/actionpack/test/dispatch/session/abstract_store_test.rb
@@ -46,6 +46,22 @@ module ActionDispatch
         assert_equal session.to_hash, session1.to_hash
       end
 
+      def test_previous_session_has_indifferent_access
+        env = {}
+        as = MemoryStore.new app
+        as.call(env)
+
+        assert @env
+        session = Request::Session.find ActionDispatch::Request.new @env
+        session[:foo] = { bar: "baz" }
+
+        as.call(@env)
+        session = Request::Session.find ActionDispatch::Request.new @env
+
+        assert_equal session[:foo][:bar], "baz"
+        assert_equal session[:foo]["bar"], "baz"
+      end
+
       private
       def app(&block)
         @env = nil

--- a/actionpack/test/dispatch/session/cache_store_test.rb
+++ b/actionpack/test/dispatch/session/cache_store_test.rb
@@ -12,6 +12,11 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
       head :ok
     end
 
+    def set_deep_session_value
+      session[:foo] = { bar: "baz" }
+      head :ok
+    end
+
     def set_serialized_session_value
       session[:foo] = SessionAutoloadTest::Foo.new
       head :ok
@@ -19,6 +24,14 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
 
     def get_session_value
       render plain: "foo: #{session[:foo].inspect}"
+    end
+
+    def get_deep_session_value_with_symbol
+      render plain: "foo: { bar: #{session[:foo][:bar].inspect} }"
+    end
+
+    def get_deep_session_value_with_string
+      render plain: "foo: { \"bar\" => #{session[:foo]["bar"].inspect} }"
     end
 
     def get_session_id
@@ -157,6 +170,22 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
       assert_not_equal '0xhax', cookies['_session_id']
       assert_equal nil, @cache.read('_session_id:0xhax')
       assert_equal({'foo' => 'bar'}, @cache.read("_session_id:#{cookies['_session_id']}"))
+    end
+  end
+
+  def test_previous_session_has_indifferent_access
+    with_test_route_set do
+      get '/set_deep_session_value'
+      assert_response :success
+      assert cookies['_session_id']
+
+      get '/get_deep_session_value_with_symbol'
+      assert_response :success
+      assert_equal 'foo: { bar: "baz" }', response.body
+
+      get '/get_deep_session_value_with_string'
+      assert_response :success
+      assert_equal 'foo: { "bar" => "baz" }', response.body
     end
   end
 

--- a/actionpack/test/dispatch/session/test_session_test.rb
+++ b/actionpack/test/dispatch/session/test_session_test.rb
@@ -60,4 +60,11 @@ class ActionController::TestSessionTest < ActiveSupport::TestCase
     session = ActionController::TestSession.new(one: '1')
     assert_equal(2, session.fetch('2') { |key| key.to_i })
   end
+
+  def test_fetch_returns_indifferent_access
+    session = ActionController::TestSession.new(three: { two: '1' })
+    three = session.fetch(:three)
+    assert_equal('1', three[:two])
+    assert_equal('1', three["two"])
+  end
 end


### PR DESCRIPTION
I noticed that sessions don't seem to have indifferent access like params do, at least at a deeper level when being accessed on a later request. 

All I could really find about it was this old post about it, although that specific part might work now, at a deeper level of the hash it still doesn't

https://www.ruby-forum.com/topic/56090
