### PR TITLE
If Postgres structure loading fails, fail loudly to stderr.

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -71,7 +71,10 @@ module ActiveRecord
         args = prepare_command_options('mysql')
         args.concat(['--execute', %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}])
         args.concat(["--database", "#{configuration['database']}"])
-        Kernel.system(*args)
+        unless Kernel.system(*args)
+          $stderr.puts "Could not load the database structure. "\
+                       "Make sure `mysqldump` is in your PATH and check the command output for warnings."
+        end
       end
 
       private

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -60,14 +60,22 @@ module ActiveRecord
         end
 
         command = "pg_dump -i -s -x -O -f #{Shellwords.escape(filename)} #{search_path} #{Shellwords.escape(configuration['database'])}"
-        raise 'Error dumping database' unless Kernel.system(command)
 
-        File.open(filename, "a") { |f| f << "SET search_path TO #{connection.schema_search_path};\n\n" }
+        if Kernel.system(command)
+          File.open(filename, "a") { |f| f << "SET search_path TO #{connection.schema_search_path};\n\n" }
+        else
+          $stderr.puts "Could not dump the database structure. "\
+                       "Make sure `psql` is in your PATH and check the command output for warnings."
+        end
       end
 
       def structure_load(filename)
         set_psql_env
-        Kernel.system("psql -X -q -f #{Shellwords.escape(filename)} #{configuration['database']}")
+        command = "psql -X -q -f #{Shellwords.escape(filename)} #{configuration['database']}"
+        unless Kernel.system(command)
+          $stderr.puts "Could not load the database structure. "\
+                       "Make sure `psql` is in your PATH and check the command output for warnings."
+        end
       end
 
       private

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -33,12 +33,20 @@ module ActiveRecord
 
       def structure_dump(filename)
         dbfile = configuration['database']
-        `sqlite3 #{dbfile} .schema > #{filename}`
+        command = "sqlite3 #{dbfile} > \"#{filename}\""
+        unless Kernel.system(command)
+          $stderr.puts "Could not dump the database structure. "\
+                       "Make sure `sqlite3` is in your PATH and check the command output for warnings."
+        end
       end
 
       def structure_load(filename)
         dbfile = configuration['database']
-        `sqlite3 #{dbfile} < "#{filename}"`
+        command = "sqlite3 #{dbfile} < \"#{filename}\""
+        unless Kernel.system(command)
+          $stderr.puts "Could not load the database structure. "\
+                       "Make sure `sqlite3` is in your PATH and check the command output for warnings."
+        end
       end
 
       private

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -314,6 +314,17 @@ module ActiveRecord
 
       ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
     end
+
+    def test_warn_when_external_structure_load_fails
+      filename = "awesome-file.sql"
+      Kernel.expects(:system).with('mysql', '--execute', %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db").returns(false)
+
+      warnings = capture(:stderr) do
+        ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+      end
+
+      assert_match(/Could not load the database structure/, warnings)
+    end
   end
 
 end

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -235,6 +235,16 @@ module ActiveRecord
       end
     end
 
+    def test_warn_when_structure_dump_fails
+      Kernel.expects(:system).with("pg_dump -i -s -x -O -f #{@filename}  my-app-db").returns(false)
+
+      warnings = capture(:stderr) do
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
+      end
+
+      assert_match(/Could not dump the database structure/, warnings)
+    end
+
     private
 
     def with_dump_schemas(value, &block)
@@ -271,6 +281,17 @@ module ActiveRecord
       Kernel.expects(:system).with("psql -X -q -f awesome\\ file.sql my-app-db")
 
       ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+    end
+
+    def test_warn_when_structure_load_fails
+      filename = "awesome-file.sql"
+      Kernel.expects(:system).with("psql -X -q -f #{filename} my-app-db").returns(false)
+
+      warnings = capture(:stderr) do
+        ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+      end
+
+      assert_match(/Could not load the database structure/, warnings)
     end
   end
 


### PR DESCRIPTION
See #20980. 

If this change is acceptable, I'll add it to the other database adapters where appropriate.
In addition, perhaps we should do this for structure_dump too.
