### PR TITLE
Replace `#=>` with `# =>` [ci skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -10,8 +10,8 @@ module SecureRandom
   #
   # The result may contain alphanumeric characters except 0, O, I and l
   #
-  #   p SecureRandom.base58 #=> "4kUgL2pdQMSCQtjE"
-  #   p SecureRandom.base58(24) #=> "77TMHrHJFvFDwodq8w7Ev2m7"
+  #   p SecureRandom.base58 # => "4kUgL2pdQMSCQtjE"
+  #   p SecureRandom.base58(24) # => "77TMHrHJFvFDwodq8w7Ev2m7"
   #
   def self.base58(n = 16)
     SecureRandom.random_bytes(n).unpack("C*").map do |byte|

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -242,7 +242,7 @@ end
 
 >> person = Person.new
 >> person.valid?
->> person.errors.details[:name] #=> [{error: :blank}]
+>> person.errors.details[:name] # => [{error: :blank}]
 ```
 
 Using `details` with custom validators is covered in the [Working with

--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -239,7 +239,7 @@ You can quickly test the RDoc output with the following command:
 
 ```
 $ echo "+:to_param+" | rdoc --pipe
-#=> <p><code>:to_param</code></p>
+# => <p><code>:to_param</code></p>
 ```
 
 ### Regular Font


### PR DESCRIPTION
@rafaelfranca suggested in https://github.com/rails/rails/commit/f7c7bcd9c2a8b0e8c2840295d001d2d4dfd4cfae that code examples should display
the result after  `# =>` and not after `#=>`.
