### PR TITLE
Support time zone conversion for custom types

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -7,28 +7,14 @@ module ActiveRecord
         end
 
         def cast(value)
-          if value.is_a?(Array)
-            value.map { |v| cast(v) }
-          elsif value.is_a?(Hash)
+          if value.is_a?(Hash)
             set_time_zone_without_conversion(super)
-          elsif value.respond_to?(:in_time_zone)
+          else
             begin
               user_input_in_time_zone(value) || super
             rescue ArgumentError
               nil
             end
-          end
-        end
-
-        private
-
-        def convert_time_to_time_zone(value)
-          if value.is_a?(Array)
-            value.map { |v| convert_time_to_time_zone(v) }
-          elsif value.acts_like?(:time)
-            value.in_time_zone
-          else
-            value
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -6,7 +6,7 @@ module ActiveRecord
           include Type::Helpers::Mutable
 
           attr_reader :subtype, :delimiter
-          delegate :type, :user_input_in_time_zone, :limit, to: :subtype
+          delegate :type, :limit, to: :subtype
 
           def initialize(subtype, delimiter = ',')
             @subtype = subtype
@@ -48,6 +48,16 @@ module ActiveRecord
           def type_cast_for_schema(value)
             return super unless value.is_a?(::Array)
             "[" + value.map { |v| subtype.type_cast_for_schema(v) }.join(", ") + "]"
+          end
+
+          def user_input_in_time_zone(value)
+            return unless value.is_a?(::Array) && subtype.respond_to?(:user_input_in_time_zone)
+            value.map { |v| subtype.user_input_in_time_zone(v) }
+          end
+
+          def convert_time_to_time_zone(value)
+            return value unless value.is_a?(::Array) && subtype.respond_to?(:convert_time_to_time_zone)
+            value.map { |v| subtype.convert_time_to_time_zone(v) }
           end
 
           private

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
@@ -46,6 +46,22 @@ module ActiveRecord
               other.type == type
           end
 
+          def user_input_in_time_zone(value)
+            return unless value.is_a?(::Range) && subtype.respond_to?(:user_input_in_time_zone)
+            ::Range.new(
+              subtype.user_input_in_time_zone(value.begin),
+              subtype.user_input_in_time_zone(value.end)
+            )
+          end
+
+          def convert_time_to_time_zone(value)
+            return value unless value.is_a?(::Range) && subtype.respond_to?(:convert_time_to_time_zone)
+            ::Range.new(
+              subtype.convert_time_to_time_zone(value.begin),
+              subtype.convert_time_to_time_zone(value.end)
+            )
+          end
+
           private
 
           def type_cast_single(value)

--- a/activerecord/lib/active_record/type/helpers/time_value.rb
+++ b/activerecord/lib/active_record/type/helpers/time_value.rb
@@ -25,7 +25,15 @@ module ActiveRecord
         end
 
         def user_input_in_time_zone(value)
-          value.in_time_zone
+          value.try(:in_time_zone)
+        end
+
+        def convert_time_to_time_zone(value)
+          if value.acts_like?(:time)
+            value.in_time_zone
+          else
+            value
+          end
         end
 
         private

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -4,11 +4,13 @@ require 'support/connection_helper'
 if ActiveRecord::Base.connection.respond_to?(:supports_ranges?) && ActiveRecord::Base.connection.supports_ranges?
   class PostgresqlRange < ActiveRecord::Base
     self.table_name = "postgresql_ranges"
+    self.time_zone_aware_types = [:datetime, :tsrange, :tstzrange]
   end
 
   class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
     self.use_transactional_tests = false
     include ConnectionHelper
+    include InTimeZone
 
     def setup
       @connection = PostgresqlRange.connection
@@ -174,6 +176,26 @@ _SQL
                             Time.parse('2010-01-01 14:30:00 +0100')...Time.parse('2010-01-01 13:30:00 +0000'))
     end
 
+    def test_timezone_awareness_tzrange
+      tz = "Pacific Time (US & Canada)"
+
+      in_time_zone tz do
+        PostgresqlRange.reset_column_information
+        time_string = Time.current.to_s
+        time = Time.zone.parse(time_string)
+
+        record = PostgresqlRange.new(tstz_range: time_string..time_string)
+        assert_equal time..time, record.tstz_range
+        assert_equal ActiveSupport::TimeZone[tz], record.tstz_range.begin.time_zone
+
+        record.save!
+        record.reload
+
+        assert_equal time..time, record.tstz_range
+        assert_equal ActiveSupport::TimeZone[tz], record.tstz_range.begin.time_zone
+      end
+    end
+
     def test_create_tsrange
       tz = ::ActiveRecord::Base.default_timezone
       assert_equal_round_trip(@new_range, :ts_range,
@@ -186,6 +208,26 @@ _SQL
                               Time.send(tz, 2010, 1, 1, 14, 30, 0)...Time.send(tz, 2011, 2, 2, 14, 30, 0))
       assert_nil_round_trip(@first_range, :ts_range,
                             Time.send(tz, 2010, 1, 1, 14, 30, 0)...Time.send(tz, 2010, 1, 1, 14, 30, 0))
+    end
+
+    def test_timezone_awareness_tsrange
+      tz = "Pacific Time (US & Canada)"
+
+      in_time_zone tz do
+        PostgresqlRange.reset_column_information
+        time_string = Time.current.to_s
+        time = Time.zone.parse(time_string)
+
+        record = PostgresqlRange.new(ts_range: time_string..time_string)
+        assert_equal time..time, record.ts_range
+        assert_equal ActiveSupport::TimeZone[tz], record.ts_range.begin.time_zone
+
+        record.save!
+        record.reload
+
+        assert_equal time..time, record.ts_range
+        assert_equal ActiveSupport::TimeZone[tz], record.ts_range.begin.time_zone
+      end
     end
 
     def test_create_numrange


### PR DESCRIPTION
For now, time aware values conversion logic is shared between `TimeZoneConversion` module and types themselves (`TimeValue` helper).

And it makes it difficult to implement time zone conversion for custom types, for example, [tsrange](https://github.com/rails/rails/issues/21116).

I've extracted some logic from module to types (and added support for `tsrange`).
