### PR TITLE
ActiveRecord::Base#[] can use alias_attribute name.

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -360,6 +360,9 @@ module ActiveRecord
     #   person[:name]            # => ActiveModel::MissingAttributeError: missing attribute: name
     #   person[:organization_id] # => ActiveModel::MissingAttributeError: missing attribute: organization_id
     def [](attr_name)
+      if alias_attr_name = attribute_aliases[attr_name]
+        attr_name = alias_attr_name
+      end
       read_attribute(attr_name) { |n| missing_attribute(n, caller) }
     end
 

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -360,7 +360,7 @@ module ActiveRecord
     #   person[:name]            # => ActiveModel::MissingAttributeError: missing attribute: name
     #   person[:organization_id] # => ActiveModel::MissingAttributeError: missing attribute: organization_id
     def [](attr_name)
-      if alias_attr_name = attribute_aliases[attr_name]
+      if alias_attr_name = attribute_aliases[attr_name.to_s]
         attr_name = alias_attr_name
       end
       read_attribute(attr_name) { |n| missing_attribute(n, caller) }
@@ -377,6 +377,9 @@ module ActiveRecord
     #   person[:age] # => 22
     #   person[:age] # => Fixnum
     def []=(attr_name, value)
+      if alias_attr_name = attribute_aliases[attr_name.to_s]
+        attr_name = alias_attr_name
+      end
       write_attribute(attr_name, value)
     end
 

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -163,7 +163,14 @@ class DirtyTest < ActiveRecord::TestCase
     assert parrot.title_changed?
     assert_nil parrot.title_was
     assert_equal parrot.name_change, parrot.title_change
+
     assert_equal parrot.name, parrot["title"]
+    assert_equal parrot.name, parrot[:title]
+
+    name = parrot["title"] = "John"
+    assert_equal name, parrot.name
+    name = parrot[:title] = "yalab"
+    assert_equal name, parrot.name
   end
 
   def test_restore_attribute!

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -163,6 +163,7 @@ class DirtyTest < ActiveRecord::TestCase
     assert parrot.title_changed?
     assert_nil parrot.title_was
     assert_equal parrot.name_change, parrot.title_change
+    assert_equal parrot.name, parrot["title"]
   end
 
   def test_restore_attribute!


### PR DESCRIPTION
Hi. 
ActiveRecord::Base#[] ignore alias attibute.
I think it is not useful.
I hacked it.

Thanks.
