### PR TITLE
Add ActiveRecord::Migration versioning

### DIFF
--- a/activerecord/lib/active_record/migration/versioning.rb
+++ b/activerecord/lib/active_record/migration/versioning.rb
@@ -1,0 +1,18 @@
+module ActiveRecord
+  class Migration
+    class V3_2  # :nodoc:
+    end
+
+    class V4_0  # :nodoc:
+    end
+
+    class V4_1  # :nodoc:
+    end
+
+    class V4_2  # :nodoc:
+    end
+
+    class V5_0  # :nodoc:
+    end
+  end
+end

--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < ActiveRecord::Migration.version(<%= ActiveRecord::Migration.current_version %>)
   def change
     create_table :<%= table_name %> do |t|
 <% attributes.each do |attribute| -%>

--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < ActiveRecord::Migration.version(<%= ActiveRecord::Migration.current_version %>)
 <%- if migration_action == 'add' -%>
   def change
 <% attributes.each do |attribute| -%>

--- a/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
@@ -3,13 +3,13 @@ require "cases/helper"
 class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
   self.use_transactional_tests = false
 
-  class EnableHstore < ActiveRecord::Migration
+  class EnableHstore < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
     def change
       enable_extension "hstore"
     end
   end
 
-  class DisableHstore < ActiveRecord::Migration
+  class DisableHstore < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
     def change
       disable_extension "hstore"
     end

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -5,7 +5,7 @@ end
 
 module ActiveRecord
   class InvertibleMigrationTest < ActiveRecord::TestCase
-    class SilentMigration < ActiveRecord::Migration
+    class SilentMigration < ActiveRecord::Migration.version("4.2")
       def write(text = '')
         # sssshhhhh!!
       end
@@ -105,7 +105,7 @@ module ActiveRecord
       end
     end
 
-    class LegacyMigration < ActiveRecord::Migration
+    class LegacyMigration < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
       def self.up
         create_table("horses") do |t|
           t.column :content, :text

--- a/activerecord/test/cases/migration/versioning_test.rb
+++ b/activerecord/test/cases/migration/versioning_test.rb
@@ -1,0 +1,25 @@
+require 'cases/helper'
+
+module ActiveRecord
+  class MigrationTest < ActiveRecord::TestCase
+    def setup
+      super
+    end
+
+    def test_error_raised_if_unknown_version_number
+      assert_raises RuntimeError do
+        ActiveRecord::Migration.version("6.0")
+      end
+
+      error = assert_raises RuntimeError do
+        ActiveRecord::Migration.version("6.0")
+      end
+
+      assert_equal error.message, "Unkown version number: 6.0, only the following version numbers are accepted: 3.2, 4.2, 5.0"
+    end
+
+    def test_current_version_is_current_rails_version
+      assert_equal ActiveRecord::Migration.current_version, ActiveRecord::VERSION::STRING.to_f
+    end
+  end
+end

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -6,7 +6,7 @@ class MigratorTest < ActiveRecord::TestCase
 
   # Use this class to sense if migrations have gone
   # up or down.
-  class Sensor < ActiveRecord::Migration
+  class Sensor < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
     attr_reader :went_up, :went_down
 
     def initialize name = self.class.name, version = nil

--- a/activerecord/test/migrations/10_urban/9_add_expressions.rb
+++ b/activerecord/test/migrations/10_urban/9_add_expressions.rb
@@ -1,4 +1,4 @@
-class AddExpressions < ActiveRecord::Migration
+class AddExpressions < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     create_table("expressions") do |t|
       t.column :expression, :string

--- a/activerecord/test/migrations/decimal/1_give_me_big_numbers.rb
+++ b/activerecord/test/migrations/decimal/1_give_me_big_numbers.rb
@@ -1,4 +1,4 @@
-class GiveMeBigNumbers < ActiveRecord::Migration
+class GiveMeBigNumbers < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     create_table :big_numbers do |table|
       table.column :bank_balance, :decimal, :precision => 10, :scale => 2

--- a/activerecord/test/migrations/magic/1_currencies_have_symbols.rb
+++ b/activerecord/test/migrations/magic/1_currencies_have_symbols.rb
@@ -1,6 +1,6 @@
 # coding: ISO-8859-15
 
-class CurrenciesHaveSymbols < ActiveRecord::Migration
+class CurrenciesHaveSymbols < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     # We use € for default currency symbol
     add_column "currencies", "symbol", :string, :default => "€"

