### PR TITLE
[ci skip] Fix broken link markup

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -357,7 +357,7 @@ This gem uses Ajax to speed up page rendering in most applications.
 
 Turbolinks attaches a click handler to all `<a>` on the page. If your browser
 supports
-[PushState](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history#The_pushState()_method),
+[PushState](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history),
 Turbolinks will make an Ajax request for the page, parse the response, and
 replace the entire `<body>` of the page with the `<body>` of the response. It
 will then use PushState to change the URL to the correct one, preserving


### PR DESCRIPTION
Under section 5.1 (How Turbolinks Works) of the [Working with javascript in rails](http://guides.rubyonrails.org/working_with_javascript_in_rails.html) guide, a link to [PushState](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history) on the developer.mozilla site exists, but its markup is broken.  Because of this, the link doesn't show the 'PushState' text as normal text in brackets and the url is displayed as a full url.

This commit fixes the broken markup so PushState text will be a hyperlink instead of the full url to the link.
