### PR TITLE
[ci skip] Adding a note to Action Mailer Basics documentation that Google increased its security measures

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -759,6 +759,9 @@ config.action_mailer.smtp_settings = {
   authentication:       'plain',
   enable_starttls_auto: true  }
 ```
+Note: As of July 15, 2014, Google increased [its security measures](https://support.google.com/accounts/answer/6010255) and now blocks attempts from apps it deems less secure.
+You can change your gmail settings [here](https://www.google.com/settings/security/lesssecureapps) to allow the attempts or 
+use another ESP to send email by replacing 'smpt.gmail.com' above with the address of your provider.
 
 Mailer Testing
 --------------


### PR DESCRIPTION
 so using the example for Gmail will return a “Password Incorrect” error,
and you will receive an email from Google that they blocked a sign-in attempt.  You can change
your Gmail settings or use another ESP.

I discovered this when I was testing a simple mailer example app and was just going to
use my personal Gmail account for the test.  I think it would be best to note this change
since now Gmail may not be the best option for a quick test.  I hope this saves time for other Rails
developers.  The Gmail example does show a good example of how to configure the smpt settings.
