### PR TITLE
Allow generating plugins for API applications

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add a `--api` option in order to generate plugins that can be added
+    inside an API application.
+
+    *Robin Dupret*
+
 *   Fix `NoMethodError` when generating a scaffold inside a full engine.
 
     *Yuji Yaginuma*

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -176,6 +176,9 @@ task default: :test
                                         desc: "If creating plugin in application's directory " +
                                                  "skip adding entry to Gemfile"
 
+      class_option :api,          type: :boolean, default: false,
+                                  desc: "Generate a smaller stack for API application plugins"
+
       def initialize(*args)
         @dummy_path = nil
         super
@@ -303,6 +306,10 @@ task default: :test
 
       def with_dummy_app?
         options[:skip_test].blank? || options[:dummy_path] != 'test/dummy'
+      end
+
+      def api?
+        options[:api]
       end
 
       def self.banner

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -89,6 +89,7 @@ task default: :test
       opts = (options || {}).slice(*PASSTHROUGH_OPTIONS)
       opts[:force] = force
       opts[:skip_bundle] = true
+      opts[:api] = options.api?
 
       invoke Rails::Generators::AppGenerator,
         [ File.expand_path(dummy_path, destination_root) ], opts

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -17,15 +17,22 @@ module Rails
 
     def app
       if mountable?
-        directory 'app'
-        empty_directory_with_keep_file "app/assets/images/#{namespaced_name}"
+        if api?
+          directory 'app', exclude_pattern: %r{app/(views|helpers)}
+        else
+          directory 'app'
+          empty_directory_with_keep_file "app/assets/images/#{namespaced_name}"
+        end
       elsif full?
         empty_directory_with_keep_file 'app/models'
         empty_directory_with_keep_file 'app/controllers'
-        empty_directory_with_keep_file 'app/views'
-        empty_directory_with_keep_file 'app/helpers'
         empty_directory_with_keep_file 'app/mailers'
-        empty_directory_with_keep_file "app/assets/images/#{namespaced_name}"
+
+        unless api?
+          empty_directory_with_keep_file "app/assets/images/#{namespaced_name}"
+          empty_directory_with_keep_file 'app/helpers'
+          empty_directory_with_keep_file 'app/views'
+        end
       end
     end
 
@@ -213,15 +220,15 @@ task default: :test
       end
 
       def create_public_stylesheets_files
-        build(:stylesheets)
+        build(:stylesheets) unless api?
       end
 
       def create_javascript_files
-        build(:javascripts)
+        build(:javascripts) unless api?
       end
 
       def create_images_directory
-        build(:images)
+        build(:images) unless api?
       end
 
       def create_bin_files

--- a/railties/lib/rails/generators/rails/plugin/templates/app/controllers/%namespaced_name%/application_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/app/controllers/%namespaced_name%/application_controller.rb.tt
@@ -1,5 +1,5 @@
 <%= wrap_in_modules <<-rb.strip_heredoc
-  class ApplicationController < ActionController::Base
+  class ApplicationController < ActionController::#{api? ? "API" : "Base"}
   end
 rb
 %>

--- a/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/engine.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/engine.rb
@@ -1,6 +1,7 @@
 <%= wrap_in_modules <<-rb.strip_heredoc
   class Engine < ::Rails::Engine
   #{mountable? ? '  isolate_namespace ' + camelized_modules : ' '}
+  #{api? ? "  config.generators.api_only = true" : ' '}
   end
 rb
 %>

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -556,6 +556,14 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_application_controller_parent_for_mountable_api_plugins
+    run_generator [destination_root, '--mountable', '--api']
+
+    assert_file "app/controllers/bukkits/application_controller.rb" do |content|
+      assert_match "ApplicationController < ActionController::API", content
+    end
+  end
+
 protected
   def action(*args, &block)
     silence(:stdout){ generator.send(*args, &block) }

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -572,6 +572,32 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+
+  def test_api_generators_configuration_for_api_engines
+    run_generator [destination_root, '--full', '--api']
+
+    assert_file "lib/bukkits/engine.rb" do |content|
+      assert_match "config.generators.api_only = true", content
+    end
+  end
+
+  def test_scaffold_generator_for_mountable_api_plugins
+    run_generator [destination_root, '--mountable', '--api']
+
+    capture(:stdout) do
+      `#{destination_root}/bin/rails g scaffold article`
+    end
+
+    assert_file "app/models/bukkits/article.rb"
+    assert_file "app/controllers/bukkits/articles_controller.rb" do |content|
+      assert_match "only: [:show, :update, :destroy]", content
+    end
+
+    assert_no_directory "app/assets"
+    assert_no_directory "app/helpers"
+    assert_no_directory "app/views"
+  end
+
 protected
   def action(*args, &block)
     silence(:stdout){ generator.send(*args, &block) }

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -564,6 +564,14 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_dummy_api_application_for_api_plugins
+    run_generator [destination_root, '--api']
+
+    assert_file "test/dummy/config/application.rb" do |content|
+      assert_match "config.api_only = true", content
+    end
+  end
+
 protected
   def action(*args, &block)
     silence(:stdout){ generator.send(*args, &block) }

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -544,6 +544,18 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_skipping_useless_folders_generation_for_api_engines
+    ['--full', '--mountable'].each do |option|
+      run_generator [destination_root, option, '--api']
+
+      assert_no_directory "app/assets"
+      assert_no_directory "app/helpers"
+      assert_no_directory "app/views"
+
+      FileUtils.rm_rf destination_root
+    end
+  end
+
 protected
   def action(*args, &block)
     silence(:stdout){ generator.send(*args, &block) }


### PR DESCRIPTION
Hello,

This pull requests adds a `--api` option in order to generate plugins that can be added inside API applications. It is split into several commits to ease the review process but once everything is fine, I can squash them.

Cross-refs #19832 and [the todo on Basecamp](https://basecamp.com/1755757/projects/6741427/todos/183482259#comment_294960031).

Have a nice day.
