### PR TITLE
Add app/assets to assets load path

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -602,6 +602,7 @@ module Rails
     initializer :append_assets_path, group: :all do |app|
       app.config.assets.paths.unshift(*paths["vendor/assets"].existent_directories)
       app.config.assets.paths.unshift(*paths["lib/assets"].existent_directories)
+      app.config.assets.paths.unshift(*paths["app"].existent_directories.grep(/\/assets\z/))
       app.config.assets.paths.unshift(*paths["app/assets"].existent_directories)
     end
 


### PR DESCRIPTION
- This will allow compiling manifest files like app/assets/manifest.js
  which are proposed in sprockets 4.
- This commit mimics changes done in
  https://github.com/rails/sprockets-rails/pull/232
  for Rails 4-2-stable branch so that apps on 4.2.x will be able to run
  on sprockets 4.
