### PR TITLE
Fix: AR subclasses to work with AC::Parameters

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/string/filters'
 require 'active_support/rescuable'
 require 'action_dispatch/http/upload'
+require 'rack/test'
 require 'stringio'
 require 'set'
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Instantiating an AR model with `ActionController::Parameters` now raises
+    an `ActiveModel::ForbiddenAttributesError` if the parameters include a
+    `type` field that has not been explicitly permitted. Previously, the
+    `type` field was simply ignored in the same situation.
+
+    *Prem Sichanugrist*
+
 *   PostgreSQL, `create_schema`, `drop_schema` and `rename_table` now quote
     schema names.
 

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -192,11 +192,11 @@ module ActiveRecord
       # If this is a StrongParameters hash, and access to inheritance_column is not permitted,
       # this will ignore the inheritance column and return nil
       def subclass_from_attributes?(attrs)
-        attribute_names.include?(inheritance_column) && attrs.is_a?(Hash)
+        attribute_names.include?(inheritance_column) && attrs.respond_to?(:to_h)
       end
 
       def subclass_from_attributes(attrs)
-        subclass_name = attrs.with_indifferent_access[inheritance_column]
+        subclass_name = attrs.to_h.with_indifferent_access[inheritance_column]
 
         if subclass_name.present?
           subclass = find_sti_class(subclass_name)

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -189,8 +189,6 @@ module ActiveRecord
 
       # Detect the subclass from the inheritance column of attrs. If the inheritance column value
       # is not self or a valid subclass, raises ActiveRecord::SubclassNotFound
-      # If this is a StrongParameters hash, and access to inheritance_column is not permitted,
-      # this will ignore the inheritance column and return nil
       def subclass_from_attributes?(attrs)
         attribute_names.include?(inheritance_column) && attrs.respond_to?(:to_h)
       end

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -6,6 +6,7 @@ require 'models/project'
 require 'models/subscriber'
 require 'models/vegetables'
 require 'models/shop'
+require 'action_controller/metal/strong_parameters'
 
 module InheritanceTestHelper
   def with_store_full_sti_class(&block)
@@ -223,6 +224,11 @@ class InheritanceTest < ActiveRecord::TestCase
     end
   end
 
+  def test_new_with_action_controller_parameters
+    params = ActionController::Parameters.new(type: 'Firm').permit(:type)
+    firm = Company.new params
+    assert_equal Firm, firm.class
+  end
 
   def test_new_with_complex_inheritance
     assert_nothing_raised { Client.new(type: 'VerySpecialClient') }


### PR DESCRIPTION
Fixes #21407

The new test fails before this commit and passes now.
Adding `to_h` was suggested by @sikachu in Basecamp.

What is your opinion about the `require 'action_controller/railtie'` I had to add?

In principle, AR should not depend on AC, but this _principle_ is already ignored in [activerecord/railtie](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/railtie.rb#L5-L9).

Let me know :ribbon:
