### PR TITLE
Applying right result of examples in ActiveSupport Multibyte [ci skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/multibyte.rb
+++ b/activesupport/lib/active_support/core_ext/string/multibyte.rb
@@ -9,12 +9,10 @@ class String
   # encapsulates the original string. A Unicode safe version of all the String methods are defined on this proxy
   # class. If the proxy class doesn't respond to a certain method, it's forwarded to the encapsulated string.
   #
-  #   name = 'Claus Müller'
-  #   name.reverse # => "rell??M sualC"
-  #   name.length  # => 13
-  #
-  #   name.mb_chars.reverse.to_s # => "rellüM sualC"
-  #   name.mb_chars.length       # => 12
+  #   >> "ǉ".upcase
+  #   => "ǉ"
+  #   >> "ǉ".mb_chars.upcase.to_s
+  #   => "Ǉ"
   #
   # == Method chaining
   #


### PR DESCRIPTION
Shown result is the example of ruby 1.8. As we all know that we start support UTF-8 case folding after Ruby 1.9.
Here is output -

![unicode_result](https://cloud.githubusercontent.com/assets/2149795/9978993/adba9b40-5f70-11e5-8154-963c8c283792.png)
