### PR TITLE
ActionPack: all_helpers_from_path needs to consider Dir.glob on a case insensitive FS

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `all_helpers_from_path` needs to consider Dir.glob on a case insensitive FS.
+
+    *Lukas Fittl*
+
 *   `url_for` does not modify its arguments when generating polymorphic URLs.
 
     *Bernerd Schaefer*

--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -99,7 +99,7 @@ module ActionController
       #   # => ["application", "chart", "rubygems"]
       def all_helpers_from_path(path)
         helpers = Array(path).flat_map do |_path|
-          extract = /^#{Regexp.quote(_path.to_s)}\/?(.*)_helper.rb$/
+          extract = /^#{Regexp.quote(_path.to_s)}\/?(.*)_helper.rb$/i
           names = Dir["#{_path}/**/*_helper.rb"].map { |file| file.sub(extract, '\1'.freeze) }
           names.sort!
         end


### PR DESCRIPTION
I've run into some odd issues with `helpers :all` on my OSX development machine, which boiled down to the following:
- Lets assume the actual on disk helper path is `/Users/x/MyProject/app/helpers`
- ActionController::Helpers::ClassMethods#all_helpers_from_path gets called with `/Users/x/myproject/app/helpers` (lowercase)
- Dir.glob returns the actual on disk location of individual helpers (with `MyProject`)
- The regular expression does **not** match due to the input path being lowercase

This ultimately surfaced as a really odd error on load, like this:

```
 Unable to load application: AbstractController::Helpers::MissingHelperError: Missing helper file helpers//users/lfittl/myproject/app/helpers/special_helper.rb_helper.rb
    from /Users/lfittl/rails/actionpack/lib/abstract_controller/helpers.rb:150:in `block in modules_for_helpers'
    from /Users/lfittl/rails/actionpack/lib/abstract_controller/helpers.rb:146:in `map!'
    from /Users/lfittl/rails/actionpack/lib/abstract_controller/helpers.rb:146:in `modules_for_helpers'
    from /Users/lfittl/rails/actionpack/lib/action_controller/metal/helpers.rb:93:in `modules_for_helpers'
    from /Users/lfittl/rails/actionpack/lib/abstract_controller/helpers.rb:109:in `helper'
    from /Users/lfittl/rails/actionpack/lib/action_controller/railties/helpers.rb:17:in `inherited'
```

Note the double `_helper.rb` in `special_helper.rb_helper.rb` due to the Regexp not matching.

I think the right fix here is to just make the regular expression match case insensitively.

:bow:
