### PR TITLE
There is no need for a constant here, also we can gain some performance.

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -654,7 +654,6 @@ module ActionController
         end
       end
 
-      EMPTY_ARRAY = []
       def hash_filter(params, filter)
         filter = filter.with_indifferent_access
 
@@ -663,7 +662,7 @@ module ActionController
           next unless value
           next unless has_key? key
 
-          if filter[key] == EMPTY_ARRAY
+          if filter[key].is_a?(Array) && filter[key].empty?
             # Declaration { comment_ids: [] }.
             array_of_permitted_scalars?(self[key]) do |val|
               params[key] = val


### PR DESCRIPTION
``` ruby
require 'benchmark/ips'
EMPTY_ARRAY = []
test = []

Benchmark.ips do |x|
  x.report('empty array') { test == [] }
  x.report('EMPTY_ARRAY') { test == EMPTY_ARRAY }
  x.report('is_a?') { test.is_a?(Array) && test.empty? }
end

Calculating -------------------------------------
         empty array    72.256k i/100ms
         EMPTY_ARRAY    79.119k i/100ms
               is_a?    92.583k i/100ms
-------------------------------------------------
         empty array      2.471M (±11.6%) i/s -     12.211M
         EMPTY_ARRAY      2.794M (±12.7%) i/s -     13.767M
               is_a?      4.916M (±15.8%) i/s -     23.886M
```
