### PR TITLE
section "2.6. Controller Namespaces and Routing" - semantic fix

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -227,7 +227,7 @@ or, for a single case:
 resources :articles, path: '/admin/articles'
 ```
 
-In each of these cases, the named routes remain the same as if you did not use `scope`. In the last case, the following paths map to `PostsController`:
+In each of these cases, the named routes remain the same as if you did not use `scope`. In the last case, the following paths map to `ArticlesController`:
 
 | HTTP Verb | Path                     | Controller#Action    | Named Helper           |
 | --------- | ------------------------ | -------------------- | ---------------------- |


### PR DESCRIPTION
Hi,

I was learning about routing and came upon an error in the section 2.6.
Throughout the section an ArticlesController is used as an example,
but instead PostsController is referenced (as shown in the picture).

![2-6-rails-guides-fix](https://cloud.githubusercontent.com/assets/3996271/8816486/e245e5f4-3027-11e5-91c3-cdc1381d74ea.png)
