### PR TITLE
raise LoadError when a non-existent file or directory is specified to the test runner

### DIFF
--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -29,12 +29,21 @@ module Minitest
     options[:patterns] = opts.order!
   end
 
+  # Running several Rake tasks in a single command would trip up the runner,
+  # as the patterns would also contain the other Rake tasks.
+  def self.rake_run(patterns) # :nodoc:
+    @rake_patterns = patterns
+    run
+  end
+
   def self.plugin_rails_init(options)
     self.run_with_rails_extension = true
 
     ENV["RAILS_ENV"] = options[:environment] || "test"
 
-    ::Rails::TestRequirer.require_files options[:patterns] unless run_with_autorun
+    unless run_with_autorun
+      ::Rails::TestRequirer.require_files @rake_patterns || options[:patterns]
+    end
 
     unless options[:full_backtrace] || ENV["BACKTRACE"]
       # Plugin can run without Rails loaded, check before filtering.

--- a/railties/lib/rails/test_unit/test_requirer.rb
+++ b/railties/lib/rails/test_unit/test_requirer.rb
@@ -18,7 +18,7 @@ module Rails
             arg = arg.gsub(/:(\d+)?$/, '')
             if Dir.exist?(arg)
               "#{arg}/**/*_test.rb"
-            elsif File.file?(arg)
+            else
               arg
             end
           end

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -7,7 +7,7 @@ task default: :test
 desc "Runs all tests in test folder"
 task :test do
   $: << "test"
-  Minitest.run(['test'])
+  Minitest.rake_run(["test"])
 end
 
 namespace :test do
@@ -24,22 +24,22 @@ namespace :test do
   ["models", "helpers", "controllers", "mailers", "integration", "jobs"].each do |name|
     task name => "test:prepare" do
       $: << "test"
-      Minitest.run(["test/#{name}"])
+      Minitest.rake_run(["test/#{name}"])
     end
   end
 
   task :generators => "test:prepare" do
     $: << "test"
-    Minitest.run(["test/lib/generators"])
+    Minitest.rake_run(["test/lib/generators"])
   end
 
   task :units => "test:prepare" do
     $: << "test"
-    Minitest.run(["test/models", "test/helpers", "test/unit"])
+    Minitest.rake_run(["test/models", "test/helpers", "test/unit"])
   end
 
   task :functionals => "test:prepare" do
     $: << "test"
-    Minitest.run(["test/controllers", "test/mailers", "test/functional"])
+    Minitest.rake_run(["test/controllers", "test/mailers", "test/functional"])
   end
 end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -340,6 +340,11 @@ module ApplicationTests
       assert_match '0 runs, 0 assertions', run_test_command('')
     end
 
+    def test_raise_error_when_specified_file_does_not_exist
+      error = capture(:stderr) { run_test_command('test/not_exists.rb') }
+      assert_match(%r{cannot load such file.+test/not_exists\.rb}, error)
+    end
+
     private
       def run_test_command(arguments = 'test/unit/test_test.rb')
         Dir.chdir(app_path) { `bin/rails t #{arguments}` }


### PR DESCRIPTION
Currently, if a file or directory that does not exist was specified in the test runner, that argument is ignored.
This commit has been modified to cause an error if there is no file or directory.

In addition, there is a problem that does not pass correctly the argument to test runner from the rake,  thereby for now test will fail,  was modified together.
