### PR TITLE
[ci skip] Fix the AS::Callbacks terminator docs

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -741,10 +741,10 @@ module ActiveSupport
       #   callback chain, preventing following before and around callbacks from
       #   being called and the event from being triggered.
       #   This should be a lambda to be executed.
-      #   The current object and the return result of the callback will be called
-      #   with the lambda.
+      #   The current object and the result lambda of the callback will be provided
+      #   to the terminator lambda.
       #
-      #     define_callbacks :validate, terminator: ->(target, result) { result == false }
+      #     define_callbacks :validate, terminator: ->(target, result_lambda) { result_lambda.call == false }
       #
       #   In this example, if any before validate callbacks returns +false+,
       #   any successive before and around callback is not executed.


### PR DESCRIPTION
The second argument of the terminator lambda is no longer the result of the callback, but the result lambda.

Please see [this test](https://github.com/rails/rails/blob/3a7609e2bafee4b071fe35136274e6ccbae8cacd/activesupport/test/callbacks_test.rb#L553)
