### PR TITLE
add system! to fail fast in bin/setup

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup
@@ -5,13 +5,17 @@ include FileUtils
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
 
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
 chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
   puts '== Installing dependencies =='
-  system 'gem install bundler --conservative'
-  system('bundle check') or system('bundle install')
+  system! 'gem install bundler --conservative'
+  system!('bundle check') or system!('bundle install')
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')
@@ -19,11 +23,11 @@ chdir APP_ROOT do
   # end
 
   puts "\n== Preparing database =="
-  system 'ruby bin/rake db:setup'
+  system! 'ruby bin/rake db:setup'
 
   puts "\n== Removing old logs and tempfiles =="
-  system 'ruby bin/rake log:clear tmp:clear'
+  system! 'ruby bin/rake log:clear tmp:clear'
 
   puts "\n== Restarting application server =="
-  system 'ruby bin/rake restart'
+  system! 'ruby bin/rake restart'
 end


### PR DESCRIPTION
`bin/setup` is a great, but it would be even nicer if it failed fast when something bad happens.  For example, If `bundle install` fails, there isn't much point in trying to go on and do other setup tasks.  The developer will probably have to fix their gem install issue first.

This PR adds a `system!` helper which will fail fast if the command fails.  When things fail, it uses [abort](http://ruby-doc.org/core-2.2.2/Kernel.html#method-i-abort) to exit out and print a message to STDERR.

/cc @senny
/cc https://github.com/rails/rails/pull/15189
