### PR TITLE
Fix params_wrapper doc [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -4,8 +4,8 @@ require 'active_support/core_ext/module/anonymous'
 require 'action_dispatch/http/mime_type'
 
 module ActionController
-  # Wraps the parameters hash into a nested hash. This will allow clients to submit
-  # POST requests without having to specify any root elements.
+  # Wraps the parameters hash into a nested hash. This will allow clients to
+  # submit requests without having to specify any root elements.
   #
   # This functionality is enabled in +config/initializers/wrap_parameters.rb+
   # and can be customized.
@@ -14,7 +14,7 @@ module ActionController
   # a non-empty array:
   #
   #     class UsersController < ApplicationController
-  #       wrap_parameters format: [:json, :xml]
+  #       wrap_parameters format: [:json, :xml, :url_encoded_form, :multipart_form]
   #     end
   #
   # If you enable +ParamsWrapper+ for +:json+ format, instead of having to


### PR DESCRIPTION
This feature also works with `PUT`, `PATCH` and `DELETE` requests.
Also developers can add `:url_encoded_form` and `:multipart_form`
into the `:format` for wrapping url encoded or multipart form data.
