### PR TITLE
ActiveRecord: Protect PostgreSQL query execution against Timeout::Error

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Ensure an injected Timeout::Error does not corrupt the local state of the
+    Postgres adapter or the pg library's connection handling.
+
+    Fixes #1627.
+
+    *Lukas Fittl*
+
 *   Correct query for PostgreSQL 8.2 compatibility.
 
     *Ben Murphy*, *Matthew Draper*

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -599,11 +599,19 @@ module ActiveRecord
         FEATURE_NOT_SUPPORTED = "0A000" #:nodoc:
 
         def execute_and_clear(sql, name, binds)
-          result = without_prepared_statement?(binds) ? exec_no_cache(sql, name, binds) :
-                                                        exec_cache(sql, name, binds)
-          ret = yield result
-          result.clear
-          ret
+          result = nil
+
+          # Unfortunately neither this adapter's prepared statement handling,
+          # nor the pg gem can handle a Timeout::Error reliably - so defer them
+          # until its safe to raise and we don't corrupt any internal state.
+          Thread.handle_interrupt(Timeout::Error => :never) do
+            result = without_prepared_statement?(binds) ? exec_no_cache(sql, name, binds) :
+                                                          exec_cache(sql, name, binds)
+          end
+
+          yield result
+        ensure
+          result.clear if result
         end
 
         def exec_no_cache(sql, name, binds)


### PR DESCRIPTION
This is a fix for #1627: `"ERROR: Prepared statement "a3" does not exist"` type errors popping up when using `rack-timeout` or a different `Thread.raise` based mechanism together with the Postgres adapter.

**Background**

In my understanding these usually happen with long-running queries - `Thread.raise` can't interrupt the query execution itself, so it ends up interrupting the thread right after the result returns, corrupting the statement cache and/or `pg`'s internal state.

This takes the idea proposed by @tenderlove in #17607 to use `Thread.handle_interrupt` for guarding the critical sections against Timeout::Error being injected.

**Notes**

Note that `rack-timeout` does not subclass its errors from `Timeout::Error` at this moment, however it seems more sensible to ask them to make that change, rather than interrupt all `StandardError`s.

I've intentionally opted to cover a rather large section of code with `handle_interrupt`, to make sure `pg`'s internal state is also kept consistent in this code path where timeouts are most likely to occur.

Feedback very welcome, this is unfortunately hard/impossible to fix outside core, short of monkey patching.

:bow:
