### PR TITLE
Do not allocate new strings for every single run_callbacks call

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -79,11 +79,20 @@ module ActiveSupport
     #   run_callbacks :save do
     #     save
     #   end
+
+    # Store a frozen copy of a callback string so it doesn't need to be
+    # allocated and de-allocated for every call
+    @@_callbacks_store = {}
+
     def run_callbacks(kind, &block)
-      send "_run_#{kind}_callbacks", &block
+      send callbacks_store(kind), &block
     end
 
     private
+
+    def callbacks_store(kind)
+      @@_callbacks_store[kind] ? @@_callbacks_store[kind] : @@_callbacks_store[kind]  = "_run_#{kind}_callbacks".freeze
+    end
 
     def __run_callbacks__(callbacks, &block)
       if callbacks.empty?


### PR DESCRIPTION
@schneems 
Pull request for addressing issue b) from https://groups.google.com/forum/#!topic/rubyonrails-core/NONkf9jLJjM

For a retrieval of 729 ActiveRecord objects (6 enum fields, created_at, updated_at) fetched from a postgres database over 8000 strings were allocated. Of these 2916 were strings allocated by ActiveSupport callbacks.rb - although no callbacks were run.

These are (measured with memory_profiler gem):

```
729  "_initialize_callbacks"
729  /Users/user_name/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:81

729  "_find_callbacks"
729  /Users/user_name/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:81

729  "initialize"
729  /Users/user_name/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:81

729  "find"
729  /Users/user_name/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:81
```

This patch intends to freeze the callbacks strings in a class variable for all Classes extending the ActiveSupport::Callbacks concern. This should result in a tangible improvement memory-management wise, as well as small speed up to the current code:

```
$_callbacks_store = {}
def callbacks_store(kind)
  $_callbacks_store[kind] ? $_callbacks_store[kind] : $_callbacks_store[kind]  = "_#{kind}_callbacks".freeze
end

kind = :initialize
Benchmark.ips do |x|
    x.report('use store') {callbacks_store(kind)}
    x.report('allocate new') {"_#{kind}_callbacks"}
end

Calculating -------------------------------------
           use store    54.817k i/100ms
        allocate new    47.754k i/100ms
-------------------------------------------------
           use store      5.942M (± 8.0%) i/s -     29.492M
        allocate new      2.800M (±11.4%) i/s -     13.849M
```

Unfortunately since run_callbacks :my_callback is entirely dynamic, there seems to be no way to predict or establish which calls could be made within the context of a running application (the more costly alternative being perhaps to freeze all callback strings when define_callbacks is called).

The cost for most Rails apps would probably be somewhere between 10-30 allocated strings for the lifetime of the App depending on their use of callbacks with ActiveRecord [registering the most](https://github.com/rails/rails/blob/master/activerecord%2Flib%2Factive_record%2Fcallbacks.rb#L274).
