### PR TITLE
Add short-hand methods for text and blob types in MySQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Add short-hand methods for text and blob types in MySQL.
+
+    In Pg and Sqlite3, `:text` and `:binary` have variable unlimited length.
+    But in MySQL, these have limited length for each types (ref #21591, #21619).
+    This change adds short-hand methods for each text and blob types.
+
+    Example:
+
+        create_table :foos do |t|
+          t.tinyblob   :tiny_blob
+          t.mediumblob :medium_blob
+          t.longblob   :long_blob
+          t.tinytext   :tiny_text
+          t.mediumtext :medium_text
+          t.longtext   :long_text
+        end
+
+    *Ryuta Kamizono*
+
 *   When calling `first` with a `limit` argument, return directly from the
     `loaded?` records if available.
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -11,6 +11,30 @@ module ActiveRecord
           args.each { |name| column(name, :blob, options) }
         end
 
+        def tinyblob(*args, **options)
+          args.each { |name| column(name, :tinyblob, options) }
+        end
+
+        def mediumblob(*args, **options)
+          args.each { |name| column(name, :mediumblob, options) }
+        end
+
+        def longblob(*args, **options)
+          args.each { |name| column(name, :longblob, options) }
+        end
+
+        def tinytext(*args, **options)
+          args.each { |name| column(name, :tinytext, options) }
+        end
+
+        def mediumtext(*args, **options)
+          args.each { |name| column(name, :mediumtext, options) }
+        end
+
+        def longtext(*args, **options)
+          args.each { |name| column(name, :longtext, options) }
+        end
+
         def json(*args, **options)
           args.each { |name| column(name, :json, options) }
         end

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -2,17 +2,17 @@ ActiveRecord::Schema.define do
   create_table :binary_fields, force: true do |t|
     t.binary :var_binary, limit: 255
     t.binary :var_binary_large, limit: 4095
-    t.blob   :tiny_blob, limit: 255
-    t.binary :normal_blob, limit: 65535
-    t.binary :medium_blob, limit: 16777215
-    t.binary :long_blob, limit: 2147483647
-    t.text   :tiny_text, limit: 255
-    t.text   :normal_text, limit: 65535
-    t.text   :medium_text, limit: 16777215
-    t.text   :long_text, limit: 2147483647
-  end
+    t.tinyblob   :tiny_blob
+    t.blob       :normal_blob
+    t.mediumblob :medium_blob
+    t.longblob   :long_blob
+    t.tinytext   :tiny_text
+    t.text       :normal_text
+    t.mediumtext :medium_text
+    t.longtext   :long_text
 
-  add_index :binary_fields, :var_binary
+    t.index :var_binary
+  end
 
   create_table :key_tests, force: true, :options => 'ENGINE=MyISAM' do |t|
     t.string :awesome


### PR DESCRIPTION
In Pg and Sqlite3, `:text` and `:binary` have variable unlimited length.
But in MySQL, these have limited length for each types (see also #21591, #21619).
This change adds short-hand methods for each text and blob types.

Before:

``` ruby
create_table :foos do |t|
  t.blob   :tiny_blob,   limit: 255
  t.binary :medium_blob, limit: 16777215
  t.binary :long_blob,   limit: 2147483647
  t.text   :tiny_text,   limit: 255
  t.text   :medium_text, limit: 16777215
  t.text   :long_text,   limit: 2147483647
end
```

Short-hand methods:

``` ruby
create_table :foos do |t|
  t.tinyblob   :tiny_blob
  t.mediumblob :medium_blob
  t.longblob   :long_blob
  t.tinytext   :tiny_text
  t.mediumtext :medium_text
  t.longtext   :long_text
end
```
