### PR TITLE
Inform user to add styles in correct location in application.css

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/assets/stylesheets/application.css
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/stylesheets/application.css
@@ -7,7 +7,8 @@
  *
  * You're free to add application-wide styles to this file and they'll appear at the bottom of the
  * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
- * files in this directory. It is generally better to create a new file per style scope.
+ * files in this directory. If you want to add any styles in this file, they should be added after the
+ * last require_* statement. It is generally better to create a new file per style scope.
  *
  *= require_tree .
  *= require_self

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/stylesheets.css
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/stylesheets.css
@@ -7,7 +7,8 @@
  *
  * You're free to add application-wide styles to this file and they'll appear at the bottom of the
  * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
- * files in this directory. It is generally better to create a new file per style scope.
+ * files in this directory. If you want to add any styles in this file, they should be added after the
+ * last require_* statement. It is generally better to create a new file per style scope.
  *
  *= require_tree .
  *= require_self


### PR DESCRIPTION
Hello Rails Team,
Ref Bug No : #21099
Description : Styles defined above require_ statement in application.css are having un-desired behaviour. After spending almost half day, i had to figure it out that correct location for them is below the last require_\* statement. From the rails team I came to know that this is a known behaviour. Updating this information will prevent users from futher encountering this difficulty.

With thanks and warm regards,
Atul
