### PR TITLE
Replace `ActiveSupport::Concurrency::Latch` with `Concurrent::CountDownLatch` from concurrent-ruby.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ PATH
     actionpack (5.0.0.alpha)
       actionview (= 5.0.0.alpha)
       activesupport (= 5.0.0.alpha)
+      concurrent-ruby (~> 0.9.0)
       rack (~> 1.6)
       rack-test (~> 0.6.3)
       rails-dom-testing (~> 1.0, >= 1.0.5)
@@ -85,6 +86,7 @@ PATH
       activesupport (= 5.0.0.alpha)
       arel (= 7.0.0.alpha)
     activesupport (5.0.0.alpha)
+      concurrent-ruby (~> 0.9.0)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -135,6 +137,7 @@ GEM
       execjs
     coffee-script-source (1.9.0)
     columnize (0.9.0)
+    concurrent-ruby (0.9.0)
     connection_pool (2.1.1)
     dalli (2.7.2)
     dante (0.1.5)

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Replaced `ActiveSupport::Concurrency::Latch` with `Concurrent::CountDownLatch`
+    from the concurrent-ruby gem.
+
+    *Jerry D'Antonio*
+
 *   Add ability to filter parameters based on parent keys.
 
         # matches {credit_card: {code: "xxxx"}}

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails-html-sanitizer', '~> 1.0', '>= 1.0.2'
   s.add_dependency 'rails-dom-testing', '~> 1.0', '>= 1.0.5'
   s.add_dependency 'actionview', version
+  s.add_dependency 'concurrent-ruby', '~> 0.9.0'
 
   s.add_development_dependency 'activemodel', version
 end

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -1,5 +1,5 @@
 require 'abstract_unit'
-require 'active_support/concurrency/latch'
+require 'concurrent/atomics'
 Thread.abort_on_exception = true
 
 module ActionController
@@ -145,7 +145,7 @@ module ActionController
         response.headers['Content-Type'] = 'text/event-stream'
         %w{ hello world }.each do |word|
           response.stream.write word
-          latch.await
+          latch.wait
         end
         response.stream.close
       end
@@ -212,7 +212,7 @@ module ActionController
         # .. plus one more, because the #each frees up a slot:
         response.stream.write '.'
 
-        latch.release
+        latch.count_down
 
         # This write will block, and eventually raise
         response.stream.write 'x'
@@ -233,7 +233,7 @@ module ActionController
         end
 
         logger.info 'Work complete'
-        latch.release
+        latch.count_down
       end
     end
 
@@ -278,7 +278,7 @@ module ActionController
     def test_async_stream
       rubinius_skip "https://github.com/rubinius/rubinius/issues/2934"
 
-      @controller.latch = ActiveSupport::Concurrency::Latch.new
+      @controller.latch = Concurrent::CountDownLatch.new
       parts             = ['hello', 'world']
 
       @controller.request  = @request
@@ -289,8 +289,8 @@ module ActionController
         resp.stream.each do |part|
           assert_equal parts.shift, part
           ol = @controller.latch
-          @controller.latch = ActiveSupport::Concurrency::Latch.new
-          ol.release
+          @controller.latch = Concurrent::CountDownLatch.new
+          ol.count_down
         end
       }
 
@@ -300,23 +300,23 @@ module ActionController
     end
 
     def test_abort_with_full_buffer
-      @controller.latch = ActiveSupport::Concurrency::Latch.new
+      @controller.latch = Concurrent::CountDownLatch.new
 
       @request.parameters[:format] = 'plain'
       @controller.request  = @request
       @controller.response = @response
 
-      got_error = ActiveSupport::Concurrency::Latch.new
+      got_error = Concurrent::CountDownLatch.new
       @response.stream.on_error do
         ActionController::Base.logger.warn 'Error while streaming'
-        got_error.release
+        got_error.count_down
       end
 
       t = Thread.new(@response) { |resp|
         resp.await_commit
         _, _, body = resp.to_a
         body.each do |part|
-          @controller.latch.await
+          @controller.latch.wait
           body.close
           break
         end
@@ -325,13 +325,13 @@ module ActionController
       capture_log_output do |output|
         @controller.process :overfill_buffer_and_die
         t.join
-        got_error.await
+        got_error.wait
         assert_match 'Error while streaming', output.rewind && output.read
       end
     end
 
     def test_ignore_client_disconnect
-      @controller.latch = ActiveSupport::Concurrency::Latch.new
+      @controller.latch = Concurrent::CountDownLatch.new
 
       @controller.request  = @request
       @controller.response = @response
@@ -349,7 +349,7 @@ module ActionController
         @controller.process :ignore_client_disconnect
         t.join
         Timeout.timeout(3) do
-          @controller.latch.await
+          @controller.latch.wait
         end
         assert_match 'Work complete', output.rewind && output.read
       end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Replaced `ActiveSupport::Concurrency::Latch` with `Concurrent::CountDownLatch`
+    from the concurrent-ruby gem.
+
+    *Jerry D'Antonio*
+
 *   Fix through associations using scopes having the scope merged multiple
     times.
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Removed `ActiveSupport::Concurrency::Latch`, superseded by `Concurrent::CountDownLatch`
+    from the concurrent-ruby gem.
+
+    *Jerry D'Antonio*
+
 *   Fix not calling `#default` on `HashWithIndifferentAccess#to_hash` when only
     `default_proc` is set, which could raise.
 

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'tzinfo',     '~> 1.1'
   s.add_dependency 'minitest',   '~> 5.1'
   s.add_dependency 'thread_safe','~> 0.3', '>= 0.3.4'
+  s.add_dependency 'concurrent-ruby', '~> 0.9.0'
 end

--- a/activesupport/lib/active_support/concurrency/latch.rb
+++ b/activesupport/lib/active_support/concurrency/latch.rb
@@ -1,26 +1,18 @@
-require 'thread'
-require 'monitor'
+require 'concurrent/atomics'
 
 module ActiveSupport
   module Concurrency
-    class Latch
-      def initialize(count = 1)
-        @count = count
-        @lock = Monitor.new
-        @cv = @lock.new_cond
-      end
+    class Latch < Concurrent::CountDownLatch
 
-      def release
-        @lock.synchronize do
-          @count -= 1 if @count > 0
-          @cv.broadcast if @count.zero?
-        end
+      def initialize(count = 1)
+        ActiveSupport::Deprecation.warn("ActiveSupport::Concurrency::Latch is deprecated. Please use Concurrent::CountDownLatch instead.")
+        super(count)
       end
+      
+      alias_method :release, :count_down
 
       def await
-        @lock.synchronize do
-          @cv.wait_while { @count > 0 }
-        end
+        wait(nil)
       end
     end
   end


### PR DESCRIPTION
This update was suggested by @tenderlove in a discussion on one of [his PRs to concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby/pull/251).
# 

The concurrent-ruby gem is a toolset containing many concurrency utilities. Many of these utilities include runtime-specific optimizations when possible. Rather than clutter the Rails codebase with concurrency utilities separate from the core task, such tools can be superseded by similar tools in the more specialized gem. This commit replaces `ActiveSupport::Concurrency::Latch` with `Concurrent::CountDownLatch`, which is functionally equivalent.
