### PR TITLE
:only and :except are now chained for routing resource(s)

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow chaining the :only and :except options for routing resource(s).
+
+        resource :account, :only => [:show, :destroy], :except => :destroy
+
+    This now yields only the show action. This chaining can be useful for passing optional :except
+    options to code that makes use of the :only option.
+
+    *Michael Colavita*
+
 *   Add ability to filter parameters based on parent keys.
 
         # matches {credit_card: {code: "xxxx"}}

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1061,13 +1061,19 @@ module ActionDispatch
             end
           end
 
-          def actions
+          def available_actions
             if only = @options[:only]
               Array(only).map(&:to_sym)
-            elsif except = @options[:except]
-              default_actions - Array(except).map(&:to_sym)
             else
               default_actions
+            end
+          end
+
+          def actions
+            if except = @options[:except]
+              available_actions - Array(except).map(&:to_sym)
+            else
+              available_actions
             end
           end
 

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -838,6 +838,28 @@ class ResourcesTest < ActionController::TestCase
     end
   end
 
+  def test_resource_has_show_action_but_does_not_have_destroy_action
+    with_routing do |set|
+      set.draw do
+        resources :products, :only => [:show, :destroy], :except => :destroy
+      end
+
+      assert_resource_allowed_routes('products', {},                    { :id => '1' }, :show, [:index, :new, :create, :edit, :update, :destroy])
+      assert_resource_allowed_routes('products', { :format => 'xml' },  { :id => '1' }, :show, [:index, :new, :create, :edit, :update, :destroy])
+    end
+  end
+
+  def test_singleton_resource_has_show_action_but_does_not_have_destroy_action
+    with_routing do |set|
+      set.draw do
+        resource :account, :only => [:show, :destroy], :except => :destroy
+      end
+
+      assert_singleton_resource_allowed_routes('accounts', {},                    :show, [:new, :create, :edit, :update, :destroy])
+      assert_singleton_resource_allowed_routes('accounts', { :format => 'xml' },  :show, [:new, :create, :edit, :update, :destroy])
+    end
+  end
+
   def test_resource_has_only_create_action_and_named_route
     with_routing do |set|
       set.draw do


### PR DESCRIPTION
Allow chaining the :only and :except options for routing resource(s).
Previously, the following yielded routes for both show and destroy:

resource :account, :only => [:show, :destroy], :except => :destroy

This now yields only the show action. This chaining can be useful for
passing optional :except options to code that already makes use of
the :only option (e.g. for a gem with its own routing methods).
