### PR TITLE
Replaced `ThreadSafe::Map` with successor `Concurrent::Map`.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,12 +122,11 @@ PATH
       activesupport (= 5.0.0.alpha)
       arel (= 7.0.0.alpha)
     activesupport (5.0.0.alpha)
-      concurrent-ruby (~> 0.9.1)
+      concurrent-ruby (~> 1.0.0.pre2, < 2.0.0)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       method_source
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     rails (5.0.0.alpha)
       actionmailer (= 5.0.0.alpha)
@@ -172,7 +171,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
-    concurrent-ruby (0.9.1)
+    concurrent-ruby (1.0.0.pre2)
     connection_pool (2.2.0)
     dalli (2.7.4)
     dante (0.2.0)

--- a/actionview/lib/action_view/dependency_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker.rb
@@ -1,9 +1,9 @@
-require 'thread_safe'
+require 'concurrent'
 require 'action_view/path_set'
 
 module ActionView
   class DependencyTracker # :nodoc:
-    @trackers = ThreadSafe::Cache.new
+    @trackers = Concurrent::Map.new
 
     def self.find_dependencies(name, template, view_paths = nil)
       tracker = @trackers[template.handler]

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -1,4 +1,4 @@
-require 'thread_safe'
+require 'concurrent'
 require 'active_support/core_ext/module/remove_method'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'action_view/template/resolver'
@@ -62,7 +62,7 @@ module ActionView
       alias :object_hash :hash
 
       attr_reader :hash
-      @details_keys = ThreadSafe::Cache.new
+      @details_keys = Concurrent::Map.new
 
       def self.get(details)
         if details[:formats]

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -1,5 +1,5 @@
 require 'action_view/renderer/partial_renderer/collection_caching'
-require 'thread_safe'
+require 'concurrent'
 
 module ActionView
   class PartialIteration
@@ -283,8 +283,8 @@ module ActionView
   class PartialRenderer < AbstractRenderer
     include CollectionCaching
 
-    PREFIXED_PARTIAL_NAMES = ThreadSafe::Cache.new do |h, k|
-      h[k] = ThreadSafe::Cache.new
+    PREFIXED_PARTIAL_NAMES = Concurrent::Map.new do |h, k|
+      h[k] = Concurrent::Map.new
     end
 
     def initialize(*)

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -3,7 +3,7 @@ require "active_support/core_ext/class"
 require "active_support/core_ext/module/attribute_accessors"
 require "action_view/template"
 require "thread"
-require "thread_safe"
+require "concurrent"
 
 module ActionView
   # = Action View Resolver
@@ -35,7 +35,7 @@ module ActionView
 
     # Threadsafe template cache
     class Cache #:nodoc:
-      class SmallCache < ThreadSafe::Cache
+      class SmallCache < Concurrent::Map
         def initialize(options = {})
           super(options.merge(:initial_capacity => 2))
         end

--- a/activejob/lib/active_job/async_job.rb
+++ b/activejob/lib/active_job/async_job.rb
@@ -1,5 +1,4 @@
 require 'concurrent'
-require 'thread_safe'
 
 module ActiveJob
   # == Active Job Async Job
@@ -31,7 +30,7 @@ module ActiveJob
       fallback_policy: :caller_runs # shouldn't matter -- 0 max queue
     }.freeze
 
-    QUEUES = ThreadSafe::Cache.new do |hash, queue_name| #:nodoc:
+    QUEUES = Concurrent::Map.new do |hash, queue_name| #:nodoc:
       hash.compute_if_absent(queue_name) { ActiveJob::AsyncJob.create_thread_pool }
     end
 

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -1,4 +1,4 @@
-require 'thread_safe'
+require 'concurrent'
 require 'mutex_m'
 
 module ActiveModel
@@ -350,7 +350,7 @@ module ActiveModel
         # significantly (in our case our test suite finishes 10% faster with
         # this cache).
         def attribute_method_matchers_cache #:nodoc:
