### PR TITLE
Ensure that scoping blocks are honored for joined associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Ensure that scoping blocks are honored for joined associations
+ 
+    Fixes #13775.
+
+    *Colin Sidoti*
+
 *   Ensure that cyclic associations with autosave don't cause duplicate errors
     to be added to the parent record.
 

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -41,29 +41,26 @@ module ActiveRecord
             key         = join_keys.key
             foreign_key = join_keys.foreign_key
 
-            constraint = build_constraint(klass, table, key, foreign_table, foreign_key)
+            constraint = table[key].eq(foreign_table[foreign_key])
 
+            #This has the constraints we need, but maybe an incorrect table alias
+            starting_rel = klass.all
+
+            #Create an empty rel with the correct alias
             predicate_builder = PredicateBuilder.new(TableMetadata.new(klass, table))
-            scope_chain_items = scope_chain[scope_chain_index].map do |item|
+            rel = ActiveRecord::Relation.create(klass, table, predicate_builder)
+            
+            #merge the starting rel's constraints to the empty
+            rel = rel.merge(starting_rel).unscope(:where).where(starting_rel.where_values_hash)
+
+            scope_chain[scope_chain_index].each do |item|
               if item.is_a?(Relation)
-                item
+                rel = rel.merge item
               else
-                ActiveRecord::Relation.create(klass, table, predicate_builder)
-                  .instance_exec(node, &item)
+                rel = rel.instance_exec(node, &item)
               end
             end
             scope_chain_index += 1
-
-            relation = ActiveRecord::Relation.create(
-              klass,
-              table,
-              predicate_builder,
-            )
-            scope_chain_items.concat [klass.send(:build_default_scope, relation)].compact
-
-            rel = scope_chain_items.inject(scope_chain_items.shift) do |left, right|
-              left.merge right
-            end
 
             if rel && !rel.arel.constraints.empty?
               binds += rel.bound_attributes
@@ -86,34 +83,6 @@ module ActiveRecord
           end
 
           JoinInformation.new joins, binds
-        end
-
-        #  Builds equality condition.
-        #
-        #  Example:
-        #
-        #  class Physician < ActiveRecord::Base
-        #    has_many :appointments
-        #  end
-        #
-        #  If I execute `Physician.joins(:appointments).to_a` then
-        #    klass         # => Physician
-        #    table         # => #<Arel::Table @name="appointments" ...>
-        #    key           # =>  physician_id
-        #    foreign_table # => #<Arel::Table @name="physicians" ...>
-        #    foreign_key   # => id
-        #
-        def build_constraint(klass, table, key, foreign_table, foreign_key)
-          constraint = table[key].eq(foreign_table[foreign_key])
-
-          if klass.finder_needs_type_condition?
-            constraint = table.create_and([
-              constraint,
-              klass.send(:type_condition, table)
-            ])
-          end
-
-          constraint
         end
 
         def table

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -41,6 +41,14 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     assert_no_match(/WHERE/i, sql)
   end
 
+  def test_scoping_block_etends_to_joins
+    Author.where(:id=>1).scoping {
+      join = Post.joins(:author).order(:id)
+      assert_not join.empty?, "expected to have posts by author id=1"
+      assert_equal Post.where(author_id: 1).order(:id).to_a, join.to_a
+    }
+  end
+
   def test_join_association_conditions_support_string_and_arel_expressions
     assert_equal 0, Author.joins(:welcome_posts_with_one_comment).count
     assert_equal 1, Author.joins(:welcome_posts_with_comments).count


### PR DESCRIPTION
Updates JoinAssocation#join_constraints to ensure that scoping blocks are honored.  Previously, join_constraints created a relation for each scope being applied to the model (default and association), and then merged those relations into a single relation.

Fixes #13775

The problem was that these individual, scoped relations were built with AR::Relation.new() as their starting point, which is completely unscoped.

Scoping blocks work by altering the value of  to return a scoped relation.  But join_constraints() never merged in that scoped relation, it simply used it as the klass for a clean, new relation.

It is important to realize that the  relation from a scoping block does not necessarily use the same Arel::Table as the relation used for a join.  Specifically, it may not have the same alias, which is particularly dangerous for where_clauses.

The new strategy for applying scopes is:
1. Build a clean, properly aliased relation
2. Merge in the impoperly aliased relation returned by klass.all
3. Unscope the where field from the merged relation
4. Reapply the where field with where(klass.all.where_values_hash), since the hash does not use raw Arel
5. Apply the scope_chain_items relevant to the association

This strategy lead to two other small changes in join_constraints:
1. klass.all returns either a default scoped relation, or a scoping block relation.  In either case, the default scope is already applied, and no longer needs to be explicitly applied in join_constraints
2. klass.all also already contains single-table inheritance constraints, so those no longer need to explicity added.  This change led to the build_constraint method being one line, so it was removed.
