### PR TITLE
Honor table prefix/suffix when deriving join table name

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -63,7 +63,12 @@ module ActiveRecord
     #   records, artists => artists_records
     #   music_artists, music_records => music_artists_records
     def self.derive_join_table_name(first_table, second_table) # :nodoc:
-      [first_table.to_s, second_table.to_s].sort.join("\0").gsub(/^(.*_)(.+)\0\1(.+)/, '\1\2_\3').tr("\0", "_")
+      join_table_name = [first_table.to_s, second_table.to_s].
+                        sort.
+                        join("\0").
+                        gsub(/^(.*_)(.+)\0\1(.+)/, '\1\2_\3').tr("\0", "_")
+
+      "#{ActiveRecord::Base.table_name_prefix}#{join_table_name}#{ActiveRecord::Base.table_name_suffix}"
     end
 
     module ClassMethods
@@ -295,6 +300,12 @@ module ActiveRecord
         reload_schema_from_cache
       end
 
+      # Guesses the table name, but does not decorate it with prefix and suffix information.
+      def undecorated_table_name(class_name = base_class.name)
+        table_name = class_name.to_s.demodulize.underscore
+        pluralize_table_names ? table_name.pluralize : table_name
+      end
+
       private
 
       def schema_loaded?
@@ -332,12 +343,6 @@ module ActiveRecord
         @columns = nil
         @columns_hash = nil
         @attribute_names = nil
-      end
-
-      # Guesses the table name, but does not decorate it with prefix and suffix information.
-      def undecorated_table_name(class_name = base_class.name)
-        table_name = class_name.to_s.demodulize.underscore
-        pluralize_table_names ? table_name.pluralize : table_name
       end
 
       # Computes and returns a table name according to default conventions.

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -569,7 +569,7 @@ module ActiveRecord
         end
 
         def derive_join_table
-          ModelSchema.derive_join_table_name active_record.table_name, klass.table_name
+          ModelSchema.derive_join_table_name active_record.undecorated_table_name, klass.undecorated_table_name
         end
 
         def primary_key(klass)

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -440,6 +440,26 @@ class BasicsTest < ActiveRecord::TestCase
     Post.reset_table_name
   end
 
+  def test_undecorated_table_name
+    ActiveRecord::Base.table_name_prefix = "myblog_"
+    Post.reset_table_name
+    assert_equal "posts", Post.undecorated_table_name
+  ensure
+    ActiveRecord::Base.table_name_prefix = ""
+    Post.reset_table_name
+  end
+
+  def test_undecorated_table_name_with_singular_table_names
+    ActiveRecord::Base.table_name_prefix = "myblog_"
+    Post.pluralize_table_names = false
+    Post.reset_table_name
+    assert_equal "post", Post.undecorated_table_name
+  ensure
+    ActiveRecord::Base.table_name_prefix = ""
+    Post.pluralize_table_names = true
+    Post.reset_table_name
+  end
+
   if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
     def test_update_all_with_order_and_limit
       assert_equal 1, Topic.limit(1).order('id DESC').update_all(:content => 'bulk updated!')

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -16,6 +16,35 @@ module ActiveRecord
         end
       end
 
+      def test_create_join_table_honors_table_name_prefix
+        ActiveRecord::Base.table_name_prefix = "music_store_"
+        connection.create_join_table :artists, :musics
+
+        assert connection.tables.include?("music_store_artists_musics")
+      ensure
+        ActiveRecord::Base.table_name_prefix = ""
+      end
+
+      def test_create_join_table_honors_table_name_suffix
+        ActiveRecord::Base.table_name_suffix = "_v2"
+        connection.create_join_table :artists, :musics
+
+        assert connection.tables.include?("artists_musics_v2")
+      ensure
+        ActiveRecord::Base.table_name_suffix = ""
+      end
+
+      def test_create_join_table_honors_table_name_prefix_and_suffix
+        ActiveRecord::Base.table_name_prefix = "music_store_"
+        ActiveRecord::Base.table_name_suffix = "_v2"
+        connection.create_join_table :artists, :musics
+
+        assert connection.tables.include?("music_store_artists_musics_v2")
+      ensure
+        ActiveRecord::Base.table_name_prefix = ""
+        ActiveRecord::Base.table_name_suffix = ""
+      end
+
       def test_create_join_table
         connection.create_join_table :artists, :musics
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -389,8 +389,8 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_join_table
-    category = Struct.new(:table_name, :pluralize_table_names).new('categories', true)
-    product = Struct.new(:table_name, :pluralize_table_names).new('products', true)
+    category = Struct.new(:table_name, :pluralize_table_names, :undecorated_table_name).new('categories', true, 'categories')
+    product = Struct.new(:table_name, :pluralize_table_names, :undecorated_table_name).new('products', true, 'products')
 
     reflection = ActiveRecord::Reflection.create(:has_many, :categories, nil, {}, product)
     reflection.stub(:klass, category) do
