### PR TITLE
Prevent destructive action on production database

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -40,6 +40,7 @@ module ActiveRecord
   autoload :CounterCache
   autoload :DynamicMatchers
   autoload :Enum
+  autoload :EnvironmentCheck
   autoload :Explain
   autoload :Inheritance
   autoload :Integration

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -969,6 +969,10 @@ module ActiveRecord
         ActiveRecord::SchemaMigration.create_table
       end
 
+      def initialize_environment_check_table
+        ActiveRecord::EnvironmentCheck.create_table
+      end
+
       def assume_migrated_upto_version(version, migrations_paths)
         migrations_paths = Array(migrations_paths)
         version = version.to_i

--- a/activerecord/lib/active_record/environment_check.rb
+++ b/activerecord/lib/active_record/environment_check.rb
@@ -1,0 +1,46 @@
+require 'active_record/scoping/default'
+require 'active_record/scoping/named'
+
+module ActiveRecord
+  # This class is used to create a table that keeps track of which environment
+  # migrations were run in. When a migration is run, its env value such as RAILS_ENV
+  # is inserted in to the `EnvironmentCheck.table_name` we can later check aginst
+  # this value before performing destructive actions.
+  class EnvironmentCheck < ActiveRecord::Base
+    class << self
+      def primary_key
+        nil
+      end
+
+      def table_name
+        "#{table_name_prefix}#{ActiveRecord::Base.environment_check_table_name}#{table_name_suffix}"
+      end
+
+      def index_name
+        "#{table_name_prefix}unique_#{ActiveRecord::Base.environment_check_table_name}#{table_name_suffix}"
+      end
+
+      def table_exists?
+        ActiveSupport::Deprecation.silence { connection.table_exists?(table_name) }
+      end
+
+      # Creates a schema table with columns +environment+ and +version+
+      def create_table
+        unless table_exists?
+
+          connection.create_table(table_name, id: false) do |t|
+            t.column :environment, :string
+            t.timestamps
+          end
+        end
+      end
+
+      def drop_table
+        if table_exists?
+          connection.remove_index table_name, name: index_name
+          connection.drop_table(table_name)
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -143,6 +143,26 @@ module ActiveRecord
     end
   end
 
+  class NoEnvironmentInSchemaError < MigrationError #:nodoc:
+    def initialize
+      msg = "Environment data not found in the schema. To resolve this issue, run: \n\n\tbin/rake db:migrate"
+      if defined?(Rails.env)
+        super("#{msg} RAILS_ENV=#{::Rails.env}")
+      else
+        super(msg)
+      end
+    end
+  end
+
+  class ProtectedEnvironmentError < ActiveRecordError #:nodoc:
+    def initialize(env = "production")
+      msg = "You are attempting to run a destructive action against your '#{env}' database\n"
+      msg << "if you are sure you want to continue, run the same command with the environment variable\n"
+      msg << "DISABLE_DATABASE_ENVIRONMENT_CHECK=1"
+      super(msg)
+    end
+  end
+
   # = Active Record Migrations
   #
   # Migrations can manage the evolution of a schema used by several physical
@@ -1078,6 +1098,7 @@ module ActiveRecord
       validate(@migrations)
 
       Base.connection.initialize_schema_migrations_table
+      Base.connection.initialize_environment_check_table
     end
 
     def current_version
@@ -1200,10 +1221,25 @@ module ActiveRecord
       if down?
         migrated.delete(version)
         ActiveRecord::SchemaMigration.where(:version => version.to_s).delete_all
-      else
+        ActiveRecord::EnvironmentCheck.order(created_at: :desc).first.try(:delete_all)
+       else
         migrated << version
