### PR TITLE
Allow to pass block to assert_called_with to support conditional returns

### DIFF
--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -19,7 +19,7 @@ module ActiveSupport
           mock = Minitest::Mock.new
 
           if args.all? { |arg| arg.is_a?(Array) }
-            args.each { |arg| mock.expect(:call, returns, arg) }
+            args.each { |arg| mock.expect(:call, (returns.respond_to?(:call) ? returns.call(arg) : returns), arg) }
           else
             mock.expect(:call, returns, args)
           end

--- a/activesupport/test/testing/method_call_assertions_test.rb
+++ b/activesupport/test/testing/method_call_assertions_test.rb
@@ -92,6 +92,14 @@ class MethodCallAssertionsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_assert_called_with_conditional_returns
+    options = {1 => :one, 2 => :two}
+    assert_called_with(@object, :<<, [ [ 1 ], [ 2 ] ], returns: proc{|x| options[x.first]}) do
+      assert_equal :one, @object << 1
+      assert_equal :two, @object << 2
+    end
+  end
+
   def test_assert_not_called
     assert_not_called(@object, :decrement) do
       @object.increment


### PR DESCRIPTION
As we allow to pass multiple arguments in `assert_called_with`, we should also allow to customize returns according to each argument set.

Fox example in

``` ruby
def test_date_or_time_select_translates_prompts
  @prompt_defaults.each do |key, prompt|
    I18n.expects(:translate).with(('datetime.prompts.' + key.to_s).to_sym, :locale => 'en').returns prompt
  end

  I18n.expects(:translate).with(:'date.order', :locale => 'en', :default => []).returns %w(year month day)
  datetime_select('post', 'updated_at', :locale => 'en', :include_seconds => true, :prompt => true)
end
```

and in

``` ruby
@fake_timezones = %w(A B C D E).map do |id|
  tz = stub(:name => id, :to_s => id)
  ActiveSupport::TimeZone.stubs(:[]).with(id).returns(tz)
  tz
end
```
