### PR TITLE
[skip ci] Lookup can be a noun but it is not a verb

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -183,7 +183,8 @@
     *arthurnn*
 
 *   `ActionController#translate` supports symbols as shortcuts.
-    When shortcut is given it also lookups without action name.
+    When a shortcut is given it also performs the lookup without the action
+    name.
 
     *Max Melentiev*
 

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -70,7 +70,7 @@ module ActionView
       #   distance_of_time_in_words(Time.now, Time.now)                                               # => less than a minute
       #
       # With the <tt>scope</tt> option, you can define a custom scope for Rails
-      # to lookup the translation.
+      # to look up the translation.
       #
       # For example you can define the following in your locale (e.g. en.yml).
       #

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -6,10 +6,11 @@ require 'action_view/template/resolver'
 module ActionView
   # = Action View Lookup Context
   #
-  # <tt>LookupContext</tt> is the object responsible to hold all information required to lookup
-  # templates, i.e. view paths and details. The LookupContext is also responsible to
-  # generate a key, given to view paths, used in the resolver cache lookup. Since
-  # this key is generated just once during the request, it speeds up all cache accesses.
+  # <tt>LookupContext</tt> is the object responsible for holding all information
+  # required for looking up templates, i.e. view paths and details.
+  # <tt>LookupContext</tt> is also responsible for generating a key, given to
+  # view paths, used in the resolver cache lookup. Since this key is generated
+  # only once during the request, it speeds up all cache accesses.
   class LookupContext #:nodoc:
     attr_accessor :prefixes, :rendered_format
 

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -103,7 +103,7 @@ module ActionView
         view_renderer.render(context, options)
       end
 
-      # Assign the rendered format to lookup context.
+      # Assign the rendered format to look up context.
       def _process_format(format, options = {}) #:nodoc:
         super
         lookup_context.formats = [format.to_sym]

--- a/actionview/lib/action_view/view_paths.rb
+++ b/actionview/lib/action_view/view_paths.rb
@@ -36,9 +36,9 @@ module ActionView
       self.class._prefixes
     end
 
-    # <tt>LookupContext</tt> is the object responsible to hold all information required to lookup
-    # templates, i.e. view paths and details. Check <tt>ActionView::LookupContext</tt> for more
-    # information.
+    # <tt>LookupContext</tt> is the object responsible for holding all
+    # information required for looking up templates, i.e. view paths and
+    # details. Check <tt>ActionView::LookupContext</tt> for more information.
     def lookup_context
       @_lookup_context ||=
         ActionView::LookupContext.new(self.class._view_paths, details_for_lookup, _prefixes)

--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -65,7 +65,8 @@ class Time
       if !time_zone || time_zone.is_a?(ActiveSupport::TimeZone)
         time_zone
       else
-        # lookup timezone based on identifier (unless we've been passed a TZInfo::Timezone)
+        # Look up the timezone based on the identifier (unless we've been
+        # passed a TZInfo::Timezone)
         unless time_zone.respond_to?(:period_for_local)
           time_zone = ActiveSupport::TimeZone[time_zone] || TZInfo::Timezone.get(time_zone)
         end

--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -103,12 +103,12 @@ module Rails
       #     hook_for :test_framework, as: :controller
       #   end
       #
-      # And now it will lookup at:
+      # And now it will look up at:
       #
       #   "test_unit:controller", "test_unit"
       #
-      # Similarly, if you want it to also lookup in the rails namespace, you just
-      # need to provide the :in value:
+      # Similarly, if you want it to also look up in the rails namespace, you
+      # just need to provide the :in value:
       #
       #   class AwesomeGenerator < Rails::Generators::Base
       #     hook_for :test_framework, in: :rails, as: :controller


### PR DESCRIPTION
Minor grammar corrections wrapped to 80 characters.
