### PR TITLE
Added missing example in `parent_name` docs [ci skip].

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/introspection.rb
+++ b/activesupport/lib/active_support/core_ext/module/introspection.rb
@@ -3,6 +3,10 @@ require 'active_support/inflector'
 class Module
   # Returns the name of the module containing this one.
   #
+  #   module M
+  #     module N
+  #     end
+  #   end
   #   M::N.parent_name # => "M"
   def parent_name
     if defined? @parent_name


### PR DESCRIPTION
Without this example, we can't evaluate  `M::N.parent_name`.
