### PR TITLE
Stop using deprecated `render :text` in test

### DIFF
--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -130,7 +130,7 @@ module ActionController #:nodoc:
       # See +send_file+ for more information on HTTP Content-* headers and caching.
       def send_data(data, options = {}) #:doc:
         send_file_headers! options
-        render options.slice(:status, :content_type).merge(:text => data)
+        render options.slice(:status, :content_type).merge(body: data)
       end
 
     private

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -502,7 +502,7 @@ module ActionController
       def authentication_request(controller, realm, message = nil)
         message ||= "HTTP Token: Access denied.\n"
         controller.headers["WWW-Authenticate"] = %(Token realm="#{realm.tr('"'.freeze, "".freeze)}")
-        controller.__send__ :render, :text => message, :status => :unauthorized
+        controller.__send__ :render, plain: message, status: :unauthorized
       end
     end
   end

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -156,16 +156,16 @@ module ActionController #:nodoc:
     # It works for both inline:
     #
     #   respond_to do |format|
-    #     format.html.any   { render text: "any"   }
-    #     format.html.phone { render text: "phone" }
+    #     format.html.any   { render html: "any"   }
+    #     format.html.phone { render html: "phone" }
     #   end
     #
     # and block syntax:
     #
     #   respond_to do |format|
     #     format.html do |variant|
-    #       variant.any(:tablet, :phablet){ render text: "any" }
-    #       variant.phone { render text: "phone" }
+    #       variant.any(:tablet, :phablet){ render html: "any" }
+    #       variant.phone { render html: "phone" }
     #     end
     #   end
     #

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -45,7 +45,7 @@ module Mime
   #
   #       respond_to do |format|
   #         format.html
-  #         format.ics { render text: @post.to_ics, mime_type: Mime::Type.lookup("text/calendar")  }
+  #         format.ics { render body: @post.to_ics, mime_type: Mime::Type.lookup("text/calendar")  }
   #         format.xml { render xml: @post }
   #       end
   #     end

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -43,12 +43,12 @@ class ActionPackAssertionsController < ActionController::Base
 
   def flash_me
     flash['hello'] = 'my name is inigo montoya...'
-    render :text => "Inconceivable!"
+    render plain: "Inconceivable!"
   end
 
   def flash_me_naked
     flash.clear
-    render :text => "wow!"
+    render plain: "wow!"
   end
 
   def assign_this
@@ -57,30 +57,30 @@ class ActionPackAssertionsController < ActionController::Base
   end
 
   def render_based_on_parameters
-    render :text => "Mr. #{params[:name]}"
+    render plain: "Mr. #{params[:name]}"
   end
 
   def render_url
-    render :text => "<div>#{url_for(:action => 'flash_me', :only_path => true)}</div>"
+    render html: "<div>#{url_for(action: 'flash_me', only_path: true)}</div>"
   end
 
   def render_text_with_custom_content_type
-    render :text => "Hello!", :content_type => Mime::RSS
+    render body: "Hello!", content_type: Mime::RSS
   end
 
   def session_stuffing
     session['xmas'] = 'turkey'
-    render :text => "ho ho ho"
+    render plain: "ho ho ho"
   end
 
   def raise_exception_on_get
     raise "get" if request.get?
-    render :text => "request method: #{request.env['REQUEST_METHOD']}"
+    render plain: "request method: #{request.env['REQUEST_METHOD']}"
   end
 
   def raise_exception_on_post
     raise "post" if request.post?
-    render :text => "request method: #{request.env['REQUEST_METHOD']}"
+    render plain: "request method: #{request.env['REQUEST_METHOD']}"
   end
 
   def render_file_absolute_path
@@ -101,7 +101,7 @@ class AssertResponseWithUnexpectedErrorController < ActionController::Base
   end
 
   def show
-    render :text => "Boom", :status => 500
+    render plain: "Boom", status: 500
   end
 end
 

--- a/actionpack/test/controller/api/conditional_get_test.rb
+++ b/actionpack/test/controller/api/conditional_get_test.rb
@@ -7,12 +7,12 @@ class ConditionalGetApiController < ActionController::API
 
   def one
     if stale?(last_modified: Time.now.utc.beginning_of_day, etag: [:foo, 123])
-      render text: "Hi!"
+      render plain: "Hi!"
     end
   end
 
   def two
-    render text: "Hi!"
+    render plain: "Hi!"
   end
 
   private

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -53,7 +53,7 @@ end
 
 class ActionMissingController < ActionController::Base
   def action_missing(action)
-    render :text => "Response for #{action}"
+    render plain: "Response for #{action}"
   end
 end
 

--- a/actionpack/test/controller/content_type_test.rb
+++ b/actionpack/test/controller/content_type_test.rb
@@ -4,29 +4,29 @@ class OldContentTypeController < ActionController::Base
   # :ported:
   def render_content_type_from_body
     response.content_type = Mime::RSS
-    render :text => "hello world!"
+    render body: "hello world!"
   end
 
   # :ported:
   def render_defaults
-    render :text => "hello world!"
+    render body: "hello world!"
   end
 
   # :ported:
   def render_content_type_from_render
-    render :text => "hello world!", :content_type => Mime::RSS
+    render body: "hello world!", :content_type => Mime::RSS
   end
 
   # :ported:
   def render_charset_from_body
     response.charset = "utf-16"
-    render :text => "hello world!"
+    render body: "hello world!"
   end
 
   # :ported:
   def render_nil_charset_from_body
     response.charset = nil
-    render :text => "hello world!"
+    render body: "hello world!"
   end
 
   def render_default_for_erb
@@ -42,10 +42,10 @@ class OldContentTypeController < ActionController::Base
 
   def render_default_content_types_for_respond_to
     respond_to do |format|
-      format.html { render :text   => "hello world!" }
-      format.xml  { render :action => "render_default_content_types_for_respond_to" }
-      format.js   { render :text   => "hello world!" }
-      format.rss  { render :text   => "hello world!", :content_type => Mime::XML }
+      format.html { render body: "hello world!" }
+      format.xml  { render action: "render_default_content_types_for_respond_to" }
+      format.js   { render body: "hello world!" }
+      format.rss  { render body: "hello world!", content_type: Mime::XML }
     end
   end
 end
@@ -64,14 +64,14 @@ class ContentTypeTest < ActionController::TestCase
   def test_render_defaults
     get :render_defaults
     assert_equal "utf-8", @response.charset
-    assert_equal Mime::HTML, @response.content_type
+    assert_equal Mime::TEXT, @response.content_type
   end
 
   def test_render_changed_charset_default
     with_default_charset "utf-16" do
       get :render_defaults
       assert_equal "utf-16", @response.charset
-      assert_equal Mime::HTML, @response.content_type
+      assert_equal Mime::TEXT, @response.content_type
     end
   end
 
@@ -92,14 +92,14 @@ class ContentTypeTest < ActionController::TestCase
   # :ported:
   def test_charset_from_body
     get :render_charset_from_body
-    assert_equal Mime::HTML, @response.content_type
+    assert_equal Mime::TEXT, @response.content_type
     assert_equal "utf-16", @response.charset
   end
 
   # :ported:
   def test_nil_charset_from_body
     get :render_nil_charset_from_body
-    assert_equal Mime::HTML, @response.content_type
+    assert_equal Mime::TEXT, @response.content_type
     assert_equal "utf-8", @response.charset, @response.headers.inspect
   end
 

--- a/actionpack/test/controller/default_url_options_with_before_action_test.rb
+++ b/actionpack/test/controller/default_url_options_with_before_action_test.rb
@@ -6,7 +6,7 @@ class ControllerWithBeforeActionAndDefaultUrlOptions < ActionController::Base
   after_action { I18n.locale = "en" }
 
   def target
-    render :text => "final response"
+    render plain: "final response"
   end
 
   def redirect

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -40,7 +40,7 @@ class FilterTest < ActionController::TestCase
     before_action :ensure_login, :except => [:go_wild]
 
     def go_wild
-      render :text => "gobble"
+      render plain: "gobble"
     end
   end
 
@@ -51,7 +51,7 @@ class FilterTest < ActionController::TestCase
 
     (1..3).each do |i|
       define_method "fail_#{i}" do
-        render :text => i.to_s
+        render plain: i.to_s
       end
     end
 
@@ -222,7 +222,7 @@ class FilterTest < ActionController::TestCase
     skip_before_action :clean_up_tmp, only: :login, if: -> { true }
 
     def login
-      render text: 'ok'
+      render plain: 'ok'
     end
   end
 
@@ -234,7 +234,7 @@ class FilterTest < ActionController::TestCase
     skip_before_action :clean_up_tmp, if: -> { true }, except: :login
 
     def login
-      render text: 'ok'
+      render plain: 'ok'
     end
   end
 
@@ -258,11 +258,11 @@ class FilterTest < ActionController::TestCase
     before_action :ensure_login, :only => :index
 
     def index
-      render :text => 'ok'
+      render plain: 'ok'
     end
 
     def public
-      render :text => 'ok'
+      render plain: 'ok'
     end
   end
 
@@ -272,7 +272,7 @@ class FilterTest < ActionController::TestCase
     before_action :ensure_login
 
     def index
-      render :text => 'ok'
+      render plain: 'ok'
     end
 
     private
@@ -383,7 +383,7 @@ class FilterTest < ActionController::TestCase
     before_action(AuditFilter)
 
     def show
-      render :text => "hello"
+      render plain: "hello"
     end
   end
 
@@ -421,11 +421,11 @@ class FilterTest < ActionController::TestCase
     before_action :second, :only => :foo
 
     def foo
-      render :text => 'foo'
+      render plain: 'foo'
     end
 
     def bar
-      render :text => 'bar'
+      render plain: 'bar'
     end
 
     protected
@@ -442,7 +442,7 @@ class FilterTest < ActionController::TestCase
     before_action :choose
 
     %w(foo bar baz).each do |action|
-      define_method(action) { render :text => action }
+      define_method(action) { render plain: action }
     end
 
     private
@@ -471,7 +471,7 @@ class FilterTest < ActionController::TestCase
       @ran_filter << 'between_before_all_and_after_all'
     end
     def show
-      render :text => 'hello'
+      render plain: 'hello'
     end
   end
 
@@ -481,7 +481,7 @@ class FilterTest < ActionController::TestCase
     def around(controller)
       yield
     rescue ErrorToRescue => ex
-      controller.__send__ :render, :text => "I rescued this: #{ex.inspect}"
+      controller.__send__ :render, plain: "I rescued this: #{ex.inspect}"
     end
   end
 

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -2,11 +2,11 @@ require 'abstract_unit'
 
 class ForceSSLController < ActionController::Base
   def banana
-    render :text => "monkey"
+    render plain: "monkey"
   end
 
   def cheeseburger
-    render :text => "sikachu"
+    render plain: "sikachu"
   end
 end
 
@@ -26,7 +26,7 @@ class ForceSSLCustomOptions < ForceSSLController
   force_ssl :notice => 'Foo, Bar!', :only => :redirect_notice
 
   def force_ssl_action
-    render :text => action_name
+    render plain: action_name
   end
 
   alias_method :redirect_host, :force_ssl_action
@@ -40,15 +40,15 @@ class ForceSSLCustomOptions < ForceSSLController
   alias_method :redirect_notice, :force_ssl_action
 
   def use_flash
-    render :text => flash[:message]
+    render plain: flash[:message]
   end
 
   def use_alert
-    render :text => flash[:alert]
+    render plain: flash[:alert]
   end
 
   def use_notice
-    render :text => flash[:notice]
+    render plain: flash[:notice]
   end
 end
 
@@ -85,10 +85,10 @@ end
 
 class RedirectToSSL < ForceSSLController
   def banana
-    force_ssl_redirect || render(:text => 'monkey')
+    force_ssl_redirect || render(plain: 'monkey')
   end
   def cheeseburger
-    force_ssl_redirect('secure.cheeseburger.host') || render(:text => 'ihaz')
+    force_ssl_redirect('secure.cheeseburger.host') || render(plain: 'ihaz')
   end
 end
 

--- a/actionpack/test/controller/http_basic_authentication_test.rb
+++ b/actionpack/test/controller/http_basic_authentication_test.rb
@@ -9,19 +9,19 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     http_basic_authenticate_with :name => "David", :password => "Goliath", :only => :search
 
     def index
-      render :text => "Hello Secret"
+      render plain: "Hello Secret"
     end
 
     def display
-      render :text => 'Definitely Maybe' if @logged_in
+      render plain: 'Definitely Maybe' if @logged_in
     end
 
     def show
-      render :text => 'Only for loooooong credentials'
+      render plain: 'Only for loooooong credentials'
     end
 
     def search
-      render :text => 'All inline'
+      render plain: 'All inline'
     end
 
     private

--- a/actionpack/test/controller/http_digest_authentication_test.rb
+++ b/actionpack/test/controller/http_digest_authentication_test.rb
@@ -10,11 +10,11 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
               'dhh' => ::Digest::MD5::hexdigest(["dhh","SuperSecret","secret"].join(":"))}
 
     def index
