### PR TITLE
ActiveRecord: use association's `unscope` when preloading

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -154,7 +154,7 @@ module ActiveRecord
             scope.where!(klass.table_name => { reflection.type => model.base_class.sti_name })
           end
 
-          scope.unscope_values = Array(values[:unscope])
+          scope.unscope_values = Array(values[:unscope]) + Array(preload_values[:unscope])
           klass.default_scoped.merge(scope)
         end
       end


### PR DESCRIPTION
Preloading an association that is using `unscope` is dropping the `unscope` part.

As they say, 10 LoC is worth a thousand words:

``` ruby
class Developer < ActiveRecord::Base
  default_scope -> { where(awesome: true) }
end

class Project < ActiveRecord::Base
  has_and_belongs_to_many :developers, -> { unscope(where: :awesome) },
end

mediocre_dev = Developer.create(awesome: false)
project = Project.create
project.developers << mediocre_dev

project.developers.reload.size
# => 1
Project.where(id: project.id).includes(:developers).first.developers.size
# => 0 — but should be 1
```

This PR fixes that behaviour. This is my first PR on AR (:tada:) so I'm not all that familiar with the internals, let me know if anything seems wrong.
