### PR TITLE
cache helper with relation not working as expected

### DIFF
--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -229,10 +229,9 @@ module ActionView
       def fragment_name_with_digest(name, virtual_path) #:nodoc:
         virtual_path ||= @virtual_path
         if virtual_path
-          names  = Array(name.is_a?(Hash) ? controller.url_for(name).split("://").last : name)
+          name  = controller.url_for(name).split("://").last if name.is_a?(Hash)
           digest = Digestor.digest name: virtual_path, finder: lookup_context, dependencies: view_cache_dependencies
-
-          [ *names, digest ]
+          [ name, digest ]
         else
           name
         end

--- a/actionview/test/activerecord/relation_cache_test.rb
+++ b/actionview/test/activerecord/relation_cache_test.rb
@@ -1,0 +1,18 @@
+require 'active_record_unit'
+
+class RelationCacheTest <  ActionView::TestCase
+  tests ActionView::Helpers::CacheHelper
+
+  def setup
+    @virtual_path = "path"
+    controller.cache_store = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  def test_cache_relation_other
+    cache(Project.all){ concat("Hello World") }
+    assert_equal "Hello World", controller.cache_store.read("views/projects-#{Project.count}/")
+  end
+
+  def view_cache_dependencies; end
+
+end

--- a/actionview/test/fixtures/project.rb
+++ b/actionview/test/fixtures/project.rb
@@ -1,3 +1,7 @@
 class Project < ActiveRecord::Base
   has_and_belongs_to_many :developers, -> { uniq }
+
+  def self.collection_cache_key(collection = all, timestamp_column = :updated_at)
+    "projects-#{collection.count}"
+  end
 end


### PR DESCRIPTION
When I try to cache a `ActiveRecord::Relation` in a template like

```
cache(User.all) do
  ...
end
```

It is generating a cache key buy converting the relation to an array instead of `ActiveRecord::Relation#cache_key`.

If you use 

```
cache([User.all]) do
  ...
end
```

it currently works as expected.

This PR changes the key generated by `cache(User.all)` to use the relation cache key.
