### PR TITLE
Don't hardcode table name

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -247,7 +247,7 @@ HEADER
       end
 
       def ignored?(table_name)
-        ['schema_migrations', ignore_tables].flatten.any? do |ignored|
+        [ActiveRecord::Base.schema_migrations_table_name, ignore_tables].flatten.any? do |ignored|
           ignored === remove_prefix_and_suffix(table_name)
         end
       end


### PR DESCRIPTION
The schema_migrations table name is configurable. We should use this value when checking for ignored table names when dumping schema instead of a hardcoded value.
