### PR TITLE
Make to work migration file with multiple db

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -576,7 +576,7 @@ module ActiveRecord
       end
 
       time   = nil
-      ActiveRecord::Base.connection_pool.with_connection do |conn|
+      connection_class.connection_pool.with_connection do |conn|
         time = Benchmark.measure do
           exec_migration(conn, direction)
         end
@@ -633,8 +633,12 @@ module ActiveRecord
       self.verbose = save
     end
 
+    def connection_class
+      ActiveRecord::Base
+    end
+
     def connection
-      @connection || ActiveRecord::Base.connection
+      @connection || connection_class.connection
     end
 
     def method_missing(method, *arguments, &block)


### PR DESCRIPTION
Before this commit `ActiveRecord::Migration` uses
`ActiveRecord::Base.connection` with hard coding.
By this user can not select other database settings
when execute migration.
This commit make it possible to define which connection use
by overwriting `ActiveRecord::Migration#connection_class`:

```
# ActiveRecord::Base.connection is set to :arunit
class Fish < ActiveRecord::Base
  establish_connection :arunit2
end

class InvertibleMigrationMultipleDb < ActiveRecord::Migration
  def connection_class
    Fish
  end

  def change
    create_table("fishes") do |t|
      t.column :name, :string
      t.column :color, :string
    end
  end
end
```
