### PR TITLE
Ensure options is a hash before symbolizing its keys

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -310,7 +310,7 @@ module ActionDispatch
           DEPRECATED_STRING_OPTIONS = %w[controller action]
 
           def deprecate_string_options(options)
-            options ||= {}
+            options = options.to_h
             deprecated_string_options = options.keys & DEPRECATED_STRING_OPTIONS
             if deprecated_string_options.any?
               msg = "Calling URL helpers with string keys #{deprecated_string_options.join(", ")} is deprecated. Use symbols instead."

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -310,7 +310,7 @@ module ActionDispatch
           DEPRECATED_STRING_OPTIONS = %w[controller action]
 
           def deprecate_string_options(options)
-            options = options.to_h
+            options = options ? options.to_h : {}
             deprecated_string_options = options.keys & DEPRECATED_STRING_OPTIONS
             if deprecated_string_options.any?
               msg = "Calling URL helpers with string keys #{deprecated_string_options.join(", ")} is deprecated. Use symbols instead."


### PR DESCRIPTION
Ensures options is a hash

[Fixes #21645]
