### PR TITLE
image_alt checksum

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -237,7 +237,7 @@ module ActionView
       #   image_alt('underscored_file_name.png')
       #   # => Underscored file name
       def image_alt(src)
-        File.basename(src, '.*').sub(/-[[:xdigit:]]{32}\z/, '').tr('-_', ' ').capitalize
+        File.basename(src, '.*').sub(/-[[:xdigit:]]{64}\z/, '').tr('-_', ' ').capitalize
       end
 
       # Returns an HTML video tag for the +sources+. If +sources+ is a string,


### PR DESCRIPTION
Rails 4.2.3

The generated alt text for image tags includes the checksum for the image  

**Rails code**

``` rails
<%= image_tag("team-work-on-the-challange.png", class: "img-responsive shadow")%>
```

**Generated HTML**

``` html
<img class="img-responsive shadow" src="/assets/team-work-on-the-challange-29ad1ff20b81673d62fa7fa3280074294d506dcf3361c7e10185c2f38be3f4d2.png" alt="Team work on the challange 29ad1ff20b81673d62fa7fa3280074294d506dcf3361c7e10185c2f38be3f4d2">
```

Looking at the image_alt method

``` ruby
def image_alt(src)
  File.basename(src, '.*').sub(/-[[:xdigit:]]{32}\z/, '').tr('-_', ' ').capitalize
end
```

Its looking for a 32 character checksum, but the generated checksum is 64 characters so its not removed.

If I override the image_alt method in a helper with the following version. Then the checksum is not shown in the alt text of the generated html

``` ruby
def image_alt(src)
  File.basename(src, '.*').sub(/-[[:xdigit:]]{64}\z/, '').tr('-_', ' ').capitalize
end
```

Have I missed something? Has the size of the checksum changed recently from 32 to 64?
