### PR TITLE
Typo on helper description and action_controller_overview

### DIFF
--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -7,8 +7,8 @@ module ActionController
   # extract complicated logic or reusable functionality is strongly encouraged. By default, each controller
   # will include all helpers. These helpers are only accessible on the controller through <tt>.helpers</tt>
   #
-  # In previous versions of \Rails the controller will include a helper whose
-  # name matches that of the controller, e.g., <tt>MyController</tt> will automatically
+  # In previous versions of \Rails the controller will include a helper which
+  # matches the name of the controller, e.g., <tt>MyController</tt> will automatically
   # include <tt>MyHelper</tt>. To return old behavior set +config.action_controller.include_all_helpers+ to +false+.
   #
   # Additional helpers can be specified using the +helper+ class method in ActionController::Base or any

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1114,7 +1114,7 @@ Rescue
 
 Most likely your application is going to contain bugs or otherwise throw an exception that needs to be handled. For example, if the user follows a link to a resource that no longer exists in the database, Active Record will throw the `ActiveRecord::RecordNotFound` exception.
 
-Rails' default exception handling displays a "500 Server Error" message for all exceptions. If the request was made locally, a nice traceback and some added information gets displayed so you can figure out what went wrong and deal with it. If the request was remote Rails will just display a simple "500 Server Error" message to the user, or a "404 Not Found" if there was a routing error or a record could not be found. Sometimes you might want to customize how these errors are caught and how they're displayed to the user. There are several levels of exception handling available in a Rails application:
+Rails default exception handling displays a "500 Server Error" message for all exceptions. If the request was made locally, a nice traceback and some added information gets displayed so you can figure out what went wrong and deal with it. If the request was remote Rails will just display a simple "500 Server Error" message to the user, or a "404 Not Found" if there was a routing error or a record could not be found. Sometimes you might want to customize how these errors are caught and how they're displayed to the user. There are several levels of exception handling available in a Rails application:
 
 ### The Default 500 and 404 Templates
 


### PR DESCRIPTION
Typo on helper description and action_controller_overview.

Helpers description was not clear and clarity of the description missing. Corrected with the proper description.
In action_controller_overview.md typo with Rails' to Rails. Added screenshot below:  

![screen shot 2015-09-01 at 8 30 46 pm](https://cloud.githubusercontent.com/assets/894678/9607748/8201a912-50e8-11e5-97bc-ce5c66f61baa.png)
