### PR TITLE
[ci skip] Fix migration file's timestamp

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -459,7 +459,7 @@ module ActiveRecord
     # Or equivalently, if +TenderloveMigration+ is defined as in the
     # documentation for Migration:
     #
-    #   require_relative '2012121212_tenderlove_migration'
+    #   require_relative '20121212123456_tenderlove_migration'
     #
     #   class FixupTLMigration < ActiveRecord::Migration
     #     def change

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -652,7 +652,7 @@ can't be done.
 You can use Active Record's ability to rollback migrations using the `revert` method:
 
 ```ruby
-require_relative '2012121212_example_migration'
+require_relative '20121212123456_example_migration'
 
 class FixupExampleMigration < ActiveRecord::Migration
   def change


### PR DESCRIPTION
In rails generally migration file's timestamp is "YYYYMMDDHHMMSS".

Is this cosmetic changes or not?
I think this is _not_. So I send PR. Please check :yellow_heart: 
