### PR TITLE
Fix STATS_DIRECTORIES warning by only loading statistics.rake once

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,14 +13,14 @@ GIT
 
 GIT
   remote: git://github.com/mikel/mail.git
-  revision: b159e0a542962fdd5e292a48cfffa560d7cf412e
+  revision: 64ef1a12efcdda53fd63e1456c2c564044bf82ce
   specs:
     mail (2.6.3.edge)
       mime-types (>= 1.16, < 3)
 
 GIT
   remote: git://github.com/rails/arel.git
-  revision: aac9da257f291ad8d2d4f914528881c240848bb2
+  revision: 935796f4fd7d75950db87156d6540028a9044fdf
   branch: master
   specs:
     arel (7.0.0.alpha)
@@ -34,23 +34,23 @@ GIT
 
 GIT
   remote: git://github.com/rails/jquery-rails.git
-  revision: 272abdd319bb3381b23182b928b25320590096b0
+  revision: 38053f45402f1ccc4cce5dd8c7005ec707376db3
   branch: master
   specs:
-    jquery-rails (4.0.3)
+    jquery-rails (4.0.4)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
 
 GIT
   remote: git://github.com/rails/sprockets-rails.git
-  revision: 85b89c44ad40af3056899808475e6e4bf65c1f5a
+  revision: 6389649358846f37507206885e3ece145862a0be
   branch: master
   specs:
-    sprockets-rails (3.0.0.beta1)
+    sprockets-rails (3.0.0)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
-      sprockets (>= 3.0.0, < 4.0)
+      sprockets (>= 3.0.0)
 
 PATH
   remote: .
@@ -113,59 +113,59 @@ GEM
   remote: https://rubygems.org/
   specs:
     amq-protocol (1.9.2)
-    backburner (0.4.6)
-      beaneater (~> 0.3.1)
-      dante (~> 0.1.5)
+    backburner (1.0.0)
+      beaneater (~> 1.0)
+      dante (> 0.1.5)
     bcrypt (3.1.10)
     bcrypt (3.1.10-x64-mingw32)
     bcrypt (3.1.10-x86-mingw32)
-    beaneater (0.3.3)
-    benchmark-ips (2.1.1)
+    beaneater (1.0.0)
+    benchmark-ips (2.3.0)
     builder (3.2.2)
     bunny (1.7.0)
       amq-protocol (>= 1.9.2)
-    byebug (4.0.5)
+    byebug (5.0.0)
       columnize (= 0.9.0)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
-    coffee-script (2.3.0)
+    coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.9.0)
+    coffee-script-source (1.9.1.1)
     columnize (0.9.0)
     concurrent-ruby (0.9.0)
-    connection_pool (2.1.1)
-    dalli (2.7.2)
-    dante (0.1.5)
+    connection_pool (2.2.0)
+    dalli (2.7.4)
+    dante (0.2.0)
     delayed_job (4.0.6)
       activesupport (>= 3.0, < 5.0)
     delayed_job_active_record (4.0.3)
       activerecord (>= 3.0, < 5.0)
       delayed_job (>= 3.0, < 4.1)
     erubis (2.7.0)
-    execjs (2.3.0)
+    execjs (2.5.2)
     hitimes (1.2.2)
     hitimes (1.2.2-x86-mingw32)
     i18n (0.7.0)
-    json (1.8.2)
+    json (1.8.3)
     kindlerb (0.1.1)
       mustache
       nokogiri
-    loofah (2.0.1)
+    loofah (2.0.2)
       nokogiri (>= 1.5.9)
     metaclass (0.0.4)
     method_source (0.8.2)
-    mime-types (2.4.3)
+    mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.3.3)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
     mono_logger (1.1.0)
-    multi_json (1.11.0)
-    mustache (1.0.0)
+    multi_json (1.11.2)
+    mustache (1.0.2)
     mysql (2.9.1)
     mysql2 (0.3.18)
     nokogiri (1.6.6.2)
@@ -174,13 +174,13 @@ GEM
       mini_portile (~> 0.6.0)
     nokogiri (1.6.6.2-x86-mingw32)
       mini_portile (~> 0.6.0)
-    pg (0.18.1)
+    pg (0.18.2)
     psych (2.0.13)
-    que (0.9.2)
+    que (0.10.0)
     queue_classic (3.1.0)
       pg (>= 0.17, < 0.19)
     racc (1.4.12)
-    rack (1.6.0)
+    rack (1.6.4)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-protection (1.5.3)
@@ -197,9 +197,10 @@ GEM
       loofah (~> 2.0)
     rake (10.4.2)
     rdoc (4.2.0)
+      json (~> 1.4)
     redcarpet (3.2.3)
     redis (3.2.1)
-    redis-namespace (1.5.1)
+    redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     resque (1.25.2)
       mono_logger (~> 1.0)
@@ -212,47 +213,46 @@ GEM
       redis (~> 3.0)
       resque (~> 1.25)
       rufus-scheduler (~> 3.0)
