### PR TITLE
Add migration versioning via Migration subclasses

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Version the API presented to migration classes, so we can change parameter
+    defaults without breaking existing migrations, or forcing them to be
+    rewritten through a deprecation cycle.
+
+    *Matthew Draper*, *Ravil Bayramgalin*
+
 *   Use bind params for `limit` and `offset`. This will generate significantly
     fewer prepared statements for common tasks like pagination. To support this
     change, passing a string containing a comma to `limit` has been deprecated,

--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -138,7 +138,7 @@ This would also define the following accessors: <tt>Product#name</tt> and
 
 * Database agnostic schema management with Migrations.
 
-    class AddSystemSettings < ActiveRecord::Migration[0.0]
+    class AddSystemSettings < ActiveRecord::Migration[5.0]
       def up
         create_table :system_settings do |t|
           t.string  :name

--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -138,7 +138,7 @@ This would also define the following accessors: <tt>Product#name</tt> and
 
 * Database agnostic schema management with Migrations.
 
-    class AddSystemSettings < ActiveRecord::Migration
+    class AddSystemSettings < ActiveRecord::Migration[0.0]
       def up
         create_table :system_settings do |t|
           t.string  :name

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1639,7 +1639,7 @@ module ActiveRecord
       # The join table should not have a primary key or a model associated with it. You must manually generate the
       # join table with a migration such as this:
       #
-      #   class CreateDevelopersProjectsJoinTable < ActiveRecord::Migration[0.0]
+      #   class CreateDevelopersProjectsJoinTable < ActiveRecord::Migration[5.0]
       #     def change
       #       create_join_table :developers, :projects
       #     end

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1639,7 +1639,7 @@ module ActiveRecord
       # The join table should not have a primary key or a model associated with it. You must manually generate the
       # join table with a migration such as this:
       #
-      #   class CreateDevelopersProjectsJoinTable < ActiveRecord::Migration
+      #   class CreateDevelopersProjectsJoinTable < ActiveRecord::Migration[0.0]
       #     def change
       #       create_join_table :developers, :projects
       #     end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -190,7 +190,7 @@ module ActiveRecord
     # Inside migration files, the +t+ object in {create_table}[rdoc-ref:SchemaStatements#create_table]
     # is actually of this type:
     #
-    #   class SomeMigration < ActiveRecord::Migration[0.0]
+    #   class SomeMigration < ActiveRecord::Migration[5.0]
     #     def up
     #       create_table :foo do |t|
     #         puts t.class  # => "ActiveRecord::ConnectionAdapters::TableDefinition"

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -190,7 +190,7 @@ module ActiveRecord
     # Inside migration files, the +t+ object in {create_table}[rdoc-ref:SchemaStatements#create_table]
     # is actually of this type:
     #
-    #   class SomeMigration < ActiveRecord::Migration
+    #   class SomeMigration < ActiveRecord::Migration[0.0]
     #     def up
     #       create_table :foo do |t|
     #         puts t.class  # => "ActiveRecord::ConnectionAdapters::TableDefinition"

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -13,7 +13,7 @@ module ActiveRecord
   # For example the following migration is not reversible.
   # Rolling back this migration will raise an ActiveRecord::IrreversibleMigration error.
   #
-  #   class IrreversibleMigrationExample < ActiveRecord::Migration
+  #   class IrreversibleMigrationExample < ActiveRecord::Migration[0.0]
   #     def change
   #       create_table :distributors do |t|
   #         t.string :zipcode
@@ -31,7 +31,7 @@ module ActiveRecord
   #
   # 1. Define <tt>#up</tt> and <tt>#down</tt> methods instead of <tt>#change</tt>:
   #
-  #  class ReversibleMigrationExample < ActiveRecord::Migration
+  #  class ReversibleMigrationExample < ActiveRecord::Migration[0.0]
   #    def up
   #      create_table :distributors do |t|
   #        t.string :zipcode
@@ -56,7 +56,7 @@ module ActiveRecord
   #
   # 2. Use the #reversible method in <tt>#change</tt> method:
   #
-  #   class ReversibleMigrationExample < ActiveRecord::Migration
+  #   class ReversibleMigrationExample < ActiveRecord::Migration[0.0]
   #     def change
   #       create_table :distributors do |t|
   #         t.string :zipcode
@@ -155,7 +155,7 @@ module ActiveRecord
   #
   # Example of a simple migration:
   #
-  #   class AddSsl < ActiveRecord::Migration
+  #   class AddSsl < ActiveRecord::Migration[0.0]
   #     def up
   #       add_column :accounts, :ssl_enabled, :boolean, default: true
   #     end
@@ -175,7 +175,7 @@ module ActiveRecord
   #
   # Example of a more complex migration that also needs to initialize data:
   #
-  #   class AddSystemSettings < ActiveRecord::Migration
+  #   class AddSystemSettings < ActiveRecord::Migration[0.0]
   #     def up
   #       create_table :system_settings do |t|
   #         t.string  :name
@@ -301,7 +301,7 @@ module ActiveRecord
   #   rails generate migration add_fieldname_to_tablename fieldname:string
   #
   # This will generate the file <tt>timestamp_add_fieldname_to_tablename.rb</tt>, which will look like this:
-  #   class AddFieldnameToTablename < ActiveRecord::Migration
+  #   class AddFieldnameToTablename < ActiveRecord::Migration[0.0]
   #     def change
   #       add_column :tablenames, :fieldname, :string
   #     end
@@ -332,7 +332,7 @@ module ActiveRecord
   #
   # Not all migrations change the schema. Some just fix the data:
   #
-  #   class RemoveEmptyTags < ActiveRecord::Migration
+  #   class RemoveEmptyTags < ActiveRecord::Migration[0.0]
   #     def up
   #       Tag.all.each { |tag| tag.destroy if tag.pages.empty? }
   #     end
@@ -345,7 +345,7 @@ module ActiveRecord
   #
   # Others remove columns when they migrate up instead of down:
   #
-  #   class RemoveUnnecessaryItemAttributes < ActiveRecord::Migration
+  #   class RemoveUnnecessaryItemAttributes < ActiveRecord::Migration[0.0]
   #     def up
   #       remove_column :items, :incomplete_items_count
   #       remove_column :items, :completed_items_count
@@ -359,7 +359,7 @@ module ActiveRecord
   #
   # And sometimes you need to do something in SQL not abstracted directly by migrations:
   #
-  #   class MakeJoinUnique < ActiveRecord::Migration
+  #   class MakeJoinUnique < ActiveRecord::Migration[0.0]
   #     def up
   #       execute "ALTER TABLE `pages_linked_pages` ADD UNIQUE `page_id_linked_page_id` (`page_id`,`linked_page_id`)"
   #     end
@@ -376,7 +376,7 @@ module ActiveRecord
   # <tt>Base#reset_column_information</tt> in order to ensure that the model has the
   # latest column data from after the new column was added. Example:
   #
-  #   class AddPeopleSalary < ActiveRecord::Migration
+  #   class AddPeopleSalary < ActiveRecord::Migration[0.0]
   #     def up
   #       add_column :people, :salary, :integer
   #       Person.reset_column_information
@@ -434,7 +434,7 @@ module ActiveRecord
   # To define a reversible migration, define the +change+ method in your
   # migration like this:
   #
-  #   class TenderloveMigration < ActiveRecord::Migration
+  #   class TenderloveMigration < ActiveRecord::Migration[0.0]
   #     def change
   #       create_table(:horses) do |t|
   #         t.column :content, :text
@@ -464,7 +464,7 @@ module ActiveRecord
   # can't execute inside a transaction though, and for these situations
   # you can turn the automatic transactions off.
   #
-  #   class ChangeEnum < ActiveRecord::Migration
+  #   class ChangeEnum < ActiveRecord::Migration[0.0]
   #     disable_ddl_transaction!
   #
   #     def up
@@ -601,7 +601,7 @@ module ActiveRecord
     # and create the table 'apples' on the way up, and the reverse
     # on the way down.
     #
-    #   class FixTLMigration < ActiveRecord::Migration
+    #   class FixTLMigration < ActiveRecord::Migration[0.0]
     #     def change
     #       revert do
     #         create_table(:horses) do |t|
@@ -620,7 +620,7 @@ module ActiveRecord
     #
     #   require_relative '20121212123456_tenderlove_migration'
     #
-    #   class FixupTLMigration < ActiveRecord::Migration
+    #   class FixupTLMigration < ActiveRecord::Migration[0.0]
     #     def change
     #       revert TenderloveMigration
     #
@@ -673,7 +673,7 @@ module ActiveRecord
     # when the three columns 'first_name', 'last_name' and 'full_name' exist,
     # even when migrating down:
     #
-    #    class SplitNameMigration < ActiveRecord::Migration
+    #    class SplitNameMigration < ActiveRecord::Migration[0.0]
     #      def change
     #        add_column :users, :first_name, :string
     #        add_column :users, :last_name, :string

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -535,6 +535,10 @@ module ActiveRecord
       attr_accessor :delegate # :nodoc:
       attr_accessor :disable_ddl_transaction # :nodoc:
 
+      def nearest_delegate # :nodoc:
+        delegate || superclass.nearest_delegate
+      end
+
       # Raises <tt>ActiveRecord::PendingMigrationError</tt> error if any migrations are pending.
       def check_pending!(connection = Base.connection)
         raise ActiveRecord::PendingMigrationError if ActiveRecord::Migrator.needs_migration?(connection)
