### PR TITLE
Change the way to force reload association from passing `true` to `reload: true`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Change the way to reload association from passing `true` to `reload: true`.
+
+    This makes the method call clearer as it defines the intention that user
+    want to force reload the association.
+
+    Example:
+
+        @user.posts(reload: true)
+        @user.profile(reload: true)
+
+    Passing only `true` to the method is now considered deprecated, and will
+    be removed in Rails 5.1.
+
+    *Prem Sichanugrist*
+
 *   Replaced `ActiveSupport::Concurrency::Latch` with `Concurrent::CountDownLatch`
     from the concurrent-ruby gem.
 

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -1,12 +1,27 @@
+require "active_support/deprecation"
+
 module ActiveRecord
   module Associations
     class SingularAssociation < Association #:nodoc:
+
+      NO_FORCE_RELOAD_ARGUMENT = Object.new # :nodoc:
+
       # Implements the reader method, e.g. foo.bar for Foo.has_one :bar
-      def reader(force_reload = false)
-        if force_reload && klass
-          klass.uncached { reload }
+      def reader(force_reload = NO_FORCE_RELOAD_ARGUMENT, reload: false)
+        if force_reload != NO_FORCE_RELOAD_ARGUMENT
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Passing only `true` to force an association to reload is now
+            deprecated and will be removed in Rails 5.1. Please pass
+            `reload: true` instead.
+          MSG
+
+          reload = force_reload
+        end
+
+        if reload && klass
+          klass.uncached { reload() }
         elsif !loaded? || stale_target?
-          reload
+          reload()
         end
 
         target

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1064,6 +1064,13 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     Column.create! record: record
     assert_equal 1, Column.count
   end
+
+  def test_association_force_reload_with_only_true_is_deprecated
+    client = Client.find(3)
+
+    assert_deprecated(/reload: true/) { client.firm(true) }
+    assert_not_deprecated { client.firm(reload: true) }
+  end
 end
 
 class BelongsToWithForeignKeyTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -293,7 +293,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     client = Client.find(3)
     client.firm = nil
     client.save
-    assert_nil client.firm(true)
+    assert_nil client.firm(reload: true)
     assert_nil client.client_of
   end
 
@@ -301,7 +301,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     client = Client.create(:name => "Primary key client", :firm_name => companies(:first_firm).name)
     client.firm_with_primary_key = nil
     client.save
-    assert_nil client.firm_with_primary_key(true)
+    assert_nil client.firm_with_primary_key(reload: true)
     assert_nil client.client_of
   end
 
@@ -318,11 +318,11 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   def test_polymorphic_association_class
     sponsor = Sponsor.new
     assert_nil sponsor.association(:sponsorable).send(:klass)
-    assert_nil sponsor.sponsorable(force_reload: true)
+    assert_nil sponsor.sponsorable(reload: true)
 
     sponsor.sponsorable_type = '' # the column doesn't have to be declared NOT NULL
     assert_nil sponsor.association(:sponsorable).send(:klass)
-    assert_nil sponsor.sponsorable(force_reload: true)
+    assert_nil sponsor.sponsorable(reload: true)
 
     sponsor.sponsorable = Member.new :name => "Bert"
     assert_equal Member, sponsor.association(:sponsorable).send(:klass)
@@ -557,7 +557,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert final_cut.persisted?
     assert firm.persisted?
     assert_equal firm, final_cut.firm
-    assert_equal firm, final_cut.firm(true)
+    assert_equal firm, final_cut.firm(reload: true)
   end
 
   def test_assignment_before_child_saved_with_primary_key
@@ -569,7 +569,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert final_cut.persisted?
     assert firm.persisted?
     assert_equal firm, final_cut.firm_with_primary_key
-    assert_equal firm, final_cut.firm_with_primary_key(true)
+    assert_equal firm, final_cut.firm_with_primary_key(reload: true)
   end
 
   def test_new_record_with_foreign_key_but_no_object

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -157,8 +157,8 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     jamis.projects << action_controller
 
     assert_equal 2, jamis.projects.size
-    assert_equal 2, jamis.projects(true).size
-    assert_equal 2, action_controller.developers(true).size
+    assert_equal 2, jamis.projects(reload: true).size
+    assert_equal 2, action_controller.developers(reload: true).size
   end
 
   def test_adding_type_mismatch
@@ -176,9 +176,9 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
     action_controller.developers << jamis
 
-    assert_equal 2, jamis.projects(true).size
+    assert_equal 2, jamis.projects(reload: true).size
     assert_equal 2, action_controller.developers.size
