### PR TITLE
Add `parents` to BLACKLISTED_CLASS_METHODS to prevent SystemStackError

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -32,7 +32,7 @@ module ActiveRecord
       end
     }
 
-    BLACKLISTED_CLASS_METHODS = %w(private public protected allocate new name parent superclass)
+    BLACKLISTED_CLASS_METHODS = %w(private public protected allocate new name parent parents superclass)
 
     class AttributeMethodCache
       def initialize


### PR DESCRIPTION
When we define `parents scope`, `SystemStackError: stack level too deep` is raised.

Ex:

```
--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -15,6 +15,8 @@ class Book < ActiveRecord::Base
   enum illustrator_visibility: [:visible, :invisible], enum_prefix: true
   enum font_size: [:small, :medium, :large], enum_prefix: :with, enum_suffix: true

+  scope :parents, -> {}
+
   def published!
     super
     "do publish work..."
```

`$ ARCONN=sqlite3 bundle exec ruby -Itest  test/cases/enum_test.rb`
All tests are error.
Because there method calls are infinite loop.

```
./rails/activerecord/lib/active_record/core.rb:244:in `arel_table'
./rails/activerecord/lib/active_record/core.rb:274:in `relation'
./rails/activerecord/lib/active_record/scoping/default.rb:102:in `build_default_scope'
./rails/activerecord/lib/active_record/scoping/named.rb:33:in `default_scoped'
./rails/activerecord/lib/active_record/scoping/named.rb:28:in `all'
./rails/activerecord/lib/active_record/scoping/named.rb:151:in `block in scope'
./rails/activerecord/lib/active_record/model_schema.rb:156:in `full_table_name_prefix'
./rails/activerecord/lib/active_record/model_schema.rb:354:in `compute_table_name'
./rails/activerecord/lib/active_record/model_schema.rb:151:in `reset_table_name'
./rails/activerecord/lib/active_record/model_schema.rb:115:in `table_name'

./rails/activerecord/lib/active_record/core.rb:244:in `arel_table'
./rails/activerecord/lib/active_record/core.rb:274:in `relation'
./rails/activerecord/lib/active_record/scoping/default.rb:102:in `build_default_scope'
./rails/activerecord/lib/active_record/scoping/named.rb:33:in `default_scoped'
./rails/activerecord/lib/active_record/scoping/named.rb:28:in `all'
./rails/activerecord/lib/active_record/scoping/named.rb:151:in `block in scope'
./rails/activerecord/lib/active_record/model_schema.rb:156:in `full_table_name_prefix'
./rails/activerecord/lib/active_record/model_schema.rb:354:in `compute_table_name'
./rails/activerecord/lib/active_record/model_schema.rb:151:in `reset_table_name'
./rails/activerecord/lib/active_record/model_schema.rb:115:in `table_name'

./rails/activerecord/lib/active_record/fixtures.rb:592:in `initialize'
./rails/activerecord/lib/active_record/fixtures.rb:515:in `new'
./rails/activerecord/lib/active_record/fixtures.rb:515:in `block (2 levels) in create_fixtures'
./rails/activerecord/lib/active_record/fixtures.rb:512:in `map'
./rails/activerecord/lib/active_record/fixtures.rb:512:in `block in create_fixtures'
./rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:285:in `disable_referential_integrity'
./rails/activerecord/lib/active_record/fixtures.rb:509:in `create_fixtures'
./rails/activerecord/lib/active_record/fixtures.rb:996:in `load_fixtures'
./rails/activerecord/lib/active_record/fixtures.rb:958:in `setup_fixtures'
./rails/activerecord/lib/active_record/fixtures.rb:831:in `before_setup'
```
