### PR TITLE
PERF: Reduce allocation in `resolve_column_aliases`.

### DIFF
--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -12,13 +12,13 @@ module ActiveRecord
     def resolve_column_aliases(hash)
       # This method is a hot spot, so for now, use Hash[] to dup the hash.
       #   https://bugs.ruby-lang.org/issues/7166
-      hash = Hash[hash]
-      hash.keys.grep(Symbol) do |key|
-        if klass.attribute_alias? key
-          hash[klass.attribute_alias(key)] = hash.delete key
+      new_hash = Hash[hash]
+      hash.each do |key, _|
+        if (key.is_a?(Symbol)) && klass.attribute_alias?(key)
+          new_hash[klass.attribute_alias(key)] = new_hash.delete(key)
         end
       end
-      hash
+      new_hash
     end
 
     def arel_attribute(column_name)


### PR DESCRIPTION
Benchmark Script Used:

```
begin
  require 'bundler/inline'
rescue LoadError => e
  $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
  raise e
end

gemfile(true) do
  source 'https://rubygems.org'
  gem 'rails', path: '~/rails' # master against ref "f1f0a3f8d99aef8aacfa81ceac3880dcac03ca06"
  gem 'arel', github: 'rails/arel', branch: 'master'
  gem 'rack', github: 'rack/rack', branch: 'master'
  gem 'sass'
  gem 'sprockets-rails', github: 'rails/sprockets-rails', branch: 'master'
  gem 'sprockets', github: 'rails/sprockets', branch: 'master'
  gem 'pg'
  gem 'benchmark-ips'
end

require 'active_record'
require 'benchmark/ips'

ActiveRecord::Base.establish_connection('postgres://postgres@localhost:5432/rubybench')

ActiveRecord::Migration.verbose = false

ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
    t.string :name, :email
    t.timestamps null: false
  end
end

class User < ActiveRecord::Base; end

attributes = {
  name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
  email: "foobar@email.com",
}

1000.times { User.create!(attributes) }

Benchmark.ips(5, 3) do |x|
  x.report('where with hash single') { User.where(name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.") }
  x.report('where with string single') { User.where("users.name = ?", "Lorem ipsum dolor sit amet, consectetur adipiscing elit.") }
  x.report('where with hash double') { User.where(name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.", email: "foobar@email.com") }
  x.report('where with string double') { User.where("users.name = ? AND users.email = ?", "Lorem ipsum dolor sit amet, consectetur adipiscing elit.", "foobar@email.com") }
  x.compare!
end
```

Before:

```
Calculating -------------------------------------
where with hash single
                         3.300k i/100ms
where with string single
                         4.965k i/100ms
where with hash double
                         2.594k i/100ms
where with string double
                         4.400k i/100ms
-------------------------------------------------
where with hash single
                         35.161k (± 1.2%) i/s -    178.200k
where with string single
                         53.368k (± 2.9%) i/s -    268.110k
where with hash double
                         27.364k (± 1.1%) i/s -    137.482k
where with string double
                         46.876k (± 2.1%) i/s -    237.600k

Comparison:
where with string single:    53368.1 i/s
where with string double:    46875.5 i/s - 1.14x slower
where with hash single:    35160.8 i/s - 1.52x slower
where with hash double:    27364.0 i/s - 1.95x slower
```

After:

```
Calculating -------------------------------------
where with hash single
                         3.403k i/100ms
where with string single
                         5.167k i/100ms
where with hash double
                         2.659k i/100ms
where with string double
                         4.597k i/100ms
-------------------------------------------------
where with hash single
                         36.410k (± 1.3%) i/s -    183.762k
where with string single
                         55.009k (± 2.6%) i/s -    279.018k
where with hash double
                         27.951k (± 1.4%) i/s -    140.927k
where with string double
                         48.362k (± 2.6%) i/s -    243.641k

Comparison:
where with string single:    55008.6 i/s
where with string double:    48361.5 i/s - 1.14x slower
where with hash single:    36410.1 i/s - 1.51x slower
where with hash double:    27950.9 i/s - 1.97x slower
```

cc/ @rafaelfranca 
