### PR TITLE
All `AR::ConnectionAdapters#tables` return only tables(exclude views)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Deprecate `connection.tables` on the SQLite3 and MySQL adapters.
+    Also deprecate passing arguments to `#tables`.
+    And deprecate `table_exists?`.
+
+    The `#tables` method of some adapters (mysql, mysql2, sqlite3) would return
+    both tables and views while others (postgresql) just return tables. To make
+    their behavior consistent, `#tables` will return only tables in the future.
+
+    The `#table_exists?` method would check both tables and views. To make
+    their behavior consistent with `#tables`, `#table_exists?` will check only
+    tables in the future.
+
+    *Yuichiro Kaneko*
+
 *   Improve support for non Active Record objects on `validates_associated`
 
     Skipping `marked_for_destruction?` when the associated object does not responds

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -263,7 +263,7 @@ module ActiveRecord
 
         yield td if block_given?
 
-        if options[:force] && table_exists?(table_name)
+        if options[:force] && data_source_exists?(table_name)
           drop_table(table_name, options)
         end
 
@@ -1088,7 +1088,7 @@ module ActiveRecord
         if index_name.length > max_index_length
           raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' is too long; the limit is #{max_index_length} characters"
         end
-        if table_exists?(table_name) && index_name_exists?(table_name, index_name, false)
+        if data_source_exists?(table_name) && index_name_exists?(table_name, index_name, false)
           raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' already exists"
         end
         index_columns = quoted_columns_for_index(column_names, options).join(", ")

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -70,6 +70,12 @@ module ActiveRecord
 
         # Returns the list of all tables in the schema search path.
         def tables(name = nil)
+          if name
+            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+              Passing arguments to #tables is deprecated without replacement.
+            MSG
+          end
+
           select_values("SELECT tablename FROM pg_tables WHERE schemaname = ANY(current_schemas(false))", 'SCHEMA')
         end
 
@@ -87,6 +93,16 @@ module ActiveRecord
         # If the schema is not specified as part of +name+ then it will only find tables within
         # the current schema search path (regardless of permissions to access tables in other schemas)
         def table_exists?(name)
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            #table_exists? currently checks both tables and views.
+            This behavior is deprecated and will be changed with Rails 5.1 to only check tables.
+            Use #data_source_exists? instead.
+          MSG
+
+          data_source_exists?(name)
+        end
+
+        def data_source_exists?(name)
           name = Utils.extract_schema_qualified_name(name.to_s)
           return false unless name.identifier
 
@@ -99,7 +115,6 @@ module ActiveRecord
               AND n.nspname = #{name.schema ? "'#{name.schema}'" : 'ANY (current_schemas(false))'}
           SQL
         end
-        alias data_source_exists? table_exists?
 
         def views # :nodoc:
           select_values(<<-SQL, 'SCHEMA')

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -312,11 +312,36 @@ module ActiveRecord
       # SCHEMA STATEMENTS ========================================
 
       def tables(name = nil) # :nodoc:
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          #tables currently returns both tables and views.
+          This behavior is deprecated and will be changed with Rails 5.1 to only return tables.
+          Use #data_sources instead.
+        MSG
+
+        if name
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Passing arguments to #tables is deprecated without replacement.
+          MSG
+        end
+
+        data_sources
+      end
+
+      def data_sources
         select_values("SELECT name FROM sqlite_master WHERE type IN ('table','view') AND name <> 'sqlite_sequence'", 'SCHEMA')
       end
-      alias data_sources tables
 
       def table_exists?(table_name)
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          #table_exists? currently checks both tables and views.
+          This behavior is deprecated and will be changed with Rails 5.1 to only check tables.
+          Use #data_source_exists? instead.
+        MSG
+
+        data_source_exists?(table_name)
+      end
+
+      def data_source_exists?(table_name)
         return false unless table_name.present?
 
         sql = "SELECT name FROM sqlite_master WHERE type IN ('table','view') AND name <> 'sqlite_sequence'"
@@ -324,7 +349,6 @@ module ActiveRecord
 
         select_values(sql, 'SCHEMA').any?
       end
-      alias data_source_exists? table_exists?
 
       def views # :nodoc:
         select_values("SELECT name FROM sqlite_master WHERE type = 'view' AND name <> 'sqlite_sequence'", 'SCHEMA')

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -967,10 +967,12 @@ module ActiveRecord
       end
 
       def get_all_versions(connection = Base.connection)
