### PR TITLE
Fix - Prevent adding of `data-disable-with` option twice in html.

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -450,9 +450,9 @@ module ActionView
             disable_with_text ||= value.clone
             tag_options.deep_merge!("data" => { "disable_with" => disable_with_text })
           else
-            tag_options.delete("data-disable-with")
             tag_options["data"].delete(:disable_with) if tag_options["data"]
           end
+          tag_options.delete("data-disable-with")
         end
 
         tag :input, tag_options

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -485,6 +485,14 @@ class FormTagHelperTest < ActionView::TestCase
     )
   end
 
+  def test_submit_tag_doesnt_have_data_disable_with_twice
+    assert_equal(
+      %(<input type="submit" name="commit" value="Save" data-confirm="Are you sure?" data-disable-with="Processing..." />),
+      submit_tag("Save", { "data-disable-with" => "Processing...", "data-confirm" => "Are you sure?" })
+    )
+  end
+
+
   def test_button_tag
     assert_dom_equal(
       %(<button name="button" type="submit">Button</button>),


### PR DESCRIPTION
Earlier
when `data-disable-with` option is added direclty as in options then

``` ruby
submit_tag("Save", { "data-disable-with" => "Processing..." })
# => <input type="submit" name="commit" value="Save" data-disable-with="Processing..." data-disable-with="Processing..." />
```

Now
when `data-disable-with` option is added direclty as in options then

``` ruby
submit_tag("Save", { "data-disable-with" => "Processing..." })
# => <input type="submit" name="commit" value="Save" data-disable-with="Processing..." />
```
