### PR TITLE
Get rid of mocha tests in actionpack - part 1

### DIFF
--- a/actionpack/test/abstract/translation_test.rb
+++ b/actionpack/test/abstract/translation_test.rb
@@ -24,7 +24,6 @@ module AbstractController
             },
           },
         })
-        @controller.stubs(action_name: :index)
       end
 
       def test_action_controller_base_responds_to_translate
@@ -44,25 +43,34 @@ module AbstractController
       end
 
       def test_lazy_lookup
-        assert_equal 'bar', @controller.t('.foo')
+        @controller.stub :action_name, :index do
+          assert_equal 'bar', @controller.t('.foo')
+        end
       end
 
       def test_lazy_lookup_with_symbol
-        assert_equal 'bar', @controller.t(:'.foo')
+        @controller.stub :action_name, :index do
+          assert_equal 'bar', @controller.t(:'.foo')
+        end
       end
 
       def test_lazy_lookup_fallback
-        assert_equal 'no_action_tr', @controller.t(:'.no_action')
+        @controller.stub :action_name, :index do
+          assert_equal 'no_action_tr', @controller.t(:'.no_action')
+        end
       end
 
       def test_default_translation
-        assert_equal 'bar', @controller.t('one.two')
+        @controller.stub :action_name, :index do
+          assert_equal 'bar', @controller.t('one.two')
+        end
       end
 
       def test_localize
         time, expected = Time.gm(2000), 'Sat, 01 Jan 2000 00:00:00 +0000'
-        I18n.stubs(:localize).with(time).returns(expected)
-        assert_equal expected, @controller.l(time)
+        I18n.stub :localize, expected do
+          assert_equal expected, @controller.l(time)
+        end
       end
     end
   end

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -397,6 +397,7 @@ def jruby_skip(message = '')
 end
 
 require 'mocha/setup' # FIXME: stop using mocha
+require 'minitest/mock'
 
 class ForkingExecutor
   class Server

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -1,6 +1,5 @@
 require 'abstract_unit'
 require 'controller/fake_models'
-require 'pathname'
 
 class TestControllerWithExtraEtags < ActionController::Base
   etag { nil  }
@@ -295,9 +294,10 @@ class ExpiresInRenderTest < ActionController::TestCase
 
   def test_date_header_when_expires_in
     time = Time.mktime(2011,10,30)
-    Time.stubs(:now).returns(time)
-    get :conditional_hello_with_expires_in
-    assert_equal Time.now.httpdate, @response.headers["Date"]
+    Time.stub :now, time do
+      get :conditional_hello_with_expires_in
+      assert_equal Time.now.httpdate, @response.headers["Date"]
+    end
   end
 end
 

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -1,5 +1,4 @@
 require 'abstract_unit'
-require 'digest/sha1'
 require "active_support/log_subscriber/test_helper"
 
 # common controller actions
@@ -133,7 +132,6 @@ end
 module RequestForgeryProtectionTests
   def setup
     @token      = "cf50faa3fe97702ca1ae"
-    @controller.stubs(:form_authenticity_token).returns(@token)
     @controller.stubs(:valid_authenticity_token?).with{ |_, t| t == @token }.returns(true)
     @controller.stubs(:valid_authenticity_token?).with{ |_, t| t != @token }.returns(false)
     @old_request_forgery_protection_token = ActionController::Base.request_forgery_protection_token
@@ -145,17 +143,21 @@ module RequestForgeryProtectionTests
   end
 
   def test_should_render_form_with_token_tag
-    assert_not_blocked do
-      get :index
+    @controller.stub :form_authenticity_token, @token do
+      assert_not_blocked do
+        get :index
+      end
+      assert_select 'form>input[name=?][value=?]', 'custom_authenticity_token', @token
     end
-    assert_select 'form>input[name=?][value=?]', 'custom_authenticity_token', @token
   end
 
   def test_should_render_button_to_with_token_tag
-    assert_not_blocked do
-      get :show_button
+    @controller.stub :form_authenticity_token, @token do
+      assert_not_blocked do
+        get :show_button
+      end
+      assert_select 'form>input[name=?][value=?]', 'custom_authenticity_token', @token
     end
-    assert_select 'form>input[name=?][value=?]', 'custom_authenticity_token', @token
   end
 
   def test_should_render_form_without_token_tag_if_remote
@@ -199,17 +201,21 @@ module RequestForgeryProtectionTests
   end
 
   def test_should_render_form_with_token_tag_if_remote_and_authenticity_token_requested
-    assert_not_blocked do
-      get :form_for_remote_with_token
+    @controller.stub :form_authenticity_token, @token do
+      assert_not_blocked do
+        get :form_for_remote_with_token
+      end
+      assert_select 'form>input[name=?][value=?]', 'custom_authenticity_token', @token
     end
-    assert_select 'form>input[name=?][value=?]', 'custom_authenticity_token', @token
   end
 
   def test_should_render_form_with_token_tag_with_authenticity_token_requested
-    assert_not_blocked do
-      get :form_for_with_token
+    @controller.stub :form_authenticity_token, @token do
+      assert_not_blocked do
+        get :form_for_with_token
+      end
+      assert_select 'form>input[name=?][value=?]', 'custom_authenticity_token', @token
     end
