### PR TITLE
Dont try to call method missing in routes if thats not what we want

### DIFF
--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -263,9 +263,15 @@ module ActionView
       end
 
       def method_missing(selector, *args)
-        if @controller.respond_to?(:_routes) &&
-          ( @controller._routes.named_routes.route_defined?(selector) ||
-            @controller._routes.mounted_helpers.method_defined?(selector) )
+        begin
+          routes = @controller.respond_to?(:_routes) && @controller._routes
+        rescue
+          # Dont call routes, if there is an error on _routes call
+        end
+
+        if routes &&
+           ( routes.named_routes.route_defined?(selector) ||
+             routes.mounted_helpers.method_defined?(selector) )
           @controller.__send__(selector, *args)
         else
           super


### PR DESCRIPTION
If, doing a test like this:

```
class BugTest < ActionView::TestCase
  def test_foo
    omg
  end
end
```

Will raise with:

```
RuntimeError: In order to use #url_for, you must include routing helpers
explicitly. For instance, `include
Rails.application.routes.url_helpers`.
```

Thats a bit confusing, as we are not calling url_for at all.

was raising here https://github.com/rails/rails/blob/master/actionpack/lib/abstract_controller/url_for.rb#L12-L15

review @rafaelfranca 
