### PR TITLE
Correcting `NameError` error message in `mattr_reader` method. Since …

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
@@ -19,9 +19,9 @@ class Module
   # The attribute name must be a valid method name in Ruby.
   #
   #   module Foo
-  #     mattr_reader :"1_Badname "
+  #     mattr_reader :"1_Badname"
   #   end
-  #   # => NameError: invalid attribute name
+  #   # => NameError: invalid attribute name: 1_Badname
   #
   # If you want to opt out the creation on the instance reader method, pass
   # <tt>instance_reader: false</tt> or <tt>instance_accessor: false</tt>.


### PR DESCRIPTION
…this commit https://github.com/rails/rails/commit/7dfbd91b0780fbd6a1dd9bfbc176e10894871d2d, `NameError` includes attribute_name also in error message [ci skip]
