### PR TITLE
Fix tests on master

### DIFF
--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -60,6 +60,7 @@ module ApplicationTests
     test "assets do not require compressors until it is used" do
       app_file "app/assets/javascripts/demo.js.erb", "<%= :alert %>();"
       add_to_env_config "production", "config.assets.compile = true"
+      add_to_env_config "production", "config.assets.precompile = []"
 
       ENV["RAILS_ENV"] = "production"
       require "#{app_path}/config/environment"

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -114,6 +114,7 @@ module ApplicationTests
       end
 
       test 'register a new extension' do
+        add_to_config "config.assets.precompile = []"
         add_to_config %q{ config.annotations.register_extensions("scss", "sass") { |annotation| /\/\/\s*(#{annotation}):?\s*(.*)$/ } }
         app_file "app/assets/stylesheets/application.css.scss", "// TODO: note in scss"
         app_file "app/assets/stylesheets/application.css.sass", "// TODO: note in sass"


### PR DESCRIPTION
Rails points at master of https://github.com/rails/sprockets-rails/ so when travis executes the tests the latest commit gets used. The change https://github.com/rails/sprockets-rails/pull/265 introduced a change with when certain files are precompiled which resulted in two failures, this PR fixes tests on master.

Related we should look into making this scenario more visible through automation or reporting. If Rails is pointed at master of a repo, it would be great if commits triggered rails tests. Currently the feedback loop is not great for this type of scenario.
