### PR TITLE
Bundler tzinfo-data in windows, even first generated new app are Mac

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -50,8 +50,6 @@ group :development do
 <% end -%>
 end
 <% end -%>
-<% if RUBY_PLATFORM.match(/bccwin|cygwin|emx|mingw|mswin|wince|java/) -%>
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-<% end -%>


### PR DESCRIPTION
Per #21602 @rafaelfranca  suggest.

Have to always leave as text in Gemfile than initial generation is writing below will cause `(erb):53:in`template': uninitialized constant Rails::Generators::AppGenerator::Bundler (NameError)`

```
<% if Bundler::WINDOWS -%>
# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
gem 'tzinfo-data'
<% end -%>
```
