### PR TITLE
Fix WARNINGS flag inside guides/Rakefile

### DIFF
--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -7,7 +7,7 @@ namespace :guides do
 
     desc "Generate HTML guides"
     task :html do
-      ENV["WARN_BROKEN_LINKS"] = "1" # authors can't disable this
+      ENV["WARNINGS"] = "1" # authors can't disable this
       ruby "rails_guides.rb"
     end
 


### PR DESCRIPTION
`WARN_BROKEN_LINKS` was renamed to `WARNINGS` in this [commit](https://github.com/rails/rails/commit/c52bec77f53a1dc4e3f61fbd45460b99f8f46fb1)