-    assert_equal 2, action_controller.developers(true).size
+    assert_equal 2, action_controller.developers(reload: true).size
   end
 
   def test_adding_from_the_project_fixed_timestamp
@@ -192,9 +192,9 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     action_controller.developers << jamis
 
     assert_equal updated_at, jamis.updated_at
-    assert_equal 2, jamis.projects(true).size
+    assert_equal 2, jamis.projects(reload: true).size
     assert_equal 2, action_controller.developers.size
-    assert_equal 2, action_controller.developers(true).size
+    assert_equal 2, action_controller.developers(reload: true).size
   end
 
   def test_adding_multiple
@@ -203,7 +203,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     aredridel.projects.reload
     aredridel.projects.push(Project.find(1), Project.find(2))
     assert_equal 2, aredridel.projects.size
-    assert_equal 2, aredridel.projects(true).size
+    assert_equal 2, aredridel.projects(reload: true).size
   end
 
   def test_adding_a_collection
@@ -212,7 +212,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     aredridel.projects.reload
     aredridel.projects.concat([Project.find(1), Project.find(2)])
     assert_equal 2, aredridel.projects.size
-    assert_equal 2, aredridel.projects(true).size
+    assert_equal 2, aredridel.projects(reload: true).size
   end
 
   def test_habtm_adding_before_save
@@ -227,7 +227,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_equal no_of_devels+1, Developer.count
     assert_equal no_of_projects+1, Project.count
     assert_equal 2, aredridel.projects.size
-    assert_equal 2, aredridel.projects(true).size
+    assert_equal 2, aredridel.projects(reload: true).size
   end
 
   def test_habtm_saving_multiple_relationships
@@ -391,8 +391,8 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     david.projects.delete(active_record)
 
     assert_equal 1, david.projects.size
-    assert_equal 1, david.projects(true).size
-    assert_equal 2, active_record.developers(true).size
+    assert_equal 1, david.projects(reload: true).size
+    assert_equal 2, active_record.developers(reload: true).size
   end
 
   def test_deleting_array
@@ -400,7 +400,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     david.projects.reload
     david.projects.delete(Project.all.to_a)
     assert_equal 0, david.projects.size
-    assert_equal 0, david.projects(true).size
+    assert_equal 0, david.projects(reload: true).size
   end
 
   def test_deleting_all
@@ -408,7 +408,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     david.projects.reload
     david.projects.clear
     assert_equal 0, david.projects.size
-    assert_equal 0, david.projects(true).size
+    assert_equal 0, david.projects(reload: true).size
   end
 
   def test_removing_associations_on_destroy
@@ -434,7 +434,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert join_records.empty?
 
     assert_equal 1, david.reload.projects.size
-    assert_equal 1, david.projects(true).size
+    assert_equal 1, david.projects(reload: true).size
   end
 
   def test_destroying_many
@@ -450,7 +450,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert join_records.empty?
 
     assert_equal 0, david.reload.projects.size
-    assert_equal 0, david.projects(true).size
+    assert_equal 0, david.projects(reload: true).size
   end
 
   def test_destroy_all
@@ -466,7 +466,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert join_records.empty?
 
     assert david.projects.empty?
-    assert david.projects(true).empty?
+    assert david.projects(reload: true).empty?
   end
 
   def test_destroy_associations_destroys_multiple_associations
@@ -482,11 +482,11 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
     join_records = Parrot.connection.select_all("SELECT * FROM parrots_pirates WHERE parrot_id = #{george.id}")
     assert join_records.empty?
-    assert george.pirates(true).empty?
+    assert george.pirates(reload: true).empty?
 
     join_records = Parrot.connection.select_all("SELECT * FROM parrots_treasures WHERE parrot_id = #{george.id}")
     assert join_records.empty?
-    assert george.treasures(true).empty?
+    assert george.treasures(reload: true).empty?
   end
 
   def test_associations_with_conditions
@@ -654,7 +654,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_habtm_respects_select
-    categories(:technology).select_testing_posts(true).each do |o|
+    categories(:technology).select_testing_posts(reload: true).each do |o|
       assert_respond_to o, :correctness_marker
     end
     assert_respond_to categories(:technology).select_testing_posts.first, :correctness_marker
@@ -726,7 +726,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
   def test_get_ids_for_loaded_associations
     developer = developers(:david)
-    developer.projects(true)
+    developer.projects(reload: true)
     assert_queries(0) do
       developer.project_ids
       developer.project_ids

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -917,4 +917,11 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
       DeveloperWithSymbolClassName.new
     end
   end
