### PR TITLE
Avoid saving whole fixture sets for each test class

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -973,11 +973,11 @@ module ActiveRecord
 
       # Load fixtures once and begin transaction.
       if run_in_transaction?
-        if @@already_loaded_fixtures[self.class]
-          @loaded_fixtures = @@already_loaded_fixtures[self.class]
+        if (fixture_table_names - @@already_loaded_fixtures.keys).empty?
+          @loaded_fixtures = @@already_loaded_fixtures.slice(*fixture_table_names)
         else
           @loaded_fixtures = load_fixtures(config)
-          @@already_loaded_fixtures[self.class] = @loaded_fixtures
+          @@already_loaded_fixtures.merge!(@loaded_fixtures)
         end
         @fixture_connections = enlist_fixture_connections
         @fixture_connections.each do |connection|
@@ -986,7 +986,7 @@ module ActiveRecord
       # Load fixtures for every test.
       else
         ActiveRecord::FixtureSet.reset_cache
-        @@already_loaded_fixtures[self.class] = nil
+        @@already_loaded_fixtures = {}
         @loaded_fixtures = load_fixtures(config)
       end
 


### PR DESCRIPTION
This changes to a single global cache of fixtures rather than using a test suite level cache. This reduces cumulative memory bloat on large test suites.

For a small selection of our test suite (884/37369 tests) this uses 2.3402% less memory. Considering we have 37369 tests this can save quite a bit of memory overall.

The following code was added to our test helper to verify usage:

``` ruby
MiniTest.after_run do
  GC.start
  puts GC.stat[:total_allocated_object]
end
```

And here are some samples:

```
GC.stat[:total_allocated_objects] before: 109594085, 106998967, 106998967
before total allocation average: 107864006

GC.stat[:total_allocated_objects] after: 106417688, 106417045, 106417813
after total allocation average: 106417515

average total allocation difference: 1.342%

memory usage before: 1153.55859375 MB
memory usage after: 1126.5625 MB

memory saved: 2.3402%
```

@arthurnn @rafaelfranca 
