### PR TITLE
Should use `server_info[:version]` instead of `info[:version]`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -254,7 +254,7 @@ module ActiveRecord
       end
 
       def full_version
-        @full_version ||= @connection.info[:version]
+        @full_version ||= @connection.server_info[:version]
       end
 
       def set_field_encoding field_name


### PR DESCRIPTION
Because `info[:version]` is a client version, the server version is `server_info[:version]`.
