### PR TITLE
Remove duplicated `Array#to_param`

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -583,10 +583,8 @@ module ActionDispatch
         PARAMETERIZE = lambda do |name, value|
           if name == :controller
             value
-          elsif value.is_a?(Array)
-            value.map(&:to_param).join('/')
-          elsif param = value.to_param
-            param
+          else
+            value.to_param
           end
         end
 


### PR DESCRIPTION
`Array#to_param` is defind in active_support/core_ext/object/to_query.rb,
so we can call `to_param` if value is_a Array.
