### PR TITLE
Use collection ids and timestamps to generate truly unique collection cache keys

### DIFF
--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -5,9 +5,9 @@ module ActiveRecord
       model_signature = collection.model_name.cache_key
 
       if collection.loaded?
-        unique_signature = collection.pluck(primary_key, timestamp_column).flatten.join("-")
+        unique_signature = collection.pluck(primary_key, timestamp_column).flatten.join("-".freeze)
       else
-        unique_signature = collection.unscope(:order).pluck(primary_key, timestamp_column).flatten.join("-")
+        unique_signature = collection.unscope(:order).pluck(primary_key, timestamp_column).flatten.join("-".freeze)
       end
 
       "#{model_signature}/collection-digest-#{Digest::SHA256.hexdigest(unique_signature)}"

--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -2,30 +2,10 @@ module ActiveRecord
   module CollectionCacheKey
 
     def collection_cache_key(collection = all, timestamp_column = :updated_at) # :nodoc:
-      query_signature = Digest::MD5.hexdigest(collection.to_sql)
-      key = "#{collection.model_name.cache_key}/query-#{query_signature}"
+      model_signature = collection.model_name.cache_key
+      unique_signature = collection.pluck(primary_key, timestamp_column).flatten.join("-")
 
-      if collection.loaded?
-        size = collection.size
-        timestamp = collection.max_by(&timestamp_column).public_send(timestamp_column)
-      else
-        column_type = type_for_attribute(timestamp_column.to_s)
-        column = "#{connection.quote_table_name(collection.table_name)}.#{connection.quote_column_name(timestamp_column)}"
-
-        query = collection
-          .select("COUNT(*) AS size", "MAX(#{column}) AS timestamp")
-          .unscope(:order)
-        result = connection.select_one(query)
-
-        size = result["size"]
-        timestamp = column_type.deserialize(result["timestamp"])
-      end
-
-      if timestamp
-        "#{key}-#{size}-#{timestamp.utc.to_s(cache_timestamp_format)}"
-      else
-        "#{key}-#{size}"
-      end
+      "#{model_signature}/collection-digest-#{Digest::SHA256.hexdigest(unique_signature)}"
     end
   end
 end

--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -3,7 +3,12 @@ module ActiveRecord
 
     def collection_cache_key(collection = all, timestamp_column = :updated_at) # :nodoc:
       model_signature = collection.model_name.cache_key
-      unique_signature = collection.pluck(primary_key, timestamp_column).flatten.join("-")
+
+      if collection.loaded?
+        unique_signature = collection.pluck(primary_key, timestamp_column).flatten.join("-")
+      else
+        unique_signature = collection.unscope(:order).pluck(primary_key, timestamp_column).flatten.join("-")
+      end
 
       "#{model_signature}/collection-digest-#{Digest::SHA256.hexdigest(unique_signature)}"
     end

--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -7,7 +7,7 @@ module ActiveRecord
       if collection.loaded?
         unique_signature = collection.pluck(primary_key, timestamp_column).flatten.join("-".freeze)
       else
-        unique_signature = collection.unscope(:order).pluck(primary_key, timestamp_column).flatten.join("-".freeze)
+        unique_signature = collection.pluck(primary_key, timestamp_column).flatten.join("-".freeze)
       end
 
       "#{model_signature}/collection-digest-#{Digest::SHA256.hexdigest(unique_signature)}"


### PR DESCRIPTION
Pull request #20884 introduced collection cache keys to help cache partials for entire collections, provided the collection members update their timestamp columns when they change.

However, as highlighted [here](https://github.com/rails/rails/pull/20884#issuecomment-128910649) and [here](https://github.com/rails/rails/pull/20884#issuecomment-132687705) the solution does not create a unique cache key identifying the collection contents in the following two scenarios.
### 1 - collection count SQL is not compatible with limit()

The collection size SQL generated [by the original PR's code](https://github.com/rails/rails/pull/20884/files#diff-c8451b85d6873f9b149babe45c4777a3R15) for `Developer.where(name: "David").limit(1)` is incorrect:

``` sql

SELECT COUNT(*) AS size, MAX("developers"."updated_at") AS timestamp 
  FROM "developers"
  WHERE "developers"."name" = "David" 
  LIMIT 1

```

The `size` returned by the above query is not what the `LIMIT` specifies, but the size of the result of all developers whose name is `David`. This is expected SQL behaviour, by the way.
### 2 - Replacing an old record in the collection does not invalidate the cache key

This has already been explained by @swalkinshaw [here](https://github.com/rails/rails/pull/20884#issuecomment-128910649) and the following test fails against master.

``` ruby
test "collection_cache_key changes when old collection members are replaced" do
  project = Project.create
  project.developers.create(updated_at: 2.hours.ago, name: "anonymous")
  project.developers.create(updated_at: 4.hours.ago, name: "eponymous")

  key1 = project.developers.collection_cache_key

  project.developers.where(name: "eponymous").destroy_all
  project.developers.create(updated_at: 5.hours.ago, name: "anonymous")

  key2 = project.developers.collection_cache_key

  assert_not_equal key2, key1
end
```
## 

The solution proposed by @swalkinshaw [here]() is what I have been using successfully in production, but in the form of an application helper called `cache_collection`. The helper mirrors the `cache` view helper accepting a collection instead of a record.

This PR implement the same solution as my `cache_collection` helper but using the `collection_cache_key` approach from #20884

I've made a few modifications. 

I've removed the SQL query signature digest, because the query contents (i.e. ids and timestamps) can uniquely identify a collection with records whose timestamp columns are properly updated when the records change.

Instead of plucking just the collection ids and the maximum timestamp, I chose to pluck all timestamps taking advantage of the fact that the `pluck` method fires just one query for both ids and timestamps.

I've also switched to a SHA256 digest to minimise the probability of a collision. My understanding is that given the large size of the digested content a collision is very improbable.
## 

Personally, I prefer the view helper approach, as it makes it more easy to see that asking for a collection cache key will incur a database request.

Having said that, and seeing as #20884 also incurs a database query, I think this more complete solution will save people some headaches when they encounter the above scenarios where the original PR would fail to provide a correct cache key.

If the Rails core team is happy with my implementation in this PR, then let me know and I will update the method documentation as well.
