### PR TITLE
[ci skip] Note that each action maps to a specific CRUD operation

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -83,7 +83,9 @@ Rails would dispatch that request to the `destroy` method on the `photos` contro
 
 ### CRUD, Verbs, and Actions
 
-In Rails, a resourceful route provides a mapping between HTTP verbs and URLs to controller actions. By convention, each action also maps to particular CRUD operations in a database. A single entry in the routing file, such as:
+In Rails, a resourceful route provides a mapping between HTTP verbs and URLs to 
+controller actions. By convention, each action also maps to a specific CRUD 
+operation in a database. A single entry in the routing file, such as:
 
 ```ruby
 resources :photos


### PR DESCRIPTION
After reading this paragraph, it sounded to me like an action was mapped to multiple CRUD operations.  I changed this to ensure someone learning about routes would know that each action only maps to one CRUD operation.

Original text:

> each action also maps to particular CRUD operations in a database.

Changed to:

> each action also maps to a specific CRUD operation in a database.

I also wrapped each line of this paragraph at 80 characters.
