### PR TITLE
Adding ability to override currency format regex in ActiveSupport number_to_currency helper

### DIFF
--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -84,6 +84,8 @@ module ActionView
       #   number given by <tt>:format</tt>).  Accepts the same fields
       #   than <tt>:format</tt>, except <tt>%n</tt> is here the
       #   absolute value of the number.
+      #   <tt>:format_mask_regex</tt> - Sets regex to be used for formatting the
+      #   currency string (default is /(\d)(?=(\d\d\d)+(?!\d))/)
       # * <tt>:raise</tt> - If true, raises +InvalidNumberError+ when
       #   the argument is invalid.
       #
@@ -103,6 +105,8 @@ module ActionView
       #   # => R$1234567890,50
       #   number_to_currency(1234567890.50, unit: "R$", separator: ",", delimiter: "", format: "%n %u")
       #   # => 1234567890,50 R$
+      #   number_to_currency(1234567890.50, unit: "₹", format_mask_regex: /(\d+?)(?=(\d\d)+(\d)(?!\d))(\.\d+)?/)
+      #   # => ₹1,23,45,67,890.50
       def number_to_currency(number, options = {})
         delegate_number_helper_method(:number_to_currency, number, options)
       end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   ActiveSupport `number_to_currency` helper enhancement: It is now possible to
+      override the default regex used for formatting the currency string.
+
+      Without override:
+        number_to_currency(10000000) 
+        # => $10,000,000
+
+      With override:
+        number_to_currency(1234567890.50, unit: "₹", format_mask_regex: /(\d+?)(?=(\d\d)+(\d)(?!\d))(\.\d+)?/) 
+        # => ₹1,00,00,000
+
+    *Shireesh Jayashetty*
+    
 *   Deprecate `:prefix` option of `number_to_human_size` with no replacement.
 
     *Jean Boussier*

--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -31,7 +31,7 @@ module ActiveSupport
           # If set, the zeros after the decimal separator will always be stripped (eg.: 1.200 will be 1.2)
           strip_insignificant_zeros: false,
           # The default currency formatting regex. The delimiter is inserted after every 3 digits, reading from right to left.
-          format_mask_regex: "/(\d)(?=(\d\d\d)+(?!\d))/"
+          format_mask_regex: /(\d)(?=(\d\d\d)+(?!\d))/
         },
 
         # Used in number_to_currency
@@ -46,7 +46,7 @@ module ActiveSupport
             precision: 2,
             significant: false,
             strip_insignificant_zeros: false,
-            format_mask_regex: "/(\d)(?=(\d\d\d)+(?!\d))/"
+            format_mask_regex: /(\d)(?=(\d\d\d)+(?!\d))/
           }
         },
 

--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -29,7 +29,9 @@ module ActiveSupport
           # of the number of decimal digits (1234 with precision 2 becomes 1200, 1.23543 becomes 1.2)
           significant: false,
           # If set, the zeros after the decimal separator will always be stripped (eg.: 1.200 will be 1.2)
-          strip_insignificant_zeros: false
+          strip_insignificant_zeros: false,
+          # The default currency formatting regex. The delimiter is inserted after every 3 digits, reading from right to left.
+          format_mask_regex: "/(\d)(?=(\d\d\d)+(?!\d))/"
         },
 
         # Used in number_to_currency
@@ -38,12 +40,13 @@ module ActiveSupport
             format: "%u%n",
             negative_format: "-%u%n",
             unit: "$",
-            # These five are to override number.format and are optional
+            # These six are to override number.format and are optional
             separator: ".",
             delimiter: ",",
             precision: 2,
             significant: false,
-            strip_insignificant_zeros: false
+            strip_insignificant_zeros: false,
+            format_mask_regex: "/(\d)(?=(\d\d\d)+(?!\d))/"
           }
         },
 

--- a/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
@@ -3,8 +3,6 @@ module ActiveSupport
     class NumberToDelimitedConverter < NumberConverter #:nodoc:
       self.validate_float = true
 
-      DELIMITED_REGEX = /(\d)(?=(\d\d\d)+(?!\d))/
-
       def convert
         parts.join(options[:separator])
       end
@@ -13,9 +11,11 @@ module ActiveSupport
 
         def parts
           left, right = number.to_s.split('.')
-          left.gsub!(DELIMITED_REGEX) do |digit_to_delimit|
+
+          left.gsub!(options[:format_mask_regex]) do |digit_to_delimit|
             "#{digit_to_delimit}#{options[:delimiter]}"
           end
+
           [left, right].compact
         end
     end

--- a/activesupport/test/number_helper_i18n_test.rb
+++ b/activesupport/test/number_helper_i18n_test.rb
@@ -51,6 +51,7 @@ module ActiveSupport
       assert_equal("&$ - 10.00", number_to_currency(10, :locale => 'ts'))
       assert_equal("(&$ - 10.00)", number_to_currency(-10, :locale => 'ts'))
       assert_equal("-10.00 - &$", number_to_currency(-10, :locale => 'ts', :format => "%n - %u"))
+      assert_equal("&$ -  1,00,00,000", number_to_currency(10000000, :locale => 'ts', :format_mask_regex => "/(\d+?)(?=(\d\d)+(\d)(?!\d))(\.\d+)?/"))
     end
 
     def test_number_to_currency_with_empty_i18n_store

--- a/activesupport/test/number_helper_i18n_test.rb
+++ b/activesupport/test/number_helper_i18n_test.rb
@@ -51,7 +51,7 @@ module ActiveSupport
       assert_equal("&$ - 10.00", number_to_currency(10, :locale => 'ts'))
       assert_equal("(&$ - 10.00)", number_to_currency(-10, :locale => 'ts'))
       assert_equal("-10.00 - &$", number_to_currency(-10, :locale => 'ts', :format => "%n - %u"))
-      assert_equal("&$ -  1,00,00,000", number_to_currency(10000000, :locale => 'ts', :format_mask_regex => "/(\d+?)(?=(\d\d)+(\d)(?!\d))(\.\d+)?/"))
+      assert_equal("&$ - 1,00,00,000.00", number_to_currency(10000000, :locale => 'ts', :format_mask_regex => /(\d+?)(?=(\d\d)+(\d)(?!\d))(\.\d+)?/))
     end
 
     def test_number_to_currency_with_empty_i18n_store


### PR DESCRIPTION
Currently number_to_currency has a hardcoded regex to format currency string. 

There are use cases where a different format mask is desired (for example in India, currency formatting is different). 

This Pull request moves the hardcoded regex into the options hash, so that it becomes possible to pass a different regex to override the default.
