### PR TITLE
[ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -443,6 +443,21 @@ module ActionDispatch
         #   dynamic segment used to generate the routes).
         #   You can access that segment from your controller using
         #   <tt>params[<:param>]</tt>.
+        #   In your router:
+        #
+        #      resources :user, param: :name
+        #
+        #   You can override <tt>ActiveRecord::Base#to_param</tt> of a related
+        #   model to constructe an URL.
+        #
+        #      class User < ActiveRecord::Base
+        #        def to_param  # overridden
+        #          name
+        #        end
+        #      end
+        #
+        #   user = User.find_by(name: 'Phusion')
+        #   user_path(user)  # => "/users/Phusion"
         #
         # [:path]
         #   The path prefix for the routes.

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -1087,6 +1087,20 @@ edit_videos GET  /videos/:identifier/edit(.:format) videos#edit
 Video.find_by(identifier: params[:identifier])
 ```
 
+You can override `ActiveRecord::Base#to_param` of a related
+model to constructe an URL.
+
+```ruby
+class Video < ActiveRecord::Base
+  def to_param  # overridden
+    identifier
+  end
+end
+
+video = Video.find_by(identifier: "Roman-Holiday")
+edit_videos_path(video) # => "/videos/Roman-Holiday"
+```
+
 Inspecting and Testing Routes
 -----------------------------
 


### PR DESCRIPTION
Add descriptions about `ActiveRecord::Base#to_param` to
- `ActionDispatch::Routing::Base#match`
- Overriding Named Route Parameters (guide)

When passes `:param` to route definision, always `to_param` method of
related model is overridden to constructe an URL by passing these
model instance to named_helper.
