### PR TITLE
Reload I18n.load_path in development

### DIFF
--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -37,10 +37,12 @@ module I18n
       enforce_available_locales = I18n.enforce_available_locales if enforce_available_locales.nil?
       I18n.enforce_available_locales = false
 
+      reloadable_paths = []
       app.config.i18n.each do |setting, value|
         case setting
         when :railties_load_path
-          app.config.i18n.load_path.unshift(*value)
+          reloadable_paths = value
+          app.config.i18n.load_path.unshift(*value.map(&:existent).flatten)
         when :load_path
           I18n.load_path += value
         else
@@ -53,7 +55,14 @@ module I18n
       # Restore available locales check so it will take place from now on.
       I18n.enforce_available_locales = enforce_available_locales
 
-      reloader = ActiveSupport::FileUpdateChecker.new(I18n.load_path.dup){ I18n.reload! }
+      directories = watched_dirs_with_extensions(reloadable_paths)
+      reloader = ActiveSupport::FileUpdateChecker.new(I18n.load_path.dup, directories) do
+        I18n.load_path.keep_if { |p| File.exist?(p) }
+        I18n.load_path |= reloadable_paths.map(&:existent).flatten
+
+        I18n.reload!
+      end
+
       app.reloaders << reloader
       ActionDispatch::Reloader.to_prepare do
         reloader.execute_if_updated
@@ -94,6 +103,12 @@ module I18n
         true
       else
         raise "Unexpected fallback type #{fallbacks.inspect}"
+      end
+    end
+
+    def self.watched_dirs_with_extensions(paths)
+      paths.each_with_object({}) do |path, result|
+        result[path.absolute_current] = path.extensions
       end
     end
   end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -589,7 +589,7 @@ module Rails
     # I18n load paths are a special case since the ones added
     # later have higher priority.
     initializer :add_locales do
-      config.i18n.railties_load_path.concat(paths["config/locales"].existent)
+      config.i18n.railties_load_path << paths["config/locales"]
     end
 
     initializer :add_view_paths do

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -123,6 +123,11 @@ module Rails
         options[:load_path]     ? load_path!     : skip_load_path!
       end
 
+      # :nodoc:
+      def absolute_current
+        File.expand_path(@current, @root.path)
+      end
+
       def children
         keys = @root.keys.find_all { |k|
           k.start_with?(@current) && k != @current
@@ -173,6 +178,11 @@ module Rails
 
       def to_ary
         @paths
+      end
+
+      # :nodoc:
+      def extensions
+        $1.split(',') if @glob =~ /\{([\S]+)\}/
       end
 
       # Expands all paths against the root and return all unique values.

--- a/railties/test/application/initializers/i18n_test.rb
+++ b/railties/test/application/initializers/i18n_test.rb
@@ -132,6 +132,79 @@ en:
       assert_equal "2", last_response.body
     end
 
+    test "new locale files are loaded" do
+      add_to_config <<-RUBY
+        config.cache_classes = false
+      RUBY
+
+      app_file "config/locales/en.yml", <<-YAML
+en:
+  foo: "1"
+      YAML
+
+      app_file 'config/routes.rb', <<-RUBY
+        Rails.application.routes.draw do
+          get '/i18n',   :to => lambda { |env| [200, {}, [I18n.t(:foo)]] }
+        end
+      RUBY
+
+      require 'rack/test'
+      extend Rack::Test::Methods
+      load_app
+
+      get "/i18n"
+      assert_equal "1", last_response.body
+
+      # Wait a full second so we have time for changes to propagate
+      sleep(1)
+
+      remove_file "config/locales/en.yml"
+      app_file "config/locales/custom.en.yml", <<-YAML
+en:
+  foo: "2"
+      YAML
+
+      get "/i18n"
+      assert_equal "2", last_response.body
+    end
+
+    test "I18n.load_path is reloaded" do
+      add_to_config <<-RUBY
+        config.cache_classes = false
+      RUBY
+
+      app_file "config/locales/en.yml", <<-YAML
+en:
+  foo: "1"
+      YAML
+
+      app_file 'config/routes.rb', <<-RUBY
+        Rails.application.routes.draw do
+          get '/i18n',   :to => lambda { |env| [200, {}, [I18n.load_path.inspect]] }
+        end
+      RUBY
+
+      require 'rack/test'
+      extend Rack::Test::Methods
+      load_app
+
+      get "/i18n"
+
+      assert_match "en.yml", last_response.body
+
+      # Wait a full second so we have time for changes to propagate
+      sleep(1)
+
+      app_file "config/locales/fr.yml", <<-YAML
+fr:
+  foo: "2"
+      YAML
+
+      get "/i18n"
+      assert_match "fr.yml", last_response.body
+      assert_match "en.yml", last_response.body
+    end
+
     # Fallbacks
     test "not using config.i18n.fallbacks does not initialize I18n.fallbacks" do
       I18n.backend = Class.new(I18n::Backend::Simple).new

--- a/railties/test/paths_test.rb
+++ b/railties/test/paths_test.rb
@@ -62,6 +62,13 @@ class PathsTest < ActiveSupport::TestCase
     assert_equal ["/foo/bar/baz"], @root["app/models"].to_a
   end
 
+  test "absolute current path" do
+    @root.add "config"
+    @root.add "config/locales"
+
+    assert_equal "/foo/bar/config/locales", @root["config/locales"].absolute_current
+  end
+
   test "adding multiple physical paths as an array" do
     @root.add "app", with: ["/app", "/app2"]
     assert_equal ["/app", "/app2"], @root["app"].to_a
@@ -213,6 +220,12 @@ class PathsTest < ActiveSupport::TestCase
     @root["app"] = "/app"
     @root["app"].glob = "*.rb"
     assert_equal "*.rb", @root["app"].glob
+  end
+
+  test "it should be possible to get extensions by glob" do
+    @root["app"] = "/app"
+    @root["app"].glob = "*.{rb,yml}"
+    assert_equal ["rb", "yml"], @root["app"].extensions
   end
 
   test "it should be possible to override a path's default glob without assignment" do


### PR DESCRIPTION
Right now, when you add new locale file in development, `rails server` should be restarted to catch new YAML files.

Of course we add new locales not so often, but in huge Rails app single locale is separated by many files, like: `billing.en.yml`, `admin.en.yml`, `dashboard.en.yml`. This patch could be quite useful in this kind of situations.

This patch also solved the case when locale file was deleted, because right now I18n would raise an error.

Generally, if we use reloading for all kinds of resources in development, why don't we use it for locales?

/cc @rafaelfranca @Sirupsen 
