### PR TITLE
Fix docs of AR::Timestamp to match #15726

### DIFF
--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -15,14 +15,21 @@ module ActiveRecord
   #
   # == Time Zone aware attributes
   #
-  # By default, ActiveRecord::Base keeps all the datetime columns time zone aware by executing following code.
+  # Active Record keeps all the <tt>datetime</tt> and <tt>time</tt> columns
+  # time-zone aware. By default, these values are stored in the database as UTC
+  # and converted back to the current Time.zone when pulled from the database.
   #
-  #   config.active_record.time_zone_aware_attributes = true
+  # This feature can be turned off completely by setting:
   #
-  # This feature can easily be turned off by assigning value <tt>false</tt> .
+  #   config.active_record.time_zone_aware_attributes = false
   #
-  # If your attributes are time zone aware and you desire to skip time zone conversion to the current Time.zone
-  # when reading certain attributes then you can do following:
+  # You can also specify that only <tt>datetime</tt> columns should be time-zone
+  # aware (while <tt>time</tt> should not) by setting:
+  #
+  #   ActiveRecord::Base.time_zone_aware_types = [:datetime]
+  #
+  # Finally, you can indicate specific attributes of a model for which time zone
+  # conversion should not applied, for instance by setting:
   #
   #   class Topic < ActiveRecord::Base
   #     self.skip_time_zone_conversion_for_attributes = [:written_on]


### PR DESCRIPTION
[ci skip]

This is how the docs look like after the commit:

<img width="1062" alt="screen shot 2015-09-08 at 9 47 58 pm" src="https://cloud.githubusercontent.com/assets/10076/9753562/524489ca-5673-11e5-9529-a9c63ac357e2.png">
