### PR TITLE
[close #18878] Proxy `rake` tasks through `rails`

### DIFF
--- a/railties/lib/rails/commands/commands_tasks.rb
+++ b/railties/lib/rails/commands/commands_tasks.rb
@@ -163,12 +163,16 @@ EOT
       #   (Help message output)
       #
       def write_error_message(command)
-        puts "Error: Command '#{command}' not recognized"
-        if %x{rake #{command} --dry-run 2>&1 } && $?.success?
-          puts "Did you mean: `$ rake #{command}` ?\n\n"
+        puts "Error: Command '#{command}' not a valid rails command"
+        require APP_PATH
+        Rails.application.load_tasks
+        if Rake::Task.task_defined?(command)
+          puts "Running: `$ bin/rake #{command}` instead\n\n"
+          system("bin/rake #{command}")
+        else
+          write_help_message
+          exit(1)
         end
-        write_help_message
-        exit(1)
       end
 
       def parse_command(command)


### PR DESCRIPTION
Currently when you accidentally run `$ bin/rails db:migrate` you got an error message:

``` shell
Error: Command 'db:migrate' not recognized
Did you mean: `$ rake db:migrate` ?
```

After this change you'll still get an error message, but it will also run the command:

``` shell
$ be rails routes
Error: Command 'routes' not a valid rails command
Running: `$ bin/rake routes` instead

                  Prefix Verb     URI Pattern                                           Controller#Action
                teaspoon          /jstest                                               Teaspoon::Engine
           users_sign_in GET      /users/sign_in(.:format)                              redirect(301, /users/auth/github)
           users_sign_up GET      /users/sign_up(.:format)                              redirect(301, /users/auth/github)
        new_user_session GET      /users/sign_in(.:format)                              devise/sessions#new
            user_session POST     /users/sign_in(.:format)                              devise/sessions#create
# ...
```

I highly recommend that we keep the warning message. Without it running `$ rails --help` won't show all available commands and `rails db:migrate` would be a touch too magical for my tastes. If we want to switch over documentation so that some commands such as `rails test` work out of the box, we should whitelist them. The alternative would be we add the `$ rake -T` output to `$ rails --help` and that would get pretty messy. 

Thanks to @repinel for the tip on speeding up the rake check
