### PR TITLE
Explicitly require AS/HWIA

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/object/deep_dup'
+require 'active_support/hash_with_indifferent_access'
 
 module ActiveRecord
   # Declare an enum attribute where the values map to integers in the database,


### PR DESCRIPTION
This file depends on AS/HWIA, so add `require`.
