### PR TITLE
[ci skip] SQL is written using statements, not sentences

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -142,7 +142,7 @@ end
 This will create a `Product` model, mapped to a `products` table at the
 database. By doing this you'll also have the ability to map the columns of each
 row in that table with the attributes of the instances of your model. Suppose
-that the `products` table was created using an SQL sentence like:
+that the `products` table was created using an SQL statement like:
 
 ```sql
 CREATE TABLE products (


### PR DESCRIPTION
This commit changes 'SQL sentence' to 'SQL statement' because SQL is defined using statements.
