### PR TITLE
Add parameter filter capability for redirect locations

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add parameter filter capability for redirect locations.
+
+    It uses the `config.filter_parameters` to match what needs to be filtered.
+    The result would be like this:
+
+        Redirected to http://secret.foo.bar?username=roque&password=[FILTERED]
+
+    Fixes #14055.
+
+    *Roque Pinel*, *Trevor Turk*
+
 ## Rails 5.0.0.beta2 (February 01, 2016) ##
 
 *   Add `-g` and `-c` (short for _grep_ and _controller_ respectively) options

--- a/actionpack/lib/action_dispatch/http/filter_parameters.rb
+++ b/actionpack/lib/action_dispatch/http/filter_parameters.rb
@@ -64,10 +64,10 @@ module ActionDispatch
         ParameterFilter.new(filters)
       end
 
-      KV_RE   = '[^&;=]+'
-      PAIR_RE = %r{(#{KV_RE})=(#{KV_RE})}
+      KEY_OR_VALUE_REGEX = '[^&;=]+'
+      PAIR_REGEX         = %r{(#{KEY_OR_VALUE_REGEX})=(#{KEY_OR_VALUE_REGEX})}
       def filtered_query_string
-        query_string.gsub(PAIR_RE) do |_|
+        query_string.gsub(PAIR_REGEX) do |_|
           parameter_filter.filter([[$1, $2]]).first.join("=")
         end
       end

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -30,6 +30,10 @@ module Another
       redirect_to "http://secret.foo.bar/"
     end
 
+    def filterable_redirector_with_params
+      redirect_to "http://secret.foo.bar?username=repinel&password=1234"
+    end
+
     def data_sender
       send_data "cool data", :filename => "file.txt"
     end
@@ -221,6 +225,32 @@ class ACLogSubscriberTest < ActionController::TestCase
 
     assert_equal 3, logs.size
     assert_equal "Redirected to [FILTERED]", logs[1]
+  end
+
+  def test_does_not_filter_redirect_params_by_default
+    get :filterable_redirector_with_params
+    wait
+
+    assert_equal 3, logs.size
+    assert_equal "Redirected to http://secret.foo.bar?username=repinel&password=1234", logs[1]
+  end
+
+  def test_filter_redirect_params_by_string
+    @request.env['action_dispatch.parameter_filter'] = ['password']
+    get :filterable_redirector_with_params
+    wait
+
+    assert_equal 3, logs.size
+    assert_equal "Redirected to http://secret.foo.bar?username=repinel&password=[FILTERED]", logs[1]
+  end
+
+  def test_filter_redirect_params_by_regexp
+    @request.env['action_dispatch.parameter_filter'] = [/pass.+/]
+    get :filterable_redirector_with_params
+    wait
+
+    assert_equal 3, logs.size
+    assert_equal "Redirected to http://secret.foo.bar?username=repinel&password=[FILTERED]", logs[1]
   end
 
   def test_send_data

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1103,7 +1103,8 @@ You can set it to a String, a Regexp, or an array of both.
 config.filter_redirect.concat ['s3.amazonaws.com', /private_path/]
 ```
 
-Matching URLs will be marked as '[FILTERED]'.
+Matching URLs will be replaced with '[FILTERED]'. However, if you only wish to filter the parameters, not the whole URLs,
+please take a look at [Parameters Filtering](#parameters-filtering).
 
 Rescue
 ------


### PR DESCRIPTION
This is a follow up of #14055 taking in consideration @jeremy's comments.

It uses the `config.parameter_filter` to match what needs to be filtered. The result would be like this:

```
Redirected to http://secret.foo.bar?username=roque&password=[FILTERED]
```

By security default, if no filter is provided, it ~~filters all parameters~~ does not filter any parameter.

/cc @trevorturk

UPDATE: changed the default behavior.
