### PR TITLE
Remove test helper method to inside test method

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -132,13 +132,9 @@ class MigrationTest < ActiveRecord::TestCase
     Person.connection.drop_table :testings2, if_exists: true
   end
 
-  def connection
-    ActiveRecord::Base.connection
-  end
-
   def test_migration_instance_has_connection
     migration = Class.new(ActiveRecord::Migration).new
-    assert_equal connection, migration.connection
+    assert_equal ActiveRecord::Base.connection, migration.connection
   end
 
   def test_method_missing_delegates_to_connection


### PR DESCRIPTION
Remove `MigrationTest#connection` and write `ActiveRecord::Base.connection`
directly to test, because `MigrationTest#connection` is only used in
`test_migration_instance_has_connection`.