--- a/activerecord/test/migrations/missing/1000_people_have_middle_names.rb
+++ b/activerecord/test/migrations/missing/1000_people_have_middle_names.rb
@@ -1,4 +1,4 @@
-class PeopleHaveMiddleNames < ActiveRecord::Migration
+class PeopleHaveMiddleNames < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     add_column "people", "middle_name", :string
   end

--- a/activerecord/test/migrations/missing/1_people_have_last_names.rb
+++ b/activerecord/test/migrations/missing/1_people_have_last_names.rb
@@ -1,4 +1,4 @@
-class PeopleHaveLastNames < ActiveRecord::Migration
+class PeopleHaveLastNames < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     add_column "people", "last_name", :string
   end

--- a/activerecord/test/migrations/missing/3_we_need_reminders.rb
+++ b/activerecord/test/migrations/missing/3_we_need_reminders.rb
@@ -1,4 +1,4 @@
-class WeNeedReminders < ActiveRecord::Migration
+class WeNeedReminders < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     create_table("reminders") do |t|
       t.column :content, :text

--- a/activerecord/test/migrations/missing/4_innocent_jointable.rb
+++ b/activerecord/test/migrations/missing/4_innocent_jointable.rb
@@ -1,4 +1,4 @@
-class InnocentJointable < ActiveRecord::Migration
+class InnocentJointable < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     create_table("people_reminders", :id => false) do |t|
       t.column :reminder_id, :integer

--- a/activerecord/test/migrations/rename/1_we_need_things.rb
+++ b/activerecord/test/migrations/rename/1_we_need_things.rb
@@ -1,4 +1,4 @@
-class WeNeedThings < ActiveRecord::Migration
+class WeNeedThings < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     create_table("things") do |t|
       t.column :content, :text

--- a/activerecord/test/migrations/rename/2_rename_things.rb
+++ b/activerecord/test/migrations/rename/2_rename_things.rb
@@ -1,4 +1,4 @@
-class RenameThings < ActiveRecord::Migration
+class RenameThings < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     rename_table "things", "awesome_things"
   end

--- a/activerecord/test/migrations/to_copy/1_people_have_hobbies.rb
+++ b/activerecord/test/migrations/to_copy/1_people_have_hobbies.rb
@@ -1,4 +1,4 @@
-class PeopleHaveLastNames < ActiveRecord::Migration
+class PeopleHaveLastNames < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     add_column "people", "hobbies", :text
   end

--- a/activerecord/test/migrations/to_copy/2_people_have_descriptions.rb
+++ b/activerecord/test/migrations/to_copy/2_people_have_descriptions.rb
@@ -1,4 +1,4 @@
-class PeopleHaveLastNames < ActiveRecord::Migration
+class PeopleHaveLastNames < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     add_column "people", "description", :text
   end

--- a/activerecord/test/migrations/to_copy2/1_create_articles.rb
+++ b/activerecord/test/migrations/to_copy2/1_create_articles.rb
@@ -1,4 +1,4 @@
-class CreateArticles < ActiveRecord::Migration
+class CreateArticles < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
   end
 

--- a/activerecord/test/migrations/to_copy2/2_create_comments.rb
+++ b/activerecord/test/migrations/to_copy2/2_create_comments.rb
@@ -1,4 +1,4 @@
-class CreateArticles < ActiveRecord::Migration
+class CreateArticles < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
   end
 

--- a/activerecord/test/migrations/to_copy_with_name_collision/1_people_have_hobbies.rb
+++ b/activerecord/test/migrations/to_copy_with_name_collision/1_people_have_hobbies.rb
@@ -1,4 +1,4 @@
-class PeopleHaveLastNames < ActiveRecord::Migration
+class PeopleHaveLastNames < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     add_column "people", "hobbies", :string
   end

--- a/activerecord/test/migrations/to_copy_with_timestamps/20090101010101_people_have_hobbies.rb
+++ b/activerecord/test/migrations/to_copy_with_timestamps/20090101010101_people_have_hobbies.rb
@@ -1,4 +1,4 @@
-class PeopleHaveLastNames < ActiveRecord::Migration
+class PeopleHaveLastNames < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     add_column "people", "hobbies", :text
   end