-      render :text => "Hello Secret"
+      render plain: "Hello Secret"
     end
 
     def display
-      render :text => 'Definitely Maybe' if @logged_in
+      render plain: 'Definitely Maybe' if @logged_in
     end
 
     private

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -7,15 +7,15 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     before_action :authenticate_long_credentials, only: :show
 
     def index
-      render :text => "Hello Secret"
+      render plain: "Hello Secret"
     end
 
     def display
-      render :text => 'Definitely Maybe'
+      render plain: 'Definitely Maybe'
     end
 
     def show
-      render :text => 'Only for loooooong credentials'
+      render plain: 'Only for loooooong credentials'
     end
 
     private

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -359,28 +359,28 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
   class IntegrationController < ActionController::Base
     def get
       respond_to do |format|
-        format.html { render :text => "OK", :status => 200 }
-        format.js { render :text => "JS OK", :status => 200 }
+        format.html { render plain: "OK", status: 200 }
+        format.js { render plain: "JS OK", status: 200 }
         format.xml { render :xml => "<root></root>", :status => 200 }
       end
     end
 
     def get_with_params
-      render :text => "foo: #{params[:foo]}", :status => 200
+      render plain: "foo: #{params[:foo]}", status: 200
     end
 
     def post
-      render :text => "Created", :status => 201
+      render plain: "Created", status: 201
     end
 
     def method
