### PR TITLE
Cleanup code and update docs for sending file

### DIFF
--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -8,8 +8,11 @@ module ActionController #:nodoc:
 
     include ActionController::Rendering
 
+    DEFAULT_SEND_FILE_DISPOSITION = :attachment #:nodoc:
     DEFAULT_SEND_FILE_TYPE        = 'application/octet-stream'.freeze #:nodoc:
-    DEFAULT_SEND_FILE_DISPOSITION = 'attachment'.freeze #:nodoc:
+    CONTENT_DISPOSITION           = 'Content-Disposition'.freeze #:nodoc:
+    CONTENT_TRANSFER_ENCODING     = 'Content-Transfer-Encoding'.freeze #:nodoc:
+    CONTENT_TRANSFER_BINARY       = 'binary'.freeze #:nodoc:
 
     protected
       # Sends the file. This uses a server-appropriate method (such as X-Sendfile)
@@ -30,7 +33,7 @@ module ActionController #:nodoc:
       #   If omitted, type will be guessed from the file extension specified in <tt>:filename</tt>.
       #   If no content type is registered for the extension, default type 'application/octet-stream' will be used.
       # * <tt>:disposition</tt> - specifies whether the file will be shown inline or downloaded.
-      #   Valid values are 'inline' and 'attachment' (default).
+      #   Valid values are :inline and :attachment (default).
       # * <tt>:status</tt> - specifies the status code to send with the response. Defaults to 200.
       # * <tt>:url_based_filename</tt> - set to +true+ if you want the browser guess the filename from
       #   the URL, which is necessary for i18n filenames on certain browsers
@@ -47,7 +50,7 @@ module ActionController #:nodoc:
       #
       # Show a JPEG in the browser:
       #
-      #   send_file '/path/to.jpeg', type: 'image/jpeg', disposition: 'inline'
+      #   send_file '/path/to.jpeg', type: 'image/jpeg', disposition: :inline
       #
       # Show a 404 page in the browser:
       #
@@ -112,7 +115,7 @@ module ActionController #:nodoc:
       #   If omitted, type will be guessed from the file extension specified in <tt>:filename</tt>.
       #   If no content type is registered for the extension, default type 'application/octet-stream' will be used.
       # * <tt>:disposition</tt> - specifies whether the file will be shown inline or downloaded.
-      #   Valid values are 'inline' and 'attachment' (default).
+      #   Valid values are :inline and :attachment (default).
       # * <tt>:status</tt> - specifies the status code to send with the response. Defaults to 200.
       #
       # Generic data download:
@@ -125,7 +128,7 @@ module ActionController #:nodoc:
       #
       # Display an image Active Record in the browser:
       #
-      #   send_data image.data, type: image.content_type, disposition: 'inline'
+      #   send_data image.data, type: image.content_type, disposition: :inline
       #
       # See +send_file+ for more information on HTTP Content-* headers and caching.
       def send_data(data, options = {}) #:doc:
@@ -138,7 +141,7 @@ module ActionController #:nodoc:
         type_provided = options.has_key?(:type)
 
         content_type = options.fetch(:type, DEFAULT_SEND_FILE_TYPE)
-        raise ArgumentError, ":type option required" if content_type.nil?
+        raise ArgumentError, ':type option required' if content_type.nil?
 
         if content_type.is_a?(Symbol)
           extension = Mime[content_type]
@@ -156,10 +159,10 @@ module ActionController #:nodoc:
         unless disposition.nil?
           disposition  = disposition.to_s
           disposition += %(; filename="#{options[:filename]}") if options[:filename]
-          headers['Content-Disposition'] = disposition
+          headers[CONTENT_DISPOSITION] = disposition
         end
 
-        headers['Content-Transfer-Encoding'] = 'binary'
+        headers[CONTENT_TRANSFER_ENCODING] = CONTENT_TRANSFER_BINARY
 
         response.sending_file = true
 

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -930,7 +930,7 @@ class ClientsController < ApplicationController
 end
 ```
 
-The `download_pdf` action in the example above will call a private method which actually generates the PDF document and returns it as a string. This string will then be streamed to the client as a file download and a filename will be suggested to the user. Sometimes when streaming files to the user, you may not want them to download the file. Take images, for example, which can be embedded into HTML pages. To tell the browser a file is not meant to be downloaded, you can set the `:disposition` option to "inline". The opposite and default value for this option is "attachment".
+The `download_pdf` action in the example above will call a private method which actually generates the PDF document and returns it as a string. This string will then be streamed to the client as a file download and a filename will be suggested to the user. Sometimes when streaming files to the user, you may not want them to download the file. Take images, for example, which can be embedded into HTML pages. To tell the browser a file is not meant to be downloaded, you can set the `:disposition` option to `:inline`. The opposite and default value for this option is `:attachment`.
 
 ### Sending Files
 

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -353,7 +353,7 @@ basename = File.expand_path(File.join(File.dirname(__FILE__), '../../files'))
 filename = File.expand_path(File.join(basename, @file.public_filename))
 raise if basename !=
      File.expand_path(File.join(File.dirname(filename), '../../../'))
-send_file filename, disposition: 'inline'
+send_file filename, disposition: :inline
 ```
 
 Another (additional) approach is to store the file names in the database and name the files on the disk after the ids in the database. This is also a good approach to avoid possible code in an uploaded file to be executed. The attachment_fu plugin does this in a similar way.


### PR DESCRIPTION
Hi. Small code optimization for method `send_file_headers!`.
And update the documentation, the use of symbol instead of a string for option `disposition`.
