### PR TITLE
fix dependent on destroy

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -615,8 +615,8 @@ module ActiveRecord
       end
 
       # Destroys the +records+ supplied and removes them from the collection.
-      # This method will _always_ remove record from the database ignoring
-      # the +:dependent+ option. Returns an array with the removed records.
+      # This method will _always_ remove record from the database.
+      # Returns an array with the removed records.
       #
       #   class Person < ActiveRecord::Base
       #     has_many :pets


### PR DESCRIPTION
Let's we have 

```
class User < ActiveRecord::Base
  belongs_to :company
end
```

```
class Company < ActiveRecord::Base
  has_many :users, dependent: :restrict_with_exception
end
```

We create company and user which belongs to company
And run something like Company.last.destroy - exception is raised, so dependent option is not ignored