-      render :text => "method: #{request.method.downcase}"
+      render plain: "method: #{request.method.downcase}"
     end
 
     def cookie_monster
       cookies["cookie_1"] = nil
       cookies["cookie_3"] = "chocolate"
-      render :text => "Gone", :status => 410
+      render plain: "Gone", status: 410
     end
 
     def set_cookie
@@ -389,7 +389,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     end
 
     def get_cookie
-      render :text => cookies["foo"]
+      render plain: cookies["foo"]
     end
 
     def redirect
@@ -760,7 +760,7 @@ end
 class ApplicationIntegrationTest < ActionDispatch::IntegrationTest
   class TestController < ActionController::Base
     def index
-      render :text => "index"
+      render plain: "index"
     end
   end
 
@@ -847,7 +847,7 @@ end
 class EnvironmentFilterIntegrationTest < ActionDispatch::IntegrationTest
   class TestController < ActionController::Base
     def post
-      render :text => "Created", :status => 201
+      render plain: "Created", status: 201
     end
   end
 
@@ -880,15 +880,15 @@ end
 class UrlOptionsIntegrationTest < ActionDispatch::IntegrationTest
   class FooController < ActionController::Base
     def index
-      render :text => "foo#index"
+      render plain: "foo#index"
     end
 
     def show
-      render :text => "foo#show"
+      render plain: "foo#show"
     end
 
     def edit
-      render :text => "foo#show"
+      render plain: "foo#show"
     end
   end
 
@@ -898,7 +898,7 @@ class UrlOptionsIntegrationTest < ActionDispatch::IntegrationTest
     end
 
     def index
-      render :text => "foo#index"
+      render plain: "foo#index"
     end
   end
 

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -125,7 +125,7 @@ module ActionController
       end
 
       def render_text
-        render :text => 'zomg'
+        render plain: 'zomg'
       end
 
       def default_header
@@ -162,7 +162,7 @@ module ActionController
       end
 
       def with_stale
-        render text: 'stale' if stale?(etag: "123", template: false)
+        render plain: 'stale' if stale?(etag: "123", template: false)
       end
 
       def exception_in_view

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -13,41 +13,41 @@ class RespondToController < ActionController::Base
 
   def html_xml_or_rss
     respond_to do |type|
-      type.html { render :text => "HTML"    }
-      type.xml  { render :text => "XML"     }
-      type.rss  { render :text => "RSS"     }
-      type.all  { render :text => "Nothing" }
+      type.html { render body: "HTML"    }
+      type.xml  { render body: "XML"     }
+      type.rss  { render body: "RSS"     }
+      type.all  { render body: "Nothing" }
     end
   end
 
   def js_or_html
     respond_to do |type|
-      type.html { render :text => "HTML"    }
-      type.js   { render :text => "JS"      }
-      type.all  { render :text => "Nothing" }
+      type.html { render body: "HTML"    }
+      type.js   { render body: "JS"      }
+      type.all  { render body: "Nothing" }
     end
   end
 
   def json_or_yaml
     respond_to do |type|
-      type.json { render :text => "JSON" }
-      type.yaml { render :text => "YAML" }
+      type.json { render body: "JSON" }
+      type.yaml { render body: "YAML" }
     end
   end
 
   def html_or_xml
     respond_to do |type|
-      type.html { render :text => "HTML"    }
-      type.xml  { render :text => "XML"     }
-      type.all  { render :text => "Nothing" }
+      type.html { render body: "HTML"    }
+      type.xml  { render body: "XML"     }
+      type.all  { render body: "Nothing" }
     end
   end
 
   def json_xml_or_html
     respond_to do |type|
-      type.json { render :text => 'JSON' }
+      type.json { render body: 'JSON' }
       type.xml { render :xml => 'XML' }
-      type.html { render :text => 'HTML' }
+      type.html { render body: 'HTML' }
     end
   end
 
@@ -56,14 +56,14 @@ class RespondToController < ActionController::Base
     request.format = :xml
 
     respond_to do |type|
