### PR TITLE
use gen_random_uuid() function from pgcrypto extension in default of uuid primary key (only PostgreSQL >= 9.4)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Use gen_random_uuid() function from pgcrypto extension in default of uuid
+    primary key (only PostgreSQL >= 9.4).
+
+    *Yuji Yaginuma*
+
 *   Fixed `where` for polymorphic associations when passed an array containing different types.
 
     Fixes #17011.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -310,6 +310,10 @@ module ActiveRecord
         postgresql_version >= 90300
       end
 
+      def supports_pgcrypto?
+        postgresql_version >= 90400
+      end
+
       def get_advisory_lock(lock_id) # :nodoc:
         unless lock_id.is_a?(Integer) && lock_id.bit_length <= 63
           raise(ArgumentError, "Postgres requires advisory lock ids to be a signed 64 bit integer")

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -18,6 +18,10 @@ module ActiveRecord
         end
 
         def create_table(table_name, options = {})
+          if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+            set_uuid_default(options)
+          end
+
           if block_given?
             super(table_name, options) do |t|
               class << t
@@ -89,6 +93,12 @@ module ActiveRecord
           end
 
           index_name
+        end
+
+        def set_uuid_default(options)
+          if options[:id] == :uuid && !options[:default]
+            options[:default] = 'uuid_generate_v4()'
+          end
         end
       end
 

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -1,6 +1,10 @@
 ActiveRecord::Schema.define do
 
-  enable_extension!('uuid-ossp', ActiveRecord::Base.connection)
+  if connection.supports_pgcrypto?
+    enable_extension!('pgcrypto', connection)
+  else
+    enable_extension!('uuid-ossp', connection)
+  end
 
   create_table :uuid_parents, id: :uuid, force: true do |t|
     t.string :name

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -313,9 +313,9 @@ You can use `uuid` type to define references in migrations:
 ```ruby
 # db/migrate/20150418012400_create_blog.rb
 enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
-create_table :posts, id: :uuid, default: 'gen_random_uuid()'
+create_table :posts, id: :uuid
 
-create_table :comments, id: :uuid, default: 'gen_random_uuid()' do |t|
+create_table :comments, id: :uuid do |t|
   # t.belongs_to :post, type: :uuid
   t.references :post, type: :uuid
 end
@@ -409,7 +409,7 @@ extension to generate random UUIDs.
 ```ruby
 # db/migrate/20131220144913_create_devices.rb
 enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
-create_table :devices, id: :uuid, default: 'gen_random_uuid()' do |t|
+create_table :devices, id: :uuid do |t|
   t.string :kind
 end
 


### PR DESCRIPTION
PostgreSQL docs (since 9.4) suggests using gen_random_uuid() function to generate random UUID,
so by default it is better to use the gen_random_uuid().
