### PR TITLE
Encode the email address as prescribed in RFC 6068 section 2.

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -468,7 +468,8 @@ module ActionView
         }.compact
         extras = extras.empty? ? '' : '?' + extras.join('&')
 
-        html_options["href"] = "mailto:#{email_address}#{extras}"
+        encoded_email_address = ERB::Util.url_encode(email_address).gsub("%40", "@")
+        html_options["href"] = "mailto:#{encoded_email_address}#{extras}"
 
         content_tag(:a, name || email_address, html_options, &block)
       end

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -500,6 +500,13 @@ class UrlHelperTest < ActiveSupport::TestCase
                  mail_to("david@loudthinking.com", "David Heinemeier Hansson", class: "admin")
   end
 
+  def test_mail_to_with_special_characters
+    assert_dom_equal(
+      %{<a href="mailto:%23%21%24%25%26%27%2A%2B-%2F%3D%3F%5E_%60%7B%7D%7C%7E@example.org">#!$%&amp;&#39;*+-/=?^_`{}|~@example.org</a>},
+      mail_to("#!$%&'*+-/=?^_`{}|~@example.org")
+    )
+  end
+
   def test_mail_with_options
     assert_dom_equal(
       %{<a href="mailto:me@example.com?cc=ccaddress%40example.com&amp;bcc=bccaddress%40example.com&amp;body=This%20is%20the%20body%20of%20the%20message.&amp;subject=This%20is%20an%20example%20email&amp;reply-to=foo%40bar.com">My email</a>},


### PR DESCRIPTION
If an email address contains certain special characters, they need to be URL-encoded in a `mailto:` link, but `mail_to` doesn't do that. This PR adds encoding.

[RFC 6068 section 2](https://tools.ietf.org/html/rfc6068#section-2) says the following:

```
   1.  A number of characters that can appear in <addr-spec> MUST be
       percent-encoded.  These are the characters that cannot appear in
       a URI according to [STD66] as well as "%" (because it is used for
       percent-encoding) and all the characters in gen-delims except "@"
       and ":" (i.e., "/", "?", "#", "[", and "]").  Of the characters
       in sub-delims, at least the following also have to be percent-
       encoded: "&", ";", and "=".  Care has to be taken both when
       encoding as well as when decoding to make sure these operations
       are applied only once.
```

The reason for adding `gsub("%40", "@")` is that `ERB::Util.url_encode` escapes `@` and I didn't want to change the behaviour of `mail_to` for normal email addresses. `@` isn't one of the characters that needs to be escaped.

@rafaelfranca
