### PR TITLE
fix reference to undefined variable in email testing guide [ci skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1115,10 +1115,13 @@ require 'test_helper'
 
 class UserMailerTest < ActionMailer::TestCase
   test "invite" do
+    # Create the email and store it for further assertions
+    email = UserMailer.create_invite('me@example.com',
+                                     'friend@example.com', Time.now)
+
     # Send the email, then test that it got queued
     assert_emails 1 do
-      email = UserMailer.create_invite('me@example.com',
-                                       'friend@example.com', Time.now).deliver_now
+      email.deliver_now
     end
 
     # Test the body of the sent email contains what we expect it to


### PR DESCRIPTION
Just noticed that the sample code on section 10.2.2 of the [Testing Guide](http://edgeguides.rubyonrails.org/testing.html#unit-testing) contains a bug: the `email` variable is defined within a block and later referenced outside that block (at which point is undefined).

This commit fixes that issue. The easier way would be to initialize `email` before the block to an arbitrary value (e.g. `nil`), but I felt that this approach is more elegant.

We could also move the rest of the assertions within the assert_emails block.

Open to any suggestions! 
