### PR TITLE
Don't return a float for ActiveSupport's years

### DIFF
--- a/activesupport/lib/active_support/core_ext/integer/time.rb
+++ b/activesupport/lib/active_support/core_ext/integer/time.rb
@@ -23,7 +23,7 @@ class Integer
   alias :month :months
 
   def years
-    ActiveSupport::Duration.new(self * 365.25.days, [[:years, self]])
+    ActiveSupport::Duration.new(self * 365.25.days.to_i, [[:years, self]])
   end
   alias :year :years
 end


### PR DESCRIPTION
Based on a suggestion in issue https://github.com/rails/rails/issues/19320

ActiveSupport's Integer patching for dates return an integer representation in almost every case, except for years. This change makes that consistent by returning an integer representation for years as well.