+
+  def test_association_force_reload_with_only_true_is_deprecated
+    developer = Developer.find(1)
+
+    assert_deprecated(/reload: true/) { developer.projects(true) }
+    assert_not_deprecated { developer.projects(reload: true) }
+  end
 end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -704,7 +704,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     natural = Client.new("name" => "Natural Company")
     companies(:first_firm).clients_of_firm << natural
     assert_equal 3, companies(:first_firm).clients_of_firm.size # checking via the collection
-    assert_equal 3, companies(:first_firm).clients_of_firm(true).size # checking using the db
+    assert_equal 3, companies(:first_firm).clients_of_firm(reload: true).size # checking using the db
     assert_equal natural, companies(:first_firm).clients_of_firm.last
   end
 
@@ -759,7 +759,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     force_signal37_to_load_all_clients_of_firm
     companies(:first_firm).clients_of_firm.concat([Client.new("name" => "Natural Company"), Client.new("name" => "Apple")])
     assert_equal 4, companies(:first_firm).clients_of_firm.size
-    assert_equal 4, companies(:first_firm).clients_of_firm(true).size
+    assert_equal 4, companies(:first_firm).clients_of_firm(reload: true).size
   end
 
   def test_transactions_when_adding_to_persisted
@@ -771,7 +771,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     rescue Client::RaisedOnSave
     end
 
-    assert !companies(:first_firm).clients_of_firm(true).include?(good)
+    assert !companies(:first_firm).clients_of_firm(reload: true).include?(good)
   end
 
   def test_transactions_when_adding_to_new_record
@@ -903,12 +903,12 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     new_client = companies(:first_firm).clients_of_firm.create("name" => "Another Client")
     assert new_client.persisted?
     assert_equal new_client, companies(:first_firm).clients_of_firm.last
-    assert_equal new_client, companies(:first_firm).clients_of_firm(true).last
+    assert_equal new_client, companies(:first_firm).clients_of_firm(reload: true).last
   end
 
   def test_create_many
     companies(:first_firm).clients_of_firm.create([{"name" => "Another Client"}, {"name" => "Another Client II"}])
-    assert_equal 4, companies(:first_firm).clients_of_firm(true).size
+    assert_equal 4, companies(:first_firm).clients_of_firm(reload: true).size
   end
 
   def test_create_followed_by_save_does_not_load_target
@@ -921,7 +921,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     force_signal37_to_load_all_clients_of_firm
     companies(:first_firm).clients_of_firm.delete(companies(:first_firm).clients_of_firm.first)
     assert_equal 1, companies(:first_firm).clients_of_firm.size
-    assert_equal 1, companies(:first_firm).clients_of_firm(true).size
+    assert_equal 1, companies(:first_firm).clients_of_firm(reload: true).size
   end
 
   def test_deleting_before_save
@@ -1058,7 +1058,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 3, companies(:first_firm).clients_of_firm.size
     companies(:first_firm).clients_of_firm.delete([companies(:first_firm).clients_of_firm[0], companies(:first_firm).clients_of_firm[1], companies(:first_firm).clients_of_firm[2]])
     assert_equal 0, companies(:first_firm).clients_of_firm.size
-    assert_equal 0, companies(:first_firm).clients_of_firm(true).size
+    assert_equal 0, companies(:first_firm).clients_of_firm(reload: true).size
   end
 
   def test_delete_all
@@ -1079,7 +1079,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     companies(:first_firm).clients_of_firm.reset
     companies(:first_firm).clients_of_firm.delete_all
     assert_equal 0, companies(:first_firm).clients_of_firm.size
-    assert_equal 0, companies(:first_firm).clients_of_firm(true).size
+    assert_equal 0, companies(:first_firm).clients_of_firm(reload: true).size
   end
 
   def test_transaction_when_deleting_persisted
@@ -1093,7 +1093,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     rescue Client::RaisedOnDestroy
     end
 
-    assert_equal [good, bad], companies(:first_firm).clients_of_firm(true)
+    assert_equal [good, bad], companies(:first_firm).clients_of_firm(reload: true)
   end
 
   def test_transaction_when_deleting_new_record
@@ -1113,7 +1113,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     firm.clients_of_firm.clear
 
     assert_equal 0, firm.clients_of_firm.size
-    assert_equal 0, firm.clients_of_firm(true).size
+    assert_equal 0, firm.clients_of_firm(reload: true).size
     assert_equal [], Client.destroyed_client_ids[firm.id]
 
     # Should not be destroyed since the association is not dependent.
@@ -1149,7 +1149,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     firm.dependent_clients_of_firm.clear
 
     assert_equal 0, firm.dependent_clients_of_firm.size
