### PR TITLE
Allow #titleize to ignore_dashes

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Add `ignore_dashes` option to
+    - `ActiveSupport::Inflector#underscore`
+    - `ActiveSupport::Inflector#titleize`
+    - `String#underscore`
+    - `String#titleize`
+
+    This allows for:
+        ActiveSupport::Inflector.underscore('e-mail')                      # => "e_mail"
+        ActiveSupport::Inflector.underscore('e-mail', ignore_dashes: true) # => "e-mail"
+        ActiveSupport::Inflector.titleize(  'e-mail')                      # => "E Mail"
+        ActiveSupport::Inflector.titleize(  'e-mail', ignore_dashes: true) # => "E-Mail"
+
+        'DANIEL DAY-LEWIS'.underscore                                      # => "daniel day_lewis"
+        'DANIEL DAY-LEWIS'.underscore(                ignore_dashes: true) # => "daniel day-lewis"
+        'DANIEL DAY-LEWIS'.titleize                                        # => "Daniel Day Lewis"
+        'DANIEL DAY-LEWIS'.titleize(                  ignore_dashes: true) # => 'Daniel Day-Lewis"
+
+    But most importantly:
+        'x-men: the last stand'.titleize                                   # => 'X Men: The Last Stand'
+        'x-men: the last stand'.titleize(             ignore_dashes: true) # => 'X-Men: The Last Stand'
+                                                                           #      ^ Finally!
+
+    *Sam Bostock*
+
 *   Prevent `Marshal.load` from looping infinitely when trying to autoload a constant
     which resolves to a different name.
 

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -99,24 +99,30 @@ class String
   # Capitalizes all the words and replaces some characters in the string to create
   # a nicer looking title. +titleize+ is meant for creating pretty output. It is not
   # used in the Rails internals.
+  # If the +ignore_dashes+ parameter is set to true, then dashes will not be
+  # converted to underscores.
   #
   # +titleize+ is also aliased as +titlecase+.
   #
   #   'man from the boondocks'.titleize # => "Man From The Boondocks"
   #   'x-men: the last stand'.titleize  # => "X Men: The Last Stand"
-  def titleize
-    ActiveSupport::Inflector.titleize(self)
+  #   'x-men: the last stand'.titleize(ignore_dashes: true)
+  #                                     # => "X-Men: The Last Stand"
+  def titleize(ignore_dashes: false)
+    ActiveSupport::Inflector.titleize(self, ignore_dashes: ignore_dashes)
   end
   alias_method :titlecase, :titleize
 
   # The reverse of +camelize+. Makes an underscored, lowercase form from the expression in the string.
+  # If the +ignore_dashes+ parameter is set to true, then dashes will not be
+  # converted to underscores.
   #
   # +underscore+ will also change '::' to '/' to convert namespaces to paths.
   #
   #   'ActiveModel'.underscore         # => "active_model"
   #   'ActiveModel::Errors'.underscore # => "active_model/errors"
-  def underscore
-    ActiveSupport::Inflector.underscore(self)
+  def underscore(ignore_dashes: false)
+    ActiveSupport::Inflector.underscore(self, ignore_dashes: ignore_dashes)
   end
 
   # Replaces underscores with dashes in the string.

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -76,6 +76,8 @@ module ActiveSupport
     end
 
     # Makes an underscored, lowercase form from the expression in the string.
+    # If the +ignore_dashes+ parameter is set to true, then dashes will not be
+    # converted to underscores.
     #
     # Changes '::' to '/' to convert namespaces to paths.
     #
@@ -86,13 +88,13 @@ module ActiveSupport
     # #camelize, though there are cases where that does not hold:
     #
     #   camelize(underscore('SSLError'))  # => "SslError"
