### PR TITLE
Corrected `to_time` output in ActiveSupport Date Conversion docs [ci …

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -75,10 +75,10 @@ class Date
   #
   #   date = Date.new(2007, 11, 10)  # => Sat, 10 Nov 2007
   #
-  #   date.to_time                   # => Sat Nov 10 00:00:00 0800 2007
-  #   date.to_time(:local)           # => Sat Nov 10 00:00:00 0800 2007
+  #   date.to_time                   # => 2007-11-10 00:00:00 0800
+  #   date.to_time(:local)           # => 2007-11-10 00:00:00 0800
   #
-  #   date.to_time(:utc)             # => Sat Nov 10 00:00:00 UTC 2007
+  #   date.to_time(:utc)             # => 2007-11-10 00:00:00 UTC
   def to_time(form = :local)
     ::Time.send(form, year, month, day)
   end


### PR DESCRIPTION
…skip]

Since https://github.com/rails/rails/commit/48583f8bf74d1cefefea3cd6591bd546a9eaff6c, to_time returns times formatted as YYYY-MM-DD HH:MM:SS UTC.
