### PR TITLE
actionpack: Code style optimization

### DIFF
--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -80,14 +80,14 @@ module ActionMailer
 
         def set_expected_mail
           @expected = Mail.new
-          @expected.content_type ["text", "plain", { "charset" => charset }]
+          @expected.content_type ['text', 'plain', { 'charset' => charset }]
           @expected.mime_version = '1.0'
         end
 
       private
 
         def charset
-          "UTF-8"
+          'UTF-8'
         end
 
         def encode(subject)

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -2,8 +2,8 @@ require 'rake/testtask'
 
 test_files = Dir.glob('test/**/*_test.rb')
 
-desc "Default Task"
-task :default => :test
+desc 'Default Task'
+task default: :test
 
 # Run the unit tests
 Rake::TestTask.new do |t|
@@ -12,20 +12,20 @@ Rake::TestTask.new do |t|
 
   t.warning = true
   t.verbose = true
-  t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
+  t.ruby_opts = ['--dev'] if defined?(JRUBY_VERSION)
 end
 
 namespace :test do
   task :isolated do
     test_files.all? do |file|
       sh(Gem.ruby, '-w', '-Ilib:test', file)
-    end or raise "Failures"
+    end or raise 'Failures'
   end
 end
 
 task :lines do
   load File.expand_path('..', File.dirname(__FILE__)) + '/tools/line_statistics'
-  files = FileList["lib/**/*.rb"]
+  files = FileList['lib/**/*.rb']
   CodeTools::LineStatistics.new(files).print_loc
 end
 

--- a/actionpack/lib/abstract_controller.rb
+++ b/actionpack/lib/abstract_controller.rb
@@ -10,7 +10,7 @@ module AbstractController
   autoload :Base
   autoload :Callbacks
   autoload :Collector
-  autoload :DoubleRenderError, "abstract_controller/rendering"
+  autoload :DoubleRenderError, 'abstract_controller/rendering'
   autoload :Helpers
   autoload :Logger
   autoload :Rendering

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -1,6 +1,6 @@
 require 'action_view'
-require "action_controller/log_subscriber"
-require "action_controller/metal/params_wrapper"
+require 'action_controller/log_subscriber'
+require 'action_controller/metal/params_wrapper'
 
 module ActionController
   # Action Controllers are the core of a web request in \Rails. They are made up of one or more actions that are executed

--- a/actionpack/lib/action_controller/caching.rb
+++ b/actionpack/lib/action_controller/caching.rb
@@ -41,9 +41,10 @@ module ActionController
       end
 
       private
-        def cache_configured?
-          perform_caching && cache_store
-        end
+
+      def cache_configured?
+        perform_caching && cache_store
+      end
     end
 
     include RackDelegation

--- a/actionpack/lib/action_controller/caching/fragments.rb
+++ b/actionpack/lib/action_controller/caching/fragments.rb
@@ -19,7 +19,7 @@ module ActionController
       # cached fragment. All keys are prefixed with <tt>views/</tt> and uses
       # ActiveSupport::Cache.expand_cache_key for the expansion.
       def fragment_cache_key(key)
-        ActiveSupport::Cache.expand_cache_key(key.is_a?(Hash) ? url_for(key).split("://").last : key, :views)
+        ActiveSupport::Cache.expand_cache_key(key.is_a?(Hash) ? url_for(key).split('://'.freeze).last : key, :views)
       end
 
       # Writes +content+ to the location signified by

--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -25,7 +25,7 @@ module ActionController
           status = ActionDispatch::ExceptionWrapper.status_code_for_exception(exception_class_name)
         end
         message = "Completed #{status} #{Rack::Utils::HTTP_STATUS_CODES[status]} in #{event.duration.round}ms"
-        message << " (#{additions.join(" | ".freeze)})" unless additions.blank?
+        message << " (#{additions.join(' | '.freeze)})" unless additions.blank?
         message
       end
     end

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -126,10 +126,10 @@ module ActionController
     # environment and response manually for performance reasons.
 
     attr_internal :headers, :response, :request
