### PR TITLE
Refactor with_transaction_returning_status method and remove unnecessary method

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -369,12 +369,7 @@ module ActiveRecord
       status = nil
       self.class.transaction do
         add_to_transaction
-        begin
-          status = yield
-        rescue ActiveRecord::Rollback
-          clear_transaction_record_state
-          status = nil
-        end
+        status = yield
 
         raise ActiveRecord::Rollback unless status
       end
@@ -474,12 +469,8 @@ module ActiveRecord
     # method recursively goes through the parent of the TransactionState and
     # checks if the ActiveRecord object reflects the state of the object.
     def sync_with_transaction_state
-      update_attributes_from_transaction_state(@transaction_state)
-    end
-
-    def update_attributes_from_transaction_state(transaction_state)
-      if transaction_state && transaction_state.finalized?
-        restore_transaction_record_state if transaction_state.rolledback?
+      if @transaction_state && @transaction_state.finalized?
+        restore_transaction_record_state if @transaction_state.rolledback?
         clear_transaction_record_state
       end
     end


### PR DESCRIPTION
We don't need to handle `ActiveRecord::Rollback` exception in `with_transaction_returning_status` method because there are any resource can throw this exception. In `ActiveRecord::ConnectionAdapters::DatabaseStatements` we are handling `ActiveRecord::Rollback` exception silently so we can't rescue this error in `with_transaction_returning_status` method.

Also `sync_with_transaction_state` method calls `update_attributes_from_transaction_state` directly without any logic. So `sync_with_transaction_state` can do what `update_attributes_from_transaction_state` does. And the only reference to
`update_attributes_from_transaction_state` method is inside of `sync_with_transaction_state`.

/cc @sgrif 
