### PR TITLE
Allow passing a block to `presence`, which is run if `present?` is true

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -41,7 +41,13 @@ class Object
   #
   # @return [Object]
   def presence
-    self if present?
+    if present?
+      if block_given?
+        yield self
+      else
+        self
+      end
+    end
   end
 end
 

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -32,4 +32,10 @@ class BlankTest < ActiveSupport::TestCase
     BLANK.each { |v| assert_equal nil, v.presence, "#{v.inspect}.presence should return nil" }
     NOT.each   { |v| assert_equal v,   v.presence, "#{v.inspect}.presence should return self" }
   end
+
+  def test_presence_with_block
+    BLANK.each { |v| assert_equal nil, v.presence{|yielded_v| [yielded_v] }, "#{v.inspect}.presence should return nil" }
+    NOT.each   { |v| assert_equal [v], v.presence{|yielded_v| [yielded_v] }, "#{v.inspect}.presence should return self" }
+  end
+
 end


### PR DESCRIPTION
In continuation of this question on SO: http://stackoverflow.com/questions/32357017/do-something-if-value-is-present

I decided to dig into activesupport to see how presence is implemented and I found it very easy to add block support.

I have done a quick benchmark though Benchmark IPS and this change seems to impose a performance penalty around 8%-12% for `presence?` calls. Perhaps the functionality could be added under a new name, if such a penalty is too much or perhaps someone has an idea for a faster implementation.
