### PR TITLE
stop using deprecated `render :text` in railties

### DIFF
--- a/railties/lib/rails/application_controller.rb
+++ b/railties/lib/rails/application_controller.rb
@@ -6,7 +6,7 @@ class Rails::ApplicationController < ActionController::Base # :nodoc:
 
   def require_local!
     unless local_request?
-      render text: '<p>For security purposes, this information is only available to local requests.</p>', status: :forbidden
+      render html: '<p>For security purposes, this information is only available to local requests.</p>'.html_safe, status: :forbidden
     end
   end
 

--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -26,7 +26,7 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
 
           if part = find_part(part_type)
             response.content_type = part_type
-            render text: part.respond_to?(:decoded) ? part.decoded : part
+            render plain: part.respond_to?(:decoded) ? part.decoded : part
           else
             raise AbstractController::ActionNotFound, "Email part '#{part_type}' not found in #{@preview.name}##{@email_action}"
           end


### PR DESCRIPTION
follow-up to #20917
