### PR TITLE
Proper usec of DateTime to match Time end_of_X functions

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix `DateTime#end_of_X` to properly handle `usec`:
+        dt = DateTime.now.end_of_day
+        dt.usec.eql?(999999) => true
+
+    Fixes #21424.
+
+    *Dan Moore*
+
 *   `number_to_currency` and `number_with_delimiter` now accept custom `delimiter_pattern` option 
      to handle placement of delimiter, to support currency formats like INR 
      

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -115,7 +115,7 @@ class DateTime
 
   # Returns a new DateTime representing the end of the day (23:59:59.999999).
   def end_of_day
-    change(:hour => 23, :min => 59, :sec => 59, :usec => 999999)
+    change(hour: 23, min: 59, sec: 59, usec: Rational(999999999, 1000))
   end
   alias :at_end_of_day :end_of_day
 
@@ -127,7 +127,7 @@ class DateTime
 
   # Returns a new DateTime representing the end of the hour (hh:59:59.999999).
   def end_of_hour
-    change(:min => 59, :sec => 59, :usec => 999999)
+    change(min: 59, sec: 59, usec: Rational(999999999, 1000))
   end
   alias :at_end_of_hour :end_of_hour
 
@@ -139,13 +139,13 @@ class DateTime
 
   # Returns a new DateTime representing the end of the minute (hh:mm:59.999999).
   def end_of_minute
-    change(:sec => 59, :usec => 999999)
+    change(sec: 59, usec: Rational(999999999, 1000))
   end
   alias :at_end_of_minute :end_of_minute
 
   # Returns a new DateTime representing the end of the second (hh:mm:ss.999999).
   def end_of_second
-    change(:usec => 999999)
+    change(usec: Rational(999999999, 1000))
   end
   alias :at_end_of_second :end_of_second
 

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -113,9 +113,9 @@ class DateTime
   alias :at_noon :middle_of_day
   alias :at_middle_of_day :middle_of_day
 
-  # Returns a new DateTime representing the end of the day (23:59:59).
+  # Returns a new DateTime representing the end of the day (23:59:59.999999).
   def end_of_day
-    change(:hour => 23, :min => 59, :sec => 59)
+    change(:hour => 23, :min => 59, :sec => 59, :usec => 999999)
   end
   alias :at_end_of_day :end_of_day
 
@@ -125,9 +125,9 @@ class DateTime
   end
   alias :at_beginning_of_hour :beginning_of_hour
 
-  # Returns a new DateTime representing the end of the hour (hh:59:59).
+  # Returns a new DateTime representing the end of the hour (hh:59:59.999999).
   def end_of_hour
-    change(:min => 59, :sec => 59)
+    change(:min => 59, :sec => 59, :usec => 999999)
   end
   alias :at_end_of_hour :end_of_hour
 
@@ -137,11 +137,17 @@ class DateTime
   end
   alias :at_beginning_of_minute :beginning_of_minute
 
-  # Returns a new DateTime representing the end of the minute (hh:mm:59).
+  # Returns a new DateTime representing the end of the minute (hh:mm:59.999999).
   def end_of_minute
-    change(:sec => 59)
+    change(:sec => 59, :usec => 999999)
   end
   alias :at_end_of_minute :end_of_minute
+
+  # Returns a new DateTime representing the end of the second (hh:mm:ss.999999).
+  def end_of_second
+    change(:usec => 999999)
+  end
+  alias :at_end_of_second :end_of_second
 
   # Adjusts DateTime to UTC by adding its offset value; offset is set to 0.
   #

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -54,7 +54,7 @@ class Time
   #   Time.new(2012, 8, 29, 12, 34, 56).seconds_since_midnight # => 45296
   #   Time.new(2012, 8, 29, 23, 59, 59).seconds_since_midnight # => 86399
   def seconds_since_midnight
-    to_i - change(:hour => 0).to_i + (usec / 1.0e+6)
+    to_i - change(hour: 0).to_i + (usec / 1.0e+6)
   end
 
   # Returns the number of seconds until 23:59:59.
@@ -127,7 +127,7 @@ class Time
 
     d = to_date.advance(options)
     d = d.gregorian if d.julian?
