### PR TITLE
remove link to outdated article in plugins guide [ci skip]

### DIFF
--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -443,4 +443,3 @@ $ bundle exec rake rdoc
 * [Developing a RubyGem using Bundler](https://github.com/radar/guides/blob/master/gem-development.md)
 * [Using .gemspecs as Intended](http://yehudakatz.com/2010/04/02/using-gemspecs-as-intended/)
 * [Gemspec Reference](http://guides.rubygems.org/specification-reference/)
-* [GemPlugins: A Brief Introduction to the Future of Rails Plugins](http://www.intridea.com/blog/2008/6/11/gemplugins-a-brief-introduction-to-the-future-of-rails-plugins)


### PR DESCRIPTION
linked article is a description of the plugins in Rails 2.1.
