### PR TITLE
Define `SchemaStatements#tables` as interface

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -23,6 +23,12 @@ module ActiveRecord
         table_name[0...table_alias_length].tr('.', '_')
       end
 
+      # Returns an array of table names.
+      #
+      def tables(name = nil)
+        raise NotImplementedError, "tables is not implemented"
+      end
+
       # Checks to see if the table +table_name+ exists on the database.
       #
       #   table_exists?(:developers)


### PR DESCRIPTION
These 3 methods expect `ConnectionAdapters` to have `tables` method,
so make it clear that `tables` method is interface.
- `ConnectionAdapters::SchemaCache#prepare_tables`
- `db:schema:cache:dump` task
- `SchemaDumper#tables`