--- a/activerecord/test/migrations/to_copy_with_timestamps/20090101010202_people_have_descriptions.rb
+++ b/activerecord/test/migrations/to_copy_with_timestamps/20090101010202_people_have_descriptions.rb
@@ -1,4 +1,4 @@
-class PeopleHaveLastNames < ActiveRecord::Migration
+class PeopleHaveLastNames < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     add_column "people", "description", :text
   end

--- a/activerecord/test/migrations/to_copy_with_timestamps2/20090101010101_create_articles.rb
+++ b/activerecord/test/migrations/to_copy_with_timestamps2/20090101010101_create_articles.rb
@@ -1,4 +1,4 @@
-class CreateArticles < ActiveRecord::Migration
+class CreateArticles < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
   end
 

--- a/activerecord/test/migrations/to_copy_with_timestamps2/20090101010202_create_comments.rb
+++ b/activerecord/test/migrations/to_copy_with_timestamps2/20090101010202_create_comments.rb
@@ -1,4 +1,4 @@
-class CreateComments < ActiveRecord::Migration
+class CreateComments < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
   end
 

--- a/activerecord/test/migrations/valid/1_valid_people_have_last_names.rb
+++ b/activerecord/test/migrations/valid/1_valid_people_have_last_names.rb
@@ -1,4 +1,4 @@
-class ValidPeopleHaveLastNames < ActiveRecord::Migration
+class ValidPeopleHaveLastNames < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     add_column "people", "last_name", :string
   end

--- a/activerecord/test/migrations/valid/2_we_need_reminders.rb
+++ b/activerecord/test/migrations/valid/2_we_need_reminders.rb
@@ -1,4 +1,4 @@
-class WeNeedReminders < ActiveRecord::Migration
+class WeNeedReminders < ActiveRecord::Migration.version("4.2")
   def self.up
     create_table("reminders") do |t|
       t.column :content, :text

--- a/activerecord/test/migrations/valid/3_innocent_jointable.rb
+++ b/activerecord/test/migrations/valid/3_innocent_jointable.rb
@@ -1,4 +1,4 @@
-class InnocentJointable < ActiveRecord::Migration
+class InnocentJointable < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     create_table("people_reminders", :id => false) do |t|
       t.column :reminder_id, :integer

--- a/activerecord/test/migrations/valid_with_subdirectories/1_valid_people_have_last_names.rb
+++ b/activerecord/test/migrations/valid_with_subdirectories/1_valid_people_have_last_names.rb
@@ -1,4 +1,4 @@
-class ValidPeopleHaveLastNames < ActiveRecord::Migration
+class ValidPeopleHaveLastNames < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     add_column "people", "last_name", :string
   end

--- a/activerecord/test/migrations/valid_with_subdirectories/sub/2_we_need_reminders.rb
+++ b/activerecord/test/migrations/valid_with_subdirectories/sub/2_we_need_reminders.rb
@@ -1,4 +1,4 @@
-class WeNeedReminders < ActiveRecord::Migration
+class WeNeedReminders < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     create_table("reminders") do |t|
       t.column :content, :text

--- a/activerecord/test/migrations/valid_with_subdirectories/sub1/3_innocent_jointable.rb
+++ b/activerecord/test/migrations/valid_with_subdirectories/sub1/3_innocent_jointable.rb
@@ -1,4 +1,4 @@
-class InnocentJointable < ActiveRecord::Migration
+class InnocentJointable < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     create_table("people_reminders", :id => false) do |t|
       t.column :reminder_id, :integer

--- a/activerecord/test/migrations/valid_with_timestamps/20100101010101_valid_with_timestamps_people_have_last_names.rb
+++ b/activerecord/test/migrations/valid_with_timestamps/20100101010101_valid_with_timestamps_people_have_last_names.rb
@@ -1,4 +1,4 @@
-class ValidWithTimestampsPeopleHaveLastNames < ActiveRecord::Migration
+class ValidWithTimestampsPeopleHaveLastNames < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     add_column "people", "last_name", :string
   end

--- a/activerecord/test/migrations/valid_with_timestamps/20100201010101_valid_with_timestamps_we_need_reminders.rb
+++ b/activerecord/test/migrations/valid_with_timestamps/20100201010101_valid_with_timestamps_we_need_reminders.rb
@@ -1,4 +1,4 @@
-class ValidWithTimestampsWeNeedReminders < ActiveRecord::Migration
+class ValidWithTimestampsWeNeedReminders < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     create_table("reminders") do |t|
       t.column :content, :text

