### PR TITLE
Add ActiveRecord::Relation#in_batches

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, to: :all
     delegate :find_by, :find_by!, to: :all
     delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, to: :all
-    delegate :find_each, :find_in_batches, :in_batches, to: :all
+    delegate :find_each, :find_in_batches, :in_batches, :with_batches, to: :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins, :or,
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly,
              :having, :create_with, :uniq, :distinct, :references, :none, :unscope, to: :all

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, to: :all
     delegate :find_by, :find_by!, to: :all
     delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, to: :all
-    delegate :find_each, :find_in_batches, to: :all
+    delegate :find_each, :find_in_batches, :each_slice, to: :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins, :or,
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly,
              :having, :create_with, :uniq, :distinct, :references, :none, :unscope, to: :all

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, to: :all
     delegate :find_by, :find_by!, to: :all
     delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, to: :all
-    delegate :find_each, :find_in_batches, :each_slice, to: :all
+    delegate :find_each, :find_in_batches, :in_batches, to: :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins, :or,
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly,
              :having, :create_with, :uniq, :distinct, :references, :none, :unscope, to: :all

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, to: :all
     delegate :find_by, :find_by!, to: :all
     delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, to: :all
-    delegate :find_each, :find_in_batches, :in_batches, :with_batches, to: :all
+    delegate :find_each, :find_in_batches, :in_batches, to: :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins, :or,
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly,
              :having, :create_with, :uniq, :distinct, :references, :none, :unscope, to: :all

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -145,15 +145,15 @@ module ActiveRecord
 
     # Yields ActiveRecord::Relation objects to work with a batch of records.
     #
-    #   Person.where("age > 21").each_slice do |relation|
+    #   Person.where("age > 21").in_batches do |relation|
     #     sleep(50)
     #     relation.update_all(cool: true)
     #   end
     #
-    # If you do not provide a block to #each_slice, it will return an Enumerator
+    # If you do not provide a block to #in_batches, it will return an Enumerator
     # which yields ActiveRecord::Relation objects for chaining with other methods:
     #
-    #   Person.each_slice.with_index do |relation, batch|
+    #   Person.in_batches.with_index do |relation, batch|
     #     puts "Processing relation ##{batch}"
     #     relation.each{|relation| relation.delete_all }
     #   end
@@ -172,7 +172,7 @@ module ActiveRecord
     # (by setting the +:begin_at+ and +:end_at+ option on each worker).
     #
     #   # Let's process the next 2000 records
-    #   Person.each_slice(begin_at: 2000, batch_size: 2000) do |relation|
+    #   Person.in_batches(begin_at: 2000, batch_size: 2000) do |relation|
     #     relation.update_all(cool: true)
     #   end
     #
@@ -183,10 +183,10 @@ module ActiveRecord
     #
     # NOTE: You can't set the limit either, that's used to control
     # the batch sizes.
-    def each_slice(begin_at: nil, end_at: nil, batch_size: 1000)
+    def in_batches(begin_at: nil, end_at: nil, batch_size: 1000)
       relation = self
       unless block_given?
-        return to_enum(:each_slice, begin_at: begin_at, end_at: end_at, batch_size: batch_size) do
+        return to_enum(:in_batches, begin_at: begin_at, end_at: end_at, batch_size: batch_size) do
           total = apply_limits(relation, begin_at, end_at).size
           (total - 1).div(batch_size) + 1
         end

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -47,6 +47,11 @@ module ActiveRecord
     # NOTE: You can't set the limit either, that's used to control
     # the batch sizes.
     def find_each(begin_at: nil, end_at: nil, batch_size: 1000, start: nil)
+      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        The #find_each method is deprecated.
+        Please use #in_batches instead.
+      MSG
+
       if start
         begin_at = start
         ActiveSupport::Deprecation.warn(<<-MSG.squish)
@@ -106,6 +111,11 @@ module ActiveRecord
     # NOTE: You can't set the limit either, that's used to control
     # the batch sizes.
     def find_in_batches(begin_at: nil, end_at: nil, batch_size: 1000, start: nil)
+      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        The #find_in_batches method is deprecated.
+        Please use #in_batches instead.
+      MSG
+
       if start
         begin_at = start
         ActiveSupport::Deprecation.warn(<<-MSG.squish)

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -202,10 +202,10 @@ module ActiveRecord
       relation = apply_limits(relation, begin_at, end_at)
       offset = 0
 
-      while true
+      loop do
         relation_yielded = relation.offset(offset)
         relation_yielded.load if load
-        break if !relation_yielded.any?
+        break if relation_yielded.none?
         yield relation_yielded
         offset += of
       end

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -159,7 +159,7 @@ module ActiveRecord
     #   end
     #
     # ==== Options
-    # * <tt>:batch_size</tt> - Specifies the size of the batch. Default to 1000.
+    # * <tt>:of</tt> - Specifies the size of the batch. Default to 1000.
     # * <tt>:begin_at</tt> - Specifies the primary key value to start from, inclusive of the value.
     # * <tt>:end_at</tt> - Specifies the primary key value to end at, inclusive of the value.
     #
@@ -172,7 +172,7 @@ module ActiveRecord
     # (by setting the +:begin_at+ and +:end_at+ option on each worker).
     #
     #   # Let's process the next 2000 records
-    #   Person.in_batches(begin_at: 2000, batch_size: 2000) do |relation|
+    #   Person.in_batches(of: 2000, begin_at: 2000) do |relation|
     #     relation.update_all(cool: true)
     #   end
     #
@@ -183,12 +183,12 @@ module ActiveRecord
     #
     # NOTE: You can't set the limit either, that's used to control
     # the batch sizes.
-    def in_batches(begin_at: nil, end_at: nil, batch_size: 1000)
+    def in_batches(of: 1000, begin_at: nil, end_at: nil)
       relation = self
       unless block_given?
-        return to_enum(:in_batches, begin_at: begin_at, end_at: end_at, batch_size: batch_size) do
+        return to_enum(:in_batches, of: of, begin_at: begin_at, end_at: end_at) do
           total = apply_limits(relation, begin_at, end_at).size
-          (total - 1).div(batch_size) + 1
+          (total - 1).div(of) + 1
         end
       end
 
