### PR TITLE
Fix `TimeWithZone#eql?` to handle `TimeWithZone` created from `DateTime`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix `TimeWithZone#eql?` to properly handle `TimeWithZone` created from `DateTime`:
+        twz = DateTime.now.in_time_zone
+        twz.eql?(twz.dup) => true
+
+    Fixes #14178.
+
+    *Roque Pinel*
+
 *   ActiveSupport::HashWithIndifferentAccess `select` and `reject` will now return
     enumerator if called without block.
 

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -247,7 +247,7 @@ module ActiveSupport
     end
 
     def eql?(other)
-      utc.eql?(other)
+      other.eql?(utc)
     end
 
     def hash

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -253,10 +253,14 @@ class TimeWithZoneTest < ActiveSupport::TestCase
   end
 
   def test_eql?
+    assert_equal true, @twz.eql?(@twz.dup)
     assert_equal true, @twz.eql?(Time.utc(2000))
     assert_equal true, @twz.eql?( ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["Hawaii"]) )
     assert_equal false, @twz.eql?( Time.utc(2000, 1, 1, 0, 0, 1) )
     assert_equal false, @twz.eql?( DateTime.civil(1999, 12, 31, 23, 59, 59) )
+
+    other_twz = ActiveSupport::TimeWithZone.new(DateTime.now.utc, @time_zone)
+    assert_equal true, other_twz.eql?(other_twz.dup)
   end
 
   def test_hash


### PR DESCRIPTION
Before:

``` ruby
  twz = DateTime.now.in_time_zone
  twz.eql?(twz.dup) => false
```

Now:

``` ruby
  twz = DateTime.now.in_time_zone
  twz.eql?(twz.dup) => true
```

Please notice that this fix the `TimeWithZone` comparison to itself, not to `DateTime`. Based on #3725, `DateTime` should not be equal to `TimeWithZone`.

Fixes #14178 based on @jeremy's comment on #14235.

/cc @rafaelfranca 
