### PR TITLE
Require sprockets-rails >= 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ PATH
       activesupport (= 5.0.0.alpha)
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.0.alpha)
-      sprockets-rails
+      sprockets-rails (>= 2.0.0)
     railties (5.0.0.alpha)
       actionpack (= 5.0.0.alpha)
       activesupport (= 5.0.0.alpha)

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'railties',      version
 
   s.add_dependency 'bundler',         '>= 1.3.0', '< 2.0'
-  s.add_dependency 'sprockets-rails'
+  s.add_dependency 'sprockets-rails', '>= 2.0.0'
 end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/commit/4d157ea8c15186c4903fa83f2dc51a5f78d13a37

Without any specification about the version of sprockets-rails, running a `bundle install` on a brand new app might result in sprockets 0.0.1 being installed.

However, the minimum requirement is sprockets-rails 2 (see https://github.com/rails/rails/pull/17752/files)

The version was simply removed to allow either version 2 or version 3, but never to allow previous versions.
