### PR TITLE
add description of passing a block to `add_source` [ci skip]

### DIFF
--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -78,7 +78,7 @@ gem_group :development, :test do
 end
 ```
 
-### add_source(source, options = {})
+### add_source(source, options={}, &block)
 
 Adds the given source to the generated application's `Gemfile`.
 
@@ -86,6 +86,14 @@ For example, if you need to source a gem from `"http://code.whytheluckystiff.net
 
 ```ruby
 add_source "http://code.whytheluckystiff.net"
+```
+
+If block is given, gem entries in block are wrapped into the source group.
+
+```ruby
+add_source "http://gems.github.com/" do
+  gem "rspec-rails"
+end
 ```
 
 ### environment/application(data=nil, options={}, &block)


### PR DESCRIPTION
block support added in 8cc01e0b2bfa75a613720c535d34e451f5de769c
