### PR TITLE
using variable name instead of **  :collision:

### DIFF
--- a/activerecord/lib/active_record/type/adapter_specific_registry.rb
+++ b/activerecord/lib/active_record/type/adapter_specific_registry.rb
@@ -82,7 +82,7 @@ module ActiveRecord
 
       private
 
-      def matches_adapter?(adapter: nil, **)
+      def matches_adapter?(adapter: nil, **kwargs)
         (self.adapter.nil? || adapter == self.adapter)
       end
 


### PR DESCRIPTION
Before that it causing waring `Unhandled exception in YARD::Handlers::Ruby::MethodHandler` when generating Rdocs. Also *\* make sence?
