### PR TITLE
Use #start_with? and #[] for speed

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -676,8 +676,8 @@ module ActionDispatch
         # Remove leading slashes from controllers
         def normalize_controller!
           if controller
-            if m = controller.match(/\A\/(?<controller_without_leading_slash>.*)/)
-              @options[:controller] = m[:controller_without_leading_slash]
+            if controller.start_with?("/".freeze)
+              @options[:controller] = controller[1..-1]
             else
               @options[:controller] = controller
             end


### PR DESCRIPTION
This is a follow-up to #21057 as per https://github.com/rails/rails/pull/21057/files#r36032324

While the readability may be slightly worse, the speed improvement is significant: Twice as fast when there's no leading `/` to remove, and over 4 times as fast when there is a leading `/`.

Benchmark:

``` rb
require 'benchmark/ips'

def match(controller)
  if controller
    if m = controller.match(/\A\/(?<controller_without_leading_slash>.*)/)
      m[:controller_without_leading_slash]
    else
      controller
    end
  end
end

def start_with(controller)
  if controller
    if controller.start_with?('/'.freeze)
      controller[1..-1]
    else
      controller
    end
  end
end

Benchmark.ips do |x|
  x.report("match") { match("no_leading_slash") }
  x.report("start_with") { start_with("no_leading_slash") }

  x.compare!
end

Benchmark.ips do |x|
  x.report("match") { match("/a_leading_slash") }
  x.report("start_with") { start_with("/a_leading_slash") }

  x.compare!
end
```

Result (Ruby 2.2.2):

```
Calculating -------------------------------------
               match    70.324k i/100ms
          start_with   111.264k i/100ms
-------------------------------------------------
               match      1.468M (± 7.1%) i/s -      7.314M
          start_with      3.787M (± 3.5%) i/s -     18.915M

Comparison:
          start_with:  3787389.4 i/s
               match:  1467636.4 i/s - 2.58x slower

Calculating -------------------------------------
               match    36.694k i/100ms
          start_with    86.071k i/100ms
-------------------------------------------------
               match    532.795k (± 4.7%) i/s -      2.679M
          start_with      2.518M (± 5.8%) i/s -     12.566M

Comparison:
          start_with:  2518366.8 i/s
               match:   532794.5 i/s - 4.73x slower
```

cc @schneems 
