### PR TITLE
use correct DB connection for generated HABTM table

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -46,7 +46,7 @@ module ActiveRecord::Associations::Builder
 
       join_model = Class.new(ActiveRecord::Base) {
         class << self;
-          attr_accessor :class_resolver
+          attr_accessor :habtm_lhs_model
           attr_accessor :name
           attr_accessor :table_name_resolver
           attr_accessor :left_reflection
@@ -58,7 +58,7 @@ module ActiveRecord::Associations::Builder
         end
 
         def self.compute_type(class_name)
-          class_resolver.compute_type class_name
+          habtm_lhs_model.compute_type class_name
         end
 
         def self.add_left_association(name, options)
@@ -72,11 +72,15 @@ module ActiveRecord::Associations::Builder
           self.right_reflection = _reflect_on_association(rhs_name)
         end
 
+        def self.retrieve_connection
+          habtm_lhs_model.retrieve_connection
+        end
+
       }
 
       join_model.name                = "HABTM_#{association_name.to_s.camelize}"
       join_model.table_name_resolver = habtm
-      join_model.class_resolver      = lhs_model
+      join_model.habtm_lhs_model     = lhs_model
 
       join_model.add_left_association :left_side, anonymous_class: lhs_model
       join_model.add_right_association association_name, belongs_to_options(options)

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -3,6 +3,7 @@ require 'models/developer'
 require 'models/computer'
 require 'models/project'
 require 'models/company'
+require 'models/course'
 require 'models/customer'
 require 'models/order'
 require 'models/categorization'
@@ -14,6 +15,7 @@ require 'models/tagging'
 require 'models/parrot'
 require 'models/person'
 require 'models/pirate'
+require 'models/professor'
 require 'models/treasure'
 require 'models/price_estimate'
 require 'models/club'
@@ -916,5 +918,15 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_nothing_raised NoMethodError do
       DeveloperWithSymbolClassName.new
     end
+  end
+
+  def test_alternate_database
+    professor = Professor.create(name: "Plum")
+    course = Course.create(name: "Forensics")
+    assert_equal 0, professor.courses.count
+    assert_nothing_raised do
+      professor.courses << course
+    end
+    assert_equal 1, professor.courses.count
   end
 end

--- a/activerecord/test/models/professor.rb
+++ b/activerecord/test/models/professor.rb
@@ -1,0 +1,5 @@
+require_dependency 'models/arunit2_model'
+
+class Professor < ARUnit2Model
+  has_and_belongs_to_many :courses
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -908,3 +908,12 @@ end
 College.connection.create_table :colleges, force: true do |t|
   t.column :name, :string, null: false
 end
+
+Professor.connection.create_table :professors, force: true do |t|
+  t.column :name, :string, null: false
+end
+
+Professor.connection.create_table :courses_professors, id: false, force: true do |t|
+  t.references :course
+  t.references :professor
+end

--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -1,6 +1,7 @@
 require 'active_support/logger'
 require 'models/college'
 require 'models/course'
+require 'models/professor'
 
 module ARTest
   def self.connection_name


### PR DESCRIPTION
This is a proposal to fix #21113 by overriding `retrieve_connection` for the generated model class to proxy to the model declaring the association.