@@ -561,7 +565,7 @@ module ActiveRecord
       end
 
       def method_missing(name, *args, &block) # :nodoc:
-        (delegate || superclass.delegate).send(name, *args, &block)
+        nearest_delegate.send(name, *args, &block)
       end
 
       def migrate(direction)

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -13,7 +13,7 @@ module ActiveRecord
   # For example the following migration is not reversible.
   # Rolling back this migration will raise an ActiveRecord::IrreversibleMigration error.
   #
-  #   class IrreversibleMigrationExample < ActiveRecord::Migration[0.0]
+  #   class IrreversibleMigrationExample < ActiveRecord::Migration[5.0]
   #     def change
   #       create_table :distributors do |t|
   #         t.string :zipcode
@@ -31,7 +31,7 @@ module ActiveRecord
   #
   # 1. Define <tt>#up</tt> and <tt>#down</tt> methods instead of <tt>#change</tt>:
   #
-  #  class ReversibleMigrationExample < ActiveRecord::Migration[0.0]
+  #  class ReversibleMigrationExample < ActiveRecord::Migration[5.0]
   #    def up
   #      create_table :distributors do |t|
   #        t.string :zipcode
@@ -56,7 +56,7 @@ module ActiveRecord
   #
   # 2. Use the #reversible method in <tt>#change</tt> method:
   #
-  #   class ReversibleMigrationExample < ActiveRecord::Migration[0.0]
+  #   class ReversibleMigrationExample < ActiveRecord::Migration[5.0]
   #     def change
   #       create_table :distributors do |t|
   #         t.string :zipcode
@@ -155,7 +155,7 @@ module ActiveRecord
   #
   # Example of a simple migration:
   #
-  #   class AddSsl < ActiveRecord::Migration[0.0]
+  #   class AddSsl < ActiveRecord::Migration[5.0]
   #     def up
   #       add_column :accounts, :ssl_enabled, :boolean, default: true
   #     end
@@ -175,7 +175,7 @@ module ActiveRecord
   #
   # Example of a more complex migration that also needs to initialize data:
   #
-  #   class AddSystemSettings < ActiveRecord::Migration[0.0]
+  #   class AddSystemSettings < ActiveRecord::Migration[5.0]
   #     def up
   #       create_table :system_settings do |t|
   #         t.string  :name
@@ -301,7 +301,7 @@ module ActiveRecord
   #   rails generate migration add_fieldname_to_tablename fieldname:string
   #
   # This will generate the file <tt>timestamp_add_fieldname_to_tablename.rb</tt>, which will look like this:
-  #   class AddFieldnameToTablename < ActiveRecord::Migration[0.0]
+  #   class AddFieldnameToTablename < ActiveRecord::Migration[5.0]
   #     def change
   #       add_column :tablenames, :fieldname, :string
   #     end
@@ -332,7 +332,7 @@ module ActiveRecord
   #
   # Not all migrations change the schema. Some just fix the data:
   #
-  #   class RemoveEmptyTags < ActiveRecord::Migration[0.0]
+  #   class RemoveEmptyTags < ActiveRecord::Migration[5.0]
   #     def up
   #       Tag.all.each { |tag| tag.destroy if tag.pages.empty? }
   #     end
@@ -345,7 +345,7 @@ module ActiveRecord
   #
   # Others remove columns when they migrate up instead of down:
   #
-  #   class RemoveUnnecessaryItemAttributes < ActiveRecord::Migration[0.0]
+  #   class RemoveUnnecessaryItemAttributes < ActiveRecord::Migration[5.0]
   #     def up
   #       remove_column :items, :incomplete_items_count
   #       remove_column :items, :completed_items_count
@@ -359,7 +359,7 @@ module ActiveRecord
   #
   # And sometimes you need to do something in SQL not abstracted directly by migrations:
   #
-  #   class MakeJoinUnique < ActiveRecord::Migration[0.0]
+  #   class MakeJoinUnique < ActiveRecord::Migration[5.0]
   #     def up
   #       execute "ALTER TABLE `pages_linked_pages` ADD UNIQUE `page_id_linked_page_id` (`page_id`,`linked_page_id`)"
   #     end
@@ -376,7 +376,7 @@ module ActiveRecord
   # <tt>Base#reset_column_information</tt> in order to ensure that the model has the
   # latest column data from after the new column was added. Example:
   #
-  #   class AddPeopleSalary < ActiveRecord::Migration[0.0]
+  #   class AddPeopleSalary < ActiveRecord::Migration[5.0]
   #     def up
   #       add_column :people, :salary, :integer
   #       Person.reset_column_information
@@ -434,7 +434,7 @@ module ActiveRecord
   # To define a reversible migration, define the +change+ method in your
   # migration like this:
   #
-  #   class TenderloveMigration < ActiveRecord::Migration[0.0]
+  #   class TenderloveMigration < ActiveRecord::Migration[5.0]
   #     def change
   #       create_table(:horses) do |t|
   #         t.column :content, :text
@@ -464,7 +464,7 @@ module ActiveRecord
   # can't execute inside a transaction though, and for these situations
   # you can turn the automatic transactions off.
   #
-  #   class ChangeEnum < ActiveRecord::Migration[0.0]
+  #   class ChangeEnum < ActiveRecord::Migration[5.0]
   #     disable_ddl_transaction!
   #
   #     def up
@@ -605,7 +605,7 @@ module ActiveRecord
     # and create the table 'apples' on the way up, and the reverse
     # on the way down.
     #
-    #   class FixTLMigration < ActiveRecord::Migration[0.0]
+    #   class FixTLMigration < ActiveRecord::Migration[5.0]
     #     def change
     #       revert do
     #         create_table(:horses) do |t|
@@ -624,7 +624,7 @@ module ActiveRecord
     #
     #   require_relative '20121212123456_tenderlove_migration'
     #
-    #   class FixupTLMigration < ActiveRecord::Migration[0.0]
+    #   class FixupTLMigration < ActiveRecord::Migration[5.0]
     #     def change
     #       revert TenderloveMigration
     #
@@ -677,7 +677,7 @@ module ActiveRecord
     # when the three columns 'first_name', 'last_name' and 'full_name' exist,
     # even when migrating down:
     #
-    #    class SplitNameMigration < ActiveRecord::Migration[0.0]
+    #    class SplitNameMigration < ActiveRecord::Migration[5.0]
     #      def change
     #        add_column :users, :first_name, :string
     #        add_column :users, :last_name, :string

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -1,0 +1,30 @@
+module ActiveRecord
+  class Migration
+    module Compatibility # :nodoc: all
+      V5_0 = Current
+
+      module FourTwoShared
+      end
+
+      class V4_2 < V5_0
+        # 4.2 is defined as a module because it needs to be shared with
+        # Legacy. When the time comes, V5_0 should be defined straight
+        # in its class.
+        include FourTwoShared
+      end
+
+      module Legacy
+        include FourTwoShared
+
+        def run(*)
+          ActiveSupport::Deprecation.warn \
+            "Directly inheriting from ActiveRecord::Migration is deprecated. " \
+            "Please specify the Rails release the migration was written for:\n" \
+            "\n" \
+            "  class #{self.class.name} < ActiveRecord::Migration[4.2]"
+          super
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -4,6 +4,30 @@ module ActiveRecord
       V5_0 = Current
 
       module FourTwoShared
+        module TableDefinition
+          def timestamps(*, **options)
+            options[:null] = true if options[:null].nil?
+            super
+          end
+        end
+
+        def create_table(table_name, options = {})
+          if block_given?
+            super(table_name, options) do |t|
+              class << t
+                prepend TableDefinition
+              end
+              yield t
+            end
+          else
+            super
+          end
+        end
+
+        def add_timestamps(*, **options)
+          options[:null] = true if options[:null].nil?
+          super
+        end
       end
 
       class V4_2 < V5_0

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -275,7 +275,7 @@ module ActiveRecord
       # when just after creating a table you want to populate it with some default
       # values, eg:
       #
-      #  class CreateJobLevels < ActiveRecord::Migration[0.0]
+      #  class CreateJobLevels < ActiveRecord::Migration[5.0]
       #    def up
       #      create_table :job_levels do |t|
       #        t.integer :id

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -275,7 +275,7 @@ module ActiveRecord
       # when just after creating a table you want to populate it with some default
       # values, eg:
       #
-      #  class CreateJobLevels < ActiveRecord::Migration
+      #  class CreateJobLevels < ActiveRecord::Migration[0.0]
       #    def up
       #      create_table :job_levels do |t|
       #        t.integer :id

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -27,7 +27,7 @@ module ActiveRecord
   #
   # ActiveRecord::Schema is only supported by database adapters that also
   # support migrations, the two features being very similar.
-  class Schema < Migration
+  class Schema < Migration::Current
     # Eval the given block. All methods available to the current connection
     # adapter are available within the block, so you can easily use the
     # database definition DSL to build up your schema (

--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     create_table :<%= table_name %><%= primary_key_type %> do |t|
 <% attributes.each do |attribute| -%>

--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
 <%- if migration_action == 'add' -%>
   def change
 <% attributes.each do |attribute| -%>