-    rufus-scheduler (3.0.9)
-      tzinfo
+    rufus-scheduler (3.1.3)
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    sequel (4.19.0)
+    sequel (4.24.0)
     serverengine (1.5.10)
       sigdump (~> 0.2.2)
-    sidekiq (3.3.2)
-      celluloid (>= 0.16.0)
-      connection_pool (>= 2.1.1)
-      json
-      redis (>= 3.0.6)
-      redis-namespace (>= 1.3.1)
-    sigdump (0.2.2)
-    sinatra (1.4.5)
+    sidekiq (3.4.2)
+      celluloid (~> 0.16.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      json (~> 1.0)
+      redis (~> 3.2, >= 3.2.1)
+      redis-namespace (~> 1.5, >= 1.5.2)
+    sigdump (0.2.3)
+    sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
+      tilt (>= 1.3, < 3)
     sneakers (1.0.4)
       bunny (~> 1.7.0)
       serverengine (~> 1.5.5)
       thor
       thread (~> 0.1.7)
-    sprockets (3.0.2)
+    sprockets (3.0.3)
       rack (~> 1.0)
     sqlite3 (1.3.10)
     stackprof (0.2.7)
-    sucker_punch (1.3.2)
+    sucker_punch (1.5.0)
       celluloid (~> 0.16.0)
     thor (0.19.1)
     thread (0.1.7)
     thread_safe (0.3.5)
-    tilt (1.4.1)
+    tilt (2.0.1)
     timers (4.0.1)
       hitimes
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.7.0)
+    uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     vegas (0.1.11)
@@ -314,6 +314,3 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   w3c_validators
-
-BUNDLED WITH
-   1.10.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,14 +13,14 @@ GIT
 
 GIT
   remote: git://github.com/mikel/mail.git
-  revision: 64ef1a12efcdda53fd63e1456c2c564044bf82ce
+  revision: b159e0a542962fdd5e292a48cfffa560d7cf412e
   specs:
     mail (2.6.3.edge)
       mime-types (>= 1.16, < 3)
 
 GIT
   remote: git://github.com/rails/arel.git
-  revision: 935796f4fd7d75950db87156d6540028a9044fdf
+  revision: aac9da257f291ad8d2d4f914528881c240848bb2
   branch: master
   specs:
     arel (7.0.0.alpha)
@@ -34,23 +34,23 @@ GIT
 
 GIT
   remote: git://github.com/rails/jquery-rails.git
-  revision: 38053f45402f1ccc4cce5dd8c7005ec707376db3
+  revision: 272abdd319bb3381b23182b928b25320590096b0
   branch: master
   specs:
-    jquery-rails (4.0.4)
+    jquery-rails (4.0.3)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
 
 GIT
   remote: git://github.com/rails/sprockets-rails.git
-  revision: 6389649358846f37507206885e3ece145862a0be
+  revision: 85b89c44ad40af3056899808475e6e4bf65c1f5a
   branch: master
   specs:
-    sprockets-rails (3.0.0)
+    sprockets-rails (3.0.0.beta1)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
-      sprockets (>= 3.0.0)
+      sprockets (>= 3.0.0, < 4.0)
 
 PATH
   remote: .
@@ -113,59 +113,59 @@ GEM
   remote: https://rubygems.org/
   specs:
     amq-protocol (1.9.2)
-    backburner (1.0.0)
-      beaneater (~> 1.0)
-      dante (> 0.1.5)
+    backburner (0.4.6)
+      beaneater (~> 0.3.1)
+      dante (~> 0.1.5)
     bcrypt (3.1.10)
     bcrypt (3.1.10-x64-mingw32)
     bcrypt (3.1.10-x86-mingw32)
-    beaneater (1.0.0)
-    benchmark-ips (2.3.0)
+    beaneater (0.3.3)
+    benchmark-ips (2.1.1)
     builder (3.2.2)
     bunny (1.7.0)
       amq-protocol (>= 1.9.2)
-    byebug (5.0.0)
+    byebug (4.0.5)
       columnize (= 0.9.0)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
-    coffee-script (2.4.1)
+    coffee-script (2.3.0)
       coffee-script-source
       execjs
-    coffee-script-source (1.9.1.1)
+    coffee-script-source (1.9.0)
     columnize (0.9.0)
     concurrent-ruby (0.9.0)
-    connection_pool (2.2.0)
-    dalli (2.7.4)
-    dante (0.2.0)
+    connection_pool (2.1.1)
+    dalli (2.7.2)
+    dante (0.1.5)
     delayed_job (4.0.6)
       activesupport (>= 3.0, < 5.0)
     delayed_job_active_record (4.0.3)
       activerecord (>= 3.0, < 5.0)
       delayed_job (>= 3.0, < 4.1)
     erubis (2.7.0)
-    execjs (2.5.2)
+    execjs (2.3.0)
     hitimes (1.2.2)
     hitimes (1.2.2-x86-mingw32)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.2)
     kindlerb (0.1.1)
       mustache
       nokogiri
