### PR TITLE
Improve MethodCallAssertions to support more cases

### DIFF
--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -5,7 +5,7 @@ module ActiveSupport
         def assert_called(object, method_name, message = nil, times: 1)
           times_called = 0
 
-          object.stub(method_name, -> { times_called += 1 }) { yield }
+          object.stub(method_name, ->(*args) { times_called += 1 }) { yield }
 
           error = "Expected #{method_name} to be called #{times} times, " \
             "but was called #{times_called} times"
@@ -13,11 +13,18 @@ module ActiveSupport
           assert_equal times, times_called, error
         end
 
-        def assert_called_with(object, method_name, args = [], returns: nil)
+        def assert_called_with(object, method_name, args = [], returns: nil, use_distinct_returns: false)
           mock = Minitest::Mock.new
 
           if args.all? { |arg| arg.is_a?(Array) }
-            args.each { |arg| mock.expect(:call, returns, arg) }
+            if use_distinct_returns
+              if returns.nil? || !returns.is_a?(Array) || returns.length != args.length
+                raise(ArgumentError, 'returns must be an array and match the number of arguments')
+              end
+              args.each_with_index { |arg, i| mock.expect(:call, returns[i], arg) }
+            else
+              args.each { |arg| mock.expect(:call, returns, arg) }
+            end
           else
             mock.expect(:call, returns, args)
           end


### PR DESCRIPTION
`assert_called` should also support methods with arguments.

`assert_called_with` should be able to handle distinct returns
when checking multiple arguments (i.e. multiple calls).
In the example bellow, `translate` is called twice with
different arguments and return each time:

``` ruby
mock = Minitest::Mock.new
mock.expect(:call, %i(year month day),
            [:'date.order', locale: 'en', default: []])
mock.expect(:call, Date::MONTHNAMES,
            [:'date.month_names', locale: 'en'])
I18n.stub(:translate, mock) do
  datetime_select('post', 'updated_at', locale: 'en')
end
mock.verify
```

The same could now be written as:

``` ruby
assert_called_with(I18n, :translate,
                   [[:'date.order', locale: 'en', default: []],
                    [:'date.month_names', locale: 'en']],
                   returns: [%i(year month day), Date::MONTHNAMES],
                   use_distinct_returns: true) do
  datetime_select('post', 'updated_at', locale: 'en')
end
```

@kaspth What do you think? Thanks
