### PR TITLE
Handle invalid encodings in message verifier

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 4.2.4 (August 14, 2015) ##
 
+*   Handle invalid UTF-8 characters in `MessageVerifier.verify`.
+
+    *Roque Pinel*, *Grey Baker*
+
 *   Fix a `SystemStackError` when encoding an `Enumerable` with `json` gem and
     with the Active Support JSON encoder loaded.
 

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -35,7 +35,7 @@ module ActiveSupport
     end
 
     def verify(signed_message)
-      raise InvalidSignature if signed_message.blank?
+      raise InvalidSignature if signed_message.nil? || !signed_message.valid_encoding? || signed_message.blank?
 
       data, digest = signed_message.split("--")
       if data.present? && digest.present? && ActiveSupport::SecurityUtils.secure_compare(digest, generate_digest(data))

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -42,6 +42,7 @@ class MessageVerifierTest < ActiveSupport::TestCase
     assert_not_verified("#{data.reverse}--#{hash}")
     assert_not_verified("#{data}--#{hash.reverse}")
     assert_not_verified("purejunk")
+    assert_not_verified("\xff") # invalid encoding
   end
 
   def test_alternative_serialization_method


### PR DESCRIPTION
Backport of https://github.com/rails/rails/pull/20440
