### PR TITLE
Fix ActiveRecord::StatementInvalid error when merge nested ActiveRecord::Relation

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -110,7 +110,7 @@ module ActiveRecord
         if other.klass == relation.klass
           relation.joins!(*other.joins_values)
         else
-          joins_dependency, rest = other.joins_values.partition do |join|
+          joins_dependency, rest = other.joins_values.reverse.partition do |join|
             case join
             when Hash, Symbol, Array
               true
@@ -125,6 +125,8 @@ module ActiveRecord
           relation.joins! rest
 
           @relation = relation.joins join_dependency
+          @relation.joins_values.reverse!
+          @relation
         end
       end
 

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -8,7 +8,7 @@ require 'models/project'
 require 'models/rating'
 
 class RelationMergingTest < ActiveRecord::TestCase
-  fixtures :developers, :comments, :authors, :posts
+  fixtures :developers, :comments, :authors, :posts, :author_addresses
 
   def test_relation_merging
     devs = Developer.where("salary >= 80000").merge(Developer.limit(2)).merge(Developer.order('id ASC').where("id < 3"))
@@ -68,6 +68,14 @@ class RelationMergingTest < ActiveRecord::TestCase
   def test_relation_merging_with_joins
     comments = Comment.joins(:post).where(:body => 'Thank you for the welcome').merge(Post.where(:body => 'Such a lovely day'))
     assert_equal 1, comments.count
+  end
+
+  def test_relation_merging_with_nested_joins
+    post_with_comments_with_ratings = Post.with_post(1).joins(:comments).merge(Comment.joins(:ratings))
+    author_with_posts_with_comments_with_ratings = Author.joins(:posts).merge(post_with_comments_with_ratings)
+    author_addresses = AuthorAddress.joins(:author).merge(author_with_posts_with_comments_with_ratings)
+
+    assert_equal 1, author_addresses.count
   end
 
   def test_relation_merging_with_association


### PR DESCRIPTION
Error occurs that invalid statement when join other nested `ActiveRecord::Relation` using `.merge`

For example:

``` ruby
class Project < ActiveRecord::Base
  has_many :teams
end

class Team < ActiveRecord::Base
  has_many :members
  belongs_to :project
end

class Member < ActiveRecord::Base
  belongs_to :team
  has_many :tasks
end

class Task < ActiveRecord::Base
  belongs_to :member

  scope :not_complete, lambda { where(complete: false).where("tasks.term <= ? ", Date.today.end_of_day) }
end
```

Result:

``` ruby
[1] pry(main)> Project.joins(:teams).merge( Team.joins(:members).merge( Member.joins(:tasks).merge(Task.not_complete) ) ).to_a
  Project Load (0.5ms)  SELECT `projects`.* FROM `projects` INNER JOIN `teams` ON `teams`.`project_id` = `projects`.`id` LEFT OUTER JOIN `tasks` ON `tasks`.`member_id` = `members`.`id` LEFT OUTER JOIN `members` ON `members`.`team_id` = `teams`.`id` WHERE `tasks`.`complete` = 0 AND (tasks.term <= '2015-08-12 23:59:59' )
ActiveRecord::StatementInvalid: Mysql2::Error: Unknown column 'members.id' in 'on clause': SELECT `projects`.* FROM `projects` INNER JOIN `teams` ON `teams`.`project_id` = `projects`.`id` LEFT OUTER JOIN `tasks` ON `tasks`.`member_id` = `members`.`id` LEFT OUTER JOIN `members` ON `members`.`team_id` = `teams`.`id` WHERE `tasks`.`complete` = 0 AND (tasks.term <= '2015-08-12 23:59:59' )
from /vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:421:in `query'
```
