### PR TITLE
Ensure that 'ActionController::Parameters' can still be passed to AR …

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -445,6 +445,9 @@ module ActiveRecord
     #   ])
     def assign_nested_attributes_for_collection_association(association_name, attributes_collection)
       options = self.nested_attributes_options[association_name]
+      if attributes_collection.respond_to?(:permitted?)
+        attributes_collection = attributes_collection.to_h
+      end
 
       unless attributes_collection.is_a?(Hash) || attributes_collection.is_a?(Array)
         raise ArgumentError, "Hash or Array expected, got #{attributes_collection.class.name} (#{attributes_collection.inspect})"
@@ -471,6 +474,9 @@ module ActiveRecord
       end
 
       attributes_collection.each do |attributes|
+        if attributes.respond_to?(:permitted?)
+          attributes = attributes.to_h
+        end
         attributes = attributes.with_indifferent_access
 
         if attributes['id'].blank?

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -1074,17 +1074,29 @@ class TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations < ActiveR
       true
     end
 
+    def [](key)
+      @hash[key]
+    end
+
     def to_h
       @hash
     end
   end
 
-  test "strong params style objects can be assigned" do
+  test "strong params style objects can be assigned for singular associations" do
     params = { name: "Stern", ship_attributes:
                ProtectedParameters.new(name: "The Black Rock") }
     part = ShipPart.new(params)
 
     assert_equal "Stern", part.name
     assert_equal "The Black Rock", part.ship.name
+  end
+
+  test "strong params style objects can be assigned for collection associations" do
+    params = { trinkets_attributes: ProtectedParameters.new("0" => ProtectedParameters.new(name: "Necklace"), "1" => ProtectedParameters.new(name: "Spoon")) }
+    part = ShipPart.new(params)
+
+    assert_equal "Necklace", part.trinkets[0].name
+    assert_equal "Spoon", part.trinkets[1].name
   end
 end


### PR DESCRIPTION
…for collection associations

This continues on from https://github.com/rails/rails/commit/68af63618223c238468af1afb093eb4ccc706761 which fixed issue #20922 for singular assocations and implements the fix for collection associations as well
