### PR TITLE
Update documentation to remove 'desirable' suggestion for what is not a clear cut approach

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -51,7 +51,7 @@ Thus, the Ruby I18n gem is split into two parts:
 
 As a user you should always only access the public methods on the I18n module, but it is useful to know about the capabilities of the backend.
 
-NOTE: It is possible (or even desirable) to swap the shipped Simple backend with a more powerful one, which would store translation data in a relational database, GetText dictionary, or similar. See section [Using different backends](#using-different-backends) below.
+NOTE: It is possible to swap the shipped Simple backend with a more powerful one, which would store translation data in a relational database, GetText dictionary, or similar. See section [Using different backends](#using-different-backends) below.
 
 ### The Public I18n API
 


### PR DESCRIPTION
I suggest to remove the desirable comment.

I have been supporting large, small and huge I18n'ed systems. I came to clearly conclude that using plain text format/YAMLs as the backend for the translated data is the way to go, it makes things far superior in:
1. Auditing, change control and versions
2. Scaling translation with external services is easier with YML and flat file, rather than dumping and re-inserting data to tables.
3. Environment management - no need to move data from dev to prod in the form of insert scripts, it's all part of the code base.

I could well be wrong, but at the very least, if not whole-heartily recommending using simple YAMLs as I18n storage, I think it would be more helpful to drop the "desirable" references to (questionable) alternatives.
