### PR TITLE
discard xml Serialization documentation that is no longer available […

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -31,12 +31,10 @@ module ActiveModel
   # of the attributes hash's keys. In order to override this behavior, take a look
   # at the private method +read_attribute_for_serialization+.
   #
-  # Most of the time though, either the JSON or XML serializations are needed.
-  # Both of these modules automatically include the
-  # <tt>ActiveModel::Serialization</tt> module, so there is no need to
-  # explicitly include it.
+  # JSON Serialization module is automatically include the <tt>ActiveModel::Serialization</tt>
+  # module, so there is no need to explicitly include it.
   #
-  # A minimal implementation including XML and JSON would be:
+  # A minimal implementation including JSON would be:
   #
   #   class Person
   #     include ActiveModel::Serializers::JSON


### PR DESCRIPTION
…ci skip]

Removed Xml Serialization by @zzak in this PR https://github.com/rails/rails/pull/21161/files, so `ActiveModel::Serialization` will not serve default with `XML serializations` cc @rafaelfranca 
