### PR TITLE
Don't fail when checking dependencies in bin/setup script

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup
@@ -15,7 +15,7 @@ chdir APP_ROOT do
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
-  system!('bundle check') or system!('bundle install')
+  system('bundle check') or system!('bundle install')
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')


### PR DESCRIPTION
Follow up of: #20926

We use `bin/setup` in our CI setup, `bundle check` should not fail, should fail on `bundle install`.

/cc @rsanheim
