### PR TITLE
Remove @connection instance variable only when defined

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/quoting_test.rb
@@ -7,14 +7,14 @@ class Mysql2QuotingTest < ActiveRecord::Mysql2TestCase
 
   test 'quoted date precision for gte 5.6.4' do
     @connection.stubs(:full_version).returns('5.6.4')
-    @connection.remove_instance_variable(:@version)
+    @connection.remove_instance_variable(:@version) if @connection.instance_variable_defined?(:@version)
     t = Time.now.change(usec: 1)
     assert_match(/\.000001\z/, @connection.quoted_date(t))
   end
 
   test 'quoted date precision for lt 5.6.4' do
     @connection.stubs(:full_version).returns('5.6.3')
-    @connection.remove_instance_variable(:@version)
+    @connection.remove_instance_variable(:@version) if @connection.instance_variable_defined?(:@version)
     t = Time.now.change(usec: 1)
     refute_match(/\.000001\z/, @connection.quoted_date(t))
   end


### PR DESCRIPTION
This pull request addresses errors reported in #20969 for mysql2 adapter since https://github.com/rails/rails/commit/430b7c8b518fc628f2647323ba2bbb8dbb6cdd35 already addresses these errors for mysql adapter.