-      type.html { render :text => "HTML"    }
-      type.xml  { render :text => "XML"     }
+      type.html { render body: "HTML"    }
+      type.xml  { render body: "XML"     }
     end
   end
 
   def just_xml
     respond_to do |type|
-      type.xml  { render :text => "XML" }
+      type.xml  { render body: "XML" }
     end
   end
 
@@ -81,52 +81,52 @@ class RespondToController < ActionController::Base
   def using_defaults_with_all
     respond_to do |type|
       type.html
-      type.all{ render text: "ALL" }
+      type.all{ render body: "ALL" }
     end
   end
 
   def made_for_content_type
     respond_to do |type|
-      type.rss  { render :text => "RSS"  }
-      type.atom { render :text => "ATOM" }
-      type.all  { render :text => "Nothing" }
+      type.rss  { render body: "RSS"  }
+      type.atom { render body: "ATOM" }
+      type.all  { render body: "Nothing" }
     end
   end
 
   def custom_type_handling
     respond_to do |type|
-      type.html { render :text => "HTML"    }
-      type.custom("application/crazy-xml")  { render :text => "Crazy XML"  }
-      type.all  { render :text => "Nothing" }
+      type.html { render body: "HTML"    }
+      type.custom("application/crazy-xml")  { render body: "Crazy XML"  }
+      type.all  { render body: "Nothing" }
     end
   end
 
 
   def custom_constant_handling
     respond_to do |type|
-      type.html   { render :text => "HTML"   }
-      type.mobile { render :text => "Mobile" }
+      type.html   { render body: "HTML"   }
+      type.mobile { render body: "Mobile" }
     end
   end
 
   def custom_constant_handling_without_block
     respond_to do |type|
-      type.html   { render :text => "HTML"   }
+      type.html   { render body: "HTML"   }
       type.mobile
     end
   end
 
   def handle_any
     respond_to do |type|
-      type.html { render :text => "HTML" }
-      type.any(:js, :xml) { render :text => "Either JS or XML" }
+      type.html { render body: "HTML" }
+      type.any(:js, :xml) { render body: "Either JS or XML" }
     end
   end
 
   def handle_any_any
     respond_to do |type|
-      type.html { render :text => 'HTML' }
-      type.any { render :text => 'Whatever you ask for, I got it' }
+      type.html { render body: 'HTML' }
+      type.any { render body: 'Whatever you ask for, I got it' }
     end
   end
 
@@ -167,15 +167,15 @@ class RespondToController < ActionController::Base
     request.variant = :mobile
 
     respond_to do |type|
-      type.html { render text: "mobile" }
+      type.html { render body: "mobile" }
     end
   end
 
   def multiple_variants_for_format
     respond_to do |type|
       type.html do |html|
-        html.tablet { render text: "tablet" }
-        html.phone  { render text: "phone" }
+        html.tablet { render body: "tablet" }
+        html.phone  { render body: "phone" }
       end
     end
   end
@@ -183,7 +183,7 @@ class RespondToController < ActionController::Base
   def variant_plus_none_for_format
     respond_to do |format|
       format.html do |variant|
-        variant.phone { render text: "phone" }
+        variant.phone { render body: "phone" }
         variant.none
       end
     end
@@ -191,9 +191,9 @@ class RespondToController < ActionController::Base
 
   def variant_inline_syntax
     respond_to do |format|
-      format.js         { render text: "js"    }
-      format.html.none  { render text: "none"  }
-      format.html.phone { render text: "phone" }
+      format.js         { render body: "js"    }
+      format.html.none  { render body: "none"  }
+      format.html.phone { render body: "phone" }
     end
   end
 
@@ -208,8 +208,8 @@ class RespondToController < ActionController::Base
   def variant_any
     respond_to do |format|
       format.html do |variant|
-        variant.any(:tablet, :phablet){ render text: "any" }
-        variant.phone { render text: "phone" }
+        variant.any(:tablet, :phablet){ render body: "any" }
+        variant.phone { render body: "phone" }
       end
     end
   end
@@ -217,23 +217,23 @@ class RespondToController < ActionController::Base
   def variant_any_any
     respond_to do |format|
       format.html do |variant|
-        variant.any   { render text: "any"   }
-        variant.phone { render text: "phone" }
+        variant.any   { render body: "any"   }
+        variant.phone { render body: "phone" }
       end
     end
   end
 
   def variant_inline_any
     respond_to do |format|
-      format.html.any(:tablet, :phablet){ render text: "any" }
-      format.html.phone { render text: "phone" }
+      format.html.any(:tablet, :phablet){ render body: "any" }
+      format.html.phone { render body: "phone" }
     end
   end
 
   def variant_inline_any_any
     respond_to do |format|
-      format.html.phone { render text: "phone" }
-      format.html.any   { render text: "any"   }
+      format.html.phone { render body: "phone" }
+      format.html.any   { render body: "any"   }
     end
   end
 
@@ -246,16 +246,16 @@ class RespondToController < ActionController::Base
 
   def variant_any_with_none
     respond_to do |format|
-      format.html.any(:none, :phone){ render text: "none or phone" }
+      format.html.any(:none, :phone){ render body: "none or phone" }
     end
   end
 
   def format_any_variant_any
     respond_to do |format|
-      format.html { render text: "HTML" }
+      format.html { render body: "HTML" }
       format.any(:js, :xml) do |variant|
-        variant.phone{ render text: "phone" }
-        variant.any(:tablet, :phablet){ render text: "tablet" }
+        variant.phone{ render body: "phone" }
+        variant.any(:tablet, :phablet){ render body: "tablet" }
       end
     end
   end
@@ -780,7 +780,7 @@ end
 class RespondToWithBlockOnDefaultRenderController < ActionController::Base
   def show
     default_render do
-      render text: 'default_render yielded'
+      render body: 'default_render yielded'
     end
   end
 end
@@ -794,6 +794,6 @@ class RespondToWithBlockOnDefaultRenderControllerTest < ActionController::TestCa
   def test_default_render_uses_block_when_no_template_exists
     get :show
     assert_equal "default_render yielded", @response.body
-    assert_equal "text/html", @response.content_type
+    assert_equal "text/plain", @response.content_type
   end
 end

