### PR TITLE
Remove check for caller_locations in Rails::Engine

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -357,12 +357,7 @@ module Rails
           Rails::Railtie::Configuration.eager_load_namespaces << base
 
           base.called_from = begin
-            call_stack = if Kernel.respond_to?(:caller_locations)
-              caller_locations.map { |l| l.absolute_path || l.path }
-            else
-              # Remove the line number from backtraces making sure we don't leave anything behind
-              caller.map { |p| p.sub(/:\d+.*/, '') }
-            end
+            call_stack = caller_locations.map { |l| l.absolute_path || l.path }
 
             File.dirname(call_stack.detect { |p| p !~ %r[railties[\w.-]*/lib/rails|rack[\w.-]*/lib/rack] })
           end


### PR DESCRIPTION
This is no longer necessary, as the minimum version requirement for Ruby is 2.2.2, and the `caller_locations` feature was added in Ruby 2.0.0. Since Rails no longer supports pre 2.0 versions of Ruby, there is no need to check first if the Kernel does respond to `caller_locations`. The answer is: yes it does.

I have not tested this on Rubinius or JRuby because I don't have those installed right now. If someone who does have those installed could make sure that `caller_locations` is available on both of those I would be most appreciative :)
