### PR TITLE
make `allow_concurrency' default in true

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -21,7 +21,7 @@ module Rails
       def initialize(*)
         super
         self.encoding = "utf-8"
-        @allow_concurrency             = nil
+        @allow_concurrency             = true
         @consider_all_requests_local   = false
         @filter_parameters             = []
         @filter_redirect               = []


### PR DESCRIPTION
https://github.com/rails/rails/blob/master/railties%2Flib%2Frails%2Fapplication%2Fdefault_middleware_stack.rb#L29-L48

The config.allow_concurrency is still in use. 
But `nil` value doesn't make sense, it should be `true`