--- a/actionpack/test/controller/new_base/base_test.rb
+++ b/actionpack/test/controller/new_base/base_test.rb
@@ -6,7 +6,7 @@ module Dispatching
     before_action :authenticate
 
     def index
-      render :text => "success"
+      render body: "success"
     end
 
     def modify_response_body
@@ -22,7 +22,7 @@ module Dispatching
     end
 
     def show_actions
-      render :text => "actions: #{action_methods.to_a.sort.join(', ')}"
+      render body: "actions: #{action_methods.to_a.sort.join(', ')}"
     end
 
     protected
@@ -51,7 +51,7 @@ module Dispatching
 
       assert_body "success"
       assert_status 200
-      assert_content_type "text/html; charset=utf-8"
+      assert_content_type "text/plain; charset=utf-8"
     end
 
     # :api: plugin

--- a/actionpack/test/controller/new_base/content_negotiation_test.rb
+++ b/actionpack/test/controller/new_base/content_negotiation_test.rb
@@ -9,7 +9,7 @@ module ContentNegotiation
     )]
 
     def all
-      render :text => self.formats.inspect
+      render plain: self.formats.inspect
     end
   end
 

--- a/actionpack/test/controller/new_base/content_type_test.rb
+++ b/actionpack/test/controller/new_base/content_type_test.rb
@@ -3,16 +3,16 @@ require 'abstract_unit'
 module ContentType
   class BaseController < ActionController::Base
     def index
-      render :text => "Hello world!"
+      render body: "Hello world!"
     end
 
     def set_on_response_obj
       response.content_type = Mime::RSS
-      render :text => "Hello world!"
+      render body: "Hello world!"
     end
 
     def set_on_render
-      render :text => "Hello world!", :content_type => Mime::RSS
+      render body: "Hello world!", content_type: Mime::RSS
     end
   end
 
@@ -30,17 +30,17 @@ module ContentType
   class CharsetController < ActionController::Base
     def set_on_response_obj
       response.charset = "utf-16"
-      render :text => "Hello world!"
+      render body: "Hello world!"
     end
 
     def set_as_nil_on_response_obj
       response.charset = nil
-      render :text => "Hello world!"
+      render body: "Hello world!"
     end
   end
 
   class ExplicitContentTypeTest < Rack::TestCase
-    test "default response is HTML and UTF8" do
+    test "default response is text/plain and UTF8" do
       with_routing do |set|
         set.draw do
           get ':controller', :action => 'index'
@@ -49,7 +49,7 @@ module ContentType
         get "/content_type/base"
 
         assert_body "Hello world!"
-        assert_header "Content-Type", "text/html; charset=utf-8"
+        assert_header "Content-Type", "text/plain; charset=utf-8"
       end
     end
 
@@ -99,14 +99,14 @@ module ContentType
       get "/content_type/charset/set_on_response_obj"
 
       assert_body   "Hello world!"
-      assert_header "Content-Type", "text/html; charset=utf-16"
+      assert_header "Content-Type", "text/plain; charset=utf-16"
     end
 
     test "setting the charset of the response as nil directly on the response object" do
       get "/content_type/charset/set_as_nil_on_response_obj"
 
       assert_body   "Hello world!"
-      assert_header "Content-Type", "text/html; charset=utf-8"
+      assert_header "Content-Type", "text/plain; charset=utf-8"
     end
   end
 end

--- a/actionpack/test/controller/new_base/render_test.rb
+++ b/actionpack/test/controller/new_base/render_test.rb
@@ -37,14 +37,14 @@ module Render
     private
 
     def secretz
-      render :text => "FAIL WHALE!"
+      render plain: "FAIL WHALE!"
     end
   end
 
   class DoubleRenderController < ActionController::Base
     def index
-      render :text => "hello"
-      render :text => "world"
+      render plain: "hello"
+      render plain: "world"
     end
   end
 

--- a/actionpack/test/controller/permitted_params_test.rb
+++ b/actionpack/test/controller/permitted_params_test.rb
@@ -2,11 +2,11 @@ require 'abstract_unit'
 
 class PeopleController < ActionController::Base
   def create
-    render text: params[:person].permitted? ? "permitted" : "forbidden"
+    render plain: params[:person].permitted? ? "permitted" : "forbidden"
   end
 
   def create_with_permit
-    render text: params[:person].permit(:name).permitted? ? "permitted" : "forbidden"
+    render plain: params[:person].permit(:name).permitted? ? "permitted" : "forbidden"
   end
 end
 

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -3,8 +3,8 @@ require 'abstract_unit'
 class RedirectController < ActionController::Base
   # empty method not used anywhere to ensure methods like
   # `status` and `location` aren't called on `redirect_to` calls
-  def status; render :text => 'called status'; end
-  def location; render :text => 'called location'; end
+  def status; render plain: 'called status'; end
+  def location; render plain: 'called location'; end
 
   def simple_redirect
     redirect_to :action => "hello_world"

--- a/actionpack/test/controller/render_json_test.rb
+++ b/actionpack/test/controller/render_json_test.rb
@@ -28,7 +28,7 @@ class RenderJsonTest < ActionController::TestCase
     end
 
     def render_json_render_to_string
-      render :text => render_to_string(:json => '[]')
+      render plain: render_to_string(json: '[]')
     end
 
     def render_json_hello_world

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -10,16 +10,16 @@ class TestControllerWithExtraEtags < ActionController::Base
   etag { nil  }
 
   def fresh
-    render text: "stale" if stale?(etag: '123', template: false)
+    render plain: "stale" if stale?(etag: '123', template: false)
   end
 
   def array
-    render text: "stale" if stale?(etag: %w(1 2 3), template: false)
+    render plain: "stale" if stale?(etag: %w(1 2 3), template: false)
   end
 
   def with_template
     if stale? template: 'test/hello_world'
-      render text: 'stale'
+      render plain: 'stale'
     end
   end
 end
@@ -622,7 +622,7 @@ class HttpCacheForeverTest < ActionController::TestCase
   class HttpCacheForeverController < ActionController::Base
     def cache_me_forever
       http_cache_forever(public: params[:public], version: params[:version] || 'v1') do
-        render text: 'hello'
+        render plain: 'hello'
       end
     end
   end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -13,7 +13,7 @@ module RequestForgeryProtectionActions
   end
 
   def unsafe
