### PR TITLE
`where_exists` and `where_not_exists` methods for ActiveRecord (backed by SQL EXISTS condition)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,32 @@
+*   Added `where_exists`, `where_not_exists` to ActiveRecord finder
+    methods.
+
+    Example:
+
+        class User < ActiveRecord::Base
+          belongs_to :group
+        end
+
+        class Group < ActiveRecord::Base
+          has_many :users
+        end
+
+        User.where_exists(:group)
+        # SELECT * FROM users WHERE EXISTS (
+        #   SELECT 1 FROM groups WHERE users.group_id = groups.id)
+
+        User.where_exists(:group, name: ['Some group', 'Another group'])
+        # SELECT * FROM users WHERE EXISTS (
+        #   SELECT 1 FROM groups WHERE users.group_id = groups.id AND
+        #     groups.name IN ('Some group', 'Another group'))
+
+        Group.where_not_exists(:user, ['name LIKE ?', 'Admin'])
+        # SELECT * FROM groups WHERE NOT (EXISTS (
+        #   SELECT 1 FROM users WHERE users.group_id = groups.id AND
+        #      (groups.name LIKE 'ADMIN')))
+
+    *Eugene Zolotarev*
+
 *   PostgreSQL, `create_schema`, `drop_schema` and `rename_table` now quote
     schema names.
 

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -12,6 +12,7 @@ module ActiveRecord
              :having, :create_with, :uniq, :distinct, :references, :none, :unscope, to: :all
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, to: :all
     delegate :pluck, :ids, to: :all
+    delegate :where_exists, :where_not_exists, to: :all
 
     # Executes a custom SQL query against your database and returns all the results. The results will
     # be returned as an array with columns requested encapsulated as attributes of the model you call


### PR DESCRIPTION
SQL "EXISTS" condition is a great way to find records for which
there is an associated record, or there aren't any associated records.
This commit adds the possibility to harness the power EXISTS with
simple ActiveRecord finder methods.

StackOverflow gives [plenty](http://stackoverflow.com/questions/31754820/rails-activerecord-where-exists-query) [of](http://stackoverflow.com/questions/14188872/rails-activerecord-return-records-where-id-exists-in-related-table) [questions](http://stackoverflow.com/questions/31754820/rails-activerecord-where-exists-query/32309243#32309243) [which](http://stackoverflow.com/questions/12456330/find-all-objects-in-a-has-one-belongs-to-model-association-where-no-association) [support](http://stackoverflow.com/questions/14251180/find-records-where-join-doesnt-exist) [my point](http://stackoverflow.com/questions/3757285/how-to-select-records-where-a-child-does-not-exist).

Today you either should use raw SQL/Arel, which is not very elegant, or come up with some Ruby solution, which is not very performant.

Adding `where_exists` and `where_not_exists` methods to ActiveRecord gives you both elegant syntax and native SQL performance. My personal (obviously biased) opinion is that such feature should've existed in Rails from the beginning.

Example:

```
class User < ActiveRecord::Base
  belongs_to :group
end

class Group < ActiveRecord::Base
  has_many :users
end

User.where_exists(:group)
# SELECT * FROM users WHERE EXISTS (
#   SELECT 1 FROM groups WHERE users.group_id = groups.id)

User.where_exists(:group, name: ['Some group', 'Another group'])
# SELECT * FROM users WHERE EXISTS (
#   SELECT 1 FROM groups WHERE users.group_id = groups.id AND
#     groups.name IN ('Some group', 'Another group'))

Group.where_not_exists(:user, ['name LIKE ?', 'Admin'])
# SELECT * FROM groups WHERE NOT (EXISTS (
#   SELECT 1 FROM users WHERE users.group_id = groups.id AND
#      (groups.name LIKE 'ADMIN')))
```

Additional selling points:
- both way (belongs_to to has_many and vice versa) support
- support for polymorphic associations
- support for :through associations (including multi-level)