-    time_advanced_by_date = change(:year => d.year, :month => d.month, :day => d.day)
+    time_advanced_by_date = change(year: d.year, month: d.month, day: d.day)
     seconds_to_advance = \
       options.fetch(:seconds, 0) +
       options.fetch(:minutes, 0) * 60 +
@@ -156,7 +156,7 @@ class Time
   # Returns a new Time representing the start of the day (0:00)
   def beginning_of_day
     #(self - seconds_since_midnight).change(usec: 0)
-    change(:hour => 0)
+    change(hour: 0)
   end
   alias :midnight :beginning_of_day
   alias :at_midnight :beginning_of_day
@@ -164,7 +164,7 @@ class Time
 
   # Returns a new Time representing the middle of the day (12:00)
   def middle_of_day
-    change(:hour => 12)
+    change(hour: 12)
   end
   alias :midday :middle_of_day
   alias :noon :middle_of_day
@@ -175,44 +175,52 @@ class Time
   # Returns a new Time representing the end of the day, 23:59:59.999999
   def end_of_day
     change(
-      :hour => 23,
-      :min => 59,
-      :sec => 59,
-      :usec => Rational(999999999, 1000)
+      hour: 23,
+      min: 59,
+      sec: 59,
+      usec: Rational(999999999, 1000)
     )
   end
   alias :at_end_of_day :end_of_day
 
   # Returns a new Time representing the start of the hour (x:00)
   def beginning_of_hour
-    change(:min => 0)
+    change(min: 0)
   end
   alias :at_beginning_of_hour :beginning_of_hour
 
   # Returns a new Time representing the end of the hour, x:59:59.999999
   def end_of_hour
     change(
-      :min => 59,
-      :sec => 59,
-      :usec => Rational(999999999, 1000)
+      min: 59,
+      sec: 59,
+      usec: Rational(999999999, 1000)
     )
   end
   alias :at_end_of_hour :end_of_hour
 
   # Returns a new Time representing the start of the minute (x:xx:00)
   def beginning_of_minute
-    change(:sec => 0)
+    change(sec: 0)
   end
   alias :at_beginning_of_minute :beginning_of_minute
 
   # Returns a new Time representing the end of the minute, x:xx:59.999999
   def end_of_minute
     change(
-      :sec => 59,
-      :usec => Rational(999999999, 1000)
+      sec: 59,
+      usec: Rational(999999999, 1000)
     )
   end
   alias :at_end_of_minute :end_of_minute
+
+  # Returns a new Time representing the end of the second, x:xx:xx.999999
+  def end_of_second
+    change(
+      usec: Rational(999999999, 1000)
+    )
+  end
+  alias :at_end_of_second :end_of_second
 
   # Returns a Range representing the whole day of the current time.
   def all_day

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -89,7 +89,7 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_end_of_day
-    assert_equal DateTime.civil(2005,2,4,23,59,59), DateTime.civil(2005,2,4,10,10,10).end_of_day
+    assert_equal DateTime.civil(2005,2,4,23,59,59,999999), DateTime.civil(2005,2,4,10,10,10).end_of_day
   end
 
   def test_beginning_of_hour
@@ -97,7 +97,7 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_end_of_hour
-    assert_equal DateTime.civil(2005,2,4,19,59,59), DateTime.civil(2005,2,4,19,30,10).end_of_hour
+    assert_equal DateTime.civil(2005,2,4,19,59,59,999999), DateTime.civil(2005,2,4,19,30,10).end_of_hour
   end
 
   def test_beginning_of_minute
@@ -105,13 +105,17 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_end_of_minute
-    assert_equal DateTime.civil(2005,2,4,19,30,59), DateTime.civil(2005,2,4,19,30,10).end_of_minute
+    assert_equal DateTime.civil(2005,2,4,19,30,59,999999), DateTime.civil(2005,2,4,19,30,10).end_of_minute
+  end
+
+  def test_end_of_second
+    assert_equal DateTime.civil(2005,2,4,19,30,10,999999), DateTime.civil(2005,2,4,19,30,10).end_of_second
   end
 
   def test_end_of_month
