### PR TITLE
Save a string allocation inside loop

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -154,12 +154,17 @@ module ActionView
           options.each_pair do |key, value|
             if TAG_PREFIXES.include?(key) && value.is_a?(Hash)
               value.each_pair do |k, v|
-                output << sep + prefix_tag_option(key, k, v, escape)
+                output << sep
+                output << prefix_tag_option(key, k, v, escape)
               end
             elsif BOOLEAN_ATTRIBUTES.include?(key)
-              output << sep + boolean_tag_option(key) if value
+              if value
+                output << sep
+                output << boolean_tag_option(key)
+              end
             elsif !value.nil?
-              output << sep + tag_option(key, value, escape)
+              output << sep
+              output << tag_option(key, value, escape)
             end
           end
           output unless output.empty?


### PR DESCRIPTION
This is a follow-up to #21057 as per https://github.com/rails/rails/pull/21057/files#r36039943

In the `tag_options` method, strings are continuously added to the `output` string. Previously, we concatenated two strings and added the generated string to `output`. By adding each of the strings to `output`, one after the other, we will save the allocation of that concatenated string.

Benchmark:

``` rb
require 'benchmark/ips'

sep = " ".freeze

Benchmark.ips do |x|
  x.report("string +") {
    output = ""
    output << sep + "foo"
  }
  x.report("string <<") {
    output = ""
    output << sep
    output << "foo"
  }
  x.compare!
end
```

Results (Ruby 2.2.2):

```
Calculating -------------------------------------
            string +    88.086k i/100ms
           string <<    94.287k i/100ms
-------------------------------------------------
            string +      2.407M (± 5.8%) i/s -     12.068M
           string <<      2.591M (± 7.0%) i/s -     12.917M

Comparison:
           string <<:  2591482.4 i/s
            string +:  2406883.7 i/s - 1.08x slower
```

cc @schneems 
