### PR TITLE
Test `mail_to` with `ActiveSupport::SafeBuffer`

### DIFF
--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -518,6 +518,13 @@ class UrlHelperTest < ActiveSupport::TestCase
     )
   end
 
+  def test_mail_to_with_html_safe_string
+    assert_dom_equal(
+      %{<a href="mailto:david@loudthinking.com">david@loudthinking.com</a>},
+      mail_to("david@loudthinking.com".html_safe)
+    )
+  end
+
   def test_mail_to_with_img
     assert_dom_equal %{<a href="mailto:feedback@example.com"><img src="/feedback.png" /></a>},
       mail_to('feedback@example.com', '<img src="/feedback.png" />'.html_safe)


### PR DESCRIPTION
I added a test case to prevent regression caused by https://github.com/rails/rails/pull/21007 in Rails 4.2.4 with Ruby 2.0.
For 4-2-stable, https://github.com/rails/rails/pull/21402 is necessary to pass this test case.
I'll backport it to 4-1-stable too if it is merged.