-          @attribute_method_matchers_cache ||= ThreadSafe::Cache.new(initial_capacity: 4)
+          @attribute_method_matchers_cache ||= Concurrent::Map.new(initial_capacity: 4)
         end
 
         def attribute_method_matchers_matching(method_name) #:nodoc:

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -1,7 +1,7 @@
 require 'active_support/core_ext/enumerable'
 require 'active_support/core_ext/string/filters'
 require 'mutex_m'
-require 'thread_safe'
+require 'concurrent'
 
 module ActiveRecord
   # = Active Record Attribute Methods
@@ -37,7 +37,7 @@ module ActiveRecord
     class AttributeMethodCache
       def initialize
         @module = Module.new
-        @method_cache = ThreadSafe::Cache.new
+        @method_cache = Concurrent::Map.new
       end
 
       def [](name)

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1,5 +1,5 @@
 require 'thread'
-require 'thread_safe'
+require 'concurrent'
 require 'monitor'
 
 module ActiveRecord
@@ -337,7 +337,7 @@ module ActiveRecord
         # that case +conn.owner+ attr should be consulted.
         # Access and modification of +@thread_cached_conns+ does not require
         # synchronization.
-        @thread_cached_conns = ThreadSafe::Cache.new(:initial_capacity => @size)
+        @thread_cached_conns = Concurrent::Map.new(:initial_capacity => @size)
 
         @connections         = []
         @automatic_reconnect = true
@@ -824,11 +824,11 @@ module ActiveRecord
         # These caches are keyed by klass.name, NOT klass. Keying them by klass
         # alone would lead to memory leaks in development mode as all previous
         # instances of the class would stay in memory.
-        @owner_to_pool = ThreadSafe::Cache.new(:initial_capacity => 2) do |h,k|
-          h[k] = ThreadSafe::Cache.new(:initial_capacity => 2)
+        @owner_to_pool = Concurrent::Map.new(:initial_capacity => 2) do |h,k|
+          h[k] = Concurrent::Map.new(:initial_capacity => 2)
         end
-        @class_to_pool = ThreadSafe::Cache.new(:initial_capacity => 2) do |h,k|
-          h[k] = ThreadSafe::Cache.new
+        @class_to_pool = Concurrent::Map.new(:initial_capacity => 2) do |h,k|
+          h[k] = Concurrent::Map.new
         end
       end
 

--- a/activerecord/lib/active_record/type/type_map.rb
+++ b/activerecord/lib/active_record/type/type_map.rb
@@ -1,12 +1,12 @@
-require 'thread_safe'
+require 'concurrent'
 
 module ActiveRecord
   module Type
     class TypeMap # :nodoc:
       def initialize
         @mapping = {}
-        @cache = ThreadSafe::Cache.new do |h, key|
-          h.fetch_or_store(key, ThreadSafe::Cache.new)
+        @cache = Concurrent::Map.new do |h, key|
+          h.fetch_or_store(key, Concurrent::Map.new)
         end
       end
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Replaced deprecated `ThreadSafe::Cache` with its successor `Concurrent::Map` now that
+    the thread_safe gem has been merged into concurrent-ruby.
+
+    *Jerry D'Antonio*
+
 *   Updated Unicode version to 8.0.0
 
     *Anshul Sharma*

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'json',       '~> 1.7', '>= 1.7.7'
   s.add_dependency 'tzinfo',     '~> 1.1'
   s.add_dependency 'minitest',   '~> 5.1'
-  s.add_dependency 'thread_safe','~> 0.3', '>= 0.3.4'
-  s.add_dependency 'concurrent-ruby', '~> 0.9.1'
+  s.add_dependency 'concurrent-ruby', '~> 1.0.0.pre2', '< 2.0.0'
   s.add_dependency 'method_source'
 end

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -1,6 +1,6 @@
 require 'set'
 require 'thread'