-    def underscore(camel_cased_word)
+    def underscore(camel_cased_word, ignore_dashes: false)
       return camel_cased_word unless camel_cased_word =~ /[A-Z-]|::/
       word = camel_cased_word.to_s.gsub('::'.freeze, '/'.freeze)
       word.gsub!(/(?:(?<=([A-Za-z\d]))|\b)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1 && '_'.freeze }#{$2.downcase}" }
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2'.freeze)
       word.gsub!(/([a-z\d])([A-Z])/, '\1_\2'.freeze)
-      word.tr!("-".freeze, "_".freeze)
+      word.tr!('-'.freeze, '_'.freeze) unless ignore_dashes
       word.downcase!
       word
     end
@@ -143,15 +145,20 @@ module ActiveSupport
     # Capitalizes all the words and replaces some characters in the string to
     # create a nicer looking title. +titleize+ is meant for creating pretty
     # output. It is not used in the Rails internals.
+    # If the +ignore_dashes+ parameter is set to true, then dashes will not be
+    # converted to underscores.
     #
     # +titleize+ is also aliased as +titlecase+.
     #
     #   titleize('man from the boondocks')   # => "Man From The Boondocks"
     #   titleize('x-men: the last stand')    # => "X Men: The Last Stand"
+    #   titleize('x-men: the last stand',
+    #            ignore_dashes: true)        # => "X-Men: The Last Stand"
     #   titleize('TheManWithoutAPast')       # => "The Man Without A Past"
     #   titleize('raiders_of_the_lost_ark')  # => "Raiders Of The Lost Ark"