-    delegate :session, :to => "@_request"
+    delegate :session, to: '@_request'
 
     def initialize
-      @_headers = {"Content-Type" => "text/html"}
+      @_headers = { 'Content-Type' => 'text/html' }
       @_status = 200
       @_request = nil
       @_response = nil
@@ -150,19 +150,19 @@ module ActionController
     # in Renderer and Redirector.
 
     def content_type=(type)
-      headers["Content-Type"] = type.to_s
+      headers['Content-Type'] = type.to_s
     end
 
     def content_type
-      headers["Content-Type"]
+      headers['Content-Type']
     end
 
     def location
-      headers["Location"]
+      headers['Location']
     end
 
     def location=(url)
-      headers["Location"] = url
+      headers['Location'] = url
     end
 
     # Basic url_for that can be overridden for more robust functionality

--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -199,20 +199,20 @@ module ActionController
     # The method will also ensure a HTTP Date header for client compatibility.
     def expires_in(seconds, options = {})
       response.cache_control.merge!(
-        :max_age         => seconds,
-        :public          => options.delete(:public),
-        :must_revalidate => options.delete(:must_revalidate)
+        max_age: seconds,
+        public: options.delete(:public),
+        must_revalidate: options.delete(:must_revalidate)
       )
       options.delete(:private)
 
-      response.cache_control[:extras] = options.map {|k,v| "#{k}=#{v}"}
+      response.cache_control[:extras] = options.map { |k,v| "#{k}=#{v}" }
       response.date = Time.now unless response.date?
     end
 
     # Sets a HTTP 1.1 Cache-Control header of <tt>no-cache</tt> so no caching should
     # occur by the browser or intermediate caches (like caching proxy servers).
     def expires_now
-      response.cache_control.replace(:no_cache => true)
+      response.cache_control.replace(no_cache: true)
     end
 
     # Cache or yield the block. The cache is supposed to never expire.
@@ -226,7 +226,7 @@ module ActionController
     #
     # * +version+: the version passed as a key for the cache.
     def http_cache_forever(public: false, version: 'v1')
