### PR TITLE
Ruby 2.2.3 in windows need nokogiri 1.6.7.rc3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,13 @@ group :test do
 end
 
 platforms :ruby do
-  gem 'nokogiri', '>= 1.4.5'
+  if Bundler::WINDOWS
+    # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+    gem 'tzinfo-data'
+    gem 'nokogiri', '>= 1.6.7.rc3'
+  else
+    gem 'nokogiri', '>= 1.4.5'
+  end
 
   # Needed for compiling the ActionDispatch::Journey parser
   gem 'racc', '>=1.4.6', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: git://github.com/rack/rack.git
-  revision: 4224c028c71c4ccca7cdb3e5a10c51af797a4d4d
+  revision: c28f271d0c91f45e13bfa8f07bed445ef91f41de
   branch: master
   specs:
     rack (2.0.0.alpha)
@@ -37,14 +37,14 @@ GIT
 
 GIT
   remote: git://github.com/rails/arel.git
-  revision: d5432b4616ff43fbb14540d351eed351e21bb20e
+  revision: 77ec13b46af2926bfcfc3073685711c874b0d272
   branch: master
   specs:
     arel (7.0.0.alpha)
 
 GIT
   remote: git://github.com/rails/globalid.git
-  revision: 8178ff2dc898a8f49dd71f6eb46f2a09712462de
+  revision: 1d8fca667740570d204fd955a0bd39ac539bac7f
   branch: master
   specs:
     globalid (0.3.6)
@@ -52,7 +52,7 @@ GIT
 
 GIT
   remote: git://github.com/rails/jquery-rails.git
-  revision: 01cb69b17083c8eb8daba13a8daba4907b1c3813
+  revision: 04fcfa29b859eef9479f89b6a799d00212902385
   branch: master
   specs:
     jquery-rails (4.0.5)
@@ -62,18 +62,18 @@ GIT
 
 GIT
   remote: git://github.com/rails/sass-rails.git
-  revision: 805cb17722b8a13ff00dffe20283a6ba2c9a45dc
+  revision: a3b25261a3d31ed9ff5dd6e841b777790fc86c55
   branch: master
   specs:
     sass-rails (6.0.0)
       railties (>= 4.0.0, < 5.0)
-      sass (~> 3.3)
+      sass (~> 3.4)
       sprockets (>= 4.0)
       sprockets-rails (< 4.0)
 
 GIT
   remote: git://github.com/rails/sprockets-rails.git
-  revision: e65e088575be4f6b994823b80a277affb0a57a5e
+  revision: 600f981fe79ff2d4179baf84bd18fac5acb58b5e
   branch: master
   specs:
     sprockets-rails (3.0.0.beta2)
@@ -83,11 +83,11 @@ GIT
 
 GIT
   remote: git://github.com/rails/sprockets.git
-  revision: 408e4ad79df056f6f2199e495782363c22a95c04
+  revision: 9675919a2733c2888a236756395f08b2294631bb
   branch: master
   specs:
     sprockets (4.0.0)
-      rack (~> 2.x)
+      rack (> 1, < 3)
 
 PATH
   remote: .
@@ -160,8 +160,8 @@ GEM
     beaneater (1.0.0)
     benchmark-ips (2.3.0)
     builder (3.2.2)
-    bunny (2.0.0)
-      amq-protocol (>= 1.9.2)
+    bunny (2.2.0)
+      amq-protocol (>= 2.0.0)
     byebug (6.0.2)
     celluloid (0.16.0)
       timers (~> 4.0.0)
@@ -195,7 +195,7 @@ GEM
     metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (2.6.1)
-    mini_portile (0.6.2)
+    mini_portile (0.7.0.rc4)
     minitest (5.3.3)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
@@ -204,15 +204,15 @@ GEM
     mustache (1.0.2)
     mysql (2.9.1)
     mysql2 (0.4.0)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
-    nokogiri (1.6.6.2-x64-mingw32)
-      mini_portile (~> 0.6.0)
-    nokogiri (1.6.6.2-x86-mingw32)
-      mini_portile (~> 0.6.0)
-    pg (0.18.2)
+    nokogiri (1.6.7.rc3)
+      mini_portile (~> 0.7.0.rc4)
+    nokogiri (1.6.7.rc3-x64-mingw32)
+      mini_portile (~> 0.7.0.rc4)
+    nokogiri (1.6.7.rc3-x86-mingw32)
+      mini_portile (~> 0.7.0.rc4)
+    pg (0.18.3)
     psych (2.0.15)
-    que (0.10.0)
+    que (0.11.2)
     racc (1.4.12)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -243,12 +243,12 @@ GEM
       redis (~> 3.0)
       resque (~> 1.25)
       rufus-scheduler (~> 3.0)
-    rufus-scheduler (3.1.3)
-    sass (3.4.17)
+    rufus-scheduler (3.1.4)
+    sass (3.4.18)
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    sequel (4.25.0)
+    sequel (4.26.0)
     serverengine (1.5.10)
       sigdump (~> 0.2.2)
     sidekiq (3.4.2)
@@ -260,8 +260,8 @@ GEM
     sigdump (0.2.3)
     sinatra (1.0)
       rack (>= 1.0)
-    sneakers (1.1.1)
-      bunny (>= 1.7.0, <= 2.0.0)
+    sneakers (2.2.0)
+      bunny (~> 2.2.0)
       serverengine (~> 1.5.5)
       thor
       thread (~> 0.1.7)
@@ -272,13 +272,15 @@ GEM
     thor (0.19.1)
     thread (0.1.7)
     thread_safe (0.3.5)
-    timers (4.0.1)
+    timers (4.0.4)
       hitimes
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.7.1)
+    tzinfo-data (1.2015.6)
+      tzinfo (>= 1.0.0)
+    uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     vegas (0.1.11)
@@ -314,7 +316,7 @@ DEPENDENCIES
   mocha (~> 0.14)
   mysql (>= 2.9.0)
   mysql2 (>= 0.4.0)
-  nokogiri (>= 1.4.5)
+  nokogiri (>= 1.6.7.rc3)
   pg (>= 0.18.0)
   psych (~> 2.0)
   qu-rails!
@@ -341,6 +343,7 @@ DEPENDENCIES
   stackprof
   sucker_punch
   turbolinks
+  tzinfo-data
   uglifier (>= 1.3.0)
   w3c_validators
 


### PR DESCRIPTION
It's the only version having correct pre-compiled so files.
