### PR TITLE
Fix ambiguous argument warning

### DIFF
--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -18,7 +18,7 @@ module ActiveRecord
       developers = Developer.where(name: "David")
       last_developer_timestamp = developers.order(updated_at: :desc).first.updated_at
 
-      assert_match /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/, developers.cache_key
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/, developers.cache_key)
 
       /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/ =~ developers.cache_key
 


### PR DESCRIPTION
The warning is:
`warning: ambiguous first argument; put parentheses or a space even after `/' operator`
