### PR TITLE
Fix state being carried over from previous transaction

### DIFF
--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -199,7 +199,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert_equal nil, @params.fetch(:foo) { nil }
   end
 
-  test 'KeyError in fetch block should not be coverd up' do
+  test 'KeyError in fetch block should not be covered up' do
     params = ActionController::Parameters.new
     e = assert_raises(KeyError) do
       params.fetch(:missing_key) { {}.fetch(:also_missing) }

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Fix state being carried over from previous transaction.
+
+    Considering the following example where `name` is a required attribute.
+    Before we had `new_record?` returning `true` for a persisted record:
+
+        author = Author.create! name: 'foo'
+        author.name = nil
+        author.save        # => false
+        author.new_record? # => true
+
+    Fixes #20824.
+
+    *Roque Pinel*
+
 *   Fix a bug where counter_cache doesn't always work with  polymorphic
     relations.
 

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -380,6 +380,10 @@ module ActiveRecord
         raise ActiveRecord::Rollback unless status
       end
       status
+    ensure
+      if @transaction_state && @transaction_state.committed?
+        clear_transaction_record_state
+      end
     end
 
     protected

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -175,6 +175,13 @@ class TransactionTest < ActiveRecord::TestCase
     assert topic.new_record?, "#{topic.inspect} should be new record"
   end
 
+  def test_transaction_state_is_cleared_when_record_is_persisted
+    author = Author.create! name: 'foo'
+    author.name = nil
+    assert_not author.save
+    assert_not author.new_record?
+  end
+
   def test_update_should_rollback_on_failure
     author = Author.find(1)
     posts_count = author.posts.size


### PR DESCRIPTION
This clears the transaction record state when the transaction finishes with a `:committed` status.

Considering the following example where `name` is a required attribute. Before we had `new_record?` returning `true` for a persisted record:

``` ruby
  author = Author.create! name: 'foo'
  author.name = nil
  author.save        # => false
  author.new_record? # => true
```

Fixes #20824 
