### PR TITLE
 Replaced render :text with render :plain in AC gem bug report template

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -32,7 +32,7 @@ class TestController < ActionController::Base
   include Rails.application.routes.url_helpers
 
   def index
-    render text: 'Home'
+    render plain: 'Home'
   end
 end
 


### PR DESCRIPTION
- Followup of https://github.com/rails/rails/pull/20929.
  [ci skip]
