### PR TITLE
Allow Minitest to load plugins. Fixes #21102

### DIFF
--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -48,4 +48,5 @@ module Minitest
   mattr_accessor(:run_with_rails_extension) { false }
 end
 
+Minitest.load_plugins
 Minitest.extensions << 'rails'


### PR DESCRIPTION
if/when we simply add extension to the list of extensions of Minitest before Minitest.load_plugins is called then Minitest will never search for other plugins and so it will be impossible to use custom reporter for rails.