-    assert_equal 0, firm.dependent_clients_of_firm(true).size
+    assert_equal 0, firm.dependent_clients_of_firm(reload: true).size
     assert_equal [], Client.destroyed_client_ids[firm.id]
 
     # Should be destroyed since the association is dependent.
@@ -1182,7 +1182,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     firm.exclusively_dependent_clients_of_firm.clear
 
     assert_equal 0, firm.exclusively_dependent_clients_of_firm.size
-    assert_equal 0, firm.exclusively_dependent_clients_of_firm(true).size
+    assert_equal 0, firm.exclusively_dependent_clients_of_firm(reload: true).size
     # no destroy-filters should have been called
     assert_equal [], Client.destroyed_client_ids[firm.id]
 
@@ -1231,7 +1231,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     # break the vanilla firm_id foreign key
     assert_equal 3, firm.clients.count
     firm.clients.first.update_columns(firm_id: nil)
-    assert_equal 2, firm.clients(true).count
+    assert_equal 2, firm.clients(reload: true).count
     assert_equal 2, firm.clients_using_primary_key_with_delete_all.count
     old_record = firm.clients_using_primary_key_with_delete_all.first
     firm = Firm.first
@@ -1257,7 +1257,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     firm.clients_of_firm.clear
 
     assert_equal 0, firm.clients_of_firm.size
-    assert_equal 0, firm.clients_of_firm(true).size
+    assert_equal 0, firm.clients_of_firm(reload: true).size
   end
 
   def test_deleting_a_item_which_is_not_in_the_collection
@@ -1265,7 +1265,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     summit = Client.find_by_name('Summit')
     companies(:first_firm).clients_of_firm.delete(summit)
     assert_equal 2, companies(:first_firm).clients_of_firm.size
-    assert_equal 2, companies(:first_firm).clients_of_firm(true).size
+    assert_equal 2, companies(:first_firm).clients_of_firm(reload: true).size
     assert_equal 2, summit.client_of
   end
 
@@ -1303,7 +1303,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal 1, companies(:first_firm).reload.clients_of_firm.size
-    assert_equal 1, companies(:first_firm).clients_of_firm(true).size
+    assert_equal 1, companies(:first_firm).clients_of_firm(reload: true).size
   end
 
   def test_destroying_by_fixnum_id
@@ -1314,7 +1314,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal 1, companies(:first_firm).reload.clients_of_firm.size
-    assert_equal 1, companies(:first_firm).clients_of_firm(true).size
+    assert_equal 1, companies(:first_firm).clients_of_firm(reload: true).size
   end
 
   def test_destroying_by_string_id
@@ -1325,7 +1325,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal 1, companies(:first_firm).reload.clients_of_firm.size
-    assert_equal 1, companies(:first_firm).clients_of_firm(true).size
+    assert_equal 1, companies(:first_firm).clients_of_firm(reload: true).size
   end
 
   def test_destroying_a_collection
@@ -1338,7 +1338,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal 1, companies(:first_firm).reload.clients_of_firm.size
-    assert_equal 1, companies(:first_firm).clients_of_firm(true).size
+    assert_equal 1, companies(:first_firm).clients_of_firm(reload: true).size
   end
 
   def test_destroy_all
@@ -1349,7 +1349,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal clients.sort_by(&:id), destroyed.sort_by(&:id)
     assert destroyed.all?(&:frozen?), "destroyed clients should be frozen"
     assert companies(:first_firm).clients_of_firm.empty?, "37signals has no clients after destroy all"
-    assert companies(:first_firm).clients_of_firm(true).empty?, "37signals has no clients after destroy all and refresh"
+    assert companies(:first_firm).clients_of_firm(reload: true).empty?, "37signals has no clients after destroy all and refresh"
   end
 
   def test_dependence
@@ -1518,7 +1518,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     rescue Client::RaisedOnSave
     end
 
-    assert_equal [good], companies(:first_firm).clients_of_firm(true)
+    assert_equal [good], companies(:first_firm).clients_of_firm(reload: true)
   end
 
   def test_transactions_when_replacing_on_new_record
@@ -1534,7 +1534,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_get_ids_for_loaded_associations
     company = companies(:first_firm)
-    company.clients(true)
+    company.clients(reload: true)
     assert_queries(0) do
       company.client_ids
       company.client_ids
@@ -1588,7 +1588,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     firm.client_ids = [companies(:first_client).id, nil, companies(:second_client).id, '']
     firm.save!
 
