### PR TITLE
Add created_at to schema_migrations and some code cleanup

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1730,4 +1730,16 @@
 
     *Yves Senn*
 
+*   Schema Migrations now contain time of creation information to track when
+    migrations were run.
+    ```
+	  database: vagrant_development
+
+	  Status   Migration ID    Migration Run             Migration Name
+	  ---------------------------------------------------------------------------
+	  up       20150918171109  2015-09-18 17:20:22 UTC   ********** NO FILE **********
+	  up       20150918210543  2015-09-18 21:07:10 UTC   Bar
+	  down     20150918210806                            Baz
+    ```
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -20,6 +20,10 @@ module ActiveRecord
         "#{table_name_prefix}unique_#{ActiveRecord::Base.schema_migrations_table_name}#{table_name_suffix}"
       end
 
+      def created_at_index_name
+        "#{table_name_prefix}created_at_#{ActiveRecord::Base.schema_migrations_table_name}#{table_name_suffix}"
+      end
+
       def table_exists?
         ActiveSupport::Deprecation.silence { connection.table_exists?(table_name) }
       end
@@ -31,8 +35,10 @@ module ActiveRecord
 
           connection.create_table(table_name, id: false) do |t|
             t.column :version, :string, version_options
+            t.column :created_at, :datetime, null: false
           end
           connection.add_index table_name, :version, unique: true, name: index_name
+          connection.add_index table_name, :created_at, name: created_at_index_name
         end
       end
 

--- a/activerecord/test/cases/migration/table_and_index_test.rb
+++ b/activerecord/test/cases/migration/table_and_index_test.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
         conn.initialize_schema_migrations_table
 
