### PR TITLE
Fix param_key when model is using relative model naming in base classes

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -238,6 +238,11 @@ module ActiveModel
         namespace = self.parents.detect do |n|
           n.respond_to?(:use_relative_model_naming?) && n.use_relative_model_naming?
         end
+
+        if respond_to?(:use_relative_model_naming?) && use_relative_model_naming?
+          namespace = name.split('::').first.constantize
+        end
+
         ActiveModel::Name.new(self, namespace)
       end
     end

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -3,6 +3,8 @@ require 'models/contact'
 require 'models/sheep'
 require 'models/track_back'
 require 'models/blog_post'
+require 'models/asset/base'
+require 'models/asset/image'
 
 class NamingTest < ActiveModel::TestCase
   def setup
@@ -191,6 +193,44 @@ class NamingUsingRelativeModelNameTest < ActiveModel::TestCase
 
   def test_i18n_key
     assert_equal :"blog/post", @model_name.i18n_key
+  end
+end
+
+class NamingUsingRelativeModelNameTestViaAbstractClass < ActiveModel::TestCase
+  def setup
+    @model_name = Asset::Image.model_name
+  end
+
+  def test_singular
+    assert_equal 'asset_image', @model_name.singular
+  end
+
+  def test_plural
+    assert_equal 'asset_images', @model_name.plural
+  end
+
+  def test_element
+    assert_equal 'image', @model_name.element
+  end
+
+  def test_collection
+    assert_equal 'asset/images', @model_name.collection
+  end
+
+  def test_human
+    assert_equal 'Image', @model_name.human
+  end
+
+  def test_route_key
+    assert_equal 'images', @model_name.route_key
+  end
+
+  def test_param_key
+    assert_equal 'image', @model_name.param_key
+  end
+
+  def test_i18n_key
+    assert_equal :"asset/image", @model_name.i18n_key
   end
 end
 

--- a/activemodel/test/models/asset/base.rb
+++ b/activemodel/test/models/asset/base.rb
@@ -1,0 +1,7 @@
+module Asset
+  class Base
+    def self.use_relative_model_naming?
+      true
+    end
+  end
+end

--- a/activemodel/test/models/asset/image.rb
+++ b/activemodel/test/models/asset/image.rb
@@ -1,0 +1,5 @@
+module Asset
+  class Image < Asset::Base
+    extend ActiveModel::Naming
+  end
+end


### PR DESCRIPTION
**TL;DR**: Models that inherit from an `Example::Base` instead of a module do not have their namespace removed in their `param_key` or `route_key`.

---

When developing, I've discovered that I opt for using abstract classes instead of modules to contain code. This same style is done with Spree; a large open-source Rails app that we can use as an example.

Spree has a [`Spree::Base`](https://github.com/spree/spree/blob/master/core/app/models/spree/base.rb) which they use to pump methods and `include`s into that many classes might use. Then, when creating a new class such as [`Spree::Asset`](https://github.com/spree/spree/blob/master/core/app/models/spree/asset.rb), they will inherit from `Spree::Base` instead of `ActiveRecord::Base`.

Except, the issue is that the `param_key` to that object is different than when you extend from a module.

To give you an example:

``` ruby
module Blog
  def self.use_relative_model_naming
    true
  end

  class Post < ActiveRecord::Base
  end
end

p Blog::Post.model_name.param_key
# => "post"

module Asset
  class Base < ActiveRecord::Base
    def self.use_relative_model_naming
      true
    end
  end
end

module Asset
  class Image < Asset::Base
  end
end

p Asset::Image.model_name.param_key
# => "asset_image"
```

As you can see in the example above, there's a difference. A work-around is as so:

``` ruby
module Asset
  def self.use_relative_model_naming
    true
  end

  class Base < ActiveRecord::Base
  end
end
```

This can be done, but its not as elegant. I think Rails should be able to expect if a class is using it in a child rather than the parent module.

I supplied two new test models into Active Support to highlight the extending from different classes. Specs were made to ensure they followed the exact same 8 tests that the others used. Then the fix was made to use the classes namespace if the current class has `#use_relative_model_naming` returning `true`.