@@ -196,7 +196,7 @@ module ActiveRecord
         logger.warn("Scoped order and limit are ignored, it's forced to be batch order and batch size")
       end
 
-      relation = relation.reorder(batch_order).limit(batch_size)
+      relation = relation.reorder(batch_order).limit(of)
       relation = apply_limits(relation, begin_at, end_at)
       relation_yielded = relation
 

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -47,11 +47,6 @@ module ActiveRecord
     # NOTE: You can't set the limit either, that's used to control
     # the batch sizes.
     def find_each(begin_at: nil, end_at: nil, batch_size: 1000, start: nil)
-      ActiveSupport::Deprecation.warn(<<-MSG.squish)
-        The #find_each method is deprecated.
-        Please use #in_batches instead with the +:load+ option set to true.
-      MSG
-
       if start
         begin_at = start
         ActiveSupport::Deprecation.warn(<<-MSG.squish)
@@ -111,11 +106,6 @@ module ActiveRecord
     # NOTE: You can't set the limit either, that's used to control
     # the batch sizes.
     def find_in_batches(begin_at: nil, end_at: nil, batch_size: 1000, start: nil)
-      ActiveSupport::Deprecation.warn(<<-MSG.squish)
-        The #find_in_batches method is deprecated.
-        Please use #in_batches instead with the +:load+ option set to true.
-      MSG
-
       if start
         begin_at = start
         ActiveSupport::Deprecation.warn(<<-MSG.squish)
@@ -204,67 +194,18 @@ module ActiveRecord
 
       loop do
         relation_yielded = relation.offset(offset)
-        relation_yielded.load if load
-        break if relation_yielded.none?
-        yield relation_yielded
-        offset += of
-      end
-    end
 
-    # Looping through a collection of records from the database
-    # (using the +all+ method, for example) is very inefficient
-    # since it will try to instantiate all the objects at once.
-    #
-    # In that case, batch processing methods allow you to work
-    # with the records in batches, thereby greatly reducing memory consumption.
-    #
-    # The #with_batches method uses #in_batches with a batch size of 1000 (or as
-    # specified by the +:of+ option).
-    #
-    #   Person.with_batches.each(&:do_awesome_stuff)
-    #
-    #   Person.where("age > 21").with_batches(of: 100) do |people|
-    #     people.each(&:party_all_night!)
-    #   end
-    #
-    # If you do not provide a block to #with_batches, it will return an Enumerator
-    # for chaining with other methods:
-    #
-    #   Person.with_batches.with_index do |person, index|
-    #     person.award_trophy(index + 1)
-    #   end
-    #
-    # ==== Options
-    # * <tt>:of</tt> - Specifies the size of the batch. Default to 1000.
-    # * <tt>:begin_at</tt> - Specifies the primary key value to start from, inclusive of the value.
-    # * <tt>:end_at</tt> - Specifies the primary key value to end at, inclusive of the value.
-    # This is especially useful if you want multiple workers dealing with
-    # the same processing queue. You can make worker 1 handle all the records
-    # between id 0 and 10,000 and worker 2 handle from 10,000 and beyond
-    # (by setting the +:begin_at+ and +:end_at+ option on each worker).
-    #
-    #   # Let's process for a batch of 2000 records, skipping the first 2000 rows
-    #   Person.with_batches(of: 2000, begin_at: 2000) do |person|
-    #     person.party_all_night!
-    #   end
-    #
-    # NOTE: It's not possible to set the order. That is automatically set to
-    # ascending on the primary key ("id ASC") to make the batch ordering
-    # work. This also means that this method only works when the primary key is
-    # orderable (e.g. an integer or string).
-    #
-    # NOTE: You can't set the limit either, that's used to control
-    # the batch sizes.
-    def with_batches(of: 1000, begin_at: nil, end_at: nil)
-      if block_given?
-        in_batches(of: of, begin_at: begin_at, end_at: end_at, load: true) do |records|
-          records.each { |record| yield record }
+        if load
+          relation_yielded.load
+          count = relation_yielded.to_a.count
+        else
+          count = relation_yielded.count
         end
-      else
-        enum_for(:with_batches, of: of, begin_at: begin_at, end_at: end_at) do
-          relation = self
-          apply_limits(relation, begin_at, end_at).size
-        end
+
+        break if count == 0
+        yield relation_yielded
+        break if count < of
+        offset += of
       end
     end
 

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -211,6 +211,63 @@ module ActiveRecord
       end
     end
 
+    # Looping through a collection of records from the database
+    # (using the +all+ method, for example) is very inefficient
+    # since it will try to instantiate all the objects at once.
+    #
+    # In that case, batch processing methods allow you to work
+    # with the records in batches, thereby greatly reducing memory consumption.
+    #
+    # The #with_batches method uses #in_batches with a batch size of 1000 (or as
+    # specified by the +:of+ option).
+    #
+    #   Person.with_batches.each(&:do_awesome_stuff)
+    #
+    #   Person.where("age > 21").with_batches(of: 100) do |people|
+    #     people.each(&:party_all_night!)
+    #   end
+    #
+    # If you do not provide a block to #with_batches, it will return an Enumerator
+    # for chaining with other methods:
+    #
+    #   Person.with_batches.with_index do |person, index|
+    #     person.award_trophy(index + 1)
+    #   end
+    #
+    # ==== Options
+    # * <tt>:of</tt> - Specifies the size of the batch. Default to 1000.
+    # * <tt>:begin_at</tt> - Specifies the primary key value to start from, inclusive of the value.
+    # * <tt>:end_at</tt> - Specifies the primary key value to end at, inclusive of the value.
+    # This is especially useful if you want multiple workers dealing with
+    # the same processing queue. You can make worker 1 handle all the records
+    # between id 0 and 10,000 and worker 2 handle from 10,000 and beyond
+    # (by setting the +:begin_at+ and +:end_at+ option on each worker).
+    #
+    #   # Let's process for a batch of 2000 records, skipping the first 2000 rows
+    #   Person.with_batches(of: 2000, begin_at: 2000) do |person|
+    #     person.party_all_night!
+    #   end
+    #
+    # NOTE: It's not possible to set the order. That is automatically set to
+    # ascending on the primary key ("id ASC") to make the batch ordering
+    # work. This also means that this method only works when the primary key is
+    # orderable (e.g. an integer or string).
+    #
+    # NOTE: You can't set the limit either, that's used to control
+    # the batch sizes.
+    def with_batches(of: 1000, begin_at: nil, end_at: nil)
+      if block_given?
+        in_batches(of: of, begin_at: begin_at, end_at: end_at, load: true) do |records|
+          records.each { |record| yield record }
+        end
+      else
+        enum_for(:with_batches, of: of, begin_at: begin_at, end_at: end_at) do
+          relation = self
+          apply_limits(relation, begin_at, end_at).size
+        end
+      end
+    end
+
     private
 
     def apply_limits(relation, begin_at, end_at)

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -212,7 +212,7 @@ class EachTest < ActiveRecord::TestCase
 
   def test_in_batches_should_return_relationes
     assert_queries(@total + 1) do
