### PR TITLE
Silence callback deprecation warning if testing AJ

### DIFF
--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -3,6 +3,7 @@ require File.expand_path('../../../load_paths', __FILE__)
 require 'active_job'
 require 'support/job_buffer'
 
+ActiveSupport.halt_callback_chains_on_return_false = false
 GlobalID.app = 'aj'
 
 @adapter  = ENV['AJ_ADAPTER'] || 'inline'


### PR DESCRIPTION
Currently the log returned by running ActiveJob tests is filled with:

> DEPRECATION WARNING: Returning `false` in a callback will not implicitly halt a callback chain in the next release of Rails. To explicitly halt a callback chain, please use `throw :abort` instead.

For instance, see https://travis-ci.org/rails/rails/builds/77978273

This happens because some setup and teardown methods [like these one](https://github.com/rails/rails/blob/master/activejob/test/cases/async_job_test.rb#L10-L17)
invoke other methods like `perform_asynchronously!` that can return `false`, but
not with the intention of halting the process if they do.

In my opinion, these deprecation warnings can be silenced to have
the log result cleaner (especially when browsing for errors).
