### PR TITLE
Deprecate force association reload by passing true

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Deprecate force association reload by passing a truthy argument to
+    association method.
+
+    For collection association, you can call `#reload` on association proxy to
+    force a reload:
+
+        @user.posts.reload   # Instead of @user.posts(true)
+
+    For singular association, you can call `#reload` on the parent object to
+    clear its association cache then call the association method:
+
+        @user.reload.profile   # Instead of @user.profile(true)
+
+    Passing a truthy argument to force association to reload will be removed in
+    Rails 5.1.
+
+    *Prem Sichanugrist*
+
 *   Replaced `ActiveSupport::Concurrency::Latch` with `Concurrent::CountDownLatch`
     from the concurrent-ruby gem.
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -1,3 +1,5 @@
+require "active_support/deprecation"
+
 module ActiveRecord
   module Associations
     # = Active Record Association Collection
@@ -28,6 +30,12 @@ module ActiveRecord
       # Implements the reader method, e.g. foo.items for Foo.has_many :items
       def reader(force_reload = false)
         if force_reload
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Passing an argument to force an association to reload is now
+            deprecated and will be removed in Rails 5.1. Please call `reload`
+            on the result collection proxy instead.
+          MSG
+
           klass.uncached { reload }
         elsif stale_target?
           reload

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -1,9 +1,17 @@
+require "active_support/deprecation"
+
 module ActiveRecord
   module Associations
     class SingularAssociation < Association #:nodoc:
       # Implements the reader method, e.g. foo.bar for Foo.has_one :bar
       def reader(force_reload = false)
         if force_reload && klass
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Passing an argument to force an association to reload is now
+            deprecated and will be removed in Rails 5.1. Please call `reload`
+            on the parent object instead.
+          MSG
+
           klass.uncached { reload }
         elsif !loaded? || stale_target?
           reload

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1064,6 +1064,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     Column.create! record: record
     assert_equal 1, Column.count
   end
+
+  def test_association_force_reload_with_only_true_is_deprecated
+    client = Client.find(3)
+
+    assert_deprecated { client.firm(true) }
+  end
 end
 
 class BelongsToWithForeignKeyTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -917,4 +917,10 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
       DeveloperWithSymbolClassName.new
     end
   end
+
+  def test_association_force_reload_with_only_true_is_deprecated
+    developer = Developer.find(1)
+
+    assert_deprecated { developer.projects(true) }
+  end
 end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2252,4 +2252,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal [first_bulb, second_bulb], car.bulbs
   end
+
+  def test_association_force_reload_with_only_true_is_deprecated
+    company = Company.find(1)
+
+    assert_deprecated { company.clients_of_firm(true) }
+  end
 end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1165,4 +1165,10 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
     assert_nil Club.new.special_favourites.distinct_value
   end
+
+  def test_association_force_reload_with_only_true_is_deprecated
+    post = Post.find(1)
+
+    assert_deprecated { post.people(true) }
+  end
 end

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -607,4 +607,10 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
       end
     end
   end
+
+  def test_association_force_reload_with_only_true_is_deprecated
+    firm = Firm.find(1)
+
+    assert_deprecated { firm.account(true) }
+  end
 end

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -344,4 +344,10 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
       end
     end
   end
+
+  def test_association_force_reload_with_only_true_is_deprecated
+    member = Member.find(1)
+
+    assert_deprecated { member.club(true) }
+  end
 end


### PR DESCRIPTION
This is created in respond to #20883 and [this google thread](https://groups.google.com/forum/#!msg/rubyonrails-core/6ZPPg1ZmjQA/ZCukF2YOzOAJ).

---

This is to simplify the association API, as you can call `reload` on the association proxy or the parent object to get the same result.

For collection association, you can call `#reload` on association proxy to force a reload:

```
@user.posts.reload   # Instead of @user.posts(true)
```

For singular association, you can call `#reload` on the parent object to clear its association cache then call the association method:

```
@user.reload.profile   # Instead of @user.profile(true)
```

Passing a truthy argument to force association to reload will be removed in Rails 5.1.
