### PR TITLE
Added Symbol#with method

### DIFF
--- a/activesupport/lib/active_support/core_ext/symbol.rb
+++ b/activesupport/lib/active_support/core_ext/symbol.rb
@@ -1,0 +1,1 @@
+require 'active_support/core_ext/symbol/with'

--- a/activesupport/lib/active_support/core_ext/symbol/with.rb
+++ b/activesupport/lib/active_support/core_ext/symbol/with.rb
@@ -1,0 +1,26 @@
+class Symbol
+
+  #Returns a lambda with partially applied parameters for use with Enumerable#map
+  #and other methods which take a proc.
+  #
+  #  a = [1,3,5,7,9]
+  #  a.map(&:+.with(2)) # => [3, 5, 7, 9, 11]
+  #
+  #Can be used with multiple parameters:
+  #
+  #  arr = ["abc", "babc", "great", "fruit"]
+  #  arr.map(&:center.with(20, '*')) # => ["********abc*********", 
+  #                                  #     "********babc********",
+  #                                  #     "*******great********", 
+  #                                  #     "*******fruit********"]
+  #
+  #And on nested proc calls as well:
+  #
+  #  [['0', '1'], ['2', '3']].map(&:map.with(&:to_i)) # => [[0, 1], [2, 3]]
+  #  [%w(a b), %w(c d)].map(&:inject.with(&:+))       # => ["ab", "cd"] 
+  #  [(1..5), (6..10)].map(&:map.with(&:*.with(2)))   # => [[2, 4, 6, 8, 10], [12, 14, 16, 18, 20]] 
+  def with(*args, &block)
+    ->(caller, *rest) { caller.send(self, *rest, *args, &block) }
+  end
+
+end

--- a/activesupport/test/core_ext/symbol_core_ext
+++ b/activesupport/test/core_ext/symbol_core_ext
@@ -1,0 +1,19 @@
+class SymbolWithTest < ActiveSupport::TestCase
+  def setup
+    @symbol = :hello
+  end
+  
+  test "returns a callable object" do
+    assert @symbol.with.methods.include?(:call)
+  end
+  
+  test "can be passed one or more parameters" do
+    assert_nothing_raised @symbol.with(3)
+    assert_nothing_raised @symbol.with(:center, 17, [])
+  end
+  
+  test "can be passed a block" do
+    assert_nothing_raised @symbol.with do |dummy_block_var|
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds a new method to the Symbol class which allows for passing parameters when using something like `arr.map(&:some_method)`.

This construct comes from http://stackoverflow.com/a/23711606

If any other tests or changes need to be made, please discuss them.

If this is an unwanted feature, just let me know :)
