### PR TITLE
Assert that the `:prefix` option of `number_to_human_size` is deprecated

### DIFF
--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -280,14 +280,16 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
   end
 
   def test_to_s__human_size_with_si_prefix
-    assert_equal '3 Bytes',    3.14159265.to_s(:human_size, :prefix => :si)
-    assert_equal '123 Bytes',  123.0.to_s(:human_size, :prefix => :si)
-    assert_equal '123 Bytes',  123.to_s(:human_size, :prefix => :si)
-    assert_equal '1.23 KB',    1234.to_s(:human_size, :prefix => :si)
-    assert_equal '12.3 KB',    12345.to_s(:human_size, :prefix => :si)
-    assert_equal '1.23 MB',    1234567.to_s(:human_size, :prefix => :si)
-    assert_equal '1.23 GB',    1234567890.to_s(:human_size, :prefix => :si)
-    assert_equal '1.23 TB',    1234567890123.to_s(:human_size, :prefix => :si)
+    assert_deprecated do
+      assert_equal '3 Bytes',    3.14159265.to_s(:human_size, :prefix => :si)
+      assert_equal '123 Bytes',  123.0.to_s(:human_size, :prefix => :si)
+      assert_equal '123 Bytes',  123.to_s(:human_size, :prefix => :si)
+      assert_equal '1.23 KB',    1234.to_s(:human_size, :prefix => :si)
+      assert_equal '12.3 KB',    12345.to_s(:human_size, :prefix => :si)
+      assert_equal '1.23 MB',    1234567.to_s(:human_size, :prefix => :si)
+      assert_equal '1.23 GB',    1234567890.to_s(:human_size, :prefix => :si)
+      assert_equal '1.23 TB',    1234567890123.to_s(:human_size, :prefix => :si)
+    end
   end
 
   def test_to_s__human_size_with_options_hash


### PR DESCRIPTION
The option was deprecated in #21191.
