### PR TITLE
Validate multiple contexts on `valid?` and `invalid?` at once

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Validate multiple contexts on `valid?` and `invalid?` at once.
+
+    Example:
+    
+        class Person
+          include ActiveModel::Validations
+    
+          attr_reader :name, :title
+          validates_presence_of :name, on: :create
+          validates_presence_of :title, on: :update
+        end
+    
+        person = Person.new
+        person.valid?([:create, :update])    # => true
+        person.errors.messages               # => {:name=>["can't be blank"], :title=>["can't be blank"]}
+
+    *Dmitry Polushkin*
+
 *   Ensure `method_missing` is called for methods passed to
     `ActiveModel::Serialization#serializable_hash` that don't exist.
 

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -162,7 +162,7 @@ module ActiveModel
           options = options.dup
           options[:if] = Array(options[:if])
           options[:if].unshift ->(o) {
-            Array(options[:on]).include?(o.validation_context)
+            !(Array(options[:on]) & Array(o.validation_context)).empty?
           }
         end
 

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -54,7 +54,7 @@ module ActiveRecord
     # Validations with no <tt>:on</tt> option will run no matter the context. Validations with
     # some <tt>:on</tt> option will only run in the specified context.
     def valid?(context = nil)
-      context ||= (new_record? ? :create : :update)
+      context ||= default_validation_context
       output = super(context)
       errors.empty? && output
     end
@@ -62,6 +62,10 @@ module ActiveRecord
     alias_method :validate, :valid?
 
   protected
+
+    def default_validation_context
+      [new_record? ? :create : :update]
+    end
 
     def raise_validation_error
       raise(RecordInvalid.new(self))

--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -52,6 +52,13 @@ class ValidationsTest < ActiveRecord::TestCase
     assert r.valid?(:special_case)
   end
 
+  def test_invalid_using_multiple_contexts
+    r = WrongReply.new(:title => 'Wrong Create')
+    assert r.invalid?([:special_case, :create])
+    assert_equal "Invalid", r.errors[:author_name].join
+    assert_equal "is Wrong Create", r.errors[:title].join
+  end
+
   def test_validate
     r = WrongReply.new
 


### PR DESCRIPTION
Lets say we have cascade of validations, when we should check more and more validations, after each step. As an example: `precreate` context should check everything in a create, but less 2 attributes (real word example).

Currently it's only possible to check validations one by one. This patch provides possibility to do all the checks at once.

Example:

``` ruby
class Person
  include ActiveModel::Validations

  attr_reader :name, :title
  validates_presence_of :name, on: :create
  validates_presence_of :title, on: :update
end

person = Person.new
person.valid?([:create, :update])    # => true
person.errors.messages               # => {:name=>["can't be blank"], :title=>["can't be blank"]}
```
