### PR TITLE
Fix mail_to to work well with Ruby 2.0

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -463,7 +463,7 @@ module ActionView
         }.compact
         extras = extras.empty? ? '' : '?' + extras.join('&')
 
-        encoded_email_address = ERB::Util.url_encode(email_address).gsub("%40", "@")
+        encoded_email_address = ERB::Util.url_encode(email_address.to_str).gsub("%40", "@")
         html_options["href"] = "mailto:#{encoded_email_address}#{extras}"
 
         content_tag(:a, name || email_address, html_options, &block)

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -515,6 +515,13 @@ class UrlHelperTest < ActiveSupport::TestCase
     )
   end
 
+  def test_mail_to_with_html_safe_string
+    assert_dom_equal(
+      %{<a href="mailto:david@loudthinking.com">david@loudthinking.com</a>},
+      mail_to("david@loudthinking.com".html_safe)
+    )
+  end
+
   def test_mail_to_with_img
     assert_dom_equal %{<a href="mailto:feedback@example.com"><img src="/feedback.png" /></a>},
       mail_to('feedback@example.com', '<img src="/feedback.png" />'.html_safe)


### PR DESCRIPTION
Related to: https://github.com/rails/rails/pull/21007

As @aaa707 commented in https://github.com/rails/rails/pull/21007#issuecomment-135349891, `mail_to` helper crashes when `ActiveSupport::SafeBuffer` is given. It occurs with only Ruby 2.0.

That's because `ERB::Util.url_encode` is not the same between Ruby 2.0 and above.
https://github.com/ruby/ruby/commit/747b1a3188125a93be49d8cdd1781f768c191ba8

``` rb
'a'.html_safe.gsub(/a/) do
  $& #=> nil
end
```

Ruby 2.0's `ERB::Util.url_encode` uses `&$` and breaks it.

So I changed the backport https://github.com/rails/rails/commit/0789e066f1194519c4f7c36533c8f02bd14968b2 to work well with Ruby 2.0.
