### PR TITLE
PERF: Scope performance.

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -24,12 +24,12 @@ module ActiveRecord
     end
 
     def build_from_hash(attributes)
-      attributes = convert_dot_notation_to_hash(attributes.stringify_keys)
+      attributes = convert_dot_notation_to_hash(attributes)
       expand_from_hash(attributes)
     end
 
     def create_binds(attributes)
-      attributes = convert_dot_notation_to_hash(attributes.stringify_keys)
+      attributes = convert_dot_notation_to_hash(attributes)
       create_binds_for_hash(attributes)
     end
 

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
@@ -10,10 +10,10 @@ module ActiveRecord
 
         table = value.associated_table
         if value.base_class
-          queries[table.association_foreign_type] = value.base_class.name
+          queries[table.association_foreign_type.to_s] = value.base_class.name
         end
 
-        queries[table.association_foreign_key] = value.ids
+        queries[table.association_foreign_key.to_s] = value.ids
         predicate_builder.build_from_hash(queries)
       end
 

--- a/activerecord/lib/active_record/relation/where_clause_factory.rb
+++ b/activerecord/lib/active_record/relation/where_clause_factory.rb
@@ -15,6 +15,7 @@ module ActiveRecord
         when Hash
           attributes = predicate_builder.resolve_column_aliases(opts)
           attributes = klass.send(:expand_hash_conditions_for_aggregates, attributes)
+          attributes.stringify_keys!
 
           attributes, binds = predicate_builder.create_binds(attributes)
 

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -6,8 +6,10 @@ module ActiveRecord
       included do
         # Stores the default scope for the class.
         class_attribute :default_scopes, instance_writer: false, instance_predicate: false
+        class_attribute :default_scope_override, instance_predicate: false
 
         self.default_scopes = []
+        self.default_scope_override = nil
       end
 
       module ClassMethods
@@ -101,7 +103,12 @@ module ActiveRecord
 
         def build_default_scope(base_rel = relation) # :nodoc:
           return if abstract_class?
-          if !Base.is_a?(method(:default_scope).owner)
+
+          if self.default_scope_override.nil?
+            self.default_scope_override = !Base.is_a?(method(:default_scope).owner)
+          end
+
+          if self.default_scope_override
             # The user has defined their own default scope method, so call that
             evaluate_default_scope { default_scope }
           elsif default_scopes.any?


### PR DESCRIPTION
Script used:

``` ruby
begin
  require 'bundler/inline'
rescue LoadError => e
  $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
  raise e
end

gemfile(true) do
  source 'https://rubygems.org'
  gem 'rails', path: '~/rails' # master against ref "f1f0a3f8d99aef8aacfa81ceac3880dcac03ca06"
  gem 'arel', github: 'rails/arel', branch: 'master'
  gem 'rack', github: 'rack/rack', branch: 'master'
  gem 'sass'
  gem 'sprockets-rails', github: 'rails/sprockets-rails', branch: 'master'
  gem 'sprockets', github: 'rails/sprockets', branch: 'master'
  gem 'pg'
  gem 'benchmark-ips'
end

require 'active_record'
require 'benchmark/ips'

ActiveRecord::Base.establish_connection('postgres://postgres@localhost:5432/rubybench')

ActiveRecord::Migration.verbose = false

ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
    t.string :name, :email
    t.timestamps null: false
  end
end

class User < ActiveRecord::Base; end

attributes = {
  name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
  email: "foobar@email.com",
}

1000.times { User.create!(attributes) }

Benchmark.ips(5, 3) do |x|
  x.report('where with hash') { User.where(name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.") }
  x.report('where with string') { User.where("users.name = ?", "Lorem ipsum dolor sit amet, consectetur adipiscing elit.") }
  x.compare!
end

key =
  if RUBY_VERSION < '2.2'
    :total_allocated_object
  else
    :total_allocated_objects
  end

before = GC.stat[key]
User.where(name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
after = GC.stat[key]
puts "Total Allocated Object: #{after - before}"

Benchmark.ips(5, 3) do |x|
  x.report('all') { User.all }
end
```

Before:

``` ruby
Calculating -------------------------------------
     where with hash     2.727k i/100ms
   where with string     4.202k i/100ms
-------------------------------------------------
     where with hash     28.893k (± 1.8%) i/s -    144.531k
   where with string     44.463k (± 3.0%) i/s -    222.706k

Comparison:
   where with string:    44463.1 i/s
     where with hash:    28893.2 i/s - 1.54x slower

Total Allocated Object: 85
Calculating -------------------------------------
                 all    16.155k i/100ms
-------------------------------------------------
                 all    177.896k (± 3.7%) i/s -    904.680k
```

After:

``` ruby
Calculating -------------------------------------
     where with hash     3.207k i/100ms
   where with string     4.732k i/100ms
-------------------------------------------------
     where with hash     33.849k (± 1.1%) i/s -    169.971k
   where with string     49.735k (± 2.3%) i/s -    250.796k

Comparison:
   where with string:    49734.8 i/s
     where with hash:    33848.8 i/s - 1.47x slower

Total Allocated Object: 83
Calculating -------------------------------------
                 all    19.699k i/100ms
-------------------------------------------------
                 all    222.530k (± 2.6%) i/s -      1.123M
```
