### PR TITLE
Standardize `ActionController::Parameters#to_unsafe_h` return value

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -183,7 +183,7 @@ module ActionController
 
     # Returns an unsafe, unfiltered +Hash+ representation of this parameter.
     def to_unsafe_h
-      @parameters
+      @parameters.to_h
     end
     alias_method :to_unsafe_hash, :to_unsafe_h
 


### PR DESCRIPTION
@sikachu per [the comment](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/strong_parameters.rb#L184) (it refers to the method returning a hash) and that `ActionController::Parameters#to_h` returns a hash, should `ActionController::Parameters#to_unsafe_h` also return a hash as opposed to a `ActiveSupport::HashWithIndifferentAccess`, for consistency?
