### PR TITLE
Adds a grammatical fix to the Rails guide on Asset pipeline [ci skip]

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -537,7 +537,7 @@ web server.
 
 Additional layers of preprocessing can be requested by adding other extensions,
 where each extension is processed in a right-to-left manner. These should be
-used in the order the processing should be applied. For example, a stylesheet
+used in the order in which the processing should be applied. For example, a stylesheet
 called `app/assets/stylesheets/projects.scss.erb` is first processed as ERB,
 then SCSS, and finally served as CSS. The same applies to a JavaScript file -
 `app/assets/javascripts/projects.coffee.erb` is processed as ERB, then


### PR DESCRIPTION
**Additional information**
- The additional wording in order to make the sentence more meaningful has been introduced wrt [Preprocessing section](http://guides.rubyonrails.org/asset_pipeline.html#preprocessing) of the [Rails guides on Asset Pipeline](http://guides.rubyonrails.org/asset_pipeline.html)
