### PR TITLE
ArrayInquirer to correctly find symbols or strings

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,13 +1,19 @@
-*   `number_to_currency` and `number_with_delimiter` now accept custom `delimiter_pattern` option 
-     to handle placement of delimiter, to support currency formats like INR 
-     
-     Example: 
-        
+*   `ActiveSupport::ArrayInquirer` will now properly find your entry regardless of whether the array
+    values are of type String or type Symbol, and whether you are asking `any?` with a String or
+    a Symbol.
+
+    *Leigh Halliday*
+
+*   `number_to_currency` and `number_with_delimiter` now accept custom `delimiter_pattern` option
+     to handle placement of delimiter, to support currency formats like INR
+
+     Example:
+
         number_to_currency(1230000, delimiter_pattern: /(\d+?)(?=(\d\d)+(\d)(?!\d))/, unit: '₹', format: "%u %n")
-        # => '₹ 12,30,000.00' 
-        
+        # => '₹ 12,30,000.00'
+
     *Vipul A M*
-    
+
 *   Deprecate `:prefix` option of `number_to_human_size` with no replacement.
 
     *Jean Boussier*

--- a/activesupport/lib/active_support/array_inquirer.rb
+++ b/activesupport/lib/active_support/array_inquirer.rb
@@ -23,7 +23,7 @@ module ActiveSupport
         super
       else
         candidates.any? do |candidate|
-          include?(candidate) || include?(candidate.to_sym)
+          include?(candidate.to_sym) || include?(candidate.to_s)
         end
       end
     end

--- a/activesupport/test/array_inquirer_test.rb
+++ b/activesupport/test/array_inquirer_test.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/array'
 
 class ArrayInquirerTest < ActiveSupport::TestCase
   def setup
-    @array_inquirer = ActiveSupport::ArrayInquirer.new([:mobile, :tablet])
+    @array_inquirer = ActiveSupport::ArrayInquirer.new([:mobile, :tablet, 'api'])
   end
 
   def test_individual
@@ -18,6 +18,11 @@ class ArrayInquirerTest < ActiveSupport::TestCase
     assert_not @array_inquirer.any?(:desktop, :watch)
   end
 
+  def test_any_string_symbol_mismatch
+    assert @array_inquirer.any?('mobile')
+    assert @array_inquirer.any?(:api)
+  end
+
   def test_any_with_block
     assert @array_inquirer.any? { |v| v == :mobile }
     assert_not @array_inquirer.any? { |v| v == :desktop }
@@ -28,7 +33,7 @@ class ArrayInquirerTest < ActiveSupport::TestCase
   end
 
   def test_inquiry
-    result = [:mobile, :tablet].inquiry
+    result = [:mobile, :tablet, 'api'].inquiry
 
     assert_instance_of ActiveSupport::ArrayInquirer, result
     assert_equal @array_inquirer, result


### PR DESCRIPTION
The problem existed where if your ArrayInquirer values were
strings but you checked them using any? with a symbol, it would
not find the value. Now it will correctly check whether both
the String form or the Symbol form are included in the Array.

Before if you checked any? with a String, it would check with a String and a Symbol,
but if you checked any? with a Symbol, it would check with a Symbol twice.

Now it will check with the original class and then check with either a String or a Symbol
depending on what type of value you were originally checking any? with.

I have added the following test which failed before my fix but now passes:

``` ruby
  def test_any_string_symbol_mismatch
    assert @array_inquirer.any?('mobile')
    assert @array_inquirer.any?(:api)
  end
```
