### PR TITLE
correct example of button_tag [ci skip]

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -258,7 +258,7 @@ this generates
 
 ```html
 <form action="/articles/1" class="button_to" data-remote="true" method="post">
-  <div><input type="submit" value="An article"></div>
+  <input type="submit" value="An article" />
 </form>
 ```
 


### PR DESCRIPTION
wrapper div has been removed in cbb917455f306cf5818644b162f22be09f77d4b2
