### PR TITLE
[ci skip] Documentation: Switch around a common phrase for readability

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -172,7 +172,7 @@ class String
   # uses the +pluralize+ method on the last word in the string.
   #
   #   'RawScaledScorer'.tableize # => "raw_scaled_scorers"
-  #   'egg_and_ham'.tableize     # => "egg_and_hams"
+  #   'ham_and_egg'.tableize     # => "ham_and_eggs"
   #   'fancyCategory'.tableize   # => "fancy_categories"
   def tableize
     ActiveSupport::Inflector.tableize(self)
@@ -182,7 +182,7 @@ class String
   # Note that this returns a string and not a class. (To convert to an actual class
   # follow +classify+ with +constantize+.)
   #
-  #   'egg_and_hams'.classify # => "EggAndHam"
+  #   'ham_and_eggs'.classify # => "HamAndEgg"
   #   'posts'.classify        # => "Post"
   def classify
     ActiveSupport::Inflector.classify(self)

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -160,7 +160,7 @@ module ActiveSupport
     # This method uses the #pluralize method on the last word in the string.
     #
     #   tableize('RawScaledScorer') # => "raw_scaled_scorers"
-    #   tableize('egg_and_ham')     # => "egg_and_hams"
+    #   tableize('ham_and_egg')     # => "ham_and_eggs"
     #   tableize('fancyCategory')   # => "fancy_categories"
     def tableize(class_name)
       pluralize(underscore(class_name))
@@ -170,7 +170,7 @@ module ActiveSupport
     # names to models. Note that this returns a string and not a Class (To
     # convert to an actual class follow +classify+ with #constantize).
     #
-    #   classify('egg_and_hams') # => "EggAndHam"
+    #   classify('ham_and_eggs') # => "HamAndEgg"
     #   classify('posts')        # => "Post"
     #
     # Singular names are not handled correctly:


### PR DESCRIPTION
Basic change to switch around the common phrase ham and eggs.