@@ -404,8 +404,8 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_join_table_with_common_prefix
-    category = Struct.new(:table_name, :pluralize_table_names).new('catalog_categories', true)
-    product = Struct.new(:table_name, :pluralize_table_names).new('catalog_products', true)
+    category = Struct.new(:table_name, :pluralize_table_names, :undecorated_table_name).new('catalog_categories', true, 'catalog_categories')
+    product = Struct.new(:table_name, :pluralize_table_names, :undecorated_table_name).new('catalog_products', true, 'catalog_products')
 
     reflection = ActiveRecord::Reflection.create(:has_many, :categories, nil, {}, product)
     reflection.stub(:klass, category) do
@@ -419,8 +419,8 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_join_table_with_different_prefix
-    category = Struct.new(:table_name, :pluralize_table_names).new('catalog_categories', true)
-    page = Struct.new(:table_name, :pluralize_table_names).new('content_pages', true)
+    category = Struct.new(:table_name, :pluralize_table_names, :undecorated_table_name).new('catalog_categories', true, 'catalog_categories')
+    page = Struct.new(:table_name, :pluralize_table_names, :undecorated_table_name).new('content_pages', true, 'content_pages')
 
     reflection = ActiveRecord::Reflection.create(:has_many, :categories, nil, {}, page)
     reflection.stub(:klass, category) do
@@ -433,9 +433,60 @@ class ReflectionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_join_table_with_table_prefix
+    ActiveRecord::Base.table_name_prefix = 'mystore_'
+
+    category = Struct.new(:table_name, :pluralize_table_names, :undecorated_table_name).new('categories', true, 'categories')
+    product = Struct.new(:table_name, :pluralize_table_names, :undecorated_table_name).new('products', true, 'products')
+
+    reflection = ActiveRecord::Reflection.create(:has_many, :categories, nil, {}, product)
+    reflection.stubs(:klass).returns(category)
+    assert_equal 'mystore_categories_products', reflection.join_table
+
+    reflection = ActiveRecord::Reflection.create(:has_many, :products, nil, {}, category)
+    reflection.stubs(:klass).returns(product)
+    assert_equal 'mystore_categories_products', reflection.join_table
+  ensure
+    ActiveRecord::Base.table_name_prefix = ''
+  end
+
+  def test_join_table_with_table_suffix
+    ActiveRecord::Base.table_name_suffix = '_test'
+
+    category = Struct.new(:table_name, :pluralize_table_names, :undecorated_table_name).new('categories', true, 'categories')
+    product = Struct.new(:table_name, :pluralize_table_names, :undecorated_table_name).new('products', true, 'products')
+
+    reflection = ActiveRecord::Reflection.create(:has_many, :categories, nil, {}, product)
+    reflection.stubs(:klass).returns(category)
+    assert_equal 'categories_products_test', reflection.join_table
+
+    reflection = ActiveRecord::Reflection.create(:has_many, :products, nil, {}, category)
+    reflection.stubs(:klass).returns(product)
+    assert_equal 'categories_products_test', reflection.join_table
+  ensure
+    ActiveRecord::Base.table_name_suffix = ''
+  end
+
+  def test_join_table_with_common_prefix_and_table_prefix
+    ActiveRecord::Base.table_name_prefix = 'mystore_'
+
+    category = Struct.new(:table_name, :pluralize_table_names, :undecorated_table_name).new('catalog_categories', true, 'catalog_categories')
+    product = Struct.new(:table_name, :pluralize_table_names, :undecorated_table_name).new('catalog_products', true, 'catalog_products')
+
+    reflection = ActiveRecord::Reflection.create(:has_many, :categories, nil, {}, product)
+    reflection.stubs(:klass).returns(category)
+    assert_equal 'mystore_catalog_categories_products', reflection.join_table
+
+    reflection = ActiveRecord::Reflection.create(:has_many, :products, nil, {}, category)
+    reflection.stubs(:klass).returns(product)
+    assert_equal 'mystore_catalog_categories_products', reflection.join_table
+  ensure
+    ActiveRecord::Base.table_name_prefix = ''
+  end
+
   def test_join_table_can_be_overridden
-    category = Struct.new(:table_name, :pluralize_table_names).new('categories', true)
-    product = Struct.new(:table_name, :pluralize_table_names).new('products', true)
+    category = Struct.new(:table_name, :pluralize_table_names, :undecorated_table_name).new('categories', true, 'categories')
+    product = Struct.new(:table_name, :pluralize_table_names, :undecorated_table_name).new('products', true, 'products')
 
     reflection = ActiveRecord::Reflection.create(:has_many, :categories, nil, { :join_table => 'product_categories' }, product)
     reflection.stub(:klass, category) do


### PR DESCRIPTION
In its effort to remove multiple instances of a common table prefix, for example with namespaced models, `ModelSchema` was causing unexpected results when a table_name_prefix was set.

This patch makes `derive_join_table_name` correctly honour global table name prefixes (and suffixes) by appending and prepending to the resulting derived table name as appropriate (and changes the AR internals so that it only passes along non-prefixed (and non-suffixed) table names).

(fixes #21307)
