### PR TITLE
Added nodoc tag for the methods which returns object of private apis

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -881,7 +881,7 @@ module ActiveRecord
         !!@association.include?(record)
       end
 
-      def arel
+      def arel #:nodoc:
         scope.arel
       end
 


### PR DESCRIPTION
`arel` returns `Arel::SelectManager` and `proxy_association` returns `ActiveRecord::Associations::HasManyAssociation` both are internal
