### PR TITLE
Support non-`id ASC` natural orderings

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1010,7 +1010,7 @@ module ActiveRecord
     end
 
     def reverse_sql_order(order_query)
-      order_query = ["#{quoted_table_name}.#{quoted_primary_key} ASC"] if order_query.empty?
+      raise "No order to reverse: #{order_query.inspect}" if order_query.empty?
 
       order_query.flat_map do |o|
         case o

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -437,16 +437,16 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal Topic.order("title").to_a.last(2), Topic.order("title").last(2)
   end
 
-  def test_last_with_integer_and_order_should_not_use_sql_limit
+  def test_last_with_integer_and_order_should_use_sql_limit
     query = assert_sql { Topic.order("title").last(5).entries }
     assert_equal 1, query.length
-    assert_no_match(/LIMIT/, query.first)
+    assert_match 'LIMIT', query.first
   end
 
-  def test_last_with_integer_and_reorder_should_not_use_sql_limit
+  def test_last_with_integer_and_reorder_should_use_sql_limit
     query = assert_sql { Topic.reorder("title").last(5).entries }
     assert_equal 1, query.length
-    assert_no_match(/LIMIT/, query.first)
+    assert_match 'LIMIT', query.first
   end
 
   def test_take_and_first_and_last_with_integer_should_return_an_array

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -831,7 +831,7 @@ class FoxyFixturesTest < ActiveRecord::TestCase
   end
 
   def test_only_generates_a_pk_if_necessary
-    m = Matey.first
+    m = Matey.take
     m.pirate = pirates(:blackbeard)
     m.target = pirates(:redbeard)
   end

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -129,7 +129,7 @@ class ViewWithoutPrimaryKeyTest < ActiveRecord::TestCase
 
   def test_attributes
     assert_equal({"name" => "Agile Web Development with Rails", "status" => 2},
-                 Paperback.first.attributes)
+                 Paperback.take.attributes)
   end
 
   def test_does_not_have_a_primary_key


### PR DESCRIPTION
Models with a natural ordering other than their primary key (including
models with no primary key at all) may now support `first` and `last`.

This differs from `default_scope` since it's used for explicitly ordered
finders only, whereas a default scope affects all finds, often casting
too wide a net.

Bonus: Models without a primary key now use SQL for `last` instead of
loading all records.

Closes #21663.
- [ ] Decide how users' models should declare their natural ordering. Override this method? Declare a scope? Declare a set of fields with `#order` arg style? Use a `class_attribute`?
- [ ] Test coverage for using ordered finders on models with no natural ordering.
