### PR TITLE
Allow validations of `has_secure_token` columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow tokens generated with `ActiveRecord::SecureToken` to be validated.
+
+    *Kyle Marek-Spartz*
+
 *   Add a native JSON data type support in MySQL.
 
     Example:

--- a/activerecord/lib/active_record/secure_token.rb
+++ b/activerecord/lib/active_record/secure_token.rb
@@ -27,7 +27,7 @@ module ActiveRecord
         # Load securerandom only when has_secure_token is used.
         require 'active_support/core_ext/securerandom'
         define_method("regenerate_#{attribute}") { update! attribute => self.class.generate_unique_secure_token }
-        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token) unless self.send("#{attribute}?")}
+        before_validation { self.send("#{attribute}=", self.class.generate_unique_secure_token) unless self.send("#{attribute}?")}
       end
 
       def generate_unique_secure_token

--- a/activerecord/test/models/user.rb
+++ b/activerecord/test/models/user.rb
@@ -1,6 +1,8 @@
 class User < ActiveRecord::Base
   has_secure_token
   has_secure_token :auth_token
+
+  validates_presence_of :token
 end
 
 class UserWithNotification < User


### PR DESCRIPTION
Presently, `has_secure_token` generates the token in a `before_create` hook. This makes it a `before_validation` hook, so that the generated token can be validated.

@robertomiranda
