### PR TITLE
Optimize enumerable methods for collection associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Optimize `none?` and `one?` methods for `CollectionAssociation` class to prevent
+    of loading the entire records into memory when no block given.
+
+    *Vitalik Danchenko*
+
 *   Add `cache_key` to ActiveRecord::Relation.
 
     Example:

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -336,6 +336,17 @@ module ActiveRecord
         end
       end
 
+      # Returns true if the collections is empty.
+      # If block given, loads all records and checks that none matches with criteria.
+      # Otherwise, equivalent to +collection.empty?+.
+      def none?
+        if block_given?
+          load_target.none? { |*block_args| yield(*block_args) }
+        else
+          empty?
+        end
+      end
+
       # Returns true if the collections is not empty.
       # If block given, loads all records and checks for one or more matches.
       # Otherwise, equivalent to +!collection.empty?+.
@@ -346,6 +357,17 @@ module ActiveRecord
           !empty?
         end
       end
+
+      # Returns true if the collections has exactly 1 record.
+      # If block given, loads all records and checks exactly one match.
+      # Otherwise, equivalent to +!collection.size == 1+.
+      def one?
+        if block_given?
+          load_target.one? { |*block_args| yield(*block_args) }
+        else
+          size == 1
+        end
+      end      
 
       # Returns true if the collection has more than 1 record.
       # If block given, loads all records and checks for two or more matches.

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -771,6 +771,39 @@ module ActiveRecord
         @association.empty?
       end
 
+      # Returns +true+ if the collection is empty.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets.count # => 0
+      #   person.pets.none?  # => true
+      #
+      #   person.pets << Pet.new(name: 'Snoop')
+      #   person.pets.count # => 1
+      #   person.pets.none?  # => false
+      #
+      # You can also pass a +block+ to define criteria. The behavior
+      # is the same, it returns true if the collection based on the
+      # criteria is not empty.
+      #
+      #   person.pets
+      #   # => [#<Pet name: "Snoop", group: "dogs">]
+      #
+      #   person.pets.none? do |pet|
+      #     pet.group == 'cats'
+      #   end
+      #   # => true
+      #
+      #   person.pets.none? do |pet|
+      #     pet.group == 'dogs'
+      #   end
+      #   # => false
+      def none?(&block)
+        @association.none?(&block)
+      end
+
       # Returns +true+ if the collection is not empty.
       #
       #   class Person < ActiveRecord::Base
@@ -802,6 +835,43 @@ module ActiveRecord
       #   # => true
       def any?(&block)
         @association.any?(&block)
+      end
+      
+      # Returns +true+ if the collection has exactly one record.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets.count # => 0
+      #   person.pets.one?  # => false
+      #
+      #   person.pets << Pet.new(name: 'Snoop')
+      #   person.pets.count # => 1
+      #   person.pets.one?  # => true
+      #
+      #   person.pets << Pet.new(name: 'Hot')
+      #   person.pets.count # => 2
+      #   person.pets.one?  # => false
+      #
+      # You can also pass a +block+ to define criteria. The behavior
+      # is the same, it returns true if the collection based on the
+      # criteria has exactly one record.
+      #
+      #   person.pets
+      #   # => [#<Pet name: "Snoop", group: "dogs">, #<Pet name: "Hot", group: "dogs">]
+      #
+      #   person.pets.one? do |pet|
+      #     pet.name == 'Snoop'
+      #   end
+      #   # => true
+      #
+      #   person.pets.one? do |pet|
+      #     pet.group == 'dogs'
+      #   end
+      #   # => false
+      def one?(&block)
+        @association.one?(&block)
       end
 
       # Returns true if the collection has more than one record.

--- a/activerecord/test/cases/associations/collection_associations_test.rb
+++ b/activerecord/test/cases/associations/collection_associations_test.rb
@@ -1,0 +1,117 @@
+require "cases/helper"
+require 'models/computer'
+require 'models/developer'
+require 'models/computer'
+require 'models/project'
+require 'models/company'
+
+class CollectionAssociationTest < ActiveRecord::TestCase
+  fixtures :developers, :projects, :developers_projects, :companies, :computers
+
+  def test_size
+    projects = Developer.first.projects
+
+    assert_queries(1) { assert_equal 2, projects.size }
+
+    assert ! projects.loaded?
+    projects.to_a # force load
+    assert_no_queries { assert_equal 2, projects.size }
+  end
+
+  def test_size_with_limit
+    projects = Developer.first.projects.limit(1)
+
+    assert_queries(1) { assert_equal 1, projects.size }
+
+    assert ! projects.loaded?
+    projects.to_a # force load
+    assert_no_queries { assert_equal 1, projects.size }
+  end
+
+  def test_size_with_zero_limit
+    projects = Developer.first.projects.limit(0)
+
+    assert_no_queries { assert_equal 0, projects.size }
+
+    assert ! projects.loaded?
+    projects.to_a # force load
+    assert_no_queries { assert_equal 0, projects.size }
+  end
+
+  def test_empty
+    projects = Developer.first.projects
+
+    assert_queries(1) { assert_equal false, projects.empty? }
+    assert ! projects.loaded?
+    projects.to_a # force load
+    assert_no_queries { assert_equal false, projects.empty? }
+
+    no_projects = projects.where(:name => "")
+    assert_queries(1) { assert_equal true, no_projects.empty? }
+    assert ! no_projects.loaded?
+  end
+
+  def test_empty_with_zero_limit
+    projects = Developer.first.projects.limit(0)
+
+    assert_no_queries { assert_equal true, projects.empty? }
+    assert ! projects.loaded?
+  end
+
+
+
+  def test_none
+    projects = Developer.first.projects
+
+    assert_queries(1) { assert_equal false, projects.none? }
+    assert ! projects.loaded?
+
+    assert_queries(1) { assert_equal false, projects.none? { |p| p.id > 0} }
+    assert projects.loaded?
+
+    assert_no_queries { assert_equal true, projects.none? { |p| p.id < 0 } }
+  end
+
+  def test_any
+    projects = Developer.first.projects
+
+    assert_queries(1) { assert_equal true, projects.any? }
+    assert ! projects.loaded?
+
+    assert_queries(1) { assert_equal true, projects.any? { |p| p.id > 0 } }
+    assert projects.loaded?
+
+    assert_no_queries { assert_equal false, projects.any? { |p| p.id < 0 } }
+  end
+
+  def test_one
+    projects = Developer.first.projects
+
+    assert_queries(1) { assert_equal false, projects.one? }
+    assert ! projects.loaded?
+
+    assert_queries(1) { assert_equal true, projects.one? { |p| p.id == 1 } }
+    assert projects.loaded?
+
+    assert_no_queries { assert_equal false, projects.one? { |p| p.id < 0 } }
+  end
+
+  def test_many
+    projects = Developer.first.projects
+
+    assert_queries(1) { assert_equal true, projects.many? }
+    assert ! projects.loaded?
+
+    assert_queries(1) { assert_equal false, projects.many? { |p| p.id == 1 } }
+    assert projects.loaded?
+
+    assert_no_queries { assert_equal false, projects.many? { |p| p.id < 0 } }
+  end
+
+  def test_many_with_limits
+    projects = Developer.first.projects
+    
+    assert_queries(1) { assert_equal true, projects.many? }
+    assert_queries(1) { assert_equal false, projects.limit(1).many? }
+  end
+end


### PR DESCRIPTION
Optimize `none?` and `one?` methods for `CollectionAssociation` class to prevent of loading the entire records into memory when no block given. And of course tests.
