### PR TITLE
Don't apply locking around basic #load / #require

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -255,12 +255,10 @@ module ActiveSupport #:nodoc:
       end
 
       def load_dependency(file)
-        Dependencies.load_interlock do
-          if Dependencies.load? && ActiveSupport::Dependencies.constant_watch_stack.watching?
-            Dependencies.new_constants_in(Object) { yield }
-          else
-            yield
-          end
+        if Dependencies.load? && ActiveSupport::Dependencies.constant_watch_stack.watching?
+          Dependencies.new_constants_in(Object) { yield }
+        else
+          yield
         end
       rescue Exception => exception  # errors from loading file
         exception.blame_file! file if exception.respond_to? :blame_file!


### PR DESCRIPTION
That's outside our remit, and dangerous... if a caller has their own locking to protect against the natural race danger, we'll deadlock against it.

@mperham reported an issue whereby one thread would end up waiting at:

```
monitor.rb:110:in `sleep'
monitor.rb:110:in `wait'
monitor.rb:110:in `wait'
monitor.rb:122:in `wait_while'
activesupport/lib/active_support/concurrency/share_lock.rb:58:in `block in start_exclusive'
monitor.rb:211:in `mon_synchronize'
activesupport/lib/active_support/concurrency/share_lock.rb:49:in `start_exclusive'
activesupport/lib/active_support/concurrency/share_lock.rb:113:in `exclusive'
activesupport/lib/active_support/dependencies/interlock.rb:11:in `loading'
activesupport/lib/active_support/dependencies.rb:37:in `load_interlock'
activesupport/lib/active_support/dependencies.rb:265:in `load_dependency'
activesupport/lib/active_support/dependencies.rb:304:in `require'
redis-3.2.1/lib/redis/client.rb:465:in `_parse_driver'
redis-3.2.1/lib/redis/client.rb:433:in `_parse_options'
redis-3.2.1/lib/redis/client.rb:74:in `initialize'
redis-3.2.1/lib/redis.rb:31:in `new'
redis-3.2.1/lib/redis.rb:31:in `initialize'
sidekiq/lib/sidekiq/redis_connection.rb:28:in `new'
sidekiq/lib/sidekiq/redis_connection.rb:28:in `build_client'
sidekiq/lib/sidekiq/redis_connection.rb:19:in `block in create'
connection_pool-2.2.0/lib/connection_pool/timed_stack.rb:169:in `call'
connection_pool-2.2.0/lib/connection_pool/timed_stack.rb:169:in `try_create'
connection_pool-2.2.0/lib/connection_pool/timed_stack.rb:81:in `block (2 levels) in pop'
connection_pool-2.2.0/lib/connection_pool/timed_stack.rb:77:in `loop'
connection_pool-2.2.0/lib/connection_pool/timed_stack.rb:77:in `block in pop'
connection_pool-2.2.0/lib/connection_pool/timed_stack.rb:76:in `synchronize'
connection_pool-2.2.0/lib/connection_pool/timed_stack.rb:76:in `pop'
connection_pool-2.2.0/lib/connection_pool.rb:89:in `checkout'
connection_pool-2.2.0/lib/connection_pool.rb:61:in `block in with'
connection_pool-2.2.0/lib/connection_pool.rb:60:in `handle_interrupt'
connection_pool-2.2.0/lib/connection_pool.rb:60:in `with'
```

with others stuck at:

```
connection_pool-2.2.0/lib/connection_pool/timed_stack.rb:76:in `synchronize'
connection_pool-2.2.0/lib/connection_pool/timed_stack.rb:76:in `pop'
connection_pool-2.2.0/lib/connection_pool.rb:89:in `checkout'
connection_pool-2.2.0/lib/connection_pool.rb:61:in `block in with'
connection_pool-2.2.0/lib/connection_pool.rb:60:in `handle_interrupt'
connection_pool-2.2.0/lib/connection_pool.rb:60:in `with'
```

So, thread A acquires the connection_pool lock, and is able to proceed. Meanwhile thread B enters app space. A now attempts to make an explicit `require` call (which would be naturally safe; protected by ruby's internal `loading` tracking), but we intervene and force it to first acquire our load lock -- it must now wait until thread B either completes, or hits a load-lock acquisition of its own. B now follows the same path, and blocks on its attempt to acquire the connection_pool lock = deadlock.

Change the above scenario from an explicit `require` to a mention of a missing constant, and we'll still deadlock after this PR -- but that one is more defensible: we have no other choice. It's also (IMO) a lower risk exposure: "user" code, which is where auto-loadable constants are likely to be mentioned, is unlikely to be casually executing inside an exclusive lock... `require` inside an exclusive lock is a not-unreasonable prospect for library code.

.. it's also fixable, by just mentioning the constant before you acquire the other lock. That doesn't apply to `require`, because we were acquiring the load lock before we even checked whether the file had already been loaded.

---

Moreover, the previous implementation was Philosophically Wrong: AS::Dep isn't supposed to be enhancing or in any way interfering with the operation of `load`/`require`. It only defines them in order to _exclude_ them from its normal behaviour.

To do so would also give a false sense of protection, against a set of dangers that would persist/return when the load interlock is removed (e.g., in a production environment where `eager_load` and `cache_classes` are both true).
