### PR TITLE
nodoc raw_write_attribute

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -45,7 +45,7 @@ module ActiveRecord
         write_attribute_with_type_cast(attr_name, value, true)
       end
 
-      def raw_write_attribute(attr_name, value)
+      def raw_write_attribute(attr_name, value) # :nodoc:
         write_attribute_with_type_cast(attr_name, value, false)
       end
 


### PR DESCRIPTION
Is this supposed to be public API? If so, I can document it instead.
:memo:
