### PR TITLE
Make assert_enqueued_with and assert_performed_with returns the matched job

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `assert_enqueued_with` and `assert_performed_with` now returns the matched
+    job instance for further assertions.
+    
+    *Jean Boussier*
+
 *   Include I18n.locale into job serialization/deserialization and use it around
     `perform`.
 


### PR DESCRIPTION
Sometimes job properties can't be asserted with pure equality. It might be because part of it is time sensitive and you need an `assert_delta` equivalent, or it might contain part of randomness.

Or it might even be that you only want to assert one of the passed arguments.

This PR makes `assert_enqueued_with` and `assert_performed_with` returns the matched job if any.

Example:

``` ruby
job = assert_enqueued_with(job: SomeJob) do
  some_business_logic
end

assert_in_delta 5.minutes.from_now, job.scheduled_at, 1
assert_equal 5, job.arguments.second
```

I know an assertion method returning a meaningful value might seems weird, but there is precedent for this. For example if you want to assert an exception message, the way do to with minitest is:

``` ruby
error = assert_raises TypeError do
  '1' + 2
end
assert_equal 'no implicit conversion of Fixnum into String', error.message
```

@rafaelfranca thoughts?

cc @etiennebarrie
