### PR TITLE
Extend `ActiveSupport::StringInquirer` to specify valid values

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   ActiveSupport::StringInquirer now allows specifying valid values so that only these
+    get inquiry methods generated. Example:
+
+        'pending'.inquiry(restricted_to: ['pending', 'active']).pending? => returns true
+        'pending'.inquiry(restricted_to: ['pending', 'active']).expired? => raises NoMethodsError
+
+    *Rafael Sales*
+
 *   Prevent `Marshal.load` from looping infinitely when trying to autoload a constant
     which resolves to a different name.
 

--- a/activesupport/lib/active_support/core_ext/string/inquiry.rb
+++ b/activesupport/lib/active_support/core_ext/string/inquiry.rb
@@ -7,7 +7,15 @@ class String
   #   env = 'production'.inquiry
   #   env.production?  # => true
   #   env.development? # => false
-  def inquiry
-    ActiveSupport::StringInquirer.new(self)
+  #
+  # The option +restricted_to+ can be set to an array so the inquirer only
+  # responds to a specific set of questions.
+  #
+  #   status = 'active'.inquiry(restricted_to: ['pending', 'active', 'finished'])
+  #   status.pending?  # => false
+  #   status.active?   # => true
+  #   status.canceled? # => raises NoMethodsError
+  def inquiry(restricted_to: nil)
+    ActiveSupport::StringInquirer.new(self, restricted_to: restricted_to)
   end
 end

--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -9,18 +9,54 @@ module ActiveSupport
   #
   #   Rails.env.production?
   class StringInquirer < String
-    private
+
+    def initialize(value, restricted_to: nil)
+      super(value)
+
+      if restricted_to
+        @restricted_to = restricted_to
+        extend RestrictInquiry
+      else
+        extend LooseInquiry
+      end
+    end
+
+    module RestrictInquiry
+      attr_reader :restricted_to
+
+      private
 
       def respond_to_missing?(method_name, include_private = false)
-        method_name[-1] == '?'
+        valid_inquiry_method?(method_name) || super
       end
 
       def method_missing(method_name, *arguments)
-        if method_name[-1] == '?'
-          self == method_name[0..-2]
+        if valid_inquiry_method?(method_name)
+          self == method_name[0...-1]
         else
           super
         end
       end
+
+      def valid_inquiry_method?(method_name)
+        restricted_to.any? { |e| e.to_s == method_name[0...-1] }
+      end
+    end
+
+    module LooseInquiry
+      private
+
+      def respond_to_missing?(method_name, include_private = false)
+        method_name[-1] == '?' || super
+      end
+
+      def method_missing(method_name, *arguments)
+        if method_name[-1] == '?'
+          self == method_name[0...-1]
+        else
+          super
+        end
+      end
+    end
   end
 end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -239,9 +239,16 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal expected, original
   end
 
-  def test_string_inquiry
+  def test_dynamic_string_inquiry
     assert "production".inquiry.production?
     assert !"production".inquiry.development?
+  end
+
+  def test_restrict_string_inquiry
+    valid_environments = ['staging', 'qa']
+    assert "staging".inquiry(restricted_to: valid_environments).staging?
+    assert !"staging".inquiry(restricted_to: valid_environments).qa?
+    assert_raises(NoMethodError) { "qa".inquiry(restricted_to: valid_environments).production? }
   end
 
   def test_truncate

--- a/activesupport/test/string_inquirer_test.rb
+++ b/activesupport/test/string_inquirer_test.rb
@@ -1,23 +1,44 @@
 require 'abstract_unit'
 
-class StringInquirerTest < ActiveSupport::TestCase
-  def setup
-    @string_inquirer = ActiveSupport::StringInquirer.new('production')
+module StringInquirerTest
+  class LooseStringInquirer < ActiveSupport::TestCase
+    def setup
+      @string_inquirer = ActiveSupport::StringInquirer.new('production')
+    end
+
+    def test_match
+      assert @string_inquirer.production?
+    end
+
+    def test_miss
+      assert_not @string_inquirer.development?
+    end
+
+    def test_missing_question_mark
+      assert_raise(NoMethodError) { @string_inquirer.production }
+    end
+
+    def test_respond_to
+      assert_respond_to @string_inquirer, :development?
+    end
   end
 
-  def test_match
-    assert @string_inquirer.production?
-  end
+  class RestrictStringInquirer < ActiveSupport::TestCase
+    def setup
+      valid_environments = ['production', 'staging', 'development']
+      @string_inquirer = ActiveSupport::StringInquirer.new('production', restricted_to: valid_environments)
+    end
 
-  def test_miss
-    assert_not @string_inquirer.development?
-  end
+    def test_match
+      assert @string_inquirer.production?
+    end
 
-  def test_missing_question_mark
-    assert_raise(NoMethodError) { @string_inquirer.production }
-  end
+    def test_miss
+      assert_not @string_inquirer.development?
+    end
 
-  def test_respond_to
-    assert_respond_to @string_inquirer, :development?
+    def test_invalid_environment
+      assert_raise(NoMethodError) { @string_inquirer.qa? }
+    end
   end
 end


### PR DESCRIPTION
`StringInquirer` now supports specifying which values are valid so that only a specific set of _inquiries_ can be called on it. Example:

``` ruby
class Offer < Struct.new(:status)
  VALID_STATUSES = %w(pending active finished)

  def status
    super.inquiry(restricted_to: VALID_STATUSES)
  end
end

> Offer.new('pending').status.pending?
=> true

> Offer.new('finished').status.active?
=> false

> Offer.new('ended').status.ended?
NoMethodError: undefined method `ended?` for "ended":ActiveSupport::StringInquirer

> Offer.new('active').status.valid_values
=> ["pending", "active", "finished"]
```

Current existing behavior of `StringInquiry` is preserved if a list of valid values is not specified:

``` ruby
> 'pending'.inquiry.pending?
=> true

> 'active'.inquiry.whaaat?
=> false
```
