### PR TITLE
Use global migrations_path configuration in Migrator

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Global `migrations_paths` configuration now being considered by
+    `Migrator.migrate(...)`. This now works as expected:
+
+      ```ruby
+      ActiveRecord::Tasks::DatabaseTasks.tap do |config|
+        config.migrations_paths = ['custom/migration/path']
+      end
+      ```
+
+    *Tobias Bielohlawek*
+
 *   Support dropping indexes concurrently in PostgreSQL.
 
     See http://www.postgresql.org/docs/9.4/static/sql-dropindex.html for more

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -134,7 +134,7 @@ module ActiveRecord
         version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
         scope   = ENV['SCOPE']
         verbose_was, Migration.verbose = Migration.verbose, verbose
-        Migrator.migrate(Migrator.migrations_paths, version) do |migration|
+        Migrator.migrate(migrations_paths, version) do |migration|
           scope.blank? || scope == migration.scope
         end
       ensure

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -277,12 +277,14 @@ module ActiveRecord
     def test_migrate_receives_correct_env_vars
       verbose, version = ENV['VERBOSE'], ENV['VERSION']
 
+      ActiveRecord::Tasks::DatabaseTasks.migrations_paths = 'custom/path'
       ENV['VERBOSE'] = 'false'
       ENV['VERSION'] = '4'
 
-      ActiveRecord::Migrator.expects(:migrate).with(ActiveRecord::Migrator.migrations_paths, 4)
+      ActiveRecord::Migrator.expects(:migrate).with('custom/path', 4)
       ActiveRecord::Tasks::DatabaseTasks.migrate
     ensure
+      ActiveRecord::Tasks::DatabaseTasks.migrations_paths = nil
       ENV['VERBOSE'], ENV['VERSION'] = verbose, version
     end
   end


### PR DESCRIPTION
This fixes a bug where a custom `migrations_paths` value wasn't considered when executing `Migrator.migrate(...)`. 

Fix is to use the global value configured on `DatabaseTasks` instead, and not the value which set (per default) on `Migrator`. Now this configuration will actually be possible:

``` ruby
ActiveRecord::Tasks::DatabaseTasks.tap do |config|
  config.migrations_paths = ['custom/migration/path']
end
```

maybe related: https://github.com/rails/rails/pull/19954
