### PR TITLE
Add support for busting cache fragments containing asset URLs

### DIFF
--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -59,6 +59,32 @@ module ActionView
       #     <%= render project.topics %>
       #   <% end %>
       #
+      # ==== Fragments with assets
+      #
+      # Cache blocks which contain asset urls need to be busted whenever the assets change.
+      #
+      # For example if we have the following:
+      #
+      #   <% cache :static_image, assets: true do %>
+      #     <%= link_to image_tag('logo.png') %>
+      #   <% end %>
+      #
+      # When a deployment is made where either `Rails.env`, `Rails.application.config.assets.version`,
+      # or `Sprockets::VERSION` change, all assets will automatically generate a new thumbprint.
+      # Any cached fragments containing this filename needs to be busted or they will 404.
+      #
+      # In the above example, the key for `:static_image` will be modified to be the following instead:
+      #
+      #   [:static_image, Rails.application.assets.version]
+      #
+      # Rails.application.assets.version is set by `Sprockets` and is equal to
+      # `"#{Rails.env}-#{Rails.application.config.assets.version}-#{Sprockets::VERSION}"`
+      # Do not confuse with `Rails.application.config.assets.version` which is configurable.
+      #
+      # If the image asset is modified between deployments, it is up to the developer to bump
+      # `Rails.application.config.assets.version` in order to cause the assets and cache fragments to be
+      # regenerated. Note that new assets added to a cache fragment will also need to bump the asset version.
+      #
       # ==== Implicit dependencies
       #
       # Most template dependencies can be derived from calls to render in the template itself.
@@ -153,11 +179,12 @@ module ActionView
       # case when using memcached.
       def cache_fragment_name(name = {}, options = nil)
         skip_digest = options && options[:skip_digest]
+        assets = options && options[:assets]
 
         if skip_digest
-          name
+          fragment_name_with_assets(name, assets)
         else
-          fragment_name_with_digest(name)
+          fragment_name_with_assets(fragment_name_with_digest(name), assets)
         end
       end
 
@@ -169,6 +196,14 @@ module ActionView
           digest = Digestor.digest name: @virtual_path, finder: lookup_context, dependencies: view_cache_dependencies
 
           [ *names, digest ]
+        else
+          name
+        end
+      end
+
+      def fragment_name_with_assets(name, assets = false) #:nodoc:
+        if assets
+          Array.wrap(name) + [Rails.application.assets.version]
         else
           name
         end


### PR DESCRIPTION
An example cache block with an asset included within:

```
<% cache :my_key do %>
  <%= link_to image_tag('my_image.png') %>
<% end %>
```

We have had a problem where we did `bundle update sprockets` and when we deployed all our images which were contained within `cache` blocks responded with 404. The only solution at this point is to manually flush the `Rails.cache` or wait until the cache expires.

This PR adds support for doing the following instead:

```
<% cache :my_key, assets: true do %>
  <%= link_to image_tag('my_image.png') %>
<% end %>
```

This will modify the cache key to add in `Rails.application.assets.version` (not to be confused with `Rails.application.config.assets.version`) so that the cache gets properly busted when either `Rails.env` (however unlikely), `Rails.application.config.assets.version`, or `Sprockets::VERSION` change.

This puts the ownership of busting the cache on the developer to know when to add `assets: true` and when to bump `Rails.application.config.assets.version` in order to both regenerate a new thumbprint as well as bust the caches which contain assets.
