### PR TITLE
DateTime Range#step with Duration

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Support `Range#step` on `DateTime` ranges with `Duration` step
+        twz = DateTime.now.in_time_zone
+        (twz..twz + 2.days).step(3.hours) do |time|
+          # every 3 hour step from twz for 2 days
+        end
+
+    *Peter Hollows*
+
 *   Deprecate `:prefix` option of `number_to_human_size` with no replacement.
 
     *Jean Boussier*

--- a/activesupport/lib/active_support/core_ext/range/each.rb
+++ b/activesupport/lib/active_support/core_ext/range/each.rb
@@ -5,9 +5,24 @@ module ActiveSupport
       super
     end
 
-    def step(n = 1, &block)
-      ensure_iteration_allowed
-      super
+    def step(step_size = 1, &block)
+      return to_enum(:step, step_size) unless block_given?
+
+      # Defer to Range for steps other than durations on times
+      unless step_size.is_a?(ActiveSupport::Duration) && self.begin.kind_of?(DateTime) && self.end.kind_of?(DateTime)
+        ensure_iteration_allowed
+        return super
+      end
+
+      # Advance through time using steps
+      time = self.begin
+      op = exclude_end? ? :< : :<=
+      while time.send(op, self.end)
+        yield time
+        time = step_size.parts.inject(time) { |t, (type, number)| t.advance(type => number) }
+      end
+
+      self
     end
 
     private

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -122,4 +122,33 @@ class RangeTest < ActiveSupport::TestCase
     datetime = DateTime.now
     assert(((datetime - 1.hour)..datetime).step(1) {})
   end
+
+  def test_date_time_with_step_duration
+    start     = DateTime.new(2011, 11, 11)
+    finish    = DateTime.new(2011, 11, 11, 2)
+    step_size = 40.minutes + 20.seconds
+    assert((start..finish).step(step_size) {})
+  end
+
+  def test_date_time_with_step_duration_inclusive_exclusive
+    start     = DateTime.new(2011, 11, 11)
+    finish    = DateTime.new(2011, 11, 11, 2)
+
+    step_size = 1.hour
+    steps = []
+    assert((start..finish).step(step_size) { |t| steps << t })
+    assert steps == [
+      DateTime.new(2011, 11, 11, 00),
+      DateTime.new(2011, 11, 11, 01),
+      DateTime.new(2011, 11, 11, 02),
+    ]
+
+    step_size = 1.hour
+    steps = []
+    assert((start...finish).step(step_size) { |t| steps << t })
+    assert steps == [
+      DateTime.new(2011, 11, 11, 00),
+      DateTime.new(2011, 11, 11, 01)
+    ]
+  end
 end


### PR DESCRIPTION
Related PRs #11474, #13667

Earlier discussion and bug-fixes:
http://stackoverflow.com/questions/19093487/ruby-create-range-of-dates#answer-19094504

Allows `Range#step` on `DateTime` ranges when `step_size` is `ActiveSupport::Duration`.
