### PR TITLE
add Deprecation.warn in active_support/core_ext/object/to_param.rb

### DIFF
--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-require 'active_support/core_ext/object/to_param'
+require 'active_support/core_ext/object/to_query'
 require 'active_support/core_ext/regexp'
 require 'active_support/dependencies/autoload'
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/benchmark'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/numeric/bytes'
 require 'active_support/core_ext/numeric/time'
-require 'active_support/core_ext/object/to_param'
+require 'active_support/core_ext/object/to_query'
 require 'active_support/core_ext/string/inflections'
 
 module ActiveSupport

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -1,7 +1,6 @@
 require 'active_support/xml_mini'
 require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/string/inflections'
-require 'active_support/core_ext/object/to_param'
 require 'active_support/core_ext/object/to_query'
 
 class Array

--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -1,7 +1,6 @@
 require 'active_support/xml_mini'
 require 'active_support/time'
 require 'active_support/core_ext/object/blank'
-require 'active_support/core_ext/object/to_param'
 require 'active_support/core_ext/object/to_query'
 require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/hash/reverse_merge'

--- a/activesupport/lib/active_support/core_ext/object.rb
+++ b/activesupport/lib/active_support/core_ext/object.rb
@@ -9,6 +9,5 @@ require 'active_support/core_ext/object/conversions'
 require 'active_support/core_ext/object/instance_variables'
 
 require 'active_support/core_ext/object/json'
-require 'active_support/core_ext/object/to_param'
 require 'active_support/core_ext/object/to_query'
 require 'active_support/core_ext/object/with_options'

--- a/activesupport/lib/active_support/core_ext/object/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/object/conversions.rb
@@ -1,4 +1,3 @@
-require 'active_support/core_ext/object/to_param'
 require 'active_support/core_ext/object/to_query'
 require 'active_support/core_ext/array/conversions'
 require 'active_support/core_ext/hash/conversions'

--- a/activesupport/lib/active_support/core_ext/object/to_param.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_param.rb
@@ -1,1 +1,3 @@
 require 'active_support/core_ext/object/to_query'
+
+ActiveSupport::Deprecation.warn('`to_param.rb` file is deprecated and will be removed. Please require `active_support/core_ext/object/to_query` instead.')

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -332,7 +332,7 @@ user_path(@user) # => "/users/357-john-smith"
 
 WARNING. Controllers need to be aware of any redefinition of `to_param` because when a request like that comes in "357-john-smith" is the value of `params[:id]`.
 
-NOTE: Defined in `active_support/core_ext/object/to_param.rb`.
+NOTE: Defined in `active_support/core_ext/object/to_query.rb`.
 
 ### `to_query`
 


### PR DESCRIPTION
This request is from #21255.
I think that `active_support/core_ext/object/to_param.rb` is deprecated and add a deprecation message.
