### PR TITLE
Fix AssociationQueryValue#ids

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
@@ -33,7 +33,11 @@ module ActiveRecord
       def ids
         case value
         when Relation
-          value.select(primary_key)
+          if value.select_values.empty?
+            value.select(primary_key)
+          else
+            value
+          end
         when Array
           value.map { |v| convert_to_id(v) }
         else

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -276,5 +276,14 @@ module ActiveRecord
 
       assert_equal essays(:david_modest_proposal), essay
     end
+
+    def test_where_on_association_with_select_relation
+      post = posts(:welcome)
+
+      query_with_foreign_key = Post.where(author_id: Comment.select(:post_id))
+      query_with_relation = Post.where(author: Comment.select(:post_id))
+
+      assert_equal query_with_relation, query_with_foreign_key
+    end
   end
 end


### PR DESCRIPTION
AssociationQueryValue#ids should return the @value if it has already select_values

Fixes #20802 