-      Post.in_batches(:batch_size => 1) do |relation|
+      Post.in_batches(of: 1) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Post, relation.first
       end
@@ -221,7 +221,7 @@ class EachTest < ActiveRecord::TestCase
 
   def test_in_batches_should_start_from_the_start_option
     assert_queries(@total) do
-      Post.in_batches(batch_size: 1, begin_at: 2) do |relation|
+      Post.in_batches(of: 1, begin_at: 2) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Post, relation.first
       end
@@ -230,7 +230,7 @@ class EachTest < ActiveRecord::TestCase
 
   def test_in_batches_should_end_at_the_end_option
     assert_queries(5 + 1) do
-      Post.in_batches(batch_size: 1, end_at: 5) do |relation|
+      Post.in_batches(of: 1, end_at: 5) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Post, relation.first
       end
@@ -239,18 +239,18 @@ class EachTest < ActiveRecord::TestCase
 
   def test_in_batches_shouldnt_execute_query_unless_needed
     assert_queries(1 + 1) do
-      Post.in_batches(:batch_size => @total) {|relation| assert_kind_of ActiveRecord::Relation, relation }
+      Post.in_batches(of: @total) {|relation| assert_kind_of ActiveRecord::Relation, relation }
     end
 
     assert_queries(1 + 1) do
