### PR TITLE
do not add common ports to HTTP_HOST

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -325,7 +325,11 @@ module ActionDispatch
           if path =~ %r{://}
             location = URI.parse(path)
             https! URI::HTTPS === location if location.scheme
-            host! "#{location.host}:#{location.port}" if location.host
+            if url_host = location.host
+              default = Rack::Request::DEFAULT_PORTS[location.scheme]
+              url_host += ":#{location.port}" if default != location.port
+              host! url_host
+            end
             path = location.query ? "#{location.path}?#{location.query}" : location.path
           end
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -755,6 +755,25 @@ class MetalIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal "http://test.com/", @request.env["HTTP_REFERER"]
   end
 
+  def test_ignores_common_ports_in_host
+    get "http://test.com"
+    assert_equal "test.com", @request.env["HTTP_HOST"]
+
+    get "https://test.com"
+    assert_equal "test.com", @request.env["HTTP_HOST"]
+  end
+
+  def test_keeps_uncommon_ports_in_host
+    get "http://test.com:123"
+    assert_equal "test.com:123", @request.env["HTTP_HOST"]
+
+    get "http://test.com:443"
+    assert_equal "test.com:443", @request.env["HTTP_HOST"]
+
+    get "https://test.com:80"
+    assert_equal "test.com:80", @request.env["HTTP_HOST"]
+  end
+
 end
 
 class ApplicationIntegrationTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
- webservers do not do it
- it makes redirect urls ugly when request.host is used for redirection

@josh @rafaelfranca @spastorino @pixeltrix 