--- a/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
@@ -3,13 +3,13 @@ require "cases/helper"
 class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
   self.use_transactional_tests = false
 
-  class EnableHstore < ActiveRecord::Migration
+  class EnableHstore < ActiveRecord::Migration::Current
     def change
       enable_extension "hstore"
     end
   end
 
-  class DisableHstore < ActiveRecord::Migration
+  class DisableHstore < ActiveRecord::Migration::Current
     def change
       disable_extension "hstore"
     end

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -86,7 +86,7 @@ if ActiveRecord::Base.connection.supports_extensions?
     end
 
     def test_hstore_migration
-      hstore_migration = Class.new(ActiveRecord::Migration) do
+      hstore_migration = Class.new(ActiveRecord::Migration::Current) do
         def change
           change_table("hstores") do |t|
             t.hstore :keys

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -5,7 +5,7 @@ end
 
 module ActiveRecord
   class InvertibleMigrationTest < ActiveRecord::TestCase
-    class SilentMigration < ActiveRecord::Migration
+    class SilentMigration < ActiveRecord::Migration::Current
       def write(text = '')
         # sssshhhhh!!
       end
@@ -105,7 +105,7 @@ module ActiveRecord
       end
     end
 
-    class LegacyMigration < ActiveRecord::Migration
+    class LegacyMigration < ActiveRecord::Migration::Current
       def self.up
         create_table("horses") do |t|
           t.column :content, :text

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -339,7 +339,7 @@ module ActiveRecord
 
       def test_change_column_null
         testing_table_with_only_foo_attribute do
-          notnull_migration = Class.new(ActiveRecord::Migration) do
+          notnull_migration = Class.new(ActiveRecord::Migration::Current) do
             def change
               change_column_null :testings, :foo, false
             end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -224,7 +224,7 @@ module ActiveRecord
         assert_match %r{\s+add_foreign_key "astronauts",.+on_update: :cascade,.+on_delete: :nullify$}, output
       end
 
-      class CreateCitiesAndHousesMigration < ActiveRecord::Migration
+      class CreateCitiesAndHousesMigration < ActiveRecord::Migration::Current
         def change
           create_table("cities") { |t| }
 
@@ -243,7 +243,7 @@ module ActiveRecord
         silence_stream($stdout) { migration.migrate(:down) }
       end
 
-      class CreateSchoolsAndClassesMigration < ActiveRecord::Migration
+      class CreateSchoolsAndClassesMigration < ActiveRecord::Migration::Current
         def change
           create_table(:schools)
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -132,12 +132,12 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_migration_instance_has_connection
-    migration = Class.new(ActiveRecord::Migration).new
+    migration = Class.new(ActiveRecord::Migration::Current).new
     assert_equal ActiveRecord::Base.connection, migration.connection
   end
 
   def test_method_missing_delegates_to_connection