-    assert_equal DateTime.civil(2005,3,31,23,59,59), DateTime.civil(2005,3,20,10,10,10).end_of_month
-    assert_equal DateTime.civil(2005,2,28,23,59,59), DateTime.civil(2005,2,20,10,10,10).end_of_month
-    assert_equal DateTime.civil(2005,4,30,23,59,59), DateTime.civil(2005,4,20,10,10,10).end_of_month
+    assert_equal DateTime.civil(2005,3,31,23,59,59,999999), DateTime.civil(2005,3,20,10,10,10).end_of_month
+    assert_equal DateTime.civil(2005,2,28,23,59,59,999999), DateTime.civil(2005,2,20,10,10,10).end_of_month
+    assert_equal DateTime.civil(2005,4,30,23,59,59,999999), DateTime.civil(2005,4,20,10,10,10).end_of_month
   end
 
   def test_last_year

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -89,7 +89,7 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_end_of_day
-    assert_equal DateTime.civil(2005,2,4,23,59,59,999999), DateTime.civil(2005,2,4,10,10,10).end_of_day
+    assert_equal "Fri, 04 Feb 2005 23:59:59.999999 +0000", DateTime.civil(2005,2,4,10,10,10).end_of_day.strftime("%a, %d %b %Y %H:%M:%S.%6N %z")
   end
 
   def test_beginning_of_hour
@@ -97,7 +97,8 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_end_of_hour
-    assert_equal DateTime.civil(2005,2,4,19,59,59,999999), DateTime.civil(2005,2,4,19,30,10).end_of_hour
+    assert_equal "Fri, 04 Feb 2005 19:59:59.999999 +0000", DateTime.civil(2005,2,4,19,30,10).end_of_hour.strftime("%a, %d %b %Y %H:%M:%S.%6N %z")
+    assert_equal 999999, DateTime.civil(2005,2,4,19,30,10).end_of_hour.usec
   end
 
   def test_beginning_of_minute
@@ -105,17 +106,20 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_end_of_minute
-    assert_equal DateTime.civil(2005,2,4,19,30,59,999999), DateTime.civil(2005,2,4,19,30,10).end_of_minute
+    assert_equal "Fri, 04 Feb 2005 19:30:59.999999 +0000", DateTime.civil(2005,2,4,19,30,10).end_of_minute.strftime("%a, %d %b %Y %H:%M:%S.%6N %z")
+    assert_equal 999999, DateTime.civil(2005,2,4,19,30,10).end_of_minute.usec
   end
 
   def test_end_of_second
-    assert_equal DateTime.civil(2005,2,4,19,30,10,999999), DateTime.civil(2005,2,4,19,30,10).end_of_second
+    assert_equal "Fri, 04 Feb 2005 19:30:10.999999 +0000", DateTime.civil(2005,2,4,19,30,10).end_of_second.strftime("%a, %d %b %Y %H:%M:%S.%6N %z")
+    assert_equal 999999, DateTime.civil(2005,2,4,19,30,10).end_of_second.usec
   end
 
   def test_end_of_month
-    assert_equal DateTime.civil(2005,3,31,23,59,59,999999), DateTime.civil(2005,3,20,10,10,10).end_of_month
-    assert_equal DateTime.civil(2005,2,28,23,59,59,999999), DateTime.civil(2005,2,20,10,10,10).end_of_month
-    assert_equal DateTime.civil(2005,4,30,23,59,59,999999), DateTime.civil(2005,4,20,10,10,10).end_of_month
+    assert_equal "Thu, 31 Mar 2005 23:59:59.999999 +0000", DateTime.civil(2005,3,20,10,10,10).end_of_month.strftime("%a, %d %b %Y %H:%M:%S.%6N %z")
+    assert_equal "Fri, 28 Feb 2005 23:59:59.999999 +0000", DateTime.civil(2005,2,20,10,10,10).end_of_month.strftime("%a, %d %b %Y %H:%M:%S.%6N %z")
+    assert_equal "Thu, 30 Apr 2005 23:59:59.999999 +0000", DateTime.civil(2005,4,20,10,10,10).end_of_month.strftime("%a, %d %b %Y %H:%M:%S.%6N %z")
+    assert_equal 999999, DateTime.civil(2005,2,4,20,10,10,10).end_of_month.usec
   end
 
   def test_last_year


### PR DESCRIPTION
Previously:
  dt = DateTime.now.end_of_day.usec # => 0
  dt = DateTime.now.end_of_month.usec # => 0
Now
  dt = DateTime.now.end_of_day.usec # => 999999
  dt = DateTime.now.end_of_month.usec # => 999999

Fixes #21424
