### PR TITLE
In the active_support number_to_currency helper,

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -29,7 +29,9 @@ module ActiveSupport
           # of the number of decimal digits (1234 with precision 2 becomes 1200, 1.23543 becomes 1.2)
           significant: false,
           # If set, the zeros after the decimal separator will always be stripped (eg.: 1.200 will be 1.2)
-          strip_insignificant_zeros: false
+          strip_insignificant_zeros: false,
+          # The default currency formatting regex. The delimiter is inserted after every 3 digits, reading from right to left.
+          format_mask_regex: /(\d)(?=(\d\d\d)+(?!\d))/
         },
 
         # Used in number_to_currency
@@ -38,12 +40,13 @@ module ActiveSupport
             format: "%u%n",
             negative_format: "-%u%n",
             unit: "$",
-            # These five are to override number.format and are optional
+            # These six are to override number.format and are optional
             separator: ".",
             delimiter: ",",
             precision: 2,
             significant: false,
-            strip_insignificant_zeros: false
+            strip_insignificant_zeros: false,
+            format_mask_regex: /(\d)(?=(\d\d\d)+(?!\d))/
           }
         },
 

--- a/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
@@ -3,8 +3,6 @@ module ActiveSupport
     class NumberToDelimitedConverter < NumberConverter #:nodoc:
       self.validate_float = true
 
-      DELIMITED_REGEX = /(\d)(?=(\d\d\d)+(?!\d))/
-
       def convert
         parts.join(options[:separator])
       end
@@ -13,9 +11,11 @@ module ActiveSupport
 
         def parts
           left, right = number.to_s.split('.')
-          left.gsub!(DELIMITED_REGEX) do |digit_to_delimit|
+
+          left.gsub!(options[:format_mask_regex]) do |digit_to_delimit|
             "#{digit_to_delimit}#{options[:delimiter]}"
           end
+
           [left, right].compact
         end
     end

--- a/activesupport/test/number_helper_i18n_test.rb
+++ b/activesupport/test/number_helper_i18n_test.rb
@@ -51,6 +51,7 @@ module ActiveSupport
       assert_equal("&$ - 10.00", number_to_currency(10, :locale => 'ts'))
       assert_equal("(&$ - 10.00)", number_to_currency(-10, :locale => 'ts'))
       assert_equal("-10.00 - &$", number_to_currency(-10, :locale => 'ts', :format => "%n - %u"))
+      assert_equal("&$ - 1,00,00,000.00", number_to_currency(10000000, :locale => 'ts', :format_mask_regex => /(\d+?)(?=(\d\d)+(\d)(?!\d))(\.\d+)?/))
     end
 
     def test_number_to_currency_with_empty_i18n_store


### PR DESCRIPTION
Currently, it is not possible to override the currency formatting REGEX from the locale file.

This commit introduces an additional option called format_mask_regex in the locale file. If specified, this will override the default regex.