-      expires_in 100.years, public: public
+      expires_in(100.years, public: public)
 
       yield if stale?(etag: "#{version}-#{request.fullpath}",
                       last_modified: Time.parse('2011-01-01').utc,
@@ -234,9 +234,9 @@ module ActionController
     end
 
     private
-      def combine_etags(options)
-        etags = etaggers.map { |etagger| instance_exec(options, &etagger) }.compact
-        etags.unshift options[:etag]
-      end
+    def combine_etags(options)
+      etags = etaggers.map { |etagger| instance_exec(options, &etagger) }.compact
+      etags.unshift(options[:etag])
+    end
   end
 end

--- a/actionpack/lib/action_controller/metal/cookies.rb
+++ b/actionpack/lib/action_controller/metal/cookies.rb
@@ -9,8 +9,8 @@ module ActionController #:nodoc:
     end
 
     private
-      def cookies
-        request.cookie_jar
-      end
+    def cookies
+      request.cookie_jar
+    end
   end
 end

--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -19,6 +19,7 @@ module ActionController
 
   class RoutingError < ActionControllerError #:nodoc:
     attr_reader :failures
+
     def initialize(message, failures=[])
       super(message)
       @failures = failures
@@ -30,7 +31,7 @@ module ActionController
 
   class MethodNotAllowed < ActionControllerError #:nodoc:
     def initialize(*allowed_methods)
-      super("Only #{allowed_methods.to_sentence(:locale => :en)} requests are allowed.")
+      super("Only #{allowed_methods.to_sentence(locale: :en)} requests are allowed.")
     end
   end
 

--- a/actionpack/lib/action_controller/metal/force_ssl.rb
+++ b/actionpack/lib/action_controller/metal/force_ssl.rb
@@ -76,10 +76,10 @@ module ActionController
     def force_ssl_redirect(host_or_options = nil)
       unless request.ssl?
         options = {
-          :protocol => 'https://',
-          :host     => request.host,
-          :path     => request.fullpath,
-          :status   => :moved_permanently
+          protocol: 'https://',
+          host:     request.host,
+          path:     request.fullpath,
+          status:   :moved_permanently
         }
 
         if host_or_options.is_a?(Hash)
@@ -90,7 +90,7 @@ module ActionController
 
         secure_url = ActionDispatch::Http::URL.url_for(options.slice(*URL_OPTIONS))
         flash.keep if respond_to?(:flash)
-        redirect_to secure_url, options.slice(*REDIRECT_OPTIONS)
+        redirect_to(secure_url, options.slice(*REDIRECT_OPTIONS))
       end
     end
   end

--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -28,7 +28,7 @@ module ActionController
       end
 
       status ||= :ok
-      
+
       location = options.delete(:location)
       content_type = options.delete(:content_type)
 
@@ -39,7 +39,7 @@ module ActionController
       self.status = status
       self.location = url_for(location) if location
 
-      self.response_body = ""
+      self.response_body = ''
 
       if include_content?(self.response_code)
         self.content_type = content_type || (Mime[formats.first] if formats)
@@ -48,7 +48,7 @@ module ActionController
         headers.delete('Content-Type')
         headers.delete('Content-Length')
       end
-      
+
       true
     end
 

--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -5,7 +5,7 @@ module ActionController
 
     # Renders the template corresponding to the controller action, if it exists.
     # The action name, format, and variant are all taken into account.
-    # For example, the "new" action with an HTML format and variant "phone" 
+    # For example, the "new" action with an HTML format and variant "phone"
     # would try to render the <tt>new.html+phone.erb</tt> template.
     #
     # If no template is found <tt>ActionController::BasicImplicitRender</tt>'s implementation is called, unless
@@ -29,7 +29,7 @@ module ActionController
 
     def method_for_action(action_name)
       super || if template_exists?(action_name.to_s, _prefixes)
-        "default_render"
+        'default_render'
       end
     end
   end

--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -17,12 +17,12 @@ module ActionController
 
     def process_action(*args)
       raw_payload = {
-        :controller => self.class.name,
-        :action     => self.action_name,
-        :params     => request.filtered_parameters,
-        :format     => request.format.try(:ref),
-        :method     => request.request_method,
-        :path       => (request.fullpath rescue "unknown")
+        controller: self.class.name,
+        action:     self.action_name,
+        params:     request.filtered_parameters,
+        format:     request.format.try(:ref),
+        method:     request.request_method,
+        path:       (request.fullpath rescue 'unknown')
       }
 
       ActiveSupport::Notifications.instrument("start_processing.action_controller", raw_payload.dup)
@@ -47,8 +47,8 @@ module ActionController
     end
 
     def send_file(path, options={})
-      ActiveSupport::Notifications.instrument("send_file.action_controller",
-        options.merge(:path => path)) do
+      ActiveSupport::Notifications.instrument('send_file.action_controller',
+        options.merge(path: path)) do
         super
       end
     end
@@ -72,7 +72,7 @@ module ActionController
 
     # A hook invoked every time a before callback is halted.
     def halted_callback_hook(filter)
-      ActiveSupport::Notifications.instrument("halted_callback.action_controller", :filter => filter)
+      ActiveSupport::Notifications.instrument("halted_callback.action_controller", filter: filter)
     end
 
     # A hook which allows you to clean up any time taken into account in

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -97,8 +97,8 @@ module ActionController
           current_options = @options.merge(options).stringify_keys
 
           WHITELISTED_OPTIONS.each do |option_name|
-            if (option_value = current_options[option_name])
-              @stream.write "#{option_name}: #{option_value}\n"
+            if option_value = current_options[option_name]
+              @stream.write("#{option_name}: #{option_value}\n")
             end
           end
 
@@ -131,8 +131,8 @@ module ActionController
 
       def write(string)
         unless @response.committed?
-          @response.headers["Cache-Control"] = "no-cache"
-          @response.headers.delete "Content-Length"
+          @response.headers['Cache-Control'] = 'no-cache'
+          @response.headers.delete('Content-Length')
         end
 
         super
@@ -144,7 +144,7 @@ module ActionController
             # Raise ClientDisconnected, which is a RuntimeError (not an
             # IOError), because that's more appropriate for something beyond
             # the developer's control.
-            raise ClientDisconnected, "client disconnected"
+            raise ClientDisconnected, 'client disconnected'
           end
         end
       end
@@ -214,7 +214,7 @@ module ActionController
         end
 
         def merge(other)
-          self.class.new @response, __getobj__.merge(other)
+          self.class.new(@response, __getobj__.merge(other))
         end
 
         def to_hash
@@ -244,7 +244,7 @@ module ActionController
       end
 
       def merge_default_headers(original, default)
-        Header.new self, super
+        Header.new(self, super)
       end
 
       def handle_conditional_get!
@@ -311,10 +311,10 @@ module ActionController
     end
 
     def set_response!(request)
-      if request.env["HTTP_VERSION"] == "HTTP/1.0"
+      if request.env['HTTP_VERSION'] == 'HTTP/1.0'
         super
       else
-        @_response         = Live::Response.new
+        @_response = Live::Response.new
         @_response.request = request
       end
     end

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -184,7 +184,7 @@ module ActionController #:nodoc:
     # Be sure to check the documentation of <tt>ActionController::MimeResponds.respond_to</tt>
     # for more examples.
     def respond_to(*mimes)
-      raise ArgumentError, "respond_to takes either types or a block, never both" if mimes.any? && block_given?
+      raise ArgumentError, 'respond_to takes either types or a block, never both' if !mimes.empty? && block_given?
 
       collector = Collector.new(mimes, request.variant)
       yield collector if block_given?
@@ -268,13 +268,12 @@ module ActionController #:nodoc:
 
       class VariantCollector #:nodoc:
         def initialize(variant = nil)
-          @variant = variant
-          @variants = {}
+          @variant, @variants = variant, {}
         end
 
         def any(*args, &block)
           if block_given?
-            if args.any? && args.none?{ |a| a == @variant }
+            if args.any? && args.none? { |a| a == @variant }
               args.each{ |v| @variants[v] = block }
             else
               @variants[:any] = block
@@ -296,9 +295,10 @@ module ActionController #:nodoc:
         end
 
         private
-          def variant_key
-            @variant.find { |variant| @variants.key?(variant) } || :any
-          end
+
+        def variant_key
+          @variant.find { |variant| @variants.key?(variant) } || :any
+        end
       end
     end
   end

--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -87,7 +87,7 @@ module ActionController
       def initialize(name, format, include, exclude, klass, model) # :nodoc:
         super
         @include_set = include
-        @name_set    = name
+        @name_set = name
       end
 
       def model
@@ -250,34 +250,34 @@ module ActionController
 
     private
 
-      # Returns the wrapper key which will be used to store wrapped parameters.
-      def _wrapper_key
-        _wrapper_options.name
-      end
+    # Returns the wrapper key which will be used to store wrapped parameters.
+    def _wrapper_key
+      _wrapper_options.name
+    end
 
-      # Returns the list of enabled formats.
-      def _wrapper_formats
-        _wrapper_options.format
-      end
+    # Returns the list of enabled formats.
+    def _wrapper_formats
+      _wrapper_options.format
+    end
 
-      # Returns the list of parameters which will be selected for wrapped.
-      def _wrap_parameters(parameters)
-        { _wrapper_key => _extract_parameters(parameters) }
-      end
+    # Returns the list of parameters which will be selected for wrapped.
+    def _wrap_parameters(parameters)
+      { _wrapper_key => _extract_parameters(parameters) }
+    end
 
-      def _extract_parameters(parameters)
-        if include_only = _wrapper_options.include
-          parameters.slice(*include_only)
-        else
-          exclude = _wrapper_options.exclude || []
-          parameters.except(*(exclude + EXCLUDE_PARAMETERS))
-        end
+    def _extract_parameters(parameters)
+      if include_only = _wrapper_options.include
+        parameters.slice(*include_only)
+      else
+        exclude = _wrapper_options.exclude || []
+        parameters.except(*(exclude + EXCLUDE_PARAMETERS))
       end
+    end
 
-      # Checks if we should perform parameters wrapping.
-      def _wrapper_enabled?
-        ref = request.content_mime_type.try(:ref)
-        _wrapper_formats.include?(ref) && _wrapper_key && !request.request_parameters[_wrapper_key]
-      end
+    # Checks if we should perform parameters wrapping.
+    def _wrapper_enabled?
+      ref = request.content_mime_type.try(:ref)
+      _wrapper_formats.include?(ref) && _wrapper_key && !request.request_parameters[_wrapper_key]
+    end
   end
 end

--- a/actionpack/lib/action_controller/metal/rack_delegation.rb
+++ b/actionpack/lib/action_controller/metal/rack_delegation.rb
@@ -6,7 +6,7 @@ module ActionController
     extend ActiveSupport::Concern
 
     delegate :headers, :status=, :location=, :content_type=,
-             :status, :location, :content_type, :response_code, :to => "@_response"
+             :status, :location, :content_type, :response_code, :to => :@_response
 
     module ClassMethods
       def build_with_env(env = {}) #:nodoc:

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -67,8 +67,8 @@ module ActionController
     # may specify some fallback behavior for this case by rescuing
     # <tt>ActionController::RedirectBackError</tt>.
     def redirect_to(options = {}, response_status = {}) #:doc:
-      raise ActionControllerError.new("Cannot redirect to nil!") unless options
-      raise ActionControllerError.new("Cannot redirect to a parameter hash!") if options.is_a?(ActionController::Parameters)
+      raise ActionControllerError.new('Cannot redirect to nil!') unless options
+      raise ActionControllerError.new('Cannot redirect to a parameter hash!') if options.is_a?(ActionController::Parameters)
       raise AbstractController::DoubleRenderError if response_body
 
       self.status        = _extract_redirect_to_status(options, response_status)
@@ -88,7 +88,7 @@ module ActionController
       when String
         request.protocol + request.host_with_port + options
       when :back
-        request.headers["Referer"] or raise RedirectBackError
+        request.headers['Referer'] or raise RedirectBackError
       when Proc
         _compute_redirect_to_location request, options.call
       else

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -34,7 +34,7 @@ module ActionController
     def render_to_string(*)
       result = super
       if result.respond_to?(:each)
-        string = ""
+        string = ''
         result.each { |r| string << r }
         string
       else
@@ -93,7 +93,7 @@ module ActionController
       end
 
       if options.delete(:nothing)
-        ActiveSupport::Deprecation.warn("`:nothing` option is deprecated and will be removed in Rails 5.1. Use `head` method to respond with empty response body.")
+        ActiveSupport::Deprecation.warn('`:nothing` option is deprecated and will be removed in Rails 5.1. Use `head` method to respond with empty response body.')
         options[:body] = nil
       end
 
@@ -118,7 +118,7 @@ module ActionController
 
       self.status = status if status
       self.content_type = content_type if content_type
-      self.headers["Location"] = url_for(location) if location
+      self.headers['Location'] = url_for(location) if location
 
       super
     end

--- a/actionpack/lib/action_controller/metal/streaming.rb
+++ b/actionpack/lib/action_controller/metal/streaming.rb
@@ -199,12 +199,12 @@ module ActionController #:nodoc:
       def _process_options(options) #:nodoc:
         super
         if options[:stream]
-          if env["HTTP_VERSION"] == "HTTP/1.0"
+          if env['HTTP_VERSION'] == 'HTTP/1.0'
             options.delete(:stream)
           else
-            headers["Cache-Control"] ||= "no-cache"
-            headers["Transfer-Encoding"] = "chunked"
-            headers.delete("Content-Length")
+            headers['Cache-Control'] ||= 'no-cache'
+            headers['Transfer-Encoding'] = 'chunked'
+            headers.delete('Content-Length')
           end
         end
       end

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -35,7 +35,7 @@ module ActionController
 
     def initialize(params) # :nodoc:
       @params = params
-      super("found unpermitted parameter#{'s' if params.size > 1 }: #{params.join(", ")}")
+      super("found unpermitted parameter#{?s if params.size > 1 }: #{params.join(", ")}")
     end
   end
 
@@ -118,7 +118,7 @@ module ActionController
     #
     #    config.always_permitted_parameters = %w( controller action format )
     cattr_accessor :always_permitted_parameters
-    self.always_permitted_parameters = %w( controller action )
+    self.always_permitted_parameters = %w(controller action)
 
     def self.const_missing(const_name)
       return super unless const_name == :NEVER_UNPERMITTED_PARAMS
@@ -232,7 +232,7 @@ module ActionController
     def permit!
       each_pair do |key, value|
         Array.wrap(value).each do |v|
-          v.permit! if v.respond_to? :permit!
+          v.permit! if v.respond_to?(:permit!)
         end
       end
 
@@ -593,7 +593,7 @@ module ActionController
         if unpermitted_keys.any?
           case self.class.action_on_unpermitted_parameters
           when :log
-            name = "unpermitted_parameters.action_controller"
+            name = 'unpermitted_parameters.action_controller'.freeze
             ActiveSupport::Notifications.instrument(name, keys: unpermitted_keys)
           when :raise
             raise ActionController::UnpermittedParameters.new(unpermitted_keys)
@@ -661,7 +661,7 @@ module ActionController
         # Slicing filters out non-declared keys.
         slice(*filter.keys).each do |key, value|
           next unless value
-          next unless has_key? key
+          next unless has_key?(key)
 
           if filter[key] == EMPTY_ARRAY
             # Declaration { comment_ids: [] }.

--- a/actionpack/lib/action_controller/metal/testing.rb
+++ b/actionpack/lib/action_controller/metal/testing.rb
@@ -24,7 +24,7 @@ module ActionController
 
     module ClassMethods
       def before_filters
-        _process_action_callbacks.find_all{|x| x.kind == :before}.map(&:name)
+        _process_action_callbacks.find_all { |x| x.kind == :before }.map(&:name)
       end
     end
   end

--- a/actionpack/lib/action_controller/metal/url_for.rb
+++ b/actionpack/lib/action_controller/metal/url_for.rb
@@ -42,7 +42,7 @@ module ActionController
           options[:original_script_name] = original_script_name
         else
           if same_origin
-            options[:script_name] = request.script_name.empty? ? "".freeze : request.script_name.dup
+            options[:script_name] = request.script_name.empty? ? ''.freeze : request.script_name.dup
           else
             options[:script_name] = script_name
           end

--- a/actionpack/lib/action_controller/middleware.rb
+++ b/actionpack/lib/action_controller/middleware.rb
@@ -28,7 +28,7 @@ module ActionController
     end
 
     def initialize(app)
-      super()
+      super
       @_app = app
     end
 

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -62,7 +62,7 @@ module ActionController
       end
     end
 
-    initializer "action_controller.compile_config_methods" do
+    initializer 'action_controller.compile_config_methods' do
       ActiveSupport.on_load(:action_controller) do
         config.compile_methods! if config.respond_to?(:compile_methods!)
       end

--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -72,29 +72,30 @@ module ActionController
     end
 
     private
-      def normalize_keys(env)
-        http_header_format(env).tap do |new_env|
-          handle_method_key! new_env
-          handle_https_key!  new_env
-        end
-      end
 
-      def http_header_format(env)
-        env.transform_keys do |key|
-          key.is_a?(Symbol) ? key.to_s.upcase : key
-        end
+    def normalize_keys(env)
+      http_header_format(env).tap do |new_env|
+        handle_method_key!(new_env)
+        handle_https_key!(new_env)
       end
+    end
 
-      def handle_method_key!(env)
-        if method = env.delete('METHOD')
-          env['REQUEST_METHOD'] = method.upcase
-        end
+    def http_header_format(env)
+      env.transform_keys do |key|
+        key.is_a?(Symbol) ? key.to_s.upcase : key
       end
+    end
 
-      def handle_https_key!(env)
-        if env.has_key? 'HTTPS'
-          env['HTTPS'] = env['HTTPS'] ? 'on' : 'off'
-        end
+    def handle_method_key!(env)
+      if method = env.delete('METHOD')
+        env['REQUEST_METHOD'] = method.upcase
       end
+    end
+
+    def handle_https_key!(env)
+      if env.has_key?('HTTPS')
+        env['HTTPS'] = env['HTTPS'] ? 'on' : 'off'
+      end
+    end
   end
 end

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -18,7 +18,7 @@ module ActionController
     def self.create
       env = {}
       env = Rails.application.env_config.merge(env) if defined?(Rails.application) && Rails.application
-      env["rack.request.cookie_hash"] = {}.with_indifferent_access
+      env['rack.request.cookie_hash'] = {}.with_indifferent_access
       new(default_env.merge(env), new_session)
     end
 
@@ -39,12 +39,12 @@ module ActionController
     end
 
     def request_parameters=(params)
-      @env["action_dispatch.request.request_parameters"] = params
+      @env['action_dispatch.request.request_parameters'] = params
     end
 
     def assign_parameters(routes, controller_path, action, parameters = {})
       parameters = parameters.symbolize_keys
-      generated_path, extra_keys = routes.generate_extras(parameters.merge(:controller => controller_path, :action => action))
+      generated_path, extra_keys = routes.generate_extras(parameters.merge(controller: controller_path, action: action))
       non_path_parameters = {}
       path_parameters = {}
 
@@ -63,9 +63,7 @@ module ActionController
       end
 
       if get?
-        if self.query_string.blank?
-          self.query_string = non_path_parameters.to_query
-        end
+        self.query_string = non_path_parameters.to_query if self.query_string.blank?
       else
         if ENCODER.should_multipart?(non_path_parameters)
           @env['CONTENT_TYPE'] = ENCODER.content_type
@@ -97,7 +95,7 @@ module ActionController
         @env['rack.input'] = StringIO.new(data)
       end
 
-      @env["PATH_INFO"] ||= generated_path
+      @env['PATH_INFO'] ||= generated_path
       path_parameters[:controller] = controller_path
       path_parameters[:action] = action
 
@@ -177,9 +175,9 @@ module ActionController
 
     private
 
-      def load!
-        @id
-      end
+    def load!
+      @id
+    end
   end
 
   # Superclass for ActionController functional tests. Functional tests allow you to


### PR DESCRIPTION
Today I started reading the rails' codebase, and for every file I read I tried to make little optimizations and code style enhancements.
Things like private methods were a little mess. For example, just in the actionpack atm I see all [these](http://sprunge.us/LVFW?rb) three ways used but I can't find any reference to follow a sort of standard. In this case, I tried to keep the way that actually we used most so far.

Following some examples of the changes I did with a little explaination next:
- `"something"` -> `'something'`: When no interpolation is needed, single quotes are faster
- `:some => :thing` -> `some: :thing`: As suggested in the rails' guidelines
- `'s'` -> `?s`: Chars are a little more performant than strings and also are more coherent in cases like this
- Brackets, spaces and some `#freeze`s because why not.

I think that a work like this one is worth the time if we'll be more strict in front of a PR with LoCs written with too much freedom compared to the actual rails' codebase.

If even you guys think the same I can spend more time doing this in both actionpack and the other components.
