### PR TITLE
Only nullify persisted has_one target associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Only try to nullify has_one target association if the record is persisted.
+
+    Fixes #21223.
+
+    *Agis Anastasopoulos*
+
 *   Uniqueness validator raises descriptive error when running on a persisted
     record without primary key.
 

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -65,7 +65,7 @@ module ActiveRecord
             when :destroy
               target.destroy
             when :nullify
-              target.update_columns(reflection.foreign_key => nil)
+              target.update_columns(reflection.foreign_key => nil) if target.persisted?
           end
         end
       end

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -107,6 +107,14 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_nil Account.find(old_account_id).firm_id
   end
 
+  def test_nullification_on_destroyed_association
+    developer = Developer.create!(name: "Someone")
+    ship = Ship.create!(name: "Planet Caravan", developer: developer)
+    ship.destroy
+    assert !ship.persisted?
+    assert !developer.persisted?
+  end
+
   def test_natural_assignment_to_nil_after_destroy
     firm = companies(:rails_core)
     old_account_id = firm.account.id

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -50,6 +50,7 @@ class Developer < ActiveRecord::Base
   has_many :firms, :through => :contracts, :source => :firm
   has_many :comments, ->(developer) { where(body: "I'm #{developer.name}") }
   has_many :ratings, through: :comments
+  has_one :ship, dependent: :nullify
 
   scope :jamises, -> { where(:name => 'Jamis') }
 

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -3,6 +3,7 @@ class Ship < ActiveRecord::Base
 
   belongs_to :pirate
   belongs_to :update_only_pirate, :class_name => 'Pirate'
+  belongs_to :developer, dependent: :destroy
   has_many :parts, :class_name => 'ShipPart'
   has_many :treasures
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -673,6 +673,7 @@ ActiveRecord::Schema.define do
   create_table :ships, force: true do |t|
     t.string :name
     t.integer :pirate_id
+    t.belongs_to :developer
     t.integer :update_only_pirate_id
     # Conventionally named column for counter_cache
     t.integer :treasures_count, default: 0


### PR DESCRIPTION
Since after 87d1aba3c `dependent: :destroy` callbacks on has_one
assocations run _after_ destroy, it is possible that a nullification is
attempted on an already destroyed target:

```
class Car < ActiveRecord::Base
  has_one :engine, dependent: :nullify
end

class Engine < ActiveRecord::Base
  belongs_to :car, dependent: :destroy
end

> car = Car.create!
> engine = Engine.create!(car: car)
> engine.destroy! # => ActiveRecord::ActiveRecordError: cannot update a
>   destroyed record
```

In the above case, `engine.destroy!` deletes `engine` and _then_ triggers the
deletion of `car`, which in turn triggers a nullification of `engine.car_id`.
However, `engine` is already destroyed at that point.

Fixes #21223.
