### PR TITLE
Remove `@connection` in `StatementPool`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -80,8 +80,7 @@ module ActiveRecord
 
       def initialize(connection, logger, connection_options, config)
         super
-        @statements = StatementPool.new(@connection,
-                                        self.class.type_cast_config_to_integer(config.fetch(:statement_limit) { 1000 }))
+        @statements = StatementPool.new(self.class.type_cast_config_to_integer(config.fetch(:statement_limit) { 1000 }))
         @client_encoding = nil
         connect
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -211,7 +211,8 @@ module ActiveRecord
 
       class StatementPool < ConnectionAdapters::StatementPool
         def initialize(connection, max)
-          super
+          super(max)
+          @connection = connection
           @counter = 0
         end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -81,8 +81,7 @@ module ActiveRecord
         super(connection, logger)
 
         @active     = nil
-        @statements = StatementPool.new(@connection,
-                                        self.class.type_cast_config_to_integer(config.fetch(:statement_limit) { 1000 }))
+        @statements = StatementPool.new(self.class.type_cast_config_to_integer(config.fetch(:statement_limit) { 1000 }))
         @config = config
 
         @visitor = Arel::Visitors::SQLite.new self

--- a/activerecord/lib/active_record/connection_adapters/statement_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/statement_pool.rb
@@ -3,10 +3,9 @@ module ActiveRecord
     class StatementPool
       include Enumerable
 
-      def initialize(connection, max = 1000)
+      def initialize(max = 1000)
         @cache = Hash.new { |h,pid| h[pid] = {} }
-        @connection = connection
-        @max        = max
+        @max = max
       end
 
       def each(&block)

--- a/activerecord/test/cases/adapters/mysql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/mysql/statement_pool_test.rb
@@ -3,7 +3,7 @@ require 'cases/helper'
 class MysqlStatementPoolTest < ActiveRecord::MysqlTestCase
   if Process.respond_to?(:fork)
     def test_cache_is_per_pid
-      cache = ActiveRecord::ConnectionAdapters::MysqlAdapter::StatementPool.new nil, 10
+      cache = ActiveRecord::ConnectionAdapters::MysqlAdapter::StatementPool.new(10)
       cache['foo'] = 'bar'
       assert_equal 'bar', cache['foo']
 

--- a/activerecord/test/cases/adapters/sqlite3/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/statement_pool_test.rb
@@ -6,7 +6,7 @@ module ActiveRecord::ConnectionAdapters
       if Process.respond_to?(:fork)
         def test_cache_is_per_pid
 
-          cache = StatementPool.new nil, 10
+          cache = StatementPool.new(10)
           cache['foo'] = 'bar'
           assert_equal 'bar', cache['foo']
 


### PR DESCRIPTION
`@connection` in `StatementPool` is only used for PG adapter.
No need for abstract `StatementPool` class.