--- a/activerecord/test/migrations/valid_with_timestamps/20100301010101_valid_with_timestamps_innocent_jointable.rb
+++ b/activerecord/test/migrations/valid_with_timestamps/20100301010101_valid_with_timestamps_innocent_jointable.rb
@@ -1,4 +1,4 @@
-class ValidWithTimestampsInnocentJointable < ActiveRecord::Migration
+class ValidWithTimestampsInnocentJointable < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
   def self.up
     create_table("people_reminders", :id => false) do |t|
       t.column :reminder_id, :integer

--- a/activerecord/test/migrations/version_check/20131219224947_migration_version_check.rb
+++ b/activerecord/test/migrations/version_check/20131219224947_migration_version_check.rb
@@ -1,4 +1,4 @@
-class MigrationVersionCheck < ActiveRecord::Migration
+class MigrationVersionCheck < ActiveRecord::Migration.version("4.2")
   def self.up
     raise "incorrect migration version" unless version == 20131219224947
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -90,7 +90,7 @@ module ApplicationTests
       RUBY
 
       app_file 'db/migrate/20140708012246_create_user.rb', <<-RUBY
-        class CreateUser < ActiveRecord::Migration
+        class CreateUser < ActiveRecord::Migration.version("#{ActiveRecord::Migration.current_version}")
           def change
             create_table :users
           end

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -63,22 +63,22 @@ module RailtiesTest
 
     test "copying migrations" do
       @plugin.write "db/migrate/1_create_users.rb", <<-RUBY
-        class CreateUsers < ActiveRecord::Migration
+        class CreateUsers < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
         end
       RUBY
 
       @plugin.write "db/migrate/2_add_last_name_to_users.rb", <<-RUBY
-        class AddLastNameToUsers < ActiveRecord::Migration
+        class AddLastNameToUsers < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
         end
       RUBY
 
       @plugin.write "db/migrate/3_create_sessions.rb", <<-RUBY
-        class CreateSessions < ActiveRecord::Migration
+        class CreateSessions < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
         end
       RUBY
 
       app_file "db/migrate/1_create_sessions.rb", <<-RUBY
-        class CreateSessions < ActiveRecord::Migration
+        class CreateSessions < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
           def up
           end
         end
@@ -123,12 +123,12 @@ module RailtiesTest
       end
 
       @plugin.write "db/migrate/1_create_users.rb", <<-RUBY
-        class CreateUsers < ActiveRecord::Migration
+        class CreateUsers < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
         end
       RUBY
 
       @blog.write "db/migrate/2_create_blogs.rb", <<-RUBY
-        class CreateBlogs < ActiveRecord::Migration
+        class CreateBlogs < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
         end
       RUBY
 
@@ -163,11 +163,11 @@ module RailtiesTest
       end
 
       @core.write "db/migrate/1_create_users.rb", <<-RUBY
-        class CreateUsers < ActiveRecord::Migration; end
+        class CreateUsers < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}"); end
       RUBY
 
       @api.write "db/migrate/2_create_keys.rb", <<-RUBY
-        class CreateKeys < ActiveRecord::Migration; end
+        class CreateKeys < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}"); end
       RUBY
 
       boot_rails
@@ -190,7 +190,7 @@ module RailtiesTest
       RUBY
 
       @plugin.write "db/migrate/0_add_first_name_to_users.rb", <<-RUBY
-        class AddFirstNameToUsers < ActiveRecord::Migration
+        class AddFirstNameToUsers < ActiveRecord::Migration.version("#{::ActiveRecord::Migration.current_version}")
         end
       RUBY
 


### PR DESCRIPTION
This allows someone to specify a version for ActiveRecord::Migrations like so:

``` ruby
  class Migration123 < ActiveRecord::Migration.version("4.2")
  end
```

To define changes for ActiveRecord::Migrations, simply put you changes within an accepted version number
class (ex: v4_2), in activerecord/lib/active_record/migration/versioning.rb.

---

A combination of the efforts by @matthewd and @brainopia, with (IMHO) easier to understand syntax.

r? @matthewd 

TODO:
- make sure tests are :+1: 
  - activerecord/test/cases/migration/foreign_key_test.rb:227
  - add versioning to activejob migrations
- update guides / examples