-    assert_select 'form>input[name=?][value=?]', 'custom_authenticity_token', @token
   end
 
   def test_should_allow_get
@@ -402,11 +408,12 @@ class RequestForgeryProtectionControllerUsingResetSessionTest < ActionController
   end
 
   test 'should emit a csrf-param meta tag and a csrf-token meta tag' do
-    @controller.stubs(:form_authenticity_token).returns(@token + '<=?')
-    get :meta
-    assert_select 'meta[name=?][content=?]', 'csrf-param', 'custom_authenticity_token'
-    assert_select 'meta[name=?]', 'csrf-token'
-    assert_match(/cf50faa3fe97702ca1ae&lt;=\?/, @response.body)
+    @controller.stub :form_authenticity_token, @token + '<=?' do
+      get :meta
+      assert_select 'meta[name=?][content=?]', 'csrf-param', 'custom_authenticity_token'
+      assert_select 'meta[name=?]', 'csrf-token'
+      assert_match(/cf50faa3fe97702ca1ae&lt;=\?/, @response.body)
+    end
   end
 end
 
@@ -485,30 +492,36 @@ class FreeCookieControllerTest < ActionController::TestCase
   def setup
     @controller = FreeCookieController.new
     @token      = "cf50faa3fe97702ca1ae"
-
-    SecureRandom.stubs(:base64).returns(@token)
     super
   end
 
   def test_should_not_render_form_with_token_tag
-    get :index
-    assert_select 'form>div>input[name=?][value=?]', 'authenticity_token', @token, false
+    SecureRandom.stub :base64, @token do
+      get :index
+      assert_select 'form>div>input[name=?][value=?]', 'authenticity_token', @token, false
+    end
   end
 
   def test_should_not_render_button_to_with_token_tag
-    get :show_button
-    assert_select 'form>div>input[name=?][value=?]', 'authenticity_token', @token, false
+    SecureRandom.stub :base64, @token do
+      get :show_button
+      assert_select 'form>div>input[name=?][value=?]', 'authenticity_token', @token, false
+    end
   end
 
   def test_should_allow_all_methods_without_token
-    [:post, :patch, :put, :delete].each do |method|
-      assert_nothing_raised { send(method, :index)}
+    SecureRandom.stub :base64, @token do
+      [:post, :patch, :put, :delete].each do |method|
+        assert_nothing_raised { send(method, :index)}
+      end
     end
   end
 
   test 'should not emit a csrf-token meta tag' do
-    get :meta
-    assert @response.body.blank?
+    SecureRandom.stub :base64, @token do
+      get :meta
+      assert @response.body.blank?
+    end
   end
 end
 
@@ -529,11 +542,11 @@ class CustomAuthenticityParamControllerTest < ActionController::TestCase
 
   def test_should_not_warn_if_form_authenticity_param_matches_form_authenticity_token
     ActionController::Base.logger = @logger
-    @controller.stubs(:valid_authenticity_token?).returns(:true)
-
     begin
-      post :index, params: { custom_token_name: 'foobar' }
-      assert_equal 0, @logger.logged(:warn).size
+      @controller.stub :valid_authenticity_token?, :true do
+        post :index, params: { custom_token_name: 'foobar' }
+        assert_equal 0, @logger.logged(:warn).size
+      end
     ensure
       ActionController::Base.logger = @old_logger
     end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -4,6 +4,8 @@ require 'active_support/json/decoding'
 require 'rails/engine'
 
 class TestCaseTest < ActionController::TestCase
+  def self.fixture_path; end;
+
   class TestController < ActionController::Base
     def no_op
       render plain: 'dummy'
@@ -849,10 +851,10 @@ XML
   end
 
   def test_fixture_path_is_accessed_from_self_instead_of_active_support_test_case
-    TestCaseTest.stubs(:fixture_path).returns(FILES_DIR)
-
-    uploaded_file = fixture_file_upload('/mona_lisa.jpg', 'image/png')
-    assert_equal File.open("#{FILES_DIR}/mona_lisa.jpg", READ_PLAIN).read, uploaded_file.read
+    TestCaseTest.stub :fixture_path, FILES_DIR do
+      uploaded_file = fixture_file_upload('/mona_lisa.jpg', 'image/png')
+      assert_equal File.open("#{FILES_DIR}/mona_lisa.jpg", READ_PLAIN).read, uploaded_file.read
+    end
   end
 
   def test_test_uploaded_file_with_binary
@@ -893,13 +895,13 @@ XML
   end
 
   def test_fixture_file_upload_relative_to_fixture_path
-    TestCaseTest.stubs(:fixture_path).returns(FILES_DIR)
-    uploaded_file = fixture_file_upload("mona_lisa.jpg", "image/jpg")
-    assert_equal File.open("#{FILES_DIR}/mona_lisa.jpg", READ_PLAIN).read, uploaded_file.read
+    TestCaseTest.stub :fixture_path, FILES_DIR do
+      uploaded_file = fixture_file_upload("mona_lisa.jpg", "image/jpg")
+      assert_equal File.open("#{FILES_DIR}/mona_lisa.jpg", READ_PLAIN).read, uploaded_file.read
+    end
   end
 
   def test_fixture_file_upload_ignores_nil_fixture_path
