### PR TITLE
Make `assert_index` private

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -87,7 +87,7 @@ module ActionDispatch
       middlewares.freeze.reverse.inject(app) { |a, e| e.build(a) }
     end
 
-  protected
+    private
 
     def assert_index(index, where)
       index = get_class index
@@ -95,8 +95,6 @@ module ActionDispatch
       raise "No such middleware to insert #{where}: #{index.inspect}" unless i
       i
     end
-
-    private
 
     def get_class(klass)
       if klass.is_a?(String) || klass.is_a?(Symbol)


### PR DESCRIPTION
This `protected` keyword looks like some leftover, since
we are not using explicit receiver, this should go under `private`
