### PR TITLE
Freeze string literals when not mutated.

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -96,7 +96,7 @@ module AbstractController
       # ==== Returns
       # * <tt>String</tt>
       def controller_path
-        @controller_path ||= name.sub(/Controller$/, '').underscore unless anonymous?
+        @controller_path ||= name.sub(/Controller$/, ''.freeze).underscore unless anonymous?
       end
 
       # Refresh the cached action_methods when a new action_method is added.

--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -181,7 +181,7 @@ module AbstractController
       end
 
       def default_helper_module!
-        module_name = name.sub(/Controller$/, '')
+        module_name = name.sub(/Controller$/, ''.freeze)
         module_path = module_name.underscore
         helper module_path
       rescue LoadError => e

--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -25,7 +25,7 @@ module ActionController
           status = ActionDispatch::ExceptionWrapper.status_code_for_exception(exception_class_name)
         end
         message = "Completed #{status} #{Rack::Utils::HTTP_STATUS_CODES[status]} in #{event.duration.round}ms"
-        message << " (#{additions.join(" | ")})" unless additions.blank?
+        message << " (#{additions.join(" | ".freeze)})" unless additions.blank?
         message
       end
     end

--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -73,7 +73,7 @@ module ActionController
 
       # Provides a proxy to access helpers methods from outside the view.
       def helpers
-        @helper_proxy ||= begin 
+        @helper_proxy ||= begin
           proxy = ActionView::Base.new
           proxy.config = config.inheritable_copy
           proxy.extend(_helpers)
@@ -100,7 +100,7 @@ module ActionController
       def all_helpers_from_path(path)
         helpers = Array(path).flat_map do |_path|
           extract = /^#{Regexp.quote(_path.to_s)}\/?(.*)_helper.rb$/
-          names = Dir["#{_path}/**/*_helper.rb"].map { |file| file.sub(extract, '\1') }
+          names = Dir["#{_path}/**/*_helper.rb"].map { |file| file.sub(extract, '\1'.freeze) }
           names.sort!
         end
         helpers.uniq!

--- a/actionpack/lib/action_dispatch/http/parameter_filter.rb
+++ b/actionpack/lib/action_dispatch/http/parameter_filter.rb
@@ -34,11 +34,11 @@ module ActionDispatch
             end
           end
 
-          deep_regexps, regexps = regexps.partition { |r| r.to_s.include?("\\.") }
-          deep_strings, strings = strings.partition { |s| s.include?("\\.") }
+          deep_regexps, regexps = regexps.partition { |r| r.to_s.include?("\\.".freeze) }
+          deep_strings, strings = strings.partition { |s| s.include?("\\.".freeze) }
 
-          regexps << Regexp.new(strings.join('|'), true) unless strings.empty?
-          deep_regexps << Regexp.new(deep_strings.join('|'), true) unless deep_strings.empty?
+          regexps << Regexp.new(strings.join('|'.freeze), true) unless strings.empty?
+          deep_regexps << Regexp.new(deep_strings.join('|'.freeze), true) unless deep_strings.empty?
 
           new regexps, deep_regexps, blocks
         end

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -245,7 +245,7 @@ module ActionDispatch
       #   req = Request.new 'HTTP_HOST' => 'example.com:8080'
       #   req.host # => "example.com"
       def host
-        raw_host_with_port.sub(/:\d+$/, '')
+        raw_host_with_port.sub(/:\d+$/, ''.freeze)
       end
 
       # Returns a \host:\port string for this request, such as "example.com" or

--- a/actionpack/lib/action_dispatch/journey/nodes/node.rb
+++ b/actionpack/lib/action_dispatch/journey/nodes/node.rb
@@ -30,7 +30,7 @@ module ActionDispatch
         end
 
         def name
-          left.tr '*:', ''
+          left.tr '*:'.freeze, ''.freeze
         end
 
         def type

--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -14,10 +14,10 @@ module ActionDispatch
         #   normalize_path("/%ab")  # => "/%AB"
         def self.normalize_path(path)
           path = "/#{path}"
-          path.squeeze!('/')
-          path.sub!(%r{/+\Z}, '')
+          path.squeeze!('/'.freeze)
+          path.sub!(%r{/+\Z}, ''.freeze)
           path.gsub!(/(%[a-f0-9]{2})/) { $1.upcase }
-          path = '/' if path == ''
+          path = '/' if path == ''.freeze
           path
         end
 