-    def titleize(word)
-      humanize(underscore(word)).gsub(/\b(?<!['’`])[a-z]/) { |match| match.capitalize }
+    def titleize(word, ignore_dashes: false)
+      humanize(underscore(word, ignore_dashes: ignore_dashes))
+        .gsub(/\b(?<!['’`])[a-z]/) { |match| match.capitalize }
     end
 
     # Creates the name of a table like Rails does for models to table names.

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -329,6 +329,32 @@ class StringInflectionsTest < ActiveSupport::TestCase
   def test_safe_constantize
     run_safe_constantize_tests_on(&:safe_constantize)
   end
+
+  test "#underscore without ignore_dashes, doesn't ignore dashes" do
+    UnderscoreNotIgnoringDashes.each do |original, underscored|
+      assert_equal underscored, original.underscore
+      assert_equal underscored, original.underscore(ignore_dashes: false)
+    end
+  end
+
+  test '#underscore with ignore_dashes, ignores dashes' do
+    UnderscoreIgnoringDashes.each do |original, underscored|
+      assert_equal underscored, original.underscore(ignore_dashes: true)
+    end
+  end
+
+  test "#titleize without ignore_dashes, doesn't ignore dashes" do
+    TitleizeNotIgnoringDashes.each do |original, titleized|
+      assert_equal titleized, original.titleize
+      assert_equal titleized, original.titleize(ignore_dashes: false)
+    end
+  end
+
+  test '#titleize with ignore_dashes, ignores dashes' do
+    TitleizeIgnoringDashes.each do |original, titleized|
+      assert_equal titleized, original.titleize(ignore_dashes: true)
+    end
+  end
 end
 
 class StringAccessTest < ActiveSupport::TestCase

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -534,4 +534,38 @@ class InflectorTest < ActiveSupport::TestCase
 
     assert_equal "HTTP", ActiveSupport::Inflector.pluralize("HTTP")
   end
+
+  def test_underscore_not_ignoring_dashes
+    UnderscoreNotIgnoringDashes.each do |original, underscored|
+      assert_equal underscored, ActiveSupport::Inflector.underscore(original)
+      assert_equal underscored,
+                   ActiveSupport::Inflector.underscore(original,
+                                                       ignore_dashes: false)
+    end
+  end
+
+  def test_underscore_ignoring_dashes
+    UnderscoreIgnoringDashes.each do |original, underscored|
+      assert_equal underscored,
+                   ActiveSupport::Inflector.underscore(original,
+                                                       ignore_dashes: true)
+    end
+  end
+
+  def test_titleize_not_ignoring_dashes
+    TitleizeNotIgnoringDashes.each do |original, titleized|
+      assert_equal titleized, ActiveSupport::Inflector.titleize(original)
+      assert_equal titleized,
+                   ActiveSupport::Inflector.titleize(original,
+                                                     ignore_dashes: false)
+    end
+  end
+
+  def test_titleize_ignoring_dashes
+    TitleizeIgnoringDashes.each do |original, titleized|
+      assert_equal titleized,
+                   ActiveSupport::Inflector.titleize(original,
+                                                     ignore_dashes: true)
+    end
+  end
 end

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -353,4 +353,44 @@ module InflectorTestCases
     'zombie' => 'zombies',
     'genus'  => 'genera'
   }
+
+  UnderscoreNotIgnoringDashes = {
+    'StringWith_no_dashes'  => 'string_with_no_dashes',
+    'StringWith-aDash'      => 'string_with_a_dash',
+    'x-men: the last stand' => 'x_men: the last stand',
+    'e-mail'                => 'e_mail',
+    'Daniel Day-Lewis'      => 'daniel day_lewis',
+    'DANIEL DAY-LEWIS'      => 'daniel day_lewis',
+    '----'                  => '____'
+  }
+
+  UnderscoreIgnoringDashes = {
+    'StringWith_no_dashes'  => 'string_with_no_dashes',
+    'StringWith-aDash'      => 'string_with-a_dash',
+    'x-men: the last stand' => 'x-men: the last stand',
+    'e-mail'                => 'e-mail',
+    'Daniel Day-Lewis'      => 'daniel day-lewis',
+    'DANIEL DAY-LEWIS'      => 'daniel day-lewis',
+    '----'                  => '----'
+  }
+
+  TitleizeNotIgnoringDashes = {
+    'StringWith_no_dashes'  => 'String With No Dashes',
+    'StringWith-aDash'      => 'String With A Dash',
+    'x-men: the last stand' => 'X Men: The Last Stand',
+    'e-mail'                => 'E Mail',
+    'Daniel Day-Lewis'      => 'Daniel Day Lewis',
+    'DANIEL DAY-LEWIS'      => 'Daniel Day Lewis',
+    '----'                  => ''
+  }
+
+  TitleizeIgnoringDashes = {
+    'StringWith_no_dashes'  => 'String With No Dashes',
+    'StringWith-aDash'      => 'String With-A Dash',
+    'x-men: the last stand' => 'X-Men: The Last Stand',
+    'e-mail'                => 'E-Mail',
+    'Daniel Day-Lewis'      => 'Daniel Day-Lewis',
+    'DANIEL DAY-LEWIS'      => 'Daniel Day-Lewis',
+    '----'                  => '----'
+  }
 end


### PR DESCRIPTION
Add `ignore_dashes` option to
    - `ActiveSupport::Inflector#underscore`
    - `ActiveSupport::Inflector#titleize`
    - `String#underscore`
    - `String#titleize`

This allows for:

``` ruby
ActiveSupport::Inflector.underscore('e-mail')                      # => "e_mail"
ActiveSupport::Inflector.underscore('e-mail', ignore_dashes: true) # => "e-mail"
ActiveSupport::Inflector.titleize(  'e-mail')                      # => "E Mail"
ActiveSupport::Inflector.titleize(  'e-mail', ignore_dashes: true) # => "E-Mail"

'DANIEL DAY-LEWIS'.underscore                                      # => "daniel day_lewis"
'DANIEL DAY-LEWIS'.underscore(                ignore_dashes: true) # => "daniel day-lewis"
'DANIEL DAY-LEWIS'.titleize                                        # => "Daniel Day Lewis"
'DANIEL DAY-LEWIS'.titleize(                  ignore_dashes: true) # => 'Daniel Day-Lewis"
```
