### PR TITLE
Enum as a human value

### DIFF
--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -28,6 +28,15 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal "visible", @book.illustrator_visibility
   end
 
+  test "human value of the state" do
+    I18n.backend.store_translations 'en', :activerecord => {:enums => {:book => {:status => {:published => "Published human form"} } } }
+    assert_equal "Published human form", @book.status.human
+  end
+
+  test "respond correctly to #to_s" do
+    assert_equal "published", @book.status.to_s
+  end
+
   test "find via scope" do
     assert_equal @book, Book.published.first
     assert_equal @book, Book.read.first


### PR DESCRIPTION
Hey guys,

Makes sense the I18n be part of the enum? I know that the idea is to [map a set of states](https://github.com/rails/rails/issues/13971#issuecomment-34530922). But these states may or may not be showed on the interface.

Today we show only the state:

``` ruby
@book.status # => published
```

The idea is that we have a method that show this in a human form like

``` ruby
@book.status.human # => Published
```

We have a similar idiom on [`Model.model_name.human`](http://api.rubyonrails.org/classes/ActiveModel/Name.html#method-i-human) and [`Model.human_attribute_name(attribute)`](http://api.rubyonrails.org/v4.1.1/classes/ActiveModel/Translation.html#method-i-human_attribute_name).

I started the code to [expose the idea and gather some feedback](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#what-about-feature-requests-questionmark). If you guys agree with this I can continue on it, improve the code(I made a proof of concept only to make the tests green), add more tests, add docs etc.

Thanks
