### PR TITLE
Added test for `any` if called without specifying any format

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -449,6 +449,13 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("Format with any!", email.parts[1].body.encoded)
   end
 
+  test 'test' do
+    error = assert_raises(ArgumentError) do
+      BaseMailer.explicit_without_specifying_format_with_any.parts
+    end
+    assert_equal "You have to supply at least one format", error.message
+  end
+
   test "explicit multipart with format(Hash)" do
     email = BaseMailer.explicit_multipart_with_options(true)
     email.ready_to_send!

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -80,6 +80,12 @@ class BaseMailer < ActionMailer::Base
     end
   end
 
+  def explicit_without_specifying_format_with_any(hash = {})
+    mail(hash) do |format|
+      format.any
+    end
+  end
+
   def explicit_multipart_with_options(include_html = false)
     mail do |format|
       format.text(content_transfer_encoding: "base64"){ render "welcome" }


### PR DESCRIPTION
Example

``` ruby
mail(hash) do |format|
  format.any
end
```
