### PR TITLE
ActiveJob: Duck typing in argument serialization for objects

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -55,11 +55,11 @@ module ActiveJob
       private_constant :GLOBALID_KEY, :SYMBOL_KEYS_KEY, :WITH_INDIFFERENT_ACCESS_KEY
 
       def serialize_argument(argument)
+        return convert_to_global_id_hash(argument) if argument.respond_to?(:to_global_id)
+
         case argument
         when *TYPE_WHITELIST
           argument
-        when GlobalID::Identification
-          convert_to_global_id_hash(argument)
         when Array
           argument.map { |arg| serialize_argument(arg) }
         when ActiveSupport::HashWithIndifferentAccess

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -5,6 +5,8 @@ require 'active_support/core_ext/hash/indifferent_access'
 require 'jobs/kwargs_job'
 
 class ArgumentSerializationTest < ActiveSupport::TestCase
+  class PersonPresenter < DelegateClass(Person); end
+
   setup do
     @person = Person.find('5')
   end
@@ -33,6 +35,10 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
 
   test 'should convert records to Global IDs' do
     assert_arguments_roundtrip [@person]
+  end
+
+  test 'should convert objects responded to_global_id to Global IDs' do
+    assert_arguments_roundtrip [PersonPresenter.new(@person)]
   end
 
   test 'should dive deep into arrays and hashes' do


### PR DESCRIPTION
Right now it's impossible to pass something that wraps an AR model. I think the better way is check the ability to convert object to global id.
