### PR TITLE
Return sums of values for Hash and multi-dimensional Array

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -12,7 +12,8 @@ module Enumerable
   #
   #  [5, 15, 10].sum # => 30
   #  ['foo', 'bar'].sum # => "foobar"
-  #  [[1, 2], [3, 1, 5]].sum => [1, 2, 3, 1, 5]
+  #  [[1, 2], [3, 1, 5]].sum => 12
+  #  { foo: 1, bar: 2 }.sum => 3
   #
   # The default sum of an empty list is zero. You can override this default:
   #
@@ -21,7 +22,10 @@ module Enumerable
     if block_given?
       map(&block).sum(identity)
     else
-      inject { |sum, element| sum + element } || identity
+      obj = self
+      obj = values if is_a?(Hash)
+      obj = flatten if is_a?(Array)
+      obj.inject { |sum, element| sum + element } || identity
     end
   end
 

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -27,6 +27,16 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal 30, enum.sum
     assert_equal 60, enum.sum { |i| i * 2}
 
+    enum = [5, [15, 10]]
+    assert_equal 30, enum.sum
+
+    enum = {a: 5, b: 15, c: 10}
+    assert_equal 30, enum.sum
+    assert_equal 60, enum.sum { |_, v| v * 2 }
+
+    enum = {5 => :a, 15 => :b, 10 => :c}
+    assert_equal 30, enum.sum { |k, _| k }
+
     enum = GenericEnumerable.new(%w(a b c))
     assert_equal 'abc', enum.sum
     assert_equal 'aabbcc', enum.sum { |i| i * 2 }
@@ -44,6 +54,8 @@ class EnumerableTests < ActiveSupport::TestCase
     expected_raise = TypeError
 
     assert_raise(expected_raise) { GenericEnumerable.new([5, 15, nil]).sum }
+    assert_raise(expected_raise) { GenericEnumerable.new([5, [15, nil]]).sum }
+
 
     payments = GenericEnumerable.new([ Payment.new(5), Payment.new(15), Payment.new(10), Payment.new(nil) ])
     assert_raise(expected_raise) { payments.sum(&:price) }


### PR DESCRIPTION
I have a question in a form of this PR about `Enumerable#sum` ;)

What's the reasoning behind it?

Because when I first saw the method called `sum` I thought it's going to return me sum of something in almost any case (referential transparency style ;)), for example:

``` ruby
> { a: 1, b: 2}.sum
# expected 3 at least
# got an array?
 => [:a, 1, :b, 2]
```

So I thought it might be a bug. But when I read the doc comment, it turned out similar behaviour on Array, not returning sum of anything that is, is actually documented:

``` ruby
# example from comment
> [[1, 2], [3, 1, 5]].sum
 => [1, 2, 3, 1, 5] # so, sum on Array gives same result as flatten
```

But, additionally, `[1, [2, 3]].sum` was breaking which make this even more weird for me.

``` ruby
> [1, [2, 3]].sum
TypeError: Array can't be coerced into Fixnum
```

I thought I'll find some answers in tests but neither `Hash` nor multi-dimensional `Array` were covered. There was also no `assert_raise` for  `[1, [2, 3]].sum` case.

Can someone elaborate what is happening here and why?

How I see it to be is in the commit.

Also, I know my tests are using standard `[]` and `{}` instead of a `GenericEnumerable` but I had trouble setting it up and thought it will suffice as a proof of concept ;) I can fix it later eventually.

Thanks ^^
