### PR TITLE
Fix displaying mailer previews on non local requests.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix displaying mailer previews on non local requests when config
+    `action_mailer.show_previews` is set
+
+    *Wojciech Wnętrzak*
+
 *   `rails server` will now honour the `PORT` environment variable
 
     *David Cornu*

--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -3,7 +3,7 @@ require 'rails/application_controller'
 class Rails::MailersController < Rails::ApplicationController # :nodoc:
   prepend_view_path ActionDispatch::DebugExceptions::RESCUES_TEMPLATE_PATH
 
-  before_action :require_local!
+  before_action :require_local!, unless: :show_previews?
   before_action :find_preview, only: :preview
 
   def index
@@ -41,6 +41,10 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
   end
 
   protected
+    def show_previews?
+      ActionMailer::Base.show_previews
+    end
+
     def find_preview
       candidates = []
       params[:path].to_s.scan(%r{/|$}){ candidates << $` }

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -31,7 +31,7 @@ module ApplicationTests
     test "/rails/mailers is accessible with correct configuraiton" do
       add_to_config "config.action_mailer.show_previews = true"
       app("production")
-      get "/rails/mailers"
+      get "/rails/mailers", {}, {"REMOTE_ADDR" => "4.2.42.42"}
       assert_equal 200, last_response.status
     end
 


### PR DESCRIPTION
When config `action_mailer.show_previews` is set, previews are displayed
regardless of local request check.

There is already a test for this case https://github.com/rails/rails/blob/424b379c73851ac24ab707b2743de2c9d8875e2f/railties/test/application/mailer_previews_test.rb#L31-L36

However request is wrongly assumed to be local (in production env it is not local) and this check was passing in tests: https://github.com/rails/rails/blob/424b379c73851ac24ab707b2743de2c9d8875e2f/railties/lib/rails/application_controller.rb#L7-L11

~~I don't know how to properly mimic remote request, to actually fix the test. I tried to setup it in similar way like in https://github.com/rails/rails/blob/424b379c73851ac24ab707b2743de2c9d8875e2f/railties/test/application/middleware/remote_ip_test.rb#L25-L28 but I didn't succees.
If anyone have a clue how to do it, let me know and I'll try to improve it.~~
