### PR TITLE
[ci skip] Modify introduction to be consistent with other guides

### DIFF
--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -8,12 +8,12 @@ classes. Active Model allows for Action Pack helpers to interact with
 plain Ruby objects. Active Model also helps build custom ORMs for use
 outside of the Rails framework.
 
-After reading this guide, you will be able to add to plain Ruby objects:
+After reading this guide, you will know: 
 
-* The ability to behave like an Active Record model.
-* Callbacks and validations like Active Record.
-* Serializers.
-* Integration with the Rails internationalization (i18n) framework.
+* How an Active Record model behaves.
+* How Callbacks and validations work. 
+* How serializers work.
+* The Rails internationalization (i18n) framework.
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Most of the guides have a consistent introduction that tells the user what they will expect to learn.  This one was different.  For example, this guide introduces the reader to the bullet list with this:

> After reading this guide, you will be able to add to plain Ruby objects:

But other guides use this format, so I changed it to match:

> After reading this guide, you will know:

Also, the sub bullets were changed to match the other guides.
