### PR TITLE
Skip _select! call unless needed for preloader

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -137,7 +137,9 @@ module ActiveRecord
           scope.where_clause = reflection_scope.where_clause + preload_scope.where_clause
           scope.references_values = Array(values[:references]) + Array(preload_values[:references])
 
-          scope._select! preload_values[:select] || values[:select] || table[Arel.star]
+          if preload_values[:select] || values[:select]
+            scope._select!(preload_values[:select] || values[:select])
+          end
           scope.includes! preload_values[:includes] || values[:includes]
           if preload_scope.joins_values.any?
             scope.joins!(preload_scope.joins_values)


### PR DESCRIPTION
This PR skips the `_select!` call during `build_scope` for preloads unless it is needed. The performance gain depends on the number of columns in the preload table. For a simple preload with ~20 columns the `_select!` call accounts for 40% of the time (of `build_scope`) and isn't needed. It also allocates ~180 strings.

The root of the issue is that `_select!` is being called with `table[Arel.*]` which is an `Arel::Node::As` and not just a string or symbol. When `_select!` attempts to do `attribute_alias` lookups it ends up calling `inspect` on the Node to convert it to a string. And that causes the model object to be inspected as well. This happens twice since `_select!` is called again during the scope merge.

Here is a benchmark comparison of doing a query that involves a preload. It does not completely isolate the `build_scope` method but does show an overall performance gain and reduction in objects created.

Before

``` ruby
Calculating -------------------------------------
posts with preload(:comments)
                       208.000  i/100ms
-------------------------------------------------
posts with preload(:comments)
                          2.047k (± 1.6%) i/s -     10.400k
Total objects allocated: 697
```

After

``` ruby
Calculating -------------------------------------
posts with preload(:comments)
                       256.000  i/100ms
-------------------------------------------------
posts with preload(:comments)
                          2.524k (± 1.9%) i/s -     12.800k
Total objects allocated: 516
```

Benchmark script

``` ruby
#!/usr/bin/env ruby

begin
  require 'bundler/inline'
rescue LoadError => e
  $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
  raise e
end

gemfile(true) do
  source 'https://rubygems.org'
  gem 'rails', path: '.' # github: 'rails/rails', :branch => 'master'
  gem 'arel', github: 'rails/arel', :branch => 'master'
  gem 'sqlite3'
  gem 'memory_profiler'
  gem 'benchmark-ips'
end

require 'active_record'

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')

ActiveRecord::Schema.define do
  create_table :posts, force: true  do |t|
    t.string  :post_col1
  end

  create_table :comments, force: true  do |t|
    t.integer :post_id
    20.times do |n|
      t.string  "comment_col#{n}"
    end
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

# Create single Post with no Comments
Post.create!
# Query once so everything is loaded
Post.all.preload(:comments).to_a

GC.disable
Benchmark.ips do |x|
  x.report('posts with preload(:comments)') { Post.all.preload(:comments).to_a }
end
GC.enable

results = MemoryProfiler.report { Post.all.preload(:comments).to_a }

puts "Total objects allocated: #{results.total_allocated}"
```
