### PR TITLE
Remove unused `pk_and_sequence_for` in AbstractMysqlAdapter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove unused `pk_and_sequence_for` in AbstractMysqlAdapter.
+
+    *Ryuta Kamizono*
+
 *   Allow fixtures files to set the model class in the YAML file itself.
 
     To load the fixtures file `accounts.yml` as the `User` model, use:

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -850,13 +850,6 @@ module ActiveRecord
         nil
       end
 
-      # Returns a table's primary key and belonging sequence.
-      def pk_and_sequence_for(table)
-        if pk = primary_key(table)
-          [ pk, nil ]
-        end
-      end
-
       def primary_keys(table_name) # :nodoc:
         raise ArgumentError unless table_name.present?
 

--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -65,30 +65,6 @@ module ActiveRecord
         end
       end
 
-      def test_pk_and_sequence_for
-        with_example_table do
-          pk, seq = @conn.pk_and_sequence_for('ex')
-          assert_equal 'id', pk
-          assert_equal @conn.default_sequence_name('ex', 'id'), seq
-        end
-      end
-
-      def test_pk_and_sequence_for_with_non_standard_primary_key
-        with_example_table '`code` INT auto_increment, PRIMARY KEY (`code`)' do
-          pk, seq = @conn.pk_and_sequence_for('ex')
-          assert_equal 'code', pk
-          assert_equal @conn.default_sequence_name('ex', 'code'), seq
-        end
-      end
-
-      def test_pk_and_sequence_for_with_custom_index_type_pk
-        with_example_table '`id` INT auto_increment, PRIMARY KEY USING BTREE (`id`)' do
-          pk, seq = @conn.pk_and_sequence_for('ex')
-          assert_equal 'id', pk
-          assert_equal @conn.default_sequence_name('ex', 'id'), seq
-        end
-      end
-
       def test_composite_primary_key
         with_example_table '`id` INT, `number` INT, foo INT, PRIMARY KEY (`id`, `number`)' do
           assert_nil @conn.primary_key('ex')


### PR DESCRIPTION
`pk_and_sequence_for` is implemented for PG and MySQL adapters (not
implemented for Sqlite3 adapter). But MySQL adapters are not using
`pk_and_sequence_for` already. We can remove the method.
