### PR TITLE
[ci skip] Swap ruby -v and the installation tip

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -92,16 +92,16 @@ Open up a command line prompt. On Mac OS X open Terminal.app, on Windows choose
 dollar sign `$` should be run in the command line. Verify that you have a
 current version of Ruby installed:
 
+```bash
+$ ruby -v
+ruby 2.2.2p95
+```
+
 TIP: A number of tools exist to help you quickly install Ruby and Ruby
 on Rails on your system. Windows users can use [Rails Installer](http://railsinstaller.org),
 while Mac OS X users can use [Tokaido](https://github.com/tokaido/tokaidoapp).
 For more installation methods for most Operating Systems take a look at
 [ruby-lang.org](https://www.ruby-lang.org/en/documentation/installation/).
-
-```bash
-$ ruby -v
-ruby 2.2.2p95
-```
 
 Many popular UNIX-like OSes ship with an acceptable version of SQLite3.
 On Windows, if you installed Rails through Rails Installer, you


### PR DESCRIPTION
When reading the [getting started guide](http://edgeguides.rubyonrails.org/getting_started.html), I felt that section 3.1 (Installing Rails) had the command and tip sections in the wrong order.  Here is an overview of how this section currently reads (paraphrased):
1. Verify ruby is installed by typing this:
2. TIP: There are tools to help you install ruby
3. ruby -v (you should expect to see something like ruby 2.2.2...)

However, I think sections 2 and 3 should be reordered, like this:
1. Verify ruby is installed by typing this:
2. ruby -v (you should expect to see something like ruby 2.2.2...)
3. TIP: There are tools to help you install ruby

When the first section tells the user to run a command, it should be immediately shown.  The tip should be in a place that immediately follows the command in case the reader encounters an error.

Here is a screenshot to the three sections under 3.1 I am referring to:

![screen shot 2015-08-11 at 9 36 37 pm](https://cloud.githubusercontent.com/assets/201071/9215507/228a50e2-4071-11e5-9098-554c726ae00d.png)
