### PR TITLE
Warn delegating to top-level-defined methods

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -286,6 +286,10 @@ module ActiveModel
           method_name = matcher.method_name(attr_name)
 
           unless instance_method_already_implemented?(method_name)
+            if Object.private_method_defined? method_name
+              warn "#{method_name.inspect} has been defined as top-level method."
+            end
+
             generate_method = "define_method_#{matcher.method_missing_target}"
 
             if respond_to?(generate_method, true)


### PR DESCRIPTION
When you define top-level method before using `define_attribute_method`, it delegates the call to the top-level method. However, the top-level method is not accessible from your object instances.
I know defining top-level method is not a great thing, but we should warn us the accident. It happens especially when you define top-level method the name of which is the same as some model's column name in your script and use it via `rails runner`.