-        if connection.table_exists?(schema_migrations_table_name)
-          SchemaMigration.all.map { |x| x.version.to_i }.sort
-        else
-          []
+        ActiveSupport::Deprecation.silence do
+          if connection.table_exists?(schema_migrations_table_name)
+            SchemaMigration.all.map { |x| x.version.to_i }.sort
+          else
+            []
+          end
         end
       end
 

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -21,7 +21,7 @@ module ActiveRecord
       end
 
       def table_exists?
-        connection.table_exists?(table_name)
+        ActiveSupport::Deprecation.silence { connection.table_exists?(table_name) }
       end
 
       def create_table(limit=nil)

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -23,7 +23,8 @@ module ActiveRecord
     end
 
     def test_tables
-      tables = @connection.tables
+      tables = nil
+      ActiveSupport::Deprecation.silence { tables = @connection.tables }
       assert tables.include?("accounts")
       assert tables.include?("authors")
       assert tables.include?("tasks")
@@ -31,9 +32,15 @@ module ActiveRecord
     end
 
     def test_table_exists?
-      assert @connection.table_exists?("accounts")
-      assert !@connection.table_exists?("nonexistingtable")
-      assert !@connection.table_exists?(nil)
+      ActiveSupport::Deprecation.silence do
+        assert @connection.table_exists?("accounts")
+        assert !@connection.table_exists?("nonexistingtable")
+        assert !@connection.table_exists?(nil)
+      end
+    end
+
+    def test_table_exists_checking_both_tables_and_views_is_deprecated
+      assert_deprecated { @connection.table_exists?("accounts") }
     end
 
     def test_data_sources
@@ -245,6 +252,16 @@ module ActiveRecord
 
         assert_not_nil error.cause
       end
+    end
+
+    if current_adapter?(:MysqlAdapter, :Mysql2Adapter, :SQLite3Adapter)
+      def test_tables_returning_both_tables_and_views_is_deprecated
+        assert_deprecated { @connection.tables }
+      end
+    end
+
+    def test_passing_arguments_to_tables_is_deprecated
+      assert_deprecated { @connection.tables(:books) }
     end
   end
 

--- a/activerecord/test/cases/adapters/mysql/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/schema_test.rb
@@ -59,13 +59,13 @@ module ActiveRecord
         assert_equal 'id', @omgpost.primary_key
       end
 
-      def test_table_exists?
+      def test_data_source_exists?
         name = @omgpost.table_name
-        assert @connection.table_exists?(name), "#{name} table should exist"
+        assert @connection.data_source_exists?(name), "#{name} data_source should exist"
       end
 
-      def test_table_exists_wrong_schema
-        assert(!@connection.table_exists?("#{@db_name}.zomg"), "table should not exist")
+      def test_data_source_exists_wrong_schema
+        assert(!@connection.data_source_exists?("#{@db_name}.zomg"), "data_source should not exist")
       end
 
       def test_dump_indexes

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -17,7 +17,7 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
 
   def test_add_index
     # add_index calls table_exists? and index_name_exists? which can't work since execute is stubbed
-    def (ActiveRecord::Base.connection).table_exists?(*); true; end
+    def (ActiveRecord::Base.connection).data_source_exists?(*); true; end
     def (ActiveRecord::Base.connection).index_name_exists?(*); false; end
 
     expected = "CREATE  INDEX `index_people_on_last_name`  ON `people` (`last_name`) "
@@ -60,7 +60,7 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_index_in_create
-    def (ActiveRecord::Base.connection).table_exists?(*); false; end
+    def (ActiveRecord::Base.connection).data_source_exists?(*); false; end
 
     %w(SPATIAL FULLTEXT UNIQUE).each do |type|
       expected = "CREATE TABLE `people` (#{type} INDEX `index_people_on_last_name`  (`last_name`) ) ENGINE=InnoDB"
@@ -78,7 +78,7 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_index_in_bulk_change
-    def (ActiveRecord::Base.connection).table_exists?(*); true; end
+    def (ActiveRecord::Base.connection).data_source_exists?(*); true; end
     def (ActiveRecord::Base.connection).index_name_exists?(*); false; end
 
     %w(SPATIAL FULLTEXT UNIQUE).each do |type|
