### PR TITLE
fix doc about ActiveRecord::Transactions::ClassMethods#transaction [ci skip]

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -204,9 +204,8 @@ module ActiveRecord
     #
     # Note that "TRUNCATE" is also a MySQL DDL statement!
     module ClassMethods
-      # See ActiveRecord::Transactions::ClassMethods for detailed documentation.
+      # See the ConnectionAdapters::DatabaseStatements#transaction API docs.
       def transaction(options = {}, &block)
-        # See the ConnectionAdapters::DatabaseStatements#transaction API docs.
         connection.transaction(options, &block)
       end
 


### PR DESCRIPTION
This comment refers itself so this causes infinite loop :smile: 
