### PR TITLE
fix invalid package name for libmysqlclient-dev mentioned in development_dependencies_install guide

### DIFF
--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -190,7 +190,7 @@ Follow the instructions given by Homebrew to start these.
 In Ubuntu just run:
 
 ```bash
-$ sudo apt-get install mysql-server libmysqlclient15-dev
+$ sudo apt-get install mysql-server libmysqlclient-dev
 $ sudo apt-get install postgresql postgresql-client postgresql-contrib libpq-dev
 ```
 


### PR DESCRIPTION
stumbled upon this issue when following the step mentioned in http://edgeguides.rubyonrails.org/development_dependencies_install.html for installing mysql in Ubuntu.

```
$ sudo apt-get install mysql-server libmysqlclient15-dev

Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package libmysqlclient15-dev
```

the updated guide is tested to be working on Ubuntu Desktop 15.04
