### PR TITLE
Security: use Bundler's recommendation to use https in Gemfile urls

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -220,7 +220,7 @@ module Rails
         else
           [GemfileEntry.version('rails',
                             Rails::VERSION::STRING,
-                            "Bundle edge Rails instead: gem 'rails', github: 'rails/rails'")]
+                            "Bundle edge Rails instead: gem 'rails', git: 'https://github.com/rails/rails.git'")]
         end
       end
 


### PR DESCRIPTION
Per http://bundler.io/git.html:

http:// and git:// URLs are insecure. A man-in-the-middle attacker could
tamper with the code as you check it out, and potentially supply you with
malicious code instead of the code you meant to check out.
Because the :github shortcut uses a git:// URL in Bundler 1.x versions,
we recommend using using HTTPS URLs or overriding the :github shortcut
with your own HTTPS git source.
