### PR TITLE
Use the PORT environment variable for rails server

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `rails server` will now honour the `PORT` environment variable
+
+    *David Cornu*
+
 *   Plugins generated using `rails plugin new` are now generated with the
     version number set to 0.1.0.
 

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -86,7 +86,7 @@ module Rails
 
     def default_options
       super.merge({
-        Port:               3000,
+        Port:               ENV.fetch('PORT', 3000).to_i,
         DoNotReverseLookup: true,
         environment:        (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || "development").dup,
         daemonize:          false,

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -44,6 +44,13 @@ class Rails::ServerTest < ActiveSupport::TestCase
     end
   end
 
+  def test_environment_with_port
+    switch_env "PORT", "1234" do
+      server = Rails::Server.new
+      assert_equal 1234, server.options[:Port]
+    end
+  end
+
   def test_caching_without_option
     args = []
     options = Rails::Server::Options.new.parse!(args)


### PR DESCRIPTION
Allow the server port to be set with the `PORT` environment variable.
- This has become somewhat of a standard on various platforms
- Would simplify setting a default port in development (which is currently only possible by either [monkey-patching](http://stackoverflow.com/a/6539193) or using a custom script to start the server)
