### PR TITLE
Use `ActiveRecord::Tasks::DatabaseTasks.migrations_paths` explicit for db tasks

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -2,8 +2,7 @@ require 'active_record'
 
 db_namespace = namespace :db do
   task :load_config do
-    ActiveRecord::Base.configurations       = ActiveRecord::Tasks::DatabaseTasks.database_configuration || {}
-    ActiveRecord::Migrator.migrations_paths = ActiveRecord::Tasks::DatabaseTasks.migrations_paths
+    ActiveRecord::Base.configurations = ActiveRecord::Tasks::DatabaseTasks.database_configuration || {}
   end
 
   namespace :create do
@@ -79,7 +78,7 @@ db_namespace = namespace :db do
     task :up => [:environment, :load_config] do
       version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
       raise 'VERSION is required' unless version
-      ActiveRecord::Migrator.run(:up, ActiveRecord::Migrator.migrations_paths, version)
+      ActiveRecord::Migrator.run(:up, ActiveRecord::Tasks::DatabaseTasks.migrations_paths, version)
       db_namespace['_dump'].invoke
     end
 
@@ -87,7 +86,7 @@ db_namespace = namespace :db do
     task :down => [:environment, :load_config] do
       version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
       raise 'VERSION is required - To go down one migration, run db:rollback' unless version
-      ActiveRecord::Migrator.run(:down, ActiveRecord::Migrator.migrations_paths, version)
+      ActiveRecord::Migrator.run(:down, ActiveRecord::Tasks::DatabaseTasks.migrations_paths, version)
       db_namespace['_dump'].invoke
     end
 
@@ -99,7 +98,7 @@ db_namespace = namespace :db do
       db_list = ActiveRecord::SchemaMigration.normalized_versions
 
       file_list =
-          ActiveRecord::Migrator.migrations_paths.flat_map do |path|
+          ActiveRecord::Tasks::DatabaseTasks.migrations_paths.flat_map do |path|
             # match "20091231235959_some_name.rb" and "001_some_name.rb" pattern
             Dir.foreach(path).grep(/^(\d{3,})_(.+)\.rb$/) do
               version = ActiveRecord::SchemaMigration.normalize_migration_number($1)
@@ -125,14 +124,14 @@ db_namespace = namespace :db do
   desc 'Rolls the schema back to the previous version (specify steps w/ STEP=n).'
   task :rollback => [:environment, :load_config] do
     step = ENV['STEP'] ? ENV['STEP'].to_i : 1
-    ActiveRecord::Migrator.rollback(ActiveRecord::Migrator.migrations_paths, step)
+    ActiveRecord::Migrator.rollback(ActiveRecord::Tasks::DatabaseTasks.migrations_paths, step)
     db_namespace['_dump'].invoke
   end
 
   # desc 'Pushes the schema to the next version (specify steps w/ STEP=n).'
   task :forward => [:environment, :load_config] do
     step = ENV['STEP'] ? ENV['STEP'].to_i : 1
-    ActiveRecord::Migrator.forward(ActiveRecord::Migrator.migrations_paths, step)
+    ActiveRecord::Migrator.forward(ActiveRecord::Tasks::DatabaseTasks.migrations_paths, step)
     db_namespace['_dump'].invoke
   end
 
@@ -160,7 +159,7 @@ db_namespace = namespace :db do
 
   # desc "Raises an error if there are pending migrations"
   task :abort_if_pending_migrations => [:environment, :load_config] do
-    pending_migrations = ActiveRecord::Migrator.open(ActiveRecord::Migrator.migrations_paths).pending_migrations
+    pending_migrations = ActiveRecord::Migrator.open(ActiveRecord::Tasks::DatabaseTasks.migrations_paths).pending_migrations
 
     if pending_migrations.any?
       puts "You have #{pending_migrations.size} pending #{pending_migrations.size > 1 ? 'migrations:' : 'migration:'}"
@@ -384,7 +383,7 @@ namespace :railties do
         puts "Copied migration #{migration.basename} from #{name}"
       end
 
-      ActiveRecord::Migration.copy(ActiveRecord::Migrator.migrations_paths.first, railties,
+      ActiveRecord::Migration.copy(ActiveRecord::Tasks::DatabaseTasks.migrations_paths.first, railties,
                                     :on_skip => on_skip, :on_copy => on_copy)
     end
   end


### PR DESCRIPTION
This defines source of truth for `migrations_paths` for running db rake tasks clearly by passing `ActiveRecord::Tasks::DatabaseTasks.migrations_paths`  explicit to `Migrator` and avoids setting `Migrator.migrations_paths` instead.

As its mainly a cosmetic change I couldn't think of any way write a test. Ideas?

Follow up on #21527  /cc @senny 
