### PR TITLE
Add title for key lengths for multiple keys.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -563,6 +563,8 @@ module ActiveRecord
       #
       #   CREATE INDEX by_name ON accounts(name(10))
       #
+      # ====== Creating an index with specific key lengths for multiple keys
+      #
       #   add_index(:accounts, [:name, :surname], name: 'by_name_surname', length: {name: 10, surname: 15})
       #
       # generates:


### PR DESCRIPTION
Previously there was no separator between the two code examples so it looked like: 

``` ruby
CREATE INDEX by_name ON accounts(name(10))
add_index(:accounts, [:name, :surname], name: 'by_name_surname', length: {name: 10, surname: 15})
```
