### PR TITLE
Make revert of `disable_extension` to work

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -17,7 +17,7 @@ module ActiveRecord
       ReversibleAndIrreversibleMethods = [:create_table, :create_join_table, :rename_table, :add_column, :remove_column,
         :rename_index, :rename_column, :add_index, :remove_index, :add_timestamps, :remove_timestamps,
         :change_column_default, :add_reference, :remove_reference, :transaction,
-        :drop_join_table, :drop_table, :execute_block, :enable_extension,
+        :drop_join_table, :drop_table, :execute_block, :enable_extension, :disable_extension,
         :change_column, :execute, :remove_columns, :change_column_null,
         :add_foreign_key, :remove_foreign_key
       ]


### PR DESCRIPTION
This is fix of #11826 which miss to add `disable_extension` to
`ReversibleAndIrreversibleMethods`. So `CommandRecorder#method_missing`
catches `change_column_default` and @delegate's method is called.
