### PR TITLE
[ci skip] Add class method route constraint doc

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -727,6 +727,22 @@ Rails.application.routes.draw do
 end
 ```
 
+or using a class method:
+
+```ruby
+class BlacklistConstraint
+  def self.matches?(request)
+    ips = Blacklist.retrieve_ips
+    ips.include?(request.remote_ip)
+  end
+end
+
+Rails.application.routes.draw do
+  get '*path', to: 'blacklist#index',
+    constraints: BlacklistConstraint
+end
+```
+
 You can also specify constraints as a lambda:
 
 ```ruby


### PR DESCRIPTION
Add an example of using a class method as an advanced route constraint to the routing docs.  This approach avoids instantiating a Constraint object every request, and looks a bit cleaner.
