### PR TITLE
Add fail fast reporting to test runner.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,35 @@
+*   Add fail fast to `bin/rails test`
+
+    Adding `--fail-fast` or `-f` when running tests will interrupt the run on
+    the first failure:
+
+    ```
+    # Running:
+
+    ................................................S......E
+
+    ArgumentError: Wups! Bet you didn't expect this!
+        test/models/bunny_test.rb:19:in `block in <class:BunnyTest>'
+
+    bin/rails test test/models/bunny_test.rb:18
+
+    ....................................F
+
+    This failed
+
+    bin/rails test test/models/bunny_test.rb:14
+
+    Interrupted. Exiting...
+
+
+    Finished in 0.051427s, 1808.3872 runs/s, 1769.4972 assertions/s.
+
+    ```
+
+    Note that any unexpected errors don't abort the run.
+
+    *Kasper Timm Hansen*
+
 *   Add inline output to `bin/rails test`
 
     Any failures or errors (and skips if running in verbose mode) are output

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,33 @@
+*   Add inline output to `bin/rails test`
+
+    Any failures or errors (and skips if running in verbose mode) are output
+    during a test run:
+
+    ```
+    # Running:
+
+    .....S..........................................F
+
+    This failed
+
+    bin/rails test test/models/bunny_test.rb:14
+
+    .................................E
+
+    ArgumentError: Wups! Bet you didn't expect this!
+        test/models/bunny_test.rb:19:in `block in <class:BunnyTest>'
+
+    bin/rails test test/models/bunny_test.rb:18
+
+    ....................
+
+    Finished in 0.069708s, 1477.6019 runs/s, 1448.9106 assertions/s.
+    ```
+
+    Output can be deferred to after a run with the `--defer-output` option.
+
+    *Kasper Timm Hansen*
+
 *   Fix displaying mailer previews on non local requests when config
     `action_mailer.show_previews` is set
 

--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -33,6 +33,11 @@ module Minitest
       options[:output_inline] = false
     end
 
+    opts.on("-f", "--fail-fast",
+            "Abort test run on first failure") do
+      options[:fail_fast] = true
+    end
+
     options[:patterns] = opts.order!
   end
 

--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -14,6 +14,8 @@ module Minitest
     opts.separator ""
     opts.separator "    bin/rails test test/controllers test/integration/login_test.rb"
     opts.separator ""
