### PR TITLE
[ci skip] Fix rdoc markup

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -11,7 +11,7 @@ module ActiveRecord
         # serialized object must be of that class on assignment and retrieval.
         # Otherwise <tt>SerializationTypeMismatch</tt> will be raised.
         #
-        # Empty objects as +{}+, in the case of +Hash+, or +[]+, in the case of
+        # Empty objects as <tt>{}</tt>, in the case of +Hash+, or <tt>[]</tt>, in the case of
         # +Array+, will always be persisted as null.
         #
         # Keep in mind that database adapters handle certain serialization tasks

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -92,7 +92,7 @@ module ActiveSupport
     #   hash = ActiveSupport::HashWithIndifferentAccess.new
     #   hash[:key] = 'value'
     #
-    # This value can be later fetched using either +:key+ or +'key'+.
+    # This value can be later fetched using either +:key+ or <tt>'key'</tt>.
     def []=(key, value)
       regular_writer(convert_key(key), convert_value(value, for: :assignment))
     end


### PR DESCRIPTION
- before

```
+{}+ ... +[]+
```

```
+'key'+
```
- after

```
{} ... []
```

```
'key'
```
