### PR TITLE
Remove unnecessary array allocation

### DIFF
--- a/activerecord/lib/active_record/type/hash_lookup_type_map.rb
+++ b/activerecord/lib/active_record/type/hash_lookup_type_map.rb
@@ -15,7 +15,7 @@ module ActiveRecord
 
       private
 
-      def perform_fetch(type, *args, &block)
+      def perform_fetch(type, args, &block)
         @mapping.fetch(type, block).call(type, *args)
       end
     end

--- a/activerecord/lib/active_record/type/type_map.rb
+++ b/activerecord/lib/active_record/type/type_map.rb
@@ -16,7 +16,7 @@ module ActiveRecord
 
       def fetch(lookup_key, *args, &block)
         @cache[lookup_key].fetch_or_store(args) do
-          perform_fetch(lookup_key, *args, &block)
+          perform_fetch(lookup_key, args, &block)
         end
       end
 
@@ -44,7 +44,7 @@ module ActiveRecord
 
       private
 
-      def perform_fetch(lookup_key, *args)
+      def perform_fetch(lookup_key, args)
         matching_pair = @mapping.reverse_each.detect do |key, _|
           key === lookup_key
         end


### PR DESCRIPTION
I'm investigating leaking memory problem in my project by analyzing objspace heap dumps. The problem not in this place, but I found that a lot of Array objects created here and it is unnecessary.
