### PR TITLE
Add fetch_all method to Hash

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -45,4 +45,19 @@ class Hash
   def extract!(*keys)
     keys.each_with_object(self.class.new) { |key, result| result[key] = delete(key) if has_key?(key) }
   end
+
+  # Slices the hash to include only the given keys and raises a KeyError if any of the keys is missing.
+  #
+  #   { a: 1, b: 2, c: 3, d: 4 }.fetch_all(:a, :b) # => {:a=>1, :b=>2}
+  #   { a: 1, b: 2 }.fetch_all(:a, :x)             # => KeyError
+
+  def fetch_all(*keys)
+    keys.each do |key|
+      unless self.has_key?(key)
+        raise KeyError.new("#{key} key not found")
+      end
+    end
+
+    self.slice(*keys)
+  end
 end

--- a/activesupport/test/core_ext/hash/fetch_all_test.rb
+++ b/activesupport/test/core_ext/hash/fetch_all_test.rb
@@ -1,0 +1,17 @@
+require 'abstract_unit'
+require 'active_support/core_ext/hash/slice'
+
+class FetchAllTest < ActiveSupport::TestCase
+  test "fetch_all returns a new hash with the keys specified by arguments" do
+    original = { a: 'a', b: 'b', c: 'c' }
+    mapped = original.fetch_all(:a, :b)
+
+    assert_equal({ a: 'a', b: 'b' }, mapped)
+  end
+
+  test "fetch_all raises a KeyError if any of the required keys is missing" do
+    assert_raise KeyError do
+      { a: 'a', b: 'b' }.fetch_all(:a, :x)
+    end
+  end
+end


### PR DESCRIPTION
How about adding this little method to Hash ? I find it useful when passing a hash of required options as an argument.
