### PR TITLE
Helpful Message On Validation Callbacks Failure

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Show a helpful error message when save!/update!/validate! fails due to a
+    before_validation callback that returned false but did not set errors.
+
+    *Brian Hempel*
+
 *   Only try to nullify has_one target association if the record is persisted.
 
     Fixes #21223.

--- a/activerecord/lib/active_record/locale/en.yml
+++ b/activerecord/lib/active_record/locale/en.yml
@@ -15,6 +15,7 @@ en:
     errors:
       messages:
         record_invalid: "Validation failed: %{errors}"
+        record_invalid_no_errors: "Validation failed, but no errors were set. A callback may have returned false."
         restrict_dependent_destroy:
           has_one: "Cannot delete record because a dependent %{record} exists"
           has_many: "Cannot delete record because dependent %{record} exist"

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -14,8 +14,12 @@ module ActiveRecord
 
     def initialize(record)
       @record = record
-      errors = @record.errors.full_messages.join(", ")
-      super(I18n.t(:"#{@record.class.i18n_scope}.errors.messages.record_invalid", :errors => errors, :default => :"errors.messages.record_invalid"))
+      if @record.errors.any?
+        errors = @record.errors.full_messages.join(", ")
+        super(I18n.t(:"#{@record.class.i18n_scope}.errors.messages.record_invalid", errors: errors, default: :"errors.messages.record_invalid"))
+      else
+        super(I18n.t(:"#{@record.class.i18n_scope}.errors.messages.record_invalid_no_errors", default: :"errors.messages.record_invalid_no_errors"))
+      end
     end
   end
 

--- a/activerecord/test/cases/validations/i18n_generate_message_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_generate_message_validation_test.rb
@@ -45,11 +45,24 @@ class I18nGenerateMessageValidationTest < ActiveRecord::TestCase
     assert_equal "Validation failed: Title is invalid, Title can't be blank", ActiveRecord::RecordInvalid.new(topic).message
   end
 
+  test "RecordInvalid exception with no errors can be localized" do
+    topic = Topic.new
+    assert_equal "Validation failed, but no errors were set. A callback may have returned false.", ActiveRecord::RecordInvalid.new(topic).message
+  end
+
   test "RecordInvalid exception translation falls back to the :errors namespace" do
     reset_i18n_load_path do
       I18n.backend.store_translations 'en', :errors => {:messages => {:record_invalid => 'fallback message'}}
       topic = Topic.new
       topic.errors.add(:title, :blank)
+      assert_equal "fallback message", ActiveRecord::RecordInvalid.new(topic).message
+    end
+  end
+
+  test "RecordInvalid exception with no errors translation falls back to the :errors namespace" do
+    reset_i18n_load_path do
+      I18n.backend.store_translations 'en', :errors => {:messages => {:record_invalid_no_errors => 'fallback message'}}
+      topic = Topic.new
       assert_equal "fallback message", ActiveRecord::RecordInvalid.new(topic).message
     end
   end


### PR DESCRIPTION
Previously, if a `before_validation` callback returned `false` but set no errors, the `save!` etc methods would give the unhelpful blank message:

`ActiveRecord::RecordInvalid: Validation failed:`

Let’s add a separate message for that case:

`ActiveRecord::RecordInvalid: Validation failed, but no errors were set.
A callback may have returned false.`

This issue arose when I made a callback that looked like:

``` ruby
before_validation -> { self.attribute = false }
```

...which subtly caused the validations to fail because the callback returned false. The blank message did not point me in the right direction.
