### PR TITLE
Rename ActiveRecord::Attribute#has_been_read? to #accessed? to keep consistency.

### DIFF
--- a/activerecord/lib/active_record/attribute.rb
+++ b/activerecord/lib/active_record/attribute.rb
@@ -51,7 +51,7 @@ module ActiveRecord
     end
 
     def changed_in_place_from?(old_value)
-      has_been_read? && type.changed_in_place?(old_value, value)
+      accessed? && type.changed_in_place?(old_value, value)
     end
 
     def with_value_from_user(value)
@@ -82,7 +82,7 @@ module ActiveRecord
       false
     end
 
-    def has_been_read?
+    def accessed?
       defined?(@value)
     end
 

--- a/activerecord/lib/active_record/attribute_set.rb
+++ b/activerecord/lib/active_record/attribute_set.rb
@@ -77,7 +77,7 @@ module ActiveRecord
     end
 
     def accessed
-      attributes.select { |_, attr| attr.has_been_read? }.keys
+      attributes.select { |_, attr| attr.accessed? }.keys
     end
 
     protected

--- a/activerecord/test/cases/attribute_test.rb
+++ b/activerecord/test/cases/attribute_test.rb
@@ -172,13 +172,13 @@ module ActiveRecord
 
     test "an attribute has not been read by default" do
       attribute = Attribute.from_database(:foo, 1, Type::Value.new)
-      assert_not attribute.has_been_read?
+      assert_not attribute.accessed?
     end
 
     test "an attribute has been read when its value is calculated" do
       attribute = Attribute.from_database(:foo, 1, Type::Value.new)
       attribute.value
-      assert attribute.has_been_read?
+      assert attribute.accessed?
     end
 
     test "an attribute can not be mutated if it has not been read,


### PR DESCRIPTION
"accessed" is present in the following mixins:
- `ActiveRecord::AttributeSet#accessed`
- `ActiveRecord::AttributeMethods#accessed_fields`

In addition, "read" is more likely to be confused with "loaded from database" (as pointed by @egilburg). /cc @sgrif 
