### PR TITLE
[ci skip] Fix typo in #any? RDoc

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -781,7 +781,7 @@ module ActiveRecord
       #   person.pets.any?  # => false
       #
       #   person.pets << Pet.new(name: 'Snoop')
-      #   person.pets.count # => 0
+      #   person.pets.count # => 1
       #   person.pets.any?  # => true
       #
       # You can also pass a +block+ to define criteria. The behavior


### PR DESCRIPTION
The RDoc for `ActiveRecord::Associations::CollectionProxy#any?` has an incorrect number of `pets`.

```
irb(main):001:0> person = Person.create(name: 'David')
irb(main):002:0> person.pets.count
=> 0
irb(main):003:0> person.pets.any?
=> false
irb(main):004:0>
irb(main):005:0* person.pets << Pet.new(name: 'Snoop')
irb(main):006:0> person.pets.count
=> 1
irb(main):007:0> person.pets.any?
=> true
```
