### PR TITLE
ActiveSupport: Fixing issue when delegating to methods named "block", "args", or "arg"

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -5,10 +5,11 @@ class Module
   # option is not used.
   class DelegationError < NoMethodError; end
 
-  RUBY_RESERVED_WORDS = Set.new(
-    %w(alias and BEGIN begin break case class def defined? do else elsif END
-       end ensure false for if in module next nil not or redo rescue retry
-       return self super then true undef unless until when while yield)
+  DELEGATION_RESERVED_METHOD_NAMES = Set.new(
+    %w(_ arg args alias and BEGIN begin block break case class def defined? do
+       else elsif END end ensure false for if in module next nil not or redo
+       rescue retry return self super then true undef unless until when while
+       yield)
   ).freeze
 
   # Provides a +delegate+ class method to easily expose contained objects'
@@ -171,7 +172,7 @@ class Module
     line = line.to_i
 
     to = to.to_s
-    to = "self.#{to}" if RUBY_RESERVED_WORDS.include?(to)
+    to = "self.#{to}" if DELEGATION_RESERVED_METHOD_NAMES.include?(to)
 
     methods.each do |method|
       # Attribute writer methods only accept one argument. Makes sure []=

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -83,6 +83,16 @@ Product = Struct.new(:name) do
   end
 end
 
+class Block
+  def hello?
+    true
+  end
+end
+
+HasBlock = Struct.new(:block) do
+  delegate :hello?, to: :block
+end
+
 class ParameterSet
   delegate :[], :[]=, :to => :@params
 
@@ -299,6 +309,11 @@ class ModuleTest < ActiveSupport::TestCase
 
     # Nested NoMethodError is the same name as the delegation
     assert_raise(NoMethodError) { product.type_name }
+  end
+
+  def test_delegation_with_method_arguments
+    has_block = HasBlock.new(Block.new)
+    assert has_block.hello?
   end
 
   def test_parent


### PR DESCRIPTION
When using `delegate` with `to: :block` (for example), the method calls the `block` argument to the method, not the method on the delegating object. For example, the following will fail even if the `Assignment` has a block:

``` ruby
class Assignment
  has_one :block 
  delegate :class, to: :block 
end
Assignment.new.class
```

The `delegate` method already prefixes certain reserved Ruby keywords with `self.`, so this patch just does the same for `block`, `args`, and `arg`. I've also included a test case that should fail without the patch applied.

Thanks!
