### PR TITLE
Add `data: { disable_with: Submitting... }` to forms

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `data: { disable_with: 'Submitting...' }` to forms, to disable
+    hitting a form's submit button multiple times.
+
+    *Jon Moss*
+
 *   Add `bin/update` script to update development environment automatically.
 
     *Mehmet Emin İNAÇ*

--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
@@ -29,6 +29,6 @@
 
 <% end -%>
   <div class="actions">
-    <%%= f.submit %>
+    <%%= f.submit data: { disable_with: 'Submitting...' } %>
   </div>
 <%% end %>


### PR DESCRIPTION
Seems like the best way to prevent users from double/triple/etc clicking on forms.

cc @derekprior @sgrif :bike: 