--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -35,7 +35,7 @@ module ActionDispatch
       paths = [path, "#{path}#{ext}", "#{path}/#{@index}#{ext}"]
 
       if match = paths.detect { |p|
-        path = File.join(@root, p.force_encoding('UTF-8'))
+        path = File.join(@root, p.force_encoding('UTF-8'.freeze))
         begin
           File.file?(path) && File.readable?(path)
         rescue SystemCallError
@@ -76,7 +76,7 @@ module ActionDispatch
       end
 
       def content_type(path)
-        ::Rack::Mime.mime_type(::File.extname(path), 'text/plain')
+        ::Rack::Mime.mime_type(::File.extname(path), 'text/plain'.freeze)
       end
 
       def gzip_encoding_accepted?(env)
@@ -112,7 +112,7 @@ module ActionDispatch
     def call(env)
       case env['REQUEST_METHOD']
       when 'GET', 'HEAD'
-        path = env['PATH_INFO'].chomp('/')
+        path = env['PATH_INFO'].chomp('/'.freeze)
         if match = @file_handler.match?(path)
           env['PATH_INFO'] = match
           return @file_handler.call(env)

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -671,7 +671,7 @@ module ActionDispatch
 
         # Remove leading slashes from controllers
         def normalize_controller!
-          @options[:controller] = controller.sub(%r{^/}, '') if controller
+          @options[:controller] = controller.sub(%r{^/}, ''.freeze) if controller
         end
 
         # Move 'index' action from options to recall

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -237,7 +237,7 @@ module ActionView
       #   image_alt('underscored_file_name.png')
       #   # => Underscored file name
       def image_alt(src)
-        File.basename(src, '.*').sub(/-[[:xdigit:]]{32}\z/, '').tr('-_', ' ').capitalize
+        File.basename(src, '.*'.freeze).sub(/-[[:xdigit:]]{32}\z/, ''.freeze).tr('-_'.freeze, ' '.freeze).capitalize
       end
 
       # Returns an HTML video tag for the +sources+. If +sources+ is a string,

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -127,7 +127,7 @@ module ActionView
         return "" unless source.present?
         return source if source =~ URI_REGEXP
 
-        tail, source = source[/([\?#].+)$/], source.sub(/([\?#].+)$/, '')
+        tail, source = source[/([\?#].+)$/], source.sub(/([\?#].+)$/, ''.freeze)
 
         if extname = compute_asset_extname(source, options)
           source = "#{source}#{extname}"

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -173,13 +173,13 @@ module ActionView
       # name instead of the prefix.
       def normalize_name(name, prefixes) #:nodoc:
         prefixes = prefixes.presence
-        parts    = name.to_s.split('/')
+        parts    = name.to_s.split('/'.freeze)
         parts.shift if parts.first.empty?
         name     = parts.pop
 
         return name, prefixes || [""] if parts.empty?
 
-        parts    = parts.join('/')
+        parts    = parts.join('/'.freeze)
         prefixes = prefixes ? prefixes.map { |p| "#{p}/#{parts}" } : [parts]
 
         return name, prefixes
@@ -204,7 +204,7 @@ module ActionView
     # add :html as fallback to :js.
     def formats=(values)
       if values
-        values.concat(default_formats) if values.delete "*/*"
+        values.concat(default_formats) if values.delete "*/*".freeze
         if values == [:js]
           values << :html
           @html_fallback_for_js = true

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -190,7 +190,7 @@ module ActionView
     end
 
     def inspect
-      @inspect ||= defined?(Rails.root) ? identifier.sub("#{Rails.root}/", '') : identifier
+      @inspect ||= defined?(Rails.root) ? identifier.sub("#{Rails.root}/", ''.freeze) : identifier
     end
 
     # This method is responsible for properly setting the encoding of the
@@ -337,13 +337,13 @@ module ActionView
       def method_name #:nodoc:
         @method_name ||= begin
           m = "_#{identifier_method_name}__#{@identifier.hash}_#{__id__}"
-          m.tr!('-', '_')
+          m.tr!('-'.freeze, '_'.freeze)
           m
         end
       end
 
       def identifier_method_name #:nodoc:
-        inspect.tr('^a-z_', '_')
+        inspect.tr('^a-z_'.freeze, '_'.freeze)
       end
 
       def instrument(action, &block)
@@ -366,7 +366,7 @@ module ActionView
       end
 
       def inferred_cache_name
-        @inferred_cache_name ||= @virtual_path.split('/').last.sub('_', '')
+        @inferred_cache_name ||= @virtual_path.split('/'.freeze).last.sub('_'.freeze, ''.freeze)
       end
   end
 end

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -222,7 +222,7 @@ module ActionView
     end
 
     def escape_entry(entry)
-      entry.gsub(/[*?{}\[\]]/, '\\\\\\&')
+      entry.gsub(/[*?{}\[\]]/, '\\\\\\&'.freeze)
     end
 
     # Returns the file mtime from the filesystem.
@@ -234,7 +234,7 @@ module ActionView
     # from the path, or the handler, we should return the array of formats given
     # to the resolver.
     def extract_handler_and_format_and_variant(path, default_formats)
-      pieces = File.basename(path).split('.')
+      pieces = File.basename(path).split('.'.freeze)
       pieces.shift
 
       extension = pieces.pop

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -372,7 +372,7 @@ module ActiveModel
             "define_method(:'#{name}') do |*args|"
           end
 
-          extra = (extra.map!(&:inspect) << "*args").join(", ")
+          extra = (extra.map!(&:inspect) << "*args").join(", ".freeze)
 
           target = if send =~ CALL_COMPILABLE_REGEXP
             "#{"self." unless include_private}#{send}(#{extra})"

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -192,7 +192,7 @@ module ActiveModel
     private
 
     def _singularize(string)
-      ActiveSupport::Inflector.underscore(string).tr('/', '_')
+      ActiveSupport::Inflector.underscore(string).tr('/'.freeze, '_'.freeze)
     end
   end
 

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -115,7 +115,7 @@ module ActiveModel
           key = "#{key.to_s.camelize}Validator"
 
           begin
-            validator = key.include?('::') ? key.constantize : const_get(key)
+            validator = key.include?('::'.freeze) ? key.constantize : const_get(key)
           rescue NameError
             raise ArgumentError, "Unknown validator: '#{key}'"
           end

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -42,7 +42,7 @@ module ActiveRecord
 
       def [](name)
         @method_cache.compute_if_absent(name) do
-          safe_name = name.unpack('h*').first
+          safe_name = name.unpack('h*'.freeze).first
           temp_method = "__temp__#{safe_name}"
           ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
           @module.module_eval method_body(temp_method, safe_name), __FILE__, __LINE__

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -37,7 +37,7 @@ module ActiveRecord
         protected
 
         def define_method_attribute(name)
-          safe_name = name.unpack('h*').first
+          safe_name = name.unpack('h*'.freeze).first
           temp_method = "__temp__#{safe_name}"
 
           ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -24,7 +24,7 @@ module ActiveRecord
         protected
 
         def define_method_attribute=(name)
-          safe_name = name.unpack('h*').first
+          safe_name = name.unpack('h*'.freeze).first
           ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
 
           generated_attribute_methods.module_eval <<-STR, __FILE__, __LINE__ + 1

--- a/activerecord/lib/active_record/connection_adapters/postgresql/type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/type_metadata.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       end
 
       def sql_type
-        super.gsub(/\[\]$/, "")
+        super.gsub(/\[\]$/, "".freeze)
       end
 
       def ==(other)

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -18,7 +18,7 @@ module ActiveRecord
           delegate = Class.new(klass) {
             include ClassSpecificRelation
           }
-          const_set klass.name.gsub('::', '_'), delegate
+          const_set klass.name.gsub('::'.freeze, '_'.freeze), delegate
           cache[klass] = delegate
         end
       end

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -52,7 +52,7 @@ module ActiveRecord
           key
         else
           key = key.to_s
-          key.split('.').first if key.include?('.')
+          key.split('.'.freeze).first if key.include?('.'.freeze)
         end
       end.compact
     end
@@ -123,10 +123,10 @@ module ActiveRecord
     end
 
     def convert_dot_notation_to_hash(attributes)
-      dot_notation = attributes.keys.select { |s| s.include?(".") }
+      dot_notation = attributes.keys.select { |s| s.include?(".".freeze) }
 
       dot_notation.each do |key|
-        table_name, column_name = key.split(".")
+        table_name, column_name = key.split(".".freeze)
         value = attributes.delete(key)
         attributes[table_name] ||= {}
 

--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -23,7 +23,7 @@ class LoadError
   # Returns true if the given path name (except perhaps for the ".rb"
   # extension) is the missing file which caused the exception to be raised.
   def is_missing?(location)
-    location.sub(/\.rb$/, '') == path.sub(/\.rb$/, '')
+    location.sub(/\.rb$/, ''.freeze) == path.sub(/\.rb$/, ''.freeze)
   end
 end
 

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -167,7 +167,7 @@ class Module
         ''
       end
 
-    file, line = caller(1, 1).first.split(':', 2)
+    file, line = caller(1, 1).first.split(':'.freeze, 2)
     line = line.to_i
 
     to = to.to_s

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -149,7 +149,7 @@ module ActiveSupport #:nodoc:
 
           # Normalize the list of new constants, and add them to the list we will return
           new_constants.each do |suffix|
-            constants << ([namespace, suffix] - ["Object"]).join("::")
+            constants << ([namespace, suffix] - ["Object"]).join("::".freeze)
           end
         end
         constants
@@ -431,7 +431,7 @@ module ActiveSupport #:nodoc:
 
     # Search for a file in autoload_paths matching the provided suffix.
     def search_for_file(path_suffix)
-      path_suffix = path_suffix.sub(/(\.rb)?$/, ".rb")
+      path_suffix = path_suffix.sub(/(\.rb)?$/, ".rb".freeze)
 
       autoload_paths.each do |root|
         path = File.join(root, path_suffix)
@@ -516,7 +516,7 @@ module ActiveSupport #:nodoc:
 
       if file_path
         expanded = File.expand_path(file_path)
-        expanded.sub!(/\.rb\z/, '')
+        expanded.sub!(/\.rb\z/, ''.freeze)
 
         if loading.include?(expanded)
           raise "Circular dependency detected while autoloading constant #{qualified_name}"

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -91,10 +91,10 @@ module ActiveSupport
     def underscore(camel_cased_word)
       return camel_cased_word unless camel_cased_word =~ /[A-Z-]|::/
       word = camel_cased_word.to_s.gsub('::'.freeze, '/'.freeze)
-      word.gsub!(/(?:(?<=([A-Za-z\d]))|\b)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1 && '_'}#{$2.downcase}" }
-      word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
-      word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
-      word.tr!("-", "_")
+      word.gsub!(/(?:(?<=([A-Za-z\d]))|\b)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1 && '_'.freeze }#{$2.downcase}" }
+      word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, ' \1_\2'.freeze)
+      word.gsub!(/([a-z\d])([A-Z])/, '\1_\2'.freeze)
+      word.tr!("-".freeze, "_".freeze)
       word.downcase!
       word
     end
@@ -127,9 +127,9 @@ module ActiveSupport
 
       inflections.humans.each { |(rule, replacement)| break if result.sub!(rule, replacement) }
 
-      result.sub!(/\A_+/, '')
-      result.sub!(/_id\z/, '')
-      result.tr!('_', ' ')
+      result.sub!(/\A_+/, ''.freeze)
+      result.sub!(/_id\z/, ''.freeze)
+      result.tr!('_'.freeze, ' '.freeze)
 
       result.gsub!(/([a-z\d]*)/i) do |match|
         "#{inflections.acronyms[match] || match.downcase}"
@@ -178,14 +178,14 @@ module ActiveSupport
     #   classify('calculus')     # => "Calculu"
     def classify(table_name)
       # strip out any leading schema name
-      camelize(singularize(table_name.to_s.sub(/.*\./, '')))
+      camelize(singularize(table_name.to_s.sub(/.*\./, ''.freeze)))
     end
 
     # Replaces underscores with dashes in the string.
     #
     #   dasherize('puni_puni') # => "puni-puni"
     def dasherize(underscored_word)
-      underscored_word.tr('_', '-')
+      underscored_word.tr('_'.freeze, '-'.freeze)
     end
 
     # Removes the module part from the expression in the string.
@@ -248,7 +248,7 @@ module ActiveSupport
     # NameError is raised when the name is not in CamelCase or the constant is
     # unknown.
     def constantize(camel_cased_word)
-      names = camel_cased_word.split('::')
+      names = camel_cased_word.split('::'.freeze)
 
       # Trigger a built-in NameError exception including the ill-formed constant in the message.
       Object.const_get(camel_cased_word) if names.empty?

--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -79,7 +79,7 @@ module ActiveSupport
         # No more than one of the separator in a row.
         parameterized_string.gsub!(/#{re_sep}{2,}/, sep)
         # Remove leading/trailing separator.
-        parameterized_string.gsub!(/^#{re_sep}|#{re_sep}$/i, '')
+        parameterized_string.gsub!(/^#{re_sep}|#{re_sep}$/i, ''.freeze)
       end
       parameterized_string.downcase
     end

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -82,7 +82,7 @@ module ActiveSupport
 
     def _decrypt(encrypted_message)
       cipher = new_cipher
-      encrypted_data, iv = encrypted_message.split("--").map {|v| ::Base64.strict_decode64(v)}
+      encrypted_data, iv = encrypted_message.split("--".freeze).map {|v| ::Base64.strict_decode64(v)}
 
       cipher.decrypt
       cipher.key = @secret

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -46,7 +46,7 @@ module ActiveSupport
     def valid_message?(signed_message)
       return if signed_message.nil? || !signed_message.valid_encoding? || signed_message.blank?
 
-      data, digest = signed_message.split("--")
+      data, digest = signed_message.split("--".freeze)
       data.present? && digest.present? && ActiveSupport::SecurityUtils.secure_compare(digest, generate_digest(data))
     end
 
@@ -74,7 +74,7 @@ module ActiveSupport
     def verified(signed_message)
       if valid_message?(signed_message)
         begin
-          data = signed_message.split("--")[0]
+          data = signed_message.split("--".freeze)[0]
           @serializer.load(decode(data))
         rescue ArgumentError => argument_error
           return if argument_error.message =~ %r{invalid base64}

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -58,7 +58,7 @@ module ActiveSupport
       # Returns a regular expression pattern that matches the passed Unicode
       # codepoints.
       def self.codepoints_to_pattern(array_of_codepoints) #:nodoc:
-        array_of_codepoints.collect{ |e| [e].pack 'U*' }.join('|')
+        array_of_codepoints.collect{ |e| [e].pack 'U*'.freeze }.join('|'.freeze)
       end
       TRAILERS_PAT = /(#{codepoints_to_pattern(LEADERS_AND_TRAILERS)})+\Z/u
       LEADERS_PAT = /\A(#{codepoints_to_pattern(LEADERS_AND_TRAILERS)})+/u


### PR DESCRIPTION
I wrote a utility that helps find areas where you could optimize your program using a frozen string instead of a string literal, it's called [let_it_go](https://github.com/schneems/let_it_go). After going through the output and adding `.freeze` I was able to eliminate the creation of 1,114 string objects on EVERY request to [codetriage](codetriage.com). How does this impact execution?

To look at memory:

``` ruby
require 'get_process_mem'

mem = GetProcessMem.new
GC.start
GC.disable
1_114.times { " " }
before = mem.mb

after = mem.mb
GC.enable
puts "Diff: #{after - before} mb"

```

Creating 1,114 string objects results in `Diff: 0.03125 mb` of RAM allocated on every request. Or 1mb every 32 requests.

To look at raw speed:

``` ruby
require 'benchmark/ips'

number_of_objects_reduced = 1_114

Benchmark.ips do |x|
  x.report("freeze")    { number_of_objects_reduced.times { " ".freeze } }
  x.report("no-freeze") { number_of_objects_reduced.times { " " } }
end
```

We get the results

```
Calculating -------------------------------------
              freeze     1.428k i/100ms
           no-freeze   609.000  i/100ms
-------------------------------------------------
              freeze     14.363k (± 8.5%) i/s -     71.400k
           no-freeze      6.084k (± 8.1%) i/s -     30.450k
```

Now we can do some maths:

``` ruby
ips = 6_226k # iterations / 1 second
call_time_before = 1.0 / ips # seconds per iteration 

ips = 15_254 # iterations / 1 second
call_time_after = 1.0 / ips # seconds per iteration 

diff = call_time_before - call_time_after

number_of_objects_reduced * diff * 100

# => 0.4530373333993266 miliseconds saved per request
```

So we're shaving off 1 second of execution time for every 220 requests. 

Is this going to be an insane speed boost to any Rails app: nope. Should we merge it: yep. 

p.s. If you know of a method call that doesn't modify a string input such as [String#gsub](https://github.com/schneems/let_it_go/blob/b0e2da69f0cca87ab581022baa43291cdf48638c/lib/let_it_go/core_ext/string.rb#L37) please [give me a pull request to the appropriate file](https://github.com/schneems/let_it_go/blob/b0e2da69f0cca87ab581022baa43291cdf48638c/lib/let_it_go/core_ext/string.rb#L37), or open an issue in LetItGo so we can track and freeze more strings. 

Keep those strings Frozen

![](https://www.dropbox.com/s/z4dj9fdsv213r4v/let-it-go.gif?dl=1)
