### PR TITLE
Use == 0 instead of .zero? in #try

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/try.rb
+++ b/activesupport/lib/active_support/core_ext/object/try.rb
@@ -8,7 +8,7 @@ module ActiveSupport
 
     def try!(*a, &b)
       if a.empty? && block_given?
-        if b.arity.zero?
+        if b.arity == 0
           instance_eval(&b)
         else
           yield self


### PR DESCRIPTION
The perf gain is relatively minor but consistent:

```
Calculating -------------------------------------
             0.zero?   137.091k i/100ms
             1.zero?   137.350k i/100ms
              0 == 0   142.207k i/100ms
              1 == 0   144.724k i/100ms
-------------------------------------------------
             0.zero?      8.893M (± 6.5%) i/s -     44.280M
             1.zero?      8.751M (± 6.4%) i/s -     43.677M
              0 == 0     10.033M (± 7.0%) i/s -     49.915M
              1 == 0      9.814M (± 8.0%) i/s -     48.772M
```

And try! is quite a big hotspot for us so every little gain is appreciable.

@rafaelfranca for review please.
