### PR TITLE
Add test cases for `safe_constantize`

### DIFF
--- a/activesupport/test/constantize_test_cases.rb
+++ b/activesupport/test/constantize_test_cases.rb
@@ -100,6 +100,8 @@ module ConstantizeTestCases
     assert_nil yield("Ace::Gas::ConstantizeTestCases")
     assert_nil yield("#<Class:0x7b8b718b>::Nested_1")
     assert_nil yield("Ace::gas")
+    assert_nil yield('Object::ABC')
+    assert_nil yield('A::Object::B')
 
     assert_raises(NameError) do
       with_autoloading_fixtures do


### PR DESCRIPTION
The issue was fixed by 7a41295, but there are no tests covering it.

Closes #15570
