### PR TITLE
make `ENV` a required argument

### DIFF
--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -16,7 +16,7 @@ module Minitest
     opts.separator ""
 
     opts.separator "Rails options:"
-    opts.on("-e", "--environment [ENV]",
+    opts.on("-e", "--environment ENV",
             "Run tests in the ENV environment") do |env|
       options[:environment] = env.strip
     end


### PR DESCRIPTION
This commit changes the error when do not specify the ENV argument to a more appropriate error. 

Before:   

```
$ ./bin/rails t -e
rails/railties/lib/rails/test_unit/minitest_plugin.rb:21:in `block in plugin_rails_options': undefined method `strip' for nil:NilClass (NoMethodError) 
```

After: 

```
$ ./bin/rails t -e
/rails/railties/lib/rails/test_unit/minitest_plugin.rb:29:in `plugin_rails_options': missing argument: -e (OptionParser::MissingArgument)
```
