### PR TITLE
Rename the enum_prefix and enum_suffix options to _prefix and _suffix

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -170,7 +170,7 @@
 
     *Aster Ryan*
 
-*   Add `:enum_prefix`/`:enum_suffix` option to `enum` definition.
+*   Add `:_prefix` and `:_suffix` options to `enum` definition.
 
     Fixes #17511, #17415.
 

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -75,22 +75,22 @@ module ActiveRecord
   #
   #   Conversation.where("status <> ?", Conversation.statuses[:archived])
   #
-  # You can use the +:enum_prefix+ or +:enum_suffix+ options when you need
-  # to define multiple enums with same values. If the passed value is +true+,
-  # the methods are prefixed/suffixed with the name of the enum.
+  # You can use the +:_prefix+ or +:_suffix+ options when you need to define
+  # multiple enums with same values. If the passed value is +true+, the methods
+  # are prefixed/suffixed with the name of the enum.
   #
   #   class Invoice < ActiveRecord::Base
-  #     enum verification: [:done, :fail], enum_prefix: true
+  #     enum verification: [:done, :fail], _prefix: true
   #   end
   #
-  # It is also possible to supply a custom prefix.
+  # It is also possible to supply a custom value:
   #
   #   class Invoice < ActiveRecord::Base
-  #     enum verification: [:done, :fail], enum_prefix: :verification_status
+  #     enum verification: [:done, :fail], _prefix: :verification_status
   #   end
   #
-  # Note that <tt>:enum_prefix</tt>/<tt>:enum_suffix</tt> are reserved keywords
-  # and can not be used as an enum name.
+  # Note that <tt>:_prefix</tt>/<tt>:_suffix</tt> are reserved keywords and can
+  # not be used as enum names.
 
   module Enum
     def self.extended(base) # :nodoc:
@@ -137,8 +137,8 @@ module ActiveRecord
 
     def enum(definitions)
       klass = self
-      enum_prefix = definitions.delete(:enum_prefix)
-      enum_suffix = definitions.delete(:enum_suffix)
+      enum_prefix = definitions.delete(:_prefix)
+      enum_suffix = definitions.delete(:_suffix)
       definitions.each do |name, values|
         # statuses = { }
         enum_values = ActiveSupport::HashWithIndifferentAccess.new

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -10,10 +10,10 @@ class Book < ActiveRecord::Base
   enum status: [:proposed, :written, :published]
   enum read_status: {unread: 0, reading: 2, read: 3}
   enum nullable_status: [:single, :married]
-  enum language: [:english, :spanish, :french], enum_prefix: :in
-  enum author_visibility: [:visible, :invisible], enum_prefix: true
-  enum illustrator_visibility: [:visible, :invisible], enum_prefix: true
-  enum font_size: [:small, :medium, :large], enum_prefix: :with, enum_suffix: true
+  enum language: [:english, :spanish, :french], _prefix: :in
+  enum author_visibility: [:visible, :invisible], _prefix: true
+  enum illustrator_visibility: [:visible, :invisible], _prefix: true
+  enum font_size: [:small, :medium, :large], _prefix: :with, _suffix: true
 
   def published!
     super


### PR DESCRIPTION
Hello,

This pull request renames the `enum_{prefix_suffix}` options to `_{prefix_suffix}` in order to make it more clear that they are reserved keywords and also it seems less redundant as the line already starts with the call to the `enum` method.

Cross-refs https://github.com/rails/rails/pull/19813#issuecomment-112147620.

Have a nice day.
