### PR TITLE
Added helper methods to stub any instance

### DIFF
--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -30,6 +30,10 @@ module ActiveSupport
         def assert_not_called(object, method_name, message = nil, &block)
           assert_called(object, method_name, message, times: 0, &block)
         end
+
+        def stub_any_instance(klass, instance: klass.new)
+          klass.stub(:new, instance) { yield instance }
+        end
     end
   end
 end

--- a/activesupport/test/testing/method_call_assertions_test.rb
+++ b/activesupport/test/testing/method_call_assertions_test.rb
@@ -95,4 +95,17 @@ class MethodCallAssertionsTest < ActiveSupport::TestCase
 
     assert_equal "Expected increment to be called 0 times, but was called 1 times.\nExpected: 0\n  Actual: 1", error.message
   end
+
+  def test_stub_any_instance
+    stub_any_instance(Level) do |instance|
+      assert_equal instance, Level.new
+    end
+  end
+
+  def test_stub_any_instance_with_instance
+    stub_any_instance(Level, instance: @object) do |instance|
+      assert_equal @object, instance
+      assert_equal instance, Level.new
+    end
+  end
 end


### PR DESCRIPTION
While removing use of mocha from action_mailer test suite, I found we're using `any_instance` assertions at many places.

For example https://github.com/rails/rails/blob/master/actionmailer/test/base_test.rb#L896

\cc @kaspth 