-    migration = Class.new(ActiveRecord::Migration) {
+    migration = Class.new(ActiveRecord::Migration::Current) {
       def connection
         Class.new {
           def create_table; "hi mom!"; end
@@ -226,7 +226,7 @@ class MigrationTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::StatementInvalid) { Reminder.first }
   end
 
-  class MockMigration < ActiveRecord::Migration
+  class MockMigration < ActiveRecord::Migration::Current
     attr_reader :went_up, :went_down
     def initialize
       @went_up   = false
@@ -268,7 +268,7 @@ class MigrationTest < ActiveRecord::TestCase
     def test_migrator_one_up_with_exception_and_rollback
       assert_no_column Person, :last_name
 
-      migration = Class.new(ActiveRecord::Migration) {
+      migration = Class.new(ActiveRecord::Migration::Current) {
         def version; 100 end
         def migrate(x)
           add_column "people", "last_name", :string
@@ -289,7 +289,7 @@ class MigrationTest < ActiveRecord::TestCase
     def test_migrator_one_up_with_exception_and_rollback_using_run
       assert_no_column Person, :last_name
 
-      migration = Class.new(ActiveRecord::Migration) {
+      migration = Class.new(ActiveRecord::Migration::Current) {
         def version; 100 end
         def migrate(x)
           add_column "people", "last_name", :string
@@ -310,7 +310,7 @@ class MigrationTest < ActiveRecord::TestCase
     def test_migration_without_transaction
       assert_no_column Person, :last_name
 
-      migration = Class.new(ActiveRecord::Migration) {
+      migration = Class.new(ActiveRecord::Migration::Current) {
         self.disable_ddl_transaction!
 
         def version; 101 end
@@ -525,7 +525,7 @@ class MigrationTest < ActiveRecord::TestCase
 
   if ActiveRecord::Base.connection.supports_advisory_locks?
     def test_migrator_generates_valid_lock_id
-      migration = Class.new(ActiveRecord::Migration).new
+      migration = Class.new(ActiveRecord::Migration::Current).new
       migrator = ActiveRecord::Migrator.new(:up, [migration], 100)
 
       lock_id = migrator.send(:generate_migrator_advisory_lock_id)
@@ -539,7 +539,7 @@ class MigrationTest < ActiveRecord::TestCase
     def test_generate_migrator_advisory_lock_id
       # It is important we are consistent with how we generate this so that
       # exclusive locking works across migrator versions
-      migration = Class.new(ActiveRecord::Migration).new
+      migration = Class.new(ActiveRecord::Migration::Current).new
       migrator = ActiveRecord::Migrator.new(:up, [migration], 100)
 
       lock_id = migrator.send(:generate_migrator_advisory_lock_id)
@@ -556,7 +556,7 @@ class MigrationTest < ActiveRecord::TestCase
     def test_migrator_one_up_with_unavailable_lock
       assert_no_column Person, :last_name
 
-      migration = Class.new(ActiveRecord::Migration) {
+      migration = Class.new(ActiveRecord::Migration::Current) {
         def version; 100 end
         def migrate(x)
           add_column "people", "last_name", :string
@@ -577,7 +577,7 @@ class MigrationTest < ActiveRecord::TestCase
     def test_migrator_one_up_with_unavailable_lock_using_run
       assert_no_column Person, :last_name
 
-      migration = Class.new(ActiveRecord::Migration) {
+      migration = Class.new(ActiveRecord::Migration::Current) {
         def version; 100 end
         def migrate(x)
           add_column "people", "last_name", :string

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -6,7 +6,7 @@ class MigratorTest < ActiveRecord::TestCase
 
   # Use this class to sense if migrations have gone
   # up or down.
-  class Sensor < ActiveRecord::Migration
+  class Sensor < ActiveRecord::Migration::Current
     attr_reader :went_up, :went_down
 
     def initialize name = self.class.name, version = nil

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -312,7 +312,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     end
   end
 
-  class CreateDogMigration < ActiveRecord::Migration
+  class CreateDogMigration < ActiveRecord::Migration::Current
     def up
       create_table("dog_owners") do |t|
       end
@@ -357,7 +357,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
   def test_schema_dump_with_table_name_prefix_and_ignoring_tables
     original, $stdout = $stdout, StringIO.new
 
-    create_cat_migration = Class.new(ActiveRecord::Migration) do
+    create_cat_migration = Class.new(ActiveRecord::Migration::Current) do
       def change
         create_table("cats") do |t|
         end

--- a/activerecord/test/migrations/10_urban/9_add_expressions.rb
+++ b/activerecord/test/migrations/10_urban/9_add_expressions.rb
@@ -1,4 +1,4 @@
-class AddExpressions < ActiveRecord::Migration
+class AddExpressions < ActiveRecord::Migration::Current
   def self.up
     create_table("expressions") do |t|
       t.column :expression, :string

--- a/activerecord/test/migrations/decimal/1_give_me_big_numbers.rb
+++ b/activerecord/test/migrations/decimal/1_give_me_big_numbers.rb
@@ -1,4 +1,4 @@
-class GiveMeBigNumbers < ActiveRecord::Migration
+class GiveMeBigNumbers < ActiveRecord::Migration::Current
   def self.up
     create_table :big_numbers do |table|
       table.column :bank_balance, :decimal, :precision => 10, :scale => 2

--- a/activerecord/test/migrations/magic/1_currencies_have_symbols.rb
+++ b/activerecord/test/migrations/magic/1_currencies_have_symbols.rb
@@ -1,6 +1,6 @@
 # coding: ISO-8859-15
 
-class CurrenciesHaveSymbols < ActiveRecord::Migration
+class CurrenciesHaveSymbols < ActiveRecord::Migration::Current
   def self.up
     # We use € for default currency symbol
     add_column "currencies", "symbol", :string, :default => "€"

--- a/activerecord/test/migrations/missing/1000_people_have_middle_names.rb
+++ b/activerecord/test/migrations/missing/1000_people_have_middle_names.rb
@@ -1,4 +1,4 @@
-class PeopleHaveMiddleNames < ActiveRecord::Migration
+class PeopleHaveMiddleNames < ActiveRecord::Migration::Current
   def self.up
     add_column "people", "middle_name", :string
   end

--- a/activerecord/test/migrations/missing/1_people_have_last_names.rb
+++ b/activerecord/test/migrations/missing/1_people_have_last_names.rb
@@ -1,4 +1,4 @@
-class PeopleHaveLastNames < ActiveRecord::Migration
+class PeopleHaveLastNames < ActiveRecord::Migration::Current
   def self.up
     add_column "people", "last_name", :string
   end

--- a/activerecord/test/migrations/missing/3_we_need_reminders.rb
+++ b/activerecord/test/migrations/missing/3_we_need_reminders.rb
@@ -1,4 +1,4 @@
-class WeNeedReminders < ActiveRecord::Migration
+class WeNeedReminders < ActiveRecord::Migration::Current
   def self.up
     create_table("reminders") do |t|
       t.column :content, :text

--- a/activerecord/test/migrations/missing/4_innocent_jointable.rb
+++ b/activerecord/test/migrations/missing/4_innocent_jointable.rb
@@ -1,4 +1,4 @@
-class InnocentJointable < ActiveRecord::Migration
+class InnocentJointable < ActiveRecord::Migration::Current
   def self.up
     create_table("people_reminders", :id => false) do |t|
       t.column :reminder_id, :integer

--- a/activerecord/test/migrations/rename/1_we_need_things.rb
+++ b/activerecord/test/migrations/rename/1_we_need_things.rb
@@ -1,4 +1,4 @@
-class WeNeedThings < ActiveRecord::Migration
+class WeNeedThings < ActiveRecord::Migration::Current
   def self.up
     create_table("things") do |t|
       t.column :content, :text

--- a/activerecord/test/migrations/rename/2_rename_things.rb
+++ b/activerecord/test/migrations/rename/2_rename_things.rb
@@ -1,4 +1,4 @@
-class RenameThings < ActiveRecord::Migration
+class RenameThings < ActiveRecord::Migration::Current
   def self.up
     rename_table "things", "awesome_things"
   end

--- a/activerecord/test/migrations/to_copy/1_people_have_hobbies.rb
+++ b/activerecord/test/migrations/to_copy/1_people_have_hobbies.rb
@@ -1,4 +1,4 @@
-class PeopleHaveLastNames < ActiveRecord::Migration
+class PeopleHaveLastNames < ActiveRecord::Migration::Current
   def self.up
     add_column "people", "hobbies", :text
   end

--- a/activerecord/test/migrations/to_copy/2_people_have_descriptions.rb
+++ b/activerecord/test/migrations/to_copy/2_people_have_descriptions.rb
@@ -1,4 +1,4 @@
-class PeopleHaveLastNames < ActiveRecord::Migration
+class PeopleHaveLastNames < ActiveRecord::Migration::Current
   def self.up
     add_column "people", "description", :text
   end

--- a/activerecord/test/migrations/to_copy2/1_create_articles.rb
+++ b/activerecord/test/migrations/to_copy2/1_create_articles.rb
@@ -1,4 +1,4 @@
-class CreateArticles < ActiveRecord::Migration
+class CreateArticles < ActiveRecord::Migration::Current
   def self.up
   end
 

--- a/activerecord/test/migrations/to_copy2/2_create_comments.rb
+++ b/activerecord/test/migrations/to_copy2/2_create_comments.rb
@@ -1,4 +1,4 @@
-class CreateArticles < ActiveRecord::Migration
+class CreateArticles < ActiveRecord::Migration::Current
   def self.up
   end
 

--- a/activerecord/test/migrations/to_copy_with_name_collision/1_people_have_hobbies.rb
+++ b/activerecord/test/migrations/to_copy_with_name_collision/1_people_have_hobbies.rb
@@ -1,4 +1,4 @@
-class PeopleHaveLastNames < ActiveRecord::Migration
+class PeopleHaveLastNames < ActiveRecord::Migration::Current
   def self.up
     add_column "people", "hobbies", :string
   end

--- a/activerecord/test/migrations/to_copy_with_timestamps/20090101010101_people_have_hobbies.rb
+++ b/activerecord/test/migrations/to_copy_with_timestamps/20090101010101_people_have_hobbies.rb
@@ -1,4 +1,4 @@
-class PeopleHaveLastNames < ActiveRecord::Migration
+class PeopleHaveLastNames < ActiveRecord::Migration::Current
   def self.up
     add_column "people", "hobbies", :text
   end

--- a/activerecord/test/migrations/to_copy_with_timestamps/20090101010202_people_have_descriptions.rb
+++ b/activerecord/test/migrations/to_copy_with_timestamps/20090101010202_people_have_descriptions.rb
@@ -1,4 +1,4 @@
-class PeopleHaveLastNames < ActiveRecord::Migration
+class PeopleHaveLastNames < ActiveRecord::Migration::Current
   def self.up
     add_column "people", "description", :text
   end

--- a/activerecord/test/migrations/to_copy_with_timestamps2/20090101010101_create_articles.rb
+++ b/activerecord/test/migrations/to_copy_with_timestamps2/20090101010101_create_articles.rb
@@ -1,4 +1,4 @@
-class CreateArticles < ActiveRecord::Migration
+class CreateArticles < ActiveRecord::Migration::Current
   def self.up
   end
 

--- a/activerecord/test/migrations/to_copy_with_timestamps2/20090101010202_create_comments.rb
+++ b/activerecord/test/migrations/to_copy_with_timestamps2/20090101010202_create_comments.rb
@@ -1,4 +1,4 @@
-class CreateComments < ActiveRecord::Migration
+class CreateComments < ActiveRecord::Migration::Current
   def self.up
   end
 

--- a/activerecord/test/migrations/valid/1_valid_people_have_last_names.rb
+++ b/activerecord/test/migrations/valid/1_valid_people_have_last_names.rb
@@ -1,4 +1,4 @@
-class ValidPeopleHaveLastNames < ActiveRecord::Migration
+class ValidPeopleHaveLastNames < ActiveRecord::Migration::Current
   def self.up
     add_column "people", "last_name", :string
   end

--- a/activerecord/test/migrations/valid/2_we_need_reminders.rb
+++ b/activerecord/test/migrations/valid/2_we_need_reminders.rb
@@ -1,4 +1,4 @@
-class WeNeedReminders < ActiveRecord::Migration
+class WeNeedReminders < ActiveRecord::Migration::Current
   def self.up
     create_table("reminders") do |t|
       t.column :content, :text

--- a/activerecord/test/migrations/valid/3_innocent_jointable.rb
+++ b/activerecord/test/migrations/valid/3_innocent_jointable.rb
@@ -1,4 +1,4 @@
-class InnocentJointable < ActiveRecord::Migration
+class InnocentJointable < ActiveRecord::Migration::Current
   def self.up
     create_table("people_reminders", :id => false) do |t|
       t.column :reminder_id, :integer

--- a/activerecord/test/migrations/valid_with_subdirectories/1_valid_people_have_last_names.rb
+++ b/activerecord/test/migrations/valid_with_subdirectories/1_valid_people_have_last_names.rb
@@ -1,4 +1,4 @@
-class ValidPeopleHaveLastNames < ActiveRecord::Migration
+class ValidPeopleHaveLastNames < ActiveRecord::Migration::Current
   def self.up
     add_column "people", "last_name", :string
   end

--- a/activerecord/test/migrations/valid_with_subdirectories/sub/2_we_need_reminders.rb
+++ b/activerecord/test/migrations/valid_with_subdirectories/sub/2_we_need_reminders.rb
@@ -1,4 +1,4 @@
-class WeNeedReminders < ActiveRecord::Migration
+class WeNeedReminders < ActiveRecord::Migration::Current
   def self.up
     create_table("reminders") do |t|
       t.column :content, :text

--- a/activerecord/test/migrations/valid_with_subdirectories/sub1/3_innocent_jointable.rb
+++ b/activerecord/test/migrations/valid_with_subdirectories/sub1/3_innocent_jointable.rb
@@ -1,4 +1,4 @@
-class InnocentJointable < ActiveRecord::Migration
+class InnocentJointable < ActiveRecord::Migration::Current
   def self.up
     create_table("people_reminders", :id => false) do |t|
       t.column :reminder_id, :integer

--- a/activerecord/test/migrations/valid_with_timestamps/20100101010101_valid_with_timestamps_people_have_last_names.rb
+++ b/activerecord/test/migrations/valid_with_timestamps/20100101010101_valid_with_timestamps_people_have_last_names.rb
@@ -1,4 +1,4 @@
-class ValidWithTimestampsPeopleHaveLastNames < ActiveRecord::Migration
+class ValidWithTimestampsPeopleHaveLastNames < ActiveRecord::Migration::Current
   def self.up
     add_column "people", "last_name", :string
   end

--- a/activerecord/test/migrations/valid_with_timestamps/20100201010101_valid_with_timestamps_we_need_reminders.rb
+++ b/activerecord/test/migrations/valid_with_timestamps/20100201010101_valid_with_timestamps_we_need_reminders.rb
@@ -1,4 +1,4 @@
-class ValidWithTimestampsWeNeedReminders < ActiveRecord::Migration
+class ValidWithTimestampsWeNeedReminders < ActiveRecord::Migration::Current
   def self.up
     create_table("reminders") do |t|
       t.column :content, :text

--- a/activerecord/test/migrations/valid_with_timestamps/20100301010101_valid_with_timestamps_innocent_jointable.rb
+++ b/activerecord/test/migrations/valid_with_timestamps/20100301010101_valid_with_timestamps_innocent_jointable.rb
@@ -1,4 +1,4 @@
-class ValidWithTimestampsInnocentJointable < ActiveRecord::Migration
+class ValidWithTimestampsInnocentJointable < ActiveRecord::Migration::Current
   def self.up
     create_table("people_reminders", :id => false) do |t|
       t.column :reminder_id, :integer

--- a/activerecord/test/migrations/version_check/20131219224947_migration_version_check.rb
+++ b/activerecord/test/migrations/version_check/20131219224947_migration_version_check.rb
@@ -1,4 +1,4 @@
-class MigrationVersionCheck < ActiveRecord::Migration
+class MigrationVersionCheck < ActiveRecord::Migration::Current
   def self.up
     raise "incorrect migration version" unless version == 20131219224947
   end

--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -350,7 +350,7 @@ database that Active Record supports using `rake`. Here's a migration that
 creates a table:
 
 ```ruby
-class CreatePublications < ActiveRecord::Migration
+class CreatePublications < ActiveRecord::Migration[0.0]
   def change
     create_table :publications do |t|
       t.string :title

--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -350,7 +350,7 @@ database that Active Record supports using `rake`. Here's a migration that
 creates a table:
 
 ```ruby
-class CreatePublications < ActiveRecord::Migration[0.0]
+class CreatePublications < ActiveRecord::Migration[5.0]
   def change
     create_table :publications do |t|
       t.string :title

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -35,7 +35,7 @@ history to the latest version. Active Record will also update your
 Here's an example of a migration:
 
 ```ruby
-class CreateProducts < ActiveRecord::Migration
+class CreateProducts < ActiveRecord::Migration[0.0]
   def change
     create_table :products do |t|
       t.string :name
@@ -72,7 +72,7 @@ If you wish for a migration to do something that Active Record doesn't know how
 to reverse, you can use `reversible`:
 
 ```ruby
-class ChangeProductsPrice < ActiveRecord::Migration
+class ChangeProductsPrice < ActiveRecord::Migration[0.0]
   def change
     reversible do |dir|
       change_table :products do |t|
@@ -87,7 +87,7 @@ end
 Alternatively, you can use `up` and `down` instead of `change`:
 
 ```ruby
-class ChangeProductsPrice < ActiveRecord::Migration
+class ChangeProductsPrice < ActiveRecord::Migration[0.0]
   def up
     change_table :products do |t|
       t.change :price, :string
@@ -129,7 +129,7 @@ $ bin/rails generate migration AddPartNumberToProducts
 This will create an empty but appropriately named migration:
 
 ```ruby
-class AddPartNumberToProducts < ActiveRecord::Migration
+class AddPartNumberToProducts < ActiveRecord::Migration[0.0]
   def change
   end
 end
@@ -146,7 +146,7 @@ $ bin/rails generate migration AddPartNumberToProducts part_number:string
 will generate
 
 ```ruby
-class AddPartNumberToProducts < ActiveRecord::Migration
+class AddPartNumberToProducts < ActiveRecord::Migration[0.0]
   def change
     add_column :products, :part_number, :string
   end
@@ -162,7 +162,7 @@ $ bin/rails generate migration AddPartNumberToProducts part_number:string:index
 will generate
 
 ```ruby
-class AddPartNumberToProducts < ActiveRecord::Migration
+class AddPartNumberToProducts < ActiveRecord::Migration[0.0]
   def change
     add_column :products, :part_number, :string
     add_index :products, :part_number
@@ -180,7 +180,7 @@ $ bin/rails generate migration RemovePartNumberFromProducts part_number:string
 generates
 
 ```ruby
-class RemovePartNumberFromProducts < ActiveRecord::Migration
+class RemovePartNumberFromProducts < ActiveRecord::Migration[0.0]
   def change
     remove_column :products, :part_number, :string
   end
@@ -196,7 +196,7 @@ $ bin/rails generate migration AddDetailsToProducts part_number:string price:dec
 generates
 
 ```ruby
-class AddDetailsToProducts < ActiveRecord::Migration
+class AddDetailsToProducts < ActiveRecord::Migration[0.0]
   def change
     add_column :products, :part_number, :string
     add_column :products, :price, :decimal
@@ -215,7 +215,7 @@ $ bin/rails generate migration CreateProducts name:string part_number:string
 generates
 
 ```ruby
-class CreateProducts < ActiveRecord::Migration
+class CreateProducts < ActiveRecord::Migration[0.0]
   def change
     create_table :products do |t|
       t.string :name
@@ -239,7 +239,7 @@ $ bin/rails generate migration AddUserRefToProducts user:references
 generates
 
 ```ruby
-class AddUserRefToProducts < ActiveRecord::Migration
+class AddUserRefToProducts < ActiveRecord::Migration[0.0]
   def change
     add_reference :products, :user, index: true, foreign_key: true
   end
@@ -257,7 +257,7 @@ $ bin/rails g migration CreateJoinTableCustomerProduct customer product
 will produce the following migration:
 
 ```ruby
-class CreateJoinTableCustomerProduct < ActiveRecord::Migration
+class CreateJoinTableCustomerProduct < ActiveRecord::Migration[0.0]
   def change
     create_join_table :customers, :products do |t|
       # t.index [:customer_id, :product_id]
@@ -281,7 +281,7 @@ $ bin/rails generate model Product name:string description:text
 will create a migration that looks like this
 
 ```ruby
-class CreateProducts < ActiveRecord::Migration
+class CreateProducts < ActiveRecord::Migration[0.0]
   def change
     create_table :products do |t|
       t.string :name
@@ -309,7 +309,7 @@ $ bin/rails generate migration AddDetailsToProducts 'price:decimal{5,2}' supplie
 will produce a migration that looks like this
 
 ```ruby
-class AddDetailsToProducts < ActiveRecord::Migration
+class AddDetailsToProducts < ActiveRecord::Migration[0.0]
   def change
     add_column :products, :price, :decimal, precision: 5, scale: 2
     add_reference :products, :supplier, polymorphic: true, index: true
@@ -563,7 +563,7 @@ to reverse. You can use `reversible` to specify what to do when running a
 migration and what else to do when reverting it. For example:
 
 ```ruby
-class ExampleMigration < ActiveRecord::Migration
+class ExampleMigration < ActiveRecord::Migration[0.0]
   def change
     create_table :distributors do |t|
       t.string :zipcode
@@ -616,7 +616,7 @@ is wise to perform the transformations in precisely the reverse order they were
 made in the `up` method. The example in the `reversible` section is equivalent to:
 
 ```ruby
-class ExampleMigration < ActiveRecord::Migration
+class ExampleMigration < ActiveRecord::Migration[0.0]
   def up
     create_table :distributors do |t|
       t.string :zipcode
@@ -659,7 +659,7 @@ You can use Active Record's ability to rollback migrations using the `revert` me
 ```ruby
 require_relative '20121212123456_example_migration'
 
-class FixupExampleMigration < ActiveRecord::Migration
+class FixupExampleMigration < ActiveRecord::Migration[0.0]
   def change
     revert ExampleMigration
 
@@ -677,7 +677,7 @@ is later decided it would be best to use Active Record validations,
 in place of the `CHECK` constraint, to verify the zipcode.
 
 ```ruby
-class DontUseConstraintForZipcodeValidationMigration < ActiveRecord::Migration
+class DontUseConstraintForZipcodeValidationMigration < ActiveRecord::Migration[0.0]
   def change
     revert do
       # copy-pasted code from ExampleMigration
@@ -841,7 +841,7 @@ Several methods are provided in migrations that allow you to control all this:
 For example, this migration:
 
 ```ruby
-class CreateProducts < ActiveRecord::Migration
+class CreateProducts < ActiveRecord::Migration[0.0]
   def change
     suppress_messages do
       create_table :products do |t|
@@ -1015,7 +1015,7 @@ to add or modify data. This is useful in an existing database that can't be dest
 and recreated, such as a production database. 
 
 ```ruby
-class AddInitialProducts < ActiveRecord::Migration
+class AddInitialProducts < ActiveRecord::Migration[0.0]
   def up
     5.times do |i|
       Product.create(name: "Product ##{i}", description: "A product.")

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -35,7 +35,7 @@ history to the latest version. Active Record will also update your
 Here's an example of a migration:
 
 ```ruby
-class CreateProducts < ActiveRecord::Migration[0.0]
+class CreateProducts < ActiveRecord::Migration[5.0]
   def change
     create_table :products do |t|
       t.string :name
@@ -72,7 +72,7 @@ If you wish for a migration to do something that Active Record doesn't know how
 to reverse, you can use `reversible`:
 
 ```ruby
-class ChangeProductsPrice < ActiveRecord::Migration[0.0]
+class ChangeProductsPrice < ActiveRecord::Migration[5.0]
   def change
     reversible do |dir|
       change_table :products do |t|
@@ -87,7 +87,7 @@ end
 Alternatively, you can use `up` and `down` instead of `change`:
 
 ```ruby
-class ChangeProductsPrice < ActiveRecord::Migration[0.0]
+class ChangeProductsPrice < ActiveRecord::Migration[5.0]
   def up
     change_table :products do |t|
       t.change :price, :string
@@ -129,7 +129,7 @@ $ bin/rails generate migration AddPartNumberToProducts
 This will create an empty but appropriately named migration:
 
 ```ruby
-class AddPartNumberToProducts < ActiveRecord::Migration[0.0]
+class AddPartNumberToProducts < ActiveRecord::Migration[5.0]
   def change
   end
 end
@@ -146,7 +146,7 @@ $ bin/rails generate migration AddPartNumberToProducts part_number:string
 will generate
 
 ```ruby
-class AddPartNumberToProducts < ActiveRecord::Migration[0.0]
+class AddPartNumberToProducts < ActiveRecord::Migration[5.0]
   def change
     add_column :products, :part_number, :string
   end
@@ -162,7 +162,7 @@ $ bin/rails generate migration AddPartNumberToProducts part_number:string:index
 will generate
 
 ```ruby
-class AddPartNumberToProducts < ActiveRecord::Migration[0.0]
+class AddPartNumberToProducts < ActiveRecord::Migration[5.0]
   def change
     add_column :products, :part_number, :string
     add_index :products, :part_number
@@ -180,7 +180,7 @@ $ bin/rails generate migration RemovePartNumberFromProducts part_number:string
 generates
 
 ```ruby
-class RemovePartNumberFromProducts < ActiveRecord::Migration[0.0]
+class RemovePartNumberFromProducts < ActiveRecord::Migration[5.0]
   def change
     remove_column :products, :part_number, :string
   end
@@ -196,7 +196,7 @@ $ bin/rails generate migration AddDetailsToProducts part_number:string price:dec
 generates
 
 ```ruby
-class AddDetailsToProducts < ActiveRecord::Migration[0.0]
+class AddDetailsToProducts < ActiveRecord::Migration[5.0]
   def change
     add_column :products, :part_number, :string
     add_column :products, :price, :decimal
@@ -215,7 +215,7 @@ $ bin/rails generate migration CreateProducts name:string part_number:string
 generates
 
 ```ruby
-class CreateProducts < ActiveRecord::Migration[0.0]
+class CreateProducts < ActiveRecord::Migration[5.0]
   def change
     create_table :products do |t|
       t.string :name
@@ -239,7 +239,7 @@ $ bin/rails generate migration AddUserRefToProducts user:references
 generates
 
 ```ruby
-class AddUserRefToProducts < ActiveRecord::Migration[0.0]
+class AddUserRefToProducts < ActiveRecord::Migration[5.0]
   def change
     add_reference :products, :user, index: true, foreign_key: true
   end
@@ -257,7 +257,7 @@ $ bin/rails g migration CreateJoinTableCustomerProduct customer product
 will produce the following migration:
 
 ```ruby
-class CreateJoinTableCustomerProduct < ActiveRecord::Migration[0.0]
+class CreateJoinTableCustomerProduct < ActiveRecord::Migration[5.0]
   def change
     create_join_table :customers, :products do |t|
       # t.index [:customer_id, :product_id]
@@ -281,7 +281,7 @@ $ bin/rails generate model Product name:string description:text
 will create a migration that looks like this
 
 ```ruby
-class CreateProducts < ActiveRecord::Migration[0.0]
+class CreateProducts < ActiveRecord::Migration[5.0]
   def change
     create_table :products do |t|
       t.string :name
@@ -309,7 +309,7 @@ $ bin/rails generate migration AddDetailsToProducts 'price:decimal{5,2}' supplie
 will produce a migration that looks like this
 
 ```ruby
-class AddDetailsToProducts < ActiveRecord::Migration[0.0]
+class AddDetailsToProducts < ActiveRecord::Migration[5.0]
   def change
     add_column :products, :price, :decimal, precision: 5, scale: 2
     add_reference :products, :supplier, polymorphic: true, index: true
@@ -563,7 +563,7 @@ to reverse. You can use `reversible` to specify what to do when running a
 migration and what else to do when reverting it. For example:
 
 ```ruby
-class ExampleMigration < ActiveRecord::Migration[0.0]
+class ExampleMigration < ActiveRecord::Migration[5.0]
   def change
     create_table :distributors do |t|
       t.string :zipcode
@@ -616,7 +616,7 @@ is wise to perform the transformations in precisely the reverse order they were
 made in the `up` method. The example in the `reversible` section is equivalent to:
 
 ```ruby
-class ExampleMigration < ActiveRecord::Migration[0.0]
+class ExampleMigration < ActiveRecord::Migration[5.0]
   def up
     create_table :distributors do |t|
       t.string :zipcode
@@ -659,7 +659,7 @@ You can use Active Record's ability to rollback migrations using the `revert` me
 ```ruby
 require_relative '20121212123456_example_migration'
 
-class FixupExampleMigration < ActiveRecord::Migration[0.0]
+class FixupExampleMigration < ActiveRecord::Migration[5.0]
   def change
     revert ExampleMigration
 
@@ -677,7 +677,7 @@ is later decided it would be best to use Active Record validations,
 in place of the `CHECK` constraint, to verify the zipcode.
 
 ```ruby
-class DontUseConstraintForZipcodeValidationMigration < ActiveRecord::Migration[0.0]
+class DontUseConstraintForZipcodeValidationMigration < ActiveRecord::Migration[5.0]
   def change
     revert do
       # copy-pasted code from ExampleMigration
@@ -841,7 +841,7 @@ Several methods are provided in migrations that allow you to control all this:
 For example, this migration:
 
 ```ruby
-class CreateProducts < ActiveRecord::Migration[0.0]
+class CreateProducts < ActiveRecord::Migration[5.0]
   def change
     suppress_messages do
       create_table :products do |t|
@@ -1015,7 +1015,7 @@ to add or modify data. This is useful in an existing database that can't be dest
 and recreated, such as a production database. 
 
 ```ruby
-class AddInitialProducts < ActiveRecord::Migration[0.0]
+class AddInitialProducts < ActiveRecord::Migration[5.0]
   def up
     5.times do |i|
       Product.create(name: "Product ##{i}", description: "A product.")

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -101,7 +101,7 @@ NOTE: `belongs_to` associations _must_ use the singular term. If you used the pl
 The corresponding migration might look like this:
 
 ```ruby
-class CreateOrders < ActiveRecord::Migration[0.0]
+class CreateOrders < ActiveRecord::Migration[5.0]
   def change
     create_table :customers do |t|
       t.string :name
@@ -132,7 +132,7 @@ end
 The corresponding migration might look like this:
 
 ```ruby
-class CreateSuppliers < ActiveRecord::Migration[0.0]
+class CreateSuppliers < ActiveRecord::Migration[5.0]
   def change
     create_table :suppliers do |t|
       t.string :name
@@ -176,7 +176,7 @@ NOTE: The name of the other model is pluralized when declaring a `has_many` asso
 The corresponding migration might look like this:
 
 ```ruby
-class CreateCustomers < ActiveRecord::Migration[0.0]
+class CreateCustomers < ActiveRecord::Migration[5.0]
   def change
     create_table :customers do |t|
       t.string :name
@@ -218,7 +218,7 @@ end
 The corresponding migration might look like this:
 
 ```ruby
-class CreateAppointments < ActiveRecord::Migration[0.0]
+class CreateAppointments < ActiveRecord::Migration[5.0]
   def change
     create_table :physicians do |t|
       t.string :name
@@ -304,7 +304,7 @@ end
 The corresponding migration might look like this:
 
 ```ruby
-class CreateAccountHistories < ActiveRecord::Migration[0.0]
+class CreateAccountHistories < ActiveRecord::Migration[5.0]
   def change
     create_table :suppliers do |t|
       t.string :name
@@ -345,7 +345,7 @@ end
 The corresponding migration might look like this:
 
 ```ruby
-class CreateAssembliesAndParts < ActiveRecord::Migration[0.0]
+class CreateAssembliesAndParts < ActiveRecord::Migration[5.0]
   def change
     create_table :assemblies do |t|
       t.string :name
@@ -384,7 +384,7 @@ end
 The corresponding migration might look like this:
 
 ```ruby
-class CreateSuppliers < ActiveRecord::Migration[0.0]
+class CreateSuppliers < ActiveRecord::Migration[5.0]
   def change
     create_table :suppliers do |t|
       t.string  :name
@@ -466,7 +466,7 @@ Similarly, you can retrieve `@product.pictures`.
 If you have an instance of the `Picture` model, you can get to its parent via `@picture.imageable`. To make this work, you need to declare both a foreign key column and a type column in the model that declares the polymorphic interface:
 
 ```ruby
-class CreatePictures < ActiveRecord::Migration[0.0]
+class CreatePictures < ActiveRecord::Migration[5.0]
   def change
     create_table :pictures do |t|
       t.string  :name
@@ -483,7 +483,7 @@ end
 This migration can be simplified by using the `t.references` form:
 
 ```ruby
-class CreatePictures < ActiveRecord::Migration[0.0]
+class CreatePictures < ActiveRecord::Migration[5.0]
   def change
     create_table :pictures do |t|
       t.string :name
@@ -514,7 +514,7 @@ With this setup, you can retrieve `@employee.subordinates` and `@employee.manage
 In your migrations/schema, you will add a references column to the model itself.
 
 ```ruby
-class CreateEmployees < ActiveRecord::Migration[0.0]
+class CreateEmployees < ActiveRecord::Migration[5.0]
   def change
     create_table :employees do |t|
       t.references :manager, index: true
@@ -575,7 +575,7 @@ end
 This declaration needs to be backed up by the proper foreign key declaration on the orders table:
 
 ```ruby
-class CreateOrders < ActiveRecord::Migration[0.0]
+class CreateOrders < ActiveRecord::Migration[5.0]
   def change
     create_table :orders do |t|
       t.datetime :order_date
@@ -611,7 +611,7 @@ end
 These need to be backed up by a migration to create the `assemblies_parts` table. This table should be created without a primary key:
 
 ```ruby
-class CreateAssembliesPartsJoinTable < ActiveRecord::Migration[0.0]
+class CreateAssembliesPartsJoinTable < ActiveRecord::Migration[5.0]
   def change
     create_table :assemblies_parts, id: false do |t|
       t.integer :assembly_id
@@ -629,7 +629,7 @@ We pass `id: false` to `create_table` because that table does not represent a mo
 You can also use the method `create_join_table`
 
 ```ruby
-class CreateAssembliesPartsJoinTable < ActiveRecord::Migration[0.0]
+class CreateAssembliesPartsJoinTable < ActiveRecord::Migration[5.0]
   def change
     create_join_table :assemblies, :parts do |t|
       t.index :assembly_id

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -101,7 +101,7 @@ NOTE: `belongs_to` associations _must_ use the singular term. If you used the pl
 The corresponding migration might look like this:
 
 ```ruby
-class CreateOrders < ActiveRecord::Migration
+class CreateOrders < ActiveRecord::Migration[0.0]
   def change
     create_table :customers do |t|
       t.string :name
@@ -132,7 +132,7 @@ end
 The corresponding migration might look like this:
 
 ```ruby
-class CreateSuppliers < ActiveRecord::Migration
+class CreateSuppliers < ActiveRecord::Migration[0.0]
   def change
     create_table :suppliers do |t|
       t.string :name
@@ -176,7 +176,7 @@ NOTE: The name of the other model is pluralized when declaring a `has_many` asso
 The corresponding migration might look like this:
 
 ```ruby
-class CreateCustomers < ActiveRecord::Migration
+class CreateCustomers < ActiveRecord::Migration[0.0]
   def change
     create_table :customers do |t|
       t.string :name
@@ -218,7 +218,7 @@ end
 The corresponding migration might look like this:
 
 ```ruby
-class CreateAppointments < ActiveRecord::Migration
+class CreateAppointments < ActiveRecord::Migration[0.0]
   def change
     create_table :physicians do |t|
       t.string :name
@@ -304,7 +304,7 @@ end
 The corresponding migration might look like this:
 
 ```ruby
-class CreateAccountHistories < ActiveRecord::Migration
+class CreateAccountHistories < ActiveRecord::Migration[0.0]
   def change
     create_table :suppliers do |t|
       t.string :name
@@ -345,7 +345,7 @@ end
 The corresponding migration might look like this:
 
 ```ruby
-class CreateAssembliesAndParts < ActiveRecord::Migration
+class CreateAssembliesAndParts < ActiveRecord::Migration[0.0]
   def change
     create_table :assemblies do |t|
       t.string :name
@@ -384,7 +384,7 @@ end
 The corresponding migration might look like this:
 
 ```ruby
-class CreateSuppliers < ActiveRecord::Migration
+class CreateSuppliers < ActiveRecord::Migration[0.0]
   def change
     create_table :suppliers do |t|
       t.string  :name
@@ -466,7 +466,7 @@ Similarly, you can retrieve `@product.pictures`.
 If you have an instance of the `Picture` model, you can get to its parent via `@picture.imageable`. To make this work, you need to declare both a foreign key column and a type column in the model that declares the polymorphic interface:
 
 ```ruby
-class CreatePictures < ActiveRecord::Migration
+class CreatePictures < ActiveRecord::Migration[0.0]
   def change
     create_table :pictures do |t|
       t.string  :name
@@ -483,7 +483,7 @@ end
 This migration can be simplified by using the `t.references` form:
 
 ```ruby
-class CreatePictures < ActiveRecord::Migration
+class CreatePictures < ActiveRecord::Migration[0.0]
   def change
     create_table :pictures do |t|
       t.string :name
@@ -514,7 +514,7 @@ With this setup, you can retrieve `@employee.subordinates` and `@employee.manage
 In your migrations/schema, you will add a references column to the model itself.
 
 ```ruby
-class CreateEmployees < ActiveRecord::Migration
+class CreateEmployees < ActiveRecord::Migration[0.0]
   def change
     create_table :employees do |t|
       t.references :manager, index: true
@@ -575,7 +575,7 @@ end
 This declaration needs to be backed up by the proper foreign key declaration on the orders table:
 
 ```ruby
-class CreateOrders < ActiveRecord::Migration
+class CreateOrders < ActiveRecord::Migration[0.0]
   def change
     create_table :orders do |t|
       t.datetime :order_date
@@ -611,7 +611,7 @@ end
 These need to be backed up by a migration to create the `assemblies_parts` table. This table should be created without a primary key:
 
 ```ruby
-class CreateAssembliesPartsJoinTable < ActiveRecord::Migration
+class CreateAssembliesPartsJoinTable < ActiveRecord::Migration[0.0]
   def change
     create_table :assemblies_parts, id: false do |t|
       t.integer :assembly_id
@@ -629,7 +629,7 @@ We pass `id: false` to `create_table` because that table does not represent a mo
 You can also use the method `create_join_table`
 
 ```ruby
-class CreateAssembliesPartsJoinTable < ActiveRecord::Migration
+class CreateAssembliesPartsJoinTable < ActiveRecord::Migration[0.0]
   def change
     create_join_table :assemblies, :parts do |t|
       t.index :assembly_id

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -679,7 +679,7 @@ If you look in the `db/migrate/YYYYMMDDHHMMSS_create_articles.rb` file
 (remember, yours will have a slightly different name), here's what you'll find:
 
 ```ruby
-class CreateArticles < ActiveRecord::Migration
+class CreateArticles < ActiveRecord::Migration[0.0]
   def change
     create_table :articles do |t|
       t.string :title
@@ -1542,7 +1542,7 @@ In addition to the model, Rails has also made a migration to create the
 corresponding database table:
 
 ```ruby
-class CreateComments < ActiveRecord::Migration
+class CreateComments < ActiveRecord::Migration[0.0]
   def change
     create_table :comments do |t|
       t.string :commenter

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -679,7 +679,7 @@ If you look in the `db/migrate/YYYYMMDDHHMMSS_create_articles.rb` file
 (remember, yours will have a slightly different name), here's what you'll find:
 
 ```ruby
-class CreateArticles < ActiveRecord::Migration[0.0]
+class CreateArticles < ActiveRecord::Migration[5.0]
   def change
     create_table :articles do |t|
       t.string :title
@@ -1542,7 +1542,7 @@ In addition to the model, Rails has also made a migration to create the
 corresponding database table:
 
 ```ruby
-class CreateComments < ActiveRecord::Migration[0.0]
+class CreateComments < ActiveRecord::Migration[5.0]
   def change
     create_table :comments do |t|
       t.string :commenter

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -103,7 +103,7 @@ module ApplicationTests
       RUBY
 
       app_file 'db/migrate/20140708012246_create_user.rb', <<-RUBY
-        class CreateUser < ActiveRecord::Migration
+        class CreateUser < ActiveRecord::Migration::Current
           def change
             create_table :users
           end

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -290,7 +290,7 @@ class LoadingTest < ActiveSupport::TestCase
     extend Rack::Test::Methods
 
     app_file "db/migrate/1_create_posts.rb", <<-MIGRATION
-      class CreatePosts < ActiveRecord::Migration
+      class CreatePosts < ActiveRecord::Migration::Current
         def change
           create_table :posts do |t|
             t.string :title, default: "TITLE"
@@ -306,7 +306,7 @@ class LoadingTest < ActiveSupport::TestCase
     assert_equal "TITLE", last_response.body
 
     app_file "db/migrate/2_add_body_to_posts.rb", <<-MIGRATION
-      class AddBodyToPosts < ActiveRecord::Migration
+      class AddBodyToPosts < ActiveRecord::Migration::Current
         def change
           add_column :posts, :body, :text, default: "BODY"
         end

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -18,7 +18,7 @@ module ApplicationTests
           `bin/rails generate model user username:string password:string`
 
           app_file "db/migrate/01_a_migration.bukkits.rb", <<-MIGRATION
-            class AMigration < ActiveRecord::Migration
+            class AMigration < ActiveRecord::Migration::Current
             end
           MIGRATION
 
@@ -158,12 +158,12 @@ module ApplicationTests
         Dir.chdir(app_path) do
 
           app_file "db/migrate/1_one_migration.rb", <<-MIGRATION
-            class OneMigration < ActiveRecord::Migration
+            class OneMigration < ActiveRecord::Migration::Current
             end
           MIGRATION
 
           app_file "db/migrate/02_two_migration.rb", <<-MIGRATION
-            class TwoMigration < ActiveRecord::Migration
+            class TwoMigration < ActiveRecord::Migration::Current
             end
           MIGRATION
 

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -7,7 +7,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
   def test_migration
     migration = "change_title_body_from_posts"
     run_generator [migration]
-    assert_migration "db/migrate/#{migration}.rb", /class ChangeTitleBodyFromPosts < ActiveRecord::Migration/
+    assert_migration "db/migrate/#{migration}.rb", /class ChangeTitleBodyFromPosts < ActiveRecord::Migration\[[0-9.]+\]/
   end
 
   def test_migrations_generated_simultaneously
@@ -26,7 +26,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
   def test_migration_with_class_name
     migration = "ChangeTitleBodyFromPosts"
     run_generator [migration]
-    assert_migration "db/migrate/change_title_body_from_posts.rb", /class #{migration} < ActiveRecord::Migration/
+    assert_migration "db/migrate/change_title_body_from_posts.rb", /class #{migration} < ActiveRecord::Migration\[[0-9.]+\]/
   end
 
   def test_migration_with_invalid_file_name

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -57,12 +57,12 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
   def test_migration
     run_generator
-    assert_migration "db/migrate/create_accounts.rb", /class CreateAccounts < ActiveRecord::Migration/
+    assert_migration "db/migrate/create_accounts.rb", /class CreateAccounts < ActiveRecord::Migration\[[0-9.]+\]/
   end
 
   def test_migration_with_namespace
     run_generator ["Gallery::Image"]
-    assert_migration "db/migrate/create_gallery_images", /class CreateGalleryImages < ActiveRecord::Migration/
+    assert_migration "db/migrate/create_gallery_images", /class CreateGalleryImages < ActiveRecord::Migration\[[0-9.]+\]/
     assert_no_migration "db/migrate/create_images"
   end
 
@@ -70,7 +70,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     run_generator ["Admin::Gallery::Image"]
     assert_no_migration "db/migrate/create_images"
     assert_no_migration "db/migrate/create_gallery_images"
-    assert_migration "db/migrate/create_admin_gallery_images", /class CreateAdminGalleryImages < ActiveRecord::Migration/
+    assert_migration "db/migrate/create_admin_gallery_images", /class CreateAdminGalleryImages < ActiveRecord::Migration\[[0-9.]+\]/
     assert_migration "db/migrate/create_admin_gallery_images", /create_table :admin_gallery_images/
   end
 
@@ -80,7 +80,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_no_migration "db/migrate/create_images"
     assert_no_migration "db/migrate/create_gallery_images"
     assert_no_migration "db/migrate/create_admin_gallery_images"
-    assert_migration "db/migrate/create_admin_gallery_image", /class CreateAdminGalleryImage < ActiveRecord::Migration/
+    assert_migration "db/migrate/create_admin_gallery_image", /class CreateAdminGalleryImage < ActiveRecord::Migration\[[0-9.]+\]/
     assert_migration "db/migrate/create_admin_gallery_image", /create_table :admin_gallery_image/
   ensure
     ActiveRecord::Base.pluralize_table_names = true
@@ -89,7 +89,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   def test_migration_with_namespaces_in_model_name_without_plurization
     ActiveRecord::Base.pluralize_table_names = false
     run_generator ["Gallery::Image"]
-    assert_migration "db/migrate/create_gallery_image", /class CreateGalleryImage < ActiveRecord::Migration/
+    assert_migration "db/migrate/create_gallery_image", /class CreateGalleryImage < ActiveRecord::Migration\[[0-9.]+\]/
     assert_no_migration "db/migrate/create_gallery_images"
   ensure
     ActiveRecord::Base.pluralize_table_names = true
@@ -98,7 +98,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   def test_migration_without_pluralization
     ActiveRecord::Base.pluralize_table_names = false
     run_generator
-    assert_migration "db/migrate/create_account", /class CreateAccount < ActiveRecord::Migration/
+    assert_migration "db/migrate/create_account", /class CreateAccount < ActiveRecord::Migration\[[0-9.]+\]/
     assert_no_migration "db/migrate/create_accounts"
   ensure
     ActiveRecord::Base.pluralize_table_names = true
@@ -193,10 +193,10 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   def test_migration_without_timestamps
     ActiveRecord::Base.timestamped_migrations = false
     run_generator ["account"]
-    assert_file  "db/migrate/001_create_accounts.rb", /class CreateAccounts < ActiveRecord::Migration/
+    assert_file  "db/migrate/001_create_accounts.rb", /class CreateAccounts < ActiveRecord::Migration\[[0-9.]+\]/
 
     run_generator ["project"]
-    assert_file  "db/migrate/002_create_projects.rb", /class CreateProjects < ActiveRecord::Migration/
+    assert_file  "db/migrate/002_create_projects.rb", /class CreateProjects < ActiveRecord::Migration\[[0-9.]+\]/
   ensure
     ActiveRecord::Base.timestamped_migrations = true
   end

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -104,12 +104,12 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
 
   def test_migration
     run_generator
-    assert_migration "db/migrate/create_test_app_accounts.rb", /create_table :test_app_accounts/, /class CreateTestAppAccounts < ActiveRecord::Migration/
+    assert_migration "db/migrate/create_test_app_accounts.rb", /create_table :test_app_accounts/, /class CreateTestAppAccounts < ActiveRecord::Migration\[[0-9.]+\]/
   end
 
   def test_migration_with_namespace
     run_generator ["Gallery::Image"]
-    assert_migration "db/migrate/create_test_app_gallery_images", /class CreateTestAppGalleryImages < ActiveRecord::Migration/
+    assert_migration "db/migrate/create_test_app_gallery_images", /class CreateTestAppGalleryImages < ActiveRecord::Migration\[[0-9.]+\]/
     assert_no_migration "db/migrate/create_test_app_images"
   end
 
@@ -117,7 +117,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
     run_generator ["Admin::Gallery::Image"]
     assert_no_migration "db/migrate/create_images"
     assert_no_migration "db/migrate/create_gallery_images"
-    assert_migration "db/migrate/create_test_app_admin_gallery_images", /class CreateTestAppAdminGalleryImages < ActiveRecord::Migration/
+    assert_migration "db/migrate/create_test_app_admin_gallery_images", /class CreateTestAppAdminGalleryImages < ActiveRecord::Migration\[[0-9.]+\]/
     assert_migration "db/migrate/create_test_app_admin_gallery_images", /create_table :test_app_admin_gallery_images/
   end
 
@@ -127,7 +127,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
     assert_no_migration "db/migrate/create_images"
     assert_no_migration "db/migrate/create_gallery_images"
     assert_no_migration "db/migrate/create_test_app_admin_gallery_images"
-    assert_migration "db/migrate/create_test_app_admin_gallery_image", /class CreateTestAppAdminGalleryImage < ActiveRecord::Migration/
+    assert_migration "db/migrate/create_test_app_admin_gallery_image", /class CreateTestAppAdminGalleryImage < ActiveRecord::Migration\[[0-9.]+\]/
     assert_migration "db/migrate/create_test_app_admin_gallery_image", /create_table :test_app_admin_gallery_image/
   ensure
     ActiveRecord::Base.pluralize_table_names = true

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -63,22 +63,22 @@ module RailtiesTest
 
     test "copying migrations" do
       @plugin.write "db/migrate/1_create_users.rb", <<-RUBY
-        class CreateUsers < ActiveRecord::Migration
+        class CreateUsers < ActiveRecord::Migration::Current
         end
       RUBY
 
       @plugin.write "db/migrate/2_add_last_name_to_users.rb", <<-RUBY
-        class AddLastNameToUsers < ActiveRecord::Migration
+        class AddLastNameToUsers < ActiveRecord::Migration::Current
         end
       RUBY
 
       @plugin.write "db/migrate/3_create_sessions.rb", <<-RUBY
-        class CreateSessions < ActiveRecord::Migration
+        class CreateSessions < ActiveRecord::Migration::Current
         end
       RUBY
 
       app_file "db/migrate/1_create_sessions.rb", <<-RUBY
-        class CreateSessions < ActiveRecord::Migration
+        class CreateSessions < ActiveRecord::Migration::Current
           def up
           end
         end
@@ -123,12 +123,12 @@ module RailtiesTest
       end
 
       @plugin.write "db/migrate/1_create_users.rb", <<-RUBY
-        class CreateUsers < ActiveRecord::Migration
+        class CreateUsers < ActiveRecord::Migration::Current
         end
       RUBY
 
       @blog.write "db/migrate/2_create_blogs.rb", <<-RUBY
-        class CreateBlogs < ActiveRecord::Migration
+        class CreateBlogs < ActiveRecord::Migration::Current
         end
       RUBY
 
@@ -163,11 +163,11 @@ module RailtiesTest
       end
 
       @core.write "db/migrate/1_create_users.rb", <<-RUBY
-        class CreateUsers < ActiveRecord::Migration; end
+        class CreateUsers < ActiveRecord::Migration::Current; end
       RUBY
 
       @api.write "db/migrate/2_create_keys.rb", <<-RUBY
-        class CreateKeys < ActiveRecord::Migration; end
+        class CreateKeys < ActiveRecord::Migration::Current; end
       RUBY
 
       boot_rails
@@ -190,7 +190,7 @@ module RailtiesTest
       RUBY
 
       @plugin.write "db/migrate/0_add_first_name_to_users.rb", <<-RUBY
-        class AddFirstNameToUsers < ActiveRecord::Migration
+        class AddFirstNameToUsers < ActiveRecord::Migration::Current
         end
       RUBY
 


### PR DESCRIPTION
This PR implements the migration versioning infrastructure, and restores the previous default on `timestamps null:` (when in 4.2-compatibility mode).