-    assert_equal 2, firm.clients(true).size
+    assert_equal 2, firm.clients(reload: true).size
     assert_equal true, firm.clients.include?(companies(:second_client))
   end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2252,4 +2252,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal [first_bulb, second_bulb], car.bulbs
   end
+
+  def test_association_force_reload_with_only_true_is_deprecated
+    company = Company.find(1)
+
+    assert_deprecated(/reload: true/) { company.clients_of_firm(true) }
+    assert_not_deprecated { company.clients_of_firm(reload: true) }
+  end
 end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -188,7 +188,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       assert post.people.include?(person)
     end
 
-    assert post.reload.people(true).include?(person)
+    assert post.reload.people(reload: true).include?(person)
   end
 
   def test_delete_all_for_with_dependent_option_destroy
@@ -229,7 +229,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     post   = posts(:thinking)
     post.people.concat [person]
     assert_equal 1, post.people.size
-    assert_equal 1, post.people(true).size
+    assert_equal 1, post.people(reload: true).size
   end
 
   def test_associate_existing_record_twice_should_add_to_target_twice
@@ -285,7 +285,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       assert posts(:thinking).people.include?(new_person)
     end
 
-    assert posts(:thinking).reload.people(true).include?(new_person)
+    assert posts(:thinking).reload.people(reload: true).include?(new_person)
   end
 
   def test_associate_new_by_building
@@ -310,8 +310,8 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       posts(:thinking).save
     end
 
-    assert posts(:thinking).reload.people(true).collect(&:first_name).include?("Bob")
-    assert posts(:thinking).reload.people(true).collect(&:first_name).include?("Ted")
+    assert posts(:thinking).reload.people(reload: true).collect(&:first_name).include?("Bob")
+    assert posts(:thinking).reload.people(reload: true).collect(&:first_name).include?("Ted")
   end
 
   def test_build_then_save_with_has_many_inverse
@@ -356,7 +356,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       assert posts(:welcome).people.empty?
     end
 
-    assert posts(:welcome).reload.people(true).empty?
+    assert posts(:welcome).reload.people(reload: true).empty?
   end
 
   def test_destroy_association
@@ -367,7 +367,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
 
     assert posts(:welcome).reload.people.empty?
-    assert posts(:welcome).people(true).empty?
+    assert posts(:welcome).people(reload: true).empty?
   end
 
   def test_destroy_all
@@ -378,7 +378,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
 
     assert posts(:welcome).reload.people.empty?
-    assert posts(:welcome).people(true).empty?
+    assert posts(:welcome).people(reload: true).empty?
   end
 
   def test_should_raise_exception_for_destroying_mismatching_records
@@ -539,7 +539,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_replace_association
-    assert_queries(4){posts(:welcome);people(:david);people(:michael); posts(:welcome).people(true)}
+    assert_queries(4){posts(:welcome);people(:david);people(:michael); posts(:welcome).people(reload: true)}
 
     # 1 query to delete the existing reader (michael)
     # 1 query to associate the new reader (david)
@@ -552,8 +552,8 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       assert !posts(:welcome).people.include?(people(:michael))
     }
 
-    assert posts(:welcome).reload.people(true).include?(people(:david))
-    assert !posts(:welcome).reload.people(true).include?(people(:michael))
+    assert posts(:welcome).reload.people(reload: true).include?(people(:david))
+    assert !posts(:welcome).reload.people(reload: true).include?(people(:michael))
   end
 
   def test_replace_order_is_preserved
@@ -592,7 +592,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       assert posts(:thinking).people.collect(&:first_name).include?("Jeb")
     end
 
-    assert posts(:thinking).reload.people(true).collect(&:first_name).include?("Jeb")
+    assert posts(:thinking).reload.people(reload: true).collect(&:first_name).include?("Jeb")
   end
 
   def test_through_record_is_built_when_created_with_where
@@ -668,7 +668,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_clear_associations
-    assert_queries(2) { posts(:welcome);posts(:welcome).people(true) }
+    assert_queries(2) { posts(:welcome);posts(:welcome).people(reload: true) }
 
     assert_queries(1) do
       posts(:welcome).people.clear
@@ -678,7 +678,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       assert posts(:welcome).people.empty?
     end
 
-    assert posts(:welcome).reload.people(true).empty?
+    assert posts(:welcome).reload.people(reload: true).empty?
   end
 
   def test_association_callback_ordering
@@ -750,7 +750,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_get_ids_for_loaded_associations
     person = people(:michael)
-    person.posts(true)
+    person.posts(reload: true)
     assert_queries(0) do
       person.post_ids
       person.post_ids
