### PR TITLE
Hide overly-aggressive route reloading behind configuration flag

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -13,7 +13,7 @@ module Rails
                     :railties_order, :relative_url_root, :secret_key_base, :secret_token,
                     :serve_static_files, :ssl_options, :static_cache_control, :static_index,
                     :session_options, :time_zone, :reload_classes_only_on_change,
-                    :beginning_of_week, :filter_redirect, :x
+                    :reload_routes_aggressively, :beginning_of_week, :filter_redirect, :x
 
       attr_writer :log_level
       attr_reader :encoding, :api_only

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -68,17 +68,21 @@ module Rails
         reloader = routes_reloader
         reloader.execute_if_updated
         self.reloaders << reloader
-        ActionDispatch::Reloader.to_prepare do
-          # We configure #execute rather than #execute_if_updated because if
-          # autoloaded constants are cleared we need to reload routes also in
-          # case any was used there, as in
-          #
-          #   mount MailPreview => 'mail_view'
-          #
-          # This means routes are also reloaded if i18n is updated, which
-          # might not be necessary, but in order to be more precise we need
-          # some sort of reloaders dependency support, to be added.
-          reloader.execute
+
+        # Since the following is expensive with large route sets (which many
+        # applications have) we're hiding it behind a config flag.
+        if config.reload_routes_aggressively
+          ActionDispatch::Reloader.to_prepare do
+            # If autoloaded constants are cleared we need to reload routes also
+            # in case any was used there, as in
+            #
+            #   mount MailPreview => 'mail_view'
+            #
+            # This means routes are also reloaded if i18n is updated, which
+            # might not be necessary, but in order to be more precise we need
+            # some sort of reloaders dependency support to be added.
+            reloader.execute
+          end
         end
       end
 

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -131,6 +131,7 @@ class LoadingTest < ActiveSupport::TestCase
   test "reload constants on development" do
     add_to_config <<-RUBY
       config.cache_classes = false
+      config.reload_routes_aggressively = true
     RUBY
 
     app_file 'config/routes.rb', <<-RUBY
@@ -205,6 +206,7 @@ class LoadingTest < ActiveSupport::TestCase
   test "added files (like db/schema.rb) also trigger reloading" do
     add_to_config <<-RUBY
       config.cache_classes = false
+      config.reload_routes_aggressively = true
     RUBY
 
     app_file 'config/routes.rb', <<-RUBY
@@ -237,6 +239,7 @@ class LoadingTest < ActiveSupport::TestCase
   test "dependencies reloading is followed by routes reloading" do
     add_to_config <<-RUBY
       config.cache_classes = false
+      config.reload_routes_aggressively = true
     RUBY
 
     app_file 'config/routes.rb', <<-RUBY
@@ -270,6 +273,7 @@ class LoadingTest < ActiveSupport::TestCase
   test "columns migrations also trigger reloading" do
     add_to_config <<-RUBY
       config.cache_classes = false
+      config.reload_routes_aggressively = true
     RUBY
 
     app_file 'config/routes.rb', <<-RUBY


### PR DESCRIPTION
Previously Rails would reload routes on _every_ single request in case a constant used in the routes file(s) had changed. This is very expensive and introduced a noticeable slowdown in all parts of the application (application routes, assets, etc.).

This sort of magic is not worth the cost of **such** a bad developer user experience, so until a better solution is found it's preferable to have it hidden behind a default-off config property.