-    render :text => 'pwn'
+    render plain: 'pwn'
   end
 
   def meta

--- a/actionpack/test/controller/rescue_test.rb
+++ b/actionpack/test/controller/rescue_test.rb
@@ -43,8 +43,8 @@ class RescueController < ActionController::Base
   rescue_from NotAllowed, :with => proc { head :forbidden }
   rescue_from 'RescueController::NotAllowedToRescueAsString', :with => proc { head :forbidden }
 
-  rescue_from InvalidRequest, :with => proc { |exception| render :text => exception.message }
-  rescue_from 'InvalidRequestToRescueAsString', :with => proc { |exception| render :text => exception.message }
+  rescue_from InvalidRequest, with: proc { |exception| render plain: exception.message }
+  rescue_from 'InvalidRequestToRescueAsString', with: proc { |exception| render plain: exception.message }
 
   rescue_from BadGateway do
     head 502
@@ -54,18 +54,18 @@ class RescueController < ActionController::Base
   end
 
   rescue_from ResourceUnavailable do |exception|
-    render :text => exception.message
+    render plain: exception.message
   end
   rescue_from 'ResourceUnavailableToRescueAsString' do |exception|
-    render :text => exception.message
+    render plain: exception.message
   end
 
   rescue_from ActionView::TemplateError do
-    render :text => 'action_view templater error'
+    render plain: 'action_view templater error'
   end
 
   rescue_from IOError do
-    render :text => 'io error'
+    render plain: 'io error'
   end
 
   before_action(only: :before_action_raises) { raise 'umm nice' }
@@ -74,7 +74,7 @@ class RescueController < ActionController::Base
   end
 
   def raises
-    render :text => 'already rendered'
+    render plain: 'already rendered'
     raise "don't panic!"
   end
 
@@ -302,7 +302,7 @@ class RescueTest < ActionDispatch::IntegrationTest
     rescue_from RecordInvalid, :with => :show_errors
 
     def foo
-      render :text => "foo"
+      render plain: "foo"
     end
 
     def invalid
@@ -315,7 +315,7 @@ class RescueTest < ActionDispatch::IntegrationTest
 
     protected
       def show_errors(exception)
-        render :text => exception.message
+        render plain: exception.message
       end
   end
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -6,78 +6,78 @@ require 'rails/engine'
 class TestCaseTest < ActionController::TestCase
   class TestController < ActionController::Base
     def no_op
-      render text: 'dummy'
+      render plain: 'dummy'
     end
 
     def set_flash
       flash["test"] = ">#{flash["test"]}<"
-      render text: 'ignore me'
+      render plain: 'ignore me'
     end
 
     def delete_flash
       flash.delete("test")
-      render :text => 'ignore me'
+      render plain: 'ignore me'
     end
 
     def set_flash_now
       flash.now["test_now"] = ">#{flash["test_now"]}<"
-      render text: 'ignore me'
+      render plain: 'ignore me'
     end
 
     def set_session
       session['string'] = 'A wonder'
       session[:symbol] = 'it works'
-      render text: 'Success'
+      render plain: 'Success'
     end
 
     def reset_the_session
       reset_session
-      render text: 'ignore me'
+      render plain: 'ignore me'
     end
 
     def render_raw_post
       raise ActiveSupport::TestCase::Assertion, "#raw_post is blank" if request.raw_post.blank?
-      render text: request.raw_post
+      render plain: request.raw_post
     end
 
     def render_body
-      render text: request.body.read
+      render plain: request.body.read
     end
 
     def test_params
-      render text: ::JSON.dump(params.to_unsafe_h)
+      render plain: ::JSON.dump(params.to_unsafe_h)
     end
 
     def test_query_parameters
-      render text: ::JSON.dump(request.query_parameters)
+      render plain: ::JSON.dump(request.query_parameters)
     end
 
     def test_request_parameters
-      render text: request.request_parameters.inspect
+      render plain: request.request_parameters.inspect
     end
 
     def test_uri
-      render text: request.fullpath
+      render plain: request.fullpath
     end
 
     def test_format
-      render text: request.format
+      render plain: request.format
     end
 
     def test_query_string
-      render text: request.query_string
+      render plain: request.query_string
     end
 
     def test_protocol
-      render text: request.protocol
+      render plain: request.protocol
     end
 
     def test_headers
-      render text: request.headers.env.to_json
+      render plain: request.headers.env.to_json
     end
 
     def test_html_output
-      render text: <<HTML
+      render plain: <<HTML
 <html>
   <body>
     <a href="/"><img src="/images/button.png" /></a>
@@ -99,7 +99,7 @@ HTML
 
     def test_xml_output
       response.content_type = "application/xml"
-      render text: <<XML
+      render plain: <<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <root>
   <area>area is an empty tag in HTML, raising an error if not in xml mode</area>
@@ -108,15 +108,15 @@ XML
     end
 
     def test_only_one_param
-      render text: (params[:left] && params[:right]) ? "EEP, Both here!" : "OK"
+      render plain: (params[:left] && params[:right]) ? "EEP, Both here!" : "OK"
     end
 
     def test_remote_addr
-      render text: (request.remote_addr || "not specified")
+      render plain: (request.remote_addr || "not specified")
     end
 
     def test_file_upload
-      render text: params[:file].size
+      render plain: params[:file].size
     end
 
     def test_send_file
@@ -170,7 +170,7 @@ XML
     before_action { @dynamic_opt = 'opt' }
 
     def test_url_options_reset
-      render text: url_for(params)
+      render plain: url_for(params)
     end
 
     def default_url_options
@@ -997,7 +997,7 @@ module EngineControllerTests
 
   class BarController < ActionController::Base
     def index
-      render text: 'bar'
+      render plain: 'bar'
     end
   end
 
@@ -1083,7 +1083,7 @@ class AnonymousControllerTest < ActionController::TestCase
   def setup
     @controller = Class.new(ActionController::Base) do
       def index
-        render text: params[:controller]
+        render plain: params[:controller]
       end
     end.new
 
@@ -1104,11 +1104,11 @@ class RoutingDefaultsTest < ActionController::TestCase
   def setup
     @controller = Class.new(ActionController::Base) do
       def post
