### PR TITLE
Fix the AS::Callbacks terminator regression from 4.2.3

### DIFF
--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -103,6 +103,7 @@ module ActiveModel
     def define_model_callbacks(*callbacks)
       options = callbacks.extract_options!
       options = {
+        terminator: deprecated_false_terminator,
         skip_after_callbacks_if_terminated: true,
         scope: [:kind, :name],
         only: [:before, :around, :after]

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -23,6 +23,7 @@ module ActiveModel
       included do
         include ActiveSupport::Callbacks
         define_callbacks :validation,
+                         terminator: deprecated_false_terminator,
                          skip_after_callbacks_if_terminated: true,
                          scope: [:kind, :name]
       end

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -11,6 +11,7 @@ module ActiveRecord
                        :before_commit_without_transaction_enrollment,
                        :commit_without_transaction_enrollment,
                        :rollback_without_transaction_enrollment,
+                       terminator: deprecated_false_terminator,
                        scope: [:kind, :name]
     end
 

--- a/activerecord/test/cases/attribute_test.rb
+++ b/activerecord/test/cases/attribute_test.rb
@@ -4,7 +4,6 @@ module ActiveRecord
   class AttributeTest < ActiveRecord::TestCase
     setup do
       @type = Minitest::Mock.new
-      @type.expect(:==, false, [false])
     end
 
     teardown do

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -277,20 +277,17 @@
 
     The preferred method to halt a callback chain from now on is to explicitly
     `throw(:abort)`.
-    In the past, returning `false` in an ActiveSupport callback had the side
-    effect of halting the callback chain. This is not recommended anymore and,
-    depending on the value of
-    `Callbacks::CallbackChain.halt_and_display_warning_on_return_false`, will
-    either not work at all or display a deprecation warning.
+    In the past, callbacks could only be halted by explicitly providing a
+    terminator and by having a callback match the conditions of the terminator.
 
 *   Add `Callbacks::CallbackChain.halt_and_display_warning_on_return_false`
 
     Setting `Callbacks::CallbackChain.halt_and_display_warning_on_return_false`
-    to `true` will let an app support the deprecated way of halting callback
-    chains by returning `false`.
+    to `true` will let an app support the deprecated way of halting Active Record,
+    Active Model and Active Model validations callback chains by returning `false`.
 
     Setting the value to `false` will tell the app to ignore any `false` value
-    returned by callbacks, and only halt the chain upon `throw(:abort)`.
+    returned by those callbacks, and only halt the chain upon `throw(:abort)`.
 
     The value can also be set with the Rails configuration option
     `config.active_support.halt_callback_chains_on_return_false`.
@@ -300,7 +297,7 @@
     For new Rails 5.0 apps, its value is set to `false` in an initializer, so
     these apps will support the new behavior by default.
 
-    *claudiob*
+    *claudiob*, *Roque Pinel*
 
 *   Changes arguments and default value of CallbackChain's `:terminator` option
 

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -766,13 +766,11 @@ module CallbacksTest
   end
 
   class CallbackFalseTerminatorWithoutConfigTest < ActiveSupport::TestCase
-    def test_returning_false_halts_callback_if_config_variable_is_not_set
+    def test_returning_false_does_not_halt_callback_if_config_variable_is_not_set
       obj = CallbackFalseTerminator.new
-      assert_deprecated do
-        obj.save
-        assert_equal :second, obj.halted
-        assert !obj.saved
-      end
+      obj.save
+      assert_equal nil, obj.halted
+      assert obj.saved
     end
   end
 
@@ -781,13 +779,11 @@ module CallbacksTest
       ActiveSupport::Callbacks::CallbackChain.halt_and_display_warning_on_return_false = true
     end
 
-    def test_returning_false_halts_callback_if_config_variable_is_true
+    def test_returning_false_does_not_halt_callback_if_config_variable_is_true
       obj = CallbackFalseTerminator.new
-      assert_deprecated do
-        obj.save
-        assert_equal :second, obj.halted
-        assert !obj.saved
-      end
+      obj.save
+      assert_equal nil, obj.halted
+      assert obj.saved
     end
   end
 


### PR DESCRIPTION
Rails 4.2.3 AS::Callbacks will not halt chain if `false` is returned. That is the behavior of specific callbacks like AR::Callbacks and AM::Callbacks.

The two test cases from https://gist.github.com/repinel/93ab39881825d913466d might illustrate my point.

Fixes #21122

@claudiob @kaspth What do you think?
