### PR TITLE
[ci skip] Removed link to reSRC.io - site closed

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -37,7 +37,6 @@ curve diving straight into Rails. There are several curated lists of online reso
 for learning Ruby:
 
 * [Official Ruby Programming Language website](https://www.ruby-lang.org/en/documentation/)
-* [reSRC's List of Free Programming Books](http://resrc.io/list/10/list-of-free-programming-books/#ruby)
 
 Be aware that some resources, while still excellent, cover versions of Ruby as old as
 1.6, and commonly 1.8, and will not include some syntax that you will see in day-to-day


### PR DESCRIPTION
I removed the link to resrc.io because the author shut down the website - permanently.  Here is the url to the website:

[http://resrc.io/list/10/list-of-free-programming-books/#ruby](http://resrc.io/list/10/list-of-free-programming-books/#ruby)

Here is a screenshot of the message posted on resrc.io:  

![screen shot 2015-08-12 at 10 32 50 am](https://cloud.githubusercontent.com/assets/201071/9228297/866f771a-40dd-11e5-8ca8-c36b589caf9e.png)
