### PR TITLE
Do not dump a view as a table in sqlite3, mysql and mysql2 adapters

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `#views` and `#view_exists?` methods on connection adapters.
+
+    *Ryuta Kamizono*
+
 *   Correct query for PostgreSQL 8.2 compatibility.
 
     *Ben Murphy*, *Matthew Draper*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -36,6 +36,19 @@ module ActiveRecord
         tables.include?(table_name.to_s)
       end
 
+      # Returns an array of view names defined in the database.
+      def views
+        raise NotImplementedError, "#views is not implemented"
+      end
+
+      # Checks to see if the view +view_name+ exists on the database.
+      #
+      #   view_exists?(:ebooks)
+      #
+      def view_exists?(view_name)
+        views.include?(view_name.to_s)
+      end
+
       # Returns an array of indexes for the given table.
       # def indexes(table_name, name = nil) end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -549,6 +549,22 @@ module ActiveRecord
         tables(nil, schema, table).any?
       end
 
+      def views # :nodoc:
+        select_values("SHOW FULL TABLES WHERE table_type = 'VIEW'", 'SCHEMA')
+      end
+
+      def view_exists?(view_name) # :nodoc:
+        return false unless view_name.present?
+
+        schema, name = view_name.to_s.split('.', 2)
+        schema, name = @config[:database], schema unless name # A view was provided without a schema
+
+        sql = "SELECT table_name FROM information_schema.tables WHERE table_type = 'VIEW'"
+        sql << " AND table_schema = #{quote(schema)} AND table_name = #{quote(name)}"
+
+        select_values(sql, 'SCHEMA').any?
+      end
+
       # Returns an array of indexes for the given table.
       def indexes(table_name, name = nil) #:nodoc:
         indexes = []

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -90,6 +90,30 @@ module ActiveRecord
           SQL
         end
 
+        def views # :nodoc:
+          select_values(<<-SQL, 'SCHEMA')
+            SELECT c.relname
+            FROM pg_class c
+            LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relkind IN ('v','m') -- (v)iew, (m)aterialized view
+            AND n.nspname = ANY (current_schemas(false))
+          SQL
+        end
+
+        def view_exists?(view_name) # :nodoc:
+          name = Utils.extract_schema_qualified_name(view_name.to_s)
+          return false unless name.identifier
+
+          select_values(<<-SQL, 'SCHEMA').any?
+            SELECT c.relname
+            FROM pg_class c
+            LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relkind IN ('v','m') -- (v)iew, (m)aterialized view
+            AND c.relname = '#{name.identifier}'
+            AND n.nspname = #{name.schema ? "'#{name.schema}'" : 'ANY (current_schemas(false))'}
+          SQL
+        end
+
         def drop_table(table_name, options = {}) # :nodoc:
           execute "DROP TABLE#{' IF EXISTS' if options[:if_exists]} #{quote_table_name(table_name)}#{' CASCADE' if options[:force] == :cascade}"
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -325,6 +325,19 @@ module ActiveRecord
         table_name && tables(nil, table_name).any?
       end
 
+      def views # :nodoc:
+        select_values("SELECT name FROM sqlite_master WHERE type = 'view' AND name <> 'sqlite_sequence'", 'SCHEMA')
+      end
+
+      def view_exists?(view_name) # :nodoc:
+        return false unless view_name.present?
+
+        sql = "SELECT name FROM sqlite_master WHERE type = 'view' AND name <> 'sqlite_sequence'"
+        sql << " AND name = #{quote(view_name)}"
+
+        select_values(sql, 'SCHEMA').any?
+      end
+
       # Returns an array of +Column+ objects for the table specified by +table_name+.
       def columns(table_name) #:nodoc:
         table_structure(table_name).map do |field|

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -89,7 +89,7 @@ HEADER
       end
 
       def tables(stream)
-        sorted_tables = @connection.tables.sort
+        sorted_tables = @connection.tables.sort - @connection.views
 
         sorted_tables.each do |table_name|
           table(table_name, stream) unless ignored?(table_name)

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -1,7 +1,9 @@
 require "cases/helper"
 require "models/book"
+require "support/schema_dumping_helper"
 
 module ViewBehavior
+  include SchemaDumpingHelper
   extend ActiveSupport::Concern
 
   included do
@@ -62,6 +64,11 @@ module ViewBehavior
     end
     assert_nil model.primary_key
   end
+
+  def test_does_not_dump_view_as_table
+    schema = dump_table_schema "ebooks"
+    assert_no_match %r{create_table "ebooks"}, schema
+  end
 end
 
 if ActiveRecord::Base.connection.supports_views?
@@ -79,6 +86,7 @@ class ViewWithPrimaryKeyTest < ActiveRecord::TestCase
 end
 
 class ViewWithoutPrimaryKeyTest < ActiveRecord::TestCase
+  include SchemaDumpingHelper
   fixtures :books
 
   class Paperback < ActiveRecord::Base; end
@@ -126,6 +134,11 @@ class ViewWithoutPrimaryKeyTest < ActiveRecord::TestCase
 
   def test_does_not_have_a_primary_key
     assert_nil Paperback.primary_key
+  end
+
+  def test_does_not_dump_view_as_table
+    schema = dump_table_schema "paperbacks"
+    assert_no_match %r{create_table "paperbacks"}, schema
   end
 end
 

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -31,6 +31,15 @@ module ViewBehavior
     assert_equal ["Ruby for Rails"], books.map(&:name)
   end
 
+  def test_views
+    assert_equal [Ebook.table_name], @connection.views
+  end
+
+  def test_view_exists
+    view_name = Ebook.table_name
+    assert @connection.view_exists?(view_name), "'#{view_name}' view should exist"
+  end
+
   def test_table_exists
     view_name = Ebook.table_name
     assert @connection.table_exists?(view_name), "'#{view_name}' table should exist"
@@ -89,6 +98,15 @@ class ViewWithoutPrimaryKeyTest < ActiveRecord::TestCase
   def test_reading
     books = Paperback.all
     assert_equal ["Agile Web Development with Rails"], books.map(&:name)
+  end
+
+  def test_views
+    assert_equal [Paperback.table_name], @connection.views
+  end
+
+  def test_view_exists
+    view_name = Paperback.table_name
+    assert @connection.view_exists?(view_name), "'#{view_name}' view should exist"
   end
 
   def test_table_exists


### PR DESCRIPTION
Related with #21601.

Now in sqlite3, mysql and mysql2 adapters, SchemaDumper dump a view as
a table. It is incorrect behavior. This change excludes a view in schema.rb.
