### PR TITLE
Run Beanstalkd integration tests in ActiveJob

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ script: 'ci/travis.rb'
 before_install:
   - gem install bundler
   - "rm ${BUNDLE_GEMFILE}.lock"
+  - curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp
+  - cd /tmp/beanstalkd-1.10/
+  - make
+  - ./beanstalkd &
+  - cd $TRAVIS_BUILD_DIR
 before_script:
   - bundle update
 cache: bundler

--- a/activejob/test/support/integration/helper.rb
+++ b/activejob/test/support/integration/helper.rb
@@ -1,4 +1,4 @@
-puts "*** rake aj:integration:#{ENV['AJ_ADAPTER']} ***\n"
+puts "\n\n*** rake aj:integration:#{ENV['AJ_ADAPTER']} ***\n"
 
 ENV["RAILS_ENV"] = "test"
 ActiveJob::Base.queue_name_prefix = nil


### PR DESCRIPTION
Added beanstalkd config to Travis so AJ tests for it can run. This takes care of one of the failures in AJ seen in travis. Please review the code as I haven't used Travis before but got the code from another beanstalkd project and their travis config.

The other failure in travis job #27998.15 is related to sidekiq but that test passed on my local machine and seems to be passing in current travis runs. Left as is for now.

The `alias_method_chain` deprecation warnings are from `turbolinks/xhr_url_for.rb:7`.

Lastly I want to thank @eileencodes for helping me get started with contributing to Rails.
