### PR TITLE
Move minitest to a development dependency

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'i18n',       '~> 0.7'
   s.add_dependency 'json',       '~> 1.7', '>= 1.7.7'
   s.add_dependency 'tzinfo',     '~> 1.1'
-  s.add_dependency 'minitest',   '~> 5.1'
   s.add_dependency 'thread_safe','~> 0.3', '>= 0.3.4'
   s.add_dependency 'concurrent-ruby', '~> 0.9.0'
+  s.add_development_dependency 'minitest',   '~> 5.1'
 end


### PR DESCRIPTION
I believe minitest is only required for developers of activesupport, not for users, and not in production. Quoting http://guides.rubygems.org/specification-reference/#add_development_dependency : "Development dependencies aren't installed by default and aren't activated when a gem is required."
