### PR TITLE
Use `ActiveRecord::Migration#connection` instead of `@connection`

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -475,13 +475,13 @@ module ActiveRecord
     def revert(*migration_classes)
       run(*migration_classes.reverse, revert: true) unless migration_classes.empty?
       if block_given?
-        if @connection.respond_to? :revert
-          @connection.revert { yield }
+        if connection.respond_to? :revert
+          connection.revert { yield }
         else
-          recorder = CommandRecorder.new(@connection)
+          recorder = CommandRecorder.new(connection)
           @connection = recorder
           suppress_messages do
-            @connection.revert { yield }
+            connection.revert { yield }
           end
           @connection = recorder.delegate
           recorder.commands.each do |cmd, args, block|
@@ -492,7 +492,7 @@ module ActiveRecord
     end
 
     def reverting?
-      @connection.respond_to?(:reverting) && @connection.reverting
+      connection.respond_to?(:reverting) && connection.reverting
     end
 
     class ReversibleBlockHelper < Struct.new(:reverting) # :nodoc:
@@ -549,7 +549,7 @@ module ActiveRecord
         revert { run(*migration_classes, direction: dir, revert: true) }
       else
         migration_classes.each do |migration_class|
-          migration_class.new.exec_migration(@connection, dir)
+          migration_class.new.exec_migration(connection, dir)
         end
       end
     end
@@ -641,7 +641,7 @@ module ActiveRecord
       arg_list = arguments.map(&:inspect) * ', '
 
       say_with_time "#{method}(#{arg_list})" do
-        unless @connection.respond_to? :revert
+        unless connection.respond_to? :revert
           unless arguments.empty? || [:execute, :enable_extension, :disable_extension].include?(method)
             arguments[0] = proper_table_name(arguments.first, table_name_options)
             if [:rename_table, :add_foreign_key].include?(method) ||


### PR DESCRIPTION
`ActiveRecord::Migration` has `connetion` method so replace to use
`connection` method to get `@connection` as much as possible
