### PR TITLE
[ActiveSupport] Add ability to use `Proc` as 'expires_in' key

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add ability to use `Proc` as `expires_in` key for `ActiveSupport::Cache::MemCacheStore`.
+
+    Example:
+
+        Rails.cache.fetch('foo', expires_in: -> { 10 }) do
+          'bar'
+        end
+
+    *Alexey Vokhmin*
+
 *   Removed `ActiveSupport::Concurrency::Latch`, superseded by `Concurrent::CountDownLatch`
     from the concurrent-ruby gem.
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -615,6 +615,7 @@ module ActiveSupport
 
         @created_at = Time.now.to_f
         @expires_in = options[:expires_in]
+        @expires_in = @expires_in.call if @expires_in.is_a?(Proc)
         @expires_in = @expires_in.to_f if @expires_in
       end
 

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -141,7 +141,9 @@ module ActiveSupport
         def write_entry(key, entry, options) # :nodoc:
           method = options && options[:unless_exist] ? :add : :set
           value = options[:raw] ? entry.value.to_s : entry
-          expires_in = options[:expires_in].to_i
+          expires_in = options[:expires_in]
+          expires_in = expires_in.call if expires_in.is_a?(Proc)
+          expires_in = expires_in.to_i
           if expires_in > 0 && !options[:raw]
             # Set the memcache expire a few minutes in the future to support race condition ttls on read
             expires_in += 5.minutes


### PR DESCRIPTION
Sometimes calculation of `expires_in` can spend a lot of time, so, will be great to do it only if it needed.

Related with: https://github.com/mperham/dalli/pull/531
