### PR TITLE
ActionView translate helper missing translation message could include interpolation keys

### DIFF
--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -88,7 +88,11 @@ module ActionView
           raise e if raise_error
 
           keys = I18n.normalize_keys(e.locale, e.key, e.options[:scope])
-          content_tag('span', keys.last.to_s.titleize, :class => 'translation_missing', :title => "translation missing: #{keys.join('.')}")
+          title = "translation missing: #{keys.join('.')}"
+          interpolation_keys = e.options.except(:default, :scope).keys
+          title << ", interpolation: #{interpolation_keys.join(', ')}" if interpolation_keys.present?
+
+          content_tag('span', keys.last.to_s.titleize, :class => 'translation_missing', :title => title)
         end
       end
       alias :t :translate

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -60,6 +60,11 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal true, translate(:"translations.missing").html_safe?
   end
 
+  def test_returns_missing_translation_message_with_interpolation_keys
+    expected = '<span class="translation_missing" title="translation missing: en.translations.missing, interpolation: first_name, last_name">Missing</span>'
+    assert_equal expected, translate(:"translations.missing", :first_name => 'foo', :last_name => 'bar')
+  end
+
   def test_raises_missing_translation_message_with_raise_config_option
     ActionView::Base.raise_on_missing_translations = true
 


### PR DESCRIPTION
Hello!

By default when using the Rails translate helper and a translation is missing, the translation keys are output in the title attribute of the span, ie. `translation missing: en.home.index.title`.

This is a great help for people translating the application. But one issue is that many calls using the translate helper also use interpolation keys, like `t('.title', name: current_user.name)`.
People translating the application have no easy way of knowing if interpolation keys are actually used and what their names are other than having access to the source code of the view.

What do you think of adding the interpolation keys in the default translation missing title message following the key name, something like in this commit: `translation missing: en.home.index.title, interpolation: name`?

Thanks!
