### PR TITLE
Provide more help when a rails runner file argument does not exist

### DIFF
--- a/railties/lib/rails/commands/runner.rb
+++ b/railties/lib/rails/commands/runner.rb
@@ -58,5 +58,11 @@ elsif File.exist?(code_or_file)
   $0 = code_or_file
   Kernel.load code_or_file
 else
-  eval(code_or_file, binding, __FILE__, __LINE__)
+  begin
+    eval(code_or_file, binding, __FILE__, __LINE__)
+  rescue SyntaxError, NameError => err
+    $stderr.puts "The argument to runner was evaluated as ruby with a #{err.class.name}: '#{code_or_file}'."
+    $stderr.puts "    If this is a file, please verify the file exists and is readable."
+    exit 1
+  end
 end

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -36,6 +36,24 @@ module ApplicationTests
       assert_match "42", Dir.chdir(app_path) { `bin/rails runner "puts User.count"` }
     end
 
+    def test_should_warn_about_missing_file_on_name_error
+      error = capture(:stderr) do
+        Dir.chdir(app_path) { `bin/rails runner "bin/count_users.rb"` }
+      end
+
+      assert_equal 1, $?.exitstatus
+      assert_match "NameError", error
+      assert_match "verify the file exists and is readable", error
+    end
+
+    def test_should_warn_about_missing_file_on_syntax_error
+      error = capture(:stderr) do
+        Dir.chdir(app_path) { `bin/rails runner "/count_users.rb"` }
+      end
+
+      assert_match "SyntaxError", error
+    end
+
     def test_should_run_file
       app_file "bin/count_users.rb", <<-SCRIPT
       puts User.count


### PR DESCRIPTION
Previously, rails runner would treat any arguments to runner that
don't exist as a file as in-line ruby similar to:

`ruby -e "puts 'Hello world'"`

If the file doesn't exist, it would evaluate it as ruby after booting
the application.  If the user mistakenly provided the wrong path, the
error was very confusing.

This commit handles the two common situations I can envision:

1) User provides a missing path with a leading slash: /home/joe/run.rb.
Previously, this would fail with an strange `unknown regexp option`
SyntaxError because the slash is treated as a regexp.

2) User provides a missing path without a leading slash: joe/run.rb.
Previously, this would fail with a `NameError` because `joe` would not
be defined.

This commit detects both situations, discards the backtrace since it
is probaly not useful for a in-line ruby argument passed to rails
runner, prints a more friendly warning and exits 1.

Below are some examples of the two situations before and after:

1) User provides a missing path with a leading slash: /home/joe/run.rb.

```
$ bin/rails r "/home/joe/run.rb"
~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands/runner.rb:63:in `eval': ~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands/runner.rb:63: unknown regexp option - j (SyntaxError)
  from ~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands/runner.rb:63:in `<top (required)>'
  from ~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands/commands_tasks.rb:123:in `require'
  from ~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands/commands_tasks.rb:123:in `require_command!'
  from ~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands/commands_tasks.rb:90:in `runner'
  from ~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
  from ~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands.rb:17:in `<top (required)>'
  from bin/rails:4:in `require'
  from bin/rails:4:in `<main>'
$ echo $?
1

```

With fix:

```
$ bin/rails r "/home/joe/run.rb"
The argument to runner was evaluated as ruby with a SyntaxError: '/home/joe/run.rb'.
    If this is a file, please verify the file exists and is readable.
$ echo $?
1
```

2) User provides a missing path without a leading slash: joe/run.rb.

```
$  bin/rails r "joe/run.rb"
~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands/runner.rb:63:in `<top (required)>': undefined local variable or method `joe' for main:Object (NameError)
  from ~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands/runner.rb:63:in `eval'
  from ~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands/runner.rb:63:in `<top (required)>'
  from ~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands/commands_tasks.rb:123:in `require'
  from ~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands/commands_tasks.rb:123:in `require_command!'
  from ~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands/commands_tasks.rb:90:in `runner'
  from ~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
  from ~/.gem/ruby/2.2.3/gems/railties-4.2.4/lib/rails/commands.rb:17:in `<top (required)>'
  from bin/rails:4:in `require'
  from bin/rails:4:in `<main>'
$ echo $?
1
```

With fix:

```
$ bin/rails r "joe/run.rb"
The argument to runner was evaluated as ruby with a NameError: 'joe/run.rb'.
    If this is a file, please verify the file exists and is readable.
$ echo $?
1
```
