### PR TITLE
RDoc: fix wrong model name `:inverse_of` with `:belongs_to` [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -619,10 +619,10 @@ module ActiveRecord
     #   @tag = @post.tags.build name: "ruby"
     #   @tag.save
     #
-    # The last line ought to save the through record (a <tt>Taggable</tt>). This will only work if the
+    # The last line ought to save the through record (a <tt>Tagging</tt>). This will only work if the
     # <tt>:inverse_of</tt> is set:
     #
-    #   class Taggable < ActiveRecord::Base
+    #   class Tagging < ActiveRecord::Base
     #     belongs_to :post
     #     belongs_to :tag, inverse_of: :taggings
     #   end
@@ -643,7 +643,7 @@ module ActiveRecord
     # You can turn off the automatic detection of inverse associations by setting
     # the <tt>:inverse_of</tt> option to <tt>false</tt> like so:
     #
-    #   class Taggable < ActiveRecord::Base
+    #   class Tagging < ActiveRecord::Base
     #     belongs_to :tag, inverse_of: false
     #   end
     #


### PR DESCRIPTION
There's a typo in ActiveRecord associations RDocs.
Wrong `Taggable` model name, instead of `Tagging` in example of using
option `:inverse_of` with `:belongs_to` association.

Commit where typo was introduced:
https://github.com/rails/rails/commit/91fd6510563f84ee473bb217bc63ed598abe3f24#diff-39001423802a8470dba9c931e66e101eR11

First it appears in `activerecord/CHANGELOG` in example of `:inverse_of`
usage:

``` ruby
    class Post < ActiveRecord::Base
      has_many :taggings
      has_many :tags, :through => :taggings
    end

    class Tagging < ActiveRecord::Base
      belongs_to :post
      belongs_to :tag, :inverse_of => :tagging # :inverse_of must be set!
    end

    class Tag < ActiveRecord::Base
      has_many :taggings
      has_many :posts, :through => :taggings
    end

    post = Post.first
    tag = post.tags.build :name => "ruby"
!>  tag.save # will save a Taggable linking to the post
```

The last line should be

``` ruby
    tag.save # will save a Tagging linking to the post
```

The same typo appears in
`activerecord/lib/active_record/associations.rb`.
The association name is given as `:inverse_of => :taggings`, but class
name is `Taggable`.

``` ruby
    #   @post = Post.first
    #   @tag = @post.tags.build :name => "ruby"
    #   @tag.save
    #
!>  # The last line ought to save the through record (a <tt>Taggable</tt>). This will only work if the
    # <tt>:inverse_of</tt> is set:
    #
!>  #   class Taggable < ActiveRecord::Base
    #     belongs_to :post
!>  #     belongs_to :tag, :inverse_of => :taggings
    #   end
```

This PR fixes model name.
