### PR TITLE
fix module name typo in API app guide [ci skip]

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -394,7 +394,7 @@ Some common modules you might want to add:
 
 - `AbstractController::Translation`: Support for the `l` and `t` localization
   and translation methods.
-- `ActionController::HTTPAuthentication::Basic` (or `Digest` or `Token`): Support
+- `ActionController::HttpAuthentication::Basic` (or `Digest` or `Token`): Support
   for basic, digest or token HTTP authentication.
 - `AbstractController::Layouts`: Support for layouts when rendering.
 - `ActionController::MimeResponds`: Support for `respond_to`.


### PR DESCRIPTION
ref: https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/http_authentication.rb#L5
