### PR TITLE
Remove unused variables

### DIFF
--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -315,7 +315,7 @@ module ActionController
       t = Thread.new(@response) { |resp|
         resp.await_commit
         _, _, body = resp.to_a
-        body.each do |part|
+        body.each do
           @controller.latch.wait
           body.close
           break
@@ -339,7 +339,7 @@ module ActionController
       t = Thread.new(@response) { |resp|
         resp.await_commit
         _, _, body = resp.to_a
-        body.each do |part|
+        body.each do
           body.close
           break
         end


### PR DESCRIPTION
I think the `part` variables are not used in the test case.
