### PR TITLE
Fixed helpers submit button Examples [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1880,8 +1880,8 @@ module ActionView
       #           create: "Add %{model}"
       #
       # ==== Examples
-      #   button("Create a post")
-      #   # => <button name='button' type='submit'>Add post</button>
+      #   button("Create post")
+      #   # => <button name='button' type='submit'>Create post</button>
       #
       #   button do
       #     content_tag(:strong, 'Ask me!')

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1881,7 +1881,7 @@ module ActionView
       #
       # ==== Examples
       #   button("Create a post")
-      #   # => <button name='button' type='submit'>Create post</button>
+      #   # => <button name='button' type='submit'>Add post</button>
       #
       #   button do
       #     content_tag(:strong, 'Ask me!')


### PR DESCRIPTION
## Document(Comment) have 2 YAML Examples

1

```
      #   en:
      #     helpers:
      #       submit:
      #         create: "Create a %{model}"
      #         update: "Confirm changes to %{model}"
      #

```

2

```
      # It also searches for a key specific for the given object:
      #
      #   en:
      #     helpers:
      #       submit:
      #         post:
      #           create: "Add %{model}"
```
## Fixed

I think `button("Create a post")` example for 

2

```
      #   en:
      #     helpers:
      #       submit:
      #         post:
      #           create: "Add %{model}"
```

so, fixed

`# => <button name='button' type='submit'>Add post</button>`
## If `button("Create a post")` example for 1

this part will fix
`# => <button name='button' type='submit'>Create a post</button>`

But, I think this example for 2.