-        render text: request.fullpath
+        render plain: request.fullpath
       end
 
       def project
-        render text: request.fullpath
+        render plain: request.fullpath
       end
     end.new
 

--- a/actionpack/test/controller/webservice_test.rb
+++ b/actionpack/test/controller/webservice_test.rb
@@ -5,9 +5,9 @@ class WebServiceTest < ActionDispatch::IntegrationTest
   class TestController < ActionController::Base
     def assign_parameters
       if params[:full]
-        render :text => dump_params_keys
+        render plain: dump_params_keys
       else
-        render :text => (params.keys - ['controller', 'action']).sort.join(", ")
+        render plain: (params.keys - ['controller', 'action']).sort.join(", ")
       end
     end
 

--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -73,26 +73,26 @@ module TestGenerationPrefix
       include RailsApplication.routes.mounted_helpers
 
       def index
-        render :text => posts_path
+        render plain: posts_path
       end
 
       def show
-        render :text => post_path(:id => params[:id])
+        render plain: post_path(id: params[:id])
       end
 
       def url_to_application
         path = main_app.url_for(:controller => "outside_engine_generating",
                                 :action => "index",
                                 :only_path => true)
-        render :text => path
+        render plain: path
       end
 
       def polymorphic_path_for_engine
-        render :text => polymorphic_path(Post.new)
+        render plain: polymorphic_path(Post.new)
       end
 
       def conflicting
-        render :text => "engine"
+        render plain: "engine"
       end
     end
 
@@ -101,28 +101,28 @@ module TestGenerationPrefix
       include RailsApplication.routes.url_helpers
 
       def index
-        render :text => blog_engine.post_path(:id => 1)
+        render plain: blog_engine.post_path(id: 1)
       end
 
       def polymorphic_path_for_engine
-        render :text => blog_engine.polymorphic_path(Post.new)
+        render plain: blog_engine.polymorphic_path(Post.new)
       end
 
       def polymorphic_path_for_app
-        render :text => polymorphic_path(Post.new)
+        render plain: polymorphic_path(Post.new)
       end
 
       def polymorphic_with_url_for
-        render :text => blog_engine.url_for(Post.new)
+        render plain: blog_engine.url_for(Post.new)
       end
 
       def conflicting
-        render :text => "application"
+        render plain: "application"
       end
 
       def ivar_usage
         @blog_engine = "Not the engine route helper"
-        render :text => blog_engine.post_path(:id => 1)
+        render plain: blog_engine.post_path(id: 1)
       end
     end
 
@@ -378,7 +378,7 @@ module TestGenerationPrefix
       include RailsApplication.routes.mounted_helpers
 
       def show
-        render :text => post_path(:id => params[:id])
+        render plain: post_path(id: params[:id])
       end
     end
 

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -17,7 +17,7 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
     end
 
     def read
-      render :text => "File: #{params[:uploaded_data].read}"
+      render plain: "File: #{params[:uploaded_data].read}"
     end
   end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3729,7 +3729,7 @@ class TestNamespaceWithControllerOption < ActionDispatch::IntegrationTest
   module ::Admin
     class StorageFilesController < ActionController::Base
       def index
-        render :text => "admin/storage_files#index"
+        render plain: "admin/storage_files#index"
       end
     end
   end
@@ -3824,7 +3824,7 @@ class TestDefaultScope < ActionDispatch::IntegrationTest
   module ::Blog
     class PostsController < ActionController::Base
       def index
-        render :text => "blog/posts#index"
+        render plain: "blog/posts#index"
       end
     end
   end
@@ -4164,13 +4164,13 @@ end
 class TestNamedRouteUrlHelpers < ActionDispatch::IntegrationTest
   class CategoriesController < ActionController::Base
     def show
-      render :text => "categories#show"
+      render plain: "categories#show"
     end
   end
 
   class ProductsController < ActionController::Base
     def show
-      render :text => "products#show"
+      render plain: "products#show"
     end
   end
 
@@ -4265,7 +4265,7 @@ end
 class TestInvalidUrls < ActionDispatch::IntegrationTest
   class FooController < ActionController::Base
     def show
-      render :text => "foo#show"
+      render plain: "foo#show"
     end
   end
 
@@ -4568,7 +4568,7 @@ end
 class TestDefaultUrlOptions < ActionDispatch::IntegrationTest
   class PostsController < ActionController::Base
     def archive
-      render :text => "posts#archive"
+      render plain: "posts#archive"
     end
   end
 

--- a/actionpack/test/dispatch/session/cache_store_test.rb
+++ b/actionpack/test/dispatch/session/cache_store_test.rb
@@ -18,11 +18,11 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
     end
 
     def get_session_value
-      render :text => "foo: #{session[:foo].inspect}"
+      render plain: "foo: #{session[:foo].inspect}"
     end
 
     def get_session_id
-      render :text => "#{request.session.id}"
+      render plain: "#{request.session.id}"
     end
 
     def call_reset_session

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -16,25 +16,25 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
     end
 
     def persistent_session_id
-      render :text => session[:session_id]
+      render plain: session[:session_id]
     end
 
     def set_session_value
       session[:foo] = "bar"
-      render :text => Rack::Utils.escape(Verifier.generate(session.to_hash))
+      render plain: Rack::Utils.escape(Verifier.generate(session.to_hash))
     end
 
     def get_session_value
-      render :text => "foo: #{session[:foo].inspect}"
+      render plain: "foo: #{session[:foo].inspect}"
     end
 
     def get_session_id
-      render :text => "id: #{request.session.id}"
+      render plain: "id: #{request.session.id}"
     end
 
     def get_class_after_reset_session
       reset_session
-      render :text => "class: #{session.class}"
+      render plain: "class: #{session.class}"
     end
 
     def call_session_clear

--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -19,11 +19,11 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
     end
 
     def get_session_value
-      render :text => "foo: #{session[:foo].inspect}"
+      render plain: "foo: #{session[:foo].inspect}"
     end
 
     def get_session_id
-      render :text => "#{request.session.id}"
+      render plain: "#{request.session.id}"
     end
 
     def call_reset_session

