### PR TITLE
Backport: AR: translate_exception_class() no longer logs error

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -457,7 +457,6 @@ module ActiveRecord
           message = "#{e.class.name}: #{e.message.force_encoding sql.encoding}: #{sql}"
         end
 
-        @logger.error message if @logger
         exception = translate_exception(e, message)
         exception.set_backtrace e.backtrace
         exception


### PR DESCRIPTION
Backport of https://github.com/rails/rails/pull/19068 into `4-2-stable`.

> `ActiveRecord::ConnectionAdapters::AbstractAdapter#translate_exception_class(e, sql)` is expected to take an error and wrap it in another error; logging the error is an unexpected (and often unwanted) side effect.

This is a tiny safe patch merged into master six months ago which removes noisy unwanted logging from rescued database errors.
