### PR TITLE
Fix Encoding::UndefinedConversionError with multibyte UTF-8 filename containing "%" character

### DIFF
--- a/actionpack/lib/action_dispatch/http/upload.rb
+++ b/actionpack/lib/action_dispatch/http/upload.rb
@@ -28,7 +28,13 @@ module ActionDispatch
         raise(ArgumentError, ':tempfile is required') unless @tempfile
 
         @original_filename = hash[:filename]
-        @original_filename &&= @original_filename.encode "UTF-8"
+        if @original_filename
+          begin
+            @original_filename.encode!(Encoding::UTF_8)
+          rescue EncodingError
+            @original_filename.force_encoding(Encoding::UTF_8)
+          end
+        end
         @content_type      = hash[:type]
         @headers           = hash[:head]
       end

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -63,6 +63,17 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
     assert_equal 'contents', file.read
   end
 
+  test "parses utf8 filename with percent character" do
+    params = parse_multipart('utf8_filename')
+    assert_equal %w(file foo), params.keys.sort
+    assert_equal 'bar', params['foo']
+
+    file = params['file']
+    assert_equal 'ファイル%名.txt', file.original_filename
+    assert_equal "text/plain", file.content_type
+    assert_equal 'contents', file.read
+  end
+
   test "parses boundary problem file" do
     params = parse_multipart('boundary_problem_file')
     assert_equal %w(file foo), params.keys.sort

--- a/actionpack/test/fixtures/multipart/utf8_filename
+++ b/actionpack/test/fixtures/multipart/utf8_filename
@@ -1,0 +1,10 @@
+--AaB03x
+Content-Disposition: form-data; name="foo"
+
+bar
+--AaB03x
+Content-Disposition: form-data; name="file"; filename="ファイル%名.txt"
+Content-Type: text/plain
+
+contents
+--AaB03x--


### PR DESCRIPTION
This sould fix #21119 .

I don't think `String#force_encoding` is the best way, but Rails 4.1.x used `String#force_encoding` .
https://github.com/rails/rails/blob/4-1-stable/actionpack/lib/action_dispatch/http/upload.rb#L71-L74
