### PR TITLE
Code cleanup

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -1,6 +1,3 @@
-require 'active_support/core_ext/hash/keys'
-require 'active_support/core_ext/hash/indifferent_access'
-
 module ActionDispatch
   module Http
     module Parameters
@@ -33,14 +30,6 @@ module ActionDispatch
       #   {'action' => 'my_action', 'controller' => 'my_controller'}
       def path_parameters
         get_header(PARAMETERS_KEY) || {}
-      end
-
-    private
-
-      # Convert nested Hash to HashWithIndifferentAccess.
-      #
-      def normalize_encode_params(params)
-        ActionDispatch::Request::Utils.normalize_encode_params params
       end
     end
   end

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -332,7 +332,7 @@ module ActionDispatch
     # Override Rack's GET method to support indifferent access
     def GET
       get_header("action_dispatch.request.query_parameters") do |k|
-        set_header k, normalize_encode_params(super || {})
+        set_header k, Request::Utils.normalize_encode_params(super || {})
       end
     rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e
       raise ActionController::BadRequest.new(:query, e)
@@ -342,7 +342,7 @@ module ActionDispatch
     # Override Rack's POST method to support indifferent access
     def POST
       get_header("action_dispatch.request.request_parameters") do
-        self.request_parameters = normalize_encode_params(super || {})
+        self.request_parameters = Request::Utils.normalize_encode_params(super || {})
       end
     rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e
       raise ActionController::BadRequest.new(:request, e)


### PR DESCRIPTION
Cleanup for `ActionDispatch::Http::Parameters` - no need for required libraries
and remove not used private method.

Apparently this method was used in `ActionDispatch::Http::Request` - fixed
by calling `Request::Utils` explicitly (as was done in other parts of the codebase)