-      Post.in_batches(:batch_size => @total + 1) {|relation| assert_kind_of ActiveRecord::Relation, relation }
+      Post.in_batches(of: @total + 1) {|relation| assert_kind_of ActiveRecord::Relation, relation }
     end
   end
 
   def test_in_batches_should_quote_batch_order
     c = Post.connection
     assert_sql(/ORDER BY #{c.quote_table_name('posts')}.#{c.quote_column_name('id')}/) do
-      Post.in_batches(:batch_size => 1) do |relation|
+      Post.in_batches(of: 1) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Post, relation.first
       end
@@ -262,7 +262,7 @@ class EachTest < ActiveRecord::TestCase
     not_a_post.stubs(:id).raises(StandardError, "not_a_post had #id called on it")
 
     assert_nothing_raised do
-      Post.in_batches(:batch_size => 1) do |relation|
+      Post.in_batches(of: 1) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Post, relation.first
 
@@ -294,7 +294,7 @@ class EachTest < ActiveRecord::TestCase
 
   def test_in_batches_should_not_modify_passed_options
     assert_nothing_raised do
-      Post.in_batches({ batch_size: 42, begin_at: 1 }.freeze){}
+      Post.in_batches({ of: 42, begin_at: 1 }.freeze){}
     end
   end
 
@@ -303,7 +303,7 @@ class EachTest < ActiveRecord::TestCase
     start_nick = nick_order_subscribers.second.nick
 
     subscribers = []
-    Subscriber.in_batches(batch_size: 1, begin_at: start_nick) do |relation|
+    Subscriber.in_batches(of: 1, begin_at: start_nick) do |relation|
       subscribers.concat(relation)
     end
 
@@ -312,7 +312,7 @@ class EachTest < ActiveRecord::TestCase
 
   def test_in_batches_should_use_any_column_as_primary_key_when_start_is_not_specified
     assert_queries(Subscriber.count + 1) do
-      Subscriber.in_batches(batch_size: 1) do |relation|
+      Subscriber.in_batches(of: 1) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Subscriber, relation.first
       end
@@ -322,7 +322,7 @@ class EachTest < ActiveRecord::TestCase
   def test_in_batches_should_return_an_enumerator
     enum = nil
     assert_queries(0) do
-      enum = Post.in_batches(:batch_size => 1)
+      enum = Post.in_batches(of: 1)
     end
     assert_queries(4) do
       enum.first(4) do |relation|

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -210,59 +210,59 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
-  def test_each_slice_should_return_relationes
+  def test_in_batches_should_return_relationes
     assert_queries(@total + 1) do
-      Post.each_slice(:batch_size => 1) do |relation|
+      Post.in_batches(:batch_size => 1) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Post, relation.first
       end
     end
   end
 
-  def test_each_slice_should_start_from_the_start_option
+  def test_in_batches_should_start_from_the_start_option
     assert_queries(@total) do
-      Post.each_slice(batch_size: 1, begin_at: 2) do |relation|
+      Post.in_batches(batch_size: 1, begin_at: 2) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Post, relation.first
       end
     end
   end
 
-  def test_each_slice_should_end_at_the_end_option
+  def test_in_batches_should_end_at_the_end_option
     assert_queries(5 + 1) do
-      Post.each_slice(batch_size: 1, end_at: 5) do |relation|
+      Post.in_batches(batch_size: 1, end_at: 5) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Post, relation.first
       end
     end
   end
 
-  def test_each_slice_shouldnt_execute_query_unless_needed
+  def test_in_batches_shouldnt_execute_query_unless_needed
     assert_queries(1 + 1) do
-      Post.each_slice(:batch_size => @total) {|relation| assert_kind_of ActiveRecord::Relation, relation }
+      Post.in_batches(:batch_size => @total) {|relation| assert_kind_of ActiveRecord::Relation, relation }
     end
 
     assert_queries(1 + 1) do
-      Post.each_slice(:batch_size => @total + 1) {|relation| assert_kind_of ActiveRecord::Relation, relation }
+      Post.in_batches(:batch_size => @total + 1) {|relation| assert_kind_of ActiveRecord::Relation, relation }
     end
   end
 
-  def test_each_slice_should_quote_batch_order
+  def test_in_batches_should_quote_batch_order
     c = Post.connection
     assert_sql(/ORDER BY #{c.quote_table_name('posts')}.#{c.quote_column_name('id')}/) do
-      Post.each_slice(:batch_size => 1) do |relation|
+      Post.in_batches(:batch_size => 1) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Post, relation.first
       end
     end
   end
 
-  def test_each_slice_should_not_use_records_after_yielding_them_in_case_original_array_is_modified
+  def test_in_batches_should_not_use_records_after_yielding_them_in_case_original_array_is_modified
     not_a_post = "not a post"
     not_a_post.stubs(:id).raises(StandardError, "not_a_post had #id called on it")
 
     assert_nothing_raised do
-      Post.each_slice(:batch_size => 1) do |relation|
+      Post.in_batches(:batch_size => 1) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Post, relation.first
 
@@ -271,11 +271,11 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
-  def test_each_slice_should_ignore_the_order_default_scope
+  def test_in_batches_should_ignore_the_order_default_scope
     # First post is with title scope
     first_post = PostWithDefaultScope.first
     posts = []
-    PostWithDefaultScope.each_slice do |relation|
+    PostWithDefaultScope.in_batches do |relation|
       posts.concat(relation)
     end
     # posts.first will be ordered using id only. Title order scope should not apply here
@@ -283,46 +283,46 @@ class EachTest < ActiveRecord::TestCase
     assert_equal posts(:welcome), posts.first
   end
 
-  def test_each_slice_should_not_ignore_the_default_scope_if_it_is_other_then_order
+  def test_in_batches_should_not_ignore_the_default_scope_if_it_is_other_then_order
     special_posts_ids = SpecialPostWithDefaultScope.all.map(&:id).sort
     posts = []
-    SpecialPostWithDefaultScope.each_slice do |relation|
+    SpecialPostWithDefaultScope.in_batches do |relation|
       posts.concat(relation)
     end
     assert_equal special_posts_ids, posts.map(&:id)
   end
 
-  def test_each_slice_should_not_modify_passed_options
+  def test_in_batches_should_not_modify_passed_options
     assert_nothing_raised do
-      Post.each_slice({ batch_size: 42, begin_at: 1 }.freeze){}
+      Post.in_batches({ batch_size: 42, begin_at: 1 }.freeze){}
     end
   end
 
-  def test_each_slice_should_use_any_column_as_primary_key
+  def test_in_batches_should_use_any_column_as_primary_key
     nick_order_subscribers = Subscriber.order('nick asc')
     start_nick = nick_order_subscribers.second.nick
 
     subscribers = []
-    Subscriber.each_slice(batch_size: 1, begin_at: start_nick) do |relation|
+    Subscriber.in_batches(batch_size: 1, begin_at: start_nick) do |relation|
       subscribers.concat(relation)
     end
 
     assert_equal nick_order_subscribers[1..-1].map(&:id), subscribers.map(&:id)
   end
 
-  def test_each_slice_should_use_any_column_as_primary_key_when_start_is_not_specified
+  def test_in_batches_should_use_any_column_as_primary_key_when_start_is_not_specified
     assert_queries(Subscriber.count + 1) do
-      Subscriber.each_slice(batch_size: 1) do |relation|
+      Subscriber.in_batches(batch_size: 1) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Subscriber, relation.first
       end
     end
   end
 
-  def test_each_slice_should_return_an_enumerator
+  def test_in_batches_should_return_an_enumerator
     enum = nil
     assert_queries(0) do
-      enum = Post.each_slice(:batch_size => 1)
+      enum = Post.in_batches(:batch_size => 1)
     end
     assert_queries(4) do
       enum.first(4) do |relation|

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -12,216 +12,117 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_each_should_execute_one_query_per_batch
-    assert_deprecated do
-      assert_queries(@total + 1) do
-        Post.find_each(:batch_size => 1) do |post|
-          assert_kind_of Post, post
-        end
+    assert_queries(@total + 1) do
+      Post.find_each(:batch_size => 1) do |post|
+        assert_kind_of Post, post
       end
     end
   end
 
-  def test_each_should_not_return_query_chain_and_execute_two_query
-    assert_deprecated do
-      assert_queries(2) do
-        result = Post.find_each(:batch_size => 100000){ }
-        assert_nil result
-      end
+  def test_each_should_not_return_query_chain_and_execute_only_one_query
+    assert_queries(1) do
+      result = Post.find_each(:batch_size => 100000){ }
+      assert_nil result
     end
   end
 
   def test_each_should_return_an_enumerator_if_no_block_is_present
-    assert_deprecated do
-      assert_queries(1 + 1) do
-        Post.find_each(:batch_size => 100000).with_index do |post, index|
-          assert_kind_of Post, post
-          assert_kind_of Integer, index
-        end
+    assert_queries(1) do
+      Post.find_each(:batch_size => 100000).with_index do |post, index|
+        assert_kind_of Post, post
+        assert_kind_of Integer, index
       end
     end
   end
 
   if Enumerator.method_defined? :size
     def test_each_should_return_a_sized_enumerator
-      assert_deprecated do
-        assert_equal 11, Post.find_each(batch_size: 1).size
-        assert_equal 5, Post.find_each(batch_size:  2, begin_at: 7).size
-        assert_equal 11, Post.find_each(batch_size: 10_000).size
-      end
+      assert_equal 11, Post.find_each(batch_size: 1).size
+      assert_equal 5, Post.find_each(batch_size:  2, begin_at: 7).size
+      assert_equal 11, Post.find_each(batch_size: 10_000).size
     end
   end
 
   def test_each_enumerator_should_execute_one_query_per_batch
-    assert_deprecated do
-      assert_queries(@total + 1) do
-        Post.find_each(:batch_size => 1).with_index do |post, index|
-          assert_kind_of Post, post
-          assert_kind_of Integer, index
-        end
+    assert_queries(@total + 1) do
+      Post.find_each(:batch_size => 1).with_index do |post, index|
+        assert_kind_of Post, post
+        assert_kind_of Integer, index
       end
     end
   end
 
   def test_each_should_execute_if_id_is_in_select
-    assert_deprecated do
-      assert_queries(6 + 1) do
-        Post.select("id, title, type").find_each(:batch_size => 2) do |post|
-          assert_kind_of Post, post
-        end
+    assert_queries(6) do
+      Post.select("id, title, type").find_each(:batch_size => 2) do |post|
+        assert_kind_of Post, post
       end
     end
   end
 
   def test_warn_if_limit_scope_is_set
     ActiveRecord::Base.logger.expects(:warn)
-    assert_deprecated do
-      Post.limit(1).find_each { |post| post }
-    end
+    Post.limit(1).find_each { |post| post }
   end
 
   def test_warn_if_order_scope_is_set
     ActiveRecord::Base.logger.expects(:warn)
-    assert_deprecated do
-      Post.order("title").find_each { |post| post }
-    end
+    Post.order("title").find_each { |post| post }
   end
 
   def test_logger_not_required
     previous_logger = ActiveRecord::Base.logger
     ActiveRecord::Base.logger = nil
-    assert_deprecated do
-      assert_nothing_raised do
-        Post.limit(1).find_each { |post| post }
-      end
-    end
-  ensure
-    ActiveRecord::Base.logger = previous_logger
-  end
-
-  def test_with_batches_should_execute_one_query_per_batch
-    assert_queries(@total + 1) do
-      Post.with_batches(of: 1) do |post|
-        assert_kind_of Post, post
-      end
-    end
-  end
-
-  def test_with_batches_should_not_return_query_chain_and_execute_two_query
-    assert_queries(2) do
-      result = Post.with_batches(of: 100000){ }
-      assert_nil result
-    end
-  end
-
-  def test_with_batches_should_return_an_enumerator_if_no_block_is_present
-    assert_queries(1 + 1) do
-      Post.with_batches(of: 100000).with_index do |post, index|
-        assert_kind_of Post, post
-        assert_kind_of Integer, index
-      end
-    end
-  end
-
-  if Enumerator.method_defined? :size
-    def test_with_batches_should_return_a_sized_enumerator
-      assert_equal 11, Post.with_batches(of: 1).size
-      assert_equal 5, Post.with_batches(of:  2, begin_at: 7).size
-      assert_equal 11, Post.with_batches(of: 10_000).size
-    end
-  end
-
-  def test_with_batches_enumerator_should_execute_one_query_per_batch
-    assert_queries(@total + 1) do
-      Post.with_batches(of: 1).with_index do |post, index|
-        assert_kind_of Post, post
-        assert_kind_of Integer, index
-      end
-    end
-  end
-
-  def test_with_batches_should_execute_if_id_is_in_select
-    assert_queries(6 + 1) do
-      Post.select("id, title, type").with_batches(of: 2) do |post|
-        assert_kind_of Post, post
-      end
-    end
-  end
-
-  def test_with_batches_warn_if_limit_scope_is_set
-    ActiveRecord::Base.logger.expects(:warn)
-    Post.limit(1).with_batches { |post| post }
-  end
-
-  def test_with_batches_warn_if_order_scope_is_set
-    ActiveRecord::Base.logger.expects(:warn)
-    Post.order("title").with_batches { |post| post }
-  end
-
-  def test_with_batches_logger_not_required
-    previous_logger = ActiveRecord::Base.logger
-    ActiveRecord::Base.logger = nil
     assert_nothing_raised do
-      Post.limit(1).with_batches { |post| post }
+      Post.limit(1).find_each { |post| post }
     end
   ensure
     ActiveRecord::Base.logger = previous_logger
   end
 
   def test_find_in_batches_should_return_batches
-    assert_deprecated do
-      assert_queries(@total + 1) do
-        Post.find_in_batches(:batch_size => 1) do |batch|
-          assert_kind_of Array, batch
-          assert_kind_of Post, batch.first
-        end
+    assert_queries(@total + 1) do
+      Post.find_in_batches(:batch_size => 1) do |batch|
+        assert_kind_of Array, batch
+        assert_kind_of Post, batch.first
       end
     end
   end
 
   def test_find_in_batches_should_start_from_the_start_option
-    assert_deprecated do
-      assert_queries(@total) do
-        Post.find_in_batches(batch_size: 1, begin_at: 2) do |batch|
-          assert_kind_of Array, batch
-          assert_kind_of Post, batch.first
-        end
+    assert_queries(@total) do
+      Post.find_in_batches(batch_size: 1, begin_at: 2) do |batch|
+        assert_kind_of Array, batch
+        assert_kind_of Post, batch.first
       end
     end
   end
 
   def test_find_in_batches_should_end_at_the_end_option
-    assert_deprecated do
-      assert_queries(6) do
-        Post.find_in_batches(batch_size: 1, end_at: 5) do |batch|
-          assert_kind_of Array, batch
-          assert_kind_of Post, batch.first
-        end
+    assert_queries(6) do
+      Post.find_in_batches(batch_size: 1, end_at: 5) do |batch|
+        assert_kind_of Array, batch
+        assert_kind_of Post, batch.first
       end
     end
   end
 
   def test_find_in_batches_shouldnt_execute_query_unless_needed
-    assert_deprecated do
-      assert_queries(2) do
-        Post.find_in_batches(:batch_size => @total) {|batch| assert_kind_of Array, batch }
-      end
+    assert_queries(2) do
+      Post.find_in_batches(:batch_size => @total) {|batch| assert_kind_of Array, batch }
     end
 
-    assert_deprecated do
-      assert_queries(2) do
-        Post.find_in_batches(:batch_size => @total + 1) {|batch| assert_kind_of Array, batch }
-      end
+    assert_queries(1) do
+      Post.find_in_batches(:batch_size => @total + 1) {|batch| assert_kind_of Array, batch }
     end
   end
 
   def test_find_in_batches_should_quote_batch_order
     c = Post.connection
-    assert_deprecated do
-      assert_sql(/ORDER BY #{c.quote_table_name('posts')}.#{c.quote_column_name('id')}/) do
-        Post.find_in_batches(:batch_size => 1) do |batch|
-          assert_kind_of Array, batch
-          assert_kind_of Post, batch.first
-        end
+    assert_sql(/ORDER BY #{c.quote_table_name('posts')}.#{c.quote_column_name('id')}/) do
+      Post.find_in_batches(:batch_size => 1) do |batch|
+        assert_kind_of Array, batch
+        assert_kind_of Post, batch.first
       end
     end
   end
@@ -230,14 +131,12 @@ class EachTest < ActiveRecord::TestCase
     not_a_post = "not a post"
     not_a_post.stubs(:id).raises(StandardError, "not_a_post had #id called on it")
 
-    assert_deprecated do
-      assert_nothing_raised do
-        Post.find_in_batches(:batch_size => 1) do |batch|
-          assert_kind_of Array, batch
-          assert_kind_of Post, batch.first
+    assert_nothing_raised do
+      Post.find_in_batches(:batch_size => 1) do |batch|
+        assert_kind_of Array, batch
+        assert_kind_of Post, batch.first
 
-          batch.map! { not_a_post }
-        end
+        batch.map! { not_a_post }
       end
     end
   end
@@ -246,10 +145,8 @@ class EachTest < ActiveRecord::TestCase
     # First post is with title scope
     first_post = PostWithDefaultScope.first
     posts = []
-    assert_deprecated do
-      PostWithDefaultScope.find_in_batches  do |batch|
-        posts.concat(batch)
-      end
+    PostWithDefaultScope.find_in_batches  do |batch|
+      posts.concat(batch)
     end
     # posts.first will be ordered using id only. Title order scope should not apply here
     assert_not_equal first_post, posts.first
@@ -259,19 +156,15 @@ class EachTest < ActiveRecord::TestCase
   def test_find_in_batches_should_not_ignore_the_default_scope_if_it_is_other_then_order
     special_posts_ids = SpecialPostWithDefaultScope.all.map(&:id).sort
     posts = []
-    assert_deprecated do
-      SpecialPostWithDefaultScope.find_in_batches do |batch|
-        posts.concat(batch)
-      end
+    SpecialPostWithDefaultScope.find_in_batches do |batch|
+      posts.concat(batch)
     end
     assert_equal special_posts_ids, posts.map(&:id)
   end
 
   def test_find_in_batches_should_not_modify_passed_options
-    assert_deprecated do
-      assert_nothing_raised do
-        Post.find_in_batches({ batch_size: 42, begin_at: 1 }.freeze){}
-      end
+    assert_nothing_raised do
+      Post.find_in_batches({ batch_size: 42, begin_at: 1 }.freeze){}
     end
   end
 
@@ -280,39 +173,31 @@ class EachTest < ActiveRecord::TestCase
     start_nick = nick_order_subscribers.second.nick
 
     subscribers = []
-    assert_deprecated do
-      Subscriber.find_in_batches(batch_size: 1, begin_at: start_nick) do |batch|
-        subscribers.concat(batch)
-      end
+    Subscriber.find_in_batches(batch_size: 1, begin_at: start_nick) do |batch|
+      subscribers.concat(batch)
     end
 
     assert_equal nick_order_subscribers[1..-1].map(&:id), subscribers.map(&:id)
   end
 
   def test_find_in_batches_should_use_any_column_as_primary_key_when_start_is_not_specified
-    assert_deprecated do
-      assert_queries(Subscriber.count + 1) do
-        Subscriber.find_in_batches(batch_size: 1) do |batch|
-          assert_kind_of Array, batch
-          assert_kind_of Subscriber, batch.first
-        end
+    assert_queries(Subscriber.count + 1) do
+      Subscriber.find_in_batches(batch_size: 1) do |batch|
+        assert_kind_of Array, batch
+        assert_kind_of Subscriber, batch.first
       end
     end
   end
 
   def test_find_in_batches_should_return_an_enumerator
     enum = nil
-    assert_deprecated do
-      assert_queries(0) do
-        enum = Post.find_in_batches(:batch_size => 1)
-      end
+    assert_queries(0) do
+      enum = Post.find_in_batches(:batch_size => 1)
     end
-    assert_deprecated do
-      assert_queries(4) do
-        enum.first(4) do |batch|
-          assert_kind_of Array, batch
-          assert_kind_of Post, batch.first
-        end
+    assert_queries(4) do
+      enum.first(4) do |batch|
+        assert_kind_of Array, batch
+        assert_kind_of Post, batch.first
       end
     end
   end
@@ -371,7 +256,7 @@ class EachTest < ActiveRecord::TestCase
       Post.in_batches(of: @total) {|relation| assert_kind_of ActiveRecord::Relation, relation }
     end
 
-    assert_queries(1 + 1) do
+    assert_queries(1) do
       Post.in_batches(of: @total + 1) {|relation| assert_kind_of ActiveRecord::Relation, relation }
     end
   end
@@ -484,13 +369,11 @@ class EachTest < ActiveRecord::TestCase
 
   if Enumerator.method_defined? :size
     def test_find_in_batches_should_return_a_sized_enumerator
-      assert_deprecated do
-        assert_equal 11, Post.find_in_batches(:batch_size => 1).size
-        assert_equal 6, Post.find_in_batches(:batch_size => 2).size
-        assert_equal 4, Post.find_in_batches(batch_size: 2, begin_at: 4).size
-        assert_equal 4, Post.find_in_batches(:batch_size => 3).size
-        assert_equal 1, Post.find_in_batches(:batch_size => 10_000).size
-      end
+      assert_equal 11, Post.find_in_batches(:batch_size => 1).size
+      assert_equal 6, Post.find_in_batches(:batch_size => 2).size
+      assert_equal 4, Post.find_in_batches(batch_size: 2, begin_at: 4).size
+      assert_equal 4, Post.find_in_batches(:batch_size => 3).size
+      assert_equal 1, Post.find_in_batches(:batch_size => 10_000).size
     end
   end
 end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -12,125 +12,157 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_each_should_execute_one_query_per_batch
-    assert_queries(@total + 1) do
-      Post.find_each(:batch_size => 1) do |post|
-        assert_kind_of Post, post
+    assert_deprecated do
+      assert_queries(@total + 1) do
+        Post.find_each(:batch_size => 1) do |post|
+          assert_kind_of Post, post
+        end
       end
     end
   end
 
   def test_each_should_not_return_query_chain_and_execute_only_one_query
-    assert_queries(1) do
-      result = Post.find_each(:batch_size => 100000){ }
-      assert_nil result
+    assert_deprecated do
+      assert_queries(1) do
+        result = Post.find_each(:batch_size => 100000){ }
+        assert_nil result
+      end
     end
   end
 
   def test_each_should_return_an_enumerator_if_no_block_is_present
-    assert_queries(1) do
-      Post.find_each(:batch_size => 100000).with_index do |post, index|
-        assert_kind_of Post, post
-        assert_kind_of Integer, index
+    assert_deprecated do
+      assert_queries(1) do
+        Post.find_each(:batch_size => 100000).with_index do |post, index|
+          assert_kind_of Post, post
+          assert_kind_of Integer, index
+        end
       end
     end
   end
 
   if Enumerator.method_defined? :size
     def test_each_should_return_a_sized_enumerator
-      assert_equal 11, Post.find_each(batch_size: 1).size
-      assert_equal 5, Post.find_each(batch_size:  2, begin_at: 7).size
-      assert_equal 11, Post.find_each(batch_size: 10_000).size
+      assert_deprecated do
+        assert_equal 11, Post.find_each(batch_size: 1).size
+        assert_equal 5, Post.find_each(batch_size:  2, begin_at: 7).size
+        assert_equal 11, Post.find_each(batch_size: 10_000).size
+      end
     end
   end
 
   def test_each_enumerator_should_execute_one_query_per_batch
-    assert_queries(@total + 1) do
-      Post.find_each(:batch_size => 1).with_index do |post, index|
-        assert_kind_of Post, post
-        assert_kind_of Integer, index
+    assert_deprecated do
+      assert_queries(@total + 1) do
+        Post.find_each(:batch_size => 1).with_index do |post, index|
+          assert_kind_of Post, post
+          assert_kind_of Integer, index
+        end
       end
     end
   end
 
   def test_each_should_raise_if_select_is_set_without_id
-    assert_raise(RuntimeError) do
-      Post.select(:title).find_each(batch_size: 1) { |post|
-        flunk "should not call this block"
-      }
+    assert_deprecated do
+      assert_raise(RuntimeError) do
+        Post.select(:title).find_each(batch_size: 1) { |post|
+          flunk "should not call this block"
+        }
+      end
     end
   end
 
   def test_each_should_execute_if_id_is_in_select
-    assert_queries(6) do
-      Post.select("id, title, type").find_each(:batch_size => 2) do |post|
-        assert_kind_of Post, post
+    assert_deprecated do
+      assert_queries(6) do
+        Post.select("id, title, type").find_each(:batch_size => 2) do |post|
+          assert_kind_of Post, post
+        end
       end
     end
   end
 
   def test_warn_if_limit_scope_is_set
     ActiveRecord::Base.logger.expects(:warn)
-    Post.limit(1).find_each { |post| post }
+    assert_deprecated do
+      Post.limit(1).find_each { |post| post }
+    end
   end
 
   def test_warn_if_order_scope_is_set
     ActiveRecord::Base.logger.expects(:warn)
-    Post.order("title").find_each { |post| post }
+    assert_deprecated do
+      Post.order("title").find_each { |post| post }
+    end
   end
 
   def test_logger_not_required
     previous_logger = ActiveRecord::Base.logger
     ActiveRecord::Base.logger = nil
-    assert_nothing_raised do
-      Post.limit(1).find_each { |post| post }
+    assert_deprecated do
+      assert_nothing_raised do
+        Post.limit(1).find_each { |post| post }
+      end
     end
   ensure
     ActiveRecord::Base.logger = previous_logger
   end
 
   def test_find_in_batches_should_return_batches
-    assert_queries(@total + 1) do
-      Post.find_in_batches(:batch_size => 1) do |batch|
-        assert_kind_of Array, batch
-        assert_kind_of Post, batch.first
+    assert_deprecated do
+      assert_queries(@total + 1) do
+        Post.find_in_batches(:batch_size => 1) do |batch|
+          assert_kind_of Array, batch
+          assert_kind_of Post, batch.first
+        end
       end
     end
   end
 
   def test_find_in_batches_should_start_from_the_start_option
-    assert_queries(@total) do
-      Post.find_in_batches(batch_size: 1, begin_at: 2) do |batch|
-        assert_kind_of Array, batch
-        assert_kind_of Post, batch.first
+    assert_deprecated do
+      assert_queries(@total) do
+        Post.find_in_batches(batch_size: 1, begin_at: 2) do |batch|
+          assert_kind_of Array, batch
+          assert_kind_of Post, batch.first
+        end
       end
     end
   end
 
   def test_find_in_batches_should_end_at_the_end_option
-    assert_queries(6) do
-      Post.find_in_batches(batch_size: 1, end_at: 5) do |batch|
-        assert_kind_of Array, batch
-        assert_kind_of Post, batch.first
+    assert_deprecated do
+      assert_queries(6) do
+        Post.find_in_batches(batch_size: 1, end_at: 5) do |batch|
+          assert_kind_of Array, batch
+          assert_kind_of Post, batch.first
+        end
       end
     end
   end
 
   def test_find_in_batches_shouldnt_execute_query_unless_needed
-    assert_queries(2) do
-      Post.find_in_batches(:batch_size => @total) {|batch| assert_kind_of Array, batch }
+    assert_deprecated do
+      assert_queries(2) do
+        Post.find_in_batches(:batch_size => @total) {|batch| assert_kind_of Array, batch }
+      end
     end
 
-    assert_queries(1) do
-      Post.find_in_batches(:batch_size => @total + 1) {|batch| assert_kind_of Array, batch }
+    assert_deprecated do
+      assert_queries(1) do
+        Post.find_in_batches(:batch_size => @total + 1) {|batch| assert_kind_of Array, batch }
+      end
     end
   end
 
   def test_find_in_batches_should_quote_batch_order
     c = Post.connection
-    assert_sql(/ORDER BY #{c.quote_table_name('posts')}.#{c.quote_column_name('id')}/) do
-      Post.find_in_batches(:batch_size => 1) do |batch|
-        assert_kind_of Array, batch
-        assert_kind_of Post, batch.first
+    assert_deprecated do
+      assert_sql(/ORDER BY #{c.quote_table_name('posts')}.#{c.quote_column_name('id')}/) do
+        Post.find_in_batches(:batch_size => 1) do |batch|
+          assert_kind_of Array, batch
+          assert_kind_of Post, batch.first
+        end
       end
     end
   end
@@ -139,12 +171,14 @@ class EachTest < ActiveRecord::TestCase
     not_a_post = "not a post"
     not_a_post.stubs(:id).raises(StandardError, "not_a_post had #id called on it")
 
-    assert_nothing_raised do
-      Post.find_in_batches(:batch_size => 1) do |batch|
-        assert_kind_of Array, batch
-        assert_kind_of Post, batch.first
+    assert_deprecated do
+      assert_nothing_raised do
+        Post.find_in_batches(:batch_size => 1) do |batch|
+          assert_kind_of Array, batch
+          assert_kind_of Post, batch.first
 
-        batch.map! { not_a_post }
+          batch.map! { not_a_post }
+        end
       end
     end
   end
@@ -153,8 +187,10 @@ class EachTest < ActiveRecord::TestCase
     # First post is with title scope
     first_post = PostWithDefaultScope.first
     posts = []
-    PostWithDefaultScope.find_in_batches  do |batch|
-      posts.concat(batch)
+    assert_deprecated do
+      PostWithDefaultScope.find_in_batches  do |batch|
+        posts.concat(batch)
+      end
     end
     # posts.first will be ordered using id only. Title order scope should not apply here
     assert_not_equal first_post, posts.first
@@ -164,15 +200,19 @@ class EachTest < ActiveRecord::TestCase
   def test_find_in_batches_should_not_ignore_the_default_scope_if_it_is_other_then_order
     special_posts_ids = SpecialPostWithDefaultScope.all.map(&:id).sort
     posts = []
-    SpecialPostWithDefaultScope.find_in_batches do |batch|
-      posts.concat(batch)
+    assert_deprecated do
+      SpecialPostWithDefaultScope.find_in_batches do |batch|
+        posts.concat(batch)
+      end
     end
     assert_equal special_posts_ids, posts.map(&:id)
   end
 
   def test_find_in_batches_should_not_modify_passed_options
-    assert_nothing_raised do
-      Post.find_in_batches({ batch_size: 42, begin_at: 1 }.freeze){}
+    assert_deprecated do
+      assert_nothing_raised do
+        Post.find_in_batches({ batch_size: 42, begin_at: 1 }.freeze){}
+      end
     end
   end
 
@@ -181,31 +221,39 @@ class EachTest < ActiveRecord::TestCase
     start_nick = nick_order_subscribers.second.nick
 
     subscribers = []
-    Subscriber.find_in_batches(batch_size: 1, begin_at: start_nick) do |batch|
-      subscribers.concat(batch)
+    assert_deprecated do
+      Subscriber.find_in_batches(batch_size: 1, begin_at: start_nick) do |batch|
+        subscribers.concat(batch)
+      end
     end
 
     assert_equal nick_order_subscribers[1..-1].map(&:id), subscribers.map(&:id)
   end
 
   def test_find_in_batches_should_use_any_column_as_primary_key_when_start_is_not_specified
-    assert_queries(Subscriber.count + 1) do
-      Subscriber.find_in_batches(batch_size: 1) do |batch|
-        assert_kind_of Array, batch
-        assert_kind_of Subscriber, batch.first
+    assert_deprecated do
+      assert_queries(Subscriber.count + 1) do
+        Subscriber.find_in_batches(batch_size: 1) do |batch|
+          assert_kind_of Array, batch
+          assert_kind_of Subscriber, batch.first
+        end
       end
     end
   end
 
   def test_find_in_batches_should_return_an_enumerator
     enum = nil
-    assert_queries(0) do
-      enum = Post.find_in_batches(:batch_size => 1)
+    assert_deprecated do
+      assert_queries(0) do
+        enum = Post.find_in_batches(:batch_size => 1)
+      end
     end
-    assert_queries(4) do
-      enum.first(4) do |batch|
-        assert_kind_of Array, batch
-        assert_kind_of Post, batch.first
+    assert_deprecated do
+      assert_queries(4) do
+        enum.first(4) do |batch|
+          assert_kind_of Array, batch
+          assert_kind_of Post, batch.first
+        end
       end
     end
   end
@@ -355,11 +403,13 @@ class EachTest < ActiveRecord::TestCase
 
   if Enumerator.method_defined? :size
     def test_find_in_batches_should_return_a_sized_enumerator
-      assert_equal 11, Post.find_in_batches(:batch_size => 1).size
-      assert_equal 6, Post.find_in_batches(:batch_size => 2).size
-      assert_equal 4, Post.find_in_batches(batch_size: 2, begin_at: 4).size
-      assert_equal 4, Post.find_in_batches(:batch_size => 3).size
-      assert_equal 1, Post.find_in_batches(:batch_size => 10_000).size
+      assert_deprecated do
+        assert_equal 11, Post.find_in_batches(:batch_size => 1).size
+        assert_equal 6, Post.find_in_batches(:batch_size => 2).size
+        assert_equal 4, Post.find_in_batches(batch_size: 2, begin_at: 4).size
+        assert_equal 4, Post.find_in_batches(:batch_size => 3).size
+        assert_equal 1, Post.find_in_batches(:batch_size => 10_000).size
+      end
     end
   end
 end


### PR DESCRIPTION
Hello everyone!

There have been many times when I needed to work with a relation in small chunks, e.g. deleting or updating a large number of rows while allowing the database to work on other tasks in between. This is especially useful if the number of affected rows is very large and we need to throttle our work in order to allow other processes to start/complete in between each iteration. It could also be used to process each slice using concurrent workers.

For example:

```
People.where('age > 21').each_slice do |relation|
  sleep 10 # other tasks
  relation.update_all(should_party: true)
end
```

Called without a block, it will return an `Enumerator`, e.g.:

```
Poeple.where('age < 18').each_slice.each(&:delete_all)
```

Other people have expressed interested in having such functionality as well. E.g., with a quick GitHub search I found #14465 and #13147. There have been other attempts to achieve the same goal, however they were backward-incompatible, not tested and not optimised.

I have written passing tests in a similar style to #find_in_batches. I have made sure that the number database queries is kept low (it is equal and in some cases less than that of #find_in_batches).

I have documented the method as well.

The method accepts a block, or returns an `Enumerator` if no block is give.

Please let me know if I need to make any modifications, or rename it so that I could get prepare it for getting merged.

PS. let me know what name you prefer for the method, e.g. #batches, #to_batches, #in_batches, #split, #each_slice, etc. The method is called #each_slice because it is dividing a single ActiveRecord::Relation object into multiple ActiveRecord::Relation objects, similar to the more familiar Array#each_slice, which divides an Enumerable into multiple Enumerable objects.