-        ActiveRecord::SchemaMigration.create!(:version => version.to_s)
+        ActiveRecord::SchemaMigration.create!(version: version.to_s)
+        ActiveRecord::EnvironmentCheck.create!(environment: ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
       end
+    end
+
+    def self.last_protected_environment
+      ActiveRecord::EnvironmentCheck.order(created_at: :desc).first.environment
+    end
+
+    def self.protected_environment?
+      return false if current_version == 0
+      raise NoEnvironmentInSchemaError unless ActiveRecord::EnvironmentCheck.table_exists?
+      environment_check = ActiveRecord::EnvironmentCheck.order(:created_at).last
+
+      raise NoEnvironmentInSchemaError unless environment_check
+      ActiveRecord::Base.protected_environments.include?(environment_check.environment)
     end
 
     def up?

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -44,6 +44,19 @@ module ActiveRecord
 
       ##
       # :singleton-method:
+      # Accessor for the name of the environment check table. By default, the value is "environment_checks"
+      class_attribute :environment_check_table_name, instance_accessor: false
+      self.environment_check_table_name = "environment_checks"
+
+      ##
+      # :singleton-method:
+      # Accessor for an array of names of environments where destructive actions should be prohibited. By default,
+      # the value is ["production"]
+      class_attribute :protected_environments, instance_accessor: false
+      self.protected_environments = ["production"]
+
+      ##
+      # :singleton-method:
       # Indicates whether table names should be the pluralized versions of the corresponding class names.
       # If true, the default table name for a Product class will be +products+. If false, it would just be +product+.
       # See table_name for the full rules on table/class naming. This is true, by default.

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -51,6 +51,9 @@ module ActiveRecord
         initialize_schema_migrations_table
         connection.assume_migrated_upto_version(info[:version], migrations_paths)
       end
+
+      ActiveRecord::EnvironmentCheck.create_table
+      ActiveRecord::EnvironmentCheck.create!(environment: ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
     end
 
     private

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -254,7 +254,7 @@ HEADER
       end
 
       def ignored?(table_name)
-        [ActiveRecord::Base.schema_migrations_table_name, ignore_tables].flatten.any? do |ignored|
+        [ActiveRecord::Base.schema_migrations_table_name, ActiveRecord::Base.environment_check_table_name, ignore_tables].flatten.any? do |ignored|
           ignored === remove_prefix_and_suffix(table_name)
         end
       end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -42,6 +42,13 @@ module ActiveRecord
 
       LOCAL_HOSTS    = ['127.0.0.1', 'localhost']
 
+      def check_protected_environments!
+        if !ENV['DISABLE_DATABASE_ENVIRONMENT_CHECK'] && ActiveRecord::Migrator.protected_environment?
+          raise ActiveRecord::ProtectedEnvironmentError.new(ActiveRecord::Migrator.last_protected_environment)
+        end
+      rescue ActiveRecord::NoDatabaseError
+      end
+
       def register_task(pattern, task)
         @tasks ||= {}
         @tasks[pattern] = task
@@ -204,6 +211,8 @@ module ActiveRecord
         else
           raise ArgumentError, "unknown format #{format.inspect}"
         end
+        ActiveRecord::EnvironmentCheck.create_table
+        ActiveRecord::EnvironmentCheck.create!(environment: ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
       end
 
       def load_schema_for(*args)

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -38,6 +38,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_match %r{create_table "accounts"}, output
     assert_match %r{create_table "authors"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
+    assert_no_match %r{create_table "environment_checks"}, output
   end
 
   def test_schema_dump_uses_force_cascade_on_create_table
@@ -158,6 +159,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "accounts"}, output
     assert_match %r{create_table "authors"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
+    assert_no_match %r{create_table "environment_checks"}, output
   end
 
   def test_schema_dump_with_regexp_ignored_table
@@ -165,6 +167,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "accounts"}, output
     assert_match %r{create_table "authors"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
+    assert_no_match %r{create_table "environment_checks"}, output
   end
 
   def test_schema_dumps_index_columns_in_right_order
@@ -342,6 +345,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "foo_.+_bar"}, output
     assert_no_match %r{add_index "foo_.+_bar"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
+    assert_no_match %r{create_table "environment_checks"}, output
 
     if ActiveRecord::Base.connection.supports_foreign_keys?
       assert_no_match %r{add_foreign_key "foo_.+_bar"}, output

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -18,6 +18,34 @@ module ActiveRecord
     sqlite3:    :sqlite_tasks
   }
 
+  class DatabaseTasksUtilsTask< ActiveRecord::TestCase
+    def test_raises_an_error_when_called_with_protected_environment
+      ActiveRecord::Migrator.stubs(:current_version).returns(1)
+
+      protected_environments = ActiveRecord::Base.protected_environments.dup
+      current_env            = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+      assert !protected_environments.include?(current_env)
+      # Assert no error
+      ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+
+      ActiveRecord::Base.protected_environments << current_env
+      assert_raise(ActiveRecord::ProtectedEnvironmentError) do
+        ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+      end
+    ensure
+      ActiveRecord::Base.protected_environments = protected_environments
+    end
+
+    def test_raises_an_error_if_no_migrations_have_been_made
+      ActiveRecord::EnvironmentCheck.stubs(:table_exists?).returns(false)
+      ActiveRecord::Migrator.stubs(:current_version).returns(1)
+
+      assert_raise(ActiveRecord::NoEnvironmentInSchemaError) do
+        ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+      end
+    end
+  end
+
   class DatabaseTasksRegisterTask < ActiveRecord::TestCase
     def test_register_task
       klazz = Class.new do

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -28,7 +28,7 @@ module ApplicationTests
         assert_not File.exist?("tmp/restart.txt")
         `bin/setup 2>&1`
         assert_equal 0, File.size("log/my.log")
-        assert_equal '["articles", "schema_migrations"]', list_tables.call
+        assert_equal '["articles", "schema_migrations", "environment_checks"]', list_tables.call
         assert File.exist?("tmp/restart.txt")
       end
     end

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -116,11 +116,11 @@ class LoadingTest < ActiveSupport::TestCase
     require "#{rails_root}/config/environment"
     setup_ar!
 
-    assert_equal [ActiveRecord::SchemaMigration], ActiveRecord::Base.descendants
+    assert_equal [ActiveRecord::SchemaMigration, ActiveRecord::EnvironmentCheck], ActiveRecord::Base.descendants
     get "/load"
-    assert_equal [ActiveRecord::SchemaMigration, Post], ActiveRecord::Base.descendants
+    assert_equal [ActiveRecord::SchemaMigration, ActiveRecord::EnvironmentCheck, Post], ActiveRecord::Base.descendants
     get "/unload"
-    assert_equal [ActiveRecord::SchemaMigration], ActiveRecord::Base.descendants
+    assert_equal [ActiveRecord::SchemaMigration, ActiveRecord::EnvironmentCheck], ActiveRecord::Base.descendants
   end
 
   test "initialize cant be called twice" do

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -85,7 +85,7 @@ module ApplicationTests
 
       test 'db:drop failure because database does not exist' do
         Dir.chdir(app_path) do
-          output = `bin/rake db:drop 2>&1`
+          output = `bin/rake db:drop:_unsafe --trace 2>&1`
           assert_match(/does not exist/, output)
           assert_equal 0, $?.exitstatus
         end
@@ -222,14 +222,14 @@ module ApplicationTests
 
           assert_equal '["posts"]', list_tables[]
           `bin/rake db:schema:load`
-          assert_equal '["posts", "comments", "schema_migrations"]', list_tables[]
+          assert_equal '["posts", "comments", "schema_migrations", "environment_checks"]', list_tables[]
 
           app_file 'db/structure.sql', <<-SQL
             CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar(255));
           SQL
 
           `bin/rake db:structure:load`
-          assert_equal '["posts", "comments", "schema_migrations", "users"]', list_tables[]
+          assert_equal '["posts", "comments", "schema_migrations", "environment_checks", "users"]', list_tables[]
         end
       end
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -24,6 +24,26 @@ module ApplicationTests
       assert $task_loaded
     end
 
+    def test_the_test_rake_task_is_protected_when_previous_migration_was_production
+      Dir.chdir(app_path) do
+        output = `bin/rails generate model product name:string;
+         env RAILS_ENV=production bin/rake db:create db:migrate;
+         env RAILS_ENV=production bin/rake db:test:prepare test 2>&1`
+
+        assert_match /ActiveRecord::ProtectedEnvironmentError/, output
+      end
+    end
+
+    def test_not_protected_when_previous_migration_was_not_production
+      Dir.chdir(app_path) do
+        output = `bin/rails generate model product name:string;
+         env RAILS_ENV=test bin/rake db:create db:migrate;
+         env RAILS_ENV=test bin/rake db:test:prepare test 2>&1`
+
+        refute_match /ActiveRecord::ProtectedEnvironmentError/, output
+      end
+    end
+
     def test_environment_is_required_in_rake_tasks
       app_file "config/environment.rb", <<-RUBY
         SuperMiddleware = Struct.new(:app)


### PR DESCRIPTION
Prevent destructive action on production database

It is possible to run your tests against your production database by accident right now. While infrequently, but as an anecdotal data point, Heroku receives a non-trivial number of requests for a database restore due to this happening. In these cases the loss can be large. 

To prevent against running tests against production we can store the "environment" version that was used when migrating the database in a new internal table. Before executing tests we can see if the database is a listed in `protected_environments` and abort. There is a manual escape valve to force this check from happening with environment variable `DISABLE_DATABASE_ENVIRONMENT_CHECK=1`
