### PR TITLE
Prevent the default block for mattr_accessor being called multiple times

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
@@ -206,7 +206,7 @@ class Module
   #   Person.class_variable_get("@@hair_colors") # => [:brown, :black, :blonde, :red]
   def mattr_accessor(*syms, &blk)
     mattr_reader(*syms, &blk)
-    mattr_writer(*syms, &blk)
+    mattr_writer(*syms)
   end
   alias :cattr_accessor :mattr_accessor
 end

--- a/activesupport/test/core_ext/module/attribute_accessor_test.rb
+++ b/activesupport/test/core_ext/module/attribute_accessor_test.rb
@@ -76,4 +76,10 @@ class ModuleAttributeAccessorTest < ActiveSupport::TestCase
     assert_equal 'default_reader_value', @module.defr
     assert_equal 'default_writer_value', @module.class_variable_get('@@defw')
   end
+
+  def test_should_not_invoke_default_value_block_multiple_times
+    count = 0
+    @module.cattr_accessor(:defcount){ count += 1 }
+    assert_equal 1, count
+  end
 end


### PR DESCRIPTION
Currently `mattr_accessor` with a block will invoke the block both when defining the writer and reader to set the default value. 

It the block is not idempotent, then this causes unexpected behaviour.

This removes the default block being passed to the writer, as it is not required as it is already set as the default value by the reader.
