### PR TITLE
Notes for inverse_of in association_basics.md [ci skip]

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -719,7 +719,7 @@ This happens because `c` and `o.customer` are two different in-memory representa
 
 ```ruby
 class Customer < ActiveRecord::Base
-  has_many :orders, inverse_of: :customer
+  has_many :orders, inverse_of: :customer # optional inverse_of
 end
 
 class Order < ActiveRecord::Base


### PR DESCRIPTION
Defining `inverse_of` on `has_many` association is not mandatory as a described [here](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations.rb#L630-L633)
