### PR TITLE
fix typo in caching guide [ci skip]

### DIFF
--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -122,7 +122,7 @@ For example, take the following view:
 Which in turn renders this view:
 
 ```erb
-<% cache game %>
+<% cache game do %>
   <%= render game %>
 <% end %>
 ```


### PR DESCRIPTION
Just added missing `do` keyword.
