### PR TITLE
`restrict_with_error` message will now respect owner’s human name 

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -15,7 +15,7 @@ module ActiveRecord
 
         when :restrict_with_error
           unless empty?
-            record = klass.human_attribute_name(reflection.name).downcase
+            record = owner.class.human_attribute_name(reflection.name).downcase
             message = owner.errors.generate_message(:base, :'restrict_dependent_destroy.many', record: record, raise: true) rescue nil
             if message
               ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -11,7 +11,7 @@ module ActiveRecord
 
         when :restrict_with_error
           if load_target
-            record = klass.human_attribute_name(reflection.name).downcase
+            record = owner.class.human_attribute_name(reflection.name).downcase
             message = owner.errors.generate_message(:base, :'restrict_dependent_destroy.one', record: record, raise: true) rescue nil
             if message
               ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1482,6 +1482,25 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert firm.companies.exists?(:name => 'child')
   end
 
+  def test_restrict_with_error_with_locale
+    I18n.backend = I18n::Backend::Simple.new
+    I18n.backend.store_translations 'en', activerecord: {attributes: {restricted_with_error_firm: {companies: 'client companies'}}}
+    firm = RestrictedWithErrorFirm.create!(:name => 'restrict')
+    firm.companies.create(:name => 'child')
+
+    assert !firm.companies.empty?
+
+    firm.destroy
+
+    assert !firm.errors.empty?
+
+    assert_equal "Cannot delete record because dependent client companies exist", firm.errors[:base].first
+    assert RestrictedWithErrorFirm.exists?(:name => 'restrict')
+    assert firm.companies.exists?(:name => 'child')
+  ensure
+    I18n.backend.reload!
+  end
+
   def test_included_in_collection
     assert_equal true, companies(:first_firm).clients.include?(Client.find(2))
   end

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -219,6 +219,24 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert firm.account.present?
   end
 
+  def test_restrict_with_error_with_locale
+    I18n.backend = I18n::Backend::Simple.new
+    I18n.backend.store_translations 'en', activerecord: {attributes: {restricted_with_error_firm: {account: 'firm account'}}}
+    firm = RestrictedWithErrorFirm.create!(:name => 'restrict')
+    firm.create_account(:credit_limit => 10)
+
+    assert_not_nil firm.account
+
+    firm.destroy
+
+    assert !firm.errors.empty?
+    assert_equal "Cannot delete record because a dependent firm account exists", firm.errors[:base].first
+    assert RestrictedWithErrorFirm.exists?(:name => 'restrict')
+    assert firm.account.present?
+  ensure
+    I18n.backend.reload!
+  end
+
   def test_successful_build_association
     firm = Firm.new("name" => "GlobalMegaCorp")
     firm.save


### PR DESCRIPTION
in any locale. [kuboon & Ronak Jangir]
Closes #10787 
