### PR TITLE
use `plain` option instead of deprecated `text` option

### DIFF
--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -31,7 +31,7 @@ class TestController < ActionController::Base
   include Rails.application.routes.url_helpers
 
   def index
-    render text: 'Home'
+    render plain: 'Home'
   end
 end
 


### PR DESCRIPTION
this will silence deprecation warnings
