### PR TITLE
Initialize symbols instead of mapping to_sym on the set of strings

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -54,11 +54,11 @@ module AbstractController
       Mime::TEXT
     end
 
-    DEFAULT_PROTECTED_INSTANCE_VARIABLES = Set.new %w(
+    DEFAULT_PROTECTED_INSTANCE_VARIABLES = Set.new %i(
       @_action_name @_response_body @_formats @_prefixes @_config
       @_view_context_class @_view_renderer @_lookup_context
       @_routes @_db_runtime
-    ).map(&:to_sym)
+    )
 
     # This method should return a hash with assigns.
     # You can overwrite this configuration per controller.


### PR DESCRIPTION
We have `%i` so no need to use `%w` with `map(&:to_sym)`

``` ruby
require 'benchmark/ips'
require 'set'

Benchmark.ips do |x|
  x.report('%w') do
    Set.new %w(
      @_action_name @_response_body @_formats @_prefixes @_config
      @_view_context_class @_view_renderer @_lookup_context
      @_routes @_db_runtime
    ).map(&:to_sym)
  end

  x.report('%i') do
    Set.new %i(
      @_action_name @_response_body @_formats @_prefixes @_config
      @_view_context_class @_view_renderer @_lookup_context
      @_routes @_db_runtime
    )
  end
end

Calculating -------------------------------------
                  %w     6.162k i/100ms
                  %i     8.277k i/100ms
-------------------------------------------------
                  %w     63.862k (±10.4%) i/s -    320.424k
                  %i     84.348k (±12.2%) i/s -    422.127k
```
