### PR TITLE
minor documentation improvement [ci skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/strip.rb
+++ b/activesupport/lib/active_support/core_ext/string/strip.rb
@@ -17,8 +17,8 @@ class String
   #
   # the user would see the usage message aligned against the left margin.
   #
-  # Technically, it looks for the least indented line in the whole string, and removes
-  # that amount of leading whitespace.
+  # Technically, it looks for the least indented non-empty line
+  # in the whole string, and removes that amount of leading whitespace.
   def strip_heredoc
     indent = scan(/^[ \t]*(?=\S)/).min.try(:size) || 0
     gsub(/^[ \t]{#{indent}}/, '')


### PR DESCRIPTION
A coworker showed me this useful feature of ActiveSupport on reading it I was concerned that it would require me to indent empty lines which would have annoyed because my editor highlights trailing whitespace in an ugly color.  I tested it though and it appears to be smarter than that so I decided to send an fix for the docs.
