### PR TITLE
Fix Persistance#become bug with wrong errors base

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -215,6 +215,7 @@ module ActiveRecord
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became.instance_variable_set("@errors", errors)
+      became.errors.instance_variable_set("@base", became)
       became
     end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -152,6 +152,7 @@ class PersistenceTest < ActiveRecord::TestCase
     original_errors = company.errors
     client = company.becomes(Client)
     assert_equal original_errors, client.errors
+    assert_equal client, client.errors.instance_variable_get("@base")
   end
 
   def test_dupd_becomes_persists_changes_from_the_original


### PR DESCRIPTION
The problem is that _copied_ `errors` object contains reference to the origin record (`@base` variable) instead of `became`. If we have, for example, different store accessors with validations in base class and became class, `Errors#generate_message` fails calling `read_attribute_for_validation`.

Test case can be found here: https://gist.github.com/palkan/7599122ed095c7000553 .
