### PR TITLE
Fix polymorphic association scope when sti_name is specified

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -49,7 +49,7 @@ module ActiveRecord
 
         binds << last_reflection.join_id_for(owner)
         if last_reflection.type
-          binds << owner.class.base_class.name
+          binds << owner.class.base_class.sti_name
         end
 
         chain.each_cons(2).each do |reflection, next_reflection|
@@ -104,7 +104,7 @@ module ActiveRecord
         scope    = scope.where(table[key].eq(bind_val))
 
         if reflection.type
-          value    = owner.class.base_class.name
+          value    = owner.class.base_class.sti_name
           bind_val = bind scope, table.table_name, reflection.type, value, tracker
           scope    = scope.where(table[reflection.type].eq(bind_val))
         else

--- a/activerecord/test/cases/associations/association_scope_test.rb
+++ b/activerecord/test/cases/associations/association_scope_test.rb
@@ -1,6 +1,8 @@
 require 'cases/helper'
 require 'models/post'
 require 'models/author'
+require "models/another_app/interior_designer"
+require "models/chef"
 
 module ActiveRecord
   module Associations
@@ -15,6 +17,15 @@ module ActiveRecord
         }
         assert_equal wheres.uniq, wheres
         assert_equal binds.uniq, binds
+      end
+
+      test 'uses STI name for polymorphic associations' do
+        scope = AssociationScope.scope(
+          AnotherApp::InteriorDesigner.new.association(:chef),
+          AnotherApp::InteriorDesigner.connection
+        )
+
+        assert scope.to_sql.include?("'InteriorDesigner'")
       end
     end
   end

--- a/activerecord/test/models/another_app/interior_designer.rb
+++ b/activerecord/test/models/another_app/interior_designer.rb
@@ -1,0 +1,9 @@
+module AnotherApp
+  class InteriorDesigner < ActiveRecord::Base
+    has_one :chef, as: :employable
+
+    def self.sti_name
+      "InteriorDesigner"
+    end
+  end
+end

--- a/activerecord/test/models/interior_designer.rb
+++ b/activerecord/test/models/interior_designer.rb
@@ -1,0 +1,3 @@
+class InteriorDesigner < ActiveRecord::Base
+  has_one :chef, as: :employable
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -886,6 +886,8 @@ ActiveRecord::Schema.define do
   end
   create_table :drink_designers, force: true do |t|
   end
+  create_table :interior_designers, force: true do |t|
+  end
   create_table :chefs, force: true do |t|
     t.integer :employable_id
     t.string :employable_type


### PR DESCRIPTION
Hi,

Association scope ignores custom `.sti_name` (and `.store_full_sti_class` attribute) for polymorphic models and uses `.name` as a type instead.

To fix it, I would like to suggest to use [sti_name](https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/inheritance.rb#L134-L136) by default.
