### PR TITLE
Fix Relation#delete_all missing bind values

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -474,7 +474,8 @@ module ActiveRecord
           stmt.wheres = arel.constraints
         end
 
-        affected = @klass.connection.delete(stmt, 'SQL', bind_values)
+        bvs = arel.bind_values + bind_values
+        affected = @klass.connection.delete(stmt, 'SQL', bvs)
 
         reset
         affected

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -211,6 +211,12 @@ module ActiveRecord
       assert_equal 3, authors(:david).posts.merge(posts_with_special_comments_with_ratings).count.length
     end
 
+    def test_conflicting_bind_values
+      assert_nothing_raised do
+        CommentWithConflictingDefaultScope.joins(:post_with_conflicting_default_scope).delete_all
+      end
+    end
+
     def test_relation_merging_with_joins_as_join_dependency_pick_proper_parent
       post = Post.create!(title: "haha", body: "huhu")
       comment = post.comments.create!(body: "hu")

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -57,3 +57,8 @@ class CommentWithDefaultScopeReferencesAssociation < Comment
   default_scope ->{ includes(:developer).order('developers.name').references(:developer) }
   belongs_to :developer
 end
+
+class CommentWithConflictingDefaultScope < Comment
+  default_scope ->{ where(author_id: 42) }
+  belongs_to :post_with_conflicting_default_scope, foreign_key: :post_id
+end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -257,3 +257,8 @@ end
 class SerializedPost < ActiveRecord::Base
   serialize :title
 end
+
+class PostWithConflictingDefaultScope < Post
+  default_scope ->{ where(author_id: 42) }
+  belongs_to :post_with_conflicting_default_scope, foreign_key: :post_id
+end


### PR DESCRIPTION
I tracked this bug with @rafaelfranca and @arthurnn.

For some yet unknown reasons only mysql2 seems impacted.

I managed to reproduce it in this gist: https://gist.github.com/byroot/b35a7978ee2bc513a01f, and AFAICT this PR fixes it.

I haven't managed to implement a regression test yet, but I'm working on it.

PS: I'm targeting 4.2-stable because this code was refactored on master and this bug fixed somehow in https://github.com/rails/rails/commit/b06f64c3480cd389d14618540d62da4978918af0 
