### PR TITLE
Return message if attribute has .base suffix

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -406,7 +406,7 @@ module ActiveModel
     #
     #   person.errors.full_message(:name, 'is invalid') # => "Name is invalid"
     def full_message(attribute, message)
-      return message if attribute == :base
+      return message if attribute == :base || attribute.to_s.end_with?('.base')
       attr_name = attribute.to_s.tr('.', '_').humanize
       attr_name = @base.class.human_attribute_name(attribute, default: attr_name)
       I18n.t(:"errors.format", {

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -264,6 +264,11 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal [], person.errors.full_messages_for(:email)
   end
 
+  test "full_message returns the given message when attribute has .base suffix" do
+    person = Person.new
+    assert_equal "press the button", person.errors.full_message(:"address.base", "press the button")
+  end
+
   test "full_message returns the given message when attribute is :base" do
     person = Person.new
     assert_equal "press the button", person.errors.full_message(:base, "press the button")


### PR DESCRIPTION
Error messages created by the saving of associated models (via
`autosave: true` on association or other) are namespaced and separated
by a period. Any error messages set by the associated model on their
base attribute should be returned in their entirety, and not prefixed
with a humanized representation of the attribute name.

Possible fix for #19863
