### PR TITLE
Remove table_exists? check in reset_column_information

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -295,7 +295,7 @@ module ActiveRecord
       def reset_column_information
         connection.clear_cache!
         undefine_attribute_methods
-        connection.schema_cache.clear_table_cache!(table_name) if table_exists?
+        connection.schema_cache.clear_table_cache!(table_name)
 
         @arel_engine        = nil
         @column_names       = nil


### PR DESCRIPTION
table_exists? goes through a cache itself.  If we are clearing the
schema cache we should not be checking a cached method.

cc @tenderlove 

This is for 4-2-stable. This was done in a [larger commit on master](https://github.com/rails/rails/commit/70ac072976c8cc6f013f0df3777e54ccae3f4f8c#diff-6c8fd220c92c2b25aa29891b59d00c04L284), so I couldn't cherry-pick.
