### PR TITLE
Fix `:reject_if` when using a method that loads the association.

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -415,7 +415,8 @@ module ActiveRecord
 
       association = association(association_name)
 
-      existing_records = if association.loaded?
+      is_association_loaded = association.loaded?
+      existing_records = if is_association_loaded
         association.target
       else
         attribute_ids = attributes_collection.map {|a| a['id'] || a[:id] }.compact
@@ -430,7 +431,7 @@ module ActiveRecord
             association.build(attributes.except(*unassignable_keys(assignment_opts)), assignment_opts)
           end
         elsif existing_record = existing_records.detect { |record| record.id.to_s == attributes['id'].to_s }
-          unless association.loaded? || call_reject_if(association_name, attributes)
+          unless is_association_loaded || call_reject_if(association_name, attributes)
             # Make sure we are operating on the actual object which is in the association's
             # proxy_target array (either by finding it, or adding it if not found)
             target_record = association.target.detect { |record| record == existing_record }


### PR DESCRIPTION
The association might get loaded while looping through the attributes,
so cache `association.loaded?` before calling any `:reject_if`.

Same as #21322, but for 3.2.
