### PR TITLE
[ci skip] Rename `Statsd` with `Stats`

### DIFF
--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -13,7 +13,7 @@ module ActiveSupport
   #       attach_to :active_record
   #
   #       def sql(event)
-  #         Statsd.timing("sql.#{event.payload[:name]}", event.duration)
+  #         Stats.timing("sql.#{event.payload[:name]}", event.duration)
   #       end
   #     end
   #   end


### PR DESCRIPTION
This code example define class `StatsSubscriber`, so I think `Statsd` is typo of `Stats`.
But I am not sure which is correct.
If `Statsd` means `Stats daemon`, it is correct.
