### PR TITLE
Consistently protect primary key attribute methods against undefined primary keys

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -8,8 +8,7 @@ module ActiveRecord
       # Returns this record's primary key value wrapped in an array if one is
       # available.
       def to_key
-        sync_with_transaction_state
-        key = self.id
+        key = id
         [key] if key
       end
 
@@ -23,26 +22,36 @@ module ActiveRecord
 
       # Sets the primary key value.
       def id=(value)
-        sync_with_transaction_state
-        write_attribute(self.class.primary_key, value) if self.class.primary_key
+        if pk = self.class.primary_key
+          sync_with_transaction_state
+          write_attribute(pk, value)
+        end
       end
 
       # Queries the primary key value.
       def id?
-        sync_with_transaction_state
-        query_attribute(self.class.primary_key)
+        if pk = self.class.primary_key
+          sync_with_transaction_state
+          query_attribute(pk)
+        else
+          false
+        end
       end
 
       # Returns the primary key value before type cast.
       def id_before_type_cast
-        sync_with_transaction_state
-        read_attribute_before_type_cast(self.class.primary_key)
+        if pk = self.class.primary_key
+          sync_with_transaction_state
+          read_attribute_before_type_cast(pk)
+        end
       end
 
       # Returns the primary key previous value.
       def id_was
-        sync_with_transaction_state
-        attribute_was(self.class.primary_key)
+        if pk = self.class.primary_key
+          sync_with_transaction_state
+          attribute_was(pk)
+        end
       end
 
       protected


### PR DESCRIPTION
These are all dependent on the presence of a defined primary key and should
have well-defined behavior is one is not present. E.g. if you call `#id_was`
without a primary key being defined, e.g. via `#update` -> `#_update_record`,
then it would fail with the mysterious "TypeError: nil is not a symbol nor a
string", raised by `__send__`, when it should just return `nil` as `#id` does.

This also incidentally removes an unnecessary `#sync_with_transaction_state`
from `#to_key`, which is redundant with the same call that occurs in #id.
