### PR TITLE
String#strip_heredocs doesn't need Object#try anymore

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/strip.rb
+++ b/activesupport/lib/active_support/core_ext/string/strip.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/object/try'
-
 class String
   # Strips indentation in heredocs.
   #


### PR DESCRIPTION
Call to Object#try was removed with this pull request https://github.com/rails/rails/pull/21596
