### PR TITLE
Correct ArgumentError message in ActiveSupport conversions docs [ci s…

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -32,7 +32,7 @@ class Array
   #   ['one', 'two', 'three'].to_sentence # => "one, two, and three"
   #
   #   ['one', 'two'].to_sentence(passing: 'invalid option')
-  #   # => ArgumentError: Unknown key :passing
+  #   # => ArgumentError: Unknown key: :passing. Valid keys are: :words_connector, :two_words_connector, :last_word_connector, :locale
   #
   #   ['one', 'two'].to_sentence(two_words_connector: '-')
   #   # => "one-two"


### PR DESCRIPTION
…kip]

This was happened after this commit https://github.com/rails/rails/commit/2ebf47aea21ff8ac10681e53e78dd7a0e5c31c6e
