### PR TITLE
Replacing lambda with proc getting argument error because of it.

### DIFF
--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -5,7 +5,7 @@ module ActiveSupport
         def assert_called(object, method_name, message = nil, times: 1)
           times_called = 0
 
-          object.stub(method_name, -> { times_called += 1 }) { yield }
+          object.stub(method_name, proc { times_called += 1 }) { yield }
 
           error = "Expected #{method_name} to be called #{times} times, " \
             "but was called #{times_called} times"

--- a/activesupport/test/testing/method_call_assertions_test.rb
+++ b/activesupport/test/testing/method_call_assertions_test.rb
@@ -27,6 +27,12 @@ class MethodCallAssertionsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_assert_called_method_with_arguments
+    assert_called(@object, :<<) do
+      @object << 2
+    end
+  end
+
   def test_assert_called_failure
     error = assert_raises(Minitest::Assertion) do
       assert_called(@object, :increment) do


### PR DESCRIPTION
`assert_called` gives error while calling with block for example 

``` ruby
assert_called(object, :deliver!) do
  with_translation 'de', email_subject: '[Anmeldung] Willkommen' do
    ActiveSupport::Deprecation.silence do
      get '/test/send_mail'
    end
    assert_equal "Mail sent - Subject: [Anmeldung] Willkommen", @response.body
  end
end
```

**Before Change**

``` ruby
ActionMailerI18nWithControllerTest#test_send_mail:
ArgumentError: wrong number of arguments (1 for 0)
    /Users/ronakjangir/projects/open_source/rails/activesupport/lib/active_support/testing/method_call_assertions.rb:8:in `block in assert_called'
```

**After Change**

``` ruby
# Running:

.

Finished in 0.191095s, 5.2330 runs/s, 10.4660 assertions/s.
```

\cc @kaspth 
