### PR TITLE
Add all to except option in routing

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add :all to except option in routing.
+
+        resources :users, except: :all do
+          resources :posts, only: :index
+        end
+
+    *Ryoji Yoshioka*
+
 *   Update `ActionController::TestSession#fetch` to behave more like
     `ActionDispatch::Request::Session#fetch` when using non-string keys.
 

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1143,7 +1143,11 @@ module ActionDispatch
             if @only
               Array(@only).map(&:to_sym)
             elsif @except
-              default_actions - Array(@except).map(&:to_sym)
+              if (except_actions = Array(@except).map(&:to_sym)).include?(:all)
+                []
+              else
+                default_actions - except_actions
+              end
             else
               default_actions
             end
@@ -1350,6 +1354,7 @@ module ActionDispatch
         #
         #     resources :cows, except: :show
         #     resources :cows, except: [:show, :index]
+        #     resources :cows, except: :all
         #
         # [:shallow]
         #   Generates shallow routes for nested resource(s). When placed on a parent resource,

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -870,6 +870,33 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal 'pass', @response.headers['X-Cascade']
   end
 
+  def test_resource_routes_with_except_all
+    draw do
+      resources :users, :except => :all do
+        resources :posts
+      end
+    end
+
+    get '/users/1/posts'
+    assert_equal 'posts#index', @response.body
+    assert_equal '/users/1/posts', user_posts_path(:user_id => 1)
+
+    get '/users'
+    assert_equal 'pass', @response.headers['X-Cascade']
+    get '/users/1'
+    assert_equal 'pass', @response.headers['X-Cascade']
+    get '/users/new'
+    assert_equal 'pass', @response.headers['X-Cascade']
+    get '/users/1/edit'
+    assert_equal 'pass', @response.headers['X-Cascade']
+    post '/users/1'
+    assert_equal 'pass', @response.headers['X-Cascade']
+    put '/users/1'
+    assert_equal 'pass', @response.headers['X-Cascade']
+    delete '/users/1'
+    assert_equal 'pass', @response.headers['X-Cascade']
+  end
+
   def test_resource_routes_only_create_update_destroy
     draw do
       resource  :past, :only => :destroy


### PR DESCRIPTION
``` rb
resources :users, only: [] do
  resources :posts, only: :index
end

# I think more readable.
resources :users, except: :all do
  resources :posts, only: :index
end
```