-require 'thread_safe'
+require 'concurrent'
 require 'pathname'
 require 'active_support/core_ext/module/aliasing'
 require 'active_support/core_ext/module/attribute_accessors'
@@ -585,7 +585,7 @@ module ActiveSupport #:nodoc:
 
     class ClassCache
       def initialize
-        @store = ThreadSafe::Cache.new
+        @store = Concurrent::Map.new
       end
 
       def empty?

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -1,4 +1,4 @@
-require 'thread_safe'
+require 'concurrent'
 require 'active_support/core_ext/array/prepend_and_append'
 require 'active_support/i18n'
 
@@ -25,7 +25,7 @@ module ActiveSupport
     # singularization rules that is runs. This guarantees that your rules run
     # before any of the rules that may already have been loaded.
     class Inflections
-      @__instance__ = ThreadSafe::Cache.new
+      @__instance__ = Concurrent::Map.new
 
       class Uncountables < Array
         def initialize

--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -1,4 +1,4 @@
-require 'thread_safe'
+require 'concurrent'
 require 'openssl'
 
 module ActiveSupport
@@ -28,7 +28,7 @@ module ActiveSupport
   class CachingKeyGenerator
     def initialize(key_generator)
       @key_generator = key_generator
-      @cache_keys = ThreadSafe::Cache.new
+      @cache_keys = Concurrent::Map.new
     end
 
     # Returns a derived key suitable for use.  The default key_size is chosen

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -1,5 +1,5 @@
 require 'mutex_m'
-require 'thread_safe'
+require 'concurrent'
 
 module ActiveSupport
   module Notifications
@@ -12,7 +12,7 @@ module ActiveSupport
 
       def initialize
         @subscribers = []
-        @listeners_for = ThreadSafe::Cache.new
+        @listeners_for = Concurrent::Map.new
         super
       end
 
@@ -51,7 +51,7 @@ module ActiveSupport
       end
 
       def listeners_for(name)
-        # this is correctly done double-checked locking (ThreadSafe::Cache's lookups have volatile semantics)
+        # this is correctly done double-checked locking (Concurrent::Map's lookups have volatile semantics)
         @listeners_for[name] || synchronize do
           # use synchronisation when accessing @subscribers
           @listeners_for[name] ||= @subscribers.select { |s| s.subscribed_to?(name) }

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -1,5 +1,5 @@
 require 'tzinfo'
-require 'thread_safe'
+require 'concurrent'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/try'
 
@@ -189,7 +189,7 @@ module ActiveSupport
     UTC_OFFSET_WITH_COLON = '%s%02d:%02d'
     UTC_OFFSET_WITHOUT_COLON = UTC_OFFSET_WITH_COLON.tr(':', '')
 
-    @lazy_zones_map = ThreadSafe::Cache.new
+    @lazy_zones_map = Concurrent::Map.new
 
     class << self
       # Assumes self represents an offset from UTC in seconds (as returned from


### PR DESCRIPTION
The `thread_safe` gem is being deprecated and all its code has been merged into `concurrent-ruby`. The new class, `Concurrent::Map`, is exactly the same as its predecessor except for fixes to two bugs discovered during the merge.

This merge was first [discussed](https://github.com/rails/rails/pull/20866#issuecomment-121021946) with @tenderlove in PR #20866.

This PR depends on a pre-release version of concurrent-ruby (1.0.0.pre2). The original merge of thread_safe happened in 1.0.0.pre1. We will release 1.0.0 _before_ Rails 5 is released. We are not adding new features, just working on performance improvements, better documentation, and other chores. We will schedule a 1.0.0 release date as soon as the Rails team needs us to.

When running the tests there are a few interpreter warnings coming from concurrent-ruby. We will clean those up before the next release. We have an issue open [here](https://github.com/ruby-concurrency/concurrent-ruby/issues/417).
