### PR TITLE
Change AC::TestResponse to AD::TestResponse

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -230,7 +230,7 @@ module ActionController
   #      request. You can modify this object before sending the HTTP request. For example,
   #      you might want to set some session properties before sending a GET request.
   # <b>@response</b>::
-  #      An ActionController::TestResponse object, representing the response
+  #      An ActionDispatch::TestResponse object, representing the response
   #      of the last HTTP response. In the above example, <tt>@response</tt> becomes valid
   #      after calling +post+. If the various assert methods are not sufficient, then you
   #      may use this object to inspect the HTTP response in detail.

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -151,7 +151,7 @@ class HelperTest < ActiveSupport::TestCase
     assert_equal "test: baz", call_controller(Fun::PdfController, "test").last.body
     #
     # request  = ActionController::TestRequest.new
-    # response = ActionController::TestResponse.new
+    # response = ActionDispatch::TestResponse.new
     # request.action = 'test'
     #
     # assert_equal 'test: baz', Fun::PdfController.process(request, response).body

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -25,7 +25,7 @@ module ActionView
         super
         self.class.controller_path = ""
         @request = ActionController::TestRequest.create
-        @response = ActionController::TestResponse.new
+        @response = ActionDispatch::TestResponse.new
 
         @request.env.delete('PATH_INFO')
         @params = {}

--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -24,7 +24,7 @@ class ViewLoadPathsTest < ActionController::TestCase
 
   def setup
     @request  = ActionController::TestRequest.create
-    @response = ActionController::TestResponse.new
+    @response = ActionDispatch::TestResponse.new
     @controller = TestController.new
     @paths = TestController.view_paths
   end


### PR DESCRIPTION
ActionController::TestResponse was removed in d9fe10c and caused a test failure on Action View as its test case still refers to it.

/cc @tenderlove 
