### PR TITLE
Set the content-type to `text/html` if the options[:html] is true

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -23,8 +23,8 @@ module AbstractController
     def render(*args, &block)
       options = _normalize_render(*args, &block)
       self.response_body = render_to_body(options)
-      if options[:plain]
-        _set_content_type Mime::TEXT.to_s
+      if options[:html]
+        _set_content_type Mime::HTML.to_s
       else
         _set_content_type _get_content_type(rendered_format)
       end

--- a/actionpack/test/controller/new_base/render_html_test.rb
+++ b/actionpack/test/controller/new_base/render_html_test.rb
@@ -4,7 +4,6 @@ module RenderHtml
   class MinimalController < ActionController::Metal
     include AbstractController::Rendering
     include ActionController::Rendering
-    include ActionView::Rendering
 
     def index
       render html: "Hello World!"


### PR DESCRIPTION
In this commit, we set the content-type to `text/html` in AbstractController if the `options[:html]` is true so that we don't include ActionView::Rendering into ActionController::Metal to set it properly.

I removed the if `options[:plain]` statement because `AbstractController#rendered_format` returns `Mime::TEXT` by default.
