### PR TITLE
Updating TestSession to access with indifference

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Updating ActionController::TestSession to behave as a hash with indifferent
+    access:
+
+    *Jeremy Friesen*
+
 *   Using strings or symbols for middleware class names is deprecated.  Convert
     things like this:
 

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -174,8 +174,8 @@ module ActionController
       clear
     end
 
-    def fetch(*args, &block)
-      @data.fetch(*args, &block)
+    def fetch(key, *args, &block)
+      @data.fetch(key.to_s, *args, &block)
     end
 
     private

--- a/actionpack/test/dispatch/session/test_session_test.rb
+++ b/actionpack/test/dispatch/session/test_session_test.rb
@@ -46,6 +46,16 @@ class ActionController::TestSessionTest < ActiveSupport::TestCase
     assert_equal('2', session.fetch(:two, '2'))
   end
 
+  def test_fetch_on_symbol_returns_value
+    session = ActionController::TestSession.new(one: '1')
+    assert_equal('1', session.fetch(:one))
+  end
+
+  def test_fetch_on_string_returns_value
+    session = ActionController::TestSession.new(one: '1')
+    assert_equal('1', session.fetch('one'))
+  end
+
   def test_fetch_returns_block_value
     session = ActionController::TestSession.new(one: '1')
     assert_equal(2, session.fetch('2') { |key| key.to_i })


### PR DESCRIPTION
The following Rails code failed (with a `KeyError` exception) under
test:

`````` ruby
class ApplicationController < ActionController::Base
  def user_strategy
    # At this point:
    # ```ruby
    # session == {
    #   "user_strategy"=>"email",
    #   "user_identifying_value"=>"hello@world.com"
    # }
    # ```
    if session.key?(:user_strategy)
      session.fetch(:user_strategy)
    end
  end
end
``````

When I checked the session's keys (`session.keys`), I got an array of
strings. If I accessed `session[:user_strategy]` I got the expected
`'email'` value. However if I used `session.fetch(:user_strategy)` I
got a `KeyError` exception.

This appears to be a Rails 4.2.4 regression (as the code works under
Rails 4.2.3).

Closes #21383
