### PR TITLE
Use memoization for collection associations ids reader

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -62,8 +62,10 @@ module ActiveRecord
             record.send(reflection.association_primary_key)
           end
         else
-          column  = "#{reflection.quoted_table_name}.#{reflection.association_primary_key}"
-          scope.pluck(column)
+          @association_ids ||= (
+            column = "#{reflection.quoted_table_name}.#{reflection.association_primary_key}"
+            scope.pluck(column)
+          )
         end
       end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2308,4 +2308,12 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_instance_of PostWithErrorDestroying, error.record
   end
+
+  def test_ids_reader_memoization
+    car = Car.create!(name: 'Tofaş')
+    bulb = Bulb.create!(car: car)
+
+    assert_equal [bulb.id], car.bulb_ids
+    assert_no_queries { car.bulb_ids }
+  end
 end


### PR DESCRIPTION
As far as I can see from the source of the Rails we don't need to set `@association_ids` to nil to force ActiveRecord to execute a query because if user changes the association either by calling records_writer or ids_writer the relation will be marked as loaded and rails will return ids from loaded collection.

Fixes #21082 
