### PR TITLE
Autosave associations should respect to value of validate option

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Autosave association should respect to value of validate option
+
+    Fixes #21058.
+
+    *Mehmet Emin İNAÇ*
+
 *   Ensure that the Suppressor runs before validations.
 
     This moves the suppressor up to be run before validations rather than after

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -74,12 +74,17 @@ module ActiveRecord
       new_record? ? :create : :update
     end
 
+    def run_validations? # :nodoc:
+      @run_validations
+    end
+
     def raise_validation_error
       raise(RecordInvalid.new(self))
     end
 
     def perform_validations(options={}) # :nodoc:
-      options[:validate] == false || valid?(options[:context])
+      @run_validations = options[:validate] != false
+      !(@run_validations && !valid?(options[:context]))
     end
   end
 end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1698,3 +1698,35 @@ class TestAutosaveAssociationWithTouch < ActiveRecord::TestCase
     assert_nothing_raised { invoice.line_items.create(:amount => 10) }
   end
 end
+
+class TestAutosaveAssociationWithValidateOption < ActiveRecord::TestCase
+  def test_autosave_with_validate_false_option_on_belongs_to_association
+    account = Account.new
+    account.build_firm
+
+    account.save(validate: false)
+
+    assert_predicate account, :persisted?
+    assert_predicate account.firm, :persisted?
+  end
+
+  def test_autosave_with_validate_false_option_on_has_one_association
+    firm = Firm.new(name: 'VNGRS')
+    account = firm.build_account
+
+    firm.save(validate: false)
+
+    assert_predicate firm, :persisted?
+    assert_predicate account, :persisted?
+  end
+
+  def test_autosave_with_validate_false_option_on_has_many_association
+    firm = Firm.new(name: 'VNGRS')
+    client = firm.clients.build(name: nil)
+
+    firm.save(validate: false)
+
+    assert_predicate firm, :persisted?
+    assert_predicate client, :persisted?
+  end
+end


### PR DESCRIPTION
I can't find any test case for current behaviour so I think this is not intended. If user tries to save object with `validate: false` option related associations should be saved with `validate: false` so user can save object and its invalid associations.
Fixes #21058
