### PR TITLE
Support MySQL 5.7.8 which enables show_compatibility_56=off

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -727,8 +727,12 @@ module ActiveRecord
 
       # SHOW VARIABLES LIKE 'name'
       def show_variable(name)
-        variables = select_all("SHOW VARIABLES LIKE '#{name}'", 'SCHEMA')
-        variables.first['Value'] unless variables.empty?
+        begin
+          variables = select_all("select @@#{name} as 'Value'", 'SCHEMA')
+          variables.first['Value'] unless variables.empty?
+        rescue ActiveRecord::StatementInvalid => _e
+          nil
+        end
       end
 
       # Returns a table's primary key and belonging sequence.

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -223,7 +223,7 @@ module ActiveRecord
         return @client_encoding if @client_encoding
 
         result = exec_query(
-          "SHOW VARIABLES WHERE Variable_name = 'character_set_client'",
+          "select @@character_set_client",
           'SCHEMA')
         @client_encoding = ENCODINGS[result.rows.last.last]
       end


### PR DESCRIPTION
This pull request addresses #21108 by using `select @@variable_name` instead of `show variables like` command.

This pull request has been tested with these environments:

```
MySQL 5.7.8 with show_compatibility_56 = off (default)
MySQL 5.7.8 with show_compatibility_56 = on 
MySQL 5.5.44 using rails-dev-box
```

The reason why `rescue .. nil` in the `show_variable` method is to make these tests pass. Without this exception handling it gets these two errors:

``` ruby
$ ARCONN=mysql ruby -Itest test/cases/adapter_test.rb -n test_show_nonexistent_variable_returns_nil
Using mysql
Run options: -n test_show_nonexistent_variable_returns_nil --seed 38937

# Running:

E

Finished in 0.006116s, 163.5047 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::AdapterTest#test_show_nonexistent_variable_returns_nil:
ActiveRecord::StatementInvalid: Mysql::Error: Unknown system variable 'foo_bar_baz': select @@foo_bar_baz as 'Value'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:317:in `query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:317:in `block in exec_without_stmt'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:514:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:508:in `log'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:316:in `exec_without_stmt'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:233:in `exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:361:in `select'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb:449:in `select'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:32:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:731:in `show_variable'
    test/cases/adapter_test.rb:80:in `test_show_nonexistent_variable_returns_nil'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

``` ruby
$ ARCONN=mysql2 ruby -Itest test/cases/adapters/mysql2/connection_test.rb -n test_logs_name_show_variable
Using mysql2
Run options: -n test_logs_name_show_variable --seed 52460

# Running:

E

Finished in 0.015369s, 65.0644 runs/s, 0.0000 assertions/s.

  1) Error:
Mysql2ConnectionTest#test_logs_name_show_variable:
ActiveRecord::StatementInvalid: Mysql2::Error: Unknown system variable 'foo': select @@foo as 'Value'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:427:in `query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:427:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:514:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:508:in `log'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:427:in `execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb:218:in `execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb:222:in `exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:361:in `select'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:32:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:731:in `show_variable'
    test/cases/adapters/mysql2/connection_test.rb:122:in `test_logs_name_show_variable'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```