@@ -828,14 +828,14 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     category = author.named_categories.build(:name => "Primary")
     author.save
     assert Categorization.exists?(:author_id => author.id, :named_category_name => category.name)
-    assert author.named_categories(true).include?(category)
+    assert author.named_categories(reload: true).include?(category)
   end
 
   def test_collection_create_with_nonstandard_primary_key_on_belongs_to
     author   = authors(:mary)
     category = author.named_categories.create(:name => "Primary")
     assert Categorization.exists?(:author_id => author.id, :named_category_name => category.name)
-    assert author.named_categories(true).include?(category)
+    assert author.named_categories(reload: true).include?(category)
   end
 
   def test_collection_exists
@@ -850,7 +850,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     category = author.named_categories.create(:name => "Primary")
     author.named_categories.delete(category)
     assert !Categorization.exists?(:author_id => author.id, :named_category_name => category.name)
-    assert author.named_categories(true).empty?
+    assert author.named_categories(reload: true).empty?
   end
 
   def test_collection_singular_ids_getter_with_string_primary_keys
@@ -871,10 +871,10 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_nothing_raised do
       book = books(:awdr)
       book.subscriber_ids = [subscribers(:second).nick]
-      assert_equal [subscribers(:second)], book.subscribers(true)
+      assert_equal [subscribers(:second)], book.subscribers(reload: true)
 
       book.subscriber_ids = []
-      assert_equal [], book.subscribers(true)
+      assert_equal [], book.subscribers(reload: true)
     end
 
   end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1165,4 +1165,11 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
     assert_nil Club.new.special_favourites.distinct_value
   end
+
+  def test_association_force_reload_with_only_true_is_deprecated
+    post = Post.find(1)
+
+    assert_deprecated(/reload: true/) { post.people(true) }
+    assert_not_deprecated { post.people(reload: true) }
+  end
 end

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -332,7 +332,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert a.persisted?
     assert_equal a, firm.account
     assert_equal a, firm.account
-    assert_equal a, firm.account(true)
+    assert_equal a, firm.account(reload: true)
   end
 
   def test_save_still_works_after_accessing_nil_has_one

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -607,4 +607,11 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
       end
     end
   end
+
+  def test_association_force_reload_with_only_true_is_deprecated
+    firm = Firm.find(1)
+
+    assert_deprecated(/reload: true/) { firm.account(true) }
+    assert_not_deprecated { firm.account(reload: true) }
+  end
 end

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -245,12 +245,12 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_not_nil @member_detail.member_type
     @member_detail.destroy
     assert_queries(1) do
-      assert_not_nil @member_detail.member_type(true)
+      assert_not_nil @member_detail.member_type(reload: true)
     end
 
     @member_detail.member.destroy
     assert_queries(1) do
-      assert_nil @member_detail.member_type(true)
+      assert_nil @member_detail.member_type(reload: true)
     end
   end
 

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -344,4 +344,11 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
       end
     end
   end
+
+  def test_association_force_reload_with_only_true_is_deprecated
+    member = Member.find(1)
+
+    assert_deprecated(/reload: true/) { member.club(true) }
+    assert_not_deprecated { member.club(reload: true) }
+  end
 end

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -213,7 +213,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     old_count = Tagging.count
     post.destroy
     assert_equal old_count-1, Tagging.count
-    assert_nil posts(:welcome).tagging(true)
+    assert_nil posts(:welcome).tagging(reload: true)
   end
 
   def test_delete_polymorphic_has_one_with_nullify
@@ -224,7 +224,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     old_count = Tagging.count
     post.destroy
     assert_equal old_count, Tagging.count
-    assert_nil posts(:welcome).tagging(true)
+    assert_nil posts(:welcome).tagging(reload: true)
   end
 
   def test_has_many_with_piggyback
@@ -461,7 +461,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     assert saved_post.tags.include?(new_tag)
 
     assert new_tag.persisted?
-    assert saved_post.reload.tags(true).include?(new_tag)
+    assert saved_post.reload.tags(reload: true).include?(new_tag)
 
 
     new_post = Post.new(:title => "Association replacement works!", :body => "You best believe it.")
@@ -474,7 +474,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
 
     new_post.save!
     assert new_post.persisted?
-    assert new_post.reload.tags(true).include?(saved_tag)
+    assert new_post.reload.tags(reload: true).include?(saved_tag)
 
     assert !posts(:thinking).tags.build.persisted?
     assert !posts(:thinking).tags.new.persisted?