-        assert_equal "p_unique_schema_migrations_s", conn.indexes(ActiveRecord::Migrator.schema_migrations_table_name)[0][:name]
+        assert_equal ["p_created_at_schema_migrations_s", "p_unique_schema_migrations_s"], conn.indexes(ActiveRecord::Migrator.schema_migrations_table_name).map(&:name).sort
       ensure
         ActiveRecord::Base.table_name_prefix = ""
         ActiveRecord::Base.table_name_suffix = ""

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -107,7 +107,7 @@ module ApplicationTests
            bin/rake db:migrate`
           output = `bin/rake db:migrate:status`
           assert_match(%r{database:\s+\S*#{Regexp.escape(expected_database)}}, output)
-          assert_match(/up\s+\d{14}\s+Create books/, output)
+          assert_match(/up\s+\d{14}\s+.{24}\s+Create books/, output)
         end
       end
 

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -70,14 +70,14 @@ module ApplicationTests
 
           output = `bin/rake db:migrate:status`
 
-          assert_match(/up\s+\d{14}\s+Create users/, output)
-          assert_match(/up\s+\d{14}\s+Add email to users/, output)
+          assert_match(/up\s+\d{14}\s+.{24}\s+Create users/, output)
+          assert_match(/up\s+\d{14}\s+.{24}\s+Add email to users/, output)
 
           `bin/rake db:rollback STEP=1`
           output = `bin/rake db:migrate:status`
 
-          assert_match(/up\s+\d{14}\s+Create users/, output)
-          assert_match(/down\s+\d{14}\s+Add email to users/, output)
+          assert_match(/up\s+\d{14}\s+.{24}\s+Create users/, output)
+          assert_match(/down\s+\d{14}\s+.{24}\s+Add email to users/, output)
         end
       end
 
@@ -91,14 +91,14 @@ module ApplicationTests
 
           output = `bin/rake db:migrate:status`
 
-          assert_match(/up\s+\d{3,}\s+Create users/, output)
-          assert_match(/up\s+\d{3,}\s+Add email to users/, output)
+          assert_match(/up\s+\d{3,}\s+.{24}\s+Create users/, output)
+          assert_match(/up\s+\d{3,}\s+.{24}\s+Add email to users/, output)
 
           `bin/rake db:rollback STEP=1`
           output = `bin/rake db:migrate:status`
 
-          assert_match(/up\s+\d{3,}\s+Create users/, output)
-          assert_match(/down\s+\d{3,}\s+Add email to users/, output)
+          assert_match(/up\s+\d{3,}\s+.{24}\s+Create users/, output)
+          assert_match(/down\s+\d{3,}\s+.{24}\s+Add email to users/, output)
         end
       end
 
@@ -110,20 +110,20 @@ module ApplicationTests
 
            output = `bin/rake db:migrate:status`
 
-           assert_match(/up\s+\d{14}\s+Create users/, output)
-           assert_match(/up\s+\d{14}\s+Add email to users/, output)
+           assert_match(/up\s+\d{14}\s+.{24}\s+Create users/, output)
+           assert_match(/up\s+\d{14}\s+.{24}\s+Add email to users/, output)
 
            `bin/rake db:rollback STEP=2`
            output = `bin/rake db:migrate:status`
 
-           assert_match(/down\s+\d{14}\s+Create users/, output)
-           assert_match(/down\s+\d{14}\s+Add email to users/, output)
+           assert_match(/down\s+\d{14}\s+.{24}\s+Create users/, output)
+           assert_match(/down\s+\d{14}\s+.{24}\s+Add email to users/, output)
 
            `bin/rake db:migrate:redo`
            output = `bin/rake db:migrate:status`
 
-           assert_match(/up\s+\d{14}\s+Create users/, output)
-           assert_match(/up\s+\d{14}\s+Add email to users/, output)
+           assert_match(/up\s+\d{14}\s+.{24}\s+Create users/, output)
+           assert_match(/up\s+\d{14}\s+.{24}\s+Add email to users/, output)
         end
       end
 
@@ -137,20 +137,20 @@ module ApplicationTests
 
            output = `bin/rake db:migrate:status`
 
-           assert_match(/up\s+\d{3,}\s+Create users/, output)
-           assert_match(/up\s+\d{3,}\s+Add email to users/, output)
+           assert_match(/up\s+\d{3,}\s+.{24}\s+Create users/, output)
+           assert_match(/up\s+\d{3,}\s+.{24}\s+Add email to users/, output)
 
            `bin/rake db:rollback STEP=2`
            output = `bin/rake db:migrate:status`
 
-           assert_match(/down\s+\d{3,}\s+Create users/, output)
-           assert_match(/down\s+\d{3,}\s+Add email to users/, output)
+           assert_match(/down\s+\d{3,}\s+.{24}\s+Create users/, output)
+           assert_match(/down\s+\d{3,}\s+.{24}\s+Add email to users/, output)
 
            `bin/rake db:migrate:redo`
            output = `bin/rake db:migrate:status`
 
-           assert_match(/up\s+\d{3,}\s+Create users/, output)
-           assert_match(/up\s+\d{3,}\s+Add email to users/, output)
+           assert_match(/up\s+\d{3,}\s+.{24}\s+Create users/, output)
+           assert_match(/up\s+\d{3,}\s+.{24}\s+Add email to users/, output)
         end
       end
 
@@ -171,8 +171,8 @@ module ApplicationTests
 
            output = `bin/rake db:migrate:status`
 
-           assert_match(/up\s+001\s+One migration/, output)
-           assert_match(/up\s+002\s+Two migration/, output)
+           assert_match(/up\s+001\s+.{24}\s+One migration/, output)
+           assert_match(/up\s+002\s+.{24}\s+Two migration/, output)
         end
       end
 
@@ -219,8 +219,8 @@ module ApplicationTests
           output = `bin/rake db:migrate:status`
           File.write('test.txt', output)
 
-          assert_match(/up\s+\d{14}\s+Create users/, output)
-          assert_match(/up\s+\d{14}\s+\** NO FILE \**/, output)
+          assert_match(/up\s+\d{14}\s+.{24}\s+Create users/, output)
+          assert_match(/up\s+\d{14}\s+.{24}\s+\** NO FILE \**/, output)
         end
       end
     end


### PR DESCRIPTION
-   Schema Migrations now contain time of creation information to track when
  migrations were run.
  
  ```
    database: vagrant_development
  
    Status   Migration ID    Migration Run             Migration Name
    ---------------------------------------------------------------------------
    up       20150918171109  2015-09-18 17:20:22 UTC   ********** NO FILE **********
    up       20150918210543  2015-09-18 21:07:10 UTC   Bar
    down     20150918210806                            Baz
  ```
