### PR TITLE
Removed duplicate require 'minitest/mock'

### DIFF
--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -1,6 +1,5 @@
 require 'abstract_unit'
 require 'active_job'
-require 'minitest/mock'
 require 'mailers/delayed_mailer'
 
 class MessageDeliveryTest < ActiveSupport::TestCase

--- a/actionpack/test/controller/parameters/always_permitted_parameters_test.rb
+++ b/actionpack/test/controller/parameters/always_permitted_parameters_test.rb
@@ -1,6 +1,5 @@
 require 'abstract_unit'
 require 'action_controller/metal/strong_parameters'
-require 'minitest/mock'
 
 class AlwaysPermittedParametersTest < ActiveSupport::TestCase
   def setup

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -13,8 +13,6 @@ I18n.enforce_available_locales = false
 require 'active_support/testing/autorun'
 require 'active_support/testing/method_call_assertions'
 
-require 'minitest/mock'
-
 # Skips the current run on Rubinius using Minitest::Assertions#skip
 def rubinius_skip(message = '')
   skip message if RUBY_ENGINE == 'rbx'

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -38,8 +38,6 @@ def jruby_skip(message = '')
   skip message if defined?(JRUBY_VERSION)
 end
 
-require 'minitest/mock'
-
 class ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 end

--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -1,6 +1,5 @@
 require 'generators/generators_test_helper'
 require 'rails/generators/rails/scaffold_controller/scaffold_controller_generator'
-require 'minitest/mock'
 
 class NamedBaseTest < Rails::Generators::TestCase
   include GeneratorsTestHelper


### PR DESCRIPTION
As it is already required in `method_call_assertions` and `method_call_assertions` is required in `abstract_unit` & `generators_test_helper`
cc @kaspth 
