### PR TITLE
Validate uniqueness of custom primary key

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -17,7 +17,12 @@ module ActiveRecord
         value = map_enum_attribute(finder_class, attribute, value)
 
         relation = build_relation(finder_class, table, attribute, value)
-        relation = relation.where.not(finder_class.primary_key => record.id) if record.persisted?
+
+        if record.persisted?
+          primary_key = finder_class.primary_key.to_sym
+          relation = relation.where.not(primary_key => record.id) unless primary_key == attribute.to_sym
+        end
+
         relation = scope_relation(record, table, relation)
         relation = relation.merge(options[:conditions]) if options[:conditions]
 

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -4,6 +4,7 @@ require 'models/reply'
 require 'models/warehouse_thing'
 require 'models/guid'
 require 'models/event'
+require 'models/keyboard'
 
 class Wizard < ActiveRecord::Base
   self.abstract_class = true
@@ -426,5 +427,19 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert_equal topic.replies.size, 1
     assert reply.valid?
     assert topic.valid?
+  end
+
+  def test_validate_uniqueness_of_custom_primary_key
+    Keyboard.validates_uniqueness_of(:key_number)
+
+    key1 = Keyboard.new(key_number: 10)
+    assert key1.save, "Should save key1 as unique"
+
+    key2 = Keyboard.new(key_number: 11)
+    assert key2.save, "Should save key2 as unique"
+
+    key2.key_number = 10
+    assert !key2.valid?, "Shouldn't be valid"
+    assert !key2.save, "Shouldn't save since primary key isn't unique"
   end
 end


### PR DESCRIPTION
There was a problem in uniqueness validator that allowed model with custom primary key to pass validation when non unique primary key value was set which resulted in exception.
