### PR TITLE
Fewer objects and refactoring

### DIFF
--- a/actionpack/lib/action_dispatch/http/filter_redirect.rb
+++ b/actionpack/lib/action_dispatch/http/filter_redirect.rb
@@ -28,7 +28,7 @@ module ActionDispatch
           if String === filter
             location.include?(filter)
           elsif Regexp === filter
-            location.match(filter)
+            location =~ filter
           end
         end
       end

--- a/actionpack/lib/action_dispatch/http/filter_redirect.rb
+++ b/actionpack/lib/action_dispatch/http/filter_redirect.rb
@@ -5,8 +5,7 @@ module ActionDispatch
       FILTERED = '[FILTERED]'.freeze # :nodoc:
 
       def filtered_location # :nodoc:
-        filters = location_filter
-        if !filters.empty? && location_filter_match?(filters)
+        if location_filter_match?
           FILTERED
         else
           location
@@ -15,7 +14,7 @@ module ActionDispatch
 
     private
 
-      def location_filter
+      def location_filters
         if request
           request.env['action_dispatch.redirect_filter'] || []
         else
@@ -23,8 +22,8 @@ module ActionDispatch
         end
       end
 
-      def location_filter_match?(filters)
-        filters.any? do |filter|
+      def location_filter_match?
+        location_filters.any? do |filter|
           if String === filter
             location.include?(filter)
           elsif Regexp === filter


### PR DESCRIPTION
Since filters are always an array and using `any?` we don't need an extra `empty?` array check (any? will return false for empty arrays)
