### PR TITLE
Array#any? is slower and not the inverse of Array#empty?

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -25,7 +25,7 @@ module ActionDispatch
           next unless name || route.dispatcher?
 
           missing_keys = missing_keys(route, parameterized_parts)
-          next if missing_keys && missing_keys.any?
+          next if missing_keys && !missing_keys.empty?
           params = options.dup.delete_if do |key, _|
             parameterized_parts.key?(key) || route.defaults.key?(key)
           end
@@ -40,7 +40,7 @@ module ActionDispatch
         end
 
         message = "No route matches #{Hash[constraints.sort_by{|k,v| k.to_s}].inspect}"
-        message << " missing required keys: #{missing_keys.sort.inspect}" if missing_keys && missing_keys.any?
+        message << " missing required keys: #{missing_keys.sort.inspect}" if missing_keys && !missing_keys.empty?
 
         raise ActionController::UrlGenerationError, message
       end


### PR DESCRIPTION
```
empty_array = []
small_array = [1] * 30
bigger_array = [1] * 300

Benchmark.ips do |x|
  x.report('empty !empty?') { !empty_array.empty? }
  x.report('small !empty?') { !small_array.empty? }
  x.report('bigger !empty?') { !bigger_array.empty? }

  x.report('empty any?') { empty_array.any? }
  x.report('small any?') { small_array.any? }
  x.report('bigger any?') { bigger_array.any? }
end
```

```
Calculating -------------------------------------
       empty !empty?   132.059k i/100ms
       small !empty?   133.974k i/100ms
      bigger !empty?   133.848k i/100ms
          empty any?   106.924k i/100ms
          small any?    85.525k i/100ms
         bigger any?    86.663k i/100ms
-------------------------------------------------
       empty !empty?      8.522M (± 7.9%) i/s -     42.391M
       small !empty?      8.501M (± 8.5%) i/s -     42.202M
      bigger !empty?      8.434M (± 8.6%) i/s -     41.894M
          empty any?      4.161M (± 8.3%) i/s -     20.743M
          small any?      2.654M (± 5.2%) i/s -     13.256M
         bigger any?      2.642M (± 6.4%) i/s -     13.173M
```

Ref: https://github.com/rails/rails/pull/21057#discussion_r35902468

@schneems for review please.
