### PR TITLE
Fix `:reject_if` when using a method that loads the association.

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -446,7 +446,8 @@ module ActiveRecord
 
       association = association(association_name)
 
-      existing_records = if association.loaded?
+      is_association_loaded = association.loaded?
+      existing_records = if is_association_loaded
         association.target
       else
         attribute_ids = attributes_collection.map {|a| a['id'] || a[:id] }.compact
@@ -461,7 +462,7 @@ module ActiveRecord
             association.build(attributes.except(*UNASSIGNABLE_KEYS))
           end
         elsif existing_record = existing_records.detect { |record| record.id.to_s == attributes['id'].to_s }
-          unless association.loaded? || call_reject_if(association_name, attributes)
+          unless is_association_loaded || call_reject_if(association_name, attributes)
             # Make sure we are operating on the actual object which is in the association's
             # proxy_target array (either by finding it, or adding it if not found)
             target_record = association.target.detect { |record| record == existing_record }

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -161,6 +161,20 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     assert man.reload.interests.empty?
   end
 
+  def test_reject_if_with_a_method_that_loads_the_association
+    Man.class_eval do
+      accepts_nested_attributes_for :interests, :reject_if => :reject_if_false, :allow_destroy => true
+      def reject_if_false
+        interests.to_a && false
+      end
+    end
+    man = Man.create(name: "John")
+    interest_photography = man.interests.create(topic: 'photography')
+    interest_gardening = man.interests.create(topic: 'gardening')
+    man.update({:interests_attributes => {'0' => interest_photography.attributes, '1' => interest_gardening.attributes.merge('_destroy' => '1')}})
+    assert_equal 1, man.reload.interests.count
+  end
+
   def test_has_many_association_updating_a_single_record
     Man.accepts_nested_attributes_for(:interests)
     man = Man.create(name: 'John')


### PR DESCRIPTION
The association might get loaded while looping through the attributes,
so cache `association.loaded?` before calling any `:reject_if`.

This was fixed in 4.1 and above in the context of #11525 (see commit 018697d).
