### PR TITLE
Fix strange messages for `rails g foo`

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -178,7 +178,7 @@ module Rails
         options     = sorted_groups.flat_map(&:last)
         suggestions = options.sort_by {|suggested| levenshtein_distance(namespace.to_s, suggested) }.first(3)
         msg =  "Could not find generator '#{namespace}'. "
-        msg << "Maybe you meant #{ suggestions.map {|s| "'#{s}'"}.to_sentence(last_word_connector: " or ") }\n"
+        msg << "Maybe you meant #{ suggestions.map {|s| "'#{s}'"}.to_sentence(last_word_connector: " or ", locale: :en) }\n"
         msg << "Run `rails generate --help` for more options."
         puts msg
       end


### PR DESCRIPTION
On my environment, `rails g foo` says:

> Could not find generator 'foo'. Maybe you meant 'job'と'task' or 'cell'
> Run `rails generate --help` for more options. 

The `と` is `and` in Japanese Hiragana, meaning it tries to localize some messages but generates strange messages.

This pull-request fixes this issue by disabling localization by `#to_sentence()`, showing `Maybe you meant 'job', 'task' or 'cell'`.
