### PR TITLE
update rails versions in guide[ci skip]

### DIFF
--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -16,9 +16,9 @@
 <% end %>
 <p>
 The guides for earlier releases:
-<a href="http://guides.rubyonrails.org/v4.2.0/">Rails 4.2.0</a>,
-<a href="http://guides.rubyonrails.org/v4.1.8/">Rails 4.1.8</a>,
-<a href="http://guides.rubyonrails.org/v4.0.12/">Rails 4.0.12</a>,
-<a href="http://guides.rubyonrails.org/v3.2.21/">Rails 3.2.21</a> and
+<a href="http://guides.rubyonrails.org/v4.2.4/">Rails 4.2.4</a>,
+<a href="http://guides.rubyonrails.org/v4.1.13/">Rails 4.1.13</a>,
+<a href="http://guides.rubyonrails.org/v4.0.13/">Rails 4.0.13</a>,
+<a href="http://guides.rubyonrails.org/v3.2.22/">Rails 3.2.22</a> and
 <a href="http://guides.rubyonrails.org/v2.3.11/">Rails 2.3.11</a>.
 </p>


### PR DESCRIPTION
Master is pointing to Current or Rails 5.0, Other updated versions have some security fixes. ex - rails 3.2.22 fixed for XML documents that are too deep can cause an stack overflow, which in turn will cause a potential `DoS attack CVE-2015-3227`.
