### PR TITLE
Fix: make Travis CI happy about guides again

### DIFF
--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -10,6 +10,9 @@ gemfile(true) do
   gem 'rails', github: 'rails/rails'
   gem 'arel', github: 'rails/arel'
   gem 'rack', github: 'rack/rack'
+  gem 'sprockets', github: 'rails/sprockets'
+  gem 'sprockets-rails', github: 'rails/sprockets-rails'
+  gem 'sass-rails', github: 'rails/sass-rails'
 end
 
 require 'action_controller/railtie'

--- a/guides/bug_report_templates/active_record_master.rb
+++ b/guides/bug_report_templates/active_record_master.rb
@@ -10,6 +10,9 @@ gemfile(true) do
   gem 'rails', github: 'rails/rails'
   gem 'arel', github: 'rails/arel'
   gem 'rack', github: 'rack/rack'
+  gem 'sprockets', github: 'rails/sprockets'
+  gem 'sprockets-rails', github: 'rails/sprockets-rails'
+  gem 'sass-rails', github: 'rails/sass-rails'
   gem 'sqlite3'
 end
 

--- a/guides/bug_report_templates/generic_master.rb
+++ b/guides/bug_report_templates/generic_master.rb
@@ -10,6 +10,9 @@ gemfile(true) do
   gem 'rails', github: 'rails/rails'
   gem 'arel', github: 'rails/arel'
   gem 'rack', github: 'rack/rack'
+  gem 'sprockets', github: 'rails/sprockets'
+  gem 'sprockets-rails', github: 'rails/sprockets-rails'
+  gem 'sass-rails', github: 'rails/sass-rails'
 end
 
 require 'active_support'


### PR DESCRIPTION
Tests on Rails [are currently failing](https://travis-ci.org/rails/rails/jobs/78255666).

The reason is the dependency of Rails master from gems that are currently on GitHub (not on RubyGems) and should be explicitly referenced in the Guides test files.
