### PR TITLE
remove base class from belongs_to polymorphic association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,28 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
+*   Fix polymorphic true with inheritance.
+    
+    Example: 
+
+        class Asset < ActiveRecord::Base
+          belongs_to :attachable, polymorphic: true
+        end
+    
+        class Post < ActiveRecord::Base
+          # Post doesn't have a type column
+          has_many :assets, as: :attachable, dependent: :destroy
+        end
+     
+        class GuestPost < Post
+        end
+     
+        class MemberPost < Post
+        end
+
+    Now attachable_type can be Post, GuestPost or MemberPost
+
+    *Dilpreet Singh*
+
 *   Fix `#columns_for_distinct` of MySQL and PostgreSQL to make
     `ActiveRecord::FinderMethods#limited_ids_for` use correct primary key values
     even if `ORDER BY` columns include other table's primary key.

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -13,7 +13,7 @@ module ActiveRecord
 
         def replace_keys(record)
           super
-          owner[reflection.foreign_type] = record ? record.class.base_class.name : nil
+          owner[reflection.foreign_type] = record ? record.class.name : nil
         end
 
         def different_target?(record)

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -118,13 +118,13 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     post = posts(:thinking)
     assert_instance_of SpecialPost, post
 
-    tagging = tags(:misc).taggings.create(taggable: post)
-    assert_equal "Post", tagging.taggable_type
+    tagging = tags(:misc).taggings.create(:taggable => post)
+    assert_equal "SpecialPost", tagging.taggable_type
   end
 
   def test_polymorphic_has_one_create_model_with_inheritance
-    tagging = tags(:misc).create_tagging(taggable: posts(:thinking))
-    assert_equal "Post", tagging.taggable_type
+    tagging = tags(:misc).create_tagging(:taggable => posts(:thinking))
+    assert_equal "SpecialPost", tagging.taggable_type
   end
 
   def test_set_polymorphic_has_many


### PR DESCRIPTION
Fix polymorphic true with inheritance.
Before this PR, it is used to store in type column the class which is directly inherited from the AR::Base.

Example:

``` ruby
 class Asset < ActiveRecord::Base
   belongs_to :attachable, polymorphic: true
 end

 class Post < ActiveRecord::Base
   # Post doesn't have a type column and is not implemented as STI
  has_many :assets, as: :attachable, dependent: :destroy
 end

 class GuestPost < Post
  #Guest Post is inherited From Post
 end

 class MemberPost < Post
  #Member Post is inherited From Post
 end

Example: asset = Asset.new(attachable: GuestPost.new)
                asset.attachable_type would always be equal to 'Post'
```

After this change, type column can have any class (descendant of the AR::Base)
Now attachable_type can be Post, GuestPost or MemberPost
Example: 

``` ruby
asset = Asset.new(attachable: GuestPost.new)
asset.attachable_type would  be equal to 'GuestPost'
```
