### PR TITLE
Fix find_by with association subquery issue

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Don't cache arguments in #find_by if they are an ActiveRecord::Relation
+
+    Fixes #20817
+
+    *Hiroaki Izu*
+
 *   Allow fixtures files to set the model class in the YAML file itself.
 
     To load the fixtures file `accounts.yml` as the `User` model, use:

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -177,7 +177,7 @@ module ActiveRecord
         hash = args.first
 
         return super if hash.values.any? { |v|
-          v.nil? || Array === v || Hash === v
+          v.nil? || Array === v || Hash === v || Relation === v
         }
 
         # We can't cache Post.find_by(author: david) ...yet

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -265,6 +265,12 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal [Account], accounts.collect(&:class).uniq
   end
 
+  def test_find_by_association_subquery
+    author = authors(:david)
+    assert_equal author.post, Post.find_by(author: Author.where(id: author))
+    assert_equal author.post, Post.find_by(author_id: Author.where(id: author))
+  end
+
   def test_take
     assert_equal topics(:first), Topic.take
   end


### PR DESCRIPTION
In this commit, `find_by` doesn't cache arguments if they are an `ActiveRecord::Relation`
so that `find_by` with association subquery works correctly.

Fixes #20817
