### PR TITLE
returning self a in scope reset `.current_scope`

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -151,14 +151,14 @@ module ActiveRecord
               scope = all.scoping { instance_exec(*args, &body) }
               scope = scope.extending(extension) if extension
 
-              scope || all
+              (!scope.equal?(self) && scope) || all
             end
           else
             singleton_class.send(:define_method, name) do |*args|
               scope = all.scoping { body.call(*args) }
               scope = scope.extending(extension) if extension
 
-              scope || all
+              (!scope.equal?(self) && scope) || all
             end
           end
         end

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -525,4 +525,12 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert_equal 1, SpecialComment.where(body: 'go crazy').created.count
   end
 
+  def test_returning_self_in_scopes_does_not_reset_current_scope
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+      scope :return_self, -> { self }
+    end
+
+    assert klass.none.return_self.blank?
+  end
 end


### PR DESCRIPTION
For example, given a class that looks like:

```
class Post < ActiveRecord::Base
  scope :tagged_only, ->(condition) {
    if condition
      self.where.not(tags_count: 0)
    else
      self
    end
  } 
end
```

with data from [posts.yml](https://github.com/ignatiusreza/rails/blob/scope_none_self/activerecord/test/fixtures/posts.yml) fixture loaded,  running the following few lines produce surprising results:

```
> Post.count
11

> Post.tagged_only(true).count
2

> Post.tagged_only(false).count
11

> Post.none.tagged_only(true).count
0

> Post.none.tagged_only(false).count
11 # this one should be 0
```

This is surprising, because `ActiveRecord` does not give any indication that the scope has been reset, and it just continue processing producing the wrong results.

In this PR, I tried to solved this issue by checking if the result given by scope is indeed `self` and if yes return `all` in it place.

Arguably, returning `self` in a scope perhaps should not be allowed, and if that's the more desirable direction, than the issue should at least be mentioned in the documentation or, even better, have `ActiveRecord` raise an exception.
