### PR TITLE
Use rack.session_options instead of directly change env

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -138,7 +138,7 @@ module ActionController #:nodoc:
           request = @controller.request
           request.session = NullSessionHash.new(request)
           request.flash = nil
-          request.env['rack.session.options'] = { skip: true }
+          request.session_options = { skip: true }
           request.cookie_jar = NullCookieJar.build(request, {})
         end
 


### PR DESCRIPTION
This pull request attempts to avoid directly manipulate request env hash like 49316d8a6357bbb19c2032faa3dfec8f7e0f0253 did.
