### PR TITLE
Remove unnecessary display width

### DIFF
--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -26,7 +26,7 @@ The Product class is automatically mapped to the table named "products",
 which might look like this:
 
    CREATE TABLE products (
-     id int(11) NOT NULL auto_increment,
+     id int NOT NULL auto_increment,
      name varchar(255),
      PRIMARY KEY  (id)
    );

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -446,14 +446,14 @@ module ActiveRecord
     # The tables for these classes could look something like:
     #
     #   CREATE TABLE users (
-    #     id int(11) NOT NULL auto_increment,
-    #     account_id int(11) default NULL,
+    #     id int NOT NULL auto_increment,
+    #     account_id int default NULL,
     #     name varchar default NULL,
     #     PRIMARY KEY  (id)
     #   )
     #
     #   CREATE TABLE accounts (
-    #     id int(11) NOT NULL auto_increment,
+    #     id int NOT NULL auto_increment,
     #     name varchar default NULL,
     #     PRIMARY KEY  (id)
     #   )

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -158,7 +158,7 @@ module ActiveRecord
       # generates:
       #
       #   CREATE TABLE suppliers (
-      #     id int(11) auto_increment PRIMARY KEY
+      #     id int auto_increment PRIMARY KEY
       #   ) ENGINE=InnoDB DEFAULT CHARSET=utf8
       #
       # ====== Rename the primary key column
@@ -170,7 +170,7 @@ module ActiveRecord
       # generates:
       #
       #   CREATE TABLE objects (
-      #     guid int(11) auto_increment PRIMARY KEY,
+      #     guid int auto_increment PRIMARY KEY,
       #     name varchar(80)
       #   )
       #
@@ -320,7 +320,7 @@ module ActiveRecord
       # [<tt>:bulk</tt>]
       #   Set this to true to make this a bulk alter query, such as
       #
-      #     ALTER TABLE `users` ADD COLUMN age INT(11), ADD COLUMN birthdate DATETIME ...
+      #     ALTER TABLE `users` ADD COLUMN age INT, ADD COLUMN birthdate DATETIME ...
       #
       #   Defaults to false.
       #

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -246,7 +246,7 @@ module ActiveRecord
       QUOTED_TRUE, QUOTED_FALSE = '1', '0'
 
       NATIVE_DATABASE_TYPES = {
-        primary_key: "int(11) auto_increment PRIMARY KEY",
+        primary_key: "int auto_increment PRIMARY KEY",
         string:      { name: "varchar", limit: 255 },
         text:        { name: "text" },
         integer:     { name: "int", limit: 4 },
@@ -1036,8 +1036,9 @@ module ActiveRecord
         when 1; 'tinyint'
         when 2; 'smallint'
         when 3; 'mediumint'
-        when nil, 4, 11; 'int(11)'  # compatibility with MySQL default
+        when nil, 4; 'int'
         when 5..8; 'bigint'
+        when 11; 'int(11)' # backward compatibility with Rails 2.0
         else raise(ActiveRecordError, "No integer type has byte size #{limit}")
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -18,7 +18,7 @@ module ActiveRecord
 
       # Instantiates a new column in the table.
       #
-      # +name+ is the column's name, such as <tt>supplier_id</tt> in <tt>supplier_id int(11)</tt>.
+      # +name+ is the column's name, such as <tt>supplier_id</tt> in <tt>supplier_id int</tt>.
       # +default+ is the type-casted default value, such as +new+ in <tt>sales_stage varchar(20) default 'new'</tt>.
       # +sql_type_metadata+ is various information about the type of the column
       # +null+ determines if this column allows +NULL+ values.

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -183,7 +183,7 @@ class MysqlConnectionTest < ActiveRecord::MysqlTestCase
 
   def with_example_table(&block)
     definition ||= <<-SQL
-      `id` int(11) auto_increment PRIMARY KEY,
+      `id` int auto_increment PRIMARY KEY,
       `data` varchar(255)
     SQL
     super(@connection, 'ex', definition, &block)

--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -83,7 +83,7 @@ module ActiveRecord
       end
 
       def test_pk_and_sequence_for_with_non_standard_primary_key
-        with_example_table '`code` INT(11) auto_increment, PRIMARY KEY (`code`)' do
+        with_example_table '`code` INT auto_increment, PRIMARY KEY (`code`)' do
           pk, seq = @conn.pk_and_sequence_for('ex')
           assert_equal 'code', pk
           assert_equal @conn.default_sequence_name('ex', 'code'), seq
@@ -91,7 +91,7 @@ module ActiveRecord
       end
 
       def test_pk_and_sequence_for_with_custom_index_type_pk
-        with_example_table '`id` INT(11) auto_increment, PRIMARY KEY USING BTREE (`id`)' do
+        with_example_table '`id` INT auto_increment, PRIMARY KEY USING BTREE (`id`)' do
           pk, seq = @conn.pk_and_sequence_for('ex')
           assert_equal 'id', pk
           assert_equal @conn.default_sequence_name('ex', 'id'), seq
@@ -99,7 +99,7 @@ module ActiveRecord
       end
 
       def test_composite_primary_key
-        with_example_table '`id` INT(11), `number` INT(11), foo INT(11), PRIMARY KEY (`id`, `number`)' do
+        with_example_table '`id` INT, `number` INT, foo INT, PRIMARY KEY (`id`, `number`)' do
           assert_nil @conn.primary_key('ex')
         end
       end
@@ -141,7 +141,7 @@ module ActiveRecord
 
       def with_example_table(definition = nil, &block)
         definition ||= <<-SQL
-          `id` int(11) auto_increment PRIMARY KEY,
+          `id` int auto_increment PRIMARY KEY,
           `number` integer,
           `data` varchar(255)
         SQL


### PR DESCRIPTION
The **(11)** does not affect the storage size of the data type, which for an
INT will always be 4 bytes. It affects the **display width**.

http://www.tocker.ca/2015/07/02/proposal-to-deprecate-mysql-integer-display-width-and-zerofill.html
