### PR TITLE
Add deprecation warning for `render :text`

### DIFF
--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -1,3 +1,6 @@
+require 'active_support/deprecation'
+require 'active_support/core_ext/string/filters'
+
 module ActionController
   module Rendering
     extend ActiveSupport::Concern
@@ -73,6 +76,17 @@ module ActionController
     # Normalize both text and status options.
     def _normalize_options(options) #:nodoc:
       _normalize_text(options)
+
+      if options[:text]
+        ActiveSupport::Deprecation.warn <<-WARNING.squish
+          `render :text` is deprecated because it does not actually render a
+          `text/plain` response. Switch to `render plain: 'plain text'` to
+          render as `text/plain`, `render html: '<strong>HTML</strong>'` to
+          render as `text/html`, or `render body: 'raw'` to match the deprecated
+          behavior and render with the default Content-Type, which is
+          `text/plain`.
+        WARNING
+      end
 
       if options[:html]
         options[:html] = ERB::Util.html_escape(options[:html])

--- a/actionpack/test/controller/new_base/render_text_test.rb
+++ b/actionpack/test/controller/new_base/render_text_test.rb
@@ -1,4 +1,5 @@
 require 'abstract_unit'
+require 'active_support/deprecation'
 
 module RenderText
   class MinimalController < ActionController::Metal
@@ -73,7 +74,10 @@ module RenderText
 
   class RenderTextTest < Rack::TestCase
     test "rendering text from a minimal controller" do
-      get "/render_text/minimal/index"
+      ActiveSupport::Deprecation.silence do
+        get "/render_text/minimal/index"
+      end
+
       assert_body "Hello World!"
       assert_status 200
     end
@@ -82,7 +86,10 @@ module RenderText
       with_routing do |set|
         set.draw { get ':controller', action: 'index' }
 
-        get "/render_text/simple"
+        ActiveSupport::Deprecation.silence do
+          get "/render_text/simple"
+        end
+
         assert_body "hello david"
         assert_status 200
       end
@@ -92,7 +99,9 @@ module RenderText
       with_routing do |set|
         set.draw { get ':controller', action: 'index' }
 
-        get "/render_text/with_layout"
+        ActiveSupport::Deprecation.silence do
+          get "/render_text/with_layout"
+        end
 
         assert_body "hello david"
         assert_status 200
@@ -100,59 +109,81 @@ module RenderText
     end
 
     test "rendering text, while also providing a custom status code" do
-      get "/render_text/with_layout/custom_code"
+      ActiveSupport::Deprecation.silence do
+        get "/render_text/with_layout/custom_code"
+      end
 
       assert_body "hello world"
       assert_status 404
     end
 
     test "rendering text with nil returns an empty body" do
-      get "/render_text/with_layout/with_nil"
+      ActiveSupport::Deprecation.silence do
+        get "/render_text/with_layout/with_nil"
+      end
 
       assert_body ""
       assert_status 200
     end
 
     test "Rendering text with nil and custom status code returns an empty body and the status" do
-      get "/render_text/with_layout/with_nil_and_status"
+      ActiveSupport::Deprecation.silence do
+        get "/render_text/with_layout/with_nil_and_status"
+      end
 
       assert_body ""
       assert_status 403
     end
 
     test "rendering text with false returns the string 'false'" do
-      get "/render_text/with_layout/with_false"
+      ActiveSupport::Deprecation.silence do
+        get "/render_text/with_layout/with_false"
+      end
 
       assert_body "false"
       assert_status 200
     end
 
     test "rendering text with layout: true" do
-      get "/render_text/with_layout/with_layout_true"
+      ActiveSupport::Deprecation.silence do
+        get "/render_text/with_layout/with_layout_true"
+      end
 
       assert_body "hello world, I'm here!"
       assert_status 200
     end
 
     test "rendering text with layout: 'greetings'" do
-      get "/render_text/with_layout/with_custom_layout"
+      ActiveSupport::Deprecation.silence do
+        get "/render_text/with_layout/with_custom_layout"
+      end
 
       assert_body "hello world, I wish thee well."
       assert_status 200
     end
 
     test "rendering text with layout: false" do
-      get "/render_text/with_layout/with_layout_false"
+      ActiveSupport::Deprecation.silence do
+        get "/render_text/with_layout/with_layout_false"
+      end
 
       assert_body "hello world"
       assert_status 200
     end
 
     test "rendering text with layout: nil" do
-      get "/render_text/with_layout/with_layout_nil"
+      ActiveSupport::Deprecation.silence do
+        get "/render_text/with_layout/with_layout_nil"
+      end
 
       assert_body "hello world"
       assert_status 200
+    end
+
+    test "rendering text displays deprecation warning" do
+      assert_deprecated do
+        get "/render_text/with_layout/with_layout_nil"
+      end
     end
   end
 end


### PR DESCRIPTION
We've started on discouraging the usage of `render :text` in #12374. This is a follow-up commit to make sure that we print out the deprecation warning as we wanted to.
