### PR TITLE
replace each with each_key when only the key is needed

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -267,7 +267,7 @@ module ActionDispatch
                 path_params -= controller_options.keys
                 path_params -= result.keys
               end
-              inner_options.each do |key, _|
+              inner_options.each_key do |key|
                 path_params.delete(key)
               end
 

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -338,7 +338,7 @@ module ActiveSupport
           end
 
           # Redefine the === method so we can write shorter rules for grapheme cluster breaks
-          @boundary.each do |k,_|
+          @boundary.each_key do |k|
             @boundary[k].instance_eval do
               def ===(other)
                 detect { |i| i === other } ? true : false


### PR DESCRIPTION
Using each_key is faster and more intention revealing.

``` sh
Calculating -------------------------------------
                each    31.378k i/100ms
            each_key    33.790k i/100ms
-------------------------------------------------
                each    450.225k (± 7.0%) i/s -      2.259M
            each_key    494.459k (± 6.3%) i/s -      2.467M

Comparison:
            each_key:   494459.4 i/s
                each:   450225.1 i/s - 1.10x slower
```
