### PR TITLE
Add documentation to get a running custom base controller

### DIFF
--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -183,7 +183,7 @@ module ActionController
     # Shortcut helper that returns all the modules included in
     # ActionController::Base except the ones passed as arguments:
     #
-    #   class MetalController
+    #   class CustomBaseController < ActionController::Metal
     #     ActionController::Base.without_modules(:ParamsWrapper, :Streaming).each do |left|
     #       include left
     #     end


### PR DESCRIPTION
While trying to build a custom ApplicationController without certain modules (via #without_modules) I learned that you had to subclass ActionController::Metal in order to have config_accessor and other things in place.

This minimal documentation change reflects this.
