### PR TITLE
Removed unused parameter `options` for `register_detail` method

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -20,7 +20,7 @@ module ActionView
     mattr_accessor :registered_details
     self.registered_details = []
 
-    def self.register_detail(name, options = {}, &block)
+    def self.register_detail(name, &block)
       self.registered_details << name
       initialize = registered_details.map { |n| "@details[:#{n}] = details[:#{n}] || default_#{n}" }
 
@@ -55,7 +55,7 @@ module ActionView
     end
     register_detail(:formats) { ActionView::Base.default_formats || [:html, :text, :js, :css,  :xml, :json] }
     register_detail(:variants) { [] }
-    register_detail(:handlers){ Template::Handlers.extensions }
+    register_detail(:handlers) { Template::Handlers.extensions }
 
     class DetailsKey #:nodoc:
       alias :eql? :equal?


### PR DESCRIPTION
This method is only called with name & block.
