### PR TITLE
Ignore relative_url_root if generating prefix

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -632,6 +632,7 @@ module ActionDispatch
                   super(options)
                 else
                   prefix_options = options.slice(*_route.segment_keys)
+                  prefix_options[:_prefix] = true
                   # we must actually delete prefix segment keys to avoid passing them to next url_for
                   _route.segment_keys.each { |k| options.delete(k) }
                   _routes.url_helpers.send("#{name}_path", prefix_options)

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -791,7 +791,11 @@ module ActionDispatch
         recall  = options.delete(:_recall) { {} }
 
         original_script_name = options.delete(:original_script_name)
-        script_name = find_script_name options
+        script_name = if options.delete(:_prefix)
+                        options.delete(:script_name) || ''
+                      else
+                        find_script_name options
+                      end
 
         if original_script_name
           script_name = original_script_name + script_name

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -9,6 +9,7 @@ module AbstractController
 
       def teardown
         W.default_url_options.clear
+        ActionDispatch::Routing::RouteSet.relative_url_root = nil
       end
 
       def test_nested_optional
@@ -262,7 +263,15 @@ module AbstractController
         assert_equal('https://www.basecamphq.com/subdir/c/a/i',
           W.new.url_for(:controller => 'c', :action => 'a', :id => 'i', :protocol => 'https')
         )
-        ActionDispatch::Routing::RouteSet.relative_url_root = nil
+      end
+
+      def test_relative_url_root_is_ignored_if_generating_prefix
+        # `config.relative_url_root` is set by ENV['RAILS_RELATIVE_URL_ROOT']
+        ActionDispatch::Routing::RouteSet.relative_url_root = '/subdir'
+        add_host!
+        assert_equal('https://www.basecamphq.com/c/a/i',
+          W.new.url_for(:controller => 'c', :action => 'a', :id => 'i', :protocol => 'https', :_prefix => true)
+        )
       end
 
       def test_named_routes

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1309,6 +1309,56 @@ YAML
       assert_equal '/foo/bukkits/bukkit', last_response.body
     end
 
+    test "paths are properly generated when application is mounted at sub-path and relative_url_root is set" do
+      add_to_config "config.relative_url_root = '/foo'"
+
+      @plugin.write "lib/bukkits.rb", <<-RUBY
+        module Bukkits
+          class Engine < ::Rails::Engine
+            isolate_namespace Bukkits
+          end
+        end
+      RUBY
+
+      app_file "app/controllers/bar_controller.rb", <<-RUBY
+        class BarController < ApplicationController
+          def index
+            render text: bukkits.bukkit_path
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get '/bar' => 'bar#index', :as => 'bar'
+          mount Bukkits::Engine => "/bukkits", :as => "bukkits"
+        end
+      RUBY
+
+      @plugin.write "config/routes.rb", <<-RUBY
+        Bukkits::Engine.routes.draw do
+          get '/bukkit' => 'bukkit#index'
+        end
+      RUBY
+
+
+      @plugin.write "app/controllers/bukkits/bukkit_controller.rb", <<-RUBY
+        class Bukkits::BukkitController < ActionController::Base
+          def index
+            render text: main_app.bar_path
+          end
+        end
+      RUBY
+
+      boot_rails
+
+      get("/bukkits/bukkit", {}, {'SCRIPT_NAME' => '/foo'})
+      assert_equal '/foo/bar', last_response.body
+
+      get("/bar", {}, {'SCRIPT_NAME' => '/foo'})
+      assert_equal '/foo/bukkits/bukkit', last_response.body
+    end
+
   private
     def app
       Rails.application


### PR DESCRIPTION
When generating the url for a mounted engine through its proxy (e.g. foo.bar_path), the relative_url_root should not be used when generating the proxy’s url prefix.

(fixes #20920)