@@ -152,7 +152,7 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_indexes_in_create
-    ActiveRecord::Base.connection.stubs(:table_exists?).with(:temp).returns(false)
+    ActiveRecord::Base.connection.stubs(:data_source_exists?).with(:temp).returns(false)
     ActiveRecord::Base.connection.stubs(:index_name_exists?).with(:index_temp_on_zip).returns(false)
 
     expected = "CREATE TEMPORARY TABLE `temp` ( INDEX `index_temp_on_zip`  (`zip`) ) ENGINE=InnoDB AS SELECT id, name, zip FROM a_really_complicated_query"

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -59,13 +59,13 @@ module ActiveRecord
         assert_equal 'id', @omgpost.primary_key
       end
 
-      def test_table_exists?
+      def test_data_source_exists?
         name = @omgpost.table_name
-        assert @connection.table_exists?(name), "#{name} table should exist"
+        assert @connection.data_source_exists?(name), "#{name} data_source should exist"
       end
 
-      def test_table_exists_wrong_schema
-        assert(!@connection.table_exists?("#{@db_name}.zomg"), "table should not exist")
+      def test_data_source_exists_wrong_schema
+        assert(!@connection.data_source_exists?("#{@db_name}.zomg"), "data_source should not exist")
       end
 
       def test_dump_indexes

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -90,7 +90,7 @@ module ActiveRecord
     end
 
     def test_tables_logs_name
-      @connection.tables('hello')
+      ActiveSupport::Deprecation.silence { @connection.tables('hello') }
       assert_equal 'SCHEMA', @subscriber.logged[0][1]
     end
 
@@ -100,7 +100,7 @@ module ActiveRecord
     end
 
     def test_table_exists_logs_name
-      @connection.table_exists?('items')
+      ActiveSupport::Deprecation.silence { @connection.table_exists?('items') }
       assert_equal 'SCHEMA', @subscriber.logged[0][1]
     end
 

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -184,42 +184,42 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     @connection.exec_query("alter table developers drop column zomg", 'sql', []) if altered
   end
 
-  def test_table_exists?
+  def test_data_source_exists?
     [Thing1, Thing2, Thing3, Thing4].each do |klass|
       name = klass.table_name
-      assert @connection.table_exists?(name), "'#{name}' table should exist"
+      assert @connection.data_source_exists?(name), "'#{name}' data_source should exist"
     end
   end
 
-  def test_table_exists_when_on_schema_search_path
+  def test_data_source_exists_when_on_schema_search_path
     with_schema_search_path(SCHEMA_NAME) do
-      assert(@connection.table_exists?(TABLE_NAME), "table should exist and be found")
+      assert(@connection.data_source_exists?(TABLE_NAME), "data_source should exist and be found")
     end
   end
 
-  def test_table_exists_when_not_on_schema_search_path
+  def test_data_source_exists_when_not_on_schema_search_path
     with_schema_search_path('PUBLIC') do
-      assert(!@connection.table_exists?(TABLE_NAME), "table exists but should not be found")
+      assert(!@connection.data_source_exists?(TABLE_NAME), "data_source exists but should not be found")
     end
   end
 
-  def test_table_exists_wrong_schema
-    assert(!@connection.table_exists?("foo.things"), "table should not exist")
+  def test_data_source_exists_wrong_schema
+    assert(!@connection.data_source_exists?("foo.things"), "data_source should not exist")
   end
 
