### PR TITLE
fix query so it works with redshift

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
@@ -36,7 +36,7 @@ module ActiveRecord
               WHERE
                 t.typname IN (%s)
                 OR t.typtype IN (%s)
-                OR t.typinput::varchar = 'array_in'
+                OR t.typinput = 'array_in'::regproc
                 OR t.typelem != 0
             SQL
           end


### PR DESCRIPTION
redshift was generating the following error:
 'cannot cast type regproc to character varying'

I'm not sure if this works in all the postgresql versions Rails is meant to support.