-    loofah (2.0.2)
+    loofah (2.0.1)
       nokogiri (>= 1.5.9)
     metaclass (0.0.4)
     method_source (0.8.2)
-    mime-types (2.6.1)
+    mime-types (2.4.3)
     mini_portile (0.6.2)
     minitest (5.3.3)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
     mono_logger (1.1.0)
-    multi_json (1.11.2)
-    mustache (1.0.2)
+    multi_json (1.11.0)
+    mustache (1.0.0)
     mysql (2.9.1)
     mysql2 (0.3.18)
     nokogiri (1.6.6.2)
@@ -174,13 +174,13 @@ GEM
       mini_portile (~> 0.6.0)
     nokogiri (1.6.6.2-x86-mingw32)
       mini_portile (~> 0.6.0)
-    pg (0.18.2)
+    pg (0.18.1)
     psych (2.0.13)
-    que (0.10.0)
+    que (0.9.2)
     queue_classic (3.1.0)
       pg (>= 0.17, < 0.19)
     racc (1.4.12)
-    rack (1.6.4)
+    rack (1.6.0)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-protection (1.5.3)
@@ -197,10 +197,9 @@ GEM
       loofah (~> 2.0)
     rake (10.4.2)
     rdoc (4.2.0)
-      json (~> 1.4)
     redcarpet (3.2.3)
     redis (3.2.1)
-    redis-namespace (1.5.2)
+    redis-namespace (1.5.1)
       redis (~> 3.0, >= 3.0.4)
     resque (1.25.2)
       mono_logger (~> 1.0)
@@ -213,46 +212,47 @@ GEM
       redis (~> 3.0)
       resque (~> 1.25)
       rufus-scheduler (~> 3.0)
-    rufus-scheduler (3.1.3)
+    rufus-scheduler (3.0.9)
+      tzinfo
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    sequel (4.24.0)
+    sequel (4.19.0)
     serverengine (1.5.10)
       sigdump (~> 0.2.2)
-    sidekiq (3.4.2)
-      celluloid (~> 0.16.0)
-      connection_pool (~> 2.2, >= 2.2.0)
-      json (~> 1.0)
-      redis (~> 3.2, >= 3.2.1)
-      redis-namespace (~> 1.5, >= 1.5.2)
-    sigdump (0.2.3)
-    sinatra (1.4.6)
+    sidekiq (3.3.2)
+      celluloid (>= 0.16.0)
+      connection_pool (>= 2.1.1)
+      json
+      redis (>= 3.0.6)
+      redis-namespace (>= 1.3.1)
+    sigdump (0.2.2)
+    sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
+      tilt (~> 1.3, >= 1.3.4)
     sneakers (1.0.4)
       bunny (~> 1.7.0)
       serverengine (~> 1.5.5)
       thor
       thread (~> 0.1.7)
-    sprockets (3.0.3)
+    sprockets (3.0.2)
       rack (~> 1.0)
     sqlite3 (1.3.10)
     stackprof (0.2.7)
-    sucker_punch (1.5.0)
+    sucker_punch (1.3.2)
       celluloid (~> 0.16.0)
     thor (0.19.1)
     thread (0.1.7)
     thread_safe (0.3.5)
-    tilt (2.0.1)
+    tilt (1.4.1)
     timers (4.0.1)
       hitimes
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.7.1)
+    uglifier (2.7.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     vegas (0.1.11)
@@ -314,3 +314,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   w3c_validators
+
+BUNDLED WITH
+   1.10.5

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix STATS_DIRECTORIES already defined warning when running rake from within
+    the top level directory of an engine that has a test app.
+    
+    Fixes #20510
+    
+    *Ersin Akinci*
+
 *   Fix `NoMethodError` when generating a scaffold inside a full engine.
 
     *Yuji Yaginuma*

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,7 +1,7 @@
 *   Fix STATS_DIRECTORIES already defined warning when running rake from within
     the top level directory of an engine that has a test app.
     
-    Fixes #20510
+    Fixes #20510.
     
     *Ersin Akinci*
 

--- a/railties/lib/rails/tasks.rb
+++ b/railties/lib/rails/tasks.rb
@@ -10,8 +10,9 @@ require 'rake'
   misc
   restart
   routes
-  statistics
   tmp
-).each do |task|
+).tap { |arr|
+  arr << 'statistics' if Rake.application.current_scope.empty?
+}.each do |task|
   load "rails/tasks/#{task}.rake"
 end


### PR DESCRIPTION
When running `rake stats` from inside an engine, the engine's Rakefile attempts to reload statistics.rake after the test app loads it, which results in STATS_DIRECTORIES being redefined and an annoying warning. This patch skips loading statistics.rake from tasks.rb if rake's current scope isn't empty, i.e. if we are running from inside an engine and not the test app dir or a normal app.

Fixes #20510.
