### PR TITLE
Add missing method name to exception description

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -971,7 +971,7 @@ module ActiveRecord
       alias_method :append, :<<
 
       def prepend(*args)
-        raise NoMethodError, "prepend on association is not defined. Please use << or append"
+        raise NoMethodError, "prepend on association is not defined. Please use <<, push or append"
       end
 
       # Equivalent to +delete_all+. The difference is that returns +self+, instead


### PR DESCRIPTION
`<<`, `push` and `append` methods are alias methods so if we are giving an exception for usages we have to show all available options.
On the other hand IMHO this is not a good experience for developers because `respond_to?` returns true for `prepend` method but we are giving a `NoMethodError` exception inside of the method. WDYT about removing this method?
