### PR TITLE
[ci skip] Fix #21364 error in documentation about ActiveRecord::Enum

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -18,10 +18,9 @@ module ActiveRecord
   #   conversation.archived? # => true
   #   conversation.status    # => "archived"
   #
-  #   # conversation.update! status: 1
+  #   # conversation.status = 1
   #   conversation.status = "archived"
   #
-  #   # conversation.update! status: nil
   #   conversation.status = nil
   #   conversation.status.nil? # => true
   #   conversation.status      # => nil


### PR DESCRIPTION
This fixes #21364 , an error in documentation about ActiveRecord::Enum.

The error also exists in other versions of Rails, such as 4.2.
