### PR TITLE
[ci skip] Replace `AR` with `Active Record` in task desc

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -229,7 +229,7 @@ db_namespace = namespace :db do
   end
 
   namespace :schema do
-    desc 'Creates a db/schema.rb file that is portable against any DB supported by AR'
+    desc 'Creates a db/schema.rb file that is portable against any DB supported by Active Record'
     task :dump => [:environment, :load_config] do
       require 'active_record/schema_dumper'
       filename = ENV['SCHEMA'] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, 'schema.rb')


### PR DESCRIPTION
Many user look `desc` of rake task and they are not familiar with `AR`.
`Active Record` is more familiar word.