--- a/actionpack/test/dispatch/url_generation_test.rb
+++ b/actionpack/test/dispatch/url_generation_test.rb
@@ -8,7 +8,7 @@ module TestUrlGeneration
     class ::MyRouteGeneratingController < ActionController::Base
       include Routes.url_helpers
       def index
-        render :text => foo_path
+        render plain: foo_path
       end
     end
 

--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -18,7 +18,7 @@ module ActionView
       #   performs HTML escape on the string first. Setting the content type as
       #   <tt>text/html</tt>.
       # * <tt>:body</tt> - Renders the text passed in, and inherits the content
-      #   type of <tt>text/html</tt> from <tt>ActionDispatch::Response</tt>
+      #   type of <tt>text/plain</tt> from <tt>ActionDispatch::Response</tt>
       #   object.
       #
       # If no options hash is passed or :update specified, the default is to render a partial and use the second parameter

--- a/actionview/test/actionpack/abstract/layouts_test.rb
+++ b/actionview/test/actionpack/abstract/layouts_test.rb
@@ -52,7 +52,7 @@ module AbstractControllerTests
       end
 
       def overwrite_skip
-        render :text => "Hello text!"
+        render plain: "Hello text!"
       end
     end
 
@@ -371,7 +371,7 @@ module AbstractControllerTests
       test "layout for anonymous controller" do
         klass = Class.new(WithString) do
           def index
-            render :text => 'index', :layout => true
+            render plain: 'index', layout: true
           end
         end
 

--- a/actionview/test/actionpack/abstract/render_test.rb
+++ b/actionview/test/actionpack/abstract/render_test.rb
@@ -1,4 +1,5 @@
 require 'abstract_unit'
+require 'active_support/deprecation'
 
 module AbstractController
   module Testing
@@ -33,7 +34,7 @@ module AbstractController
       end
 
       def text
-        render :text => "With Text"
+        render plain: "With Text"
       end
 
       def default

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -121,7 +121,7 @@ class TestController < ApplicationController
   # :ported:
   def render_hello_world_from_variable
     @person = "david"
-    render :text => "hello #{@person}"
+    render plain: "hello #{@person}"
   end
 
   # :ported:
@@ -143,13 +143,13 @@ class TestController < ApplicationController
 
   # :ported:
   def render_text_hello_world
-    render :text => "hello world"
+    render plain: "hello world"
   end
 
   # :ported:
   def render_text_hello_world_with_layout
     @variable_for_layout = ", I am here!"
-    render :text => "hello world", :layout => true
+    render plain: "hello world", :layout => true
   end
 
   def hello_world_with_layout_false
@@ -212,26 +212,26 @@ class TestController < ApplicationController
 
   # :ported:
   def render_custom_code
-    render :text => "hello world", :status => 404
+    render plain: "hello world", :status => 404
   end
 
   # :ported:
   def render_text_with_nil
-    render :text => nil
+    render plain: nil
   end
 
   # :ported:
   def render_text_with_false
-    render :text => false
+    render plain: false
   end
 
   def render_text_with_resource
-    render :text => Customer.new("David")
+    render plain: Customer.new("David")
   end
 
   # :ported:
   def render_nothing_with_appendix
-    render :text => "appended"
+    render plain: "appended"
   end
 
   # This test is testing 3 things:
@@ -262,7 +262,7 @@ class TestController < ApplicationController
 
   # :ported:
   def blank_response
-    render :text => ' '
+    render plain: ' '
   end
 
   # :ported:
@@ -294,7 +294,7 @@ class TestController < ApplicationController
 
   def hello_in_a_string
     @customers = [ Customer.new("david"), Customer.new("mary") ]
-    render :text => "How's there? " + render_to_string(:template => "test/list")
+    render plain: "How's there? " + render_to_string(:template => "test/list")
   end
 
   def accessing_params_in_template
@@ -362,7 +362,7 @@ class TestController < ApplicationController
 
   def render_to_string_with_assigns
     @before = "i'm before the render"
-    render_to_string :text => "foo"
+    render_to_string plain: "foo"
     @after = "i'm after the render"
     render :template => "test/hello_world"
   end
@@ -409,8 +409,8 @@ class TestController < ApplicationController
 
   # :ported:
   def double_render
-    render :text => "hello"
-    render :text => "world"
+    render plain: "hello"
+    render plain: "world"
   end
 
   def double_redirect
@@ -419,13 +419,13 @@ class TestController < ApplicationController
   end
 
   def render_and_redirect
-    render :text => "hello"
+    render plain: "hello"
     redirect_to :action => "double_render"
   end
 
   def render_to_string_and_render
-    @stuff = render_to_string :text => "here is some cached stuff"
-    render :text => "Hi web users! #{@stuff}"
+    @stuff = render_to_string plain: "here is some cached stuff"
+    render plain: "Hi web users! #{@stuff}"
   end
 
   def render_to_string_with_inline_and_render
@@ -454,7 +454,7 @@ class TestController < ApplicationController
   # :addressed:
   def render_text_with_assigns
     @hello = "world"
-    render :text => "foo"
+    render plain: "foo"
   end
 
   def render_with_assigns_option
@@ -467,7 +467,7 @@ class TestController < ApplicationController
 
   def render_content_type_from_body
     response.content_type = Mime::RSS
-    render :text => "hello world!"
+    render body: "hello world!"
   end
 
   def render_using_layout_around_block
@@ -770,7 +770,7 @@ class RenderTest < ActionController::TestCase
   # :ported:
   def test_do_with_render_text_and_layout
     get :render_text_hello_world_with_layout
-    assert_equal "<html>hello world, I am here!</html>", @response.body
+    assert_equal "{{hello world, I am here!}}\n", @response.body
   end
 
   # :ported:

--- a/actionview/test/fixtures/actionpack/layouts/standard.text.erb
+++ b/actionview/test/fixtures/actionpack/layouts/standard.text.erb
@@ -1,0 +1,1 @@
+{{<%= yield %><%= @variable_for_layout %>}}


### PR DESCRIPTION
This will silence deprecation warnings when running test suite.

Most of the test can be changed from `render :text` to render `:plain` or `render :body` right away. However, there are some tests that needed to be fixed by hand as they actually assert the default Content-Type returned from `render :body`.
