### PR TITLE
Parametrize break sequence for word_wrap on ActionView Text Helpers

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add a break_sequence option to word_wrap so you can specify a custom break.
+
+    * Mauricio Gomez *
+
 *   Add wildcard matching to explicit dependencies.
 
     Turns:

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -250,12 +250,15 @@ module ActionView
       #
       #   word_wrap('Once upon a time', line_width: 1)
       #   # => Once\nupon\na\ntime
-      def word_wrap(text, options = {})
-        line_width = options.fetch(:line_width, 80)
-
+      #
+      #   You can also specify a custom +break_sequence+ ("\n" by default)
+      #
+      #   word_wrap('Once upon a time', line_width: 1, break_sequence: "\r\n")
+      #   # => Once\r\nupon\r\na\r\ntime
+      def word_wrap(text, line_width: 80, break_sequence: "\n")
         text.split("\n").collect! do |line|
-          line.length > line_width ? line.gsub(/(.{1,#{line_width}})(\s+|$)/, "\\1\n").strip : line
-        end * "\n"
+          line.length > line_width ? line.gsub(/(.{1,#{line_width}})(\s+|$)/, "\\1#{break_sequence}").strip : line
+        end * break_sequence
       end
 
       # Returns +text+ transformed into HTML using simple formatting rules.

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -366,6 +366,10 @@ class TextHelperTest < ActionView::TestCase
     assert_equal options, passed_options
   end
 
+  def test_word_wrap_with_custom_break_sequence
+    assert_equal("1234567890\r\n1234567890\r\n1234567890", word_wrap("1234567890 " * 3, line_width: 2, break_sequence: "\r\n"))
+  end
+
   def test_pluralization
     assert_equal("1 count", pluralize(1, "count"))
     assert_equal("2 counts", pluralize(2, "count"))


### PR DESCRIPTION
Sometimes you need a specific break sequence while using word wrap and as today the only option we have is "\n" and is hardcoded.

With this change you will be able to specify any break sequence ("\r\n" for example) as an option.
