### PR TITLE
Use the default inheritance `:type` when instantiating a new object.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Use the default inheritance `:type` when instantiating a new object.
+
+    Example:
+
+        # In the schema, BaseModel specifies 'SubType' as the default `:type` value
+        subtype = BaseModel.new
+        assert_equals SubType, subtype.class
+
+    *Eric Siegel*
+
 *   Correct query for PostgreSQL 8.2 compatibility.
 
     *Ben Murphy*, *Matthew Draper*

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -192,11 +192,18 @@ module ActiveRecord
       # If this is a StrongParameters hash, and access to inheritance_column is not permitted,
       # this will ignore the inheritance column and return nil
       def subclass_from_attributes?(attrs)
-        attribute_names.include?(inheritance_column) && attrs.is_a?(Hash)
+        inheritance_default = column_defaults[inheritance_column]
+
+        attribute_names.include?(inheritance_column) &&
+          (attrs.is_a?(Hash) or inheritance_default.present?)
       end
 
       def subclass_from_attributes(attrs)
-        subclass_name = attrs.with_indifferent_access[inheritance_column]
+        # Add the inheritance_column's default value.
+        indifferent_attrs = (attrs || {}).with_indifferent_access
+        indifferent_attrs[inheritance_column] ||= column_defaults[inheritance_column]
+
+        subclass_name = indifferent_attrs.with_indifferent_access[inheritance_column]
 
         if subclass_name.present?
           subclass = find_sti_class(subclass_name)

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -6,6 +6,7 @@ require 'models/project'
 require 'models/subscriber'
 require 'models/vegetables'
 require 'models/shop'
+require 'models/storage_devices'
 
 module InheritanceTestHelper
   def with_store_full_sti_class(&block)
@@ -189,6 +190,20 @@ class InheritanceTest < ActiveRecord::TestCase
   def test_inheritance_new_with_subclass
     firm = Company.new(:type => 'Firm')
     assert_equal Firm, firm.class
+  end
+
+  def test_inheritance_new_with_default_subclass
+    harddrive = StorageDevice.new
+    assert_equal HardDrive, harddrive.class
+  end
+
+  def test_inheritance_new_with_default_subclass_and_specified_subclass
+    flashdrive = StorageDevice.new(:type => 'FlashDrive')
+    assert_equal FlashDrive, flashdrive.class
+  end
+
+  def test_inheritance_new_with_default_subclass_specify_invalid_type
+    assert_raise(ActiveRecord::SubclassNotFound) { StorageDevice.new(:type => 'InvalidType') }
   end
 
   def test_new_with_abstract_class

--- a/activerecord/test/models/storage_devices.rb
+++ b/activerecord/test/models/storage_devices.rb
@@ -1,0 +1,10 @@
+class StorageDevice < ActiveRecord::Base
+  # default :type is HardDrive
+  validates_inclusion_of :type, in: %w(HardDrive FlashDrive)
+end
+
+class HardDrive < StorageDevice
+end
+
+class FlashDrive < StorageDevice
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -710,6 +710,10 @@ ActiveRecord::Schema.define do
     t.string :sponsorable_type
   end
 
+  create_table :storage_devices, force: true do |t|
+    t.string :type, default: 'HardDrive'
+  end
+
   create_table :string_key_objects, id: false, primary_key: :id, force: true do |t|
     t.string     :id
     t.string     :name


### PR DESCRIPTION
Calling `new` on some base model will now instantiate the default subtype
as specified in the schema.
