### PR TITLE
Verify target schema version when migrating to an older version

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Verify the target schema version before rolling back.
+    Don't rollback database to version 0 when `rake db:migrate` is
+    executed with incorrect VERSION.
+
+    *Vlad Yarotsky*
+
 *   Correct query for PostgreSQL 8.2 compatibility.
 
     *Ben Murphy*, *Matthew Draper*

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -87,6 +87,22 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Migrator.migrations_paths = old_path
   end
 
+  def test_does_not_rollback_to_unknown_version
+    migrations_path = MIGRATIONS_ROOT + "/valid"
+    old_path = ActiveRecord::Migrator.migrations_paths
+    ActiveRecord::Migrator.migrations_paths = migrations_path
+    ActiveRecord::Migrator.up(migrations_path)
+
+    assert_raises ActiveRecord::UnknownSchemaVersionError do
+      bad_version = MIGRATIONS_ROOT + "/valid/1_valid_people_have_last_names.rb"
+      ActiveRecord::Migrator.down(MIGRATIONS_ROOT + "/valid", bad_version)
+    end
+    assert_equal 3, ActiveRecord::Migrator.current_version
+    assert_equal false, ActiveRecord::Migrator.needs_migration?
+  ensure
+    ActiveRecord::Migrator.migrations_paths = old_path
+  end
+
   def test_migration_detection_without_schema_migration_table
     ActiveRecord::Base.connection.drop_table 'schema_migrations', if_exists: true
 


### PR DESCRIPTION
Don't rollback to version 0 if VERSION is not a known applied migration.

I've recently ran `VERSION=db/migrate/20150916110000_my_migration.rb bundle exec rake db:migrate` (notice a copy-paste error in VERSION value) on a database in a shared environment, hoping to apply a few things up to my latest migration. Instead it started rolling back older migrations, resulting in a dropped column. 
The underlying cause is that in rake tasks the `VERSION` environment variable is cast to a number using `to_i`. In my case, it resulted in `0`.

It does not really make much sense to roll back to an older schema version if that version is unknown, and this patch addresses the described issue, as well as fixes my use case.
Better to be safe than sorry! :smile: 
