### PR TITLE
Correct cache store superclass in comment

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -26,7 +26,7 @@ module ActiveSupport
     end
 
     class << self
-      # Creates a new CacheStore object according to the given options.
+      # Creates a new Store object according to the given options.
       #
       # If no arguments are passed to this method, then a new
       # ActiveSupport::Cache::MemoryStore object will be returned.


### PR DESCRIPTION
The documentation of `ActiveSupport::Cache.lookup_store` refers to `CacheStore`, but the superclass of cache stores (`MemoryStore`, `MemCacheStore`, etc.) is `Store`. This commit corrects the error. Readers who want to inspect the implementation won't waste time searching for a class called `CacheStore` — as I just did!
