### PR TITLE
Add #with_indifferent_access to AC::Parameters to clean up the needed…

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -187,6 +187,12 @@ module ActionController
     end
     alias_method :to_unsafe_hash, :to_unsafe_h
 
+    # Returns a safe +HashWithIndifferentAccess+ representation of this parameter with all
+    # unpermitted keys removed.
+    def with_indifferent_access
+      to_h.with_indifferent_access
+    end
+
     # Convert all hashes in values into parameters, then yield each pair like
     # the same way as <tt>Hash#each_pair</tt>
     def each_pair(&block)

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -280,6 +280,44 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert_equal({ "controller" => "users", "action" => "create" }, params.to_h)
   end
 
+  test "with_indifferent_access returns empty hash on unpermitted params" do
+    assert @params.with_indifferent_access.is_a? HashWithIndifferentAccess
+    assert_not @params.with_indifferent_access.is_a? ActionController::Parameters
+    assert @params.with_indifferent_access.empty?
+  end
+
+  test "with_indifferent_access returns converted hash on permitted params" do
+    @params.permit!
+
+    assert @params.with_indifferent_access.is_a? HashWithIndifferentAccess
+    assert_not @params.with_indifferent_access.is_a? ActionController::Parameters
+  end
+
+  test "with_indifferent_access returns converted hash when .permit_all_parameters is set" do
+    begin
+      ActionController::Parameters.permit_all_parameters = true
+      params = ActionController::Parameters.new(crab: "Senjougahara Hitagi")
+
+      assert params.with_indifferent_access.is_a? HashWithIndifferentAccess
+      assert_not @params.with_indifferent_access.is_a? ActionController::Parameters
+      assert_equal({ "crab" => "Senjougahara Hitagi" }, params.with_indifferent_access)
+    ensure
+      ActionController::Parameters.permit_all_parameters = false
+    end
+  end
+
+  test "with_indifferent_access returns always permitted parameter on unpermitted params" do
+    params = ActionController::Parameters.new(
+      controller: "users",
+      action: "create",
+      user: {
+        name: "Sengoku Nadeko"
+      }
+    )
+
+    assert_equal({ "controller" => "users", "action" => "create" }, params.with_indifferent_access)
+  end
+
   test "to_unsafe_h returns unfiltered params" do
     assert @params.to_h.is_a? Hash
     assert_not @params.to_h.is_a? ActionController::Parameters

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -386,9 +386,6 @@ module ActiveRecord
     # then the existing record will be marked for destruction.
     def assign_nested_attributes_for_one_to_one_association(association_name, attributes)
       options = self.nested_attributes_options[association_name]
-      if attributes.respond_to?(:permitted?)
-        attributes = attributes.to_h
-      end
       attributes = attributes.with_indifferent_access
       existing_record = send(association_name)
 
@@ -445,8 +442,8 @@ module ActiveRecord
     #   ])
     def assign_nested_attributes_for_collection_association(association_name, attributes_collection)
       options = self.nested_attributes_options[association_name]
-      if attributes_collection.respond_to?(:permitted?)
-        attributes_collection = attributes_collection.to_h
+      if attributes_collection.respond_to?(:with_indifferent_access)
+        attributes_collection = attributes_collection.with_indifferent_access
       end
 
       unless attributes_collection.is_a?(Hash) || attributes_collection.is_a?(Array)
@@ -456,8 +453,7 @@ module ActiveRecord
       check_record_limit!(options[:limit], attributes_collection)
 
       if attributes_collection.is_a? Hash
-        keys = attributes_collection.keys
-        attributes_collection = if keys.include?('id') || keys.include?(:id)
+        attributes_collection = if attributes_collection.has_key?('id')
           [attributes_collection]
         else
           attributes_collection.values
@@ -474,9 +470,6 @@ module ActiveRecord
       end
 
       attributes_collection.each do |attributes|
-        if attributes.respond_to?(:permitted?)
-          attributes = attributes.to_h
-        end
         attributes = attributes.with_indifferent_access
 
         if attributes['id'].blank?

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -1081,6 +1081,10 @@ class TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations < ActiveR
     def to_h
       @hash
     end
+
+    def with_indifferent_access
+      to_h.with_indifferent_access
+    end
   end
 
   test "strong params style objects can be assigned for singular associations" do


### PR DESCRIPTION
… changes for nested attributes  

Adding #with_indifferent_access to AC::Parameters simplifies the changes needed for compatibility with nested attributes
