### PR TITLE
Update the URL when changing mailer preview formats

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Added javascript to update the URL on mailer previews with the currently
+    selected email format. Reloading the page now keeps you on your selected
+    format rather than going back to the default html version.
+
+    *James Kerr*
+
 *   Add fail fast to `bin/rails test`
 
     Adding `--fail-fast` or `-f` when running tests will interrupt the run on

--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -94,7 +94,7 @@
 
     <% if @email.multipart? %>
       <dd>
-        <select onchange="document.getElementsByName('messageBody')[0].src=this.options[this.selectedIndex].value;">
+        <select onchange="formatChanged(this);">
           <option <%= request.format == Mime[:html] ? 'selected' : '' %> value="?part=text%2Fhtml">View as HTML email</option>
           <option <%= request.format == Mime[:text] ? 'selected' : '' %> value="?part=text%2Fplain">View as plain-text email</option>
         </select>
@@ -111,6 +111,20 @@
     This is probably because the <em>mail</em> method has not been called in <em><%= @preview.preview_name %>#<%= @email_action %></em>.
   </p>
 <% end %>
+
+<script>
+  function formatChanged(form) {
+    var part_name = form.options[form.selectedIndex].value
+    var iframe =document.getElementsByName('messageBody')[0];
+    iframe.contentWindow.location.replace(part_name);
+
+    if (history.replaceState) {
+      var url    = location.pathname.replace(/\.(txt|html)$/, '');
+      var format = /html/.test(part_name) ? '.html' : '.txt';
+      window.history.replaceState({}, '', url + format);
+    }
+  }
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
Added javascript to update the URL on mailer previews with the currently selected email format. Reloading the page now keeps you on your selected format rather than going back to the default html version.

This is done using javascript's history.pushState only if the developer's browser supports it.
