### PR TITLE
Add exception backtrace to Instrumenter payload

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,29 @@
+* Add backtrace to exception information in
+  `ActiveSupport::Notifications::Instrumenter` when an exception is raised
+  within the `#instrument` block.
+
+        ActiveSupport::Notifications.instrument "my.custom.event" do
+            raise "FAIL"
+        end
+
+        Before:
+
+        ActiveSupport::Notifications
+          .subscribe "my.custom.event" do |name, started, finished, unique_id, payload|
+            puts payload[:exception].inspect # ["RuntimeError", "FAIL"]
+        end
+
+        After:
+
+        ActiveSupport::Notifications
+          .subscribe "my.custom.event" do |name, started, finished, unique_id, payload|
+            puts payload[:exception].inspect
+            # ["RuntimeError", "FAIL", ['path/to/line/with/error.rb',
+            #   'path/to/line/from/rails.rb', ...]]
+        end
+
+    *Paul Springett*
+
 *   Fix `TimeWithZone#eql?` to properly handle `TimeWithZone` created from `DateTime`:
         twz = DateTime.now.in_time_zone
         twz.eql?(twz.dup) => true

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -19,7 +19,7 @@ module ActiveSupport
         begin
           yield payload
         rescue Exception => e
-          payload[:exception] = [e.class.name, e.message]
+          payload[:exception] = [e.class.name, e.message, e.backtrace]
           raise e
         ensure
           finish name, payload

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -209,7 +209,12 @@ module Notifications
     def test_instrument_publishes_when_exception_is_raised
       begin
         instrument(:awesome, :payload => "notifications") do
-          raise "FAIL"
+          begin
+            raise "FAIL"
+          rescue RuntimeError => e
+            e.set_backtrace(['path/to/file/with/error.rb'])
+            raise e
+          end
         end
       rescue RuntimeError => e
         assert_equal "FAIL", e.message
@@ -217,7 +222,7 @@ module Notifications
 
       assert_equal 1, @events.size
       assert_equal Hash[:payload => "notifications",
-        :exception => ["RuntimeError", "FAIL"]], @events.last.payload
+        :exception => ["RuntimeError", "FAIL", ['path/to/file/with/error.rb']]], @events.last.payload
     end
 
     def test_event_is_pushed_even_without_block


### PR DESCRIPTION
Add backtrace to exception information in `ActiveSupport::Notifications::Instrumenter` when an exception is raised within the `#instrument` block.

Appends backtrace Array to the payload `:exception`, in addition to the exception class and message already given.

```
ActiveSupport::Notifications.instrument "my.custom.event" do
    raise "FAIL"
end
```

Before:

```
ActiveSupport::Notifications
  .subscribe "my.custom.event" do |name, started, finished, unique_id, payload|
    puts payload[:exception].inspect # ["RuntimeError", "FAIL"]
end
```

After:

```
ActiveSupport::Notifications
  .subscribe "my.custom.event" do |name, started, finished, unique_id, payload|
    puts payload[:exception].inspect
    # ["RuntimeError", "FAIL", ['path/to/line/with/error.rb', 'path/to/line/from/rails.rb', ...]]
end
```

> Rationale: `LogSubscriber` classes hook into ActiveSupport's notifications API. Currently it's possible to use the LogSubscribers to send log information about the exception class and message to a log endpoint (in our case as JSON to Logstash over UDP).
> 
> This addition allows a LogSubscriber to choose to also send the exception backtrace if required.
> 
> Without it, AKAIK there's not a way to log the exception backtrace using LogSubscribers.