+    opts.separator "By default test failures and errors are reported inline during a run."
+    opts.separator ""
 
     opts.separator "Rails options:"
     opts.on("-e", "--environment ENV",
@@ -24,6 +26,11 @@ module Minitest
     opts.on("-b", "--backtrace",
             "Show the complete backtrace") do
       options[:full_backtrace] = true
+    end
+
+    opts.on("-d", "--defer-output",
+            "Output test failures and errors after the test run") do
+      options[:output_inline] = false
     end
 
     options[:patterns] = opts.order!

--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -17,6 +17,10 @@ module Rails
         io.puts format_rerun_snippet(result)
         io.puts
       end
+
+      if fail_fast? && result.failure && !result.error? && !result.skipped?
+        raise Interrupt
+      end
     end
 
     def report
@@ -46,6 +50,10 @@ module Rails
     private
       def output_inline?
         options.fetch(:output_inline, true)
+      end
+
+      def fail_fast?
+        options[:fail_fast]
       end
 
       def format_rerun_snippet(result)

--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -6,8 +6,21 @@ module Rails
     class_attribute :executable
     self.executable = "bin/rails test"
 
+    def record(result)
+      super
+
+      if output_inline? && result.failure && (!result.skipped? || options[:verbose])
+        io.puts
+        io.puts
+        io.puts result.failures.map(&:message)
+        io.puts
+        io.puts format_rerun_snippet(result)
+        io.puts
+      end
+    end
+
     def report
-      return if filtered_results.empty?
+      return if output_inline? || filtered_results.empty?
       io.puts
       io.puts "Failed tests:"
       io.puts
@@ -15,10 +28,7 @@ module Rails
     end
 
     def aggregated_results # :nodoc:
-      filtered_results.map do |result|
-        location, line = result.method(result.name).source_location
-        "#{self.executable} #{relative_path_for(location)}:#{line}"
-      end.join "\n"
+      filtered_results.map { |result| format_rerun_snippet(result) }.join "\n"
     end
 
     def filtered_results
@@ -32,5 +42,15 @@ module Rails
     def relative_path_for(file)
       file.sub(/^#{Rails.root}\/?/, '')
     end
+
+    private
+      def output_inline?
+        options.fetch(:output_inline, true)
+      end
+
+      def format_rerun_snippet(result)
+        location, line = result.method(result.name).source_location
+        "#{self.executable} #{relative_path_for(location)}:#{line}"
+      end
   end
 end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -355,6 +355,21 @@ module ApplicationTests
       assert_match %r{Running:\n\nF\n\nwups!\n\nbin/rails test test/models/post_test.rb:4}, output
     end
 
+    def test_fail_fast
+      app_file 'test/models/post_test.rb', <<-RUBY
+        require 'test_helper'
+
+        class PostTest < ActiveSupport::TestCase
+          def test_post
+            assert false, 'wups!'
+          end
+        end
+      RUBY
+
+      assert_match(/Interrupt/,
+        capture(:stderr) { run_test_command('test/models/post_test.rb --fail-fast') })
+    end
+
     def test_raise_error_when_specified_file_does_not_exist
       error = capture(:stderr) { run_test_command('test/not_exists.rb') }
       assert_match(%r{cannot load such file.+test/not_exists\.rb}, error)

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -340,6 +340,21 @@ module ApplicationTests
       assert_match '0 runs, 0 assertions', run_test_command('')
     end
 
+    def test_output_inline_by_default
+      app_file 'test/models/post_test.rb', <<-RUBY
+        require 'test_helper'
+
+        class PostTest < ActiveSupport::TestCase
+          def test_post
+            assert false, 'wups!'
+          end
+        end
+      RUBY
+
+      output = run_test_command('test/models/post_test.rb')
+      assert_match %r{Running:\n\nF\n\nwups!\n\nbin/rails test test/models/post_test.rb:4}, output
+    end
+
     def test_raise_error_when_specified_file_does_not_exist
       error = capture(:stderr) { run_test_command('test/not_exists.rb') }
       assert_match(%r{cannot load such file.+test/not_exists\.rb}, error)


### PR DESCRIPTION
### Inline output

Any failures or errors will be reported inline during the run by default.
Skipped tests will be reported if run in verbose mode.

Any result is output with failure messages and a rerun snippet for that test. I've tried to keep it minimal and relied on Minitest's summary reporter for details:

```
# Running:

.....S..........................................F

This failed

bin/rails test test/models/bunny_test.rb:14

.................................E

ArgumentError: Wups! Bet you didn't expect this!
    test/models/bunny_test.rb:19:in `block in <class:BunnyTest>'

bin/rails test test/models/bunny_test.rb:18

....................

Finished in 0.069708s, 1477.6019 runs/s, 1448.9106 assertions/s.

  1) Failure:
BunnyTest#test_something_failing [/Users/kasperhansen/Documents/code/collection_caching_test/test/models/bunny_test.rb:15]:
This failed


  2) Error:
BunnyTest#test_error_me:
ArgumentError: Wups! Bet you didn't expect this!
    test/models/bunny_test.rb:19:in `block in <class:BunnyTest>'

103 runs, 101 assertions, 1 failures, 1 errors, 1 skips

You have skipped tests. Run with --verbose for details.
```

Note that Minitest already informs us, we can get info about skipped tests if we run with `--verbose`. Handy!
### Fail fast

Aborts the test run on the first failure. Suit that groove with the last config option:

```
minitest options:
    -h, --help                       Display this help.
    -s, --seed SEED                  Sets random seed. Also via env. Eg: SEED=n rake
    -v, --verbose                    Verbose. Show progress processing files.
    -n, --name PATTERN               Filter run on /regexp/ or string.

Known extensions: pride, rails
    -p, --pride                      Pride. Show your testing pride!

Usage: bin/rails test [options] [files or directories]
You can run a single test by appending a line number to a filename:

    bin/rails test test/models/user_test.rb:27

You can run multiple files and directories at the same time:

    bin/rails test test/controllers test/integration/login_test.rb

By default test failures and errors are reported inline during a run.

Rails options:
    -e, --environment ENV            Run tests in the ENV environment
    -b, --backtrace                  Show the complete backtrace
    -f, --fail-fast                  Abort test run on first failure
```

Here's what it looks like:

```
# Run with bin/rails test --fail-fast
# Running:

................................................S......E

ArgumentError: Wups! Bet you didn't expect this!
    test/models/bunny_test.rb:19:in `block in <class:BunnyTest>'

bin/rails test test/models/bunny_test.rb:18

....................................F

This failed

bin/rails test test/models/bunny_test.rb:14

Interrupted. Exiting...


Finished in 0.051427s, 1808.3872 runs/s, 1769.4972 assertions/s.

  1) Error:
BunnyTest#test_error_me:
ArgumentError: Wups! Bet you didn't expect this!
    test/models/bunny_test.rb:19:in `block in <class:BunnyTest>'


  2) Failure:
BunnyTest#test_something_failing [/Users/kasperhansen/Documents/code/collection_caching_test/test/models/bunny_test.rb:15]:
This failed

93 runs, 91 assertions, 1 failures, 1 errors, 1 skips
```

cc @senny @arthurnn @dhh
