### PR TITLE
use `average_scheduled_poll_interval` option instead of deprecated `poll_interval`

### DIFF
--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -57,7 +57,7 @@ module SidekiqJobsManager
                                        concurrency: 1,
                                        timeout: 1,
                                       })
-      Sidekiq.poll_interval = 0.5
+      Sidekiq.average_scheduled_poll_interval = 0.5
       Sidekiq::Scheduled.const_set :INITIAL_WAIT, 1
       begin
         sidekiq.run


### PR DESCRIPTION
this removes the following warning:

```
DEPRECATION: `config.poll_interval = 0.5` will be removed in Sidekiq 4. Please update to `config.average_scheduled_poll_interval = 0.5`.
```