-    TestCaseTest.stubs(:fixture_path).returns(nil)
     uploaded_file = fixture_file_upload("#{FILES_DIR}/mona_lisa.jpg", "image/jpg")
     assert_equal File.open("#{FILES_DIR}/mona_lisa.jpg", READ_PLAIN).read, uploaded_file.read
   end

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -321,10 +321,12 @@ class CookiesTest < ActionController::TestCase
   end
 
   def test_setting_cookie_with_secure_when_always_write_cookie_is_true
-    ActionDispatch::Cookies::CookieJar.any_instance.stubs(:always_write_cookie).returns(true)
+    old_cookie, @request.cookie_jar.always_write_cookie = @request.cookie_jar.always_write_cookie, true
     get :authenticate_with_secure
     assert_cookie_header "user_name=david; path=/; secure"
     assert_equal({"user_name" => "david"}, @response.cookies)
+  ensure
+    @request.cookie_jar.always_write_cookie = old_cookie
   end
 
   def test_not_setting_cookie_with_secure

--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -17,8 +17,6 @@ module ActionDispatch
     end
 
     setup do
-      Rails.stubs(:root).returns(Pathname.new('.'))
-
       @cleaner = ActiveSupport::BacktraceCleaner.new
       @cleaner.add_silencer { |line| line !~ /^lib/ }
     end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 require 'erb'
 require 'abstract_unit'
 require 'controller/fake_controllers'
@@ -4190,11 +4189,11 @@ class TestNamedRouteUrlHelpers < ActionDispatch::IntegrationTest
   include Routes.url_helpers
 
   test "url helpers do not ignore nil parameters when using non-optimized routes" do
-    Routes.stubs(:optimize_routes_generation?).returns(false)
-
-    get "/categories/1"
-    assert_response :success
-    assert_raises(ActionController::UrlGenerationError) { product_path(nil) }
+    Routes.stub :optimize_routes_generation?, false do
+      get "/categories/1"
+      assert_response :success
+      assert_raises(ActionController::UrlGenerationError) { product_path(nil) }
+    end
   end
 end
 

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -274,28 +274,32 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
     with_test_route_set(:expire_after => 5.hours) do
       # First request accesses the session
       time = Time.local(2008, 4, 24)
-      Time.stubs(:now).returns(time)
-      expected_expiry = (time + 5.hours).gmtime.strftime("%a, %d %b %Y %H:%M:%S -0000")
+      cookie_body = nil
 
-      cookies[SessionKey] = SignedBar
+      Time.stub :now, time do
+        expected_expiry = (time + 5.hours).gmtime.strftime("%a, %d %b %Y %H:%M:%S -0000")
 
-      get '/set_session_value'
-      assert_response :success
+        cookies[SessionKey] = SignedBar
 
-      cookie_body = response.body
-      assert_equal "_myapp_session=#{cookie_body}; path=/; expires=#{expected_expiry}; HttpOnly",
-        headers['Set-Cookie']
+        get '/set_session_value'
+        assert_response :success
+
+        cookie_body = response.body
+        assert_equal "_myapp_session=#{cookie_body}; path=/; expires=#{expected_expiry}; HttpOnly",
+          headers['Set-Cookie']
+      end
 
       # Second request does not access the session
       time = Time.local(2008, 4, 25)
-      Time.stubs(:now).returns(time)
-      expected_expiry = (time + 5.hours).gmtime.strftime("%a, %d %b %Y %H:%M:%S -0000")
+      Time.stub :now, time do
+        expected_expiry = (time + 5.hours).gmtime.strftime("%a, %d %b %Y %H:%M:%S -0000")
 
-      get '/no_session_access'
-      assert_response :success
+        get '/no_session_access'
+        assert_response :success
 
-      assert_equal "_myapp_session=#{cookie_body}; path=/; expires=#{expected_expiry}; HttpOnly",
-        headers['Set-Cookie']
+        assert_equal "_myapp_session=#{cookie_body}; path=/; expires=#{expected_expiry}; HttpOnly",
+          headers['Set-Cookie']
+      end
     end
   end
 

--- a/actionpack/test/dispatch/test_request_test.rb
+++ b/actionpack/test/dispatch/test_request_test.rb
@@ -53,10 +53,8 @@ class TestRequestTest < ActiveSupport::TestCase
     assert_cookies({"user_name" => "david"}, req.cookie_jar)
   end
 
-  test "does not complain when Rails.application is nil" do
-    Rails.stubs(:application).returns(nil)
+  test "does not complain when there is no application config" do
     req = ActionDispatch::TestRequest.create({})
-
     assert_equal false, req.env.empty?
   end
 


### PR DESCRIPTION
The idea is to gradually introducing minitest stubs/mocks and at the end get rid of mocha dependency.
To not making too big PRs that are hard to review, I thought I split this task into series of 2 (maybe 3) PRs.
I also removed some unused requires/stubs.
