### PR TITLE
Add ActiveSupport::SymbolInquirer

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -57,6 +57,7 @@ module ActiveSupport
     autoload :OrderedHash
     autoload :OrderedOptions
     autoload :StringInquirer
+    autoload :SymbolInquirer
     autoload :TaggedLogging
     autoload :XmlMini
     autoload :ArrayInquirer

--- a/activesupport/lib/active_support/core_ext/symbol.rb
+++ b/activesupport/lib/active_support/core_ext/symbol.rb
@@ -1,0 +1,1 @@
+require 'active_support/core_ext/symbol/inquiry'

--- a/activesupport/lib/active_support/core_ext/symbol/inquiry.rb
+++ b/activesupport/lib/active_support/core_ext/symbol/inquiry.rb
@@ -1,0 +1,13 @@
+require 'active_support/symbol_inquirer'
+
+class Symbol
+  # Wraps the current symbol in the <tt>ActiveSupport::SymbolInquirer</tt> class,
+  # which gives you a prettier way to test for equality.
+  #
+  #   env = :production.inquiry
+  #   env.production?  # => true
+  #   env.development? # => false
+  def inquiry
+    ActiveSupport::SymbolInquirer.new(self)
+  end
+end

--- a/activesupport/lib/active_support/symbol_inquirer.rb
+++ b/activesupport/lib/active_support/symbol_inquirer.rb
@@ -1,0 +1,23 @@
+module ActiveSupport
+  # Wrapping a string in this class gives you a prettier way to test
+  # for equality:
+  #   env = ActiveSupport::SymbolInquirer.new(:production)
+  #
+  #   env.production?  # => true
+  #   env.development? # => false
+  class SymbolInquirer < SimpleDelegator
+    private
+
+      def respond_to_missing?(method_name, include_private = false)
+        method_name[-1] == '?'
+      end
+
+      def method_missing(method_name, *arguments)
+        if method_name[-1] == '?'
+          to_s == method_name[0..-2]
+        else
+          super
+        end
+      end
+  end
+end

--- a/activesupport/test/symbol_inquirer_test.rb
+++ b/activesupport/test/symbol_inquirer_test.rb
@@ -1,0 +1,23 @@
+require 'abstract_unit'
+
+class SymbolInquirerTest < ActiveSupport::TestCase
+  def setup
+    @symbol_inquirer = ActiveSupport::SymbolInquirer.new(:production)
+  end
+
+  def test_match
+    assert @symbol_inquirer.production?
+  end
+
+  def test_miss
+    assert_not @symbol_inquirer.development?
+  end
+
+  def test_missing_question_mark
+    assert_raise(NoMethodError) { @symbol_inquirer.production }
+  end
+
+  def test_respond_to
+    assert_respond_to @symbol_inquirer, :development?
+  end
+end


### PR DESCRIPTION
Basically StringInquirer, but for Symbols.

Symbol doesn't implement an initializer, so I subclass SimpleDelegator instead.
