### PR TITLE
Add test case for calling with_transaction_returning_status with a block which raises exception

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -369,12 +369,7 @@ module ActiveRecord
       status = nil
       self.class.transaction do
         add_to_transaction
-        begin
-          status = yield
-        rescue ActiveRecord::Rollback
-          clear_transaction_record_state
-          status = nil
-        end
+        status = yield
 
         raise ActiveRecord::Rollback unless status
       end

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -696,6 +696,19 @@ class TransactionTest < ActiveRecord::TestCase
     connection.drop_table 'transaction_without_primary_keys', if_exists: true
   end
 
+  def test_calling_with_transaction_returning_status_with_block_which_raises_exception
+    author = Author.create!(name: 'Mehmet Emin İNAÇ')
+
+    author.expects(:clear_transaction_record_state).once
+
+    assert_no_difference(-> { Author.count }) do
+      author.with_transaction_returning_status do
+        Author.create!(name: 'Barış Can Daylık')
+        raise ActiveRecord::Rollback
+      end
+    end
+  end
+
   private
 
   %w(validation save destroy).each do |filter|


### PR DESCRIPTION
Also while writing test case I've discovered that rescue from `ActiveRecord::Rollback` exception is unnecessary.
Because even if the given block raises an exception it will be handled by `ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction` method.

Handing `ActiveRecord::Rollback` and then calling `clear_transaction_record_state` is unnecessary because ensure block always run. Because it's name is `ensure`.

Handing `ActiveRecord::Rollback` and setting `status` to nil is also unnecessary because of the raise instruction after this rescue block.

`clear_transaction_record_state` will run in `ensure` block even if the exception raised because we are setting `@transaction` object by calling `add_to_transaction` before calling block and it sets the `@transaction` object as we expect and if clause in ensure block works as expected.

@sgrif I know we have discussed this in previous pull request but I think you've missed somethings about removing rescue block. Can you please review this again?
