### PR TITLE
Improving rake:routes output readability for restful methods

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1172,11 +1172,11 @@ module ActionDispatch
         # the plural):
         #
         #   GET       /profile/new
-        #   POST      /profile
-        #   GET       /profile
         #   GET       /profile/edit
+        #   GET       /profile
         #   PATCH/PUT /profile
         #   DELETE    /profile
+        #   POST      /profile
         #
         # === Options
         # Takes same options as +resources+.
@@ -1192,15 +1192,11 @@ module ActionDispatch
 
             concerns(options[:concerns]) if options[:concerns]
 
-            collection do
-              post :create
-            end if parent_resource.actions.include?(:create)
-
-            new do
-              get :new
-            end if parent_resource.actions.include?(:new)
+            get :new, on: :new if parent_resource.actions.include?(:new)
 
             set_member_mappings_for_resource
+
+            post :create, on: :collection if parent_resource.actions.include?(:create)
           end
 
           self

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -94,6 +94,23 @@ module ActionDispatch
         ], output
       end
 
+      def test_inspect_routes_shows_resource_route
+        output = draw do
+          resource :profile
+        end
+
+        assert_equal [
+          "      Prefix Verb   URI Pattern             Controller#Action",
+          " new_profile GET    /profile/new(.:format)  profiles#new",
+          "edit_profile GET    /profile/edit(.:format) profiles#edit",
+          "     profile GET    /profile(.:format)      profiles#show",
+          "             PATCH  /profile(.:format)      profiles#update",
+          "             PUT    /profile(.:format)      profiles#update",
+          "             DELETE /profile(.:format)      profiles#destroy",
+          "             POST   /profile(.:format)      profiles#create"
+        ], output
+      end
+
       def test_inspect_routes_shows_resources_route
         output = draw do
           resources :articles


### PR DESCRIPTION
Inspired by @loicteixeira 's #20894 I reviewed the output for rake routes for this sample file

```
# routes.rb
Rails.application.routes.draw do
  resource  :profile
  resources :users
end
```

Before

```
      Prefix Verb   URI Pattern               Controller#Action
     profile POST   /profile(.:format)        profiles#create
 new_profile GET    /profile/new(.:format)    profiles#new
edit_profile GET    /profile/edit(.:format)   profiles#edit
             GET    /profile(.:format)        profiles#show
             PATCH  /profile(.:format)        profiles#update
             PUT    /profile(.:format)        profiles#update
             DELETE /profile(.:format)        profiles#destroy

       users GET    /users(.:format)          users#index
             POST   /users(.:format)          users#create
    new_user GET    /users/new(.:format)      users#new
   edit_user GET    /users/:id/edit(.:format) users#edit
        user GET    /users/:id(.:format)      users#show
             PATCH  /users/:id(.:format)      users#update
             PUT    /users/:id(.:format)      users#update
             DELETE /users/:id(.:format)      users#destroy

```

First, given his reasons on the cited issue #20894 I would agree the output is a bit misleading.
Thus I believe one way to fix this would be to place `POST /profile` after the member routes so it is no longer the one that prefixes the helper.

Second, I would suggest `new_user GET /users/new` should come before `POST /users` as it follows the path the user will normally experience those routes.

Third, I saw there were no tests to ensure the output of `resource :profile` were displayed correctly, so I added them.

Here is the same code with the 2 cited alterations.
Please pay attention to the order of them items

```
# routes.rb
Rails.application.routes.draw do
  resource  :profile
  resources :users
end
```

After

```
      Prefix Verb   URI Pattern               Controller#Action
 new_profile GET    /profile/new(.:format)    profiles#new
edit_profile GET    /profile/edit(.:format)   profiles#edit
     profile GET    /profile(.:format)        profiles#show
             PATCH  /profile(.:format)        profiles#update
             PUT    /profile(.:format)        profiles#update
             DELETE /profile(.:format)        profiles#destroy
             POST   /profile(.:format)        profiles#create

       users GET    /users(.:format)          users#index
    new_user GET    /users/new(.:format)      users#new
             POST   /users(.:format)          users#create
   edit_user GET    /users/:id/edit(.:format) users#edit
        user GET    /users/:id(.:format)      users#show
             PATCH  /users/:id(.:format)      users#update
             PUT    /users/:id(.:format)      users#update
             DELETE /users/:id(.:format)      users#destroy
```

I hope you see this contribution as a small improvement on reducing the learning curve for new developers.

Please ping me should you have any concerns or have a better disposition in mind.