-  def test_table_exists_quoted_names
+  def test_data_source_exists_quoted_names
     [ %("#{SCHEMA_NAME}"."#{TABLE_NAME}"), %(#{SCHEMA_NAME}."#{TABLE_NAME}"), %(#{SCHEMA_NAME}."#{TABLE_NAME}")].each do |given|
-      assert(@connection.table_exists?(given), "table should exist when specified as #{given}")
+      assert(@connection.data_source_exists?(given), "data_source should exist when specified as #{given}")
     end
     with_schema_search_path(SCHEMA_NAME) do
       given = %("#{TABLE_NAME}")
-      assert(@connection.table_exists?(given), "table should exist when specified as #{given}")
+      assert(@connection.data_source_exists?(given), "data_source should exist when specified as #{given}")
     end
   end
 
-  def test_table_exists_quoted_table
+  def test_data_source_exists_quoted_table
     with_schema_search_path(SCHEMA_NAME) do
-        assert(@connection.table_exists?('"things.table"'), "table should exist")
+      assert(@connection.data_source_exists?('"things.table"'), "data_source should exist")
     end
   end
 

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -284,9 +284,9 @@ module ActiveRecord
 
       def test_tables
         with_example_table do
-          assert_equal %w{ ex }, @conn.tables
+          ActiveSupport::Deprecation.silence { assert_equal %w{ ex }, @conn.tables }
           with_example_table 'id integer PRIMARY KEY AUTOINCREMENT, number integer', 'people' do
-            assert_equal %w{ ex people }.sort, @conn.tables.sort
+            ActiveSupport::Deprecation.silence { assert_equal %w{ ex people }.sort, @conn.tables.sort }
           end
         end
       end
@@ -297,7 +297,9 @@ module ActiveRecord
           WHERE type IN ('table','view') AND name <> 'sqlite_sequence'
         SQL
         assert_logged [[sql.squish, 'SCHEMA', []]] do
-          @conn.tables('hello')
+          ActiveSupport::Deprecation.silence do
+            @conn.tables('hello')
+          end
         end
       end
 
@@ -316,7 +318,9 @@ module ActiveRecord
             WHERE type IN ('table','view') AND name <> 'sqlite_sequence' AND name = 'ex'
           SQL
           assert_logged [[sql.squish, 'SCHEMA', []]] do
-            assert @conn.table_exists?('ex')
+            ActiveSupport::Deprecation.silence do
+              assert @conn.table_exists?('ex')
+            end
           end
         end
       end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -405,9 +405,9 @@ module ActiveRecord
 
       def test_drop_table_if_exists
         connection.create_table(:testings)
-        assert connection.table_exists?(:testings)
+        ActiveSupport::Deprecation.silence { assert connection.table_exists?(:testings) }
         connection.drop_table(:testings, if_exists: true)
-        assert_not connection.table_exists?(:testings)
+        ActiveSupport::Deprecation.silence { assert_not connection.table_exists?(:testings) }
       end
 
       def test_drop_table_if_exists_nothing_raised

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -164,7 +164,7 @@ class ReferencesWithoutForeignKeySupportTest < ActiveRecord::TestCase
       t.references :testing_parent, foreign_key: true
     end
 
-    assert_includes @connection.tables, "testings"
+    assert_includes @connection.data_sources, "testings"
   end
 end
 end

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -15,7 +15,7 @@ module ActiveRecord
       end
 
       def teardown
-        rename_table :octopi, :test_models if connection.table_exists? :octopi
+        ActiveSupport::Deprecation.silence { rename_table :octopi, :test_models if connection.table_exists? :octopi }
         super
       end
 
@@ -83,7 +83,7 @@ module ActiveRecord
           enable_extension!('uuid-ossp', connection)
           connection.create_table :cats, id: :uuid
           assert_nothing_raised { rename_table :cats, :felines }
-          assert connection.table_exists? :felines
+          ActiveSupport::Deprecation.silence { assert connection.table_exists? :felines }
         ensure
           disable_extension!('uuid-ossp', connection)
           connection.drop_table :cats, if_exists: true

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -313,9 +313,9 @@ class MigratorTest < ActiveRecord::TestCase
     _, migrator = migrator_class(3)
 
     ActiveRecord::Base.connection.drop_table "schema_migrations", if_exists: true
-    assert_not ActiveRecord::Base.connection.table_exists?('schema_migrations')
+    ActiveSupport::Deprecation.silence { assert_not ActiveRecord::Base.connection.table_exists?('schema_migrations') }
     migrator.migrate("valid", 1)
-    assert ActiveRecord::Base.connection.table_exists?('schema_migrations')
+    ActiveSupport::Deprecation.silence { assert ActiveRecord::Base.connection.table_exists?('schema_migrations') }
   end
 
   def test_migrator_forward

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -44,7 +44,7 @@ class PooledConnectionsTest < ActiveRecord::TestCase
         conn = ActiveRecord::Base.connection_pool.checkout
         ActiveRecord::Base.connection_pool.checkin conn
         @connection_count += 1
-        ActiveRecord::Base.connection.tables
+        ActiveRecord::Base.connection.data_sources
       rescue ActiveRecord::ConnectionTimeoutError
         @timed_out += 1
       end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -224,7 +224,7 @@ class PrimaryKeyAnyTypeTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.drop_table(:barcodes) if @connection.table_exists? :barcodes
+    @connection.drop_table(:barcodes, if_exists: true)
   end
 
   def test_any_type_primary_key

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -45,7 +45,7 @@ module ViewBehavior
   def test_table_exists
     view_name = Ebook.table_name
     # TODO: switch this assertion around once we changed #tables to not return views.
-    assert @connection.table_exists?(view_name), "'#{view_name}' table should exist"
+    ActiveSupport::Deprecation.silence { assert @connection.table_exists?(view_name), "'#{view_name}' table should exist" }
   end
 
   def test_views_ara_valid_data_sources
@@ -87,7 +87,7 @@ class ViewWithPrimaryKeyTest < ActiveRecord::TestCase
   end
 
   def drop_view(name)
-    @connection.execute "DROP VIEW #{name}" if @connection.table_exists? name
+    @connection.execute "DROP VIEW #{name}" if @connection.view_exists? name
   end
 end
 
@@ -106,7 +106,7 @@ class ViewWithoutPrimaryKeyTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.execute "DROP VIEW paperbacks" if @connection.table_exists? "paperbacks"
+    @connection.execute "DROP VIEW paperbacks" if @connection.view_exists? "paperbacks"
   end
 
   def test_reading
@@ -125,7 +125,8 @@ class ViewWithoutPrimaryKeyTest < ActiveRecord::TestCase
 
   def test_table_exists
     view_name = Paperback.table_name
-    assert @connection.table_exists?(view_name), "'#{view_name}' table should exist"
+    # TODO: switch this assertion around once we changed #tables to not return views.
+    ActiveSupport::Deprecation.silence { assert @connection.table_exists?(view_name), "'#{view_name}' table should exist" }    
   end
 
   def test_column_definitions
@@ -167,7 +168,7 @@ class UpdateableViewTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @connection.execute "DROP VIEW printed_books" if @connection.table_exists? "printed_books"
+    @connection.execute "DROP VIEW printed_books" if @connection.view_exists? "printed_books"
   end
 
   def test_update_record
@@ -209,8 +210,7 @@ class MaterializedViewTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def drop_view(name)
-    @connection.execute "DROP MATERIALIZED VIEW #{name}" if @connection.table_exists? name
-
+    @connection.execute "DROP MATERIALIZED VIEW #{name}" if @connection.view_exists? name
   end
 end
 end

--- a/activerecord/test/support/schema_dumping_helper.rb
+++ b/activerecord/test/support/schema_dumping_helper.rb
@@ -1,7 +1,7 @@
 module SchemaDumpingHelper
   def dump_table_schema(table, connection = ActiveRecord::Base.connection)
     old_ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
-    ActiveRecord::SchemaDumper.ignore_tables = connection.tables - [table]
+    ActiveRecord::SchemaDumper.ignore_tables = connection.data_sources - [table]
     stream = StringIO.new
     ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
     stream.string


### PR DESCRIPTION
As reported on https://github.com/rails/rails/issues/21509,
`tables` method of adapters for mysql and sqlite include view
but for postgresql does not include. This commit fix all of them
to return only tables(exclude views). Close #21509.

This commit includes these fixes:

**Implement `tables_and_views` for mysql and sqlite**

`tables` method of adapters for mysql and sqlite has two
functions.
1. Return all tables names
2. Return all tables names which matches to database name or table name
   (specified by argument)

Move no. 2 function to `tables_and_views` method.

**Change arguments of `tables` method**

Now the responsibility of `tables` is to return all tables names,
so change this method to be argument-less method.

**Change some tests**
- `test_tables_quoting` in activerecord/test/cases/adapters/mysql2/schema_test.rb
  This test asserts database name is quoted internally. `tables_and_views` accepts
  database name. So change from `@connection.tables` to `@connection.tables_and_views`.
- `test_tables_logs_name` in activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
  This test asserts what SQL is executed. SQL created by `tables` is changed, so change `sql`
  used to assertion.
