### PR TITLE
safe_join: use flat_map

### DIFF
--- a/actionview/lib/action_view/helpers/output_safety_helper.rb
+++ b/actionview/lib/action_view/helpers/output_safety_helper.rb
@@ -31,7 +31,7 @@ module ActionView #:nodoc:
       def safe_join(array, sep=$,)
         sep = ERB::Util.unwrapped_html_escape(sep)
 
-        array.flatten.map! { |i| ERB::Util.unwrapped_html_escape(i) }.join(sep).html_safe
+        array.flat_map{ |i| ERB::Util.unwrapped_html_escape(i) }.join(sep).html_safe
       end
     end
   end


### PR DESCRIPTION
The performance gain is quite small for flat arrays, it serve more like an example to transition to `flat_map` 

``` ruby
N = 100_000
ARRAY_DATA = %w[<b></b> <i></i>]
Benchmark.bmbm do |x|
  x.report 'flatten.map!' do
    N.times do 
      ARRAY_DATA.flatten.map!{ |i| ERB::Util.unwrapped_html_escape(i) }.join.html_safe
    end
  end

  x.report 'flat_map' do
    N.times do 
      ARRAY_DATA.flat_map{ |i| ERB::Util.unwrapped_html_escape(i) }.join.html_safe
    end
  end
end
```

```
Rehearsal ------------------------------------------------
flatten.map!   1.590000   0.010000   1.600000 (  1.597511)
flat_map       1.490000   0.000000   1.490000 (  1.496186)
--------------------------------------- total: 3.090000sec

                   user     system      total        real
flatten.map!   1.490000   0.000000   1.490000 (  1.493790)
flat_map       1.460000   0.000000   1.460000 (  1.462477)
```
