### PR TITLE
[WIP] PERF: Cache `PredicateBuilder#handler_for`.

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -13,6 +13,7 @@ module ActiveRecord
     def initialize(table)
       @table = table
       @handlers = []
+      @handlers_cache = {}
 
       register_handler(BasicObject, BasicObjectHandler.new(self))
       register_handler(Class, ClassHandler.new(self))
@@ -137,7 +138,11 @@ module ActiveRecord
     end
 
     def handler_for(object)
-      @handlers.detect { |klass, _| klass === object }.last
+      if handler = @handlers_cache[object.class]
+        handler
+      else
+        @handlers_cache[object.class] = @handlers.detect { |klass, _| klass === object }.last
+      end
     end
 
     def can_be_bound?(column_name, value)


### PR DESCRIPTION
Benchmark Script:

```
begin
  require 'bundler/inline'
rescue LoadError => e
  $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
  raise e
end

gemfile(true) do
  source 'https://rubygems.org'
  gem 'rails', path: '~/rails' # master against ref "f1f0a3f8d99aef8aacfa81ceac3880dcac03ca06"
  gem 'arel', github: 'rails/arel', branch: 'master'
  gem 'rack', github: 'rack/rack', branch: 'master'
  gem 'sass'
  gem 'sprockets-rails', github: 'rails/sprockets-rails', branch: 'master'
  gem 'sprockets', github: 'rails/sprockets', branch: 'master'
  gem 'pg'
  gem 'benchmark-ips'
end

require 'active_record'
require 'benchmark/ips'

ActiveRecord::Base.establish_connection('postgres://postgres@localhost:5432/rubybench')

ActiveRecord::Migration.verbose = false

ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
    t.string :name, :email
    t.timestamps null: false
  end
end

class User < ActiveRecord::Base; end

attributes = {
  name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
  email: "foobar@email.com",
}

1000.times { User.create!(attributes) }

Benchmark.ips(5, 3) do |x|
  x.report('where with hash single') { User.where(name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.") }
  x.report('where with hash double') { User.where(name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.", email: "foobar@email.com") }
end

key =
  if RUBY_VERSION < '2.2'
    :total_allocated_object
  else
    :total_allocated_objects
  end

before = GC.stat[key]
User.where(name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.", email: "foobar@email.com")
after = GC.stat[key]
puts "Total Allocated Object: #{after - before}"

```

Before:

```
Calculating -------------------------------------
where with hash single
                         3.394k i/100ms
where with hash double
                         2.660k i/100ms
-------------------------------------------------
where with hash single
                         36.367k (± 1.7%) i/s -    183.276k
where with hash double
                         28.148k (± 1.3%) i/s -    140.980k
Total Allocated Object: 91

```

After:

```
Calculating ------------------------------------
where with hash single
                         3.798k i/100ms
where with hash double
                         3.104k i/100ms
-------------------------------------------------
where with hash single
                         40.946k (± 1.6%) i/s -    205.092k
where with hash double
                         33.045k (± 1.4%) i/s -    167.616k
Total Allocated Object: 79
```
