### PR TITLE
Include interpolation values to translation_missing helper

### DIFF
--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -88,7 +88,14 @@ module ActionView
           raise e if raise_error
 
           keys = I18n.normalize_keys(e.locale, e.key, e.options[:scope])
-          content_tag('span', keys.last.to_s.titleize, :class => 'translation_missing', :title => "translation missing: #{keys.join('.')}")
+          title = "translation missing: #{keys.join('.')}"
+
+          interpolations = options.except(:default)
+          if interpolations.any?
+            title << ", " << interpolations.map { |k, v| "#{k}: #{ERB::Util.html_escape(v)}" }.join(', ')
+          end
+
+          content_tag('span', keys.last.to_s.titleize, class: 'translation_missing', title: title)
         end
       end
       alias :t :translate

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -60,6 +60,12 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal true, translate(:"translations.missing").html_safe?
   end
 
+  def test_returns_missing_translation_message_with_unescaped_interpolation
+    expected = '<span class="translation_missing" title="translation missing: en.translations.missing, name: Kir, year: 2015, vulnerable: &amp;quot; onclick=&amp;quot;alert()&amp;quot;">Missing</span>'
+    assert_equal expected, translate(:"translations.missing", name: "Kir", year: "2015", vulnerable: %{" onclick="alert()"})
+    assert translate(:"translations.missing").html_safe?
+  end
+
   def test_raises_missing_translation_message_with_raise_config_option
     ActionView::Base.raise_on_missing_translations = true
 


### PR DESCRIPTION
It would be great to see what are interpolation values that are passed to the missing translation.
