### PR TITLE
When used by ActionMailer, ActionView should automatically use the correct MIME type just as it does when used by ActionDispatch

### DIFF
--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -49,3 +49,10 @@ module ActionMailer
   autoload :MessageDelivery
   autoload :DeliveryJob
 end
+
+autoload :Mime, 'action_dispatch/http/mime_type'
+
+ActiveSupport.on_load(:action_view) do
+  ActionView::Base.default_formats ||= Mime::SET.symbols
+  ActionView::Template::Types.delegate_to Mime
+end


### PR DESCRIPTION
See discussion in #11157
