### PR TITLE
Append value to check_box_tag HTML id to make it unique

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -361,6 +361,9 @@ module ActionView
       #   check_box_tag 'rock', 'rock music'
       #   # => <input id="rock" name="rock" type="checkbox" value="rock music" />
       #
+      #   check_box_tag "languages[]", "ruby"
+      #   # => <input type="checkbox" name="languages[]" id="languages_ruby" value="ruby" />
+      #
       #   check_box_tag 'receive_email', 'yes', true
       #   # => <input checked="checked" id="receive_email" name="receive_email" type="checkbox" value="yes" />
       #
@@ -370,7 +373,14 @@ module ActionView
       #   check_box_tag 'eula', 'accepted', false, disabled: true
       #   # => <input disabled="disabled" id="eula" name="eula" type="checkbox" value="accepted" />
       def check_box_tag(name, value = "1", checked = false, options = {})
-        html_options = { "type" => "checkbox", "name" => name, "id" => sanitize_to_id(name), "value" => value }.update(options.stringify_keys)
+        html_options = { "type" => "checkbox", "name" => name, "value" => value }.update(options.stringify_keys)
+
+        html_options["id"] ||= if name.end_with?("[]")
+          "#{sanitize_to_id(name)}#{sanitize_to_id(value)}"
+        else
+          sanitize_to_id(name)
+        end
+
         html_options["checked"] = "checked" if checked
         tag :input, html_options
       end

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -64,6 +64,18 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal expected, actual
   end
 
+  def test_multiple_check_box_tag
+    actual = check_box_tag "languages[]", "ruby"
+    expected = %(<input type="checkbox" name="languages[]" id="languages_ruby" value="ruby" />)
+    assert_dom_equal expected, actual
+  end
+
+  def test_check_box_tag_with_options
+    actual = check_box_tag "languages[]", "ruby", false, :id => "ruby", :checked => true
+    expected = %(<input type="checkbox" name="languages[]" id="ruby" value="ruby" checked="checked" />)
+    assert_dom_equal expected, actual
+  end
+
   def test_check_box_tag_id_sanitized
     label_elem = root_elem(check_box_tag("project[2][admin]"))
     assert_match VALID_HTML_ID, label_elem['id']


### PR DESCRIPTION
## Problem

check_box_tag helper generates duplicated HTML ID:

```
<%= check_box_tag “languages[]”, “ruby” %>
<%= check_box_tag “languages[]”, “javascript” %>
```

output:

```
 <input type="checkbox" name="languages[]" id="languages__" value="ruby">
 <input type="checkbox" name="languages[]" id="languages__" value="javascript"">
```
## Solution

Append value to check_box_tag HTML id to make it unique if it’s multiple check_box (i.e. input name ending with `[]`). 

I think this behavior is consistent with `radio_button_tag` and `collection_check_boxes` helper which append value to HTML id too. 

output result:

```
<input type="checkbox" name="languages[]" id="languages_ruby" value="ruby" />
<input type="checkbox" name="languages[]" id="languages_javascript" value="javascript" />
```
