### PR TITLE
Allow mysql and mysql2 tests run by database user with password

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -88,15 +88,15 @@ namespace :db do
     desc 'Build the MySQL test databases'
     task :build do
       config = ARTest.config['connections']['mysql']
-      %x( mysql --user=#{config['arunit']['username']} -e "create DATABASE #{config['arunit']['database']} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci ")
-      %x( mysql --user=#{config['arunit2']['username']} -e "create DATABASE #{config['arunit2']['database']} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci ")
+      %x( mysql --user=#{config['arunit']['username']} --password=#{config['arunit']['password']} -e "create DATABASE #{config['arunit']['database']} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci ")
+      %x( mysql --user=#{config['arunit2']['username']} --password=#{config['arunit2']['password']} -e "create DATABASE #{config['arunit2']['database']} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci ")
     end
 
     desc 'Drop the MySQL test databases'
     task :drop do
       config = ARTest.config['connections']['mysql']
-      %x( mysqladmin --user=#{config['arunit']['username']} -f drop #{config['arunit']['database']} )
-      %x( mysqladmin --user=#{config['arunit2']['username']} -f drop #{config['arunit2']['database']} )
+      %x( mysqladmin --user=#{config['arunit']['username']} --password=#{config['arunit']['password']} -f drop #{config['arunit']['database']} )
+      %x( mysqladmin --user=#{config['arunit2']['username']} --password=#{config['arunit2']['password']} -f drop #{config['arunit2']['database']} )
     end
 
     desc 'Rebuild the MySQL test databases'

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -26,7 +26,7 @@ class MysqlConnectionTest < ActiveRecord::MysqlTestCase
       run_without_connection do
         ar_config = ARTest.connection_config['arunit']
 
-        url = "mysql://#{ar_config["username"]}@localhost/#{ar_config["database"]}"
+        url = "mysql://#{ar_config["username"]}:#{ar_config["password"]}@localhost/#{ar_config["database"]}"
         Klass.establish_connection(url)
         assert_equal ar_config['database'], Klass.connection.current_database
       end


### PR DESCRIPTION
This pull request enables to perform activerecord unit tests using mysql database user with password protected based on #21107.
It addresses two type of errors:
- Create activerecord_unittest and activerecord_unittest2 database, it gets `ERROR 1045 (28000)` errors

``` ruby
$ rake db:mysql:build
ERROR 1045 (28000): Access denied for user 'rails'@'localhost' (using password: NO)
ERROR 1045 (28000): Access denied for user 'rails'@'localhost' (using password: NO)
$
```
- One of mysql test gets `Mysql::Error: Access denied for user 'rails'@'localhost' (using password: NO)`

``` ruby
$ ARCONN=mysql ruby -Itest test/cases/adapters/mysql/connection_test.rb -n test_connect_with_url
Using mysql
Run options: -n test_connect_with_url --seed 15610

# Running:

E

Finished in 0.008920s, 112.1061 runs/s, 0.0000 assertions/s.

  1) Error:
MysqlConnectionTest#test_connect_with_url:
Mysql::Error: Access denied for user 'rails'@'localhost' (using password: NO)
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:433:in `real_connect'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:433:in `connect'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:86:in `initialize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:38:in `new'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:38:in `mysql_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:719:in `new_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:763:in `checkout_new_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:742:in `try_to_checkout_new_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:703:in `acquire_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:499:in `checkout'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:362:in `connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:875:in `retrieve_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_handling.rb:113:in `retrieve_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_handling.rb:87:in `connection'
    test/cases/adapters/mysql/connection_test.rb:31:in `block in test_connect_with_url'
    /home/yahonda/git/rails/activerecord/test/support/connection_helper.rb:4:in `run_without_connection'
    test/cases/adapters/mysql/connection_test.rb:26:in `test_connect_with_url'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```
# Side effects caused by this commit

Due to this commit, it causes these warnings regardless password set to the user or not

```
$ rake db:mysql:build
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
```
# Steps to reproduce
- Use MySQL 5.7.8 rc with validate_password plugin enabled

```
mysql> select @@version;
+-----------+
| @@version |
+-----------+
| 5.7.8-rc  |
+-----------+
1 row in set (0.00 sec)

mysql>
```

``` sql
$ mysql -uroot -p

mysql> SHOW VARIABLES LIKE 'validate_password%';
+--------------------------------------+--------+
| Variable_name                        | Value  |
+--------------------------------------+--------+
| validate_password_dictionary_file    |        |
| validate_password_length             | 8      |
| validate_password_mixed_case_count   | 1      |
| validate_password_number_count       | 1      |
| validate_password_policy             | MEDIUM |
| validate_password_special_char_count | 1      |
+--------------------------------------+--------+
6 rows in set (0.00 sec)
```
- creating a user without password gets `ERROR 1819 (HY000)` as expected

``` sql
mysql> CREATE USER 'rails'@'localhost';
ERROR 1819 (HY000): Your password does not satisfy the current policy requirements
```
- creating a user with password

``` ruby
mysql> CREATE USER 'rails'@'localhost' IDENTIFIED BY 'Pass_w0rd';
Query OK, 0 rows affected (0.00 sec)

mysql> GRANT ALL PRIVILEGES ON activerecord_unittest.* to 'rails'@'localhost';
Query OK, 0 rows affected (0.00 sec)

mysql> GRANT ALL PRIVILEGES ON activerecord_unittest2.* to 'rails'@'localhost';
Query OK, 0 rows affected (0.00 sec)

mysql> GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* to 'rails'@'localhost';
Query OK, 0 rows affected (0.00 sec)

mysql>
```
- Edit rails/activerecord/test/config.yml file to include the password

``` ruby
$ cd rails/activerecord/
$ vi test/config.yml

$ diff -c test/config.example.yml test/config.yml
*** test/config.example.yml     2015-01-06 16:21:01.908540483 +0000
--- test/config.yml     2015-08-18 12:16:30.246192608 +0000
***************
*** 54,72 ****
--- 54,76 ----
    mysql:
      arunit:
        username: rails
+       password: Pass_w0rd
        encoding: utf8
        collation: utf8_unicode_ci
      arunit2:
        username: rails
+       password: Pass_w0rd
        encoding: utf8

    mysql2:
      arunit:
        username: rails
+       password: Pass_w0rd
        encoding: utf8
        collation: utf8_unicode_ci
      arunit2:
        username: rails
+       password: Pass_w0rd
        encoding: utf8

    oracle:
$
```
- Create activerecord_unittest and activerecord_unittest2 database, it gets `ERROR 1045 (28000)` errors
  since Rake tasks does not expect password.

``` ruby
$ rake db:mysql:build
ERROR 1045 (28000): Access denied for user 'rails'@'localhost' (using password: NO)
ERROR 1045 (28000): Access denied for user 'rails'@'localhost' (using password: NO)
$
```
- Perform one of mysql test

``` ruby
$ ARCONN=mysql ruby -Itest test/cases/adapters/mysql/connection_test.rb -n test_connect_with_url
Using mysql
Run options: -n test_connect_with_url --seed 15610

# Running:

E

Finished in 0.008920s, 112.1061 runs/s, 0.0000 assertions/s.

  1) Error:
MysqlConnectionTest#test_connect_with_url:
Mysql::Error: Access denied for user 'rails'@'localhost' (using password: NO)
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:433:in `real_connect'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:433:in `connect'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:86:in `initialize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:38:in `new'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:38:in `mysql_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:719:in `new_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:763:in `checkout_new_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:742:in `try_to_checkout_new_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:703:in `acquire_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:499:in `checkout'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:362:in `connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:875:in `retrieve_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_handling.rb:113:in `retrieve_connection'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_handling.rb:87:in `connection'
    test/cases/adapters/mysql/connection_test.rb:31:in `block in test_connect_with_url'
    /home/yahonda/git/rails/activerecord/test/support/connection_helper.rb:4:in `run_without_connection'
    test/cases/adapters/mysql/connection_test.rb:26:in `test_connect_with_url'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```
