### PR TITLE
Make `change_column_default` to work

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -14,6 +14,13 @@ module ActiveRecord
     # * rename_index
     # * rename_table
     class CommandRecorder
+      ReversibleAndIrreversibleMethods = [:create_table, :create_join_table, :rename_table, :add_column, :remove_column,
+        :rename_index, :rename_column, :add_index, :remove_index, :add_timestamps, :remove_timestamps,
+        :change_column_default, :add_reference, :remove_reference, :transaction,
+        :drop_join_table, :drop_table, :execute_block, :enable_extension,
+        :change_column, :execute, :remove_columns, :change_column_null,
+        :add_foreign_key, :remove_foreign_key
+      ]
       include JoinTable
 
       attr_accessor :commands, :delegate, :reverting
@@ -70,14 +77,7 @@ module ActiveRecord
         super || delegate.respond_to?(*args)
       end
 
-      [:create_table, :create_join_table, :rename_table, :add_column, :remove_column,
-        :rename_index, :rename_column, :add_index, :remove_index, :add_timestamps, :remove_timestamps,
-        :add_reference, :remove_reference, :transaction,
-        :drop_join_table, :drop_table, :execute_block, :enable_extension,
-        :change_column, :execute, :remove_columns, :change_column_null,
-        :add_foreign_key, :remove_foreign_key
-       # irreversible methods need to be here too
-      ].each do |method|
+      ReversibleAndIrreversibleMethods.each do |method|
         class_eval <<-EOV, __FILE__, __LINE__ + 1
           def #{method}(*args, &block)          # def create_table(*args, &block)
             record(:"#{method}", args, &block)  #   record(:create_table, args, &block)

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -1,5 +1,8 @@
 require "cases/helper"
 
+class Horse < ActiveRecord::Base
+end
+
 module ActiveRecord
   class InvertibleMigrationTest < ActiveRecord::TestCase
     class SilentMigration < ActiveRecord::Migration
@@ -73,6 +76,20 @@ module ActiveRecord
         change_table("horses") do |t|
           t.remove_index [:name, :color]
         end
+      end
+    end
+
+    class ChangeColumnDefault1 < SilentMigration
+      def change
+        create_table("horses") do |t|
+          t.column :name, :string, default: "Sekitoba"
+        end
+      end
+    end
+
+    class ChangeColumnDefault2 < SilentMigration
+      def change
+        change_column_default :horses, :name, from: "Sekitoba", to: "Diomed"
       end
     end
 
@@ -221,6 +238,22 @@ module ActiveRecord
       assert revert.connection.table_exists?("horses")
       revert.migrate :up
       assert !revert.connection.table_exists?("horses")
+    end
+
+    def test_migrate_revert_change_column_default
+      index_definition = ["horses", [:name, :color]]
+      migration1 = ChangeColumnDefault1.new
+      migration1.migrate(:up)
+      assert_equal "Sekitoba", Horse.new.name
+
+      migration2 = ChangeColumnDefault2.new
+      migration2.migrate(:up)
+      Horse.reset_column_information
+      assert_equal "Diomed", Horse.new.name
+
+      migration2.migrate(:down)
+      Horse.reset_column_information
+      assert_equal "Sekitoba", Horse.new.name
     end
 
     def test_revert_order


### PR DESCRIPTION
This is fix of #20018 which removes `change_column_default` from
array, so `CommandRecorder#method_missing` catches
`change_column_default` and @delegate's method is called.

This PR
- fix this bug
- define `ReversibleAndIrreversibleMethods` const making clear
  which this array means to prevent these miss
