### PR TITLE
10X speed improvements for AS::Dependencies.loadable_constants_for_path

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -421,13 +421,13 @@ module ActiveSupport #:nodoc:
 
       bases.each do |root|
         expanded_root = File.expand_path(root)
-        next unless %r{\A#{Regexp.escape(expanded_root)}(/|\\)} =~ expanded_path
+        next unless expanded_path.start_with?(expanded_root)
 
-        nesting = expanded_path[(expanded_root.size)..-1]
-        nesting = nesting[1..-1] if nesting && nesting[0] == ?/
-        next if nesting.blank?
+        root_size = expanded_root.size
+        next if expanded_path[root_size] != ?/.freeze
 
-        paths << nesting.camelize
+        nesting = expanded_path[(root_size + 1)..-1]
+        paths << nesting.camelize unless nesting.blank?
       end
 
       paths.uniq!


### PR DESCRIPTION
When the autoload_paths start to grows, this methods is quite a hotspot

``` ruby
>> ActiveSupport::Dependencies.autoload_paths.size
=> 49
>> Benchmark.ips { |x| x.report('baseline') { ActiveSupport::Dependencies.loadable_constants_for_path(File.expand_path('app/models/shop')) }}
```

```
Calculating -------------------------------------
            baseline    90.000  i/100ms
-------------------------------------------------
            baseline      1.073k (±20.2%) i/s -      4.950k
```

After the patch

```
Calculating -------------------------------------
             patched   883.000  i/100ms
-------------------------------------------------
             patched     11.050k (±19.7%) i/s -     50.331k
```

cc @rafaelfranca 