@@ -490,7 +490,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     assert_nil( wrong = post_thinking.taggings.detect { |t| t.class != Tagging },
                 message = "Expected a Tagging in taggings collection, got #{wrong.class}.")
     assert_equal(count + 1, post_thinking.reload.tags.size)
-    assert_equal(count + 1, post_thinking.tags(true).size)
+    assert_equal(count + 1, post_thinking.tags(reload: true).size)
 
     assert_kind_of Tag, post_thinking.tags.create!(:name => 'foo')
     assert_nil( wrong = post_thinking.tags.detect { |t| t.class != Tag },
@@ -498,7 +498,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     assert_nil( wrong = post_thinking.taggings.detect { |t| t.class != Tagging },
                 message = "Expected a Tagging in taggings collection, got #{wrong.class}.")
     assert_equal(count + 2, post_thinking.reload.tags.size)
-    assert_equal(count + 2, post_thinking.tags(true).size)
+    assert_equal(count + 2, post_thinking.tags(reload: true).size)
 
     assert_nothing_raised { post_thinking.tags.concat(Tag.create!(:name => 'abc'), Tag.create!(:name => 'def')) }
     assert_nil( wrong = post_thinking.tags.detect { |t| t.class != Tag },
@@ -506,7 +506,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     assert_nil( wrong = post_thinking.taggings.detect { |t| t.class != Tagging },
                 message = "Expected a Tagging in taggings collection, got #{wrong.class}.")
     assert_equal(count + 4, post_thinking.reload.tags.size)
-    assert_equal(count + 4, post_thinking.tags(true).size)
+    assert_equal(count + 4, post_thinking.tags(reload: true).size)
 
     # Raises if the wrong reflection name is used to set the Edge belongs_to
     assert_nothing_raised { vertices(:vertex_1).sinks << vertices(:vertex_5) }
@@ -544,11 +544,11 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     book = Book.create!(:name => 'Getting Real')
     book_awdr = books(:awdr)
     book_awdr.references << book
-    assert_equal(count + 1, book_awdr.references(true).size)
+    assert_equal(count + 1, book_awdr.references(reload: true).size)
 
     assert_nothing_raised { book_awdr.references.delete(book) }
     assert_equal(count, book_awdr.references.size)
-    assert_equal(count, book_awdr.references(true).size)
+    assert_equal(count, book_awdr.references(reload: true).size)
     assert_equal(references_before.sort, book_awdr.references.sort)
   end
 
@@ -558,14 +558,14 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     tag = Tag.create!(:name => 'doomed')
     post_thinking = posts(:thinking)
     post_thinking.tags << tag
-    assert_equal(count + 1, post_thinking.taggings(true).size)
-    assert_equal(count + 1, post_thinking.reload.tags(true).size)
+    assert_equal(count + 1, post_thinking.taggings(reload: true).size)
+    assert_equal(count + 1, post_thinking.reload.tags(reload: true).size)
     assert_not_equal(tags_before, post_thinking.tags.sort)
 
     assert_nothing_raised { post_thinking.tags.delete(tag) }
     assert_equal(count, post_thinking.tags.size)
-    assert_equal(count, post_thinking.tags(true).size)
-    assert_equal(count, post_thinking.taggings(true).size)
+    assert_equal(count, post_thinking.tags(reload: true).size)
+    assert_equal(count, post_thinking.taggings(reload: true).size)
     assert_equal(tags_before, post_thinking.tags.sort)
   end
 
@@ -577,11 +577,11 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     quaked = Tag.create!(:name => 'quaked')
     post_thinking = posts(:thinking)
     post_thinking.tags << doomed << doomed2
-    assert_equal(count + 2, post_thinking.reload.tags(true).size)
+    assert_equal(count + 2, post_thinking.reload.tags(reload: true).size)
 
     assert_nothing_raised { post_thinking.tags.delete(doomed, doomed2, quaked) }
     assert_equal(count, post_thinking.tags.size)
-    assert_equal(count, post_thinking.tags(true).size)
+    assert_equal(count, post_thinking.tags(reload: true).size)
     assert_equal(tags_before, post_thinking.tags.sort)
   end
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -93,8 +93,8 @@ class AssociationsTest < ActiveRecord::TestCase
     assert firm.clients.empty?, "New firm should have cached no client objects"
     assert_equal 0, firm.clients.size, "New firm should have cached 0 clients count"
 
-    assert !firm.clients(true).empty?, "New firm should have reloaded client objects"
-    assert_equal 1, firm.clients(true).size, "New firm should have reloaded clients count"
+    assert !firm.clients(reload: true).empty?, "New firm should have reloaded client objects"
+    assert_equal 1, firm.clients(reload: true).size, "New firm should have reloaded clients count"
   end
 
   def test_using_limitable_reflections_helper
@@ -113,7 +113,7 @@ class AssociationsTest < ActiveRecord::TestCase
     ActiveRecord::Base.cache do
       firm.clients.each {}
       assert_queries(0) { assert_not_nil firm.clients.each {} }
-      assert_queries(1) { assert_not_nil firm.clients(true).each {} }
+      assert_queries(1) { assert_not_nil firm.clients(reload: true).each {} }
     end
   end
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -149,7 +149,7 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
     assert_equal a, firm.account
     assert firm.save
     assert_equal a, firm.account
-    assert_equal a, firm.account(true)
+    assert_equal a, firm.account(reload: true)
   end
 
   def test_assignment_before_either_saved
@@ -162,7 +162,7 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
     assert firm.persisted?
     assert a.persisted?
     assert_equal a, firm.account
-    assert_equal a, firm.account(true)
+    assert_equal a, firm.account(reload: true)
   end
 
   def test_not_resaved_when_unchanged
@@ -248,7 +248,7 @@ class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::Test
     assert apple.save
     assert apple.persisted?
     assert_equal apple, client.firm
-    assert_equal apple, client.firm(true)
+    assert_equal apple, client.firm(reload: true)
   end
 
   def test_assignment_before_either_saved
@@ -261,7 +261,7 @@ class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::Test
     assert final_cut.persisted?
     assert apple.persisted?
     assert_equal apple, final_cut.firm
-    assert_equal apple, final_cut.firm(true)
+    assert_equal apple, final_cut.firm(reload: true)
   end
 
   def test_store_two_association_with_one_save
@@ -456,7 +456,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     assert_equal new_client, companies(:first_firm).clients_of_firm.last
     assert !companies(:first_firm).save
     assert !new_client.persisted?
-    assert_equal 2, companies(:first_firm).clients_of_firm(true).size
+    assert_equal 2, companies(:first_firm).clients_of_firm(reload: true).size
   end
 
   def test_adding_before_save
@@ -481,7 +481,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     assert_equal no_of_clients + 2, Client.count  # Clients were saved to database.
 
     assert_equal 2, new_firm.clients_of_firm.size
-    assert_equal 2, new_firm.clients_of_firm(true).size
+    assert_equal 2, new_firm.clients_of_firm(reload: true).size
   end
 
   def test_assign_ids
@@ -510,7 +510,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     company.name += '-changed'
     assert_queries(2) { assert company.save }
     assert new_client.persisted?
-    assert_equal 3, company.clients_of_firm(true).size
+    assert_equal 3, company.clients_of_firm(reload: true).size
   end
 
   def test_build_many_before_save
@@ -519,7 +519,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
 
     company.name += '-changed'
     assert_queries(3) { assert company.save }
-    assert_equal 4, company.clients_of_firm(true).size
+    assert_equal 4, company.clients_of_firm(reload: true).size
   end
 
   def test_build_via_block_before_save
@@ -530,7 +530,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     company.name += '-changed'
     assert_queries(2) { assert company.save }
     assert new_client.persisted?
-    assert_equal 3, company.clients_of_firm(true).size
+    assert_equal 3, company.clients_of_firm(reload: true).size
   end
 
   def test_build_many_via_block_before_save
@@ -543,7 +543,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
 
     company.name += '-changed'
     assert_queries(3) { assert company.save }
-    assert_equal 4, company.clients_of_firm(true).size
+    assert_equal 4, company.clients_of_firm(reload: true).size
   end
 
   def test_replace_on_new_object

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -181,7 +181,7 @@ class TransactionTest < ActiveRecord::TestCase
     assert posts_count > 0
     status = author.update(name: nil, post_ids: [])
     assert !status
-    assert_equal posts_count, author.posts(true).size
+    assert_equal posts_count, author.posts(reload: true).size
   end
 
   def test_update_should_rollback_on_failure!
@@ -191,7 +191,7 @@ class TransactionTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::RecordInvalid) do
       author.update!(name: nil, post_ids: [])
     end
-    assert_equal posts_count, author.posts(true).size
+    assert_equal posts_count, author.posts(reload: true).size
   end
 
   def test_cancellation_from_returning_false_in_before_filter


### PR DESCRIPTION
This makes the method call clearer as it defines the intention that user want to force reload the association.

Example:

``` ruby
@user.posts(reload: true)
@user.profile(reload: true)
```

Passing only `true` to the method is now considered deprecated, and user will get a deprecation warning message. The old usage will be completely removed in Rails 5.1.
